### PR TITLE
docs(CONTRIBUTING.md): add linting/formatting command guideline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ uv pip install pip && uv run mypy --install-types --non-interactive \
 ### Linting
 
 ```bash
-uv run ruff check .
+uv run ruff check --output-format=github .
 ```
 
 ### Formating

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,3 +45,61 @@ be approved:
 If you can't contribute code, you can still help us greatly by helping out community members who
 may have questions about the framework and how to use it. Join the `#agents` channel on
 [our Slack](https://livekit.io/join-slack).
+
+## Typechecking, linting and formatting
+
+The CI validates this but to do checks locally see the following example commmands:
+
+### Typechecking
+
+```bash
+uv pip install pip && uv run mypy --install-types --non-interactive \
+    -p livekit.agents \
+    -p livekit.plugins.openai \
+    -p livekit.plugins.anthropic \
+    -p livekit.plugins.mistralai \
+    -p livekit.plugins.assemblyai \
+    -p livekit.plugins.aws \
+    -p livekit.plugins.azure \
+    -p livekit.plugins.bey \
+    -p livekit.plugins.bithuman \
+    -p livekit.plugins.cartesia \
+    -p livekit.plugins.clova \
+    -p livekit.plugins.deepgram \
+    -p livekit.plugins.elevenlabs \
+    -p livekit.plugins.fal \
+    -p livekit.plugins.gladia \
+    -p livekit.plugins.google \
+    -p livekit.plugins.groq \
+    -p livekit.plugins.hume \
+    -p livekit.plugins.minimal \
+    -p livekit.plugins.neuphonic \
+    -p livekit.plugins.nltk \
+    -p livekit.plugins.playai \
+    -p livekit.plugins.resemble \
+    -p livekit.plugins.rime \
+    -p livekit.plugins.silero \
+    -p livekit.plugins.speechify \
+    -p livekit.plugins.speechmatics \
+    -p livekit.plugins.tavus \
+    -p livekit.plugins.turn_detector \
+    -p livekit.plugins.hedra \
+    -p livekit.plugins.langchain \
+    -p livekit.plugins.baseten \
+    -p livekit.plugins.sarvam \
+    -p livekit.plugins.inworld \
+    -p livekit.plugins.simli \
+    -p livekit.plugins.anam
+```
+
+### Linting
+
+```bash
+uv run ruff check .
+```
+
+### Formating
+
+```bash
+uv run ruff format .
+```


### PR DESCRIPTION
It wasn't immediately clear to me as a contibutor what commands to run for linting/typechecking/formatting without inspecting what the CI scripts were doing, so thought it would be nice to make it more explicit. In particular, even after reading the CI scripts, I didn't notice you need to run a `uv pip install pip` before the `uv run mypy` will work, so I hope this will help other contributors get up and running faster.