### PR TITLE
Revert "default load function should be aware of available virtual memory"

### DIFF
--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -39,8 +39,7 @@ LoadFnc = Callable[[], float]
 
 
 def cpu_load_fnc() -> float:
-    mem = psutil.virtual_memory()
-    return max(psutil.cpu_percent() / 100, mem.percent / 100)
+    return psutil.cpu_percent() / 100
 
 
 @define(kw_only=True)


### PR DESCRIPTION
Reverts livekit/agents#253