### PR TITLE
Fix baseten STT api key lookup

### DIFF
--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/stt.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/stt.py
@@ -89,8 +89,7 @@ class STT(stt.STT):
             ),
         )
 
-        if not is_given(api_key):
-            api_key = os.environ.get("BASETEN_API_KEY")
+        api_key = api_key or os.environ.get("BASETEN_API_KEY")
 
         if not api_key:
             raise ValueError(


### PR DESCRIPTION
it was using `is_given` on a param that defaults to `None` which didn't work, so the env var lookup doesn't work. I changed it to match the way model_endpoint is checked and also how the TTS plugin is set up.