### PR TITLE
Explictly calling ctx.connect before wait_for_participant

### DIFF
--- a/examples/avatar_agents/audio_wave/agent_worker.py
+++ b/examples/avatar_agents/audio_wave/agent_worker.py
@@ -65,7 +65,7 @@ async def launch_avatar_worker(
 
 async def entrypoint(ctx: JobContext, avatar_dispatcher_url: str):
     await ctx.connect()
-    
+
     agent = Agent(instructions="Talk to me!")
     session = AgentSession(
         llm=openai.realtime.RealtimeModel(),

--- a/examples/voice_agents/silent_function_call.py
+++ b/examples/voice_agents/silent_function_call.py
@@ -36,7 +36,7 @@ class MyAgent(Agent):
 
 async def entrypoint(ctx: JobContext):
     await ctx.connect()
-    
+
     agent = AgentSession(
         stt=deepgram.STT(),
         llm=openai.LLM(model="gpt-4o-mini"),


### PR DESCRIPTION
In the cases where await ctx.wait_for_participant() is called in the entrypoint, it has to be done _after_ ctx.connect(). For the examples, re-added ([original diff to remove ctx.connect()](https://github.com/livekit/agents/pull/2909/files)) the explicit call to 'await ctx.connect()' to the entrypoint function to avoid waiting for session.start() to connect to the room. This enables an earlier call of ctx.wait_for_participant() to happen before a session is started.