### PR TITLE
fix: skip done speech when scheduling

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -874,6 +874,10 @@ class AgentActivity(RecognitionHooks):
             await self._q_updated.wait()
             while self._speech_q:
                 _, _, speech = heapq.heappop(self._speech_q)
+                if speech.done():
+                    # skip done speech (interrupted when it's in the queue)
+                    self._current_speech = None
+                    continue
                 self._current_speech = speech
                 if self.min_consecutive_speech_delay > 0.0:
                     await asyncio.sleep(
@@ -1300,12 +1304,12 @@ class AgentActivity(RecognitionHooks):
         )
         audio_output = self._session.output.audio if self._session.output.audio_enabled else None
 
-        await speech_handle.wait_if_not_interrupted(
-            [asyncio.ensure_future(speech_handle._wait_for_authorization())]
-        )
+        wait_for_authorization = asyncio.ensure_future(speech_handle._wait_for_authorization())
+        await speech_handle.wait_if_not_interrupted([wait_for_authorization])
         speech_handle._clear_authorization()
 
         if speech_handle.interrupted:
+            await utils.aio.cancel_and_wait(wait_for_authorization)
             return
 
         text_source: AsyncIterable[str] | None = None
@@ -1506,14 +1510,13 @@ class AgentActivity(RecognitionHooks):
 
         self._session._update_agent_state("thinking")
 
-        await speech_handle.wait_if_not_interrupted(
-            [asyncio.ensure_future(speech_handle._wait_for_authorization())]
-        )
+        wait_for_authorization = asyncio.ensure_future(speech_handle._wait_for_authorization())
+        await speech_handle.wait_if_not_interrupted([wait_for_authorization])
         speech_handle._clear_authorization()
 
         if speech_handle.interrupted:
             current_span.set_attribute(trace_types.ATTR_SPEECH_INTERRUPTED, True)
-            await utils.aio.cancel_and_wait(*tasks)
+            await utils.aio.cancel_and_wait(*tasks, wait_for_authorization)
             await text_tee.aclose()
             return
 
@@ -1741,9 +1744,10 @@ class AgentActivity(RecognitionHooks):
     ) -> None:
         assert self._rt_session is not None, "rt_session is not available"
 
-        await speech_handle.wait_if_not_interrupted(
-            [asyncio.ensure_future(speech_handle._wait_for_authorization())]
-        )
+        wait_for_authorization = asyncio.ensure_future(speech_handle._wait_for_authorization())
+        await speech_handle.wait_if_not_interrupted([wait_for_authorization])
+        if speech_handle.interrupted:
+            await utils.aio.cancel_and_wait(wait_for_authorization)
 
         if user_input is not None:
             chat_ctx = self._rt_session.chat_ctx.copy()
@@ -1802,12 +1806,12 @@ class AgentActivity(RecognitionHooks):
         )
         tool_ctx = llm.ToolContext(self.tools)
 
-        await speech_handle.wait_if_not_interrupted(
-            [asyncio.ensure_future(speech_handle._wait_for_authorization())]
-        )
+        wait_for_authorization = asyncio.ensure_future(speech_handle._wait_for_authorization())
+        await speech_handle.wait_if_not_interrupted([wait_for_authorization])
         speech_handle._clear_authorization()
 
         if speech_handle.interrupted:
+            await utils.aio.cancel_and_wait(wait_for_authorization)
             current_span.set_attribute(trace_types.ATTR_SPEECH_INTERRUPTED, True)
             return  # TODO(theomonnom): remove the message from the serverside history
 

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/realtime_api.py
@@ -701,10 +701,14 @@ class RealtimeSession(llm.RealtimeSession):
                         break
 
                 async for response in session.receive():
-                    if (not self._current_generation or self._current_generation._done) and (
-                        response.server_content or response.tool_call
-                    ):
-                        self._start_new_generation()
+                    if not self._current_generation or self._current_generation._done:
+                        if response.server_content and response.server_content.interrupted:
+                            # interrupt a generation already done
+                            self._handle_input_speech_started()
+                            continue
+
+                        if response.server_content or response.tool_call:
+                            self._start_new_generation()
 
                     if response.session_resumption_update:
                         if (

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/realtime_api.py
@@ -705,7 +705,8 @@ class RealtimeSession(llm.RealtimeSession):
                         if response.server_content and response.server_content.interrupted:
                             # interrupt a generation already done
                             self._handle_input_speech_started()
-                            continue
+                            # reset the flag and still start a new generation in case it has any other content
+                            response.server_content.interrupted = False
 
                         if response.server_content or response.tool_call:
                             self._start_new_generation()


### PR DESCRIPTION
if a speech was interrupted when it's in the queue, it will be marked as done before scheduling. when it's scheduled, `await speech._wait_for_generation()` in `_scheduling_task` will never return