### PR TITLE
fix(deepgram): correctly handle timeout related errors

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -483,9 +483,10 @@ class SpeechStreamv2(stt.SpeechStream):
                 self._event_ch.send_nowait(end_event)
 
         elif data["type"] == "Error":
+            logger.warning(f"deepgram sent an error", extra={"data": data})
             desc = data.get("description") or "unknown error from deepgram"
-            status_code = data.get("code") or -1
-            raise APIStatusError(message=desc, status_code=status_code)
+            code = -1
+            raise APIStatusError(message=desc, status_code=code)
 
 
 def _parse_transcription(language: str, data: dict[str, Any]) -> list[stt.SpeechData]:

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -483,7 +483,7 @@ class SpeechStreamv2(stt.SpeechStream):
                 self._event_ch.send_nowait(end_event)
 
         elif data["type"] == "Error":
-            logger.warning(f"deepgram sent an error", extra={"data": data})
+            logger.warning("deepgram sent an error", extra={"data": data})
             desc = data.get("description") or "unknown error from deepgram"
             code = -1
             raise APIStatusError(message=desc, status_code=code)


### PR DESCRIPTION
Deepgram v2 returns a string error code when they are surfacing errors. The most prominent example of this is timeout. if we are not sending data for awhile, DG will timeout with `INACTIVE_CLIENT`, which we were parsing incorrectly as an int.