### PR TITLE
allow to edit the chat_ctx inside on_user_turn_completed

### DIFF
--- a/examples/voice_agents/push_to_talk.py
+++ b/examples/voice_agents/push_to_talk.py
@@ -28,7 +28,7 @@ class MyAgent(Agent):
             # llm=openai.realtime.RealtimeModel(voice="alloy", turn_detection=None),
         )
 
-    async def on_user_turn_completed(self, chat_ctx: ChatContext, new_message: ChatMessage) -> None:
+    async def on_user_turn_completed(self, turn_ctx: ChatContext, new_message: ChatMessage) -> None:
         # callback before generating a reply after user turn committed
         if not new_message.text_content:
             # for example, raise StopResponse to stop the agent from generating a reply

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -254,7 +254,7 @@ class Agent:
         pass
 
     async def on_user_turn_completed(
-        self, chat_ctx: llm.ChatContext, new_message: llm.ChatMessage
+        self, turn_ctx: llm.ChatContext, new_message: llm.ChatMessage
     ) -> None:
         """Called when the user has finished speaking, and the LLM is about to respond
 

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -364,19 +364,25 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         if self._activity is None:
             raise RuntimeError("AgentSession isn't running")
 
+        user_message = (
+            llm.ChatMessage(role="user", content=[user_input])
+            if is_given(user_input)
+            else NOT_GIVEN
+        )
+
         if self._activity.draining:
             if self._next_activity is None:
                 raise RuntimeError("AgentSession is closing, cannot use generate_reply()")
 
             return self._next_activity.generate_reply(
-                user_input=user_input,
+                user_message=user_message,
                 instructions=instructions,
                 tool_choice=tool_choice,
                 allow_interruptions=allow_interruptions,
             )
 
         return self._activity.generate_reply(
-            user_input=user_input,
+            user_message=user_message,
             instructions=instructions,
             tool_choice=tool_choice,
             allow_interruptions=allow_interruptions,


### PR DESCRIPTION
- This is currently only implemented for the stateless LLM, this will require more work for the Realtime models (We will need to hash each message, and find the differences to update to the OpenAI server)
- The changes made to the chat_ctx are only for the current turn, they're not preserved inside the Agent.chat_ctx (Only the new user message will be kept) 