### PR TITLE
fix(openai-realtime): nest session.update audio fields; omit null tur…

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/utils.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/utils.py
@@ -91,20 +91,25 @@ def to_turn_detection(
 
     if isinstance(turn_detection, TurnDetection):
         if turn_detection.type == "server_vad":
-            return realtime.realtime_audio_input_turn_detection.ServerVad(
-                type="server_vad",
-                threshold=turn_detection.threshold,
-                prefix_padding_ms=turn_detection.prefix_padding_ms,
-                silence_duration_ms=turn_detection.silence_duration_ms,
-                create_response=turn_detection.create_response,
-            )
+            kwargs = {"type": "server_vad"}
+            if turn_detection.threshold is not None:
+                kwargs["threshold"] = turn_detection.threshold
+            if turn_detection.prefix_padding_ms is not None:
+                kwargs["prefix_padding_ms"] = turn_detection.prefix_padding_ms
+            if turn_detection.silence_duration_ms is not None:
+                kwargs["silence_duration_ms"] = turn_detection.silence_duration_ms
+            if turn_detection.create_response is not None:
+                kwargs["create_response"] = turn_detection.create_response
+            return realtime.realtime_audio_input_turn_detection.ServerVad(**kwargs)
         elif turn_detection.type == "semantic_vad":
-            return realtime.realtime_audio_input_turn_detection.SemanticVad(
-                type="semantic_vad",
-                create_response=turn_detection.create_response,
-                eagerness=turn_detection.eagerness,
-                interrupt_response=turn_detection.interrupt_response,
-            )
+            kwargs = {"type": "semantic_vad"}
+            if turn_detection.create_response is not None:
+                kwargs["create_response"] = turn_detection.create_response
+            if turn_detection.eagerness is not None:
+                kwargs["eagerness"] = turn_detection.eagerness
+            if turn_detection.interrupt_response is not None:
+                kwargs["interrupt_response"] = turn_detection.interrupt_response
+            return realtime.realtime_audio_input_turn_detection.SemanticVad(**kwargs)
         else:
             raise ValueError(f"unsupported turn detection type: {turn_detection.type}")
     return turn_detection


### PR DESCRIPTION
…n_detection

OpenAI Realtime v1 expects audio-related options to be nested under `session.audio`.
Sending them at the top level (e.g., `session.turn_detection`, `session.voice`,
`session.input_audio_transcription`) results in `unknown_parameter` errors.
Additionally, `turn_detection.create_response: null` is rejected with `invalid_type`.

What’s changed
- RealtimeSession.update_options:
  - voice → session.audio.output.voice
  - speed → session.audio.output.speed
  - turn_detection → session.audio.input.turn_detection
  - input_audio_transcription → session.audio.input.transcription
  - input_audio_noise_reduction → session.audio.input.noise_reduction
  - Only include `audio` in the payload when at least one of the above is set.
- utils.to_turn_detection:
  - Build kwargs conditionally (only include fields when not None), so
    `create_response` is never serialized as `null`.

Why
- Fixes these runtime errors from OpenAI Realtime:
  - Unknown parameter: 'session.turn_detection'
  - Unknown parameter: 'session.voice'
  - Unknown parameter: 'session.input_audio_transcription'
  - Unknown parameter: 'session.input_audio_noise_reduction'
  - Invalid type for 'session.audio.input.turn_detection.create_response': expected boolean, got null
