### PR TITLE
trace: attach agent session root span before closing

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -589,6 +589,10 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         drain: bool = False,
         error: llm.LLMError | stt.STTError | tts.TTSError | llm.RealtimeModelError | None = None,
     ) -> None:
+        if self._root_span_context:
+            # make `activity.drain` and `on_exit` under the root span
+            otel_context.attach(self._root_span_context)
+
         async with self._lock:
             if not self._started:
                 return


### PR DESCRIPTION
fix the issue when call the `session._aclose_impl` outside the agent session (e.g. in `shutdown_callback`), the activity drain and on_exit spans are in a separate trace.

<img width="699" height="62" alt="image" src="https://github.com/user-attachments/assets/dfd8f65e-d4f8-45cc-8bdf-e16eb4ec884b" />

