### PR TITLE
Use assigned key and secret

### DIFF
--- a/livekit-plugins/livekit-plugins-bey/livekit/plugins/bey/avatar.py
+++ b/livekit-plugins/livekit-plugins-bey/livekit/plugins/bey/avatar.py
@@ -84,7 +84,7 @@ class AvatarSession:
             )
 
         livekit_token = (
-            api.AccessToken()
+            api.AccessToken(api_key=livekit_api_key, api_secret=livekit_api_secret)
             .with_kind("agent")
             .with_identity(self._avatar_participant_identity)
             .with_name(self._avatar_participant_name)

--- a/livekit-plugins/livekit-plugins-tavus/livekit/plugins/tavus/avatar.py
+++ b/livekit-plugins/livekit-plugins-tavus/livekit/plugins/tavus/avatar.py
@@ -78,7 +78,7 @@ class AvatarSession:
             )
 
         livekit_token = (
-            api.AccessToken()
+            api.AccessToken(api_key=livekit_api_key, api_secret=livekit_api_secret)
             .with_kind("agent")
             .with_identity(self._avatar_participant_identity)
             .with_name(self._avatar_participant_name)


### PR DESCRIPTION
This PR makes sure both plugins (bay & tavus) use the assigned LK api and secret, instead of reading from env.