### PR TITLE
remove duplicated message

### DIFF
--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -721,6 +721,12 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                 # the speech is playing but not committed yet, add it to the chat context for this new reply synthesis
                 # First add the previous function call message if any
                 if playing_speech.extra_tools_messages:
+                    if playing_speech.fnc_text_message_id is not None:
+                        # there is a message alongside the function calls
+                        msgs = copied_ctx.messages
+                        if msgs and msgs[-1].id == playing_speech.fnc_text_message_id:
+                            # replace it with the tool call message if it's the last in the ctx
+                            msgs.pop()
                     copied_ctx.messages.extend(playing_speech.extra_tools_messages)
 
                 # Then add the previous assistant message


### PR DESCRIPTION
This is the same fix as for the main chat context when speech is committed but to make sure that when we call the LLM with a copied chat_ctx, just after a tool call, we don't have the tool text message duplicated
@longcw 