### PR TITLE
fix using raw tools with ChatContext copies

### DIFF
--- a/.github/next-release/changeset-cb19d9f7.md
+++ b/.github/next-release/changeset-cb19d9f7.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+fix using raw tools with ChatContext copies (#2096)

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -205,9 +205,7 @@ class ChatContext:
 
         valid_tools = set()
         if is_given(tools):
-            valid_tools = {
-                tool if isinstance(tool, str) else get_tool_name(tool) for tool in tools
-            }
+            valid_tools = {tool if isinstance(tool, str) else get_tool_name(tool) for tool in tools}
 
         for item in self.items:
             if exclude_function_call and item.type in [

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -201,12 +201,12 @@ class ChatContext:
     ) -> ChatContext:
         items = []
 
-        from .tool_context import get_function_info
+        from .tool_context import get_tool_name
 
         valid_tools = set()
         if is_given(tools):
             valid_tools = {
-                tool if isinstance(tool, str) else get_function_info(tool).name for tool in tools
+                tool if isinstance(tool, str) else get_tool_name(tool) for tool in tools
             }
 
         for item in self.items:

--- a/livekit-agents/livekit/agents/llm/tool_context.py
+++ b/livekit-agents/livekit/agents/llm/tool_context.py
@@ -190,21 +190,23 @@ def is_raw_function_tool(f: Callable) -> TypeGuard[RawFunctionTool]:
 def get_raw_function_info(f: RawFunctionTool) -> _RawFunctionToolInfo:
     return getattr(f, "__livekit_raw_tool_info")
 
+
 def get_tool_name(f: Callable) -> str:
     if is_raw_function_tool(f):
         info = get_raw_function_info(f)
-        if hasattr(info, 'name'):
+        if hasattr(info, "name"):
             return info.name
         else:
             raise ValueError(f"Could not extract name from raw tool info: {info}")
     elif is_function_tool(f):
         info = get_function_info(f)
-        if hasattr(info, 'name'):
+        if hasattr(info, "name"):
             return info.name
         else:
             raise ValueError(f"Could not extract name from function tool info: {info}")
     else:
         raise ValueError(f"Unknown tool type: {type(f)}")
+
 
 def find_function_tools(cls_or_obj: Any) -> list[FunctionTool | RawFunctionTool]:
     methods: list[FunctionTool | RawFunctionTool] = []

--- a/livekit-agents/livekit/agents/llm/tool_context.py
+++ b/livekit-agents/livekit/agents/llm/tool_context.py
@@ -190,6 +190,21 @@ def is_raw_function_tool(f: Callable) -> TypeGuard[RawFunctionTool]:
 def get_raw_function_info(f: RawFunctionTool) -> _RawFunctionToolInfo:
     return getattr(f, "__livekit_raw_tool_info")
 
+def get_tool_name(f: Callable) -> str:
+    if is_raw_function_tool(f):
+        info = get_raw_function_info(f)
+        if hasattr(info, 'name'):
+            return info.name
+        else:
+            raise ValueError(f"Could not extract name from raw tool info: {info}")
+    elif is_function_tool(f):
+        info = get_function_info(f)
+        if hasattr(info, 'name'):
+            return info.name
+        else:
+            raise ValueError(f"Could not extract name from function tool info: {info}")
+    else:
+        raise ValueError(f"Unknown tool type: {type(f)}")
 
 def find_function_tools(cls_or_obj: Any) -> list[FunctionTool | RawFunctionTool]:
     methods: list[FunctionTool | RawFunctionTool] = []

--- a/livekit-agents/livekit/agents/llm/tool_context.py
+++ b/livekit-agents/livekit/agents/llm/tool_context.py
@@ -191,23 +191,6 @@ def get_raw_function_info(f: RawFunctionTool) -> _RawFunctionToolInfo:
     return getattr(f, "__livekit_raw_tool_info")
 
 
-def get_tool_name(f: Callable) -> str:
-    if is_raw_function_tool(f):
-        info = get_raw_function_info(f)
-        if hasattr(info, "name"):
-            return info.name
-        else:
-            raise ValueError(f"Could not extract name from raw tool info: {info}")
-    elif is_function_tool(f):
-        info = get_function_info(f)
-        if hasattr(info, "name"):
-            return info.name
-        else:
-            raise ValueError(f"Could not extract name from function tool info: {info}")
-    else:
-        raise ValueError(f"Unknown tool type: {type(f)}")
-
-
 def find_function_tools(cls_or_obj: Any) -> list[FunctionTool | RawFunctionTool]:
     methods: list[FunctionTool | RawFunctionTool] = []
     for _, member in inspect.getmembers(cls_or_obj):


### PR DESCRIPTION
Previously raw function tools definitions only worked when specified as class members. When specifying them directly when instantiating an Agent, it would fail because ChatContext#copy didn't know how to handle them.