### PR TITLE
fix: fix speech_buffer missing data in VADStream

### DIFF
--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py
@@ -273,7 +273,7 @@ class VADStream(agents.vad.VADStream):
 
                 # copy the inference window to the speech buffer
                 available_space = len(speech_buffer) - speech_buffer_index
-                to_copy_buffer = min(self._model.window_size_samples, available_space)
+                to_copy_buffer = min(len(input_frame.data), available_space)
                 if to_copy_buffer > 0:
                     speech_buffer[
                         speech_buffer_index : speech_buffer_index + to_copy_buffer


### PR DESCRIPTION
Originally `speech_buffer` got only a subset of the audio data for each audio frame from mic bc of
```python
to_copy_buffer = min(self._model.window_size_samples, available_space)
```

This makes the subsequent non-stream STT doesn't work (e.g. openai.STT). Fix it by copying all data to the buffer.