### PR TITLE
supress StopResponse exception in llm inference

### DIFF
--- a/.github/next-release/changeset-55384ed9.md
+++ b/.github/next-release/changeset-55384ed9.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+supress StopResponse exception in llm inference (#2207)

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -112,6 +112,8 @@ def perform_llm_inference(
                         logger.warning(
                             f"LLM node returned an unexpected type: {type(chunk)}",
                         )
+            except StopResponse:
+                return  # ignore this turn
             finally:
                 if isinstance(llm_node, _ACloseable):
                     await llm_node.aclose()


### PR DESCRIPTION
users might want to stop response in LLM node, similar to how we do it in `on_user_turn_completed`https://github.com/livekit/agents/blob/b9b18d37525350dbf9a222ff01f2b369cbf101e3/livekit-agents/livekit/agents/voice/agent_activity.py#L891

PTAL @davidzhao @theomonnom @longcw 