### PR TITLE
allow returning Exception inside function tools

### DIFF
--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -576,6 +576,11 @@ def make_tool_output(
 ) -> ToolExecutionOutput:
     from .agent import Agent
 
+    # support returning Exception instead of raising them (for devex purposes inside evals)
+    if isinstance(output, BaseException):
+        exception = output
+        output = None
+
     if isinstance(exception, ToolError):
         return ToolExecutionOutput(
             fnc_call=fnc_call.model_copy(),


### PR DESCRIPTION
This is purely for devex purposes inside the evals API e.g:

```
        with mock_tools(
            DriveThruAgent, {"order_regular_item": lambda: RuntimeError("test failure")}
        ):
```