### PR TITLE
fix tool choice

### DIFF
--- a/.github/next-release/changeset-6a626bb2.md
+++ b/.github/next-release/changeset-6a626bb2.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+fix tool choice (#2332)

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1341,7 +1341,9 @@ class AgentActivity(RecognitionHooks):
                         chat_ctx=chat_ctx,
                         tools=tools,
                         model_settings=ModelSettings(
-                            tool_choice=model_settings.tool_choice if not draining else "none",
+                            tool_choice="none"
+                            if draining or model_settings.tool_choice == "none"
+                            else "auto",
                         ),
                         _tools_messages=[*new_calls, *new_fnc_outputs],
                     ),
@@ -1636,7 +1638,9 @@ class AgentActivity(RecognitionHooks):
                     self._realtime_reply_task(
                         speech_handle=handle,
                         model_settings=ModelSettings(
-                            tool_choice=model_settings.tool_choice if not draining else "none",
+                            tool_choice="none"
+                            if draining or model_settings.tool_choice == "none"
+                            else "auto",
                         ),
                     ),
                     owned_speech_handle=handle,

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1341,6 +1341,8 @@ class AgentActivity(RecognitionHooks):
                         chat_ctx=chat_ctx,
                         tools=tools,
                         model_settings=ModelSettings(
+                            # Avoid setting tool_choice to "required" or a specific function when
+                            # passing tool response back to the LLM
                             tool_choice="none"
                             if draining or model_settings.tool_choice == "none"
                             else "auto",
@@ -1638,6 +1640,8 @@ class AgentActivity(RecognitionHooks):
                     self._realtime_reply_task(
                         speech_handle=handle,
                         model_settings=ModelSettings(
+                            # Avoid setting tool_choice to "required" or a specific function when
+                            # passing tool response back to the LLM
                             tool_choice="none"
                             if draining or model_settings.tool_choice == "none"
                             else "auto",


### PR DESCRIPTION
Currently, tool_choice is not usable when set to "required" or a specific function. This PR ensures tool_choice is reset to "auto" or "none" temporarily when passing back  tool response to the LLM, so it can be used practically.