### PR TITLE
Support dotenv for workers

### DIFF
--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -35,6 +35,9 @@ from urllib.parse import urlparse
 
 import websockets
 from livekit import api, rtc, protocol
+import dotenv
+
+dotenv.load_dotenv()
 
 MAX_RECONNECT_ATTEMPTS = 5
 RECONNECT_INTERVAL = 5

--- a/livekit-agents/setup.py
+++ b/livekit-agents/setup.py
@@ -58,6 +58,7 @@ setuptools.setup(
         "livekit-protocol>=0.1.0",
         "livekit-protocol",
         "websockets>=12.0",
+        "python-dotenv>=1.0.0",
     ],
     package_data={},
     project_urls={


### PR DESCRIPTION
So that agent devs can develop with their environment in a `.env` file.