### PR TITLE
Bug fix in agent_activity.py: user_state events were not fired

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -660,6 +660,7 @@ class AgentActivity(RecognitionHooks):
 
     def _on_input_speech_started(self, _: llm.InputSpeechStartedEvent) -> None:
         log_event("input_speech_started")
+        self._session._update_user_state("speaking")
         # self.interrupt() isn't going to raise when allow_interruptions is False, llm.InputSpeechStartedEvent is only fired by the server when the turn_detection is enabled.  # noqa: E501
         # When using the server-side turn_detection, we don't allow allow_interruptions to be False.
         try:
@@ -671,6 +672,7 @@ class AgentActivity(RecognitionHooks):
 
     def _on_input_speech_stopped(self, ev: llm.InputSpeechStoppedEvent) -> None:
         log_event("input_speech_stopped")
+        self._session._update_user_state("listening")
         if ev.user_transcription_enabled:
             self._session.emit(
                 "user_input_transcribed",


### PR DESCRIPTION
For the realtime model, the user state events:
self._session._update_user_state("listening")
and
self._session._update_user_state("speaking")
were not fired at all.
They were correctly fired in response to VAD events in on_start_of_speech and on_end_of_speech

This is a 2-liner fix: just firing the event at the right time.

Critical bug for me because my app relies on these events.