### PR TITLE
Clean up Cartesia audio frame send

### DIFF
--- a/.changeset/soft-geckos-appear.md
+++ b/.changeset/soft-geckos-appear.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-cartesia": patch
+---
+
+Simplify streaming logic, possibly fix glitchy audio

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -317,13 +317,9 @@ class SynthesizeStream(tts.SynthesizeStream):
                     for frame in audio_bstream.write(b64data):
                         _send_audio_frame(frame, segment_id, False)
                 elif data.get("done"):
-                    last_frame: rtc.AudioFrame | None = None
-                    for frame in audio_bstream.flush():
-                        if last_frame is not None:
-                            _send_audio_frame(frame, segment_id, False)
-                        last_frame = frame
-                    if last_frame is not None:
-                        _send_audio_frame(last_frame, segment_id, True)
+                    frames = enumerate(audio_bstream.flush())
+                    for i, frame in frames:
+                        _send_audio_frame(frame, segment_id, i == len(frames) - 1)
 
                     if segment_id == request_id:
                         # we're not going to receive more frames, close the connection

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -284,7 +284,9 @@ class SynthesizeStream(tts.SynthesizeStream):
                 num_channels=NUM_CHANNELS,
             )
 
-            def _send_audio_frame(frame: rtc.AudioFrame, is_final: bool):
+            def _send_audio_frame(
+                frame: rtc.AudioFrame, segment_id: str, is_final: bool
+            ):
                 self._event_ch.send_nowait(
                     tts.SynthesizedAudio(
                         request_id=request_id,
@@ -313,15 +315,15 @@ class SynthesizeStream(tts.SynthesizeStream):
                 if data.get("data"):
                     b64data = base64.b64decode(data["data"])
                     for frame in audio_bstream.write(b64data):
-                        _send_audio_frame(frame, False)
+                        _send_audio_frame(frame, segment_id, False)
                 elif data.get("done"):
                     last_frame: rtc.AudioFrame | None = None
                     for frame in audio_bstream.flush():
                         if last_frame is not None:
-                            _send_audio_frame(frame, False)
+                            _send_audio_frame(frame, segment_id, False)
                         last_frame = frame
                     if last_frame is not None:
-                        _send_audio_frame(last_frame, True)
+                        _send_audio_frame(last_frame, segment_id, True)
 
                     if segment_id == request_id:
                         # we're not going to receive more frames, close the connection

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -317,8 +317,8 @@ class SynthesizeStream(tts.SynthesizeStream):
                     for frame in audio_bstream.write(b64data):
                         _send_audio_frame(frame, segment_id, False)
                 elif data.get("done"):
-                    frames = enumerate(audio_bstream.flush())
-                    for i, frame in frames:
+                    frames = list(audio_bstream.flush())
+                    for i, frame in enumerate(frames):
                         _send_audio_frame(frame, segment_id, i == len(frames) - 1)
 
                     if segment_id == request_id:


### PR DESCRIPTION
We're running into an issue where our audio gets glitchy every so often (I sent a sample on Slack) - I think it's because we're either reordering or dropping frames.