### PR TITLE
aws: Add support for hardcoded credentials in STT

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
@@ -16,7 +16,7 @@ import asyncio
 import os
 from dataclasses import dataclass
 
-from amazon_transcribe.auth import AwsCrtCredentialResolver
+from amazon_transcribe.auth import AwsCrtCredentialResolver, StaticCredentialResolver
 from amazon_transcribe.client import TranscribeStreamingClient
 from amazon_transcribe.exceptions import BadRequestException
 from amazon_transcribe.model import Result, StartStreamTranscriptionEventStream, TranscriptEvent
@@ -58,6 +58,8 @@ class STT(stt.STT):
         self,
         *,
         region: NotGivenOr[str] = NOT_GIVEN,
+        api_key: NotGivenOr[str] = NOT_GIVEN,
+        api_secret: NotGivenOr[str] = NOT_GIVEN,
         sample_rate: int = 24000,
         language: str = "en-US",
         encoding: str = "pcm",
@@ -76,6 +78,17 @@ class STT(stt.STT):
 
         if not is_given(region):
             region = os.getenv("AWS_REGION") or DEFAULT_REGION
+        self._region = region
+        if is_given(api_key) and is_given(api_secret):
+            credential_resolver = StaticCredentialResolver(
+                access_key_id=api_key,
+                secret_access_key=api_secret,
+            )
+        else:
+            credential_resolver = AwsCrtCredentialResolver(None)  # type: ignore
+        self._client = TranscribeStreamingClient(
+            region=self._region, credential_resolver=credential_resolver
+        )
 
         self._config = STTOptions(
             language=language,


### PR DESCRIPTION
This PR adds support for hardcoded credentials in the AWS STT integration.

In #2297, api_key and api_secret were removed by @davidzhao to simplify the interface. While this improved usability, it also reduced flexibility. In certain cases—such as when environment variables or IAM roles are unavailable—users may still need to provide credentials manually.

This update restores that flexibility by reintroducing support for explicit credential configuration. It aligns with AWS best practices, which also allow manual credential setup when needed, while remaining compatible with existing authentication mechanisms.