### PR TITLE
PlayAI plugin: don't reconnect the websocket for each request (and update PlayAI Python SDK)

### DIFF
--- a/livekit-plugins/livekit-plugins-playai/setup.py
+++ b/livekit-plugins/livekit-plugins-playai/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
     python_requires=">=3.9.0",
     install_requires=[
         "livekit-agents[codecs]>=0.12.3",
-        "pyht>=0.1.10",
+        "pyht>=0.1.11",
         "aiohttp",
         "livekit",
     ],


### PR DESCRIPTION
This should resolve the latency that customers were experiencing due to reestablishing the WS before every requests.

This was done because of server-side WebSocket disconnect problems, which are now handled gracefully in the PlayAI Python SDK (version updated here)