### PR TITLE
rework silero vad

### DIFF
--- a/livekit-agents/livekit/agents/stt/stream_adapter.py
+++ b/livekit-agents/livekit/agents/stt/stream_adapter.py
@@ -82,6 +82,8 @@ class StreamAdapterWrapper(SpeechStream):
                     )
                     self._event_queue.put_nowait(event)
 
+                    print(event)
+
                     final_event = SpeechEvent(
                         type=SpeechEventType.FINAL_TRANSCRIPT,
                         alternatives=[event.alternatives[0]],
@@ -109,7 +111,7 @@ class StreamAdapterWrapper(SpeechStream):
         if not wait:
             self._main_task.cancel()
 
-        await self._vad_stream.aclose(wait=wait)
+        await self._vad_stream.aclose()
         with contextlib.suppress(asyncio.CancelledError):
             await self._main_task
 

--- a/livekit-agents/livekit/agents/stt/stream_adapter.py
+++ b/livekit-agents/livekit/agents/stt/stream_adapter.py
@@ -80,9 +80,6 @@ class StreamAdapterWrapper(SpeechStream):
                     event = await self._stt.recognize(
                         buffer=merged_frames, *self._args, **self._kwargs
                     )
-                    self._event_queue.put_nowait(event)
-
-                    print(event)
 
                     final_event = SpeechEvent(
                         type=SpeechEventType.FINAL_TRANSCRIPT,

--- a/livekit-agents/livekit/agents/vad.py
+++ b/livekit-agents/livekit/agents/vad.py
@@ -41,9 +41,6 @@ class VAD(ABC):
 
 
 class VADStream(ABC):
-    def __init__(self) -> None:
-        pass
-
     @abstractmethod
     def push_frame(self, frame: rtc.AudioFrame) -> None:
         pass

--- a/livekit-agents/livekit/agents/vad.py
+++ b/livekit-agents/livekit/agents/vad.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import AsyncIterator, List
 
 from livekit import rtc
+from . import aio
 
 
 class VADEventType(Enum):
@@ -36,41 +37,27 @@ class VAD(ABC):
     @abstractmethod
     def stream(
         self,
-        *,
-        min_speaking_duration: float = 0.16,
-        min_silence_duration: float = 1.3,
-        padding_duration: float = 0.1,
-        sample_rate: int = 16000,
-        max_buffered_speech: float = 45.0,
     ) -> "VADStream":
-        """Returns a VADStream that can be used to push audio frames and receive VAD events
-        Args:
-          min_speaking_duration: minimum duration of speech to trigger a START_SPEAKING event
-
-          min_silence_duration: in the end of each speech chunk wait for min_silence_duration_ms before separating it
-              the padding is not always precise, it is generally rounded to the nearest 40ms depending on the vad implementation
-
-          padding_duration: frames to pad the start and end of the speech with
-
-          sample_rate: sample rate of the inference/processing
-
-          max_buffered_speech: max buffered speech in seconds that we keep until the END_SPEAKING event is triggered
-              it is unrecommended to use 0.0 as it may cause OOM if the user doesn't stop speaking"""
         pass
 
 
 class VADStream(ABC):
-    @abstractmethod
-    def push_frame(self, frame: rtc.AudioFrame) -> None:
-        pass
+    def __init__(self) -> None:
+        self._event_ch = aio.Chan[VADEvent]()
+        self._closed = False
 
     @abstractmethod
-    async def aclose(self, *, wait: bool = True) -> None:
-        pass
+    def push_frame(self, frame: rtc.AudioFrame) -> None:
+        if self._closed:
+            raise ValueError("VADStream is closed")
+
+    @abstractmethod
+    async def aclose(self) -> None:
+        self._closed = True
 
     @abstractmethod
     async def __anext__(self) -> VADEvent:
-        raise StopAsyncIteration
+        return await self._event_ch.__anext__()
 
     def __aiter__(self) -> AsyncIterator[VADEvent]:
-        return self
+        return self._event_ch

--- a/livekit-agents/livekit/agents/vad.py
+++ b/livekit-agents/livekit/agents/vad.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import AsyncIterator, List
 
 from livekit import rtc
+
 from . import aio
 
 
@@ -25,8 +26,6 @@ class VADEvent:
     """list of audio frames of the speech"""
     probability: float = 0.0
     """smoothed probability of the speech (only for INFERENCE_DONE event)"""
-    raw_inference_prob: float = 0.0
-    """raw probability of the speech (only for INFERENCE_DONE event)"""
     inference_duration: float = 0.0
     """duration of the inference in seconds (only for INFERENCE_DONE event)"""
     speaking: bool = False
@@ -43,21 +42,18 @@ class VAD(ABC):
 
 class VADStream(ABC):
     def __init__(self) -> None:
-        self._event_ch = aio.Chan[VADEvent]()
-        self._closed = False
+        pass
 
     @abstractmethod
     def push_frame(self, frame: rtc.AudioFrame) -> None:
-        if self._closed:
-            raise ValueError("VADStream is closed")
+        pass
 
     @abstractmethod
     async def aclose(self) -> None:
-        self._closed = True
+        pass
 
     @abstractmethod
-    async def __anext__(self) -> VADEvent:
-        return await self._event_ch.__anext__()
+    async def __anext__(self) -> VADEvent: ...
 
-    def __aiter__(self) -> AsyncIterator[VADEvent]:
-        return self._event_ch
+    @abstractmethod
+    def __aiter__(self) -> AsyncIterator[VADEvent]: ...

--- a/livekit-agents/livekit/agents/vad.py
+++ b/livekit-agents/livekit/agents/vad.py
@@ -5,8 +5,6 @@ from typing import AsyncIterator, List
 
 from livekit import rtc
 
-from . import aio
-
 
 class VADEventType(Enum):
     START_OF_SPEECH = 1

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/__init__.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/__init__.py
@@ -17,7 +17,6 @@ from .version import __version__
 
 __all__ = ["VAD", "VADStream", "__version__"]
 
-import torch
 from livekit.agents import Plugin
 
 
@@ -26,9 +25,7 @@ class SileroPlugin(Plugin):
         super().__init__(__name__, __version__, __package__)
 
     def download_files(self):
-        _ = torch.hub.load(
-            repo_or_dir="snakers4/silero-vad", model="silero_vad", onnx=True
-        )
+        pass
 
 
 Plugin.register_plugin(SileroPlugin())

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/onnx_model.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/onnx_model.py
@@ -1,0 +1,69 @@
+import asyncio
+import importlib.resources
+import atexit
+import onnxruntime
+import numpy as np
+
+from typing import Any
+from contextlib import ExitStack
+from .log import logger
+
+_resource_files = ExitStack()
+atexit.register(_resource_files.close)
+
+
+SUPPORTED_SAMPLE_RATES = [8000, 16000]
+
+
+def new_inference_session(force_cpu: bool) -> onnxruntime.InferenceSession:
+    res = (
+        importlib.resources.files("livekit.plugins.silero.resources")
+        / "silero_vad.onnx"
+    )
+    ctx = importlib.resources.as_file(res)
+    path = _resource_files.enter_context(ctx)
+
+    opts = onnxruntime.SessionOptions()
+    opts.inter_op_num_threads = 1
+    opts.intra_op_num_threads = 1
+    opts.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL
+
+    if force_cpu and "CPUExecutionProvider" in onnxruntime.get_available_providers():
+        session = onnxruntime.InferenceSession(
+            str(path), providers=["CPUExecutionProvider"], ess_options=opts
+        )
+    else:
+        session = onnxruntime.InferenceSession(str(path), sess_options=opts)
+
+    return session
+
+
+class OnnxModel:
+    def __init__(
+        self, *, onnx_session: onnxruntime.InferenceSession, sample_rate: int
+    ) -> None:
+        self._sess = onnx_session
+        self._sample_rate = sample_rate
+
+        if sample_rate not in SUPPORTED_SAMPLE_RATES:
+            raise ValueError("Silero VAD only supports 8KHz and 16KHz sample rates")
+
+        self.reset_states()
+
+    def reset_states(self) -> None:
+        self._h = np.zeros((2, 1, 64)).astype(np.float32)
+        self._c = np.zeros((2, 1, 64)).astype(np.float32)
+
+    def __call__(self, x: np.ndarray) -> float:
+        if x.ndim == 1:
+            x = np.expand_dims(x, axis=0)
+
+        ort_inputs = {
+            "input": x,
+            "h": self._h,
+            "c": self._c,
+            "sr": np.array(self._sample_rate, dtype=np.int64),
+        }
+        ort_outputs = self._sess.run(None, ort_inputs)
+        out, self._h, self._c = ort_outputs
+        return out.item()

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/onnx_model.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/onnx_model.py
@@ -3,7 +3,7 @@ import importlib.resources
 from contextlib import ExitStack
 
 import numpy as np
-import onnxruntime # type: ignore
+import onnxruntime  # type: ignore
 
 _resource_files = ExitStack()
 atexit.register(_resource_files.close)

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/onnx_model.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/onnx_model.py
@@ -3,7 +3,7 @@ import importlib.resources
 from contextlib import ExitStack
 
 import numpy as np
-import onnxruntime
+import onnxruntime # type: ignore
 
 _resource_files = ExitStack()
 atexit.register(_resource_files.close)

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/onnx_model.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/onnx_model.py
@@ -1,12 +1,9 @@
-import asyncio
-import importlib.resources
 import atexit
-import onnxruntime
-import numpy as np
-
-from typing import Any
+import importlib.resources
 from contextlib import ExitStack
-from .log import logger
+
+import numpy as np
+import onnxruntime
 
 _resource_files = ExitStack()
 atexit.register(_resource_files.close)

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/resources/.gitattributes
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/resources/.gitattributes
@@ -1,0 +1,1 @@
+**/*.onnx filter=lfs diff=lfs merge=lfs -text

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/resources/__init__.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Used by importlib.resources and setuptools"""

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/resources/silero_vad.onnx
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/resources/silero_vad.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbff36c44682f33530d825097aa401c431f8d6379e86be399aaa3a522c4de75b
+size 1806752

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py
@@ -42,11 +42,11 @@ class VAD(agents.vad.VAD):
     def __init__(
         self,
         *,
-        min_speech_duration: float = 0.25,  # 250ms
-        min_silence_duration: float = 2,  # 100ms
+        min_speech_duration: float = 0.260,  # 260ms
+        min_silence_duration: float = 0.15,  # 150ms
         padding_duration: float = 0.1,
         max_buffered_speech: float = 60.0,
-        activation_threshold: float = 0.5,
+        activation_threshold: float = 0.35,
         sample_rate: int = 16000,
         window_size_samples: int = 1024,
         force_cpu: bool = True,

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py
@@ -15,20 +15,16 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import time
-import numpy as np
-
-from collections import deque
 from dataclasses import dataclass
-from typing import AsyncIterator, List, Optional
+from typing import AsyncIterator, Optional
 
+import numpy as np
 from livekit import agents, rtc
-
 from livekit.agents import aio
 
-from .log import logger
 from . import onnx_model
+from .log import logger
 
 
 @dataclass
@@ -47,7 +43,7 @@ class VAD(agents.vad.VAD):
         self,
         *,
         min_speech_duration: float = 0.25,  # 250ms
-        min_silence_duration: float = 0.1,  # 100ms
+        min_silence_duration: float = 2,  # 100ms
         padding_duration: float = 0.1,
         max_buffered_speech: float = 60.0,
         activation_threshold: float = 0.5,

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py
@@ -21,9 +21,11 @@ import numpy as np
 
 from collections import deque
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import AsyncIterator, List, Optional
 
 from livekit import agents, rtc
+
+from livekit.agents import aio
 
 from .log import logger
 from . import onnx_model
@@ -113,15 +115,16 @@ class VADStream(agents.vad.VADStream):
         opts: _VADOptions,
         model: onnx_model.OnnxModel,
     ) -> None:
-        super().__init__()
         self._opts, self._model = opts, model
         self._main_atask = asyncio.create_task(self._main_task())
 
+        self._original_sample_rate: int | None = None
         self._window_data: _WindowData | None = None
-        self._window_index = 0
-        self._pushed_sample_rate: int | None = None
+        self._remaining_samples = opts.window_size_samples
 
         self._input_q = asyncio.Queue[Optional[_WindowData]]()
+        self._event_ch = aio.Chan[agents.vad.VADEvent]()
+        self._closed = False
 
     def push_frame(self, frame: rtc.AudioFrame) -> None:
         """
@@ -129,18 +132,19 @@ class VADStream(agents.vad.VADStream):
         The frames are split into chunks of the given window size and processed.
         (Buffered if the window size is not reached yet)
         """
-        super().push_frame(frame)
+        if self._closed:
+            raise ValueError("vad stream is closed")
 
         if frame.sample_rate != 8000 and frame.sample_rate % 16000 != 0:
             raise ValueError("only 8KHz and 16KHz*X sample rates are supported")
 
         if (
-            self._pushed_sample_rate is not None
-            and self._pushed_sample_rate != frame.sample_rate
+            self._original_sample_rate is not None
+            and self._original_sample_rate != frame.sample_rate
         ):
             raise ValueError("a frame with another sample rate was already pushed")
 
-        self._pushed_sample_rate = frame.sample_rate
+        self._original_sample_rate = frame.sample_rate
         step = frame.sample_rate // 16000
 
         if self._window_data is None:
@@ -153,155 +157,140 @@ class VADStream(agents.vad.VADStream):
                 ),
             )
 
-        if frame.num_channels != 1
+        if frame.num_channels != 1:
             raise ValueError("vad currently only supports mono audio frames")
 
-        ndata = np.frombuffer(frame.data, dtype=np.int16)
+        og_frame = np.frombuffer(frame.data, dtype=np.int16)
+        if_frame = og_frame[::step].astype(np.float32) / np.iinfo(np.int16).max
 
-        rem_samples = len(ndata)
-        while rem_samples > 0:
-            window_index = self._window_index
-            window_size = self._opts.window_size_samples
+        remaining_data = len(if_frame)
+        while remaining_data > 0:
+            i = self._opts.window_size_samples - self._remaining_samples
+            to_copy = min(remaining_data, self._remaining_samples)
+            self._remaining_samples -= to_copy
+            remaining_data -= to_copy
 
-            to_copy = min(rem_samples, window_size - window_index)
-            self._window_data.original_frame[window_index : window_index + to_copy] = (
-                ndata[:to_copy]
+            self._window_data.original_data[i * step : i * step + to_copy * step] = (
+                og_frame[: to_copy * step]
             )
-            self._window_data.inference_frame[window_index : window_index + to_copy] = (
-                ndata[:to_copy].astype(np.float32) / np.iinfo(np.int16).max
-            )
+            self._window_data.inference_data[i : i + to_copy] = if_frame[:to_copy]
 
-            rem_samples -= to_copy
-            self._window_index += to_copy
-
-            if self._window_index == window_size:
+            if self._remaining_samples == 0:
                 self._input_q.put_nowait(self._window_data)
                 self._window_data = _WindowData(
-                    inference_frame=np.zeros(window_size, dtype=np.float32),
-                    original_frame=np.zeros(window_size, dtype=np.int16),
+                    inference_data=np.zeros(
+                        self._opts.window_size_samples, dtype=np.float32
+                    ),
+                    original_data=np.zeros(
+                        self._opts.window_size_samples * step, dtype=np.int16
+                    ),
                 )
-                self._window_index = 0
+                self._remaining_samples = self._opts.window_size_samples
 
     async def aclose(self) -> None:
-        super().aclose()
+        if self._closed:
+            return
+
+        self._closed = True
+        self._input_q.put_nowait(None)
         await self._main_atask
 
+    @agents.utils.log_exceptions(logger=logger)
     async def _main_task(self):
+        pub_speaking = False
+        pub_speech_buf = np.array([], dtype=np.int16)
+
+        may_start_at_sample = -1
+        may_end_at_sample = -1
+
+        min_speech_samples = self._opts.min_speech_duration * self._opts.sample_rate
+        min_silence_samples = self._opts.min_silence_duration * self._opts.sample_rate
+
         while True:
-            data = await self._input_q.get()
-            if data is None:
+            window_data = await self._input_q.get()
+            if window_data is None:
                 break
 
-            window = data.inference_frame
-            raw_prob = await asyncio.to_thread(lambda: self._model(window))
+            assert self._original_sample_rate is not None
 
-            print(raw_prob)
+            inference_data = window_data.inference_data
+            start_time = time.time()
+            probability = await asyncio.to_thread(lambda: self._model(inference_data))
+            inference_duration = time.time() - start_time
 
-    async def _run_inference(self) -> None:
-        # run inference
-        start_time = time.time()
-        raw_prob = await asyncio.to_thread(
-            lambda: self._model(tensor, self._sample_rate).item()
-        )
-        probability = self._filter.apply(1.0, raw_prob)
-        inference_duration = time.time() - start_time
-
-        # inference done
-        event = agents.vad.VADEvent(
-            type=agents.vad.VADEventType.INFERENCE_DONE,
-            samples_index=self._current_sample,
-            probability=probability,
-            raw_inference_prob=raw_prob,
-            inference_duration=inference_duration,
-        )
-        self._event_queue.put_nowait(event)
-
-        self._dispatch_event(original_frames, probability, raw_prob, inference_duration)
-        self._current_sample += merged_frame.samples_per_channel
-
-    def _dispatch_event(
-        self,
-        original_frames: List[rtc.AudioFrame],
-        probability: float,
-        raw_inference_prob: float,
-        inference_duration: float,
-    ):
-        """
-        Dispatches a VAD event based on the speech probability and the options
-        Args:
-            speech_prob: speech probability of the current frame
-            original_frames: original frames of the current inference
-        """
-
-        self._buffered_frames.extend(original_frames)
-
-        if len(self._buffered_frames) > max_buffer_count:
-            self._buffered_frames = self._buffered_frames[-max_buffer_count:]
-
-        if probability >= self._threshold:
-            # speaking, wait for min_speaking_duration to trigger START_OF_SPEECH
-            self._waiting_end = False
-            if not self._waiting_start and not self._speaking:
-                self._waiting_start = True
-                self._start_speech = self._current_sample
-
-            if self._waiting_start and (
-                self._current_sample - self._start_speech >= self._min_speaking_samples
-            ):
-                self._waiting_start = False
-                self._speaking = True
-
-                # since we're waiting for the min_spaking_duration to trigger START_OF_SPEECH,
-                # put the speech that were used to trigger the start here
-                print("START OF SPEECH")
-                event = agents.vad.VADEvent(
-                    type=agents.vad.VADEventType.START_OF_SPEECH,
-                    samples_index=self._start_speech,
-                    frames=[],
-                    speaking=True,
+            window_duration = self._opts.window_size_samples / self._opts.sample_rate
+            if inference_duration > window_duration:
+                # slower than realtime
+                logger.warning(
+                    "vad inference took too long — slower than realtime: %f",
+                    inference_duration,
                 )
-                self._buffered_frames = []
-                self._event_queue.put_nowait(event)
 
-        # we don't check the speech_prob here
-        event = agents.vad.VADEvent(
-            type=agents.vad.VADEventType.INFERENCE_DONE,
-            samples_index=self._current_sample,
-            frames=original_frames.copy(),
-            probability=probability,
-            raw_inference_prob=raw_inference_prob,
-            inference_duration=inference_duration,
-            speaking=self._speaking,
-        )
-        self._event_queue.put_nowait(event)
-
-        if probability < self._threshold:
-            # stopped speaking, s for min_silence_duration to trigger END_OF_SPEECH,
-            self._waiting_start = False
-            if not self._waiting_end and self._speaking:
-                self._waiting_end = True
-                self._end_speech = self._current_sample
-
-            if self._waiting_end and (
-                self._current_sample - self._end_speech
-                >= max(self._min_silence_samples, self._padding_duration_samples)
-            ):
-                self._waiting_end = False
-                self._speaking = False
-                print("END OF SPEECH")
-                event = agents.vad.VADEvent(
-                    type=agents.vad.VADEventType.END_OF_SPEECH,
-                    samples_index=self._end_speech,
-                    duration=(self._end_speech - self._start_speech)
-                    / self._sample_rate,
-                    frames=self._buffered_frames.copy(),
-                    speaking=False,
+            self._event_ch.send_nowait(
+                agents.vad.VADEvent(
+                    type=agents.vad.VADEventType.INFERENCE_DONE,
+                    samples_index=self._current_sample,
+                    probability=probability,
+                    inference_duration=inference_duration,
                 )
-                self._event_queue.put_nowait(event)
+            )
+            self._current_sample += self._opts.window_size_samples
+
+            # append new data to current speech buffer
+            pub_speech_buf = np.append(pub_speech_buf, window_data.original_data)
+            cl = self._opts.padding_duration
+            if not pub_speaking:
+                cl += self._opts.min_speech_duration
+            else:
+                cl += self._opts.max_buffered_speech
+
+            cl = int(cl) * self._original_sample_rate
+            if len(pub_speech_buf) > cl:
+                pub_speech_buf = pub_speech_buf[-cl:]
+
+            # dispatch start/end when needed
+            if probability >= self._opts.activation_threshold:
+                may_end_at_sample = -1
+
+                if may_start_at_sample == -1:
+                    may_start_at_sample = self._current_sample + min_speech_samples
+
+                if may_start_at_sample <= self._current_sample and not pub_speaking:
+                    pub_speaking = True
+                    self._event_ch.send_nowait(
+                        agents.vad.VADEvent(
+                            type=agents.vad.VADEventType.START_OF_SPEECH,
+                            samples_index=self._current_sample,
+                        )
+                    )
+
+            else:
+                may_start_at_sample = -1
+
+                if may_end_at_sample == -1:
+                    may_end_at_sample = self._current_sample + min_silence_samples
+
+                if may_end_at_sample <= self._current_sample and pub_speaking:
+                    pub_speaking = False
+
+                    frame = rtc.AudioFrame(
+                        sample_rate=self._original_sample_rate,
+                        num_channels=1,
+                        samples_per_channel=len(pub_speech_buf),
+                        data=pub_speech_buf.tobytes(),
+                    )
+
+                    self._event_ch.send_nowait(
+                        agents.vad.VADEvent(
+                            type=agents.vad.VADEventType.END_OF_SPEECH,
+                            samples_index=self._current_sample,
+                            duration=len(pub_speech_buf) / self._original_sample_rate,
+                            frames=[frame],
+                        )
+                    )
 
     async def __anext__(self) -> agents.vad.VADEvent:
-        evt = await self._event_queue.get()
-        if evt is None:
-            raise StopAsyncIteration
+        return await self._event_ch.__anext__()
 
-        return evt
+    def __aiter__(self) -> AsyncIterator[agents.vad.VADEvent]:
+        return self._event_ch

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py
@@ -17,155 +17,187 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import time
+import numpy as np
+
 from collections import deque
+from dataclasses import dataclass
 from typing import List, Optional
 
-import numpy as np
-import torch
 from livekit import agents, rtc
 
 from .log import logger
+from . import onnx_model
+
+
+@dataclass
+class _VADOptions:
+    min_speech_duration: float
+    min_silence_duration: float
+    padding_duration: float
+    max_buffered_speech: float
+    window_size_samples: int
+    activation_threshold: float
+    sample_rate: int
 
 
 class VAD(agents.vad.VAD):
-    def __init__(self, *, model_path: str | None = None, use_onnx: bool = True) -> None:
-        if model_path:
-            model = torch.jit.load(model_path)
-            model.eval()
-        else:
-            model, _ = torch.hub.load(
-                repo_or_dir="snakers4/silero-vad",
-                model="silero_vad",
-                onnx=use_onnx,
-            )
-        self._model = model
+    def __init__(
+        self,
+        *,
+        min_speech_duration: float = 0.25,  # 250ms
+        min_silence_duration: float = 0.1,  # 100ms
+        padding_duration: float = 0.1,
+        max_buffered_speech: float = 60.0,
+        activation_threshold: float = 0.5,
+        sample_rate: int = 16000,
+        window_size_samples: int = 1024,
+        force_cpu: bool = True,
+    ) -> None:
+        """
+        Initialize the Silero VAD with the given options.
+        The options are already set to strong defaults.
+
+        Args:
+            min_speech_duration: minimum duration of speech to start a new speech chunk
+            min_silence_duration: In the end of each speech, wait min_silence_duration before ending the speech
+            padding_duration: pad the chunks with this duration on both sides
+            max_buffered_speech: maximum duration of speech to keep in the buffer (in seconds)
+            activation_threshold: threshold to consider a frame as speech
+            sample_rate: sample rate for the inference (only 8KHz and 16KHz are supported)
+            window_size_samples: audio chunk size to use for the inference
+                512, 1024, 1536 samples for 16000 sample rate and 256, 512, 768 samples for 8000 sample rate
+            force_cpu: force to use CPU for inference
+        """
+
+        if sample_rate not in onnx_model.SUPPORTED_SAMPLE_RATES:
+            raise ValueError("Silero VAD only supports 8KHz and 16KHz sample rates")
+
+        if sample_rate == 8000 and window_size_samples not in [256, 512, 768]:
+            raise ValueError("window_size_samples must be 256, 512, or 768 for 8KHz")
+
+        if sample_rate == 16000 and window_size_samples not in [512, 1024, 1536]:
+            raise ValueError("window_size_samples must be 512, 1024, or 1536 for 16KHz")
+
+        self._onnx_session = onnx_model.new_inference_session(force_cpu)
+        self._opts = _VADOptions(
+            min_speech_duration=min_speech_duration,
+            min_silence_duration=min_silence_duration,
+            padding_duration=padding_duration,
+            max_buffered_speech=max_buffered_speech,
+            activation_threshold=activation_threshold,
+            sample_rate=sample_rate,
+            window_size_samples=window_size_samples,
+        )
 
     def stream(
         self,
-        *,
-        min_speaking_duration: float = 0.2,
-        min_silence_duration: float = 0.8,
-        padding_duration: float = 0.1,
-        sample_rate: int = 16000,
-        max_buffered_speech: float = 45.0,
-        threshold: float = 0.2,
     ) -> "VADStream":
         return VADStream(
-            self._model,
-            min_speaking_duration=min_speaking_duration,
-            min_silence_duration=min_silence_duration,
-            padding_duration=padding_duration,
-            sample_rate=sample_rate,
-            max_buffered_speech=max_buffered_speech,
-            threshold=threshold,
+            self._opts,
+            onnx_model.OnnxModel(
+                onnx_session=self._onnx_session, sample_rate=self._opts.sample_rate
+            ),
         )
 
 
-# Based on https://github.com/snakers4/silero-vad/blob/94504ece54c8caeebb808410b08ae55ee82dba82/utils_vad.py#L428
+@dataclass
+class _WindowData:
+    inference_data: np.ndarray
+    # data returned to the user are the original frames (int16)
+    original_data: np.ndarray
+
+
 class VADStream(agents.vad.VADStream):
     def __init__(
         self,
-        model,
-        *,
-        min_speaking_duration: float,
-        min_silence_duration: float,
-        padding_duration: float,
-        sample_rate: int,
-        max_buffered_speech: float,
-        threshold: float,
+        opts: _VADOptions,
+        model: onnx_model.OnnxModel,
     ) -> None:
-        self._min_speaking_duration = min_speaking_duration
-        self._min_silence_duration = min_silence_duration
-        self._padding_duration = padding_duration
-        self._sample_rate = sample_rate
-        self._max_buffered_speech = max_buffered_speech
-        self._threshold = threshold
+        super().__init__()
+        self._opts, self._model = opts, model
+        self._main_atask = asyncio.create_task(self._main_task())
 
-        if sample_rate not in [8000, 16000]:
-            raise ValueError("Silero VAD only supports 8KHz and 16KHz sample rates")
+        self._window_data: _WindowData | None = None
+        self._window_index = 0
+        self._pushed_sample_rate: int | None = None
 
-        self._queue = asyncio.Queue[Optional[rtc.AudioFrame]]()
-        self._event_queue = asyncio.Queue[Optional[agents.vad.VADEvent]]()
-        self._model = model
-
-        self._closed = False
-        self._speaking = False
-        self._waiting_start = False
-        self._waiting_end = False
-        self._current_sample = 0
-        self._filter = agents.utils.ExpFilter(0.8)
-        self._min_speaking_samples = min_speaking_duration * sample_rate
-        self._min_silence_samples = min_silence_duration * sample_rate
-        self._padding_duration_samples = padding_duration * sample_rate
-        self._max_buffered_samples = max_buffered_speech * sample_rate
-
-        self._queued_frames: deque[rtc.AudioFrame] = deque()
-        self._original_frames: deque[rtc.AudioFrame] = deque()
-        self._buffered_frames: List[rtc.AudioFrame] = []
-        self._main_task = asyncio.create_task(self._run())
+        self._input_q = asyncio.Queue[Optional[_WindowData]]()
 
     def push_frame(self, frame: rtc.AudioFrame) -> None:
-        if self._closed:
-            raise ValueError("cannot push frame to closed stream")
+        """
+        Push frame to the VAD stream for processing.
+        The frames are split into chunks of the given window size and processed.
+        (Buffered if the window size is not reached yet)
+        """
+        super().push_frame(frame)
 
-        self._queue.put_nowait(frame)
+        if frame.sample_rate != 8000 and frame.sample_rate % 16000 != 0:
+            raise ValueError("only 8KHz and 16KHz*X sample rates are supported")
 
-    async def aclose(self, *, wait: bool = True) -> None:
-        self._closed = True
-        if not wait:
-            self._main_task.cancel()
+        if (
+            self._pushed_sample_rate is not None
+            and self._pushed_sample_rate != frame.sample_rate
+        ):
+            raise ValueError("a frame with another sample rate was already pushed")
 
-        self._queue.put_nowait(None)
-        with contextlib.suppress(asyncio.CancelledError):
-            await self._main_task
+        self._pushed_sample_rate = frame.sample_rate
+        step = frame.sample_rate // 16000
 
-    async def _run(self):
-        try:
-            while True:
-                frame = await self._queue.get()
-                if frame is None:
-                    break  # None is sent inside aclose
+        if self._window_data is None:
+            self._window_data = _WindowData(
+                inference_data=np.zeros(
+                    self._opts.window_size_samples, dtype=np.float32
+                ),
+                original_data=np.zeros(
+                    self._opts.window_size_samples * step, dtype=np.int16
+                ),
+            )
 
-                self._queue.task_done()
+        if frame.num_channels != 1
+            raise ValueError("vad currently only supports mono audio frames")
 
-                # resample to silero's sample rate
-                resampled_frame = frame.remix_and_resample(
-                    self._sample_rate, 1
-                )  # TODO: This is technically wrong, fix when we have a better resampler
-                self._original_frames.append(frame)
-                self._queued_frames.append(resampled_frame)
+        ndata = np.frombuffer(frame.data, dtype=np.int16)
 
-                # run inference by chunks of 40ms until we run out of data
-                while True:
-                    available_length = sum(
-                        f.samples_per_channel for f in self._queued_frames
-                    )
+        rem_samples = len(ndata)
+        while rem_samples > 0:
+            window_index = self._window_index
+            window_size = self._opts.window_size_samples
 
-                    samples_40ms = self._sample_rate // 1000 * 40
-                    if available_length < samples_40ms:
-                        break
+            to_copy = min(rem_samples, window_size - window_index)
+            self._window_data.original_frame[window_index : window_index + to_copy] = (
+                ndata[:to_copy]
+            )
+            self._window_data.inference_frame[window_index : window_index + to_copy] = (
+                ndata[:to_copy].astype(np.float32) / np.iinfo(np.int16).max
+            )
 
-                    await asyncio.shield(self._run_inference())
+            rem_samples -= to_copy
+            self._window_index += to_copy
 
-        except Exception:
-            logger.exception("silero stream failed")
-        finally:
-            self._event_queue.put_nowait(None)
+            if self._window_index == window_size:
+                self._input_q.put_nowait(self._window_data)
+                self._window_data = _WindowData(
+                    inference_frame=np.zeros(window_size, dtype=np.float32),
+                    original_frame=np.zeros(window_size, dtype=np.int16),
+                )
+                self._window_index = 0
+
+    async def aclose(self) -> None:
+        super().aclose()
+        await self._main_atask
+
+    async def _main_task(self):
+        while True:
+            data = await self._input_q.get()
+            if data is None:
+                break
+
+            window = data.inference_frame
+            raw_prob = await asyncio.to_thread(lambda: self._model(window))
+
+            print(raw_prob)
 
     async def _run_inference(self) -> None:
-        # merge the first 4 frames (we know each is 10ms)
-        if len(self._queued_frames) < 4:
-            return
-
-        original_frames = [self._original_frames.popleft() for _ in range(4)]
-        merged_frame = agents.utils.merge_frames(
-            [self._queued_frames.popleft() for _ in range(4)]
-        )
-
-        # convert data_40ms to tensor & f32
-        tensor = torch.from_numpy(np.frombuffer(merged_frame.data, dtype=np.int16))
-        tensor = tensor.to(torch.float32) / 32768.0
-
         # run inference
         start_time = time.time()
         raw_prob = await asyncio.to_thread(
@@ -201,29 +233,10 @@ class VADStream(agents.vad.VADStream):
             original_frames: original frames of the current inference
         """
 
-        samples_10ms = self._sample_rate / 100
-        padding_count = int(
-            self._padding_duration_samples // samples_10ms
-        )  # number of frames to keep for the padding (one side)
-
         self._buffered_frames.extend(original_frames)
-        if (
-            not self._speaking
-            and not self._waiting_start
-            and len(self._buffered_frames) > padding_count
-        ):
-            self._buffered_frames = self._buffered_frames[
-                len(self._buffered_frames) - padding_count :
-            ]
 
-        max_buffer_len = padding_count + max(
-            int(self._max_buffered_samples // samples_10ms),
-            int(self._min_speaking_samples // samples_10ms),
-        )
-        if len(self._buffered_frames) > max_buffer_len:
-            self._buffered_frames = self._buffered_frames[
-                len(self._buffered_frames) - max_buffer_len :
-            ]
+        if len(self._buffered_frames) > max_buffer_count:
+            self._buffered_frames = self._buffered_frames[-max_buffer_count:]
 
         if probability >= self._threshold:
             # speaking, wait for min_speaking_duration to trigger START_OF_SPEECH
@@ -240,19 +253,21 @@ class VADStream(agents.vad.VADStream):
 
                 # since we're waiting for the min_spaking_duration to trigger START_OF_SPEECH,
                 # put the speech that were used to trigger the start here
+                print("START OF SPEECH")
                 event = agents.vad.VADEvent(
                     type=agents.vad.VADEventType.START_OF_SPEECH,
                     samples_index=self._start_speech,
-                    frames=self._buffered_frames[padding_count:],
+                    frames=[],
                     speaking=True,
                 )
+                self._buffered_frames = []
                 self._event_queue.put_nowait(event)
 
         # we don't check the speech_prob here
         event = agents.vad.VADEvent(
             type=agents.vad.VADEventType.INFERENCE_DONE,
             samples_index=self._current_sample,
-            frames=original_frames,
+            frames=original_frames.copy(),
             probability=probability,
             raw_inference_prob=raw_inference_prob,
             inference_duration=inference_duration,
@@ -273,12 +288,13 @@ class VADStream(agents.vad.VADStream):
             ):
                 self._waiting_end = False
                 self._speaking = False
+                print("END OF SPEECH")
                 event = agents.vad.VADEvent(
                     type=agents.vad.VADEventType.END_OF_SPEECH,
                     samples_index=self._end_speech,
                     duration=(self._end_speech - self._start_speech)
                     / self._sample_rate,
-                    frames=self._buffered_frames,
+                    frames=self._buffered_frames.copy(),
                     speaking=False,
                 )
                 self._event_queue.put_nowait(event)

--- a/livekit-plugins/livekit-plugins-silero/setup.py
+++ b/livekit-plugins/livekit-plugins-silero/setup.py
@@ -49,12 +49,11 @@ setuptools.setup(
     python_requires=">=3.9.0",
     install_requires=[
         "livekit-agents~=0.7",
-        "torch >= 2, < 3",
-        "torchaudio >= 2",
-        "numpy >= 1, < 2",
-        "onnxruntime~=1.17.0",
+        "onnxruntime~=1.18",
+        "numpy~=1.26",
     ],
     package_data={
+        "livekit.plugins.silero.resources": ["silero_vad.onnx"],
         "livekit.plugins.silero": ["py.typed"],
     },
     project_urls={

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -35,7 +35,7 @@ def read_mp3_file(filename: str) -> rtc.AudioFrame:
     return agents.utils.merge_frames(frames)
 
 
-RECOGNIZE_STT = [deepgram.STT(), google.STT(), openai.STT(), azure.STT()]
+RECOGNIZE_STT = [deepgram.STT(), google.STT(), openai.STT()]
 
 
 @pytest.mark.usefixtures("job_process")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,21 +1,23 @@
-import jiwer
+import jiwer as tr
 
 
 def wer(hypothesis: str, reference: str) -> float:
-    transformers = jiwer.Compose(
+    wer_standardize_contiguous = tr.Compose(
         [
-            jiwer.ExpandCommonEnglishContractions(),
-            jiwer.RemoveEmptyStrings(),
-            jiwer.ToLowerCase(),
-            jiwer.RemoveMultipleSpaces(),
-            jiwer.Strip(),
-            jiwer.RemovePunctuation(),
-            jiwer.ReduceToListOfListOfWords(),
+            tr.ToLowerCase(),
+            tr.ExpandCommonEnglishContractions(),
+            tr.RemoveKaldiNonWords(),
+            tr.RemoveWhiteSpace(replace_by_space=True),
+            tr.RemoveMultipleSpaces(),
+            tr.Strip(),
+            tr.ReduceToSingleSentence(),
+            tr.ReduceToListOfListOfWords(),
         ]
     )
-    return jiwer.wer(
+
+    return tr.wer(
         reference,
         hypothesis,
-        reference_transform=transformers,
-        hypothesis_transform=transformers,
+        reference_transform=wer_standardize_contiguous,
+        hypothesis_transform=wer_standardize_contiguous,
     )


### PR DESCRIPTION
- remove pytorch dependency
   - we only use onnxruntime now (avg size of onnxruntime is 7MB, silero model is 1.5MB)
- use right window sizes (enforce the same one used while training the model)
- allow 16Khz*X sample rates (not technically right, we sample each sr//16000 step)
- fixed warning when loading the silero model
- the model is now embedded inside the pypi package
- move vad paramters to silero.VAD constructor
- fix duplicate final transcripts on the stt.StreamAdapter 

EDIT: the tests should now be fixed 