### PR TITLE
fix context when functions have been called

### DIFF
--- a/.changeset/witty-fishes-stare.md
+++ b/.changeset/witty-fishes-stare.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+fix context when functions have been called

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -698,6 +698,11 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                 not playing_speech.user_question or playing_speech.user_committed
             ) and not playing_speech.speech_committed:
                 # the speech is playing but not committed yet, add it to the chat context for this new reply synthesis
+                # First add the previous function call message if any
+                if playing_speech.extra_tools_messages:
+                    copied_ctx.messages.extend(playing_speech.extra_tools_messages)
+
+                # Then add the previous assistant message
                 copied_ctx.messages.append(
                     ChatMessage.create(
                         text=playing_speech.synthesis_handle.tts_forwarder.played_text,


### PR DESCRIPTION
If a function has been called but the extra tools haven't been committed to the chat context, the response will be generated with a copied chat ctx that doesn't include those calls, and thus the LLM will 're-call' them.
This is a fix so the copied chat ctx contains those calls as well.