### PR TITLE
feat(google): Add thinking_config support, new model, and expanded voice profiles for google gemini TTS

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/api_proto.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/api_proto.py
@@ -10,11 +10,43 @@ LiveAPIModels = Literal[
     # models supported on Gemini API
     "gemini-2.0-flash-live-001",
     "gemini-live-2.5-flash-preview",
+    "gemini-2.5-flash-native-audio-preview-09-2025",
     "gemini-2.5-flash-preview-native-audio-dialog",
     "gemini-2.5-flash-exp-native-audio-thinking-dialog",
 ]
 
-Voice = Literal["Puck", "Charon", "Kore", "Fenrir", "Aoede", "Leda", "Orus", "Zephyr"]
+Voice = Literal[
+    "Achernar",
+    "Achird",
+    "Algenib",
+    "Algieba",
+    "Alnilam",
+    "Aoede",
+    "Autonoe",
+    "Callirrhoe",
+    "Charon",
+    "Despina",
+    "Enceladus",
+    "Erinome",
+    "Fenrir",
+    "Gacrux",
+    "Iapetus",
+    "Kore",
+    "Laomedeia",
+    "Leda",
+    "Orus",
+    "Pulcherrima",
+    "Puck",
+    "Rasalgethi",
+    "Sadachbia",
+    "Sadaltager",
+    "Schedar",
+    "Sulafat",
+    "Umbriel",
+    "Vindemiatrix",
+    "Zephyr",
+    "Zubenelgenubi",
+]
 
 
 ClientEvents = Union[

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/realtime_api.py
@@ -823,6 +823,9 @@ class RealtimeSession(llm.RealtimeSession):
                 frequency_penalty=self._opts.frequency_penalty
                 if is_given(self._opts.frequency_penalty)
                 else None,
+                thinking_config=self._opts.thinking_config
+                if is_given(self._opts.thinking_config)
+                else None,
             ),
             system_instruction=types.Content(parts=[types.Part(text=self._opts.instructions)])
             if is_given(self._opts.instructions)
@@ -849,8 +852,6 @@ class RealtimeSession(llm.RealtimeSession):
             conf.realtime_input_config = self._opts.realtime_input_config
         if is_given(self._opts.context_window_compression):
             conf.context_window_compression = self._opts.context_window_compression
-        if is_given(self._opts.thinking_config):
-            conf.thinking_config = self._opts.thinking_config
 
         return conf
 

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/realtime/realtime_api.py
@@ -78,6 +78,7 @@ class _RealtimeOptions:
     gemini_tools: NotGivenOr[list[_LLMTool]] = NOT_GIVEN
     tool_behavior: NotGivenOr[types.Behavior] = NOT_GIVEN
     tool_response_scheduling: NotGivenOr[types.FunctionResponseScheduling] = NOT_GIVEN
+    thinking_config: NotGivenOr[types.ThinkingConfig] = NOT_GIVEN
 
 
 @dataclass
@@ -144,6 +145,7 @@ class RealtimeModel(llm.RealtimeModel):
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
         http_options: NotGivenOr[types.HttpOptions] = NOT_GIVEN,
         _gemini_tools: NotGivenOr[list[_LLMTool]] = NOT_GIVEN,
+        thinking_config: NotGivenOr[types.ThinkingConfig] = NOT_GIVEN,
     ) -> None:
         """
         Initializes a RealtimeModel instance for interacting with Google's Realtime API.
@@ -180,6 +182,7 @@ class RealtimeModel(llm.RealtimeModel):
             context_window_compression (ContextWindowCompressionConfig, optional): The configuration for context window compression. Defaults to None.
             tool_behavior (Behavior, optional): The behavior for tool call. Default behavior is BLOCK in Gemini Realtime API.
             tool_response_scheduling (FunctionResponseScheduling, optional): The scheduling for tool response. Default scheduling is WHEN_IDLE.
+            thinking_config (ThinkingConfig, optional): Native audio thinking configuration.
             conn_options (APIConnectOptions, optional): The configuration for the API connection. Defaults to DEFAULT_API_CONNECT_OPTIONS.
             _gemini_tools (list[LLMTool], optional): Gemini-specific tools to use for the session. This parameter is experimental and may change.
 
@@ -274,6 +277,7 @@ class RealtimeModel(llm.RealtimeModel):
             tool_behavior=tool_behavior,
             conn_options=conn_options,
             http_options=http_options,
+            thinking_config=thinking_config,
         )
 
         self._sessions = weakref.WeakSet[RealtimeSession]()
@@ -510,7 +514,12 @@ class RealtimeSession(llm.RealtimeSession):
         for f in self._resample_audio(frame):
             for nf in self._bstream.write(f.data.tobytes()):
                 realtime_input = types.LiveClientRealtimeInput(
-                    media_chunks=[types.Blob(data=nf.data.tobytes(), mime_type="audio/pcm")]
+                    media_chunks=[
+                        types.Blob(
+                            data=nf.data.tobytes(),
+                            mime_type=f"audio/pcm;rate={INPUT_AUDIO_SAMPLE_RATE}",
+                        )
+                    ]
                 )
                 self._send_client_event(realtime_input)
 
@@ -840,6 +849,8 @@ class RealtimeSession(llm.RealtimeSession):
             conf.realtime_input_config = self._opts.realtime_input_config
         if is_given(self._opts.context_window_compression):
             conf.context_window_compression = self._opts.context_window_compression
+        if is_given(self._opts.thinking_config):
+            conf.thinking_config = self._opts.thinking_config
 
         return conf
 


### PR DESCRIPTION
## Changes

### New Feature
- Add support for `thinking_config` parameter in RealtimeModel and RealtimeSession
  - Enables native audio thinking configuration for Gemini models
  - Parameter is properly threaded through the configuration setup

### Model Support
- Add `gemini-2.5-flash-native-audio-preview-09-2025` to supported models

### Voice Profiles
- Expand available voice options from 8 to 31 voices
- Added voices: Achernar, Achird, Algenib, Algieba, Alnilam, Autonoe, Callirrhoe, Despina, Enceladus, Erinome, Gacrux, Iapetus, Laomedeia, Pulcherrima, Rasalgethi, Sadachbia, Sadaltager, Schedar, Sulafat, Umbriel, Vindemiatrix, and Zubenelgenubi
- Existing voices retained: Puck, Charon, Kore, Fenrir, Aoede, Leda, Orus, Zephyr

### Minor Improvements
- Update audio mime type to include sample rate (`audio/pcm;rate={INPUT_AUDIO_SAMPLE_RATE}`)