### PR TITLE
improvements to endpointing latency

### DIFF
--- a/.changeset/proud-starfishes-film.md
+++ b/.changeset/proud-starfishes-film.md
@@ -1,0 +1,6 @@
+---
+"livekit-plugins-turn-detector": patch
+"livekit-agents": patch
+---
+
+improvements to endpointing latency

--- a/examples/voice-pipeline-agent/turn_detector.py
+++ b/examples/voice-pipeline-agent/turn_detector.py
@@ -1,0 +1,76 @@
+import logging
+
+from dotenv import load_dotenv
+from livekit.agents import (
+    AutoSubscribe,
+    JobContext,
+    JobProcess,
+    WorkerOptions,
+    cli,
+    llm,
+    metrics,
+)
+from livekit.agents.pipeline import VoicePipelineAgent
+from livekit.plugins import deepgram, openai, silero, turn_detector
+
+load_dotenv()
+logger = logging.getLogger("voice-assistant")
+
+
+def prewarm(proc: JobProcess):
+    proc.userdata["vad"] = silero.VAD.load()
+
+
+# This example uses our open-weight turn detection model to detect when the user is
+# done speaking. This approach is more accurate than the default VAD model, reducing
+# false positive interruptions by the agent.
+async def entrypoint(ctx: JobContext):
+    initial_ctx = llm.ChatContext().append(
+        role="system",
+        text=(
+            "You are a voice assistant created by LiveKit. Your interface with users will be voice. "
+            "You should use short and concise responses, and avoiding usage of unpronouncable punctuation."
+        ),
+    )
+
+    logger.info(f"connecting to room {ctx.room.name}")
+    await ctx.connect(auto_subscribe=AutoSubscribe.AUDIO_ONLY)
+
+    # wait for the first participant to connect
+    participant = await ctx.wait_for_participant()
+    logger.info(f"starting voice assistant for participant {participant.identity}")
+
+    agent = VoicePipelineAgent(
+        vad=ctx.proc.userdata["vad"],
+        stt=deepgram.STT(),
+        llm=openai.LLM(),
+        tts=openai.TTS(),
+        chat_ctx=initial_ctx,
+        turn_detector=turn_detector.EOUModel(),
+    )
+
+    agent.start(ctx.room, participant)
+
+    usage_collector = metrics.UsageCollector()
+
+    @agent.on("metrics_collected")
+    def _on_metrics_collected(mtrcs: metrics.AgentMetrics):
+        metrics.log_metrics(mtrcs)
+        usage_collector.collect(mtrcs)
+
+    async def log_usage():
+        summary = usage_collector.get_summary()
+        logger.info(f"Usage: ${summary}")
+
+    ctx.add_shutdown_callback(log_usage)
+
+    await agent.say("Hey, how can I help you today?", allow_interruptions=True)
+
+
+if __name__ == "__main__":
+    cli.run_app(
+        WorkerOptions(
+            entrypoint_fnc=entrypoint,
+            prewarm_fnc=prewarm,
+        ),
+    )

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -1109,11 +1109,10 @@ class _DeferredReplyValidation:
     PUNCTUATION = ".!?"
     PUNCTUATION_REDUCE_FACTOR = 0.75
 
-    LATE_TRANSCRIPT_TOLERANCE = 1.5  # late compared to end of speech
-
     # Long delay to use when the model thinks the user is still speaking
-    # TODO: make this configurable
     UNLIKELY_ENDPOINT_DELAY = 6
+
+    FINAL_TRANSCRIPT_TIMEOUT = 5
 
     def __init__(
         self,
@@ -1127,40 +1126,65 @@ class _DeferredReplyValidation:
         self._validating_task: asyncio.Task | None = None
         self._last_final_transcript: str = ""
         self._last_language: str | None = None
+        self._last_recv_start_of_speech_time: float = 0.0
         self._last_recv_end_of_speech_time: float = 0.0
+        self._last_recv_transcript_time: float = 0.0
         self._speaking = False
 
         self._agent = agent
         self._end_of_speech_delay = min_endpointing_delay
-        self._final_transcript_delay = min_endpointing_delay
 
     @property
     def validating(self) -> bool:
         return self._validating_task is not None and not self._validating_task.done()
 
+    def _compute_delay(self) -> float | None:
+        """Computes the amount of time to wait before validating the agent reply.
+
+        This function should be called after the agent has received final transcript, or after VAD
+        """
+        # never interrupt the user while they are speaking
+        if self._speaking:
+            return None
+
+        # if STT doesn't give us the final transcript after end of speech, we'll still validate the reply
+        # to prevent the agent from getting "stuck"
+        # in this case, the agent will not have final transcript, so it'll trigger the user input with empty
+        if not self._last_final_transcript:
+            return self.FINAL_TRANSCRIPT_TIMEOUT
+
+        delay = self._end_of_speech_delay
+        if self._end_with_punctuation():
+            delay = delay * self.PUNCTUATION_REDUCE_FACTOR
+
+        # the delay should be computed from end of earlier timestamp, that's the true end of user speech
+        end_of_speech_time = self._last_recv_end_of_speech_time
+        if (
+            self._last_recv_transcript_time > 0
+            and self._last_recv_transcript_time > self._last_recv_start_of_speech_time
+            and self._last_recv_transcript_time < end_of_speech_time
+        ):
+            end_of_speech_time = self._last_recv_transcript_time
+
+        elapsed_time = time.time() - end_of_speech_time
+        if elapsed_time < delay:
+            delay -= elapsed_time
+        else:
+            delay = 0
+        return delay
+
     def on_human_final_transcript(self, transcript: str, language: str | None) -> None:
         self._last_final_transcript += " " + transcript.strip()  # type: ignore
         self._last_language = language
+        self._last_recv_transcript_time = time.time()
 
-        if self._speaking:
-            return
-
-        has_recent_end_of_speech = (
-            time.time() - self._last_recv_end_of_speech_time
-            < self.LATE_TRANSCRIPT_TOLERANCE
-        )
-        delay = (
-            self._end_of_speech_delay
-            if has_recent_end_of_speech
-            else self._final_transcript_delay
-        )
-        delay = delay * (
-            self.PUNCTUATION_REDUCE_FACTOR if self._end_with_punctuation() else 1.0
-        )
-        self._run(delay)
+        delay = self._compute_delay()
+        if delay is not None:
+            self._run(delay)
 
     def on_human_start_of_speech(self, ev: vad.VADEvent) -> None:
         self._speaking = True
+        self._last_recv_start_of_speech_time = time.time()
         if self.validating:
             assert self._validating_task is not None
             self._validating_task.cancel()
@@ -1169,10 +1193,8 @@ class _DeferredReplyValidation:
         self._speaking = False
         self._last_recv_end_of_speech_time = time.time()
 
-        if self._last_final_transcript:
-            delay = self._end_of_speech_delay * (
-                self.PUNCTUATION_REDUCE_FACTOR if self._end_with_punctuation() else 1.0
-            )
+        delay = self._compute_delay()
+        if delay is not None:
             self._run(delay)
 
     async def aclose(self) -> None:

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -177,6 +177,7 @@ class LLM(llm.LLM):
 
         ``api_key`` must be set to your Cerebras API key, either using the argument or by setting
         the ``CEREBRAS_API_KEY`` environmental variable.
+        @integrations:cerebras:llm
         """
 
         api_key = api_key or os.environ.get("CEREBRAS_API_KEY")

--- a/livekit-plugins/livekit-plugins-turn-detector/setup.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
         "livekit-agents>=0.11",
         "transformers>=4.46",
         "numpy>=1.26",
-        "torch>=2.0",
+        "torch>=2.5.1",
     ],
     package_data={"livekit.plugins.turn_detector": ["py.typed"]},
     project_urls={


### PR DESCRIPTION
it can take some time for final transcriptions to arrive. we would use end-of-speech timing to compute end of utterance delay, instead of from the moment final transcripts arrive.

also fixed the case where agents would be stuck when final transcripts do not end up coming in.

driveby, added a turn detector example