### PR TITLE
make RoomIO input track source configurable

### DIFF
--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -11,6 +11,7 @@ import livekit.rtc as rtc
 from livekit.rtc._proto.track_pb2 import AudioTrackFeature
 
 from ...log import logger
+from ...types import NOT_GIVEN, NotGivenOr
 from ...utils import aio, log_exceptions
 from ..io import AudioInput, VideoInput
 from ._pre_connect_audio import PreConnectAudioHandler
@@ -208,9 +209,10 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         num_channels: int,
         noise_cancellation: rtc.NoiseCancellationOptions | None,
         pre_connect_audio_handler: PreConnectAudioHandler | None,
+        track_source: NotGivenOr[list[rtc.TrackSource.ValueType]] = NOT_GIVEN,
     ) -> None:
         _ParticipantInputStream.__init__(
-            self, room=room, track_source=rtc.TrackSource.SOURCE_MICROPHONE
+            self, room=room, track_source=track_source or [rtc.TrackSource.SOURCE_MICROPHONE]
         )
         self._sample_rate = sample_rate
         self._num_channels = num_channels
@@ -306,14 +308,17 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
 
 
 class _ParticipantVideoInputStream(_ParticipantInputStream[rtc.VideoFrame], VideoInput):
-    def __init__(self, room: rtc.Room) -> None:
+    def __init__(
+        self,
+        room: rtc.Room,
+        *,
+        track_source: NotGivenOr[list[rtc.TrackSource.ValueType]] = NOT_GIVEN,
+    ) -> None:
         _ParticipantInputStream.__init__(
             self,
             room=room,
-            track_source=[
-                rtc.TrackSource.SOURCE_CAMERA,
-                rtc.TrackSource.SOURCE_SCREENSHARE,
-            ],
+            track_source=track_source
+            or [rtc.TrackSource.SOURCE_CAMERA, rtc.TrackSource.SOURCE_SCREENSHARE],
         )
 
     @override

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -87,6 +87,10 @@ class RoomInputOptions:
     close_on_disconnect: bool = True
     """Close the AgentSession if the linked participant disconnects with reasons in
     CLIENT_INITIATED, ROOM_DELETED, or USER_REJECTED."""
+    accepted_audio_sources: NotGivenOr[list[rtc.TrackSource.ValueType]] = NOT_GIVEN
+    """Accepted audio sources. If not provided, accept `SOURCE_MICROPHONE`."""
+    accepted_video_sources: NotGivenOr[list[rtc.TrackSource.ValueType]] = NOT_GIVEN
+    """Accepted video sources. If not provided, accept `SOURCE_CAMERA` and `SOURCE_SCREENSHARE`."""
 
 
 @dataclass
@@ -170,7 +174,9 @@ class RoomIO:
                     )
 
         if self._input_options.video_enabled:
-            self._video_input = _ParticipantVideoInputStream(self._room)
+            self._video_input = _ParticipantVideoInputStream(
+                self._room, track_source=self._input_options.accepted_video_sources
+            )
 
         if self._input_options.audio_enabled or not utils.is_given(
             self._input_options.audio_enabled
@@ -181,6 +187,7 @@ class RoomIO:
                 num_channels=self._input_options.audio_num_channels,
                 noise_cancellation=self._input_options.noise_cancellation,
                 pre_connect_audio_handler=self._pre_connect_audio_handler,
+                track_source=self._input_options.accepted_audio_sources,
             )
 
         # -- create outputs --


### PR DESCRIPTION
fix https://github.com/livekit/agents/issues/2400

To accept screenshare audio
```python
room_input_options=RoomInputOptions(
            video_enabled=True,
            accepted_audio_sources=[
                rtc.TrackSource.SOURCE_SCREENSHARE_AUDIO,
                rtc.TrackSource.SOURCE_MICROPHONE,
            ],
        ),
```