### PR TITLE
fix: add extra_chat_message to the end of the function call outputs

### DIFF
--- a/.changeset/gentle-dolphins-judge.md
+++ b/.changeset/gentle-dolphins-judge.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+add extra chat messages to the end of the function call outputs

--- a/examples/voice-pipeline-agent/function_calling_weather.py
+++ b/examples/voice-pipeline-agent/function_calling_weather.py
@@ -50,12 +50,11 @@ class AssistantFnc(llm.FunctionContext):
         ]
         message = random.choice(filler_messages).format(location=location)
 
-        # NOTE: set add_to_fnc_call_ctx=True will add the message to the end
+        # NOTE: set add_to_chat_ctx=True will add the message to the end
         #   of the chat context of the function call for answer synthesis
-        speech_handle = await call_ctx.agent.say(message, add_to_fnc_call_ctx=True)  # noqa: F841
+        speech_handle = await call_ctx.agent.say(message, add_to_chat_ctx=True)  # noqa: F841
 
-        # Or wait for the speech to finish, the said message will be added to the chat context
-        # automatically when the `add_to_chat_ctx` is True (default)
+        # To wait for the speech to finish
         # await speech_handle.join()
 
         logger.info(f"getting weather for {location}")

--- a/examples/voice-pipeline-agent/function_calling_weather.py
+++ b/examples/voice-pipeline-agent/function_calling_weather.py
@@ -49,16 +49,10 @@ class AssistantFnc(llm.FunctionContext):
             "The current weather in {location} is ",
         ]
         message = random.choice(filler_messages).format(location=location)
-        speech_handle = await call_ctx.agent.say(message)  # noqa: F841
 
-        # (optional) add the filler message to the chat context for synthesis the tool call speech
-        said_message = llm.ChatMessage(role="assistant", content=message)
-
-        # option 1: add the message to the beginning of the function call outputs
-        # call_ctx.chat_ctx.messages.append(said_message)
-
-        # option 2: add the message to the end of the function call outputs
-        call_ctx.add_extra_chat_message(said_message)
+        # NOTE: set add_to_fnc_call_ctx=True will add the message to the end
+        #   of the chat context of the function call for answer synthesis
+        speech_handle = await call_ctx.agent.say(message, add_to_fnc_call_ctx=True)  # noqa: F841
 
         # Or wait for the speech to finish, the said message will be added to the chat context
         # automatically when the `add_to_chat_ctx` is True (default)

--- a/examples/voice-pipeline-agent/function_calling_weather.py
+++ b/examples/voice-pipeline-agent/function_calling_weather.py
@@ -1,4 +1,5 @@
 import logging
+import random
 from typing import Annotated
 
 import aiohttp
@@ -39,11 +40,25 @@ class AssistantFnc(llm.FunctionContext):
         # while awaiting the completion of the function call. To create a more dynamic and engaging
         # interaction, consider varying the responses based on context or user input.
         call_ctx = AgentCallContext.get_current()
-        message = f"Let me check the weather in {location} for you."
+        # message = f"Let me check the weather in {location} for you."
+        message = f"Here is the weather in {location}: "
+        filler_messages = [
+            "Let me check the weather in {location} for you.",
+            "Let me see what the weather is like in {location} right now.",
+            # LLM will complete this sentence if it is added to the end of the chat context
+            "The current weather in {location} is ",
+        ]
+        message = random.choice(filler_messages).format(location=location)
         speech_handle = await call_ctx.agent.say(message)  # noqa: F841
 
         # (optional) add the filler message to the chat context for synthesis the tool call speech
-        call_ctx.chat_ctx.append(text=message, role="assistant")
+        said_message = llm.ChatMessage(role="assistant", content=message)
+
+        # option 1: add the message to the beginning of the function call outputs
+        # call_ctx.chat_ctx.messages.append(said_message)
+
+        # option 2: add the message to the end of the function call outputs
+        call_ctx.add_extra_chat_message(said_message)
 
         # Or wait for the speech to finish, the said message will be added to the chat context
         # automatically when the `add_to_chat_ctx` is True (default)


### PR DESCRIPTION
For https://github.com/livekit/agents/issues/1162

When adding the said message in function call to the end of the function call outputs, the LLM can complete the answer following the added text, for example
```python
agent.say("The current weather in New York is")

# The answer LLM after function call will be
"overcast with a temperature of 37°F."
```
If the said message is added before the function call outputs, the LLM tend to repeat it some times
```python
The current weather in New York is  # agent.say
The current weather in New York is overcast with a temperature of 37°F.  # answer LLM output
```