### PR TITLE
support simple word and sentence split for character-based language

### DIFF
--- a/.github/next-release/changeset-990dabed.md
+++ b/.github/next-release/changeset-990dabed.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+support simple word and sentence split for character-based language (#2263)

--- a/livekit-agents/livekit/agents/tokenize/_basic_sent.py
+++ b/livekit-agents/livekit/agents/tokenize/_basic_sent.py
@@ -39,17 +39,11 @@ def split_sentences(
     text = re.sub(r" "+suffixes+"[.] "+starters," \\1<stop> \\2",text)
     text = re.sub(r" "+suffixes+"[.]"," \\1<prd>",text)
     text = re.sub(r" " + alphabets + "[.]"," \\1<prd>",text)
-    if "”" in text:
-        text = text.replace(".”","”.")
-    if "\"" in text:
-        text = text.replace(".\"","\".")
-    if "!" in text:
-        text = text.replace("!\"","\"!")
-    if "?" in text:
-        text = text.replace("?\"","\"?")
-    text = text.replace(".",".<stop>")
-    text = text.replace("?","?<stop>")
-    text = text.replace("!","!<stop>")
+
+    # mark end of sentence punctuations with <stop>
+    text = re.sub(r"([.!?。！？])([\"”])", "\\1\\2<stop>", text)
+    text = re.sub(r"([.!?。！？])(?![\"”])", "\\1<stop>", text)
+
     text = text.replace("<prd>",".")
     # fmt: on
 

--- a/livekit-agents/livekit/agents/tokenize/_basic_word.py
+++ b/livekit-agents/livekit/agents/tokenize/_basic_word.py
@@ -5,25 +5,58 @@ from . import tokenizer
 
 def split_words(text: str, ignore_punctuation: bool = True) -> list[tuple[str, int, int]]:
     """
-    Split the text into words.
+    Split text into words, supporting both space-separated languages (like English)
+    and character-based languages (like Chinese, Japanese, Korean, Thai, etc).
+
+    For non-spaced scripts (CJK, Thai, Arabic, Hebrew, Indic, etc), each character
+    is treated as a separate word. For other languages, words are split by whitespace.
+
     Returns a list of words with their start and end indices of the original text.
     """
-    matches = re.finditer(r"\S+", text)
     words: list[tuple[str, int, int]] = []
 
-    for match in matches:
-        word = match.group(0)
-        start_pos = match.start()
-        end_pos = match.end()
+    # CJK: \u4e00-\u9fff, \u3040-\u30ff, \u3400-\u4dbf
+    # Thai: \u0E00-\u0E7F
+    # Arabic: \u0600-\u06FF
+    # Hebrew: \u0590-\u05FF
+    # Devanagari (Hindi): \u0900-\u097F
+    char_based_codes = re.compile(
+        r"[\u4e00-\u9fff\u3040-\u30ff\u3400-\u4dbf"  # CJK scripts
+        r"\u0E00-\u0E7F\u0600-\u06FF\u0590-\u05FF"  # Thai, Arabic, Hebrew
+        r"\u0900-\u097F\u0980-\u09FF\u0A00-\u0A7F\u0A80-\u0AFF\u0B00-\u0B7F]"  # Indic scripts
+    )
 
-        if ignore_punctuation:
-            # TODO(theomonnom): acronyms passthrough
-            translation_table = str.maketrans("", "", "".join(tokenizer.PUNCTUATIONS))
+    pos = 0
+    word_start = 0
+
+    translation_table = (
+        str.maketrans("", "", "".join(tokenizer.PUNCTUATIONS)) if ignore_punctuation else None
+    )
+
+    def _add_current_word(start: int, end: int):
+        word = text[start:end]
+        if translation_table and word:
             word = word.translate(translation_table)
 
-            if not word:
-                continue
+        if word:
+            words.append((word, start, end))
 
-        words.append((word, start_pos, end_pos))
+    for pos, char in enumerate(text):
+        if char.isspace():
+            # reached whitespace, commit current word
+            _add_current_word(word_start, pos)
+            word_start = pos + 1
+            continue
+
+        if char_based_codes.match(char):
+            if word_start < pos:
+                _add_current_word(word_start, pos)
+
+            # commit character as a word
+            _add_current_word(pos, pos + 1)
+            word_start = pos + 1
+
+    # add the last word if there is one
+    _add_current_word(word_start, len(text))
 
     return words

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -19,6 +19,8 @@ TEXT = (
     "f(x) = x * 2.54 + 42. "
     "Hey!\n Hi! Hello! "
     "\n\n"
+    "This is a sentence. 这是一个中文句子。これは日本語の文章です。"
+    "你好！LiveKit是一个直播音频和视频应用程序和服务的平台。"
 )
 
 EXPECTED_MIN_20 = [
@@ -28,7 +30,9 @@ EXPECTED_MIN_20 = [
     "This is a test. Another test.",
     "A short sentence. A longer sentence that is longer than the previous sentence.",
     "f(x) = x * 2.54 + 42.",
-    "Hey! Hi! Hello!",
+    "Hey! Hi! Hello! This is a sentence.",
+    "这是一个中文句子。 これは日本語の文章です。",
+    "你好！ LiveKit是一个直播音频和视频应用程序和服务的平台。",
 ]
 
 EXPECTED_MIN_20_RETAIN_FORMAT = [
@@ -38,11 +42,25 @@ EXPECTED_MIN_20_RETAIN_FORMAT = [
     " \nThis is a test. Another test.",
     " A short sentence.\nA longer sentence that is longer than the previous sentence.",
     " f(x) = x * 2.54 + 42.",
-    " Hey!\n Hi! Hello! \n\n",
+    " Hey!\n Hi! Hello! \n\nThis is a sentence.",
+    " 这是一个中文句子。これは日本語の文章です。",
+    "你好！LiveKit是一个直播音频和视频应用程序和服务的平台。",
+]
+
+EXPECTED_MIN_20_NLTK = [
+    "Hi! LiveKit is a platform for live audio and video applications and services.",
+    "R.T.C stands for Real-Time Communication... again R.T.C.",
+    "Mr. Theo is testing the sentence tokenizer.",
+    "This is a test. Another test.",
+    "A short sentence. A longer sentence that is longer than the previous sentence.",
+    "f(x) = x * 2.54 + 42.",
+    "Hey! Hi! Hello! This is a sentence.",
+    # nltk does not support character-based languages like CJK
+    "这是一个中文句子。これは日本語の文章です。你好！LiveKit是一个直播音频和视频应用程序和服务的平台。",
 ]
 
 SENT_TOKENIZERS = [
-    (nltk.SentenceTokenizer(min_sentence_len=20), EXPECTED_MIN_20),
+    (nltk.SentenceTokenizer(min_sentence_len=20), EXPECTED_MIN_20_NLTK),
     (basic.SentenceTokenizer(min_sentence_len=20), EXPECTED_MIN_20),
     (
         basic.SentenceTokenizer(min_sentence_len=20, retain_format=True),
@@ -54,6 +72,7 @@ SENT_TOKENIZERS = [
 @pytest.mark.parametrize("tokenizer, expected", SENT_TOKENIZERS)
 def test_sent_tokenizer(tokenizer: tokenize.SentenceTokenizer, expected: list[str]):
     segmented = tokenizer.tokenize(text=TEXT)
+    print(segmented)
     for i, segment in enumerate(expected):
         assert segment == segmented[i]
 
@@ -133,7 +152,10 @@ async def test_streamed_word_tokenizer(tokenizer: tokenize.WordTokenizer):
         assert ev.token == WORDS_EXPECTED[i]
 
 
-WORDS_PUNCT_TEXT = 'This is <phoneme alphabet="cmu-arpabet" ph="AE K CH UW AH L IY">actually</phoneme> tricky to handle.'  # noqa: E501
+WORDS_PUNCT_TEXT = (
+    'This is <phoneme alphabet="cmu-arpabet" ph="AE K CH UW AH L IY">actually</phoneme> tricky to handle.'  # noqa: E501
+    "这是一个中文句子。 これは日本語の文章です。"
+)
 
 WORDS_PUNCT_EXPECTED = [
     "This",
@@ -150,6 +172,27 @@ WORDS_PUNCT_EXPECTED = [
     "tricky",
     "to",
     "handle.",
+    "这",
+    "是",
+    "一",
+    "个",
+    "中",
+    "文",
+    "句",
+    "子",
+    "。",
+    "こ",
+    "れ",
+    "は",
+    "日",
+    "本",
+    "語",
+    "の",
+    "文",
+    "章",
+    "で",
+    "す",
+    "。",
 ]
 
 WORD_PUNCT_TOKENIZERS = [basic.WordTokenizer(ignore_punctuation=False)]


### PR DESCRIPTION
A simple fix for character based languages (Chinese, Japanese, Korean, etc.) before https://github.com/livekit/agents/issues/1811

Fix https://github.com/livekit/agents/issues/1985