### PR TITLE
fix: LLM to honor custom timeouts

### DIFF
--- a/livekit-agents/livekit/agents/llm/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/fallback_adapter.py
@@ -38,9 +38,10 @@ class FallbackAdapter(
         self,
         llm: list[LLM],
         *,
-        attempt_timeout: float = 10.0,
-        max_retry_per_llm: int = 1,
-        retry_interval: float = 5,
+        attempt_timeout: float = 5.0,
+        # use fallback instead of retrying
+        max_retry_per_llm: int = 0,
+        retry_interval: float = 0.5,
     ) -> None:
         if len(llm) < 1:
             raise ValueError("at least one LLM instance must be provided.")

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -143,6 +143,8 @@ class LLMStream(ABC):
             try:
                 return await self._run()
             except APIError as e:
+                retry_interval = self._conn_options._interval_for_retry(i)
+
                 if self._conn_options.max_retry == 0 or not e.retryable:
                     self._emit_error(e, recoverable=False)
                     raise
@@ -155,7 +157,7 @@ class LLMStream(ABC):
                 else:
                     self._emit_error(e, recoverable=True)
                     logger.warning(
-                        f"failed to generate LLM completion, retrying in {self._conn_options.retry_interval}s",  # noqa: E501
+                        f"failed to generate LLM completion, retrying in {retry_interval}s",  # noqa: E501
                         exc_info=e,
                         extra={
                             "llm": self._llm._label,
@@ -163,8 +165,10 @@ class LLMStream(ABC):
                         },
                     )
 
-                await asyncio.sleep(self._conn_options.retry_interval)
-                # Reset the flag when retrying
+                if retry_interval > 0:
+                    await asyncio.sleep(retry_interval)
+
+                # reset the flag when retrying
                 self._current_attempt_has_error = False
 
             except Exception as e:

--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
@@ -199,6 +199,7 @@ class LLM(llm.LLM):
             messages=messages,
             model=self._opts.model,
             stream=True,
+            timeout=conn_options.timeout,
             **extra,
         )
 

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -312,6 +312,9 @@ class LLMStream(llm.LLMStream):
                     if extra_data.system_messages
                     else None
                 ),
+                http_options=types.HttpOptions(
+                    timeout=int(self._conn_options.timeout * 1000),
+                ),
                 **self._extra_kwargs,
             )
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -646,6 +646,7 @@ class LLMStream(llm.LLMStream):
                 model=self._model,
                 stream_options={"include_usage": True},
                 stream=True,
+                timeout=httpx.Timeout(self._conn_options.timeout),
                 **self._extra_kwargs,
             )
 


### PR DESCRIPTION
previously, timeouts passed to `LLM.chat` were not being used.

also improves fallback adapter defaults.