### PR TITLE
openai: fix incorrect API urls on Windows

### DIFF
--- a/.changeset/unlucky-starfishes-fold.md
+++ b/.changeset/unlucky-starfishes-fold.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-openai": patch
+---
+
+openai: fix incorrect API urls on Windows

--- a/livekit-agents/livekit/agents/voice_assistant/voice_assistant.py
+++ b/livekit-agents/livekit/agents/voice_assistant/voice_assistant.py
@@ -378,7 +378,7 @@ class VoiceAssistant(utils.EventEmitter[EventTypes]):
 
         def _on_final_transcript(ev: stt.SpeechEvent) -> None:
             self._transcribed_text += (
-                ' ' if self._transcribed_text else ''
+                " " if self._transcribed_text else ""
             ) + ev.alternatives[0].text
 
             if self._opts.preemptive_synthesis:

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import dataclasses
 import io
+import os
 import urllib.parse
 import wave
 from dataclasses import dataclass
@@ -64,7 +65,9 @@ class STT(stt.STT):
             detect_language=detect_language,
             model=model,
             api_key=api_key,
-            endpoint=urllib.parse.urljoin(get_base_url(base_url), "audio/transcriptions"),
+            endpoint=urllib.parse.urljoin(
+                get_base_url(base_url), "audio/transcriptions"
+            ),
         )
         self._session = http_session
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 import dataclasses
 import io
 import os
-import urllib.parse
 import wave
 from dataclasses import dataclass
+from pathlib import PurePosixPath
 
 import aiohttp
 from livekit import agents
@@ -60,14 +60,15 @@ class STT(stt.STT):
         if detect_language:
             language = ""
 
+        base = PurePosixPath(get_base_url(base_url))
+        endpoint = str(base / "audio/transcriptions")
+
         self._opts = _STTOptions(
             language=language,
             detect_language=detect_language,
             model=model,
             api_key=api_key,
-            endpoint=urllib.parse.urljoin(
-                get_base_url(base_url), "audio/transcriptions"
-            ),
+            endpoint=endpoint,
         )
         self._session = http_session
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import dataclasses
 import io
-import os
+import urllib.parse
 import wave
 from dataclasses import dataclass
 
@@ -64,7 +64,7 @@ class STT(stt.STT):
             detect_language=detect_language,
             model=model,
             api_key=api_key,
-            endpoint=os.path.join(get_base_url(base_url), "audio/transcriptions"),
+            endpoint=urllib.parse.urljoin(get_base_url(base_url), "audio/transcriptions"),
         )
         self._session = http_session
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import urllib.parse
 from dataclasses import dataclass
 from typing import AsyncContextManager
 
@@ -35,7 +34,6 @@ OPENAI_TTS_CHANNELS = 1
 class _TTSOptions:
     model: TTSModels
     voice: TTSVoices
-    endpoint: str
     speed: float
 
 
@@ -73,7 +71,6 @@ class TTS(tts.TTS):
         self._opts = _TTSOptions(
             model=model,
             voice=voice,
-            endpoint=urllib.parse.urljoin(get_base_url(base_url), "audio/speech"),
             speed=speed,
         )
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-import os
+import urllib.parse
 from dataclasses import dataclass
 from typing import AsyncContextManager
 
@@ -73,7 +73,7 @@ class TTS(tts.TTS):
         self._opts = _TTSOptions(
             model=model,
             voice=voice,
-            endpoint=os.path.join(get_base_url(base_url), "audio/speech"),
+            endpoint=urllib.parse.urljoin(get_base_url(base_url), "audio/speech"),
             speed=speed,
         )
 


### PR DESCRIPTION
os.path.join uses backslash on windows. the appropriate fnc to use is urllib.parse.urljoin