### PR TITLE
use the forkserver on Linux by default 

### DIFF
--- a/livekit-agents/livekit/agents/tts/stream_adapter.py
+++ b/livekit-agents/livekit/agents/tts/stream_adapter.py
@@ -7,7 +7,6 @@ from .. import tokenize, utils
 from ..types import DEFAULT_API_CONNECT_OPTIONS, APIConnectOptions
 from .tts import TTS, ChunkedStream, SynthesizedAudio, SynthesizeStream, TTSCapabilities
 
-
 # already a retry mechanism in TTS.synthesize, don't retry in stream adapter
 DEFAULT_STREAM_ADAPTER_API_CONNECT_OPTIONS = APIConnectOptions(
     max_retry=0, timeout=DEFAULT_API_CONNECT_OPTIONS.timeout

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -52,6 +52,7 @@ from .job import (
     RunningJobInfo,
 )
 from .log import DEV_LEVEL, logger
+from .plugin import Plugin
 from .types import NOT_GIVEN, NotGivenOr
 from .utils import is_given
 from .utils.hw import get_cpu_monitor
@@ -215,6 +216,13 @@ class WorkerOptions:
 
     By default it uses ``HTTP_PROXY`` or ``HTTPS_PROXY`` from environment
     """
+    multiprocessing_context: Literal["spawn", "forkserver"] = (
+        "spawn" if not sys.platform.startswith("linux") else "forkserver"
+    )
+    """The multiprocessing context to use.
+
+    By default it uses "spawn" on all platforms, but "forkserver" on Linux.
+    """
 
     def validate_config(self, devmode: bool):
         load_threshold = _WorkerEnvOption.getvalue(self.load_threshold, devmode)
@@ -278,9 +286,7 @@ class Worker(utils.EventEmitter[EventTypes]):
         self._devmode = devmode
         self._register = register
 
-        # using spawn context for all platforms. We may have further optimizations for
-        # Linux with forkserver, but for now, this is the safest option
-        mp_ctx = mp.get_context("spawn")
+        self._mp_ctx = mp.get_context(self._opts.multiprocessing_context)
 
         self._inference_executor: ipc.inference_proc_executor.InferenceProcExecutor | None = None
         if len(_InferenceRunner.registered_runners) > 0:
@@ -293,7 +299,7 @@ class Worker(utils.EventEmitter[EventTypes]):
                 ping_interval=5,
                 ping_timeout=60,
                 high_ping_threshold=2.5,
-                mp_ctx=mp_ctx,
+                mp_ctx=self._mp_ctx,
                 loop=self._loop,
                 http_proxy=opts.http_proxy or None,
             )
@@ -305,7 +311,7 @@ class Worker(utils.EventEmitter[EventTypes]):
             loop=self._loop,
             job_executor_type=opts.job_executor_type,
             inference_executor=self._inference_executor,
-            mp_ctx=mp_ctx,
+            mp_ctx=self._mp_ctx,
             initialize_timeout=opts.initialize_process_timeout,
             close_timeout=opts.shutdown_process_timeout,
             memory_warn_mb=opts.job_memory_warn_mb,
@@ -386,6 +392,10 @@ class Worker(utils.EventEmitter[EventTypes]):
             "starting worker",
             extra={"version": __version__, "rtc-version": rtc.__version__},
         )
+
+        plugin_packages = [p.package for p in Plugin.registered_plugins]
+        logger.info("preloading plugins", extra={"packages": plugin_packages})
+        self._mp_ctx.set_forkserver_preload(plugin_packages)
 
         if self._inference_executor is not None:
             logger.info("starting inference executor")

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -393,9 +393,10 @@ class Worker(utils.EventEmitter[EventTypes]):
             extra={"version": __version__, "rtc-version": rtc.__version__},
         )
 
-        plugin_packages = [p.package for p in Plugin.registered_plugins]
-        logger.info("preloading plugins", extra={"packages": plugin_packages})
-        self._mp_ctx.set_forkserver_preload(plugin_packages)
+        if self._opts.multiprocessing_context == "forkserver":
+            plugin_packages = [p.package for p in Plugin.registered_plugins]
+            logger.info("preloading plugins", extra={"packages": plugin_packages})
+            self._mp_ctx.set_forkserver_preload(plugin_packages)
 
         if self._inference_executor is not None:
             logger.info("starting inference executor")


### PR DESCRIPTION
- also load every registered plugins
- processes are now launched instantly 0.02seconds instead of 3 seconds on the basic_agent.py example

Users can still use the old behaviour using `WorkerOptions(multiprocessing_context="spawn")`

This is safe as long as our plugins don't start threads at import time 