### PR TITLE
add log_context_fields

### DIFF
--- a/.github/next-release/changeset-eaa2b51d.md
+++ b/.github/next-release/changeset-eaa2b51d.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+add add_log_record_callback (#1846)

--- a/.github/next-release/changeset-eaa2b51d.md
+++ b/.github/next-release/changeset-eaa2b51d.md
@@ -2,4 +2,4 @@
 "livekit-agents": patch
 ---
 
-add add_log_record_callback (#1846)
+add log_context_fields (#1846)

--- a/examples/voice_agents/extending-logger.py
+++ b/examples/voice_agents/extending-logger.py
@@ -1,0 +1,28 @@
+import logging
+
+from dotenv import load_dotenv
+
+from livekit.agents import Agent, AgentSession, JobContext, WorkerOptions, cli
+from livekit.plugins import openai
+
+load_dotenv()
+
+
+async def entrypoint(ctx: JobContext):
+    user_id = "fake_user_id"
+
+    def inject_fields(record: logging.LogRecord):
+        record.user_id = user_id
+
+    ctx.add_log_record_callback(inject_fields)
+
+    await ctx.connect()
+
+    agent = Agent(instructions="You are a helpful assistant.")
+    session = AgentSession(llm=openai.realtime.RealtimeModel())
+
+    await session.start(agent=agent, room=ctx.room)
+
+
+if __name__ == "__main__":
+    cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))

--- a/examples/voice_agents/extending-logger.py
+++ b/examples/voice_agents/extending-logger.py
@@ -1,4 +1,3 @@
-import logging
 
 from dotenv import load_dotenv
 
@@ -10,11 +9,7 @@ load_dotenv()
 
 async def entrypoint(ctx: JobContext):
     user_id = "fake_user_id"
-
-    def inject_fields(record: logging.LogRecord):
-        record.user_id = user_id
-
-    ctx.add_log_record_callback(inject_fields)
+    ctx.log_fields = {"user_id": user_id}
 
     await ctx.connect()
 

--- a/examples/voice_agents/extending-logger.py
+++ b/examples/voice_agents/extending-logger.py
@@ -1,4 +1,3 @@
-
 from dotenv import load_dotenv
 
 from livekit.agents import Agent, AgentSession, JobContext, WorkerOptions, cli
@@ -9,7 +8,7 @@ load_dotenv()
 
 async def entrypoint(ctx: JobContext):
     user_id = "fake_user_id"
-    ctx.log_fields = {"user_id": user_id}
+    ctx.log_context_fields = {"user_id": user_id}
 
     await ctx.connect()
 

--- a/livekit-agents/livekit/agents/__init__.py
+++ b/livekit-agents/livekit/agents/__init__.py
@@ -20,7 +20,7 @@ from ._exceptions import (
     APITimeoutError,
     AssignmentTimeoutError,
 )
-from .job import AutoSubscribe, JobContext, JobExecutorType, JobProcess, JobRequest
+from .job import AutoSubscribe, JobContext, JobExecutorType, JobProcess, JobRequest, get_job_context
 from .llm.chat_context import (
     ChatContent,
     ChatContext,
@@ -55,6 +55,7 @@ __all__ = [
     "JobProcess",
     "JobContext",
     "JobRequest",
+    "get_job_context",
     "JobExecutorType",
     "AutoSubscribe",
     "AgentState",

--- a/livekit-agents/livekit/agents/__init__.py
+++ b/livekit-agents/livekit/agents/__init__.py
@@ -30,7 +30,7 @@ from .llm.chat_context import (
     FunctionCall,
     FunctionCallOutput,
 )
-from .llm.tool_context import function_tool
+from .llm.tool_context import FunctionTool, function_tool
 from .plugin import Plugin
 from .types import (
     DEFAULT_API_CONNECT_OPTIONS,
@@ -41,7 +41,7 @@ from .types import (
     NotGivenOr,
 )
 from .version import __version__
-from .voice import Agent, AgentEvent, AgentSession, RunContext, io
+from .voice import Agent, AgentEvent, AgentSession, ModelSettings, RunContext, io
 from .voice.background_audio import BackgroundAudio
 from .voice.room_io import RoomInputOptions, RoomIO, RoomOutputOptions
 from .worker import Worker, WorkerOptions, WorkerPermissions, WorkerType
@@ -59,6 +59,7 @@ __all__ = [
     "JobExecutorType",
     "AutoSubscribe",
     "AgentState",
+    "FunctionTool",
     "function_tool",
     "ChatContext",
     "ChatItem",
@@ -75,6 +76,7 @@ __all__ = [
     "Plugin",
     "AgentSession",
     "AgentEvent",
+    "ModelSettings",
     "Agent",
     "cli",
     "AssignmentTimeoutError",

--- a/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
@@ -29,7 +29,7 @@ from livekit import rtc
 
 from ..cli import cli
 from ..debug import tracing
-from ..job import JobContext, JobProcess, _JobContextVar, JobExecutorType
+from ..job import JobContext, JobExecutorType, JobProcess, _JobContextVar
 from ..log import logger
 from ..utils import aio, http_context, log_exceptions, shortuuid
 from .channel import Message

--- a/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
@@ -29,7 +29,7 @@ from livekit import rtc
 
 from ..cli import cli
 from ..debug import tracing
-from ..job import JobContext, JobProcess, _JobContextVar
+from ..job import JobContext, JobProcess, _JobContextVar, JobExecutorType
 from ..log import logger
 from ..utils import aio, http_context, log_exceptions, shortuuid
 from .channel import Message
@@ -59,7 +59,12 @@ class ProcStartArgs:
 def proc_main(args: ProcStartArgs) -> None:
     from .proc_client import _ProcClient
 
-    job_proc = _JobProc(args.initialize_process_fnc, args.job_entrypoint_fnc, args.user_arguments)
+    job_proc = _JobProc(
+        args.initialize_process_fnc,
+        args.job_entrypoint_fnc,
+        JobExecutorType.PROCESS,
+        args.user_arguments,
+    )
 
     client = _ProcClient(
         args.mp_cch,
@@ -124,11 +129,12 @@ class _JobProc:
         self,
         initialize_process_fnc: Callable[[JobProcess], Any],
         job_entrypoint_fnc: Callable[[JobContext], Any],
+        executor_type: JobExecutorType,
         user_arguments: Any | None = None,
     ) -> None:
         self._initialize_process_fnc = initialize_process_fnc
         self._job_entrypoint_fnc = job_entrypoint_fnc
-        self._job_proc = JobProcess(user_arguments=user_arguments)
+        self._job_proc = JobProcess(executor_type=executor_type, user_arguments=user_arguments)
         self._job_task: asyncio.Task | None = None
 
         # used to warn users if both connect and shutdown are not called inside the job_entry
@@ -328,7 +334,10 @@ def thread_main(
         from .proc_client import _ProcClient
 
         job_proc = _JobProc(
-            args.initialize_process_fnc, args.job_entrypoint_fnc, args.user_arguments
+            args.initialize_process_fnc,
+            args.job_entrypoint_fnc,
+            JobExecutorType.THREAD,
+            args.user_arguments,
         )
 
         client = _ProcClient(

--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -16,8 +16,8 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
-import logging
 import functools
+import logging
 import multiprocessing as mp
 from collections.abc import Coroutine
 from dataclasses import dataclass

--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -174,7 +174,7 @@ class JobContext:
         return self._room.local_participant
 
     @property
-    def log_fields(self) -> dict[str, Any]:
+    def log_context_fields(self) -> dict[str, Any]:
         """
         Returns the current dictionary of log fields that will be injected into log records.
 
@@ -182,12 +182,12 @@ class JobContext:
         worker ID, trace IDs, or other diagnostic context.
 
         The returned dictionary can be directly edited, or entirely replaced via assignment
-        (e.g., `job_context.log_fields = {...}`)
+        (e.g., `job_context.log_context_fields = {...}`)
         """
         return self._log_fields
 
-    @log_fields.setter
-    def log_fields(self, fields: dict[str, Any]) -> None:
+    @log_context_fields.setter
+    def log_context_fields(self, fields: dict[str, Any]) -> None:
         """
         Sets the log fields to be injected into future log records.
 

--- a/livekit-agents/livekit/agents/voice/__init__.py
+++ b/livekit-agents/livekit/agents/voice/__init__.py
@@ -1,4 +1,4 @@
-from .agent import Agent, InlineTask
+from .agent import Agent, InlineTask, ModelSettings
 from .agent_session import AgentSession
 from .chat_cli import ChatCLI
 from .events import (
@@ -18,6 +18,7 @@ __all__ = [
     "ChatCLI",
     "AgentSession",
     "Agent",
+    "ModelSettings",
     "InlineTask",
     "SpeechHandle",
     "RunContext",


### PR DESCRIPTION
This add a way to inject fields to every log (and is JobContext aware — also works for THREAD executor type).

Exposing the logger is going to be too hard for now, we have a quite opinionated approach with IPC 


handles https://github.com/livekit/agents/issues/1815 


will add the worker_id in another PR 