### PR TITLE
add `cancel_tool_reply` to function_tools_executed event

### DIFF
--- a/examples/voice_agents/silent_function_call.py
+++ b/examples/voice_agents/silent_function_call.py
@@ -2,7 +2,14 @@ import logging
 
 from dotenv import load_dotenv
 
-from livekit.agents import Agent, AgentSession, JobContext, WorkerOptions, cli
+from livekit.agents import (
+    Agent,
+    AgentSession,
+    FunctionToolsExecutedEvent,
+    JobContext,
+    WorkerOptions,
+    cli,
+)
 from livekit.agents.llm import function_tool
 from livekit.plugins import cartesia, deepgram, openai, silero
 
@@ -10,6 +17,11 @@ logger = logging.getLogger("silent-function-call")
 logger.setLevel(logging.INFO)
 
 load_dotenv()
+
+# This example shows how to execute function tools without generating a reply.
+# A tool without a return value won't generate a reply automatically.
+# If multiple tools are called in parallel, it creates a reply if any of them has a output,
+# you can prevent the reply by calling `ev.prevent_tool_reply()` in the `function_tools_executed` event handler.
 
 
 class MyAgent(Agent):
@@ -27,17 +39,19 @@ class MyAgent(Agent):
         self.light_on = True
         logger.info("Light is now on")
 
+        # a tool without a return value won't generate a reply automatically
+
     @function_tool()
     async def turn_off_light(self):
         """Called when user asks to turn off the light."""
         self.light_on = False
         logger.info("Light is now off")
 
+        return "Light is now off"
+
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
-    agent = AgentSession(
+    session = AgentSession(
         stt=deepgram.STT(),
         llm=openai.LLM(model="gpt-4o-mini"),
         tts=cartesia.TTS(),
@@ -45,8 +59,14 @@ async def entrypoint(ctx: JobContext):
         # llm=openai.realtime.RealtimeModel(voice="alloy"),
     )
 
-    await ctx.wait_for_participant()
-    await agent.start(agent=MyAgent(), room=ctx.room)
+    @session.on("function_tools_executed")
+    def on_function_tools_executed(ev: FunctionToolsExecutedEvent):
+        tools = (fnc.name for fnc in ev.function_calls)
+        if "turn_off_light" in tools:
+            # you can also prevent the tool reply after all tools executed
+            ev.prevent_tool_reply()
+
+    await session.start(agent=MyAgent(), room=ctx.room)
 
 
 if __name__ == "__main__":

--- a/examples/voice_agents/silent_function_call.py
+++ b/examples/voice_agents/silent_function_call.py
@@ -21,7 +21,7 @@ load_dotenv()
 # This example shows how to execute function tools without generating a reply.
 # A tool without a return value won't generate a reply automatically.
 # If multiple tools are called in parallel, it creates a reply if any of them has a output,
-# you can prevent the reply by calling `ev.prevent_tool_reply()` in the `function_tools_executed` event handler.
+# you can cancel the reply by calling `ev.cancel_tool_reply()` in the `function_tools_executed` event handler.
 
 
 class MyAgent(Agent):
@@ -64,7 +64,7 @@ async def entrypoint(ctx: JobContext):
         tools = (fnc.name for fnc in ev.function_calls)
         if "turn_off_light" in tools:
             # you can also prevent the tool reply after all tools executed
-            ev.prevent_tool_reply()
+            ev.cancel_tool_reply()
 
     await session.start(agent=MyAgent(), room=ctx.room)
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1717,18 +1717,20 @@ class AgentActivity(RecognitionHooks):
 
             new_calls: list[llm.FunctionCall] = []
             new_fnc_outputs: list[llm.FunctionCallOutput] = []
-            generate_tool_reply: bool = False
             new_agent_task: Agent | None = None
             ignore_task_switch = False
             fnc_executed_ev = FunctionToolsExecutedEvent(
-                function_calls=[], function_call_outputs=[]
+                function_calls=[],
+                function_call_outputs=[],
+                _reply_required=False,
+                _handoff_required=False,
             )
             for sanitized_out in tool_output.output:
                 if sanitized_out.fnc_call_out is not None:
                     new_calls.append(sanitized_out.fnc_call)
                     new_fnc_outputs.append(sanitized_out.fnc_call_out)
                     if sanitized_out.reply_required:
-                        generate_tool_reply = True
+                        fnc_executed_ev._reply_required = True
 
                 # add the function call and output to the event, including the None outputs
                 fnc_executed_ev.function_calls.append(sanitized_out.fnc_call)
@@ -1741,18 +1743,18 @@ class AgentActivity(RecognitionHooks):
 
                 new_agent_task = sanitized_out.agent_task
 
-            try:
-                self._session.emit("function_tools_executed", fnc_executed_ev)
-            except StopResponse:
-                generate_tool_reply = False
+            if new_agent_task and not ignore_task_switch:
+                fnc_executed_ev._handoff_required = True
+
+            self._session.emit("function_tools_executed", fnc_executed_ev)
 
             draining = self.scheduling_paused
-            if not ignore_task_switch and new_agent_task is not None:
+            if new_agent_task and not ignore_task_switch and fnc_executed_ev._handoff_required:
                 self._session.update_agent(new_agent_task)
                 draining = True
 
             tool_messages = new_calls + new_fnc_outputs
-            if generate_tool_reply:
+            if fnc_executed_ev._reply_required:
                 chat_ctx.items.extend(tool_messages)
 
                 tool_response_task = self._create_speech_task(
@@ -2103,6 +2105,8 @@ class AgentActivity(RecognitionHooks):
             fnc_executed_ev = FunctionToolsExecutedEvent(
                 function_calls=[],
                 function_call_outputs=[],
+                _reply_required=False,
+                _handoff_required=False,
             )
             new_agent_task: Agent | None = None
             ignore_task_switch = False
@@ -2116,6 +2120,7 @@ class AgentActivity(RecognitionHooks):
                     new_fnc_outputs.append(sanitized_out.fnc_call_out)
                     if sanitized_out.reply_required:
                         generate_tool_reply = True
+                        fnc_executed_ev._reply_required = True
 
                 if new_agent_task is not None and sanitized_out.agent_task is not None:
                     logger.error(
@@ -2125,10 +2130,13 @@ class AgentActivity(RecognitionHooks):
 
                 new_agent_task = sanitized_out.agent_task
 
+            if new_agent_task and not ignore_task_switch:
+                fnc_executed_ev._handoff_required = True
+
             self._session.emit("function_tools_executed", fnc_executed_ev)
 
             draining = self.scheduling_paused
-            if not ignore_task_switch and new_agent_task is not None:
+            if new_agent_task and not ignore_task_switch and fnc_executed_ev._handoff_required:
                 self._session.update_agent(new_agent_task)
                 draining = True
 
@@ -2143,7 +2151,10 @@ class AgentActivity(RecognitionHooks):
                         extra={"error": str(e)},
                     )
 
-            if generate_tool_reply and not self.llm.capabilities.auto_tool_reply_generation:
+            if (
+                fnc_executed_ev._reply_required
+                and not self.llm.capabilities.auto_tool_reply_generation
+            ):
                 self._rt_session.interrupt()
 
                 self._create_speech_task(
@@ -2162,6 +2173,14 @@ class AgentActivity(RecognitionHooks):
                 )
                 self._schedule_speech(
                     speech_handle, SpeechHandle.SPEECH_PRIORITY_NORMAL, force=True
+                )
+            elif (
+                self.llm.capabilities.auto_tool_reply_generation
+                and not fnc_executed_ev._reply_required
+                and generate_tool_reply
+            ):
+                logger.warning(
+                    f"Tool reply cannot be prevented when using {self.llm._label}, it generates reply automatically."
                 )
 
     # move them to the end to avoid shadowing the same named modules for mypy

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1740,7 +1740,11 @@ class AgentActivity(RecognitionHooks):
                     # TODO(long): should we mark the function call as failed to notify the LLM?
 
                 new_agent_task = sanitized_out.agent_task
-            self._session.emit("function_tools_executed", fnc_executed_ev)
+
+            try:
+                self._session.emit("function_tools_executed", fnc_executed_ev)
+            except StopResponse:
+                generate_tool_reply = False
 
             draining = self.scheduling_paused
             if not ignore_task_switch and new_agent_task is not None:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1720,10 +1720,7 @@ class AgentActivity(RecognitionHooks):
             new_agent_task: Agent | None = None
             ignore_task_switch = False
             fnc_executed_ev = FunctionToolsExecutedEvent(
-                function_calls=[],
-                function_call_outputs=[],
-                _reply_required=False,
-                _handoff_required=False,
+                function_calls=[], function_call_outputs=[]
             )
             for sanitized_out in tool_output.output:
                 if sanitized_out.fnc_call_out is not None:
@@ -1749,7 +1746,7 @@ class AgentActivity(RecognitionHooks):
             self._session.emit("function_tools_executed", fnc_executed_ev)
 
             draining = self.scheduling_paused
-            if new_agent_task and not ignore_task_switch and fnc_executed_ev._handoff_required:
+            if fnc_executed_ev._handoff_required and new_agent_task and not ignore_task_switch:
                 self._session.update_agent(new_agent_task)
                 draining = True
 
@@ -2103,10 +2100,7 @@ class AgentActivity(RecognitionHooks):
             new_fnc_outputs: list[llm.FunctionCallOutput] = []
             generate_tool_reply: bool = False
             fnc_executed_ev = FunctionToolsExecutedEvent(
-                function_calls=[],
-                function_call_outputs=[],
-                _reply_required=False,
-                _handoff_required=False,
+                function_calls=[], function_call_outputs=[]
             )
             new_agent_task: Agent | None = None
             ignore_task_switch = False
@@ -2136,7 +2130,7 @@ class AgentActivity(RecognitionHooks):
             self._session.emit("function_tools_executed", fnc_executed_ev)
 
             draining = self.scheduling_paused
-            if new_agent_task and not ignore_task_switch and fnc_executed_ev._handoff_required:
+            if fnc_executed_ev._handoff_required and new_agent_task and not ignore_task_switch:
                 self._session.update_agent(new_agent_task)
                 draining = True
 

--- a/livekit-agents/livekit/agents/voice/events.py
+++ b/livekit-agents/livekit/agents/voice/events.py
@@ -152,9 +152,25 @@ class FunctionToolsExecutedEvent(BaseModel):
     function_calls: list[FunctionCall]
     function_call_outputs: list[FunctionCallOutput | None]
     created_at: float = Field(default_factory=time.time)
+    _reply_required: bool = Field(exclude=True)
+    _handoff_required: bool = Field(exclude=True)
 
     def zipped(self) -> list[tuple[FunctionCall, FunctionCallOutput | None]]:
         return list(zip(self.function_calls, self.function_call_outputs))
+
+    def prevent_tool_reply(self) -> None:
+        self._reply_required = False
+
+    def prevent_agent_handoff(self) -> None:
+        self._handoff_required = False
+
+    @property
+    def has_tool_reply(self) -> bool:
+        return self._reply_required
+
+    @property
+    def has_agent_handoff(self) -> bool:
+        return self._handoff_required
 
     @model_validator(mode="after")
     def verify_lists_length(self) -> Self:

--- a/livekit-agents/livekit/agents/voice/events.py
+++ b/livekit-agents/livekit/agents/voice/events.py
@@ -158,10 +158,10 @@ class FunctionToolsExecutedEvent(BaseModel):
     def zipped(self) -> list[tuple[FunctionCall, FunctionCallOutput | None]]:
         return list(zip(self.function_calls, self.function_call_outputs))
 
-    def prevent_tool_reply(self) -> None:
+    def cancel_tool_reply(self) -> None:
         self._reply_required = False
 
-    def prevent_agent_handoff(self) -> None:
+    def cancel_agent_handoff(self) -> None:
         self._handoff_required = False
 
     @property

--- a/livekit-agents/livekit/agents/voice/events.py
+++ b/livekit-agents/livekit/agents/voice/events.py
@@ -152,8 +152,8 @@ class FunctionToolsExecutedEvent(BaseModel):
     function_calls: list[FunctionCall]
     function_call_outputs: list[FunctionCallOutput | None]
     created_at: float = Field(default_factory=time.time)
-    _reply_required: bool = Field(exclude=True)
-    _handoff_required: bool = Field(exclude=True)
+    _reply_required: bool
+    _handoff_required: bool
 
     def zipped(self) -> list[tuple[FunctionCall, FunctionCallOutput | None]]:
         return list(zip(self.function_calls, self.function_call_outputs))

--- a/livekit-agents/livekit/agents/voice/events.py
+++ b/livekit-agents/livekit/agents/voice/events.py
@@ -4,7 +4,7 @@ import time
 from enum import Enum, unique
 from typing import TYPE_CHECKING, Annotated, Any, Generic, Literal, TypeVar, Union
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 from typing_extensions import Self
 
 from ..llm import (
@@ -152,8 +152,8 @@ class FunctionToolsExecutedEvent(BaseModel):
     function_calls: list[FunctionCall]
     function_call_outputs: list[FunctionCallOutput | None]
     created_at: float = Field(default_factory=time.time)
-    _reply_required: bool
-    _handoff_required: bool
+    _reply_required: bool = PrivateAttr(default=False)
+    _handoff_required: bool = PrivateAttr(default=False)
 
     def zipped(self) -> list[tuple[FunctionCall, FunctionCallOutput | None]]:
         return list(zip(self.function_calls, self.function_call_outputs))


### PR DESCRIPTION
if there are parallel tool calls, the tool executions won't know each other. this is useful when ppl want to skip the tool response when another tool returns a new Agent.