### PR TITLE
fix conversion of chat context to dict

### DIFF
--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -308,7 +308,7 @@ class ChatContext:
                 item.model_dump(
                     mode="json",
                     exclude_none=True,
-                    exclude_defaults=True,
+                    exclude_defaults=False,
                     exclude=exclude_fields,
                 )
                 for item in items


### PR DESCRIPTION
If `exclude_defaults` is `True`, the type won't be included in the dict and so you won't be able to convert the dict back to chat context