### PR TITLE
feat(azure-stt): add configurable punctuation option to Azure STT

### DIFF
--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
@@ -57,7 +57,7 @@ class STTOptions:
     speech_endpoint: NotGivenOr[str] = NOT_GIVEN
     profanity: NotGivenOr[speechsdk.enums.ProfanityOption] = NOT_GIVEN
     phrase_list: NotGivenOr[list[str] | None] = NOT_GIVEN
-    punctuation: NotGivenOr[bool] = NOT_GIVEN
+    explicit_punctuation: bool
 
 
 class STT(stt.STT):
@@ -78,7 +78,7 @@ class STT(stt.STT):
         profanity: NotGivenOr[speechsdk.enums.ProfanityOption] = NOT_GIVEN,
         speech_endpoint: NotGivenOr[str] = NOT_GIVEN,
         phrase_list: NotGivenOr[list[str] | None] = NOT_GIVEN,
-        punctuation: NotGivenOr[bool] = NOT_GIVEN,
+        explicit_punctuation: bool = False,
     ):
         """
         Create a new instance of Azure STT.
@@ -94,8 +94,9 @@ class STT(stt.STT):
         Args:
             phrase_list: List of words or phrases to boost recognition accuracy.
                         Azure will give higher priority to these phrases during recognition.
-            punctuation: Controls punctuation behavior. If False, sets explicit punctuation mode.
-                        If True or NOT_GIVEN, uses Azure's default punctuation behavior.
+            explicit_punctuation: Controls punctuation behavior. If True, enables explicit punctuation mode
+                        where punctuation marks are added explicitly. If False (default), uses Azure's
+                        default punctuation behavior.
         """
 
         super().__init__(capabilities=stt.STTCapabilities(streaming=True, interim_results=True))
@@ -142,7 +143,7 @@ class STT(stt.STT):
             profanity=profanity,
             speech_endpoint=speech_endpoint,
             phrase_list=phrase_list,
-            punctuation=punctuation,
+            explicit_punctuation=explicit_punctuation,
         )
         self._streams = weakref.WeakSet[SpeechStream]()
 
@@ -373,7 +374,7 @@ def _create_speech_recognizer(
         speech_config.set_profanity(config.profanity)
 
     # Set punctuation behavior if specified
-    if is_given(config.punctuation) and config.punctuation is False:
+    if config.explicit_punctuation:
         speech_config.set_service_property(
             "punctuation", "explicit", speechsdk.ServicePropertyChannel.UriQueryParameter
         )

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
@@ -57,6 +57,7 @@ class STTOptions:
     speech_endpoint: NotGivenOr[str] = NOT_GIVEN
     profanity: NotGivenOr[speechsdk.enums.ProfanityOption] = NOT_GIVEN
     phrase_list: NotGivenOr[list[str] | None] = NOT_GIVEN
+    punctuation: NotGivenOr[str] = NOT_GIVEN
 
 
 class STT(stt.STT):
@@ -77,6 +78,7 @@ class STT(stt.STT):
         profanity: NotGivenOr[speechsdk.enums.ProfanityOption] = NOT_GIVEN,
         speech_endpoint: NotGivenOr[str] = NOT_GIVEN,
         phrase_list: NotGivenOr[list[str] | None] = NOT_GIVEN,
+        punctuation: NotGivenOr[str] = NOT_GIVEN,
     ):
         """
         Create a new instance of Azure STT.
@@ -92,6 +94,8 @@ class STT(stt.STT):
         Args:
             phrase_list: List of words or phrases to boost recognition accuracy.
                         Azure will give higher priority to these phrases during recognition.
+            punctuation: Controls punctuation behavior. Valid values are 'explicit', 'implicit', or None.
+                        'explicit' adds punctuation marks explicitly, 'implicit' uses natural speech patterns.
         """
 
         super().__init__(capabilities=stt.STTCapabilities(streaming=True, interim_results=True))
@@ -138,6 +142,7 @@ class STT(stt.STT):
             profanity=profanity,
             speech_endpoint=speech_endpoint,
             phrase_list=phrase_list,
+            punctuation=punctuation,
         )
         self._streams = weakref.WeakSet[SpeechStream]()
 
@@ -366,6 +371,12 @@ def _create_speech_recognizer(
         )
     if is_given(config.profanity):
         speech_config.set_profanity(config.profanity)
+
+    # Set punctuation behavior if specified
+    if is_given(config.punctuation):
+        speech_config.set_service_property(
+            "punctuation", config.punctuation, speechsdk.ServicePropertyChannel.UriQueryParameter
+        )
 
     kwargs: dict[str, Any] = {}
     if config.language and len(config.language) > 1:

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
@@ -57,7 +57,7 @@ class STTOptions:
     speech_endpoint: NotGivenOr[str] = NOT_GIVEN
     profanity: NotGivenOr[speechsdk.enums.ProfanityOption] = NOT_GIVEN
     phrase_list: NotGivenOr[list[str] | None] = NOT_GIVEN
-    explicit_punctuation: bool
+    explicit_punctuation: bool = False
 
 
 class STT(stt.STT):

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
@@ -57,7 +57,7 @@ class STTOptions:
     speech_endpoint: NotGivenOr[str] = NOT_GIVEN
     profanity: NotGivenOr[speechsdk.enums.ProfanityOption] = NOT_GIVEN
     phrase_list: NotGivenOr[list[str] | None] = NOT_GIVEN
-    punctuation: NotGivenOr[str] = NOT_GIVEN
+    punctuation: NotGivenOr[bool] = NOT_GIVEN
 
 
 class STT(stt.STT):
@@ -78,7 +78,7 @@ class STT(stt.STT):
         profanity: NotGivenOr[speechsdk.enums.ProfanityOption] = NOT_GIVEN,
         speech_endpoint: NotGivenOr[str] = NOT_GIVEN,
         phrase_list: NotGivenOr[list[str] | None] = NOT_GIVEN,
-        punctuation: NotGivenOr[str] = NOT_GIVEN,
+        punctuation: NotGivenOr[bool] = NOT_GIVEN,
     ):
         """
         Create a new instance of Azure STT.
@@ -94,8 +94,8 @@ class STT(stt.STT):
         Args:
             phrase_list: List of words or phrases to boost recognition accuracy.
                         Azure will give higher priority to these phrases during recognition.
-            punctuation: Controls punctuation behavior. Valid values are 'explicit', 'implicit', or None.
-                        'explicit' adds punctuation marks explicitly, 'implicit' uses natural speech patterns.
+            punctuation: Controls punctuation behavior. If False, sets explicit punctuation mode.
+                        If True or NOT_GIVEN, uses Azure's default punctuation behavior.
         """
 
         super().__init__(capabilities=stt.STTCapabilities(streaming=True, interim_results=True))
@@ -373,9 +373,9 @@ def _create_speech_recognizer(
         speech_config.set_profanity(config.profanity)
 
     # Set punctuation behavior if specified
-    if is_given(config.punctuation):
+    if is_given(config.punctuation) and config.punctuation is False:
         speech_config.set_service_property(
-            "punctuation", config.punctuation, speechsdk.ServicePropertyChannel.UriQueryParameter
+            "punctuation", "explicit", speechsdk.ServicePropertyChannel.UriQueryParameter
         )
 
     kwargs: dict[str, Any] = {}


### PR DESCRIPTION
This pull request adds support for configuring punctuation behavior in the Azure Speech-to-Text (STT) plugin. The main change is the introduction of a new `punctuation` option, allowing users to explicitly control how punctuation is handled during speech recognition.

**Azure STT punctuation option support:**

* Added a `punctuation` field to the `STTOptions` class, allowing users to specify punctuation handling.
* Updated the `STT` class constructor to accept the new `punctuation` parameter and documented its behavior in the docstring. [[1]](diffhunk://#diff-e385d376ee185b8e05288d55722a2672de5aae917b2d20f50a0bc86be4af9259R81) [[2]](diffhunk://#diff-e385d376ee185b8e05288d55722a2672de5aae917b2d20f50a0bc86be4af9259R97-R98)
* Passed the `punctuation` option through to the internal configuration in the `STT` class.
* Modified the `_create_speech_recognizer` function to set the Azure service property for punctuation when the option is explicitly set to `False`.