### PR TITLE
feat(Google): Add markup for TTS HD voices

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
@@ -52,6 +52,7 @@ class _TTSOptions:
     volume_gain_db: float
     custom_pronunciations: CustomPronunciations | None
     enable_ssml: bool
+    use_markup: bool
 
 
 class TTS(tts.TTS):
@@ -75,6 +76,7 @@ class TTS(tts.TTS):
         custom_pronunciations: NotGivenOr[CustomPronunciations] = NOT_GIVEN,
         use_streaming: bool = True,
         enable_ssml: bool = False,
+        use_markup: bool = False,
     ) -> None:
         """
         Create a new instance of Google TTS.
@@ -100,6 +102,7 @@ class TTS(tts.TTS):
             custom_pronunciations (CustomPronunciations, optional): Custom pronunciations for the TTS. Default is None.
             use_streaming (bool, optional): Whether to use streaming synthesis. Default is True.
             enable_ssml (bool, optional): Whether to enable SSML support. Default is False.
+            use_markup (bool, optional): Whether to enable markup input for HD voices. Default is False.
         """  # noqa: E501
         super().__init__(
             capabilities=tts.TTSCapabilities(streaming=use_streaming),
@@ -107,8 +110,11 @@ class TTS(tts.TTS):
             num_channels=1,
         )
 
-        if enable_ssml and use_streaming:
-            raise ValueError("SSML support is not available for streaming synthesis")
+        if enable_ssml:
+            if use_streaming:
+                raise ValueError("SSML support is not available for streaming synthesis")
+            if use_markup:
+                raise ValueError("SSML support is not available for markup input")
 
         self._client: texttospeech.TextToSpeechAsyncClient | None = None
         self._credentials_info = credentials_info
@@ -145,6 +151,7 @@ class TTS(tts.TTS):
             volume_gain_db=volume_gain_db,
             custom_pronunciations=pronunciations,
             enable_ssml=enable_ssml,
+            use_markup=use_markup,
         )
         self._streams = weakref.WeakSet[SynthesizeStream]()
 
@@ -238,19 +245,21 @@ class ChunkedStream(tts.ChunkedStream):
 
     async def _run(self, output_emitter: tts.AudioEmitter) -> None:
         try:
-            input = (
-                texttospeech.SynthesisInput(
-                    ssml=self._build_ssml(),
-                    custom_pronunciations=self._opts.custom_pronunciations,
+            if self._opts.use_markup:
+                tts_input = texttospeech.SynthesisInput(
+                    markup=self._input_text, custom_pronunciations=self._opts.custom_pronunciations
                 )
-                if self._opts.enable_ssml
-                else texttospeech.SynthesisInput(
-                    text=self._input_text,
-                    custom_pronunciations=self._opts.custom_pronunciations,
+            elif self._opts.enable_ssml:
+                tts_input = texttospeech.SynthesisInput(
+                    ssml=self._build_ssml(), custom_pronunciations=self._opts.custom_pronunciations
                 )
-            )
+            else:
+                tts_input = texttospeech.SynthesisInput(
+                    text=self._input_text, custom_pronunciations=self._opts.custom_pronunciations
+                )
+
             response: SynthesizeSpeechResponse = await self._tts._ensure_client().synthesize_speech(
-                input=input,
+                input=tts_input,
                 voice=self._opts.voice,
                 audio_config=texttospeech.AudioConfig(
                     audio_encoding=self._opts.encoding,
@@ -355,8 +364,12 @@ class SynthesizeStream(tts.SynthesizeStream):
 
                 async for input in input_stream:
                     self._mark_started()
-                    yield texttospeech.StreamingSynthesizeRequest(
-                        input=texttospeech.StreamingSynthesisInput(text=input.token)
+                    yield (
+                        texttospeech.StreamingSynthesizeRequest(
+                            input=texttospeech.StreamingSynthesisInput(markup=input.token)
+                            if self._opts.use_markup
+                            else texttospeech.StreamingSynthesisInput(text=input.token)
+                        )
                     )
 
             except Exception:


### PR DESCRIPTION
## Summary
Adds support for [Google TTS pause control markup](https://cloud.google.com/text-to-speech/docs/chirp3-hd#pause_control) by extending the `tts_node`.

## Notes
I noticed that **when `use_tts_aligned_transcript=True` (default), the transcript also outputs the `[pause]` markup**, which might not be ideal for frontend display.  
Would you recommend flagging this in the code itself, or is it better documented in the integration guide?