### PR TITLE
Update tts init to export StreamAdapter

### DIFF
--- a/livekit-agents/livekit/agents/tts/__init__.py
+++ b/livekit-agents/livekit/agents/tts/__init__.py
@@ -6,7 +6,10 @@ from .tts import (
     SynthesisEventType,
 )
 
-from .stream_adapter import StreamAdapterWrapper
+from .stream_adapter import (
+    StreamAdapterWrapper,
+    StreamAdapter,
+)
 
 __all__ = [
     "TTS",
@@ -15,4 +18,5 @@ __all__ = [
     "SynthesizeStream",
     "SynthesisEventType",
     "StreamAdapterWrapper",
+    "StreamAdapter",
 ]


### PR DESCRIPTION
This class was incorrectly not included. requiring exporting it using: 

`from livekit.agents.tts.stream_adapter import StreamAdapter`

This should allow an import line like:

`from livekit.agents.tts import SynthesisEvent, SynthesisEventType, StreamAdapterWrapper, StreamAdapter`