### PR TITLE
fix(google-tts): Audio encoding for Chirp3 voices not compatible with PCM encoding

### DIFF
--- a/.github/next-release/changeset-63a32de3.md
+++ b/.github/next-release/changeset-63a32de3.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-google": patch
+---
+
+fix(google-tts): Audio encoding for Chirp3 voices not compatible with PCM encoding (#2176)

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
@@ -56,6 +56,7 @@ class TTS(tts.TTS):
         effects_profile_id: str = "",
         speaking_rate: float = 1.0,
         location: str = "global",
+        audio_encoding: texttospeech.AudioEncoding = texttospeech.AudioEncoding.PCM,
         credentials_info: NotGivenOr[dict] = NOT_GIVEN,
         credentials_file: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
@@ -105,7 +106,7 @@ class TTS(tts.TTS):
         self._opts = _TTSOptions(
             voice=voice_params,
             audio_config=texttospeech.AudioConfig(
-                audio_encoding=texttospeech.AudioEncoding.PCM,
+                audio_encoding=audio_encoding,
                 sample_rate_hertz=sample_rate,
                 pitch=pitch,
                 effects_profile_id=effects_profile_id,


### PR DESCRIPTION
Fixes an issue introduced in: https://github.com/livekit/agents/pull/2139
https://github.com/livekit/agents/pull/2139#issuecomment-2845691859

This PR addresses an issue where Google TTS voices, specifically those in the Chirp3 family, could not be used due to incompatible audio encoding requests. The default PCM encoding used by the agent framework is not supported by these specific voices.

**Problem Details:**
When attempting to synthesize speech using a Chirp3 voice via `livekit.plugins.google.tts.TTS`, the underlying API rejects the request with a `400 Bad Request` status. The error message clearly states the supported output encodings: `ALAW`, `LINEAR16`, `MULAW`, `MP3`, and `OGG_OPUS`.

**Example Error Snippet**
`livekit.agents._exceptions.APIStatusError: This voice currently only supports ALAW, LINEAR16, MULAW, MP3 and OGG_OPUS output. (status_code=400, request_id=None, body=None) {"tts": "livekit.plugins.google.tts.TTS", "attempt": 2, "streamed": false, "pid": 31836, "job_id": "AJ_xTbpV4gK3xgb"}`

**Solution:**
This change exposes the audio encoding configuration for the TTS plugin. This allows users to explicitly set a compatible encoding, such as `LINEAR16`, enabling the use of Chirp3 voices.
