### PR TITLE
ensure correct message ordering when injecting speeches in on_user_turn_completed

### DIFF
--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -316,6 +316,12 @@ class ChatContext:
         }
 
     def find_insertion_index(self, *, created_at: float) -> int:
+        """
+        Returns the index to insert an item by creation time.
+
+        Iterates in reverse, assuming items are sorted by `created_at`.
+        Finds the position after the last item with `created_at <=` the given timestamp.
+        """
         for i in reversed(range(len(self._items))):
             item = self._items[i]
             if item.type == "message" and item.created_at <= created_at:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1022,8 +1022,10 @@ class AgentActivity(RecognitionHooks):
         tool_ctx = llm.ToolContext(tools)
 
         if new_message is not None:
-            chat_ctx.items.append(new_message)
-            self._agent._chat_ctx.items.append(new_message)
+            idx = chat_ctx.find_insertion_index(created_at=new_message.created_at)
+            chat_ctx.items.insert(idx, new_message)
+            idx = self._agent._chat_ctx.find_insertion_index(created_at=new_message.created_at)
+            self._agent._chat_ctx.items.insert(idx, new_message)
             self._session._conversation_item_added(new_message)
 
         if instructions is not None:


### PR DESCRIPTION
```python
async def on_user_turn_completed(self, turn_ctx: ChatContext, new_message: ChatMessage):
    speech_handle = await self.session.say("This is an injected message")
```

Before: 
```
{"id":"item_eed0cfc736ee","role":"assistant","content":["This is an injected message"]},{"id":"item_5d337e233c63","role":"user","content":["Yo. What's up?"]},{"id":"item_84930d36a271","role":"assistant","content":["Hello! I'm here to help you with any questions or information you need. How can I assist you today?"]}
```

After:
```
{"id":"item_70e653ea1735","role":"user","content":["Yo. What's up?"]},{"id":"item_a776e29ab8eb","role":"assistant","content":["This is an injected message"]},{"id":"item_7a7e4ddc0d1a","role":"assistant","content":["Hello! I'm here to help you with any questions or information you need. What's up with you?"]}
```