### PR TITLE
OAI realtime model wait for updated event

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -777,7 +777,8 @@ class RealtimeSession(
         async def _check_session_update_done() -> None:
             try:
                 await asyncio.wait_for(
-                    self._session_update_done.wait(), timeout=SESSION_UPDATE_TIMEOUT
+                    self._session_update_done.wait(),
+                    timeout=self._realtime_model._opts.conn_options.timeout,
                 )
             except asyncio.TimeoutError as e:
                 logger.error("update_session timed out when creating the connection.")


### PR DESCRIPTION
wait for update event to be responded for `update_tools`, `update_instructions` and session starts.

this will raise an error if session update event is not responded before timeout, to avoid a silent failure.