### PR TITLE
add delete_room_on_close to RoomInputOptions

### DIFF
--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -485,5 +485,6 @@ class RoomIO:
         self._update_state_atask = asyncio.create_task(_set_state())
 
     def _on_agent_session_close(self, ev: CloseEvent) -> None:
-        job_ctx = get_job_context()
-        self._delete_room_task = job_ctx.delete_room()
+        if self._input_options.delete_room_on_close:
+            job_ctx = get_job_context()
+            self._delete_room_task = job_ctx.delete_room()

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 from livekit import rtc
 
 from ... import utils
+from ...job import get_job_context
 from ...log import logger
 from ...types import (
     ATTRIBUTE_AGENT_STATE,
@@ -16,7 +17,7 @@ from ...types import (
     TOPIC_CHAT,
     NotGivenOr,
 )
-from ..events import AgentStateChangedEvent, CloseReason, UserInputTranscribedEvent
+from ..events import AgentStateChangedEvent, CloseEvent, CloseReason, UserInputTranscribedEvent
 from ..io import AudioInput, AudioOutput, TextOutput, VideoInput
 from ..transcription import TranscriptSynchronizer
 from ._pre_connect_audio import PreConnectAudioHandler
@@ -82,6 +83,8 @@ class RoomInputOptions:
     close_on_disconnect: bool = True
     """Close the AgentSession if the linked participant disconnects with reasons in
     CLIENT_INITIATED, ROOM_DELETED, or USER_REJECTED."""
+    delete_room_on_close: bool = True
+    """Delete the room when the AgentSession is closed"""
 
 
 @dataclass
@@ -146,6 +149,7 @@ class RoomIO:
         self._tasks: set[asyncio.Task[Any]] = set()
         self._update_state_atask: asyncio.Task[None] | None = None
         self._close_session_atask: asyncio.Task[None] | None = None
+        self._delete_room_task: asyncio.Task[None] | None = None
 
         self._pre_connect_audio_handler: PreConnectAudioHandler | None = None
         self._text_stream_handler_registered = False
@@ -249,6 +253,7 @@ class RoomIO:
 
         self._agent_session.on("agent_state_changed", self._on_agent_state_changed)
         self._agent_session.on("user_input_transcribed", self._on_user_input_transcribed)
+        self._agent_session.on("close", self._on_agent_session_close)
         self._agent_session._room_io = self
 
     async def aclose(self) -> None:
@@ -419,13 +424,13 @@ class RoomIO:
     def _on_participant_disconnected(self, participant: rtc.RemoteParticipant) -> None:
         if not (linked := self.linked_participant) or participant.identity != linked.identity:
             return
-
         self._participant_available_fut = asyncio.Future[rtc.RemoteParticipant]()
 
         if (
             self._input_options.close_on_disconnect
             and participant.disconnect_reason in DEFAULT_CLOSE_ON_DISCONNECT_REASONS
             and not self._close_session_atask
+            and not self._delete_room_task
         ):
             logger.info(
                 "closing agent session due to participant disconnect "
@@ -478,3 +483,7 @@ class RoomIO:
             self._update_state_atask.cancel()
 
         self._update_state_atask = asyncio.create_task(_set_state())
+
+    def _on_agent_session_close(self, ev: CloseEvent) -> None:
+        job_ctx = get_job_context()
+        self._delete_room_task = job_ctx.delete_room()


### PR DESCRIPTION
when the `AgentSession` closes, the room is deleted by default