### PR TITLE
Add single space between transcribed speech fragments

### DIFF
--- a/.changeset/big-insects-dance.md
+++ b/.changeset/big-insects-dance.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+voiceassistant: add single space between transcribed speech fragments

--- a/livekit-agents/livekit/agents/voice_assistant/voice_assistant.py
+++ b/livekit-agents/livekit/agents/voice_assistant/voice_assistant.py
@@ -377,7 +377,7 @@ class VoiceAssistant(utils.EventEmitter[EventTypes]):
             self._transcribed_interim_text = ev.alternatives[0].text
 
         def _on_final_transcript(ev: stt.SpeechEvent) -> None:
-            self._transcribed_text += ev.alternatives[0].text
+            self._transcribed_text += " " + ev.alternatives[0].text
 
             if self._opts.preemptive_synthesis:
                 self._synthesize_agent_reply()


### PR DESCRIPTION
Initially, when user was talking to agent in slow manner..

Ie something like Hello...I..am..doing..good, then it was registering those as different chunks and the final text that was being formed was "Iamdoinggood" (See No Spaces)

However if user speak the same sentence fast and fluent like "I am doing good" then transcription had proper spaces.

This was due to the logic to simply append transcription without adding any additional space, this patch fixes it and make the text better for OpenAI to parse