### PR TITLE
plugins: add docstrings explaining API keys

### DIFF
--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
@@ -48,6 +48,18 @@ class LLM(llm.LLM):
         user: str | None = None,
         client: anthropic.AsyncClient | None = None,
     ) -> None:
+        """
+        Create a new instance of Anthropic LLM.
+
+        ``api_key`` must be set to your Anthropic API key, either using the argument or by setting
+        the ``ANTHROPIC_API_KEY`` environmental variable.
+        """
+
+        # throw an error on our end
+        api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+        if api_key is None:
+            raise ValueError("Anthropic API key is required")
+
         self._opts = LLMOptions(model=model, user=user)
         self._client = client or anthropic.AsyncClient(
             api_key=api_key,

--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import base64
 import inspect
 import json
+import os
 from dataclasses import dataclass
 from typing import Any, Awaitable, List, Tuple, get_args, get_origin
 

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
@@ -45,6 +45,13 @@ class STT(stt.STT):
         num_channels: int = 1,
         languages: list[str] = [],  # when empty, auto-detect the language
     ):
+        """
+        Create a new instance of Azure STT.
+
+        ``speech_key`` and ``speech_region`` must be set, either using arguments or by setting the
+        ``AZURE_SPEECH_KEY`` and ``AZURE_SPEECH_REGION`` environmental variables, respectively.
+        """
+
         super().__init__(
             capabilities=stt.STTCapabilities(streaming=True, interim_results=True)
         )

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
@@ -42,6 +42,13 @@ class TTS(tts.TTS):
         speech_region: str | None = None,
         voice: str | None = None,
     ) -> None:
+        """
+        Create a new instance of Azure TTS.
+
+        ``speech_key`` and ``speech_region`` must be set, either using arguments or by setting the
+        ``AZURE_SPEECH_KEY`` and ``AZURE_SPEECH_REGION`` environmental variables, respectively.
+        """
+
         super().__init__(
             capabilities=tts.TTSCapabilities(
                 streaming=False,

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -57,6 +57,13 @@ class TTS(tts.TTS):
         api_key: str | None = None,
         http_session: aiohttp.ClientSession | None = None,
     ) -> None:
+        """
+        Create a new instance of Cartesia TTS.
+
+        ``api_key`` must be set to your Cartesia API key, either using the argument or by setting
+        the ``CARTESIA_API_KEY`` environmental variable.
+        """
+
         super().__init__(
             capabilities=tts.TTSCapabilities(streaming=True),
             sample_rate=sample_rate,

--- a/livekit-plugins/livekit-plugins-clova/livekit/plugins/clova/stt.py
+++ b/livekit-plugins/livekit-plugins-clova/livekit/plugins/clova/stt.py
@@ -39,6 +39,13 @@ class STT(stt.STT):
         http_session: Optional[aiohttp.ClientSession] = None,
         threshold: float = 0.5,
     ):
+        """
+        Create a new instance of Clova STT.
+
+        ``secret`` and ``invoke_url`` must be set, either using arguments or by setting the
+        ``CLOVA_STT_SECRET_KEY`` and ``CLOVA_STT_INVOKE_URL`` environmental variables, respectively.
+        """
+
         super().__init__(
             capabilities=STTCapabilities(streaming=False, interim_results=True)
         )

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -68,6 +68,13 @@ class STT(stt.STT):
         api_key: str | None = None,
         http_session: aiohttp.ClientSession | None = None,
     ) -> None:
+        """
+        Create a new instance of Deepgram STT.
+
+        ``api_key`` must be set to your Deepgram API key, either using the argument or by setting
+        the ``DEEPGRAM_API_KEY`` environmental variable.
+        """
+
         super().__init__(
             capabilities=stt.STTCapabilities(
                 streaming=True, interim_results=interim_results

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -104,6 +104,13 @@ class TTS(tts.TTS):
         chunk_length_schedule: list[int] = [80, 120, 200, 260],  # range is [50, 500]
         http_session: aiohttp.ClientSession | None = None,
     ) -> None:
+        """
+        Create a new instance of ElevenLabs TTS.
+
+        ``api_key`` must be set to your ElevenLabs API key, either using the argument or by setting
+        the ``ELEVEN_API_KEY`` environmental variable.
+        """
+
         super().__init__(
             capabilities=tts.TTSCapabilities(
                 streaming=True,

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -58,8 +58,11 @@ class STT(stt.STT):
         credentials_file: str | None = None,
     ):
         """
-        if no credentials is provided, it will use the credentials on the environment
-        GOOGLE_APPLICATION_CREDENTIALS (default behavior of Google SpeechAsyncClient)
+        Create a new instance of Google STT.
+
+        Credentials must be provided, either by using the ``credentials_info`` dict, or reading
+        from the file specified in ``credentials_file`` or the ``GOOGLE_APPLICATION_CREDENTIALS``
+        environmental variable.
         """
         super().__init__(
             capabilities=stt.STTCapabilities(streaming=True, interim_results=True)

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
@@ -51,9 +51,13 @@ class TTS(tts.TTS):
         credentials_file: str | None = None,
     ) -> None:
         """
-        if no credentials is provided, it will use the credentials on the environment
-        GOOGLE_APPLICATION_CREDENTIALS (default behavior of Google TextToSpeechAsyncClient)
+        Create a new instance of Google TTS.
+
+        Credentials must be provided, either by using the ``credentials_info`` dict, or reading
+        from the file specified in ``credentials_file`` or the ``GOOGLE_APPLICATION_CREDENTIALS``
+        environmental variable.
         """
+
         super().__init__(
             capabilities=tts.TTSCapabilities(
                 streaming=False,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -52,6 +52,18 @@ class LLM(llm.LLM):
         user: str | None = None,
         client: openai.AsyncClient | None = None,
     ) -> None:
+        """
+        Create a new instance of OpenAI LLM.
+
+        ``api_key`` must be set to your OpenAI API key, either using the argument or by setting the
+        ``OPENAI_API_KEY`` environmental variable.
+        """
+
+        # throw an error on our end
+        api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        if api_key is None:
+            raise ValueError("OpenAI API key is required")
+
         self._opts = LLMOptions(model=model, user=user)
         self._client = client or openai.AsyncClient(
             api_key=api_key,
@@ -116,6 +128,18 @@ class LLM(llm.LLM):
         client: openai.AsyncClient | None = None,
         user: str | None = None,
     ) -> LLM:
+        """
+        Create a new instance of Fireworks LLM.
+
+        ``api_key`` must be set to your Fireworks API key, either using the argument or by setting
+        the ``FIREWORKS_API_KEY`` environmental variable.
+        """
+
+        # shim for not using OPENAI_API_KEY
+        api_key = api_key or os.environ.get("FIREWORKS_API_KEY")
+        if api_key is None:
+            raise ValueError("Fireworks API key is required")
+
         return LLM(
             model=model, api_key=api_key, base_url=base_url, client=client, user=user
         )
@@ -129,6 +153,18 @@ class LLM(llm.LLM):
         client: openai.AsyncClient | None = None,
         user: str | None = None,
     ) -> LLM:
+        """
+        Create a new instance of Groq LLM.
+
+        ``api_key`` must be set to your Groq API key, either using the argument or by setting
+        the ``GROQ_API_KEY`` environmental variable.
+        """
+
+        # shim for not using OPENAI_API_KEY
+        api_key = api_key or os.environ.get("GROQ_API_KEY")
+        if api_key is None:
+            raise ValueError("Groq API key is required")
+
         return LLM(
             model=model, api_key=api_key, base_url=base_url, client=client, user=user
         )
@@ -142,6 +178,18 @@ class LLM(llm.LLM):
         client: openai.AsyncClient | None = None,
         user: str | None = None,
     ) -> LLM:
+        """
+        Create a new instance of OctoAI LLM.
+
+        ``api_key`` must be set to your OctoAI API key, either using the argument or by setting
+        the ``OCTO_API_KEY`` environmental variable.
+        """
+
+        # shim for not using OPENAI_API_KEY
+        api_key = api_key or os.environ.get("OCTO_API_KEY")
+        if api_key is None:
+            raise ValueError("OctoAI API key is required")
+
         return LLM(
             model=model, api_key=api_key, base_url=base_url, client=client, user=user
         )
@@ -153,6 +201,10 @@ class LLM(llm.LLM):
         base_url: str | None = "http://localhost:11434/v1",
         client: openai.AsyncClient | None = None,
     ) -> LLM:
+        """
+        Create a new instance of Ollama LLM.
+        """
+
         return LLM(model=model, api_key="ollama", base_url=base_url, client=client)
 
     @staticmethod
@@ -177,6 +229,18 @@ class LLM(llm.LLM):
         client: openai.AsyncClient | None = None,
         user: str | None = None,
     ) -> LLM:
+        """
+        Create a new instance of TogetherAI LLM.
+
+        ``api_key`` must be set to your TogetherAI API key, either using the argument or by setting
+        the ``TOGETHER_API_KEY`` environmental variable.
+        """
+
+        # shim for not using OPENAI_API_KEY
+        api_key = api_key or os.environ.get("TOGETHER_API_KEY")
+        if api_key is None:
+            raise ValueError("TogetherAI API key is required")
+
         return LLM(
             model=model, api_key=api_key, base_url=base_url, client=client, user=user
         )

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from dataclasses import dataclass
 from typing import Any, Awaitable, MutableSet
 
@@ -182,11 +183,11 @@ class LLM(llm.LLM):
         Create a new instance of OctoAI LLM.
 
         ``api_key`` must be set to your OctoAI API key, either using the argument or by setting
-        the ``OCTO_API_KEY`` environmental variable.
+        the ``OCTOAI_TOKEN`` environmental variable.
         """
 
         # shim for not using OPENAI_API_KEY
-        api_key = api_key or os.environ.get("OCTO_API_KEY")
+        api_key = api_key or os.environ.get("OCTOAI_TOKEN")
         if api_key is None:
             raise ValueError("OctoAI API key is required")
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import dataclasses
 import io
+import os
 import wave
 from dataclasses import dataclass
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -47,6 +47,13 @@ class STT(stt.STT):
         api_key: str | None = None,
         client: openai.AsyncClient | None = None,
     ):
+        """
+        Create a new instance of OpenAI STT.
+
+        ``api_key`` must be set to your OpenAI API key, either using the argument or by setting the
+        ``OPENAI_API_KEY`` environmental variable.
+        """
+
         super().__init__(
             capabilities=stt.STTCapabilities(streaming=False, interim_results=False)
         )
@@ -58,6 +65,11 @@ class STT(stt.STT):
             detect_language=detect_language,
             model=model,
         )
+
+        # throw an error on our end
+        api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        if api_key is None:
+            raise ValueError("OpenAI API key is required")
 
         self._client = client or openai.AsyncClient(
             api_key=api_key,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import AsyncContextManager
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -48,6 +48,13 @@ class TTS(tts.TTS):
         api_key: str | None = None,
         client: openai.AsyncClient | None = None,
     ) -> None:
+        """
+        Create a new instance of OpenAI TTS.
+
+        ``api_key`` must be set to your OpenAI API key, either using the argument or by setting the
+        ``OPENAI_API_KEY`` environmental variable.
+        """
+
         super().__init__(
             capabilities=tts.TTSCapabilities(
                 streaming=False,
@@ -55,6 +62,11 @@ class TTS(tts.TTS):
             sample_rate=OPENAI_TTS_SAMPLE_RATE,
             num_channels=OPENAI_TTS_CHANNELS,
         )
+
+        # throw an error on our end
+        api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        if api_key is None:
+            raise ValueError("OpenAI API key is required")
 
         self._client = client or openai.AsyncClient(
             api_key=api_key,


### PR DESCRIPTION
also provide envvar shims for openai.LLM alt providers

<code>``</code> means "inline code" in reStructuredText