### PR TITLE
Added ability to set custom Rime URL

### DIFF
--- a/.github/next-release/changeset-bc4c7ae8.md
+++ b/.github/next-release/changeset-bc4c7ae8.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-rime": patch
+---
+
+Added ability to set custom Rime URL for self-hosted deployments (#2158)

--- a/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
+++ b/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
@@ -66,9 +66,6 @@ class _Mistv2Options:
     phonemize_between_brackets: NotGivenOr[bool] = NOT_GIVEN
 
 
-DEFAULT_API_URL = "https://users.rime.ai/v1/rime-tts"
-
-
 NUM_CHANNELS = 1
 
 
@@ -76,6 +73,7 @@ class TTS(tts.TTS):
     def __init__(
         self,
         *,
+        api_url: str = "https://users.rime.ai/v1/rime-tts",
         model: TTSModels | str = "arcana",
         speaker: NotGivenOr[ArcanaVoices | str] = NOT_GIVEN,
         # Arcana options
@@ -236,7 +234,7 @@ class ChunkedStream(tts.ChunkedStream):
         decode_task: asyncio.Task | None = None
         try:
             async with self._session.post(
-                DEFAULT_API_URL,
+                self._tts._api_url,
                 headers=headers,
                 json=payload,
                 timeout=self._conn_options.timeout,


### PR DESCRIPTION
This PR allows a user to override the default Rime URL in the case of using self-hosted deployments