### PR TITLE
Bug Fix - wrong transition to SPEAKING when the agent is in fact listening

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1380,7 +1380,6 @@ class AgentActivity(RecognitionHooks):
                 self._session._conversation_item_added(msg)
             return
 
-        self._session._update_agent_state("speaking")
         speech_handle._mark_playout_done()  # mark the playout done before waiting for the tool execution  # noqa: E501
 
         for msg_id, text_out, _ in message_outputs:


### PR DESCRIPTION
The agent-state was falsely returned to SPEAKING right after switching to LISTENING.
Tested with the openai realtime model after patching the code locally.

I have timers in my app relying on agent-state so this is a critical bug for me.