### PR TITLE
remove unnecessary async function

### DIFF
--- a/.changeset/modern-geese-applaud.md
+++ b/.changeset/modern-geese-applaud.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+fix: remove unnecessary async function

--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -123,9 +123,7 @@ def _apply_auto_subscribe_opts(room: rtc.Room, auto_subscribe: AutoSubscribe) ->
             _subscribe_if_needed(pub)
 
     @room.on("track_published")
-    async def on_track_published(
-        pub: rtc.RemoteTrackPublication, _: rtc.RemoteParticipant
-    ):
+    def on_track_published(pub: rtc.RemoteTrackPublication, _: rtc.RemoteParticipant):
         _subscribe_if_needed(pub)
 
 


### PR DESCRIPTION
was seeing this warning in my agent logs when running the `examples/voice-assistant/minimal_assistant.py` example:

```bash
/Users/nabil/repos/livekit-test/.venv/lib/python3.12/site-packages/livekit/rtc/_event_emitter.py:14: RuntimeWarning: coroutine '_apply_auto_subscribe_opts.<locals>.on_track_published' was never awaited
  callback(*args, **kwargs)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

making function synchronous resolved this, as _subcribe_if_needed() does not need to be async.

---

I no longer see any warnings in my agent logs after this change.