### PR TITLE
evals ci: use python 3.12

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.12"
 
       - name: Install the project
         run: uv sync --all-extras --dev


### PR DESCRIPTION
DriveThru agent uses some syntax that requires newer python versions 