### PR TITLE
bump versions

### DIFF
--- a/examples/_deployed/kitt/requirements.txt
+++ b/examples/_deployed/kitt/requirements.txt
@@ -1,6 +1,6 @@
 livekit-agents~=0.7.2
-livekit-plugins-openai~=0.6.dev0
-livekit-plugins-deepgram~=0.6.dev0
-livekit-plugins-elevenlabs~=0.6.dev0
-livekit-plugins-silero~=0.6.dev0
+livekit-plugins-openai~=0.6
+livekit-plugins-deepgram~=0.5
+livekit-plugins-elevenlabs~=0.6
+livekit-plugins-silero~=0.5
 

--- a/examples/_deployed/kitt/requirements.txt
+++ b/examples/_deployed/kitt/requirements.txt
@@ -1,4 +1,4 @@
-livekit-agents~=0.8.dev0
+livekit-agents~=0.7.2
 livekit-plugins-openai~=0.6.dev0
 livekit-plugins-deepgram~=0.6.dev0
 livekit-plugins-elevenlabs~=0.6.dev0

--- a/examples/simple-color/requirements.txt
+++ b/examples/simple-color/requirements.txt
@@ -1,1 +1,1 @@
-livekit-agents~=0.7.0
+livekit-agents~=0.7.2

--- a/examples/speech-to-text/requirements.txt
+++ b/examples/speech-to-text/requirements.txt
@@ -1,2 +1,2 @@
-livekit-agents~=0.7.0
-livekit-plugins-deepgram~=0.5.0
+livekit-agents~=0.7.2
+livekit-plugins-deepgram~=0.5

--- a/examples/text-to-speech/requirements.txt
+++ b/examples/text-to-speech/requirements.txt
@@ -1,2 +1,2 @@
-livekit-agents[codecs]~=0.7.0
-livekit-plugins-openai~=0.5.0
+livekit-agents~=0.7.2
+livekit-plugins-openai~=0.6.0

--- a/examples/voice-assistant/minimal_assistant.py
+++ b/examples/voice-assistant/minimal_assistant.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 
-from livekit.agents import JobContext, JobRequest, WorkerOptions, cli, tokenize, tts
+from livekit.agents import JobContext, JobRequest, WorkerOptions, cli
 from livekit.agents.llm import (
     ChatContext,
     ChatMessage,
@@ -21,19 +21,11 @@ async def entrypoint(ctx: JobContext):
         ]
     )
 
-    # Since OpenAI does not support streaming TTS, we'll use it with a StreamAdapter
-    # to make it compatible with the VoiceAssistant
-    # TODO: this can be removed in the next version
-    openai_tts = tts.StreamAdapter(
-        tts=openai.TTS(voice="alloy"),
-        sentence_tokenizer=tokenize.basic.SentenceTokenizer(),
-    )
-
     assistant = VoiceAssistant(
         vad=silero.VAD(),
         stt=deepgram.STT(),
         llm=openai.LLM(),
-        tts=openai_tts,
+        tts=openai.TTS(voice="alloy"),
         chat_ctx=initial_ctx,
     )
     assistant.start(ctx.room)

--- a/examples/voice-assistant/requirements.txt
+++ b/examples/voice-assistant/requirements.txt
@@ -1,6 +1,6 @@
 livekit-agents~=0.7.2
-livekit-plugins-openai~=0.5.0
-livekit-plugins-deepgram~=0.5.0
-livekit-plugins-elevenlabs~=0.5.0
-livekit-plugins-silero~=0.5.0
+livekit-plugins-openai~=0.6
+livekit-plugins-deepgram~=0.5
+livekit-plugins-elevenlabs~=0.6
+livekit-plugins-silero~=0.5
 

--- a/examples/voice-assistant/requirements.txt
+++ b/examples/voice-assistant/requirements.txt
@@ -1,4 +1,4 @@
-livekit-agents~=0.7.0
+livekit-agents~=0.7.2
 livekit-plugins-openai~=0.5.0
 livekit-plugins-deepgram~=0.5.0
 livekit-plugins-elevenlabs~=0.5.0

--- a/livekit-agents/livekit/agents/version.py
+++ b/livekit-agents/livekit/agents/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/version.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/livekit-plugins/livekit-plugins-azure/setup.py
+++ b/livekit-plugins/livekit-plugins-azure/setup.py
@@ -46,8 +46,7 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
     install_requires=[
-        "livekit >= 0.9.0",
-        "livekit-agents >= 0.3.0",
+        "livekit-agents~=0.7",
         "azure-cognitiveservices-speech >= 1.35.0",
     ],
     package_data={},

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/version.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/livekit-plugins/livekit-plugins-cartesia/setup.py
+++ b/livekit-plugins/livekit-plugins-cartesia/setup.py
@@ -39,7 +39,6 @@ setuptools.setup(
         "Topic :: Multimedia :: Video",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3 :: Only",
@@ -47,7 +46,7 @@ setuptools.setup(
     keywords=["webrtc", "realtime", "audio", "video", "livekit"],
     license="Apache-2.0",
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
-    python_requires=">=3.8.0",
+    python_requires=">=3.9.0",
     install_requires=[
         "livekit-agents~=0.7",
     ],

--- a/livekit-plugins/livekit-plugins-cartesia/setup.py
+++ b/livekit-plugins/livekit-plugins-cartesia/setup.py
@@ -49,7 +49,6 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.8.0",
     install_requires=[
-        "livekit ~= 0.11",
         "livekit-agents~=0.7",
     ],
     project_urls={

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/version.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.5.1"

--- a/livekit-plugins/livekit-plugins-deepgram/setup.py
+++ b/livekit-plugins/livekit-plugins-deepgram/setup.py
@@ -27,7 +27,7 @@ with open(os.path.join(here, "livekit", "plugins", "deepgram", "version.py"), "r
 setuptools.setup(
     name="livekit-plugins-deepgram",
     version=about["__version__"],
-    description="Agent Framework plugin for services using DeepGram's API.",
+    description="Agent Framework plugin for services using Deepgram's API.",
     long_description=(here / "README.md").read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
     url="https://github.com/livekit/agents",
@@ -48,9 +48,7 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
     install_requires=[
-        "livekit ~= 0.11",
         "livekit-agents~=0.7",
-        "aiohttp >= 3.7.4",
     ],
     package_data={
         "livekit.plugins.deepgram": ["py.typed"],

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/version.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.5.1"

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/version.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"

--- a/livekit-plugins/livekit-plugins-elevenlabs/setup.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/setup.py
@@ -50,7 +50,7 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
     install_requires=[
-        "livekit-agents[codecs]~=0.7",
+        "livekit-agents[codecs]>=0.7.2",
     ],
     package_data={
         "livekit.plugins.elevenlabs": ["py.typed"],

--- a/livekit-plugins/livekit-plugins-elevenlabs/setup.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/setup.py
@@ -50,9 +50,7 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
     install_requires=[
-        "livekit ~= 0.11",
         "livekit-agents[codecs]~=0.7",
-        "aiohttp >= 3.8.5",
     ],
     package_data={
         "livekit.plugins.elevenlabs": ["py.typed"],

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/version.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.5.1"

--- a/livekit-plugins/livekit-plugins-google/setup.py
+++ b/livekit-plugins/livekit-plugins-google/setup.py
@@ -50,15 +50,8 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.7.0",
     install_requires=[
-        "numpy >= 1, < 2",
-        "google-api-core >= 2, < 3",
-        "google-auth >= 2, < 3",
-        "google-cloud-core >= 2, < 3",
         "google-cloud-speech >= 2, < 3",
         "google-cloud-texttospeech >= 2, < 3",
-        "google-cloud-translate >= 3, < 4",
-        "googleapis-common-protos >= 1, < 2",
-        "livekit ~= 0.11",
         "livekit-agents~=0.7",
     ],
     package_data={

--- a/livekit-plugins/livekit-plugins-google/setup.py
+++ b/livekit-plugins/livekit-plugins-google/setup.py
@@ -39,8 +39,6 @@ setuptools.setup(
         "Topic :: Multimedia :: Video",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3 :: Only",
@@ -48,7 +46,7 @@ setuptools.setup(
     keywords=["webrtc", "realtime", "audio", "video", "livekit"],
     license="Apache-2.0",
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
-    python_requires=">=3.7.0",
+    python_requires=">=3.9.0",
     install_requires=[
         "google-cloud-speech >= 2, < 3",
         "google-cloud-texttospeech >= 2, < 3",

--- a/livekit-plugins/livekit-plugins-nltk/livekit/plugins/nltk/version.py
+++ b/livekit-plugins/livekit-plugins-nltk/livekit/plugins/nltk/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.dev0"
+__version__ = "0.6.1"

--- a/livekit-plugins/livekit-plugins-nltk/setup.py
+++ b/livekit-plugins/livekit-plugins-nltk/setup.py
@@ -47,9 +47,8 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
     install_requires=[
-        "livekit~=0.11",
-        "nltk >= 3, < 4",
         "livekit-agents~=0.7",
+        "nltk >= 3, < 4",
     ],
     package_data={
         "livekit.plugins.nltk": ["py.typed"],

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/version.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.6.0"

--- a/livekit-plugins/livekit-plugins-openai/setup.py
+++ b/livekit-plugins/livekit-plugins-openai/setup.py
@@ -48,11 +48,8 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
     install_requires=[
-        "livekit ~= 0.11",
-        "livekit-agents[codecs, images]~=0.7",
+        "livekit-agents[codecs, images]>=0.7.2",
         "openai ~= 1.30.0",
-        "pillow ~= 10.3.0",
-        "requests >= 2, < 3",
     ],
     package_data={
         "livekit.plugins.openai": ["py.typed"],

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/version.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.5.1"

--- a/livekit-plugins/livekit-plugins-silero/setup.py
+++ b/livekit-plugins/livekit-plugins-silero/setup.py
@@ -39,7 +39,6 @@ setuptools.setup(
         "Topic :: Multimedia :: Video",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3 :: Only",
@@ -47,16 +46,17 @@ setuptools.setup(
     keywords=["webrtc", "realtime", "audio", "video", "livekit"],
     license="Apache-2.0",
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
-    python_requires=">=3.8.0",
+    python_requires=">=3.9.0",
     install_requires=[
-        "livekit ~= 0.11",
         "livekit-agents~=0.7",
         "torch >= 2, < 3",
         "torchaudio >= 2",
         "numpy >= 1, < 2",
         "onnxruntime~=1.17.0",
     ],
-    package_data={"livekit.plugins.silero": ["files/silero_vad.jit"]},
+    package_data={
+        "livekit.plugins.silero": ["py.typed"],
+    },
     project_urls={
         "Documentation": "https://docs.livekit.io",
         "Website": "https://livekit.io/",


### PR DESCRIPTION
- livekit-agents==v0.7.2
- livekit-plugins-openai==v0.6.0
- livekit-plugins-elevenlabs==v0.6.0
- livekit-plugins-silero==v0.5.1
- livekit-plugins-deepgram==v0.5.1
- livekit-plugins-google==v0.5.1
- livekit-plugins-cartesia==v0.1.1
- livekit-plugins-azure==v0.2.1
- livekit-plugins-nltk==v0.6.1

also removed unused dependencies