### PR TITLE
Bump version of pypa/gh-action-pypi-publish in workflows/publish-package.yml

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -102,7 +102,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -102,7 +102,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Current SHA is a few years old - https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.4.2 - proposing updating to the latest https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.4