### PR TITLE
Draft: mistral with openai

### DIFF
--- a/.changeset/seven-boxes-give.md
+++ b/.changeset/seven-boxes-give.md
@@ -1,0 +1,6 @@
+---
+"livekit-plugins-openai": patch
+"livekit-agents": patch
+---
+
+feat: mistral support

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -50,6 +50,7 @@ class Choice:
 @dataclass
 class LLMCapabilities:
     supports_choices_on_int: bool = True
+    supports_stream_options: bool = True
 
 
 @dataclass

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -37,6 +37,17 @@ AssistantTools = Literal["code_interpreter", "file_search", "function"]
 
 # adapters for OpenAI-compatible LLMs
 
+MistralChatModels = Literal[
+    "mistral-large-latest",
+    "ministral-3b-latest",
+    "ministral-8b-latest",
+    "mistral-small-latest",
+    "mistral-large-2411",
+    "ministral-3b-2410",
+    "ministral-8b-2410",
+    "mistral-small-2409",
+]
+
 TelnyxChatModels = Literal[
     "meta-llama/Meta-Llama-3.1-8B-Instruct",
     "meta-llama/Meta-Llama-3.1-70B-Instruct",


### PR DESCRIPTION
### What
This PR implements Mistral AI support with openai LLM

### Why
Feature Improvement

### How
Example Usage
```python
    agent = VoicePipelineAgent(
        vad=ctx.proc.userdata["vad"],
        stt=openai.STT(),
        llm=openai.LLM.with_mistral(),
        tts=openai.TTS(),
        fnc_ctx=fnc_ctx,
        chat_ctx=initial_chat_ctx,
    )
```