### PR TITLE
update test runner images

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,22 +21,22 @@ jobs:
         os: [
             # disabled Intel Macs due to pytorch 2.3+ not supporting it
             # macos-14-large,
-            macos-14,
-            windows-2019,
-            ubuntu-20.04,
+            macos-latest,
+            windows-latest,
+            ubuntu-latest,
             ubuntu-24.04-arm,
           ]
         python_version: ["3.9", "3.12"]
         test_group: ["base"]
         include:
           # Include llm, stt, and tts tests only on Ubuntu 20.04 with Python 3.9
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             python_version: "3.12"
             test_group: llm
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             python_version: "3.12"
             test_group: stt
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             python_version: "3.12"
             test_group: tts
 
@@ -65,12 +65,12 @@ jobs:
           cache: "pip"
 
       - name: Install ffmpeg (Linux)
-        if: ${{ matrix.os == 'ubuntu-20.04' || matrix.os == 'namespace-profile-default-arm64' }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
       # Azure plugin fails with OpenSSL3, and Ubuntu 22.04 does not include libssl1.1 in its repos
       - name: Install libssl 1.1 (Linux 22.04)
-        if: ${{ matrix.os == 'namespace-profile-default-arm64' }}
+        if: ${{ matrix.os == 'ubuntu-24.04-arm' }}
         run: |
           wget https://old-releases.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1-1ubuntu2.1_arm64.deb
           wget https://old-releases.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.1.1-1ubuntu2.1_arm64.deb
@@ -83,7 +83,7 @@ jobs:
         run: brew install ffmpeg
 
       - name: Install ffmpeg (Windows)
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ startsWith(matrix.os, 'windows') }}
         run: choco install ffmpeg
 
       - name: Install packages


### PR DESCRIPTION
updating images ahead of deprecation. updating all images, not just ubuntu-20.04.
https://github.com/actions/runner-images/issues/11101