### PR TITLE
Fix Google STT Word‑timings error.

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -562,8 +562,11 @@ def _recognize_response_to_speech_event(
         confidence += result.alternatives[0].confidence
 
     # not sure why start_offset and end_offset returns a timedelta
-    start_offset = resp.results[0].alternatives[0].words[0].start_offset
-    end_offset = resp.results[-1].alternatives[0].words[-1].end_offset
+    try:
+        start_time = resp.results[0].alternatives[0].words[0].start_offset.total_seconds()
+        end_time = resp.results[-1].alternatives[0].words[-1].end_offset.total_seconds()
+    except IndexError:
+        start_time = end_time = 0
 
     confidence /= len(resp.results)
     lg = resp.results[0].language_code
@@ -572,8 +575,8 @@ def _recognize_response_to_speech_event(
         alternatives=[
             stt.SpeechData(
                 language=lg,
-                start_time=start_offset.total_seconds(),  # type: ignore
-                end_time=end_offset.total_seconds(),  # type: ignore
+                start_time=start_time,
+                end_time=end_time,
                 confidence=confidence,
                 text=text,
             )

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -563,8 +563,8 @@ def _recognize_response_to_speech_event(
 
     # not sure why start_offset and end_offset returns a timedelta
     try:
-        start_time = resp.results[0].alternatives[0].words[0].start_offset.total_seconds()
-        end_time = resp.results[-1].alternatives[0].words[-1].end_offset.total_seconds()
+        start_time = resp.results[0].alternatives[0].words[0].start_offset.total_seconds()  # type: ignore
+        end_time = resp.results[-1].alternatives[0].words[-1].end_offset.total_seconds()  # type: ignore
     except IndexError:
         start_time = end_time = 0
 


### PR DESCRIPTION
## Error
When using `google.TTS(model="chirp_2", enable_word_time_offsets=False)`, since there is no word offsets, the `resp.results[0].alternatives[0].words[0].start_offset` call in `_recognize_response_to_speech_event` raise an error.

```
Traceback (most recent call last):
  File "agents/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py", line 267, in _recognize_impl
    return _recognize_response_to_speech_event(raw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "agents/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py", line 565, in _recognize_response_to_speech_event
    start_offset = resp.results[0].alternatives[0].words[0].start_offset
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
  File ".venv/lib/python3.12/site-packages/proto/marshal/collections/repeated.py", line 130, in __getitem__
    return self._marshal.to_python(self._pb_type, self.pb[key])
                                                  ~~~~~~~^^^^^
IndexError: list index out of range
```

## Related links
From [Google Chirp 2](https://cloud.google.com/speech-to-text/v2/docs/chirp_2-model#feature_support_and_limitations): "Word-timings (Timestamps): Automatically generated by the model and can be optionally enabled. **It is possible that transcrption quality and speed will degrade slightly.**"