### PR TITLE
Improve test names for better readability

### DIFF
--- a/.changeset/twenty-apes-pay.md
+++ b/.changeset/twenty-apes-pay.md
@@ -1,5 +1,0 @@
----
-"livekit-agents": patch
----
-
-Improve test names for better readability

--- a/.changeset/twenty-apes-pay.md
+++ b/.changeset/twenty-apes-pay.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Improve test names for better readability

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -79,7 +79,7 @@ def test_hashable_typeinfo():
 
 
 LLMS: list[Callable[[], llm.LLM]] = [
-    lambda: openai.LLM(),
+    pytest.param(lambda: openai.LLM(), id="openai"),
     # lambda: openai.beta.AssistantLLM(
     #     assistant_opts=openai.beta.AssistantOptions(
     #         create_options=openai.beta.AssistantCreateOptions(
@@ -89,8 +89,8 @@ LLMS: list[Callable[[], llm.LLM]] = [
     #         )
     #     )
     # ),
-    lambda: anthropic.LLM(),
-    lambda: openai.LLM.with_vertex(),
+    pytest.param(lambda: anthropic.LLM(), id="anthropic"),
+    pytest.param(lambda: openai.LLM.with_vertex(), id="openai.with_vertex"),
 ]
 
 

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -5,16 +5,18 @@ Do speech recognition on a long audio file and compare the result with the expec
 import asyncio
 import time
 from itertools import product
+from typing import Callable
 
 import pytest
 from livekit import agents
+from livekit.agents import stt
 from livekit.plugins import assemblyai, azure, deepgram, fal, google, openai, silero
 
 from .utils import make_test_speech, wer
 
 SAMPLE_RATES = [24000, 44100]  # test multiple input sample rates
 WER_THRESHOLD = 0.2
-RECOGNIZE_STT = [
+RECOGNIZE_STT: list[Callable[[], stt.STT]] = [
     pytest.param(lambda: deepgram.STT(), id="deepgram"),
     pytest.param(lambda: google.STT(), id="google"),
     pytest.param(
@@ -50,7 +52,7 @@ async def test_recognize(stt_factory, sample_rate):
 
 
 STREAM_VAD = silero.VAD.load(min_silence_duration=0.75)
-STREAM_STT = [
+STREAM_STT: list[Callable[[], stt.STT]] = [
     pytest.param(lambda: assemblyai.STT(), id="assemblyai"),
     pytest.param(lambda: deepgram.STT(), id="deepgram"),
     pytest.param(lambda: google.STT(), id="google"),

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -4,7 +4,6 @@ Do speech recognition on a long audio file and compare the result with the expec
 
 import asyncio
 import time
-from itertools import product
 from typing import Callable
 
 import pytest
@@ -34,9 +33,8 @@ RECOGNIZE_STT: list[Callable[[], stt.STT]] = [
 
 
 @pytest.mark.usefixtures("job_process")
-@pytest.mark.parametrize(
-    "stt_factory, sample_rate", product(RECOGNIZE_STT, SAMPLE_RATES)
-)
+@pytest.mark.parametrize("stt_factory", RECOGNIZE_STT)
+@pytest.mark.parametrize("sample_rate", SAMPLE_RATES)
 async def test_recognize(stt_factory, sample_rate):
     async with stt_factory() as stt:
         frames, transcript = make_test_speech(sample_rate=sample_rate)
@@ -78,7 +76,8 @@ STREAM_STT: list[Callable[[], stt.STT]] = [
 
 
 @pytest.mark.usefixtures("job_process")
-@pytest.mark.parametrize("stt_factory, sample_rate", product(STREAM_STT, SAMPLE_RATES))
+@pytest.mark.parametrize("stt_factory", STREAM_STT)
+@pytest.mark.parametrize("sample_rate", SAMPLE_RATES)
 async def test_stream(stt_factory, sample_rate):
     stt = stt_factory()
 

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -15,16 +15,19 @@ from .utils import make_test_speech, wer
 SAMPLE_RATES = [24000, 44100]  # test multiple input sample rates
 WER_THRESHOLD = 0.2
 RECOGNIZE_STT = [
-    lambda: deepgram.STT(),
-    lambda: google.STT(),
-    lambda: google.STT(
-        languages=["en-AU"],
-        model="chirp_2",
-        spoken_punctuation=False,
-        location="us-central1",
+    pytest.param(lambda: deepgram.STT(), id="deepgram"),
+    pytest.param(lambda: google.STT(), id="google"),
+    pytest.param(
+        lambda: google.STT(
+            languages=["en-AU"],
+            model="chirp_2",
+            spoken_punctuation=False,
+            location="us-central1",
+        ),
+        id="google.chirp_2",
     ),
-    lambda: openai.STT(),
-    lambda: fal.WizperSTT(),
+    pytest.param(lambda: openai.STT(), id="openai"),
+    pytest.param(lambda: fal.WizperSTT(), id="fal"),
 ]
 
 
@@ -48,18 +51,27 @@ async def test_recognize(stt_factory, sample_rate):
 
 STREAM_VAD = silero.VAD.load(min_silence_duration=0.75)
 STREAM_STT = [
-    lambda: assemblyai.STT(),
-    lambda: deepgram.STT(),
-    lambda: google.STT(),
-    lambda: agents.stt.StreamAdapter(stt=openai.STT(), vad=STREAM_VAD),
-    lambda: agents.stt.StreamAdapter(stt=openai.STT.with_groq(), vad=STREAM_VAD),
-    lambda: google.STT(
-        languages=["en-AU"],
-        model="chirp_2",
-        spoken_punctuation=False,
-        location="us-central1",
+    pytest.param(lambda: assemblyai.STT(), id="assemblyai"),
+    pytest.param(lambda: deepgram.STT(), id="deepgram"),
+    pytest.param(lambda: google.STT(), id="google"),
+    pytest.param(
+        lambda: agents.stt.StreamAdapter(stt=openai.STT(), vad=STREAM_VAD),
+        id="openai.stream",
     ),
-    lambda: azure.STT(),
+    pytest.param(
+        lambda: agents.stt.StreamAdapter(stt=openai.STT.with_groq(), vad=STREAM_VAD),
+        id="openai.with_groq.stream",
+    ),
+    pytest.param(
+        lambda: google.STT(
+            languages=["en-AU"],
+            model="chirp_2",
+            spoken_punctuation=False,
+            location="us-central1",
+        ),
+        id="google.chirp_2",
+    ),
+    pytest.param(lambda: azure.STT(), id="azure"),
 ]
 
 

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -34,12 +34,14 @@ async def _assert_valid_synthesized_audio(
 
 
 SYNTHESIZE_TTS = [
-    lambda: elevenlabs.TTS(),
-    lambda: elevenlabs.TTS(encoding="pcm_44100"),
-    lambda: openai.TTS(),
-    lambda: google.TTS(),
-    lambda: azure.TTS(),
-    lambda: cartesia.TTS(),
+    pytest.param(lambda: elevenlabs.TTS(), id="elevenlabs"),
+    pytest.param(
+        lambda: elevenlabs.TTS(encoding="pcm_44100"), id="elevenlabs.pcm_44100"
+    ),
+    pytest.param(lambda: openai.TTS(), id="openai"),
+    pytest.param(lambda: google.TTS(), id="google"),
+    pytest.param(lambda: azure.TTS(), id="azure"),
+    pytest.param(lambda: cartesia.TTS(), id="cartesia"),
 ]
 
 
@@ -61,17 +63,28 @@ async def test_synthesize(tts_factory):
 
 STREAM_SENT_TOKENIZER = tokenize.basic.SentenceTokenizer(min_sentence_len=20)
 STREAM_TTS = [
-    lambda: elevenlabs.TTS(),
-    lambda: elevenlabs.TTS(encoding="pcm_44100"),
-    lambda: cartesia.TTS(),
-    lambda: agents.tts.StreamAdapter(
-        tts=openai.TTS(), sentence_tokenizer=STREAM_SENT_TOKENIZER
+    pytest.param(lambda: elevenlabs.TTS(), id="elevenlabs"),
+    pytest.param(
+        lambda: elevenlabs.TTS(encoding="pcm_44100"), id="elevenlabs.pcm_44100"
     ),
-    lambda: agents.tts.StreamAdapter(
-        tts=google.TTS(), sentence_tokenizer=STREAM_SENT_TOKENIZER
+    pytest.param(lambda: cartesia.TTS(), id="cartesia"),
+    pytest.param(
+        lambda: agents.tts.StreamAdapter(
+            tts=openai.TTS(), sentence_tokenizer=STREAM_SENT_TOKENIZER
+        ),
+        id="openai.stream",
     ),
-    lambda: agents.tts.StreamAdapter(
-        tts=azure.TTS(), sentence_tokenizer=STREAM_SENT_TOKENIZER
+    pytest.param(
+        lambda: agents.tts.StreamAdapter(
+            tts=google.TTS(), sentence_tokenizer=STREAM_SENT_TOKENIZER
+        ),
+        id="google.stream",
+    ),
+    pytest.param(
+        lambda: agents.tts.StreamAdapter(
+            tts=azure.TTS(), sentence_tokenizer=STREAM_SENT_TOKENIZER
+        ),
+        id="azure.stream",
     ),
 ]
 

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -4,10 +4,11 @@ We verify the content using a good STT model
 """
 
 import dataclasses
+from typing import Callable
 
 import pytest
 from livekit import agents
-from livekit.agents import APIConnectionError, tokenize
+from livekit.agents import APIConnectionError, tokenize, tts
 from livekit.agents.utils import AudioBuffer, merge_frames
 from livekit.plugins import azure, cartesia, elevenlabs, google, openai
 
@@ -33,7 +34,7 @@ async def _assert_valid_synthesized_audio(
     ), "num channels should be the same"
 
 
-SYNTHESIZE_TTS = [
+SYNTHESIZE_TTS: list[Callable[[], tts.TTS]] = [
     pytest.param(lambda: elevenlabs.TTS(), id="elevenlabs"),
     pytest.param(
         lambda: elevenlabs.TTS(encoding="pcm_44100"), id="elevenlabs.pcm_44100"
@@ -62,7 +63,7 @@ async def test_synthesize(tts_factory):
 
 
 STREAM_SENT_TOKENIZER = tokenize.basic.SentenceTokenizer(min_sentence_len=20)
-STREAM_TTS = [
+STREAM_TTS: list[Callable[[], tts.TTS]] = [
     pytest.param(lambda: elevenlabs.TTS(), id="elevenlabs"),
     pytest.param(
         lambda: elevenlabs.TTS(encoding="pcm_44100"), id="elevenlabs.pcm_44100"


### PR DESCRIPTION
This PR updates test names to enhance readability by adding id parameters in pytest.mark.parametrize.