### PR TITLE
fix: double transcript issue  for google stt

### DIFF
--- a/.changeset/honest-windows-wink.md
+++ b/.changeset/honest-windows-wink.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-google": patch
+---
+
+remove `enable_voice_activity_events` param from google stt

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -94,7 +94,7 @@ class STT(stt.STT):
         punctuate: bool = True,
         spoken_punctuation: bool = False,
         model: SpeechModels | str = "latest_long",
-        location: str = "us-central1",
+        location: str = "global",
         sample_rate: int = 16000,
         credentials_info: dict | None = None,
         credentials_file: str | None = None,
@@ -114,7 +114,7 @@ class STT(stt.STT):
             punctuate(bool): whether to punctuate the audio (default: True)
             spoken_punctuation(bool): whether to use spoken punctuation (default: False)
             model(SpeechModels): the model to use for recognition default: "latest_long"
-            location(str): the location to use for recognition default: "us-central1"
+            location(str): the location to use for recognition default: "global"
             sample_rate(int): the sample rate of the audio default: 16000
             credentials_info(dict): the credentials info to use for recognition (default: None)
             credentials_file(str): the credentials file to use for recognition (default: None)
@@ -488,7 +488,6 @@ class SpeechStream(stt.SpeechStream):
                             ),
                         ),
                         streaming_features=cloud_speech.StreamingRecognitionFeatures(
-                            enable_voice_activity_events=True,
                             interim_results=self._config.interim_results,
                         ),
                     )

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -15,6 +15,7 @@ from livekit.plugins import (
     azure,
     deepgram,
     fal,
+    google,
     openai,
     silero,
     speechmatics,
@@ -63,7 +64,7 @@ STREAM_STT: list[Callable[[], stt.STT]] = [
     pytest.param(lambda: aws.STT(), id="aws"),
     pytest.param(lambda: assemblyai.STT(), id="assemblyai"),
     pytest.param(lambda: deepgram.STT(), id="deepgram"),
-    # pytest.param(lambda: google.STT(), id="google"),
+    pytest.param(lambda: google.STT(), id="google"),
     pytest.param(
         lambda: agents.stt.StreamAdapter(stt=openai.STT(), vad=STREAM_VAD),
         id="openai.stream",
@@ -72,15 +73,15 @@ STREAM_STT: list[Callable[[], stt.STT]] = [
         lambda: agents.stt.StreamAdapter(stt=openai.STT.with_groq(), vad=STREAM_VAD),
         id="openai.with_groq.stream",
     ),
-    # pytest.param(
-    #     lambda: google.STT(
-    #         languages=["en-AU"],
-    #         model="chirp_2",
-    #         spoken_punctuation=False,
-    #         location="us-central1",
-    #     ),
-    #     id="google.chirp_2",
-    # ),
+    pytest.param(
+        lambda: google.STT(
+            languages=["en-AU"],
+            model="chirp_2",
+            spoken_punctuation=False,
+            location="us-central1",
+        ),
+        id="google.chirp_2",
+    ),
     pytest.param(lambda: azure.STT(), id="azure"),
     pytest.param(lambda: speechmatics.STT(), id="speechmatics"),
 ]


### PR DESCRIPTION
remove `enable_voice_activity_events`  param from google stt