### PR TITLE
Removes the split_utterances option from Hume TTS plugin

### DIFF
--- a/.github/next-release/changeset-955cda8e.md
+++ b/.github/next-release/changeset-955cda8e.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-hume": patch
+---
+
+Removes the split_utterances option from Hume TTS plugin (#2638)

--- a/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
+++ b/livekit-plugins/livekit-plugins-hume/livekit/plugins/hume/tts.py
@@ -67,7 +67,6 @@ class _TTSOptions:
     api_key: str
     utterance_options: PostedUtterance
     context: PostedContext | None
-    split_utterances: bool
     instant_mode: bool
     audio_format: AudioFormat
     base_url: str
@@ -83,7 +82,6 @@ class TTS(tts.TTS):
         api_key: str | None = None,
         utterance_options: NotGivenOr[PostedUtterance] = NOT_GIVEN,
         context: PostedContext | None = None,
-        split_utterances: bool = True,
         instant_mode: bool = True,
         audio_format: AudioFormat = AudioFormat.mp3,
         base_url: str = DEFAULT_BASE_URL,
@@ -106,7 +104,6 @@ class TTS(tts.TTS):
             api_key=key,
             utterance_options=base_utterance,
             context=context,
-            split_utterances=split_utterances,
             instant_mode=instant_mode,
             audio_format=audio_format,
             base_url=base_url,
@@ -124,7 +121,6 @@ class TTS(tts.TTS):
         *,
         utterance_options: NotGivenOr[PostedUtterance] = NOT_GIVEN,
         context: NotGivenOr[PostedContext] = NOT_GIVEN,
-        split_utterances: NotGivenOr[bool] = NOT_GIVEN,
         instant_mode: NotGivenOr[bool] = NOT_GIVEN,
         audio_format: NotGivenOr[AudioFormat] = NOT_GIVEN,
     ) -> None:
@@ -132,8 +128,6 @@ class TTS(tts.TTS):
             self._opts.utterance_options = cast(PostedUtterance, dict(utterance_options))
         if is_given(context):
             self._opts.context = cast(PostedContext, context)
-        if is_given(split_utterances):
-            self._opts.split_utterances = split_utterances
         if is_given(instant_mode):
             self._opts.instant_mode = instant_mode
         if is_given(audio_format):
@@ -157,7 +151,6 @@ class ChunkedStream(tts.ChunkedStream):
 
         payload: dict[str, Any] = {
             "utterances": [utterance],
-            "split_utterances": self._opts.split_utterances,
             "strip_headers": True,
             "instant_mode": self._opts.instant_mode,
             "format": {"type": self._opts.audio_format.value},


### PR DESCRIPTION
## Hume TTS Plugin Changes

- **Remove the `split_utterances` option.**
    - The `split_utterances` flag only alters how the API’s `snippets` array is structured in the response body. 
    - Since the plugin extracts and returns only the raw audio payload, this setting has no effect on end-user output and can be removed to simplify the plugin's interface.