### PR TITLE
fix(stt): Correct metrics calculation on recognize retries

### DIFF
--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -114,9 +114,9 @@ class STT(
         language: NotGivenOr[str] = NOT_GIVEN,
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
     ) -> SpeechEvent:
+        start_time = time.perf_counter()
         for i in range(conn_options.max_retry + 1):
             try:
-                start_time = time.perf_counter()
                 event = await self._recognize_impl(
                     buffer, language=language, conn_options=conn_options
                 )


### PR DESCRIPTION
The `start_time` for the `recognize` method was incorrectly placed inside the retry loop. This resulted in two issues:

1. The reported `duration` only measured the time of the last successful attempt, not the total duration including retries.
2. An `STTMetrics` event was emitted after each attempt, leading to the `audio_duration` being counted multiple times for the same operation when retries occurred.

This commit moves the `start_time` initialization outside the loop. Now, the `duration` accurately reflects the total time spent, and metrics are emitted only once upon final success, ensuring correct accounting of `audio_duration`.