### PR TITLE
Fix: FunctionOutputResponse not getting recognised to gemini live-api

### DIFF
--- a/.github/next-release/changeset-2dbbc82b.md
+++ b/.github/next-release/changeset-2dbbc82b.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-google": patch
+---
+
+Fix: FunctionOutputResponse not getting recognised to gemini live-api (#2185)


### PR DESCRIPTION
Hi Team, 

**Contribution** to fix: #2174 

**Context**: FunctionOutputResponse to a tool-call for realtime api was not getting sent to the gemini live api.  Because of deprecated function getting used.  

**Problem**: 
1. Whenever the tool response is injected back - the model speaks out as "tool_outputs" 
2. Model is not able to derive the context - from the tool-response(a.k.a) unable to understand. 

**Solution**: Using the latest apis - seems to be fixing this issue.


**Document link:** https://googleapis.github.io/python-genai/genai.html#module-genai.types

### Important Note: (Maybe we can update the documentation)
During several debugging found that the functionResponse should be always string - and it should not contain any special characters. 

```python
types.FunctionResponse(
    id=msg.call_id,
    name=msg.name,
    response={"output": msg.output}, #the msg.output should be str and should not contain special character.
)
```

Presence of special character in the response, is also leading to model not recognising the tool-call. 

cc: @davidzhao 