### PR TITLE
feat: Azure.STT support profanity_option

### DIFF
--- a/.changeset/lemon-eagles-glow.md
+++ b/.changeset/lemon-eagles-glow.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-azure": patch
+---
+
+feat: Azure.STT support profanity_option

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
@@ -42,6 +42,7 @@ class STTOptions:
         str
     ]  # see https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support?tabs=stt
     speech_endpoint: str | None = None
+    profanity: speechsdk.enums.ProfanityOption | None = None
 
 
 class STT(stt.STT):
@@ -61,6 +62,7 @@ class STT(stt.STT):
         languages: list[str] = ["en-US"],
         # for compatibility with other STT plugins
         language: str | None = None,
+        profanity: speechsdk.enums.ProfanityOption | None = None,
     ):
         """
         Create a new instance of Azure STT.
@@ -102,6 +104,7 @@ class STT(stt.STT):
             segmentation_silence_timeout_ms=segmentation_silence_timeout_ms,
             segmentation_max_time_ms=segmentation_max_time_ms,
             segmentation_strategy=segmentation_strategy,
+            profanity=profanity,
         )
         self._streams = weakref.WeakSet[SpeechStream]()
 
@@ -330,6 +333,8 @@ def _create_speech_recognizer(
             speechsdk.enums.PropertyId.Speech_SegmentationStrategy,
             str(config.segmentation_strategy),
         )
+    if config.profanity is not None:
+        speech_config.set_profanity(config.profanity)
 
     auto_detect_source_language_config = None
     if config.languages and len(config.languages) >= 1:


### PR DESCRIPTION
The Azure SDK’s default setting of `ProfanityOption.Masked` can cause issues with certain sentences.