### PR TITLE
Fix not awaiting forward task

### DIFF
--- a/.changeset/dry-drinks-poke.md
+++ b/.changeset/dry-drinks-poke.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Fix not awaiting forward task in TTS forwarder, leading to warnings.


### PR DESCRIPTION
Really just wrapping in a try block!

This would cause errors like:

```
{"message": "Task was destroyed but it is pending!\ntask: <Task pending name='Task-124' coro=<TTSSegmentsForwarder._main_task.<locals>._forward_task() running at /app/.venv/lib/python3.12/site-packages/livekit/agents/utils/log.py:16> wait_for=<Future pending cb=[Task.task_wakeup()]>>", "level": "ERROR", "name": "asyncio", "pid": 1923, "job_id": "AJ_VKu3CSTZGMS9", "timestamp": "2025-01-06T18:11:34.516550+00:00"}
```

Fixes: #1264 