### PR TITLE
Adding UtteranceEnd support for Deepgram

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -45,6 +45,7 @@ class STTOptions:
     smart_format: bool
     no_delay: bool
     endpointing_ms: int
+    utterance_end_ms: int
     filler_words: bool
     sample_rate: int
     num_channels: int
@@ -63,6 +64,7 @@ class STT(stt.STT):
         smart_format: bool = True,
         no_delay: bool = True,
         endpointing_ms: int = 25,
+        utterance_end_ms: int | None,
         filler_words: bool = False,
         keywords: list[Tuple[str, float]] = [],
         api_key: str | None = None,
@@ -112,6 +114,7 @@ class STT(stt.STT):
             smart_format=smart_format,
             no_delay=no_delay,
             endpointing_ms=endpointing_ms,
+            utterance_end_ms=utterance_end_ms,
             filler_words=filler_words,
             sample_rate=48000,
             num_channels=1,
@@ -230,6 +233,13 @@ class SpeechStream(stt.SpeechStream):
                     "filler_words": self._opts.filler_words,
                     "keywords": self._opts.keywords,
                 }
+
+                if self._opts.utterance_end_ms:
+                    if not self._opts.interim_results:
+                        logger.exception(
+                            f"interim_results must be set to True for utterance_end_ms to work."
+                        )
+                    live_config["utterance_end_ms"] = self._opts.utterance_end_ms,
 
                 if self._opts.language:
                     live_config["language"] = self._opts.language
@@ -391,6 +401,12 @@ class SpeechStream(stt.SpeechStream):
 
         elif data["type"] == "Metadata":
             pass  # metadata is too noisy
+        elif data["type"] == "UtteranceEnd":
+            if self._speaking:
+                self._speaking = False
+                self._event_ch.send_nowait(
+                    stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH)
+                )
         else:
             logger.warning("received unexpected message from deepgram %s", data)
 


### PR DESCRIPTION
Adding support for UtteranceEnd to Deepgram agent plugin. The UtteranceEnd is another feature offered by Deepgram to detect end of speech.

The Deepgram documentation is here:
https://developers.deepgram.com/docs/utterance-end
