### PR TITLE
Make VoicePipelineAgent generic

### DIFF
--- a/.changeset/hungry-crabs-cry.md
+++ b/.changeset/hungry-crabs-cry.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Make VoicePipelineAgent generic on its parameters


### PR DESCRIPTION
Now callers can say

```
MyVoicePipelineAgent = VoicePipelineAgent[MyAgentFunctionContext, openai.LLM, openai.TTS, silero.VAD, deepgram.STT]
...
def before_llm_cb(agent: MyVoicePipelineAgent, chat_ctx: llm.ChatContext):
   agent.fnc_ctx # is a MyAgentFunctionContext type

agent = MyVoicePipelineAgent(before_llm_cb=before_llm_cb)
```
