### PR TITLE
Restrict v0 examples package requirements to <1.0

### DIFF
--- a/examples/hive-moderation-agent/requirements.txt
+++ b/examples/hive-moderation-agent/requirements.txt
@@ -1,5 +1,5 @@
 livekit
-livekit-agents
+livekit-agents<1.0.0
 python-dotenv
 Pillow
 aiohttp

--- a/examples/participant-entrypoint/requirements.txt
+++ b/examples/participant-entrypoint/requirements.txt
@@ -1,2 +1,2 @@
-livekit-agents>=0.12.16
+livekit-agents>=0.12.16,<1.0.0
 python-dotenv~=1.0

--- a/examples/simple-color/requirements.txt
+++ b/examples/simple-color/requirements.txt
@@ -1,2 +1,2 @@
-livekit-agents>=0.12.16
+livekit-agents>=0.12.16,<1.0.0
 python-dotenv~=1.0

--- a/examples/speech-to-text/requirements.txt
+++ b/examples/speech-to-text/requirements.txt
@@ -1,3 +1,3 @@
-livekit-agents>=0.12.16
-livekit-plugins-deepgram>=0.6.20
+livekit-agents>=0.12.16,<1.0.0
+livekit-plugins-deepgram>=0.6.20,<1.0.0
 python-dotenv~=1.0

--- a/examples/text-to-speech/requirements.txt
+++ b/examples/text-to-speech/requirements.txt
@@ -1,5 +1,5 @@
-livekit-agents>=0.12.16
-livekit-plugins-openai>=1.0.0
-livekit-plugins-cartesia>=0.4.8
-livekit-plugins-elevenlabs>=0.7.14
+livekit-agents>=0.12.16,<1.0.0
+livekit-plugins-openai>=0.11.0,<1.0.0
+livekit-plugins-cartesia>=0.4.8,<1.0.0
+livekit-plugins-elevenlabs>=0.7.14,<1.0.0
 python-dotenv~=1.0

--- a/examples/voice-pipeline-agent/requirements.txt
+++ b/examples/voice-pipeline-agent/requirements.txt
@@ -1,8 +1,8 @@
-livekit-agents>=0.12.16
-livekit-plugins-deepgram>=0.6.20
-livekit-plugins-google>=0.10.6
-livekit-plugins-openai[vertex]>=0.10.10
-livekit-plugins-silero>=0.7.4
-livekit-plugins-rag>=0.2.3
+livekit-agents>=0.12.16,<1.0.0
+livekit-plugins-deepgram>=0.6.20,<1.0.0
+livekit-plugins-google>=0.10.6,<1.0.0
+livekit-plugins-openai[vertex]>=0.10.10,<1.0.0
+livekit-plugins-silero>=0.7.4,<1.0.0
+livekit-plugins-rag>=0.2.3,<1.0.0
 python-dotenv~=1.0
 aiofile~=3.8.8


### PR DESCRIPTION
Updating the package requirements for pre-1.0 examples to ensure that we only pull versions prior to v1.0.0 in order to maintain compatibility.