### PR TITLE
deepgram: disable smart_format by default

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -77,7 +77,7 @@ class STT(stt.STT):
         detect_language: bool = False,
         interim_results: bool = True,
         punctuate: bool = True,
-        smart_format: bool = True,
+        smart_format: bool = False,
         sample_rate: int = 16000,
         no_delay: bool = True,
         endpointing_ms: int = 25,


### PR DESCRIPTION
align with deepgram default: https://developers.deepgram.com/docs/smart-format