### PR TITLE
configure screenshare audio track to appear in transcriptions and room I/O

### DIFF
--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -242,7 +242,7 @@ class _ParticipantLegacyTranscriptionOutput:
     ) -> None:
         if (
             not self._is_local_proxy_participant(participant)
-            or track.source != rtc.TrackSource.SOURCE_MICROPHONE
+            or track.source not in [rtc.TrackSource.SOURCE_MICROPHONE, rtc.TrackSource.SOURCE_SCREENSHARE_AUDIO]
         ):
             return
 
@@ -255,7 +255,7 @@ class _ParticipantLegacyTranscriptionOutput:
         if (
             self._participant_identity is None
             or self._participant_identity != self._room.local_participant.identity
-            or track.source != rtc.TrackSource.SOURCE_MICROPHONE
+            or track.source not in [rtc.TrackSource.SOURCE_MICROPHONE, rtc.TrackSource.SOURCE_SCREENSHARE_AUDIO]
         ):
             return
 
@@ -398,7 +398,7 @@ class _ParticipantStreamTranscriptionOutput:
         if (
             self._participant_identity is None
             or participant.identity != self._participant_identity
-            or track.source != rtc.TrackSource.SOURCE_MICROPHONE
+            or track.source not in [rtc.TrackSource.SOURCE_MICROPHONE, rtc.TrackSource.SOURCE_SCREENSHARE_AUDIO]
         ):
             return
 
@@ -408,7 +408,7 @@ class _ParticipantStreamTranscriptionOutput:
         if (
             self._participant_identity is None
             or self._participant_identity != self._room.local_participant.identity
-            or track.source != rtc.TrackSource.SOURCE_MICROPHONE
+            or track.source not in [rtc.TrackSource.SOURCE_MICROPHONE, rtc.TrackSource.SOURCE_SCREENSHARE_AUDIO]
         ):
             return
 

--- a/livekit-agents/livekit/agents/voice/transcription/_utils.py
+++ b/livekit-agents/livekit/agents/voice/transcription/_utils.py
@@ -16,7 +16,7 @@ def find_micro_track_id(room: rtc.Room, identity: str) -> str:
     # find first micro track
     track_id = None
     for track in p.track_publications.values():
-        if track.source == rtc.TrackSource.SOURCE_MICROPHONE:
+        if track.source in [rtc.TrackSource.SOURCE_MICROPHONE, rtc.TrackSource.SOURCE_SCREENSHARE_AUDIO]:
             track_id = track.sid
             break
 


### PR DESCRIPTION
fix: support screenshare audio in transcription and room I/O

- Update find_micro_track_id() to detect both microphone and screenshare audio tracks
- Update _ParticipantLegacyTranscriptionOutput to handle screenshare audio sources
- Fixes issue where screenshare audio was not being processed by STT nodes

Closes #2400 