### PR TITLE
Remove unnecessary version pins

### DIFF
--- a/.changeset/1682.md
+++ b/.changeset/1682.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Remove unnecessary version pins

--- a/livekit-agents/setup.py
+++ b/livekit-agents/setup.py
@@ -54,10 +54,10 @@ setuptools.setup(
         "protobuf>=3",
         "pyjwt>=2.0.0",
         "types-protobuf>=4,<5",
-        "watchfiles~=0.22",
-        "psutil~=5.9",
-        "aiohttp~=3.10",
-        "typing-extensions~=4.12",
+        "watchfiles>=0.22",
+        "psutil>=5.9",
+        "aiohttp>=3.10",
+        "typing-extensions>=4.12",
     ],
     extras_require={
         ':sys_platform=="win32"': [


### PR DESCRIPTION
These are behind latest

See also https://iscinumpy.dev/post/bound-version-constraints/