### PR TITLE
added deepwiki badge for weekly repo refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,8 @@ Runs the agent with production-ready optimizations.
 
 The Agents framework is under active development in a rapidly evolving field. We welcome and appreciate contributions of any kind, be it feedback, bugfixes, features, new plugins and tools, or better documentation. You can file issues under this repo, open a PR, or chat with us in LiveKit's [Slack community](https://livekit.io/join-slack).
 
+[![Ask DeepWiki for understanding the codebase](https://deepwiki.com/badge.svg)](https://deepwiki.com/livekit/agents)
+
 <!--BEGIN_REPO_NAV-->
 
 <br/><table>


### PR DESCRIPTION
Hey all - I feel it'd be nice to have a weekly refresh of the codebase on deepwiki.com as it is evolving rapidly. Deepwiki needs the badge to be added for tracking the codebase to the weekly sync queue.

I am not associated with devin in any way but I find the tool pretty useful and others who are contributing might too. 