### PR TITLE
google-genai version bump

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/_utils.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/_utils.py
@@ -12,12 +12,12 @@ from livekit.agents.llm.function_context import _is_optional_type
 from google.genai import types
 
 JSON_SCHEMA_TYPE_MAP: dict[type, types.Type] = {
-    str: "STRING",
-    int: "INTEGER",
-    float: "NUMBER",
-    bool: "BOOLEAN",
-    dict: "OBJECT",
-    list: "ARRAY",
+    str: types.Type.STRING,
+    int: types.Type.INTEGER,
+    float: types.Type.NUMBER,
+    bool: types.Type.BOOLEAN,
+    dict: types.Type.OBJECT,
+    list: types.Type.ARRAY,
 }
 
 __all__ = ["_build_gemini_ctx", "_build_tools"]
@@ -38,7 +38,7 @@ def _build_parameters(arguments: Dict[str, Any]) -> types.Schema | None:
             item_type = get_args(py_type)[0]
             if item_type not in JSON_SCHEMA_TYPE_MAP:
                 raise ValueError(f"Unsupported type: {item_type}")
-            prop.type = "ARRAY"
+            prop.type = types.Type.ARRAY
             prop.items = types.Schema(type=JSON_SCHEMA_TYPE_MAP[item_type])
 
             if arg_info.choices:

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/_utils.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/_utils.py
@@ -10,14 +10,15 @@ from livekit.agents import llm, utils
 from livekit.agents.llm.function_context import _is_optional_type
 
 from google.genai import types
+from google.genai.types import Type as GenaiType
 
-JSON_SCHEMA_TYPE_MAP: dict[type, types.Type] = {
-    str: types.Type.STRING,
-    int: types.Type.INTEGER,
-    float: types.Type.NUMBER,
-    bool: types.Type.BOOLEAN,
-    dict: types.Type.OBJECT,
-    list: types.Type.ARRAY,
+JSON_SCHEMA_TYPE_MAP: dict[type, GenaiType] = {
+    str: GenaiType.STRING,
+    int: GenaiType.INTEGER,
+    float: GenaiType.NUMBER,
+    bool: GenaiType.BOOLEAN,
+    dict: GenaiType.OBJECT,
+    list: GenaiType.ARRAY,
 }
 
 __all__ = ["_build_gemini_ctx", "_build_tools"]
@@ -38,7 +39,7 @@ def _build_parameters(arguments: Dict[str, Any]) -> types.Schema | None:
             item_type = get_args(py_type)[0]
             if item_type not in JSON_SCHEMA_TYPE_MAP:
                 raise ValueError(f"Unsupported type: {item_type}")
-            prop.type = types.Type.ARRAY
+            prop.type = GenaiType.ARRAY
             prop.items = types.Schema(type=JSON_SCHEMA_TYPE_MAP[item_type])
 
             if arg_info.choices:
@@ -62,7 +63,7 @@ def _build_parameters(arguments: Dict[str, Any]) -> types.Schema | None:
             required.append(arg_name)
 
     if properties:
-        parameters = types.Schema(type="OBJECT", properties=properties)
+        parameters = types.Schema(type=GenaiType.OBJECT, properties=properties)
         if required:
             parameters.required = required
 

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/_utils.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/_utils.py
@@ -120,7 +120,6 @@ def _build_gemini_ctx(
                 parts.append(
                     types.Part(
                         function_call=types.FunctionCall(
-                            id=fnc.tool_call_id,
                             name=fnc.function_info.name,
                             args=fnc.arguments,
                         )
@@ -133,7 +132,6 @@ def _build_gemini_ctx(
                     parts.append(
                         types.Part(
                             function_response=types.FunctionResponse(
-                                id=msg.tool_call_id,
                                 name=msg.name,
                                 response=msg.content,
                             )
@@ -143,7 +141,6 @@ def _build_gemini_ctx(
                     parts.append(
                         types.Part(
                             function_response=types.FunctionResponse(
-                                id=msg.tool_call_id,
                                 name=msg.name,
                                 response={"result": msg.content},
                             )

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/realtime_api.py
@@ -107,7 +107,7 @@ class RealtimeModel:
         model: LiveAPIModels | str = "gemini-2.0-flash-exp",
         api_key: str | None = None,
         voice: Voice | str = "Puck",
-        modalities: list[Modality] = ["AUDIO"],
+        modalities: list[Modality] = [Modality.AUDIO],
         enable_user_audio_transcription: bool = True,
         enable_agent_audio_transcription: bool = True,
         vertexai: bool = False,

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/realtime_api.py
@@ -11,12 +11,12 @@ from livekit.agents import llm, utils
 from livekit.agents.llm.function_context import _create_ai_function_info
 
 from google import genai
-from google.genai._api_client import HttpOptions
 from google.genai.types import (
     Blob,
     Content,
     FunctionResponse,
     GenerationConfig,
+    HttpOptions,
     LiveClientContent,
     LiveClientRealtimeInput,
     LiveClientToolResponse,
@@ -104,7 +104,7 @@ class RealtimeModel:
         self,
         *,
         instructions: str | None = None,
-        model: LiveAPIModels | str = "gemini-2.0-flash-001",
+        model: LiveAPIModels | str = "gemini-2.0-flash-exp",
         api_key: str | None = None,
         voice: Voice | str = "Puck",
         modalities: list[Modality] = ["AUDIO"],
@@ -136,7 +136,7 @@ class RealtimeModel:
             instructions (str, optional): Initial system instructions for the model. Defaults to "".
             api_key (str or None, optional): Google Gemini API key. If None, will attempt to read from the environment variable GOOGLE_API_KEY.
             modalities (list[Modality], optional): Modalities to use, such as ["TEXT", "AUDIO"]. Defaults to ["AUDIO"].
-            model (str or None, optional): The name of the model to use. Defaults to "gemini-2.0-flash-001".
+            model (str or None, optional): The name of the model to use. Defaults to "gemini-2.0-flash-exp".
             voice (api_proto.Voice, optional): Voice setting for audio outputs. Defaults to "Puck".
             enable_user_audio_transcription (bool, optional): Whether to enable user audio transcription. Defaults to True
             enable_agent_audio_transcription (bool, optional): Whether to enable agent audio transcription. Defaults to True

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/transcriber.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/transcriber.py
@@ -55,7 +55,7 @@ class TranscriberSession(utils.EventEmitter[EventTypes]):
             parts=[types.Part(text=SYSTEM_INSTRUCTIONS)]
         )
         self._config = types.LiveConnectConfig(
-            response_modalities=["TEXT"],
+            response_modalities=[types.Modality.TEXT],
             system_instruction=system_instructions,
             generation_config=types.GenerationConfig(temperature=0.0),
         )

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -282,7 +282,7 @@ class LLMStream(llm.LLMStream):
                 system_instruction=system_instruction,
                 **opts,
             )
-            async for response in self._client.aio.models.generate_content_stream(
+            async for response in await self._client.aio.models.generate_content_stream(
                 model=self._model,
                 contents=cast(types.ContentListUnion, turns),
                 config=config,

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -286,8 +286,8 @@ class LLMStream(llm.LLMStream):
                 model=self._model,
                 contents=cast(types.ContentListUnion, turns),
                 config=config,
-            )  # type: ignore
-            async for response in stream:
+            )
+            async for response in stream:  # type: ignore
                 if response.prompt_feedback:
                     raise APIStatusError(
                         response.prompt_feedback.json(),

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -240,7 +240,7 @@ class LLMStream(llm.LLMStream):
                         # specific function
                         tool_config = types.ToolConfig(
                             function_calling_config=types.FunctionCallingConfig(
-                                mode="ANY",
+                                mode=types.FunctionCallingConfigMode.ANY,
                                 allowed_function_names=[self._tool_choice.name],
                             )
                         )
@@ -248,7 +248,7 @@ class LLMStream(llm.LLMStream):
                         # model must call any function
                         tool_config = types.ToolConfig(
                             function_calling_config=types.FunctionCallingConfig(
-                                mode="ANY",
+                                mode=types.FunctionCallingConfigMode.ANY,
                                 allowed_function_names=[
                                     fnc.name
                                     for fnc in self._fnc_ctx.ai_functions.values()
@@ -259,14 +259,14 @@ class LLMStream(llm.LLMStream):
                         # model can call any function
                         tool_config = types.ToolConfig(
                             function_calling_config=types.FunctionCallingConfig(
-                                mode="AUTO"
+                                mode=types.FunctionCallingConfigMode.AUTO
                             )
                         )
                     elif self._tool_choice == "none":
                         # model cannot call any function
                         tool_config = types.ToolConfig(
                             function_calling_config=types.FunctionCallingConfig(
-                                mode="NONE",
+                                mode=types.FunctionCallingConfigMode.NONE,
                             )
                         )
                     opts["tool_config"] = tool_config

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -282,11 +282,12 @@ class LLMStream(llm.LLMStream):
                 system_instruction=system_instruction,
                 **opts,
             )
-            async for response in await self._client.aio.models.generate_content_stream(
+            stream = await self._client.aio.models.generate_content_stream(
                 model=self._model,
                 contents=cast(types.ContentListUnion, turns),
                 config=config,
-            ):
+            )  # type: ignore
+            async for response in stream:
                 if response.prompt_feedback:
                     raise APIStatusError(
                         response.prompt_feedback.json(),

--- a/livekit-plugins/livekit-plugins-google/setup.py
+++ b/livekit-plugins/livekit-plugins-google/setup.py
@@ -51,7 +51,7 @@ setuptools.setup(
         "google-auth >= 2, < 3",
         "google-cloud-speech >= 2, < 3",
         "google-cloud-texttospeech >= 2, < 3",
-        "google-genai == 0.5.0",
+        "google-genai == 1.1.0",
         "livekit-agents>=0.12.11",
     ],
     package_data={"livekit.plugins.google": ["py.typed"]},

--- a/livekit-plugins/livekit-plugins-google/setup.py
+++ b/livekit-plugins/livekit-plugins-google/setup.py
@@ -51,7 +51,7 @@ setuptools.setup(
         "google-auth >= 2, < 3",
         "google-cloud-speech >= 2, < 3",
         "google-cloud-texttospeech >= 2, < 3",
-        "google-genai == 1.1.0",
+        "google-genai == 1.2.0",
         "livekit-agents>=0.12.11",
     ],
     package_data={"livekit.plugins.google": ["py.typed"]},

--- a/livekit-plugins/livekit-plugins-google/setup.py
+++ b/livekit-plugins/livekit-plugins-google/setup.py
@@ -51,7 +51,7 @@ setuptools.setup(
         "google-auth >= 2, < 3",
         "google-cloud-speech >= 2, < 3",
         "google-cloud-texttospeech >= 2, < 3",
-        "google-genai == 1.2.0",
+        "google-genai == 1.3.0",
         "livekit-agents>=0.12.11",
     ],
     package_data={"livekit.plugins.google": ["py.typed"]},


### PR DESCRIPTION
- update `google-genai` version to latest `1.1.0`
- roll back default model to `gemini-2.0-flash-exp` for realtime, fixes https://github.com/livekit/agents/issues/1466