### PR TITLE
Fix stack dump on shutdown

### DIFF
--- a/.changeset/heavy-turtles-rule.md
+++ b/.changeset/heavy-turtles-rule.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Fix stack dump on closed stream

--- a/livekit-agents/livekit/agents/ipc/job_main.py
+++ b/livekit-agents/livekit/agents/ipc/job_main.py
@@ -208,7 +208,11 @@ async def _async_main(
     async def _read_ipc_task():
         nonlocal job_task
         while True:
-            msg = await channel.arecv_message(cch, proto.IPC_MESSAGES)
+            try:
+                msg = await channel.arecv_message(cch, proto.IPC_MESSAGES)
+            except duplex_unix.DuplexClosed:
+                break
+
             with contextlib.suppress(utils.aio.SleepFinished):
                 no_msg_timeout.reset()
 


### PR DESCRIPTION
When shutting down a job, I'd see:


```
2024-11-01 10:08:47,004 ERROR [livekit.agents] [log.py:21] [trace_id=1def6cfeeb92063a45eb46e9e9500303 span_id=d183818fae3b8fa7 resource.service.name= trace_sampled=True] - Error in _read_ipc_task                                                                                                                                                                                                                                                                                                    
Traceback (most recent call last):
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/utils/aio/duplex_unix.py", line 35, in recv_bytes
    len_bytes = await self._reader.readexactly(4)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/streams.py", line 750, in readexactly
    raise exceptions.IncompleteReadError(incomplete, n)
asyncio.exceptions.IncompleteReadError: 0 bytes read on a total of 4 expected bytes

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/utils/log.py", line 16, in async_fn_logs
    return await fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/ipc/job_main.py", line 211, in _read_ipc_task
    msg = await channel.arecv_message(cch, proto.IPC_MESSAGES)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/ipc/channel.py", line 47, in arecv_message
    return _read_message(await dplx.recv_bytes(), messages)
                         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/utils/aio/duplex_unix.py", line 43, in recv_bytes
    raise DuplexClosed()
livekit.agents.utils.aio.duplex_unix.DuplexClosed
2024-11-01 10:08:47,004 ERROR [livekit.agents] [log.py:21] [trace_id=2d6cb01bbbe36fb6a5eeb5d8dda86246 span_id=1fcf9fb9b3a0edb4 resource.service.name= trace_sampled=True] - Error in _read_ipc_task
Traceback (most recent call last):
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/utils/aio/duplex_unix.py", line 35, in recv_bytes
    len_bytes = await self._reader.readexactly(4)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/streams.py", line 750, in readexactly
    raise exceptions.IncompleteReadError(incomplete, n)
asyncio.exceptions.IncompleteReadError: 0 bytes read on a total of 4 expected bytes

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/utils/log.py", line 16, in async_fn_logs
    return await fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/ipc/job_main.py", line 211, in _read_ipc_task
    msg = await channel.arecv_message(cch, proto.IPC_MESSAGES)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/ipc/channel.py", line 47, in arecv_message
    return _read_message(await dplx.recv_bytes(), messages)
                         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/utils/aio/duplex_unix.py", line 43, in recv_bytes
    raise DuplexClosed()
livekit.agents.utils.aio.duplex_unix.DuplexClosed
2024-11-01 10:08:47,004 ERROR [livekit.agents] [log.py:21] [trace_id=52453bc25471c64df1daa34327a4df39 span_id=4e4334920ba359f6 resource.service.name= trace_sampled=True] - Error in _read_ipc_task
Traceback (most recent call last):
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/utils/aio/duplex_unix.py", line 35, in recv_bytes
    len_bytes = await self._reader.readexactly(4)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/streams.py", line 750, in readexactly
    raise exceptions.IncompleteReadError(incomplete, n)
asyncio.exceptions.IncompleteReadError: 0 bytes read on a total of 4 expected bytes

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/utils/log.py", line 16, in async_fn_logs
    return await fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/ipc/job_main.py", line 211, in _read_ipc_task
    msg = await channel.arecv_message(cch, proto.IPC_MESSAGES)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/ipc/channel.py", line 47, in arecv_message
    return _read_message(await dplx.recv_bytes(), messages)
                         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/martin/Library/Caches/pypoetry/virtualenvs/agent-x_OPPxuI-py3.12/lib/python3.12/site-packages/livekit/agents/utils/aio/duplex_unix.py", line 43, in recv_bytes
    raise DuplexClosed()
livekit.agents.utils.aio.duplex_unix.DuplexClosed
```