### PR TITLE
feat: (elevenlabs-tts) Add option for preferred_transcript_alignment

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/models.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/models.py
@@ -20,3 +20,8 @@ TTSEncoding = Literal[
     "mp3_44100_128",
     "mp3_44100_192",
 ]
+
+TranscriptAlignment = Literal[
+    "normalized",
+    "original",
+]

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -225,7 +225,9 @@ class TTS(tts.TTS):
             is_given(preferred_transcript_alignment)
             and preferred_transcript_alignment != self._opts.preferred_transcript_alignment
         ):
-            self._opts.preferred_transcript_alignment = cast(TranscriptAlignment, preferred_transcript_alignment)
+            self._opts.preferred_transcript_alignment = cast(
+                TranscriptAlignment, preferred_transcript_alignment
+            )
             changed = True
 
         if changed and self._current_connection:

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -21,7 +21,7 @@ import json
 import os
 import weakref
 from dataclasses import dataclass, replace
-from typing import Any, Union
+from typing import Any, Union, cast
 
 import aiohttp
 
@@ -225,7 +225,7 @@ class TTS(tts.TTS):
             is_given(preferred_transcript_alignment)
             and preferred_transcript_alignment != self._opts.preferred_transcript_alignment
         ):
-            self._opts.preferred_transcript_alignment = preferred_transcript_alignment
+            self._opts.preferred_transcript_alignment = cast(TranscriptAlignment, preferred_transcript_alignment)
             changed = True
 
         if changed and self._current_connection:


### PR DESCRIPTION
### Description
Resolves [#3330](https://github.com/livekit/agents/issues/3330) - SSML tags are getting dropped in TTS node for ElevenLabs on 1.2.7 and above

### Problem
When _use_tts_aligned_transcript_ is enabled in ElevenLabs TTS, SSML tags were being stripped from the transcript output, causing users to lose important markup information that may be needed for downstream processing or display purposes.

### Solution
Added a new preferred_transcript_alignment configuration option to the ElevenLabs TTS node that allows users to choose how transcript text should be handled:

"_normalized_" (default): Uses the processed/normalized text without SSML tags (existing behavior)
"_original_": Retains the original input text including SSML tags in the transcript

### Technical Details

The new option only takes effect when _use_tts_aligned_transcript_ is set to true
Maintains backward compatibility by defaulting to "_normalized_" behavior
Allows users who need SSML preservation to opt into "_original_" mode

### Usage
```
tts=elevenlabs.TTS(
    preferred_transcript_alignment="original"  # Retains SSML tags
)

```
### Testing

 

- [x] Verified that "normalized" mode works as before
- [x]  Verified that "original" mode preserves SSML tags in transcript
- [x]  Confirmed backward compatibility with existing configurations