### PR TITLE
feat: connection pooling & reuse to improve latency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,6 @@ jobs:
           sudo dpkg -i libssl1.1_1.1.1-1ubuntu2.1_arm64.deb
           sudo dpkg -i libssl-dev_1.1.1-1ubuntu2.1_arm64.deb
 
-
       - name: Install ffmpeg (macOS)
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: brew install ffmpeg
@@ -122,7 +121,7 @@ jobs:
 
           case "${{ matrix.test_group }}" in
             base)
-              test_files="test_aio.py test_tokenizer.py test_vad.py test_ipc.py test_tts_fallback.py test_stt_fallback.py test_message_change.py test_build_func_desc.py test_create_func.py"
+              test_files="test_aio.py test_tokenizer.py test_vad.py test_ipc.py test_tts_fallback.py test_stt_fallback.py test_message_change.py test_build_func_desc.py test_create_func.py test_pool.py"
               ;;
             llm)
               test_files="test_llm.py"

--- a/livekit-agents/livekit/agents/tts/tts.py
+++ b/livekit-agents/livekit/agents/tts/tts.py
@@ -5,7 +5,15 @@ import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from types import TracebackType
-from typing import AsyncIterable, AsyncIterator, Generic, Literal, TypeVar, Union
+from typing import (
+    AsyncIterable,
+    AsyncIterator,
+    Generic,
+    Literal,
+    Optional,
+    TypeVar,
+    Union,
+)
 
 from livekit import rtc
 
@@ -45,13 +53,19 @@ class TTS(
     Generic[TEvent],
 ):
     def __init__(
-        self, *, capabilities: TTSCapabilities, sample_rate: int, num_channels: int
+        self,
+        *,
+        capabilities: TTSCapabilities,
+        sample_rate: int,
+        num_channels: int,
+        conn_options: Optional[APIConnectOptions] = None,
     ) -> None:
         super().__init__()
         self._capabilities = capabilities
         self._sample_rate = sample_rate
         self._num_channels = num_channels
         self._label = f"{type(self).__module__}.{type(self).__name__}"
+        self._conn_options = conn_options or DEFAULT_API_CONNECT_OPTIONS
 
     @property
     def label(self) -> str:
@@ -74,11 +88,11 @@ class TTS(
         self,
         text: str,
         *,
-        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+        conn_options: Optional[APIConnectOptions] = None,
     ) -> ChunkedStream: ...
 
     def stream(
-        self, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
+        self, *, conn_options: Optional[APIConnectOptions] = None
     ) -> SynthesizeStream:
         raise NotImplementedError(
             "streaming is not supported by this TTS, please use a different TTS or use a StreamAdapter"
@@ -102,11 +116,15 @@ class ChunkedStream(ABC):
     """Used by the non-streamed synthesize API, some providers support chunked http responses"""
 
     def __init__(
-        self, *, tts: TTS, input_text: str, conn_options: APIConnectOptions
+        self,
+        *,
+        tts: TTS,
+        input_text: str,
+        conn_options: Optional[APIConnectOptions] = None,
     ) -> None:
         self._input_text = input_text
         self._tts = tts
-        self._conn_options = conn_options
+        self._conn_options = conn_options or DEFAULT_API_CONNECT_OPTIONS
         self._event_ch = aio.Chan[SynthesizedAudio]()
 
         self._event_aiter, monitor_aiter = aio.itertools.tee(self._event_ch, 2)
@@ -235,10 +253,12 @@ class ChunkedStream(ABC):
 class SynthesizeStream(ABC):
     class _FlushSentinel: ...
 
-    def __init__(self, *, tts: TTS, conn_options: APIConnectOptions) -> None:
+    def __init__(
+        self, *, tts: TTS, conn_options: Optional[APIConnectOptions] = None
+    ) -> None:
         super().__init__()
         self._tts = tts
-        self._conn_options = conn_options
+        self._conn_options = conn_options or DEFAULT_API_CONNECT_OPTIONS
         self._input_ch = aio.Chan[Union[str, SynthesizeStream._FlushSentinel]]()
         self._event_ch = aio.Chan[SynthesizedAudio]()
         self._event_aiter, self._monitor_aiter = aio.itertools.tee(self._event_ch, 2)

--- a/livekit-agents/livekit/agents/utils/__init__.py
+++ b/livekit-agents/livekit/agents/utils/__init__.py
@@ -7,6 +7,7 @@ from .exp_filter import ExpFilter
 from .log import log_exceptions
 from .misc import is_given, shortuuid, time_ms
 from .moving_average import MovingAverage
+from .pool import ConnectionPool
 
 EventEmitter = rtc.EventEmitter
 
@@ -28,4 +29,5 @@ __all__ = [
     "hw",
     "is_given",
     "_compute_changes",
+    "ConnectionPool",
 ]

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,0 +1,122 @@
+import time
+
+import pytest
+from livekit.agents.utils.pool import ConnectionPool
+
+
+# A simple dummy connection object.
+class DummyConnection:
+    def __init__(self, id):
+        self.id = id
+
+    def __repr__(self):
+        return f"DummyConnection({self.id})"
+
+
+# Factory to produce a dummy async connect callback that returns unique DummyConnection objects.
+def dummy_connect_factory():
+    counter = 0
+
+    async def dummy_connect():
+        nonlocal counter
+        counter += 1
+        return DummyConnection(counter)
+
+    return dummy_connect
+
+
+@pytest.mark.asyncio
+async def test_get_reuses_connection():
+    """
+    Test that when a connection is returned to the pool via put(),
+    the subsequent call to get() reuses the same connection if it hasn't expired.
+    """
+    dummy_connect = dummy_connect_factory()
+    pool = ConnectionPool(max_session_duration=60, connect_cb=dummy_connect)
+
+    conn1 = await pool.get()
+    # Return the connection to the pool
+    pool.put(conn1)
+
+    conn2 = await pool.get()
+    assert conn1 is conn2, (
+        "Expected the same connection to be reused when it hasn't expired."
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_creates_new_connection_when_none_available():
+    """
+    Test that get() creates a new connection when there are no available connections.
+    """
+    dummy_connect = dummy_connect_factory()
+    pool = ConnectionPool(max_session_duration=60, connect_cb=dummy_connect)
+
+    conn1 = await pool.get()
+    # Not putting conn1 back means the available pool is empty,
+    # so calling get() again should create a new connection.
+    conn2 = await pool.get()
+    assert conn1 is not conn2, (
+        "Expected a new connection when no available connection exists."
+    )
+
+
+@pytest.mark.asyncio
+async def test_reset_connection():
+    """
+    Test that after resetting a connection (via reset()), the connection is not reused.
+    """
+    dummy_connect = dummy_connect_factory()
+    pool = ConnectionPool(max_session_duration=60, connect_cb=dummy_connect)
+
+    conn = await pool.get()
+    pool.put(conn)
+    # Reset the connection which should remove it from the pool.
+    pool.reset(conn)
+
+    # Even if we try to put it back, it won't be added because it's not tracked anymore.
+    pool.put(conn)
+    new_conn = await pool.get()
+    assert new_conn is not conn, "Expected a reset connection to not be reused."
+
+
+@pytest.mark.asyncio
+async def test_maybe_reset_not_expired():
+    """
+    Test that maybe_reset does not remove a connection that is still within its valid session duration.
+    """
+    dummy_connect = dummy_connect_factory()
+    pool = ConnectionPool(max_session_duration=60, connect_cb=dummy_connect)
+
+    conn = await pool.get()
+    pool.put(conn)
+    # Since the connection is fresh, maybe_reset() should leave it intact.
+    pool.maybe_reset(conn)
+    assert conn in pool._connections, (
+        "Connection should not be reset if within max_session_duration."
+    )
+
+
+@pytest.mark.asyncio
+async def test_maybe_reset_expired():
+    """
+    Test that maybe_reset removes an expired connection.
+    """
+    # Use a short max duration to simulate expiration.
+    dummy_connect = dummy_connect_factory()
+    pool = ConnectionPool(max_session_duration=1, connect_cb=dummy_connect)
+
+    conn = await pool.get()
+    pool.put(conn)
+    # Artificially set the connection's timestamp in the past to simulate expiration.
+    pool._connections[conn] = (
+        time.time() - 2
+    )  # 2 seconds ago (max_session_duration is 1)
+
+    pool.maybe_reset(conn)
+    assert conn not in pool._connections, (
+        "Expired connection should be removed from _connections."
+    )
+    assert conn not in pool._available, (
+        "Expired connection should be removed from _available."
+    )


### PR DESCRIPTION
With SpeechStream, we'd like to logically create a new connection instance each time. This tends to introduce a bit of latency if a new connection needs to be made to TTS each time.

This PR introduces a generic connection pool, so the underlying connections can be reused without breaking the abstractions.