### PR TITLE
don't ever send meta to openai

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1053,6 +1053,8 @@ class RealtimeSession(
             elif is_raw_function_tool(tool):
                 tool_info = get_raw_function_info(tool)
                 tool_desc = tool_info.raw_schema
+                if "meta" in tool_desc:
+                    del tool_desc["meta"]  # unset meta key
                 tool_desc["type"] = "function"  # internally tagged
             else:
                 logger.error(


### PR DESCRIPTION
https://github.com/livekit/agents/pull/3212 fixed the problem of 
```
"Error(message=\"Unknown parameter: 'session.tools[3].meta'.\", type='invalid_request_error', code='unknown_parameter', event_id='tools_update_2fb43fca9f1c', param='session.tools[3].meta')"
```

But it did this by removing the meta only for the cases where meta is empty. However, meta is part of the MCP specification and tools can very well have a meta field.

In this PR we trim the meta from the tools right before passing them to OAI in the realtime API, which is the one that has super strict model validations.