### PR TITLE
voice_assistant: fix _linked_participant race

### DIFF
--- a/livekit-agents/livekit/agents/voice_assistant/assistant.py
+++ b/livekit-agents/livekit/agents/voice_assistant/assistant.py
@@ -324,13 +324,17 @@ class VoiceAssistant(utils.EventEmitter[EventTypes]):
         p = self._start_args.room.participants_by_identity.get(identity)
         assert p is not None
 
+        # link partcipant before subscribing to tracks to avoid race where
+        # _on_track_published or _on_track_subscribed is quickly called before
+        # self._linked_participant is set
+        self._linked_participant = identity
+        self._log_debug(f"assistant - linked participant {identity}")
+
         for pub in p.tracks.values():
             if pub.subscribed:
                 self._on_track_subscribed(pub.track, pub, p)  # type: ignore
             else:
                 self._on_track_published(pub, p)
-
-        self._linked_participant = identity
 
     def _on_participant_connected(self, participant: rtc.RemoteParticipant):
         if not self._linked_participant:


### PR DESCRIPTION
Perhaps this was done intentionally (?), but there is a potential race condition (which I've encountered) where the callback to, say, `_on_track_subscribed` comes immediately after `self._on_track_subscribed()`, but before `self._linked_participant = identity` in the `voice_assistant/_link_participant()` function. This simply moves the assignment before the callbacks are registered.