### PR TITLE
fix missing simultaneous message & tool call

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1800,6 +1800,7 @@ class AgentActivity(RecognitionHooks):
             )
 
         if generated_msg:
+            chat_ctx.insert(generated_msg)
             self._agent._chat_ctx.insert(generated_msg)
             self._session._conversation_item_added(generated_msg)
             current_span.set_attribute(


### PR DESCRIPTION
When the LLM returns both a message, and one or more tool calls, the message was not being added to the locally copied chat context. This resulted in the tool call result being executed without the first message. Typically this caused the model to repeat itself.

I believe this resolves the issue #3407.