### PR TITLE
Gladia STT - add new parameters to gladia stt

### DIFF
--- a/.github/next-release/changeset-8f8eb6a2.md
+++ b/.github/next-release/changeset-8f8eb6a2.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-gladia": patch
+---
+
+Gladia STT - add new parameters to gladia stt (#2649)

--- a/.github/next-release/changeset-e46145c3.md
+++ b/.github/next-release/changeset-e46145c3.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Fix : Increase audio mixer timeout (#2646)

--- a/livekit-agents/livekit/agents/voice/background_audio.py
+++ b/livekit-agents/livekit/agents/voice/background_audio.py
@@ -98,7 +98,7 @@ class BackgroundAudioPlayer:
         self._thinking_sound = thinking_sound if is_given(thinking_sound) else None
 
         self._audio_source = rtc.AudioSource(48000, 1, queue_size_ms=_AUDIO_SOURCE_BUFFER_MS)
-        self._audio_mixer = rtc.AudioMixer(48000, 1, blocksize=4800, capacity=1)
+        self._audio_mixer = rtc.AudioMixer(48000, 1, blocksize=4800, capacity=1, stream_timeout_ms=200)
         self._publication: rtc.LocalTrackPublication | None = None
         self._lock = asyncio.Lock()
 

--- a/livekit-agents/livekit/agents/voice/background_audio.py
+++ b/livekit-agents/livekit/agents/voice/background_audio.py
@@ -98,7 +98,9 @@ class BackgroundAudioPlayer:
         self._thinking_sound = thinking_sound if is_given(thinking_sound) else None
 
         self._audio_source = rtc.AudioSource(48000, 1, queue_size_ms=_AUDIO_SOURCE_BUFFER_MS)
-        self._audio_mixer = rtc.AudioMixer(48000, 1, blocksize=4800, capacity=1, stream_timeout_ms=200)
+        self._audio_mixer = rtc.AudioMixer(
+            48000, 1, blocksize=4800, capacity=1, stream_timeout_ms=200
+        )
         self._publication: rtc.LocalTrackPublication | None = None
         self._lock = asyncio.Lock()
 

--- a/livekit-plugins/livekit-plugins-gladia/README.md
+++ b/livekit-plugins/livekit-plugins-gladia/README.md
@@ -38,17 +38,42 @@ stt = GladiaSTT(
 
 # With more options
 stt = GladiaSTT(
-    languages=["en", "fr"],  # Specify languages or let Gladia auto-detect
-    code_switching=True,     # Allow switching between languages during recognition
-    sample_rate=16000,       # Audio sample rate in Hz
-    bit_depth=16,            # Audio bit depth
-    channels=1,              # Number of audio channels
-    encoding="wav/pcm",      # Audio encoding format
-    energy_filter=True,      # Enable voice activity detection
+    languages=["en", "fr"],                     # Specify languages or let Gladia auto-detect
+    code_switching=True,                        # Allow switching between languages during recognition
+    sample_rate=16000,                          # Audio sample rate in Hz
+    bit_depth=16,                               # Audio bit depth
+    channels=1,                                 # Number of audio channels
+    encoding="wav/pcm",                         # Audio encoding format
+    energy_filter=True,                         # Enable voice activity detection
     translation_enabled=True,
     translation_target_languages=["en"],
     translation_model="base",
     translation_match_original_utterances=True
+    translation_context_adaptation= False,      # Enable context-aware translation
+    translation_context= None,                  # Context input to guide translation
+    translation_informal=False,                 # Use informal tone in translation
+    pre_processing_audio_enhancer=False,        # Apply pre-processing to the audio stream to enhance the quality
+    pre_processing_speech_threshold=0.6,        # Sensitivity for speech detection; closer to 1 = stricter, less background noise
+
+    # Custom_vocabulary exemple
+    custom_vocabulary=[
+        "Westeros",
+        {"value": "Stark"},
+        {
+            "value": "Night's Watch",
+            "pronunciations": ["Nightz Watch"],
+            "intensity": 0.4,
+            "language": "en"
+        }
+    ],
+
+    # Custom_spelling exemple
+    custom_spelling={
+        "Gorish": ["ghorish", "gaurish", "gaureish"],
+        "Data Science": ["data-science", "data science"],
+        ".": ["period", "full stop"],
+        "SQL": ["sequel"]
+    }
 )
 
 # Update options after initialization

--- a/livekit-plugins/livekit-plugins-gladia/livekit/plugins/gladia/stt.py
+++ b/livekit-plugins/livekit-plugins-gladia/livekit/plugins/gladia/stt.py
@@ -22,7 +22,7 @@ import os
 import weakref
 from dataclasses import dataclass
 from enum import Enum
-from typing import Literal
+from typing import Any, Literal
 
 import aiohttp
 import numpy as np
@@ -129,7 +129,7 @@ class STTOptions:
     )
 
 
-def _build_streaming_config(opts: STTOptions) -> dict:
+def _build_streaming_config(opts: STTOptions) -> dict[str, Any]:
     """Build the streaming configuration for Gladia API."""
     streaming_config = {
         "encoding": opts.encoding,
@@ -692,6 +692,8 @@ class SpeechStream(stt.SpeechStream):
         translation_informal: bool | None = None,
         custom_vocabulary: list[str | dict] | None = None,
         custom_spelling: dict[str, list[str]] | None = None,
+        pre_processing_audio_enhancer: bool | None = None,
+        pre_processing_speech_threshold: float | None = None,
     ) -> None:
         if languages is not None or code_switching is not None:
             language_config = dataclasses.replace(
@@ -743,6 +745,17 @@ class SpeechStream(stt.SpeechStream):
                 else self._opts.translation_config.informal,
             )
             self._opts.translation_config = translation_config
+
+        if pre_processing_audio_enhancer is not None or pre_processing_speech_threshold is not None:
+            self._opts.pre_processing = dataclasses.replace(
+                self._opts.pre_processing,
+                audio_enhancer=pre_processing_audio_enhancer
+                if pre_processing_audio_enhancer is not None
+                else self._opts.pre_processing.audio_enhancer,
+                speech_threshold=pre_processing_speech_threshold
+                if pre_processing_speech_threshold is not None
+                else self._opts.pre_processing.speech_threshold,
+            )
 
         if interim_results is not None:
             self._opts.interim_results = interim_results

--- a/livekit-plugins/livekit-plugins-gladia/livekit/plugins/gladia/stt.py
+++ b/livekit-plugins/livekit-plugins-gladia/livekit/plugins/gladia/stt.py
@@ -131,7 +131,7 @@ class STTOptions:
 
 def _build_streaming_config(opts: STTOptions) -> dict[str, Any]:
     """Build the streaming configuration for Gladia API."""
-    streaming_config = {
+    streaming_config: dict[str, Any] = {
         "encoding": opts.encoding,
         "sample_rate": opts.sample_rate,
         "bit_depth": opts.bit_depth,

--- a/livekit-plugins/livekit-plugins-gladia/livekit/plugins/gladia/stt.py
+++ b/livekit-plugins/livekit-plugins-gladia/livekit/plugins/gladia/stt.py
@@ -98,6 +98,16 @@ class TranslationConfiguration:
     target_languages: list[str] = dataclasses.field(default_factory=list)
     model: str = "base"
     match_original_utterances: bool = True
+    lipsync: bool = True
+    context_adaptation: bool = False
+    context: str | None = None
+    informal: bool = False
+
+
+@dataclass
+class PreProcessingConfiguration:
+    audio_enhancer: bool = False
+    speech_threshold: float = 0.6
 
 
 @dataclass
@@ -112,7 +122,63 @@ class STTOptions:
         default_factory=TranslationConfiguration
     )
     energy_filter: AudioEnergyFilter | bool = False
+    custom_vocabulary: list[str | dict] | None = None
+    custom_spelling: dict[str, list[str]] | None = None
+    pre_processing: PreProcessingConfiguration = dataclasses.field(
+        default_factory=PreProcessingConfiguration
+    )
 
+
+def _build_streaming_config(opts: STTOptions) -> dict:
+    """Build the streaming configuration for Gladia API."""
+    streaming_config = {
+        "encoding": opts.encoding,
+        "sample_rate": opts.sample_rate,
+        "bit_depth": opts.bit_depth,
+        "channels": opts.channels,
+        "language_config": {
+            "languages": opts.language_config.languages or [],
+            "code_switching": opts.language_config.code_switching,
+        },
+        "realtime_processing": {
+            "words_accurate_timestamps": False,
+        },
+    }
+
+    if opts.custom_vocabulary:
+        streaming_config["realtime_processing"]["custom_vocabulary"] = True  # type: ignore
+        streaming_config["realtime_processing"]["custom_vocabulary_config"] = {  # type: ignore
+            "vocabulary": opts.custom_vocabulary,
+        }
+
+    if opts.custom_spelling:
+        streaming_config["realtime_processing"]["custom_spelling"] = True  # type: ignore
+        streaming_config["realtime_processing"]["custom_spelling_config"] = {  # type: ignore
+            "spelling_dictionary": opts.custom_spelling,
+        }
+
+    if opts.pre_processing:
+        streaming_config["pre_processing"] = {
+            "audio_enhancer": opts.pre_processing.audio_enhancer,
+            "speech_threshold": opts.pre_processing.speech_threshold,
+    }
+
+    if opts.translation_config.enabled:
+        streaming_config["realtime_processing"]["translation"] = True  # type: ignore
+        translation_cfg = {
+            "target_languages": opts.translation_config.target_languages,
+            "model": opts.translation_config.model,
+            "match_original_utterances": opts.translation_config.match_original_utterances,
+            "lipsync": opts.translation_config.lipsync,
+            "context_adaptation": opts.translation_config.context_adaptation,
+            "informal": opts.translation_config.informal,
+        }
+        if opts.translation_config.context:
+            translation_cfg["context"] = opts.translation_config.context
+
+        streaming_config["realtime_processing"]["translation_config"] = translation_cfg  # type: ignore
+
+    return streaming_config
 
 class STT(stt.STT):
     def __init__(
@@ -133,6 +199,14 @@ class STT(stt.STT):
         translation_target_languages: list[str] | None = None,
         translation_model: str = "base",
         translation_match_original_utterances: bool = True,
+        translation_lipsync: bool = True,
+        translation_context_adaptation: bool = False,
+        translation_context: str | None = None,
+        translation_informal: bool = False,
+        custom_vocabulary: list[str | dict] | None = None,
+        custom_spelling: dict[str, list[str]] | None = None,
+        pre_processing_audio_enhancer: bool = False,
+        pre_processing_speech_threshold: float = 0.6,
     ) -> None:
         """Create a new instance of Gladia STT.
 
@@ -159,6 +233,14 @@ class STT(stt.STT):
             translation_model: Translation model to use. Defaults to "base".
             translation_match_original_utterances: Whether to match original utterances with
                                                     translations. Defaults to True.
+            translation_lipsync: If True, enables lipsync generation for translations.
+            translation_context_adaptation: If True, adapts translation to the context.
+            translation_context: A string providing context for translation.
+            translation_informal: If True, uses informal translation style.
+            custom_vocabulary: A list of custom vocabulary to use for recognition.
+            custom_spelling: A dictionary of custom spelling to use for transcription.
+            pre_processing_audio_enhancer: Whether to enable audio enhancement pre-processing.
+            pre_processing_speech_threshold: The speech threshold for pre-processing.
 
         Raises:
             ValueError: If no API key is provided or found in environment variables.
@@ -181,6 +263,15 @@ class STT(stt.STT):
             target_languages=translation_target_languages or [],
             model=translation_model,
             match_original_utterances=translation_match_original_utterances,
+            lipsync=translation_lipsync,
+            context_adaptation=translation_context_adaptation,
+            context=translation_context,
+            informal=translation_informal,
+        )
+
+        pre_processing_config = PreProcessingConfiguration(
+            audio_enhancer=pre_processing_audio_enhancer,
+            speech_threshold=pre_processing_speech_threshold
         )
 
         if translation_enabled and not translation_target_languages:
@@ -196,7 +287,10 @@ class STT(stt.STT):
             channels=channels,
             encoding=encoding,
             translation_config=translation_config,
+            pre_processing=pre_processing_config,
             energy_filter=energy_filter,
+            custom_vocabulary=custom_vocabulary,
+            custom_spelling=custom_spelling,
         )
         self._session = http_session
         self._streams: weakref.WeakSet[SpeechStream] = weakref.WeakSet()
@@ -216,43 +310,7 @@ class STT(stt.STT):
     ) -> stt.SpeechEvent:
         """Implement synchronous speech recognition for Gladia using the live endpoint."""
         config = self._sanitize_options(languages=[language] if is_given(language) else None)
-
-        streaming_config = {
-            "encoding": config.encoding,
-            "sample_rate": config.sample_rate,
-            "bit_depth": config.bit_depth,
-            "channels": config.channels,
-            "language_config": {
-                "languages": config.language_config.languages or [],
-                "code_switching": config.language_config.code_switching,
-            },
-            "realtime_processing": {
-                "words_accurate_timestamps": False,
-                "custom_vocabulary": False,
-                "custom_vocabulary_config": {
-                    "vocabulary": [
-                        "Gladia",
-                        {"value": "Gladia", "intensity": 0.5},
-                    ],
-                    "default_intensity": 0.5,
-                },
-                "custom_spelling": False,
-                "custom_spelling_config": {
-                    "spelling_dictionary": {
-                        "SQL": ["Sequel"],
-                    }
-                },
-            },
-        }
-
-        # Add translation configuration if enabled
-        if config.translation_config.enabled:
-            streaming_config["realtime_processing"]["translation"] = True  # type: ignore
-            streaming_config["realtime_processing"]["translation_config"] = {  # type: ignore
-                "target_languages": config.translation_config.target_languages,
-                "model": config.translation_config.model,
-                "match_original_utterances": config.translation_config.match_original_utterances,
-            }
+        streaming_config = _build_streaming_config(config)
 
         try:
             # Initialize a session with Gladia
@@ -459,6 +517,14 @@ class STT(stt.STT):
         translation_target_languages: list[str] | None = None,
         translation_model: str | None = None,
         translation_match_original_utterances: bool | None = None,
+        translation_lipsync: bool | None = None,
+        translation_context_adaptation: bool | None = None,
+        translation_context: str | None = None,
+        translation_informal: bool | None = None,
+        custom_vocabulary: list[str | dict] | None = None,
+        custom_spelling: dict[str, list[str]] | None = None,
+        pre_processing_audio_enhancer: bool | None = None,
+        pre_processing_speech_threshold: float | None = None,
     ) -> None:
         if languages is not None or code_switching is not None:
             language_config = dataclasses.replace(
@@ -477,6 +543,10 @@ class STT(stt.STT):
             or translation_target_languages is not None
             or translation_model is not None
             or translation_match_original_utterances is not None
+            or translation_lipsync is not None
+            or translation_context_adaptation is not None
+            or translation_context is not None
+            or translation_informal is not None
         ):
             translation_config = dataclasses.replace(
                 self._opts.translation_config,
@@ -492,8 +562,31 @@ class STT(stt.STT):
                 match_original_utterances=translation_match_original_utterances
                 if translation_match_original_utterances is not None
                 else self._opts.translation_config.match_original_utterances,
+                lipsync=translation_lipsync
+                if translation_lipsync is not None
+                else self._opts.translation_config.lipsync,
+                context_adaptation=translation_context_adaptation
+                if translation_context_adaptation is not None
+                else self._opts.translation_config.context_adaptation,
+                context=translation_context
+                if translation_context is not None
+                else self._opts.translation_config.context,
+                informal=translation_informal
+                if translation_informal is not None
+                else self._opts.translation_config.informal,
             )
             self._opts.translation_config = translation_config
+
+        if pre_processing_audio_enhancer is not None or pre_processing_speech_threshold is not None:
+            self._opts.pre_processing = dataclasses.replace(
+                self._opts.pre_processing,
+                audio_enhancer=pre_processing_audio_enhancer
+                if pre_processing_audio_enhancer is not None
+                else self._opts.pre_processing.audio_enhancer,
+                speech_threshold=pre_processing_speech_threshold
+                if pre_processing_speech_threshold is not None
+                else self._opts.pre_processing.speech_threshold,
+            )
 
         if interim_results is not None:
             self._opts.interim_results = interim_results
@@ -505,6 +598,10 @@ class STT(stt.STT):
             self._opts.channels = channels
         if encoding is not None:
             self._opts.encoding = encoding
+        if custom_vocabulary is not None:
+            self._opts.custom_vocabulary = custom_vocabulary
+        if custom_spelling is not None:
+            self._opts.custom_spelling = custom_spelling
 
         for stream in self._streams:
             stream.update_options(
@@ -519,6 +616,14 @@ class STT(stt.STT):
                 translation_target_languages=translation_target_languages,
                 translation_model=translation_model,
                 translation_match_original_utterances=translation_match_original_utterances,
+                translation_lipsync=translation_lipsync,
+                translation_context_adaptation=translation_context_adaptation,
+                translation_context=translation_context,
+                translation_informal=translation_informal,
+                custom_vocabulary=custom_vocabulary,
+                custom_spelling=custom_spelling,
+                pre_processing_audio_enhancer=pre_processing_audio_enhancer,
+                pre_processing_speech_threshold=pre_processing_speech_threshold,
             )
 
     def _sanitize_options(self, *, languages: list[str] | None = None) -> STTOptions:
@@ -581,6 +686,12 @@ class SpeechStream(stt.SpeechStream):
         translation_target_languages: list[str] | None = None,
         translation_model: str | None = None,
         translation_match_original_utterances: bool | None = None,
+        translation_lipsync: bool | None = None,
+        translation_context_adaptation: bool | None = None,
+        translation_context: str | None = None,
+        translation_informal: bool | None = None,
+        custom_vocabulary: list[str | dict] | None = None,
+        custom_spelling: dict[str, list[str]] | None = None,
     ) -> None:
         if languages is not None or code_switching is not None:
             language_config = dataclasses.replace(
@@ -599,6 +710,10 @@ class SpeechStream(stt.SpeechStream):
             or translation_target_languages is not None
             or translation_model is not None
             or translation_match_original_utterances is not None
+            or translation_lipsync is not None
+            or translation_context_adaptation is not None
+            or translation_context is not None
+            or translation_informal is not None
         ):
             translation_config = dataclasses.replace(
                 self._opts.translation_config,
@@ -614,6 +729,18 @@ class SpeechStream(stt.SpeechStream):
                 match_original_utterances=translation_match_original_utterances
                 if translation_match_original_utterances is not None
                 else self._opts.translation_config.match_original_utterances,
+                lipsync=translation_lipsync
+                if translation_lipsync is not None
+                else self._opts.translation_config.lipsync,
+                context_adaptation=translation_context_adaptation
+                if translation_context_adaptation is not None
+                else self._opts.translation_config.context_adaptation,
+                context=translation_context
+                if translation_context is not None
+                else self._opts.translation_config.context,
+                informal=translation_informal
+                if translation_informal is not None
+                else self._opts.translation_config.informal,
             )
             self._opts.translation_config = translation_config
 
@@ -627,6 +754,10 @@ class SpeechStream(stt.SpeechStream):
             self._opts.channels = channels
         if encoding is not None:
             self._opts.encoding = encoding
+        if custom_vocabulary is not None:
+            self._opts.custom_vocabulary = custom_vocabulary
+        if custom_spelling is not None:
+            self._opts.custom_spelling = custom_spelling
 
         self._reconnect_event.set()
 
@@ -689,29 +820,7 @@ class SpeechStream(stt.SpeechStream):
 
     async def _init_live_session(self) -> dict:
         """Initialize a live session with Gladia."""
-        streaming_config = {
-            "encoding": self._opts.encoding,
-            "sample_rate": self._opts.sample_rate,
-            "bit_depth": self._opts.bit_depth,
-            "channels": self._opts.channels,
-            "language_config": {
-                "languages": self._opts.language_config.languages or [],
-                "code_switching": self._opts.language_config.code_switching,
-            },
-            "realtime_processing": {},
-        }
-
-        # Add translation configuration if enabled
-        if self._opts.translation_config.enabled:
-            streaming_config["realtime_processing"]["translation"] = True  # type: ignore
-            streaming_config["realtime_processing"]["translation_config"] = {  # type: ignore
-                "target_languages": self._opts.translation_config.target_languages,
-                "model": self._opts.translation_config.model,
-                "match_original_utterances": (
-                    self._opts.translation_config.match_original_utterances
-                ),
-            }
-
+        streaming_config = _build_streaming_config(self._opts)
         try:
             async with self._session.post(
                 url=self._base_url,

--- a/livekit-plugins/livekit-plugins-gladia/livekit/plugins/gladia/stt.py
+++ b/livekit-plugins/livekit-plugins-gladia/livekit/plugins/gladia/stt.py
@@ -161,7 +161,7 @@ def _build_streaming_config(opts: STTOptions) -> dict[str, Any]:
         streaming_config["pre_processing"] = {
             "audio_enhancer": opts.pre_processing.audio_enhancer,
             "speech_threshold": opts.pre_processing.speech_threshold,
-    }
+        }
 
     if opts.translation_config.enabled:
         streaming_config["realtime_processing"]["translation"] = True
@@ -179,6 +179,7 @@ def _build_streaming_config(opts: STTOptions) -> dict[str, Any]:
         streaming_config["realtime_processing"]["translation_config"] = translation_cfg
 
     return streaming_config
+
 
 class STT(stt.STT):
     def __init__(
@@ -271,7 +272,7 @@ class STT(stt.STT):
 
         pre_processing_config = PreProcessingConfiguration(
             audio_enhancer=pre_processing_audio_enhancer,
-            speech_threshold=pre_processing_speech_threshold
+            speech_threshold=pre_processing_speech_threshold,
         )
 
         if translation_enabled and not translation_target_languages:

--- a/livekit-plugins/livekit-plugins-gladia/livekit/plugins/gladia/stt.py
+++ b/livekit-plugins/livekit-plugins-gladia/livekit/plugins/gladia/stt.py
@@ -146,14 +146,14 @@ def _build_streaming_config(opts: STTOptions) -> dict[str, Any]:
     }
 
     if opts.custom_vocabulary:
-        streaming_config["realtime_processing"]["custom_vocabulary"] = True  # type: ignore
-        streaming_config["realtime_processing"]["custom_vocabulary_config"] = {  # type: ignore
+        streaming_config["realtime_processing"]["custom_vocabulary"] = True
+        streaming_config["realtime_processing"]["custom_vocabulary_config"] = {
             "vocabulary": opts.custom_vocabulary,
         }
 
     if opts.custom_spelling:
-        streaming_config["realtime_processing"]["custom_spelling"] = True  # type: ignore
-        streaming_config["realtime_processing"]["custom_spelling_config"] = {  # type: ignore
+        streaming_config["realtime_processing"]["custom_spelling"] = True
+        streaming_config["realtime_processing"]["custom_spelling_config"] = {
             "spelling_dictionary": opts.custom_spelling,
         }
 
@@ -164,7 +164,7 @@ def _build_streaming_config(opts: STTOptions) -> dict[str, Any]:
     }
 
     if opts.translation_config.enabled:
-        streaming_config["realtime_processing"]["translation"] = True  # type: ignore
+        streaming_config["realtime_processing"]["translation"] = True
         translation_cfg = {
             "target_languages": opts.translation_config.target_languages,
             "model": opts.translation_config.model,
@@ -176,7 +176,7 @@ def _build_streaming_config(opts: STTOptions) -> dict[str, Any]:
         if opts.translation_config.context:
             translation_cfg["context"] = opts.translation_config.context
 
-        streaming_config["realtime_processing"]["translation_config"] = translation_cfg  # type: ignore
+        streaming_config["realtime_processing"]["translation_config"] = translation_cfg
 
     return streaming_config
 


### PR DESCRIPTION
This update enhances the documentation for the Gladia plugin usage by:

Expanding the advanced GladiaSTT configuration example with additional parameters:

- translation_context_adaptation, translation_context, and translation_informal for more control over translation behavior.

- pre_processing_audio_enhancer and pre_processing_speech_threshold to fine-tune audio preprocessing.

Introducing real-world examples for:

- custom_vocabulary: includes weighted entries and optional pronunciation hints.

- custom_spelling: demonstrates normalization of alternative spellings or phonetic variants.