### PR TITLE
handle decoder errors and tts prewarm

### DIFF
--- a/.changeset/blue-ants-heal.md
+++ b/.changeset/blue-ants-heal.md
@@ -1,0 +1,8 @@
+---
+"livekit-plugins-elevenlabs": patch
+"livekit-plugins-cartesia": patch
+"livekit-plugins-deepgram": patch
+"livekit-agents": patch
+---
+
+added a tts.prewarm method to start the connection pool early.

--- a/.changeset/eleven-brooms-watch.md
+++ b/.changeset/eleven-brooms-watch.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+fixed a bug in AudioStreamDecoder where it could fail on close

--- a/.changeset/fluffy-apricots-attack.md
+++ b/.changeset/fluffy-apricots-attack.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-elevenlabs": patch
+---
+
+deprecated elevenlabs' optimize_stream_latency option

--- a/examples/voice-pipeline-agent/function_calling_weather.py
+++ b/examples/voice-pipeline-agent/function_calling_weather.py
@@ -13,7 +13,7 @@ from livekit.agents import (
     llm,
     metrics,
 )
-from livekit.agents.pipeline import AgentCallContext, VoicePipelineAgent
+from livekit.agents.pipeline import VoicePipelineAgent
 from livekit.plugins import deepgram, openai, silero
 
 load_dotenv()
@@ -51,9 +51,9 @@ class AssistantFnc(llm.FunctionContext):
         # that it might take awhile:
         # Option 1: you can use .say filler message immediately after the call is triggered
         # Option 2: you can prompt the agent to return a text response when it's making a function call
-        agent = AgentCallContext.get_current().agent
 
         # uncomment for option 1
+        # agent = AgentCallContext.get_current().agent
         # filler_messages = [
         #     "Let me check the weather in {location} for you.",
         #     "Let me see what the weather is like in {location} right now.",

--- a/livekit-agents/livekit/agents/cli/log.py
+++ b/livekit-agents/livekit/agents/cli/log.py
@@ -19,6 +19,8 @@ NOISY_LOGGERS = [
     "watchfiles",
     "anthropic",
     "websockets.client",
+    "botocore",
+    "aiobotocore",
 ]
 
 

--- a/livekit-agents/livekit/agents/tts/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/tts/fallback_adapter.py
@@ -138,6 +138,10 @@ class FallbackAdapter(
             conn_options=conn_options or DEFAULT_FALLBACK_API_CONNECT_OPTIONS,
         )
 
+    def prewarm(self) -> None:
+        if self._tts_instances:
+            self._tts_instances[0].prewarm()
+
     async def aclose(self) -> None:
         for tts_status in self._status:
             if tts_status.recovering_task is not None:

--- a/livekit-agents/livekit/agents/tts/stream_adapter.py
+++ b/livekit-agents/livekit/agents/tts/stream_adapter.py
@@ -55,6 +55,9 @@ class StreamAdapter(TTS):
             sentence_tokenizer=self._sentence_tokenizer,
         )
 
+    def prewarm(self) -> None:
+        self._tts.prewarm()
+
 
 class StreamAdapterWrapper(SynthesizeStream):
     def __init__(

--- a/livekit-agents/livekit/agents/tts/tts.py
+++ b/livekit-agents/livekit/agents/tts/tts.py
@@ -98,7 +98,7 @@ class TTS(
             "streaming is not supported by this TTS, please use a different TTS or use a StreamAdapter"
         )
 
-    async def prewarm(self) -> None:
+    def prewarm(self) -> None:
         """Pre-warm connection to the TTS service"""
         pass
 

--- a/livekit-agents/livekit/agents/tts/tts.py
+++ b/livekit-agents/livekit/agents/tts/tts.py
@@ -98,6 +98,10 @@ class TTS(
             "streaming is not supported by this TTS, please use a different TTS or use a StreamAdapter"
         )
 
+    async def prewarm(self) -> None:
+        """Pre-warm connection to the TTS service"""
+        pass
+
     async def aclose(self) -> None: ...
 
     async def __aenter__(self) -> TTS:

--- a/livekit-agents/livekit/agents/utils/codecs/decoder.py
+++ b/livekit-agents/livekit/agents/utils/codecs/decoder.py
@@ -58,6 +58,7 @@ class StreamBuffer:
         with self._data_available:
             while True:
                 if self._buffer.closed:
+                    logger.info("sb - buffer closed")
                     return b""
                 # always read from beginning
                 self._buffer.seek(0)
@@ -70,6 +71,7 @@ class StreamBuffer:
                     return data
 
                 if self._eof:
+                    logger.info("sb - eof")
                     return b""
 
                 self._data_available.wait()
@@ -78,10 +80,11 @@ class StreamBuffer:
         """Signal that no more data will be written."""
         with self._data_available:
             self._eof = True
+            logger.info("sb - ending input, notifying all")
             self._data_available.notify_all()
 
     def close(self):
-        logger.info("closing buffer")
+        logger.info("sb - closing buffer")
         self._buffer.close()
 
 
@@ -160,7 +163,7 @@ class AudioStreamDecoder:
                         )
                     )
         except Exception:
-            logger.exception("Error decoding audio")
+            logger.exception("error decoding audio")
         finally:
             logger.info("decode loop finally reached, closing output stream")
             self._output_ch.close()

--- a/livekit-agents/livekit/agents/utils/codecs/decoder.py
+++ b/livekit-agents/livekit/agents/utils/codecs/decoder.py
@@ -58,7 +58,6 @@ class StreamBuffer:
         with self._data_available:
             while True:
                 if self._buffer.closed:
-                    logger.info("sb - buffer closed")
                     return b""
                 # always read from beginning
                 self._buffer.seek(0)
@@ -68,11 +67,9 @@ class StreamBuffer:
                     # shrink the buffer to remove already-read data
                     remaining = self._buffer.read()
                     self._buffer = io.BytesIO(remaining)
-                    logger.info("sb - returning data")
                     return data
 
                 if self._eof:
-                    logger.info("sb - eof")
                     return b""
 
                 self._data_available.wait()
@@ -81,11 +78,9 @@ class StreamBuffer:
         """Signal that no more data will be written."""
         with self._data_available:
             self._eof = True
-            logger.info("sb - ending input, notifying all")
             self._data_available.notify_all()
 
     def close(self):
-        logger.info("sb - closing buffer")
         self._buffer.close()
 
 
@@ -135,12 +130,9 @@ class AudioStreamDecoder:
         self._input_buf.end_input()
 
     def _decode_loop(self):
-
         try:
-            logger.info("decoding loop - opening container")
             container = av.open(self._input_buf)
             audio_stream = next(s for s in container.streams if s.type == "audio")
-            logger.info("decoding loop - found audio stream")
             resampler = av.AudioResampler(
                 # convert to signed 16-bit little endian
                 format="s16",
@@ -169,7 +161,6 @@ class AudioStreamDecoder:
         except Exception:
             logger.exception("error decoding audio")
         finally:
-            logger.info("decode loop finally reached, closing output stream")
             self._output_ch.close()
 
     def __aiter__(self) -> AsyncIterator[rtc.AudioFrame]:
@@ -179,7 +170,6 @@ class AudioStreamDecoder:
         try:
             return await self._output_ch.recv()
         except aio.ChanClosed:
-            logger.info("output_ch received aio.ChanClosed")
             raise StopAsyncIteration
 
     async def aclose(self):
@@ -188,10 +178,9 @@ class AudioStreamDecoder:
         self._closed = True
         self.end_input()
         self._input_buf.close()
-        # wait for decode loop to finish
+        # wait for decode loop to finish, only if anything's been pushed
         try:
-            logger.info("waiting for output channel to close")
-            await self._output_ch.recv()
+            if self._started:
+                await self._output_ch.recv()
         except aio.ChanClosed:
-            logger.info("received aio.ChanClosed")
             pass

--- a/livekit-agents/livekit/agents/utils/codecs/decoder.py
+++ b/livekit-agents/livekit/agents/utils/codecs/decoder.py
@@ -62,7 +62,6 @@ class StreamBuffer:
                     return b""
                 # always read from beginning
                 self._buffer.seek(0)
-                logger.info("sb - reading from buffer")
                 data = self._buffer.read(size)
 
                 if data:
@@ -76,7 +75,6 @@ class StreamBuffer:
                     logger.info("sb - eof")
                     return b""
 
-                logger.info("sb - waiting for data")
                 self._data_available.wait()
 
     def end_input(self):
@@ -181,16 +179,14 @@ class AudioStreamDecoder:
         try:
             return await self._output_ch.recv()
         except aio.ChanClosed:
+            logger.info("output_ch received aio.ChanClosed")
             raise StopAsyncIteration
 
     async def aclose(self):
         if self._closed:
             return
-        logger.info("setting to closed")
         self._closed = True
-        logger.info("ending input")
         self.end_input()
-        logger.info("closing input buffer")
         self._input_buf.close()
         # wait for decode loop to finish
         try:

--- a/livekit-agents/livekit/agents/utils/codecs/decoder.py
+++ b/livekit-agents/livekit/agents/utils/codecs/decoder.py
@@ -17,6 +17,7 @@ import io
 from concurrent.futures import ThreadPoolExecutor
 from typing import AsyncIterator, Optional
 
+from livekit.agents.log import logger
 from livekit.agents.utils import aio
 
 try:
@@ -56,6 +57,8 @@ class StreamBuffer:
 
         with self._data_available:
             while True:
+                if self._buffer.closed:
+                    return b""
                 self._buffer.seek(0)  # Rewind for reading
                 data = self._buffer.read(size)
 
@@ -157,6 +160,8 @@ class AudioStreamDecoder:
                             ),
                         )
                     )
+        except Exception:
+            logger.exception("Error decoding audio")
         finally:
             self._output_ch.close()
 

--- a/livekit-agents/livekit/agents/utils/connection_pool.py
+++ b/livekit-agents/livekit/agents/utils/connection_pool.py
@@ -50,7 +50,7 @@ class ConnectionPool(Generic[T]):
         # store connections to be reaped (closed) later.
         self._to_close: Set[T] = set()
 
-        self._prewarm_task: weakref.ref[asyncio.Task] | None = None
+        self._prewarm_task: Optional[weakref.ref[asyncio.Task]] = None
 
     async def _connect(self) -> T:
         """Create a new connection.

--- a/livekit-agents/livekit/agents/utils/connection_pool.py
+++ b/livekit-agents/livekit/agents/utils/connection_pool.py
@@ -1,4 +1,6 @@
+import asyncio
 import time
+import weakref
 from contextlib import asynccontextmanager
 from typing import (
     AsyncGenerator,
@@ -9,6 +11,8 @@ from typing import (
     Set,
     TypeVar,
 )
+
+from . import aio
 
 T = TypeVar("T")
 
@@ -46,6 +50,8 @@ class ConnectionPool(Generic[T]):
         # store connections to be reaped (closed) later.
         self._to_close: Set[T] = set()
 
+        self._prewarm_task = None
+
     async def _connect(self) -> T:
         """Create a new connection.
 
@@ -57,7 +63,9 @@ class ConnectionPool(Generic[T]):
         """
         if self._connect_cb is None:
             raise NotImplementedError("Must provide connect_cb or implement connect()")
-        return await self._connect_cb()
+        connection = await self._connect_cb()
+        self._connections[connection] = time.time()
+        return connection
 
     async def _drain_to_close(self) -> None:
         """Drain and close all the connections queued for closing."""
@@ -104,9 +112,7 @@ class ConnectionPool(Generic[T]):
             # connection expired; mark it for resetting.
             self.remove(conn)
 
-        conn = await self._connect()
-        self._connections[conn] = now
-        return conn
+        return await self._connect()
 
     def put(self, conn: T) -> None:
         """Mark a connection as available for reuse.
@@ -151,7 +157,29 @@ class ConnectionPool(Generic[T]):
         self._connections.clear()
         self._available.clear()
 
+    def prewarm(self) -> None:
+        """Initiate prewarming of the connection pool without blocking.
+
+        This method starts a background task that creates a new connection if none exist.
+        The task automatically cleans itself up when the connection pool is closed.
+        """
+        if self._prewarm_task is not None or self._connections:
+            return
+
+        async def _prewarm_impl():
+            if not self._connections:
+                conn = await self._connect()
+                self._available.add(conn)
+
+        task = asyncio.create_task(_prewarm_impl())
+        self._prewarm_task = weakref.ref(task)
+
     async def aclose(self):
         """Close all connections, draining any pending connection closures."""
+        if self._prewarm_task is not None:
+            task = self._prewarm_task()
+            if task:
+                aio.gracefully_cancel(task)
+
         self.invalidate()
         await self._drain_to_close()

--- a/livekit-agents/livekit/agents/utils/connection_pool.py
+++ b/livekit-agents/livekit/agents/utils/connection_pool.py
@@ -50,7 +50,7 @@ class ConnectionPool(Generic[T]):
         # store connections to be reaped (closed) later.
         self._to_close: Set[T] = set()
 
-        self._prewarm_task = None
+        self._prewarm_task: weakref.ref[asyncio.Task] | None = None
 
     async def _connect(self) -> T:
         """Create a new connection.

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/log.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/log.py
@@ -1,5 +1,3 @@
 import logging
 
 logger = logging.getLogger("livekit.plugins.aws")
-for logger_name in ["botocore", "aiobotocore"]:
-    logging.getLogger(logger_name).setLevel(logging.INFO)

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -148,10 +148,8 @@ class TTS(tts.TTS):
 
         return self._session
 
-    async def prewarm(self) -> None:
-        async with self._pool.connection():
-            # open the connection and return it back to the pool
-            pass
+    def prewarm(self) -> None:
+        self._pool.prewarm()
 
     def update_options(
         self,

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -148,6 +148,11 @@ class TTS(tts.TTS):
 
         return self._session
 
+    async def prewarm(self) -> None:
+        async with self._pool.connection():
+            # open the connection and return it back to the pool
+            pass
+
     def update_options(
         self,
         *,

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -642,7 +642,6 @@ class SpeechStream(stt.SpeechStream):
                     self._event_ch.send_nowait(start_event)
 
                 if is_final_transcript:
-                    logger.debug(f"deepgram received final transcript: {alts[0].text}")
                     final_event = stt.SpeechEvent(
                         type=stt.SpeechEventType.FINAL_TRANSCRIPT,
                         request_id=request_id,

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -442,6 +442,7 @@ class SpeechStream(stt.SpeechStream):
             except Exception:
                 return
 
+        @utils.log_exceptions(logger=logger)
         async def send_task(ws: aiohttp.ClientWebSocketResponse):
             nonlocal closing_ws
 
@@ -494,6 +495,7 @@ class SpeechStream(stt.SpeechStream):
             closing_ws = True
             await ws.send_str(SpeechStream._CLOSE_MSG)
 
+        @utils.log_exceptions(logger=logger)
         async def recv_task(ws: aiohttp.ClientWebSocketResponse):
             nonlocal closing_ws
             while True:
@@ -640,6 +642,7 @@ class SpeechStream(stt.SpeechStream):
                     self._event_ch.send_nowait(start_event)
 
                 if is_final_transcript:
+                    logger.debug(f"deepgram received final transcript: {alts[0].text}")
                     final_event = stt.SpeechEvent(
                         type=stt.SpeechEventType.FINAL_TRANSCRIPT,
                         request_id=request_id,

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
@@ -157,6 +157,9 @@ class TTS(tts.TTS):
         self._streams.add(stream)
         return stream
 
+    def prewarm(self) -> None:
+        self._pool.prewarm()
+
     async def aclose(self) -> None:
         for stream in list(self._streams):
             await stream.aclose()

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -198,10 +198,8 @@ class TTS(tts.TTS):
 
         return self._session
 
-    async def prewarm(self) -> None:
-        async with self._pool.connection():
-            # open the connection and return it back to the pool
-            pass
+    def prewarm(self) -> None:
+        self._pool.prewarm()
 
     async def list_voices(self) -> List[Voice]:
         async with self._ensure_session().get(

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -322,6 +322,10 @@ class STT(stt.STT):
                 keywords=keywords,
             )
 
+    async def aclose(self) -> None:
+        await self._pool.aclose()
+        await super().aclose()
+
 
 class SpeechStream(stt.SpeechStream):
     def __init__(

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -185,7 +185,6 @@ class ChunkedStream(tts.ChunkedStream):
             num_channels=OPENAI_TTS_CHANNELS,
         )
 
-
         async def _decode_loop():
             try:
                 logger.info("starting decode loop")

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -217,6 +217,4 @@ class ChunkedStream(tts.ChunkedStream):
             raise APIConnectionError() from e
         finally:
             await utils.aio.gracefully_cancel(decode_task)
-            logger.info("closing decoder")
             await decoder.aclose()
-            logger.info("closed decoder")

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -32,6 +32,7 @@ import openai
 
 from .models import TTSModels, TTSVoices
 from .utils import AsyncAzureADTokenProvider
+from .log import logger
 
 OPENAI_TTS_SAMPLE_RATE = 48000
 OPENAI_TTS_CHANNELS = 1
@@ -184,6 +185,7 @@ class ChunkedStream(tts.ChunkedStream):
             num_channels=OPENAI_TTS_CHANNELS,
         )
 
+
         async def _decode_loop():
             try:
                 async with oai_stream as stream:
@@ -192,6 +194,7 @@ class ChunkedStream(tts.ChunkedStream):
             finally:
                 decoder.end_input()
 
+        logger.info("starting decode loop")
         decode_task = asyncio.create_task(_decode_loop())
 
         try:
@@ -214,5 +217,8 @@ class ChunkedStream(tts.ChunkedStream):
         except Exception as e:
             raise APIConnectionError() from e
         finally:
+            logger.info("closing decode loop")
             await utils.aio.gracefully_cancel(decode_task)
+            logger.info("closing decoder")
             await decoder.aclose()
+            logger.info("closed decoder")

--- a/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
+++ b/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
@@ -306,8 +306,9 @@ def live_transcription_to_speech_data(data: dict) -> List[stt.SpeechData]:
         )
 
         for alt in result.get("alternatives", []):
+            # newlines should not be in transcript
             content, confidence, language = (
-                alt.get("content", "").strip(),
+                alt.get("content", "").strip().replace("\n", ""),
                 alt.get("confidence", 1.0),
                 alt.get("language", "en"),
             )

--- a/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
+++ b/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
@@ -306,9 +306,8 @@ def live_transcription_to_speech_data(data: dict) -> List[stt.SpeechData]:
         )
 
         for alt in result.get("alternatives", []):
-            # newlines should not be in transcript
             content, confidence, language = (
-                alt.get("content", "").strip().replace("\n", ""),
+                alt.get("content", "").strip(),
                 alt.get("confidence", 1.0),
                 alt.get("language", "en"),
             )

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -23,7 +23,7 @@ from livekit.plugins import (
 from .utils import make_test_speech, wer
 
 SAMPLE_RATES = [24000, 44100]  # test multiple input sample rates
-WER_THRESHOLD = 0.2
+WER_THRESHOLD = 0.25
 RECOGNIZE_STT: list[Callable[[], stt.STT]] = [
     pytest.param(lambda: deepgram.STT(), id="deepgram"),
     # pytest.param(lambda: google.STT(), id="google"),


### PR DESCRIPTION
- added a tts.prewarm method to start the connection pool early. we should do this automatically in v1. currently just the stubs
- in agent_output, combined both streaming and non-streaming synthesis paths
- fixed a bug in AudioStreamDecoder where it could fail on close
- deprecated elevenlabs' `optimize_stream_latency` option