### PR TITLE
Improve chat_cli status printing

### DIFF
--- a/livekit-agents/livekit/agents/voice/chat_cli.py
+++ b/livekit-agents/livekit/agents/voice/chat_cli.py
@@ -455,9 +455,12 @@ class ChatCLI:
 
         color_code = 31 if amplitude_db > 0.75 else 33 if amplitude_db > 0.5 else 32
         bar = "#" * nb_bar + "-" * (MAX_AUDIO_BAR - nb_bar)
+        sys.stdout.write(f"\033[s")  # Save cursor position
+        sys.stdout.write(f"\033[999B")  # Move to bottom
         sys.stdout.write(
             f"\r[Audio] {self._input_device_name[-20:]} [{self._micro_db:6.2f} dBFS] {_esc(color_code)}[{bar}]{_esc(0)}"  # noqa: E501
         )
+        sys.stdout.write(f"\033[u")  # Restore cursor position
         sys.stdout.flush()
 
     def _print_text_mode(self) -> None:


### PR DESCRIPTION
Restore the cursor position after printing so that other logging appears above the status line

Before:

```shell
[Audio] cBook Air Microphone [-65.09 dBFS] [##----------------------------]log message
```

After:

```
log message
[Audio] cBook Air Microphone [-65.09 dBFS] [##----------------------------]
```