### PR TITLE
fix: check if scheduling_paused after on_user_turn_completed callback

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1182,6 +1182,13 @@ class AgentActivity(RecognitionHooks):
             if self._rt_session is not None:
                 self._rt_session.interrupt()
 
+        if self._scheduling_paused:
+            logger.warning(
+                "skipping on_user_turn_completed, speech scheduling is paused",
+                extra={"user_input": info.new_transcript},
+            )
+            return
+
         # id is generated
         user_message: llm.ChatMessage = llm.ChatMessage(
             role="user",


### PR DESCRIPTION
the scheduling may fail after `on_user_turn_completed` callback. this pr adds check after the `on_user_turn_completed` callback, and there is no async calls between the check and `_generate_reply`.