### PR TITLE
remove aiodns from livekit-agents

### DIFF
--- a/.changeset/young-monkeys-allow.md
+++ b/.changeset/young-monkeys-allow.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+remove aiodns from livekit-agents

--- a/livekit-agents/setup.py
+++ b/livekit-agents/setup.py
@@ -63,9 +63,6 @@ setuptools.setup(
         ':sys_platform=="win32"': [
             "colorama"
         ],  # fix logs color on windows (devmode only)
-        ':sys_platform!="win32"': [
-            "aiodns~=3.2"
-        ],  # use default aiohttp resolver on windows
         "codecs": ["av>=12.0.0", "numpy>=1.26.0"],
         "images": ["pillow>=10.3.0"],
     },


### PR DESCRIPTION
This is causing very long connection time for some users

Using this library should be an user choice, not a choice made by livekit-agents 