### PR TITLE
fix(plugins:elevenlabs): fix exception in STT when serializing bool form field tag_audio_events

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
@@ -101,7 +101,7 @@ class STT(stt.STT):
         form.add_field("file", wav_bytes, filename="audio.wav", content_type="audio/x-wav")
         form.add_field("model_id", "scribe_v1")
         form.add_field("language_code", self._opts.language_code)
-        form.add_field("tag_audio_events", self._opts.tag_audio_events)
+        form.add_field("tag_audio_events", str(self._opts.tag_audio_events).lower())
 
         try:
             async with self._ensure_session().post(


### PR DESCRIPTION
Fixes exception when using elevenlabs.STT():

```
2025-08-28 13:53:24,909 - WARNING livekit.agents - failed to recognize speech, retrying in 0.1s
Traceback (most recent call last):
  File "/Users/mike/Documents/livekit/working/ai/venv/lib/python3.10/site-packages/aiohttp/formdata.py", line 152, in _gen_form_data
    part = payload.get_payload(
  File "/Users/mike/Documents/livekit/working/ai/venv/lib/python3.10/site-packages/aiohttp/payload.py", line 73, in get_payload
    return PAYLOAD_REGISTRY.get(data, *args, **kwargs)
  File "/Users/mike/Documents/livekit/working/ai/venv/lib/python3.10/site-packages/aiohttp/payload.py", line 131, in get
    raise LookupError()
aiohttp.payload.LookupError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/mike/Documents/livekit/working/ai/venv/lib/python3.10/site-packages/livekit/plugins/elevenlabs/stt.py", line 108, in _recognize_impl
    async with self._ensure_session().post(
  File "/Users/mike/Documents/livekit/working/ai/venv/lib/python3.10/site-packages/aiohttp/client.py", line 1488, in __aenter__
    self._resp: _RetType = await self._coro
  File "/Users/mike/Documents/livekit/working/ai/venv/lib/python3.10/site-packages/aiohttp/client.py", line 693, in _request
    req = self._request_class(
  File "/Users/mike/Documents/livekit/working/ai/venv/lib/python3.10/site-packages/aiohttp/client_reqrep.py", line 895, in __init__
    self.update_body_from_data(data)
  File "/Users/mike/Documents/livekit/working/ai/venv/lib/python3.10/site-packages/aiohttp/client_reqrep.py", line 1187, in update_body_from_data
    maybe_payload = body() if isinstance(body, FormData) else body
  File "/Users/mike/Documents/livekit/working/ai/venv/lib/python3.10/site-packages/aiohttp/formdata.py", line 177, in __call__
    return self._gen_form_data()
  File "/Users/mike/Documents/livekit/working/ai/venv/lib/python3.10/site-packages/aiohttp/formdata.py", line 156, in _gen_form_data
    raise TypeError(
TypeError: Can not serialize value type: <class 'bool'>
 headers: {}
 value: True
```