### PR TITLE
Adding "str" check on before_llm_cb response

### DIFF
--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -765,8 +765,8 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                 handle.cancel()
                 return
 
-            # fallback to default impl if no custom/user stream is returned
-            if not isinstance(llm_stream, LLMStream):
+            # fallback to default impl if no custom/user stream or llm processed str is returned
+            if not isinstance(llm_stream, LLMStream) and not isinstance(llm_stream, str):
                 llm_stream = _default_before_llm_cb(self, chat_ctx=copied_ctx)
 
             if handle.interrupted:


### PR DESCRIPTION
The reason for that PR is that someone could want to do LLM processing manually before sending the answer to the agent to be synthesized. The only way to do this is with `before_llm_cb`.

For example, I have two tasks that need LLM processing and are self-excluding. I want to do them in parallel so that I do not increase the latency. The choice between those 2 tasks is done by another LLM task, like this:
![image](https://github.com/user-attachments/assets/fb0c2849-961f-4788-9743-02704936e2f1)

By the end, LLM 1 and LLM 2 are already processed so I should have a final text or string and I do not want to create another LLM chat context and make the processing all over again. Since `_synthesize_agent_speech` already supports `llm_stream` as str, this could be accomplished by prevent the fallback from creating a default cb when `llm_stream` is `str`.