### PR TITLE
chore: add keyterms support for AssemblyAI plugin

### DIFF
--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -50,6 +50,7 @@ class STTOptions:
     min_end_of_turn_silence_when_confident: NotGivenOr[int] = NOT_GIVEN
     max_turn_silence: NotGivenOr[int] = NOT_GIVEN
     format_turns: NotGivenOr[bool] = NOT_GIVEN
+    keyterms_prompt: NotGivenOr[list[str]] = NOT_GIVEN
 
 
 class STT(stt.STT):
@@ -63,6 +64,7 @@ class STT(stt.STT):
         min_end_of_turn_silence_when_confident: NotGivenOr[int] = NOT_GIVEN,
         max_turn_silence: NotGivenOr[int] = NOT_GIVEN,
         format_turns: NotGivenOr[bool] = NOT_GIVEN,
+        keyterms_prompt: NotGivenOr[list[str]] = NOT_GIVEN,
         http_session: aiohttp.ClientSession | None = None,
         buffer_size_seconds: float = 0.05,
     ):
@@ -85,6 +87,7 @@ class STT(stt.STT):
             min_end_of_turn_silence_when_confident=min_end_of_turn_silence_when_confident,
             max_turn_silence=max_turn_silence,
             format_turns=format_turns,
+            keyterms_prompt=keyterms_prompt,
         )
         self._session = http_session
         self._streams = weakref.WeakSet[SpeechStream]()
@@ -300,6 +303,9 @@ class SpeechStream(stt.SpeechStream):
             "max_turn_silence": self._opts.max_turn_silence
             if is_given(self._opts.max_turn_silence)
             else None,
+            "keyterms_prompt": json.dumps(self._opts.keyterms_prompt)
+            if is_given(self._opts.keyterms_prompt)
+            else None,
         }
 
         headers = {
@@ -310,7 +316,7 @@ class SpeechStream(stt.SpeechStream):
 
         ws_url = "wss://streaming.assemblyai.com/v3/ws"
         filtered_config = {k: v for k, v in live_config.items() if v is not None}
-        url = f"{ws_url}?{urlencode(filtered_config).lower()}"
+        url = f"{ws_url}?{urlencode(filtered_config)}"
         ws = await self._session.ws_connect(url, headers=headers)
         return ws
 


### PR DESCRIPTION
Added keyterms prompt which accepts a list of strings, then JSONifies and URL encodes the list.
Remove .lower() from the URL since keyterms are case sensitive

Keyterms docs: https://www.assemblyai.com/docs/speech-to-text/universal-streaming/keyterms-prompting