### PR TITLE
Update deepgram endpointing 

### DIFF
--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -18,7 +18,7 @@ class SpeechData:
 class SpeechEvent:
     is_final: bool
     alternatives: List[SpeechData]
-    speech_final: bool = False
+    end_of_speech: bool = False
 
 
 class STT(ABC):

--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -17,6 +17,7 @@ class SpeechData:
 @dataclass
 class SpeechEvent:
     is_final: bool
+    speech_final: bool
     alternatives: List[SpeechData]
 
 

--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -17,8 +17,8 @@ class SpeechData:
 @dataclass
 class SpeechEvent:
     is_final: bool
-    speech_final: bool
     alternatives: List[SpeechData]
+    speech_final: bool = False
 
 
 class STT(ABC):

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -22,6 +22,7 @@ class STTOptions:
     punctuate: bool
     model: DeepgramModels
     smart_format: bool
+    endpointing: Optional[str]
 
 
 class STT(stt.STT):
@@ -36,6 +37,7 @@ class STT(stt.STT):
         model: DeepgramModels = "nova-2-general",
         api_key: Optional[str] = None,
         api_url: Optional[str] = None,
+        min_silence_duration: float = 0,
     ) -> None:
         super().__init__(streaming_supported=True)
         api_key = api_key or os.environ.get("DEEPGRAM_API_KEY")
@@ -51,6 +53,7 @@ class STT(stt.STT):
             punctuate=punctuate,
             model=model,
             smart_format=smart_format,
+            endpointing=str(int(min_silence_duration * 1000)) if min_silence_duration else None,
         )
 
     def _sanitize_options(
@@ -197,6 +200,7 @@ class SpeechStream(stt.SpeechStream):
                     sample_rate=self._sample_rate,
                     smart_format=self._config.smart_format,
                     punctuate=self._config.punctuate,
+                    endpointing=self._config.endpointing,
                 )
                 await self._live.start(dg_opts)
                 opened = True

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -247,7 +247,7 @@ def live_transcription_to_speech_event(
 
     return stt.SpeechEvent(
         is_final=event.is_final or False,  # could be None?
-        speech_final=event.speech_final or False,
+        end_of_speech=event.speech_final or False,
         alternatives=[
             stt.SpeechData(
                 language=language or "",

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -24,7 +24,6 @@ class STTOptions:
     smart_format: bool
     endpointing: Optional[str]
 
-
 class STT(stt.STT):
     def __init__(
         self,
@@ -37,7 +36,7 @@ class STT(stt.STT):
         model: DeepgramModels = "nova-2-general",
         api_key: Optional[str] = None,
         api_url: Optional[str] = None,
-        min_silence_duration: float = 0,
+        min_silence_duration: int = 10,
     ) -> None:
         super().__init__(streaming_supported=True)
         api_key = api_key or os.environ.get("DEEPGRAM_API_KEY")
@@ -53,7 +52,7 @@ class STT(stt.STT):
             punctuate=punctuate,
             model=model,
             smart_format=smart_format,
-            endpointing=str(int(min_silence_duration * 1000)) if min_silence_duration else None,
+            endpointing=str(min_silence_duration),
         )
 
     def _sanitize_options(
@@ -248,6 +247,7 @@ def live_transcription_to_speech_event(
 
     return stt.SpeechEvent(
         is_final=event.is_final or False,  # could be None?
+        speech_final=event.speech_final or False,
         alternatives=[
             stt.SpeechData(
                 language=language or "",


### PR DESCRIPTION
Notes: 
- Added `speech_final` to `SpeechEvent`. Defaulted to `False` because looks like it's being used elsewhere. 
- Return `speech_final` for each `SpeechEvent`. 
- Add `utterance_end_ms` for more control over VAD

Relevant Docs:
https://developers.deepgram.com/docs/understanding-end-of-speech-detection 
https://developers.deepgram.com/docs/understand-endpointing-interim-results