### PR TITLE
Do not `wait_on_enter` when resuming `Agent` after `AgentTask` execution

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -715,7 +715,7 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                     )
                 )
 
-                await session._update_activity(old_agent, new_activity="resume")
+                await session._update_activity(old_agent, new_activity="resume", wait_on_enter=False)
 
     def __await__(self) -> Generator[None, None, TaskResult_T]:
         return self.__await_impl().__await__()

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -715,7 +715,9 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                     )
                 )
 
-                await session._update_activity(old_agent, new_activity="resume", wait_on_enter=False)
+                await session._update_activity(
+                    old_agent, new_activity="resume", wait_on_enter=False
+                )
 
     def __await__(self) -> Generator[None, None, TaskResult_T]:
         return self.__await_impl().__await__()


### PR DESCRIPTION
I can't think of a reason why we would want to `wait_on_enter` when resuming the same `Agent` after executing an `AgentTask`. By making this fix, it also makes the example workflow in the documentation not halt after the first question.

The example workflow:

```python agent.py console```

**agent.py**
```
from dotenv import load_dotenv

from livekit import agents
from livekit.agents import AgentSession, Agent, AgentTask, function_tool
from livekit.plugins import openai, silero

load_dotenv()

class CollectConsent(AgentTask[bool]):
    def __init__(self, chat_ctx):
        super().__init__(
            instructions="Ask for recording consent and get a clear yes or no answer.",
            chat_ctx=chat_ctx
        )

    async def on_enter(self) -> None:
        await self.session.generate_reply(instructions="Ask for permission to record the call for quality assurance purposes.")

    @function_tool
    async def consent_given(self) -> None:
        """Use this when the user gives consent to record."""
        self.complete(True)

    @function_tool
    async def consent_denied(self) -> None:
        """Use this when the user denies consent to record."""
        self.complete(False)

class CustomerServiceAgent(Agent):
    def __init__(self):
        super().__init__(instructions="You are a friendly customer service representative.")

    async def on_enter(self) -> None:
        if await CollectConsent(chat_ctx=self.chat_ctx):
            await self.session.generate_reply(instructions="Offer your assistance to the user.")
        else:
            await self.session.generate_reply(instructions="Inform the user that you are unable to proceed and will end the call.")

async def entrypoint(ctx: agents.JobContext):
    session = AgentSession(
        vad=silero.VAD.load(),
        stt=openai.STT(),
        llm=openai.LLM(),
        tts=openai.TTS(),
    )
    await session.start(room=ctx.room, agent=CustomerServiceAgent())

if __name__ == "__main__":
    agents.cli.run_app(agents.WorkerOptions(entrypoint_fnc=entrypoint))
```