### PR TITLE
fix user speaking span duration

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1057,7 +1057,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         elif self._user_speaking_span is not None:
             end_time = last_speaking_time or time.time()
             self._user_speaking_span.set_attribute(trace_types.ATTR_END_TIME, end_time)
-            self._user_speaking_span.end(end_time=int(end_time * 1_000_000_000))  # nanoseconds
+            self._user_speaking_span.end()
             self._user_speaking_span = None
 
         if state == "listening" and self._agent_state == "listening":


### PR DESCRIPTION
addresses #3396 

removed converting the end time to nanoseconds for an accurate speaking duration span