### PR TITLE
feat: support cached prompt metrics for Gemini LLM

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -325,6 +325,7 @@ class LLMStream(llm.LLMStream):
                             usage=llm.CompletionUsage(
                                 completion_tokens=usage.candidates_token_count or 0,
                                 prompt_tokens=usage.prompt_token_count or 0,
+                                prompt_cached_tokens=usage.cached_content_token_count or 0,
                                 total_tokens=usage.total_token_count or 0,
                             ),
                         )

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/models.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/models.py
@@ -95,6 +95,8 @@ SpeechLanguages = Literal[
 Gender = Literal["male", "female", "neutral"]
 
 ChatModels = Literal[
+    "gemini-2.5-pro-preview-05-06",
+    "gemini-2.5-flash-preview-04-17",
     "gemini-2.0-flash-001",
     "gemini-2.0-flash-lite-preview-02-05",
     "gemini-2.0-pro-exp-02-05",


### PR DESCRIPTION
Since Google has introduced implicit caching for the Gemini 2.5 Flash and Pro models, it’s beneficial to include information about cached input in the metrics. More details can be found in the official announcement: https://developers.googleblog.com/en/gemini-2-5-models-now-support-implicit-caching/

Additionally, this PR updates the list of available models for the Google LLM provider to include the newest Gemini versions.

Example log output:
```
2025-05-10 01:41:58,739 - INFO livekit.agents - LLM metrics: ttft=1.93, input_tokens=2834,  cached_input_tokens=1909, output_tokens=27, tokens_per_second=13.68 {"room": "playground-4xOP-jDVN", "pid": 88079, "job_id": "AJ_E8rmWvgTDawx"}
```