### PR TITLE
warning incorrect threshold config

### DIFF
--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -234,6 +234,7 @@ def _run_dev(
 
 def run_worker(args: proto.CliArgs) -> None:
     setup_logging(args.log_level, args.devmode)
+    args.validate_config()
 
     loop = asyncio.get_event_loop()
     worker = Worker(args.opts, devmode=args.devmode, loop=loop)

--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -234,7 +234,7 @@ def _run_dev(
 
 def run_worker(args: proto.CliArgs) -> None:
     setup_logging(args.log_level, args.devmode)
-    args.validate_config()
+    args.opts.validate_config(args.devmode)
 
     loop = asyncio.get_event_loop()
     worker = Worker(args.opts, devmode=args.devmode, loop=loop)

--- a/livekit-agents/livekit/agents/cli/proto.py
+++ b/livekit-agents/livekit/agents/cli/proto.py
@@ -30,6 +30,9 @@ class CliArgs:
     # when reload/dev mode is enabled
     mp_cch: socket.socket | None = None
 
+    def validate_config(self):
+        self.opts.validate_config(self.devmode)
+
 
 @dataclass
 class ActiveJobsRequest:

--- a/livekit-agents/livekit/agents/cli/proto.py
+++ b/livekit-agents/livekit/agents/cli/proto.py
@@ -30,9 +30,6 @@ class CliArgs:
     # when reload/dev mode is enabled
     mp_cch: socket.socket | None = None
 
-    def validate_config(self):
-        self.opts.validate_config(self.devmode)
-
 
 @dataclass
 class ActiveJobsRequest:

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -186,12 +186,11 @@ class WorkerOptions:
     """
 
     def validate_config(self, devmode: bool):
-        if not devmode:
-            load_threshold = _WorkerEnvOption.getvalue(self.load_threshold, False)
-            if load_threshold > 1:
-                logger.warning(
-                    f"load_threshold in prod env must be less than 1, current value: {load_threshold}"
-                )
+        load_threshold = _WorkerEnvOption.getvalue(self.load_threshold, devmode)
+        if load_threshold > 1 and not devmode:
+            logger.warning(
+                f"load_threshold in prod env must be less than 1, current value: {load_threshold}"
+            )
 
 
 EventTypes = Literal["worker_registered"]

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -185,6 +185,14 @@ class WorkerOptions:
     The HTTP server is used as a health check endpoint.
     """
 
+    def validate_config(self, devmode: bool):
+        if not devmode:
+            load_threshold = _WorkerEnvOption.getvalue(self.load_threshold, False)
+            if load_threshold > 1:
+                logger.warning(
+                    f"load_threshold in prod env must be less than 1, current value: {load_threshold}"
+                )
+
 
 EventTypes = Literal["worker_registered"]
 


### PR DESCRIPTION
Give a warning when config for load threshold is invalid.
```
{"message": "load_threshold in prod env must be less than 1, current value: 2", "level": "WARNING", "name": "livekit.agents", "timestamp": "2024-10-12T08:20:02.168613+00:00"}
```
This pr is for issue https://github.com/livekit/agents/issues/884