### PR TITLE
avoid duplicate room io initialization

### DIFF
--- a/.github/next-release/changeset-5e7650bc.md
+++ b/.github/next-release/changeset-5e7650bc.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+avoid duplicate room io initialization (#2037)

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -221,7 +221,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 chat_cli = ChatCLI(self)
                 await chat_cli.start()
 
-            elif is_given(room):
+            elif is_given(room) and not self._room_io:
                 room_input_options = copy.deepcopy(room_input_options)
                 room_output_options = copy.deepcopy(room_output_options)
 
@@ -264,7 +264,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 await self._room_io.start()
 
             else:
-                if not self.output.audio and not self.output.transcription:
+                if not self._room_io and not self.output.audio and not self.output.transcription:
                     logger.warning(
                         "session starts without output, forgetting to pass `room` to `AgentSession.start()`?"  # noqa: E501
                     )

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -112,7 +112,12 @@ class RoomIO:
             self._on_participant_connected(participant)
 
         if self._input_options.text_enabled:
-            self._room.register_text_stream_handler(TOPIC_CHAT, self._on_user_text_input)
+            try:
+                self._room.register_text_stream_handler(TOPIC_CHAT, self._on_user_text_input)
+            except ValueError:
+                logger.warning(
+                    f"text stream handler for topic '{TOPIC_CHAT}' already set, ignoring"
+                )
 
         if self._input_options.video_enabled:
             self._video_input = _ParticipantVideoInputStream(self._room)
@@ -191,6 +196,7 @@ class RoomIO:
 
         self._agent_session.on("agent_state_changed", self._on_agent_state_changed)
         self._agent_session.on("user_input_transcribed", self._on_user_input_transcribed)
+        self._agent_session._room_io = self
 
     async def aclose(self) -> None:
         self._room.off("participant_connected", self._on_participant_connected)


### PR DESCRIPTION
to avoid error when RoomIO already created explicitly
```python
    room_io = RoomIO(session, room=ctx.room)
    await room_io.start()
    await session.start(
        agent=..., room=ctx.room
    )
```