### PR TITLE
Bug fix: _play_speech get stuck due to orphan speech handle.

### DIFF
--- a/.changeset/pink-kiwis-grab.md
+++ b/.changeset/pink-kiwis-grab.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+fix: _play_speech get stuck due to orphan speech handle

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -706,6 +706,8 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
         self._agent_reply_task = asyncio.create_task(
             self._synthesize_answer_task(self._agent_reply_task, new_handle)
         )
+        self._agent_reply_task.add_done_callback(
+            lambda t: new_handle.cancel() if t.cancelled() else None)
 
     @utils.log_exceptions(logger=logger)
     async def _synthesize_answer_task(

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -707,7 +707,8 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
             self._synthesize_answer_task(self._agent_reply_task, new_handle)
         )
         self._agent_reply_task.add_done_callback(
-            lambda t: new_handle.cancel() if t.cancelled() else None)
+            lambda t: new_handle.cancel() if t.cancelled() else None
+        )
 
     @utils.log_exceptions(logger=logger)
     async def _synthesize_answer_task(


### PR DESCRIPTION
When a new _synthesize_answer_task is created, it is possible that the old _synthesize_answer_task is waiting for the llm_stream at
```python
llm_stream = await llm_stream
```

In this case, the new task will cancel the old one. However, the handle of the old task is not correctly canceled.

This would result in the handle never being initialized by `_synthesize_answer_task`.

As a result, the `_play_speech` function will stuck at `await speech_handle.wait_for_initialization()`, and blocks all the subsequent speeches.

Note that the old handle is supposed to be canceled by `self._pending_agent_reply.cancel()` in the `_synthesize_agent_reply function`. However, this is not working properly since `self._pending_agent_reply` is assigned to `None` in the `_validate_reply_if_possible` function.