### PR TITLE
Add diarization support

### DIFF
--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -44,6 +44,7 @@ class SpeechData:
     start_time: float = 0.0
     end_time: float = 0.0
     confidence: float = 0.0  # [0, 1]
+    speaker: str | None = None
 
 
 @dataclass

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -855,7 +855,11 @@ class AgentActivity(RecognitionHooks):
 
         self._session.emit(
             "user_input_transcribed",
-            UserInputTranscribedEvent(transcript=ev.alternatives[0].text, is_final=False),
+            UserInputTranscribedEvent(
+                transcript=ev.alternatives[0].text,
+                is_final=False,
+                speaker=ev.alternatives[0].speaker,
+            ),
         )
 
     def on_final_transcript(self, ev: stt.SpeechEvent) -> None:
@@ -865,7 +869,11 @@ class AgentActivity(RecognitionHooks):
 
         self._session.emit(
             "user_input_transcribed",
-            UserInputTranscribedEvent(transcript=ev.alternatives[0].text, is_final=True),
+            UserInputTranscribedEvent(
+                transcript=ev.alternatives[0].text,
+                is_final=True,
+                speaker=ev.alternatives[0].speaker,
+            ),
         )
 
     async def on_end_of_turn(self, info: _EndOfTurnInfo) -> bool:

--- a/livekit-agents/livekit/agents/voice/events.py
+++ b/livekit-agents/livekit/agents/voice/events.py
@@ -88,6 +88,7 @@ class UserInputTranscribedEvent(BaseModel):
     type: Literal["user_input_transcribed"] = "user_input_transcribed"
     transcript: str
     is_final: bool
+    speaker: str | None = None
 
 
 class MetricsCollectedEvent(BaseModel):

--- a/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
+++ b/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
@@ -69,6 +69,7 @@ class STT(stt.STT):
                 operating_point="enhanced",
                 enable_partials=True,
                 max_delay=0.7,
+                speaker_diarization_config={"max_speakers": 2},
             )
         if not is_given(connection_settings):
             connection_settings = ConnectionSettings(  # noqa: B008
@@ -316,6 +317,7 @@ def live_transcription_to_speech_data(data: dict) -> list[stt.SpeechData]:
                 alt.get("confidence", 1.0),
                 alt.get("language", "en"),
             )
+            speaker = alt.get("speaker")
 
             if not content:
                 continue
@@ -326,8 +328,9 @@ def live_transcription_to_speech_data(data: dict) -> list[stt.SpeechData]:
             elif speech_data and start_time == speech_data[-1].end_time:
                 speech_data[-1].text += " " + content
             else:
-                speech_data.append(
-                    stt.SpeechData(language, content, start_time, end_time, confidence)
-                )
+                sd = stt.SpeechData(language, content, start_time, end_time, confidence)
+                if speaker is not None:
+                    sd.speaker = speaker
+                speech_data.append(sd)
 
     return speech_data

--- a/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/types.py
+++ b/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/types.py
@@ -49,6 +49,9 @@ class TranscriptionConfig:
     transcript_filtering_config: Optional[dict] = None
     """Removes disfluencies with the remove_disfluencies setting."""
 
+    speaker_diarization_config: Optional[dict] = None
+    """Options for speaker diarization such as ``max_speakers``."""
+
     def asdict(self) -> dict[Any, Any]:
         """Returns model as a dict while excluding None values recursively."""
         return asdict(self, dict_factory=lambda x: {k: v for (k, v) in x if v is not None})


### PR DESCRIPTION
This PR adds support for STT-provided diarization, meaning that a single track can have multiple speakers logged in the transcription.

Today, the only plugin that supports realtime diarization is Speechmatics, but I imagine there will be more widespread support for this in the future.

I tried to be minimally invasive here, if people want the speaker to be passed to the LLM they can add it into the STT node.