### PR TITLE
Added session expiry emitter and handler

### DIFF
--- a/livekit-agents/livekit/agents/multimodal/multimodal_agent.py
+++ b/livekit-agents/livekit/agents/multimodal/multimodal_agent.py
@@ -159,6 +159,19 @@ class MultimodalAgent(utils.EventEmitter[EventTypes]):
 
         from livekit.plugins.openai import realtime
 
+        @self._session.on("session_expired")
+        def _on_session_expired():
+            logger.warning(
+                "The realtime API session has expired. Creating a new session with existing context."
+            )
+            
+            self._session = self._model.session(
+                chat_ctx=self._chat_ctx, fnc_ctx=self._fnc_ctx
+            )
+            
+            # Schedule the initialization and start task
+            asyncio.create_task(_init_and_start())
+
         @self._session.on("response_content_added")
         def _on_content_added(message: realtime.RealtimeContent):
             if message.content_type == "text":

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1060,6 +1060,8 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
         self._session_id = session_created["session"]["id"]
 
     def _handle_error(self, error: api_proto.ServerEvent.Error):
+        if error["error"]["code"] == "session_expired":
+            self.emit("session_expired")
         logger.error(
             "OpenAI S2S error %s",
             error,


### PR DESCRIPTION
I've added an emitter to fire off from the session when we get

```
{"message": "OpenAI S2S error {'type': 'error', 'event_id': 'event_AW4k97NLw8djhOYGTmAKE', 'error': {'type': 'invalid_request_error', 'code': 'session_expired', 'message': 'Your session hit the maximum duration of 15 minutes.', 'param': None, 'event_id': None}}", "level": "ERROR", "name": "livekit.plugins.openai.realtime", "session_id": "sess_AW4VdS3rzu9Urm09yxmVF", "pid": 14, "job_id": "AJ_tvF6DWGpnsJx", "timestamp": "2024-11-21T16:54:53.552867+00:00"}
```

This is then handled by creating a new session.
