### PR TITLE
avoid nested function calls

### DIFF
--- a/.changeset/soft-apples-itch.md
+++ b/.changeset/soft-apples-itch.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+pipeline-agent: avoid nested function calls

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -727,7 +727,6 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
 
                 answer_llm_stream = self._llm.chat(
                     chat_ctx=chat_ctx,
-                    fnc_ctx=self._fnc_ctx,
                 )
                 answer_synthesis = self._synthesize_agent_speech(
                     speech_handle.id, answer_llm_stream


### PR DESCRIPTION
nested function calls result in no answer from the agent. Some LLMs of different providers may hallucinate a function call