### PR TITLE
Configure Prometheus in multi process mode

### DIFF
--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import logging
 import multiprocessing as mp
+import os
 import socket
 import sys
 import threading
@@ -278,6 +279,23 @@ class SupervisedProc(ABC):
 
         await self._join_fut
         self._exitcode = self._proc.exitcode
+
+        # Mark process as dead for prometheus multiprocess mode.
+        # This is required to clean up stale metrics.
+        if "PROMETHEUS_MULTIPROC_DIR" in os.environ and self._pid:
+            try:
+                from prometheus_client import multiprocess
+                multiprocess.mark_process_dead(self._pid)
+                logger.debug(
+                    "marked process as dead for prometheus multiprocess mode",
+                    extra=self.logging_extra(),
+                )
+            except Exception as e:
+                logger.warning(
+                    f"failed to mark process as dead for prometheus: {e}",
+                    extra=self.logging_extra(),
+                )
+
         self._proc.close()
         await aio.cancel_and_wait(ping_task, read_ipc_task, main_task)
 

--- a/livekit-agents/livekit/agents/telemetry/http_server.py
+++ b/livekit-agents/livekit/agents/telemetry/http_server.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import os
 
 import aiohttp.web_request
 from aiohttp import web
 from prometheus_client import (
     CONTENT_TYPE_LATEST,
+    CollectorRegistry,
     generate_latest,
+    multiprocess,
 )
 
 from .. import utils
@@ -14,9 +17,15 @@ from .. import utils
 
 async def metrics(_request: aiohttp.web_request.Request) -> web.Response:
     def _get_metrics() -> bytes:
-        # registry = CollectorRegistry(auto_describe=True)
-        # multiprocess.MultiProcessCollector(registry)
-        return generate_latest()
+        # Check if multiprocess mode is enabled
+        if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
+            # Create a new registry for this request to collect metrics from all processes
+            registry = CollectorRegistry(auto_describe=True)
+            multiprocess.MultiProcessCollector(registry)
+            return generate_latest(registry)
+        else:
+            # Use default global registry if multiprocess mode is not enabled
+            return generate_latest()
 
     loop = asyncio.get_running_loop()
     data = await loop.run_in_executor(None, _get_metrics)

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -228,6 +228,11 @@ class WorkerOptions:
     """
     prometheus_port: NotGivenOr[int] = NOT_GIVEN
     """When enabled, will expose prometheus metrics on :{prometheus_port}/metrics"""
+    prometheus_multiproc_dir: str | None = None
+    """Directory for prometheus multiprocess mode to enable metrics collection from child job processes.
+    When set, the PROMETHEUS_MULTIPROC_DIR environment variable will be configured automatically.
+    When None (default), multiprocess mode is disabled and only main process metrics are collected.
+    Users can also set PROMETHEUS_MULTIPROC_DIR environment variable directly before starting the worker."""
 
     def validate_config(self, devmode: bool) -> None:
         load_threshold = _WorkerEnvOption.getvalue(self.load_threshold, devmode)
@@ -369,6 +374,17 @@ class Worker(utils.EventEmitter[EventTypes]):
         self._http_server.app.add_routes([web.get("/worker", worker)])
 
         self._prometheus_server: telemetry.http_server.HttpServer | None = None
+        self._prometheus_multiproc_dir: str | None = None
+
+        # Setup prometheus multiprocess mode if explicitly configured
+        if opts.prometheus_multiproc_dir:
+            self._prometheus_multiproc_dir = opts.prometheus_multiproc_dir
+            # Set environment variable for prometheus multiprocess mode
+            os.environ["PROMETHEUS_MULTIPROC_DIR"] = self._prometheus_multiproc_dir
+        elif "PROMETHEUS_MULTIPROC_DIR" in os.environ:
+            # Use existing environment variable if already set
+            self._prometheus_multiproc_dir = os.environ["PROMETHEUS_MULTIPROC_DIR"]
+
         if is_given(self._opts.prometheus_port):
             self._prometheus_server = telemetry.http_server.HttpServer(
                 opts.host, self._opts.prometheus_port, loop=self._loop
@@ -391,6 +407,21 @@ class Worker(utils.EventEmitter[EventTypes]):
             "starting worker",
             extra={"version": __version__, "rtc-version": rtc.__version__},
         )
+
+        # Clean prometheus multiprocess directory to avoid stale metrics (only if it exists)
+        if self._prometheus_multiproc_dir and os.path.exists(self._prometheus_multiproc_dir):
+            logger.debug(
+                "cleaning prometheus multiprocess directory",
+                extra={"dir": self._prometheus_multiproc_dir},
+            )
+            # Remove all files in the directory but keep the directory itself
+            for filename in os.listdir(self._prometheus_multiproc_dir):
+                file_path = os.path.join(self._prometheus_multiproc_dir, filename)
+                try:
+                    if os.path.isfile(file_path):
+                        os.unlink(file_path)
+                except Exception as e:
+                    logger.warning(f"failed to remove {file_path}: {e}")
 
         if self._opts.multiprocessing_context == "forkserver":
             plugin_packages = [p.package for p in Plugin.registered_plugins] + ["av"]
@@ -441,6 +472,10 @@ class Worker(utils.EventEmitter[EventTypes]):
                     return self._opts.load_fnc(self)  # type: ignore
 
                 self._worker_load = await asyncio.get_event_loop().run_in_executor(None, load_fnc)
+
+                # Update child process count metric for prometheus multiprocess mode
+                if self._prometheus_multiproc_dir:
+                    telemetry.metrics._update_child_proc_count()
 
                 load_threshold = _WorkerEnvOption.getvalue(self._opts.load_threshold, self._devmode)
                 default_num_idle_processes = _WorkerEnvOption.getvalue(


### PR DESCRIPTION
# Add Prometheus multi-process metrics Support

## Overview

This implementation adds support for Prometheus metrics collection from child job processes in the LiveKit workers. 
When multi-process mode is enabled, metrics from all child job processes are aggregated and exposed through the `/metrics` endpoint.

## Problem

Prometheus runs in single-process mode by default, but LiveKit workers are multi-process. 
Because of this, the `/metrics` endpoint only exposed metrics from the main worker process because:

1. Each process has its own separate instance of the Prometheus global `REGISTRY`
2. Child processes write metrics to their own memory space
3. The HTTP server in the main process only reads from its own registry

If we want to create new metrics inside the entrypoint function, we need to put the Prometheus client in multi-process mode.

## Solution

I've followed the docs to implement multi-process mode using the `prometheus_client`: https://prometheus.github.io/client_python/multiprocess/

1. We need to set a `PROMETHEUS_MULTIPROC_DIR` environment variable to a temporary directory that Prometheus can use to write metrics (before startup).
2. The metrics endpoint aggregates data from all files when scraped
3. Stale metrics from dead processes are automatically cleaned up

## Limitations

Prometheus multi-process mode has some inherent limitations:

- Registries can not be used as normal, all instantiated metrics are exported
- Registering metrics to a registry later used by a MultiProcessCollector may cause duplicate metrics to be exported
- Custom collectors do not work (e.g. cpu and memory metrics)
- Gauges cannot use set_function
- Info and Enum metrics do not work
- The pushgateway cannot be used
- Gauges cannot use the pid label
- Exemplars are not supported
- Remove and Clear of labels are currently not supported in multiprocess mode.

## Usage

### Option 1: Set Environment Variable (Recommended)

Set the `PROMETHEUS_MULTIPROC_DIR` environment variable before starting your agent:

```bash
export PROMETHEUS_MULTIPROC_DIR=/tmp/prometheus
mkdir -p $PROMETHEUS_MULTIPROC_DIR
python your_agent.py
```

### Option 2: Configure via WorkerOptions

```python
from livekit.agents import WorkerOptions
from livekit import agents

opts = WorkerOptions(
    entrypoint_fnc=entrypoint,
    prometheus_port=9999,
    prometheus_multiproc_dir="/tmp/prometheus"
)

agents.cli.run_app(opts)
```

## Backward Compatibility

**This change is fully backward compatible:**

- If `PROMETHEUS_MULTIPROC_DIR` is **not set**, the system works exactly as before (single-process mode)
- If `PROMETHEUS_MULTIPROC_DIR` **is set**, multi-process mode is automatically enabled

## Files Modified

1. **`worker.py`**
   - Detects `prometheus_multiproc_dir` option or `PROMETHEUS_MULTIPROC_DIR` environment variable
   - Sets environment variable for child processes
   - Cleans directory on startup
   - Periodically updates child process count metric

2. **`telemetry/metrics.py`**
   - Added `multiprocess_mode` parameter to Gauge metrics
   - Removed `set_function()` (not supported in multiprocess mode)
   - Added explicit update function for child process count

3. **`telemetry/http_server.py`**
   - Detects if multiprocess mode is enabled
   - Uses `MultiProcessCollector` to aggregate metrics from all processes
   - Falls back to default registry if multiprocess mode is disabled

4. **`ipc/supervised_proc.py`**
   - Calls `mark_process_dead(pid)` when child processes exit
   - Ensures proper cleanup of stale metrics

## Disk Permissions

The process must have write permissions in the directory specified by `PROMETHEUS_MULTIPROC_DIR`.
If you are running your worker inside a Kubernetes pod, you can use a `emptyDir` volume to store the metrics.

## Migration Guide to enable Multi-Process metrics

1. Set `PROMETHEUS_MULTIPROC_DIR` environment variable
2. Create the directory with write permissions
3. Restart your agent
4. Verify metrics are being aggregated

Example for Kubernetes:
```yaml
apiVersion: v1
kind: Pod
spec:
  containers:
  - name: agent
    env:
    - name: PROMETHEUS_MULTIPROC_DIR
      value: /tmp/prometheus
    volumeMounts:
    - name: metrics
      mountPath: /tmp/prometheus
  volumes:
  - name: metrics
    emptyDir: {}
```
