### PR TITLE
Add deepgram model default for non-English language

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -78,6 +78,9 @@ class STT(stt.STT):
         if api_key is None:
             raise ValueError("Deepgram API key is required")
 
+        if language != "en-US":
+            model = "nova-2-general"
+
         self._api_key = api_key
 
         self._opts = STTOptions(


### PR DESCRIPTION
I started getting these errors after upgrading some of my plugin versions.

```
"/Users/gabrielpuliatti/Library/Caches/pypoetry/virtualenvs/soldev-br2qwqYc-py3.11/lib/python3.11/site-packages/livekit/plugins/deepgram/stt.py", line 215, in _run
    ws = await self._session.ws_connect(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gabrielpuliatti/Library/Caches/pypoetry/virtualenvs/soldev-br2qwqYc-py3.11/lib/python3.11/site-packages/aiohttp/client.py", line 947, in _ws_connect
    raise WSServerHandshakeError(
aiohttp.client_exceptions.WSServerHandshakeError: 400, message='Invalid response status', url='wss://api.deepgram.com/v1/listen?model=nova-2-conversationalai&punctuate=true&smart_format=true&no_delay=true&interim_results=true&encoding=linear16&vad_events=true&sample_rate=48000&channels=1&endpointing=25&filler_words=false&language=es-419' {"pid": 49987, "job_id": "AJ_Z7a3fQXSwX4E"}
```

In livekit-plugins-deepgram 0.6.3 the default model for deepgram was updated. The issue is that model only supports English. This PR sets the default model back to nova-2-general if the language is other than English. 