### PR TITLE
added alternative ChatImage data field: base64_string

### DIFF
--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -25,7 +25,8 @@ ChatRole = Literal["system", "user", "assistant", "tool"]
 
 @dataclass
 class ChatImage:
-    image: str | rtc.VideoFrame
+    image: str | rtc.VideoFrame | None = None
+    base64_string: str | None = None
     inference_width: int | None = None
     inference_height: int | None = None
     _cache: dict[Any, Any] = field(default_factory=dict, repr=False, init=False)

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -293,6 +293,11 @@ def _build_oai_image_content(image: llm.ChatImage, cache_key: Any):
             "type": "image_url",
             "image_url": {"url": image.image, "detail": "auto"},
         }
+    elif isinstance(image.base64_string, str):  # base64 string
+        return {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/jpeg;base64,{image.base64_string}"},
+        }
     elif isinstance(image.image, rtc.VideoFrame):  # VideoFrame
         if cache_key not in image._cache:
             # inside our internal implementation, we allow to put extra metadata to


### PR DESCRIPTION
probably could be a more robust change including implementation on other plugins, stricter typing to enforce mutual exclusivity with `image` field, etc

but wanted to put it out to get initial thoughts.

alternative approach could be to overload the `image` field and use a different and use a different property to signify that it is base64 instead of URL.

issue: https://github.com/livekit/agents/issues/610