### PR TITLE
fix update_instructions on copied chat ctx

### DIFF
--- a/.github/next-release/changeset-23110904.md
+++ b/.github/next-release/changeset-23110904.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+fix update_instructions on copied chat ctx (#1822)

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -173,6 +173,9 @@ class ChatContext:
     def get_by_id(self, item_id: str) -> ChatItem | None:
         return next((item for item in self.items if item.id == item_id), None)
 
+    def index_by_id(self, item_id: str) -> int | None:
+        return next((i for i, item in enumerate(self.items) if item.id == item_id), None)
+
     def copy(
         self,
         *,

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -567,9 +567,12 @@ def update_instructions(chat_ctx: ChatContext, *, instructions: str, add_if_miss
     Raises:
         ValueError: If an existing instruction message is not of type "message".
     """
-    if msg := chat_ctx.get_by_id(INSTRUCTIONS_MESSAGE_ID):
-        if msg.type == "message":
-            msg.content = [instructions]
+    if idx := chat_ctx.index_by_id(INSTRUCTIONS_MESSAGE_ID):
+        if chat_ctx.items[idx].type == "message":
+            # create a new instance to avoid mutating the original
+            chat_ctx.items[idx] = llm.ChatMessage(
+                id=INSTRUCTIONS_MESSAGE_ID, role="system", content=[instructions]
+            )
         else:
             raise ValueError(
                 "expected the instructions inside the chat_ctx to be of type 'message'"


### PR DESCRIPTION
`update_instructions` on copied chat ctx still modifies the original `chat_ctx` bc the it's a shadow copy.