### PR TITLE
Uses default sample rate and original audio without resampling

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -149,7 +149,7 @@ class SpeechStream(stt.SpeechStream):
         self,
         config: STTOptions,
         api_key: str,
-        sample_rate: int = 16000,
+        sample_rate: int = 44000,
         num_channels: int = 1,
         max_retry: int = 32,
     ) -> None:
@@ -279,9 +279,12 @@ class SpeechStream(stt.SpeechStream):
                 if isinstance(data, rtc.AudioFrame):
                     # TODO(theomonnom): The remix_and_resample method is low quality
                     # and should be replaced with a continuous resampling
-                    frame = data.remix_and_resample(
-                        self._sample_rate, self._num_channels
-                    )
+                    # frame = data.remix_and_resample(
+                    #     self._sample_rate, self._num_channels
+                    # )
+                    # For now uses default sample rate.
+                    frame = data
+    
                     await ws.send_bytes(frame.data.tobytes())
                 elif data == SpeechStream._CLOSE_MSG:
                     closing_ws = True

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -149,7 +149,7 @@ class SpeechStream(stt.SpeechStream):
         self,
         config: STTOptions,
         api_key: str,
-        sample_rate: int = 44000,
+        sample_rate: int = 48000,
         num_channels: int = 1,
         max_retry: int = 32,
     ) -> None:


### PR DESCRIPTION
Uses default sample rate and original audio without resampling sample for depgram live stream

This addresses the issue highlighted here:
https://github.com/livekit/agents/issues/202