### PR TITLE
feat: cgroups v1 support, lower idle processes

### DIFF
--- a/livekit-agents/livekit/agents/ipc/proc_pool.py
+++ b/livekit-agents/livekit/agents/ipc/proc_pool.py
@@ -22,7 +22,7 @@ EventTypes = Literal[
     "process_job_launched",
 ]
 
-MAX_CONCURRENT_INITIALIZATIONS = math.ceil(get_cpu_monitor().cpu_count())
+MAX_CONCURRENT_INITIALIZATIONS = min(math.ceil(get_cpu_monitor().cpu_count()), 4)
 
 
 class ProcPool(utils.EventEmitter[EventTypes]):

--- a/livekit-agents/livekit/agents/utils/hw/cpu.py
+++ b/livekit-agents/livekit/agents/utils/hw/cpu.py
@@ -1,6 +1,7 @@
 import os
 import time
 from abc import ABC, abstractmethod
+from typing import Optional
 
 import psutil
 
@@ -92,7 +93,7 @@ class CGroupV1CPUMonitor(CPUMonitor):
         percent = usage_seconds / (interval * num_cpus)
         return min(percent, 1.0)
 
-    def _read_cfs_quota_and_period(self) -> tuple[int | None, int]:
+    def _read_cfs_quota_and_period(self) -> tuple[Optional[int], Optional[int]]:
         quota_path_candidates = [
             "/sys/fs/cgroup/cpu/cpu.cfs_quota_us",
         ]

--- a/livekit-agents/livekit/agents/utils/hw/cpu.py
+++ b/livekit-agents/livekit/agents/utils/hw/cpu.py
@@ -114,7 +114,7 @@ class CGroupV1CPUMonitor(CPUMonitor):
             raise RuntimeError("Failed to read cpuacct.usage for cgroup v1")
         return value
 
-    def _read_first_int(self, paths: list[str]) -> int | None:
+    def _read_first_int(self, paths: list[str]) -> Optional[int]:
         for p in paths:
             try:
                 with open(p) as f:

--- a/livekit-agents/livekit/agents/utils/hw/cpu.py
+++ b/livekit-agents/livekit/agents/utils/hw/cpu.py
@@ -107,7 +107,6 @@ class CGroupV1CPUMonitor(CPUMonitor):
     def _read_cpuacct_usage(self) -> int:
         candidates = [
             "/sys/fs/cgroup/cpuacct/cpuacct.usage",
-            "/sys/fs/cgroup/cpu,cpuacct/cpuacct.usage",
         ]
         value = self._read_first_int(candidates)
         if value is None:

--- a/livekit-agents/livekit/agents/utils/hw/cpu.py
+++ b/livekit-agents/livekit/agents/utils/hw/cpu.py
@@ -74,11 +74,73 @@ class CGroupV2CPUMonitor(CPUMonitor):
         raise RuntimeError("Failed to read CPU usage")
 
 
+class CGroupV1CPUMonitor(CPUMonitor):
+    def cpu_count(self) -> float:
+        quota, period = self._read_cfs_quota_and_period()
+        if quota is None or quota < 0 or period is None or period <= 0:
+            return os.cpu_count() or 1.0
+        return max(1.0 * quota / period, 1.0)
+
+    def cpu_percent(self, interval: float = 0.5) -> float:
+        usage_start = self._read_cpuacct_usage()
+        time.sleep(interval)
+        usage_end = self._read_cpuacct_usage()
+        usage_diff_ns = usage_end - usage_start
+
+        usage_seconds = usage_diff_ns / 1_000_000_000
+        num_cpus = self.cpu_count()
+        percent = usage_seconds / (interval * num_cpus)
+        return min(percent, 1.0)
+
+    def _read_cfs_quota_and_period(self) -> tuple[int | None, int]:
+        quota_path_candidates = [
+            "/sys/fs/cgroup/cpu/cpu.cfs_quota_us",
+        ]
+        period_path_candidates = [
+            "/sys/fs/cgroup/cpu/cpu.cfs_period_us",
+        ]
+        quota = self._read_first_int(quota_path_candidates)
+        period = self._read_first_int(period_path_candidates)
+        return quota, period
+
+    def _read_cpuacct_usage(self) -> int:
+        candidates = [
+            "/sys/fs/cgroup/cpuacct/cpuacct.usage",
+            "/sys/fs/cgroup/cpu,cpuacct/cpuacct.usage",
+        ]
+        value = self._read_first_int(candidates)
+        if value is None:
+            raise RuntimeError("Failed to read cpuacct.usage for cgroup v1")
+        return value
+
+    def _read_first_int(self, paths: list[str]) -> int | None:
+        for p in paths:
+            try:
+                with open(p) as f:
+                    return int(f.read().strip())
+            except FileNotFoundError:
+                continue
+            except ValueError:
+                continue
+        return None
+
+
 def get_cpu_monitor() -> CPUMonitor:
     if _is_cgroup_v2():
         return CGroupV2CPUMonitor()
+    if _is_cgroup_v1():
+        return CGroupV1CPUMonitor()
     return DefaultCPUMonitor()
 
 
 def _is_cgroup_v2() -> bool:
     return os.path.exists("/sys/fs/cgroup/cpu.stat")
+
+
+def _is_cgroup_v1() -> bool:
+    candidates = [
+        "/sys/fs/cgroup/cpu/cpu.cfs_quota_us",
+        "/sys/fs/cgroup/cpu/cpu.cfs_period_us",
+        "/sys/fs/cgroup/cpuacct/cpuacct.usage",
+    ]
+    return any(os.path.exists(p) for p in candidates)

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -175,7 +175,7 @@ class WorkerOptions:
     drain_timeout: int = 1800
     """Number of seconds to wait for current jobs to finish upon receiving TERM or INT signal."""
     num_idle_processes: int | _WorkerEnvOption[int] = _WorkerEnvOption(
-        dev_default=0, prod_default=math.ceil(get_cpu_monitor().cpu_count())
+        dev_default=0, prod_default=min(math.ceil(get_cpu_monitor().cpu_count()), 4)
     )
     """Number of idle processes to keep warm."""
     shutdown_process_timeout: float = 60.0

--- a/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/base.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/base.py
@@ -91,7 +91,7 @@ class _EUORunnerBase(_InferenceRunner):
             )
             sess_options = ort.SessionOptions()
             sess_options.intra_op_num_threads = max(
-                1, math.ceil(hw.get_cpu_monitor().cpu_count()) // 2
+                1, min(math.ceil(hw.get_cpu_monitor().cpu_count()) // 2, 4)
             )
             sess_options.inter_op_num_threads = 1
             sess_options.add_session_config_entry("session.dynamic_block_base", "4")


### PR DESCRIPTION
the way we get CPU count isn't accurate. on cgroupsv1 instances, the quota is often unset, leading it to still use the host CPU count.

here we'll put a upper cap on concurrent processes spun up as well as idle processes, to reduce the likelihood that it'll try to use the entire machine