### PR TITLE
Make VAD optional for voice agents that use streaming STT

### DIFF
--- a/.changeset/large-impalas-serve.md
+++ b/.changeset/large-impalas-serve.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Make VAD optional for agents that use streaming STT

--- a/livekit-agents/livekit/agents/pipeline/human_input.py
+++ b/livekit-agents/livekit/agents/pipeline/human_input.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from enum import Enum
 from typing import Literal
 
 from livekit import rtc
@@ -19,17 +20,26 @@ EventTypes = Literal[
 ]
 
 
+class SpeechDetectionMode(str, Enum):
+    VAD = "vad"
+    STT = "stt"
+
+
 class HumanInput(utils.EventEmitter[EventTypes]):
     def __init__(
         self,
         *,
         room: rtc.Room,
-        vad: voice_activity_detection.VAD,
+        vad: voice_activity_detection.VAD | None,
         stt: speech_to_text.STT,
         participant: rtc.RemoteParticipant,
         transcription: bool,
+        speech_detection_mode: SpeechDetectionMode = SpeechDetectionMode.VAD,
     ) -> None:
         super().__init__()
+        if speech_detection_mode == SpeechDetectionMode.VAD and vad is None:
+            raise ValueError("VAD is required for SpeechDetectionMode.VAD")
+
         self._room, self._vad, self._stt, self._participant, self._transcription = (
             room,
             vad,
@@ -41,8 +51,10 @@ class HumanInput(utils.EventEmitter[EventTypes]):
         self._recognize_atask: asyncio.Task[None] | None = None
 
         self._closed = False
-        self._speaking = False
+        self._vad_speaking = False
+        self._stt_speaking = False
         self._speech_probability = 0.0
+        self._speech_detection_mode = speech_detection_mode
 
         self._room.on("track_published", self._subscribe_to_microphone)
         self._room.on("track_subscribed", self._subscribe_to_microphone)
@@ -62,7 +74,14 @@ class HumanInput(utils.EventEmitter[EventTypes]):
 
     @property
     def speaking(self) -> bool:
-        return self._speaking
+        if self._speech_detection_mode == SpeechDetectionMode.VAD:
+            return self._vad_speaking
+        elif self._speech_detection_mode == SpeechDetectionMode.STT:
+            return self._stt_speaking
+        else:
+            raise ValueError(
+                f"Invalid speech detection mode: {self._speech_detection_mode}"
+            )
 
     @property
     def speaking_probability(self) -> float:
@@ -98,7 +117,11 @@ class HumanInput(utils.EventEmitter[EventTypes]):
         """
         Receive the frames from the user audio stream and detect voice activity.
         """
-        vad_stream = self._vad.stream()
+        if self._speech_detection_mode == SpeechDetectionMode.VAD:
+            vad_stream = self._vad.stream()
+        else:
+            vad_stream = None
+
         stt_stream = self._stt.stream()
 
         def _before_forward(
@@ -120,18 +143,23 @@ class HumanInput(utils.EventEmitter[EventTypes]):
             # forward the audio stream to the VAD and STT streams
             async for ev in audio_stream:
                 stt_stream.push_frame(ev.frame)
-                vad_stream.push_frame(ev.frame)
+
+                if vad_stream is not None:
+                    vad_stream.push_frame(ev.frame)
 
         async def _vad_stream_co() -> None:
+            if vad_stream is None:
+                return
+
             async for ev in vad_stream:
                 if ev.type == voice_activity_detection.VADEventType.START_OF_SPEECH:
-                    self._speaking = True
+                    self._vad_speaking = True
                     self.emit("start_of_speech", ev)
                 elif ev.type == voice_activity_detection.VADEventType.INFERENCE_DONE:
                     self._speech_probability = ev.probability
                     self.emit("vad_inference_done", ev)
                 elif ev.type == voice_activity_detection.VADEventType.END_OF_SPEECH:
-                    self._speaking = False
+                    self._vad_speaking = False
                     self.emit("end_of_speech", ev)
 
         async def _stt_stream_co() -> None:
@@ -139,8 +167,10 @@ class HumanInput(utils.EventEmitter[EventTypes]):
                 stt_forwarder.update(ev)
 
                 if ev.type == speech_to_text.SpeechEventType.FINAL_TRANSCRIPT:
+                    self._stt_speaking = False
                     self.emit("final_transcript", ev)
                 elif ev.type == speech_to_text.SpeechEventType.INTERIM_TRANSCRIPT:
+                    self._stt_speaking = True
                     self.emit("interim_transcript", ev)
 
         tasks = [
@@ -155,4 +185,5 @@ class HumanInput(utils.EventEmitter[EventTypes]):
 
             await stt_forwarder.aclose()
             await stt_stream.aclose()
-            await vad_stream.aclose()
+            if vad_stream is not None:
+                await vad_stream.aclose()


### PR DESCRIPTION
For agents using streaming STT, the VAD isn't strictly necessary. In particular this reduces CPU usage quite a bit.