### PR TITLE
Disable ensure_ascii

### DIFF
--- a/livekit-agents/livekit/agents/cli/log.py
+++ b/livekit-agents/livekit/agents/cli/log.py
@@ -143,7 +143,7 @@ class JsonFormatter(logging.Formatter):
 
         log_record["timestamp"] = datetime.fromtimestamp(record.created, tz=timezone.utc)
 
-        return json.dumps(log_record, cls=JsonFormatter.JsonEncoder, ensure_ascii=True)
+        return json.dumps(log_record, cls=JsonFormatter.JsonEncoder, ensure_ascii=False)
 
 
 class ColoredFormatter(logging.Formatter):
@@ -191,7 +191,7 @@ class ColoredFormatter(logging.Formatter):
         args.update(self._esc_codes)
 
         if extra:
-            args["extra"] = json.dumps(extra, cls=JsonFormatter.JsonEncoder, ensure_ascii=True)
+            args["extra"] = json.dumps(extra, cls=JsonFormatter.JsonEncoder, ensure_ascii=False)
 
         for field in self._required_fields:
             if field in extra:


### PR DESCRIPTION
Disable ensure_ascii (`livekit-agents/livekit/agents/cli/log.py`)

This update will help log user and agent transcripts in languages that use the Cyrillic character set.