### PR TITLE
fix initial session update for realtime model

### DIFF
--- a/.github/next-release/changeset-814000cb.md
+++ b/.github/next-release/changeset-814000cb.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-openai": patch
+---
+
+fix initial session update for realtime model (#1835)


### PR DESCRIPTION
https://livekit-users.slack.com/archives/C07FY8WHGPM/p1743479917168779

> In v1rc4, I have this weird issue where ChatGPT realtime will do the initial generate_reply() with the default voice, then switch to selected voice for next replies.

```python
    session = AgentSession(
            llm=openai.realtime.RealtimeModel(
                model="gpt-4o-realtime-preview",
                voice='ash'
            ),
            vad=ctx.proc.userdata["vad"],
        )

    await session.start(
        room=ctx.room,
        agent=assistant,
        room_input_options=room_io.RoomInputOptions(
            # noise_cancellation=noise_cancellation.BVC(),
        ),
        room_output_options=room_io.RoomOutputOptions(
            transcription_enabled=True
        )
    )
    await session.generate_reply()
```