### PR TITLE
add Deepgram multi support

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/models.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/models.py
@@ -77,4 +77,5 @@ DeepgramLanguages = Literal[
     "pt-BR",
     "ru",
     "th",
+    "multi",
 ]

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -775,4 +775,22 @@ def _validate_model(
             f"{model} does not support language {language}, falling back to nova-2-general"
         )
         return "nova-2-general"
+
+    # see https://developers.deepgram.com/docs/multilingual-code-switching
+    if (
+        is_given(language)
+        and language == "multi"
+        and model
+        not in {
+            "nova-3",
+            "nova-3-general",
+            "nova-2",
+            "nova-2-general",
+        }
+    ):
+        logger.warning(
+            f"{model} does not support multilingual code-switching, falling back to nova-3-general"
+        )
+        return "nova-3-general"
+
     return model


### PR DESCRIPTION
Addressing the first issue mentioned in #1887 

Reference: https://developers.deepgram.com/docs/multilingual-code-switching

- Added the "multi" language and a check for compatibility.