### PR TITLE
fix: Gemini API failing with empty turns when only system messages exist

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
@@ -99,10 +99,11 @@ def to_chat_ctx(
     if current_role is not None and parts:
         turns.append(types.Content(role=current_role, parts=parts))
 
-    # # Gemini requires the last message to end with user's turn before they can generate
-    # # currently not used because to_chat_ctx should not be used to force a new generation
-    # if current_role != "user":
-    #     turns.append(types.Content(role="user", parts=[types.Part(text=".")]))
+    # Gemini requires at least one turn to generate a response
+    # If there are no turns, add a minimal user turn with a placeholder
+    if not turns:
+        logger.debug("No turns in chat context, adding minimal user turn with placeholder")
+        turns.append(types.Content(role="user", parts=[types.Part(text=".")]))
 
     return turns, system_instruction
 


### PR DESCRIPTION
## Issue
When using `generate_reply` with an agent that has no conversation history, Gemini API fails because it requires at least one user turn to generate a response. This occurs when the chat context contains only system messages (like instructions), resulting in empty turns being sent to the API.

## Fix
Revert code in `to_chat_ctx` that inserts a minimal user turn with a placeholder text (".") when no turns exist. This ensures Gemini always has something to respond to, even when generating a reply with a fresh agent that has no conversation history yet.

resolves #2116 