### PR TITLE
Lock google-genai package to stable v1.20.0

### DIFF
--- a/livekit-plugins/livekit-plugins-google/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-google/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "google-auth >= 2, < 3",
     "google-cloud-speech >= 2, < 3",
     "google-cloud-texttospeech >= 2.27, < 3",
-    "google-genai >= v1.21.1",
+    "google-genai == v1.20.0",
     "livekit-agents>=1.1.4",
 ]
 


### PR DESCRIPTION
This change pins the google-genai package to version 1.20.0 to avoid a `JSONDecodeError` and an `ERROR asyncio - Unclosed client session` that occur during streaming with version 1.21.1 and above.

### This issue is documented in:
https://github.com/googleapis/python-genai/issues/1024
https://github.com/googleapis/python-genai/issues/1014