### PR TITLE
feat: support interruptions via interim transcripts for AssemblyAI plugin

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -45,9 +45,7 @@ class _TurnDetector(Protocol):
     async def unlikely_threshold(self, language: str | None) -> float | None: ...
     async def supports_language(self, language: str | None) -> bool: ...
 
-    async def predict_end_of_turn(
-        self, chat_ctx: llm.ChatContext, *, timeout: float | None = None
-    ) -> float: ...
+    async def predict_end_of_turn(self, chat_ctx: llm.ChatContext) -> float: ...
 
 
 class RecognitionHooks(Protocol):
@@ -296,12 +294,41 @@ class AudioRecognition:
             self._hooks.on_interim_transcript(ev)
             self._audio_interim_transcript = ev.alternatives[0].text
 
+        elif ev.type == stt.SpeechEventType.START_OF_SPEECH:
+            # Handle START_OF_SPEECH for interruptions (similar to VAD logic)
+            with trace.use_span(self._ensure_user_turn_span()):
+                # Create a fake VAD event for hooks compatibility
+                start_vad_event = vad.VADEvent(
+                    type=vad.VADEventType.START_OF_SPEECH,
+                    samples_index=0,
+                    timestamp=0.0,
+                    speech_duration=1.0,
+                    silence_duration=0.0
+                )
+                self._hooks.on_start_of_speech(start_vad_event)
+                
+                # Also trigger inference done event for interruption logic
+                inference_vad_event = vad.VADEvent(
+                    type=vad.VADEventType.INFERENCE_DONE,
+                    samples_index=0,
+                    timestamp=0.0,
+                    speech_duration=1.0,  # Set to 1.0 to pass min_interruption_duration check
+                    silence_duration=0.0
+                )
+                self._hooks.on_vad_inference_done(inference_vad_event)
+
+            self._speaking = True
+            self._user_turn_committed = False  # Reset turn commitment for new turn
+            self._last_speaking_time = time.time()
+
+            if self._end_of_turn_task is not None:
+                self._end_of_turn_task.cancel()
+
         elif ev.type == stt.SpeechEventType.END_OF_SPEECH and self._turn_detection_mode == "stt":
+            self._speaking = False  # Reset speaking flag
             self._user_turn_committed = True
-            if not self._speaking:
-                # start response after vad fires END_OF_SPEECH to avoid vad interruption
-                chat_ctx = self._hooks.retrieve_chat_ctx().copy()
-                self._run_eou_detection(chat_ctx)
+            chat_ctx = self._hooks.retrieve_chat_ctx().copy()
+            self._run_eou_detection(chat_ctx)
 
     async def _on_vad_event(self, ev: vad.VADEvent) -> None:
         if ev.type == vad.VADEventType.START_OF_SPEECH:
@@ -351,29 +378,21 @@ class AudioRecognition:
             user_turn_span = self._ensure_user_turn_span()
             if turn_detector is not None:
                 if not await turn_detector.supports_language(self._last_language):
-                    logger.info("Turn detector does not support language %s", self._last_language)
+                    logger.debug("Turn detector does not support language %s", self._last_language)
                 else:
                     with (
                         trace.use_span(user_turn_span),
                         tracer.start_as_current_span("eou_detection") as eou_detection_span,
                     ):
-                        # if there are failures, we should not hold the pipeline up
-                        end_of_turn_probability = 0.0
-                        unlikely_threshold: float | None = None
-                        try:
-                            end_of_turn_probability = await turn_detector.predict_end_of_turn(
-                                chat_ctx
-                            )
-                            unlikely_threshold = await turn_detector.unlikely_threshold(
-                                self._last_language
-                            )
-                            if (
-                                unlikely_threshold is not None
-                                and end_of_turn_probability < unlikely_threshold
-                            ):
-                                endpointing_delay = self._max_endpointing_delay
-                        except Exception:
-                            logger.exception("Error predicting end of turn")
+                        end_of_turn_probability = await turn_detector.predict_end_of_turn(chat_ctx)
+                        unlikely_threshold = await turn_detector.unlikely_threshold(
+                            self._last_language
+                        )
+                        if (
+                            unlikely_threshold is not None
+                            and end_of_turn_probability < unlikely_threshold
+                        ):
+                            endpointing_delay = self._max_endpointing_delay
 
                         eou_detection_span.set_attributes(
                             {

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -31,6 +31,7 @@ from livekit.agents import (
     APIStatusError,
     stt,
     utils,
+    vad,
 )
 from livekit.agents.types import (
     NOT_GIVEN,
@@ -169,6 +170,7 @@ class SpeechStream(stt.SpeechStream):
         self._session = http_session
         self._speech_duration: float = 0
         self._reconnect_event = asyncio.Event()
+        self._start_of_speech_sent = False
 
     def update_options(
         self,
@@ -321,6 +323,11 @@ class SpeechStream(stt.SpeechStream):
             words = data.get("words", [])
             end_of_turn = data.get("end_of_turn")
 
+            # Emit START_OF_SPEECH when we receive the first word (only once per turn)
+            if len(words) == 1 and not self._start_of_speech_sent:
+                self._event_ch.send_nowait(stt.SpeechEvent(type=stt.SpeechEventType.START_OF_SPEECH))
+                self._start_of_speech_sent = True
+
             if transcript and end_of_turn:
                 turn_is_formatted = data.get("turn_is_formatted", False)
                 if not self._opts.format_turns or (self._opts.format_turns and turn_is_formatted):
@@ -333,8 +340,11 @@ class SpeechStream(stt.SpeechStream):
                     # skip emitting final transcript if format_turns is enabled but this
                     # turn isn't formatted
                     return
-                self._event_ch.send_nowait(final_event)
                 self._event_ch.send_nowait(stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH))
+                self._event_ch.send_nowait(final_event)
+                
+                # Reset flag for next turn
+                self._start_of_speech_sent = False
 
                 if self._speech_duration > 0.0:
                     usage_event = stt.SpeechEvent(


### PR DESCRIPTION
Hi team! This PR adds support for interruptions via the AssemblyAI plugin using interim transcripts. It mimics the VAD inference done event when STT start of speech is received. This is to support AssemblyAI's plugin if VAD is not included in the agent pipeline, since we have now integrated VAD into the turn detection model and therefore don't want to run it twice.

Please feel free to adjust the PR as needed and happy to address any comments! :)