### PR TITLE
Improve decoding speed for wav

### DIFF
--- a/.github/next-release/changeset-51b7bc26.md
+++ b/.github/next-release/changeset-51b7bc26.md
@@ -1,0 +1,6 @@
+---
+"livekit-agents": patch
+"livekit-plugins-rime": patch
+---
+
+Improve decoding speed for wav, support for Rime arcane (#2141)

--- a/livekit-agents/livekit/agents/utils/audio.py
+++ b/livekit-agents/livekit/agents/utils/audio.py
@@ -11,7 +11,6 @@ from livekit import rtc
 
 from ..log import logger
 from .aio.utils import cancel_and_wait
-from .codecs import AudioStreamDecoder
 
 # deprecated aliases
 AudioBuffer = Union[list[rtc.AudioFrame], rtc.AudioFrame]
@@ -164,6 +163,8 @@ async def audio_frames_from_file(
     Returns:
         AsyncIterable[rtc.AudioFrame]: An async iterable that yields decoded AudioFrame
     """
+    from .codecs import AudioStreamDecoder
+
     decoder = AudioStreamDecoder(sample_rate=sample_rate, num_channels=num_channels)
 
     async def file_reader():

--- a/livekit-agents/livekit/agents/utils/codecs/decoder.py
+++ b/livekit-agents/livekit/agents/utils/codecs/decoder.py
@@ -182,7 +182,7 @@ class AudioStreamDecoder:
 
     def _decode_wav_loop(self):
         """Decode wav data from the buffer without ffmpeg, parse header and emit PCM frames.
-        
+
         This can be much faster than using ffmpeg, as we are emitting frames as quickly as possible.
         """
 
@@ -220,7 +220,6 @@ class AudioStreamDecoder:
                     )
                     if audio_format != 1:
                         raise ValueError(f"Unsupported WAV audio format: {audio_format}")
-                    sampwidth = bits_per_sample // 8
                     fmt_chunk_found = True
 
             # parse data chunk

--- a/livekit-agents/livekit/agents/utils/codecs/decoder.py
+++ b/livekit-agents/livekit/agents/utils/codecs/decoder.py
@@ -197,7 +197,7 @@ class AudioStreamDecoder:
                     raise ValueError("Invalid WAV file: incomplete header")
                 header += chunk
             if header[:4] != b"RIFF" or header[8:12] != b"WAVE":
-                raise ValueError("Invalid WAV file: missing RIFF/WAVE")
+                raise ValueError(f"Invalid WAV file: missing RIFF/WAVE: {header}")
 
             # parse fmt chunk
             fmt_chunk_found = False

--- a/livekit-agents/livekit/agents/utils/codecs/decoder.py
+++ b/livekit-agents/livekit/agents/utils/codecs/decoder.py
@@ -94,7 +94,7 @@ class AudioStreamDecoder:
     _executor: Optional[ThreadPoolExecutor] = None
 
     def __init__(
-        self, *, sample_rate: int = 48000, num_channels: int = 1, format: str | None = None
+        self, *, sample_rate: int = 48000, num_channels: int = 1, format: Optional[str] = None
     ):
         self._sample_rate = sample_rate
         self._layout = "mono"

--- a/livekit-agents/livekit/agents/utils/codecs/decoder.py
+++ b/livekit-agents/livekit/agents/utils/codecs/decoder.py
@@ -15,6 +15,7 @@
 import asyncio
 import contextlib
 import io
+import struct
 import threading
 from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
@@ -92,13 +93,16 @@ class AudioStreamDecoder:
     _max_workers: int = 10
     _executor: Optional[ThreadPoolExecutor] = None
 
-    def __init__(self, *, sample_rate: int = 48000, num_channels: int = 1):
+    def __init__(
+        self, *, sample_rate: int = 48000, num_channels: int = 1, format: str | None = None
+    ):
         self._sample_rate = sample_rate
         self._layout = "mono"
         if num_channels == 2:
             self._layout = "stereo"
         elif num_channels != 1:
             raise ValueError(f"Invalid number of channels: {num_channels}")
+        self._format = format.lower() if format else None
 
         self._output_ch = aio.Chan[rtc.AudioFrame]()
         self._closed = False
@@ -114,7 +118,12 @@ class AudioStreamDecoder:
         self._input_buf.write(chunk)
         if not self._started:
             self._started = True
-            self._loop.run_in_executor(self.__class__._executor, self._decode_loop)
+            # choose decode loop based on format
+            if self._format == "wav":
+                target = self._decode_wav_loop
+            else:
+                target = self._decode_loop
+            self._loop.run_in_executor(self.__class__._executor, target)
 
     def end_input(self):
         self._input_buf.end_input()
@@ -126,7 +135,22 @@ class AudioStreamDecoder:
         container: av.container.InputContainer | None = None
         resampler: av.AudioResampler | None = None
         try:
-            container = av.open(self._input_buf, mode="r")
+            # open container in low-latency streaming mode
+            container = av.open(
+                self._input_buf,
+                mode="r",
+                buffer_size=1024,
+                options={
+                    "fflags": "nobuffer+flush_packets",
+                    "probesize": "32",
+                    "analyzeduration": "0",
+                    "max_delay": "0",
+                },
+            )
+            # explicitly disable internal buffering flags on the FFmpeg container
+            container.flags |= (
+                av.container.Flags.no_buffer.value | av.container.Flags.flush_packets.value
+            )
             if len(container.streams.audio) == 0:
                 raise ValueError("no audio stream found")
 
@@ -155,6 +179,97 @@ class AudioStreamDecoder:
             self._loop.call_soon_threadsafe(self._output_ch.close)
             if container:
                 container.close()
+
+    def _decode_wav_loop(self):
+        """Decode wav data from the buffer without ffmpeg, parse header and emit PCM frames.
+        
+        This can be much faster than using ffmpeg, as we are emitting frames as quickly as possible.
+        """
+
+        try:
+            from livekit.agents.utils.audio import AudioByteStream
+
+            # parse RIFF header
+            header = b""
+            while len(header) < 12:
+                chunk = self._input_buf.read(12 - len(header))
+                if not chunk:
+                    raise ValueError("Invalid WAV file: incomplete header")
+                header += chunk
+            if header[:4] != b"RIFF" or header[8:12] != b"WAVE":
+                raise ValueError("Invalid WAV file: missing RIFF/WAVE")
+
+            # parse fmt chunk
+            fmt_chunk_found = False
+            while not fmt_chunk_found:
+                sub_header = self._input_buf.read(8)
+                if len(sub_header) < 8:
+                    raise ValueError("Invalid WAV file: incomplete fmt chunk header")
+                chunk_id, chunk_size = struct.unpack("<4sI", sub_header)
+                data = b""
+                remaining = chunk_size
+                while remaining > 0:
+                    part = self._input_buf.read(min(1024, remaining))
+                    if not part:
+                        raise ValueError("Invalid WAV file: incomplete fmt chunk data")
+                    data += part
+                    remaining -= len(part)
+                if chunk_id == b"fmt ":
+                    audio_format, wave_channels, wave_rate, _, _, bits_per_sample = struct.unpack(
+                        "<HHIIHH", data[:16]
+                    )
+                    if audio_format != 1:
+                        raise ValueError(f"Unsupported WAV audio format: {audio_format}")
+                    sampwidth = bits_per_sample // 8
+                    fmt_chunk_found = True
+
+            # parse data chunk
+            data_chunk_found = False
+            while not data_chunk_found:
+                sub_header = self._input_buf.read(8)
+                if len(sub_header) < 8:
+                    raise ValueError("Invalid WAV file: incomplete data chunk header")
+                chunk_id, chunk_size = struct.unpack("<4sI", sub_header)
+                if chunk_id == b"data":
+                    data_chunk_found = True
+                else:
+                    # skip chunk data
+                    to_skip = chunk_size
+                    while to_skip > 0:
+                        skipped = self._input_buf.read(min(1024, to_skip))
+                        if not skipped:
+                            raise ValueError(
+                                "Invalid WAV file: incomplete chunk while seeking data"
+                            )
+                        to_skip -= len(skipped)
+
+            # now ready to decode
+            bstream = AudioByteStream(sample_rate=wave_rate, num_channels=wave_channels)
+            resampler = rtc.AudioResampler(
+                input_rate=wave_rate, output_rate=self._sample_rate, num_channels=wave_channels
+            )
+
+            def resample_and_push(frame: rtc.AudioFrame):
+                for resampled_frame in resampler.push(frame):
+                    self._loop.call_soon_threadsafe(
+                        self._output_ch.send_nowait,
+                        resampled_frame,
+                    )
+
+            while True:
+                chunk = self._input_buf.read(1024)
+                if not chunk:
+                    break
+                frames = bstream.push(chunk)
+                for rtc_frame in frames:
+                    resample_and_push(rtc_frame)
+
+            for rtc_frame in bstream.flush():
+                resample_and_push(rtc_frame)
+        except Exception:
+            logger.exception("error decoding wav")
+        finally:
+            self._loop.call_soon_threadsafe(self._output_ch.close)
 
     def __aiter__(self) -> AsyncIterator[rtc.AudioFrame]:
         return self

--- a/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/models.py
+++ b/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/models.py
@@ -1,3 +1,3 @@
 from typing import Literal
 
-TTSModels = Literal["mist", "mistv2"]
+TTSModels = Literal["mist", "mistv2", "arcana"]

--- a/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/models.py
+++ b/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/models.py
@@ -1,3 +1,10 @@
 from typing import Literal
 
-TTSModels = Literal["mist", "mistv2", "arcana"]
+TTSModels = Literal["mistv2", "arcana"]
+
+# https://docs.rime.ai/api-reference/voices
+ArcanaVoices = Literal[
+    "luna", "celeste", "orion", "ursa", "astra", "esther", "estelle", "andromeda"
+]
+
+DefaultMistv2Voice = "cove"

--- a/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
+++ b/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
@@ -155,7 +155,7 @@ class ChunkedStream(tts.ChunkedStream):
     async def _run(self) -> None:
         request_id = utils.shortuuid()
         headers = {
-            "accept": "audio/mp3",
+            "accept": "audio/wav",
             "Authorization": f"Bearer {self._api_key}",
             "content-type": "application/json",
         }
@@ -166,14 +166,17 @@ class ChunkedStream(tts.ChunkedStream):
             "lang": self._opts.lang,
             "samplingRate": self._opts.sample_rate,
             "speedAlpha": self._opts.speed_alpha,
-            "reduceLatency": self._opts.reduce_latency,
             "pauseBetweenBrackets": self._opts.pause_between_brackets,
             "phonemizeBetweenBrackets": self._opts.phonemize_between_brackets,
+            "audioFormat": "wav",
         }
+        if self._opts.reduce_latency:
+            payload["reduceLatency"] = True
 
         decoder = utils.codecs.AudioStreamDecoder(
             sample_rate=self._opts.sample_rate,
             num_channels=NUM_CHANNELS,
+            format="wav",
         )
 
         decode_task: asyncio.Task | None = None
@@ -199,6 +202,7 @@ class ChunkedStream(tts.ChunkedStream):
                     request_id=request_id,
                     segment_id=self._segment_id,
                 )
+
                 async for frame in decoder:
                     emitter.push(frame)
                 emitter.flush()

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -159,7 +159,9 @@ SYNTHESIZE_TTS = [
     ),
     pytest.param(
         lambda: {
-            "tts": rime.TTS(),
+            "tts": rime.TTS(
+                model="mistv2",
+            ),
             "proxy-upstream": "users.rime.ai:443",
         },
         id="rime",


### PR DESCRIPTION
Certain TTS (like Rime) would stream data back close to realtime. In those cases, it could increase the time it takes to receive the first frame due to libav decoder being conservative about buffering content. Switching to a streaming wav decoder to improve TTFB (Rime went from 1s to 300ms)