### PR TITLE
Updating metrics for cached tokens for Realtime model (OpenAI)

### DIFF
--- a/.github/next-release/changeset-cf5a2ec7.md
+++ b/.github/next-release/changeset-cf5a2ec7.md
@@ -1,0 +1,6 @@
+---
+"livekit-agents": patch
+"livekit-plugins-openai": patch
+---
+
+Updating metrics for cached tokens for Realtime model (OpenAI) (#2621)

--- a/livekit-agents/livekit/agents/cli/log.py
+++ b/livekit-agents/livekit/agents/cli/log.py
@@ -143,7 +143,7 @@ class JsonFormatter(logging.Formatter):
 
         log_record["timestamp"] = datetime.fromtimestamp(record.created, tz=timezone.utc)
 
-        return json.dumps(log_record, cls=JsonFormatter.JsonEncoder, ensure_ascii=True)
+        return json.dumps(log_record, cls=JsonFormatter.JsonEncoder, ensure_ascii=False)
 
 
 class ColoredFormatter(logging.Formatter):
@@ -191,7 +191,7 @@ class ColoredFormatter(logging.Formatter):
         args.update(self._esc_codes)
 
         if extra:
-            args["extra"] = json.dumps(extra, cls=JsonFormatter.JsonEncoder, ensure_ascii=True)
+            args["extra"] = json.dumps(extra, cls=JsonFormatter.JsonEncoder, ensure_ascii=False)
 
         for field in self._required_fields:
             if field in extra:

--- a/livekit-agents/livekit/agents/cli/log.py
+++ b/livekit-agents/livekit/agents/cli/log.py
@@ -143,7 +143,7 @@ class JsonFormatter(logging.Formatter):
 
         log_record["timestamp"] = datetime.fromtimestamp(record.created, tz=timezone.utc)
 
-        return json.dumps(log_record, cls=JsonFormatter.JsonEncoder, ensure_ascii=False)
+        return json.dumps(log_record, cls=JsonFormatter.JsonEncoder, ensure_ascii=True)
 
 
 class ColoredFormatter(logging.Formatter):
@@ -191,7 +191,7 @@ class ColoredFormatter(logging.Formatter):
         args.update(self._esc_codes)
 
         if extra:
-            args["extra"] = json.dumps(extra, cls=JsonFormatter.JsonEncoder, ensure_ascii=False)
+            args["extra"] = json.dumps(extra, cls=JsonFormatter.JsonEncoder, ensure_ascii=True)
 
         for field in self._required_fields:
             if field in extra:

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1525,11 +1525,14 @@ class RealtimeSession(
                 text_tokens=usage.get("input_token_details", {}).get("text_tokens", 0),
                 cached_tokens_details=RealtimeModelMetrics.CachedTokenDetails(
                     text_tokens=usage.get("input_token_details", {})
-                        .get("cached_tokens_details", {}).get("text_tokens", 0),
+                    .get("cached_tokens_details", {})
+                    .get("text_tokens", 0),
                     audio_tokens=usage.get("input_token_details", {})
-                        .get("cached_tokens_details", {}).get("audio_tokens", 0),
+                    .get("cached_tokens_details", {})
+                    .get("audio_tokens", 0),
                     image_tokens=usage.get("input_token_details", {})
-                        .get("cached_tokens_details", {}).get("image_tokens", 0),
+                    .get("cached_tokens_details", {})
+                    .get("image_tokens", 0),
                 ),
             ),
             output_token_details=RealtimeModelMetrics.OutputTokenDetails(

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1524,11 +1524,13 @@ class RealtimeSession(
                 cached_tokens=usage.get("input_token_details", {}).get("cached_tokens", 0),
                 text_tokens=usage.get("input_token_details", {}).get("text_tokens", 0),
                 cached_tokens_details=RealtimeModelMetrics.CachedTokenDetails(
-                    text_tokens=usage.get("input_token_details", {}).get("cached_tokens_details", {}).get("text_tokens", 0),
-                    audio_tokens=usage.get("input_token_details", {}).get("cached_tokens_details", {}).get("audio_tokens", 0),
-                    image_tokens=usage.get("input_token_details", {}).get("cached_tokens_details", {}).get("image_tokens", 0),
+                    text_tokens=usage.get("input_token_details", {})
+                        .get("cached_tokens_details", {}).get("text_tokens", 0),
+                    audio_tokens=usage.get("input_token_details", {})
+                        .get("cached_tokens_details", {}).get("audio_tokens", 0),
+                    image_tokens=usage.get("input_token_details", {})
+                        .get("cached_tokens_details", {}).get("image_tokens", 0),
                 ),
-                image_tokens=0,
             ),
             output_token_details=RealtimeModelMetrics.OutputTokenDetails(
                 text_tokens=usage.get("output_token_details", {}).get("text_tokens", 0),

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1534,6 +1534,7 @@ class RealtimeSession(
                     .get("cached_tokens_details", {})
                     .get("image_tokens", 0),
                 ),
+                image_tokens=0,
             ),
             output_token_details=RealtimeModelMetrics.OutputTokenDetails(
                 text_tokens=usage.get("output_token_details", {}).get("text_tokens", 0),

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1523,7 +1523,11 @@ class RealtimeSession(
                 audio_tokens=usage.get("input_token_details", {}).get("audio_tokens", 0),
                 cached_tokens=usage.get("input_token_details", {}).get("cached_tokens", 0),
                 text_tokens=usage.get("input_token_details", {}).get("text_tokens", 0),
-                cached_tokens_details=None,
+                cached_tokens_details=RealtimeModelMetrics.CachedTokenDetails(
+                    text_tokens=usage.get("input_token_details", {}).get("cached_tokens_details", {}).get("text_tokens", 0),
+                    audio_tokens=usage.get("input_token_details", {}).get("cached_tokens_details", {}).get("audio_tokens", 0),
+                    image_tokens=usage.get("input_token_details", {}).get("cached_tokens_details", {}).get("image_tokens", 0),
+                ),
                 image_tokens=0,
             ),
             output_token_details=RealtimeModelMetrics.OutputTokenDetails(


### PR DESCRIPTION
Update cached_tokens_details (`livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py`)

This update will help you obtain more accurate metrics on tokens spent, which means you will be able to calculate costs more accurately:
```python
prices_llm = {
        "ctp": 2.5,
        "itp": 5,
        "iap": 40,
        "otp": 20,
        "oap": 80
} # gpt-4o-realtime-preview ($ per M tokens)

def _on_metrics_collected(self, ev: RealtimeModelMetrics):  
    metric_data = {
        "cached_text_tokens": ev.metrics.input_token_details.cached_tokens_details.text_tokens,
        "cached_audio_tokens": ev.metrics.input_token_details.cached_tokens_details.audio_tokens,
        "input_text_tokens": ev.metrics.input_token_details.text_tokens,
        "input_audio_tokens": ev.metrics.input_token_details.audio_tokens,
        "output_text_tokens": ev.metrics.output_token_details.text_tokens,
        "output_audio_tokens": ev.metrics.output_token_details.audio_tokens,
    }
    only_cached_text_tokens = metric_data['cached_text_tokens']
    only_cached_audio_tokens = metric_data['cached_audio_tokens']
    cached_text_tokens = (only_cached_text_tokens * prices_llm['ctp']) / 1000000
    cached_audio_tokens = (only_cached_audio_tokens * prices_llm['ctp']) / 1000000
    input_text = ((metric_data['input_text_tokens']-only_cached_text_tokens) * prices_llm['itp']) / 1000000
    input_audio = ((metric_data['input_audio_tokens']-only_cached_audio_tokens) * prices_llm['iap']) / 1000000
    output_text = (metric_data['output_text_tokens'] * prices_llm['otp']) / 1000000
    output_audio = (metric_data['output_audio_tokens'] * prices_llm['oap']) / 1000000
    metric_data['total_price'] = input_text + cached_text_tokens + cached_audio_tokens + input_audio + output_text + output_audio
    print(round(metric_data['total_price'], 3))
```