### PR TITLE
Fix grammar and clarify migration guide instructions in 0.8-migration…

### DIFF
--- a/0.8-migration-guide.md
+++ b/0.8-migration-guide.md
@@ -1,6 +1,6 @@
 # Migrating to 0.8.x
 
-v0.8 is a major release of the framework, featuring significant reliability improvements to VoiceAssistant. This update includes a few breaking API changes that will impact the way you build your agents. We strive to minimize breaking changes and will stabilize the API as we approach version 1.0.
+v0.8 is a major release of the framework, featuring significant reliability improvements to VoiceAssistant. This update includes a few breaking API changes that will impact the way you build your agents. We strive to minimize breaking changes, and will stabilize the API as we approach version 1.0.
 
 ## Job and Worker API
 
@@ -8,9 +8,9 @@ v0.8 is a major release of the framework, featuring significant reliability impr
 
 `entrypoint_fnc` is now a parameter in WorkerOptions. Previously, you were required to explicitly accept the job.
 
-### Namespace had been removed
+### Namespace has been removed
 
-We've removed the namespace option in order to simplify the registration process. In future versions, it'll be possible to provide an explicit `agent_name` to spin up multiple kinds of agents for each room.
+We've removed the namespace option in order to simplify the registration process. In future versions, it'll be possible to provide an explicit `agent_name` to launch multiple kinds of agents for each room.
 
 ### Connecting to room is explicit
 
@@ -125,7 +125,7 @@ await stt_stream.aclose()
 
 ### SynthesizedAudio changed and SynthesisEvent removed
 
-SynthesizedAudio dataclass had gone through a major change
+SynthesizedAudio dataclass has gone through a major change
 
 ```python
 # New SynthesizedAudio dataclass
@@ -155,7 +155,7 @@ Similar to the STT changes, this coaxes the TTS provider into generating a respo
 
 ### SynthesizeStream.end_input
 
-Similar to the STT changes, this replaces aclose(wait=True).
+Similar to the STT changes, aclose(wait=True) has been replaced.
 
 ### SynthesizeStream.aclose
 


### PR DESCRIPTION
Corrected grammatical errors such as subject-verb agreement and article usage.