### PR TITLE
fix(cli): update main_file path to use current directory

### DIFF
--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -1,7 +1,7 @@
 import asyncio
+import os
 import pathlib
 import signal
-import sys
 
 import click
 from livekit.protocol import models
@@ -216,7 +216,7 @@ def _run_dev(
         from .watcher import WatchServer
 
         setup_logging(log_level, args.devmode)
-        main_file = pathlib.Path(sys.argv[0]).parent
+        main_file = pathlib.Path(os.getcwd())
 
         async def _run_loop():
             server = WatchServer(


### PR DESCRIPTION
Use `os.getcwd()` to set the `main_file` path, ensuring it points to the current working directory instead of the script directory. This change solves problems on script execution context handling in managed virtual enviroments such as rye/uv/poetry.

edit: This causes problem when `--watch` enabled. It's looking for changes on `.venv/bin` dir.