### PR TITLE
improved handling of LLM errors, do not retry if already began

### DIFF
--- a/.changeset/gorgeous-sheep-grow.md
+++ b/.changeset/gorgeous-sheep-grow.md
@@ -1,0 +1,7 @@
+---
+"livekit-plugins-anthropic": patch
+"livekit-plugins-openai": patch
+"livekit-agents": patch
+---
+
+improved handling of LLM errors, do not retry if already began

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -148,7 +148,7 @@ class LLMStream(ABC):
             try:
                 return await self._run()
             except APIError as e:
-                if self._conn_options.max_retry == 0:
+                if self._conn_options.max_retry == 0 or not e.retryable:
                     raise
                 elif i == self._conn_options.max_retry:
                     raise APIConnectionError(

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -312,7 +312,10 @@ class SynthesizeStream(tts.SynthesizeStream):
                     aiohttp.WSMsgType.CLOSE,
                     aiohttp.WSMsgType.CLOSING,
                 ):
-                    raise Exception("Cartesia connection closed unexpectedly")
+                    raise APIStatusError(
+                        "Cartesia connection closed unexpectedly",
+                        request_id=request_id,
+                    )
 
                 if msg.type != aiohttp.WSMsgType.TEXT:
                     logger.warning("unexpected Cartesia message type %s", msg.type)

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
@@ -314,8 +314,9 @@ class SynthesizeStream(tts.SynthesizeStream):
                     aiohttp.WSMsgType.CLOSING,
                 ):
                     if not closing_ws:
-                        raise Exception(
-                            "Deepgram websocket connection closed unexpectedly"
+                        raise APIStatusError(
+                            "Deepgram websocket connection closed unexpectedly",
+                            request_id=request_id,
                         )
                     return
 
@@ -390,13 +391,16 @@ class SynthesizeStream(tts.SynthesizeStream):
                     )
 
             except asyncio.TimeoutError as e:
-                raise APITimeoutError() from e
+                raise APITimeoutError(request_id=request_id) from e
             except aiohttp.ClientResponseError as e:
                 raise APIStatusError(
-                    message=e.message, status_code=e.status, request_id=None, body=None
+                    message=e.message,
+                    status_code=e.status,
+                    request_id=request_id,
+                    body=None,
                 ) from e
             except Exception as e:
-                raise APIConnectionError() from e
+                raise APIConnectionError(request_id=request_id) from e
             finally:
                 if ws is not None and not ws.closed:
                     await ws.close()

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
@@ -391,7 +391,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                     )
 
             except asyncio.TimeoutError as e:
-                raise APITimeoutError(request_id=request_id) from e
+                raise APITimeoutError() from e
             except aiohttp.ClientResponseError as e:
                 raise APIStatusError(
                     message=e.message,
@@ -400,7 +400,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                     body=None,
                 ) from e
             except Exception as e:
-                raise APIConnectionError(request_id=request_id) from e
+                raise APIConnectionError() from e
             finally:
                 if ws is not None and not ws.closed:
                     await ws.close()

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -469,8 +469,9 @@ class SynthesizeStream(tts.SynthesizeStream):
                     aiohttp.WSMsgType.CLOSING,
                 ):
                     if not eos_sent:
-                        raise Exception(
-                            "11labs connection closed unexpectedly, not all tokens have been consumed"
+                        raise APIStatusError(
+                            "11labs connection closed unexpectedly, not all tokens have been consumed",
+                            request_id=request_id,
                         )
                     return
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -706,6 +706,7 @@ class LLMStream(llm.LLMStream):
         self._fnc_name: str | None = None
         self._fnc_raw_arguments: str | None = None
         self._tool_index: int | None = None
+        retryable = True
 
         try:
             opts: dict[str, Any] = dict()
@@ -750,7 +751,6 @@ class LLMStream(llm.LLMStream):
                 **opts,
             )
 
-            retryable = True
             async with stream:
                 async for chunk in stream:
                     for choice in chunk.choices:


### PR DESCRIPTION
LLM could timeout after producing initial tokens, in those cases the inference request should not be retried. the error would be propagated to the caller (PipelineAgent), who could handle it similarly to an interruption. (i.e. flagging it and performing new inference)