### PR TITLE
Update to v4 versions with multiple artifact download

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -47,7 +47,7 @@ jobs:
         run: python -m build
 
       - name: Upload distribution package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
           path: "${{ startsWith(inputs.package, 'livekit-plugin') && 'livekit-plugins/' || '' }}${{ inputs.package }}/dist/"
@@ -82,7 +82,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 3
 
       - name: Upload distribution package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
           path: livekit-plugins/livekit-plugins-browser/dist/

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -84,7 +84,7 @@ jobs:
     uses: livekit/agents/.github/workflows/build-package.yml@main
     with:
       package: ${{ matrix.package.name }}
-      artifact_name: python-package-distributions
+      artifact_name: python-package-dist-${{matrix.package.name}}
 
   publish:
     needs:
@@ -96,10 +96,11 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: python-package-distributions
-          path: dist/
+          path: dist
+          pattern: python-package-dist-*
+          merge-multiple: true
 
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -27,7 +27,7 @@ jobs:
           submodules: true
           lfs: true
         env:
-          GITHUB_TOKEN: ${{ secrets.CHANGESETS_PUSH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_PUSH_DEPLOY_KEY }}
 
       - uses: pnpm/action-setup@v4
       - name: Use Node.js 20


### PR DESCRIPTION
Sorry about the previous breaking PR, this shouldn't have slipped past, but I only relied on the CI passing in the PR. 

While it's not possible to upload multiple artifacts to the same name anymore with the v4 upload artifact action, it _is_ possible to merge multiple artifact downloads into the same folder with v4 download artifact.

This PR merges all artifacts with the pattern `python-package-dist-*` into the `dist` folder. The idea is that no other changes are required, keeping the diff here minimal. Don't have a good way to test this though. 