### PR TITLE
Make sure there is some queued duration before waiting for audio playout

### DIFF
--- a/.changeset/cold-kings-accept.md
+++ b/.changeset/cold-kings-accept.md
@@ -1,5 +1,5 @@
 ---
-"livekit-agents": minor
+"livekit-agents": patch
 ---
 
 Fix bug where empty audio would cause agent to get stuck.

--- a/.changeset/cold-kings-accept.md
+++ b/.changeset/cold-kings-accept.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": minor
+---
+
+Fix bug where empty audio would cause agent to get stuck.

--- a/livekit-agents/livekit/agents/pipeline/agent_playout.py
+++ b/livekit-agents/livekit/agents/pipeline/agent_playout.py
@@ -147,7 +147,8 @@ class AgentPlayout(utils.EventEmitter[EventTypes]):
                 handle._pushed_duration += frame.samples_per_channel / frame.sample_rate
                 await self._audio_source.capture_frame(frame)
 
-            await self._audio_source.wait_for_playout()
+            if self._audio_source.queued_duration > 0:
+                await self._audio_source.wait_for_playout()
 
         capture_task = asyncio.create_task(_capture_task())
         try:

--- a/livekit-agents/package.json
+++ b/livekit-agents/package.json
@@ -1,5 +1,5 @@
 {
   "name": "livekit-agents",
   "private": true,
-  "version": "0.10.0"
+  "version": "0.10.1"
 }

--- a/livekit-agents/package.json
+++ b/livekit-agents/package.json
@@ -1,5 +1,5 @@
 {
   "name": "livekit-agents",
   "private": true,
-  "version": "0.10.1"
+  "version": "0.10.0"
 }


### PR DESCRIPTION
I believe this fixes https://github.com/livekit/agents/issues/825

The problem seems to be we get occasional empty audio frames which causes freezes.