### PR TITLE
Add a format provider for VLLM models.

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/__init__.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/__init__.py
@@ -1,3 +1,3 @@
-from . import anthropic, aws, google, mistralai, openai
+from . import anthropic, aws, google, mistralai, openai, vllm
 
-__all__ = ["openai", "google", "aws", "anthropic", "mistralai"]
+__all__ = ["openai", "google", "aws", "anthropic", "mistralai", "vllm"]

--- a/livekit-agents/livekit/agents/llm/_provider_format/vllm.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/vllm.py
@@ -19,7 +19,7 @@ def to_chat_ctx(
         messages.append({"role": "user", "content": dummy_user_message})
     if len(messages) > 1 and messages[0]["role"] == "system" and messages[1]["role"] == "assistant":
         messages.insert(1, {"role": "user", "content": "Hello"})
-    collated = []
+    collated: list[dict] = []
     for msg in messages:
         if len(collated) > 0 and collated[-1]["role"] == msg["role"]:
             collated[-1]["content"] += " " + msg["content"]

--- a/livekit-agents/livekit/agents/llm/_provider_format/vllm.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/vllm.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from livekit.agents import llm
+
+from .openai import to_chat_ctx as openai_to_chat_ctx
+
+
+def to_chat_ctx(
+    chat_ctx: llm.ChatContext,
+    *,
+    inject_dummy_user_message: bool = True,
+    dummy_user_message: str = "",
+) -> tuple[list[dict], Literal[None]]:
+    messages, _ = openai_to_chat_ctx(chat_ctx, inject_dummy_user_message=inject_dummy_user_message)
+
+    if len(messages) == 1 and messages[0]["role"] == "system":
+        messages.append({"role": "user", "content": dummy_user_message})
+    if len(messages) > 1 and messages[0]["role"] == "system" and messages[1]["role"] == "assistant":
+        messages.insert(1, {"role": "user", "content": "Hello"})
+    collated = []
+    for msg in messages:
+        if len(collated) > 0 and collated[-1]["role"] == msg["role"]:
+            collated[-1]["content"] += " " + msg["content"]
+        else:
+            collated.append(msg)
+    return collated, None

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -408,11 +408,16 @@ class ChatContext:
     ) -> tuple[list[dict], Literal[None]]: ...
 
     @overload
+    def to_provider_format(
+        self, format: Literal["vllm"], *, inject_dummy_user_message: bool = True
+    ) -> tuple[list[dict], Literal[None]]: ...
+
+    @overload
     def to_provider_format(self, format: str, **kwargs: Any) -> tuple[list[dict], Any]: ...
 
     def to_provider_format(
         self,
-        format: Literal["openai", "google", "aws", "anthropic", "mistralai"] | str,
+        format: Literal["openai", "google", "aws", "anthropic", "mistralai", "vllm"] | str,
         *,
         inject_dummy_user_message: bool = True,
         **kwargs: Any,
@@ -437,6 +442,8 @@ class ChatContext:
             return _provider_format.anthropic.to_chat_ctx(self, **kwargs)
         elif format == "mistralai":
             return _provider_format.mistralai.to_chat_ctx(self, **kwargs)
+        elif format == "vllm":
+            return _provider_format.vllm.to_chat_ctx(self, **kwargs)
         else:
             raise ValueError(f"Unsupported provider format: {format}")
 


### PR DESCRIPTION
Some VLLM models, e.g. gemma 3 12B, expect some strict ordering on message roles, i.e. these should be `system`, `user`, `assistant`, `user`, `assistant`, etc. I haven't been able to get this to work with any of the existing `provider_fmt` options, `mistrlai` ensures that the last message is a `user` message but doesn't compact the existing `user` or `assistant` messages.

This PR adds a new format provider option, `vllm`, which ensures that the roles are presented in the proper ordering. Consecutive `user` messages are compacted together. This was tested to work properly with vllm 0.9.1 and various models (gemma 3, mistral).

Not sure if this the right way to solve this issue so let me know if there is a better alternative.