### PR TITLE
Deepgram Nova-3 multi-language support

### DIFF
--- a/.github/next-release/changeset-65b3292c.md
+++ b/.github/next-release/changeset-65b3292c.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-deepgram": patch
+---
+
+Deepgram Nova-3 multi-language support (#1923)

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -779,9 +779,6 @@ def _validate_model(
         "nova-2-medical",
         "nova-2-drivethru",
         "nova-2-automotive",
-        # nova-3 will support more languages, but english-only for now
-        "nova-3",
-        "nova-3-general",
     }
     if is_given(language) and language not in ("en-US", "en") and model in en_only_models:
         logger.warning(


### PR DESCRIPTION
## Context

Nova-3 already supports multi-language, as you can see here: https://deepgram.com/learn/introducing-nova-3-speech-to-text-api

> Nova-3 is the first voice AI model to offer real-time multilingual transcription.

But, if you tried with a configuration like this one:
```python
    deepgram_stt = deepgram.STT(
        model='nova-3',
        language='multi',
    )
```

You will receive this error in the logs and it will switch back to `nova-2`:

![image](https://github.com/user-attachments/assets/67ceb393-a78e-43aa-85c2-6284d9773f95)

## JBTD

So remove the `nova-3` model from the English-only Deepgram models.

