### PR TITLE
fix gemini llm: avoid mixing tool output and user message in a single turn

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/google.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/google.py
@@ -34,7 +34,8 @@ def to_chat_ctx(
         elif msg.type == "function_call":
             role = "model"
         elif msg.type == "function_call_output":
-            role = "user"
+            # tool output shouldn't be mixed with other messages
+            role = "tool"
 
         # if the effective role changed, finalize the previous turn.
         if role != current_role:
@@ -75,6 +76,11 @@ def to_chat_ctx(
 
     if current_role is not None and parts:
         turns.append({"role": current_role, "parts": parts})
+
+    # convert role tool to user for gemini
+    for turn in turns:
+        if turn["role"] == "tool":
+            turn["role"] = "user"
 
     # Gemini requires the last message to end with user's turn before they can generate
     if inject_dummy_user_message and current_role != "user":


### PR DESCRIPTION
When a tool output didn't create a response, the follow up user message may be added to the same turn of the tool output, the expect messages are like following:
```python
 {'parts': [{'text': "Yeah. What's the word in New York?"}], 'role': 'user'},
 {'parts': [{'text': 'I can look up the weather for you in New York. I will '
                     'need the latitude and longitude for that, but I can '
                     'estimate'}],
  'role': 'model'},
 {'parts': [{'text': 'Yes.'}], 'role': 'user'},
 {'parts': [{'function_call': {'args': {'latitude': '40.7128',
                                        'location': 'New York',
                                        'longitude': '-74.0060'},
                               'id': 'function_call_7bd887d7da6c',
                               'name': 'lookup_weather'}}],
  'role': 'model'},
 {'parts': [{'function_response': {'id': 'function_call_7bd887d7da6c',
                                   'name': 'lookup_weather',
                                   'response': {'output': ''}}}],
  'role': 'user'},  # <--no response generated here or interrupted
 {'parts': [{'text': 'Hello. How are you?'}], 'role': 'user'}]
```