### PR TITLE
enh: Extending api to support chirp_2 model, and support passing location

### DIFF
--- a/.changeset/chatty-grapes-scream.md
+++ b/.changeset/chatty-grapes-scream.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-google": minor
+---
+
+Add support for google STT chirp_2 model.

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/models.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/models.py
@@ -3,7 +3,13 @@ from typing import Literal
 # Speech to Text v2
 
 SpeechModels = Literal[
-    "long", "short", "telephony", "medical_dictation", "medical_conversation", "chirp"
+    "long",
+    "short",
+    "telephony",
+    "medical_dictation",
+    "medical_conversation",
+    "chirp",
+    "chirp_2",
 ]
 
 SpeechLanguages = Literal[

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = "function"
 log_cli = true
 log_cli_level = DEBUG

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -38,6 +38,12 @@ def read_mp3_file(filename: str) -> rtc.AudioFrame:
 RECOGNIZE_STT = [
     deepgram.STT(),
     google.STT(),
+    google.STT(
+        languages=["en-AU"],
+        model="chirp_2",
+        spoken_punctuation=False,
+        location="us-central1",
+    ),
     openai.STT(),
 ]
 
@@ -62,6 +68,12 @@ STREAM_STT = [
     assemblyai.STT(),
     deepgram.STT(),
     google.STT(),
+    google.STT(
+        languages=["en-AU"],
+        model="chirp_2",
+        spoken_punctuation=False,
+        location="us-central1",
+    ),
     agents.stt.StreamAdapter(stt=openai.STT(), vad=STREAM_VAD),
     azure.STT(),
 ]


### PR DESCRIPTION
Add support for `chirp_2` [transcription model](https://cloud.google.com/speech-to-text/v2/docs/transcription-model), that is supported in both batch and streaming transcription see [release notes](https://cloud.google.com/speech-to-text/docs/release-notes#October_07_2024)

Update tests to include both default SST, and SST with new model passing specific [location and language](https://cloud.google.com/speech-to-text/v2/docs/speech-to-text-supported-languages).  Note that spoken punctuation is not supported with this model.