### PR TITLE
Add option for a min delay between playouts

### DIFF
--- a/.changeset/great-walls-shout.md
+++ b/.changeset/great-walls-shout.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Add configurable minimum time between consecutive agent outputs


### PR DESCRIPTION
My agent occasionally wants to play audio immediately after it's done playing - this is to allow for a minimum gap between the two to avoid awkward responses. I've found a value around 0.7 is good, but I wanted to leave it at 0 to avoid a behavior change.