### PR TITLE
Bug fix: Ensure mock room name is string in console mode

### DIFF
--- a/livekit-agents/livekit/agents/ipc/mock_room.py
+++ b/livekit-agents/livekit/agents/ipc/mock_room.py
@@ -6,6 +6,7 @@ MockRoom = create_autospec(rtc.Room, instance=True)
 MockRoom.local_participant = create_autospec(rtc.LocalParticipant, instance=True)
 MockRoom._info = create_autospec(rtc.room.proto_room.RoomInfo, instance=True)
 MockRoom.isconnected.return_value = True
+MockRoom.name = str(MockRoom.name)
 
 mock_remote_participant = create_autospec(rtc.RemoteParticipant, instance=True)
 mock_remote_participant.identity = "fake_human"

--- a/livekit-agents/livekit/agents/ipc/mock_room.py
+++ b/livekit-agents/livekit/agents/ipc/mock_room.py
@@ -6,7 +6,7 @@ MockRoom = create_autospec(rtc.Room, instance=True)
 MockRoom.local_participant = create_autospec(rtc.LocalParticipant, instance=True)
 MockRoom._info = create_autospec(rtc.room.proto_room.RoomInfo, instance=True)
 MockRoom.isconnected.return_value = True
-MockRoom.name = str(MockRoom.name)
+MockRoom.name = "fake_room"
 
 mock_remote_participant = create_autospec(rtc.RemoteParticipant, instance=True)
 mock_remote_participant.identity = "fake_human"


### PR DESCRIPTION
Running agents via the console (`python main.py console`) could lead to a `TypeError: bad argument type for built-in operation` when making API calls such as `api.DeleteRoomRequest(room=...)` or `api.RoomCompositeEgressRequest(room_name=...)`.

The root cause was that the simulated `JobContext` used in console mode relied on a mock `Room` object provided by `livekit.agents.ipc.mock_room`. This mock implementation assigned a `unittest.mock.MagicMock` object to its `.name` attribute. Protobuf message constructors expect a `str` for string fields and cannot handle `MagicMock` objects, resulting in the TypeError.

This commit fixes the issue by modifying the `MockRoom` implementation in `livekit/agents/ipc/mock_room.py`. The `.name` attribute is now explicitly cast to its string representation (`str(MockRoom.name)`), ensuring that consumers always receive a string value instead of a mock object.

This resolves the TypeError and allows API calls involving the room name to succeed when running agents in console mode.