### PR TITLE
fix transcription delay when VAD false negative

### DIFF
--- a/livekit-agents/livekit/agents/metrics/base.py
+++ b/livekit-agents/livekit/agents/metrics/base.py
@@ -62,10 +62,14 @@ class EOUMetrics(BaseModel):
     type: Literal["eou_metrics"] = "eou_metrics"
     timestamp: float
     end_of_utterance_delay: float
-    """Amount of time between the end of speech from VAD and the decision to end the user's turn."""
+    """Amount of time between the end of speech from VAD and the decision to end the user's turn.
+    Negative value if the end of speech was not detected.
+    """
 
     transcription_delay: float
-    """Time taken to obtain the transcript after the end of the user's speech."""
+    """Time taken to obtain the transcript after the end of the user's speech.
+    Negative value if the end of speech was not detected.
+    """
 
     on_user_turn_completed_delay: float
     """Time taken to invoke the user's `Agent.on_user_turn_completed` callback."""

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -357,13 +357,19 @@ class AudioRecognition:
                 if self._final_transcript_confidence
                 else 0
             )
+
+            if last_speaking_time <= 0 :
+                transcription_delay = -1
+                end_of_utterance_delay = -1
+            else:
+                transcription_delay = max(self._last_final_transcript_time - last_speaking_time, 0)
+                end_of_utterance_delay = time.time() - last_speaking_time
+
             committed = self._hooks.on_end_of_turn(
                 _EndOfTurnInfo(
                     new_transcript=self._audio_transcript,
-                    transcription_delay=max(
-                        self._last_final_transcript_time - last_speaking_time, 0
-                    ),
-                    end_of_utterance_delay=time.time() - last_speaking_time,
+                    transcription_delay=transcription_delay,
+                    end_of_utterance_delay=end_of_utterance_delay,
                     transcript_confidence=confidence_avg,
                 )
             )


### PR DESCRIPTION
partially fix https://github.com/livekit/agents/issues/2361 and https://github.com/livekit/agents/issues/2606 when STT fired but VAD failed to detect the speech. In the middle of the conversation it may still use a out-of-date `last_speaking_time` if VAD has false negative.