### PR TITLE
openai: add api_key argument

### DIFF
--- a/.changeset/angry-drinks-hunt.md
+++ b/.changeset/angry-drinks-hunt.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-openai": patch
+---
+
+openai: add api_key argument

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -31,8 +31,6 @@ from .log import logger
 from .models import ChatModels
 from .utils import AsyncAzureADTokenProvider, get_base_url
 
-DEFAULT_MODEL = "gpt-4o"
-
 
 @dataclass
 class LLMOptions:
@@ -43,12 +41,14 @@ class LLM(llm.LLM):
     def __init__(
         self,
         *,
-        model: str | ChatModels = DEFAULT_MODEL,
+        model: str | ChatModels = "gpt-4o",
+        api_key: str | None = None,
         base_url: str | None = None,
         client: openai.AsyncClient | None = None,
     ) -> None:
         self._opts = LLMOptions(model=model)
         self._client = client or openai.AsyncClient(
+            api_key=api_key,
             base_url=get_base_url(base_url),
             http_client=httpx.AsyncClient(
                 timeout=5.0,
@@ -65,7 +65,7 @@ class LLM(llm.LLM):
     @staticmethod
     def create_azure_client(
         *,
-        model: str | ChatModels = DEFAULT_MODEL,
+        model: str | ChatModels = "gpt-4o",
         azure_endpoint: str | None = None,
         azure_deployment: str | None = None,
         api_version: str | None = None,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -47,6 +47,7 @@ class TTS(tts.TTS):
         voice: TTSVoices = "alloy",
         speed: float = 1.0,
         base_url: str | None = None,
+        api_key: str | None = None,
         client: openai.AsyncClient | None = None,
     ) -> None:
         super().__init__(
@@ -58,6 +59,7 @@ class TTS(tts.TTS):
         )
 
         self._client = client or openai.AsyncClient(
+            api_key=api_key,
             base_url=get_base_url(base_url),
             http_client=httpx.AsyncClient(
                 timeout=5.0,


### PR DESCRIPTION
this was blocking people using another provider (using the base_url) and openai at the same time. (The key could only be specified using the OPENAI_API_KEY envvar)