### PR TITLE
Add out-of-band responses + controlled response timing 

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/api_proto.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/api_proto.py
@@ -76,6 +76,7 @@ class ServerVad(TypedDict):
     threshold: NotRequired[float]
     prefix_padding_ms: NotRequired[int]
     silence_duration_ms: NotRequired[int]
+    create_response: NotRequired[bool]
 
 
 class FunctionTool(TypedDict):
@@ -307,6 +308,8 @@ class ClientEvent:
         tools: list[FunctionTool]
         tool_choice: ToolChoice
         temperature: float
+        conversation: Literal["auto", "none"]
+        metadata: NotRequired[map | None]
         max_output_tokens: int | Literal["inf"]
 
     class ResponseCreate(TypedDict):

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1754,4 +1754,3 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
 
     def logging_extra(self) -> dict:
         return {"session_id": self._session_id}
-    

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -722,7 +722,7 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
                 "cancel_existing", "cancel_new", "keep_both"
             ] = "keep_both",
             instructions: str = "",
-            modalities: list[api_proto.Modality] = "audio",
+            modalities: list[api_proto.Modality] = ["text", "audio"],
             conversation: Literal["auto", "none"] = "auto",
             metadata: map | None = None,
         ) -> asyncio.Future[bool]:

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -721,8 +721,8 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
             on_duplicate: Literal[
                 "cancel_existing", "cancel_new", "keep_both"
             ] = "keep_both",
-            instructions: str | None = None,
-            modalities: list[api_proto.Modality] | None = None,
+            instructions: str = "",
+            modalities: list[api_proto.Modality] = "audio",
             conversation: Literal["auto", "none"] = "auto",
             metadata: map | None = None,
         ) -> asyncio.Future[bool]:
@@ -734,7 +734,7 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
                     - "cancel_new": Skip creating new response if one is in progress
                     - "keep_both": Wait for the existing response to be done and then create a new one
                 instructions: explicit prompt used for out-of-band events
-                modalities: set of modalities that the model can respond in
+                modalities: set of modalities that the model can respond in, defaults to audio
                 conversation: specifies whether respones is out-of-band
                     - "auto": Contents of the response will be added to the default conversation
                     - "none": Creates an out-of-band response which will not add items to default conversation
@@ -1443,7 +1443,7 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
         response = response_created["response"]
         done_fut = self._loop.create_future()
         status_details = response.get("status_details")
-        metadata = response.get("metadata")
+        metadata = cast(map, response.get("metadata"))
         new_response = RealtimeResponse(
             id=response["id"],
             status=response["status"],
@@ -1624,7 +1624,7 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
 
         response.status = response_data["status"]
         response.status_details = response_data.get("status_details")
-        response.metadata = response_data.get("metadata")
+        response.metadata = cast(map, response_data.get("metadata"))
         response.output = cast(list[RealtimeOutput], response_data.get("output"))
         response.usage = response_data.get("usage")
 


### PR DESCRIPTION
I recently came across new additions that OpenAI developed and would love for them to be included in Livekit!

I worked on [out-of-band responses](https://platform.openai.com/docs/guides/realtime-model-capabilities#create-responses-outside-the-default-conversation) and an [extra VAD option](https://platform.openai.com/docs/guides/realtime-model-capabilities#voice-activity-detection-vad) where responses are not automatic. I also added an option to turn server VAD off by `turn_detection="None"`  in `session.update()`.

Please let me know your thoughts! :-)

