### PR TITLE
fix shutdown error stack trace

### DIFF
--- a/.changeset/serious-worms-tap.md
+++ b/.changeset/serious-worms-tap.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Fix stack dump on room shutdown

--- a/livekit-agents/livekit/agents/ipc/job_main.py
+++ b/livekit-agents/livekit/agents/ipc/job_main.py
@@ -7,10 +7,11 @@ import logging
 import pickle
 import queue
 import socket
+import sys
 import threading
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
-import sys
+
 from livekit import rtc
 
 from .. import utils
@@ -48,7 +49,7 @@ class LogQueueHandler(logging.Handler):
     def emit(self, record: logging.LogRecord) -> None:
         try:
             # Check if Python is shutting down
-            if not hasattr(sys, "meta_path") or sys.meta_path is None:
+            if sys.is_finalizing():
                 return
 
             # from https://github.com/python/cpython/blob/91b7f2e7f6593acefda4fa860250dd87d6f849bf/Lib/logging/handlers.py#L1453

--- a/livekit-agents/livekit/agents/ipc/job_main.py
+++ b/livekit-agents/livekit/agents/ipc/job_main.py
@@ -10,7 +10,7 @@ import socket
 import threading
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
-
+import sys
 from livekit import rtc
 
 from .. import utils
@@ -47,6 +47,10 @@ class LogQueueHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:
         try:
+            # Check if Python is shutting down
+            if not hasattr(sys, "meta_path") or sys.meta_path is None:
+                return
+
             # from https://github.com/python/cpython/blob/91b7f2e7f6593acefda4fa860250dd87d6f849bf/Lib/logging/handlers.py#L1453
             msg = self.format(record)
             record = copy.copy(record)


### PR DESCRIPTION
We would see stack traces when rooms exited:

```
--- Logging error ---
Traceback (most recent call last):
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/ipc/job_main.py", line 52, in emit
    record = copy.copy(record)
             ^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/copy.py", line 87, in copy
    rv = reductor(4)
         ^^^^^^^^^^^
ImportError: sys.meta_path is None, Python is likely shutting down
Call stack:
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/aiohttp/client.py", line 425, in __del__
    self._loop.call_exception_handler(context)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 1846, in call_exception_handler
    self.default_exception_handler(context)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 1820, in default_exception_handler
    logger.error('\n'.join(log_lines), exc_info=exc_info)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1568, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1684, in _log
    self.handle(record)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1700, in handle
    self.callHandlers(record)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1762, in callHandlers
    hdlr.handle(record)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1028, in handle
    self.emit(record)
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/ipc/job_main.py", line 68, in emit
    self.handleError(record)
Message: 'Unclosed client session\nclient_session: <aiohttp.client.ClientSession object at 0x127fa2de0>'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/ipc/job_main.py", line 52, in emit
    record = copy.copy(record)
             ^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/copy.py", line 87, in copy
    rv = reductor(4)
         ^^^^^^^^^^^
ImportError: sys.meta_path is None, Python is likely shutting down
Call stack:
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/aiohttp/connector.py", line 307, in __del__
    self._loop.call_exception_handler(context)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 1846, in call_exception_handler
    self.default_exception_handler(context)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 1820, in default_exception_handler
    logger.error('\n'.join(log_lines), exc_info=exc_info)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1568, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1684, in _log
    self.handle(record)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1700, in handle
    self.callHandlers(record)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1762, in callHandlers
    hdlr.handle(record)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1028, in handle
    self.emit(record)
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/ipc/job_main.py", line 68, in emit
    self.handleError(record)
Message: "Unclosed connector\nconnections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x140c254f0>, 729943.46028), (<aiohttp.client_proto.ResponseHandler object at 0x140c24230>, 729943.706343791)]']\nconnector: <aiohttp.connector.TCPConnector object at 0x1406f64e0>"
Arguments: ()
```