### PR TITLE
improve interruption handling, avoid agent from getting stuck

### DIFF
--- a/.changeset/silent-oranges-warn.md
+++ b/.changeset/silent-oranges-warn.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+improve interruption handling, avoid agent from getting stuck

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -1163,7 +1163,7 @@ class _DeferredReplyValidation:
 
     @property
     def validating(self) -> bool:
-        return self._validating_task and not self._validating_task.done()
+        return self._validating_task is not None and not self._validating_task.done()
 
     def _compute_delay(self) -> float | None:
         """Computes the amount of time to wait before validating the agent reply.

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -1214,6 +1214,7 @@ class _DeferredReplyValidation:
         self._last_recv_start_of_speech_time = time.perf_counter()
         if self.validating:
             assert self._validating_task is not None
+            self._validating_task.cancel()
 
     def on_human_end_of_speech(self, ev: vad.VADEvent) -> None:
         self._speaking = False

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -714,6 +714,9 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                     )
                 )
 
+        # we want to add this question even if it's empty. during false positive interruptions,
+        # adding an empty user message gives the LLM context so it could continue from where
+        # it had been interrupted.
         copied_ctx.messages.append(
             ChatMessage.create(text=handle.user_question, role="user")
         )


### PR DESCRIPTION
there are a couple of conditions that could cause the agent to be stuck. This is because the current speech could be interrupted first (because it's acting on VAD events), but the handling of that event only comes in later during validations. 

this change ensures that if we ever get to the validation stage, and the agent is not currently speaking, we would always generate a new thread, even if the incoming transcript is empty. If interrupted with a cough (as an example), it will allow the agent to pick up from where it'd left off.

fixes #1229