### PR TITLE
feat(langgraph): support subgraphs in LLMAdapter and normalize astream outputs

### DIFF
--- a/livekit-plugins/livekit-plugins-langchain/livekit/plugins/langchain/langgraph.py
+++ b/livekit-plugins/livekit-plugins-langchain/livekit/plugins/langchain/langgraph.py
@@ -38,10 +38,12 @@ class LLMAdapter(llm.LLM):
         graph: PregelProtocol,
         *,
         config: RunnableConfig | None = None,
+        subgraphs: bool = False,
     ) -> None:
         super().__init__()
         self._graph = graph
         self._config = config
+        self._subgraphs = subgraphs
 
     def chat(
         self,
@@ -53,7 +55,7 @@ class LLMAdapter(llm.LLM):
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
         extra_kwargs: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
-    ) -> LangGraphStream:
+    ) -> "LangGraphStream":
         return LangGraphStream(
             self,
             chat_ctx=chat_ctx,
@@ -61,6 +63,7 @@ class LLMAdapter(llm.LLM):
             graph=self._graph,
             conn_options=conn_options,
             config=self._config,
+            subgraphs=self._subgraphs,
         )
 
 
@@ -74,6 +77,7 @@ class LangGraphStream(llm.LLMStream):
         conn_options: APIConnectOptions,
         graph: PregelProtocol,
         config: RunnableConfig | None = None,
+        subgraphs: bool = False,
     ):
         super().__init__(
             llm,
@@ -83,16 +87,33 @@ class LangGraphStream(llm.LLMStream):
         )
         self._graph = graph
         self._config = config
+        self._subgraphs = subgraphs
 
     async def _run(self) -> None:
         state = self._chat_ctx_to_state()
 
-        async for message_chunk, _ in self._graph.astream(
-            state,
-            self._config,
-            stream_mode="messages",
-        ):
-            chat_chunk = _to_chat_chunk(message_chunk)
+        # Some LangGraph versions don't accept the `subgraphs` kwarg yet.
+        # Try with it first; fall back gracefully if it's unsupported.
+        try:
+            aiter = self._graph.astream(
+                state,
+                self._config,
+                stream_mode="messages",
+                subgraphs=self._subgraphs,
+            )
+        except TypeError:
+            aiter = self._graph.astream(
+                state,
+                self._config,
+                stream_mode="messages",
+            )
+
+        async for item in aiter:
+            token_like = _extract_message_chunk(item)
+            if token_like is None:
+                continue
+
+            chat_chunk = _to_chat_chunk(token_like)
             if chat_chunk:
                 self._event_ch.send_nowait(chat_chunk)
 
@@ -112,9 +133,47 @@ class LangGraphStream(llm.LLMStream):
                     elif item.role in ["system", "developer"]:
                         messages.append(SystemMessage(content=content, id=item.id))
 
-        return {
-            "messages": messages,
-        }
+        return {"messages": messages}
+
+
+def _extract_message_chunk(item: Any) -> BaseMessageChunk | str | None:
+    """
+    Normalize outputs from graph.astream(..., stream_mode='messages', [subgraphs]).
+
+    Expected shapes:
+      - (token, meta)
+      - (namespace, (token, meta))                  # with subgraphs=True
+      - (mode, (token, meta))                       # future-friendly
+      - (namespace, mode, (token, meta))            # future-friendly
+    Also tolerate direct token-like values for robustness.
+    """
+    # Already a token-like thing?
+    if isinstance(item, (BaseMessageChunk, str)):
+        return item
+
+    if not isinstance(item, tuple):
+        return None
+
+    # (token, meta)
+    if len(item) == 2 and not isinstance(item[1], tuple):
+        token, _meta = item
+        return token
+
+    # (namespace, (token, meta))  OR  (mode, (token, meta))
+    if len(item) == 2 and isinstance(item[1], tuple):
+        inner = item[1]
+        if len(inner) == 2:
+            token, _meta = inner
+            return token
+
+    # (namespace, mode, (token, meta))
+    if len(item) == 3 and isinstance(item[2], tuple):
+        inner = item[2]
+        if len(inner) == 2:
+            token, _meta = inner
+            return token
+
+    return None
 
 
 def _to_chat_chunk(msg: str | Any) -> llm.ChatChunk | None:
@@ -125,8 +184,8 @@ def _to_chat_chunk(msg: str | Any) -> llm.ChatChunk | None:
         content = msg
     elif isinstance(msg, BaseMessageChunk):
         content = msg.text()
-        if msg.id:
-            message_id = msg.id
+        if getattr(msg, "id", None):
+            message_id = msg.id  # type: ignore[assignment]
 
     if not content:
         return None

--- a/livekit-plugins/livekit-plugins-langchain/livekit/plugins/langchain/langgraph.py
+++ b/livekit-plugins/livekit-plugins-langchain/livekit/plugins/langchain/langgraph.py
@@ -55,7 +55,7 @@ class LLMAdapter(llm.LLM):
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
         extra_kwargs: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
-    ) -> "LangGraphStream":
+    ) -> LangGraphStream:
         return LangGraphStream(
             self,
             chat_ctx=chat_ctx,


### PR DESCRIPTION
**What & why**
Adds optional `subgraphs: bool=False` to `LLMAdapter` and normalizes the various tuple shapes emitted by `graph.astream(..., stream_mode="messages")`. This enables LiveKit to stream tokens from LangGraph **subgraphs** (child graphs) when `subgraphs=True`.

**Changes**

* `LLMAdapter.__init__(..., subgraphs: bool=False)`; threaded into `LangGraphStream`.
* `LangGraphStream._run()`:

  * Calls `graph.astream(..., subgraphs=self._subgraphs)` with a `TypeError` fallback.
  * Normalizes items via `_extract_message_chunk(...)` to pull out `token` regardless of tuple shape.
* Keeps `ChatChunk` emission logic unchanged.

**BC & compatibility**

* Backward compatible; default is `subgraphs=False`.
* Older LangGraph versions: graceful fallback (retry without `subgraphs` kwarg).

**Linked issue:** #3111 
