### PR TITLE
feat: add max_tokens option to LLM and LLMStream classes

### DIFF
--- a/.changeset/weak-rabbits-cheat.md
+++ b/.changeset/weak-rabbits-cheat.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-openai": major
+---
+
+feat: add max_tokens option to LLM and LLMStream classes

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -66,6 +66,7 @@ class LLMOptions:
     tool_choice: Union[ToolChoice, Literal["auto", "required", "none"]] = "auto"
     store: bool | None = None
     metadata: dict[str, str] | None = None
+    max_tokens: int | None = None
 
 
 class LLM(llm.LLM):
@@ -82,6 +83,7 @@ class LLM(llm.LLM):
         tool_choice: Union[ToolChoice, Literal["auto", "required", "none"]] = "auto",
         store: bool | None = None,
         metadata: dict[str, str] | None = None,
+        max_tokens: int | None = None,
     ) -> None:
         """
         Create a new instance of OpenAI LLM.
@@ -104,6 +106,7 @@ class LLM(llm.LLM):
             tool_choice=tool_choice,
             store=store,
             metadata=metadata,
+            max_tokens=max_tokens,
         )
         self._client = client or openai.AsyncClient(
             api_key=api_key,
@@ -359,6 +362,7 @@ class LLM(llm.LLM):
         temperature: float | None = None,
         parallel_tool_calls: bool | None = None,
         tool_choice: Union[ToolChoice, Literal["auto", "required", "none"]] = "auto",
+        max_tokens: int | None = None,
     ) -> LLM:
         """
         Create a new instance of Groq LLM.
@@ -376,6 +380,7 @@ class LLM(llm.LLM):
             temperature=temperature,
             parallel_tool_calls=parallel_tool_calls,
             tool_choice=tool_choice,
+            max_tokens=max_tokens,
         )
 
     @staticmethod
@@ -686,6 +691,7 @@ class LLMStream(llm.LLMStream):
                 else None,
                 "temperature": self._temperature,
                 "metadata": self._llm._opts.metadata,
+                "max_tokens": self._llm._opts.max_tokens,
                 "store": self._llm._opts.store,
                 "n": self._n,
                 "stream": True,


### PR DESCRIPTION
This pull request introduces a new `max_tokens` parameter to the `LLMOptions` and related methods in the `livekit-plugins/livekit-plugins-openai` package. The changes ensure that the `max_tokens` parameter is properly integrated and utilized within the class methods.

Key changes include:

* Added `max_tokens` parameter to `LLMOptions` class in `livekit/plugins/openai/llm.py`.
* Updated `__init__` method to accept and initialize `max_tokens` parameter in `livekit/plugins/openai/llm.py`. [[1]](diffhunk://#diff-0186148b58ae1916b3785d774437ad73ec257f2cf4a83d6adb686413aa041febR86) [[2]](diffhunk://#diff-0186148b58ae1916b3785d774437ad73ec257f2cf4a83d6adb686413aa041febR109)
* Modified `with_groq` method to include `max_tokens` parameter in `livekit/plugins/openai/llm.py`. [[1]](diffhunk://#diff-0186148b58ae1916b3785d774437ad73ec257f2cf4a83d6adb686413aa041febR365) [[2]](diffhunk://#diff-0186148b58ae1916b3785d774437ad73ec257f2cf4a83d6adb686413aa041febR383)
* Included `max_tokens` in the `_run` method's configuration dictionary in `livekit/plugins/openai/llm.py`.