### PR TITLE
update Cartesia plugin default model and voice id

### DIFF
--- a/.changeset/cool-clouds-hang.md
+++ b/.changeset/cool-clouds-hang.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-cartesia": patch
+---
+
+update Cartesia plugin default model and voice id

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/models.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/models.py
@@ -10,7 +10,7 @@ TTSEncoding = Literal[
 
 TTSModels = Literal["sonic-english", "sonic-multilingual"]
 TTSLanguages = Literal["en", "es", "fr", "de", "pt", "zh", "ja"]
-TTSDefaultVoiceId = "c2ac25f9-ecc4-4f56-9095-651354df60c0"
+TTSDefaultVoiceId = "794f9389-aac1-45b6-b726-9d9369183238"
 TTSVoiceSpeed = Literal["fastest", "fast", "normal", "slow", "slowest"]
 TTSVoiceEmotion = Literal[
     "anger:lowest",

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -67,7 +67,7 @@ class TTS(tts.TTS):
     def __init__(
         self,
         *,
-        model: TTSModels | str = "sonic-english",
+        model: TTSModels | str = "sonic",
         language: str = "en",
         encoding: TTSEncoding = "pcm_s16le",
         voice: str | list[float] = TTSDefaultVoiceId,


### PR DESCRIPTION
This change updates the default model to `sonic` (see https://docs.cartesia.ai/build-with-sonic/models for details about our model aliases).

It also updates the default voice ID to one that we like a bit better.

(Hope you all are doing well :)