### PR TITLE
Fix dangling websocket connections

### DIFF
--- a/.github/next-release/changeset-d1555002.md
+++ b/.github/next-release/changeset-d1555002.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Fix dangling websocket connections (#2027)

--- a/livekit-agents/livekit/agents/utils/connection_pool.py
+++ b/livekit-agents/livekit/agents/utils/connection_pool.py
@@ -76,7 +76,7 @@ class ConnectionPool(Generic[T]):
         conn = await self.get()
         try:
             yield conn
-        except Exception:
+        except BaseException:
             self.remove(conn)
             raise
         else:


### PR DESCRIPTION
This should address #2010 

In my testing, errors like `asyncio.CancelledError` are not captured (siblings of Exception) and have led to multiple dangling websocket connections (present in `_connections`, but not in `_available` or `_to_close`

change made to print out related issues
<img width="580" alt="image" src="https://github.com/user-attachments/assets/73191a09-9ab2-4736-9172-5b7e239023bb" />

```
Connection context manager except block: CancelledError
Traceback (most recent call last):
  File "/Users/chenghao/Developer/ai-worker/.venv/lib/python3.12/site-packages/livekit/agents/utils/connection_pool.py", line 78, in connection
    yield conn
  File "/Users/chenghao/Developer/ai-worker/.venv/lib/python3.12/site-packages/livekit/plugins/cartesia/tts.py", line 381, in _run
    await asyncio.gather(*tasks)
  File "/Users/chenghao/Developer/ai-worker/.venv/lib/python3.12/site-packages/livekit/plugins/cartesia/tts.py", line 322, in _input_task
    async for data in self._input_ch:
  File "/Users/chenghao/Developer/ai-worker/.venv/lib/python3.12/site-packages/livekit/agents/utils/aio/channel.py", line 176, in __anext__
    return await self.recv()
           ^^^^^^^^^^^^^^^^^
  File "/Users/chenghao/Developer/ai-worker/.venv/lib/python3.12/site-packages/livekit/agents/utils/aio/channel.py", line 106, in recv
    await g
asyncio.exceptions.CancelledError
Connection: <aiohttp.client_ws.ClientWebSocketResponse object at 0x164ac61b0>, at 1744883769.559446
Connection: <aiohttp.client_ws.ClientWebSocketResponse object at 0x164bd7c80>, at 1744883774.7242858
Connection context manager finally block
Connection: <aiohttp.client_ws.ClientWebSocketResponse object at 0x164ac61b0>, at 1744883769.559446
Connection: <aiohttp.client_ws.ClientWebSocketResponse object at 0x164bd7c80>, at 1744883774.7242858
```