### PR TITLE
feat(otel): add gen_ai attributes to llm_request and add plugin override

### DIFF
--- a/examples/voice_agents/langfuse_trace.py
+++ b/examples/voice_agents/langfuse_trace.py
@@ -8,7 +8,7 @@ from livekit.agents import Agent, AgentSession, JobContext, RunContext, WorkerOp
 from livekit.agents.debug import set_tracer_provider
 from livekit.agents.llm import function_tool
 from livekit.agents.voice import MetricsCollectedEvent
-from livekit.plugins import deepgram, openai, silero
+from livekit.plugins import deepgram, openai
 from livekit.plugins.turn_detector.multilingual import MultilingualModel
 
 logger = logging.getLogger("langfuse-trace-example")
@@ -42,7 +42,7 @@ def setup_langfuse(
     trace_provider = TracerProvider()
     trace_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
     set_tracer_provider(trace_provider)
-    
+
     # Also set the global OpenTelemetry tracer provider for OpenAI instrumentation
     trace.set_tracer_provider(trace_provider)
 

--- a/livekit-agents/livekit/agents/debug/trace_types.py
+++ b/livekit-agents/livekit/agents/debug/trace_types.py
@@ -1,6 +1,5 @@
 # Import official OpenTelemetry semantic conventions
 from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
-from opentelemetry.semconv._incubating.attributes import error_attributes
 
 ATTR_SPEECH_ID = "lk.speech_id"
 ATTR_AGENT_LABEL = "lk.agent_label"

--- a/livekit-agents/livekit/agents/debug/trace_types.py
+++ b/livekit-agents/livekit/agents/debug/trace_types.py
@@ -1,3 +1,7 @@
+# Import official OpenTelemetry semantic conventions
+from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
+from opentelemetry.semconv._incubating.attributes import error_attributes
+
 ATTR_SPEECH_ID = "lk.speech_id"
 ATTR_AGENT_LABEL = "lk.agent_label"
 ATTR_START_TIME = "lk.start_time"
@@ -44,3 +48,31 @@ ATTR_END_OF_UTTERANCE_DELAY = "lk.end_of_utterance_delay"
 # metrics
 ATTR_LLM_METRICS = "lk.llm_metrics"
 ATTR_TTS_METRICS = "lk.tts_metrics"
+
+# OpenTelemetry GenAI attributes - use only for direct LLM model interactions
+ATTR_GEN_AI_REQUEST_MODEL = gen_ai_attributes.GEN_AI_REQUEST_MODEL
+ATTR_GEN_AI_SYSTEM = gen_ai_attributes.GEN_AI_SYSTEM
+ATTR_GEN_AI_OPERATION_NAME = gen_ai_attributes.GEN_AI_OPERATION_NAME
+ATTR_GEN_AI_RESPONSE_ID = gen_ai_attributes.GEN_AI_RESPONSE_ID
+ATTR_GEN_AI_RESPONSE_MODEL = gen_ai_attributes.GEN_AI_RESPONSE_MODEL
+ATTR_GEN_AI_USAGE_INPUT_TOKENS = gen_ai_attributes.GEN_AI_USAGE_INPUT_TOKENS
+ATTR_GEN_AI_USAGE_OUTPUT_TOKENS = gen_ai_attributes.GEN_AI_USAGE_OUTPUT_TOKENS
+
+# OpenLLMetry standard attributes
+ATTR_LLM_USAGE_TOTAL_TOKENS = "llm.usage.total_tokens"
+ATTR_LLM_IS_STREAMING = "llm.is_streaming"
+
+# OpenLLMetry standard attributes - function/tool requests
+ATTR_LLM_REQUEST_FUNCTIONS_NAME = "llm.request.functions.{}.name"
+ATTR_LLM_REQUEST_FUNCTIONS_DESCRIPTION = "llm.request.functions.{}.description"
+ATTR_LLM_REQUEST_FUNCTIONS_PARAMETERS = "llm.request.functions.{}.parameters"
+
+# OpenTelemetry GenAI event names (for structured logging)
+EVENT_GEN_AI_SYSTEM_MESSAGE = "gen_ai.system.message"
+EVENT_GEN_AI_USER_MESSAGE = "gen_ai.user.message"
+EVENT_GEN_AI_ASSISTANT_MESSAGE = "gen_ai.assistant.message"
+EVENT_GEN_AI_TOOL_MESSAGE = "gen_ai.tool.message"
+EVENT_GEN_AI_CHOICE = "gen_ai.choice"
+
+# Platform-specific attributes
+ATTR_LANGFUSE_COMPLETION_START_TIME = "langfuse.observation.completion_start_time"

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -4,9 +4,9 @@ import asyncio
 import base64
 import json
 import time
-from datetime import datetime, timezone
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterable, AsyncIterator
+from datetime import datetime, timezone
 from types import TracebackType
 from typing import Any, Generic, Literal, TypeVar, Union
 
@@ -28,10 +28,10 @@ from ..types import (
     NotGivenOr,
 )
 from ..utils import aio
-from ..utils.images import encode, EncodeOptions
+from ..utils.images import EncodeOptions, encode
 from .chat_context import (
     AudioContent,
-    ChatContext, 
+    ChatContext,
     ChatMessage,
     ChatRole,
     FunctionCall,
@@ -39,13 +39,13 @@ from .chat_context import (
     ImageContent,
 )
 from .tool_context import (
-    FunctionTool, 
-    RawFunctionTool, 
+    FunctionTool,
+    RawFunctionTool,
     ToolChoice,
-    get_function_info, 
-    get_raw_function_info, 
+    get_function_info,
+    get_raw_function_info,
     is_function_tool,
-    is_raw_function_tool
+    is_raw_function_tool,
 )
 
 
@@ -107,40 +107,40 @@ class LLM(
     @property
     def label(self) -> str:
         return self._label
-    
+
     @property
     def model(self) -> str:
         """Get the model name/identifier for this LLM instance.
-        
+
         Returns:
             The model name if available, "unknown" otherwise.
-            
+
         Note:
             Plugins should override this property to provide their model information.
         """
         return "unknown"
-    
-    @property 
+
+    @property
     def provider(self) -> str:
         """Get the provider for this LLM instance.
-        
+
         Returns:
             The provider following OpenTelemetry GenAI conventions if available, "unknown" otherwise.
-            
+
         Note:
             Plugins should override this property to provide their provider information.
-            Use lowercase standardized values like: "openai", "anthropic", "cohere", 
+            Use lowercase standardized values like: "openai", "anthropic", "cohere",
             "aws.bedrock", "azure.ai.openai", "gcp.gemini", etc.
         """
         return "unknown"
-    
+
     @property
     def has_opentelemetry_instrumentation(self) -> bool:
         """Check if this plugin provides OpenTelemetry instrumentation.
-        
+
         Returns:
             True if the plugin provides native OpenTelemetry instrumentation, False otherwise.
-            
+
         Note:
             Plugins should override this property to indicate if they provide OpenTelemetry
             instrumentation. This allows the hybrid approach to make more informed decisions
@@ -217,7 +217,7 @@ class LLMStream(ABC):
             else:
                 # Provider has auto-instrumentation - let it handle span creation
                 self._llm_request_span = None
-            
+
             try:
                 return await self._run()
             except APIError as e:
@@ -225,7 +225,7 @@ class LLMStream(ABC):
                 if self._llm_request_span:
                     self._llm_request_span.record_exception(e)
                     self._llm_request_span.set_status(Status(StatusCode.ERROR, description=str(e)))
-                    
+
                 retry_interval = self._conn_options._interval_for_retry(i)
 
                 if self._conn_options.max_retry == 0 or not e.retryable:
@@ -261,152 +261,137 @@ class LLMStream(ABC):
                     self._llm_request_span.set_status(Status(StatusCode.ERROR, description=str(e)))
                 self._emit_error(e, recoverable=False)
                 raise
-    
-    
+
     def _add_genai_attributes(self) -> None:
         """Add OpenTelemetry GenAI semantic conventions to the current span."""
         if not self._llm_request_span:
             return
-            
+
         # Add model and provider information using trace_types constants
-        self._llm_request_span.set_attribute(
-            trace_types.ATTR_GEN_AI_REQUEST_MODEL, 
-            self._llm.model
-        )
-        
-        self._llm_request_span.set_attribute(
-            trace_types.ATTR_GEN_AI_SYSTEM, 
-            self._llm.provider
-        )
-        
+        self._llm_request_span.set_attribute(trace_types.ATTR_GEN_AI_REQUEST_MODEL, self._llm.model)
+
+        self._llm_request_span.set_attribute(trace_types.ATTR_GEN_AI_SYSTEM, self._llm.provider)
+
         # Add operation name
-        self._llm_request_span.set_attribute(
-            trace_types.ATTR_GEN_AI_OPERATION_NAME, 
-            "chat"
-        )
-        
+        self._llm_request_span.set_attribute(trace_types.ATTR_GEN_AI_OPERATION_NAME, "chat")
+
         # Add streaming indicator (this is always true for LLMStream)
-        self._llm_request_span.set_attribute(
-            trace_types.ATTR_LLM_IS_STREAMING, 
-            True
-        )
-        
+        self._llm_request_span.set_attribute(trace_types.ATTR_LLM_IS_STREAMING, True)
+
         # Emit OpenTelemetry GenAI events for conversation context
         # Events are the standard way to capture conversation content in OpenTelemetry
         self._emit_conversation_events()
-        
+
         # Add function information for available tools (OpenLLMetry standard)
         if self._tools:
             for i, tool in enumerate(self._tools):
                 if is_function_tool(tool):
                     info = get_function_info(tool)
                     self._llm_request_span.set_attribute(
-                        trace_types.ATTR_LLM_REQUEST_FUNCTIONS_NAME.format(i),
-                        info.name
+                        trace_types.ATTR_LLM_REQUEST_FUNCTIONS_NAME.format(i), info.name
                     )
                     if info.description:
                         self._llm_request_span.set_attribute(
                             trace_types.ATTR_LLM_REQUEST_FUNCTIONS_DESCRIPTION.format(i),
-                            info.description
+                            info.description,
                         )
                 elif is_raw_function_tool(tool):
                     raw_info = get_raw_function_info(tool)
                     self._llm_request_span.set_attribute(
-                        trace_types.ATTR_LLM_REQUEST_FUNCTIONS_NAME.format(i),
-                        raw_info.name
+                        trace_types.ATTR_LLM_REQUEST_FUNCTIONS_NAME.format(i), raw_info.name
                     )
                     # For raw function tools, description and parameters are in the raw_schema
                     if "description" in raw_info.raw_schema:
                         self._llm_request_span.set_attribute(
                             trace_types.ATTR_LLM_REQUEST_FUNCTIONS_DESCRIPTION.format(i),
-                            raw_info.raw_schema["description"]
+                            raw_info.raw_schema["description"],
                         )
                     if "parameters" in raw_info.raw_schema:
                         self._llm_request_span.set_attribute(
                             trace_types.ATTR_LLM_REQUEST_FUNCTIONS_PARAMETERS.format(i),
-                            json.dumps(raw_info.raw_schema["parameters"])
+                            json.dumps(raw_info.raw_schema["parameters"]),
                         )
-    
 
-    def _add_completion_attributes(self, usage: CompletionUsage | None, request_id: str, metrics: Any, response_content: str, tool_calls: list[FunctionToolCall], completion_start_time: float | None) -> None:
+    def _add_completion_attributes(
+        self,
+        usage: CompletionUsage | None,
+        request_id: str,
+        metrics: Any,
+        response_content: str,
+        tool_calls: list[FunctionToolCall],
+        completion_start_time: float | None,
+    ) -> None:
         """Add OpenTelemetry completion attributes after LLM completion."""
         if not self._llm_request_span:
             return
 
         # Add response ID
         if request_id:
-            self._llm_request_span.set_attribute(
-                trace_types.ATTR_GEN_AI_RESPONSE_ID, 
-                request_id
-            )
-        
+            self._llm_request_span.set_attribute(trace_types.ATTR_GEN_AI_RESPONSE_ID, request_id)
+
         # Add usage/token information
         if usage:
             if usage.prompt_tokens is not None:
                 self._llm_request_span.set_attribute(
-                    trace_types.ATTR_GEN_AI_USAGE_INPUT_TOKENS, 
-                    usage.prompt_tokens
+                    trace_types.ATTR_GEN_AI_USAGE_INPUT_TOKENS, usage.prompt_tokens
                 )
-            
+
             if usage.completion_tokens is not None:
                 self._llm_request_span.set_attribute(
-                    trace_types.ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, 
-                    usage.completion_tokens
+                    trace_types.ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, usage.completion_tokens
                 )
-            
+
             # Add total tokens (OpenLLMetry standard)
             if usage.total_tokens is not None:
                 self._llm_request_span.set_attribute(
-                    trace_types.ATTR_LLM_USAGE_TOTAL_TOKENS,
-                    usage.total_tokens
+                    trace_types.ATTR_LLM_USAGE_TOTAL_TOKENS, usage.total_tokens
                 )
-        
+
         # Add model name to response
         self._llm_request_span.set_attribute(
-            trace_types.ATTR_GEN_AI_RESPONSE_MODEL, 
-            self._llm.model
+            trace_types.ATTR_GEN_AI_RESPONSE_MODEL, self._llm.model
         )
-        
+
         # Add LiveKit-specific metrics
         self._llm_request_span.set_attribute(
-            trace_types.ATTR_LLM_METRICS, 
-            metrics.model_dump_json()
+            trace_types.ATTR_LLM_METRICS, metrics.model_dump_json()
         )
-        
+
         # Add completion start time for Langfuse
         if completion_start_time is not None:
             self._llm_request_span.set_attribute(
-                trace_types.ATTR_LANGFUSE_COMPLETION_START_TIME, 
-                f"\"{completion_start_time}\"",
+                trace_types.ATTR_LANGFUSE_COMPLETION_START_TIME,
+                f'"{completion_start_time}"',
             )
-        
+
         # Emit response event if we have content or tool calls
         if response_content or tool_calls:
             try:
                 response_event_body = {}
-                
+
                 # Add content if present
                 if response_content:
                     response_event_body["content"] = response_content
-                
+
                 # Add tool calls if present
                 if tool_calls:
-                    response_event_body["tool_calls"] = json.dumps([
-                        {
-                            "name": tool_call.name,
-                            "arguments": tool_call.arguments,
-                        }
-                        for tool_call in tool_calls
-                    ])
-                
+                    response_event_body["tool_calls"] = json.dumps(
+                        [
+                            {
+                                "name": tool_call.name,
+                                "arguments": tool_call.arguments,
+                            }
+                            for tool_call in tool_calls
+                        ]
+                    )
+
                 self._llm_request_span.add_event(
-                    name=trace_types.EVENT_GEN_AI_CHOICE, 
-                    attributes=response_event_body
+                    name=trace_types.EVENT_GEN_AI_CHOICE, attributes=response_event_body
                 )
             except Exception as e:
                 # Don't let event emission errors break the main flow
                 logger.debug("Failed to emit response event", exc_info=e)
-        
+
         # End the span now that all attributes are set
         self._llm_request_span.end()
         self._llm_request_span = None
@@ -415,13 +400,13 @@ class LLMStream(ABC):
         """Emit OpenTelemetry GenAI events for conversation context."""
         if not self._chat_ctx.items:
             return
-            
+
         # Emit events for each conversation item
         for item in self._chat_ctx.items:
             try:
                 if isinstance(item, ChatMessage):
                     event_name = self._get_message_event_name(item.role)
-                    
+
                     # Extract content following OpenLLMetry patterns
                     # OpenLLMetry serializes complex content as JSON arrays for multimodal support
                     content_for_event = []
@@ -431,76 +416,78 @@ class LLMStream(ABC):
                         elif isinstance(content_item, ImageContent):
                             # Follow OpenLLMetry image content format
                             if isinstance(content_item.image, str):
-                                content_for_event.append({
-                                    "type": "image_url",
-                                    "image_url": {"url": content_item.image}
-                                })
+                                content_for_event.append(
+                                    {"type": "image_url", "image_url": {"url": content_item.image}}
+                                )
                             else:
                                 # rtc.VideoFrame - encode as base64 data URL
                                 try:
                                     # Encode frame to JPEG bytes
-                                    image_bytes = encode(content_item.image, EncodeOptions(format="JPEG", quality=75))
-                                    
+                                    image_bytes = encode(
+                                        content_item.image, EncodeOptions(format="JPEG", quality=75)
+                                    )
+
                                     # Create data URL
                                     data_url = f"data:image/jpeg;base64,{base64.b64encode(image_bytes).decode('utf-8')}"
-                                    
-                                    content_for_event.append({
-                                        "type": "image_url",
-                                        "image_url": {"url": data_url}
-                                    })
+
+                                    content_for_event.append(
+                                        {"type": "image_url", "image_url": {"url": data_url}}
+                                    )
                                 except Exception as e:
                                     # Fallback to placeholder if encoding fails
                                     logger.debug("Failed to encode VideoFrame", exc_info=e)
-                                    content_for_event.append({
-                                        "type": "image_url", 
-                                        "image_url": {"url": f"[ImageFrame: {content_item.id}]"}
-                                    })
+                                    content_for_event.append(
+                                        {
+                                            "type": "image_url",
+                                            "image_url": {
+                                                "url": f"[ImageFrame: {content_item.id}]"
+                                            },
+                                        }
+                                    )
                         elif isinstance(content_item, AudioContent):
                             # Audio not supported in OpenLLMetry - use placeholder
-                            content_for_event.append({
-                                "type": "text",
-                                "text": f"[Audio: {content_item.id}]"
-                            })
+                            content_for_event.append(
+                                {"type": "text", "text": f"[Audio: {content_item.id}]"}
+                            )
                         else:
                             content_for_event.append({"type": "text", "text": str(content_item)})
-                    
+
                     # For event content, use the structured format if complex, otherwise simple text
                     if len(content_for_event) == 1 and content_for_event[0].get("type") == "text":
                         content_text = content_for_event[0]["text"]
                     else:
                         content_text = json.dumps(content_for_event)
-                    
+
                     # Create event body
                     event_body = {
                         "content": content_text,
                     }
-                    
+
                     # Add role if it's not redundant with event name
                     if item.role not in event_name:
                         event_body["role"] = item.role
-                    
+
                     # Emit the event to the LLM request span
                     self._llm_request_span.add_event(name=event_name, attributes=event_body)
-                    
+
                 elif isinstance(item, (FunctionCall, FunctionCallOutput)):
                     # Emit tool message event for function calls
                     if isinstance(item, FunctionCall):
                         content = item.arguments
                     else:  # FunctionCallOutput
                         content = item.output
-                        
-                    event_body = {
-                        "content": content,
-                        "name": item.name
-                    }
-                    
+
+                    event_body = {"content": content, "name": item.name}
+
                     # Emit the event to the LLM request span
-                    self._llm_request_span.add_event(name=trace_types.EVENT_GEN_AI_TOOL_MESSAGE, attributes=event_body)
-                    
+                    self._llm_request_span.add_event(
+                        name=trace_types.EVENT_GEN_AI_TOOL_MESSAGE, attributes=event_body
+                    )
+
             except Exception as e:
                 # Don't let event emission errors break the main flow
                 logger.debug("Failed to emit GenAI event", exc_info=e)
-    
+
     def _get_message_event_name(self, role: str) -> str:
         """Get the appropriate GenAI event name for a message role."""
         role_to_event = {
@@ -531,12 +518,12 @@ class LLMStream(ABC):
         response_content = ""
         tool_calls: list[FunctionToolCall] = []
         completion_start_time = None
-        
+
         async for ev in event_aiter:
             request_id = ev.id
             if ttft == -1.0:
                 ttft = time.perf_counter() - start_time
-                
+
                 # Capture completion start time when first token arrives
                 completion_start_time = datetime.now(timezone.utc).isoformat()
 
@@ -568,7 +555,9 @@ class LLMStream(ABC):
             total_tokens=usage.total_tokens if usage else 0,
             tokens_per_second=usage.completion_tokens / duration if usage else 0.0,
         )
-        self._add_completion_attributes(usage, request_id, metrics, response_content, tool_calls, completion_start_time)
+        self._add_completion_attributes(
+            usage, request_id, metrics, response_content, tool_calls, completion_start_time
+        )
         self._llm.emit("metrics_collected", metrics)
 
     @property

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import json
 import time
+from datetime import datetime, timezone
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterable, AsyncIterator
 from types import TracebackType
 from typing import Any, Generic, Literal, TypeVar, Union
 
 from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
 from pydantic import BaseModel, ConfigDict, Field
 
 from livekit import rtc
@@ -24,8 +28,25 @@ from ..types import (
     NotGivenOr,
 )
 from ..utils import aio
-from .chat_context import ChatContext, ChatRole
-from .tool_context import FunctionTool, RawFunctionTool, ToolChoice
+from ..utils.images import encode, EncodeOptions
+from .chat_context import (
+    AudioContent,
+    ChatContext, 
+    ChatMessage,
+    ChatRole,
+    FunctionCall,
+    FunctionCallOutput,
+    ImageContent,
+)
+from .tool_context import (
+    FunctionTool, 
+    RawFunctionTool, 
+    ToolChoice,
+    get_function_info, 
+    get_raw_function_info, 
+    is_function_tool,
+    is_raw_function_tool
+)
 
 
 class CompletionUsage(BaseModel):
@@ -86,6 +107,46 @@ class LLM(
     @property
     def label(self) -> str:
         return self._label
+    
+    @property
+    def model(self) -> str:
+        """Get the model name/identifier for this LLM instance.
+        
+        Returns:
+            The model name if available, "unknown" otherwise.
+            
+        Note:
+            Plugins should override this property to provide their model information.
+        """
+        return "unknown"
+    
+    @property 
+    def provider(self) -> str:
+        """Get the provider for this LLM instance.
+        
+        Returns:
+            The provider following OpenTelemetry GenAI conventions if available, "unknown" otherwise.
+            
+        Note:
+            Plugins should override this property to provide their provider information.
+            Use lowercase standardized values like: "openai", "anthropic", "cohere", 
+            "aws.bedrock", "azure.ai.openai", "gcp.gemini", etc.
+        """
+        return "unknown"
+    
+    @property
+    def has_opentelemetry_instrumentation(self) -> bool:
+        """Check if this plugin provides OpenTelemetry instrumentation.
+        
+        Returns:
+            True if the plugin provides native OpenTelemetry instrumentation, False otherwise.
+            
+        Note:
+            Plugins should override this property to indicate if they provide OpenTelemetry
+            instrumentation. This allows the hybrid approach to make more informed decisions
+            about span creation.
+        """
+        return False
 
     @abstractmethod
     def chat(
@@ -146,13 +207,25 @@ class LLMStream(ABC):
     @abstractmethod
     async def _run(self) -> None: ...
 
-    @tracer.start_as_current_span("llm_request", end_on_exit=False)
     async def _main_task(self) -> None:
-        self._llm_request_span = trace.get_current_span()
         for i in range(self._conn_options.max_retry + 1):
+            # Only create our own span if the provider doesn't have auto-instrumentation
+            if not self._llm.has_opentelemetry_instrumentation:
+                # No auto-instrumentation - create our own span as the generation span
+                self._llm_request_span = tracer.start_span("llm_request")
+                self._add_genai_attributes()
+            else:
+                # Provider has auto-instrumentation - let it handle span creation
+                self._llm_request_span = None
+            
             try:
                 return await self._run()
             except APIError as e:
+                # Record the exception on the span
+                if self._llm_request_span:
+                    self._llm_request_span.record_exception(e)
+                    self._llm_request_span.set_status(Status(StatusCode.ERROR, description=str(e)))
+                    
                 retry_interval = self._conn_options._interval_for_retry(i)
 
                 if self._conn_options.max_retry == 0 or not e.retryable:
@@ -182,8 +255,260 @@ class LLMStream(ABC):
                 self._current_attempt_has_error = False
 
             except Exception as e:
+                # Record the exception on the span
+                if self._llm_request_span:
+                    self._llm_request_span.record_exception(e)
+                    self._llm_request_span.set_status(Status(StatusCode.ERROR, description=str(e)))
                 self._emit_error(e, recoverable=False)
                 raise
+    
+    
+    def _add_genai_attributes(self) -> None:
+        """Add OpenTelemetry GenAI semantic conventions to the current span."""
+        if not self._llm_request_span:
+            return
+            
+        # Add model and provider information using trace_types constants
+        self._llm_request_span.set_attribute(
+            trace_types.ATTR_GEN_AI_REQUEST_MODEL, 
+            self._llm.model
+        )
+        
+        self._llm_request_span.set_attribute(
+            trace_types.ATTR_GEN_AI_SYSTEM, 
+            self._llm.provider
+        )
+        
+        # Add operation name
+        self._llm_request_span.set_attribute(
+            trace_types.ATTR_GEN_AI_OPERATION_NAME, 
+            "chat"
+        )
+        
+        # Add streaming indicator (this is always true for LLMStream)
+        self._llm_request_span.set_attribute(
+            trace_types.ATTR_LLM_IS_STREAMING, 
+            True
+        )
+        
+        # Emit OpenTelemetry GenAI events for conversation context
+        # Events are the standard way to capture conversation content in OpenTelemetry
+        self._emit_conversation_events()
+        
+        # Add function information for available tools (OpenLLMetry standard)
+        if self._tools:
+            for i, tool in enumerate(self._tools):
+                if is_function_tool(tool):
+                    info = get_function_info(tool)
+                    self._llm_request_span.set_attribute(
+                        trace_types.ATTR_LLM_REQUEST_FUNCTIONS_NAME.format(i),
+                        info.name
+                    )
+                    if info.description:
+                        self._llm_request_span.set_attribute(
+                            trace_types.ATTR_LLM_REQUEST_FUNCTIONS_DESCRIPTION.format(i),
+                            info.description
+                        )
+                elif is_raw_function_tool(tool):
+                    raw_info = get_raw_function_info(tool)
+                    self._llm_request_span.set_attribute(
+                        trace_types.ATTR_LLM_REQUEST_FUNCTIONS_NAME.format(i),
+                        raw_info.name
+                    )
+                    # For raw function tools, description and parameters are in the raw_schema
+                    if "description" in raw_info.raw_schema:
+                        self._llm_request_span.set_attribute(
+                            trace_types.ATTR_LLM_REQUEST_FUNCTIONS_DESCRIPTION.format(i),
+                            raw_info.raw_schema["description"]
+                        )
+                    if "parameters" in raw_info.raw_schema:
+                        self._llm_request_span.set_attribute(
+                            trace_types.ATTR_LLM_REQUEST_FUNCTIONS_PARAMETERS.format(i),
+                            json.dumps(raw_info.raw_schema["parameters"])
+                        )
+    
+
+    def _add_completion_attributes(self, usage: CompletionUsage | None, request_id: str, metrics: Any, response_content: str, tool_calls: list[FunctionToolCall], completion_start_time: float | None) -> None:
+        """Add OpenTelemetry completion attributes after LLM completion."""
+        if not self._llm_request_span:
+            return
+
+        # Add response ID
+        if request_id:
+            self._llm_request_span.set_attribute(
+                trace_types.ATTR_GEN_AI_RESPONSE_ID, 
+                request_id
+            )
+        
+        # Add usage/token information
+        if usage:
+            if usage.prompt_tokens is not None:
+                self._llm_request_span.set_attribute(
+                    trace_types.ATTR_GEN_AI_USAGE_INPUT_TOKENS, 
+                    usage.prompt_tokens
+                )
+            
+            if usage.completion_tokens is not None:
+                self._llm_request_span.set_attribute(
+                    trace_types.ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, 
+                    usage.completion_tokens
+                )
+            
+            # Add total tokens (OpenLLMetry standard)
+            if usage.total_tokens is not None:
+                self._llm_request_span.set_attribute(
+                    trace_types.ATTR_LLM_USAGE_TOTAL_TOKENS,
+                    usage.total_tokens
+                )
+        
+        # Add model name to response
+        self._llm_request_span.set_attribute(
+            trace_types.ATTR_GEN_AI_RESPONSE_MODEL, 
+            self._llm.model
+        )
+        
+        # Add LiveKit-specific metrics
+        self._llm_request_span.set_attribute(
+            trace_types.ATTR_LLM_METRICS, 
+            metrics.model_dump_json()
+        )
+        
+        # Add completion start time for Langfuse
+        if completion_start_time is not None:
+            self._llm_request_span.set_attribute(
+                trace_types.ATTR_LANGFUSE_COMPLETION_START_TIME, 
+                f"\"{completion_start_time}\"",
+            )
+        
+        # Emit response event if we have content or tool calls
+        if response_content or tool_calls:
+            try:
+                response_event_body = {}
+                
+                # Add content if present
+                if response_content:
+                    response_event_body["content"] = response_content
+                
+                # Add tool calls if present
+                if tool_calls:
+                    response_event_body["tool_calls"] = json.dumps([
+                        {
+                            "name": tool_call.name,
+                            "arguments": tool_call.arguments,
+                        }
+                        for tool_call in tool_calls
+                    ])
+                
+                self._llm_request_span.add_event(
+                    name=trace_types.EVENT_GEN_AI_CHOICE, 
+                    attributes=response_event_body
+                )
+            except Exception as e:
+                # Don't let event emission errors break the main flow
+                logger.debug("Failed to emit response event", exc_info=e)
+        
+        # End the span now that all attributes are set
+        self._llm_request_span.end()
+        self._llm_request_span = None
+
+    def _emit_conversation_events(self) -> None:
+        """Emit OpenTelemetry GenAI events for conversation context."""
+        if not self._chat_ctx.items:
+            return
+            
+        # Emit events for each conversation item
+        for item in self._chat_ctx.items:
+            try:
+                if isinstance(item, ChatMessage):
+                    event_name = self._get_message_event_name(item.role)
+                    
+                    # Extract content following OpenLLMetry patterns
+                    # OpenLLMetry serializes complex content as JSON arrays for multimodal support
+                    content_for_event = []
+                    for content_item in item.content:
+                        if isinstance(content_item, str):
+                            content_for_event.append({"type": "text", "text": content_item})
+                        elif isinstance(content_item, ImageContent):
+                            # Follow OpenLLMetry image content format
+                            if isinstance(content_item.image, str):
+                                content_for_event.append({
+                                    "type": "image_url",
+                                    "image_url": {"url": content_item.image}
+                                })
+                            else:
+                                # rtc.VideoFrame - encode as base64 data URL
+                                try:
+                                    # Encode frame to JPEG bytes
+                                    image_bytes = encode(content_item.image, EncodeOptions(format="JPEG", quality=75))
+                                    
+                                    # Create data URL
+                                    data_url = f"data:image/jpeg;base64,{base64.b64encode(image_bytes).decode('utf-8')}"
+                                    
+                                    content_for_event.append({
+                                        "type": "image_url",
+                                        "image_url": {"url": data_url}
+                                    })
+                                except Exception as e:
+                                    # Fallback to placeholder if encoding fails
+                                    logger.debug("Failed to encode VideoFrame", exc_info=e)
+                                    content_for_event.append({
+                                        "type": "image_url", 
+                                        "image_url": {"url": f"[ImageFrame: {content_item.id}]"}
+                                    })
+                        elif isinstance(content_item, AudioContent):
+                            # Audio not supported in OpenLLMetry - use placeholder
+                            content_for_event.append({
+                                "type": "text",
+                                "text": f"[Audio: {content_item.id}]"
+                            })
+                        else:
+                            content_for_event.append({"type": "text", "text": str(content_item)})
+                    
+                    # For event content, use the structured format if complex, otherwise simple text
+                    if len(content_for_event) == 1 and content_for_event[0].get("type") == "text":
+                        content_text = content_for_event[0]["text"]
+                    else:
+                        content_text = json.dumps(content_for_event)
+                    
+                    # Create event body
+                    event_body = {
+                        "content": content_text,
+                    }
+                    
+                    # Add role if it's not redundant with event name
+                    if item.role not in event_name:
+                        event_body["role"] = item.role
+                    
+                    # Emit the event to the LLM request span
+                    self._llm_request_span.add_event(name=event_name, attributes=event_body)
+                    
+                elif isinstance(item, (FunctionCall, FunctionCallOutput)):
+                    # Emit tool message event for function calls
+                    if isinstance(item, FunctionCall):
+                        content = item.arguments
+                    else:  # FunctionCallOutput
+                        content = item.output
+                        
+                    event_body = {
+                        "content": content,
+                        "name": item.name
+                    }
+                    
+                    # Emit the event to the LLM request span
+                    self._llm_request_span.add_event(name=trace_types.EVENT_GEN_AI_TOOL_MESSAGE, attributes=event_body)
+                    
+            except Exception as e:
+                # Don't let event emission errors break the main flow
+                logger.debug("Failed to emit GenAI event", exc_info=e)
+    
+    def _get_message_event_name(self, role: str) -> str:
+        """Get the appropriate GenAI event name for a message role."""
+        role_to_event = {
+            "system": trace_types.EVENT_GEN_AI_SYSTEM_MESSAGE,
+            "user": trace_types.EVENT_GEN_AI_USER_MESSAGE,
+            "assistant": trace_types.EVENT_GEN_AI_ASSISTANT_MESSAGE,
+        }
+        return role_to_event.get(role.lower(), trace_types.EVENT_GEN_AI_USER_MESSAGE)
 
     def _emit_error(self, api_error: Exception, recoverable: bool) -> None:
         self._current_attempt_has_error = True
@@ -203,11 +528,24 @@ class LLMStream(ABC):
         ttft = -1.0
         request_id = ""
         usage: CompletionUsage | None = None
-
+        response_content = ""
+        tool_calls: list[FunctionToolCall] = []
+        completion_start_time = None
+        
         async for ev in event_aiter:
             request_id = ev.id
             if ttft == -1.0:
                 ttft = time.perf_counter() - start_time
+                
+                # Capture completion start time when first token arrives
+                completion_start_time = datetime.now(timezone.utc).isoformat()
+
+            # Collect response content and tool calls from deltas
+            if ev.delta:
+                if ev.delta.content:
+                    response_content += ev.delta.content
+                if ev.delta.tool_calls:
+                    tool_calls.extend(ev.delta.tool_calls)
 
             if ev.usage is not None:
                 usage = ev.usage
@@ -230,10 +568,7 @@ class LLMStream(ABC):
             total_tokens=usage.total_tokens if usage else 0,
             tokens_per_second=usage.completion_tokens / duration if usage else 0.0,
         )
-        if self._llm_request_span:
-            self._llm_request_span.set_attribute(
-                trace_types.ATTR_LLM_METRICS, metrics.model_dump_json()
-            )
+        self._add_completion_attributes(usage, request_id, metrics, response_content, tool_calls, completion_start_time)
         self._llm.emit("metrics_collected", metrics)
 
     @property

--- a/livekit-agents/pyproject.toml
+++ b/livekit-agents/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "opentelemetry-api>=1.34",
     "opentelemetry-sdk>=1.34.1",
     "opentelemetry-exporter-otlp>=1.34.1",
+    "opentelemetry-semantic-conventions==0.55b1",
 ]
 
 [project.optional-dependencies]

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
@@ -53,6 +53,16 @@ from .log import logger
 class OpenAIPlugin(Plugin):
     def __init__(self) -> None:
         super().__init__(__name__, __version__, __package__, logger)
+        
+        # Initialize OpenAI OpenTelemetry instrumentation
+        try:
+            from opentelemetry.instrumentation.openai import OpenAIInstrumentor
+            instrumentor = OpenAIInstrumentor()
+            instrumentor.instrument()
+        except ImportError as e:
+            logger.warning(f"OpenAI OpenTelemetry instrumentation not available", exc_info=e)
+        except Exception as e:
+            logger.warning(f"Failed to initialize OpenAI OpenTelemetry instrumentation", exc_info=e)
 
 
 Plugin.register_plugin(OpenAIPlugin())

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
@@ -53,16 +53,17 @@ from .log import logger
 class OpenAIPlugin(Plugin):
     def __init__(self) -> None:
         super().__init__(__name__, __version__, __package__, logger)
-        
+
         # Initialize OpenAI OpenTelemetry instrumentation
         try:
             from opentelemetry.instrumentation.openai import OpenAIInstrumentor
+
             instrumentor = OpenAIInstrumentor()
             instrumentor.instrument()
         except ImportError as e:
-            logger.warning(f"OpenAI OpenTelemetry instrumentation not available", exc_info=e)
+            logger.warning("OpenAI OpenTelemetry instrumentation not available", exc_info=e)
         except Exception as e:
-            logger.warning(f"Failed to initialize OpenAI OpenTelemetry instrumentation", exc_info=e)
+            logger.warning("Failed to initialize OpenAI OpenTelemetry instrumentation", exc_info=e)
 
 
 Plugin.register_plugin(OpenAIPlugin())

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -129,12 +129,12 @@ class LLM(llm.LLM):
     def model(self) -> str:
         """Get the model name for this LLM instance."""
         return str(self._opts.model)
-    
+
     @property
     def provider(self) -> str:
         """Get the provider for this LLM instance."""
         return self._provider_fmt
-    
+
     @property
     def has_opentelemetry_instrumentation(self) -> bool:
         """Check if this plugin provides OpenTelemetry instrumentation."""

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -125,6 +125,22 @@ class LLM(llm.LLM):
 
         self._prewarm_task: asyncio.Task | None = None
 
+    @property
+    def model(self) -> str:
+        """Get the model name for this LLM instance."""
+        return str(self._opts.model)
+    
+    @property
+    def provider(self) -> str:
+        """Get the provider for this LLM instance."""
+        return self._provider_fmt
+    
+    @property
+    def has_opentelemetry_instrumentation(self) -> bool:
+        """Check if this plugin provides OpenTelemetry instrumentation."""
+        # return False
+        return True  # OpenAI plugin now has official OpenTelemetry instrumentation
+
     @staticmethod
     def with_azure(
         *,

--- a/livekit-plugins/livekit-plugins-openai/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-openai/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
     "livekit-agents[codecs, images]>=1.1.6",
     "openai[realtime]>=1.84.0",
+    "opentelemetry-instrumentation-openai>=0.41.0",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1777,6 +1777,7 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-semantic-conventions" },
     { name = "protobuf" },
     { name = "psutil" },
     { name = "pydantic" },
@@ -1952,6 +1953,7 @@ requires-dist = [
     { name = "opentelemetry-api", specifier = ">=1.34" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.34.1" },
     { name = "opentelemetry-sdk", specifier = ">=1.34.1" },
+    { name = "opentelemetry-semantic-conventions", specifier = "==0.55b1" },
     { name = "pillow", marker = "extra == 'images'", specifier = ">=10.3.0" },
     { name = "protobuf", specifier = ">=3" },
     { name = "psutil", specifier = ">=7.0" },
@@ -2350,6 +2352,7 @@ source = { editable = "livekit-plugins/livekit-plugins-openai" }
 dependencies = [
     { name = "livekit-agents", extra = ["codecs", "images"] },
     { name = "openai", extra = ["realtime"] },
+    { name = "opentelemetry-instrumentation-openai" },
 ]
 
 [package.optional-dependencies]
@@ -2362,6 +2365,7 @@ requires-dist = [
     { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0.0" },
     { name = "livekit-agents", extras = ["codecs", "images"], editable = "livekit-agents" },
     { name = "openai", extras = ["realtime"], specifier = ">=1.84.0" },
+    { name = "opentelemetry-instrumentation-openai", specifier = ">=0.41.0" },
 ]
 provides-extras = ["vertex"]
 
@@ -3467,6 +3471,37 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation"
+version = "0.55b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/69/d8995f229ddf4d98b9c85dd126aeca03dd1742f6dc5d3bc0d2f6dae1535c/opentelemetry_instrumentation-0.55b1.tar.gz", hash = "sha256:2dc50aa207b9bfa16f70a1a0571e011e737a9917408934675b89ef4d5718c87b", size = 28552 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/7d/8ddfda1506c2fcca137924d5688ccabffa1aed9ec0955b7d0772de02cec3/opentelemetry_instrumentation-0.55b1-py3-none-any.whl", hash = "sha256:cbb1496b42bc394e01bc63701b10e69094e8564e281de063e4328d122cc7a97e", size = 31108 },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-openai"
+version = "0.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-semantic-conventions-ai" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/df/e9604cc3ab35eb5d761a0c81b03c4602b6068076b7e0e58a9d904281a241/opentelemetry_instrumentation_openai-0.41.0.tar.gz", hash = "sha256:055bfff2d044a463a72f484c63c47e1d0f09fd3baf55701dd02ff39a72c1d59b", size = 23312 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/23/393b2ffe1220469f4512c621f9f13afca5da24bafbf140464b81201401ec/opentelemetry_instrumentation_openai-0.41.0-py3-none-any.whl", hash = "sha256:078bcb6d0df120b8851d2a2c7160c05c06931031167301779f5f8687b25ad410", size = 33405 },
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "1.34.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3503,6 +3538,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5d/f0/f33458486da911f47c4aa6db9bda308bb80f3236c111bf848bd870c16b16/opentelemetry_semantic_conventions-0.55b1.tar.gz", hash = "sha256:ef95b1f009159c28d7a7849f5cbc71c4c34c845bb514d66adfdf1b3fff3598b3", size = 119829 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/89/267b0af1b1d0ba828f0e60642b6a5116ac1fd917cde7fc02821627029bd1/opentelemetry_semantic_conventions-0.55b1-py3-none-any.whl", hash = "sha256:5da81dfdf7d52e3d37f8fe88d5e771e191de924cfff5f550ab0b8f7b2409baed", size = 196223 },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions-ai"
+version = "0.4.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/5d/ccc07fb79e7ee07887db0d7a729a640857d57b2e5023870e8ebdad2f11b4/opentelemetry_semantic_conventions_ai-0.4.10.tar.gz", hash = "sha256:3d8d1ea515a8470e135ca698459a4fd1d99fa297fc8c4bf14fdb1c789207bdc6", size = 4918 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c4/54b68f5d03a4eb7c34e0e2863d6a9cd7b3b1a981daec0060eff219880fce/opentelemetry_semantic_conventions_ai-0.4.10-py3-none-any.whl", hash = "sha256:3e78251971ba58cc135a85d2a7868052add9b39e8090bcfb1b43c5045e70b803", size = 5621 },
 ]
 
 [[package]]


### PR DESCRIPTION
Enhances the existing OpenTelemetry tracing implementation (#2873) by adding standard GenAI semantic conventions to LLM spans and enabling plugins to override with official provider instrumentation for more accurate tracing.

## Changes

### **OpenTelemetry GenAI Attributes**
- **Standard generation span**: Added OpenTelemetry GenAI semantic conventions so `llm_request` spans are automatically recognized as generation spans
- **Complete LLM layer attributes**: Includes all standard attributes available at the LLM abstraction layer (model, provider, tokens, etc.)
- **Conversation events**: Structured events for system/user/assistant messages with multimodal support
- **Tool information**: Function parameter tracking in span attributes

### **Improved Retry Observability**
- **Per-attempt tracing**: Each retry attempt now gets its own span for granular observability of retry behavior
- **Individual timing**: See duration and status of each specific attempt
- **Error attribution**: Exceptions recorded on the specific attempt that failed

### **Plugin Override Support**
- **Provider instrumentation detection**: New `has_opentelemetry_instrumentation` property allows plugins to indicate official OpenTelemetry support
- **Accurate provider spans**: When available, plugins can override the `llm_request` span with official provider instrumentation
- **Removes LiveKit abstractions**: Provider spans capture exactly what's sent to the client, without LiveKit's LLM abstraction layer modifications

### **Langfuse Integration**
- **Time to first token**: Added `langfuse.observation.completion_start_time` attribute with ISO UTC timestamp

### **OpenAI Example Implementation**
- **Official instrumentation**: Integrated `opentelemetry-instrumentation-openai` package as example of plugin override
- **Auto-initialization**: OpenAI instrumentor automatically initialized in plugin startup
- **Model/provider properties**: Expose accurate model and provider information for span attributes

## Technical Details

### Files Modified
- `livekit-agents/livekit/agents/llm/llm.py` - Main tracing logic with hybrid approach
- `livekit-agents/livekit/agents/debug/trace_types.py` - OpenTelemetry GenAI attribute constants
- `livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py` - Model/provider properties
- `livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py` - Auto-instrumentation setup
- `examples/voice_agents/langfuse_trace.py` - Adjusted global tracer provider setup

## Testing Status

✅ Basic functionality verified  
✅ OpenAI plugin integration tested  
✅ New attribute availability confirmed  
✅ Import compatibility validated  
⚠️ **Video frame encoding needs testing** - Multimodal content with `rtc.VideoFrame` requires validation

## Questions for Review

1. **Plugin override approach**: Is the `has_opentelemetry_instrumentation` property the right way to detect and enable provider instrumentation override? (Note: I chose override vs. nesting to avoid double-counting generation spans and maintain clear semantic boundaries - when provider instrumentation is available, it replaces the `llm_request` span entirely rather than creating nested spans)
2. **GenAI attribute completeness**: Are we missing any important OpenTelemetry GenAI semantic conventions at the LLM layer?
3. **Video frame handling**: The current approach encodes `rtc.VideoFrame` to base64 JPEG - is this the preferred method for multimodal traces?
4. **Langfuse-specific attributes**: Should we include custom attributes like `langfuse.observation.completion_start_time` for vendor-specific requirements, or keep the tracing implementation purely standards-compliant?

## Related

- Enhances #2873 
- Addresses https://github.com/livekit/agents/issues/2260
- Follows OpenTelemetry GenAI conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/

## Screenshots

### Default LLM Request Span
<img width="1011" height="945" alt="Screenshot 2025-07-14 at 10 35 21 PM" src="https://github.com/user-attachments/assets/456f86c3-3d72-4fae-addd-246ec2b666da" />

### Plugin Override
<img width="1009" height="956" alt="Screenshot 2025-07-14 at 10 35 50 PM" src="https://github.com/user-attachments/assets/49fbb83a-b789-4ba4-93fe-f205d4c1a51e" />
