### PR TITLE
Include item id when converting to LG messages

### DIFF
--- a/livekit-plugins/livekit-plugins-langchain/livekit/plugins/langchain/langgraph.py
+++ b/livekit-plugins/livekit-plugins-langchain/livekit/plugins/langchain/langgraph.py
@@ -106,11 +106,11 @@ class LangGraphStream(llm.LLMStream):
                 content = item.text_content
                 if content:
                     if item.role == "assistant":
-                        messages.append(AIMessage(content=content))
+                        messages.append(AIMessage(content=content, id=item.id))
                     elif item.role == "user":
-                        messages.append(HumanMessage(content=content))
+                        messages.append(HumanMessage(content=content, id=item.id))
                     elif item.role in ["system", "developer"]:
-                        messages.append(SystemMessage(content=content))
+                        messages.append(SystemMessage(content=content, id=item.id))
 
         return {
             "messages": messages,


### PR DESCRIPTION
When using a checkpointer with LangGraph, a common pattern is to use the `add_messages` reducer function when appending new messages to a thread. This prevents duplication of messages by only appending new messages, or updating existing ones if already present.

This change includes LiveKit's `item.id` when converting the LK ChatContext to LG's GraphState to prevent message duplication when invoking LG Graphs with checkpoints.

https://langchain-ai.github.io/langgraph/reference/graphs/#langgraph.graph.message.add_messages