### PR TITLE
fix: empty agent transcript

### DIFF
--- a/.changeset/brave-plums-help.md
+++ b/.changeset/brave-plums-help.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+fix: empty agent transcript

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -882,6 +882,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
 
             if interrupted:
                 collected_text += "..."
+
             if collected_text:
                 msg = ChatMessage.create(text=collected_text, role="assistant")
                 self._chat_ctx.messages.append(msg)

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -882,25 +882,25 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
 
             if interrupted:
                 collected_text += "..."
+            if collected_text:
+                msg = ChatMessage.create(text=collected_text, role="assistant")
+                self._chat_ctx.messages.append(msg)
 
-            msg = ChatMessage.create(text=collected_text, role="assistant")
-            self._chat_ctx.messages.append(msg)
+                speech_handle.mark_speech_committed()
 
-            speech_handle.mark_speech_committed()
+                if interrupted:
+                    self.emit("agent_speech_interrupted", msg)
+                else:
+                    self.emit("agent_speech_committed", msg)
 
-            if interrupted:
-                self.emit("agent_speech_interrupted", msg)
-            else:
-                self.emit("agent_speech_committed", msg)
-
-            logger.debug(
-                "committed agent speech",
-                extra={
-                    "agent_transcript": collected_text,
-                    "interrupted": interrupted,
-                    "speech_id": speech_handle.id,
-                },
-            )
+                logger.debug(
+                    "committed agent speech",
+                    extra={
+                        "agent_transcript": collected_text,
+                        "interrupted": interrupted,
+                        "speech_id": speech_handle.id,
+                    },
+                )
 
         # mark the speech as done
         speech_handle._set_done()


### PR DESCRIPTION
This PR fixes the bug where a message was being added to the chat context even when `msg.content` was empty.

![image](https://github.com/user-attachments/assets/010711a8-e5cf-4854-91e4-ad41c6a2abc3)
It's the same speech id which has tool calls with no content from model's response
![image](https://github.com/user-attachments/assets/6334cdc2-6e55-48d9-83eb-31958059d9cd)

