### PR TITLE
fix: exclude temperature parameter for gpt-5 and similar models

### DIFF
--- a/livekit-agents/livekit/agents/voice/run_result.py
+++ b/livekit-agents/livekit/agents/voice/run_result.py
@@ -880,13 +880,18 @@ class ChatMessageAssert:
         )
 
         arguments: str | None = None
+        extra_kwargs = {}
+        excluded_models_temperature = ["gpt-5"]  # Add model names here to exclude temperature
+
+        if not any(excluded_model in llm_v.model for excluded_model in excluded_models_temperature):
+            extra_kwargs["temperature"] = 0.0
 
         # TODO(theomonnom): LLMStream should provide utilities to make function calling easier.
         async for chunk in llm_v.chat(
             chat_ctx=chat_ctx,
             tools=[check_intent],
             tool_choice={"type": "function", "function": {"name": "check_intent"}},
-            extra_kwargs={"temperature": 0.0},
+            extra_kwargs=extra_kwargs,
         ):
             if not chunk.delta:
                 continue


### PR DESCRIPTION
### Summary
This PR fixes an issue where certain models (like `gpt-5`) should not receive a `temperature` parameter.  
Previously, `temperature=0.0` was always passed in `extra_kwargs`, which caused problems for models that do not accept this argument.

### Changes
- Introduced `excluded_models_temperature` list (currently includes `gpt-5`).
- Updated `extra_kwargs` logic to skip adding `temperature` if the model contains any excluded model name as substring.

### Before
```python
async for chunk in llm_v.chat(
    chat_ctx=chat_ctx,
    tools=[check_intent],
    tool_choice={"type": "function", "function": {"name": "check_intent"}},
    extra_kwargs={"temperature": 0.0},
):
```
### After
```python
extra_kwargs = {}
excluded_models_temperature = ["gpt-5"]  # Models excluded from temperature
if not any(excluded_model in llm_v.model for excluded_model in excluded_models_temperature):
    extra_kwargs["temperature"] = 0.0

async for chunk in llm_v.chat(
    chat_ctx=chat_ctx,
    tools=[check_intent],
    tool_choice={"type": "function", "function": {"name": "check_intent"}},
    extra_kwargs=extra_kwargs,
):
```

### Test Cases

```python
from livekit.agents import AgentSession
from livekit.plugins import openai
import pytest
from my_agent import Assistant


@pytest.mark.asyncio
async def test_assistant_greeting() -> None:
    async with (
        openai.LLM(model="gpt-5-nano") as llm,
        AgentSession(llm=llm) as session,
    ):
        await session.start(Assistant())

        result = await session.run(user_input="Hello")

        await result.expect.next_event().is_message(role="assistant").judge(
            llm, intent="Makes a friendly introduction and offers assistance."
        )
        
        result.expect.no_more_events()
```

#### Before Fix:
<img width="1569" height="436" alt="image" src="https://github.com/user-attachments/assets/c37c810c-6901-4d67-b39c-885adb282f05" />

#### After Fix:
<img width="1557" height="210" alt="image" src="https://github.com/user-attachments/assets/6cb666e9-ef94-48d2-b885-8dd549462e46" />

### Issue Reference

Fixes: [#3556](https://github.com/livekit/agents/issues/3556)

### Notes

More models can be added to excluded_models_temperature in the future if needed.

This change ensures compatibility with gpt-5 while maintaining the original behavior for other models.