### PR TITLE
Introducing LiveKit Agents Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ The following plugins are available today:
 
 Documentation on the framework and how to use it can be found [here](https://docs.livekit.io/agents)
 
+You can also [Ask LiveKit Agents Guru](https://gurubase.io/g/livekit-agents), it is a LiveKit Agents focused AI to answer your questions.
+
 ## Example agents
 
 | Description                                                                                                   | Demo Link                                       | Code Link                                                                                      |


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [LiveKit Agents Guru](https://gurubase.io/g/livekit-agents) to Gurubase. LiveKit Agents Guru uses the data from this repo and data from the [docs](https://docs.livekit.io/agents/) to answer questions by leveraging the LLM.

In this PR, I showcased the "LiveKit Agents Guru", which highlights that LiveKit Agents now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable LiveKit Agents Guru in Gurubase, just let me know that's totally fine.