### PR TITLE
livekit-plugins-aws: update the dependencies to allow for versions greater than specified version

### DIFF
--- a/.github/next-release/changeset-e65c5aa1.md
+++ b/.github/next-release/changeset-e65c5aa1.md
@@ -1,0 +1,7 @@
+---
+"livekit-agents": patch
+"livekit-plugins-aws": patch
+"livekit-plugins-openai": patch
+---
+
+livekit-plugins-aws: update the dependencies to allow for versions greater than specified version (#2244)

--- a/livekit-plugins/livekit-plugins-aws/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-aws/pyproject.toml
@@ -24,9 +24,9 @@ classifiers = [
 ]
 dependencies = [
     "livekit-agents>=1.0.20",
-    "aioboto3==14.1.0",
-    "amazon-transcribe==0.6.2",
-    "boto3==1.37.1",
+    "aioboto3>=14.1.0",
+    "amazon-transcribe>=0.6.2",
+    "boto3>=1.37.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
Some users have complained that the dependency on `boto3==1.37.1` is too restrictive.  I tested LLM/STT/TTS with newest versions of each without any issues.

``` python
   session = AgentSession(
        vad=ctx.proc.userdata["vad"],
        llm=aws.LLM(
            model="anthropic.claude-3-5-sonnet-20240620-v1:0",
            temperature=0.8,
        ),
         stt = aws.STT(
             language="en-US",
         ),
        tts=aws.TTS(
            voice="Ruth",
            speech_engine="generative",
            language="en-US",
        ),
        turn_detection=multilingual.MultilingualModel(),
    )
```