### PR TITLE
fix: prevent deadlock in speech scheduling after consecutive delay

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -962,6 +962,11 @@ class AgentActivity(RecognitionHooks):
                     await asyncio.sleep(
                         self.min_consecutive_speech_delay - (time.time() - last_playout_ts)
                     )
+                    # check again if speech is done after sleep delay
+                    if speech.done():
+                        # skip done speech (interrupted during delay)
+                        self._current_speech = None
+                        continue
                 speech._authorize_generation()
                 await speech._wait_for_generation()
                 self._current_speech = None


### PR DESCRIPTION
Add race condition check in _scheduling_task to avoid processing already-done speeches after min_consecutive_speech_delay sleep. This prevents potential deadlocks when speech.done() changes between the initial check and generation authorization.

- Add speech.done() check after asyncio.sleep() in delay branch
- Only check when min_consecutive_speech_delay > 0.0 to optimize performance
- Prevents calling _authorize_generation() on completed speeches

fix: https://github.com/livekit/agents/issues/3496