### PR TITLE
Fix center_aspect_fit, add center_aspect_scale resizing option

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -23,22 +23,7 @@ on:
 jobs:
   build_plugins:
     runs-on: ubuntu-latest
-    if: |
-      inputs.package == 'livekit-agents' ||
-      inputs.package == 'livekit-plugins-assemblyai' ||
-      inputs.package == 'livekit-plugins-azure' ||
-      inputs.package == 'livekit-plugins-cartesia' ||
-      inputs.package == 'livekit-plugins-deepgram' ||
-      inputs.package == 'livekit-plugins-elevenlabs' ||
-      inputs.package == 'livekit-plugins-google' ||
-      inputs.package == 'livekit-plugins-minimal' ||
-      inputs.package == 'livekit-plugins-nltk' ||
-      inputs.package == 'livekit-plugins-openai' ||
-      inputs.package == 'livekit-plugins-rag' ||
-      inputs.package == 'livekit-plugins-silero' ||
-      inputs.package == 'livekit-plugins-anthropic' ||
-      inputs.package == 'livekit-plugins-llama-index'
-
+    if: inputs.package != 'livekit-plugins-browser'
     defaults:
       run:
         working-directory: "${{ startsWith(inputs.package, 'livekit-plugin') && 'livekit-plugins/' || '' }}${{ inputs.package }}"

--- a/livekit-agents/livekit/agents/utils/images/image.py
+++ b/livekit-agents/livekit/agents/utils/images/image.py
@@ -99,13 +99,13 @@ def _resize_image(image: Any, options: EncodeOptions):
 
         resized = image.resize((new_width, new_height))
 
-        paste_x = (resize_opts.width - new_width) // 2
-        paste_y = (resize_opts.height - new_height) // 2
-
         Image.Image.paste(
             result,
             resized,
-            (paste_x, paste_y),
+            (
+                (resize_opts.width - new_width) // 2,
+                (resize_opts.height - new_height) // 2,
+            ),
         )
         return result
     elif resize_opts.strategy == "center_aspect_cover":

--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
@@ -441,7 +441,7 @@ def _build_anthropic_image_content(
                 opts.resize_options = utils.images.ResizeOptions(
                     width=image.inference_width,
                     height=image.inference_height,
-                    strategy="center_aspect_fit",
+                    strategy="scale_aspect_fit",
                 )
 
             encoded_data = utils.images.encode(image.image, opts)

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/beta/assistant_llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/beta/assistant_llm.py
@@ -532,7 +532,7 @@ class AssistantLLMStream(llm.LLMStream):
             opts.resize_options = utils.images.ResizeOptions(
                 width=inference_width,
                 height=inference_height,
-                strategy="center_aspect_fit",
+                strategy="scale_aspect_fit",
             )
 
         encoded_data = utils.images.encode(frame, opts)

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/utils.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/utils.py
@@ -78,7 +78,7 @@ def _build_oai_image_content(image: llm.ChatImage, cache_key: Any):
                 opts.resize_options = utils.images.ResizeOptions(
                     width=image.inference_width,
                     height=image.inference_height,
-                    strategy="center_aspect_fit",
+                    strategy="scale_aspect_fit",
                 )
 
             encoded_data = utils.images.encode(image.image, opts)


### PR DESCRIPTION
Working on ChatImage, I noticed that center_aspect_fit gave the same result as center_aspect_cover for a portrait-oriented image (due to typo/bug in its logic). That's fixed, so now it letterboxes portrait images correctly.

I also noticed that our default implementation adds black letterboxing to images when they go to inference. This is undesirable, as the letterboxing may be misinterpreted as useful image data. It's better to send an image in its original aspect ratio and let the model's internal systems resize it in a way that allows it to ignore excess area (internally it will be seen as a square, but they may differ in what color/value they use for "blank pixels"). So I added a strategy called `scale_aspect_fit` and made it the new default.

I also added a method that lets you resize in the 'cover' strategy without actually cropping the image, called `scale_aspect_fill`.

I left the old options in place but did change the default... there's also no direct way to override it anyways, you'd have to encode the image yourself (which is what i'm doing in my demo project)