### PR TITLE
Add mulaw encoding option to ElevenLabs plugin

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/models.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/models.py
@@ -18,4 +18,5 @@ TTSEncoding = Literal[
     "pcm_16000",
     "pcm_22050",
     "pcm_44100",
+    "ulaw_8000",
 ]


### PR DESCRIPTION
Add support for ElevenLabs' [mulaw encoding format ](https://elevenlabs.io/docs/api-reference/websockets#query-parameters)(`ulaw_8000`) since services such as Twilio recommend using this encoding for outbound calls.