### PR TITLE
fix 11labs tts when audio is an empty string

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -468,7 +468,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                     start_times_ms = start_times_ms[-len(text_buffer) :]
                     durations_ms = durations_ms[-len(text_buffer) :]
 
-                if data.get("audio"):
+                if data.get("audio") is not None:
                     b64data = base64.b64decode(data["audio"])
                     output_emitter.push(b64data)
                 elif data.get("isFinal"):


### PR DESCRIPTION
fix https://livekit-users.slack.com/archives/C07FY8WHGPM/p1753207414610429

it shouldn't raise error when `audio` is an empty string
> livekit.agents._exceptions.APIError: unexpected 11labs message {'audio': '', 'isFinal': None, 'normalizedAlignment': None, 'alignment': None} (body=None, retryable=True)