### PR TITLE
Transport additional arguments passed to Groq to wrapped OAI LLM

### DIFF
--- a/livekit-plugins/livekit-plugins-groq/livekit/plugins/groq/services.py
+++ b/livekit-plugins/livekit-plugins-groq/livekit/plugins/groq/services.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from typing import Any
 
 import openai
 from openai.types import ReasoningEffort
@@ -32,6 +33,7 @@ class LLM(OpenAILLM):
         base_url: NotGivenOr[str] = "https://api.groq.com/openai/v1",
         reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
         client: openai.AsyncClient | None = None,
+        **kwargs: Any,
     ):
         """
         Create a new instance of Groq LLM.
@@ -59,6 +61,7 @@ class LLM(OpenAILLM):
             parallel_tool_calls=parallel_tool_calls,
             tool_choice=tool_choice,
             reasoning_effort=reasoning_effort,
+            **kwargs,
         )
 
 


### PR DESCRIPTION
Groq LLM is a wrapper of the OpenAI one, and it is not accepting any additional argument the OAI LLM could accept, like the `max_completion_tokens`, so we cannot use it.
