### PR TITLE
feat(playht): add Play3.0-mini engine support

### DIFF
--- a/.changeset/warm-suns-fly.md
+++ b/.changeset/warm-suns-fly.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-playht": patch
+---
+
+feat(playht): add Play3.0-mini engine support

--- a/livekit-plugins/livekit-plugins-playht/livekit/plugins/playht/models.py
+++ b/livekit-plugins/livekit-plugins-playht/livekit/plugins/playht/models.py
@@ -1,6 +1,11 @@
 from typing import Literal
 
-TTSEngines = Literal["PlayHT2.0", "PlayHT1.0", "PlayHT2.0-turbo"]
+TTSEngines = Literal[
+    "PlayHT2.0",
+    "PlayHT1.0",
+    "PlayHT2.0-turbo",
+    "Play3.0-mini",
+]
 
 TTSEncoding = Literal[
     "mp3_22050_32",

--- a/livekit-plugins/livekit-plugins-playht/livekit/plugins/playht/tts.py
+++ b/livekit-plugins/livekit-plugins-playht/livekit/plugins/playht/tts.py
@@ -32,6 +32,8 @@ def _encoding_from_format(output_format: TTSEncoding) -> _Encoding:
         return "mp3"
     elif output_format.startswith("pcm"):
         return "pcm"
+    elif output_format.startswith("wav"):
+        return "pcm"
 
     raise ValueError(f"Unknown format: {output_format}")
 
@@ -46,7 +48,7 @@ class Voice:
 DEFAULT_VOICE = Voice(
     id="s3://peregrine-voices/mel22/manifest.json",
     name="Will",
-    voice_engine="PlayHT2.0",
+    voice_engine="Play3.0-mini",
 )
 
 ACCEPT_HEADER = {


### PR DESCRIPTION
- Introduce "Play3.0-mini" to the TTSEngines literal for expanded voice engine options.
- Handle "wav" format in _encoding_from_format function for better output format support.
- Update default voice engine to "Play3.0-mini" for the DEFAULT_VOICE configuration.