### PR TITLE
Zg/hume plugin tweaks

### DIFF
--- a/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/__init__.py
+++ b/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/__init__.py
@@ -19,10 +19,10 @@ __version__ = "1.0.0"
 # make imports available
 from hume.tts import (
     Format,
+    FormatWav,
     PostedContext,
     PostedUtterance,
-    PostedUtteranceVoiceWithId,
-    PostedUtteranceVoiceWithName,
+    PostedUtteranceVoice,
 )
 from livekit.agents import Plugin
 
@@ -32,10 +32,10 @@ from .tts import TTS
 __all__ = [
     "TTS",
     "Format",
-    "PostedUtterance",
+    "FormatWav",
     "PostedContext",
-    "PostedUtteranceVoiceWithName",
-    "PostedUtteranceVoiceWithId",
+    "PostedUtterance",
+    "PostedUtteranceVoice",
 ]
 
 

--- a/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/__init__.py
+++ b/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/__init__.py
@@ -19,9 +19,7 @@ __version__ = "1.0.0"
 # make imports available
 from hume.tts import (
     Format,
-    FormatWav,
     PostedContext,
-    PostedUtterance,
     PostedUtteranceVoice,
 )
 from livekit.agents import Plugin
@@ -32,9 +30,7 @@ from .tts import TTS
 __all__ = [
     "TTS",
     "Format",
-    "FormatWav",
     "PostedContext",
-    "PostedUtterance",
     "PostedUtteranceVoice",
 ]
 

--- a/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
+++ b/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
@@ -180,7 +180,6 @@ class TTS(tts.TTS):
                 If disabled, each chunk’s audio will be its own audio file, each with its headers.
         """
 
-
         if is_given(voice):
             self._opts.voice = voice
         if is_given(description):
@@ -246,7 +245,7 @@ class ChunkedStream(tts.ChunkedStream):
 
                 utterance_kwargs = {
                     "text": self._input_text,
-                    **{k: v for k, v in utterance_options.items() if v is not None}
+                    **{k: v for k, v in utterance_options.items() if v is not None},
                 }
 
                 try:

--- a/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
+++ b/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
@@ -56,7 +56,6 @@ class _TTSOptions:
     format: Format
     split_utterances: bool
     strip_headers: bool
-    num_generations: int
     instant_mode: bool
     word_tokenizer: tokenize.WordTokenizer
 
@@ -69,7 +68,6 @@ class TTS(tts.TTS):
         context: NotGivenOr[PostedContext] = NOT_GIVEN,
         format: NotGivenOr[Format] = NOT_GIVEN,
         split_utterances: bool = False,
-        num_generations: int = 1,
         instant_mode: bool = False,
         strip_headers: bool = True,
         api_key: NotGivenOr[str] = NOT_GIVEN,
@@ -91,8 +89,6 @@ class TTS(tts.TTS):
                 When enabled (True), input utterances are split into natural-sounding segments.
                 When disabled (False), maintains one-to-one mapping between input and output.
                 Defaults to False.
-            num_generations (int): Number of generations of the audio to produce.
-                Must be between 1 and 5. Defaults to 1.
             instant_mode (bool): Enables ultra-low latency streaming, reducing time to first chunk.
                 Recommended for real-time applications. Only for streaming endpoints.
                 With this enabled, requests incur 10% higher cost. Defaults to False.
@@ -132,7 +128,6 @@ class TTS(tts.TTS):
             format=format if is_given(format) else FormatWav(),
             api_key=self._api_key,
             split_utterances=split_utterances,
-            num_generations=num_generations,
             strip_headers=strip_headers,
             instant_mode=instant_mode,
             word_tokenizer=word_tokenizer,
@@ -153,7 +148,6 @@ class TTS(tts.TTS):
         context: NotGivenOr[PostedContext] = NOT_GIVEN,
         format: NotGivenOr[Format] = NOT_GIVEN,
         split_utterances: NotGivenOr[bool] = NOT_GIVEN,
-        num_generations: NotGivenOr[int] = NOT_GIVEN,
         instant_mode: NotGivenOr[bool] = NOT_GIVEN,
         strip_headers: NotGivenOr[bool] = NOT_GIVEN,
     ) -> None:
@@ -168,7 +162,6 @@ class TTS(tts.TTS):
             split_utterances (NotGivenOr[bool]): Controls how audio output is segmented.
                 When True, utterances are split into natural-sounding segments.
                 When False, maintains one-to-one mapping between input and output.
-            num_generations (NotGivenOr[int]): Number of speech generations to produce (1-5).
             instant_mode (NotGivenOr[bool]): Enables ultra-low latency streaming.
                 Reduces time to first audio chunk, recommended for real-time applications.
                 Note: Incurs 10% higher cost when enabled.
@@ -185,8 +178,6 @@ class TTS(tts.TTS):
             self._opts.context = context
         if is_given(split_utterances):
             self._opts.split_utterances = split_utterances
-        if is_given(num_generations):
-            self._opts.num_generations = num_generations
         if is_given(instant_mode):
             self._opts.instant_mode = instant_mode
         if is_given(strip_headers):
@@ -248,7 +239,6 @@ class ChunkedStream(tts.ChunkedStream):
                         ],
                         context=self._opts.context,
                         format=self._opts.format,
-                        num_generations=self._opts.num_generations,
                         split_utterances=self._opts.split_utterances,
                         instant_mode=self._opts.instant_mode,
                         strip_headers=self._opts.strip_headers,

--- a/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
+++ b/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
@@ -39,7 +39,7 @@ from livekit.agents.types import (
 from livekit.agents.utils import is_given
 
 # Default audio settings
-DEFAULT_SAMPLE_RATE = 24000
+DEFAULT_SAMPLE_RATE = 48000
 DEFAULT_NUM_CHANNELS = 1
 
 # Default TTS settings
@@ -54,7 +54,6 @@ class _TTSOptions:
     utterance_options: PostedUtterance
     context: PostedContext | None
     format: Format
-    sample_rate: int
     split_utterances: bool
     strip_headers: bool
     num_generations: int
@@ -76,7 +75,6 @@ class TTS(tts.TTS):
         api_key: NotGivenOr[str] = NOT_GIVEN,
         word_tokenizer: tokenize.WordTokenizer | None = None,
         http_session: aiohttp.ClientSession | None = None,
-        sample_rate: int = 24000,
     ) -> None:
         """Initialize the Hume TTS client.
 
@@ -107,14 +105,13 @@ class TTS(tts.TTS):
                 If None, a basic word tokenizer will be used.
             http_session (aiohttp.ClientSession | None): Optional HTTP session for API requests.
                 If None, a new session will be created.
-            sample_rate (int): Audio sample rate in Hz. Defaults to 24000.
         """
 
         super().__init__(
             capabilities=tts.TTSCapabilities(
                 streaming=False,
             ),
-            sample_rate=sample_rate,
+            sample_rate=DEFAULT_SAMPLE_RATE,
             num_channels=DEFAULT_NUM_CHANNELS,
         )
 
@@ -134,7 +131,6 @@ class TTS(tts.TTS):
             context=context if is_given(context) else None,
             format=format if is_given(format) else FormatWav(),
             api_key=self._api_key,
-            sample_rate=self.sample_rate,
             split_utterances=split_utterances,
             num_generations=num_generations,
             strip_headers=strip_headers,
@@ -229,7 +225,7 @@ class ChunkedStream(tts.ChunkedStream):
         request_id = utils.shortuuid()
 
         decoder = utils.codecs.AudioStreamDecoder(
-            sample_rate=self._opts.sample_rate,
+            sample_rate=DEFAULT_SAMPLE_RATE,
             num_channels=DEFAULT_NUM_CHANNELS,
         )
 

--- a/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
+++ b/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
@@ -54,7 +54,6 @@ class _TTSOptions:
     utterance_options: PostedUtterance
     context: PostedContext | None
     format: Format
-    split_utterances: bool
     strip_headers: bool
     instant_mode: bool
     word_tokenizer: tokenize.WordTokenizer
@@ -67,7 +66,6 @@ class TTS(tts.TTS):
         utterance_options: NotGivenOr[PostedUtterance] = NOT_GIVEN,
         context: NotGivenOr[PostedContext] = NOT_GIVEN,
         format: NotGivenOr[Format] = NOT_GIVEN,
-        split_utterances: bool = False,
         instant_mode: bool = False,
         strip_headers: bool = True,
         api_key: NotGivenOr[str] = NOT_GIVEN,
@@ -85,10 +83,6 @@ class TTS(tts.TTS):
                 consistent speech style and prosody across multiple requests.
             format (NotGivenOr[Format]): Specifies the output audio file format (WAV, MP3 or PCM).
                 Defaults to WAV format.
-            split_utterances (bool): Controls how audio output is segmented in the response.
-                When enabled (True), input utterances are split into natural-sounding segments.
-                When disabled (False), maintains one-to-one mapping between input and output.
-                Defaults to False.
             instant_mode (bool): Enables ultra-low latency streaming, reducing time to first chunk.
                 Recommended for real-time applications. Only for streaming endpoints.
                 With this enabled, requests incur 10% higher cost. Defaults to False.
@@ -127,7 +121,6 @@ class TTS(tts.TTS):
             context=context if is_given(context) else None,
             format=format if is_given(format) else FormatWav(),
             api_key=self._api_key,
-            split_utterances=split_utterances,
             strip_headers=strip_headers,
             instant_mode=instant_mode,
             word_tokenizer=word_tokenizer,
@@ -147,7 +140,6 @@ class TTS(tts.TTS):
         utterance_options: NotGivenOr[PostedUtterance] = NOT_GIVEN,
         context: NotGivenOr[PostedContext] = NOT_GIVEN,
         format: NotGivenOr[Format] = NOT_GIVEN,
-        split_utterances: NotGivenOr[bool] = NOT_GIVEN,
         instant_mode: NotGivenOr[bool] = NOT_GIVEN,
         strip_headers: NotGivenOr[bool] = NOT_GIVEN,
     ) -> None:
@@ -159,9 +151,6 @@ class TTS(tts.TTS):
             context (Optional[PostedContext]): Utterances to use as context for generating
                 consistent speech style and prosody across multiple requests.
             format (NotGivenOr[Format]): Specifies the output audio file format (WAV, MP3 or PCM).
-            split_utterances (NotGivenOr[bool]): Controls how audio output is segmented.
-                When True, utterances are split into natural-sounding segments.
-                When False, maintains one-to-one mapping between input and output.
             instant_mode (NotGivenOr[bool]): Enables ultra-low latency streaming.
                 Reduces time to first audio chunk, recommended for real-time applications.
                 Note: Incurs 10% higher cost when enabled.
@@ -176,8 +165,6 @@ class TTS(tts.TTS):
             self._opts.format = format
         if is_given(context):
             self._opts.context = context
-        if is_given(split_utterances):
-            self._opts.split_utterances = split_utterances
         if is_given(instant_mode):
             self._opts.instant_mode = instant_mode
         if is_given(strip_headers):
@@ -239,7 +226,6 @@ class ChunkedStream(tts.ChunkedStream):
                         ],
                         context=self._opts.context,
                         format=self._opts.format,
-                        split_utterances=self._opts.split_utterances,
                         instant_mode=self._opts.instant_mode,
                         strip_headers=self._opts.strip_headers,
                     ):


### PR DESCRIPTION
**Update defaults and accepted parameters for Hume Plugin**
- Removes `sample_rate` parameter and updates default sample rate to `48000` (Hz). 
    - The Hume API does not currently support setting the sample rate, and only outputs audio with a sample rate of `48000` Hz.
- Removes the `num_generations` parameter, allowing for the API to default to `1`. 
    - When more than one generation is specified all generations are streamed at once (e.g., `gen1_chunk1`, `gen2_chunk1`, `gen1_chunk2`, `gen2_chunk2`...etc.)
- Removes `split_utterances` parameter, allowing for the API to default to `true`. 
    - Since the audio is being fed directly to the emitter, and only a single utterance is specified per request, this argument will make no difference to the end user.
- Simplifies the API surface area of the plugin to reflect only a single `utterance` is specified on each request. 
    - Removes `utterance_options` parameter in favor of making `voice`, `description`, and `speed` each individual parameters.
    - Removes `trailing_silence` parameter since `trailing_silence` is an API field for injecting pauses between utterances when multiple utterances are provided.