### PR TITLE
chore(Deepgram STT): add nova-3 model to type literal

### DIFF
--- a/.changeset/nine-foxes-wink.md
+++ b/.changeset/nine-foxes-wink.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-deepgram": patch
+---
+
+chore(Deepgram STT): add nova-3 model to type literal

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/models.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/models.py
@@ -14,6 +14,7 @@ DeepgramModels = Literal[
     "nova-2-medical",
     "nova-2-drivethru",
     "nova-2-automotive",
+    "nova-3-general",
     "enhanced-general",
     "enhanced-meeting",
     "enhanced-phonecall",


### PR DESCRIPTION
With the early access release of [Nova 3 from Deepgram](https://developers.deepgram.com/docs/models-languages-overview#nova-3) add the general model to the model type literal for STT