### PR TITLE
Fix: multimodal - audio_samples should never be negative

### DIFF
--- a/livekit-agents/livekit/agents/multimodal/agent_playout.py
+++ b/livekit-agents/livekit/agents/multimodal/agent_playout.py
@@ -42,7 +42,9 @@ class PlayoutHandle:
         if self._total_played_time is not None:
             return int(self._total_played_time * 24000)
 
-        return int((self._pushed_duration - self._audio_source.queued_duration) * 24000)
+        return max(
+            int((self._pushed_duration - self._audio_source.queued_duration) * 24000), 0
+        )
 
     @property
     def text_chars(self) -> int:


### PR DESCRIPTION
Fix agent_playout.py: audio_samples should be non-negative

See: https://github.com/livekit/agents-js/pull/319

Similar issues: https://github.com/livekit/agents-js/issues/304
