### PR TITLE
pin google-cloud-texttospeech version >= 2.24

### DIFF
--- a/livekit-plugins/livekit-plugins-google/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-google/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
     "google-auth >= 2, < 3",
     "google-cloud-speech >= 2, < 3",
-    "google-cloud-texttospeech >= 2, < 3",
+    "google-cloud-texttospeech >= 2.24, < 3",
     "google-genai >= 1.14.0",
     "livekit-agents>=1.0.20",
 ]


### PR DESCRIPTION
`texttospeech.AudioEncoding.PCM` was added after 2.24 https://github.com/googleapis/google-cloud-python/releases/tag/google-cloud-texttospeech-v2.24.0

Fix https://github.com/livekit/agents/issues/2267