### PR TITLE
fix: set USE_DOCSTRING as default for ai_callable

### DIFF
--- a/.changeset/nasty-rings-wave.md
+++ b/.changeset/nasty-rings-wave.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+set USE_DOCSTRING as default for ai_callable

--- a/examples/voice-pipeline-agent/function_calling_weather.py
+++ b/examples/voice-pipeline-agent/function_calling_weather.py
@@ -27,7 +27,7 @@ class AssistantFnc(llm.FunctionContext):
     The class defines a set of LLM functions that the assistant can execute.
     """
 
-    @llm.ai_callable(description=llm.USE_DOCSTRING)
+    @llm.ai_callable()
     async def get_weather(
         self,
         location: Annotated[

--- a/examples/voice-pipeline-agent/function_calling_weather.py
+++ b/examples/voice-pipeline-agent/function_calling_weather.py
@@ -27,7 +27,7 @@ class AssistantFnc(llm.FunctionContext):
     The class defines a set of LLM functions that the assistant can execute.
     """
 
-    @llm.ai_callable()
+    @llm.ai_callable(description=llm.USE_DOCSTRING)
     async def get_weather(
         self,
         location: Annotated[

--- a/livekit-agents/livekit/agents/llm/function_context.py
+++ b/livekit-agents/livekit/agents/llm/function_context.py
@@ -105,7 +105,7 @@ class CalledFunction:
 def ai_callable(
     *,
     name: str | None = None,
-    description: str | _UseDocMarker | None = USE_DOCSTRING,
+    description: str | _UseDocMarker = USE_DOCSTRING,
     auto_retry: bool = False,
 ) -> Callable:
     def deco(f):
@@ -127,7 +127,7 @@ class FunctionContext:
         self,
         *,
         name: str | None = None,
-        description: str | _UseDocMarker | None = USE_DOCSTRING,
+        description: str | _UseDocMarker = USE_DOCSTRING,
         auto_retry: bool = True,
     ) -> Callable:
         def deco(f):
@@ -243,19 +243,17 @@ def _extract_types(annotation: type) -> tuple[type, TypeInfo | None]:
 def _set_metadata(
     f: Callable,
     name: str | None = None,
-    desc: str | _UseDocMarker | None = None,
+    desc: str | _UseDocMarker = USE_DOCSTRING,
     auto_retry: bool = False,
 ) -> None:
-    if desc is None:
-        desc = ""
-
     if isinstance(desc, _UseDocMarker):
-        desc = inspect.getdoc(f)
-        if desc is None:
+        docstring = inspect.getdoc(f)
+        if docstring is None:
             raise ValueError(
                 f"missing docstring for function {f.__name__}, "
                 "use explicit description or provide docstring"
             )
+        desc = docstring
 
     metadata = _AIFncMetadata(
         name=name or f.__name__, description=desc, auto_retry=auto_retry

--- a/livekit-agents/livekit/agents/llm/function_context.py
+++ b/livekit-agents/livekit/agents/llm/function_context.py
@@ -105,7 +105,7 @@ class CalledFunction:
 def ai_callable(
     *,
     name: str | None = None,
-    description: str | _UseDocMarker | None = None,
+    description: str | _UseDocMarker | None = USE_DOCSTRING,
     auto_retry: bool = False,
 ) -> Callable:
     def deco(f):
@@ -127,7 +127,7 @@ class FunctionContext:
         self,
         *,
         name: str | None = None,
-        description: str | _UseDocMarker | None = None,
+        description: str | _UseDocMarker | None = USE_DOCSTRING,
         auto_retry: bool = True,
     ) -> Callable:
         def deco(f):

--- a/tests/test_create_func.py
+++ b/tests/test_create_func.py
@@ -43,11 +43,15 @@ def test_func_basic():
 
 def test_func_duplicate():
     class TestFunctionContext(llm.FunctionContext):
-        @llm.ai_callable(name="duplicate_function")
+        @llm.ai_callable(
+            name="duplicate_function", description="A simple test function"
+        )
         def fn1(self):
             pass
 
-        @llm.ai_callable(name="duplicate_function")
+        @llm.ai_callable(
+            name="duplicate_function", description="A simple test function"
+        )
         def fn2(self):
             pass
 
@@ -55,6 +59,21 @@ def test_func_duplicate():
         ValueError, match="duplicate ai_callable name: duplicate_function"
     ):
         TestFunctionContext()
+
+
+def test_func_with_docstring():
+    class TestFunctionContext(llm.FunctionContext):
+        @llm.ai_callable()
+        def test_fn(self):
+            """A simple test function"""
+            pass
+
+    fnc_ctx = TestFunctionContext()
+    assert (
+        "test_fn" in fnc_ctx.ai_functions
+    ), "Function should be registered in ai_functions"
+
+    assert fnc_ctx.ai_functions["test_fn"].description == "A simple test function"
 
 
 def test_func_with_optional_parameter():


### PR DESCRIPTION
`@llm.ai_callable` need a explicit `description=llm.USE_DOCSTRING` to use the docstring as the description.