### PR TITLE
Fix elevenlabs voice settings breaking

### DIFF
--- a/.changeset/warm-kiwis-cover.md
+++ b/.changeset/warm-kiwis-cover.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-elevenlabs": patch
+---
+
+Fix elevenlabs voice settings breaking

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -168,7 +168,7 @@ class ChunkedStream(tts.ChunkedStream):
         segment_id = utils.shortuuid()
 
         voice_settings = (
-            dataclasses.asdict(self._opts.voice.settings)
+            _strip_nones(dataclasses.asdict(self._opts.voice.settings))
             if self._opts.voice.settings
             else None
         )
@@ -300,7 +300,7 @@ class SynthesizeStream(tts.SynthesizeStream):
         init_pkt = dict(
             text=" ",
             try_trigger_generation=True,
-            voice_settings=dataclasses.asdict(self._opts.voice.settings)
+            voice_settings=_strip_nones(dataclasses.asdict(self._opts.voice.settings))
             if self._opts.voice.settings
             else None,
             generation_config=dict(
@@ -403,6 +403,8 @@ def _dict_to_voices_list(data: dict[str, Any]):
         )
     return voices
 
+def _strip_nones(data: dict[str, Any]):
+    return {k: v for k, v in data.items() if v is not None}
 
 def _synthesize_url(opts: _TTSOptions) -> str:
     base_url = opts.base_url

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -403,8 +403,10 @@ def _dict_to_voices_list(data: dict[str, Any]):
         )
     return voices
 
+
 def _strip_nones(data: dict[str, Any]):
     return {k: v for k, v in data.items() if v is not None}
+
 
 def _synthesize_url(opts: _TTSOptions) -> str:
     base_url = opts.base_url


### PR DESCRIPTION
11labs API requires `style` float and `use_speaker_boost` boolean. defaulting to None gets translated to JSON as `null` type. this sets them to their default values noted in the API here: https://api.elevenlabs.io/v1/voices/settings/default