### PR TITLE
force interrupt speech in aclose_impl

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -671,13 +671,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
             if self._activity is not None:
                 if not drain:
-                    try:
-                        await self._activity.interrupt()
-                    except RuntimeError:
-                        # uninterruptible speech
-                        # TODO(long): force interrupt or wait for it to finish?
-                        # it might be an audio played from the error callback
-                        pass
+                    await self._activity.interrupt(force=True)
                 await self._activity.drain()
 
                 # wait any uninterruptible speech to finish


### PR DESCRIPTION
There was a TODO here before, and I think it can be removed now.