### PR TITLE
[Cartesia] Adding base url option to Cartesia TTS plugin

### DIFF
--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -64,12 +64,10 @@ class _TTSOptions:
     base_url: str
 
     def get_http_url(self, path: str) -> str:
-        protocol = "http" if "localhost" in self.base_url else "https"
-        return f"{protocol}://{self.base_url}{path}"
+        return f"{self.base_url}{path}"
 
     def get_ws_url(self, path: str) -> str:
-        protocol = "ws" if "localhost" in self.base_url else "wss"
-        return f"{protocol}://{self.base_url}{path}"
+        return f"{self.base_url.replace('http', 'ws', 1)}{path}"
 
 
 class TTS(tts.TTS):
@@ -85,7 +83,7 @@ class TTS(tts.TTS):
         sample_rate: int = 24000,
         api_key: str | None = None,
         http_session: aiohttp.ClientSession | None = None,
-        base_url: str = "api.cartesia.ai",
+        base_url: str = "https://api.cartesia.ai",
     ) -> None:
         """
         Create a new instance of Cartesia TTS.
@@ -102,7 +100,7 @@ class TTS(tts.TTS):
             sample_rate (int, optional): The audio sample rate in Hz. Defaults to 24000.
             api_key (str, optional): The Cartesia API key. If not provided, it will be read from the CARTESIA_API_KEY environment variable.
             http_session (aiohttp.ClientSession | None, optional): An existing aiohttp ClientSession to use. If not provided, a new session will be created.
-            base_url (str, optional): The base URL for the Cartesia API. Defaults to "api.cartesia.ai".
+            base_url (str, optional): The base URL for the Cartesia API. Defaults to "https://api.cartesia.ai".
         """
 
         super().__init__(

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -356,7 +356,9 @@ class SynthesizeStream(tts.SynthesizeStream):
                 else:
                     logger.error("unexpected Cartesia message %s", data)
 
-        url = self._opts.get_ws_url(f"/tts/websocket?api_key={self._opts.api_key}&cartesia_version={API_VERSION}")
+        url = self._opts.get_ws_url(
+            f"/tts/websocket?api_key={self._opts.api_key}&cartesia_version={API_VERSION}"
+        )
 
         ws: aiohttp.ClientWebSocketResponse | None = None
 

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -61,6 +61,15 @@ class _TTSOptions:
     emotion: list[TTSVoiceEmotion | str] | None
     api_key: str
     language: str
+    base_url: str
+
+    def get_http_url(self, path: str) -> str:
+        protocol = "http" if "localhost" in self.base_url else "https"
+        return f"{protocol}://{self.base_url}{path}"
+
+    def get_ws_url(self, path: str) -> str:
+        protocol = "ws" if "localhost" in self.base_url else "wss"
+        return f"{protocol}://{self.base_url}{path}"
 
 
 class TTS(tts.TTS):
@@ -76,6 +85,7 @@ class TTS(tts.TTS):
         sample_rate: int = 24000,
         api_key: str | None = None,
         http_session: aiohttp.ClientSession | None = None,
+        base_url: str = "api.cartesia.ai",
     ) -> None:
         """
         Create a new instance of Cartesia TTS.
@@ -92,6 +102,7 @@ class TTS(tts.TTS):
             sample_rate (int, optional): The audio sample rate in Hz. Defaults to 24000.
             api_key (str, optional): The Cartesia API key. If not provided, it will be read from the CARTESIA_API_KEY environment variable.
             http_session (aiohttp.ClientSession | None, optional): An existing aiohttp ClientSession to use. If not provided, a new session will be created.
+            base_url (str, optional): The base URL for the Cartesia API. Defaults to "api.cartesia.ai".
         """
 
         super().__init__(
@@ -113,6 +124,7 @@ class TTS(tts.TTS):
             speed=speed,
             emotion=emotion,
             api_key=api_key,
+            base_url=base_url,
         )
         self._session = http_session
 
@@ -207,7 +219,7 @@ class ChunkedStream(tts.ChunkedStream):
 
         try:
             async with self._session.post(
-                "https://api.cartesia.ai/tts/bytes",
+                self._opts.get_http_url("/tts/bytes"),
                 headers=headers,
                 json=json,
                 timeout=aiohttp.ClientTimeout(
@@ -344,7 +356,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                 else:
                     logger.error("unexpected Cartesia message %s", data)
 
-        url = f"wss://api.cartesia.ai/tts/websocket?api_key={self._opts.api_key}&cartesia_version={API_VERSION}"
+        url = self._opts.get_ws_url(f"/tts/websocket?api_key={self._opts.api_key}&cartesia_version={API_VERSION}")
 
         ws: aiohttp.ClientWebSocketResponse | None = None
 


### PR DESCRIPTION
Per request from some of our customers, we want to provide the optionality to specify the base URL for the Cartesia API when using the Cartesia TTS plugin, including localhost for debugging purposes.