### PR TITLE
feat: add model attribute to metrics tracking in LLM

### DIFF
--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -266,6 +266,7 @@ class LLMStream(ABC):
             prompt_cached_tokens=usage.prompt_cached_tokens if usage else 0,
             total_tokens=usage.total_tokens if usage else 0,
             tokens_per_second=usage.completion_tokens / duration if usage else 0.0,
+            model=self._llm.model,
         )
         if self._llm_request_span:
             # livekit metrics attribute

--- a/livekit-agents/livekit/agents/metrics/base.py
+++ b/livekit-agents/livekit/agents/metrics/base.py
@@ -18,6 +18,7 @@ class LLMMetrics(BaseModel):
     prompt_cached_tokens: int
     total_tokens: int
     tokens_per_second: float
+    model: str
     speech_id: str | None = None
 
 

--- a/livekit-agents/livekit/agents/metrics/utils.py
+++ b/livekit-agents/livekit/agents/metrics/utils.py
@@ -19,6 +19,7 @@ def log_metrics(metrics: AgentMetrics, *, logger: logging.Logger | None = None) 
                 "prompt_cached_tokens": metrics.prompt_cached_tokens,
                 "completion_tokens": metrics.completion_tokens,
                 "tokens_per_second": round(metrics.tokens_per_second, 2),
+                "model": metrics.model,
             },
         )
     elif isinstance(metrics, RealtimeModelMetrics):


### PR DESCRIPTION
I need to analyze LLM metrics logs to calculate costs. Since each agent uses a different LLM model, it is necessary to add a model field in the logs.