### PR TITLE
examples/text-to-speech/sync_tts_transcription.py: add `.end_input()` after `.flush()`

### DIFF
--- a/examples/text-to-speech/sync_tts_transcription.py
+++ b/examples/text-to-speech/sync_tts_transcription.py
@@ -83,6 +83,7 @@ async def _eg_streamed_tts_stream(
         tts_forwarder.push_text(chunk)
 
     tts_stream.flush()
+    tts_stream.end_input()
     tts_forwarder.mark_text_segment_end()
 
     playout_q = asyncio.Queue[Optional[rtc.AudioFrame]]()


### PR DESCRIPTION
https://livekit-users.slack.com/archives/C01KVTJH6BX/p1723198697156069?thread_ts=1722507759.754139&cid=C01KVTJH6BX