### PR TITLE
fixes audio and video frame events in examples

### DIFF
--- a/examples/agent-quickstart/painter.py
+++ b/examples/agent-quickstart/painter.py
@@ -70,8 +70,8 @@ class PainterAgent:
         stt_stream = stt.stream()
         self.ctx.create_task(self.stt_worker(stt_stream))
 
-        async for frame in audio_stream:
-            stt_stream.push_frame(frame)
+        async for audio_frame_event in audio_stream:
+            stt_stream.push_frame(audio_frame_event.frame)
         await stt_stream.flush()
 
     async def stt_worker(self, stt_stream: agents.stt.SpeechStream):

--- a/examples/fal/fal.py
+++ b/examples/fal/fal.py
@@ -120,18 +120,18 @@ class FalAI:
     # Video processing
     async def process_video_track(self, track: rtc.Track):
         video_stream = rtc.VideoStream(track)
-        async for video_frame in video_stream:
+        async for video_frame_event in video_stream:
             if self.game_state.game_state == GAME_STATE.PLAYING:
                 self.fal_stream.push_frame(
-                    video_frame,
+                    video_frame_event.frame,
                     prompt=f"webcam screenshot of {self.game_state.current_celebrity}. HD. High Quality.",
                     strength=0.625,
                 )
                 # Keep sending video frames until we receive a FAL frame
                 if not self.received_fal_frame:
-                    self.video_out.capture_frame(video_frame)
+                    self.video_out.capture_frame(video_frame_event.frame)
             else:
-                self.video_out.capture_frame(video_frame)
+                self.video_out.capture_frame(video_frame_event.frame)
 
     async def send_fal_frames(self):
         async for video_frame in self.fal_stream:
@@ -143,8 +143,8 @@ class FalAI:
     # Audio processing
     async def process_audio_track(self, track: rtc.Track):
         audio_stream = rtc.AudioStream(track)
-        async for audio_frame in audio_stream:
-            self.stt_stream.push_frame(audio_frame)
+        async for audio_frame_event in audio_stream:
+            self.stt_stream.push_frame(audio_frame_event.frame)
 
     async def process_stt(self):
         async for e in self.stt_stream:

--- a/examples/kitt/kitt.py
+++ b/examples/kitt/kitt.py
@@ -121,10 +121,10 @@ class KITT:
         audio_stream = rtc.AudioStream(track)
         stream = self.stt_plugin.stream()
         self.ctx.create_task(self.process_stt_stream(stream))
-        async for audio_frame in audio_stream:
+        async for audio_frame_event in audio_stream:
             if self._agent_state != AgentState.LISTENING:
                 continue
-            stream.push_frame(audio_frame)
+            stream.push_frame(audio_frame_event.frame)
         await stream.flush()
 
     async def process_stt_stream(self, stream):


### PR DESCRIPTION
There was changes made to `rtc.AudioStream` and `rtc.VideoStream` to return an FrameEvent object instead of the Frame in this pull request https://github.com/livekit/python-sdks/pull/155. This causes issues in the livekit examples as they are still expecting a Frame object and then throws an error that the attribute `remix_and_resample` doesn't exist on the object.

I've updated all examples impacted by this change.