### PR TITLE
fix leaked tasks on realtime generation

### DIFF
--- a/.github/next-release/changeset-b63aa935.md
+++ b/.github/next-release/changeset-b63aa935.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+fix leaked tasks on realtime generation (#1760)


### PR DESCRIPTION
Fix those errors:
```
2025-03-27 14:02:54,262 - ERROR asyncio - Task exception was never retrieved
future: <Task finished name='Task-29' coro=<<async_generator_athrow without __name__>()> exception=RuntimeError('aclose(): asynchronous generator is already running')> 
RuntimeError: aclose(): asynchronous generator is already running
2025-03-27 14:02:54,267 - ERROR asyncio - Task was destroyed but it is pending!
task: <Task pending name='Task-17' coro=<_text_forwarding_task() done, defined at /Users/theomonnom/livekit/agents/livekit-agents/livekit/agents/utils/log.py:13> wait_for=<Future pending cb=[Task.task_wakeup()]>> 
2025-03-27 14:02:54,267 - ERROR asyncio - Task was destroyed but it is pending!
task: <Task pending name='Task-18' coro=<_audio_forwarding_task() done, defined at /Users/theomonnom/livekit/agents/livekit-agents/livekit/agents/utils/log.py:13> wait_for=<Future pending cb=[Task.task_wakeup()]>> 
2025-03-27 14:02:54,267 - ERROR asyncio - Task was destroyed but it is pending!
task: <Task pending name='Task-25' coro=<_text_forwarding_task() done, defined at /Users/theomonnom/livekit/agents/livekit-agents/livekit/agents/utils/log.py:13> wait_for=<Future pending cb=[Task.task_wakeup()]>> 
2025-03-27 14:02:54,267 - ERROR asyncio - Task was destroyed but it is pending!
task: <Task pending name='Task-26' coro=<_audio_forwarding_task() done, defined at /Users/theomonnom/livekit/agents/livekit-agents/livekit/agents/utils/log.py:13> wait_for=<Future pending cb=[Task.task_wakeup()]>>
```