### PR TITLE
End of utterance Assertion Error Rescue

### DIFF
--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -1331,7 +1331,7 @@ class _DeferredReplyValidation:
                     if eot_prob < unlikely_threshold:
                         delay = self._max_endpointing_delay
                     delay = max(0, delay - elasped)
-                except TimeoutError:
+                except (TimeoutError, AssertionError):
                     pass  # inference process is unresponsive
 
             await asyncio.sleep(delay)


### PR DESCRIPTION
If the EOU predictor is not responsive and returns non the assertion error should not cause the PipelineAgent to die.