### PR TITLE
chore(docs): update publish-docs workflow to use uv

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,30 +21,35 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
       - name: Create and activate virtual environment
         run: |
-          python -m venv venv
-          source venv/bin/activate
+          uv venv 
+          source .venv/bin/activate
+
+      - name: Install package and all plugins
+        run: |
+          source .venv/bin/activate
+          uv sync --active
 
       - name: Install pdoc and other dependencies
         run: |
-          source venv/bin/activate
-          python -m pip install pdoc3 setuptools
-
-      - name: Install package
-        run: |
-          source venv/bin/activate
-          pip install ./livekit-agents
-          ./livekit-plugins/install_local.sh
+          source .venv/bin/activate
+          uv pip install pdoc3 setuptools
 
       - name: Build Docs
         run: |
-          source venv/bin/activate
-          python -m pdoc --skip-errors --html livekit --output-dir docs
+          source .venv/bin/activate
+          uv run --active pdoc --skip-errors --html --output-dir=docs livekit
 
       - name: S3 Upload
         run: |
-          source venv/bin/activate
+          source .venv/bin/activate
           aws s3 cp docs/ s3://livekit-docs/python --recursive
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_DEPLOY_AWS_ACCESS_KEY }}


### PR DESCRIPTION
Pydocs cannot currently be deployed in `dev-1.0` or any branch after migrating to `uv`. This attempts to fix up the deploy workflow.

https://www.loom.com/share/d08dc82ad5af498ca63e8914a9ae8c5b