### PR TITLE
Fix prob cutoff

### DIFF
--- a/.changeset/late-dolphins-help.md
+++ b/.changeset/late-dolphins-help.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-turn-detector": patch
+---
+
+adjust default probability cutoff

--- a/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/eou.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/eou.py
@@ -123,7 +123,7 @@ class EOUModel:
     def __init__(
         self,
         inference_executor: InferenceExecutor | None = None,
-        unlikely_threshold: float = 0.15,
+        unlikely_threshold: float = 0.008,
     ) -> None:
         self._executor = (
             inference_executor or get_current_job_context().inference_executor


### PR DESCRIPTION
this should fix the utterance delays at _true turn endings_ that some folks have noticed with the new model. 

with this updated threshold the new model has the same TPR (true positive rate) as the old model,  but a much higher TNR. in other words, it's better at preventing interruptions from the agent, without sacrificing higher latency at true turn endings.

for reference, here's the metrics comparison using our latest evaluation set:
```
                         threshold    tpr    tnr
OLD model OLD threshold      0.150  0.988  0.796
NEW model OLD threshold      0.150  0.943  0.976
NEW model NEW threshold      0.008  0.988  0.905
``` 
