### PR TITLE
bug fix: Deepgram TTS: mip_opt_out value must be lower case

### DIFF
--- a/.github/next-release/changeset-6ccb04ca.md
+++ b/.github/next-release/changeset-6ccb04ca.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-deepgram": patch
+---
+
+bug fix: Deepgram TTS: mip_opt_out value must be lower case (#2237)

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
@@ -102,7 +102,7 @@ class TTS(tts.TTS):
             "encoding": self._opts.encoding,
             "model": self._opts.model,
             "sample_rate": self._opts.sample_rate,
-            "mip_opt_out": self._opts.mip_opt_out,
+            "mip_opt_out": str(self._opts.mip_opt_out).lower(),
         }
         return await asyncio.wait_for(
             session.ws_connect(
@@ -212,7 +212,7 @@ class ChunkedStream(tts.ChunkedStream):
                 "encoding": self._opts.encoding,
                 "model": self._opts.model,
                 "sample_rate": self._opts.sample_rate,
-                "mip_opt_out": self._opts.mip_opt_out,
+                "mip_opt_out": str(self._opts.mip_opt_out).lower(),
             }
             async with self._session.post(
                 _to_deepgram_url(config, self._base_url, websocket=False),
@@ -386,7 +386,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                     "encoding": self._opts.encoding,
                     "model": self._opts.model,
                     "sample_rate": self._opts.sample_rate,
-                    "mip_opt_out": self._opts.mip_opt_out,
+                    "mip_opt_out": str(self._opts.mip_opt_out).lower(),
                 }
                 ws = await asyncio.wait_for(
                     self._session.ws_connect(


### PR DESCRIPTION
Fixes this exception:
```
2025-05-08 14:14:41,139 - WARNING livekit.agents - failed to synthesize speech, retrying in 2.0s
Traceback (most recent call last):
  File "/Users/mike/Documents/livekit/working/ai/venv/lib/python3.10/site-packages/livekit/plugins/deepgram/tts.py", line 391, in _run
    ws = await asyncio.wait_for(
  File "/Users/mike/.pyenv/versions/3.10.15/lib/python3.10/asyncio/tasks.py", line 445, in wait_for
    return fut.result()
  File "/Users/mike/Documents/livekit/working/ai/venv/lib/python3.10/site-packages/aiohttp/client.py", line 1409, in send
    return self._coro.send(arg)
  File "/Users/mike/Documents/livekit/working/ai/venv/lib/python3.10/site-packages/aiohttp/client.py", line 1021, in _ws_connect
    raise WSServerHandshakeError(
aiohttp.client_exceptions.WSServerHandshakeError: 400, message='Invalid response status', url='wss://api.deepgram.com/v1/speak?encoding=linear16&model=aura-2-theia-en&sample_rate=24000&mip_opt_out=False'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/mike/Documents/livekit/working/ai/venv/lib/python3.10/site-packages/livekit/agents/tts/tts.py", line 301, in _main_task
    return await self._run()
  File "/Users/mike/Documents/livekit/working/ai/venv/lib/python3.10/site-packages/livekit/plugins/deepgram/tts.py", line 428, in _run
    raise APIStatusError(
livekit.agents._exceptions.APIStatusError: Invalid response status (status_code=400, request_id=, body=None)
```