### PR TITLE
fix(sarvam-tts): add bulbul:v3-beta support and make pitch/loudness optional

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -100,9 +100,25 @@ MODEL_SPEAKER_COMPATIBILITY = {
     },
     "bulbul:v3-beta": {
         "all": [
-            "sakshi", "harsh", "chirag", "ritu", "aditya", "isha", "priya", "neha",
-            "rahul", "pooja", "rohan", "simran", "kavya", "anjali", "sneha",
-            "kiran", "vikram", "rajesh", "sunita"
+            "sakshi",
+            "harsh",
+            "chirag",
+            "ritu",
+            "aditya",
+            "isha",
+            "priya",
+            "neha",
+            "rahul",
+            "pooja",
+            "rohan",
+            "simran",
+            "kavya",
+            "anjali",
+            "sneha",
+            "kiran",
+            "vikram",
+            "rajesh",
+            "sunita",
         ],
     },
 }
@@ -280,7 +296,8 @@ class ChunkedStream(tts.ChunkedStream):
                     error_text = await res.text()
                     logger.error(f"Sarvam TTS API error: {res.status} - {error_text}")
                     raise APIStatusError(
-                        message=f"Sarvam TTS API Error: {error_text}", status_code=res.status
+                        message=f"Sarvam TTS API Error: {error_text}",
+                        status_code=res.status,
                     )
 
                 response_json = await res.json()

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -42,7 +42,7 @@ from .log import logger
 SARVAM_TTS_BASE_URL = "https://api.sarvam.ai/text-to-speech"
 
 # Sarvam TTS specific models and speakers
-SarvamTTSModels = Literal["bulbul:v2"]
+SarvamTTSModels = Literal["bulbul:v2", "bulbul:v3-beta"]
 
 # Supported languages in BCP-47 format
 SarvamTTSLanguages = Literal[
@@ -69,6 +69,26 @@ SarvamTTSSpeakers = Literal[
     "abhilash",
     "karun",
     "hitesh",
+    # bulbul:v3-beta speakers (lowercase)
+    "sakshi",
+    "harsh",
+    "chirag",
+    "ritu",
+    "aditya",
+    "isha",
+    "priya",
+    "neha",
+    "rahul",
+    "pooja",
+    "rohan",
+    "simran",
+    "kavya",
+    "anjali",
+    "sneha",
+    "kiran",
+    "vikram",
+    "rajesh",
+    "sunita",
 ]
 
 # Model-Speaker compatibility mapping
@@ -77,6 +97,13 @@ MODEL_SPEAKER_COMPATIBILITY = {
         "female": ["anushka", "manisha", "vidya", "arya"],
         "male": ["abhilash", "karun", "hitesh"],
         "all": ["anushka", "manisha", "vidya", "arya", "abhilash", "karun", "hitesh"],
+    },
+    "bulbul:v3-beta": {
+        "all": [
+            "sakshi", "harsh", "chirag", "ritu", "aditya", "isha", "priya", "neha",
+            "rahul", "pooja", "rohan", "simran", "kavya", "anjali", "sneha", 
+            "kiran", "vikram", "rajesh", "sunita"
+        ],
     },
 }
 
@@ -136,13 +163,13 @@ class TTS(tts.TTS):
 
     Args:
         target_language_code: BCP-47 language code for supported Indian languages
-        model: Sarvam TTS model to use (only bulbul:v2 supported)
+        model: Sarvam TTS model to use (bulbul:v2 or bulbul:v3-beta)
         speaker: Voice to use for synthesis
         speech_sample_rate: Audio sample rate in Hz
         num_channels: Number of audio channels (Sarvam outputs mono)
-        pitch: Voice pitch adjustment (-20.0 to 20.0)
+        pitch: Voice pitch adjustment (-20.0 to 20.0) - only supported in v2 for now 
         pace: Speech rate multiplier (0.5 to 2.0)
-        loudness: Volume multiplier (0.5 to 2.0)
+        loudness: Volume multiplier (0.5 to 2.0) - only supported in v2 for now
         enable_preprocessing: Whether to use text preprocessing
         api_key: Sarvam.ai API key (required)
         base_url: API endpoint URL
@@ -226,13 +253,16 @@ class ChunkedStream(tts.ChunkedStream):
             "target_language_code": self._opts.target_language_code,
             "text": self._input_text,
             "speaker": self._opts.speaker,
-            "pitch": self._opts.pitch,
             "pace": self._opts.pace,
-            "loudness": self._opts.loudness,
             "speech_sample_rate": self._opts.speech_sample_rate,
             "enable_preprocessing": self._opts.enable_preprocessing,
             "model": self._opts.model,
         }
+        
+        # Only include pitch and loudness for v2 model (not supported in v3-beta)
+        if self._opts.model == "bulbul:v2":
+            payload["pitch"] = self._opts.pitch
+            payload["loudness"] = self._opts.loudness
         headers = {
             "api-subscription-key": self._opts.api_key,
             "Content-Type": "application/json",

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -42,7 +42,7 @@ from .log import logger
 SARVAM_TTS_BASE_URL = "https://api.sarvam.ai/text-to-speech"
 
 # Sarvam TTS specific models and speakers
-SarvamTTSModels = Literal["bulbul:v2", "bulbul:v3-beta"]
+SarvamTTSModels = Literal["bulbul:v2"]
 
 # Supported languages in BCP-47 format
 SarvamTTSLanguages = Literal[
@@ -69,26 +69,6 @@ SarvamTTSSpeakers = Literal[
     "abhilash",
     "karun",
     "hitesh",
-    # bulbul:v3-beta speakers (lowercase)
-    "sakshi",
-    "harsh",
-    "chirag",
-    "ritu",
-    "aditya",
-    "isha",
-    "priya",
-    "neha",
-    "rahul",
-    "pooja",
-    "rohan",
-    "simran",
-    "kavya",
-    "anjali",
-    "sneha",
-    "kiran",
-    "vikram",
-    "rajesh",
-    "sunita",
 ]
 
 # Model-Speaker compatibility mapping
@@ -97,30 +77,7 @@ MODEL_SPEAKER_COMPATIBILITY = {
         "female": ["anushka", "manisha", "vidya", "arya"],
         "male": ["abhilash", "karun", "hitesh"],
         "all": ["anushka", "manisha", "vidya", "arya", "abhilash", "karun", "hitesh"],
-    },
-    "bulbul:v3-beta": {
-        "all": [
-            "sakshi",
-            "harsh",
-            "chirag",
-            "ritu",
-            "aditya",
-            "isha",
-            "priya",
-            "neha",
-            "rahul",
-            "pooja",
-            "rohan",
-            "simran",
-            "kavya",
-            "anjali",
-            "sneha",
-            "kiran",
-            "vikram",
-            "rajesh",
-            "sunita",
-        ],
-    },
+    }
 }
 
 
@@ -179,7 +136,7 @@ class TTS(tts.TTS):
 
     Args:
         target_language_code: BCP-47 language code for supported Indian languages
-        model: Sarvam TTS model to use (bulbul:v2 or bulbul:v3-beta)
+        model: Sarvam TTS model to use (bulbul:v2)
         speaker: Voice to use for synthesis
         speech_sample_rate: Audio sample rate in Hz
         num_channels: Number of audio channels (Sarvam outputs mono)

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -101,7 +101,7 @@ MODEL_SPEAKER_COMPATIBILITY = {
     "bulbul:v3-beta": {
         "all": [
             "sakshi", "harsh", "chirag", "ritu", "aditya", "isha", "priya", "neha",
-            "rahul", "pooja", "rohan", "simran", "kavya", "anjali", "sneha", 
+            "rahul", "pooja", "rohan", "simran", "kavya", "anjali", "sneha",
             "kiran", "vikram", "rajesh", "sunita"
         ],
     },
@@ -167,7 +167,7 @@ class TTS(tts.TTS):
         speaker: Voice to use for synthesis
         speech_sample_rate: Audio sample rate in Hz
         num_channels: Number of audio channels (Sarvam outputs mono)
-        pitch: Voice pitch adjustment (-20.0 to 20.0) - only supported in v2 for now 
+        pitch: Voice pitch adjustment (-20.0 to 20.0) - only supported in v2 for now
         pace: Speech rate multiplier (0.5 to 2.0)
         loudness: Volume multiplier (0.5 to 2.0) - only supported in v2 for now
         enable_preprocessing: Whether to use text preprocessing
@@ -258,7 +258,6 @@ class ChunkedStream(tts.ChunkedStream):
             "enable_preprocessing": self._opts.enable_preprocessing,
             "model": self._opts.model,
         }
-        
         # Only include pitch and loudness for v2 model (not supported in v3-beta)
         if self._opts.model == "bulbul:v2":
             payload["pitch"] = self._opts.pitch


### PR DESCRIPTION
# fix(sarvam-tts): add bulbul:v3-beta support and make pitch/loudness optional

## What does this PR do?  
This PR updates the **Sarvam.ai TTS integration** in LiveKit agents to support the recently released `bulbul:v3-beta` model.  

## Why is this needed?  
- Sarvam deprecated the **mandatory `pitch` and `loudness` parameters** in `bulbul:v3-beta`.  
- LiveKit’s existing integration enforces these fields, which causes runtime errors when developers try the new model.  

## Changes made  
- Made `pitch` and `loudness` optional → only included in API payload for `bulbul:v2`.  
- Introduced **model-speaker compatibility validation** to avoid misconfiguration.  

## Impact  
- Developers can now use both **`bulbul:v2`** and **`bulbul:v3-beta`** seamlessly.  
- Backward compatibility is preserved for v2 users.  
- Unlocks testing and adoption of Sarvam’s new TTS model within LiveKit.  

https://www.notion.so/sarvamai/Bulbul-V3-Beta-testing-26539c96b62d80259fe2c8dff4138433?source=copy_link