### PR TITLE
BUG FIX: tts router fallback adapter streaming fix

### DIFF
--- a/livekit-agents/livekit/agents/tts/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/tts/fallback_adapter.py
@@ -80,9 +80,21 @@ class FallbackAdapter(
 
         num_channels = tts[0].num_channels
 
+        non_streaming_tts = [t for t in tts if not t.capabilities.streaming]
+        if non_streaming_tts:
+            from ..tokenize import basic
+            from ..tts import StreamAdapter
+
+            tts = [
+                StreamAdapter(tts=t, sentence_tokenizer=basic.SentenceTokenizer())
+                if not t.capabilities.streaming
+                else t
+                for t in tts
+            ]
+
         super().__init__(
             capabilities=TTSCapabilities(
-                streaming=all(t.capabilities.streaming for t in tts),
+                streaming=True,
             ),
             sample_rate=sample_rate,
             num_channels=num_channels,


### PR DESCRIPTION
fixes #2930 

Updates:
- All non streaming TTS are wrapped with StreamAdapter same as in default tts node
- Fallback Adapter's streaming capability set to True