### PR TITLE
Fix tool call output type error

### DIFF
--- a/.changeset/fresh-mayflies-shout.md
+++ b/.changeset/fresh-mayflies-shout.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-openai": patch
+---
+
+oai-realtime: fix function calls

--- a/examples/multimodal_agent.py
+++ b/examples/multimodal_agent.py
@@ -58,6 +58,7 @@ async def entrypoint(ctx: JobContext):
                 threshold=0.6, prefix_padding_ms=200, silence_duration_ms=500
             ),
         )
+        fnc_ctx=fnc_ctx,
     )
     assistant.start(ctx.room)
 


### PR DESCRIPTION
Solves #827.

In `realtime_model.py`, tool call outputs (`message_content`) are not strings by the time they reach the assertion `assert isinstance(message_content, str)`. 

This PR handles tool calls before other message types, which depend on `message_content` being a list. You can also just replace `message_content` with `message.content`, and keep the original order— both fixes work.

Tested according to the [minimal Multimodel Agent + Function calling example here](https://docs.livekit.io/agents/voice-agent/function-calling/).

Also: extraordinary work, Livekit team! Thank you for everything you do. ❤️ and ofc no need to solve it this way / merge if there's another fix you're working on.