### PR TITLE
fix: don't hardcode role=assistant on openai

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -707,7 +707,7 @@ class LLMStream(llm.LLMStream):
                     call_chunk = llm.ChatChunk(
                         id=id,
                         delta=llm.ChoiceDelta(
-                            role="assistant",
+                            role=delta.role,
                             content=delta.content,
                             tool_calls=[
                                 llm.FunctionToolCall(
@@ -735,7 +735,7 @@ class LLMStream(llm.LLMStream):
             call_chunk = llm.ChatChunk(
                 id=id,
                 delta=llm.ChoiceDelta(
-                    role="assistant",
+                    role=delta.role,
                     content=delta.content,
                     tool_calls=[
                         llm.FunctionToolCall(
@@ -756,5 +756,5 @@ class LLMStream(llm.LLMStream):
 
         return llm.ChatChunk(
             id=id,
-            delta=llm.ChoiceDelta(content=delta.content, role="assistant"),
+            delta=llm.ChoiceDelta(content=delta.content, role=delta.role),
         )


### PR DESCRIPTION
There are several valid potential roles that could be returned: https://github.com/openai/openai-python/blob/35df552d032873b62c2ae127a0efce60947dbed0/src/openai/types/chat/chat_completion_chunk.py#L73

This avoids overwriting them, to give more flexibility when building systems with the OpenAI LLM implementation as a base. 