### PR TITLE
Feature: add try except if there could be problems when tty and sounddevice are not available

### DIFF
--- a/.github/next-release/changeset-76274fba.md
+++ b/.github/next-release/changeset-76274fba.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Feature: add try except if there could be problems when tty and sounddevice are not available (#2566)


### PR DESCRIPTION
On some virtual machines, the `tty` and `sounddevice` code may throw errors due to the absence of corresponding virtualization hardware. Here, a `try-except` block is added to prevent such errors.
