### PR TITLE
Fix generate_reply for Gemini LLM

### DIFF
--- a/.github/next-release/changeset-ed9ee113.md
+++ b/.github/next-release/changeset-ed9ee113.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-google": patch
+---
+
+Fix generate_reply for Gemini LLM (#2183)

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -270,7 +270,7 @@ class LLMStream(llm.LLMStream):
         request_id = utils.shortuuid()
 
         try:
-            turns, system_instruction = to_chat_ctx(self._chat_ctx, id(self._llm))
+            turns, system_instruction = to_chat_ctx(self._chat_ctx, id(self._llm), generate=True)
             function_declarations = to_fnc_ctx(self._tools)
             if function_declarations:
                 self._extra_kwargs["tools"] = [

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
@@ -39,7 +39,10 @@ def get_tool_results_for_realtime(chat_ctx: llm.ChatContext) -> types.LiveClient
 
 
 def to_chat_ctx(
-    chat_ctx: llm.ChatContext, cache_key: Any, ignore_functions: bool = False
+    chat_ctx: llm.ChatContext,
+    cache_key: Any,
+    ignore_functions: bool = False,
+    generate: bool = False,
 ) -> tuple[list[types.Content], types.Content | None]:
     turns: list[types.Content] = []
     system_instruction: types.Content | None = None
@@ -99,10 +102,9 @@ def to_chat_ctx(
     if current_role is not None and parts:
         turns.append(types.Content(role=current_role, parts=parts))
 
-    # # Gemini requires the last message to end with user's turn before they can generate
-    # # currently not used because to_chat_ctx should not be used to force a new generation
-    # if current_role != "user":
-    #     turns.append(types.Content(role="user", parts=[types.Part(text=".")]))
+    # Gemini requires the last message to end with user's turn before they can generate
+    if generate and current_role != "user":
+        turns.append(types.Content(role="user", parts=[types.Part(text=".")]))
 
     return turns, system_instruction
 


### PR DESCRIPTION
Gemini requires generation requests to end with the user's turn

fixes #2180 