### PR TITLE
Hume plugin fixes

### DIFF
--- a/.github/next-release/changeset-4fe732da.md
+++ b/.github/next-release/changeset-4fe732da.md
@@ -1,0 +1,6 @@
+---
+"livekit-agents": patch
+"livekit-plugins-hume": patch
+---
+
+Hume plugin fixes (#2591)

--- a/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/__init__.py
+++ b/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/__init__.py
@@ -21,10 +21,10 @@ from __future__ import annotations
 
 from livekit.agents import Plugin
 
-from .tts import TTS, PostedContext, PostedUtterance
+from .tts import TTS, PostedContext, PostedUtterance, AudioFormat
 from .version import __version__
 
-__all__ = ["TTS", "PostedContext", "PostedUtterance"]
+__all__ = ["TTS", "PostedContext", "PostedUtterance", "AudioFormat"]
 
 
 class HumeAIPlugin(Plugin):

--- a/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/__init__.py
+++ b/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/__init__.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from livekit.agents import Plugin
 
-from .tts import TTS, PostedContext, PostedUtterance, AudioFormat
+from .tts import TTS, AudioFormat, PostedContext, PostedUtterance
 from .version import __version__
 
 __all__ = ["TTS", "PostedContext", "PostedUtterance", "AudioFormat"]

--- a/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
+++ b/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
@@ -40,8 +40,18 @@ class PostedUtterance(TypedDict, total=False):
     trailing_silence: float
 
 
-class PostedContext(TypedDict, total=False):
+class PostedContextWithGenerationId(TypedDict, total=False):
+    generation_id: str
+
+
+class PostedContextWithUtterances(TypedDict, total=False):
     utterances: list[PostedUtterance]
+
+
+PostedContext = Union[
+    PostedContextWithGenerationId, 
+    PostedContextWithUtterances
+]
 
 
 @dataclass

--- a/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
+++ b/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
@@ -19,7 +19,7 @@ import base64
 import json
 import os
 from dataclasses import dataclass, replace
-from typing import Any, TypedDict
+from typing import Any, Literal, TypedDict
 
 import aiohttp
 
@@ -51,7 +51,7 @@ class PostedContextWithUtterances(TypedDict, total=False):
 
 PostedContext = Union[
     PostedContextWithGenerationId, 
-    PostedContextWithUtterances
+    PostedContextWithUtterances,
 ]
 
 
@@ -78,6 +78,7 @@ class TTS(tts.TTS):
         *,
         api_key: str | None = None,
         utterance_options: NotGivenOr[PostedUtterance] = NOT_GIVEN,
+        context: NotGivenOr[PostedContext] = NOT_GIVEN,
         split_utterances: bool = True,
         instant_mode: bool = True,
         audio_format: AudioFormat = "mp3"
@@ -103,7 +104,7 @@ class TTS(tts.TTS):
         self._opts = _TTSOptions(
             api_key=key,
             utterance_options=default_utterance,
-            context=None,
+            context=context,
             split_utterances=split_utterances,
             instant_mode=instant_mode,
             audio_format=audio_format,

--- a/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
+++ b/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
@@ -30,6 +30,7 @@ from livekit.agents.utils import is_given
 API_AUTH_HEADER = "X-Hume-Api-Key"
 STREAM_PATH = "/v0/tts/stream/json"
 DEFAULT_BASE_URL = "https://api.hume.ai"
+SUPPORTED_SAMPLE_RATE = 48000
 
 
 class PostedUtterance(TypedDict, total=False):
@@ -59,7 +60,6 @@ class _TTSOptions:
     api_key: str
     utterance_options: PostedUtterance
     context: PostedContext | None
-    sample_rate: int
     split_utterances: bool
     instant_mode: bool
     base_url: str
@@ -76,13 +76,12 @@ class TTS(tts.TTS):
         utterance_options: NotGivenOr[PostedUtterance] = NOT_GIVEN,
         split_utterances: bool = True,
         instant_mode: bool = True,
-        sample_rate: int = 24000,
         base_url: str = DEFAULT_BASE_URL,
         http_session: aiohttp.ClientSession | None = None,
     ):
         super().__init__(
             capabilities=tts.TTSCapabilities(streaming=True),
-            sample_rate=sample_rate,
+            sample_rate=SUPPORTED_SAMPLE_RATE,
             num_channels=1,
         )
         key = api_key or os.environ.get("HUME_API_KEY")
@@ -100,7 +99,6 @@ class TTS(tts.TTS):
             api_key=key,
             utterance_options=default_utterance,
             context=None,
-            sample_rate=sample_rate,
             split_utterances=split_utterances,
             instant_mode=instant_mode,
             base_url=base_url,
@@ -168,7 +166,7 @@ class ChunkedStream(tts.ChunkedStream):
                 resp.raise_for_status()
                 output_emitter.initialize(
                     request_id=utils.shortuuid(),
-                    sample_rate=self._opts.sample_rate,
+                    sample_rate=SUPPORTED_SAMPLE_RATE,
                     num_channels=self._tts.num_channels,
                     mime_type="audio/mp3",
                 )

--- a/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
+++ b/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
@@ -20,7 +20,7 @@ import json
 import os
 from dataclasses import dataclass, replace
 from enum import Enum
-from typing import Any, TypedDict, Union
+from typing import Any, TypedDict, Union, cast
 
 import aiohttp
 
@@ -99,7 +99,7 @@ class TTS(tts.TTS):
             raise ValueError("Hume API key is required via api_key or HUME_API_KEY env var")
 
         base_utterance: PostedUtterance = (
-            dict(utterance_options) if is_given(utterance_options) else {}
+            cast(PostedUtterance, dict(utterance_options)) if is_given(utterance_options) else {}
         )
 
         self._opts = _TTSOptions(
@@ -129,9 +129,9 @@ class TTS(tts.TTS):
         audio_format: NotGivenOr[AudioFormat] = NOT_GIVEN,
     ) -> None:
         if is_given(utterance_options):
-            self._opts.utterance_options = dict(utterance_options)
+            self._opts.utterance_options = cast(PostedUtterance, dict(utterance_options))
         if is_given(context):
-            self._opts.context = context
+            self._opts.context = cast(PostedContext, context)
         if is_given(split_utterances):
             self._opts.split_utterances = split_utterances
         if is_given(instant_mode):

--- a/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
+++ b/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
@@ -19,7 +19,7 @@ import base64
 import json
 import os
 from dataclasses import dataclass, replace
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, TypedDict, Union
 
 import aiohttp
 
@@ -50,7 +50,7 @@ class PostedContextWithUtterances(TypedDict, total=False):
 
 
 PostedContext = Union[
-    PostedContextWithGenerationId, 
+    PostedContextWithGenerationId,
     PostedContextWithUtterances,
 ]
 
@@ -81,7 +81,7 @@ class TTS(tts.TTS):
         context: NotGivenOr[PostedContext] = NOT_GIVEN,
         split_utterances: bool = True,
         instant_mode: bool = True,
-        audio_format: AudioFormat = "mp3"
+        audio_format: AudioFormat = "mp3",
         base_url: str = DEFAULT_BASE_URL,
         http_session: aiohttp.ClientSession | None = None,
     ):
@@ -178,7 +178,7 @@ class ChunkedStream(tts.ChunkedStream):
                     request_id=utils.shortuuid(),
                     sample_rate=SUPPORTED_SAMPLE_RATE,
                     num_channels=self._tts.num_channels,
-                    mime_type=f"audio/{audio_format}",
+                    mime_type=f"audio/{self._opts.audio_format}",
                 )
 
                 async for raw_line in resp.content:

--- a/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
+++ b/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
@@ -98,16 +98,13 @@ class TTS(tts.TTS):
         if not key:
             raise ValueError("Hume API key is required via api_key or HUME_API_KEY env var")
 
-        default_utterance: PostedUtterance = {
-            "speed": 1.0,
-            "trailing_silence": 0.35,
-        }
-        if is_given(utterance_options):
-            default_utterance.update(utterance_options)
+        base_utterance: PostedUtterance = (
+            dict(utterance_options) if is_given(utterance_options) else {}
+        )
 
         self._opts = _TTSOptions(
             api_key=key,
-            utterance_options=default_utterance,
+            utterance_options=base_utterance,
             context=context,
             split_utterances=split_utterances,
             instant_mode=instant_mode,
@@ -132,7 +129,7 @@ class TTS(tts.TTS):
         audio_format: NotGivenOr[AudioFormat] = NOT_GIVEN,
     ) -> None:
         if is_given(utterance_options):
-            self._opts.utterance_options = utterance_options
+            self._opts.utterance_options = dict(utterance_options)
         if is_given(context):
             self._opts.context = context
         if is_given(split_utterances):


### PR DESCRIPTION
**Changes to Hume Plugin**

- Updates `PostedContext` type to support specifying context with a `generation_id`
    - This is the more common way to specify [context](https://dev.hume.ai/reference/text-to-speech-tts/synthesize-json#request.body.context.ContextGenerationId.generation_id) in Hume's TTS API.
- Updates plugin to no longer default `context` to `None`, despite presence of user provided `context`.
- Updates default sample rate from `24kHz` to `48kHz` and removes the `sample_rate` option.
    - Sample rate should not be configurable for this plugin, because the Hume TTS API only outputs audio with a sample rate of 48kHz. The sample rate of speech audio is not currently configurable through the API.)
- Add `audio_format` option to make audio format configurable.
    - The plugin currently defaults to 'mp3' when the Hume TTS API also supports 'wav' and 'pcm'.
- Removes default `speed` and `trailing_silence` from base utterance in favor of API defaults when `speed` or `trailing_silence` options are not specified. 