### PR TITLE
feat(realtime_model): correctly emit errors when the response is done

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1552,6 +1552,8 @@ class RealtimeSession(
 
         For example this method will emit an error if we receive a "failed" status, e.g.
         with type "invalid_request_error" due to code "inference_rate_limit_exceeded".
+
+        In other failures it will emit a debug level log.
         """
         if event.response.status == "completed":
             return
@@ -1575,7 +1577,7 @@ class RealtimeSession(
                 recoverable=True,
             )
         elif event.response.status in {"cancelled", "incomplete"}:
-            logger.warning(
+            logger.debug(
                 "OpenAI Realtime API response done but not complete with status: %s",
                 event.response.status,
                 extra={


### PR DESCRIPTION
**The main problem problem this PR addresses**

When Realtime API hits a rate limit or "failure" of response.done, no logs are emitted to users unless they have `LK_OPENAI_DEBUG=1` enabled, and even if they do, its logged at debug not error level. This leads to the model (from the user perspective) simply being unresponsive without any clear reason.

**CI Failure**

The failing unit test seems to be unrelated to this PR? `httpcore.LocalProtocolError: Illegal header value b'Bearer '`


**The solution**

1. This PR emits an error if the Realtime API failed to complete a response e.g. due to rate limiting (before this PR, it would not even be logged at DEBUG level, and if you did enable `LK_OPENAI_DEBUG=1` it would still only be shown at debug level. Given this is genuinely an error (a failure of the API which will cause the agent to not respond at all) - I think it should be emited as such.

2. In the case of a done response which was cancelled or incomplete, this can be due to intentional actions of the user code (like two overlapping generate reply requests) and so we log these debug level.

To explain the motivation for (2), I appreciate this is already visible if the user sets the flag ``LK_OPENAI_DEBUG=1` but that is problematic because:

- This is an undocumented flag currently
-  `LK_OPENAI_DEBUG=1` is very very spammy, and most of the logs would not be useful in regular debugging - however knowing why your request to API did not complete is generally useful I think