### PR TITLE
Add ElevenLabs plugin support for SSML break tags

### DIFF
--- a/.github/next-release/changeset-4c7519f9.md
+++ b/.github/next-release/changeset-4c7519f9.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-elevenlabs": patch
+---
+
+Add ElevenLabs plugin support for SSML break tags (#2173)


### PR DESCRIPTION
ElevenLabs has support for SSML pauses in speech using  `<break time="0.3s" />`.
This PR adds support for them, in addition to the existing phonemes, waiting for the full tag to be present before passing it to TTS, not doing this can result in glitchy speech as it tries to speak partial XML.