### PR TITLE
fix: add speech_endpoint to Azure STT and TTS class init for custom endpoint

### DIFF
--- a/.github/next-release/changeset-79b2e16a.md
+++ b/.github/next-release/changeset-79b2e16a.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-azure": patch
+---
+
+fix: add speech_endpoint to Azure STT and TTS class init for custom endpoint (#1884)

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
@@ -65,12 +65,15 @@ class STT(stt.STT):
         # Azure handles multiple languages and can auto-detect the language used. It requires the candidate set to be set.  # noqa: E501
         language: NotGivenOr[str | list[str] | None] = NOT_GIVEN,
         profanity: NotGivenOr[speechsdk.enums.ProfanityOption] = NOT_GIVEN,
+        speech_endpoint: NotGivenOr[str] = NOT_GIVEN,
     ):
         """
         Create a new instance of Azure STT.
 
         Either ``speech_host`` or ``speech_key`` and ``speech_region`` or
-        ``speech_auth_token`` and ``speech_region`` must be set using arguments.
+        ``speech_auth_token`` and ``speech_region`` or
+        ``speech_key`` and ``speech_endpoint``
+        must be set using arguments.
          Alternatively,  set the ``AZURE_SPEECH_HOST``, ``AZURE_SPEECH_KEY``
         and ``AZURE_SPEECH_REGION`` environmental variables, respectively.
         ``speech_auth_token`` must be set using the arguments as it's an ephemeral token.
@@ -96,9 +99,10 @@ class STT(stt.STT):
             is_given(speech_host)
             or (is_given(speech_key) and is_given(speech_region))
             or (is_given(speech_auth_token) and is_given(speech_region))
+            or (is_given(speech_key) and is_given(speech_endpoint))
         ):
             raise ValueError(
-                "AZURE_SPEECH_HOST or AZURE_SPEECH_KEY and AZURE_SPEECH_REGION or speech_auth_token and AZURE_SPEECH_REGION must be set"  # noqa: E501
+                "AZURE_SPEECH_HOST or AZURE_SPEECH_KEY and AZURE_SPEECH_REGION or speech_auth_token and AZURE_SPEECH_REGION or AZURE_SPEECH_KEY and speech_endpoint must be set"  # noqa: E501
             )
 
         self._config = STTOptions(
@@ -113,6 +117,7 @@ class STT(stt.STT):
             segmentation_max_time_ms=segmentation_max_time_ms,
             segmentation_strategy=segmentation_strategy,
             profanity=profanity,
+            speech_endpoint=speech_endpoint,
         )
         self._streams = weakref.WeakSet[SpeechStream]()
 

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
@@ -172,6 +172,7 @@ class TTS(tts.TTS):
         on_synthesizing_event: NotGivenOr[Callable] = NOT_GIVEN,
         on_viseme_event: NotGivenOr[Callable] = NOT_GIVEN,
         on_word_boundary_event: NotGivenOr[Callable] = NOT_GIVEN,
+        speech_endpoint: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
         """
         Create a new instance of Azure TTS.
@@ -209,9 +210,10 @@ class TTS(tts.TTS):
             is_given(speech_host)
             or (is_given(speech_key) and is_given(speech_region))
             or (is_given(speech_auth_token) and is_given(speech_region))
+            or (is_given(speech_key) and is_given(speech_endpoint))
         ):
             raise ValueError(
-                "AZURE_SPEECH_HOST or AZURE_SPEECH_KEY and AZURE_SPEECH_REGION or speech_auth_token and AZURE_SPEECH_REGION must be set"  # noqa: E501
+                "AZURE_SPEECH_HOST or AZURE_SPEECH_KEY and AZURE_SPEECH_REGION or speech_auth_token and AZURE_SPEECH_REGION or AZURE_SPEECH_KEY and speech_endpoint must be set"  # noqa: E501
             )
 
         if is_given(prosody):
@@ -238,6 +240,7 @@ class TTS(tts.TTS):
             on_synthesizing_event=on_synthesizing_event,
             on_viseme_event=on_viseme_event,
             on_word_boundary_event=on_word_boundary_event,
+            speech_endpoint=speech_endpoint,
         )
 
     def update_options(


### PR DESCRIPTION
We faced issues when attempting to pass a custom speech endpoint to the STT and TTS classes. Upon investigation, we discovered that the custom endpoint was not being passed to the __init__ method of these classes.

When the changes in PR #1362  were merged, the speech_endpoint property was introduced but was not integrated into the following areas:
- It was not added as a parameter in the __init__ method of the Azure STT and TTS classes.
- It was not included in the configuration (_config variables), which is required to pass it to the Azure SpeechConfig class.

This resulted in speech_endpoint being unavailable for usage in custom speech service configurations.