### PR TITLE
added new parameters and removed unused one in Speechmatics

### DIFF
--- a/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/types.py
+++ b/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/types.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 
 @dataclass
 class TranscriptionConfig:
-    """Real-time: Defines transcription parameters."""
+    """Real-time: Defines transcription parameters. See https://docs.speechmatics.com/rt-api-ref#transcription-config"""
 
     language: str = "en"
     """ISO 639-1 language code. eg. `en`"""
@@ -39,12 +39,15 @@ class TranscriptionConfig:
     entity. Fixed means that max_delay specified ignores any potential
     entity that would not be completed within that threshold."""
 
-    streaming_mode: Optional[bool] = None
-    """Indicates if we run the engine in streaming mode, or regular RT mode."""
-
     enable_partials: Optional[bool] = None
     """Indicates if partials for transcription, where words are produced
     immediately, is enabled."""
+
+    audio_filtering_config: Optional[dict] = None
+    """Puts a lower limit on the volume of processed audio by using the volume_threshold setting."""
+
+    transcript_filtering_config: Optional[dict] = None
+    """Removes disfluencies with the remove_disfluencies setting."""
 
     def asdict(self) -> dict[Any, Any]:
         """Returns model as a dict while excluding None values recursively."""


### PR DESCRIPTION
- Added two new options from their latest doc;
- Removed one that does not exist in the doc and caused issues in my testing.

Hi @dumitrugutu, just want to double-check with you on the `streaming_mode` flag. I couldn't find it in the latest [docs](https://docs.speechmatics.com/rt-api-ref#transcription-config), and whenever I enabled it, the plugin did not work. Do you have any ideas about this parameter/issue?

The issue message whenever streaming_mode is set to True:

```text
{"message": "failed to recognize speech, retrying in 0.1s\nTraceback (most recent call last):\n  File \"/Users/chenghao/Developer/ai-worker/.venv/lib/python3.12/site-packages/livekit/agents/stt/stt.py\", line 218, in _main_task\n    return await self._run()\n           ^^^^^^^^^^^^^^^^^\n  File \"/Users/chenghao/Developer/ai-worker/.venv/lib/python3.12/site-packages/livekit/plugins/speechmatics/stt.py\", line 230, in _run\n    task.result()\n  File \"/Users/chenghao/Developer/ai-worker/.venv/lib/python3.12/site-packages/livekit/plugins/speechmatics/stt.py\", line 202, in recv_task\n    raise APIStatusError(\nlivekit.agents._exceptions.APIStatusError: Speechmatics connection closed unexpectedly: WSMessage(type=<WSMsgType.CLOSE: 8>, data=1003, extra='protocol_error') (status_code=-1, request_id=None, body=None)", "level": "WARNING", "name": "livekit.agents", "tts": "livekit.plugins.speechmatics.stt.STT", "attempt": 0, "streamed": true, "pid": 43822, "job_id": "AJ_8DFwsbQM6SMw", "timestamp": "2025-04-02T10:37:50.514485+00:00"}
```