### PR TITLE
Support more input transcription parameters for openai realtime

### DIFF
--- a/.changeset/fresh-foxes-remember.md
+++ b/.changeset/fresh-foxes-remember.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-openai": patch
+---
+
+Support more input transcription parameters for openai realtime

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/api_proto.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/api_proto.py
@@ -69,6 +69,8 @@ class ContentPart(TypedDict):
 
 class InputAudioTranscription(TypedDict):
     model: InputTranscriptionModel | str
+    language: NotRequired[str]
+    prompt: NotRequired[str]
 
 
 class ServerVad(TypedDict):

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -149,6 +149,8 @@ class ServerVadOptions:
 @dataclass
 class InputTranscriptionOptions:
     model: api_proto.InputTranscriptionModel | str
+    language: str | None = None
+    prompt: str | None = None
 
 
 @dataclass
@@ -976,6 +978,14 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
             input_audio_transcription_opts = {
                 "model": self._opts.input_audio_transcription.model,
             }
+            if self._opts.input_audio_transcription.language is not None:
+                input_audio_transcription_opts["language"] = (
+                    self._opts.input_audio_transcription.language
+                )
+            if self._opts.input_audio_transcription.prompt is not None:
+                input_audio_transcription_opts["prompt"] = (
+                    self._opts.input_audio_transcription.prompt
+                )
 
         session_data: api_proto.ClientEvent.SessionUpdateData = {
             "modalities": self._opts.modalities,
@@ -1296,6 +1306,8 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
         else:
             input_audio_transcription = InputTranscriptionOptions(
                 model=session["input_audio_transcription"]["model"],
+                language=session["input_audio_transcription"].get("language"),
+                prompt=session["input_audio_transcription"].get("prompt"),
             )
 
         self.emit(


### PR DESCRIPTION
As per the [documentation](https://platform.openai.com/docs/api-reference/realtime-sessions/create#realtime-sessions-create-input_audio_transcription), the OpenAI realtime API allows to specify `language` and `prompt` parameters as input to the transcription model. This PR adds support for it.

Closes #1430.