### PR TITLE
cast deepgram sttv2 status_code to int from str

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -485,7 +485,7 @@ class SpeechStreamv2(stt.SpeechStream):
         elif data["type"] == "Error":
             desc = data.get("description") or "unknown error from deepgram"
             status_code = data.get("code") or -1
-            raise APIStatusError(message=desc, status_code=status_code)
+            raise APIStatusError(message=desc, status_code=int(status_code))
 
 
 def _parse_transcription(language: str, data: dict[str, Any]) -> list[stt.SpeechData]:


### PR DESCRIPTION
`data.get("code")` returns string. Cast it to int to prevent

```
TypeError
'>=' not supported between instances of 'str' and 'int'
```