### PR TITLE
feat: add image content support in LangGraph message serialization

### DIFF
--- a/livekit-plugins/livekit-plugins-langchain/livekit/plugins/langchain/langgraph.py
+++ b/livekit-plugins/livekit-plugins-langchain/livekit/plugins/langchain/langgraph.py
@@ -16,13 +16,18 @@ from __future__ import annotations
 
 from typing import Any
 
-from langchain_core.messages import AIMessage, BaseMessageChunk, HumanMessage, SystemMessage
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessageChunk,
+    HumanMessage,
+    SystemMessage,
+)
 from langchain_core.runnables import RunnableConfig
 from langgraph.pregel.protocol import PregelProtocol
 
 from livekit.agents import llm, utils
 from livekit.agents.llm import ToolChoice
-from livekit.agents.llm.chat_context import ChatContext, ChatMessage
+from livekit.agents.llm.chat_context import ChatContext, ChatMessage, ImageContent
 from livekit.agents.llm.tool_context import FunctionTool, RawFunctionTool
 from livekit.agents.types import (
     DEFAULT_API_CONNECT_OPTIONS,
@@ -123,17 +128,50 @@ class LangGraphStream(llm.LLMStream):
         messages: list[AIMessage | HumanMessage | SystemMessage] = []
         for item in self._chat_ctx.items:
             # only support chat messages, ignoring tool calls
-            if isinstance(item, ChatMessage):
-                content = item.text_content
-                if content:
-                    if item.role == "assistant":
-                        messages.append(AIMessage(content=content, id=item.id))
-                    elif item.role == "user":
-                        messages.append(HumanMessage(content=content, id=item.id))
-                    elif item.role in ["system", "developer"]:
-                        messages.append(SystemMessage(content=content, id=item.id))
+            if not isinstance(item, ChatMessage):
+                continue
+
+            content = _serialize_chat_message_content(item)
+            if content:
+                if item.role == "assistant":
+                    messages.append(AIMessage(content=content, id=item.id))
+                elif item.role == "user":
+                    messages.append(HumanMessage(content=content, id=item.id))
+                elif item.role in ["system", "developer"]:
+                    messages.append(SystemMessage(content=content, id=item.id))
 
         return {"messages": messages}
+
+
+def _serialize_chat_message_content(
+    item: ChatMessage,
+) -> str | list[dict[str, Any]] | None:
+    """Serialize chat message content into LangChain compatible format.
+    
+    Args:
+        item: The chat message to serialize
+        
+    Returns:
+        str: For text-only messages, returns the text content
+        list[dict]: For messages with images, returns a list of serialized content
+        None: If message has no valid content
+    """
+    if not any(isinstance(c, ImageContent) for c in item.content):
+        return item.text_content
+
+    return [
+        (
+            {"type": "text", "text": c}
+            if isinstance(c, str)
+            else (
+                {"type": "image_url", "image_url": {"url": c.image}}
+                if isinstance(c, ImageContent)
+                else None
+            )
+        )
+        for c in item.content
+        if isinstance(c, (str, ImageContent))
+    ]
 
 
 def _extract_message_chunk(item: Any) -> BaseMessageChunk | str | None:


### PR DESCRIPTION
Adds image content support to LangGraph message serialization so that messages containing images are properly handled by LangChain/LangGraph pipelines.


* Introduced `_serialize_chat_message_content()` to handle multimodal `ChatMessage` content:

  * Text-only → returns string (backward-compatible).
  * Multimodal → returns list of blocks:

    * text → `{"type": "text", "text": "..."}`
    * image → `{"type": "image_url", "image_url": {"url": "<image_url>"}}`
* Updated `LangGraphStream._chat_ctx_to_state()` to use the serializer for `AIMessage`, `HumanMessage`, and `SystemMessage`.


**Why**
Previously, image content wasn’t serialized into LangChain’s multimodal format, preventing proper handling in graph pipelines.