### PR TITLE
fix interrupting nested speech from before_llm_cb

### DIFF
--- a/.changeset/sixty-plums-teach.md
+++ b/.changeset/sixty-plums-teach.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+fix interrupting nested speech from before_llm_cb


### PR DESCRIPTION
Fix RuntimeError when the main speech was interrupted but continued `synthesis_handle.play()` if the interruption occurred at the end of a nested speech from `before_llm_cb`. https://github.com/livekit/agents/issues/1503