### PR TITLE
test gha uses github standard arm runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
             macos-14,
             windows-2019,
             ubuntu-20.04,
-            ubuntu-24.04-arm64-m,
+            ubuntu-24.04-arm,
           ]
         python_version: ["3.9", "3.12"]
         test_group: ["base"]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
             macos-14,
             windows-2019,
             ubuntu-20.04,
-            namespace-profile-default-arm64,
+            ubuntu-24.04-arm64-m,
           ]
         python_version: ["3.9", "3.12"]
         test_group: ["base"]


### PR DESCRIPTION
GitHub includes usage of the following runners for free for public repos:
https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories