### PR TITLE
voiceassistant: fix AssertionError when there is no user_question

### DIFF
--- a/.changeset/sharp-hornets-talk.md
+++ b/.changeset/sharp-hornets-talk.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+voiceassistant: fix AssertionError when there is no user_question

--- a/livekit-agents/livekit/agents/voice_assistant/voice_assistant.py
+++ b/livekit-agents/livekit/agents/voice_assistant/voice_assistant.py
@@ -556,7 +556,7 @@ class VoiceAssistant(utils.EventEmitter[EventTypes]):
 
         while not join_fut.done():
             await asyncio.wait(
-                [join_fut], return_when=asyncio.FIRST_COMPLETED, timeout=1.0
+                [join_fut], return_when=asyncio.FIRST_COMPLETED, timeout=0.5
             )
 
             _commit_user_question_if_needed()
@@ -576,7 +576,7 @@ class VoiceAssistant(utils.EventEmitter[EventTypes]):
         if is_using_tools and not interrupted:
             assert isinstance(speech_info.source, LLMStream)
             assert (
-                user_speech_committed
+                not user_question or user_speech_committed
             ), "user speech should have been committed before using tools"
 
             # execute functions


### PR DESCRIPTION
This could happens when using function calling with the VoiceAssistant.say method