### PR TITLE
fix schedule speech on windows when monotonic_ns resolution is rough

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -695,6 +695,8 @@ class AgentActivity(RecognitionHooks):
                 heapq.heappush(self._speech_q, (-priority, time.perf_counter_ns(), speech))
                 break
             except TypeError:
+                # handle TypeError when identical timestamps cause speech comparison failure
+                # with perf_counter_ns(), collisions should be rare
                 pass
 
         self._wake_up_main_task()

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -689,8 +689,14 @@ class AgentActivity(RecognitionHooks):
         if self.draining and not bypass_draining:
             raise RuntimeError("cannot schedule new speech, the agent is draining")
 
-        # Negate the priority to make it a max heap
-        heapq.heappush(self._speech_q, (-priority, time.monotonic_ns(), speech))
+        while True:
+            try:
+                # negate the priority to make it a max heap
+                heapq.heappush(self._speech_q, (-priority, time.perf_counter_ns(), speech))
+                break
+            except TypeError:
+                pass
+
         self._wake_up_main_task()
 
     @utils.log_exceptions(logger=logger)


### PR DESCRIPTION
Before python 3.13, on Windows, time.monotonic() uses gGetTickCount64() clock which has a resolution of 15.6 ms.
https://github.com/python/cpython/pull/116781

Replaced it with `time.perf_counter_ns` for python < 3.13 on Windows, fix https://github.com/livekit/agents/issues/2764
