### PR TITLE
properly closes connection with elevenlabs when completing stream

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -184,7 +184,9 @@ class SynthesizeStream(tts.SynthesizeStream):
         retry_count = 0
         listen_task: Optional[asyncio.Task] = None
         ws: Optional[aiohttp.ClientWebSocketResponse] = None
-        while True:
+        completed = False
+
+        while not completed:
             try:
                 ws = await self._try_connect()
                 retry_count = 0  # reset retry count
@@ -212,6 +214,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                         self._event_queue.put_nowait(
                             tts.SynthesisEvent(type=tts.SynthesisEventType.FINISHED)
                         )
+                        completed = True
                         break
 
             except asyncio.CancelledError:


### PR DESCRIPTION
Currently the stream isn't closed when elevenlabs finishes getting data. This is due to not breaking out of the parent `while True` loop on line 182 of `tts.py`. Since we only break out of the inner `while not ws.closed` loop we never get to the bottom of _run which sets `self._closed` to true. Because of this, we never get a `StopAsyncIteration` in `__anext__`. This prevents the kitt example from running an aclose on the tts stream.