### PR TITLE
BlingFire: use Release config on Windows 

### DIFF
--- a/livekit-plugins/livekit-blingfire/CMakeLists.txt
+++ b/livekit-plugins/livekit-blingfire/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.19)
 project(lk_blingfire)
 
-set(CMAKE_CONFIGURATION_TYPES Release CACHE STRING "" FORCE)
-set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -21,29 +18,3 @@ include_directories(${blingfire_SOURCE_DIR})
 
 pybind11_add_module(lk_blingfire src/main.cpp)
 target_link_libraries(lk_blingfire PRIVATE blingfiretokdll_static fsaClient)
-
-# remove hardcoded values from Blingfire builds
-if(WIN32 AND MSVC)
-  set(_no_debug_targets
-      fsaClient
-      fsaClientTiny
-      fsaCompile
-      blingfiretokdll_static
-      lk_blingfire)
-
-  foreach(t ${_no_debug_targets})
-    get_target_property(_copts ${t} COMPILE_OPTIONS)
-    if(_copts)
-      list(REMOVE_ITEM _copts "/Zi" "/ZI" "/Z7" "/GL")
-      set_target_properties(${t} PROPERTIES COMPILE_OPTIONS "${_copts}")
-    endif()
-
-    get_target_property(_lopts ${t} LINK_OPTIONS)
-    if(_lopts)
-      list(REMOVE_ITEM _lopts "/DEBUG" "/LTCG")
-      set_target_properties(${t} PROPERTIES LINK_OPTIONS "${_lopts}")
-    endif()
-
-    target_link_options(${t} PRIVATE "/DEBUG:NONE" "/PDB:")
-  endforeach()
-endif()

--- a/livekit-plugins/livekit-blingfire/setup.py
+++ b/livekit-plugins/livekit-blingfire/setup.py
@@ -64,7 +64,7 @@ class CMakeBuild(build_ext):
 
         subprocess.run(["cmake", ext.sourcedir, *cmake_args], cwd=self.build_temp, check=True)
         subprocess.run(
-            ["cmake", "--build", ".", "--target", ext.name], cwd=self.build_temp, check=True
+            ["cmake", "--build", ".", "--target", ext.name, "--config", "Release"], cwd=self.build_temp, check=True
         )
 
 


### PR DESCRIPTION
TIL but:
CMAKE_BUILD_TYPE is ignored on multi-config generators like Visual Studio on Windows.