### PR TITLE
Setting openai temperature on `LLM.chat`

### DIFF
--- a/.github/next-release/changeset-1b1bcfd3.md
+++ b/.github/next-release/changeset-1b1bcfd3.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-openai": patch
+---
+
+Setting openai temperature on `LLM.chat` (#2353)

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -556,6 +556,9 @@ class LLM(llm.LLM):
         if is_given(self._opts.max_completion_tokens):
             extra["max_completion_tokens"] = self._opts.max_completion_tokens
 
+        if is_given(self._opts.temperature):
+            extra["temperature"] = self._opts.temperature
+
         parallel_tool_calls = (
             parallel_tool_calls if is_given(parallel_tool_calls) else self._opts.parallel_tool_calls
         )


### PR DESCRIPTION
# Changes
- previously temperature was not overridden in the extra_kwargs passed on chat.completion