### PR TITLE
enh: Update to also pass ClientOptions to credentials args

### DIFF
--- a/.changeset/little-phones-drive.md
+++ b/.changeset/little-phones-drive.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-google": patch
+---
+
+Update to support passing chirp_2 location for other STT credentials

--- a/livekit-plugins/install_plugins_editable.sh
+++ b/livekit-plugins/install_plugins_editable.sh
@@ -11,6 +11,7 @@ pip install -e ./livekit-plugins-azure --config-settings editable_mode=strict
 pip install -e ./livekit-plugins-cartesia --config-settings editable_mode=strict
 pip install -e ./livekit-plugins-deepgram --config-settings editable_mode=strict
 pip install -e ./livekit-plugins-elevenlabs --config-settings editable_mode=strict
+pip install -e ./livekit-plugins-fal --config-settings editable_mode=strict
 pip install -e ./livekit-plugins-google --config-settings editable_mode=strict
 pip install -e ./livekit-plugins-minimal --config-settings editable_mode=strict
 pip install -e ./livekit-plugins-nltk --config-settings editable_mode=strict

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -129,21 +129,25 @@ class STT(stt.STT):
     def _ensure_client(self) -> SpeechAsyncClient:
         # Add support for passing a specific location that matches recognizer
         # see: https://cloud.google.com/speech-to-text/v2/docs/speech-to-text-supported-languages
-        args = {}
+        client_options = None
         if self._location != "global":
-            args["client_options"] = ClientOptions(
+            client_options = ClientOptions(
                 api_endpoint=f"{self._location}-speech.googleapis.com"
             )
         if self._credentials_info:
             self._client = SpeechAsyncClient.from_service_account_info(
-                self._credentials_info, **args
+                self._credentials_info,
+                client_options=client_options,
             )
         elif self._credentials_file:
             self._client = SpeechAsyncClient.from_service_account_file(
-                self._credentials_file, **args
+                self._credentials_file,
+                client_options=client_options,
             )
         else:
-            self._client = SpeechAsyncClient(**args)
+            self._client = SpeechAsyncClient(
+                client_options=client_options,
+            )
         assert self._client is not None
         return self._client
 

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -127,24 +127,23 @@ class STT(stt.STT):
         )
 
     def _ensure_client(self) -> SpeechAsyncClient:
+        # Add support for passing a specific location that matches recognizer
+        # see: https://cloud.google.com/speech-to-text/v2/docs/speech-to-text-supported-languages
+        args = {}
+        if self._location != "global":
+            args["client_options"] = ClientOptions(
+                api_endpoint=f"{self._location}-speech.googleapis.com"
+            )
         if self._credentials_info:
             self._client = SpeechAsyncClient.from_service_account_info(
-                self._credentials_info
+                self._credentials_info, **args
             )
         elif self._credentials_file:
             self._client = SpeechAsyncClient.from_service_account_file(
-                self._credentials_file
+                self._credentials_file, **args
             )
-        elif self._location == "global":
-            self._client = SpeechAsyncClient()
         else:
-            # Add support for passing a specific location that matches recognizer
-            # see: https://cloud.google.com/speech-to-text/v2/docs/speech-to-text-supported-languages
-            self._client = SpeechAsyncClient(
-                client_options=ClientOptions(
-                    api_endpoint=f"{self._location}-speech.googleapis.com"
-                )
-            )
+            self._client = SpeechAsyncClient(**args)
         assert self._client is not None
         return self._client
 


### PR DESCRIPTION
* Additional update to support setting `client_options` for other SpeechAsyncClient constructors
   - extends #1089 
* Update tests install for FAL

cc @theomonnom