### PR TITLE
feat: enable keyterm prompting in deepgram for de, nl, sv, da

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -729,7 +729,10 @@ def _validate_keyterms(
         )
 
     if is_given(keyterms) and (
-        (model.startswith("nova-3") and language not in ("en-US", "en"))
+        (
+            model.startswith("nova-3")
+            and language not in ("en-US", "en", "de", "nl", "sv", "sv-SE", "da", "da-DK")
+        )
         or not model.startswith("nova-3")
     ):
         raise ValueError(


### PR DESCRIPTION
Deepgram released new monolingual models (see [here](https://developers.deepgram.com/changelog/speech-to-text-changelog#nova-3-model-update)) that all support keyterm prompting.