### PR TITLE
Bug fix: Safe handling in ChatContext.truncate() when fewer items than max_items

### DIFF
--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -287,6 +287,10 @@ class ChatContext:
         Removes leading function calls to avoid partial function outputs.
         Preserves the first system message by adding it back to the beginning.
         """
+
+        if len(self._items) <= max_items:
+            return self
+
         instructions = next(
             (item for item in self._items if item.type == "message" and item.role == "system"),
             None,


### PR DESCRIPTION
This PR resolves a bug in the ChatContext.truncate() method where the system message could be duplicated when truncation was applied on a context with fewer items than max_items. The fix is simple and quite self explanatory.