### PR TITLE
fix azure speech for all types of configs

### DIFF
--- a/.changeset/blue-boats-sin.md
+++ b/.changeset/blue-boats-sin.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-azure": patch
+---
+
+azure speech support all different configs

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
@@ -41,6 +41,7 @@ class STTOptions:
     languages: list[
         str
     ]  # see https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support?tabs=stt
+    speech_endpoint: str | None = None
 
 
 class STT(stt.STT):
@@ -305,16 +306,14 @@ class SpeechStream(stt.SpeechStream):
 def _create_speech_recognizer(
     *, config: STTOptions, stream: speechsdk.audio.AudioInputStream
 ) -> speechsdk.SpeechRecognizer:
-    if config.speech_host:
-        speech_config = speechsdk.SpeechConfig(host=config.speech_host)
-    if config.speech_auth_token:
-        speech_config = speechsdk.SpeechConfig(
-            auth_token=config.speech_auth_token, region=config.speech_region
-        )
-    else:
-        speech_config = speechsdk.SpeechConfig(
-            subscription=config.speech_key, region=config.speech_region
-        )
+    # let the SpeechConfig constructor to validate the arguments
+    speech_config = speechsdk.SpeechConfig(
+        subscription=config.speech_key,
+        region=config.speech_region,
+        endpoint=config.speech_endpoint,
+        host=config.speech_host,
+        auth_token=config.speech_auth_token,
+    )
 
     if config.segmentation_silence_timeout_ms:
         speech_config.set_property(

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
@@ -120,6 +120,7 @@ class _TTSOptions:
     language: str | None = None
     # See https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-synthesis-markup-voice#adjust-prosody
     prosody: ProsodyConfig | None = None
+    speech_endpoint: str | None = None
 
 
 class TTS(tts.TTS):
@@ -324,20 +325,15 @@ class _PushAudioOutputStreamCallback(speechsdk.audio.PushAudioOutputStreamCallba
 def _create_speech_synthesizer(
     *, config: _TTSOptions, stream: speechsdk.audio.AudioOutputStream
 ) -> speechsdk.SpeechSynthesizer:
-    if config.speech_host:
-        speech_config = speechsdk.SpeechConfig(host=config.speech_host)
-    if config.speech_auth_token:
-        speech_config = speechsdk.SpeechConfig(
-            auth_token=config.speech_auth_token,
-            region=config.speech_region,
-            speech_recognition_language=config.language or "en-US",
-        )
-    else:
-        speech_config = speechsdk.SpeechConfig(
-            subscription=config.speech_key,
-            region=config.speech_region,
-            speech_recognition_language=config.language or "en-US",
-        )
+    # let the SpeechConfig constructor to validate the arguments
+    speech_config = speechsdk.SpeechConfig(
+        subscription=config.speech_key,
+        region=config.speech_region,
+        endpoint=config.speech_endpoint,
+        host=config.speech_host,
+        auth_token=config.speech_auth_token,
+        speech_recognition_language=config.language or "en-US",
+    )
 
     speech_config.set_speech_synthesis_output_format(
         SUPPORTED_SAMPLE_RATE[config.sample_rate]


### PR DESCRIPTION
Pass all options to the `SpeechConfig` as it already has the sanity check (https://learn.microsoft.com/en-us/python/api/azure-cognitiveservices-speech/azure.cognitiveservices.speech.speechconfig?view=azure-python)
```python
        if endpoint is not None or host is not None:
            if region is not None:
                raise ValueError('cannot construct SpeechConfig with both region and endpoint or host information')
            if auth_token is not None:
                raise ValueError('cannot specify both auth_token and endpoint or host when constructing SpeechConfig. '
                                 'Set authorization token separately after creating SpeechConfig.')

        if region is not None and subscription is None and auth_token is None:
            raise ValueError('either subscription key or authorization token must be given along with a region')

        if subscription is not None and endpoint is None and host is None and region is None:
            raise ValueError('either endpoint, host, or region must be given along with a subscription key')

```

fixes #1361