### PR TITLE
Sequential Interruption Handling

### DIFF
--- a/.github/next-release/changeset-5b8490a6.md
+++ b/.github/next-release/changeset-5b8490a6.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Sequential Interruption Handling (#2038)

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -809,6 +809,10 @@ class AgentActivity(RecognitionHooks):
         # the user can edit it for the current generation, but changes will not be kept inside the
         # Agent.chat_ctx
         temp_mutable_chat_ctx = self._agent.chat_ctx.copy()
+        if self._session._interruption_handling == "sequential" and self._current_speech is not None:
+                await self._current_speech.wait_for_playout()
+
+        user_message = llm.ChatMessage(role="user", content=[new_transcript])
         start_time = time.time()
         try:
             await self._agent.on_user_turn_completed(

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -44,6 +44,9 @@ class VoiceOptions:
 Userdata_T = TypeVar("Userdata_T")
 
 TurnDetectionMode = Union[Literal["stt", "vad", "realtime_llm", "manual"], _TurnDetector]
+
+InterruptionHandlingMode = Literal["parallel", "sequential"]
+
 """
 The mode of turn detection to use.
 
@@ -70,6 +73,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         tts: NotGivenOr[tts.TTS] = NOT_GIVEN,
         userdata: NotGivenOr[Userdata_T] = NOT_GIVEN,
         allow_interruptions: bool = True,
+        interruption_handling: InterruptionHandlingMode = "parallel",
         discard_audio_if_uninterruptible: bool = True,
         min_interruption_duration: float = 0.5,
         min_endpointing_delay: float = 0.5,
@@ -121,6 +125,8 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         self._userdata: Userdata_T | None = userdata if is_given(userdata) else None
         self._closing_task: asyncio.Task | None = None
+
+        self._interruption_handling = interruption_handling
 
     @property
     def userdata(self) -> Userdata_T:

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import httpx
 from langfuse import openai
+from langfuse.openai import AsyncOpenAI
 
 from livekit.agents import APIConnectionError, APIStatusError, APITimeoutError, llm
 from livekit.agents.llm import ToolChoice, utils as llm_utils
@@ -71,7 +72,7 @@ class LLM(llm.LLM):
         model: str | ChatModels = "gpt-4o",
         api_key: NotGivenOr[str] = NOT_GIVEN,
         base_url: NotGivenOr[str] = NOT_GIVEN,
-        client: openai.AsyncClient | None = None,
+        client: AsyncOpenAI | None = None,
         user: NotGivenOr[str] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
@@ -96,7 +97,7 @@ class LLM(llm.LLM):
             store=store,
             metadata=metadata,
         )
-        self._client = client or openai.AsyncClient(
+        self._client = client or AsyncOpenAI(
             api_key=api_key if is_given(api_key) else None,
             base_url=base_url if is_given(base_url) else None,
             max_retries=0,
@@ -173,7 +174,7 @@ class LLM(llm.LLM):
         model: str | CerebrasChatModels = "llama3.1-8b",
         api_key: str | None = None,
         base_url: str = "https://api.cerebras.ai/v1",
-        client: openai.AsyncClient | None = None,
+        client: AsyncOpenAI | None = None,
         user: NotGivenOr[str] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
@@ -210,7 +211,7 @@ class LLM(llm.LLM):
         model: str = "accounts/fireworks/models/llama-v3p3-70b-instruct",
         api_key: str | None = None,
         base_url: str = "https://api.fireworks.ai/inference/v1",
-        client: openai.AsyncClient | None = None,
+        client: AsyncOpenAI | None = None,
         user: NotGivenOr[str] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
@@ -246,7 +247,7 @@ class LLM(llm.LLM):
         model: str | XAIChatModels = "grok-2-public",
         api_key: str | None = None,
         base_url: str = "https://api.x.ai/v1",
-        client: openai.AsyncClient | None = None,
+        client: AsyncOpenAI | None = None,
         user: NotGivenOr[str] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
@@ -281,7 +282,7 @@ class LLM(llm.LLM):
         model: str | DeepSeekChatModels = "deepseek-chat",
         api_key: str | None = None,
         base_url: str = "https://api.deepseek.com/v1",
-        client: openai.AsyncClient | None = None,
+        client: AsyncOpenAI | None = None,
         user: NotGivenOr[str] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
@@ -317,7 +318,7 @@ class LLM(llm.LLM):
         model: str | OctoChatModels = "llama-2-13b-chat",
         api_key: str | None = None,
         base_url: str = "https://text.octoai.run/v1",
-        client: openai.AsyncClient | None = None,
+        client: AsyncOpenAI | None = None,
         user: NotGivenOr[str] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
@@ -352,7 +353,7 @@ class LLM(llm.LLM):
         *,
         model: str = "llama3.1",
         base_url: str = "http://localhost:11434/v1",
-        client: openai.AsyncClient | None = None,
+        client: AsyncOpenAI | None = None,
         temperature: NotGivenOr[float] = NOT_GIVEN,
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: ToolChoice = "auto",
@@ -377,7 +378,7 @@ class LLM(llm.LLM):
         model: str | PerplexityChatModels = "llama-3.1-sonar-small-128k-chat",
         api_key: str | None = None,
         base_url: str = "https://api.perplexity.ai",
-        client: openai.AsyncClient | None = None,
+        client: AsyncOpenAI | None = None,
         user: NotGivenOr[str] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
@@ -413,7 +414,7 @@ class LLM(llm.LLM):
         model: str | TogetherChatModels = "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
         api_key: str | None = None,
         base_url: str = "https://api.together.xyz/v1",
-        client: openai.AsyncClient | None = None,
+        client: AsyncOpenAI | None = None,
         user: NotGivenOr[str] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
@@ -449,7 +450,7 @@ class LLM(llm.LLM):
         model: str | TelnyxChatModels = "meta-llama/Meta-Llama-3.1-70B-Instruct",
         api_key: str | None = None,
         base_url: str = "https://api.telnyx.com/v2/ai",
-        client: openai.AsyncClient | None = None,
+        client: AsyncOpenAI | None = None,
         user: NotGivenOr[str] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
@@ -541,7 +542,7 @@ class LLMStream(llm.LLMStream):
         llm: LLM,
         *,
         model: str | ChatModels,
-        client: openai.AsyncClient,
+        client: AsyncOpenAI,
         chat_ctx: llm.ChatContext,
         tools: list[FunctionTool],
         conn_options: APIConnectOptions,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -20,8 +20,8 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
+from langfuse import openai
 
-import openai
 from livekit.agents import APIConnectionError, APIStatusError, APITimeoutError, llm
 from livekit.agents.llm import ToolChoice, utils as llm_utils
 from livekit.agents.llm.chat_context import ChatContext

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -597,16 +597,17 @@ class LLMStream(llm.LLMStream):
                         )
                         self._event_ch.send_nowait(chunk)
 
-        except openai.APITimeoutError:
-            raise APITimeoutError(retryable=retryable) from None
-        except openai.APIStatusError as e:
-            raise APIStatusError(
-                e.message,
-                status_code=e.status_code,
-                request_id=e.request_id,
-                body=e.body,
-                retryable=retryable,
-            ) from None
+        # TODO: handle timeout and status errors (not supported by langfuse)
+        # except openai.APITimeoutError:
+        #     raise APITimeoutError(retryable=retryable) from None
+        # except openai.APIStatusError as e:
+        #     raise APIStatusError(
+        #         e.message,
+        #         status_code=e.status_code,
+        #         request_id=e.request_id,
+        #         body=e.body,
+        #         retryable=retryable,
+        #     ) from None
         except Exception as e:
             raise APIConnectionError(retryable=retryable) from e
 

--- a/livekit-plugins/livekit-plugins-openai/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-openai/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
     "livekit-agents[codecs, images]>=1.0.13",
     "openai[realtime]>=1.68.2",
+    "langfuse==2.60.3",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ members = [
     "livekit-plugins-assemblyai",
     "livekit-plugins-aws",
     "livekit-plugins-azure",
+    "livekit-plugins-bey",
     "livekit-plugins-cartesia",
     "livekit-plugins-clova",
     "livekit-plugins-deepgram",
@@ -375,6 +376,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/83/c5/b593f08f70b73b8a997b87673235f83ec42d9c9bf0fae7f348e889dfc00c/azure_cognitiveservices_speech-1.43.0-py3-none-win32.whl", hash = "sha256:36570806a6b8fe12696a0372193ecc623bc629e355fa1edc67c03ac71731066b", size = 2152884 },
     { url = "https://files.pythonhosted.org/packages/f5/b8/b1e7894cb4bcd721356eb1687e6f17112c2c659f4365827b8e7daac07c7d/azure_cognitiveservices_speech-1.43.0-py3-none-win_amd64.whl", hash = "sha256:50a50aabc69434d1311c09eaa640622c1d47d270e6cbcf5d192a04325cb7de4c", size = 2410492 },
     { url = "https://files.pythonhosted.org/packages/5e/79/8d16e2cdeb01459726818558f1b484106b89e8b54ad85a847e471a5c2659/azure_cognitiveservices_speech-1.43.0-py3-none-win_arm64.whl", hash = "sha256:29dab439a3789196c38b169a74fb4eefa4ede59e79f062541c08cc39a2d786a5", size = 2205218 },
+]
+
+[[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148 },
 ]
 
 [[package]]
@@ -1137,6 +1147,25 @@ wheels = [
 ]
 
 [[package]]
+name = "langfuse"
+version = "2.60.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "backoff" },
+    { name = "httpx" },
+    { name = "idna" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/7a/a998b48823a609af8f5096cb322a4ddfded01d565509cd6b511a2e5891ca/langfuse-2.60.3.tar.gz", hash = "sha256:171c0caf07a26282bd0403c6c15886ef1f447def42d6570684c94d6d9ae61d6e", size = 152467 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/6b/4d3bdea30ceb3e4cf3ac1a2f104ffc20b6caa636549874262b2fa8cedaec/langfuse-2.60.3-py3-none-any.whl", hash = "sha256:2b866c44f24d5f06b617d7f14f75a2e42577538b530e4e26dc6ad770d6d1399e", size = 275008 },
+]
+
+[[package]]
 name = "livekit"
 version = "1.0.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1194,6 +1223,9 @@ aws = [
 ]
 azure = [
     { name = "livekit-plugins-azure" },
+]
+bey = [
+    { name = "livekit-plugins-bey" },
 ]
 cartesia = [
     { name = "livekit-plugins-cartesia" },
@@ -1270,6 +1302,7 @@ requires-dist = [
     { name = "livekit-plugins-assemblyai", marker = "extra == 'assemblyai'", editable = "livekit-plugins/livekit-plugins-assemblyai" },
     { name = "livekit-plugins-aws", marker = "extra == 'aws'", editable = "livekit-plugins/livekit-plugins-aws" },
     { name = "livekit-plugins-azure", marker = "extra == 'azure'", editable = "livekit-plugins/livekit-plugins-azure" },
+    { name = "livekit-plugins-bey", marker = "extra == 'bey'", editable = "livekit-plugins/livekit-plugins-bey" },
     { name = "livekit-plugins-cartesia", marker = "extra == 'cartesia'", editable = "livekit-plugins/livekit-plugins-cartesia" },
     { name = "livekit-plugins-clova", marker = "extra == 'clova'", editable = "livekit-plugins/livekit-plugins-clova" },
     { name = "livekit-plugins-deepgram", marker = "extra == 'deepgram'", editable = "livekit-plugins/livekit-plugins-deepgram" },
@@ -1301,7 +1334,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.12" },
     { name = "watchfiles", specifier = ">=1.0" },
 ]
-provides-extras = ["anthropic", "assemblyai", "aws", "azure", "cartesia", "clova", "codecs", "deepgram", "elevenlabs", "fal", "gladia", "google", "groq", "images", "neuphonic", "nltk", "openai", "playai", "resemble", "rime", "silero", "speechmatics", "turn-detector"]
+provides-extras = ["anthropic", "assemblyai", "aws", "azure", "bey", "cartesia", "clova", "codecs", "deepgram", "elevenlabs", "fal", "gladia", "google", "groq", "images", "neuphonic", "nltk", "openai", "playai", "resemble", "rime", "silero", "speechmatics", "turn-detector"]
 
 [[package]]
 name = "livekit-api"
@@ -1374,6 +1407,16 @@ requires-dist = [
     { name = "azure-cognitiveservices-speech", specifier = ">=1.43.0" },
     { name = "livekit-agents", editable = "livekit-agents" },
 ]
+
+[[package]]
+name = "livekit-plugins-bey"
+source = { editable = "livekit-plugins/livekit-plugins-bey" }
+dependencies = [
+    { name = "livekit-agents" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "livekit-agents", editable = "livekit-agents" }]
 
 [[package]]
 name = "livekit-plugins-cartesia"
@@ -1531,6 +1574,7 @@ requires-dist = [
 name = "livekit-plugins-openai"
 source = { editable = "livekit-plugins/livekit-plugins-openai" }
 dependencies = [
+    { name = "langfuse" },
     { name = "livekit-agents", extra = ["codecs", "images"] },
     { name = "openai", extra = ["realtime"] },
 ]
@@ -1543,6 +1587,7 @@ vertex = [
 [package.metadata]
 requires-dist = [
     { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0.0" },
+    { name = "langfuse", specifier = "==2.60.3" },
     { name = "livekit-agents", extras = ["codecs", "images"], editable = "livekit-agents" },
     { name = "openai", extras = ["realtime"], specifier = ">=1.68.2" },
 ]


### PR DESCRIPTION
# Changes

* This adds an optional parameter to the agent session called `interruption_handling`
* `interruption_handling` specifies if interruptions should be handled in parallel or sequentially
* The default is `parallel` (existing behavior)
* If `sequential` is used, interruptions are not sent to the LLM until the agent finishes speaking

# Examples

This is useful for situations like booking appointments

## Booking Appointments with `parallel` Interruption Handling

* Customer: Book me an appointment at 6 pm
* Agent: [calling schedule_appointment first time]
* Customer: [while tool call executing] Hello? Book me an appointment at 6 pm
* Agent: [calling schedule_appointment second time]

## Booking Appointments with `sequential` Interruption Handling

* Customer: Book me an appointment at 6 pm
* Agent: [calling schedule_appointment first time]
* Customer: [while tool call executing] Hello? Book me an appointment at 6 pm
* Agent: [does not call schedule_appointment again]

