### PR TITLE
move drain_timeout to WorkerOptions, increase default to 30 mins

### DIFF
--- a/livekit-agents/livekit/agents/cli/_run.py
+++ b/livekit-agents/livekit/agents/cli/_run.py
@@ -107,7 +107,7 @@ def run_worker(args: proto.CliArgs, *, jupyter: bool = False) -> None:
 
         try:
             if not args.devmode:
-                loop.run_until_complete(worker.drain(timeout=args.drain_timeout))
+                loop.run_until_complete(worker.drain(timeout=args.opts.drain_timeout))
 
             loop.run_until_complete(worker.aclose())
 

--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -1,6 +1,5 @@
 from __future__ import annotations  # noqa: I001
 
-
 import click
 
 from .. import utils
@@ -48,15 +47,17 @@ def run_app(
     @click.option(
         "--drain-timeout",
         type=int,
-        default=0,
+        default=None,
         help="Time in seconds to wait for jobs to finish before shutting down",
     )
-    def start(log_level: str, url: str, api_key: str, api_secret: str, drain_timeout: int) -> None:
+    def start(
+        log_level: str, url: str, api_key: str, api_secret: str, drain_timeout: int | None = None
+    ) -> None:
         opts.ws_url = url or opts.ws_url
         opts.api_key = api_key or opts.api_key
         opts.api_secret = api_secret or opts.api_secret
         # backwards compatibility
-        if drain_timeout > 0:
+        if drain_timeout is not None:
             opts.drain_timeout = drain_timeout
         args = proto.CliArgs(
             opts=opts,

--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -47,13 +47,17 @@ def run_app(
     )
     @click.option(
         "--drain-timeout",
-        default=60,
+        type=int,
+        default=0,
         help="Time in seconds to wait for jobs to finish before shutting down",
     )
     def start(log_level: str, url: str, api_key: str, api_secret: str, drain_timeout: int) -> None:
         opts.ws_url = url or opts.ws_url
         opts.api_key = api_key or opts.api_key
         opts.api_secret = api_secret or opts.api_secret
+        # backwards compatibility
+        if drain_timeout > 0:
+            opts.drain_timeout = drain_timeout
         args = proto.CliArgs(
             opts=opts,
             log_level=log_level,
@@ -61,7 +65,6 @@ def run_app(
             asyncio_debug=False,
             register=True,
             watch=False,
-            drain_timeout=drain_timeout,
         )
         global CLI_ARGUMENTS
         CLI_ARGUMENTS = args
@@ -110,13 +113,13 @@ def run_app(
         opts.ws_url = url or opts.ws_url
         opts.api_key = api_key or opts.api_key
         opts.api_secret = api_secret or opts.api_secret
+        opts.drain_timeout = 0
         args = proto.CliArgs(
             opts=opts,
             log_level=log_level,
             devmode=True,
             asyncio_debug=asyncio_debug,
             watch=watch,
-            drain_timeout=0,
             register=True,
         )
         global CLI_ARGUMENTS
@@ -149,7 +152,7 @@ def run_app(
         opts.ws_url = url or opts.ws_url or "ws://localhost:7881/fake_console_url"
         opts.api_key = api_key or opts.api_key or "fake_console_key"
         opts.api_secret = api_secret or opts.api_secret or "fake_console_secret"
-
+        opts.drain_timeout = 0
         args = proto.CliArgs(
             opts=opts,
             log_level="DEBUG",
@@ -157,7 +160,6 @@ def run_app(
             asyncio_debug=False,
             watch=False,
             console=True,
-            drain_timeout=0,
             register=False,
             simulate_job=SimulateJobInfo(room="mock-console"),
         )
@@ -212,6 +214,7 @@ def run_app(
         opts.ws_url = url or opts.ws_url
         opts.api_key = api_key or opts.api_key
         opts.api_secret = api_secret or opts.api_secret
+        opts.drain_timeout = 0
         args = proto.CliArgs(
             opts=opts,
             log_level=log_level,
@@ -219,7 +222,6 @@ def run_app(
             register=False,
             asyncio_debug=asyncio_debug,
             watch=watch,
-            drain_timeout=0,
             simulate_job=SimulateJobInfo(room=room, participant_identity=participant_identity),
         )
         global CLI_ARGUMENTS

--- a/livekit-agents/livekit/agents/cli/proto.py
+++ b/livekit-agents/livekit/agents/cli/proto.py
@@ -19,7 +19,6 @@ class CliArgs:
     devmode: bool
     asyncio_debug: bool
     watch: bool
-    drain_timeout: int
 
     console: bool = False
     # whether to run the worker in console mode (console subcommand

--- a/livekit-agents/livekit/agents/jupyter.py
+++ b/livekit-agents/livekit/agents/jupyter.py
@@ -102,13 +102,13 @@ def run_app(
             root.removeHandler(handler)
 
     opts.job_executor_type = JobExecutorType.THREAD
+    opts.drain_timeout = 0
     args = proto.CliArgs(
         opts=opts,
         log_level="DEBUG",
         devmode=True,
         asyncio_debug=False,
         watch=False,
-        drain_timeout=0,
         register=False,
         simulate_job=agent_token,
     )

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -173,7 +173,8 @@ class WorkerOptions:
     Defaults to 0 (disabled).
     """  # noqa: E501
 
-    """Number of idle processes to keep warm."""
+    drain_timeout: int = 1800
+    """Number of seconds to wait for current jobs to finish upon receiving TERM or INT signal."""
     num_idle_processes: int | _WorkerEnvOption[int] = _WorkerEnvOption(
         dev_default=0, prod_default=math.ceil(get_cpu_monitor().cpu_count())
     )


### PR DESCRIPTION
60s default is too aggressive for most sessions to finish.

WorkerOptions is a more consistent place for users to set worker settings