### PR TITLE
reuse SpeechHandle for all generations inside a single turn

### DIFF
--- a/livekit-agents/livekit/agents/ipc/proc_client.py
+++ b/livekit-agents/livekit/agents/ipc/proc_client.py
@@ -77,7 +77,6 @@ class _ProcClient:
         asyncio.set_event_loop(loop)
         loop.set_debug(self._init_req.asyncio_debug)
         loop.slow_callback_duration = 0.1  # 100ms
-        aio.debug.hook_slow_callbacks(2.0)
 
         try:
             self._task = loop.create_task(self._monitor_task(), name="proc_client_main")

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -96,9 +96,7 @@ class AgentActivity(RecognitionHooks):
         self._drain_blocked_tasks: list[asyncio.Task[Any]] = []
 
         if self._turn_detection_mode == "vad" and not self.vad:
-            logger.warning(
-                "turn_detection is set to 'vad', but no VAD model is provided"
-            )
+            logger.warning("turn_detection is set to 'vad', but no VAD model is provided")
             self._turn_detection_mode = None
 
         if self._turn_detection_mode == "stt" and not self.stt:
@@ -240,9 +238,7 @@ class AgentActivity(RecognitionHooks):
                 self._agent._chat_ctx, instructions=instructions, add_if_missing=True
             )
 
-    async def update_tools(
-        self, tools: list[llm.FunctionTool | llm.RawFunctionTool]
-    ) -> None:
+    async def update_tools(self, tools: list[llm.FunctionTool | llm.RawFunctionTool]) -> None:
         tools = list(set(tools))
         self._agent._tools = tools
 
@@ -266,9 +262,7 @@ class AgentActivity(RecognitionHooks):
                 chat_ctx, instructions=self._agent.instructions, add_if_missing=True
             )
 
-    def update_options(
-        self, *, tool_choice: NotGivenOr[llm.ToolChoice | None] = NOT_GIVEN
-    ) -> None:
+    def update_options(self, *, tool_choice: NotGivenOr[llm.ToolChoice | None] = NOT_GIVEN) -> None:
         if utils.is_given(tool_choice):
             self._tool_choice = cast(Optional[llm.ToolChoice], tool_choice)
 
@@ -279,7 +273,7 @@ class AgentActivity(RecognitionHooks):
         self,
         coro: Coroutine[Any, Any, Any],
         *,
-        owned_speech_handle: SpeechHandle | None = None,
+        speech_handle: SpeechHandle | None = None,
         name: str | None = None,
     ) -> asyncio.Task[Any]:
         """
@@ -289,19 +283,24 @@ class AgentActivity(RecognitionHooks):
         # https://github.com/python/cpython/pull/31837 alternative impl
         tk = _AgentActivityContextVar.set(self)
         tk1 = None
-        if owned_speech_handle is not None:
-            tk1 = _SpeechHandleContextVar.set(owned_speech_handle)
+        if speech_handle is not None:
+            tk1 = _SpeechHandleContextVar.set(speech_handle)
 
         task = asyncio.create_task(coro, name=name)
         self._speech_tasks.append(task)
         task.add_done_callback(lambda _: self._speech_tasks.remove(task))
 
-        _set_activity_task_info(task, speech_handle=owned_speech_handle)
+        _set_activity_task_info(task, speech_handle=speech_handle)
 
-        if owned_speech_handle is not None:
-            # make sure to finish playout in case something goes wrong
-            # the tasks should normally do this before their function calls
-            task.add_done_callback(lambda _: owned_speech_handle._mark_playout_done())
+        if speech_handle is not None:
+            # mark a speech_handle as done, if every "linked" tasks are done
+            speech_handle._tasks.append(task)
+
+            def _mark_done_if_needed(_: asyncio.Task):
+                if all([task.done() for task in speech_handle._tasks]):
+                    speech_handle._mark_done()
+
+            task.add_done_callback(_mark_done_if_needed)
 
         task.add_done_callback(lambda _: self._wake_up_scheduling_task())
         _AgentActivityContextVar.reset(tk)
@@ -341,9 +340,7 @@ class AgentActivity(RecognitionHooks):
             await self._start_session()
             self._started = True
 
-            task = self._create_speech_task(
-                self._agent.on_enter(), name="AgentTask_on_enter"
-            )
+            task = self._create_speech_task(self._agent.on_enter(), name="AgentTask_on_enter")
             _set_activity_task_info(task, inline_task=True)
 
     async def _start_session(self):
@@ -421,9 +418,7 @@ class AgentActivity(RecognitionHooks):
             hooks=self,
             stt=self._agent.stt_node if self.stt else None,
             vad=self.vad,
-            turn_detector=self.turn_detection
-            if not isinstance(self.turn_detection, str)
-            else None,
+            turn_detector=self.turn_detection if not isinstance(self.turn_detection, str) else None,
             min_endpointing_delay=self._session.options.min_endpointing_delay,
             max_endpointing_delay=self._session.options.max_endpointing_delay,
             turn_detection_mode=self._turn_detection_mode,  # type: ignore
@@ -432,11 +427,10 @@ class AgentActivity(RecognitionHooks):
 
     async def drain(self) -> None:
         # `drain` must only be called by AgentSession
+        # AgentSession makes sure there is always one agent available to the users.
 
         async with self._lock:
-            task = self._create_speech_task(
-                self._agent.on_exit(), name="AgentTask_on_exit"
-            )
+            task = self._create_speech_task(self._agent.on_exit(), name="AgentTask_on_exit")
             _set_activity_task_info(task, inline_task=True)
 
             await self._pause_scheduling_task()
@@ -515,12 +509,8 @@ class AgentActivity(RecognitionHooks):
 
             if isinstance(self.llm, llm.RealtimeModel) and self._rt_session is not None:
                 self._rt_session.off("generation_created", self._on_generation_created)
-                self._rt_session.off(
-                    "input_speech_started", self._on_input_speech_started
-                )
-                self._rt_session.off(
-                    "input_speech_stopped", self._on_input_speech_stopped
-                )
+                self._rt_session.off("input_speech_started", self._on_input_speech_started)
+                self._rt_session.off("input_speech_stopped", self._on_input_speech_stopped)
                 self._rt_session.off(
                     "input_audio_transcription_completed",
                     self._on_input_audio_transcription_completed,
@@ -584,9 +574,7 @@ class AgentActivity(RecognitionHooks):
             and self._session.output.audio
             and self._session.output.audio_enabled
         ):
-            raise RuntimeError(
-                "trying to generate speech from text without a TTS model"
-            )
+            raise RuntimeError("trying to generate speech from text without a TTS model")
 
         if (
             isinstance(self.llm, llm.RealtimeModel)
@@ -617,7 +605,7 @@ class AgentActivity(RecognitionHooks):
                 add_to_chat_ctx=add_to_chat_ctx,
                 model_settings=ModelSettings(),
             ),
-            owned_speech_handle=handle,
+            speech_handle=handle,
             name="AgentActivity.tts_say",
         )
         task.add_done_callback(self._on_pipeline_reply_done)
@@ -667,9 +655,7 @@ class AgentActivity(RecognitionHooks):
         )
         self._session.emit(
             "speech_created",
-            SpeechCreatedEvent(
-                speech_handle=handle, user_initiated=True, source="generate_reply"
-            ),
+            SpeechCreatedEvent(speech_handle=handle, user_initiated=True, source="generate_reply"),
         )
 
         if isinstance(self.llm, llm.RealtimeModel):
@@ -681,7 +667,7 @@ class AgentActivity(RecognitionHooks):
                     instructions=instructions or None,
                     model_settings=ModelSettings(tool_choice=tool_choice),
                 ),
-                owned_speech_handle=handle,
+                speech_handle=handle,
                 name="AgentActivity.realtime_reply",
             )
 
@@ -705,7 +691,7 @@ class AgentActivity(RecognitionHooks):
                         else self._tool_choice
                     ),
                 ),
-                owned_speech_handle=handle,
+                speech_handle=handle,
                 name="AgentActivity.pipeline_reply",
             )
             task.add_done_callback(self._on_pipeline_reply_done)
@@ -762,9 +748,7 @@ class AgentActivity(RecognitionHooks):
             transcript_timeout=transcript_timeout,
         )
 
-    def _schedule_speech(
-        self, speech: SpeechHandle, priority: int, force: bool = False
-    ) -> None:
+    def _schedule_speech(self, speech: SpeechHandle, priority: int, force: bool = False) -> None:
         # when force=True, we still allow to schedule a new speech even if `pause_speech_scheduling` is
         # waiting for the schedule_task to drain.
         # This allows for tool responses to be generated before the AgentActivity is finalized.
@@ -793,11 +777,10 @@ class AgentActivity(RecognitionHooks):
                 self._current_speech = speech
                 if self.min_consecutive_speech_delay > 0.0:
                     await asyncio.sleep(
-                        self.min_consecutive_speech_delay
-                        - (time.time() - last_playout_ts)
+                        self.min_consecutive_speech_delay - (time.time() - last_playout_ts)
                     )
-                speech._authorize_playout()
-                await speech.wait_for_playout()
+                speech._authorize_generation()
+                await speech._wait_for_generation()
                 self._current_speech = None
                 last_playout_ts = time.time()
 
@@ -889,9 +872,7 @@ class AgentActivity(RecognitionHooks):
                 UserInputTranscribedEvent(transcript="", is_final=False),
             )
 
-    def _on_input_audio_transcription_completed(
-        self, ev: llm.InputTranscriptionCompleted
-    ) -> None:
+    def _on_input_audio_transcription_completed(self, ev: llm.InputTranscriptionCompleted) -> None:
         log_event("input_audio_transcription_completed")
         self._session.emit(
             "user_input_transcribed",
@@ -909,24 +890,20 @@ class AgentActivity(RecognitionHooks):
 
         if self._scheduling_paused:
             # TODO(theomonnom): should we "forward" this new turn to the next agent?
-            logger.warning(
-                "skipping new realtime generation, the speech scheduling is not running"
-            )
+            logger.warning("skipping new realtime generation, the speech scheduling is not running")
             return
 
         handle = SpeechHandle.create(allow_interruptions=self.allow_interruptions)
         self._session.emit(
             "speech_created",
-            SpeechCreatedEvent(
-                speech_handle=handle, user_initiated=False, source="generate_reply"
-            ),
+            SpeechCreatedEvent(speech_handle=handle, user_initiated=False, source="generate_reply"),
         )
 
         self._create_speech_task(
             self._realtime_generation_task(
                 speech_handle=handle, generation_ev=ev, model_settings=ModelSettings()
             ),
-            owned_speech_handle=handle,
+            speech_handle=handle,
             name="AgentActivity.realtime_generation",
         )
         self._schedule_speech(handle, SpeechHandle.SPEECH_PRIORITY_NORMAL)
@@ -944,10 +921,7 @@ class AgentActivity(RecognitionHooks):
             # ignore vad inference done event if turn_detection is manual or realtime_llm
             return
 
-        if (
-            isinstance(self.llm, llm.RealtimeModel)
-            and self.llm.capabilities.turn_detection
-        ):
+        if isinstance(self.llm, llm.RealtimeModel) and self.llm.capabilities.turn_detection:
             # ignore if turn_detection is enabled on the realtime model
             return
 
@@ -986,10 +960,7 @@ class AgentActivity(RecognitionHooks):
             self._current_speech.interrupt()
 
     def on_interim_transcript(self, ev: stt.SpeechEvent) -> None:
-        if (
-            isinstance(self.llm, llm.RealtimeModel)
-            and self.llm.capabilities.user_transcription
-        ):
+        if isinstance(self.llm, llm.RealtimeModel) and self.llm.capabilities.user_transcription:
             # skip stt transcription if user_transcription is enabled on the realtime model
             return
 
@@ -1003,10 +974,7 @@ class AgentActivity(RecognitionHooks):
         )
 
     def on_final_transcript(self, ev: stt.SpeechEvent) -> None:
-        if (
-            isinstance(self.llm, llm.RealtimeModel)
-            and self.llm.capabilities.user_transcription
-        ):
+        if isinstance(self.llm, llm.RealtimeModel) and self.llm.capabilities.user_transcription:
             # skip stt transcription if user_transcription is enabled on the realtime model
             return
 
@@ -1098,9 +1066,7 @@ class AgentActivity(RecognitionHooks):
                 self._rt_session.interrupt()
 
         # id is generated
-        user_message: llm.ChatMessage = llm.ChatMessage(
-            role="user", content=[info.new_transcript]
-        )
+        user_message: llm.ChatMessage = llm.ChatMessage(role="user", content=[info.new_transcript])
 
         # create a temporary mutable chat context to pass to on_user_turn_completed
         # the user can edit it for the current generation, but changes will not be kept inside the
@@ -1144,9 +1110,7 @@ class AgentActivity(RecognitionHooks):
             on_user_turn_completed_delay=callback_duration,
             speech_id=speech_handle.id,
         )
-        self._session.emit(
-            "metrics_collected", MetricsCollectedEvent(metrics=eou_metrics)
-        )
+        self._session.emit("metrics_collected", MetricsCollectedEvent(metrics=eou_metrics))
 
     # AudioRecognition is calling this method to retrieve the chat context before running the TurnDetector model  # noqa: E501
     def retrieve_chat_ctx(self) -> llm.ChatContext:
@@ -1155,9 +1119,7 @@ class AgentActivity(RecognitionHooks):
     # endregion
 
     def _on_pipeline_reply_done(self, _: asyncio.Task[None]) -> None:
-        if not self._speech_q and (
-            not self._current_speech or self._current_speech.done()
-        ):
+        if not self._speech_q and (not self._current_speech or self._current_speech.done()):
             self._session._update_agent_state("listening")
 
     @utils.log_exceptions(logger=logger)
@@ -1174,9 +1136,7 @@ class AgentActivity(RecognitionHooks):
             if self._session.output.transcription_enabled
             else None
         )
-        audio_output = (
-            self._session.output.audio if self._session.output.audio_enabled else None
-        )
+        audio_output = self._session.output.audio if self._session.output.audio_enabled else None
 
         await speech_handle.wait_if_not_interrupted(
             [asyncio.ensure_future(speech_handle._wait_for_authorization())]
@@ -1260,7 +1220,7 @@ class AgentActivity(RecognitionHooks):
                 content=text_out.text if text_out else "",
                 interrupted=speech_handle.interrupted,
             )
-            speech_handle._set_chat_message(msg)
+            speech_handle._chat_items.append(msg)
             self._session._conversation_item_added(msg)
 
         if self._session.agent_state == "speaking":
@@ -1280,15 +1240,9 @@ class AgentActivity(RecognitionHooks):
     ) -> None:
         from .agent import ModelSettings
 
-        log_event(
-            "generation started",
-            speech_id=speech_handle.id,
-            step_index=speech_handle.step_index,
-        )
+        log_event("generation started", speech_id=speech_handle.id)
 
-        audio_output = (
-            self._session.output.audio if self._session.output.audio_enabled else None
-        )
+        audio_output = self._session.output.audio if self._session.output.audio_enabled else None
         text_output = (
             self._session.output.transcription
             if self._session.output.transcription_enabled
@@ -1304,9 +1258,7 @@ class AgentActivity(RecognitionHooks):
 
         if instructions is not None:
             try:
-                update_instructions(
-                    chat_ctx, instructions=instructions, add_if_missing=True
-                )
+                update_instructions(chat_ctx, instructions=instructions, add_if_missing=True)
             except ValueError:
                 logger.exception("failed to update the instructions")
 
@@ -1424,11 +1376,12 @@ class AgentActivity(RecognitionHooks):
                 )
                 self._agent._chat_ctx.insert(msg)
                 self._session._conversation_item_added(msg)
-                speech_handle._set_chat_message(msg)
+                speech_handle._chat_items.append(msg)
 
             if self._session.agent_state == "speaking":
                 self._session._update_agent_state("listening")
-            speech_handle._mark_playout_done()
+
+            speech_handle._mark_generation_done()
             await utils.aio.cancel_and_wait(exe_task)
             return
 
@@ -1442,7 +1395,7 @@ class AgentActivity(RecognitionHooks):
             )
             self._agent._chat_ctx.insert(msg)
             self._session._conversation_item_added(msg)
-            speech_handle._set_chat_message(msg)
+            speech_handle._chat_items.append(msg)
 
         if len(tool_output.output) > 0:
             self._session._update_agent_state("thinking")
@@ -1451,14 +1404,14 @@ class AgentActivity(RecognitionHooks):
 
         log_event("playout completed", speech_id=speech_handle.id)
 
-        speech_handle._mark_playout_done()  # mark the playout done before waiting for the tool execution  # noqa: E501
+        speech_handle._mark_generation_done()  # mark the playout done before waiting for the tool execution  # noqa: E501
 
         await exe_task
 
         # important: no agent output should be used after this point
 
         if len(tool_output.output) > 0:
-            if speech_handle.step_index >= self._session.options.max_tool_steps:
+            if speech_handle.num_steps >= self._session.options.max_tool_steps + 1:
                 logger.warning(
                     "maximum number of function calls steps reached",
                     extra={"speech_id": speech_handle.id},
@@ -1468,6 +1421,8 @@ class AgentActivity(RecognitionHooks):
                     speech_id=speech_handle.id,
                 )
                 return
+
+            speech_handle._num_steps += 1
 
             new_calls: list[llm.FunctionCall] = []
             new_fnc_outputs: list[llm.FunctionCallOutput] = []
@@ -1492,9 +1447,7 @@ class AgentActivity(RecognitionHooks):
                 fnc_executed_ev.function_call_outputs.append(sanitized_out.fnc_call_out)
 
                 if new_agent_task is not None and sanitized_out.agent_task is not None:
-                    logger.error(
-                        "expected to receive only one AgentTask from the tool executions",
-                    )
+                    logger.error("expected to receive only one AgentTask from the tool executions")
                     ignore_task_switch = True
                     # TODO(long): should we mark the function call as failed to notify the LLM?
 
@@ -1507,25 +1460,14 @@ class AgentActivity(RecognitionHooks):
                 draining = True
 
             tool_messages = new_calls + new_fnc_outputs
+            speech_handle._chat_items.extend(tool_messages)
+
             if generate_tool_reply:
                 chat_ctx.items.extend(tool_messages)
 
-                handle = SpeechHandle.create(
-                    allow_interruptions=speech_handle.allow_interruptions,
-                    step_index=speech_handle.step_index + 1,
-                    parent=speech_handle,
-                )
-                self._session.emit(
-                    "speech_created",
-                    SpeechCreatedEvent(
-                        speech_handle=handle,
-                        user_initiated=False,
-                        source="tool_response",
-                    ),
-                )
                 tool_response_task = self._create_speech_task(
                     self._pipeline_reply_task(
-                        speech_handle=handle,
+                        speech_handle=speech_handle,
                         chat_ctx=chat_ctx,
                         tools=tools,
                         model_settings=ModelSettings(
@@ -1537,12 +1479,12 @@ class AgentActivity(RecognitionHooks):
                         ),
                         _tools_messages=tool_messages,
                     ),
-                    owned_speech_handle=handle,
+                    speech_handle=speech_handle,
                     name="AgentActivity.pipeline_reply",
                 )
                 tool_response_task.add_done_callback(self._on_pipeline_reply_done)
                 self._schedule_speech(
-                    handle, SpeechHandle.SPEECH_PRIORITY_NORMAL, force=True
+                    speech_handle, SpeechHandle.SPEECH_PRIORITY_NORMAL, force=True
                 )
             elif len(new_fnc_outputs) > 0:
                 # add the tool calls and outputs to the chat context even no reply is generated
@@ -1564,6 +1506,7 @@ class AgentActivity(RecognitionHooks):
         await speech_handle.wait_if_not_interrupted(
             [asyncio.ensure_future(speech_handle._wait_for_authorization())]
         )
+        speech_handle._clear_authorization()
 
         if user_input is not None:
             chat_ctx = self._rt_session.chat_ctx.copy()
@@ -1607,16 +1550,9 @@ class AgentActivity(RecognitionHooks):
         assert self._rt_session is not None, "rt_session is not available"
         assert isinstance(self.llm, llm.RealtimeModel), "llm is not a realtime model"
 
-        log_event(
-            "generation started",
-            speech_id=speech_handle.id,
-            step_index=speech_handle.step_index,
-            realtime=True,
-        )
+        log_event("generation started", speech_id=speech_handle.id, realtime=True)
 
-        audio_output = (
-            self._session.output.audio if self._session.output.audio_enabled else None
-        )
+        audio_output = self._session.output.audio if self._session.output.audio_enabled else None
         text_output = (
             self._session.output.transcription
             if self._session.output.transcription_enabled
@@ -1627,6 +1563,7 @@ class AgentActivity(RecognitionHooks):
         await speech_handle.wait_if_not_interrupted(
             [asyncio.ensure_future(speech_handle._wait_for_authorization())]
         )
+        speech_handle._clear_authorization()
 
         if speech_handle.interrupted:
             return  # TODO(theomonnom): remove the message from the serverside history
@@ -1647,12 +1584,8 @@ class AgentActivity(RecognitionHooks):
                         )
                         break
 
-                    tr_node = self._agent.transcription_node(
-                        msg.text_stream, model_settings
-                    )
-                    tr_node_result = (
-                        await tr_node if asyncio.iscoroutine(tr_node) else tr_node
-                    )
+                    tr_node = self._agent.transcription_node(msg.text_stream, model_settings)
+                    tr_node_result = await tr_node if asyncio.iscoroutine(tr_node) else tr_node
                     text_out: _TextOutput | None = None
                     if tr_node_result is not None:
                         forward_task, text_out = perform_text_forwarding(
@@ -1749,10 +1682,10 @@ class AgentActivity(RecognitionHooks):
                         interrupted=True,
                     )
                     self._agent._chat_ctx.items.append(msg)
-                    speech_handle._set_chat_message(msg)
+                    speech_handle._chat_items.append(msg)
                     self._session._conversation_item_added(msg)
 
-            speech_handle._mark_playout_done()
+            speech_handle._mark_generation_done()
             await utils.aio.cancel_and_wait(exe_task)
             return
 
@@ -1766,11 +1699,10 @@ class AgentActivity(RecognitionHooks):
                 interrupted=False,
             )
             self._agent._chat_ctx.items.append(msg)
-            speech_handle._set_chat_message(msg)
+            speech_handle._chat_items.append(msg)
             self._session._conversation_item_added(msg)
 
-        # mark playout must be done before _set_chat_message
-        speech_handle._mark_playout_done()  # mark the playout done before waiting for the tool execution  # noqa: E501
+        speech_handle._mark_generation_done()  # mark the playout done before waiting for the tool execution  # noqa: E501
 
         tool_output.first_tool_fut.add_done_callback(
             lambda _: self._session._update_agent_state("thinking")
@@ -1780,6 +1712,8 @@ class AgentActivity(RecognitionHooks):
         # important: no agent ouput should be used after this point
 
         if len(tool_output.output) > 0:
+            speech_handle._num_steps += 1
+
             new_fnc_outputs: list[llm.FunctionCallOutput] = []
             generate_tool_reply: bool = False
             fnc_executed_ev = FunctionToolsExecutedEvent(
@@ -1796,6 +1730,10 @@ class AgentActivity(RecognitionHooks):
                 fnc_executed_ev.function_calls.append(sanitized_out.fnc_call)
                 fnc_executed_ev.function_call_outputs.append(sanitized_out.fnc_call_out)
 
+                speech_handle._chat_items.append(sanitized_out.fnc_call)
+                if sanitized_out.fnc_call_out:
+                    speech_handle._chat_items.append(sanitized_out.fnc_call_out)
+
                 if sanitized_out.fnc_call_out is not None:
                     new_fnc_outputs.append(sanitized_out.fnc_call_out)
                     if sanitized_out.reply_required:
@@ -1808,6 +1746,7 @@ class AgentActivity(RecognitionHooks):
                     ignore_task_switch = True
 
                 new_agent_task = sanitized_out.agent_task
+
             self._session.emit("function_tools_executed", fnc_executed_ev)
 
             draining = self.scheduling_paused
@@ -1826,28 +1765,12 @@ class AgentActivity(RecognitionHooks):
                         extra={"error": str(e)},
                     )
 
-            if (
-                generate_tool_reply
-                and not self.llm.capabilities.auto_tool_reply_generation
-            ):
+            if generate_tool_reply and not self.llm.capabilities.auto_tool_reply_generation:
                 self._rt_session.interrupt()
 
-                handle = SpeechHandle.create(
-                    allow_interruptions=speech_handle.allow_interruptions,
-                    step_index=speech_handle.step_index + 1,
-                    parent=speech_handle,
-                )
-                self._session.emit(
-                    "speech_created",
-                    SpeechCreatedEvent(
-                        speech_handle=handle,
-                        user_initiated=False,
-                        source="tool_response",
-                    ),
-                )
                 self._create_speech_task(
                     self._realtime_reply_task(
-                        speech_handle=handle,
+                        speech_handle=speech_handle,
                         model_settings=ModelSettings(
                             # Avoid setting tool_choice to "required" or a specific function when
                             # passing tool response back to the LLM
@@ -1856,11 +1779,11 @@ class AgentActivity(RecognitionHooks):
                             else "auto",
                         ),
                     ),
-                    owned_speech_handle=handle,
+                    speech_handle=speech_handle,
                     name="AgentActivity.realtime_reply",
                 )
                 self._schedule_speech(
-                    handle, SpeechHandle.SPEECH_PRIORITY_NORMAL, force=True
+                    speech_handle, SpeechHandle.SPEECH_PRIORITY_NORMAL, force=True
                 )
 
     # move them to the end to avoid shadowing the same named modules for mypy

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -77,9 +77,7 @@ class VoiceOptions:
 Userdata_T = TypeVar("Userdata_T")
 Run_T = TypeVar("Run_T")
 
-TurnDetectionMode = Union[
-    Literal["stt", "vad", "realtime_llm", "manual"], _TurnDetector
-]
+TurnDetectionMode = Union[Literal["stt", "vad", "realtime_llm", "manual"], _TurnDetector]
 """
 The mode of turn detection to use.
 
@@ -260,9 +258,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         self._tts_error_counts = 0
 
         # configurable IO
-        self._input = io.AgentInput(
-            self._on_video_input_changed, self._on_audio_input_changed
-        )
+        self._input = io.AgentInput(self._on_video_input_changed, self._on_audio_input_changed)
         self._output = io.AgentOutput(
             self._on_video_output_changed,
             self._on_audio_output_changed,
@@ -410,9 +406,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                     )
 
                 chat_cli = ChatCLI(self)
-                tasks.append(
-                    asyncio.create_task(chat_cli.start(), name="_chat_cli_start")
-                )
+                tasks.append(asyncio.create_task(chat_cli.start(), name="_chat_cli_start"))
 
             elif is_given(room) and not self._room_io:
                 room_input_options = copy.copy(
@@ -449,16 +443,10 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                     input_options=room_input_options,
                     output_options=room_output_options,
                 )
-                tasks.append(
-                    asyncio.create_task(self._room_io.start(), name="_room_io_start")
-                )
+                tasks.append(asyncio.create_task(self._room_io.start(), name="_room_io_start"))
 
             else:
-                if (
-                    not self._room_io
-                    and not self.output.audio
-                    and not self.output.transcription
-                ):
+                if not self._room_io and not self.output.audio and not self.output.transcription:
                     logger.warning(
                         "session starts without output, forgetting to pass `room` to `AgentSession.start()`?"  # noqa: E501
                     )
@@ -468,9 +456,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 job_ctx = get_job_context()
                 if self._room_io:
                     # automatically connect to the room when room io is used
-                    tasks.append(
-                        asyncio.create_task(job_ctx.connect(), name="_job_ctx_connect")
-                    )
+                    tasks.append(asyncio.create_task(job_ctx.connect(), name="_job_ctx_connect"))
 
                 if not self._job_context_cb_registered:
                     job_ctx.add_tracing_callback(self._trace_chat_ctx)
@@ -509,12 +495,8 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             return  # can happen at startup
 
         chat_ctx = self._activity.agent.chat_ctx
-        debug.Tracing.store_kv(
-            "chat_ctx", chat_ctx.to_dict(exclude_function_call=False)
-        )
-        debug.Tracing.store_kv(
-            "history", self.history.to_dict(exclude_function_call=False)
-        )
+        debug.Tracing.store_kv("chat_ctx", chat_ctx.to_dict(exclude_function_call=False))
+        debug.Tracing.store_kv("history", self.history.to_dict(exclude_function_call=False))
 
     async def drain(self) -> None:
         if self._activity is None:
@@ -527,11 +509,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         self,
         *,
         reason: CloseReason,
-        error: llm.LLMError
-        | stt.STTError
-        | tts.TTSError
-        | llm.RealtimeModelError
-        | None = None,
+        error: llm.LLMError | stt.STTError | tts.TTSError | llm.RealtimeModelError | None = None,
     ) -> None:
         async with self._lock:
             if not self._started:
@@ -646,9 +624,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         if self._activity.scheduling_paused:
             if self._next_activity is None:
-                raise RuntimeError(
-                    "AgentSession is closing, cannot use generate_reply()"
-                )
+                raise RuntimeError("AgentSession is closing, cannot use generate_reply()")
 
             return self._next_activity._generate_reply(
                 user_message=user_message,
@@ -722,16 +698,12 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
             if new_activity == "start":
                 if agent._activity is not None:
-                    raise RuntimeError(
-                        "cannot start agent: an activity is already running"
-                    )
+                    raise RuntimeError("cannot start agent: an activity is already running")
 
                 self._next_activity = AgentActivity(agent, self)
             elif new_activity == "resume":
                 if agent._activity is None:
-                    raise RuntimeError(
-                        "cannot resume agent: no existing active activity to resume"
-                    )
+                    raise RuntimeError("cannot resume agent: no existing active activity to resume")
 
                 self._next_activity = agent._activity
 
@@ -770,9 +742,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             if self._tts_error_counts <= self.conn_options.max_unrecoverable_errors:
                 return
 
-        logger.error(
-            "AgentSession is closing due to unrecoverable error", exc_info=error.error
-        )
+        logger.error("AgentSession is closing due to unrecoverable error", exc_info=error.error)
 
         def on_close_done(_: asyncio.Task[None]) -> None:
             self._closing_task = None
@@ -800,9 +770,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         async for frame in video_input:
             if self._activity is not None:
-                if self._video_sampler is not None and not self._video_sampler(
-                    frame, self
-                ):
+                if self._video_sampler is not None and not self._video_sampler(frame, self):
                     continue  # ignore this frame
 
                 self._activity.push_video(frame)

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -322,9 +322,7 @@ async def _execute_tools_task(
                 )
                 continue
 
-            if not is_function_tool(function_tool) and not is_raw_function_tool(
-                function_tool
-            ):
+            if not is_function_tool(function_tool) and not is_raw_function_tool(function_tool):
                 logger.error(
                     f"unknown tool type: {type(function_tool)}",
                     extra={
@@ -423,9 +421,7 @@ async def _execute_tools_task(
                 tool_output.output.append(py_out)
                 tasks.remove(task)
 
-            task.add_done_callback(
-                partial(_log_exceptions, py_out=py_out, fnc_call=fnc_call)
-            )
+            task.add_done_callback(partial(_log_exceptions, py_out=py_out, fnc_call=fnc_call))
 
         await asyncio.shield(asyncio.gather(*tasks, return_exceptions=True))
 
@@ -538,9 +534,7 @@ class _PythonOutput:
             or isinstance(self.output, tuple)
         ):
             agent_tasks = [item for item in self.output if isinstance(item, Agent)]
-            other_outputs = [
-                item for item in self.output if not isinstance(item, Agent)
-            ]
+            other_outputs = [item for item in self.output if not isinstance(item, Agent)]
             if len(agent_tasks) > 1:
                 logger.error(
                     f"AI function `{self.fnc_call.name}` returned multiple AgentTask instances, ignoring the output",  # noqa: E501
@@ -591,14 +585,11 @@ class _PythonOutput:
                 llm.FunctionCallOutput(
                     name=self.fnc_call.name,
                     call_id=self.fnc_call.call_id,
-                    output=str(
-                        fnc_out or ""
-                    ),  # take the string representation of the output
+                    output=str(fnc_out or ""),  # take the string representation of the output
                     is_error=False,
                 )
             ),
-            reply_required=fnc_out
-            is not None,  # require a reply if the tool returned an output
+            reply_required=fnc_out is not None,  # require a reply if the tool returned an output
             agent_task=task,
         )
 
@@ -609,9 +600,7 @@ The ID of the instructions message in the chat context. (only for stateless LLMs
 """
 
 
-def update_instructions(
-    chat_ctx: ChatContext, *, instructions: str, add_if_missing: bool
-) -> None:
+def update_instructions(chat_ctx: ChatContext, *, instructions: str, add_if_missing: bool) -> None:
     """
     Update the instruction message in the chat context or insert a new one if missing.
 
@@ -636,9 +625,7 @@ def update_instructions(
         # insert the instructions at the beginning of the chat context
         chat_ctx.items.insert(
             0,
-            llm.ChatMessage(
-                id=INSTRUCTIONS_MESSAGE_ID, role="system", content=[instructions]
-            ),
+            llm.ChatMessage(id=INSTRUCTIONS_MESSAGE_ID, role="system", content=[instructions]),
         )
 
 

--- a/livekit-agents/livekit/agents/voice/speech_handle.py
+++ b/livekit-agents/livekit/agents/voice/speech_handle.py
@@ -31,45 +31,35 @@ class SpeechHandle:
     SPEECH_PRIORITY_HIGH = 10
     """Priority for important messages that should be played before others."""
 
-    def __init__(
-        self,
-        *,
-        speech_id: str,
-        allow_interruptions: bool,
-        step_index: int,
-        parent: SpeechHandle | None,
-    ) -> None:
+    def __init__(self, *, speech_id: str, allow_interruptions: bool) -> None:
         self._id = speech_id
-        self._step_index = step_index
         self._allow_interruptions = allow_interruptions
-        self._interrupt_fut = asyncio.Future[None]()
-        self._authorize_fut = asyncio.Future[None]()
-        self._playout_done_fut = asyncio.Future[None]()
-        self._parent = parent
 
-        self._chat_message: llm.ChatMessage | None = None
+        self._interrupt_fut = asyncio.Future[None]()
+        self._done_fut = asyncio.Future[None]()
+        self._generation_fut = asyncio.Future[None]()
+        self._authorize_event = asyncio.Event()
+
+        # internal tasks used by this generation
+        self._tasks: list[asyncio.Task] = []
         self._chat_items: list[llm.ChatItem] = []
+        self._num_steps = 0
 
     @staticmethod
     def create(
         allow_interruptions: bool = True,
-        step_index: int = 0,
-        parent: SpeechHandle | None = None,
     ) -> SpeechHandle:
         return SpeechHandle(
-            speech_id=utils.shortuuid("speech_"),
-            allow_interruptions=allow_interruptions,
-            step_index=step_index,
-            parent=parent,
+            speech_id=utils.shortuuid("speech_"), allow_interruptions=allow_interruptions
         )
+
+    @property
+    def num_steps(self) -> int:
+        return self._num_steps
 
     @property
     def id(self) -> str:
         return self._id
-
-    @property
-    def step_index(self) -> int:
-        return self._step_index
 
     @property
     def interrupted(self) -> bool:
@@ -79,39 +69,12 @@ class SpeechHandle:
     def allow_interruptions(self) -> bool:
         return self._allow_interruptions
 
-    def result(self) -> RunResult:
-        raise
-
-    # -> User: What is the weather?
-    # -> Assistant: Let me check that for you
-    # -> Tool: get_weather
-    # -> Assistant: The weather in San Francisco is ...
-
-    # @property
-    # def chat_message(self) -> llm.ChatMessage | None:
-    #     """
-    #     Returns the assistant's generated chat message associated with this speech handle.
-
-    #     Only available once the speech playout is complete.
-    #     """
-    #     return self._chat_message
-
-    # TODO(theomonnom): should we introduce chat_items property as well for generated tools?
-
     @property
     def chat_items(self) -> list[llm.ChatItem]:
         return self._chat_items
 
-    @property
-    def parent(self) -> SpeechHandle | None:
-        """
-        The parent handle that initiated the creation of the current speech handle.
-        This happens when a tool call is made, a new SpeechHandle will be created for the tool response.
-        """  # noqa: E501
-        return self._parent
-
     def done(self) -> bool:
-        return self._playout_done_fut.done()
+        return self._done_fut.done()
 
     def interrupt(self) -> SpeechHandle:
         """Interrupt the current speech generation.
@@ -134,7 +97,7 @@ class SpeechHandle:
         return self
 
     async def wait_for_playout(self) -> None:
-        await asyncio.shield(self._playout_done_fut)
+        await asyncio.shield(self._done_fut)
 
     def __await__(self) -> Generator[None, None, SpeechHandle]:
         async def _await_impl() -> SpeechHandle:
@@ -144,7 +107,7 @@ class SpeechHandle:
         return _await_impl().__await__()
 
     def add_done_callback(self, callback: Callable[[SpeechHandle], None]) -> None:
-        self._playout_done_fut.add_done_callback(lambda _: callback(self))
+        self._done_fut.add_done_callback(lambda _: callback(self))
 
     async def wait_if_not_interrupted(self, aw: list[asyncio.futures.Future[Any]]) -> None:
         fs: list[asyncio.Future[Any]] = [
@@ -153,22 +116,24 @@ class SpeechHandle:
         ]
         await asyncio.wait(fs, return_when=asyncio.FIRST_COMPLETED)
 
-    def _authorize_playout(self) -> None:
-        self._authorize_fut.set_result(None)
+    def _authorize_generation(self) -> None:
+        self._generation_fut = asyncio.Future()
+        self._authorize_event.set()
+
+    def _clear_authorization(self) -> None:
+        self._authorize_event.clear()
 
     async def _wait_for_authorization(self) -> None:
-        await asyncio.shield(self._authorize_fut)
+        await self._authorize_event.wait()
 
-    def _mark_playout_done(self) -> None:
+    def _mark_generation_done(self) -> None:
+        with contextlib.suppress(asyncio.InvalidStateError):
+            self._generation_fut.set_result(None)
+
+    async def _wait_for_generation(self) -> None:
+        await asyncio.shield(self._generation_fut)
+
+    def _mark_done(self) -> None:
         with contextlib.suppress(asyncio.InvalidStateError):
             # will raise InvalidStateError if the future is already done (interrupted)
-            self._playout_done_fut.set_result(None)
-
-    def _set_chat_message(self, chat_message: llm.ChatMessage) -> None:
-        if self.done():
-            raise RuntimeError("Cannot set chat message after speech has been played")
-
-        if self._chat_message is not None:
-            raise RuntimeError("Chat message already set")
-
-        self._chat_message = chat_message
+            self._done_fut.set_result(None)


### PR DESCRIPTION
multiple benefits:
- all items created by a generation (including tools) can be accessed using `SpeechHandle.chat_items`
- all generations inside a turn will have the same `speech_id` (now `turn_id==speech_id`)
- required by our evals framework 

handles: https://github.com/livekit/agents/issues/1999, https://github.com/livekit/agents/issues/2550