### PR TITLE
fix cartesia error when input text is empty

### DIFF
--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -349,9 +349,6 @@ class SynthesizeStream(tts.SynthesizeStream):
                     continue
 
                 data = json.loads(msg.data)
-                if data.get("type") == "error":
-                    raise APIError(f"Cartesia returned error: {data}")
-
                 segment_id = data.get("context_id")
                 if current_segment_id is None:
                     current_segment_id = segment_id
@@ -372,6 +369,8 @@ class SynthesizeStream(tts.SynthesizeStream):
                         output_emitter.push_timed_transcript(
                             TimedString(text=word, start_time=start, end_time=end)
                         )
+                elif data.get("type") == "error":
+                    raise APIError(f"Cartesia returned error: {data}")
                 else:
                     logger.warning("unexpected message %s", data)
 


### PR DESCRIPTION
cartesia tts returns an error `{'type': 'error', 'context_id': '49c376fe1e6a', 'status_code': 400, 'done': True, 'error': 'transcript empty or contains only punctuation: first transcript for WS is empty or contains only punctuation'}` when input text is empty.

ignore the error message if `done` is True.

fix https://github.com/livekit/agents/issues/3084