### PR TITLE
Fix Neuphonic CI Tests.

### DIFF
--- a/livekit-plugins/livekit-plugins-neuphonic/livekit/plugins/neuphonic/tts.py
+++ b/livekit-plugins/livekit-plugins-neuphonic/livekit/plugins/neuphonic/tts.py
@@ -134,9 +134,14 @@ class TTS(tts.TTS):
             num_channels=NUM_CHANNELS,
         )
 
-        neuphonic_api_key = api_key if is_given(api_key) else os.environ.get("NEUPHONIC_API_TOKEN")
+        neuphonic_api_key = (
+            api_key
+            if is_given(api_key)
+            else os.environ.get("NEUPHONIC_API_KEY") or os.environ.get("NEUPHONIC_API_TOKEN")
+        )
+
         if not neuphonic_api_key:
-            raise ValueError("API key must be provided or set in NEUPHONIC_API_TOKEN")
+            raise ValueError("API key must be provided or set in NEUPHONIC_API_KEY")
 
         self._opts = _TTSOptions(
             model=model,


### PR DESCRIPTION
Neuphonic tests are failing due to the code using `NEUPHONIC_API_TOKEN` but the github workflow setting `NEUPHONIC_API_KEY`.

This PR fixes this issue in a backwards compatible way.