### PR TITLE
feat(pipeline): expose agent publication

### DIFF
--- a/.changeset/poor-tools-repair.md
+++ b/.changeset/poor-tools-repair.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+feat(pipeline): expose agent publication

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -338,6 +338,10 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
     def vad(self) -> vad.VAD:
         return self._vad
 
+    @property
+    def agent_publication(self) -> rtc.LocalTrackPublication:
+        return self._agent_publication
+
     def start(
         self, room: rtc.Room, participant: rtc.RemoteParticipant | str | None = None
     ) -> None:


### PR DESCRIPTION
we recommend users to listen to LocalTrackPublication.wait_for_subscription() to know when a SIP user has picked up a call, but this is not currently exposed in VPA. 