### PR TITLE
plugins: openai: llm: add support for service_tier

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -68,6 +68,7 @@ class _LLMOptions:
     store: NotGivenOr[bool]
     metadata: NotGivenOr[dict[str, str]]
     max_completion_tokens: NotGivenOr[int]
+    service_tier: NotGivenOr[str]
 
 
 class LLM(llm.LLM):
@@ -87,6 +88,7 @@ class LLM(llm.LLM):
         max_completion_tokens: NotGivenOr[int] = NOT_GIVEN,
         timeout: httpx.Timeout | None = None,
         _provider_fmt: NotGivenOr[str] = NOT_GIVEN,
+        service_tier: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
         """
         Create a new instance of OpenAI LLM.
@@ -104,6 +106,7 @@ class LLM(llm.LLM):
             store=store,
             metadata=metadata,
             max_completion_tokens=max_completion_tokens,
+            service_tier=service_tier,
         )
         self._provider_fmt = _provider_fmt or "openai"
         self._client = client or openai.AsyncClient(
@@ -566,6 +569,9 @@ class LLM(llm.LLM):
 
         if is_given(self._opts.temperature):
             extra["temperature"] = self._opts.temperature
+
+        if is_given(self._opts.service_tier):
+            extra["service_tier"] = self._opts.service_tier
 
         parallel_tool_calls = (
             parallel_tool_calls if is_given(parallel_tool_calls) else self._opts.parallel_tool_calls


### PR DESCRIPTION
added support for [`service_tier`](https://platform.openai.com/docs/api-reference/chat/create#chat-create-service_tier).  Additional details [here](https://openai.com/api-priority-processing/#how-it-works).