### PR TITLE
Fixed a problem that before_llm_cb return value is not canceled even if False when the return value is coroutine.

### DIFF
--- a/.changeset/nice-icons-watch.md
+++ b/.changeset/nice-icons-watch.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+fix before_llm_cb not handling coroutines returning False

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -563,12 +563,12 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
         )
 
         llm_stream = self._opts.before_llm_cb(self, copied_ctx)
+        if asyncio.iscoroutine(llm_stream):
+            llm_stream = await llm_stream
+
         if llm_stream is False:
             handle.cancel()
             return
-
-        if asyncio.iscoroutine(llm_stream):
-            llm_stream = await llm_stream
 
         # fallback to default impl if no custom/user stream is returned
         if not isinstance(llm_stream, LLMStream):


### PR DESCRIPTION
https://github.com/livekit/agents/issues/958#issue-2600681919