### PR TITLE
chore: Refactor chat completion creation to a separate method

### DIFF
--- a/.changeset/slimy-eels-drive.md
+++ b/.changeset/slimy-eels-drive.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-openai": patch
+---
+
+Refactor chat completion creation to a separate method

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -630,13 +630,15 @@ class LLM(llm.LLM):
 
     @wraps(AsyncCompletions.create)
     def create_chat_completions_stream(self, **kwargs):
-        return self._client.chat.completions.create(**{
-            "model": self._opts.model,
-            "stream_options": {"include_usage": True},
-            "stream": True,
-            "user": self._opts.user or openai.NOT_GIVEN,
-            **kwargs,
-        })
+        return self._client.chat.completions.create(
+            **{
+                "model": self._opts.model,
+                "stream_options": {"include_usage": True},
+                "stream": True,
+                "user": self._opts.user or openai.NOT_GIVEN,
+                **kwargs,
+            }
+        )
 
     def chat(
         self,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -630,13 +630,13 @@ class LLM(llm.LLM):
 
     @wraps(AsyncCompletions.create)
     def create_chat_completions_stream(self, **kwargs):
-        return self._client.chat.completions.create(
-            model=self._opts.model,
-            stream_options={"include_usage": True},
-            stream=True,
-            user=self._opts.user or openai.NOT_GIVEN,
+        return self._client.chat.completions.create(**{
+            "model": self._opts.model,
+            "stream_options": {"include_usage": True},
+            "stream": True,
+            "user": self._opts.user or openai.NOT_GIVEN,
             **kwargs,
-        )
+        })
 
     def chat(
         self,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 
 import asyncio
 import datetime
-from functools import wraps
 import os
 from dataclasses import dataclass
+from functools import wraps
 from typing import Any, Awaitable, Literal, MutableSet, Union
 
 import aiohttp


### PR DESCRIPTION
This allows to:
- simplify the `chat` method 
- customize OpenAI completion arguments in subclasses.