### PR TITLE
fix tool format when there is messages between tool call and output

### DIFF
--- a/.github/next-release/changeset-9bd9e220.md
+++ b/.github/next-release/changeset-9bd9e220.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-openai": patch
+---
+
+fix tool format when there is messages between tool call and output (#1977)

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/utils.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/utils.py
@@ -4,9 +4,11 @@ import base64
 import os
 from collections import OrderedDict
 from collections.abc import Awaitable
+from dataclasses import dataclass, field
 from typing import Any, Callable, Union
 
 from livekit.agents import llm
+from livekit.agents.log import logger
 from openai.types.chat import (
     ChatCompletionContentPartParam,
     ChatCompletionMessageParam,
@@ -26,41 +28,106 @@ def to_fnc_ctx(fnc_ctx: list[llm.FunctionTool]) -> list[ChatCompletionToolParam]
     return [llm.utils.build_strict_openai_schema(fnc) for fnc in fnc_ctx]
 
 
+@dataclass
+class _ChatItemGroup:
+    message: llm.ChatMessage | None = None
+    tool_calls: list[llm.FunctionCall] = field(default_factory=list)
+    tool_outputs: list[llm.FunctionCallOutput] = field(default_factory=list)
+
+    def add(self, item: llm.ChatItem) -> _ChatItemGroup:
+        if item.type == "message":
+            assert self.message is None, "only one message is allowed in a group"
+            self.message = item
+        elif item.type == "function_call":
+            self.tool_calls.append(item)
+        elif item.type == "function_call_output":
+            self.tool_outputs.append(item)
+        return self
+
+    def to_chat_items(self, cache_key: Any) -> list[ChatCompletionMessageParam]:
+        tool_calls = {tool_call.call_id: tool_call for tool_call in self.tool_calls}
+        tool_outputs = {tool_output.call_id: tool_output for tool_output in self.tool_outputs}
+
+        valid_tools = set(tool_calls.keys()) & set(tool_outputs.keys())
+        # remove invalid tool calls and tool outputs
+        if len(tool_calls) != len(valid_tools) or len(tool_outputs) != len(valid_tools):
+            for tool_call in self.tool_calls:
+                if tool_call.call_id not in valid_tools:
+                    logger.warning(
+                        "function call missing the corresponding function output, ignoring",
+                        extra={"call_id": tool_call.call_id, "tool_name": tool_call.name},
+                    )
+                    tool_calls.pop(tool_call.call_id)
+
+            for tool_output in self.tool_outputs:
+                if tool_output.call_id not in valid_tools:
+                    logger.warning(
+                        "function output missing the corresponding function call, ignoring",
+                        extra={"call_id": tool_output.call_id, "tool_name": tool_output.name},
+                    )
+                    tool_outputs.pop(tool_output.call_id)
+
+        if not self.message and not tool_calls and not tool_outputs:
+            return []
+
+        msg = (
+            _to_chat_item(self.message, cache_key)
+            if self.message
+            else {"role": "assistant", "tool_calls": []}
+        )
+        if tool_calls:
+            msg.setdefault("tool_calls", [])
+        for tool_call in tool_calls.values():
+            msg["tool_calls"].append(
+                {
+                    "id": tool_call.call_id,
+                    "type": "function",
+                    "function": {"name": tool_call.name, "arguments": tool_call.arguments},
+                }
+            )
+        items = [msg]
+        for tool_output in tool_outputs.values():
+            items.append(_to_chat_item(tool_output, cache_key))
+        return items
+
+
 def to_chat_ctx(chat_ctx: llm.ChatContext, cache_key: Any) -> list[ChatCompletionMessageParam]:
-    # group the message and function_calls
-    item_groups: dict[str, list[llm.ChatItem]] = OrderedDict()
+    # OAI requires the tool calls to be followed by the corresponding tool outputs
+    # we group them first and remove invalid tool calls and outputs before converting
+
+    item_groups: dict[str, _ChatItemGroup] = OrderedDict()  # item_id to group of items
+    tool_outputs: list[llm.FunctionCallOutput] = []
     for item in chat_ctx.items:
         if (item.type == "message" and item.role == "assistant") or item.type == "function_call":
+            # only assistant messages and function calls can be grouped
             group_id = item.id.split("/")[0]
             if group_id not in item_groups:
-                item_groups[group_id] = []
-            item_groups[group_id].append(item)
+                item_groups[group_id] = _ChatItemGroup().add(item)
+            else:
+                item_groups[group_id].add(item)
+        elif item.type == "function_call_output":
+            tool_outputs.append(item)
         else:
-            item_groups[item.id] = [item]
+            item_groups[item.id] = _ChatItemGroup().add(item)
 
-    return [_group_to_chat_item(items, cache_key) for items in item_groups.values()]
+    # add tool outputs to their corresponding groups
+    call_id_to_group: dict[str, _ChatItemGroup] = {
+        tool_call.call_id: group for group in item_groups.values() for tool_call in group.tool_calls
+    }
+    for tool_output in tool_outputs:
+        if tool_output.call_id not in call_id_to_group:
+            logger.warning(
+                "function output missing the corresponding function call, ignoring",
+                extra={"call_id": tool_output.call_id, "tool_name": tool_output.name},
+            )
+            continue
 
+        call_id_to_group[tool_output.call_id].add(tool_output)
 
-def _group_to_chat_item(items: list[llm.ChatItem], cache_key: Any) -> ChatCompletionMessageParam:
-    if len(items) == 1:
-        return _to_chat_item(items[0], cache_key)
-    else:
-        msg = {"role": "assistant", "tool_calls": []}
-        for item in items:
-            if item.type == "message":
-                assert item.role == "assistant", "only assistant messages can be grouped"
-                assert "content" not in msg, "only one assistant message is allowed in a group"
-
-                msg.update(_to_chat_item(item, cache_key))
-            elif item.type == "function_call":
-                msg["tool_calls"].append(
-                    {
-                        "id": item.call_id,
-                        "type": "function",
-                        "function": {"name": item.name, "arguments": item.arguments},
-                    }
-                )
-        return msg
+    messages = []
+    for group in item_groups.values():
+        messages.extend(group.to_chat_items(cache_key))
+    return messages
 
 
 def _to_chat_item(msg: llm.ChatItem, cache_key: Any) -> ChatCompletionMessageParam:


### PR DESCRIPTION
OpenAI requires the tool call messages followed by the corresponding tool outputs, if there is a text message alongside the tool calls, we group the tool calls to the item of the message, there may be other conversation messages added between the tool calls and tool outputs causing the error

```python
 ChatMessage(id='item_b3da83a73067', type='message', role='user', content=["What's the weather in Chicago today?"], interrupted=False, hash=None),
 ChatMessage(id='item_6d8477a9f505', type='message', role='assistant', content=['I will now check the weather in Chicago for today. Please hold on for a moment.'], interrupted=False, hash=None),
 ChatMessage(id='item_7a6b787c7a51', type='message', role='user', content=['Tell me a joke.'], interrupted=False, hash=None),
 ChatMessage(id='item_f809f37e94de', type='message', role='assistant', content=["Why don't skeletons fight each other? They don't have the guts!"], interrupted=False, hash=None),
 FunctionCall(id='item_6d8477a9f505/fnc_0', type='function_call', call_id='call_pD6HsRnMpg3Q4P13rzuDrZ9X', arguments='{}', name='get_weather_today'),
 FunctionCallOutput(id='item_4c930c3e7349', name='get_weather_today', type='function_call_output', call_id='call_pD6HsRnMpg3Q4P13rzuDrZ9X', output='The weather is sunny today.', is_error=False),
 ChatMessage(id='item_a2f401979733', type='message', role='assistant', content=['The weather in Chicago today is sunny. Enjoy the sunshine! If you need more information or another update, feel free to ask.'], interrupted=False, hash=None),
 ChatMessage(id='item_aff1ce355c4e', type='message', role='user', content=["What's your name?"], interrupted=False, hash=None)]
```