### PR TITLE
Proposal: Add simple video input support for gemini live

### DIFF
--- a/livekit-plugins/livekit-plugins-google/README.md
+++ b/livekit-plugins/livekit-plugins-google/README.md
@@ -16,3 +16,57 @@ To use the STT and TTS API, you'll need to enable the respective services for yo
 
 - Cloud Speech-to-Text API
 - Cloud Text-to-Speech API
+
+
+## Gemini Multimodal Live
+
+Gemini Multimodal Live can be used with the `MultimodalAgent` class. See examples/multimodal_agent/gemini_agent.py for an example.
+
+### Live Video Input (experimental)
+
+You can push video frames to your Gemini Multimodal Live session alongside the audio automatically handled by the `MultimodalAgent`.  The basic approach is to subscribe to the video track, create a video stream, sample frames at a suitable frame rate, and push them into the RealtimeSession:
+
+```
+# Make sure you subscribe to audio and video tracks
+await ctx.connect(auto_subscribe=AutoSubscribe.SUBSCRIBE_ALL)
+
+# Create your RealtimeModel and store a reference
+model = google.beta.realtime.RealtimeModel(
+    # ...
+)
+
+# Create your MultimodalAgent as usual
+agent = MultimodalAgent(
+    model=model,
+    # ...
+)
+
+# Async method to process the video track and push frames to Gemini
+async def _process_video_track(self, track: Track):
+    video_stream = VideoStream(track)
+    last_frame_time = 0
+    
+    async for event in video_stream:
+        current_time = asyncio.get_event_loop().time()
+        
+        # Sample at 1 FPS
+        if current_time - last_frame_time < 1.0: 
+            continue
+            
+        last_frame_time = current_time
+        frame = event.frame
+        
+        # Push the frame into the RealtimeSession
+        model.sessions[0].push_video_frame(frame)
+        
+    await video_stream.aclose()
+
+# Subscribe to new tracks and process them
+@ctx.room.on("track_subscribed")
+def _on_track_subscribed(track: Track, pub, participant):
+    if track.kind == TrackKind.KIND_VIDEO:
+        asyncio.create_task(self._process_video_track(track))
+```
+
+
+

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/realtime_api.py
@@ -327,12 +327,27 @@ class GeminiRealtimeSession(utils.EventEmitter[EventTypes]):
         self._fnc_ctx = value
 
     def push_media_chunk(self, data: bytes, mime_type: str) -> None:
+        """Push a raw media chunk to the Gemini Multimodal Live session.
+
+        Args:
+            data (bytes): The data to push.
+            mime_type (str): The MIME type of the data.
+        """
         realtime_input = LiveClientRealtimeInput(
             media_chunks=[Blob(data=data, mime_type=mime_type)],
         )
         self._queue_msg(realtime_input)
 
     def push_video_frame(self, frame: rtc.VideoFrame) -> None:
+        """Push a video frame to the Gemini Multimodal Live session.
+
+        Args:
+            frame (rtc.VideoFrame): The video frame to push.
+
+        Notes: 
+        - This will be enqueued immediately so you should use a sampling frame rate that makes sense for your application.
+        - The default is to encode as a JPEG at 1024x1024. If you need more control, see `push_media_chunk`.
+        """
         encoded_data = images.encode(
             frame,
             images.EncodeOptions(


### PR DESCRIPTION
There is active developer interest in this feature and its pretty easy to at least provide a hook on the RealtimeSession to push video frames through and we can give a little guidance on how to use it. The interface will of course change with 1.0 and we can perfect it then.

I've tested this and it works pretty well.