### PR TITLE
Support manual vad for realtime api

### DIFF
--- a/.changeset/twenty-rockets-approve.md
+++ b/.changeset/twenty-rockets-approve.md
@@ -1,0 +1,6 @@
+---
+"livekit-plugins-openai": patch
+"livekit-agents": patch
+---
+
+support disabling server VAD for OpenAI realtime model

--- a/livekit-agents/livekit/agents/multimodal/multimodal_agent.py
+++ b/livekit-agents/livekit/agents/multimodal/multimodal_agent.py
@@ -29,6 +29,7 @@ EventTypes = Literal[
     "user_stopped_speaking",
     "agent_started_speaking",
     "agent_stopped_speaking",
+    "input_speech_committed",
     "user_speech_committed",
     "agent_speech_committed",
     "agent_speech_interrupted",
@@ -302,6 +303,7 @@ class MultimodalAgent(utils.EventEmitter[EventTypes]):
                     alternatives=[stt.SpeechData(language="", text="")],
                 )
             )
+            self.emit("input_speech_committed")
 
         @self._session.on("input_speech_transcription_completed")
         def _input_speech_transcription_completed(ev: _InputTranscriptionProto):
@@ -328,18 +330,7 @@ class MultimodalAgent(utils.EventEmitter[EventTypes]):
         @self._session.on("input_speech_started")
         def _input_speech_started():
             self.emit("user_started_speaking")
-            self._update_state("listening")
-            if self._playing_handle is not None and not self._playing_handle.done():
-                self._playing_handle.interrupt()
-
-                if self._model.capabilities.supports_truncate:
-                    self._session._truncate_conversation_item(
-                        item_id=self._playing_handle.item_id,
-                        content_index=self._playing_handle.content_index,
-                        audio_end_ms=int(
-                            self._playing_handle.audio_samples / 24000 * 1000
-                        ),
-                    )
+            self.interrupt()
 
         @self._session.on("input_speech_stopped")
         def _input_speech_stopped():
@@ -356,6 +347,18 @@ class MultimodalAgent(utils.EventEmitter[EventTypes]):
         @self._session.on("metrics_collected")
         def _metrics_collected(metrics: MultimodalLLMMetrics):
             self.emit("metrics_collected", metrics)
+
+    def interrupt(self) -> None:
+        if self._playing_handle is not None and not self._playing_handle.done():
+            self._playing_handle.interrupt()
+
+            if self._model.capabilities.supports_truncate:
+                self._session._truncate_conversation_item(
+                    item_id=self._playing_handle.item_id,
+                    content_index=self._playing_handle.content_index,
+                    audio_end_ms=int(self._playing_handle.audio_samples / 24000 * 1000),
+                )
+        self._update_state("listening")
 
     def _update_state(self, state: AgentState, delay: float = 0.0):
         """Set the current state of the agent"""

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -195,6 +195,13 @@ DEFAULT_SERVER_VAD_OPTIONS = ServerVadOptions(
 DEFAULT_INPUT_AUDIO_TRANSCRIPTION = InputTranscriptionOptions(model="whisper-1")
 
 
+class _NOTSET:
+    pass
+
+
+NOTSET = _NOTSET()
+
+
 class RealtimeModel:
     @overload
     def __init__(
@@ -207,7 +214,7 @@ class RealtimeModel:
         input_audio_format: api_proto.AudioFormat = "pcm16",
         output_audio_format: api_proto.AudioFormat = "pcm16",
         input_audio_transcription: InputTranscriptionOptions = DEFAULT_INPUT_AUDIO_TRANSCRIPTION,
-        turn_detection: ServerVadOptions = DEFAULT_SERVER_VAD_OPTIONS,
+        turn_detection: Optional[ServerVadOptions] = DEFAULT_SERVER_VAD_OPTIONS,
         tool_choice: api_proto.ToolChoice = "auto",
         temperature: float = 0.8,
         max_response_output_tokens: int | Literal["inf"] = "inf",
@@ -232,7 +239,7 @@ class RealtimeModel:
         input_audio_format: api_proto.AudioFormat = "pcm16",
         output_audio_format: api_proto.AudioFormat = "pcm16",
         input_audio_transcription: InputTranscriptionOptions = DEFAULT_INPUT_AUDIO_TRANSCRIPTION,
-        turn_detection: ServerVadOptions = DEFAULT_SERVER_VAD_OPTIONS,
+        turn_detection: Optional[ServerVadOptions] = DEFAULT_SERVER_VAD_OPTIONS,
         tool_choice: api_proto.ToolChoice = "auto",
         temperature: float = 0.8,
         max_response_output_tokens: int | Literal["inf"] = "inf",
@@ -250,7 +257,7 @@ class RealtimeModel:
         input_audio_format: api_proto.AudioFormat = "pcm16",
         output_audio_format: api_proto.AudioFormat = "pcm16",
         input_audio_transcription: InputTranscriptionOptions = DEFAULT_INPUT_AUDIO_TRANSCRIPTION,
-        turn_detection: ServerVadOptions = DEFAULT_SERVER_VAD_OPTIONS,
+        turn_detection: Optional[ServerVadOptions] = DEFAULT_SERVER_VAD_OPTIONS,
         tool_choice: api_proto.ToolChoice = "auto",
         temperature: float = 0.8,
         max_response_output_tokens: int | Literal["inf"] = "inf",
@@ -347,7 +354,7 @@ class RealtimeModel:
         input_audio_format: api_proto.AudioFormat = "pcm16",
         output_audio_format: api_proto.AudioFormat = "pcm16",
         input_audio_transcription: InputTranscriptionOptions = DEFAULT_INPUT_AUDIO_TRANSCRIPTION,
-        turn_detection: ServerVadOptions = DEFAULT_SERVER_VAD_OPTIONS,
+        turn_detection: Optional[ServerVadOptions] = DEFAULT_SERVER_VAD_OPTIONS,
         tool_choice: api_proto.ToolChoice = "auto",
         temperature: float = 0.8,
         max_response_output_tokens: int | Literal["inf"] = "inf",
@@ -451,8 +458,8 @@ class RealtimeModel:
         input_audio_format: api_proto.AudioFormat | None = None,
         output_audio_format: api_proto.AudioFormat | None = None,
         tool_choice: api_proto.ToolChoice | None = None,
-        input_audio_transcription: InputTranscriptionOptions | None = None,
-        turn_detection: ServerVadOptions | None = None,
+        input_audio_transcription: InputTranscriptionOptions | None | _NOTSET = NOTSET,
+        turn_detection: ServerVadOptions | None | _NOTSET = NOTSET,
         temperature: float | None = None,
         max_response_output_tokens: int | Literal["inf"] | None = None,
     ) -> RealtimeSession:
@@ -469,9 +476,9 @@ class RealtimeModel:
             opts.output_audio_format = output_audio_format
         if tool_choice is not None:
             opts.tool_choice = tool_choice
-        if input_audio_transcription is not None:
-            opts.input_audio_transcription
-        if turn_detection is not None:
+        if not isinstance(input_audio_transcription, _NOTSET):
+            opts.input_audio_transcription = input_audio_transcription
+        if not isinstance(turn_detection, _NOTSET):
             opts.turn_detection = turn_detection
         if temperature is not None:
             opts.temperature = temperature
@@ -879,8 +886,8 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
         voice: api_proto.Voice | None = None,
         input_audio_format: api_proto.AudioFormat | None = None,
         output_audio_format: api_proto.AudioFormat | None = None,
-        input_audio_transcription: InputTranscriptionOptions | None = None,
-        turn_detection: ServerVadOptions | None = None,
+        input_audio_transcription: InputTranscriptionOptions | None | _NOTSET = NOTSET,
+        turn_detection: ServerVadOptions | None | _NOTSET = NOTSET,
         tool_choice: api_proto.ToolChoice | None = None,
         temperature: float | None = None,
         max_response_output_tokens: int | Literal["inf"] | None = None,
@@ -896,9 +903,9 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
             self._opts.input_audio_format = input_audio_format
         if output_audio_format is not None:
             self._opts.output_audio_format = output_audio_format
-        if input_audio_transcription is not None:
+        if not isinstance(input_audio_transcription, _NOTSET):
             self._opts.input_audio_transcription = input_audio_transcription
-        if turn_detection is not None:
+        if not isinstance(turn_detection, _NOTSET):
             self._opts.turn_detection = turn_detection
         if tool_choice is not None:
             self._opts.tool_choice = tool_choice

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -14,6 +14,7 @@ from livekit import rtc
 from livekit.agents import llm, utils
 from livekit.agents.llm.function_context import _create_ai_function_info
 from livekit.agents.metrics import MultimodalLLMError, MultimodalLLMMetrics
+from livekit.agents.types import NOT_GIVEN, NotGivenOr
 from typing_extensions import TypedDict
 
 from .._oai_api import build_oai_function_description
@@ -193,13 +194,6 @@ DEFAULT_SERVER_VAD_OPTIONS = ServerVadOptions(
 )
 
 DEFAULT_INPUT_AUDIO_TRANSCRIPTION = InputTranscriptionOptions(model="whisper-1")
-
-
-class _NOTSET:
-    pass
-
-
-NOTSET = _NOTSET()
 
 
 class RealtimeModel:
@@ -458,8 +452,10 @@ class RealtimeModel:
         input_audio_format: api_proto.AudioFormat | None = None,
         output_audio_format: api_proto.AudioFormat | None = None,
         tool_choice: api_proto.ToolChoice | None = None,
-        input_audio_transcription: InputTranscriptionOptions | None | _NOTSET = NOTSET,
-        turn_detection: ServerVadOptions | None | _NOTSET = NOTSET,
+        input_audio_transcription: NotGivenOr[
+            InputTranscriptionOptions | None
+        ] = NOT_GIVEN,
+        turn_detection: NotGivenOr[ServerVadOptions | None] = NOT_GIVEN,
         temperature: float | None = None,
         max_response_output_tokens: int | Literal["inf"] | None = None,
     ) -> RealtimeSession:
@@ -476,9 +472,9 @@ class RealtimeModel:
             opts.output_audio_format = output_audio_format
         if tool_choice is not None:
             opts.tool_choice = tool_choice
-        if not isinstance(input_audio_transcription, _NOTSET):
+        if utils.is_given(input_audio_transcription):
             opts.input_audio_transcription = input_audio_transcription
-        if not isinstance(turn_detection, _NOTSET):
+        if utils.is_given(turn_detection):
             opts.turn_detection = turn_detection
         if temperature is not None:
             opts.temperature = temperature
@@ -886,8 +882,10 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
         voice: api_proto.Voice | None = None,
         input_audio_format: api_proto.AudioFormat | None = None,
         output_audio_format: api_proto.AudioFormat | None = None,
-        input_audio_transcription: InputTranscriptionOptions | None | _NOTSET = NOTSET,
-        turn_detection: ServerVadOptions | None | _NOTSET = NOTSET,
+        input_audio_transcription: NotGivenOr[
+            InputTranscriptionOptions | None
+        ] = NOT_GIVEN,
+        turn_detection: NotGivenOr[ServerVadOptions | None] = NOT_GIVEN,
         tool_choice: api_proto.ToolChoice | None = None,
         temperature: float | None = None,
         max_response_output_tokens: int | Literal["inf"] | None = None,
@@ -903,9 +901,9 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
             self._opts.input_audio_format = input_audio_format
         if output_audio_format is not None:
             self._opts.output_audio_format = output_audio_format
-        if not isinstance(input_audio_transcription, _NOTSET):
+        if utils.is_given(input_audio_transcription):
             self._opts.input_audio_transcription = input_audio_transcription
-        if not isinstance(turn_detection, _NOTSET):
+        if utils.is_given(turn_detection):
             self._opts.turn_detection = turn_detection
         if tool_choice is not None:
             self._opts.tool_choice = tool_choice


### PR DESCRIPTION
To disable the server VAD for OAI realtime api, set `turn_detection=None`
```python
model=openai.realtime.RealtimeModel(
            voice="alloy",
            temperature=0.8,
            instructions="You are a helpful assistant",
            turn_detection=None,
        )
```

To manually commit user speech and trigger response:
```python
# at the end of the user's turn
session: RealtimeSession = agent._session
session.input_audio_buffer.commit() 

# listen to the input_speech_committed event and create a new response after that
@agent.on("input_speech_committed")
def _on_input_speech_committed():
    agent.interrupt()  # can also be called when the local VAD detects the start of the user speech
    session: RealtimeSession = agent._session
    session.response.create(on_duplicate="cancel_existing")
```