### PR TITLE
Reduce the initial sleep

### DIFF
--- a/examples/_deployed/kitt/kitt.py
+++ b/examples/_deployed/kitt/kitt.py
@@ -53,7 +53,7 @@ async def entrypoint(ctx: JobContext):
 
     assistant.start(ctx.room)
 
-    await asyncio.sleep(3)
+    await asyncio.sleep(0.5)
     await assistant.say("Hey, how can I help you today?", allow_interruptions=True)
 
 


### PR DESCRIPTION
With the baked-in latency everywhere else in the pipeline. 500ms should be more than enough time for clients to subscribe to audio tracks.