### PR TITLE
feat: expose user_speech_committed and agent_speech_committed for multimodal agents

### DIFF
--- a/.changeset/proud-wombats-perform.md
+++ b/.changeset/proud-wombats-perform.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+expose transcriptions for multimodal agents

--- a/livekit-agents/livekit/agents/multimodal/agent_playout.py
+++ b/livekit-agents/livekit/agents/multimodal/agent_playout.py
@@ -165,6 +165,9 @@ class AgentPlayout(utils.EventEmitter[EventTypes]):
 
             await utils.aio.gracefully_cancel(read_text_task)
 
+            # make sure the text_data.sentence_stream is closed
+            handle._tr_fwd.mark_text_segment_end()
+
             if not first_frame and not handle.interrupted:
                 handle._tr_fwd.segment_playout_finished()
 

--- a/livekit-agents/livekit/agents/multimodal/agent_playout.py
+++ b/livekit-agents/livekit/agents/multimodal/agent_playout.py
@@ -165,11 +165,12 @@ class AgentPlayout(utils.EventEmitter[EventTypes]):
 
             await utils.aio.gracefully_cancel(read_text_task)
 
-            if not first_frame:
-                if not handle.interrupted:
-                    handle._tr_fwd.segment_playout_finished()
+            if not first_frame and not handle.interrupted:
+                handle._tr_fwd.segment_playout_finished()
 
-                self.emit("playout_stopped", handle.interrupted)
-
-            handle._done_fut.set_result(None)
             await handle._tr_fwd.aclose()
+            handle._done_fut.set_result(None)
+
+            # emit playout_stopped after the transcription forwarder has been closed
+            if not first_frame:
+                self.emit("playout_stopped", handle.interrupted)

--- a/livekit-agents/livekit/agents/multimodal/multimodal_agent.py
+++ b/livekit-agents/livekit/agents/multimodal/multimodal_agent.py
@@ -185,6 +185,7 @@ class MultimodalAgent(utils.EventEmitter[EventTypes]):
 
         @self._session.on("input_speech_started")
         def _input_speech_started():
+            self.emit("user_started_speaking")
             self._update_state("listening")
             if self._playing_handle is not None and not self._playing_handle.done():
                 self._playing_handle.interrupt()
@@ -194,6 +195,10 @@ class MultimodalAgent(utils.EventEmitter[EventTypes]):
                     content_index=self._playing_handle.content_index,
                     audio_end_ms=int(self._playing_handle.audio_samples / 24000 * 1000),
                 )
+
+        @self._session.on("input_speech_stopped")
+        def _input_speech_stopped():
+            self.emit("user_stopped_speaking")
 
     def _update_state(self, state: AgentState, delay: float = 0.0):
         """Set the current state of the agent"""


### PR DESCRIPTION
- Expose the `user_speech_committed`, `agent_speech_committed`, and `agent_speech_interrupted` for multimodal agents
- Emit `user_started_speaking` and `user_stopped_speaking` for multimodal agents
- Fixed a bug that `handle._tr_fwd` of multimodal agents cannot be closed for some interruption cases


Related to: https://github.com/livekit/agents/issues/877