### PR TITLE
enable - gemini-live-2.5-flash-preview

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/api_proto.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/api_proto.py
@@ -9,6 +9,7 @@ LiveAPIModels = Literal[
     "gemini-2.0-flash-exp",
     # models supported on Gemini API
     "gemini-2.0-flash-live-001",
+    "gemini-live-2.5-flash-preview",
     "gemini-2.5-flash-preview-native-audio-dialog",
     "gemini-2.5-flash-exp-native-audio-thinking-dialog",
 ]


### PR DESCRIPTION
https://ai.google.dev/gemini-api/docs/live#audio-generation

A much more stable version of Gemini: gemini-live-2.5-flash-preview.