### PR TITLE
limit noisy logs & keep the root logger info

### DIFF
--- a/livekit-agents/livekit/agents/cli/log.py
+++ b/livekit-agents/livekit/agents/cli/log.py
@@ -17,6 +17,7 @@ NOISY_LOGGERS = [
     "httpcore",
     "openai",
     "livekit",
+    "watchfiles",
 ]
 
 # skip default LogRecord attributes
@@ -205,9 +206,7 @@ def setup_logging(log_level: str, devmode: bool) -> None:
 
     root = logging.getLogger()
     root.addHandler(handler)
-
-    if root.level == logging.NOTSET:
-        root.setLevel(log_level)
+    root.setLevel(log_level)
 
     for noisy_logger in NOISY_LOGGERS:
         logger = logging.getLogger(noisy_logger)

--- a/livekit-agents/livekit/agents/cli/log.py
+++ b/livekit-agents/livekit/agents/cli/log.py
@@ -11,6 +11,14 @@ from typing import Any, Dict, Tuple
 
 from ..plugin import Plugin
 
+# noisy loggers are set to warn by default
+NOISY_LOGGERS = [
+    "httpx",
+    "httpcore",
+    "openai",
+    "livekit",
+]
+
 # skip default LogRecord attributes
 # http://docs.python.org/library/logging.html#logrecord-attributes
 _RESERVED_ATTRS: Tuple[str, ...] = (
@@ -92,6 +100,7 @@ class JsonFormatter(logging.Formatter):
         """Formats a log record and serializes to json"""
         message_dict: Dict[str, Any] = {}
         message_dict["level"] = record.levelname
+        message_dict["name"] = record.name
 
         if isinstance(record.msg, dict):
             message_dict = record.msg
@@ -198,7 +207,12 @@ def setup_logging(log_level: str, devmode: bool) -> None:
     root.addHandler(handler)
 
     if root.level == logging.NOTSET:
-        root.setLevel(logging.WARN)
+        root.setLevel(log_level)
+
+    for noisy_logger in NOISY_LOGGERS:
+        logger = logging.getLogger(noisy_logger)
+        if logger.level == logging.NOTSET:
+            logger.setLevel(logging.WARN)
 
     from ..log import logger
 


### PR DESCRIPTION
the root logger was in warning mode to avoid noisy logs.

we know keep a list of noisy loggers instead and put them to warn if the user didn't specify any level yet