### PR TITLE
Do not retry on already streamed tokens

### DIFF
--- a/.changeset/dirty-jeans-burn.md
+++ b/.changeset/dirty-jeans-burn.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Do not retry on already streamed tokens

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -191,6 +191,8 @@ class LLMStream(ABC):
                         extra={
                             "llm": self._llm._label,
                             "attempt": i + 1,
+                            "num_sends": self._event_ch.num_sends,
+                            "num_receives": self._event_ch.num_receives,
                         },
                     )
                     raise

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -13,11 +13,11 @@ from typing import (
     Literal,
     TypeVar,
     Union,
-    override,
 )
 
 from livekit import rtc
 from livekit.agents._exceptions import APIConnectionError, APIError
+from typing_extensions import override
 
 from .. import utils
 from ..log import logger

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -98,9 +98,9 @@ class TrackedChannel(aio.Chan[T]):
         return await super().recv()
 
     @override
-    async def recv_nowait(self) -> T:
+    def recv_nowait(self) -> T:
         self.has_received = True
-        return await super().recv_nowait()
+        return super().recv_nowait()
 
 
 class LLM(


### PR DESCRIPTION
Part 1 of #1238

This should address timeouts causing duplicate audio, however I believe the behavior will be the LLM gets stuck and just goes silent.