### PR TITLE
Cartesia TTS: gracefully handle websocket connection closing after long period of silence

### DIFF
--- a/.github/next-release/changeset-600494da.md
+++ b/.github/next-release/changeset-600494da.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-cartesia": patch
+---
+
+fix: gracefully handle WS conn closing after long period of silence (#2630)


### PR DESCRIPTION
Cartesia seems to kill the WebSocket after 60 seconds of no messages being sent. If we wrap these exceptions as `APIError`, the built-in retry mechanism will automatically create a fresh connection.

This is similar to https://github.com/livekit/agents/issues/2281 and https://github.com/livekit/agents/pull/2282