### PR TITLE
feat(azure-stt): add configurable punctuation option to Azure STT

### DIFF
--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
@@ -57,6 +57,7 @@ class STTOptions:
     speech_endpoint: NotGivenOr[str] = NOT_GIVEN
     profanity: NotGivenOr[speechsdk.enums.ProfanityOption] = NOT_GIVEN
     phrase_list: NotGivenOr[list[str] | None] = NOT_GIVEN
+    punctuation: NotGivenOr[str] = NOT_GIVEN
 
 
 class STT(stt.STT):
@@ -77,6 +78,7 @@ class STT(stt.STT):
         profanity: NotGivenOr[speechsdk.enums.ProfanityOption] = NOT_GIVEN,
         speech_endpoint: NotGivenOr[str] = NOT_GIVEN,
         phrase_list: NotGivenOr[list[str] | None] = NOT_GIVEN,
+        punctuation: NotGivenOr[str] = NOT_GIVEN,
     ):
         """
         Create a new instance of Azure STT.
@@ -92,6 +94,8 @@ class STT(stt.STT):
         Args:
             phrase_list: List of words or phrases to boost recognition accuracy.
                         Azure will give higher priority to these phrases during recognition.
+            punctuation: Controls punctuation behavior. Valid values are 'explicit', 'implicit', or None.
+                        'explicit' adds punctuation marks explicitly, 'implicit' uses natural speech patterns.
         """
 
         super().__init__(capabilities=stt.STTCapabilities(streaming=True, interim_results=True))
@@ -138,6 +142,7 @@ class STT(stt.STT):
             profanity=profanity,
             speech_endpoint=speech_endpoint,
             phrase_list=phrase_list,
+            punctuation=punctuation,
         )
         self._streams = weakref.WeakSet[SpeechStream]()
 
@@ -366,6 +371,10 @@ def _create_speech_recognizer(
         )
     if is_given(config.profanity):
         speech_config.set_profanity(config.profanity)
+    
+    # Set punctuation behavior if specified
+    if is_given(config.punctuation):
+        speech_config.set_service_property('punctuation', config.punctuation, speechsdk.ServicePropertyChannel.UriQueryParameter)
 
     kwargs: dict[str, Any] = {}
     if config.language and len(config.language) > 1:


### PR DESCRIPTION
- Added `punctuation` option to `STTOptions` dataclass and `STT` constructor.
- Documented the new `punctuation` argument in the class docstring.
- Set punctuation behavior in Azure SpeechConfig if specified.