### PR TITLE
fix: allow CPU override from environment

### DIFF
--- a/livekit-agents/livekit/agents/utils/hw/cpu.py
+++ b/livekit-agents/livekit/agents/utils/hw/cpu.py
@@ -22,7 +22,7 @@ class CPUMonitor(ABC):
         pass
 
 
-def _cpu_count_from_env() -> float | None:
+def _cpu_count_from_env() -> Optional[float]:
     try:
         if "NUM_CPUS" in os.environ:
             return float(os.environ["NUM_CPUS"])

--- a/livekit-agents/livekit/agents/utils/hw/cpu.py
+++ b/livekit-agents/livekit/agents/utils/hw/cpu.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 import psutil
 
+from ...log import logger
+
 
 class CPUMonitor(ABC):
     @abstractmethod
@@ -20,9 +22,18 @@ class CPUMonitor(ABC):
         pass
 
 
+def _cpu_count_from_env() -> float | None:
+    try:
+        if "NUM_CPUS" in os.environ:
+            return float(os.environ["NUM_CPUS"])
+    except ValueError:
+        logger.warning("Failed to parse NUM_CPUS from environment", exc_info=True)
+    return None
+
+
 class DefaultCPUMonitor(CPUMonitor):
     def cpu_count(self) -> float:
-        return psutil.cpu_count() or 1.0
+        return _cpu_count_from_env() or psutil.cpu_count() or 1.0
 
     def cpu_percent(self, interval: float = 0.5) -> float:
         return psutil.cpu_percent(interval) / 100.0
@@ -36,7 +47,7 @@ class CGroupV2CPUMonitor(CPUMonitor):
         # Otherwise, the quota is a number that represents the maximum CPU time in microseconds that the cgroup can use within a given period.  # noqa: E501
         quota, period = self._read_cpu_max()
         if quota == "max":
-            return os.cpu_count() or 1
+            return _cpu_count_from_env() or psutil.cpu_count() or 1.0
         return 1.0 * int(quota) / period
 
     def cpu_percent(self, interval: float = 0.5) -> float:
@@ -45,13 +56,10 @@ class CGroupV2CPUMonitor(CPUMonitor):
         cpu_usage_end = self._read_cpu_usage()
         cpu_usage_diff = cpu_usage_end - cpu_usage_start
 
-        # Convert microseconds to seconds
+        # microseconds to seconds
         cpu_usage_seconds = cpu_usage_diff / 1_000_000
 
-        # Get the number of CPUs available to the container
         num_cpus = self.cpu_count()
-
-        # Calculate the percentage
         cpu_usage_percent = cpu_usage_seconds / (interval * num_cpus)
 
         return min(cpu_usage_percent, 1)
@@ -77,9 +85,13 @@ class CGroupV2CPUMonitor(CPUMonitor):
 
 class CGroupV1CPUMonitor(CPUMonitor):
     def cpu_count(self) -> float:
+        # often, cgroups v1 quota isn't set correctly, so we need to rely on an env var to
+        # correctly determine the number of CPUs
+        # we do not want to use the node CPU count, as it could overstate the number available
+        # to the container
         quota, period = self._read_cfs_quota_and_period()
         if quota is None or quota < 0 or period is None or period <= 0:
-            return os.cpu_count() or 1.0
+            return _cpu_count_from_env() or 2.0
         return max(1.0 * quota / period, 1.0)
 
     def cpu_percent(self, interval: float = 0.5) -> float:
@@ -91,7 +103,7 @@ class CGroupV1CPUMonitor(CPUMonitor):
         usage_seconds = usage_diff_ns / 1_000_000_000
         num_cpus = self.cpu_count()
         percent = usage_seconds / (interval * num_cpus)
-        return min(percent, 1.0)
+        return max(min(percent, 1.0), 0.0)
 
     def _read_cfs_quota_and_period(self) -> tuple[Optional[int], Optional[int]]:
         quota_path_candidates = [

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -440,6 +440,7 @@ class Worker(utils.EventEmitter[EventTypes]):
                     return self._opts.load_fnc(self)  # type: ignore
 
                 self._worker_load = await asyncio.get_event_loop().run_in_executor(None, load_fnc)
+                logger.info(f"worker load: {self._worker_load}")
 
                 load_threshold = _WorkerEnvOption.getvalue(self._opts.load_threshold, self._devmode)
                 default_num_idle_processes = _WorkerEnvOption.getvalue(
@@ -935,6 +936,7 @@ class Worker(utils.EventEmitter[EventTypes]):
         )
 
         update = agent.UpdateWorkerStatus(load=self._worker_load, status=status, job_count=job_cnt)
+        logger.info(f"update_worker_status: load: {self._worker_load}, status: {status}, job_count: {job_cnt}")
 
         # only log if status has changed
         if self._previous_status != status and not self._draining:

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -440,7 +440,6 @@ class Worker(utils.EventEmitter[EventTypes]):
                     return self._opts.load_fnc(self)  # type: ignore
 
                 self._worker_load = await asyncio.get_event_loop().run_in_executor(None, load_fnc)
-                logger.info(f"worker load: {self._worker_load}")
 
                 load_threshold = _WorkerEnvOption.getvalue(self._opts.load_threshold, self._devmode)
                 default_num_idle_processes = _WorkerEnvOption.getvalue(
@@ -936,7 +935,6 @@ class Worker(utils.EventEmitter[EventTypes]):
         )
 
         update = agent.UpdateWorkerStatus(load=self._worker_load, status=status, job_count=job_cnt)
-        logger.info(f"update_worker_status: load: {self._worker_load}, status: {status}, job_count: {job_cnt}")
 
         # only log if status has changed
         if self._previous_status != status and not self._draining:


### PR DESCRIPTION
often cgroupsv1 does not set the quota properly. this could cause issues on environments like AWS ECS where we are led to believe there are 64 cores available to the agent, when only 3 are assigned.

for those environments, it's now possible to set an environment variable `NUM_CPUS`, indicating the number of cores that the agent is allowed to use