### PR TITLE
remove macos-14-large 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-14-large
-            platform: macos
           - os: macos-14
             platform: macos
           - os: windows-2019


### PR DESCRIPTION
it is failing and it is the same as macos-14
idk why we added it