### PR TITLE
feat: add usage tracking to AWS LLM plugin

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -291,7 +291,8 @@ class LLMStream(llm.LLMStream):
             elif self._tool_call_id:
                 chat_chunk = self._try_build_function(request_id, chunk)
                 self._index = 0
-                return chat_chunk
+                if chat_chunk:
+                    return chat_chunk
 
         return None
 

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -289,10 +289,10 @@ class LLMStream(llm.LLMStream):
                 self._index = 0
                 return chat_chunk
             elif self._tool_call_id:
-                chat_chunk = self._try_build_function(request_id, chunk)
+                chat_chunk_function = self._try_build_function(request_id, chunk)
                 self._index = 0
-                if chat_chunk:
-                    return chat_chunk
+                if chat_chunk_function:
+                    return chat_chunk_function
 
         return None
 

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -282,7 +282,8 @@ class LLMStream(llm.LLMStream):
                     usage=llm.CompletionUsage(
                         completion_tokens=metadata["usage"]["outputTokens"],
                         prompt_tokens=metadata["usage"]["inputTokens"],
-                        total_tokens=metadata["usage"]["totalTokens"])
+                        total_tokens=metadata["usage"]["totalTokens"],
+                    ),
                 )
                 self._text = ""
                 self._index = None
@@ -335,7 +336,8 @@ class LLMStream(llm.LLMStream):
             usage=llm.CompletionUsage(
                 completion_tokens=metadata["usage"]["outputTokens"],
                 prompt_tokens=metadata["usage"]["inputTokens"],
-                total_tokens=metadata["usage"]["totalTokens"])
+                total_tokens=metadata["usage"]["totalTokens"],
+            ),
         )
 
 

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -288,7 +288,7 @@ class LLMStream(llm.LLMStream):
                 self._index = None
                 return chat_chunk
             elif self._tool_call_id:
-                chat_chunk =  self._try_build_function(request_id, chunk)
+                chat_chunk = self._try_build_function(request_id, chunk)
                 self._index = None
                 return chat_chunk
 

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -271,7 +271,7 @@ class LLMStream(llm.LLMStream):
         elif "metadata" in chunk:
             metadata = chunk["metadata"]
             if self._text:
-                chat_chunk = llm.ChatChunk(
+                chat_chunk_text = llm.ChatChunk(
                     request_id=request_id,
                     choices=[
                         llm.Choice(
@@ -287,12 +287,11 @@ class LLMStream(llm.LLMStream):
                 )
                 self._text = ""
                 self._index = 0
-                return chat_chunk
+                return chat_chunk_text
             elif self._tool_call_id:
                 chat_chunk_function = self._try_build_function(request_id, chunk)
                 self._index = 0
-                if chat_chunk_function:
-                    return chat_chunk_function
+                return chat_chunk_function
 
         return None
 

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -179,7 +179,7 @@ class LLMStream(llm.LLMStream):
         self._fnc_name: str | None = None
         self._fnc_raw_arguments: str | None = None
         self._text: str = ""
-        self._index: int | None = None
+        self._index: int = 0
 
         retryable = True
 
@@ -286,11 +286,11 @@ class LLMStream(llm.LLMStream):
                     ),
                 )
                 self._text = ""
-                self._index = None
+                self._index = 0
                 return chat_chunk
             elif self._tool_call_id:
                 chat_chunk = self._try_build_function(request_id, chunk)
-                self._index = None
+                self._index = 0
                 return chat_chunk
 
         return None

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -258,12 +258,14 @@ class LLMStream(llm.LLMStream):
             self._tool_call_id = tool_use["toolUseId"]
             self._fnc_name = tool_use["name"]
             self._fnc_raw_arguments = ""
+
         elif "contentBlockDelta" in chunk:
             delta = chunk["contentBlockDelta"]["delta"]
             if "toolUse" in delta:
                 self._fnc_raw_arguments += delta["toolUse"]["input"]
             elif "text" in delta:
                 self._text += delta["text"]
+
         elif "contentBlockStop" in chunk:
             if self._text:
                 chat_chunk = llm.ChatChunk(
@@ -279,6 +281,7 @@ class LLMStream(llm.LLMStream):
                 return chat_chunk
             elif self._tool_call_id:
                 return self._try_build_function(request_id, chunk)
+
         elif "metadata" in chunk:
             metadata = chunk["metadata"]
             return llm.ChatChunk(


### PR DESCRIPTION
## Description
This PR adds token usage tracking for AWS Bedrock LLM models. Previously, when using AWS Bedrock models, the token counts (`llm_prompt_tokens` and `llm_completion_tokens`) were always zero, resulting in incorrect cost calculations. The implementation now correctly extracts token usage data from the AWS Bedrock API response metadata.

## Problem
When running agents with AWS Bedrock LLM models, the `UsageCollector` returns zero values for `summary.llm_prompt_tokens` and `summary.llm_completion_tokens`, making cost calculations incorrect when using code like:
```python
lm_cost = (
  summary.llm_prompt_tokens * BEDROCK_LLM_INPUT_PRICE
  + summary.llm_completion_tokens * BEDROCK_LLM_OUTPUT_PRICE
)
```
## Solution
Updated the AWS plugin to extract token usage information from the metadata section of the AWS Bedrock response. The API returns this data in the format:
```python
'metadata': {
    'usage': {
        'inputTokens': 123,
        'outputTokens': 123,
        'totalTokens': 123
    }
}
```

This PR properly parses these values and includes them in the ChatChunk objects.

## Testing
Tested with Claude 3.5 Haiku model (`us.anthropic.claude-3-5-haiku-20241022-v1:0`) on AWS Bedrock. Cost calculations now correctly reflect token usage.

```json 
{"message": "Pipeline LLM metrics: sequence_id=<SEQUENCE_ID>, ttft=3.88, input_tokens=521, output_tokens=97, tokens_per_second=25.03", "level": "INFO", "name": "livekit.agents", "pid": 48, "job_id": "<JOB_ID>", "timestamp": "2025-03-25T09:03:30.256970+00:00"}

{"message": "Total cost: $0.0101 (LLM: $0.0008, TTS: $0.0075, STT: $0.0018)", "level": "INFO", "name": "voice-agent", "pid": 48, "job_id": "<JOB_ID>", "timestamp": "2025-03-25T09:04:07.752879+00:00"}
```

## Related Issues
Resolves issues with cost tracking for AWS Bedrock LLM models.