### PR TITLE
Add new OpenAI models to ChatModels

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -18,6 +18,9 @@ TTSVoices = Literal[
 ]
 DalleModels = Literal["dall-e-2", "dall-e-3"]
 ChatModels = Literal[
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4.1-nano",
     "gpt-4o",
     "gpt-4o-2024-05-13",
     "gpt-4o-mini",


### PR DESCRIPTION
List new OpenAI 4.1-series models released today via the API in ChatModels