### PR TITLE
fix: add retries to recover from realtime api text mode

### DIFF
--- a/.changeset/great-swans-beg.md
+++ b/.changeset/great-swans-beg.md
@@ -1,0 +1,6 @@
+---
+"livekit-plugins-openai": patch
+"livekit-agents": patch
+---
+
+Add retries to recover from text mode to audio model for realtime API

--- a/livekit-agents/livekit/agents/multimodal/multimodal_agent.py
+++ b/livekit-agents/livekit/agents/multimodal/multimodal_agent.py
@@ -67,8 +67,25 @@ class MultimodalAgent(utils.EventEmitter[EventTypes]):
         chat_ctx: llm.ChatContext | None = None,
         fnc_ctx: llm.FunctionContext | None = None,
         transcription: AgentTranscriptionOptions = AgentTranscriptionOptions(),
+        max_text_response_retries: int = 5,
         loop: asyncio.AbstractEventLoop | None = None,
     ):
+        """Create a new MultimodalAgent.
+
+        Args:
+            model: S2SModel instance.
+            vad: Voice Activity Detection (VAD) instance.
+            chat_ctx: Chat context for the assistant.
+            fnc_ctx: Function context for the assistant.
+            transcription: Options for assistant transcription.
+            max_text_response_retries: Maximum number of retries to recover
+                from text responses to audio mode. OpenAI's realtime API has a
+                chance to return text responses instead of audio if the chat
+                context includes text system or assistant messages. The agent will
+                attempt to recover to audio mode by deleting the text response
+                and appending an empty audio message to the conversation.
+            loop: Event loop to use. Default to asyncio.get_event_loop().
+        """
         super().__init__()
         self._loop = loop or asyncio.get_event_loop()
 
@@ -98,6 +115,9 @@ class MultimodalAgent(utils.EventEmitter[EventTypes]):
 
         self._update_state_task: asyncio.Task | None = None
         self._http_session: aiohttp.ClientSession | None = None
+
+        self._text_response_retries = 0
+        self._max_text_response_retries = max_text_response_retries
 
     @property
     def vad(self) -> vad.VAD | None:
@@ -162,9 +182,6 @@ class MultimodalAgent(utils.EventEmitter[EventTypes]):
         @self._session.on("response_content_added")
         def _on_content_added(message: realtime.RealtimeContent):
             if message.content_type == "text":
-                logger.warning(
-                    "The realtime API returned a text content part, which is not supported"
-                )
                 return
 
             tr_fwd = transcription.TTSSegmentsForwarder(
@@ -183,6 +200,31 @@ class MultimodalAgent(utils.EventEmitter[EventTypes]):
                 text_stream=message.text_stream,
                 audio_stream=message.audio_stream,
             )
+
+        @self._session.on("response_content_done")
+        def _response_content_done(message: realtime.RealtimeContent):
+            if message.content_type == "text":
+                if self._text_response_retries >= self._max_text_response_retries:
+                    raise RuntimeError(
+                        f"The OpenAI Realtime API returned a text response "
+                        f"after {self._max_text_response_retries} retries. "
+                        f"Please try to reduce the number of text system or "
+                        f"assistant messages in the chat context."
+                    )
+
+                self._text_response_retries += 1
+                logger.warning(
+                    "The OpenAI Realtime API returned a text response instead of audio. "
+                    "Attempting to recover to audio mode...",
+                    extra={
+                        "item_id": message.item_id,
+                        "text": message.text,
+                        "retries": self._text_response_retries,
+                    },
+                )
+                self._session._recover_from_text_response(message.item_id)
+            else:
+                self._text_response_retries = 0
 
         @self._session.on("input_speech_committed")
         def _input_speech_committed():

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -873,24 +873,8 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
         if changes.to_add and not any(
             isinstance(msg.content, llm.ChatAudio) for _, msg in changes.to_add
         ):
-            # Patch: add an empty audio message to the chat context
-            # to set the API in audio mode
-            data = b"\x00\x00" * api_proto.SAMPLE_RATE
-            _empty_audio = rtc.AudioFrame(
-                data=data,
-                sample_rate=api_proto.SAMPLE_RATE,
-                num_channels=api_proto.NUM_CHANNELS,
-                samples_per_channel=len(data) // 2,
-            )
-            changes.to_add.append(
-                (
-                    None,
-                    llm.ChatMessage(
-                        role="user", content=llm.ChatAudio(frame=_empty_audio)
-                    ),
-                )
-            )
-            logger.debug("added empty audio message to the chat context")
+            # Patch: append an empty audio message to set the API in audio mode
+            changes.to_add.append((None, self._create_empty_user_audio_message(1.0)))
 
         _futs = [
             self.conversation.item.delete(item_id=msg.id) for msg in changes.to_delete
@@ -901,6 +885,27 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
 
         # wait for all the futures to complete
         await asyncio.gather(*_futs)
+
+    def _create_empty_user_audio_message(self, duration: float) -> llm.ChatMessage:
+        samples = int(duration * api_proto.SAMPLE_RATE)
+        return llm.ChatMessage(
+            role="user",
+            content=llm.ChatAudio(
+                frame=rtc.AudioFrame(
+                    data=b"\x00\x00" * samples,
+                    sample_rate=api_proto.SAMPLE_RATE,
+                    num_channels=api_proto.NUM_CHANNELS,
+                    samples_per_channel=samples,
+                )
+            ),
+        )
+
+    def _recover_from_text_response(self, item_id: str | None = None) -> None:
+        if item_id:
+            # remove the text response if needed
+            self.conversation.item.delete(item_id=item_id)
+        self.conversation.item.create(self._create_empty_user_audio_message(1.0))
+        self.response.create()
 
     def _update_converstation_item_content(
         self, item_id: str, content: llm.ChatContent | list[llm.ChatContent] | None
@@ -1031,6 +1036,8 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
                         self._handle_response_audio_transcript_delta(data)
                     elif event == "response.audio.done":
                         self._handle_response_audio_done(data)
+                    elif event == "response.text.done":
+                        self._handle_response_text_done(data)
                     elif event == "response.audio_transcript.done":
                         self._handle_response_audio_transcript_done(data)
                     elif event == "response.content_part.done":
@@ -1302,6 +1309,12 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
         content = self._get_content(response_audio_done)
         assert isinstance(content.audio_stream, utils.aio.Chan)
         content.audio_stream.close()
+
+    def _handle_response_text_done(
+        self, response_text_done: api_proto.ServerEvent.ResponseTextDone
+    ):
+        content = self._get_content(response_text_done)
+        content.text = response_text_done["text"]
 
     def _handle_response_audio_transcript_done(
         self,


### PR DESCRIPTION
Sometimes the real-time API responds in text mode, so a retry method needs to be added to remove the text response, append an empty user audio message, and request a new response.

The example log messages:
> WARNING livekit.agents - The OpenAI Realtime API returned a text response instead of audio. Attempting to recover to audio mode... {"item_id": "item_AW3WzU2ZflaraUBqpibe3", "text": "Hello! How can I assist you with finding movies today? Please let me know the city, province, and date you're interested in.", "retries": 1}

