### PR TITLE
elevenlabs: error on non-PCM data

### DIFF
--- a/.changeset/violet-students-shout.md
+++ b/.changeset/violet-students-shout.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-elevenlabs": patch
+---
+
+gracefully error on non-PCM data

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -181,6 +181,10 @@ class ChunkedStream(tts.ChunkedStream):
             headers={AUTHORIZATION_HEADER: self._opts.api_key},
             json=data,
         ) as resp:
+            if resp.content_type != "audio/pcm":
+                content = await resp.text()
+                logger.error("11labs returned non-PCM data: %s", content)
+                return
             async for bytes_data, _ in resp.content.iter_chunks():
                 for frame in bstream.write(bytes_data):
                     self._event_ch.send_nowait(

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -181,9 +181,9 @@ class ChunkedStream(tts.ChunkedStream):
             headers={AUTHORIZATION_HEADER: self._opts.api_key},
             json=data,
         ) as resp:
-            if resp.content_type != "audio/pcm":
+            if not resp.content_type.startswith("audio/"):
                 content = await resp.text()
-                logger.error("11labs returned non-PCM data: %s", content)
+                logger.error("11labs returned non-audio data: %s", content)
                 return
             async for bytes_data, _ in resp.content.iter_chunks():
                 for frame in bstream.write(bytes_data):

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -156,7 +156,8 @@ class ChunkedStream(tts.ChunkedStream):
     ) -> None:
         super().__init__()
         self._text, self._opts, self._session = text, opts, session
-        self._mp3_decoder = utils.codecs.Mp3StreamDecoder()
+        if _encoding_from_format(self._opts.encoding) == "mp3":
+            self._mp3_decoder = utils.codecs.Mp3StreamDecoder()
 
     @utils.log_exceptions(logger=logger)
     async def _main_task(self) -> None:
@@ -192,7 +193,9 @@ class ChunkedStream(tts.ChunkedStream):
                     for frame in self._mp3_decoder.decode_chunk(bytes_data):
                         self._event_ch.send_nowait(
                             tts.SynthesizedAudio(
-                                request_id=request_id, segment_id=segment_id, frame=frame
+                                request_id=request_id,
+                                segment_id=segment_id,
+                                frame=frame,
                             )
                         )
             else:
@@ -200,7 +203,9 @@ class ChunkedStream(tts.ChunkedStream):
                     for frame in bstream.write(bytes_data):
                         self._event_ch.send_nowait(
                             tts.SynthesizedAudio(
-                                request_id=request_id, segment_id=segment_id, frame=frame
+                                request_id=request_id,
+                                segment_id=segment_id,
+                                frame=frame,
                             )
                         )
 

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -408,11 +408,11 @@ def _synthesize_url(opts: _TTSOptions) -> str:
     base_url = opts.base_url
     voice_id = opts.voice.id
     model_id = opts.model_id
-    sample_rate = _sample_rate_from_format(opts.encoding)
+    output_format = opts.encoding
     latency = opts.streaming_latency
     return (
         f"{base_url}/text-to-speech/{voice_id}/stream?"
-        f"model_id={model_id}&output_format=pcm_{sample_rate}&optimize_streaming_latency={latency}"
+        f"model_id={model_id}&output_format={output_format}&optimize_streaming_latency={latency}"
     )
 
 


### PR DESCRIPTION
will now output the following and skip synthesis instead of attempting to process data as PCM:

```
2024-08-02 12:01:38,006 - ERROR livekit.plugins.elevenlabs - 11labs returned non-PCM data: {"detail":{"status":"invalid_api_key","message":"Invalid API key"}} {"pid": 59945, "job_id": "AJ_5oARRaVErZCW"}
```