### PR TITLE
fix Deepgram missing first word, disabled energy filter by default

### DIFF
--- a/.changeset/empty-jars-shave.md
+++ b/.changeset/empty-jars-shave.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-deepgram": patch
+---
+
+fix Deepgram missing first word, disabled energy filter by default

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,6 +116,7 @@ jobs:
           GOOGLE_CREDENTIALS_JSON: ${{ secrets.GOOGLE_CREDENTIALS_JSON }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ASSEMBLYAI_API_KEY: ${{ secrets.ASSEMBLYAI_API_KEY }}
+          FAL_KEY: ${{ secrets.FAL_KEY }}
           GOOGLE_APPLICATION_CREDENTIALS: google.json
           PYTEST_ADDOPTS: "--color=yes"
         working-directory: tests

--- a/examples/speech-to-text/transcriber.py
+++ b/examples/speech-to-text/transcriber.py
@@ -16,7 +16,6 @@ from livekit.plugins import deepgram, silero
 load_dotenv()
 
 logger = logging.getLogger("transcriber")
-logger.setLevel(logging.INFO)
 
 
 async def _forward_transcription(
@@ -29,6 +28,9 @@ async def _forward_transcription(
             pass
         elif ev.type == stt.SpeechEventType.FINAL_TRANSCRIPT:
             print(" -> ", ev.alternatives[0].text)
+        elif ev.type == stt.SpeechEventType.RECOGNITION_USAGE:
+            logger.debug(f"metrics: {ev.recognition_usage}")
+
         stt_forwarder.update(ev)
 
 

--- a/examples/speech-to-text/transcriber.py
+++ b/examples/speech-to-text/transcriber.py
@@ -11,7 +11,7 @@ from livekit.agents import (
     stt,
     transcription,
 )
-from livekit.plugins import openai, silero
+from livekit.plugins import deepgram, silero
 
 load_dotenv()
 
@@ -34,8 +34,10 @@ async def _forward_transcription(
 
 async def entrypoint(ctx: JobContext):
     logger.info(f"starting transcriber (speech to text) example, room: {ctx.room.name}")
-    # this example uses OpenAI Whisper, but you can use assemblyai,deepgram, google, azure, etc.
-    stt_impl = openai.STT()
+    # this example uses OpenAI Whisper, but you can use assemblyai, deepgram, google, azure, etc.
+    stt_impl = deepgram.STT(
+        energy_filter=True,
+    )
 
     if not stt_impl.capabilities.streaming:
         # wrap with a stream adapter to use streaming semantics

--- a/examples/speech-to-text/transcriber.py
+++ b/examples/speech-to-text/transcriber.py
@@ -11,7 +11,7 @@ from livekit.agents import (
     stt,
     transcription,
 )
-from livekit.plugins import deepgram, silero
+from livekit.plugins import openai, silero
 
 load_dotenv()
 
@@ -37,7 +37,7 @@ async def _forward_transcription(
 async def entrypoint(ctx: JobContext):
     logger.info(f"starting transcriber (speech to text) example, room: {ctx.room.name}")
     # this example uses OpenAI Whisper, but you can use assemblyai, deepgram, google, azure, etc.
-    stt_impl = deepgram.STT(
+    stt_impl = openai.STT(
         energy_filter=True,
     )
 

--- a/livekit-agents/livekit/agents/metrics/__init__.py
+++ b/livekit-agents/livekit/agents/metrics/__init__.py
@@ -10,6 +10,7 @@ from .base import (
     TTSMetrics,
     VADMetrics,
 )
+from .periodic_collector import PeriodicCollector
 from .usage_collector import UsageCollector, UsageSummary
 from .utils import log_metrics
 
@@ -26,5 +27,6 @@ __all__ = [
     "TTSMetrics",
     "UsageSummary",
     "UsageCollector",
+    "PeriodicCollector",
     "log_metrics",
 ]

--- a/livekit-agents/livekit/agents/metrics/periodic_collector.py
+++ b/livekit-agents/livekit/agents/metrics/periodic_collector.py
@@ -1,5 +1,5 @@
 import time
-from typing import Callable, Generic, TypeVar
+from typing import Callable, Generic, Optional, TypeVar
 
 T = TypeVar("T")
 
@@ -17,7 +17,7 @@ class PeriodicCollector(Generic[T]):
         self._duration = duration
         self._callback = callback
         self._last_flush_time = time.monotonic()
-        self._total: T | None = None
+        self._total: Optional[T] = None
 
     def push(self, value: T) -> None:
         """Add a value to the accumulator"""

--- a/livekit-agents/livekit/agents/metrics/periodic_collector.py
+++ b/livekit-agents/livekit/agents/metrics/periodic_collector.py
@@ -1,0 +1,36 @@
+import time
+from typing import Callable, Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class PeriodicCollector(Generic[T]):
+    def __init__(self, callback: Callable[[T], None], *, duration: float) -> None:
+        """
+        Create a new periodic collector that accumulates values and calls the callback
+        after the specified duration if there are values to report.
+
+        Args:
+            duration: Time in seconds between callback invocations
+            callback: Function to call with accumulated value when duration expires
+        """
+        self._duration = duration
+        self._callback = callback
+        self._last_flush_time = time.monotonic()
+        self._total: T | None = None
+
+    def push(self, value: T) -> None:
+        """Add a value to the accumulator"""
+        if self._total is None:
+            self._total = value
+        else:
+            self._total += value  # type: ignore
+        if time.monotonic() - self._last_flush_time >= self._duration:
+            self.flush()
+
+    def flush(self) -> None:
+        """Force callback to be called with current total if non-zero"""
+        if self._total is not None:
+            self._callback(self._total)
+            self._total = None
+        self._last_flush_time = time.monotonic()

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/__init__.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/__init__.py
@@ -1,7 +1,7 @@
-from .stt import STT, SpeechStream
+from .stt import STT, AudioEnergyFilter, SpeechStream
 from .version import __version__
 
-__all__ = ["STT", "SpeechStream", "__version__"]
+__all__ = ["STT", "SpeechStream", "AudioEnergyFilter", "__version__"]
 
 
 from livekit.agents import Plugin

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -279,13 +279,12 @@ class SpeechStream(stt.SpeechStream):
         self._speaking = False
         self._max_retry = max_retry
 
+        self._audio_energy_filter: Optional[AudioEnergyFilter] = None
         if opts.energy_filter:
             if isinstance(opts.energy_filter, AudioEnergyFilter):
                 self._audio_energy_filter = opts.energy_filter
             else:
                 self._audio_energy_filter = AudioEnergyFilter()
-        else:
-            self._audio_energy_filter = None
 
         self._pushed_audio_duration = 0.0
         self._request_id = ""

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -22,7 +22,7 @@ import os
 import wave
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 from urllib.parse import urlencode
 
 import aiohttp
@@ -49,36 +49,42 @@ BASE_URL_WS = "wss://api.deepgram.com/v1/listen"
 MAGIC_NUMBER_THRESHOLD = 0.004**2
 
 
-class _AudioEnergyFilter:
-    class _State(Enum):
+class AudioEnergyFilter:
+    class State(Enum):
         START = 0
         SPEAKING = 1
         SILENCE = 2
         END = 3
 
-    def __init__(self, *, min_silence: float = 1.5):
+    def __init__(
+        self, *, min_silence: float = 1.5, rms_threshold: float = MAGIC_NUMBER_THRESHOLD
+    ):
         self._cooldown_seconds = min_silence
         self._cooldown = min_silence
-        self._state = self._State.SILENCE
+        self._state = self.State.SILENCE
+        self._rms_threshold = rms_threshold
 
-    def update(self, frame: rtc.AudioFrame) -> _State:
+    def update(self, frame: rtc.AudioFrame) -> State:
         arr = np.frombuffer(frame.data, dtype=np.int16)
         float_arr = arr.astype(np.float32) / 32768.0
         rms = np.mean(np.square(float_arr))
 
-        if rms > MAGIC_NUMBER_THRESHOLD:
+        if rms > self._rms_threshold:
             self._cooldown = self._cooldown_seconds
-            if self._state in (self._State.SILENCE, self._State.END):
-                self._state = self._State.START
+            if self._state in (self.State.SILENCE, self.State.END):
+                self._state = self.State.START
             else:
-                self._state = self._State.SPEAKING
+                self._state = self.State.SPEAKING
         else:
-            self._cooldown -= frame.duration
             if self._cooldown <= 0:
-                if self._state in (self._State.SPEAKING, self._State.START):
-                    self._state = self._State.END
-                else:
-                    self._state = self._State.SILENCE
+                if self._state in (self.State.SPEAKING, self.State.START):
+                    self._state = self.State.END
+                elif self._state == self.State.END:
+                    self._state = self.State.SILENCE
+            else:
+                # keep speaking during cooldown
+                self._cooldown -= frame.duration
+                self._state = self.State.SPEAKING
 
         return self._state
 
@@ -98,6 +104,7 @@ class STTOptions:
     num_channels: int
     keywords: list[Tuple[str, float]]
     profanity_filter: bool
+    energy_filter: AudioEnergyFilter | bool = False
 
 
 class STT(stt.STT):
@@ -118,6 +125,7 @@ class STT(stt.STT):
         profanity_filter: bool = False,
         api_key: str | None = None,
         http_session: aiohttp.ClientSession | None = None,
+        energy_filter: AudioEnergyFilter | bool = False,
     ) -> None:
         """
         Create a new instance of Deepgram STT.
@@ -168,6 +176,7 @@ class STT(stt.STT):
             num_channels=1,
             keywords=keywords,
             profanity_filter=profanity_filter,
+            energy_filter=energy_filter,
         )
         self._session = http_session
 
@@ -269,7 +278,14 @@ class SpeechStream(stt.SpeechStream):
         self._session = http_session
         self._speaking = False
         self._max_retry = max_retry
-        self._audio_energy_filter = _AudioEnergyFilter()
+
+        if opts.energy_filter:
+            if isinstance(opts.energy_filter, AudioEnergyFilter):
+                self._audio_energy_filter = opts.energy_filter
+            else:
+                self._audio_energy_filter = AudioEnergyFilter()
+        else:
+            self._audio_energy_filter = None
 
         self._pushed_audio_duration = 0.0
         self._request_id = ""
@@ -361,32 +377,52 @@ class SpeechStream(stt.SpeechStream):
                 samples_per_channel=samples_50ms,
             )
 
+            has_ended = False
+            last_frame: Optional[rtc.AudioFrame] = None
             async for data in self._input_ch:
-                if isinstance(data, self._FlushSentinel):
+                frames: list[rtc.AudioFrame] = []
+                if isinstance(data, rtc.AudioFrame):
+                    state = self._check_energy_state(data)
+                    if state in (
+                        AudioEnergyFilter.State.START,
+                        AudioEnergyFilter.State.SPEAKING,
+                    ):
+                        if last_frame:
+                            frames.extend(
+                                audio_bstream.write(last_frame.data.tobytes())
+                            )
+                            last_frame = None
+                        frames.extend(audio_bstream.write(data.data.tobytes()))
+                    elif state == AudioEnergyFilter.State.END:
+                        # no need to buffer as we have cooldown period
+                        frames = audio_bstream.flush()
+                        has_ended = True
+                    elif state == AudioEnergyFilter.State.SILENCE:
+                        # buffer the last silence frame, since it could contain beginning of speech
+                        # TODO: improve accuracy by using a ring buffer with longer window
+                        last_frame = data
+                elif isinstance(data, self._FlushSentinel):
                     frames = audio_bstream.flush()
-                else:
-                    frames = audio_bstream.write(data.data.tobytes())
+                    has_ended = True
 
                 for frame in frames:
-                    state = self._audio_energy_filter.update(frame)
-                    if state in (
-                        _AudioEnergyFilter._State.START,
-                        _AudioEnergyFilter._State.SPEAKING,
-                    ):
-                        self._pushed_audio_duration += frame.duration
-                        await ws.send_bytes(frame.data.tobytes())
-                    elif state == _AudioEnergyFilter._State.END:
-                        usage_event = stt.SpeechEvent(
-                            type=stt.SpeechEventType.RECOGNITION_USAGE,
-                            request_id=self._request_id,
-                            alternatives=[],
-                            recognition_usage=stt.RecognitionUsage(
-                                audio_duration=self._pushed_audio_duration
-                            ),
-                        )
-                        self._pushed_audio_duration = 0.0
-                        self._event_ch.send_nowait(usage_event)
+                    self._pushed_audio_duration += frame.duration
+                    await ws.send_bytes(frame.data.tobytes())
+
+                    if has_ended:
                         await ws.send_str(SpeechStream._FINALIZE_MSG)
+                        has_ended = False
+                        if self._pushed_audio_duration > 0:
+                            usage_event = stt.SpeechEvent(
+                                type=stt.SpeechEventType.RECOGNITION_USAGE,
+                                request_id=self._request_id,
+                                alternatives=[],
+                                recognition_usage=stt.RecognitionUsage(
+                                    audio_duration=self._pushed_audio_duration
+                                ),
+                            )
+                            self._pushed_audio_duration = 0.0
+                            self._event_ch.send_nowait(usage_event)
 
             # tell deepgram we are done sending audio/inputs
             closing_ws = True
@@ -426,6 +462,11 @@ class SpeechStream(stt.SpeechStream):
             await asyncio.gather(*tasks)
         finally:
             await utils.aio.gracefully_cancel(*tasks)
+
+    def _check_energy_state(self, frame: rtc.AudioFrame) -> AudioEnergyFilter.State:
+        if self._audio_energy_filter:
+            return self._audio_energy_filter.update(frame)
+        return AudioEnergyFilter.State.SPEAKING
 
     def _process_stream_event(self, data: dict) -> None:
         assert self._opts.language is not None


### PR DESCRIPTION
- energy filter should run on smaller chunks of audio
- it's disabled by default, as it's an optimization
- buffers audio frame immediately prior to energy detection to improve accuracy