### PR TITLE
Support empty array of parameters when using raw_schema

### DIFF
--- a/.github/next-release/changeset-053d451c.md
+++ b/.github/next-release/changeset-053d451c.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Support empty array of parameters when creating a function tool using raw_schema (#2328)

--- a/livekit-agents/livekit/agents/llm/tool_context.py
+++ b/livekit-agents/livekit/agents/llm/tool_context.py
@@ -154,7 +154,7 @@ def function_tool(
         if raw_schema is not None:
             name = raw_schema.get("name")
             parameters = raw_schema.get("parameters")
-            
+
             if name is None or parameters is None:
                 raise ValueError("raw function description must contain a name and parameters key")
             if not name:

--- a/livekit-agents/livekit/agents/llm/tool_context.py
+++ b/livekit-agents/livekit/agents/llm/tool_context.py
@@ -152,8 +152,13 @@ def function_tool(
 ) -> FunctionTool | RawFunctionTool | Callable[[F | Raw_F], FunctionTool | RawFunctionTool]:
     def deco(func: F | Raw_F) -> RawFunctionTool | FunctionTool:
         if raw_schema is not None:
-            if not raw_schema.get("name") or not raw_schema.get("parameters"):
+            name = raw_schema.get("name")
+            parameters = raw_schema.get("parameters")
+            
+            if name is None or parameters is None:
                 raise ValueError("raw function description must contain a name and parameters key")
+            if not name:
+                raise ValueError("raw function name can not be empty")
 
             info = _RawFunctionToolInfo(raw_schema={**raw_schema}, name=raw_schema["name"])
             setattr(func, "__livekit_raw_tool_info", info)


### PR DESCRIPTION
It's possible to have function tools that do not need any arguments. The current code fails when passing an empty parameters array.