### PR TITLE
Expose usage metrics for Realtime model

### DIFF
--- a/.changeset/gentle-suits-cheat.md
+++ b/.changeset/gentle-suits-cheat.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-openai": patch
+---
+
+Expose usage metrics for Realtime model

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/api_proto.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/api_proto.py
@@ -141,10 +141,21 @@ ResponseStatusDetails = Union[
 ]
 
 
+class InputTokenDetails(TypedDict):
+    cached_tokens: int
+    text_tokens: int
+    audio_tokens: int
+
+class OutputTokenDetails(TypedDict):
+    text_tokens: int
+    audio_tokens: int
+
 class Usage(TypedDict):
     total_tokens: int
     input_tokens: int
     output_tokens: int
+    input_token_details: InputTokenDetails
+    output_token_details: OutputTokenDetails
 
 
 class Resource:

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/api_proto.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/api_proto.py
@@ -146,9 +146,11 @@ class InputTokenDetails(TypedDict):
     text_tokens: int
     audio_tokens: int
 
+
 class OutputTokenDetails(TypedDict):
     text_tokens: int
     audio_tokens: int
+
 
 class Usage(TypedDict):
     total_tokens: int

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -60,6 +60,8 @@ class RealtimeResponse:
     """details of the status (only with "incomplete, cancelled and failed")"""
     output: list[RealtimeOutput]
     """list of outputs"""
+    usage: api_proto.Usage | None
+    """usage of the response"""
     done_fut: asyncio.Future[None]
     """future that will be set when the response is completed"""
 
@@ -972,6 +974,7 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
             status=response["status"],
             status_details=status_details,
             output=[],
+            usage=response["usage"],
             done_fut=done_fut,
         )
         self._pending_responses[new_response.id] = new_response
@@ -1117,6 +1120,7 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
 
         response.status = response_data["status"]
         response.status_details = response_data.get("status_details")
+        response.usage = response_data.get("usage")
 
         if response.status == "failed":
             assert response.status_details is not None

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -974,7 +974,7 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
             status=response["status"],
             status_details=status_details,
             output=[],
-            usage=response["usage"],
+            usage=response.get("usage"),
             done_fut=done_fut,
         )
         self._pending_responses[new_response.id] = new_response


### PR DESCRIPTION
Handles #1010  to include usage (number of input/output tokens) in the response_done event for realtime model

Conforms to the usage object model as shown at https://platform.openai.com/docs/api-reference/realtime-server-events/response/done at time of submission