### PR TITLE
Avoid session end deepgram errors

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -539,7 +539,9 @@ class SpeechStream(stt.SpeechStream):
                     aiohttp.WSMsgType.CLOSE,
                     aiohttp.WSMsgType.CLOSING,
                 ):
-                    if closing_ws:  # close is expected, see SpeechStream.aclose
+                    # close is expected, see SpeechStream.aclose
+                    # or when the agent session ends, the http session is closed
+                    if closing_ws or self._session.closed:
                         return
 
                     # this will trigger a reconnection, see the _run loop


### PR DESCRIPTION
Previously, when a call ends, we got `raise APIStatusError(message="deepgram connection closed unexpectedly")`.

Interestingly, it happens with 
* self hosted ws DG endpoints
* ws proxy + wss deepgram cloud endpoints
but not wss deep cloud endpoints.

I found when that happens, the client session is already gone. This is to avoid such exceptions.
Tested with fallback as well, a connectivity issue will not cause client session closed, so fallback continue works.

Please feel free to let me know if you have better ideas. @longcw 