### PR TITLE
Converted self._speech_q into an asyncio.Queue to safely manage speech tasks 

### DIFF
--- a/.changeset/silly-gifts-bake.md
+++ b/.changeset/silly-gifts-bake.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+use asyncio.Queue to safely manage speech tasks

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -537,241 +537,238 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
     async def _synthesize_answer_task(
         self, old_task: asyncio.Task[None], handle: SpeechHandle
     ) -> None:
-        try:
-            if old_task is not None:
-                await utils.aio.gracefully_cancel(old_task)
+        if old_task is not None:
+            await utils.aio.gracefully_cancel(old_task)
 
-            copied_ctx = self._chat_ctx.copy()
+        copied_ctx = self._chat_ctx.copy()
 
-            playing_speech = self._playing_speech
-            if playing_speech is not None and playing_speech.initialized:
-                if (
-                    not playing_speech.user_question or playing_speech.user_commited
-                ) and not playing_speech.speech_commited:
-                    # the speech is playing but not committed yet, add it to the chat context for this new reply synthesis
-                    copied_ctx.messages.append(
-                        ChatMessage.create(
-                            text=playing_speech.synthesis_handle.tts_forwarder.played_text,
-                            role="assistant",
-                        )
+        playing_speech = self._playing_speech
+        if playing_speech is not None and playing_speech.initialized:
+            if (
+                not playing_speech.user_question or playing_speech.user_commited
+            ) and not playing_speech.speech_commited:
+                # the speech is playing but not committed yet, add it to the chat context for this new reply synthesis
+                copied_ctx.messages.append(
+                    ChatMessage.create(
+                        text=playing_speech.synthesis_handle.tts_forwarder.played_text,
+                        role="assistant",
                     )
+                )
 
-            copied_ctx.messages.append(
-                ChatMessage.create(text=handle.user_question, role="user")
-            )
+        copied_ctx.messages.append(
+            ChatMessage.create(text=handle.user_question, role="user")
+        )
 
-            llm_stream = self._opts.before_llm_cb(self, copied_ctx)
-            if llm_stream is False:
-                handle.cancel()
-                return
+        llm_stream = self._opts.before_llm_cb(self, copied_ctx)
+        if llm_stream is False:
+            handle.cancel()
+            return
 
-            if asyncio.iscoroutine(llm_stream):
-                llm_stream = await llm_stream
+        if asyncio.iscoroutine(llm_stream):
+            llm_stream = await llm_stream
 
-            # fallback to default impl if no custom/user stream is returned
-            if not isinstance(llm_stream, LLMStream):
-                llm_stream = _default_before_llm_cb(self, chat_ctx=copied_ctx)
+        # fallback to default impl if no custom/user stream is returned
+        if not isinstance(llm_stream, LLMStream):
+            llm_stream = _default_before_llm_cb(self, chat_ctx=copied_ctx)
 
-            if handle.interrupted:
-                return
+        if handle.interrupted:
+            return
 
-            synthesis_handle = self._synthesize_agent_speech(handle.id, llm_stream)
-            handle.initialize(source=llm_stream, synthesis_handle=synthesis_handle)
+        synthesis_handle = self._synthesize_agent_speech(handle.id, llm_stream)
+        handle.initialize(source=llm_stream, synthesis_handle=synthesis_handle)
 
-            # TODO(theomonnom): Find a more reliable way to get the elapsed time from the last end of speech
-            # (VAD could not have detected any speech - maybe unlikely?)
-            if self._last_end_of_speech_time is not None:
-                elapsed = round(time.time() - self._last_end_of_speech_time, 3)
-            else:
-                elapsed = -1.0
+        # TODO(theomonnom): Find a more reliable way to get the elapsed time from the last end of speech
+        # (VAD could not have detected any speech - maybe unlikely?)
+        if self._last_end_of_speech_time is not None:
+            elapsed = round(time.time() - self._last_end_of_speech_time, 3)
+        else:
+            elapsed = -1.0
 
-            logger.debug(
-                "synthesizing agent reply",
-                extra={
-                    "speech_id": handle.id,
-                    "elapsed": elapsed,
-                },
-            )
-        except Exception as e:
-            logger.exception(f"Error in synthesizing answer task: {e}")
+        logger.debug(
+            "synthesizing agent reply",
+            extra={
+                "speech_id": handle.id,
+                "elapsed": elapsed,
+            },
+        )
 
     async def _play_speech(self, speech_handle: SpeechHandle) -> None:
         try:
             await speech_handle.wait_for_initialization()
-            await self._agent_publication.wait_for_subscription()
+        except asyncio.CancelledError:
+            return
 
-            synthesis_handle = speech_handle.synthesis_handle
-            if synthesis_handle.interrupted:
+        await self._agent_publication.wait_for_subscription()
+
+        synthesis_handle = speech_handle.synthesis_handle
+        if synthesis_handle.interrupted:
+            return
+
+        user_question = speech_handle.user_question
+
+        play_handle = synthesis_handle.play()
+        join_fut = play_handle.join()
+
+        def _commit_user_question_if_needed() -> None:
+            if (
+                not user_question
+                or synthesis_handle.interrupted
+                or speech_handle.user_commited
+            ):
                 return
 
-            user_question = speech_handle.user_question
-
-            play_handle = synthesis_handle.play()
-            join_fut = play_handle.join()
-
-            def _commit_user_question_if_needed() -> None:
-                if (
-                    not user_question
-                    or synthesis_handle.interrupted
-                    or speech_handle.user_commited
-                ):
-                    return
-
-                is_using_tools = isinstance(speech_handle.source, LLMStream) and len(
-                    speech_handle.source.function_calls
-                )
-
-                # make sure at least some speech was played before committing the user message
-                # since we try to validate as fast as possible it is possible the agent gets interrupted
-                # really quickly (barely audible), we don't want to mark this question as "answered".
-                if (
-                    speech_handle.allow_interruptions
-                    and not is_using_tools
-                    and (
-                        play_handle.time_played < self.MIN_TIME_PLAYED_FOR_COMMIT
-                        and not join_fut.done()
-                    )
-                ):
-                    return
-
-                logger.debug(
-                    "committed user transcript", extra={"user_transcript": user_question}
-                )
-                user_msg = ChatMessage.create(text=user_question, role="user")
-                self._chat_ctx.messages.append(user_msg)
-                self.emit("user_speech_committed", user_msg)
-
-                self._transcribed_text = self._transcribed_text[len(user_question):]
-                speech_handle.mark_user_commited()
-
-            # wait for the play_handle to finish and check every 1s if the user question should be committed
-            _commit_user_question_if_needed()
-
-            while not join_fut.done():
-                await asyncio.wait(
-                    [join_fut], return_when=asyncio.FIRST_COMPLETED, timeout=0.5
-                )
-
-                _commit_user_question_if_needed()
-
-                if speech_handle.interrupted:
-                    break
-
-            _commit_user_question_if_needed()
-
-            collected_text = speech_handle.synthesis_handle.tts_forwarder.played_text
-            interrupted = speech_handle.interrupted
             is_using_tools = isinstance(speech_handle.source, LLMStream) and len(
                 speech_handle.source.function_calls
             )
 
-            extra_tools_messages = []  # additional messages from the functions to add to the context if needed
+            # make sure at least some speech was played before committing the user message
+            # since we try to validate as fast as possible it is possible the agent gets interrupted
+            # really quickly (barely audible), we don't want to mark this question as "answered".
+            if (
+                speech_handle.allow_interruptions
+                and not is_using_tools
+                and (
+                    play_handle.time_played < self.MIN_TIME_PLAYED_FOR_COMMIT
+                    and not join_fut.done()
+                )
+            ):
+                return
 
-            # if the answer is using tools, execute the functions and automatically generate
-            # a response to the user question from the returned values
-            if is_using_tools and not interrupted:
-                assert isinstance(speech_handle.source, LLMStream)
-                assert (
-                    not user_question or speech_handle.user_commited
-                ), "user speech should have been committed before using tools"
+            logger.debug(
+                "committed user transcript", extra={"user_transcript": user_question}
+            )
+            user_msg = ChatMessage.create(text=user_question, role="user")
+            self._chat_ctx.messages.append(user_msg)
+            self.emit("user_speech_committed", user_msg)
 
-                # execute functions
-                call_ctx = AgentCallContext(self, speech_handle.source)
-                tk = _CallContextVar.set(call_ctx)
-                self.emit("function_calls_collected", speech_handle.source.function_calls)
-                called_fncs_info = speech_handle.source.function_calls
+            self._transcribed_text = self._transcribed_text[len(user_question) :]
+            speech_handle.mark_user_commited()
 
-                called_fncs = []
-                for fnc in called_fncs_info:
-                    called_fnc = fnc.execute()
-                    called_fncs.append(called_fnc)
-                    logger.debug(
-                        "executing ai function",
+        # wait for the play_handle to finish and check every 1s if the user question should be committed
+        _commit_user_question_if_needed()
+
+        while not join_fut.done():
+            await asyncio.wait(
+                [join_fut], return_when=asyncio.FIRST_COMPLETED, timeout=0.5
+            )
+
+            _commit_user_question_if_needed()
+
+            if speech_handle.interrupted:
+                break
+
+        _commit_user_question_if_needed()
+
+        collected_text = speech_handle.synthesis_handle.tts_forwarder.played_text
+        interrupted = speech_handle.interrupted
+        is_using_tools = isinstance(speech_handle.source, LLMStream) and len(
+            speech_handle.source.function_calls
+        )
+
+        extra_tools_messages = []  # additional messages from the functions to add to the context if needed
+
+        # if the answer is using tools, execute the functions and automatically generate
+        # a response to the user question from the returned values
+        if is_using_tools and not interrupted:
+            assert isinstance(speech_handle.source, LLMStream)
+            assert (
+                not user_question or speech_handle.user_commited
+            ), "user speech should have been committed before using tools"
+
+            # execute functions
+            call_ctx = AgentCallContext(self, speech_handle.source)
+            tk = _CallContextVar.set(call_ctx)
+            self.emit("function_calls_collected", speech_handle.source.function_calls)
+            called_fncs_info = speech_handle.source.function_calls
+
+            called_fncs = []
+            for fnc in called_fncs_info:
+                called_fnc = fnc.execute()
+                called_fncs.append(called_fnc)
+                logger.debug(
+                    "executing ai function",
+                    extra={
+                        "function": fnc.function_info.name,
+                        "speech_id": speech_handle.id,
+                    },
+                )
+                try:
+                    await called_fnc.task
+                except Exception as e:
+                    logger.exception(
+                        "error executing ai function",
                         extra={
                             "function": fnc.function_info.name,
                             "speech_id": speech_handle.id,
                         },
-                    )
-                    try:
-                        await called_fnc.task
-                    except Exception as e:
-                        logger.exception(
-                            "error executing ai function",
-                            extra={
-                                "function": fnc.function_info.name,
-                                "speech_id": speech_handle.id,
-                            },
-                            exc_info=e,
-                        )
-
-                self.emit("function_calls_finished", called_fncs)
-                _CallContextVar.reset(tk)
-
-                tool_calls = []
-                tool_calls_results_msg = []
-
-                for called_fnc in called_fncs:
-                    # ignore the function calls that returns None
-                    if called_fnc.result is None:
-                        continue
-
-                    tool_calls.append(called_fnc.call_info)
-                    tool_calls_results_msg.append(
-                        ChatMessage.create_tool_from_called_function(called_fnc)
+                        exc_info=e,
                     )
 
-                if tool_calls:
-                    extra_tools_messages.append(
-                        ChatMessage.create_tool_calls(tool_calls, text=collected_text)
-                    )
-                    extra_tools_messages.extend(tool_calls_results_msg)
+            self.emit("function_calls_finished", called_fncs)
+            _CallContextVar.reset(tk)
 
-                    chat_ctx = speech_handle.source.chat_ctx.copy()
-                    chat_ctx.messages.extend(extra_tools_messages)
+            tool_calls = []
+            tool_calls_results_msg = []
 
-                    answer_llm_stream = self._llm.chat(
-                        chat_ctx=chat_ctx,
-                    )
-                    answer_synthesis = self._synthesize_agent_speech(
-                        speech_handle.id, answer_llm_stream
-                    )
-                    # replace the synthesis handle with the new one to allow interruption
-                    speech_handle.synthesis_handle = answer_synthesis
-                    play_handle = answer_synthesis.play()
-                    await play_handle.join()
-                    
-                    collected_text = answer_synthesis.tts_forwarder.played_text
-                    interrupted = answer_synthesis.interrupted
+            for called_fnc in called_fncs:
+                # ignore the function calls that returns None
+                if called_fnc.result is None:
+                    continue
 
-            if speech_handle.add_to_chat_ctx and (
-                not user_question or speech_handle.user_commited
-            ):
-                self._chat_ctx.messages.extend(extra_tools_messages)
-
-                if interrupted:
-                    collected_text += "..."
-
-                msg = ChatMessage.create(text=collected_text, role="assistant")
-                self._chat_ctx.messages.append(msg)
-
-                speech_handle.mark_speech_commited()
-
-                if interrupted:
-                    self.emit("agent_speech_interrupted", msg)
-                else:
-                    self.emit("agent_speech_committed", msg)
-
-                logger.debug(
-                    "committed agent speech",
-                    extra={
-                        "agent_transcript": collected_text,
-                        "interrupted": interrupted,
-                        "speech_id": speech_handle.id,
-                    },
+                tool_calls.append(called_fnc.call_info)
+                tool_calls_results_msg.append(
+                    ChatMessage.create_tool_from_called_function(called_fnc)
                 )
 
-        except Exception as e:
-            logger.exception(f"Error while playing speech: {e}")
+            if tool_calls:
+                extra_tools_messages.append(
+                    ChatMessage.create_tool_calls(tool_calls, text=collected_text)
+                )
+                extra_tools_messages.extend(tool_calls_results_msg)
+
+                chat_ctx = speech_handle.source.chat_ctx.copy()
+                chat_ctx.messages.extend(extra_tools_messages)
+
+                answer_llm_stream = self._llm.chat(
+                    chat_ctx=chat_ctx,
+                )
+                answer_synthesis = self._synthesize_agent_speech(
+                    speech_handle.id, answer_llm_stream
+                )
+                # replace the synthesis handle with the new one to allow interruption
+                speech_handle.synthesis_handle = answer_synthesis
+                play_handle = answer_synthesis.play()
+                await play_handle.join()
+
+                collected_text = answer_synthesis.tts_forwarder.played_text
+                interrupted = answer_synthesis.interrupted
+
+        if speech_handle.add_to_chat_ctx and (
+            not user_question or speech_handle.user_commited
+        ):
+            self._chat_ctx.messages.extend(extra_tools_messages)
+
+            if interrupted:
+                collected_text += "..."
+
+            msg = ChatMessage.create(text=collected_text, role="assistant")
+            self._chat_ctx.messages.append(msg)
+
+            speech_handle.mark_speech_commited()
+
+            if interrupted:
+                self.emit("agent_speech_interrupted", msg)
+            else:
+                self.emit("agent_speech_committed", msg)
+
+            logger.debug(
+                "committed agent speech",
+                extra={
+                    "agent_transcript": collected_text,
+                    "interrupted": interrupted,
+                    "speech_id": speech_handle.id,
+                },
+            )
 
     def _synthesize_agent_speech(
         self,


### PR DESCRIPTION
We're manually managing the `self._speech_q` list with `asyncio.Event()`
- **PR :** use `asyncio.Queue` since it's built for handling of asynchronous producer-consumer patterns.

CC: @davidzhao  @theomonnom please review it and let me know there's any change