### PR TITLE
bump openai plugin agents dependency version

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/setup.py
+++ b/livekit-plugins/livekit-plugins-openai/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
     install_requires=[
-        "livekit-agents[codecs, images]>=0.12.3",
+        "livekit-agents[codecs, images]==1.0.0.dev3",
         "openai[realtime]>=1.65",
     ],
     extras_require={


### PR DESCRIPTION
since this is a dev version it won't automatically meet the `>=0.12.3` criteria and in docker build it gets stuck in an unfulfillable dependency hell. not sure why it doesn't in venv though.