### PR TITLE
Revert to upload-artifacts@v3, update dependency versions

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,25 @@
+{
+  "mode": "pre",
+  "tag": "dev",
+  "initialVersions": {
+    "livekit-agents": "0.12.3",
+    "livekit-plugins-anthropic": "0.2.8",
+    "livekit-plugins-assemblyai": "0.2.1",
+    "livekit-plugins-azure": "0.5.1",
+    "livekit-plugins-browser": "0.0.5",
+    "livekit-plugins-cartesia": "0.4.5",
+    "livekit-plugins-deepgram": "0.6.15",
+    "livekit-plugins-elevenlabs": "0.7.9",
+    "livekit-plugins-fal": "0.2.2",
+    "livekit-plugins-google": "0.8.1",
+    "livekit-plugins-llama-index": "0.2.2",
+    "livekit-plugins-minimal": "0.2.1",
+    "livekit-plugins-nltk": "0.7.3",
+    "livekit-plugins-openai": "0.10.11",
+    "livekit-plugins-playht": "1.0.3",
+    "livekit-plugins-rag": "0.2.3",
+    "livekit-plugins-silero": "0.7.4",
+    "livekit-plugins-turn-detector": "0.3.3"
+  },
+  "changesets": []
+}

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -47,7 +47,7 @@ jobs:
         run: python -m build
 
       - name: Upload distribution package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.artifact_name }}
           path: "${{ startsWith(inputs.package, 'livekit-plugin') && 'livekit-plugins/' || '' }}${{ inputs.package }}/dist/"
@@ -82,7 +82,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 3
 
       - name: Upload distribution package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.artifact_name }}
           path: livekit-plugins/livekit-plugins-browser/dist/

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -74,7 +74,7 @@ jobs:
       - name: override packages
         id: override
         run: |
-          echo "publishedPackages=[\"livekit-agents\"]" >> $GITHUB_OUTPUT
+          echo 'publishedPackages=[{"name":"livekit-agents","version":"0.12.3"}]' >> $GITHUB_OUTPUT
 
       - name: debug packages
         run: echo "${{ steps.override.outputs.publishedPackages }}"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -74,7 +74,7 @@ jobs:
       - name: override packages
         id: override
         run: |
-          echo 'publishedPackages=[{"name":"livekit-agents","version":"0.12.3"}]' >> $GITHUB_OUTPUT
+          echo 'publishedPackages=[{"name":"livekit-plugins-anthropic","version":"0.2.8"},{"name":"livekit-plugins-azure","version":"0.5.1"},{"name":"livekit-plugins-browser","version":"0.0.5"},{"name":"livekit-plugins-deepgram","version":"0.6.15"},{"name":"livekit-plugins-openai","version":"0.10.11"},{"name":"livekit-plugins-turn-detector","version":"0.3.3"}]' >> $GITHUB_OUTPUT
 
       - name: debug packages
         run: echo "${{ steps.override.outputs.publishedPackages }}"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -19,7 +19,9 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     outputs:
-      packages: ${{ steps.changesets.outputs.publishedPackages }}
+      #packages: ${{ steps.changesets.outputs.publishedPackages }}
+      packages:
+        - livekit-agents
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -77,7 +77,7 @@ jobs:
           echo "publishedPackages=['livekit-agents']" >> $GITHUB_OUTPUT
 
       - name: debug packages
-        run: echo "${{ steps.changesets.outputs.publishedPackages }}"
+        run: echo "${{ steps.override.outputs.publishedPackages }}"
 
   build:
     needs:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -87,7 +87,7 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.bump.outputs.packages) }}
 
-    uses: livekit/agents/.github/workflows/build-package.yml@main
+    uses: livekit/agents/.github/workflows/build-package.yml@use-unique-artifacts
     with:
       package: ${{ matrix.package.name }}
       artifact_name: python-package-distributions

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -81,7 +81,7 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.bump.outputs.packages) }}
 
-    uses: livekit/agents/.github/workflows/build-package.yml@use-unique-artifacts
+    uses: livekit/agents/.github/workflows/build-package.yml@main
     with:
       package: ${{ matrix.package.name }}
       artifact_name: python-package-distributions

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -19,8 +19,7 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     outputs:
-      #packages: ${{ steps.changesets.outputs.publishedPackages }}
-      packages: ${{ steps.override.outputs.publishedPackages }}
+      packages: ${{ steps.changesets.outputs.publishedPackages }}
 
     steps:
       - uses: actions/checkout@v4
@@ -71,13 +70,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: override packages
-        id: override
-        run: |
-          echo 'publishedPackages=[{"name":"livekit-plugins-anthropic","version":"0.2.8"},{"name":"livekit-plugins-azure","version":"0.5.1"},{"name":"livekit-plugins-browser","version":"0.0.5"},{"name":"livekit-plugins-deepgram","version":"0.6.15"},{"name":"livekit-plugins-openai","version":"0.10.11"},{"name":"livekit-plugins-turn-detector","version":"0.3.3"}]' >> $GITHUB_OUTPUT
-
       - name: debug packages
-        run: echo "${{ steps.override.outputs.publishedPackages }}"
+        run: echo "${{ steps.changesets.outputs.publishedPackages }}"
 
   build:
     needs:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -102,7 +102,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -20,10 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       #packages: ${{ steps.changesets.outputs.publishedPackages }}
-      packages: >-
-        [
-          "livekit-agents",
-        ]
+      packages: ${{ steps.override.outputs.publishedPackages }}
 
     steps:
       - uses: actions/checkout@v4
@@ -73,6 +70,11 @@ jobs:
           publish: pnpm ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: override packages
+        id: override
+        run: |
+          echo "publishedPackages=['livekit-agents']" >> $GITHUB_OUTPUT
 
       - name: debug packages
         run: echo "${{ steps.changesets.outputs.publishedPackages }}"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -74,7 +74,7 @@ jobs:
       - name: override packages
         id: override
         run: |
-          echo "publishedPackages=['livekit-agents']" >> $GITHUB_OUTPUT
+          echo "publishedPackages=[\"livekit-agents\"]" >> $GITHUB_OUTPUT
 
       - name: debug packages
         run: echo "${{ steps.override.outputs.publishedPackages }}"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -20,8 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       #packages: ${{ steps.changesets.outputs.publishedPackages }}
-      packages:
-        - livekit-agents
+      packages: >-
+        [
+          "livekit-agents",
+        ]
 
     steps:
       - uses: actions/checkout@v4

--- a/livekit-plugins/livekit-plugins-anthropic/setup.py
+++ b/livekit-plugins/livekit-plugins-anthropic/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
     license="Apache-2.0",
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
-    install_requires=["livekit-agents>=0.11", "anthropic>=0.34"],
+    install_requires=["livekit-agents>=0.12.3", "anthropic>=0.34"],
     package_data={"livekit.plugins.anthropic": ["py.typed"]},
     project_urls={
         "Documentation": "https://docs.livekit.io",

--- a/livekit-plugins/livekit-plugins-assemblyai/setup.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
     install_requires=[
-        "livekit-agents>=0.11",
+        "livekit-agents>=0.12.3",
     ],
     package_data={},
     project_urls={

--- a/livekit-plugins/livekit-plugins-azure/setup.py
+++ b/livekit-plugins/livekit-plugins-azure/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
     install_requires=[
-        "livekit-agents>=0.11",
+        "livekit-agents>=0.12.3",
         "azure-cognitiveservices-speech>=1.41.0",
     ],
     package_data={},

--- a/livekit-plugins/livekit-plugins-browser/setup.py
+++ b/livekit-plugins/livekit-plugins-browser/setup.py
@@ -113,7 +113,7 @@ setuptools.setup(
     cmdclass={"build_ext": CMakeBuild},
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
-    install_requires=["livekit-agents>=0.11"],
+    install_requires=["livekit-agents>=0.12.3"],
     package_data={
         "livekit.plugins.browser": ["py.typed"],
         "livekit.plugins.browser.resources": ["**", "lkcef_app.app"],

--- a/livekit-plugins/livekit-plugins-cartesia/setup.py
+++ b/livekit-plugins/livekit-plugins-cartesia/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
     license="Apache-2.0",
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
-    install_requires=["livekit-agents>=0.11"],
+    install_requires=["livekit-agents>=0.12.3"],
     project_urls={
         "Documentation": "https://docs.livekit.io",
         "Website": "https://livekit.io/",

--- a/livekit-plugins/livekit-plugins-clova/setup.py
+++ b/livekit-plugins/livekit-plugins-clova/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
     license="Apache-2.0",
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
-    install_requires=["livekit-agents>=0.11", "pydub~=0.25.1"],
+    install_requires=["livekit-agents>=0.12.3", "pydub~=0.25.1"],
     project_urls={
         "Documentation": "https://docs.livekit.io",
         "Website": "https://livekit.io/",

--- a/livekit-plugins/livekit-plugins-deepgram/setup.py
+++ b/livekit-plugins/livekit-plugins-deepgram/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
     license="Apache-2.0",
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
-    install_requires=["livekit-agents>=0.12.2", "numpy>=1.26"],
+    install_requires=["livekit-agents>=0.12.3", "numpy>=1.26"],
     package_data={"livekit.plugins.deepgram": ["py.typed"]},
     project_urls={
         "Documentation": "https://docs.livekit.io",

--- a/livekit-plugins/livekit-plugins-elevenlabs/setup.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
     license="Apache-2.0",
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
-    install_requires=["livekit-agents[codecs]>=0.11"],
+    install_requires=["livekit-agents[codecs]>=0.12.3"],
     package_data={"livekit.plugins.elevenlabs": ["py.typed"]},
     project_urls={
         "Documentation": "https://docs.livekit.io",

--- a/livekit-plugins/livekit-plugins-fal/setup.py
+++ b/livekit-plugins/livekit-plugins-fal/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
     license="Apache-2.0",
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
-    install_requires=["livekit-agents>=0.11", "fal_client"],
+    install_requires=["livekit-agents>=0.12.3", "fal_client"],
     package_data={"livekit.plugins.fal": ["py.typed"]},
     project_urls={
         "Documentation": "https://docs.livekit.io",

--- a/livekit-plugins/livekit-plugins-google/setup.py
+++ b/livekit-plugins/livekit-plugins-google/setup.py
@@ -51,7 +51,7 @@ setuptools.setup(
         "google-auth >= 2, < 3",
         "google-cloud-speech >= 2, < 3",
         "google-cloud-texttospeech >= 2, < 3",
-        "livekit-agents>=0.11",
+        "livekit-agents>=0.12.3",
     ],
     package_data={"livekit.plugins.google": ["py.typed"]},
     project_urls={

--- a/livekit-plugins/livekit-plugins-llama-index/setup.py
+++ b/livekit-plugins/livekit-plugins-llama-index/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
     license="Apache-2.0",
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
-    install_requires=["livekit-agents>=0.11"],
+    install_requires=["livekit-agents>=0.12.3"],
     package_data={"livekit.plugins.llama_index": ["py.typed"]},
     project_urls={
         "Documentation": "https://docs.livekit.io",

--- a/livekit-plugins/livekit-plugins-openai/setup.py
+++ b/livekit-plugins/livekit-plugins-openai/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
     install_requires=[
-        "livekit-agents[codecs, images]>=0.11",
+        "livekit-agents[codecs, images]>=0.12.3",
         "openai>=1.50",
     ],
     extras_require={

--- a/livekit-plugins/livekit-plugins-playht/setup.py
+++ b/livekit-plugins/livekit-plugins-playht/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
     install_requires=[
-        "livekit-agents[codecs]>=0.11",
+        "livekit-agents[codecs]>=0.12.3",
         "pyht",
         "aiohttp",
         "livekit",

--- a/livekit-plugins/livekit-plugins-rag/setup.py
+++ b/livekit-plugins/livekit-plugins-rag/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
     license="Apache-2.0",
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
-    install_requires=["livekit-agents>=0.11", "annoy>=1.17"],
+    install_requires=["livekit-agents>=0.12.3", "annoy>=1.17"],
     package_data={"livekit.plugins.rag": ["py.typed"]},
     project_urls={
         "Documentation": "https://docs.livekit.io",

--- a/livekit-plugins/livekit-plugins-silero/setup.py
+++ b/livekit-plugins/livekit-plugins-silero/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
     license="Apache-2.0",
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
-    install_requires=["livekit-agents>=0.11", "onnxruntime>=1.18", "numpy>=1.26"],
+    install_requires=["livekit-agents>=0.12.3", "onnxruntime>=1.18", "numpy>=1.26"],
     package_data={
         "livekit.plugins.silero.resources": ["silero_vad.onnx"],
         "livekit.plugins.silero": ["py.typed"],

--- a/livekit-plugins/livekit-plugins-turn-detector/setup.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/setup.py
@@ -50,7 +50,7 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
     install_requires=[
-        "livekit-agents>=0.11",
+        "livekit-agents>=0.12.3",
         "transformers>=4.47.1",
         "numpy>=1.26",
         "onnxruntime>=1.18",


### PR DESCRIPTION
upload-artifacts v4 has [a breaking change](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes) that impacts our CI.

We rely on uploading to the same directory for build + publish, they no longer support it.

reverting for now so we can get some builds out