### PR TITLE
fix: avoid duplicated chat ctx for function call with messages

### DIFF
--- a/.changeset/curvy-knives-promise.md
+++ b/.changeset/curvy-knives-promise.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+avoid duplicated chat ctx for function calls with messages

--- a/examples/voice-pipeline-agent/function_calling_weather.py
+++ b/examples/voice-pipeline-agent/function_calling_weather.py
@@ -67,8 +67,8 @@ class AssistantFnc(llm.FunctionContext):
                         f"Failed to get weather data, status code: {response.status}"
                     )
 
-        # To wait for the speech to finish before giving results of the function call
-        await speech_handle.join()
+        # (optional) To wait for the speech to finish before giving results of the function call
+        # await speech_handle.join()
         return weather_data
 
 

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -904,9 +904,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                 return
 
             # create a nested speech handle
-            extra_tools_messages = [
-                ChatMessage.create_tool_calls(tool_calls_info)
-            ]
+            extra_tools_messages = [ChatMessage.create_tool_calls(tool_calls_info)]
             extra_tools_messages.extend(tool_calls_results)
 
             new_speech_handle = SpeechHandle.create_tool_speech(

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -905,7 +905,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
 
             # create a nested speech handle
             extra_tools_messages = [
-                ChatMessage.create_tool_calls(tool_calls_info, text=collected_text)
+                ChatMessage.create_tool_calls(tool_calls_info)
             ]
             extra_tools_messages.extend(tool_calls_results)
 

--- a/livekit-agents/livekit/agents/pipeline/speech_handle.py
+++ b/livekit-agents/livekit/agents/pipeline/speech_handle.py
@@ -19,6 +19,7 @@ class SpeechHandle:
         user_question: str,
         fnc_nested_depth: int = 0,
         extra_tools_messages: list[ChatMessage] | None = None,
+        fnc_text_message_id: str | None = None,
     ) -> None:
         self._id = id
         self._allow_interruptions = allow_interruptions
@@ -41,6 +42,7 @@ class SpeechHandle:
         # nested speech handle and function calls
         self._fnc_nested_depth = fnc_nested_depth
         self._fnc_extra_tools_messages: list[ChatMessage] | None = extra_tools_messages
+        self._fnc_text_message_id: str | None = fnc_text_message_id
 
         self._nested_speech_handles: list[SpeechHandle] = []
         self._nested_speech_changed = asyncio.Event()
@@ -82,6 +84,7 @@ class SpeechHandle:
         add_to_chat_ctx: bool,
         fnc_nested_depth: int,
         extra_tools_messages: list[ChatMessage],
+        fnc_text_message_id: str | None = None,
     ) -> SpeechHandle:
         return SpeechHandle(
             id=utils.shortuuid(),
@@ -91,6 +94,7 @@ class SpeechHandle:
             user_question="",
             fnc_nested_depth=fnc_nested_depth,
             extra_tools_messages=extra_tools_messages,
+            fnc_text_message_id=fnc_text_message_id,
         )
 
     async def wait_for_initialization(self) -> None:
@@ -199,6 +203,10 @@ class SpeechHandle:
     @property
     def extra_tools_messages(self) -> list[ChatMessage] | None:
         return self._fnc_extra_tools_messages
+
+    @property
+    def fnc_text_message_id(self) -> str | None:
+        return self._fnc_text_message_id
 
     def add_nested_speech(self, speech_handle: SpeechHandle) -> None:
         self._nested_speech_handles.append(speech_handle)


### PR DESCRIPTION
When there is a message along with the function calls, the message will be added to the chat ctx twice: after it's played, and after the function calls finished.
```python
[
...
 ChatMessage(role='assistant',
             id='item_1158d15105e5',
             name=None,
             content=' Hello from the weather station. Would you like to know '
                     'the weather? If so, tell me your location.',
             tool_calls=None,
             tool_call_id=None,
             tool_exception=None),
 ChatMessage(role='user',
             id='item_bf51c7ec1c80',
             name=None,
             content='New York.',
             tool_calls=None,
             tool_call_id=None,
             tool_exception=None),
 ChatMessage(role='assistant',
             id='item_d41fa35f7251',
             name=None,
             content=' Let me check the weather in New York for you.',
             tool_calls=None,
             tool_call_id=None,
             tool_exception=None),
 ChatMessage(role='assistant',
             id='item_cb041bd44d6c',
             name=None,
             content=' Let me check the weather in New York for you.',
             tool_calls=[FunctionCallInfo(tool_call_id='call_nuu9ElDEKiU3FgShMJCshaly',
      ...
             tool_exception=None),
 ChatMessage(role='tool',
             id='item_6dabd488c4a1',
             name='get_weather',
             content='The weather in New York is Clear +33°F.',
             tool_calls=None,
             tool_call_id='call_nuu9ElDEKiU3FgShMJCshaly',
             tool_exception=None),
...
```
I have tested that remove the text for `ChatMessage.create_tool_calls(tool_calls_info, text=collected_text)` won't affect the follow up answers.