### PR TITLE
Fix : Increase audio mixer timeout

### DIFF
--- a/.github/next-release/changeset-e46145c3.md
+++ b/.github/next-release/changeset-e46145c3.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Fix : Increase audio mixer timeout (#2646)

--- a/livekit-agents/livekit/agents/voice/background_audio.py
+++ b/livekit-agents/livekit/agents/voice/background_audio.py
@@ -98,7 +98,7 @@ class BackgroundAudioPlayer:
         self._thinking_sound = thinking_sound if is_given(thinking_sound) else None
 
         self._audio_source = rtc.AudioSource(48000, 1, queue_size_ms=_AUDIO_SOURCE_BUFFER_MS)
-        self._audio_mixer = rtc.AudioMixer(48000, 1, blocksize=4800, capacity=1)
+        self._audio_mixer = rtc.AudioMixer(48000, 1, blocksize=4800, capacity=1, stream_timeout_ms=200)
         self._publication: rtc.LocalTrackPublication | None = None
         self._lock = asyncio.Lock()
 


### PR DESCRIPTION
We observe frequent timeouts for the background audio.

I increased the default timeout to fix it.

Other options are 
- Increasing default timeout of `AudioMixer`
- Adding param `audio_mixer_kwargs` to `BackgroundAudioPlayer`
- Adding param `stream_timeout_ms` to `BackgroundAudioPlayer`

What would be the preferred approach?