### PR TITLE
Added g++ to Dockerfile-example to Support Building annoy Dependency

### DIFF
--- a/examples/Dockerfile-example
+++ b/examples/Dockerfile-example
@@ -21,11 +21,11 @@ RUN adduser \
     --uid "${UID}" \
     appuser
 
-
-# Install gcc and other build dependencies.
+# Install gcc, g++ and other build dependencies.
 RUN apt-get update && \
     apt-get install -y \
     gcc \
+    g++ \
     python3-dev \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### Summary
This PR updates `examples/Dockerfile-example` to include `g++` as a build dependency, fixing a build failure when using the `requirements.txt` from `examples/voice-pipeline-agent/`. The `annoy` package, a transitive dependency of one of the listed packages (likely `livekit-plugins-silero`), requires a C++ compiler, but the original Dockerfile only included `gcc`.

### Problem
When building the Docker image with:
- Dockerfile: `examples/Dockerfile-example`
- `requirements.txt`: `examples/voice-pipeline-agent/requirements.txt`

The process fails with:
```
gcc: fatal error: cannot execute ‘cc1plus’: execvp: No such file or directory
compilation terminated.
error: command '/usr/bin/gcc' failed with exit code 1
ERROR: Failed building wheel for annoy
```

This happens because `annoy` contains C++ code (e.g., `annoymodule.cc`), and `gcc` alone cannot compile it without `g++`.

### Testing
- Built the image locally using the updated Dockerfile and `requirements.txt` from `examples/voice-pipeline-agent/`.
- Confirmed the build completes successfully without errors.
- Tested with base image `python:3.11.6-slim`.

### Impact
- Fixes the build process for users following the `voice-pipeline-agent` example.
- Adds a minimal dependency (`g++`) with a small size increase, preserving the example’s “minimal” intent while ensuring functionality.

### Related Issue
#1578 

This change ensures the example Dockerfile works out-of-the-box with the provided `voice-pipeline-agent` example. Let me know if any adjustments are needed!
