### PR TITLE
Add handlers for supported synthesis events for Azure TTS

### DIFF
--- a/.changeset/weak-weeks-shave.md
+++ b/.changeset/weak-weeks-shave.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-azure": patch
+---
+
+Add handlers for supported synthesis events for Azure TTS

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
@@ -147,9 +147,9 @@ class _TTSOptions:
     on_bookmark_reached_event: Callable | None = None,
     on_synthesis_canceled_event: Callable | None = None,
     on_synthesis_completed_event: Callable | None = None,
-    on_synthesis_started_event: Callable | None = None
-    on_synthesizing_event: Callable | None = None
-    on_viseme_event: Callable | None = None
+    on_synthesis_started_event: Callable | None = None,
+    on_synthesizing_event: Callable | None = None,
+    on_viseme_event: Callable | None = None,
     on_word_boundary_event: Callable | None = None
 
 

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
@@ -144,13 +144,13 @@ class _TTSOptions:
     speech_endpoint: str | None = None
     style: StyleConfig | None = None
     # See https://learn.microsoft.com/en-us/azure/ai-services/speech-service/how-to-speech-synthesis?tabs=browserjs%2Cterminal&pivots=programming-language-python
-    on_bookmark_reached_event: Callable[[speechsdk.SpeechSynthesisBookmarkEventArgs], None] | None = None,
-    on_synthesis_canceled_event: Callable[[speechsdk.SpeechSynthesisEventArgs], None] | None = None,
-    on_synthesis_completed_event: Callable[[speechsdk.SpeechSynthesisEventArgs], None] | None = None,
-    on_synthesis_started_event: Callable[[speechsdk.SpeechSynthesisEventArgs], None] | None = None,
-    on_synthesizing_event: Callable[[speechsdk.SpeechSynthesisEventArgs], None] | None = None,
-    on_viseme_event: Callable[[speechsdk.SpeechSynthesisVisemeEventArgs], None] | None = None,
-    on_word_boundary_event: Callable[[speechsdk.SpeechSynthesisWordBoundaryEventArgs], None] | None = None,
+    on_bookmark_reached_event: Callable | None = None,
+    on_synthesis_canceled_event: Callable | None = None,
+    on_synthesis_completed_event: Callable | None = None,
+    on_synthesis_started_event: Callable | None = None
+    on_synthesizing_event: Callable | None = None
+    on_viseme_event: Callable | None = None
+    on_word_boundary_event: Callable | None = None
 
 
 class TTS(tts.TTS):
@@ -167,13 +167,13 @@ class TTS(tts.TTS):
         speech_auth_token: str | None = None,
         endpoint_id: str | None = None,
         style: StyleConfig | None = None,
-        on_bookmark_reached_event: Callable[[speechsdk.SpeechSynthesisBookmarkEventArgs], None] | None = None,
-        on_synthesis_canceled_event: Callable[[speechsdk.SpeechSynthesisEventArgs], None] | None = None,
-        on_synthesis_completed_event: Callable[[speechsdk.SpeechSynthesisEventArgs], None] | None = None,
-        on_synthesis_started_event: Callable[[speechsdk.SpeechSynthesisEventArgs], None] | None = None,
-        on_synthesizing_event: Callable[[speechsdk.SpeechSynthesisEventArgs], None] | None = None,
-        on_viseme_event: Callable[[speechsdk.SpeechSynthesisVisemeEventArgs], None] | None = None,
-        on_word_boundary_event: Callable[[speechsdk.SpeechSynthesisWordBoundaryEventArgs], None] | None = None,
+        on_bookmark_reached_event: Callable | None = None,
+        on_synthesis_canceled_event: Callable | None = None,
+        on_synthesis_completed_event: Callable | None = None,
+        on_synthesis_started_event: Callable | None = None,
+        on_synthesizing_event: Callable | None = None,
+        on_viseme_event: Callable | None = None,
+        on_word_boundary_event: Callable | None = None,
     ) -> None:
         """
         Create a new instance of Azure TTS.

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
@@ -234,7 +234,7 @@ class TTS(tts.TTS):
             on_synthesis_started_event=on_synthesis_started_event,
             on_synthesizing_event=on_synthesizing_event,
             on_viseme_event=on_viseme_event,
-            on_word_boundary_event=on_word_boundary_event,
+            on_word_boundary_event=on_word_boundary_event
         )
 
     def update_options(

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
@@ -173,7 +173,7 @@ class TTS(tts.TTS):
         on_synthesis_started_event: Callable | None = None,
         on_synthesizing_event: Callable | None = None,
         on_viseme_event: Callable | None = None,
-        on_word_boundary_event: Callable | None = None,
+        on_word_boundary_event: Callable | None = None
     ) -> None:
         """
         Create a new instance of Azure TTS.

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
@@ -173,7 +173,7 @@ class TTS(tts.TTS):
         on_synthesis_started_event: Callable | None = None,
         on_synthesizing_event: Callable | None = None,
         on_viseme_event: Callable | None = None,
-        on_word_boundary_event: Callable | None = None
+        on_word_boundary_event: Callable | None = None,
     ) -> None:
         """
         Create a new instance of Azure TTS.
@@ -234,7 +234,7 @@ class TTS(tts.TTS):
             on_synthesis_started_event=on_synthesis_started_event,
             on_synthesizing_event=on_synthesizing_event,
             on_viseme_event=on_viseme_event,
-            on_word_boundary_event=on_word_boundary_event
+            on_word_boundary_event=on_word_boundary_event,
         )
 
     def update_options(

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
@@ -16,7 +16,7 @@ import asyncio
 import contextlib
 import os
 from dataclasses import dataclass
-from typing import Literal
+from typing import Callable, Literal
 
 from livekit.agents import (
     DEFAULT_API_CONNECT_OPTIONS,
@@ -143,6 +143,14 @@ class _TTSOptions:
     prosody: ProsodyConfig | None = None
     speech_endpoint: str | None = None
     style: StyleConfig | None = None
+    # See https://learn.microsoft.com/en-us/azure/ai-services/speech-service/how-to-speech-synthesis?tabs=browserjs%2Cterminal&pivots=programming-language-python
+    on_bookmark_reached_event: Callable[[speechsdk.SpeechSynthesisBookmarkEventArgs], None] | None = None,
+    on_synthesis_canceled_event: Callable[[speechsdk.SpeechSynthesisEventArgs], None] | None = None,
+    on_synthesis_completed_event: Callable[[speechsdk.SpeechSynthesisEventArgs], None] | None = None,
+    on_synthesis_started_event: Callable[[speechsdk.SpeechSynthesisEventArgs], None] | None = None,
+    on_synthesizing_event: Callable[[speechsdk.SpeechSynthesisEventArgs], None] | None = None,
+    on_viseme_event: Callable[[speechsdk.SpeechSynthesisVisemeEventArgs], None] | None = None,
+    on_word_boundary_event: Callable[[speechsdk.SpeechSynthesisWordBoundaryEventArgs], None] | None = None,
 
 
 class TTS(tts.TTS):
@@ -159,6 +167,13 @@ class TTS(tts.TTS):
         speech_auth_token: str | None = None,
         endpoint_id: str | None = None,
         style: StyleConfig | None = None,
+        on_bookmark_reached_event: Callable[[speechsdk.SpeechSynthesisBookmarkEventArgs], None] | None = None,
+        on_synthesis_canceled_event: Callable[[speechsdk.SpeechSynthesisEventArgs], None] | None = None,
+        on_synthesis_completed_event: Callable[[speechsdk.SpeechSynthesisEventArgs], None] | None = None,
+        on_synthesis_started_event: Callable[[speechsdk.SpeechSynthesisEventArgs], None] | None = None,
+        on_synthesizing_event: Callable[[speechsdk.SpeechSynthesisEventArgs], None] | None = None,
+        on_viseme_event: Callable[[speechsdk.SpeechSynthesisVisemeEventArgs], None] | None = None,
+        on_word_boundary_event: Callable[[speechsdk.SpeechSynthesisWordBoundaryEventArgs], None] | None = None,
     ) -> None:
         """
         Create a new instance of Azure TTS.
@@ -213,6 +228,13 @@ class TTS(tts.TTS):
             language=language,
             prosody=prosody,
             style=style,
+            on_bookmark_reached_event=on_bookmark_reached_event,
+            on_synthesis_canceled_event=on_synthesis_canceled_event,
+            on_synthesis_completed_event=on_synthesis_completed_event,
+            on_synthesis_started_event=on_synthesis_started_event,
+            on_synthesizing_event=on_synthesizing_event,
+            on_viseme_event=on_viseme_event,
+            on_word_boundary_event=on_word_boundary_event,
         )
 
     def update_options(
@@ -395,6 +417,23 @@ def _create_speech_synthesizer(
         if config.endpoint_id is not None:
             speech_config.endpoint_id = config.endpoint_id
 
-    return speechsdk.SpeechSynthesizer(
+    synthesizer = speechsdk.SpeechSynthesizer(
         speech_config=speech_config, audio_config=stream_config
     )
+
+    if config.on_bookmark_reached_event:
+        synthesizer.bookmark_reached.connect(config.on_bookmark_reached_event)
+    if config.on_synthesis_canceled_event:
+        synthesizer.synthesis_canceled.connect(config.on_synthesis_canceled_event)
+    if config.on_synthesis_completed_event:
+        synthesizer.synthesis_completed.connect(config.on_synthesis_completed_event)
+    if config.on_synthesis_started_event:
+        synthesizer.synthesis_started.connect(config.on_synthesis_started_event)
+    if config.on_synthesizing_event:
+        synthesizer.synthesizing.connect(config.on_synthesizing_event)
+    if config.on_viseme_event:
+        synthesizer.viseme_received.connect(config.on_viseme_event)
+    if config.on_word_boundary_event:
+        synthesizer.synthesis_word_boundary.connect(config.on_word_boundary_event)
+
+    return synthesizer

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
@@ -144,12 +144,12 @@ class _TTSOptions:
     speech_endpoint: str | None = None
     style: StyleConfig | None = None
     # See https://learn.microsoft.com/en-us/azure/ai-services/speech-service/how-to-speech-synthesis?tabs=browserjs%2Cterminal&pivots=programming-language-python
-    on_bookmark_reached_event: Callable | None = None,
-    on_synthesis_canceled_event: Callable | None = None,
-    on_synthesis_completed_event: Callable | None = None,
-    on_synthesis_started_event: Callable | None = None,
-    on_synthesizing_event: Callable | None = None,
-    on_viseme_event: Callable | None = None,
+    on_bookmark_reached_event: Callable | None = None
+    on_synthesis_canceled_event: Callable | None = None
+    on_synthesis_completed_event: Callable | None = None
+    on_synthesis_started_event: Callable | None = None
+    on_synthesizing_event: Callable | None = None
+    on_viseme_event: Callable | None = None
     on_word_boundary_event: Callable | None = None
 
 


### PR DESCRIPTION
Adding handlers for each of the `SpeechSynthesizer` subscribable events according to the [docs](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/how-to-speech-synthesis?tabs=browserjs%2Cterminal&pivots=programming-language-python):
- `BookmarkReached`
- `SynthesisCanceled`
- `SynthesisCompleted`
- `SynthesisStarted`
- `Synthesizing`
- `VisemeReceived`
- `WordBoundary`