### PR TITLE
elevenlabs: update default model to eleven_turbo_v2_5

### DIFF
--- a/.changeset/khaki-gorillas-cross.md
+++ b/.changeset/khaki-gorillas-cross.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-elevenlabs": patch
+---
+
+elevenlabs: update default model to eleven_turbo_v2_5

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/models.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/models.py
@@ -5,6 +5,7 @@ TTSModels = Literal[
     "eleven_multilingual_v1",
     "eleven_multilingual_v2",
     "eleven_turbo_v2",
+    "eleven_turbo_v2_5"
 ]
 
 TTSEncoding = Literal[

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/models.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/models.py
@@ -5,7 +5,7 @@ TTSModels = Literal[
     "eleven_multilingual_v1",
     "eleven_multilingual_v2",
     "eleven_turbo_v2",
-    "eleven_turbo_v2_5"
+    "eleven_turbo_v2_5",
 ]
 
 TTSEncoding = Literal[

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -93,7 +93,7 @@ class TTS(tts.TTS):
         self,
         *,
         voice: Voice = DEFAULT_VOICE,
-        model_id: TTSModels = "eleven_turbo_v2",
+        model_id: TTSModels = "eleven_turbo_v2_5",
         api_key: str | None = None,
         base_url: str | None = None,
         encoding: TTSEncoding = "mp3_22050_32",


### PR DESCRIPTION
This model should have a faster inference time (the first time to first frame didn't really reduced tho)