### PR TITLE
Remove max parallel setting for release action

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -74,7 +74,6 @@ jobs:
     strategy:
       matrix:
         package: ${{ fromJson(needs.bump.outputs.packages) }}
-      max-parallel: 1
     defaults:
       run:
         working-directory: "${{ startsWith(matrix.package.name, 'livekit-plugin') && 'livekit-plugins/' || '' }}${{ matrix.package.name }}"


### PR DESCRIPTION
@theomonnom handled the parallel git upload issue already by adding `--rebase --autostash` to the commit step.