### PR TITLE
Add inference ID

### DIFF
--- a/.changeset/clean-laws-explode.md
+++ b/.changeset/clean-laws-explode.md
@@ -1,0 +1,7 @@
+---
+"livekit-plugins-anthropic": patch
+"livekit-plugins-openai": patch
+"livekit-agents": patch
+---
+
+added inference_id to llm chat method signature

--- a/.changeset/six-apricots-study.md
+++ b/.changeset/six-apricots-study.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+add inference id

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -42,6 +42,7 @@ class ChatMessage:
     tool_calls: list[function_context.FunctionCallInfo] | None = None
     tool_call_id: str | None = None
     tool_exception: Exception | None = None
+    inference_id: str | None = None
     _metadata: dict[str, Any] = field(default_factory=dict, repr=False, init=False)
 
     @staticmethod
@@ -75,10 +76,14 @@ class ChatMessage:
 
     @staticmethod
     def create(
-        *, text: str = "", images: list[ChatImage] = [], role: ChatRole = "system"
+        *,
+        text: str = "",
+        images: list[ChatImage] = [],
+        role: ChatRole = "system",
+        inference_id: str | None = None,
     ) -> "ChatMessage":
         if len(images) == 0:
-            return ChatMessage(role=role, content=text)
+            return ChatMessage(role=role, content=text, inference_id=inference_id)
         else:
             content: list[str | ChatImage] = []
             if text:
@@ -87,7 +92,7 @@ class ChatMessage:
             if len(images) > 0:
                 content.extend(images)
 
-            return ChatMessage(role=role, content=content)
+            return ChatMessage(role=role, content=content, inference_id=inference_id)
 
     def copy(self):
         content = self.content
@@ -104,6 +109,7 @@ class ChatMessage:
             content=content,
             tool_calls=tool_calls,
             tool_call_id=self.tool_call_id,
+            inference_id=self.inference_id,
         )
         copied_msg._metadata = self._metadata
         return copied_msg
@@ -115,9 +121,18 @@ class ChatContext:
     _metadata: dict[str, Any] = field(default_factory=dict, repr=False, init=False)
 
     def append(
-        self, *, text: str = "", images: list[ChatImage] = [], role: ChatRole = "system"
+        self,
+        *,
+        text: str = "",
+        images: list[ChatImage] = [],
+        role: ChatRole = "system",
+        inference_id: str | None = None,
     ) -> ChatContext:
-        self.messages.append(ChatMessage.create(text=text, images=images, role=role))
+        self.messages.append(
+            ChatMessage.create(
+                text=text, images=images, role=role, inference_id=inference_id
+            )
+        )
         return self
 
     def copy(self) -> ChatContext:

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -38,6 +38,7 @@ class LLM(abc.ABC):
         temperature: float | None = None,
         n: int | None = None,
         parallel_tool_calls: bool | None = None,
+        inference_id: str | None = None,
     ) -> "LLMStream": ...
 
 

--- a/livekit-agents/livekit/agents/voice_assistant/speech_handle.py
+++ b/livekit-agents/livekit/agents/voice_assistant/speech_handle.py
@@ -42,6 +42,19 @@ class SpeechHandle:
         add_to_chat_ctx: bool,
         user_question: str,
     ) -> SpeechHandle:
+        """
+        Creates a SpeechHandle for an assistant message that is in response to something a human has said,
+        represented by `user_question` (though it may not be literally a question). Downstream callers should
+        use this instance's `id` as an inference identifier to connect LLM calls with chat messages.
+
+        Args:
+            allow_interruptions: Whether to allow interruptions during speech playback.
+            add_to_chat_ctx: Whether to add the speech to the chat context.
+            user_question: The user's utterance that led to this speech handle being created.
+
+        Returns:
+            SpeechHandle: The created instance.
+        """
         return SpeechHandle(
             id=utils.shortuuid(),
             allow_interruptions=allow_interruptions,
@@ -55,9 +68,24 @@ class SpeechHandle:
         *,
         allow_interruptions: bool,
         add_to_chat_ctx: bool,
+        inference_id: str | None = None,
     ) -> SpeechHandle:
+        """
+        Creates a SpeechHandle for an assistant message that is not in response to something the user says,
+        for example the opening message for an agent or an out-of-band interrupt. Because the LLM inference
+        happened before this instance was created
+
+        Args:
+            allow_interruptions: Whether to allow interruptions during speech playback.
+            add_to_chat_ctx: Whether to add the speech to the chat context.
+            inference_id: Optional ID provided by callers to connect speech chat message to inference requests.
+                          If not provided, a random ID will be generated.
+
+        Returns:
+            SpeechHandle: The created instance.
+        """
         return SpeechHandle(
-            id=utils.shortuuid(),
+            id=inference_id or utils.shortuuid(),
             allow_interruptions=allow_interruptions,
             add_to_chat_ctx=add_to_chat_ctx,
             is_reply=False,

--- a/livekit-agents/livekit/agents/voice_assistant/voice_assistant.py
+++ b/livekit-agents/livekit/agents/voice_assistant/voice_assistant.py
@@ -73,7 +73,7 @@ class AssistantCallContext:
 
 
 def _default_before_llm_cb(
-    assistant: VoiceAssistant, chat_ctx: ChatContext, inference_id: str
+    assistant: VoiceAssistant, chat_ctx: ChatContext, inference_id: Optional[str]
 ) -> LLMStream:
     return assistant.llm.chat(
         chat_ctx=chat_ctx,
@@ -551,7 +551,7 @@ class VoiceAssistant(utils.EventEmitter[EventTypes]):
             ChatMessage.create(text=handle.user_question, role="user")
         )
 
-        llm_stream = self._opts.before_llm_cb(self, copied_ctx, inference_id=handle.id)
+        llm_stream = self._opts.before_llm_cb(self, copied_ctx, handle.id)
         if llm_stream is False:
             return
 

--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
@@ -85,6 +85,7 @@ class LLM(llm.LLM):
         temperature: float | None = None,
         n: int | None = 1,
         parallel_tool_calls: bool | None = None,
+        inference_id: str | None = None,
     ) -> "LLMStream":
         if temperature is None:
             temperature = self._opts.temperature

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/beta/assistant_llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/beta/assistant_llm.py
@@ -167,6 +167,7 @@ class AssistantLLM(llm.LLM):
         temperature: float | None = None,
         n: int | None = None,
         parallel_tool_calls: bool | None = None,
+        inference_id: str | None = None,
     ):
         if n is not None:
             logger.warning("OpenAI Assistants does not support the 'n' parameter")

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -388,6 +388,7 @@ class LLM(llm.LLM):
         temperature: float | None = None,
         n: int | None = 1,
         parallel_tool_calls: bool | None = None,
+        inference_id: str | None = None,
     ) -> "LLMStream":
         opts: dict[str, Any] = dict()
         if fnc_ctx and len(fnc_ctx.ai_functions) > 0:


### PR DESCRIPTION
This PR reuses the `SpeechHandle` ID to serve as an _inference ID_, enabling LLM invocations to be joined against text in the chat log. This allows consumers to commit side effects only once audio is actually played back to the user (vs. being ignored due to interruption, etc).

The approach here is intended to be minimal & backwards compatible. `ChatMessage` now has an `id` which is set from `SpeechHandle` where possible. In the case where it cannot (`.say(...)` calls, which are invoked before a SpeechHandle is created), we allow callers to supply their own inference ID, if they want.

At LLM invocation time we pass the inference ID through the LLM callback and into the LLM interface itself. (Note: I would love a confirmation that _this_ part of the PR is backwards compatible! Seemed higher risk than the rest).