### PR TITLE
Fix: Use synchronized transcript for interrupted session.say() responses

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -23,7 +23,6 @@ from ..metrics import (
 from ..tokenize.basic import split_words
 from ..types import NOT_GIVEN, NotGivenOr
 from ..utils.misc import is_given
-from . import io
 from .agent import Agent, ModelSettings
 from .audio_recognition import AudioRecognition, RecognitionHooks, _EndOfTurnInfo
 from .events import (

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -23,6 +23,7 @@ from ..metrics import (
 from ..tokenize.basic import split_words
 from ..types import NOT_GIVEN, NotGivenOr
 from ..utils.misc import is_given
+from . import io
 from .agent import Agent, ModelSettings
 from .audio_recognition import AudioRecognition, RecognitionHooks, _EndOfTurnInfo
 from .events import (
@@ -1117,12 +1118,32 @@ class AgentActivity(RecognitionHooks):
 
             audio_out.first_frame_fut.add_done_callback(_on_first_frame)
 
+        # capture playback event to track synchronized transcript when interrupted
+        playback_ev: io.PlaybackFinishedEvent | None = None
+        playback_fut: asyncio.Future[io.PlaybackFinishedEvent] | None = None
+
+        if audio_output is not None:
+            playback_fut = asyncio.Future[io.PlaybackFinishedEvent]()
+
+            def on_playback_finished(ev: io.PlaybackFinishedEvent) -> None:
+                if not playback_fut.done():
+                    playback_fut.set_result(ev)
+
+            audio_output.once("playback_finished", on_playback_finished)
+
         await speech_handle.wait_if_not_interrupted([*tasks])
 
         if audio_output is not None:
             await speech_handle.wait_if_not_interrupted(
                 [asyncio.ensure_future(audio_output.wait_for_playout())]
             )
+
+            # retrieve the playback event if available
+            if playback_fut and playback_fut.done():
+                playback_ev = playback_fut.result()
+
+            # clean up listener to prevent memory leaks
+            audio_output.off("playback_finished", on_playback_finished)
 
         if speech_handle.interrupted:
             await utils.aio.cancel_and_wait(*tasks)
@@ -1131,14 +1152,23 @@ class AgentActivity(RecognitionHooks):
                 audio_output.clear_buffer()
                 await audio_output.wait_for_playout()
 
+                # capture playback event after interruption
+                if playback_fut and playback_fut.done():
+                    playback_ev = playback_fut.result()
+
         if tee is not None:
             await tee.aclose()
 
         if add_to_chat_ctx:
+            # use synchronized transcript when available after interruption
+            final_text = ""
+            if speech_handle.interrupted and playback_ev and playback_ev.synchronized_transcript:
+                final_text = playback_ev.synchronized_transcript
+            else:
+                final_text = text_out.text if text_out else ""
+
             msg = self._agent._chat_ctx.add_message(
-                role="assistant",
-                content=text_out.text if text_out else "",
-                interrupted=speech_handle.interrupted,
+                role="assistant", content=final_text, interrupted=speech_handle.interrupted
             )
             speech_handle._set_chat_message(msg)
             self._session._conversation_item_added(msg)


### PR DESCRIPTION
We started our proof of concept using `session.generate_reply()`.

When the user interrupted the agent, it was useful to have only the part which was actually spoken for `interrupted` messages.

When we moved to generating responses separately in our platform and then using `session.say()`, `interrupted` messages would contain the full content - not just the portion which was read aloud.

This PR aims to align the behaviour of `session.say()` to `session.generate_reply()` by only adding the spoken content to the chat context for interrupted messages.