### PR TITLE
feat: enhance openai LLM metrics to include cached prompt tokens

### DIFF
--- a/.github/next-release/changeset-b2ba978e.md
+++ b/.github/next-release/changeset-b2ba978e.md
@@ -1,0 +1,6 @@
+---
+"livekit-agents": patch
+"livekit-plugins-openai": patch
+---
+
+feat: enhance openai LLM metrics to include cached prompt tokens (#1998)

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -29,6 +29,7 @@ from .tool_context import FunctionTool, ToolChoice
 class CompletionUsage(BaseModel):
     completion_tokens: int
     prompt_tokens: int
+    prompt_cached_tokens: int = 0
     cache_creation_tokens: int = 0
     cache_read_tokens: int = 0
     total_tokens: int
@@ -201,6 +202,7 @@ class LLMStream(ABC):
             label=self._llm._label,
             completion_tokens=usage.completion_tokens if usage else 0,
             prompt_tokens=usage.prompt_tokens if usage else 0,
+            cached_prompt_tokens=usage.prompt_cached_tokens if usage else 0,
             total_tokens=usage.total_tokens if usage else 0,
             tokens_per_second=usage.completion_tokens / duration if usage else 0.0,
         )

--- a/livekit-agents/livekit/agents/metrics/base.py
+++ b/livekit-agents/livekit/agents/metrics/base.py
@@ -15,6 +15,7 @@ class LLMMetrics(BaseModel):
     cancelled: bool
     completion_tokens: int
     prompt_tokens: int
+    cached_prompt_tokens: int
     total_tokens: int
     tokens_per_second: float
     speech_id: str | None = None

--- a/livekit-agents/livekit/agents/metrics/usage_collector.py
+++ b/livekit-agents/livekit/agents/metrics/usage_collector.py
@@ -7,6 +7,7 @@ from .base import AgentMetrics, LLMMetrics, STTMetrics, TTSMetrics
 @dataclass
 class UsageSummary:
     llm_prompt_tokens: int
+    llm_cached_prompt_tokens: int
     llm_completion_tokens: int
     tts_characters_count: int
     stt_audio_duration: float
@@ -14,7 +15,7 @@ class UsageSummary:
 
 class UsageCollector:
     def __init__(self) -> None:
-        self._summary = UsageSummary(0, 0, 0, 0.0)
+        self._summary = UsageSummary(0, 0, 0, 0, 0.0)
 
     def __call__(self, metrics: AgentMetrics) -> None:
         self.collect(metrics)
@@ -22,6 +23,7 @@ class UsageCollector:
     def collect(self, metrics: AgentMetrics) -> None:
         if isinstance(metrics, LLMMetrics):
             self._summary.llm_prompt_tokens += metrics.prompt_tokens
+            self._summary.llm_cached_prompt_tokens += metrics.cached_prompt_tokens
             self._summary.llm_completion_tokens += metrics.completion_tokens
 
         elif isinstance(metrics, TTSMetrics):

--- a/livekit-agents/livekit/agents/metrics/utils.py
+++ b/livekit-agents/livekit/agents/metrics/utils.py
@@ -12,7 +12,7 @@ def log_metrics(metrics: AgentMetrics, *, logger: logging.Logger | None = None):
 
     if isinstance(metrics, LLMMetrics):
         logger.info(
-            f"LLM metrics: ttft={metrics.ttft:.2f}, input_tokens={metrics.prompt_tokens}, output_tokens={metrics.completion_tokens}, tokens_per_second={metrics.tokens_per_second:.2f}"  # noqa: E501
+            f"LLM metrics: ttft={metrics.ttft:.2f}, input_tokens={metrics.prompt_tokens},  cached_input_tokens={metrics.cached_prompt_tokens}, output_tokens={metrics.completion_tokens}, tokens_per_second={metrics.tokens_per_second:.2f}"  # noqa: E501
         )
     elif isinstance(metrics, TTSMetrics):
         logger.info(

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -588,6 +588,9 @@ class LLMStream(llm.LLMStream):
                             usage=llm.CompletionUsage(
                                 completion_tokens=chunk.usage.completion_tokens,
                                 prompt_tokens=chunk.usage.prompt_tokens,
+                                prompt_cached_tokens=chunk.usage.prompt_tokens_details.cached_tokens
+                                if chunk.usage.prompt_tokens_details
+                                else 0,
                                 total_tokens=chunk.usage.total_tokens,
                             ),
                         )


### PR DESCRIPTION
This PR adds support for tracking cached prompt tokens when using the OpenAI LLM.
This helps accurately calculate costs, as OpenAI offers a discount for cached input tokens.
More information: [Prompt Caching - OpenAI Docs](https://platform.openai.com/docs/guides/prompt-caching#what-can-be-cached)

Example log output:

```
2025-04-14 23:00:02,367 - INFO livekit.agents - LLM metrics: ttft=0.68, input_tokens=2086,  cached_input_tokens=1664, output_tokens=16, tokens_per_second=18.31 {"room": "playground-Ktdz-LIdp", "user_id": "your user_id", "pid": 75018, "job_id": "AJ_AYcqXfTmJrir"}
```

```
2025-04-14 23:33:41,638 - INFO basic-agent - Usage: UsageSummary(llm_prompt_tokens=15914, llm_cached_prompt_tokens=9728, llm_completion_tokens=270, tts_characters_count=773, stt_audio_duration=85.49999999999983) {"room": "playground-R9wb-fmOf", "user_id": "your user_id", "pid": 87721, "job_id": "AJ_sJz4QrvhE3R6"}
```