### PR TITLE
Set Hume SDK version to 0.8.3 or greater

### DIFF
--- a/livekit-plugins/livekit-plugins-hume/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-hume/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
     "aiohttp>=3.8.0",
     "livekit-agents>=1.0.17",
-    "hume>=0.7.0"
+    "hume>=0.8.3"
 ]
 
 [project.urls]

--- a/livekit-plugins/livekit-plugins-hume/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-hume/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
     "aiohttp>=3.8.0",
     "livekit-agents>=1.0.17",
-    "hume"
+    "hume>=0.7.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
This resolves a dependency conflict on websockets when used with the google or openai plugins.