### PR TITLE
Advertise supported room inputs and outputs over participant attributes

### DIFF
--- a/livekit-agents/livekit/agents/types.py
+++ b/livekit-agents/livekit/agents/types.py
@@ -21,6 +21,23 @@ With components-js, this can be easily retrieved using:
 const { state, ... } = useVoiceAssistant();
 ```
 """
+ATTRIBUTE_AGENT_INPUTS = "lk.agent.inputs"
+"""
+The supported inputs of the agent, stored in the agent's attributes.
+
+This is a comma-separated list. Supported values are:
+- `audio`
+- `video`
+- `text`
+"""
+ATTRIBUTE_AGENT_OUTPUTS = "lk.agent.outputs"
+"""
+The supported outputs of the agent, stored in the agent's attributes.
+
+This is a comma-separated list. Supported values are:
+- `audio`
+- `transcription`
+"""
 
 TOPIC_CHAT = "lk.chat"
 TOPIC_TRANSCRIPTION = "lk.transcription"

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -11,6 +11,8 @@ from ... import utils
 from ...log import logger
 from ...types import (
     ATTRIBUTE_AGENT_STATE,
+    ATTRIBUTE_AGENT_INPUTS,
+    ATTRIBUTE_AGENT_OUTPUTS,
     ATTRIBUTE_PUBLISH_ON_BEHALF,
     NOT_GIVEN,
     TOPIC_CHAT,
@@ -413,7 +415,7 @@ class RoomIO:
 
             attrs = {}
 
-            attrs[ATTRIBUTE_AGENT_STATE] = self._agent_session.state
+            attrs[ATTRIBUTE_AGENT_STATE] = self._agent_session._agent_state
 
             inputs = []
             if self._input_options.audio_enabled:
@@ -422,14 +424,14 @@ class RoomIO:
                 inputs.append("video")
             if self._input_options.text_enabled:
                 inputs.append("text")
-            attrs["lk.agent_inputs"] = ",".join(inputs)
+            attrs[ATTRIBUTE_AGENT_INPUTS] = ",".join(inputs)
 
             outputs = []
             if self._output_options.audio_enabled:
                 outputs.append("audio")
             if self._output_options.transcription_enabled:
                 outputs.append("transcription")
-            attrs["lk.agent_outputs"] = ",".join(outputs)
+            attrs[ATTRIBUTE_AGENT_OUTPUTS] = ",".join(outputs)
 
             if attrs:
                 await self._room.local_participant.set_attributes(attrs)

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -11,8 +11,6 @@ from ... import utils
 from ...log import logger
 from ...types import (
     ATTRIBUTE_AGENT_STATE,
-    ATTRIBUTE_AGENT_INPUTS,
-    ATTRIBUTE_AGENT_OUTPUTS,
     ATTRIBUTE_PUBLISH_ON_BEHALF,
     NOT_GIVEN,
     TOPIC_CHAT,
@@ -78,6 +76,7 @@ class RoomInputOptions:
     pre_connect_audio_timeout: float = 3.0
     """The pre-connect audio will be ignored if it doesn't arrive within this time."""
 
+
 @dataclass
 class RoomOutputOptions:
     transcription_enabled: bool = True
@@ -90,6 +89,7 @@ class RoomOutputOptions:
     sync_transcription: NotGivenOr[bool] = NOT_GIVEN
     """False to disable transcription synchronization with audio output.
     Otherwise, transcription is emitted as quickly as available."""
+
 
 DEFAULT_ROOM_INPUT_OPTIONS = RoomInputOptions()
 DEFAULT_ROOM_OUTPUT_OPTIONS = RoomOutputOptions()
@@ -130,7 +130,7 @@ class RoomIO:
         self._user_transcript_ch = utils.aio.Chan[UserInputTranscribedEvent]()
         self._user_transcript_atask: asyncio.Task[None] | None = None
         self._tasks: set[asyncio.Task[Any]] = set()
-        self._update_attributes_atask: asyncio.Task[None] | None = None
+        self._update_state_atask: asyncio.Task[None] | None = None
 
         self._pre_connect_audio_handler: PreConnectAudioHandler | None = None
 
@@ -233,8 +233,8 @@ class RoomIO:
         if self._user_transcript_atask:
             await utils.aio.cancel_and_wait(self._user_transcript_atask)
 
-        if self._update_attributes_atask:
-            await utils.aio.cancel_and_wait(self._update_attributes_atask)
+        if self._update_state_atask:
+            await utils.aio.cancel_and_wait(self._update_state_atask)
 
         if self._pre_connect_audio_handler:
             await self._pre_connect_audio_handler.aclose()
@@ -310,9 +310,6 @@ class RoomIO:
 
         self._update_transcription_output(self._user_tr_output, participant_identity)
 
-        # Update both state and capabilities when participant changes
-        self._update_attributes()
-
     def unset_participant(self) -> None:
         self._participant_identity = None
         self._participant_available_fut = asyncio.Future[rtc.RemoteParticipant]()
@@ -353,8 +350,6 @@ class RoomIO:
     def _on_connection_state_changed(self, state: rtc.ConnectionState.ValueType) -> None:
         if self._room.isconnected() and not self._room_connected_fut.done():
             self._room_connected_fut.set_result(None)
-            # Update both state and capabilities when connected
-            self._update_attributes()
 
     def _on_participant_connected(self, participant: rtc.RemoteParticipant) -> None:
         if self._participant_available_fut.done():
@@ -405,41 +400,17 @@ class RoomIO:
         task.add_done_callback(self._tasks.discard)
 
     def _on_agent_state_changed(self, ev: AgentStateChangedEvent) -> None:
-        self._update_attributes()
-
-    def _update_attributes(self) -> None:
         @utils.log_exceptions(logger=logger)
-        async def _update() -> None:
-            if not self._room.isconnected():
-                return
+        async def _set_state() -> None:
+            if self._room.isconnected():
+                await self._room.local_participant.set_attributes(
+                    {ATTRIBUTE_AGENT_STATE: ev.new_state}
+                )
 
-            attrs = {}
+        if self._update_state_atask is not None:
+            self._update_state_atask.cancel()
 
-            attrs[ATTRIBUTE_AGENT_STATE] = self._agent_session._agent_state
-
-            inputs = []
-            if self._input_options.audio_enabled:
-                inputs.append("audio")
-            if self._input_options.video_enabled:
-                inputs.append("video")
-            if self._input_options.text_enabled:
-                inputs.append("text")
-            attrs[ATTRIBUTE_AGENT_INPUTS] = ",".join(inputs)
-
-            outputs = []
-            if self._output_options.audio_enabled:
-                outputs.append("audio")
-            if self._output_options.transcription_enabled:
-                outputs.append("transcription")
-            attrs[ATTRIBUTE_AGENT_OUTPUTS] = ",".join(outputs)
-
-            if attrs:
-                await self._room.local_participant.set_attributes(attrs)
-
-        if self._update_attributes_atask is not None:
-            self._update_attributes_atask.cancel()
-
-        self._update_attributes_atask = asyncio.create_task(_update())
+        self._update_state_atask = asyncio.create_task(_set_state())
 
     def _create_transcription_output(
         self, is_delta_stream: bool, participant: rtc.Participant | str | None = None
@@ -467,21 +438,3 @@ class RoomIO:
                 sink, (_ParticipantLegacyTranscriptionOutput, _ParticipantTranscriptionOutput)
             ):
                 sink.set_participant(participant_identity)
-
-    @property
-    def input_options(self) -> RoomInputOptions:
-        return self._input_options
-
-    @input_options.setter
-    def input_options(self, options: RoomInputOptions) -> None:
-        self._input_options = options
-        self._update_attributes()
-
-    @property
-    def output_options(self) -> RoomOutputOptions:
-        return self._output_options
-
-    @output_options.setter
-    def output_options(self, options: RoomOutputOptions) -> None:
-        self._output_options = options
-        self._update_attributes()


### PR DESCRIPTION
This allows frontends to adapt to the agent that connects, and is needed for the new sandbox/starter apps that will have full support for audio, text, and video.

I've kept this as simple as possible to start. RoomIO settings cannot be changed (AFAICT) mid-session so this does not yet track changes but would be easy to update to do so.

Here's a screenshot from a modified version of agent playground

<img width="359" alt="image" src="https://github.com/user-attachments/assets/8c302cdc-c0f9-4c53-b82f-de6d8d978ec7" />
