### PR TITLE
[feature] Add support for input_audio_noise_reduction in RealtimeModel (for OpenAI Realtime API)

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -57,7 +57,7 @@ from openai.types.beta.realtime import (
     session_update_event,
 )
 from openai.types.beta.realtime.response_create_event import Response
-from openai.types.beta.realtime.session import InputAudioTranscription, TurnDetection
+from openai.types.beta.realtime.session import InputAudioTranscription, InputAudioNoiseReduction, TurnDetection
 
 from ..log import logger
 
@@ -89,6 +89,7 @@ class _RealtimeOptions:
     temperature: float
     tool_choice: llm.ToolChoice | None
     input_audio_transcription: InputAudioTranscription | None
+    input_audio_noise_reduction: InputAudioNoiseReduction | None
     turn_detection: TurnDetection | None
     api_key: str
     base_url: str
@@ -174,6 +175,7 @@ class RealtimeModel(llm.RealtimeModel):
         model: str = "gpt-4o-realtime-preview",
         voice: str = "alloy",
         input_audio_transcription: NotGivenOr[InputAudioTranscription | None] = NOT_GIVEN,
+        input_audio_noise_reduction: NotGivenOr[InputAudioNoiseReduction | None] = NOT_GIVEN,
         turn_detection: NotGivenOr[TurnDetection | None] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
         tool_choice: NotGivenOr[llm.ToolChoice | None] = NOT_GIVEN,
@@ -193,6 +195,7 @@ class RealtimeModel(llm.RealtimeModel):
         base_url: str | None = None,
         voice: str = "alloy",
         input_audio_transcription: NotGivenOr[InputAudioTranscription | None] = NOT_GIVEN,
+        input_audio_noise_reduction: NotGivenOr[InputAudioNoiseReduction | None] = NOT_GIVEN,
         turn_detection: NotGivenOr[TurnDetection | None] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
         tool_choice: NotGivenOr[llm.ToolChoice | None] = NOT_GIVEN,
@@ -208,6 +211,7 @@ class RealtimeModel(llm.RealtimeModel):
         tool_choice: NotGivenOr[llm.ToolChoice | None] = NOT_GIVEN,
         base_url: NotGivenOr[str] = NOT_GIVEN,
         input_audio_transcription: NotGivenOr[InputAudioTranscription | None] = NOT_GIVEN,
+        input_audio_noise_reduction: NotGivenOr[InputAudioNoiseReduction | None] = NOT_GIVEN,
         turn_detection: NotGivenOr[TurnDetection | None] = NOT_GIVEN,
         api_key: str | None = None,
         http_session: aiohttp.ClientSession | None = None,
@@ -257,6 +261,9 @@ class RealtimeModel(llm.RealtimeModel):
             input_audio_transcription=input_audio_transcription
             if is_given(input_audio_transcription)
             else DEFAULT_INPUT_AUDIO_TRANSCRIPTION,
+            input_audio_noise_reduction=input_audio_noise_reduction
+            if is_given(input_audio_noise_reduction)
+            else None,
             turn_detection=turn_detection if is_given(turn_detection) else DEFAULT_TURN_DETECTION,
             api_key=api_key,
             base_url=base_url_val,
@@ -280,6 +287,7 @@ class RealtimeModel(llm.RealtimeModel):
         base_url: str | None = None,
         voice: str = "alloy",
         input_audio_transcription: NotGivenOr[InputAudioTranscription | None] = NOT_GIVEN,
+        input_audio_noise_reduction: NotGivenOr[InputAudioNoiseReduction | None] = NOT_GIVEN,
         turn_detection: NotGivenOr[TurnDetection | None] = NOT_GIVEN,
         temperature: float = 0.8,
         http_session: aiohttp.ClientSession | None = None,
@@ -342,6 +350,7 @@ class RealtimeModel(llm.RealtimeModel):
         return cls(
             voice=voice,
             input_audio_transcription=input_audio_transcription,
+            input_audio_noise_reduction=input_audio_noise_reduction,
             turn_detection=turn_detection,
             temperature=temperature,
             api_key=api_key,
@@ -358,6 +367,7 @@ class RealtimeModel(llm.RealtimeModel):
         voice: NotGivenOr[str] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
         turn_detection: NotGivenOr[TurnDetection | None] = NOT_GIVEN,
+        input_audio_noise_reduction: NotGivenOr[InputAudioNoiseReduction | None] = NOT_GIVEN,
         tool_choice: NotGivenOr[llm.ToolChoice | None] = NOT_GIVEN,
     ) -> None:
         if is_given(voice):
@@ -368,6 +378,9 @@ class RealtimeModel(llm.RealtimeModel):
 
         if is_given(turn_detection):
             self._opts.turn_detection = turn_detection
+            
+        if is_given(input_audio_noise_reduction):
+            self._opts.input_audio_noise_reduction = input_audio_noise_reduction
 
         if is_given(tool_choice):
             self._opts.tool_choice = tool_choice
@@ -377,6 +390,7 @@ class RealtimeModel(llm.RealtimeModel):
                 voice=voice,
                 temperature=temperature,
                 turn_detection=turn_detection,
+                input_audio_noise_reduction=input_audio_noise_reduction,
                 tool_choice=tool_choice,
             )
 
@@ -669,6 +683,19 @@ class RealtimeSession(
             else None
         )
 
+        input_audio_noise_reduction = self._realtime_model._opts.input_audio_noise_reduction
+        input_audio_noise_reduction = (
+            session_update_event.SessionInputAudioNoiseReduction.model_validate(
+                input_audio_noise_reduction.model_dump(
+                    by_alias=True,
+                    exclude_unset=True,
+                    exclude_defaults=True,
+                )
+            )
+            if input_audio_noise_reduction
+            else None
+        )
+
         # initial session update
         self.send_event(
             SessionUpdateEvent(
@@ -683,6 +710,7 @@ class RealtimeSession(
                     modalities=["text", "audio"],
                     turn_detection=turn_detection,
                     input_audio_transcription=input_audio_transcription,
+                    input_audio_noise_reduction=input_audio_noise_reduction,
                     temperature=self._realtime_model._opts.temperature,
                 ),
                 event_id=utils.shortuuid("session_update_"),
@@ -704,6 +732,7 @@ class RealtimeSession(
         voice: NotGivenOr[str] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
         turn_detection: NotGivenOr[TurnDetection | None] = NOT_GIVEN,
+        input_audio_noise_reduction: NotGivenOr[InputAudioNoiseReduction | None] = NOT_GIVEN,
     ) -> None:
         kwargs = {}
 
@@ -724,6 +753,9 @@ class RealtimeSession(
 
         if is_given(turn_detection):
             kwargs["turn_detection"] = turn_detection
+            
+        if is_given(input_audio_noise_reduction):
+            kwargs["input_audio_noise_reduction"] = input_audio_noise_reduction
 
         if kwargs:
             self.send_event(

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -57,7 +57,11 @@ from openai.types.beta.realtime import (
     session_update_event,
 )
 from openai.types.beta.realtime.response_create_event import Response
-from openai.types.beta.realtime.session import InputAudioTranscription, InputAudioNoiseReduction, TurnDetection
+from openai.types.beta.realtime.session import (
+    InputAudioNoiseReduction,
+    InputAudioTranscription,
+    TurnDetection,
+)
 
 from ..log import logger
 
@@ -304,6 +308,7 @@ class RealtimeModel(llm.RealtimeModel):
             base_url (str or None, optional): Base URL for the API endpoint. If None, constructed from the azure_endpoint.
             voice (api_proto.Voice, optional): Voice setting for audio outputs. Defaults to "alloy".
             input_audio_transcription (InputTranscriptionOptions, optional): Options for transcribing input audio. Defaults to DEFAULT_INPUT_AUDIO_TRANSCRIPTION.
+            input_audio_noise_reduction (InputAudioNoiseReduction or None, optional): Configuration for input audio noise reduction. `near_field` is for close-talking microphones such as headphones, `far_field` is for far-field microphones such as laptop or conference room microphones. Defaults to None.
             turn_detection (ServerVadOptions, optional): Options for server-based voice activity detection (VAD). Defaults to DEFAULT_SERVER_VAD_OPTIONS.
             temperature (float, optional): Sampling temperature for response generation. Defaults to 0.8.
             max_response_output_tokens (int or Literal["inf"], optional): Maximum number of tokens in the response. Defaults to "inf".
@@ -370,6 +375,18 @@ class RealtimeModel(llm.RealtimeModel):
         input_audio_noise_reduction: NotGivenOr[InputAudioNoiseReduction | None] = NOT_GIVEN,
         tool_choice: NotGivenOr[llm.ToolChoice | None] = NOT_GIVEN,
     ) -> None:
+        """
+        Update the options for this RealtimeModel instance.
+
+        Args:
+            voice: Voice setting for audio outputs.
+            temperature: Sampling temperature for response generation.
+            turn_detection: Options for server-based voice activity detection (VAD).
+            input_audio_noise_reduction: Configuration for input audio noise reduction.
+                `near_field` is for close-talking microphones such as headphones,
+                `far_field` is for far-field microphones such as laptop or conference rooms.
+            tool_choice: Controls how the model uses tools.
+        """
         if is_given(voice):
             self._opts.voice = voice
 
@@ -378,7 +395,7 @@ class RealtimeModel(llm.RealtimeModel):
 
         if is_given(turn_detection):
             self._opts.turn_detection = turn_detection
-            
+
         if is_given(input_audio_noise_reduction):
             self._opts.input_audio_noise_reduction = input_audio_noise_reduction
 
@@ -753,7 +770,7 @@ class RealtimeSession(
 
         if is_given(turn_detection):
             kwargs["turn_detection"] = turn_detection
-            
+
         if is_given(input_audio_noise_reduction):
             kwargs["input_audio_noise_reduction"] = input_audio_noise_reduction
 


### PR DESCRIPTION
# Add support for input_audio_noise_reduction in RealtimeModel

## Issue
Resolves #2312

## Summary
OpenAI Realtime API supports `input_audio_noise_reduction` session property with `near_field` or `far_field` modes, but LiveKit's RealtimeModel was missing this field. This PR adds support for this parameter, allowing developers to enable official noise-reduction modes when using LiveKit Agents.

## Implementation
- Added `input_audio_noise_reduction` field to `_RealtimeOptions` dataclass
- Added `input_audio_noise_reduction` parameter to all `RealtimeModel.__init__` overloads
- Updated `_initial_session_update` method to process the new parameter
- Added `input_audio_noise_reduction` support to `update_options` method

## Example Usage
```python
from livekit.plugins.openai.realtime import RealtimeModel
from openai.types.beta.realtime.session import InputAudioNoiseReduction

# near_field mode for close-talking microphones (headphones, etc.)
model = RealtimeModel(
    model="gpt-4o-realtime-preview",
    input_audio_noise_reduction=InputAudioNoiseReduction(type="near_field"),
)

# far_field mode for distant microphones (laptop or conference room)
model = RealtimeModel(
    model="gpt-4o-realtime-preview",
    input_audio_noise_reduction=InputAudioNoiseReduction(type="far_field"),
)
```