### PR TITLE
Ensure STT exceptions are being propagated

### DIFF
--- a/.changeset/giant-ways-invite.md
+++ b/.changeset/giant-ways-invite.md
@@ -1,0 +1,8 @@
+---
+"livekit-plugins-assemblyai": patch
+"livekit-plugins-deepgram": patch
+"livekit-plugins-google": patch
+"livekit-plugins-azure": patch
+---
+
+fix: Ensure STT exceptions are being propagated

--- a/livekit-agents/livekit/agents/_exceptions.py
+++ b/livekit-agents/livekit/agents/_exceptions.py
@@ -48,9 +48,9 @@ class APIStatusError(APIError):
         self,
         message: str,
         *,
-        status_code: int,
-        request_id: str | None,
-        body: object | None,
+        status_code: int = -1,
+        request_id: str | None = None,
+        body: object | None = None,
     ) -> None:
         super().__init__(message, body=body)
 

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -25,7 +25,13 @@ from typing import List, Literal, Optional
 from urllib.parse import urlencode
 
 import aiohttp
-from livekit.agents import DEFAULT_API_CONNECT_OPTIONS, APIConnectOptions, stt, utils
+from livekit.agents import (
+    DEFAULT_API_CONNECT_OPTIONS,
+    APIConnectOptions,
+    APIStatusError,
+    stt,
+    utils,
+)
 from livekit.agents.stt import SpeechEvent
 from livekit.agents.utils import AudioBuffer
 
@@ -274,8 +280,11 @@ class SpeechStream(stt.SpeechStream):
                     if closing_ws:  # close is expected, see SpeechStream.aclose
                         return
 
-                    raise Exception(
+                    raise APIStatusError(
                         "AssemblyAI connection closed unexpectedly",
+                        status_code=-1,
+                        request_id=None,
+                        body=None,
                     )  # this will trigger a reconnection, see the _run loop
 
                 if msg.type != aiohttp.WSMsgType.TEXT:

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -282,9 +282,6 @@ class SpeechStream(stt.SpeechStream):
 
                     raise APIStatusError(
                         "AssemblyAI connection closed unexpectedly",
-                        status_code=-1,
-                        request_id=None,
-                        body=None,
                     )  # this will trigger a reconnection, see the _run loop
 
                 if msg.type != aiohttp.WSMsgType.TEXT:

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -305,6 +305,10 @@ class SpeechStream(stt.SpeechStream):
                         [asyncio.gather(*tasks), wait_reconnect_task],
                         return_when=asyncio.FIRST_COMPLETED,
                     )  # type: ignore
+                    for task in done:
+                        if task != wait_reconnect_task:
+                            task.result()
+
                     if wait_reconnect_task not in done:
                         break
 

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
@@ -199,10 +199,13 @@ class SpeechStream(stt.SpeechStream):
                 wait_reconnect_task = asyncio.create_task(self._reconnect_event.wait())
 
                 try:
-                    await asyncio.wait(
+                    done, _ = await asyncio.wait(
                         [process_input_task, wait_reconnect_task],
                         return_when=asyncio.FIRST_COMPLETED,
                     )
+                    for task in done:
+                        if task != wait_reconnect_task:
+                            task.result()
                 finally:
                     await utils.aio.gracefully_cancel(
                         process_input_task, wait_reconnect_task

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -472,10 +472,7 @@ class SpeechStream(stt.SpeechStream):
 
                     # this will trigger a reconnection, see the _run loop
                     raise APIStatusError(
-                        message="deepgram connection closed unexpectedly",
-                        status_code=-1,
-                        request_id=None,
-                        body=None,
+                        message="deepgram connection closed unexpectedly"
                     )
 
                 if msg.type != aiohttp.WSMsgType.TEXT:

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -499,12 +499,10 @@ class SpeechStream(stt.SpeechStream):
                         return_when=asyncio.FIRST_COMPLETED,
                     )  # type: ignore
 
-                    # need to propagate exceptions from completed tasks
+                    # propagate exceptions from completed tasks
                     for task in done:
                         if task != wait_reconnect_task:
-                            exc = task.exception()
-                            if exc is not None:
-                                raise exc
+                            task.result()
 
                     if wait_reconnect_task not in done:
                         break

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -471,7 +471,12 @@ class SpeechStream(stt.SpeechStream):
                         return
 
                     # this will trigger a reconnection, see the _run loop
-                    raise APIStatusError("deepgram connection closed unexpectedly")
+                    raise APIStatusError(
+                        message="deepgram connection closed unexpectedly",
+                        status_code=-1,
+                        request_id=None,
+                        body=None,
+                    )
 
                 if msg.type != aiohttp.WSMsgType.TEXT:
                     logger.warning("unexpected deepgram message type %s", msg.type)

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -438,10 +438,13 @@ class SpeechStream(stt.SpeechStream):
                 process_stream_task = asyncio.create_task(process_stream(stream))
                 wait_reconnect_task = asyncio.create_task(self._reconnect_event.wait())
                 try:
-                    await asyncio.wait(
+                    done, _ = await asyncio.wait(
                         [process_stream_task, wait_reconnect_task],
                         return_when=asyncio.FIRST_COMPLETED,
                     )
+                    for task in done:
+                        if task != wait_reconnect_task:
+                            task.result()
                 finally:
                     await utils.aio.gracefully_cancel(
                         process_stream_task, wait_reconnect_task


### PR DESCRIPTION
when #1131 changed plugins to use `asyncio.await` instead of `asyncio.gather`, it broke the retry mechanisms that we had.

`.gather` automatically propagates exceptions, while `.await` does not. this means we'd have to propagate them explicitly in order for retries to work.