### PR TITLE
encode boost words

### DIFF
--- a/.changeset/hot-trainers-press.md
+++ b/.changeset/hot-trainers-press.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-assemblyai": patch
+---
+
+assemblyai: encode boost words

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -318,7 +318,9 @@ class SpeechStream(stt.SpeechStream):
     async def _connect_ws(self) -> aiohttp.ClientWebSocketResponse:
         live_config = {
             "sample_rate": self._opts.sample_rate,
-            "word_boost": json.dumps(self._opts.word_boost) if self._opts.word_boost is not None else None,
+            "word_boost": json.dumps(self._opts.word_boost)
+            if self._opts.word_boost is not None
+            else None,
             "encoding": self._opts.encoding,
             "disable_partial_transcripts": self._opts.disable_partial_transcripts,
             "enable_extra_session_information": self._opts.enable_extra_session_information,

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -318,7 +318,7 @@ class SpeechStream(stt.SpeechStream):
     async def _connect_ws(self) -> aiohttp.ClientWebSocketResponse:
         live_config = {
             "sample_rate": self._opts.sample_rate,
-            "word_boost": self._opts.word_boost,
+            "word_boost": json.dumps(self._opts.word_boost) if self._opts.word_boost is not None else None,
             "encoding": self._opts.encoding,
             "disable_partial_transcripts": self._opts.disable_partial_transcripts,
             "enable_extra_session_information": self._opts.enable_extra_session_information,


### PR DESCRIPTION
Boost words do not work with the Assembly AI plugin as they are not encoded in the URL. This fix encodes them.