### PR TITLE
fix(voice assistant): missing spaces between transcript chunks

### DIFF
--- a/.changeset/empty-rings-begin.md
+++ b/.changeset/empty-rings-begin.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+voice_assistant: fix missing spaces between transcript chunks

--- a/livekit-agents/livekit/agents/voice_assistant/voice_assistant.py
+++ b/livekit-agents/livekit/agents/voice_assistant/voice_assistant.py
@@ -377,7 +377,9 @@ class VoiceAssistant(utils.EventEmitter[EventTypes]):
             self._transcribed_interim_text = ev.alternatives[0].text
 
         def _on_final_transcript(ev: stt.SpeechEvent) -> None:
-            self._transcribed_text += ev.alternatives[0].text
+            self._transcribed_text += (
+                ' ' if self._transcribed_text else ''
+            ) + ev.alternatives[0].text
 
             if self._opts.preemptive_synthesis:
                 self._synthesize_agent_reply()


### PR DESCRIPTION
If a user speaks slowly or trails off a bit we are finding that Deepgram will return multiple chunks of "final" transcripts, which are concatenated without a space creating things like this:

> Yeah. I mean, I I haven't packedyet at all, but she's got, Harry all packed up, so that's the most important part.Know,

(Notice lack of space between "packed" and "yet" and before "Know")