### PR TITLE
fix: prevent duplicate metrics when switching between agents

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -381,6 +381,32 @@ class AgentActivity(RecognitionHooks):
             if not self._draining:
                 logger.warning("task closing without draining")
 
+            # Unregister event handlers to prevent duplicate metrics
+            if isinstance(self.llm, llm.LLM):
+                self.llm.off("metrics_collected", self._on_metrics_collected)
+                self.llm.off("error", self._on_error)
+
+            if isinstance(self.llm, llm.RealtimeModel) and self._rt_session is not None:
+                self._rt_session.off("generation_created", self._on_generation_created)
+                self._rt_session.off("input_speech_started", self._on_input_speech_started)
+                self._rt_session.off("input_speech_stopped", self._on_input_speech_stopped)
+                self._rt_session.off(
+                    "input_audio_transcription_completed",
+                    self._on_input_audio_transcription_completed,
+                )
+                self._rt_session.off("error", self._on_error)
+
+            if isinstance(self.stt, stt.STT):
+                self.stt.off("metrics_collected", self._on_metrics_collected)
+                self.stt.off("error", self._on_error)
+
+            if isinstance(self.tts, tts.TTS):
+                self.tts.off("metrics_collected", self._on_metrics_collected)
+                self.tts.off("error", self._on_error)
+
+            if isinstance(self.vad, vad.VAD):
+                self.vad.off("metrics_collected", self._on_metrics_collected)
+
             if self._rt_session is not None:
                 await self._rt_session.aclose()
 


### PR DESCRIPTION
## Problem
When switching between agents using the workflow handoff feature, metrics events were being duplicated with each new agent. After one agent handoff, metrics would be doubled; after two handoffs, they would be tripled, and so on.

```
2025-04-23 22:32:57,295 - INFO livekit.agents - TTS metrics: ttfb=1.271504916017875, audio_duration=9.30 {"pid": 20532, "job_id": "AJ_cX6L8hCzAr6z"}
2025-04-23 22:32:57,295 - INFO livekit.agents - TTS metrics: ttfb=1.271504916017875, audio_duration=9.30 {"pid": 20532, "job_id": "AJ_cX6L8hCzAr6z"}
2025-04-23 22:32:57,299 - INFO livekit.agents - LLM metrics: ttft=0.43, input_tokens=165,  cached_input_tokens=0, output_tokens=15, tokens_per_second=22.37 {"pid": 20532, "job_id": "AJ_cX6L8hCzAr6z"}
2025-04-23 22:32:57,299 - INFO livekit.agents - LLM metrics: ttft=0.43, input_tokens=165,  cached_input_tokens=0, output_tokens=15, tokens_per_second=22.37 {"pid": 20532, "job_id": "AJ_cX6L8hCzAr6z"}
2025-04-23 22:32:59,241 - INFO livekit.agents - TTS metrics: ttfb=1.9902509171515703, audio_duration=1.75 {"pid": 20532, "job_id": "AJ_cX6L8hCzAr6z"}
2025-04-23 22:32:59,241 - INFO livekit.agents - TTS metrics: ttfb=1.9902509171515703, audio_duration=1.75 {"pid": 20532, "job_id": "AJ_cX6L8hCzAr6z"}
2025-04-23 22:33:00,522 - INFO livekit.agents - TTS metrics: ttfb=1.1746300829108804, audio_duration=1.40 {"pid": 20532, "job_id": "AJ_cX6L8hCzAr6z"}
2025-04-23 22:33:00,522 - INFO livekit.agents - TTS metrics: ttfb=1.1746300829108804, audio_duration=1.40 {"pid": 20532, "job_id": "AJ_cX6L8hCzAr6z"}
2025-04-23 22:33:01,654 - INFO livekit.agents - STT metrics: audio_duration=5.00 {"pid": 20532, "job_id": "AJ_cX6L8hCzAr6z"}
2025-04-23 22:33:01,654 - INFO livekit.agents - STT metrics: audio_duration=5.00 {"pid": 20532, "job_id": "AJ_cX6L8hCzAr6z"}
2025-04-23 22:33:06,713 - INFO livekit.agents - STT metrics: audio_duration=5.05 {"pid": 20532, "job_id": "AJ_cX6L8hCzAr6z"}
2025-04-23 22:33:06,713 - INFO livekit.agents - STT metrics: audio_duration=5.05 {"pid": 20532, "job_id": "AJ_cX6L8hCzAr6z"}
```

## Steps to reproduce:
1. Edit `examples/voice_agents/multi_agent.py` and remove custom tts and llm components in `StoryAgent` constructor
2. Run the multi-agent example:
```
uv run examples/voice_agents/multi_agent.py dev
```
3. Interact with the initial agent and trigger a handoff to the `StoryAgent`
4. Observe that metrics are now emitted twice for each event

## Solution
Modified the `AgentActivity.aclose()` method to properly unregister all event handlers when an agent's activity is closed.