### PR TITLE
[Rime] Increase timeout for `arcana` model to allow for synthesis of long audio 

### DIFF
--- a/.github/next-release/changeset-7b1d7851.md
+++ b/.github/next-release/changeset-7b1d7851.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-rime": patch
+---
+
+Increase timeout for `arcana` model to allow for synthesis of long audio  (#2343)


### PR DESCRIPTION
## What changed
The new `arcana` model can take much longer than `mistv2` due to it's architecture. As long as 80% of the duration of the actual audio. 

demonstrated by this curl request:  

```bash
curl -v -X POST "https://users.rime.ai/" \
    -H "Authorization: Bearer $RIME_API_KEY" \
    -H 'Accept: audio/wav' \
    -H 'Content-Type: application/json' \
    -d '{
        "text": "oh, totally! like, um, okay so there was this one time, um, me and my friends went to this art festival in san francisco, right? and it was, like, super fun, but also kinda chaotic <laugh>. so, like, we were checking out all these booths with, like, amazing art and stuff, and I- I even brought along my sketchbook, um, to doodle, you know? so, like, at one point, I see this artist who was doing live paintings and, like, Ive never seen anything like it, right? anyway, Im standing there just vibing, and I accidentally bumped into this guy who was, like, super into astrology like me! <laugh>. and we started talking about our signs, and he was a gemini, and, like, for some reason we, like, bonded over how geminis always get called two-faced, and I was just like, dude, chill, we\u2019re just versatile, you know?",
        "speaker":"celeste",
        "modelId": "arcana"
    }' \
    --output celeste_long_text.mp3

100 2856k    0 2856k  100   901  73169     22  0:00:40  0:00:39  0:00:01 75809
```
0:00:39 for a 0:01:00 long audio. 

