### PR TITLE
Support speed param when calling openai TTS

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -38,6 +38,7 @@ class _TTSOptions:
     voice: TTSVoices
     api_key: str
     endpoint: str
+    speed: float
 
 
 class TTS(tts.TTS):
@@ -49,6 +50,7 @@ class TTS(tts.TTS):
         api_key: str | None = None,
         base_url: str | None = None,
         http_session: aiohttp.ClientSession | None = None,
+        speed: float = 1.0,
     ) -> None:
         super().__init__(
             streaming_supported=False,
@@ -65,6 +67,7 @@ class TTS(tts.TTS):
             voice=voice,
             api_key=api_key,
             endpoint=os.path.join(get_base_url(base_url), "audio/speech"),
+            speed=speed,
         )
         self._session = http_session
 
@@ -102,6 +105,7 @@ class ChunkedStream(tts.ChunkedStream):
                     "model": self._opts.model,
                     "voice": self._opts.voice,
                     "response_format": "mp3",
+                    "speed": self._opts.speed,
                 },
             ) as resp:
                 async for data, _ in resp.content.iter_chunks():


### PR DESCRIPTION
This PR adds support for `speed` param when calling OpenAI TTS

Ref: https://platform.openai.com/docs/api-reference/audio/createSpeech#audio-createspeech-speed