### PR TITLE
Fix the problem of infinite loop when agent speech is interrupted

### DIFF
--- a/.changeset/moody-doors-poke.md
+++ b/.changeset/moody-doors-poke.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+fix VoiceAssisstant being stuck when interrupting before user speech is committed

--- a/livekit-agents/livekit/agents/voice_assistant/voice_assistant.py
+++ b/livekit-agents/livekit/agents/voice_assistant/voice_assistant.py
@@ -642,7 +642,6 @@ class VoiceAssistant(utils.EventEmitter[EventTypes]):
             _commit_user_question_if_needed()
             
             if speech_handle.interrupted:
-                logger.warning(f"speech interrupted, quit loop")
                 break
 
         _commit_user_question_if_needed()

--- a/livekit-agents/livekit/agents/voice_assistant/voice_assistant.py
+++ b/livekit-agents/livekit/agents/voice_assistant/voice_assistant.py
@@ -640,6 +640,10 @@ class VoiceAssistant(utils.EventEmitter[EventTypes]):
             )
 
             _commit_user_question_if_needed()
+            
+            if speech_handle.interrupted:
+                logger.warning(f"speech interrupted, quit loop")
+                break
 
         _commit_user_question_if_needed()
 


### PR DESCRIPTION
When playing the Agent's speech, if the user interrupts, the while loop here will become an infinite loop and needs to be exited when interrupted.