### PR TITLE
revert #3206, do not auto enable use_tts_aligned_transcript

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -284,11 +284,7 @@ class AgentActivity(RecognitionHooks):
             else self._session.options.use_tts_aligned_transcript
         )
 
-        if is_given(use_aligned_transcript):
-            return use_aligned_transcript
-
-        # enable for non-streaming stt automatically if not specified
-        return self.tts is not None and not self.tts.capabilities.streaming
+        return use_aligned_transcript is True
 
     async def update_instructions(self, instructions: str) -> None:
         self._agent._instructions = instructions


### PR DESCRIPTION
considering the side effect, reverting the automatic enabled `use_tts_aligned_transcript` https://github.com/livekit/agents/issues/3421