### PR TITLE
add blingfire plugin

### DIFF
--- a/livekit-agents/pyproject.toml
+++ b/livekit-agents/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "colorama>=0.4.6",
     "av>=12.0.0",
     "numpy>=1.26.0",
+    "pydantic>=2.10.6",
 ]
 
 [project.optional-dependencies]

--- a/livekit-plugins/livekit-plugins-blingfire/README.md
+++ b/livekit-plugins/livekit-plugins-blingfire/README.md
@@ -1,0 +1,13 @@
+# LiveKit Plugins Blingfire
+
+Agent Framework plugin for [Blingfire](https://github.com/microsoft/BlingFire)-based text processing. Currently featuring a `SentenceTokenizer`.
+
+## Installation
+
+```bash
+pip install livekit-plugins-blingfire
+```
+
+## Known Issues
+
+On devices with Apple Silicon, you might encounter an issue with "libblingfiretokdll.dylib". Please follow this [comment](https://github.com/microsoft/BlingFire/issues/171#issuecomment-1706545005) for a solution.

--- a/livekit-plugins/livekit-plugins-blingfire/livekit/plugins/blingfire/__init__.py
+++ b/livekit-plugins/livekit-plugins-blingfire/livekit/plugins/blingfire/__init__.py
@@ -1,0 +1,41 @@
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from .sentence_tokenizer import SentenceTokenizer
+from .version import __version__
+
+__all__ = ["SentenceTokenizer", "__version__"]
+
+
+from livekit.agents import Plugin
+
+from .log import logger
+
+
+class BlingfirePlugin(Plugin):
+    def __init__(self):
+        super().__init__(__name__, __version__, __package__, logger)
+
+
+Plugin.register_plugin(BlingfirePlugin())
+
+# Cleanup docs of unexported modules
+_module = dir()
+NOT_IN_ALL = [m for m in _module if m not in __all__]
+
+__pdoc__ = {}
+
+for n in NOT_IN_ALL:
+    __pdoc__[n] = False

--- a/livekit-plugins/livekit-plugins-blingfire/livekit/plugins/blingfire/log.py
+++ b/livekit-plugins/livekit-plugins-blingfire/livekit/plugins/blingfire/log.py
@@ -1,0 +1,3 @@
+import logging
+
+logger = logging.getLogger("livekit.plugins.blingfire")

--- a/livekit-plugins/livekit-plugins-blingfire/livekit/plugins/blingfire/sentence_tokenizer.py
+++ b/livekit-plugins/livekit-plugins-blingfire/livekit/plugins/blingfire/sentence_tokenizer.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from blingfire import text_to_sentences  # type: ignore
+from livekit import agents
+
+# nltk is using the punkt tokenizer
+# https://www.nltk.org/_modules/nltk/tokenize/punkt.html
+# this code is using a whitespace to concatenate small sentences together
+# (languages such as Chinese and Japanese are not yet supported)
+
+
+@dataclass
+class _TokenizerOptions:
+    min_sentence_len: int
+    stream_context_len: int
+
+
+class SentenceTokenizer(agents.tokenize.SentenceTokenizer):
+    def __init__(
+        self,
+        *,
+        min_sentence_len: int = 20,
+        stream_context_len: int = 10,
+    ) -> None:
+        super().__init__()
+        self._config = _TokenizerOptions(
+            min_sentence_len=min_sentence_len,
+            stream_context_len=stream_context_len,
+        )
+
+    def tokenize(self, text: str) -> list[str]:
+        new_sentences = []
+        buff = ""
+        for sentence in self._tokenize(text):
+            buff += sentence + " "
+            if len(buff) - 1 >= self._config.min_sentence_len:
+                new_sentences.append(buff.rstrip())
+                buff = ""
+
+        if buff:
+            new_sentences.append(buff.rstrip())
+
+        return new_sentences
+
+    def _tokenize(self, text: str) -> list[str]:
+        sentences: str = text_to_sentences(text)
+        return sentences.split("\n")
+
+    def stream(self) -> agents.tokenize.SentenceStream:
+        return agents.tokenize.BufferedSentenceStream(
+            tokenizer=self._tokenize,
+            min_token_len=self._config.min_sentence_len,
+            min_ctx_len=self._config.stream_context_len,
+        )

--- a/livekit-plugins/livekit-plugins-blingfire/livekit/plugins/blingfire/version.py
+++ b/livekit-plugins/livekit-plugins-blingfire/livekit/plugins/blingfire/version.py
@@ -1,0 +1,15 @@
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "1.0.0.rc4"

--- a/livekit-plugins/livekit-plugins-blingfire/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-blingfire/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "livekit-plugins-blingfire"
+dynamic = ["version"]
+description = "Agent Framework plugin for BlingFire-based text processing."
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.9.0"
+authors = [{ name = "LiveKit", email = "support@livekit.io" }]
+keywords = ["webrtc", "realtime", "audio", "video", "livekit"]
+classifiers = [
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Topic :: Multimedia :: Sound/Audio",
+  "Topic :: Multimedia :: Video",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3 :: Only",
+]
+dependencies = ["blingfire>=0.1.8", "livekit-agents>=1.0.0.rc4"]
+
+[project.urls]
+Documentation = "https://docs.livekit.io"
+Website = "https://livekit.io/"
+Source = "https://github.com/livekit/agents"
+
+[tool.hatch.version]
+path = "livekit/plugins/blingfire/version.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["livekit"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/livekit"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.5",
+]

--- a/livekit-plugins/livekit-plugins-blingfire/tests/test_tokenizer.py
+++ b/livekit-plugins/livekit-plugins-blingfire/tests/test_tokenizer.py
@@ -1,0 +1,23 @@
+import pytest
+
+from livekit.plugins.blingfire import SentenceTokenizer
+
+
+@pytest.fixture
+def tokenizer():
+    return SentenceTokenizer(min_sentence_len=1)
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("Hello, world!", ["Hello, world!"]),
+        (
+            "Hello, world! Should this work?? This should work, too... How about this?",
+            ["Hello, world!", "Should this work??", "This should work, too...", "How about this?"],
+        ),
+        ("你好，世界！ 这是一句测试文本。", ["你好，世界！", "这是一句测试文本。"]),
+    ],
+)
+def test_tokenizer(tokenizer: SentenceTokenizer, text: str, expected: list[str]):
+    assert tokenizer.tokenize(text) == expected

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ livekit-plugins-fal = { workspace = true }
 livekit-plugins-google = { workspace = true }
 livekit-plugins-llama-index = { workspace = true }
 livekit-plugins-nltk = { workspace = true }
+livekit-plugins-blingfire = { workspace = true }
 livekit-plugins-openai = { workspace = true }
 livekit-plugins-rag = { workspace = true }
 livekit-plugins-rime = { workspace = true }
@@ -31,12 +32,12 @@ exclude = ["livekit-plugins/livekit-plugins-browser"]
 
 [dependency-groups]
 dev = [
-    "python-dotenv>=1.0.1",
-    "mypy",
-    "pytest",
-    "ruff",
-    "pytest-asyncio>=0.25.3",
-    "jiwer>=3.1.0",
+  "python-dotenv>=1.0.1",
+  "mypy",
+  "pytest",
+  "ruff",
+  "pytest-asyncio>=0.25.3",
+  "jiwer>=3.1.0",
 ]
 
 [tool.ruff]
@@ -46,13 +47,13 @@ exclude = [".github"]
 
 [tool.ruff.lint]
 select = [
-    "E",  # pycodestyle errors
-    "W",  # pycodestyle warnings
-    "F",  # pyflakes
-    "I",  # isort
-    "B",  # flake8-bugbear
-    "C4", # flake8-comprehensions
-    "UP", # pyupgrade
+  "E",  # pycodestyle errors
+  "W",  # pycodestyle warnings
+  "F",  # pyflakes
+  "I",  # isort
+  "B",  # flake8-bugbear
+  "C4", # flake8-comprehensions
+  "UP", # pyupgrade
 ]
 
 [tool.ruff.lint.isort]

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ members = [
     "livekit-plugins-assemblyai",
     "livekit-plugins-aws",
     "livekit-plugins-azure",
+    "livekit-plugins-blingfire",
     "livekit-plugins-cartesia",
     "livekit-plugins-clova",
     "livekit-plugins-deepgram",
@@ -367,6 +368,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/fd/af607bdfa95306b13fcdeadcd48d28b80b27cc5e3b99e2bde96f6212cd3a/azure_cognitiveservices_speech-1.42.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:106fbdb165a215cada47d7e95851e0b9d2755a3f2355369bab4915ad001efe89", size = 39508123 },
     { url = "https://files.pythonhosted.org/packages/17/fb/1c998efbfcb1e44f9dc4dbb8b182ea3e5287fdc167aa352aef4685e29435/azure_cognitiveservices_speech-1.42.0-py3-none-win32.whl", hash = "sha256:7d57218beec24360a8b7ce89755c2c133259e3411c233ef0a659b951e4c4c904", size = 2109807 },
     { url = "https://files.pythonhosted.org/packages/52/bb/ef7a29f5717cca646be6698d80e542446a6a442be897c8f67bf93551c672/azure_cognitiveservices_speech-1.42.0-py3-none-win_amd64.whl", hash = "sha256:32076ee03b3b402a2e8841f2c21e5cd54dc3ffbf5af183426344727298c8bbd4", size = 2377971 },
+]
+
+[[package]]
+name = "blingfire"
+version = "0.1.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/55/e5b9ac53281b89b7fb182c9858b78c6109e350797e93f5e4cbdb90dfbbe6/blingfire-0.1.8.tar.gz", hash = "sha256:fac20b4c1bb6519a32716a8bf64f0fcb7b6ea7631ad1ffab29f14df85c5b4d6a", size = 41948752 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6e/bbf134837ca86e416183e98c4ed2f4e35cb805296a940fb96e58faaa2123/blingfire-0.1.8-py3-none-any.whl", hash = "sha256:9534102bb81f69bc175e2373ef46d8eb0a2a43da052442c7708bfcef171899df", size = 42060688 },
 ]
 
 [[package]]
@@ -1165,6 +1175,7 @@ dependencies = [
     { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "protobuf" },
     { name = "psutil" },
+    { name = "pydantic" },
     { name = "pyjwt" },
     { name = "sounddevice" },
     { name = "types-protobuf" },
@@ -1283,6 +1294,7 @@ requires-dist = [
     { name = "pillow", marker = "extra == 'images'", specifier = ">=10.3.0" },
     { name = "protobuf", specifier = ">=3" },
     { name = "psutil", specifier = ">=7.0" },
+    { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pyjwt", specifier = ">=2.0" },
     { name = "sounddevice", specifier = ">=0.5" },
     { name = "types-protobuf", specifier = ">=4,<5" },
@@ -1362,6 +1374,28 @@ requires-dist = [
     { name = "azure-cognitiveservices-speech", specifier = ">=1.41.0" },
     { name = "livekit-agents", editable = "livekit-agents" },
 ]
+
+[[package]]
+name = "livekit-plugins-blingfire"
+source = { editable = "livekit-plugins/livekit-plugins-blingfire" }
+dependencies = [
+    { name = "blingfire" },
+    { name = "livekit-agents" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "blingfire", specifier = ">=0.1.8" },
+    { name = "livekit-agents", editable = "livekit-agents" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.3.5" }]
 
 [[package]]
 name = "livekit-plugins-cartesia"


### PR DESCRIPTION
- Added missing pydantic dependency in `agents`
- Added a blingfire plugin*

One caveat in installing blingfire with Apple Silicon: users might need to manually swap a `.dylib` file. 

In writing this, I realized that I forgot about the nltk plugin and Cartesia tts uses the default sentence tokenizer without an option to change.