### PR TITLE
Add wait_for_participant to mma example

### DIFF
--- a/examples/multimodal_agent.py
+++ b/examples/multimodal_agent.py
@@ -49,6 +49,10 @@ async def entrypoint(ctx: JobContext):
 
     await ctx.connect(auto_subscribe=AutoSubscribe.AUDIO_ONLY)
 
+    print("waiting for participant")
+    await ctx.wait_for_participant()
+    
+    print("participant joined, starting agent")
     assistant = multimodal.MultimodalAgent(
         model=openai.realtime.RealtimeModel(
             voice="alloy",

--- a/examples/multimodal_agent.py
+++ b/examples/multimodal_agent.py
@@ -51,7 +51,7 @@ async def entrypoint(ctx: JobContext):
 
     print("waiting for participant")
     await ctx.wait_for_participant()
-    
+
     print("participant joined, starting agent")
     assistant = multimodal.MultimodalAgent(
         model=openai.realtime.RealtimeModel(


### PR DESCRIPTION
This was already in other VPA examples but missing here. It's not always necessary but improves reliability (e.g. SIP) and seems worth having in the default case.