### PR TITLE
Add Deepgram keyterms validataion

### DIFF
--- a/.github/next-release/changeset-5f2df41d.md
+++ b/.github/next-release/changeset-5f2df41d.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-deepgram": patch
+---
+
+Add Deepgram keyterms and keywords validataion (#1898)

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -793,20 +793,18 @@ def _validate_keyterms(
     See: https://developers.deepgram.com/docs/keyterm and https://developers.deepgram.com/docs/keywords
     """
     if model.startswith("nova-3") and is_given(keywords):
-        logger.warning(
+        raise ValueError(
             "Keywords is only available for use with Nova-2, Nova-1, Enhanced, and "
             "Base speech to text models. For Nova-3, use Keyterm Prompting."
         )
-        return keyterms, NOT_GIVEN
 
     if is_given(keyterms) and (
         (model.startswith("nova-3") and language not in ("en-US", "en"))
         or not model.startswith("nova-3")
     ):
-        logger.warning(
+        raise ValueError(
             "Keyterm Prompting is only available for English transcription using the Nova-3 Model. "
             "To boost recognition of keywords using another model, use the Keywords feature."
         )
-        return NOT_GIVEN, keywords
 
     return keyterms, keywords

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -184,7 +184,7 @@ class STT(stt.STT):
             raise ValueError("Deepgram API key is required")
 
         model = _validate_model(model, language)
-        keyterms, keywords = _validate_keyterms(model, language, keyterms, keywords)
+        _validate_keyterms(model, language, keyterms, keywords)
 
         self._opts = STTOptions(
             language=language,
@@ -784,10 +784,7 @@ def _validate_keyterms(
     language: NotGivenOr[DeepgramLanguages | str],
     keyterms: NotGivenOr[list[str]],
     keywords: NotGivenOr[list[tuple[str, float]]],
-) -> tuple[
-    NotGivenOr[list[str]],
-    NotGivenOr[list[tuple[str, float]]],
-]:
+) -> None:
     """
     Validating keyterms and keywords for model compatibility.
     See: https://developers.deepgram.com/docs/keyterm and https://developers.deepgram.com/docs/keywords
@@ -806,5 +803,3 @@ def _validate_keyterms(
             "Keyterm Prompting is only available for English transcription using the Nova-3 Model. "
             "To boost recognition of keywords using another model, use the Keywords feature."
         )
-
-    return keyterms, keywords

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -788,6 +788,10 @@ def _validate_keyterms(
     NotGivenOr[list[str]],
     NotGivenOr[list[tuple[str, float]]],
 ]:
+    """
+    Validating keyterms and keywords for model compatibility.
+    See: https://developers.deepgram.com/docs/keyterm and https://developers.deepgram.com/docs/keywords
+    """
     if model.startswith("nova-3") and is_given(keywords):
         logger.warning(
             "Keywords is only available for use with Nova-2, Nova-1, Enhanced, and "
@@ -795,13 +799,10 @@ def _validate_keyterms(
         )
         return keyterms, NOT_GIVEN
 
-    if model.startswith("nova-3") and language not in ("en-US", "en") and is_given(keyterms):
-        logger.warning(
-            "Keyterm Prompting is only available for English transcription using the Nova-3 Model."
-        )
-        return NOT_GIVEN, keywords
-
-    if not model.startswith("nova-3") and is_given(keyterms):
+    if is_given(keyterms) and (
+        (model.startswith("nova-3") and language not in ("en-US", "en"))
+        or not model.startswith("nova-3")
+    ):
         logger.warning(
             "Keyterm Prompting is only available for English transcription using the Nova-3 Model. "
             "To boost recognition of keywords using another model, use the Keywords feature."


### PR DESCRIPTION
This address the second issue mentioned in #1887 

Reference docs: 
- https://developers.deepgram.com/docs/keywords
- https://developers.deepgram.com/docs/keyterm

TL;DR
keyterms only work with Nova-3 in English;
keywords work with other models;