### PR TITLE
Updating Cartesia Version

### DIFF
--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -49,7 +49,7 @@ from .models import (
 
 API_AUTH_HEADER = "X-API-Key"
 API_VERSION_HEADER = "Cartesia-Version"
-API_VERSION = "2024-06-10"
+API_VERSION = "2025-04-16"
 
 
 @dataclass

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/version.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.14"
+__version__ = "1.3.0"


### PR DESCRIPTION
## Changes
- Updating Cartesia TTS Version to `2025-04-16`
- Bumping Version to `1.3.0`

## Testing
- Tested with Agent setup locally
- Tested with both Stream and Chunked Outputs