### PR TITLE
fix(stt): resolve audio_duration over-reporting in streaming STT plugins

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -41,7 +41,7 @@ from livekit.agents.types import (
 )
 from livekit.agents.utils import AudioBuffer, is_given
 
-from ._utils import PeriodicCollector, _to_deepgram_url
+from ._utils import _to_deepgram_url
 from .log import logger
 from .models import DeepgramLanguages, DeepgramModels
 
@@ -361,10 +361,7 @@ class SpeechStream(stt.SpeechStream):
         self._session = http_session
         self._opts.endpoint_url = base_url
         self._speaking = False
-        self._audio_duration_collector = PeriodicCollector(
-            callback=self._on_audio_duration_report,
-            duration=5.0,
-        )
+        self._speech_duration = 0.0
 
         self._request_id = ""
         self._reconnect_event = asyncio.Event()
@@ -463,11 +460,10 @@ class SpeechStream(stt.SpeechStream):
                     has_ended = True
 
                 for frame in frames:
-                    self._audio_duration_collector.push(frame.duration)
+                    self._speech_duration += frame.duration
                     await ws.send_bytes(frame.data.tobytes())
 
                     if has_ended:
-                        self._audio_duration_collector.flush()
                         await ws.send_str(SpeechStream._FINALIZE_MSG)
                         has_ended = False
 
@@ -581,15 +577,6 @@ class SpeechStream(stt.SpeechStream):
             raise APIConnectionError("failed to connect to deepgram") from e
         return ws
 
-    def _on_audio_duration_report(self, duration: float) -> None:
-        usage_event = stt.SpeechEvent(
-            type=stt.SpeechEventType.RECOGNITION_USAGE,
-            request_id=self._request_id,
-            alternatives=[],
-            recognition_usage=stt.RecognitionUsage(audio_duration=duration),
-        )
-        self._event_ch.send_nowait(usage_event)
-
     def _process_stream_event(self, data: dict) -> None:
         assert self._opts.language is not None
 
@@ -648,6 +635,17 @@ class SpeechStream(stt.SpeechStream):
             if is_endpoint and self._speaking:
                 self._speaking = False
                 self._event_ch.send_nowait(stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH))
+                
+                # Report usage only at the end of speech
+                if self._speech_duration > 0:
+                    usage_event = stt.SpeechEvent(
+                        type=stt.SpeechEventType.RECOGNITION_USAGE,
+                        request_id=request_id,
+                        alternatives=[],
+                        recognition_usage=stt.RecognitionUsage(audio_duration=self._speech_duration),
+                    )
+                    self._event_ch.send_nowait(usage_event)
+                    self._speech_duration = 0.0
 
         elif data["type"] == "Metadata":
             pass  # metadata is too noisy


### PR DESCRIPTION
**Background information:**
By summing up the audio_duration in the STT metrics, I found that the total duration is even longer than the time connected to livekit, which makes it impossible to accurately reflect the actual usage of STT. I am trying to fix this issue.

**Problem:**
STTMetrics.audio_duration was being over-reported in streaming scenarios due to inappropriate usage reporting mechanism in Deepgram and Gladia plugins. The periodic reporting approach (every 5 seconds) caused duplicate counting of the same audio segments, leading to inflated usage metrics.

**Root Cause:**
- Used PeriodicCollector that accumulated audio duration and reported every 5s
- This resulted in overlapping time periods being counted multiple times
- Audio segments were reported before speech completion, causing duplication

**Solution:**
- Replace PeriodicCollector with simple duration accumulation
- Report usage only once at END_OF_SPEECH event
- Reset duration counter after each report to prevent carryover
- Align with Speechmatics plugin's correct implementation pattern

**Changes:**
- Deepgram: Remove PeriodicCollector, add _speech_duration tracking
- Gladia: Remove PeriodicCollector, add _speech_duration tracking
- Both: Report usage only at speech completion with immediate reset

**Impact:**
- Accurate audio duration reporting in streaming STT scenarios
- Consistent metrics across all STT plugin implementations
- Eliminates false usage inflation that affected billing/analytics"