### PR TITLE
ensure job status updates contain the correct status

### DIFF
--- a/.changeset/lazy-buckets-obey.md
+++ b/.changeset/lazy-buckets-obey.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+ensure job status updates contain the correct status

--- a/livekit-agents/livekit/agents/ipc/job_proc_executor.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_executor.py
@@ -102,7 +102,6 @@ class ProcJobExecutor(SupervisedProc):
     async def _supervise_task(self) -> None:
         await super()._supervise_task()
 
-        logger.info(f"job exit code: {self.exitcode}")
         self._job_status = JobStatus.SUCCESS if self.exitcode == 0 else JobStatus.FAILED
 
     async def _do_inference_task(self, inf_req: proto.InferenceRequest) -> None:

--- a/livekit-agents/livekit/agents/ipc/job_proc_executor.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_executor.py
@@ -101,9 +101,11 @@ class ProcJobExecutor(SupervisedProc):
     @log_exceptions(logger=logger)
     async def _supervise_task(self) -> None:
         try:
-                await super()._supervise_task()
+            await super()._supervise_task()
         finally:
-                self._job_status = JobStatus.SUCCESS if self.exitcode == 0 else JobStatus.FAILED
+            self._job_status = (
+                JobStatus.SUCCESS if self.exitcode == 0 else JobStatus.FAILED
+            )
 
     async def _do_inference_task(self, inf_req: proto.InferenceRequest) -> None:
         if self._inference_executor is None:

--- a/livekit-agents/livekit/agents/ipc/job_proc_executor.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_executor.py
@@ -98,9 +98,12 @@ class ProcJobExecutor(SupervisedProc):
         finally:
             await aio.gracefully_cancel(*self._inference_tasks)
 
-            self._job_status = (
-                JobStatus.SUCCESS if self.exitcode == 0 else JobStatus.FAILED
-            )
+    @log_exceptions(logger=logger)
+    async def _supervise_task(self) -> None:
+        await super()._supervise_task()
+
+        logger.info(f"job exit code: {self.exitcode}")
+        self._job_status = JobStatus.SUCCESS if self.exitcode == 0 else JobStatus.FAILED
 
     async def _do_inference_task(self, inf_req: proto.InferenceRequest) -> None:
         if self._inference_executor is None:

--- a/livekit-agents/livekit/agents/ipc/job_proc_executor.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_executor.py
@@ -100,9 +100,10 @@ class ProcJobExecutor(SupervisedProc):
 
     @log_exceptions(logger=logger)
     async def _supervise_task(self) -> None:
-        await super()._supervise_task()
-
-        self._job_status = JobStatus.SUCCESS if self.exitcode == 0 else JobStatus.FAILED
+        try:
+                await super()._supervise_task()
+        finally:
+                self._job_status = JobStatus.SUCCESS if self.exitcode == 0 else JobStatus.FAILED
 
     async def _do_inference_task(self, inf_req: proto.InferenceRequest) -> None:
         if self._inference_executor is None:


### PR DESCRIPTION
we were marking every job as failed to the server, due to an order of op error. _main_task is running within the subprocess, and would not be able to retrieve its own exit code.

it was always None, and was evaluated to JobStatus.FAILED