### PR TITLE
func call error

### DIFF
--- a/.changeset/lazy-rabbits-confess.md
+++ b/.changeset/lazy-rabbits-confess.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+handles error in function calls

--- a/examples/voice-pipeline-agent/function_calling_weather.py
+++ b/examples/voice-pipeline-agent/function_calling_weather.py
@@ -42,7 +42,7 @@ class AssistantFnc(llm.FunctionContext):
                     # response from the function call is returned to the LLM
                     return f"The weather in {location} is {weather_data}."
                 else:
-                    raise f"Failed to get weather data, status code: {response.status}"
+                    return f"Failed to get weather data, status code: {response.status}"
 
 
 def prewarm_process(proc: JobProcess):


### PR DESCRIPTION
added `return` instead of `raise` in `get_weather`, so llm can handle errors in function call
previously :
![fnc_call_issue](https://github.com/user-attachments/assets/e551860a-8553-4772-ae53-0a4620150061)

after fix :
![image](https://github.com/user-attachments/assets/ba5acd24-ae87-44f5-9eb7-af30ebeabb4a)

PTAL @theomonnom @davidzhao 
