### PR TITLE
Add store and metadata to LLMs

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -64,7 +64,7 @@ class LLMOptions:
     parallel_tool_calls: bool | None
     tool_choice: Union[ToolChoice, Literal["auto", "required", "none"]] = "auto"
     store: bool | None = None
-    metadata: dict[str, Any] | None = None
+    metadata: dict[str, str] | None = None
 
 
 class LLM(llm.LLM):
@@ -80,7 +80,7 @@ class LLM(llm.LLM):
         parallel_tool_calls: bool | None = None,
         tool_choice: Union[ToolChoice, Literal["auto", "required", "none"]] = "auto",
         store: bool | None = None,
-        metadata: dict[str, Any] | None = None,
+        metadata: dict[str, str] | None = None,
     ) -> None:
         """
         Create a new instance of OpenAI LLM.

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -63,6 +63,8 @@ class LLMOptions:
     temperature: float | None
     parallel_tool_calls: bool | None
     tool_choice: Union[ToolChoice, Literal["auto", "required", "none"]] = "auto"
+    store: bool | None = None
+    metadata: dict[str, Any] | None = None
 
 
 class LLM(llm.LLM):
@@ -77,6 +79,8 @@ class LLM(llm.LLM):
         temperature: float | None = None,
         parallel_tool_calls: bool | None = None,
         tool_choice: Union[ToolChoice, Literal["auto", "required", "none"]] = "auto",
+        store: bool | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         """
         Create a new instance of OpenAI LLM.
@@ -93,6 +97,8 @@ class LLM(llm.LLM):
             temperature=temperature,
             parallel_tool_calls=parallel_tool_calls,
             tool_choice=tool_choice,
+            store=store,
+            metadata=metadata,
         )
         self._client = client or openai.AsyncClient(
             api_key=api_key,
@@ -738,6 +744,8 @@ class LLMStream(llm.LLMStream):
                 stream_options={"include_usage": True},
                 stream=True,
                 user=user,
+                store=self._llm._opts.store,
+                metadata=self._llm._opts.metadata,
                 **opts,
             )
 


### PR DESCRIPTION
OpenAI offers to store the conversations with metadata directly in their platform. This code enables that. There was an approved pull request for this but I closed it due to conflicts and errors in the main branch. Bringing it back now.

@davidzhao 