### PR TITLE
skip response if no llm set in user turn completed

### DIFF
--- a/.github/next-release/changeset-afeb4064.md
+++ b/.github/next-release/changeset-afeb4064.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+skip response if no llm set in user turn completed (#2441)

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -931,7 +931,9 @@ class AgentActivity(RecognitionHooks):
                 self._rt_session.interrupt()
 
         # id is generated
-        user_message = llm.ChatMessage(role="user", content=[info.new_transcript])
+        user_message: llm.ChatMessage | None = llm.ChatMessage(
+            role="user", content=[info.new_transcript]
+        )
 
         # create a temporary mutable chat context to pass to on_user_turn_completed
         # the user can edit it for the current generation, but changes will not be kept inside the
@@ -952,7 +954,9 @@ class AgentActivity(RecognitionHooks):
 
         if isinstance(self.llm, llm.RealtimeModel):
             # ignore stt transcription for realtime model
-            user_message = None  # type: ignore
+            user_message = None
+        elif self.llm is None:
+            return  # skip response if no llm is set
 
         # Ensure the new message is passed to generate_reply
         # This preserves the original message_id, making it easier for users to track responses

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -551,6 +551,9 @@ class AgentActivity(RecognitionHooks):
             instructions=instructions or None,
         )
 
+        if self.llm is None:
+            raise RuntimeError("trying to generate reply without an LLM model")
+
         from .agent import _get_inline_task_info
 
         task = asyncio.current_task()

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -931,9 +931,7 @@ class AgentActivity(RecognitionHooks):
                 self._rt_session.interrupt()
 
         # id is generated
-        user_message: llm.ChatMessage | None = llm.ChatMessage(
-            role="user", content=[info.new_transcript]
-        )
+        user_message: llm.ChatMessage = llm.ChatMessage(role="user", content=[info.new_transcript])
 
         # create a temporary mutable chat context to pass to on_user_turn_completed
         # the user can edit it for the current generation, but changes will not be kept inside the
@@ -954,7 +952,7 @@ class AgentActivity(RecognitionHooks):
 
         if isinstance(self.llm, llm.RealtimeModel):
             # ignore stt transcription for realtime model
-            user_message = None
+            user_message = None  # type: ignore
         elif self.llm is None:
             return  # skip response if no llm is set
 


### PR DESCRIPTION
fix https://github.com/livekit/agents/issues/2436

When `llm` is None, `session.generate_reply` will create a speech handle but never processed that blocks the agent. User has to raise `StopResponse` in `on_user_turn_completed` if we don't skip the reply automatically.