### PR TITLE
🛠 Fix: Properly retrieve exceptions after graceful task cancellation

### DIFF
--- a/.github/next-release/changeset-23d9c87a.md
+++ b/.github/next-release/changeset-23d9c87a.md
@@ -2,4 +2,4 @@
 "livekit-agents": patch
 ---
 
-🛠 Fix: Properly retrieve exceptions after graceful task cancellation (#1991)
+Fix: Properly retrieve exceptions after graceful task cancellation (#1991)

--- a/.github/next-release/changeset-23d9c87a.md
+++ b/.github/next-release/changeset-23d9c87a.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+🛠 Fix: Properly retrieve exceptions after graceful task cancellation (#1991)

--- a/livekit-agents/livekit/agents/utils/aio/utils.py
+++ b/livekit-agents/livekit/agents/utils/aio/utils.py
@@ -29,6 +29,7 @@ async def cancel_and_wait(*futures: asyncio.Future):
                 except Exception:
                     pass  # Exception already retrieved or not present
 
+
 def _release_waiter(waiter, *_):
     if not waiter.done():
         waiter.set_result(None)

--- a/livekit-agents/livekit/agents/utils/aio/utils.py
+++ b/livekit-agents/livekit/agents/utils/aio/utils.py
@@ -21,6 +21,13 @@ async def cancel_and_wait(*futures: asyncio.Future):
             _, cb = waiters[i]
             fut.remove_done_callback(cb)
 
+        # ✅ NEW: Safely retrieve exceptions to silence warnings
+        for fut in futures:
+            if fut.done():
+                try:
+                    _ = fut.exception()
+                except Exception:
+                    pass  # Exception already retrieved or not present
 
 def _release_waiter(waiter, *_):
     if not waiter.done():


### PR DESCRIPTION
### Summary

This PR improves the `gracefully_cancel` (now called `cancel_and_wait`) function by ensuring that exceptions from cancelled or completed tasks are explicitly retrieved. This prevents `asyncio` from logging warnings like:

```
_GatheringFuture exception was never retrieved
future: <_GatheringFuture finished exception=CancelledError()>
```

### Root Cause

Previously, `gracefully_cancel`:
- Cancelled tasks
- Waited for their completion via internal waiters
- **Did not retrieve `.exception()` from the tasks**

When `asyncio.gather()` is used, it returns a `_GatheringFuture`, which wraps multiple tasks. If the gathered task is cancelled or raises an exception and that exception is never accessed, `asyncio` logs a warning — even if the tasks are awaited indirectly.

### Fix

After all futures are awaited, we now iterate over each future:
- Call `fut.exception()` to mark the exception as retrieved

### Example

Previously:
```python
await gracefully_cancel(*tasks)
# Logs: _GatheringFuture exception was never retrieved
```

Now:
```python
await gracefully_cancel(*tasks)
# No warning – all exceptions are properly retrieved
```

### Impact

- Silences unwanted `_GatheringFuture` warnings in normal cancellation flows
- Improves robustness and clarity during shutdown
- No behavioral change to existing application logic