### PR TITLE
fix false positive interruption tripping up certain LLMs

### DIFF
--- a/.changeset/famous-owls-attack.md
+++ b/.changeset/famous-owls-attack.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+fix false positive interruption tripping up certain LLMs


### PR DESCRIPTION
LLMs like Anthropic and Gemini do not accept empty content as part of the user question. Using a continue marker to ensure output continues from point of interruption