### PR TITLE
Fix race in default load calc.

### DIFF
--- a/.changeset/chilly-tables-speak.md
+++ b/.changeset/chilly-tables-speak.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Fix race in load calc initialization

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -72,8 +72,8 @@ class _DefaultLoadCalc:
         self._thread = threading.Thread(
             target=self._calc_load, daemon=True, name="worker_cpu_load_monitor"
         )
-        self._thread.start()
         self._lock = threading.Lock()
+        self._thread.start()
 
     def _calc_load(self) -> None:
         while True:


### PR DESCRIPTION
the thread could start and then lock would be undefined, and you'd get the occasional

`AttributeError: '_DefaultLoadCalc' object has no attribute '_lock'`