### PR TITLE
Handle optional func args in tool calls when set to `None`

### DIFF
--- a/.changeset/lazy-boats-drum.md
+++ b/.changeset/lazy-boats-drum.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-openai": patch
+---
+
+Handle optional func args in tool calls when set to `None`

--- a/.changeset/wild-plants-dream.md
+++ b/.changeset/wild-plants-dream.md
@@ -1,0 +1,6 @@
+---
+"livekit-plugins-openai": patch
+"livekit-agents": patch
+---
+
+fix: Handle optional func args in tool calls when set to `None`

--- a/livekit-agents/livekit/agents/llm/function_context.py
+++ b/livekit-agents/livekit/agents/llm/function_context.py
@@ -54,6 +54,7 @@ class FunctionArgInfo:
     type: type
     default: Any
     choices: tuple | None
+    is_optional: bool
 
 
 @dataclass(frozen=True)
@@ -188,6 +189,7 @@ class FunctionContext:
                 type=inner_th,
                 default=param.default,
                 choices=choices,
+                is_optional=is_optional,
             )
 
         self._fncs[metadata.name] = FunctionInfo(

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/_oai_api.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/_oai_api.py
@@ -64,13 +64,19 @@ def create_ai_function_info(
             inner_type = typing.get_args(arg_info.type)[0]
             sanitized_value = [
                 _sanitize_primitive(
-                    value=v, expected_type=inner_type, choices=arg_info.choices
+                    value=v,
+                    expected_type=inner_type,
+                    choices=arg_info.choices,
+                    is_optional=arg_info.is_optional,
                 )
                 for v in arg_value
             ]
         else:
             sanitized_value = _sanitize_primitive(
-                value=arg_value, expected_type=arg_info.type, choices=arg_info.choices
+                value=arg_value,
+                expected_type=arg_info.type,
+                choices=arg_info.choices,
+                is_optional=arg_info.is_optional,
             )
 
         sanitized_arguments[arg_info.name] = sanitized_value
@@ -147,8 +153,11 @@ def build_oai_function_description(
 
 
 def _sanitize_primitive(
-    *, value: Any, expected_type: type, choices: tuple | None
+    *, value: Any, expected_type: type, choices: tuple | None, is_optional: bool = False
 ) -> Any:
+    if is_optional and value is None:
+        return None
+
     if expected_type is str:
         if not isinstance(value, str):
             raise ValueError(f"expected str, got {type(value)}")


### PR DESCRIPTION
This PR fixes ValueError when optional function args are set to `None`

Related issues: 
https://github.com/livekit/agents/issues/1185
https://github.com/livekit/agents/issues/1208