### PR TITLE
fix(turn-detector): improve accuracy by combining adjacent turns

### DIFF
--- a/.github/next-release/changeset-66686fac.md
+++ b/.github/next-release/changeset-66686fac.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-turn-detector": patch
+---
+
+fix(turn-detector): improve accuracy by combining adjacent turns (#2595)

--- a/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/base.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/base.py
@@ -34,13 +34,19 @@ class _EUORunnerBase(_InferenceRunner):
 
     def _format_chat_ctx(self, chat_ctx: list[dict[str, Any]]) -> str:
         new_chat_ctx = []
+        last_msg: dict[str, Any] | None = None
         for msg in chat_ctx:
             content = msg["content"]
             if not content:
                 continue
 
-            msg["content"] = content
-            new_chat_ctx.append(msg)
+            # need to combine adjacent turns together to match training data
+            if last_msg and last_msg["role"] == msg["role"]:
+                last_msg["content"] += content
+            else:
+                msg["content"] = content
+                new_chat_ctx.append(msg)
+                last_msg = msg
 
         convo_text = self._tokenizer.apply_chat_template(
             new_chat_ctx,


### PR DESCRIPTION
when consecutive turns from the same are present in chat context, it confuses the turn detector since the model isn't trained to expect that case