### PR TITLE
Deregister callbacks in `AgentActivity` drain

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -375,6 +375,8 @@ class AgentActivity(RecognitionHooks):
             task = self._create_speech_task(self._agent.on_exit(), name="AgentTask_on_exit")
             _authorize_inline_task(task)
 
+            self._deregister_callbacks()
+
             self._wake_up_main_task()
             self._draining = True
             if self._main_atask is not None:
@@ -668,6 +670,18 @@ class AgentActivity(RecognitionHooks):
         ):
             ev.speech_id = speech_handle.id
         self._session.emit("metrics_collected", MetricsCollectedEvent(metrics=ev))
+    
+    def _deregister_callbacks(self):
+        # TODO: use off_all() once merged
+        # https://github.com/livekit/python-sdks/pull/426
+        if isinstance(self.llm, llm.RealtimeModel) or isinstance(self.llm, llm.LLM):
+            self.llm._events.clear()
+        if isinstance(self.stt, stt.STT):
+            self.stt._events.clear()
+        if isinstance(self.tts, tts.TTS):
+            self.tts._events.clear()
+        if isinstance(self.vad, vad.VAD):
+            self.vad._events.clear()
 
     def _on_error(
         self, error: llm.LLMError | stt.STTError | tts.TTSError | llm.RealtimeModelError

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -670,7 +670,7 @@ class AgentActivity(RecognitionHooks):
         ):
             ev.speech_id = speech_handle.id
         self._session.emit("metrics_collected", MetricsCollectedEvent(metrics=ev))
-    
+
     def _deregister_callbacks(self):
         # TODO: use off_all() once merged
         # https://github.com/livekit/python-sdks/pull/426


### PR DESCRIPTION
When calling `_update_activity_task` from `AgentSession` to switch tasks, we start a new `AgentActivity` and add callbacks to the constituent `LLM`, `STT`, `TTS`, and `VAD` models. For example, the `start` method has:
```
if isinstance(self.llm, llm.LLM):
    self.llm.on("metrics_collected", self._on_metrics_collected)
    self.llm.on("error", self._on_error)
```

The problem is that when we initialize a new `AgentActivity` we pass the same `AgentSession` as a parameter, and if the `LLM`, `STT`, `TTS`, and `VAD` models were instantiated at the `AgentSession` level, then the same model objects will receive a duplicate callback because the `on` method registers the same method under two different `AgentActivity` objects. This results in `_on_metrics_collected` being invoked once for each activity transition.

The easiest way to solve this is to deregister every callback across all events upon draining an `AgentActivity` and relying on the next `start` to re-register the callbacks appropriately.
