### PR TITLE
Ensure ctx.api uses WorkerOptions credentials by exporting LIVEKIT_* in worker

### DIFF
--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -158,8 +158,10 @@ class JobContext:
     def api(self) -> api.LiveKitAPI:
         """Returns an LiveKitAPI for making API calls to LiveKit.
 
-        This property requires LIVEKIT_API_KEY and LIVEKIT_API_SECRET to be set in the environment.
-        If they are passed in WorkerOptions, it would not be able to satisfy this API.
+        Credentials are sourced from environment variables if not provided explicitly.
+        When starting via the worker, values passed in `WorkerOptions` are exported to
+        LIVEKIT_URL, LIVEKIT_API_KEY, and LIVEKIT_API_SECRET so this API is always
+        usable inside job entrypoints.
         """
         return api.LiveKitAPI(session=http_context.http_session())
 

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -255,10 +255,10 @@ class Worker(utils.EventEmitter[EventTypes]):
         loop: asyncio.AbstractEventLoop | None = None,
     ) -> None:
         super().__init__()
-        opts.ws_url = opts.ws_url or os.environ.get("LIVEKIT_URL") or ""
-        opts.api_key = opts.api_key or os.environ.get("LIVEKIT_API_KEY") or ""
-        opts.api_secret = opts.api_secret or os.environ.get("LIVEKIT_API_SECRET") or ""
-        opts._worker_token = os.environ.get("LIVEKIT_WORKER_TOKEN") or None
+        opts.ws_url = opts.ws_url or os.environ.get("LIVEKIT_URL", "")
+        opts.api_key = opts.api_key or os.environ.get("LIVEKIT_API_KEY", "")
+        opts.api_secret = opts.api_secret or os.environ.get("LIVEKIT_API_SECRET", "")
+        opts._worker_token = os.environ.get("LIVEKIT_WORKER_TOKEN", None)
 
         if not opts.ws_url:
             raise ValueError("ws_url is required, or add LIVEKIT_URL in your environment")
@@ -270,6 +270,13 @@ class Worker(utils.EventEmitter[EventTypes]):
             raise ValueError(
                 "api_secret is required, or add LIVEKIT_API_SECRET in your environment"
             )
+
+        # Ensure job processes and thread executors can initialize JobContext.api
+        # by inheriting credentials from environment variables. This guarantees that
+        # ctx.api works even when credentials are only supplied via WorkerOptions.
+        os.environ["LIVEKIT_URL"] = opts.ws_url
+        os.environ["LIVEKIT_API_KEY"] = opts.api_key
+        os.environ["LIVEKIT_API_SECRET"] = opts.api_secret
 
         if opts.job_memory_limit_mb > 0 and opts.job_executor_type != JobExecutorType.PROCESS:
             logger.warning(


### PR DESCRIPTION
## Problem

Passing `api_key`, `api_secret`, and `ws_url` via `WorkerOptions` didn’t affect `ctx.api` because `JobContext.api` reads credentials from environment variables. This caused failures when env vars weren’t set.

## Solution:

After validating options in Worker.__init__, export:

```
LIVEKIT_URL = opts.ws_url
LIVEKIT_API_KEY = opts.api_key
LIVEKIT_API_SECRET = opts.api_secret
```

So child job processes/threads inherit the correct credentials. Updated `JobContext.api` docstring accordingly.

## Behavior

`ctx.api` now works when creds are provided only via `WorkerOptions`.
Backwards compatible with env-based config and CLI flags.