### PR TITLE
use aiodns resolver by default

### DIFF
--- a/.changeset/cool-olives-act.md
+++ b/.changeset/cool-olives-act.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+use aiodns by default

--- a/livekit-agents/setup.py
+++ b/livekit-agents/setup.py
@@ -56,6 +56,8 @@ setuptools.setup(
         "types-protobuf>=4,<5",
         "watchfiles~=0.22",
         "psutil~=5.9",
+        "aiohttp~=3.10",
+        "aiodns~=3.2",
     ],
     extras_require={
         ':sys_platform=="win32"': [


### PR DESCRIPTION
> For speeding up DNS resolving by client API you may install [aiodns](https://docs.aiohttp.org/en/stable/glossary.html#term-aiodns) as well. This option is highly recommended:

https://docs.aiohttp.org/en/stable/

> aiohttp.DefaultResolver by default (asynchronous if aiodns>=1.1 is installed).
> The resolver is aiohttp.ThreadedResolver by default, asynchronous version is pretty robust but might fail in very rare cases.

https://docs.aiohttp.org/en/stable/client_reference.html


This will use the async resolver instead of aiohttp.ThreadedResolver by default (recommended by aiohttp)