### PR TITLE
support for additional deepgram config

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -98,6 +98,7 @@ class STTOptions:
     num_channels: int
     keywords: list[Tuple[str, float]]
     profanity_filter: bool
+    additional_config: dict = dataclasses.field(default_factory=dict)
 
 
 class STT(stt.STT):
@@ -118,6 +119,7 @@ class STT(stt.STT):
         profanity_filter: bool = False,
         api_key: str | None = None,
         http_session: aiohttp.ClientSession | None = None,
+        additional_config: dict | None = None,
     ) -> None:
         """
         Create a new instance of Deepgram STT.
@@ -168,6 +170,7 @@ class STT(stt.STT):
             num_channels=1,
             keywords=keywords,
             profanity_filter=profanity_filter,
+            additional_config=additional_config or {},
         )
         self._session = http_session
 
@@ -242,6 +245,9 @@ class STT(stt.STT):
 
         if config.detect_language:
             config.language = None
+
+        for key, value in self._opts.additional_config.items():
+            setattr(config, key, value)
 
         return config
 


### PR DESCRIPTION
## Summary of Changes

### 1. Addition of `additional_config` Parameter
- The `STTOptions` dataclass now includes an `additional_config` field, which is a dictionary for storing extra configuration parameters for deepgram.
- This allows users to pass parameters like `paragraph` and `diarize` when initializing the `STT` class.

### 2. Integration of `additional_config` in STT Initialization
- The `STT` class constructor now accepts an `additional_config` argument, which is then passed to the `STTOptions` dataclass.
- This dictionary dynamically updates configuration options during the `_sanitize_options` method call.

### 3. Dynamic Configuration Handling
- The `_sanitize_options` method has been updated to incorporate additional configuration options specified in `additional_config`.
- This ensures that any extra parameters are included in requests to the Deepgram API.

## Example Usage

Users can now initialize the `STT` class with additional configuration parameters as follows:

```python
from livekit.plugins import deepgram

stt_instance = deepgram.STT(
    additional_config={
        "paragraph": True,
        "diarize": True
    }
)
