### PR TITLE
chore: Replace ValueError with logger.warning for missing GOOGLE_APPLICATION_CREDENTIALS environment variable

### DIFF
--- a/.changeset/rich-spiders-develop.md
+++ b/.changeset/rich-spiders-develop.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-google": patch
+---
+
+chore: Replace ValueError with logger.warning for missing GOOGLE_APPLICATION_CREDENTIALS environment variable

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -108,8 +108,8 @@ class LLM(llm.LLM):
         self._api_key = api_key or os.environ.get("GOOGLE_API_KEY", None)
         _gac = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
         if _gac is None:
-            raise ValueError(
-                "`GOOGLE_APPLICATION_CREDENTIALS` environment variable is not set. please set it to the path of the service account key file."
+            logger.warning(
+                "`GOOGLE_APPLICATION_CREDENTIALS` environment variable is not set. please set it to the path of the service account key file. Otherwise, use any of the other Google Cloud auth methods."
             )
 
         if vertexai:


### PR DESCRIPTION
## Overview

According to the Google Auth library, authentication should be possible without the `GOOGLE_APPLICATION_CREDENTIALS` environment variable by using commands like `gcloud auth application-default login` and `gcloud config set project` . However, the current implementation does not support this, so this pull request addresses and fixes that issue by logging a warning instead of raising a `ValueError` when the environment variable is not set. This change ensures consistency with the existing implementation and allows the use of alternative Google authentication methods.

## Changes

* Replace the `ValueError` with a `logger.warning`

## Related Information

By modifying the implementation to log a warning instead of raising an error, this pull request aligns the behavior with the intended flexibility of the Google Auth library (below). This allows applications to rely on other authentication methods seamlessly, enhancing compatibility with various deployment environments and configurations.

* Existing implementation's warning message:
https://github.com/livekit/agents/blob/489f7867ecbddfaf7ed157c8b5288de335a338f1/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py#L224-L228
* Google Auth library's Credentials flexibility:
https://github.com/googleapis/google-auth-library-python/blob/main/google/auth/_default.py#L577-L607