### PR TITLE
fix(agent_activity): correctly nest OpenTelemetry spans within existing spans

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -9,7 +9,7 @@ from collections.abc import AsyncIterable, Coroutine, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
-from opentelemetry import trace
+from opentelemetry import trace, context as otel_context
 
 from livekit import rtc
 from livekit.agents.llm.realtime import MessageGeneration
@@ -359,7 +359,19 @@ class AgentActivity(RecognitionHooks):
         if speech_handle is not None:
             tk1 = _SpeechHandleContextVar.set(speech_handle)
 
-        task = asyncio.create_task(coro, name=name)
+        # Capture the current OpenTelemetry context to ensure proper span nesting
+        current_context = otel_context.get_current()
+
+        # Create a wrapper coroutine that runs in the captured context
+        async def _context_aware_coro() -> Any:
+            # Attach the captured context before running the original coroutine
+            token = otel_context.attach(current_context)
+            try:
+                return await coro
+            finally:
+                otel_context.detach(token)
+
+        task = asyncio.create_task(_context_aware_coro(), name=name)
         self._speech_tasks.append(task)
         task.add_done_callback(lambda _: self._speech_tasks.remove(task))
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -9,7 +9,7 @@ from collections.abc import AsyncIterable, Coroutine, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
-from opentelemetry import trace, context as otel_context
+from opentelemetry import context as otel_context, trace
 
 from livekit import rtc
 from livekit.agents.llm.realtime import MessageGeneration


### PR DESCRIPTION
Without these, we see a new OpenTelemetry span being created for each realtime_assistant_turn

Before this PR:

- Many spans per session

<img width="1552" height="1108" alt="image" src="https://github.com/user-attachments/assets/3674434e-ce9b-49a3-bbdf-930f6addc236" />


After:

- A single span  per session
<img width="385" height="1198" alt="image" src="https://github.com/user-attachments/assets/a899bd24-1770-4478-bdaf-90583dfe9bec" />
