### PR TITLE
Enable Google TTS with application default credentials

### DIFF
--- a/.changeset/tender-bikes-dream.md
+++ b/.changeset/tender-bikes-dream.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-google": minor
+---
+
+Enable use of Google STT with Application Default Credentials.

--- a/livekit-plugins/livekit-plugins-google/README.md
+++ b/livekit-plugins/livekit-plugins-google/README.md
@@ -10,4 +10,4 @@ pip install livekit-plugins-google
 
 ## Pre-requisites
 
-For credentials, you'll need a Google Cloud account and obtain the correct credentials. Credentials can be passed directly or set as [GOOGLE_APPLICATION_CREDENTIALS](https://cloud.google.com/docs/authentication/application-default-credentials) environment variable.
+For credentials, you'll need a Google Cloud account and obtain the correct credentials. Credentials can be passed directly or via Application Default Credentials as specified in [How Application Default Credentials works](https://cloud.google.com/docs/authentication/application-default-credentials).

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -112,7 +112,11 @@ class STT(stt.STT):
         # recognizers may improve latency https://cloud.google.com/speech-to-text/v2/docs/recognizers#understand_recognizers
 
         # TODO(theomonnom): find a better way to access the project_id
-        project_id = self._ensure_client().transport._credentials.project_id  # type: ignore
+        try:
+            project_id = self._ensure_client().transport._credentials.project_id  # type: ignore
+        except AttributeError:
+            from google.auth import default as ga_default
+            _, project_id = ga_default()
         return f"projects/{project_id}/locations/global/recognizers/_"
 
     def _sanitize_options(self, *, language: str | None = None) -> STTOptions:

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -23,6 +23,8 @@ from typing import AsyncIterable, List, Union
 from livekit import agents, rtc
 from livekit.agents import stt, utils
 
+from google.auth import default as gauth_default
+from google.auth.exceptions import DefaultCredentialsError
 from google.cloud.speech_v2 import SpeechAsyncClient
 from google.cloud.speech_v2.types import cloud_speech
 
@@ -61,8 +63,8 @@ class STT(stt.STT):
         Create a new instance of Google STT.
 
         Credentials must be provided, either by using the ``credentials_info`` dict, or reading
-        from the file specified in ``credentials_file`` or the ``GOOGLE_APPLICATION_CREDENTIALS``
-        environmental variable.
+        from the file specified in ``credentials_file`` or via Application Default Credentials as
+        described in https://cloud.google.com/docs/authentication/application-default-credentials
         """
         super().__init__(
             capabilities=stt.STTCapabilities(streaming=True, interim_results=True)
@@ -73,10 +75,13 @@ class STT(stt.STT):
         self._credentials_file = credentials_file
 
         if credentials_file is None and credentials_info is None:
-            creds = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
-            if not creds:
+            try:
+                gauth_default()
+            except DefaultCredentialsError:
                 raise ValueError(
-                    "GOOGLE_APPLICATION_CREDENTIALS must be set if no credentials is provided"
+                    "Application default credentials must be available "
+                    "when using Google STT without explicitly passing "
+                    "credentials through credentials_info or credentials_file."
                 )
 
         if isinstance(languages, str):

--- a/livekit-plugins/livekit-plugins-google/setup.py
+++ b/livekit-plugins/livekit-plugins-google/setup.py
@@ -48,6 +48,7 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
     install_requires=[
+        "google-auth >= 2, < 3",
         "google-cloud-speech >= 2, < 3",
         "google-cloud-texttospeech >= 2, < 3",
         "livekit-agents>=0.8.0.dev0",


### PR DESCRIPTION
Enable the use of the Google TTS plugin via application default
credentials, where no credential info is provided explicitly,
and instead is default via the default resolution order.

This enables two other common configurations including
deployment on Google Cloud where application
credentials are injected via the VM Metadata Service or on
developer systems where credentials are stored at
`~/.config/gcloud/application_default_credentials.json`
without setting the `GOOGLE_APPLICATION_CREDENTIALS`
environment variable.