### PR TITLE
fix(plugins-google): Fix Google TTS update options parameter names

### DIFF
--- a/.github/next-release/changeset-de15f366.md
+++ b/.github/next-release/changeset-de15f366.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-google": patch
+---
+
+fix(plugins-google): Fix Google TTS update options parameter names (#2124)

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
@@ -132,11 +132,11 @@ class TTS(tts.TTS):
         """  # noqa: E501
         params = {}
         if is_given(language):
-            params["language"] = language
+            params["language_code"] = str(language)
         if is_given(gender):
-            params["gender"] = gender
+            params["ssml_gender"] = _gender_from_str(str(gender))
         if is_given(voice_name):
-            params["voice_name"] = voice_name
+            params["name"] = voice_name
 
         if params:
             self._opts.voice = texttospeech.VoiceSelectionParams(**params)


### PR DESCRIPTION
**Fix Google TTS Update Options Parameter Names**

This PR fixes the `update_options` method in the Google TTS plugin (`livekit.plugins.google.tts.TTS`), which was broken by incorrect internal parameter mapping introduced in [PR #2025](https://github.com/livekit/agents/pull/2025).

The parameter names used internally for `VoiceSelectionParams` have been corrected, restoring the ability to update language, gender, and voice name
