### PR TITLE
fix openai realtime response create

### DIFF
--- a/.changeset/proud-onions-drop.md
+++ b/.changeset/proud-onions-drop.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-openai": patch
+---
+
+fix response create for openai realtime model

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/api_proto.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/api_proto.py
@@ -309,7 +309,7 @@ class ClientEvent:
         tool_choice: ToolChoice
         temperature: float
         conversation: Literal["auto", "none"]
-        metadata: NotRequired[map | None]
+        metadata: NotRequired[dict[str, str] | None]
         max_output_tokens: int | Literal["inf"]
 
     class ResponseCreate(TypedDict):

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -6,7 +6,7 @@ import os
 import time
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import AsyncIterable, Literal, Optional, Union, cast, overload
+from typing import Any, AsyncIterable, Literal, Optional, Union, cast, overload
 from urllib.parse import urlencode
 
 import aiohttp
@@ -768,7 +768,9 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
                 **self._sess.logging_extra(),
             }
 
-            response_request = {"conversation": conversation}
+            response_request: api_proto.ClientEvent.ResponseCreateData = {
+                "conversation": conversation
+            }
             if instructions is not None:
                 response_request["instructions"] = instructions
             if modalities is not None:

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -143,7 +143,7 @@ class ServerVadOptions:
     threshold: float
     prefix_padding_ms: int
     silence_duration_ms: int
-    create_response: bool
+    create_response: bool = True
 
 
 @dataclass
@@ -722,10 +722,10 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
             on_duplicate: Literal[
                 "cancel_existing", "cancel_new", "keep_both"
             ] = "keep_both",
-            instructions: str = "",
-            modalities: list[api_proto.Modality] = ["text", "audio"],
+            instructions: Optional[str] = None,
+            modalities: Optional[list[api_proto.Modality]] = None,
             conversation: Literal["auto", "none"] = "auto",
-            metadata: map | None = None,
+            metadata: Optional[dict[str, str]] = None,
         ) -> asyncio.Future[bool]:
             """Creates a new response.
 
@@ -736,7 +736,7 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
                     - "keep_both": Wait for the existing response to be done and then create a new one
                 instructions: explicit prompt used for out-of-band events
                 modalities: set of modalities that the model can respond in, defaults to audio
-                conversation: specifies whether respones is out-of-band
+                conversation: specifies whether response is out-of-band
                     - "auto": Contents of the response will be added to the default conversation
                     - "none": Creates an out-of-band response which will not add items to default conversation
                 metadata: set of key-value pairs that can be used for storing additional information
@@ -768,6 +768,14 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
                 **self._sess.logging_extra(),
             }
 
+            response_request = {"conversation": conversation}
+            if instructions is not None:
+                response_request["instructions"] = instructions
+            if modalities is not None:
+                response_request["modalities"] = modalities
+            if metadata is not None:
+                response_request["metadata"] = metadata
+
             if (
                 not active_resp_id
                 or self._sess._pending_responses[active_resp_id].done_fut.done()
@@ -776,12 +784,7 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
                 self._sess._queue_msg(
                     {
                         "type": "response.create",
-                        "response": {
-                            "instructions": instructions,
-                            "modalities": modalities,
-                            "conversation": conversation,
-                            "metadata": metadata,
-                        },
+                        "response": response_request,
                     }
                 )
                 _fut = asyncio.Future[bool]()
@@ -823,12 +826,7 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
                 self._sess._queue_msg(
                     {
                         "type": "response.create",
-                        "response": {
-                            "instructions": instructions,
-                            "modalities": modalities,
-                            "conversation": conversation,
-                            "metadata": metadata,
-                        },
+                        "response": response_request,
                     }
                 )
                 return True
@@ -1283,7 +1281,7 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
                 threshold=session["turn_detection"]["threshold"],
                 prefix_padding_ms=session["turn_detection"]["prefix_padding_ms"],
                 silence_duration_ms=session["turn_detection"]["silence_duration_ms"],
-                create_response=True,
+                create_response=session["turn_detection"]["create_response"],
             )
         if session["input_audio_transcription"] is None:
             input_audio_transcription = None

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -6,7 +6,7 @@ import os
 import time
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, AsyncIterable, Literal, Optional, Union, cast, overload
+from typing import AsyncIterable, Literal, Optional, Union, cast, overload
 from urllib.parse import urlencode
 
 import aiohttp


### PR DESCRIPTION
Fixed a bug since https://github.com/livekit/agents/pull/1320 that overwrites the instructions with empty unexpectedly during response creation in the OpenAI Realtime model.