### PR TITLE
disable vertex from test_llm.py

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -91,7 +91,6 @@ LLMS: list[Callable[[], llm.LLM]] = [
     #     )
     # ),
     pytest.param(lambda: anthropic.LLM(), id="anthropic"),
-    pytest.param(lambda: openai.LLM.with_vertex(), id="openai.with_vertex"),
 ]
 
 


### PR DESCRIPTION
- The Vertex LLM frequently fails due to rate limits, so we are temporarily disabling it.