### PR TITLE
Replace opencv-python with opencv-python-headless to minimize depende…

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/setup.py
+++ b/livekit-plugins/livekit-plugins-openai/setup.py
@@ -54,7 +54,7 @@ setuptools.setup(
         "numpy >= 1.24.0",
         "openai >= 1.0.0",
         "audioread >= 3, < 4",
-        "opencv-python >= 4, < 5",
+        "opencv-python-headless >= 4, < 5",
         "requests >= 2, < 3",
     ],
     package_data={},


### PR DESCRIPTION
According to the official documentation of `opencv-python`, if there's no need to show image on GUI by calling `cv2.imshow`, it's better to use `opencv-python-headless` instead, which don't require GUI libraries such as X11, therefore more suitable for server-end deployment.

> Select the correct package for your environment:

> 
> There are four different packages (see options 1, 2, 3 and 4 below) and you should SELECT ONLY ONE OF THEM. Do not install multiple different packages in the same environment. There is no plugin architecture: all the packages use the same namespace (cv2). If you installed multiple different packages in the same environment, uninstall them all with pip uninstall and reinstall only one package.

> 
> a. Packages for standard desktop environments (Windows, macOS, almost any GNU/Linux distribution)

> 
> Option 1 - Main modules package: pip install opencv-python
> Option 2 - Full package (contains both main modules and contrib/extra modules): pip install opencv-contrib-python (check contrib/extra modules listing from [OpenCV documentation](https://docs.opencv.org/master/))
> b. Packages for server (headless) environments (such as Docker, cloud environments etc.), no GUI library dependencies

> 
> These packages are smaller than the two other packages above because they do not contain any GUI functionality (not compiled with Qt / other GUI components). This means that the packages avoid a heavy dependency chain to X11 libraries and you will have for example smaller Docker images as a result. You should always use these packages if you do not use cv2.imshow et al. or you are using some other package (such as PyQt) than OpenCV to create your GUI.

> Option 3 - Headless main modules package: pip install opencv-python-headless
> Option 4 - Headless full package (contains both main modules and contrib/extra modules): pip install opencv-contrib-python-headless (check contrib/extra modules listing from [OpenCV documentation](https://docs.opencv.org/master/))

Reference:
- https://pypi.org/project/opencv-python/








