### PR TITLE
Fix bug with before_tts_cb when speech is string but before_tts_cb returns async iterable

### DIFF
--- a/.changeset/heavy-donkeys-check.md
+++ b/.changeset/heavy-donkeys-check.md
@@ -2,4 +2,4 @@
 "livekit-agents": patch
 ---
 
-Fix bug in before_tts_cb where AsyncIterable[str] was not being handled correctly.
+Fix bug where if the tts_source was a string but before_tts_cb returned AsyncIterable[str], the transcript would not be synthesized.

--- a/.changeset/heavy-donkeys-check.md
+++ b/.changeset/heavy-donkeys-check.md
@@ -2,4 +2,4 @@
 "livekit-agents": patch
 ---
 
-Allow async methods to be passed as before_tts_cb
+Fix bug in before_tts_cb where AsyncIterable[str] was not being handled correctly.

--- a/.changeset/heavy-donkeys-check.md
+++ b/.changeset/heavy-donkeys-check.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Allow async methods to be passed as before_tts_cb

--- a/livekit-agents/livekit/agents/pipeline/agent_output.py
+++ b/livekit-agents/livekit/agents/pipeline/agent_output.py
@@ -276,7 +276,6 @@ async def _stream_synthesis_task(
 
     tts_stream = handle._tts.stream()
     read_tts_atask: asyncio.Task | None = None
-
     read_transcript_atask: asyncio.Task | None = None
 
     try:

--- a/livekit-agents/livekit/agents/pipeline/agent_output.py
+++ b/livekit-agents/livekit/agents/pipeline/agent_output.py
@@ -189,6 +189,7 @@ class AgentOutput:
             await utils.aio.gracefully_cancel(synth)
 
 
+@utils.log_exceptions(logger=logger)
 async def _str_synthesis_task(
     tts_text: str, transcript: str, handle: SynthesisHandle
 ) -> None:

--- a/livekit-agents/livekit/agents/pipeline/agent_output.py
+++ b/livekit-agents/livekit/agents/pipeline/agent_output.py
@@ -172,14 +172,6 @@ class AgentOutput:
             tts_source = await tts_source
         if isinstance(transcript_source, Awaitable):
             transcript_source = await transcript_source
-        if not self._tts.capabilities.streaming:
-            logger.debug(
-                "forcing tts source to be a string since TTS does not streaming"
-            )
-            if isinstance(tts_source, AsyncIterable):
-                tts_source = "".join([seg async for seg in tts_source])
-            if isinstance(transcript_source, AsyncIterable):
-                transcript_source = "".join([seg async for seg in transcript_source])
 
         if isinstance(tts_source, str) and isinstance(transcript_source, str):
             co = _str_synthesis_task(tts_source, transcript_source, handle)

--- a/livekit-agents/livekit/agents/pipeline/agent_output.py
+++ b/livekit-agents/livekit/agents/pipeline/agent_output.py
@@ -12,7 +12,7 @@ from .. import tts as text_to_speech
 from .agent_playout import AgentPlayout, PlayoutHandle
 from .log import logger
 
-AgentSpeech = AsyncIterable[str] | str
+AgentSpeech = Union[AsyncIterable[str], str]
 SpeechSource = Union[Awaitable[AgentSpeech], AgentSpeech]
 
 

--- a/livekit-agents/livekit/agents/pipeline/agent_output.py
+++ b/livekit-agents/livekit/agents/pipeline/agent_output.py
@@ -172,9 +172,18 @@ class AgentOutput:
             tts_source = await tts_source
         if isinstance(transcript_source, Awaitable):
             transcript_source = await transcript_source
+        if not self._tts.capabilities.streaming:
+            logger.debug("forcing tts source to be a string since TTS is not streaming")
+            if isinstance(tts_source, AsyncIterable):
+                # force the tts source to be a string
+                tts_source = await asyncio.to_thread("".join, tts_source)
+            if isinstance(transcript_source, AsyncIterable):
+                # force the transcript source to be a string
+                transcript_source = await asyncio.to_thread("".join, transcript_source)
 
         if isinstance(tts_source, str) and isinstance(transcript_source, str):
             co = _str_synthesis_task(tts_source, transcript_source, handle)
+
         else:
             co = _stream_synthesis_task(tts_source, transcript_source, handle)
 

--- a/livekit-agents/livekit/agents/pipeline/agent_output.py
+++ b/livekit-agents/livekit/agents/pipeline/agent_output.py
@@ -243,7 +243,7 @@ async def _str_synthesis_task(
 @utils.log_exceptions(logger=logger)
 async def _stream_synthesis_task(
     tts_source: AsyncIterable[str],
-    transcript_source: str | AsyncIterable[str],
+    transcript_source: AgentSpeech,
     handle: SynthesisHandle,
 ) -> None:
     """synthesize speech from streamed text"""

--- a/livekit-agents/livekit/agents/pipeline/agent_output.py
+++ b/livekit-agents/livekit/agents/pipeline/agent_output.py
@@ -178,10 +178,10 @@ class AgentOutput:
             )
             if isinstance(tts_source, AsyncIterable):
                 # force the tts source to be a string
-                tts_source = await asyncio.to_thread("".join, tts_source)
+                tts_source = "".join([seg async for seg in tts_source])
             if isinstance(transcript_source, AsyncIterable):
                 # force the transcript source to be a string
-                transcript_source = await asyncio.to_thread("".join, transcript_source)
+                transcript_source = "".join([seg async for seg in transcript_source])
 
         if isinstance(tts_source, str) and isinstance(transcript_source, str):
             co = _str_synthesis_task(tts_source, transcript_source, handle)

--- a/livekit-agents/livekit/agents/pipeline/agent_output.py
+++ b/livekit-agents/livekit/agents/pipeline/agent_output.py
@@ -185,6 +185,10 @@ class AgentOutput:
             await utils.aio.gracefully_cancel(synth)
 
 
+async def _str_to_aiter(s: str) -> AsyncIterable[str]:
+    yield s
+
+
 @utils.log_exceptions(logger=logger)
 async def _stream_synthesis_task(
     tts_source: AsyncIterable[str] | str,
@@ -193,9 +197,9 @@ async def _stream_synthesis_task(
 ) -> None:
     """synthesize speech from streamed text"""
     if isinstance(tts_source, str):
-        tts_source = iter([tts_source])
+        tts_source = _str_to_aiter(tts_source)
     if isinstance(transcript_source, str):
-        transcript_source = iter([transcript_source])
+        transcript_source = _str_to_aiter(transcript_source)
 
     @utils.log_exceptions(logger=logger)
     async def _read_generated_audio_task():

--- a/livekit-agents/livekit/agents/pipeline/agent_output.py
+++ b/livekit-agents/livekit/agents/pipeline/agent_output.py
@@ -173,7 +173,9 @@ class AgentOutput:
         if isinstance(transcript_source, Awaitable):
             transcript_source = await transcript_source
         if not self._tts.capabilities.streaming:
-            logger.debug("forcing tts source to be a string since TTS is not streaming")
+            logger.debug(
+                "forcing tts source to be a string since TTS does not streaming"
+            )
             if isinstance(tts_source, AsyncIterable):
                 # force the tts source to be a string
                 tts_source = await asyncio.to_thread("".join, tts_source)

--- a/livekit-agents/livekit/agents/pipeline/agent_output.py
+++ b/livekit-agents/livekit/agents/pipeline/agent_output.py
@@ -177,10 +177,8 @@ class AgentOutput:
                 "forcing tts source to be a string since TTS does not streaming"
             )
             if isinstance(tts_source, AsyncIterable):
-                # force the tts source to be a string
                 tts_source = "".join([seg async for seg in tts_source])
             if isinstance(transcript_source, AsyncIterable):
-                # force the transcript source to be a string
                 transcript_source = "".join([seg async for seg in transcript_source])
 
         if isinstance(tts_source, str) and isinstance(transcript_source, str):

--- a/livekit-agents/livekit/agents/pipeline/agent_output.py
+++ b/livekit-agents/livekit/agents/pipeline/agent_output.py
@@ -12,8 +12,7 @@ from .. import tts as text_to_speech
 from .agent_playout import AgentPlayout, PlayoutHandle
 from .log import logger
 
-AgentSpeech = Union[AsyncIterable[str], str]
-SpeechSource = Union[Awaitable[AgentSpeech], AgentSpeech]
+SpeechSource = Union[str, Awaitable[str], AsyncIterable[str]]
 
 
 class SynthesisHandle:
@@ -243,7 +242,7 @@ async def _str_synthesis_task(
 @utils.log_exceptions(logger=logger)
 async def _stream_synthesis_task(
     tts_source: AsyncIterable[str],
-    transcript_source: AgentSpeech,
+    transcript_source: str | AsyncIterable[str],
     handle: SynthesisHandle,
 ) -> None:
     """synthesize speech from streamed text"""

--- a/livekit-agents/livekit/agents/pipeline/agent_output.py
+++ b/livekit-agents/livekit/agents/pipeline/agent_output.py
@@ -12,7 +12,8 @@ from .. import tts as text_to_speech
 from .agent_playout import AgentPlayout, PlayoutHandle
 from .log import logger
 
-SpeechSource = Union[AsyncIterable[str], str, Awaitable[str]]
+AgentSpeech = AsyncIterable[str] | str
+SpeechSource = Union[Awaitable[AgentSpeech], AgentSpeech]
 
 
 class SynthesisHandle:
@@ -170,8 +171,11 @@ class AgentOutput:
 
         if isinstance(tts_source, Awaitable):
             tts_source = await tts_source
-            co = _str_synthesis_task(tts_source, transcript_source, handle)
-        elif isinstance(tts_source, str):
+        if isinstance(transcript_source, Awaitable):
+            transcript_source = await transcript_source
+
+        if isinstance(tts_source, str):
+            assert isinstance(transcript_source, str)
             co = _str_synthesis_task(tts_source, transcript_source, handle)
         else:
             co = _stream_synthesis_task(tts_source, transcript_source, handle)
@@ -186,15 +190,29 @@ class AgentOutput:
             await utils.aio.gracefully_cancel(synth)
 
 
+def _push_transcript(handle: SynthesisHandle, transcript: str) -> None:
+    if not handle.tts_forwarder.closed:
+        handle.tts_forwarder.push_text(transcript)
+        handle.tts_forwarder.mark_text_segment_end()
+
+
+async def _read_transcript_task(
+    transcript_source: AsyncIterable[str], handle: SynthesisHandle
+) -> None:
+    async for seg in transcript_source:
+        if not handle._tr_fwd.closed:
+            handle._tr_fwd.push_text(seg)
+
+    if not handle.tts_forwarder.closed:
+        handle.tts_forwarder.mark_text_segment_end()
+
+
 @utils.log_exceptions(logger=logger)
 async def _str_synthesis_task(
     tts_text: str, transcript: str, handle: SynthesisHandle
 ) -> None:
     """synthesize speech from a string"""
-    if not handle.tts_forwarder.closed:
-        handle.tts_forwarder.push_text(transcript)
-        handle.tts_forwarder.mark_text_segment_end()
-
+    _push_transcript(handle, transcript)
     start_time = time.time()
     first_frame = True
 
@@ -225,7 +243,7 @@ async def _str_synthesis_task(
 @utils.log_exceptions(logger=logger)
 async def _stream_synthesis_task(
     tts_source: AsyncIterable[str],
-    transcript_source: AsyncIterable[str],
+    transcript_source: str | AsyncIterable[str],
     handle: SynthesisHandle,
 ) -> None:
     """synthesize speech from streamed text"""
@@ -254,15 +272,6 @@ async def _stream_synthesis_task(
         if handle._tr_fwd and not handle._tr_fwd.closed:
             handle._tr_fwd.mark_audio_segment_end()
 
-    @utils.log_exceptions(logger=logger)
-    async def _read_transcript_task():
-        async for seg in transcript_source:
-            if not handle._tr_fwd.closed:
-                handle._tr_fwd.push_text(seg)
-
-        if not handle.tts_forwarder.closed:
-            handle.tts_forwarder.mark_text_segment_end()
-
     # otherwise, stream the text to the TTS
     tts_stream = handle._tts.stream()
     read_tts_atask: asyncio.Task | None = None
@@ -273,20 +282,28 @@ async def _stream_synthesis_task(
             if read_tts_atask is None:
                 # start the task when we receive the first text segment (so start_time is more accurate)
                 read_tts_atask = asyncio.create_task(_read_generated_audio_task())
-                read_transcript_atask = asyncio.create_task(_read_transcript_task())
+                if isinstance(transcript_source, str):
+                    _push_transcript(handle, transcript_source)
+                    read_transcript_atask = None
+                else:
+                    read_transcript_atask = asyncio.create_task(
+                        _read_transcript_task(transcript_source, handle)
+                    )
 
             tts_stream.push_text(seg)
 
         tts_stream.end_input()
 
         if read_tts_atask is not None:
-            assert read_transcript_atask is not None
             await read_tts_atask
+        if read_transcript_atask is not None:
             await read_transcript_atask
 
     finally:
         if read_tts_atask is not None:
-            assert read_transcript_atask is not None
-            await utils.aio.gracefully_cancel(read_tts_atask, read_transcript_atask)
+            if read_transcript_atask is not None:
+                await utils.aio.gracefully_cancel(read_tts_atask, read_transcript_atask)
+            else:
+                await utils.aio.gracefully_cancel(read_tts_atask)
 
         await tts_stream.aclose()

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -12,7 +12,7 @@ from .. import stt, tokenize, tts, utils, vad
 from .._constants import ATTRIBUTE_AGENT_STATE
 from .._types import AgentState
 from ..llm import LLM, ChatContext, ChatMessage, FunctionContext, LLMStream
-from .agent_output import AgentOutput, SynthesisHandle
+from .agent_output import AgentOutput, SpeechSource, SynthesisHandle
 from .agent_playout import AgentPlayout
 from .human_input import HumanInput
 from .log import logger
@@ -28,7 +28,7 @@ WillSynthesizeAssistantReply = BeforeLLMCallback
 
 BeforeTTSCallback = Callable[
     ["VoicePipelineAgent", Union[str, AsyncIterable[str]]],
-    Union[str, AsyncIterable[str], Awaitable[str]],
+    SpeechSource,
 ]
 
 

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -784,7 +784,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
 
         tts_source = self._opts.before_tts_cb(self, og_source)
         if tts_source is None:
-            logger.error("before_tts_cb must return str or AsyncIterable[str]")
+            raise ValueError("before_tts_cb must return str or AsyncIterable[str]")
 
         return self._agent_output.synthesize(
             speech_id=speech_id,


### PR DESCRIPTION
If you said agent.say(), but your before_tts_cb returned an AsyncIterable, it'd throw - because the transcript was a string but the before_tts_cb was AsyncIterable.