### PR TITLE
add(plugin/deepgram): accepts parameter profanity_filter

### DIFF
--- a/.changeset/popular-needles-kiss.md
+++ b/.changeset/popular-needles-kiss.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-deepgram": patch
+---
+
+accepts parameter profanity_filter

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -140,6 +140,7 @@ class STT(stt.STT):
             "detect_language": config.detect_language,
             "smart_format": config.smart_format,
             "keywords": self._opts.keywords,
+            "profanity_filter": config.profanity_filter,
         }
         if config.language:
             recognize_config["language"] = config.language

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -50,6 +50,7 @@ class STTOptions:
     sample_rate: int
     num_channels: int
     keywords: list[Tuple[str, float]]
+    profanity_filter: bool
 
 
 class STT(stt.STT):
@@ -66,6 +67,7 @@ class STT(stt.STT):
         endpointing_ms: int = 25,
         filler_words: bool = False,
         keywords: list[Tuple[str, float]] = [],
+        profanity_filter: bool = False,
         api_key: str | None = None,
         http_session: aiohttp.ClientSession | None = None,
     ) -> None:
@@ -117,6 +119,7 @@ class STT(stt.STT):
             sample_rate=48000,
             num_channels=1,
             keywords=keywords,
+            profanity_filter=profanity_filter,
         )
         self._session = http_session
 
@@ -231,6 +234,7 @@ class SpeechStream(stt.SpeechStream):
                     else self._opts.endpointing_ms,
                     "filler_words": self._opts.filler_words,
                     "keywords": self._opts.keywords,
+                    "profanity_filter": self._opts.profanity_filter,
                 }
 
                 if self._opts.language:


### PR DESCRIPTION
Deepgram supports `profanity_filter` which recognizes profanity and converts it to the nearest recognized non-profane word or removes it from the transcript completely.
https://developers.deepgram.com/docs/profanity-filter

Adds support for this option in `STTOptions` and forwards the option in the live_config