### PR TITLE
feat: add environment variable to customize the logger name

### DIFF
--- a/livekit-agents/livekit/agents/log.py
+++ b/livekit-agents/livekit/agents/log.py
@@ -1,6 +1,18 @@
+"""
+Logging configuration for LiveKit Agents.
+
+This module sets up logging for the LiveKit Agents framework.
+
+Environment Variables:
+    LIVEKIT_LOGGER_NAME: Custom logger name to use instead of the default one.
+                         This allows applications to customize the logger name for 
+                         better integration with their logging infrastructure.
+"""
 import logging
+import os
 
 DEV_LEVEL = 23
 logging.addLevelName(DEV_LEVEL, "DEV")
 
-logger = logging.getLogger("livekit.agents")
+DEFAULT_LOGGER_NAME = "livekit.agents"
+logger = logging.getLogger(os.environ.get("LIVEKIT_LOGGER_NAME", DEFAULT_LOGGER_NAME))


### PR DESCRIPTION
Allow applications to customize the logger name for better integration with their logging infrastructure. , instead of `livekit.agents`.

The default behavior stays the same if the environment variable isn't set.