### PR TITLE
add(plugin/deepgram): accepts optional parameter utterance_end_ms

### DIFF
--- a/.changeset/chatty-kiwis-divide.md
+++ b/.changeset/chatty-kiwis-divide.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-deepgram": patch
+---
+
+accepts optional parameter utterance_end_ms

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -21,7 +21,7 @@ import json
 import os
 import wave
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 from urllib.parse import urlencode
 
 import aiohttp
@@ -46,6 +46,7 @@ class STTOptions:
     smart_format: bool
     no_delay: bool
     endpointing_ms: int
+    utterance_end_ms: Optional[int]
     filler_words: bool
     sample_rate: int
     num_channels: int
@@ -64,6 +65,7 @@ class STT(stt.STT):
         smart_format: bool = True,
         no_delay: bool = True,
         endpointing_ms: int = 25,
+        utterance_end_ms: Optional[int] = None,
         filler_words: bool = False,
         keywords: list[Tuple[str, float]] = [],
         api_key: str | None = None,
@@ -113,6 +115,7 @@ class STT(stt.STT):
             smart_format=smart_format,
             no_delay=no_delay,
             endpointing_ms=endpointing_ms,
+            utterance_end_ms=utterance_end_ms,
             filler_words=filler_words,
             sample_rate=48000,
             num_channels=1,
@@ -235,6 +238,9 @@ class SpeechStream(stt.SpeechStream):
 
                 if self._opts.language:
                     live_config["language"] = self._opts.language
+
+                if self._opts.utterance_end_ms:
+                    live_config["utterance_end_ms"] = self._opts.utterance_end_ms
 
                 headers = {"Authorization": f"Token {self._api_key}"}
                 ws = await self._session.ws_connect(


### PR DESCRIPTION
Deepgram supports utterance end detection which can be enabled by supplying a timeout. This requires `interim_results` to be enabled. More information on their docs pages https://developers.deepgram.com/docs/utterance-end

To test this, pass the kwarg to the stt class.

```
voice_assistant = VoiceAssistant(
  stt=deepgram.STT(
    api_key="",
    model="nova-2-phonecall",
    interim_results=True,
    utterance_end_ms=5000,
  ),
  ...
)
```