### PR TITLE
Cancel main task in aclose

### DIFF
--- a/.changeset/young-walls-fry.md
+++ b/.changeset/young-walls-fry.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Cancel the \_main_atask on aclose

--- a/.changeset/young-walls-fry.md
+++ b/.changeset/young-walls-fry.md
@@ -2,4 +2,4 @@
 "livekit-agents": patch
 ---
 
-Cancel the \_main_atask on aclose
+Cancel the _main_atask on aclose

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -671,16 +671,12 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
             ):
                 return
 
-            is_using_tools = isinstance(speech_handle.source, LLMStream) and len(
-                speech_handle.source.function_calls
-            )
-
             # make sure at least some speech was played before committing the user message
             # since we try to validate as fast as possible it is possible the agent gets interrupted
             # really quickly (barely audible), we don't want to mark this question as "answered".
             if (
                 speech_handle.allow_interruptions
-                and not is_using_tools
+                and not speech_handle.is_using_tools()
                 and (
                     play_handle.time_played < self.MIN_TIME_PLAYED_FOR_COMMIT
                     and not join_fut.done()

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -269,6 +269,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
         self._speech_q_changed = asyncio.Event()
 
         self._update_state_task: asyncio.Task | None = None
+        self._main_atask: asyncio.Task | None = None
 
         self._last_final_transcript_time: float | None = None
         self._last_speech_time: float | None = None
@@ -437,7 +438,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
         if not self._started:
             return
 
-        if hasattr(self, "_main_atask"):
+        if self._main_atask is not None:
             await utils.aio.gracefully_cancel(self._main_atask)
 
         self._room.off("participant_connected", self._on_participant_connected)

--- a/livekit-agents/livekit/agents/pipeline/speech_handle.py
+++ b/livekit-agents/livekit/agents/pipeline/speech_handle.py
@@ -64,6 +64,14 @@ class SpeechHandle:
             user_question="",
         )
 
+    def collected_text(self) -> str:
+        if self.interrupted:
+            return self.synthesis_handle.tts_forwarder.played_text + "..."
+        return self.synthesis_handle.tts_forwarder.played_text
+
+    def is_using_tools(self) -> bool:
+        return isinstance(self.source, LLMStream) and len(self.source.function_calls)
+
     async def wait_for_initialization(self) -> None:
         await asyncio.shield(self._init_fut)
 


### PR DESCRIPTION
Also simplified a few places in the main loop code - no other functional changes.

This wasn't really a big deal, since the job logic would clean it up anyway. But if someone was using it outside of a job, it'd run forever.