### PR TITLE
Fix realtime using default voice for first response

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -316,6 +316,7 @@ class RealtimeSession(llm.RealtimeSession):
                 type="session.update",
                 session=session_update_event.Session(
                     model=self._realtime_model._opts.model,  # type: ignore
+                    voice=self._realtime_model._opts.voice,  # type: ignore
                     instructions=instructions,
                 ),
                 event_id=event_id,


### PR DESCRIPTION
## Context
- Despite setting voice on the `RealtimeModel`, the first response from an `AgentTask` can sometimes use the default voice
- Seems to be a race condition whereby `update_instructions` called from the `AgentTask` is passing a voice of `None`
- Ensuring `update_instructions` always passes the voice gets around resolves the issue (though fixing the race condition itself might be preferable)

```
SessionUpdateEvent(
    session=Session(
        input_audio_format=None,
        input_audio_transcription=None,
        instructions="""
            {prompt}
        """,
        max_response_output_tokens=None,
        modalities=None,
        model="gpt-4o-realtime-preview-2024-12-17",
        output_audio_format=None,
        temperature=None,
        tool_choice=None,
        tools=None,
        turn_detection=None,
        voice=None
    ),
    type="session.update",
    event_id="instructions_update_f5fdeee44746"
)
SessionUpdateEvent(
    session=Session(
        input_audio_format=None,
        input_audio_transcription=SessionInputAudioTranscription(
            language=None,
            model="whisper-1",
            prompt=None
        ),
        instructions=None,
        max_response_output_tokens=None,
        modalities=None,
        model="gpt-4o-realtime-preview-2024-12-17",
        output_audio_format=None,
        temperature=None,
        tool_choice=None,
        tools=None,
        turn_detection=None,
        voice="verse"
    ),
    type="session.update",
    event_id="session_update_262c3335f2c8"
)
```