### PR TITLE
anthropic tool issue

### DIFF
--- a/.changeset/warm-candles-kneel.md
+++ b/.changeset/warm-candles-kneel.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-anthropic": patch
+---
+
+anthropic tool fix

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -800,10 +800,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                 chat_ctx.messages.extend(extra_tools_messages)
 
                 answer_llm_stream = self._llm.chat(
-                    chat_ctx=chat_ctx,
-                    fnc_ctx=self.fnc_ctx
-                    if i < self._opts.max_nested_fnc_calls - 1
-                    else None,
+                    chat_ctx=chat_ctx, fnc_ctx=self.fnc_ctx
                 )
                 answer_synthesis = self._synthesize_agent_speech(
                     speech_handle.id, answer_llm_stream

--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
@@ -44,6 +44,8 @@ class LLMOptions:
     model: str | ChatModels
     user: str | None
     temperature: float | None
+    tools: List[anthropic.types.ToolParam] | None = None
+    disable_parallel_tool_use: bool = False
 
 
 class LLM(llm.LLM):
@@ -92,7 +94,7 @@ class LLM(llm.LLM):
         fnc_ctx: llm.FunctionContext | None = None,
         temperature: float | None = None,
         n: int | None = 1,
-        parallel_tool_calls: bool | None = None,
+        disable_parallel_tool_use: bool = False,
     ) -> "LLMStream":
         if temperature is None:
             temperature = self._opts.temperature
@@ -103,24 +105,29 @@ class LLM(llm.LLM):
             for fnc in fnc_ctx.ai_functions.values():
                 fncs_desc.append(_build_function_description(fnc))
 
-            opts["tools"] = fncs_desc
+            self._opts.tools = fncs_desc
 
-            if fnc_ctx and parallel_tool_calls is not None:
-                opts["parallel_tool_calls"] = parallel_tool_calls
+            if fnc_ctx and disable_parallel_tool_use is not None:
+                self._opts.disable_parallel_tool_use = disable_parallel_tool_use
 
         latest_system_message = _latest_system_message(chat_ctx)
         anthropic_ctx = _build_anthropic_context(chat_ctx.messages, id(self))
         collaped_anthropic_ctx = _merge_messages(anthropic_ctx)
+        tool_choice = {
+            "type": "auto",  # Todo : let user choose
+            "disable_parallel_tool_use": self._opts.disable_parallel_tool_use,
+        }
 
         stream = self._client.messages.create(
             max_tokens=opts.get("max_tokens", 1024),
             system=latest_system_message,
             messages=collaped_anthropic_ctx,
             model=self._opts.model,
+            tools=self._opts.tools,
+            tool_choice=tool_choice,
             temperature=temperature or anthropic.NOT_GIVEN,
             top_k=n or anthropic.NOT_GIVEN,
             stream=True,
-            **opts,
         )
 
         return LLMStream(


### PR DESCRIPTION
fixes https://github.com/livekit/agents/issues/1048

docs: https://docs.anthropic.com/en/docs/build-with-claude/tool-use

encountered another issue while I was testing further for parallel tool calling, anthropic sends `RawMessageStopEvent` two times if there are two tool calls, ideally it should be just one time. @theomonnom @davidzhao 
```
2024-11-06 21:42:20,352 - DEBUG livekit.agents.pipeline - committed agent speech {"agent_transcript": " Hello from the weather station. Would you like to know the weather? If so, tell me your location.", "interrupted": false, "speech_id": "9c011146ed84"}
2024-11-06 21:42:25,055 - DEBUG livekit.agents.pipeline - received user transcript {"user_transcript": "London and Delhi."}
2024-11-06 21:42:26,158 - DEBUG livekit.agents.pipeline - validated agent reply {"speech_id": "5f174005ba8b"}
2024-11-06 21:42:27,532 - DEBUG livekit.plugins.anthropic - received event RawMessageStartEvent(message=Message(id='msg_013uZ4hUmwy9anaKhr6TLiEU', content=[], model='claude-3-5-sonnet-20241022', role='assistant', stop_reason=None, stop_sequence=None, type='message', usage=Usage(input_tokens=435, output_tokens=1)), type='message_start')   
2024-11-06 21:42:27,533 - DEBUG livekit.plugins.anthropic - received event RawContentBlockStartEvent(content_block=TextBlock(text='', type='text'), index=0, type='content_block_start')
2024-11-06 21:42:27,535 - DEBUG livekit.plugins.anthropic - received event RawContentBlockDeltaEvent(delta=TextDelta(text='I', type='text_delta'), index=0, type='content_block_delta')
2024-11-06 21:42:27,667 - DEBUG livekit.plugins.anthropic - received event RawContentBlockDeltaEvent(delta=TextDelta(text="'ll check the weather for both London and Delhi for", type='text_delta'), index=0, type='content_block_delta')
2024-11-06 21:42:27,857 - DEBUG livekit.plugins.anthropic - received event RawContentBlockDeltaEvent(delta=TextDelta(text=' you.', type='text_delta'), index=0, type='content_block_delta')
2024-11-06 21:42:28,185 - DEBUG livekit.plugins.anthropic - received event RawContentBlockStopEvent(index=0, type='content_block_stop') 
2024-11-06 21:42:28,187 - DEBUG livekit.plugins.anthropic - received event RawContentBlockStartEvent(content_block=ToolUseBlock(id='toolu_01XUPbticW5Qpun2wiL8SePc', input={}, name='get_weather', type='tool_use'), index=1, type='content_block_start')
2024-11-06 21:42:28,189 - DEBUG livekit.plugins.anthropic - received event RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='', type='input_json_delta'), index=1, type='content_block_delta')
2024-11-06 21:42:28,658 - DEBUG livekit.plugins.anthropic - received event RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='{"locatio', type='input_json_delta'), index=1, type='content_block_delta')
2024-11-06 21:42:28,660 - DEBUG livekit.plugins.anthropic - received event RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='n": "L', type='input_json_delta'), index=1, type='content_block_delta')
2024-11-06 21:42:28,661 - DEBUG livekit.plugins.anthropic - received event RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='ondon"}', type='input_json_delta'), index=1, type='content_block_delta')
2024-11-06 21:42:28,662 - DEBUG livekit.plugins.anthropic - received event RawContentBlockStopEvent(index=1, type='content_block_stop')
2024-11-06 21:42:28,664 - DEBUG livekit.plugins.anthropic - received event RawMessageDeltaEvent(delta=Delta(stop_reason='tool_use', stop_sequence=None), type='message_delta', usage=MessageDeltaUsage(output_tokens=74))
2024-11-06 21:42:28,668 - DEBUG livekit.plugins.anthropic - received event RawMessageStopEvent(type='message_stop')
2024-11-06 21:42:30,890 - DEBUG livekit.agents.pipeline - speech playout started {"speech_id": "5f174005ba8b"}
2024-11-06 21:42:34,299 - DEBUG livekit.agents.pipeline - speech playout finished {"speech_id": "5f174005ba8b", "interrupted": false}
2024-11-06 21:42:34,299 - DEBUG livekit.agents.pipeline - executing ai function {"function": "get_weather", "speech_id": "5f174005ba8b"}
2024-11-06 21:42:34,300 - INFO weather-demo - getting weather for London
2024-11-06 21:42:36,573 - DEBUG livekit.plugins.anthropic - received event RawMessageStartEvent(message=Message(id='msg_01SpC76mCmGsRkDVeHG8VAFt', content=[], model='claude-3-5-sonnet-20241022', role='assistant', stop_reason=None, stop_sequence=None, type='message', usage=Usage(input_tokens=526, output_tokens=35)), type='messart')
2024-11-06 21:42:36,576 - DEBUG livekit.plugins.anthropic - received event RawContentBlockStartEvent(content_block=ToolUseBlock(id='toolu_01T3fPNb5Lstu4uX7c17KUEx', input={}, name='get_weather', type='tool_use'), index=0, type='content_block_start')
2024-11-06 21:42:36,577 - DEBUG livekit.plugins.anthropic - received event RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='', type='input_json_delta'), index=0, type='content_block_delta')
2024-11-06 21:42:36,853 - DEBUG livekit.plugins.anthropic - received event RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='{"', type='input_json_delta'), index=0, type='content_block_delta')
2024-11-06 21:42:36,855 - DEBUG livekit.plugins.anthropic - received event RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='loca', type='input_json_delta'), index=0, type='content_block_delta')
2024-11-06 21:42:36,855 - DEBUG livekit.plugins.anthropic - received event RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='tion": "De', type='input_json_delta'), index=0, type='content_block_delta')
2024-11-06 21:42:36,861 - DEBUG livekit.plugins.anthropic - received event RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='lhi"}', type='input_json_delta'), index=0, type='content_block_delta')
2024-11-06 21:42:37,090 - DEBUG livekit.plugins.anthropic - received event RawContentBlockStopEvent(index=0, type='content_block_stop')
2024-11-06 21:42:37,090 - DEBUG livekit.plugins.anthropic - received event RawMessageDeltaEvent(delta=Delta(stop_reason='tool_use', stop_sequence=None), type='message_delta', usage=MessageDeltaUsage(output_tokens=55))
2024-11-06 21:42:37,091 - DEBUG livekit.plugins.anthropic - received event RawMessageStopEvent(type='message_stop')
2024-11-06 21:42:37,092 - DEBUG livekit.agents.pipeline - speech playout finished {"speech_id": "5f174005ba8b", "interrupted": false}
2024-11-06 21:42:37,092 - DEBUG livekit.agents.pipeline - committed agent speech {"agent_transcript": "", "interrupted": false, "speech_id": "5f174005ba8b"}        
```