### PR TITLE
add duration_per_frame for datastream audio receiver

### DIFF
--- a/.github/next-release/changeset-e1c5da38.md
+++ b/.github/next-release/changeset-e1c5da38.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+add duration_per_frame for datastream audio receiver (#2474)


### PR DESCRIPTION
make the audio frame duration configurable for avatar which needs a fixed window of audio