### PR TITLE
feat: add reasoning effort option to OpenAI LLM configuration

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -49,6 +49,7 @@ from .models import (
     DeepSeekChatModels,
     OctoChatModels,
     PerplexityChatModels,
+    ReasoningEffort,
     TelnyxChatModels,
     TogetherChatModels,
     XAIChatModels,
@@ -69,6 +70,7 @@ class _LLMOptions:
     metadata: NotGivenOr[dict[str, str]]
     max_completion_tokens: NotGivenOr[int]
     service_tier: NotGivenOr[str]
+    reasoning_effort: NotGivenOr[ReasoningEffort]
 
 
 class LLM(llm.LLM):
@@ -89,6 +91,7 @@ class LLM(llm.LLM):
         timeout: httpx.Timeout | None = None,
         _provider_fmt: NotGivenOr[str] = NOT_GIVEN,
         service_tier: NotGivenOr[str] = NOT_GIVEN,
+        reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
     ) -> None:
         """
         Create a new instance of OpenAI LLM.
@@ -107,6 +110,7 @@ class LLM(llm.LLM):
             metadata=metadata,
             max_completion_tokens=max_completion_tokens,
             service_tier=service_tier,
+            reasoning_effort=reasoning_effort,
         )
         self._provider_fmt = _provider_fmt or "openai"
         self._client = client or openai.AsyncClient(
@@ -572,6 +576,9 @@ class LLM(llm.LLM):
 
         if is_given(self._opts.service_tier):
             extra["service_tier"] = self._opts.service_tier
+
+        if is_given(self._opts.reasoning_effort):
+            extra["reasoning_effort"] = self._opts.reasoning_effort
 
         parallel_tool_calls = (
             parallel_tool_calls if is_given(parallel_tool_calls) else self._opts.parallel_tool_calls

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -54,6 +54,8 @@ EmbeddingModels = Literal[
 
 AssistantTools = Literal["code_interpreter", "file_search", "function"]
 
+ReasoningEffort = Literal["minimal", "low", "medium", "high"]
+
 # adapters for OpenAI-compatible LLMs
 
 TelnyxChatModels = Literal[


### PR DESCRIPTION
Added [reasoning effort](https://platform.openai.com/docs/guides/latest-model#minimal-reasoning-effort) option to the OpenAI plugin. This is crucial because the default value is `medium`, which can lead to increased latency compared to non-thinking models.

According to [OpenAI's migration guide](https://platform.openai.com/docs/guides/latest-model?lang=python&reasoning-effort-mode=chat&verbosity-mode=chat#migrating-from-other-models-to-gpt-5), when migrating from GPT-4.1 to GPT-5, it is recommended to use the `low` or `minimal` reasoning effort. 
