### PR TITLE
Lazy create http session if needed

### DIFF
--- a/livekit-agents/livekit/agents/utils/http_context.py
+++ b/livekit-agents/livekit/agents/utils/http_context.py
@@ -33,7 +33,7 @@ def http_session() -> aiohttp.ClientSession:
     val = _ContextVar.get(None)  # type: ignore
     if val is None:
         raise RuntimeError(
-            "Attempted to use an http session outside of a job context. This is probably because you are trying to use a plugin without also using the agent worker api. You may need to create your own aiohttp.ClientSession, pass it into the plugin constructor as a kwarg, and manage its lifecycle."
+            "Attempted to use an http session outside of a job context. This is probably because you are trying to use a plugin without using the agent worker api. You may need to create your own aiohttp.ClientSession, pass it into the plugin constructor as a kwarg, and manage its lifecycle."
         )
 
     return val()  # type: ignore

--- a/livekit-agents/livekit/agents/utils/http_context.py
+++ b/livekit-agents/livekit/agents/utils/http_context.py
@@ -31,10 +31,12 @@ def http_session() -> aiohttp.ClientSession:
     """
 
     val = _ContextVar.get(None)  # type: ignore
-    if val:
-        return val()
+    if val is None:
+        raise RuntimeError(
+            "Attempted to use an http session outside of a job context. This is probably because you are trying to use a plugin without also using the agent worker api. You may need to create your own aiohttp.ClientSession, pass it into the plugin constructor as a kwarg, and manage its lifecycle."
+        )
 
-    return _new_session_ctx()()
+    return val()  # type: ignore
 
 
 async def _close_http_ctx():

--- a/livekit-agents/livekit/agents/utils/http_context.py
+++ b/livekit-agents/livekit/agents/utils/http_context.py
@@ -31,10 +31,10 @@ def http_session() -> aiohttp.ClientSession:
     """
 
     val = _ContextVar.get(None)  # type: ignore
-    if val is None:
-        raise RuntimeError("no http_session() context available")
+    if val:
+        return val()
 
-    return val()  # type: ignore
+    return _new_session_ctx()()
 
 
 async def _close_http_ctx():


### PR DESCRIPTION
Some users are using the plugins by themselves without the agent subprocess/worker code. In these cases, a global http_session is never created. IMO this use case is perfectly legitimate.