### PR TITLE
Make mp3 decoder synchronous + Deepgram Tweaks

### DIFF
--- a/livekit-agents/livekit/agents/codecs/mp3.py
+++ b/livekit-agents/livekit/agents/codecs/mp3.py
@@ -39,7 +39,11 @@ class Mp3StreamDecoder:
         packets = self._codec.parse(chunk)
         result: List[rtc.AudioFrame] = []
         for packet in packets:
-            decoded = self._codec.decode(packet)
+            try:
+                decoded = self._codec.decode(packet)
+            except Exception as e:
+                logging.warning(f"Error decoding packet: {e}")
+                continue
             for frame in decoded:
                 nchannels = len(frame.layout.channels)
                 if frame.format.is_planar and nchannels > 1:

--- a/livekit-agents/livekit/agents/codecs/mp3.py
+++ b/livekit-agents/livekit/agents/codecs/mp3.py
@@ -42,7 +42,7 @@ class Mp3StreamDecoder:
             try:
                 decoded = self._codec.decode(packet)
             except Exception as e:
-                logging.warning(f"Error decoding packet: {e}")
+                logging.warning(f"Error decoding packet, skipping: {e}")
                 continue
             for frame in decoded:
                 nchannels = len(frame.layout.channels)

--- a/livekit-agents/livekit/agents/codecs/mp3.py
+++ b/livekit-agents/livekit/agents/codecs/mp3.py
@@ -36,8 +36,6 @@ class Mp3StreamDecoder:
         self._codec = av.CodecContext.create("mp3", "r")  # noqa
 
     def decode_chunk(self, chunk: bytes) -> List[rtc.AudioFrame]:
-        if self._closed:
-            raise ValueError("Cannot push chunk to closed decoder")
         packets = self._codec.parse(chunk)
         decoded = self._decode_input(packets)
         result: List[rtc.AudioFrame] = []

--- a/livekit-agents/livekit/agents/codecs/mp3.py
+++ b/livekit-agents/livekit/agents/codecs/mp3.py
@@ -37,7 +37,7 @@ class Mp3StreamDecoder:
 
     def decode_chunk(self, chunk: bytes) -> List[rtc.AudioFrame]:
         packets = self._codec.parse(chunk)
-        decoded = self._decode_input(packets)
+        decoded = self._codec.decode(packets)
         result: List[rtc.AudioFrame] = []
         for frame in decoded:
             nchannels = len(frame.layout.channels)

--- a/livekit-agents/livekit/agents/codecs/mp3.py
+++ b/livekit-agents/livekit/agents/codecs/mp3.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import ctypes
 import logging
 from importlib import import_module
 from typing import List
-
 from livekit import rtc
 
 
@@ -34,71 +32,32 @@ class Mp3StreamDecoder:
             raise ImportError(
                 "You haven't included the decoder_utils optional dependencies. Please install the decoder_utils extra by running `pip install livekit-agents[decoder_utils]`"
             )
-        self._closed = False
-        self._input_queue = asyncio.Queue()
-        self._output_queue = asyncio.Queue()
 
         self._codec = av.CodecContext.create("mp3", "r")  # noqa
-        self._run_task = asyncio.create_task(self._run())
 
-    def close(self):
-        self._closed = True
-        self._input_queue.put_nowait(None)
-
-    def push_chunk(self, chunk: bytes):
+    def decode_chunk(self, chunk: bytes) -> List[rtc.AudioFrame]:
         if self._closed:
             raise ValueError("Cannot push chunk to closed decoder")
-        self._input_queue.put_nowait(chunk)
-
-    async def _run(self):
-        while True:
-            input = await self._input_queue.get()
-            if input is None:
-                self._output_queue.put_nowait(None)
-                break
-
-            result_frames = await asyncio.to_thread(self._decode_input, input)
-            for frame in result_frames:
-                await self._output_queue.put(frame)
-
-    def _decode_input(self, input: bytes):
-        packets = self._codec.parse(input)
-        result_frames: List[rtc.AudioFrame] = []
-        for packet in packets:
-            try:
-                decoded = self._codec.decode(packet)
-                for frame in decoded:
-                    nchannels = len(frame.layout.channels)
-                    if frame.format.is_planar and nchannels > 1:
-                        logging.warning(
-                            "TODO: planar audio has not yet been considered, skipping frame"
-                        )
-                        continue
-                    plane = frame.planes[0]
-                    ptr = plane.buffer_ptr
-                    size = plane.buffer_size
-                    byte_array_pointer = ctypes.cast(
-                        ptr, ctypes.POINTER(ctypes.c_char * size)
-                    )
-                    result_frames.append(
-                        rtc.AudioFrame(
-                            data=bytes(byte_array_pointer.contents),
-                            num_channels=nchannels,
-                            sample_rate=frame.sample_rate,
-                            samples_per_channel=frame.samples,
-                        )
-                    )
-            except Exception as e:
-                logging.error(f"Error decoding chunk: {e}")
+        packets = self._codec.parse(chunk)
+        decoded = self._decode_input(packets)
+        result: List[rtc.AudioFrame] = []
+        for frame in decoded:
+            nchannels = len(frame.layout.channels)
+            if frame.format.is_planar and nchannels > 1:
+                logging.warning(
+                    "TODO: planar audio has not yet been considered, skipping frame"
+                )
                 continue
-
-        return result_frames
-
-    def __aiter__(self):
-        return self
-
-    async def __anext__(self):
-        packet = await self._output_queue.get()
-        if packet is None:
-            raise StopAsyncIteration
-        return packet
+            plane = frame.planes[0]
+            ptr = plane.buffer_ptr
+            size = plane.buffer_size
+            byte_array_pointer = ctypes.cast(ptr, ctypes.POINTER(ctypes.c_char * size))
+            result.append(
+                rtc.AudioFrame(
+                    data=bytes(byte_array_pointer.contents),
+                    num_channels=nchannels,
+                    sample_rate=frame.sample_rate,
+                    samples_per_channel=frame.samples,
+                )
+            )
+        return result

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -325,13 +325,21 @@ class SpeechStream(stt.SpeechStream):
         if len(self._final_events) > 0:
             confidence /= len(self._final_events)  # avg. of confidence
 
+        # In rare cases, an utterance end event can come
+        # even if there was no transcribed text
+        start_time = 0
+        end_time = 0
+        if len(self._final_events) > 0:
+            start_time = self._final_events[0].alternatives[0].start_time
+            end_time = self._final_events[-1].alternatives[0].end_time
+
         end_event = stt.SpeechEvent(
             type=stt.SpeechEventType.END_OF_SPEECH,
             alternatives=[
                 stt.SpeechData(
                     language=self._config.language,
-                    start_time=self._final_events[0].alternatives[0].start_time,
-                    end_time=self._final_events[-1].alternatives[0].end_time,
+                    start_time=start_time,
+                    end_time=end_time,
                     confidence=confidence,
                     text=sentence,
                 )

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -311,8 +311,7 @@ class SpeechStream(stt.SpeechStream):
             )
             return
 
-        if len(self._final_events) == 0:
-            logging.warning("received end of speech without any final transcription")
+        self._speaking = False
 
         # combine all final transcripts since the start of the speech
         sentence = ""
@@ -322,9 +321,10 @@ class SpeechStream(stt.SpeechStream):
             confidence += alt.alternatives[0].confidence
 
         sentence = sentence.rstrip()
-        confidence /= len(self._final_events)  # avg. of confidence
 
-        self._speaking = False
+        if len(self._final_events) > 0:
+            confidence /= len(self._final_events)  # avg. of confidence
+
         end_event = stt.SpeechEvent(
             type=stt.SpeechEventType.END_OF_SPEECH,
             alternatives=[

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import os
 from collections.abc import AsyncIterable
 from typing import Optional
 
 import aiohttp
 from livekit.agents import codecs, tts, utils
-
-import openai
 
 from .models import TTSModels, TTSVoices
 
@@ -45,7 +42,6 @@ class TTS(tts.TTS):
         self._session = aiohttp.ClientSession(
             headers={"Authorization": f"Bearer {api_key}"}
         )
-        self._client = openai.AsyncOpenAI(api_key=api_key)
 
     async def synthesize(
         self, text: str, model: TTSModels = "tts-1", voice: TTSVoices = "alloy"

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -17,7 +17,7 @@ from collections.abc import AsyncIterable
 from typing import Optional
 
 import aiohttp
-from livekit.agents import codecs, tts, utils
+from livekit.agents import codecs, tts
 
 from .models import TTSModels, TTSVoices
 
@@ -59,6 +59,5 @@ class TTS(tts.TTS):
         ) as resp:
             async for data in resp.content.iter_chunked(4096):
                 frames = decoder.decode_chunk(data)
-                if len(frames) > 0:
-                    frame = utils.merge_frames(frames)
+                for frame in frames:
                     yield tts.SynthesizedAudio(text=text, data=frame)

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -59,6 +59,6 @@ class TTS(tts.TTS):
         ) as resp:
             async for data in resp.content.iter_chunked(4096):
                 frames = decoder.decode_chunk(data)
-                frame = utils.merge_frames(frames)
-                yield tts.SynthesizedAudio(text=text, data=frame)
-                decoder.push_chunk(data)
+                if len(frames) > 0:
+                    frame = utils.merge_frames(frames)
+                    yield tts.SynthesizedAudio(text=text, data=frame)

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -27,7 +27,10 @@ def read_mp3_file(filename: str) -> List[rtc.AudioFrame]:
     frames: List[rtc.AudioFrame] = []
     with open(filename, "rb") as file:
         for chunk in iter(lambda: file.read(4096), b""):
-            frames.extend(mp3.decode_chunk(chunk))
+            try:
+                frames.extend(mp3.decode_chunk(chunk))
+            except Exception as e:
+                print(f"Error decoding chunk: {e}", chunk)
 
     return agents.utils.merge_frames(frames)
 

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -23,20 +23,13 @@ they stared steadily in front of them, and instead of the eyes of the girl, the 
 
 
 def read_mp3_file(filename: str) -> List[rtc.AudioFrame]:
-    async def decode():
-        mp3 = agents.codecs.Mp3StreamDecoder()
-        with open(filename, "rb") as file:
-            for chunk in iter(lambda: file.read(4096), b""):
-                mp3.push_chunk(chunk)
+    mp3 = agents.codecs.Mp3StreamDecoder()
+    frames: List[rtc.AudioFrame] = []
+    with open(filename, "rb") as file:
+        for chunk in iter(lambda: file.read(4096), b""):
+            frames.extend(mp3.decode_chunk(chunk))
 
-        mp3.close()
-
-        frames: List[rtc.AudioFrame] = []
-        async for data in mp3:
-            frames.append(data)
-        return agents.utils.merge_frames(frames)
-
-    return asyncio.get_event_loop().run_until_complete(decode())
+    return agents.utils.merge_frames(frames)
 
 
 def read_wav_file(filename: str) -> rtc.AudioFrame:


### PR DESCRIPTION
- make the mp3 decoder synchronous
- deepgram APIs are pretty annoying. Everything seems to have its own brain:
  - speechstarted doesn't care about speech_final or utterance end
  - utterance end doesn't care if there were any transcripts with non-empty text.
  - I'm accounting for them in this PR now. This keeps our API such that START is always matched with END even though deepgram doesn't do that.