### PR TITLE
Added a Semantic VAD configuration option

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/__init__.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/__init__.py
@@ -11,6 +11,8 @@ from .realtime_model import (
     RealtimeSession,
     RealtimeSessionOptions,
     RealtimeToolCall,
+    SemanticVadEagerness,
+    SemanticVadOptions,
     ServerVadOptions,
 )
 
@@ -30,4 +32,6 @@ __all__ = [
     "api_proto",
     "DEFAULT_INPUT_AUDIO_TRANSCRIPTION",
     "DEFAULT_SERVER_VAD_OPTIONS",
+    "SemanticVadEagerness",
+    "SemanticVadOptions",
 ]

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/api_proto.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/api_proto.py
@@ -198,7 +198,7 @@ class Resource:
         input_audio_format: AudioFormat
         output_audio_format: AudioFormat
         input_audio_transcription: InputAudioTranscription | None
-        turn_detection: ServerVad | SemanticVad | None
+        turn_detection: Union[ServerVad, SemanticVad, None]
         tools: list[FunctionTool]
         tool_choice: ToolChoice
         temperature: float
@@ -227,7 +227,7 @@ class ClientEvent:
         input_audio_format: AudioFormat
         output_audio_format: AudioFormat
         input_audio_transcription: InputAudioTranscription | None
-        turn_detection: ServerVad | SemanticVad | None
+        turn_detection: Union[ServerVad, SemanticVad, None]
         tools: list[FunctionTool]
         tool_choice: ToolChoice
         temperature: float

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/api_proto.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/api_proto.py
@@ -81,6 +81,13 @@ class ServerVad(TypedDict):
     create_response: NotRequired[bool]
 
 
+class SemanticVad(TypedDict):
+    type: Literal["semantic_vad"]
+    eagerness: NotRequired[Literal["low", "medium", "high", "auto"]]
+    create_response: NotRequired[bool]
+    interrupt_response: NotRequired[bool]
+
+
 class FunctionTool(TypedDict):
     type: Literal["function"]
     name: str
@@ -191,7 +198,7 @@ class Resource:
         input_audio_format: AudioFormat
         output_audio_format: AudioFormat
         input_audio_transcription: InputAudioTranscription | None
-        turn_detection: ServerVad | None
+        turn_detection: ServerVad | SemanticVad | None
         tools: list[FunctionTool]
         tool_choice: ToolChoice
         temperature: float
@@ -220,7 +227,7 @@ class ClientEvent:
         input_audio_format: AudioFormat
         output_audio_format: AudioFormat
         input_audio_transcription: InputAudioTranscription | None
-        turn_detection: ServerVad | None
+        turn_detection: ServerVad | SemanticVad | None
         tools: list[FunctionTool]
         tool_choice: ToolChoice
         temperature: float

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1331,9 +1331,8 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
     ):
         session = session_updated["session"]
         session_turn_detection = session["turn_detection"]
-        if session_turn_detection is None:
-            turn_detection = None
-        else:
+        turn_detection: Union[ServerVadOptions, SemanticVadOptions, None] = None
+        if session_turn_detection is not None:
             turn_detection_type = session_turn_detection.get("type")
             if turn_detection_type == "server_vad":
                 session_turn_detection_opts = cast(
@@ -1348,19 +1347,23 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
                     create_response=session_turn_detection_opts["create_response"],
                 )
             elif turn_detection_type == "semantic_vad":
-                session_turn_detection_opts = cast(
+                session_turn_detection_semantic = cast(
                     api_proto.SemanticVad, session_turn_detection
                 )
+                eagerness_value = session_turn_detection_semantic.get(
+                    "eagerness", "auto"
+                )
+                create_response_value = session_turn_detection_semantic.get(
+                    "create_response", True
+                )
+                interrupt_response_value = session_turn_detection_semantic.get(
+                    "interrupt_response", True
+                )
+
                 turn_detection = SemanticVadOptions(
-                    eagerness=SemanticVadEagerness(
-                        session_turn_detection_opts.get("eagerness", "auto")
-                    ),
-                    create_response=session_turn_detection_opts.get(
-                        "create_response", True
-                    ),
-                    interrupt_response=session_turn_detection_opts.get(
-                        "interrupt_response", True
-                    ),
+                    eagerness=SemanticVadEagerness(eagerness_value),
+                    create_response=bool(create_response_value),
+                    interrupt_response=bool(interrupt_response_value),
                 )
             else:
                 turn_detection = None

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -186,7 +186,7 @@ class RealtimeSessionOptions:
     input_audio_format: api_proto.AudioFormat
     output_audio_format: api_proto.AudioFormat
     input_audio_transcription: InputTranscriptionOptions | None
-    turn_detection: ServerVadOptions | SemanticVadOptions | None
+    turn_detection: Union[ServerVadOptions, SemanticVadOptions, None]
     tool_choice: api_proto.ToolChoice
     temperature: float
     max_response_output_tokens: int | Literal["inf"]
@@ -484,7 +484,7 @@ class RealtimeModel:
             InputTranscriptionOptions | None
         ] = NOT_GIVEN,
         turn_detection: NotGivenOr[
-            ServerVadOptions | SemanticVadOptions | None
+            Union[ServerVadOptions, SemanticVadOptions, None]
         ] = NOT_GIVEN,
         temperature: float | None = None,
         max_response_output_tokens: int | Literal["inf"] | None = None,
@@ -952,7 +952,7 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
             InputTranscriptionOptions | None
         ] = NOT_GIVEN,
         turn_detection: NotGivenOr[
-            ServerVadOptions | SemanticVadOptions | None
+            Union[ServerVadOptions, SemanticVadOptions, None]
         ] = NOT_GIVEN,
         tool_choice: api_proto.ToolChoice | None = None,
         temperature: float | None = None,
@@ -989,7 +989,7 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
                 function_data["type"] = "function"
                 tools.append(function_data)
 
-        server_vad_opts: api_proto.ServerVad | api_proto.SemanticVad | None = None
+        server_vad_opts: Union[api_proto.ServerVad, api_proto.SemanticVad, None] = None
         if self._opts.turn_detection is not None:
             if isinstance(self._opts.turn_detection, ServerVadOptions):
                 server_vad_opts = {
@@ -1330,7 +1330,7 @@ class RealtimeSession(utils.EventEmitter[EventTypes]):
             turn_detection = None
         else:
             turn_detection_type = session["turn_detection"].get("type")
-            if turn_detection_type == "server_vaddd":
+            if turn_detection_type == "server_vad":
                 turn_detection = ServerVadOptions(
                     threshold=session["turn_detection"]["threshold"],
                     prefix_padding_ms=session["turn_detection"]["prefix_padding_ms"],


### PR DESCRIPTION
There is a new VAD mechanism available to the OpenAI realtime model: semantic VAD.
https://platform.openai.com/docs/guides/realtime-vad#semantic-vad
I've added this option to the OpenAI realtime plugin.