### PR TITLE
not starting audio_recognition for realtime models

### DIFF
--- a/livekit-agents/livekit/agents/voice/task_activity.py
+++ b/livekit-agents/livekit/agents/voice/task_activity.py
@@ -138,14 +138,6 @@ class TaskActivity(RecognitionHooks):
         async with self._lock:
             self._agent_task._activity = self
             self._main_atask = asyncio.create_task(self._main_task(), name="_main_task")
-            self._audio_recognition = AudioRecognition(
-                hooks=self,
-                stt=self._agent_task.stt_node,
-                vad=self.vad,
-                turn_detector=self.turn_detector,
-                min_endpointing_delay=self._agent.options.min_endpointing_delay,
-            )
-            self._audio_recognition.start()
 
             if isinstance(self.llm, llm.RealtimeModel):
                 self._rt_session = self.llm.session()
@@ -172,6 +164,15 @@ class TaskActivity(RecognitionHooks):
                     logger.exception("failed to update the fnc_ctx")
 
             elif isinstance(self.llm, llm.LLM):
+                self._audio_recognition = AudioRecognition(
+                    hooks=self,
+                    stt=self._agent_task.stt_node,
+                    vad=self.vad,
+                    turn_detector=self.turn_detector,
+                    min_endpointing_delay=self._agent.options.min_endpointing_delay,
+                )
+                self._audio_recognition.start()
+
                 try:
                     update_instructions(
                         self._agent_task._chat_ctx,


### PR DESCRIPTION
Right now if you start a RealtimeModel from the dev-1.0 branch, it tries to start an audio_recognition task which requires an STT and a VAD. both are redundant with realtime models
```
2025-03-10 22:23:58,816 - ERROR livekit.agents - Error in _stt_task
Traceback (most recent call last):
  File "/Users/imatas/apps/agents/livekit-agents/livekit/agents/utils/log.py", line 16, in async_fn_logs
    return await fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/imatas/apps/agents/livekit-agents/livekit/agents/voice/audio_recognition.py", line 219, in _stt_task
    async for ev in node:
  File "/Users/imatas/apps/agents/livekit-agents/livekit/agents/voice/agent_task.py", line 132, in stt_node
    assert activity.stt is not None, "stt_node called but no STT node is available"
           ^^^^^^^^^^^^^^^^^^^^^^^^
```