### PR TITLE
Do not pass function context if at max depth

### DIFF
--- a/.changeset/khaki-candles-rest.md
+++ b/.changeset/khaki-candles-rest.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Do not pass function context if at max depth

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -943,7 +943,12 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
             chat_ctx = call_ctx.chat_ctx.copy()
             chat_ctx.messages.extend(extra_tools_messages)
             chat_ctx.messages.extend(call_ctx.extra_chat_messages)
-            answer_llm_stream = self._llm.chat(chat_ctx=chat_ctx, fnc_ctx=self.fnc_ctx)
+            answer_llm_stream = self._llm.chat(
+                chat_ctx=chat_ctx,
+                fnc_ctx=self.fnc_ctx
+                if new_speech_handle.fnc_nested_depth < self._opts.max_nested_fnc_calls
+                else None,
+            )
 
             synthesis_handle = self._synthesize_agent_speech(
                 new_speech_handle.id, answer_llm_stream


### PR DESCRIPTION
As it stands, the agent just stops when it hits the maximum depth - this way it'll be forced to synthesize a reply.