### PR TITLE
deepgram: Add min_silence_duration to deepgram client.

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -22,6 +22,7 @@ class STTOptions:
     punctuate: bool
     model: DeepgramModels
     smart_format: bool
+    endpointing: Optional[str]
 
 
 class STT(stt.STT):
@@ -36,6 +37,7 @@ class STT(stt.STT):
         model: DeepgramModels = "nova-2-general",
         api_key: Optional[str] = None,
         api_url: Optional[str] = None,
+        min_silence_duration: float = 0,
     ) -> None:
         super().__init__(streaming_supported=True)
         api_key = api_key or os.environ.get("DEEPGRAM_API_KEY")
@@ -51,6 +53,7 @@ class STT(stt.STT):
             punctuate=punctuate,
             model=model,
             smart_format=smart_format,
+            endpointing=str(int(min_silence_duration * 1000)) if min_silence_duration else None,
         )
 
     def _sanitize_options(
@@ -197,6 +200,7 @@ class SpeechStream(stt.SpeechStream):
                     sample_rate=self._sample_rate,
                     smart_format=self._config.smart_format,
                     punctuate=self._config.punctuate,
+                    endpointing=self._config.endpointing,
                 )
                 await self._live.start(dg_opts)
                 opened = True


### PR DESCRIPTION

`Deepgram` controls vad by endpointing parameter, this fix allows to configure min_silence_duration in agents layer. If there is any instruction on setting up tests, please let me know so that i can test it easily. 
