### PR TITLE
Azure TTS Prosody SSML support

### DIFF
--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
@@ -24,6 +24,7 @@ AZURE_SAMPLE_RATE: int = 16000
 AZURE_BITS_PER_SAMPLE: int = 16
 AZURE_NUM_CHANNELS: int = 1
 
+
 @dataclass
 class ProsodyConfig:
     """

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
@@ -43,22 +43,26 @@ class ProsodyConfig:
     pitch: Literal["x-low", "low", "medium", "high", "x-high"] | None = None
 
     def validate(self) -> None:
-        if isinstance(self.rate, float) and not 0.5 <= self.rate <= 2:
-            raise ValueError("Prosody rate must be between 0.5 and 2")
-        if isinstance(self.volume, float) and not 0 <= self.volume <= 100:
-            raise ValueError("Prosody volume must be between 0 and 100")
-        if self.pitch not in ["x-low", "low", "medium", "high", "x-high"]:
-            raise ValueError(
-                "Prosody pitch must be one of 'x-low', 'low', 'medium', 'high', 'x-high'"
-            )
-        if self.rate not in ["x-slow", "slow", "medium", "fast", "x-fast"]:
-            raise ValueError(
-                "Prosody rate must be one of 'x-slow', 'slow', 'medium', 'fast', 'x-fast'"
-            )
+        if self.rate:
+            if isinstance(self.rate, float) and not 0.5 <= self.rate <= 2:
+                raise ValueError("Prosody rate must be between 0.5 and 2")
+            if self.rate not in ["x-slow", "slow", "medium", "fast", "x-fast"]:
+                raise ValueError(
+                    "Prosody rate must be one of 'x-slow', 'slow', 'medium', 'fast', 'x-fast'"
+                )
+        if self.volume:
+            if isinstance(self.volume, float) and not 0 <= self.volume <= 100:
+                raise ValueError("Prosody volume must be between 0 and 100")
         if self.volume not in ["silent", "x-soft", "soft", "medium", "loud", "x-loud"]:
             raise ValueError(
                 "Prosody volume must be one of 'silent', 'x-soft', 'soft', 'medium', 'loud', 'x-loud'"
             )
+
+        if self.pitch:
+            if self.pitch not in ["x-low", "low", "medium", "high", "x-high"]:
+                raise ValueError(
+                    "Prosody pitch must be one of 'x-low', 'low', 'medium', 'high', 'x-high'"
+                )
 
     def __post_init__(self):
         self.validate()

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
@@ -53,16 +53,22 @@ class ProsodyConfig:
         if self.volume:
             if isinstance(self.volume, float) and not 0 <= self.volume <= 100:
                 raise ValueError("Prosody volume must be between 0 and 100")
-        if self.volume not in ["silent", "x-soft", "soft", "medium", "loud", "x-loud"]:
-            raise ValueError(
-                "Prosody volume must be one of 'silent', 'x-soft', 'soft', 'medium', 'loud', 'x-loud'"
-            )
-
-        if self.pitch:
-            if self.pitch not in ["x-low", "low", "medium", "high", "x-high"]:
+            if self.volume not in [
+                "silent",
+                "x-soft",
+                "soft",
+                "medium",
+                "loud",
+                "x-loud",
+            ]:
                 raise ValueError(
-                    "Prosody pitch must be one of 'x-low', 'low', 'medium', 'high', 'x-high'"
+                    "Prosody volume must be one of 'silent', 'x-soft', 'soft', 'medium', 'loud', 'x-loud'"
                 )
+
+        if self.pitch and self.pitch not in ["x-low", "low", "medium", "high", "x-high"]:
+            raise ValueError(
+                "Prosody pitch must be one of 'x-low', 'low', 'medium', 'high', 'x-high'"
+            )
 
     def __post_init__(self):
         self.validate()

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
@@ -33,14 +33,14 @@ class ProsodyConfig:
     Args:
         rate: Speaking rate. Can be one of "x-slow", "slow", "medium", "fast", "x-fast", or a float. A float value of 1.0 represents normal speed.
         volume: Speaking volume. Can be one of "silent", "x-soft", "soft", "medium", "loud", "x-loud", or a float. A float value of 100 (x-loud) represents the highest volume and it's the default pitch.
-        pitch: Speaking pitch. Can be one of "x-low", "low", "medium", "high", "x-high".
+        pitch: Speaking pitch. Can be one of "x-low", "low", "medium", "high", "x-high". The default pitch is "medium".
     """
 
-    rate: Literal["x-slow", "slow", "medium", "fast", "x-fast"] | float | None = "medium"
+    rate: Literal["x-slow", "slow", "medium", "fast", "x-fast"] | float | None = None
     volume: (
         Literal["silent", "x-soft", "soft", "medium", "loud", "x-loud"] | float | None
     ) = "x-loud"
-    pitch: Literal["x-low", "low", "medium", "high", "x-high"] | None = "medium"
+    pitch: Literal["x-low", "low", "medium", "high", "x-high"] | None = None
 
     def validate(self) -> None:
         if isinstance(self.rate, float) and not 0.5 <= self.rate <= 2:


### PR DESCRIPTION
In this PR, I have added support for SSML prosody tags in Azure TTS. This will allow users to control the speech rate, pitch, and volume of the generated speech. The prosody tag is a part of the SSML specification and is supported by Azure TTS.

To use the prosody tags in Azure TTS component the user needs to provide a `ProsodyConfig` object to the `TTS` component. 
The `ProsodyConfig` is validated in the `TTS` component.


```python
@dataclass
class ProsodyConfig:
    """
    Prosody configuration for Azure TTS.

    Args:
        rate: Speaking rate. Can be one of "x-slow", "slow", "medium", "fast", "x-fast", or a float. A float value of 1.0 represents normal speed.
        volume: Speaking volume. Can be one of "silent", "x-soft", "soft", "medium", "loud", "x-loud", or a float. A float value of 100 (x-loud) represents the highest volume and it's the default pitch.
        pitch: Speaking pitch. Can be one of "x-low", "low", "medium", "high", "x-high".
    """

    rate: Literal["x-slow", "slow", "medium", "fast", "x-fast"] | float | None = "medium"
    volume: (
        Literal["silent", "x-soft", "soft", "medium", "loud", "x-loud"] | float | None
    ) = "x-loud"
    pitch: Literal["x-low", "low", "medium", "high", "x-high"] | None = "medium"

```

When the user specify the `ProsodyConfig` object, the `TTS` component will generate the SSML with the prosody tags and use the `speak_ssml_async` method to generate the speech. Otherwise, the `TTS` component will use the default `speak_text_async` method to generate the speech.


No changes are required in the `TTS` component to support the prosody tags. The `TTS` component will automatically generate the SSML with the prosody tags if the `ProsodyConfig` object is provided.

I also added the language parameter to the TTS initialization to explicitly specify the language of the text to be synthesized, useful when the model is multilingual.

https://github.com/livekit/agents/issues/911
