### PR TITLE
fix bug related to emit error msg

### DIFF
--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -56,6 +56,7 @@ EventTypes = Literal[
     "function_calls_collected",
     "function_calls_finished",
     "metrics_collected",
+    "error_message_collected",
 ]
 
 _CallContextVar = contextvars.ContextVar["AgentCallContext"](
@@ -929,6 +930,9 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                         continue
 
                     yield content
+
+            except Exception as e:
+                self.emit("error_message_collected", e)
             finally:
                 await stream.aclose()
 


### PR DESCRIPTION
fix bug related to emit error msg #1155 

I decided to create an emit callback named `error_message_collected` to handle errors effectively.  
This callback will emit any exceptions encountered during the chunk loop.  
I added exception handling within the chunk loop to capture and emit these errors.  
The emitted errors will then be processed to ensure proper handling.  
This approach ensures the application can react appropriately, such as providing audible feedback.