### PR TITLE
avoid warnings when function depth matches limit

### DIFF
--- a/.changeset/quiet-dots-fly.md
+++ b/.changeset/quiet-dots-fly.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+avoid warnings when function depth matches limit

--- a/examples/voice-pipeline-agent/function_calling_weather.py
+++ b/examples/voice-pipeline-agent/function_calling_weather.py
@@ -37,7 +37,7 @@ class AssistantFnc(llm.FunctionContext):
     ):
         """Called when the user asks about the weather. This function will return the weather for the given location."""
         # Clean the location string of special characters
-        location = re.sub(r"[^a-zA-Z0-9]", " ", location).strip()
+        location = re.sub(r"[^a-zA-Z0-9]+", " ", location).strip()
 
         # When a function call is running, there are a couple of options to inform the user
         # that it might take awhile:
@@ -90,7 +90,7 @@ async def entrypoint(ctx: JobContext):
             "You are a weather assistant created by LiveKit. Your interface with users will be voice. "
             "You will provide weather information for a given location. "
             # when using option 1, you can suppress from the agent with prompt
-            "do not say anything while waiting for the function call to complete."
+            "do not return any text while calling the function."
             # uncomment this to use option 2
             # "when performing function calls, let user know that you are checking the weather."
         ),

--- a/examples/voice-pipeline-agent/function_calling_weather.py
+++ b/examples/voice-pipeline-agent/function_calling_weather.py
@@ -1,6 +1,7 @@
 import logging
 import random
 import urllib
+import re
 from typing import Annotated
 
 import aiohttp
@@ -35,6 +36,9 @@ class AssistantFnc(llm.FunctionContext):
         ],
     ):
         """Called when the user asks about the weather. This function will return the weather for the given location."""
+        # Clean the location string of special characters
+        location = re.sub(r"[^a-zA-Z0-9]", " ", location).strip()
+
         # When a function call is running, there are a couple of options to inform the user
         # that it might take awhile:
         # Option 1: you can use .say filler message immediately after the call is triggered
@@ -62,6 +66,7 @@ class AssistantFnc(llm.FunctionContext):
                     weather_data = (
                         f"The weather in {location} is {await response.text()}."
                     )
+                    logger.info(f"weather data: {weather_data}")
                 else:
                     raise Exception(
                         f"Failed to get weather data, status code: {response.status}"

--- a/examples/voice-pipeline-agent/function_calling_weather.py
+++ b/examples/voice-pipeline-agent/function_calling_weather.py
@@ -1,7 +1,7 @@
 import logging
 import random
-import urllib
 import re
+import urllib
 from typing import Annotated
 
 import aiohttp

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -963,15 +963,17 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
             fnc_ctx = self.fnc_ctx
             if (
                 fnc_ctx
-                and new_speech_handle.fnc_nested_depth > self._opts.max_nested_fnc_calls
+                and new_speech_handle.fnc_nested_depth
+                >= self._opts.max_nested_fnc_calls
             ):
-                logger.warning(
-                    "max function calls nested depth reached, not propagating fnc ctx",
-                    extra={
-                        "speech_id": speech_handle.id,
-                        "fnc_nested_depth": speech_handle.fnc_nested_depth,
-                    },
-                )
+                if len(fnc_ctx.ai_functions) > 1:
+                    logger.warning(
+                        "max function calls nested depth reached, not propagating fnc ctx",
+                        extra={
+                            "speech_id": speech_handle.id,
+                            "fnc_nested_depth": speech_handle.fnc_nested_depth,
+                        },
+                    )
                 fnc_ctx = None
             answer_llm_stream = self._llm.chat(
                 chat_ctx=chat_ctx,

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -967,8 +967,8 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                 >= self._opts.max_nested_fnc_calls
             ):
                 if len(fnc_ctx.ai_functions) > 1:
-                    logger.warning(
-                        "max function calls nested depth reached, not propagating fnc ctx",
+                    logger.info(
+                        "max function calls nested depth reached, dropping function context. increase max_nested_fnc_calls to enable additional nesting.",
                         extra={
                             "speech_id": speech_handle.id,
                             "fnc_nested_depth": speech_handle.fnc_nested_depth,

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -963,8 +963,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
             fnc_ctx = self.fnc_ctx
             if (
                 fnc_ctx
-                and new_speech_handle.fnc_nested_depth
-                >= self._opts.max_nested_fnc_calls
+                and new_speech_handle.fnc_nested_depth > self._opts.max_nested_fnc_calls
             ):
                 logger.warning(
                     "max function calls nested depth reached, not propagating fnc ctx",


### PR DESCRIPTION
currently we'd get warnings when synthesizing the response to a function call. due to a current limitation, we aren't able to only include the function that we are processing.