### PR TITLE
Removed OpenAI-Beta header as per the docs

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -649,7 +649,6 @@ class RealtimeSession(
                 headers["api-key"] = self._realtime_model._opts.api_key
         else:
             headers["Authorization"] = f"Bearer {self._realtime_model._opts.api_key}"
-            headers["OpenAI-Beta"] = "realtime=v1"
 
         url = process_base_url(
             self._realtime_model._opts.base_url,


### PR DESCRIPTION
In the docs:
https://platform.openai.com/docs/guides/realtime#beta-to-ga-migration
For REST API requests, WebSocket connections, and other interfaces with the Realtime API, beta users had to include the following header with each request:
OpenAI-Beta: realtime=v1
This header should be removed for requests to the GA interface. To retain the behavior of the beta API, you should continue to include this header.