### PR TITLE
Fix module name usage in action

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -63,101 +63,93 @@ jobs:
       - name: debug packages
         run: echo "${{ steps.changesets.outputs.publishedPackages }}"
 
-  debug-outputs:
+  build:
     needs:
       - bump
+    strategy:
+      matrix:
+        package: ${{ fromJson(needs.bump.outputs.packages) }}
+    defaults:
+      run:
+        working-directory: "${{ startsWith(matrix.package.name, 'livekit-plugin') && '/livekit-plugins/' || '/' }}${{ matrix.package.name }}"
+
     runs-on: ubuntu-latest
+
     steps:
-      - name: Echo outputs
-        run: echo "${{needs.bump.outputs.packages}}"
+      - uses: actions/checkout@v4
 
-  # build:
-  #   needs:
-  #     - bump
-  #   strategy:
-  #     matrix:
-  #       package: ${{ fromJson(needs.bump.outputs.packages) }}
-  #   defaults:
-  #     run:
-  #       working-directory: ${{ matrix.package.name }}
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.x"
 
-  #   runs-on: ubuntu-latest
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
 
-  #   steps:
-  #     - uses: actions/checkout@v4
+      - name: Bump version.py
+        run: |
+          export module=$(${{ matrix.package.name }} | tr '-' '/')
+          export version=$(sed 's|-\([0-9]*\)$|\1|' <<< ${{ matrix.package.version }})
+          sed -i "s/__version__.*/__version__ = \"$version\"/" $module/version.py
 
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: "3.x"
+      - name: Build package
+        run: python -m build
 
-  #     - name: Install dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-package-distributions
+          path: ${{ github.workspace }}/dist/
 
-  #     - name: Bump version.py
-  #       run: |
-  #         export module=$(sed 's/^.*\///' <<< ${{ matrix.package.name }} | tr '-' '/')
-  #         export version=$(sed 's|-\([0-9]*\)$|\1|' <<< ${{ matrix.package.version }})
-  #         sed -i "s/__version__.*/__version__ = \"$version\"/" $module/version.py
+  publish:
+    needs:
+      - build
 
-  #     - name: Build package
-  #       run: python -m build
+    runs-on: ubuntu-latest
 
-  #     - name: Store the distribution packages
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: python-package-distributions
-  #         path: ${{ matrix.package.name }}/dist/
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
 
-  # publish:
-  #   needs:
-  #     - build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
-  #   runs-on: ubuntu-latest
+  docs:
+    needs:
+      - bump
+      - publish
+    strategy:
+      matrix:
+        package: ${{ fromJSON(needs.bump.outputs.packages) }}
 
-  #   steps:
-  #     - name: Download all the dists
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: python-package-distributions
-  #         path: dist/
+    runs-on: ubuntu-latest
+    env:
+      package: $(sed 's/^.*\///' <<< ${{ matrix.package.name }})
+      module: $(tr '-' '/' <<< $package)
 
-  #     - name: Publish package
-  #       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-  #       with:
-  #         user: __token__
-  #         password: ${{ secrets.PYPI_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
 
-  # docs:
-  #   needs:
-  #     - bump
-  #     - publish
-  #   strategy:
-  #     matrix:
-  #       package: ${{ fromJSON(needs.bump.outputs.packages) }}
+      - name: Install pdoc
+        run: python -m pip install --upgrade pdoc
 
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     package: $(sed 's/^.*\///' <<< ${{ matrix.package.name }})
-  #     module: $(tr '-' '/' <<< $package)
+      - name: Install package
+        run: python -m pip install $package/
 
-  #   steps:
-  #     - uses: actions/checkout@v3
+      - name: Build Docs
+        run: python -m pdoc $module --docformat=google --output-dir docs
 
-  #     - name: Install pdoc
-  #       run: python -m pip install --upgrade pdoc
-
-  #     - name: Install package
-  #       run: python -m pip install $package/
-
-  #     - name: Build Docs
-  #       run: python -m pdoc $module --docformat=google --output-dir docs
-
-  #     - name: S3 Upload
-  #       run: aws s3 cp docs/ s3://livekit-docs/$package --recursive
-  #       env:
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_DEPLOY_AWS_ACCESS_KEY }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_DEPLOY_AWS_API_SECRET }}
-  #         AWS_DEFAULT_REGION: "us-east-1"
+      - name: S3 Upload
+        run: aws s3 cp docs/ s3://livekit-docs/$package --recursive
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_DEPLOY_AWS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_DEPLOY_AWS_API_SECRET }}
+          AWS_DEFAULT_REGION: "us-east-1"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -71,7 +71,7 @@ jobs:
         package: ${{ fromJson(needs.bump.outputs.packages) }}
     defaults:
       run:
-        working-directory: "${{ startsWith(matrix.package.name, 'livekit-plugin') && '/livekit-plugins/' || '/' }}${{ matrix.package.name }}"
+        working-directory: "${{ startsWith(matrix.package.name, 'livekit-plugin') && 'livekit-plugins/' || '' }}${{ matrix.package.name }}"
 
     runs-on: ubuntu-latest
 

--- a/livekit-plugins/livekit-plugins-minimal/README.md
+++ b/livekit-plugins/livekit-plugins-minimal/README.md
@@ -4,8 +4,11 @@ This is a minimal example of a LiveKit plugin for Agents.
 
 ### Developer note
 
-When copying this directory over to create a new `livekit-plugins` package, make sure the `"name"` field in `package.json` follows the proper naming convention for CI:
+When copying this directory over to create a new `livekit-plugins` package, make sure it's nested within the `livekit-plugins` folder and that the `"name"` field in `package.json` follows the proper naming convention for CI:
 
 ```json
-  "name": "livekit-plugins/livekit-plugins-<name>"
+{
+  "name": "livekit-plugins-<name>",
+  "private": true
+}
 ```


### PR DESCRIPTION
Previously we had package names defined as `livekit-plugins/livekit-plugin-NAME`. 

In order for changesets to work properly the package names have to be formatted in a npm compliant way. 
This is why I changed the name pattern to `livekit-plugin-NAME`. This has the advantage to be aligned with the pypi package names. 

Due to this change the way we define the CWD of the build job needs to change. 
Instead of relying on the package name as a path equivalent (which we did with the `livekit-plugins/livekit-plugin-NAME` pattern), we instead introduce the convention that all `livekit-plugin-NAME` packages live within the `livekit-plugins` folder. 
This is pretty reasonable, I think, and allows us to construct the CWD directly from the package name. 