### PR TITLE
feat(ci): allow parallel deployment of v0 and v1 docs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Create and activate virtual environment
         run: |
-          uv venv 
+          uv venv
           source .venv/bin/activate
 
       - name: Install package and all plugins
@@ -50,7 +50,14 @@ jobs:
       - name: S3 Upload
         run: |
           source .venv/bin/activate
-          aws s3 cp docs/ s3://livekit-docs/python --recursive
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          # If branch is main, upload to /v1
+          if [[ $BRANCH == "main" ]]; then
+            aws s3 cp docs/ s3://livekit-docs/python/v1 --recursive
+          # Else, upload to root, preserving the v1 directory
+          else
+            aws s3 sync docs/ s3://livekit-docs/python --exclude "v1/*" --delete
+          fi
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_DEPLOY_AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_DEPLOY_AWS_API_SECRET }}


### PR DESCRIPTION
Allows parallel deployment of `1.0` and `0.x` docs as follows:

- If workflow is triggered on `main` branch, build and upload docs site to `s3://livekit-docs/python/v1`
- Else, build and sync to `s3://livekit-docs/python`, preserving the `/v1` directory to prevent nuking them when updating legacy docs.

NOTE: will still need to upgrade `0.x` to use `uv`, since the build script depends on it. Will also need to cherrypick this version of the workflow and merge to `0.x` branch , since the branch's own version of the action is used when triggered via `workflow_dispatch`.