### PR TITLE
Support room audio recording with RecorderIO

### DIFF
--- a/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
+++ b/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
@@ -244,9 +244,11 @@ class RecorderAudioInput(io.AudioInput):
 
         return frame
 
-    def on_attached(self) -> None: ...
+    def on_attached(self) -> None:
+        self.__audio_input.on_attached()
 
-    def on_detached(self) -> None: ...
+    def on_detached(self) -> None:
+        self.__audio_input.on_detached()
 
 
 class RecorderAudioOutput(io.AudioOutput):


### PR DESCRIPTION
Implement `on_attached` and `on_detached` to support room session recording with RecorderIO. This should make it possible to do this:

```python
session.input.audio = recorder_io.record_input(session.input.audio)
```

without loosing the _attached status.

This should address #3527 

Tested with the following modified example code:

```
import asyncio
import logging
from datetime import datetime

from dotenv import load_dotenv

from livekit.agents import (
    Agent,
    AgentSession,
    JobContext,
    JobProcess,
    MetricsCollectedEvent,
    RoomInputOptions,
    RoomOutputOptions,
    RunContext,
    WorkerOptions,
    cli,
    metrics,
)
from livekit.agents.llm import function_tool
from livekit.agents.voice.recorder_io import RecorderIO
from livekit.plugins import deepgram, openai, silero
from livekit.plugins.turn_detector.multilingual import MultilingualModel

# uncomment to enable Krisp background voice/noise cancellation
# from livekit.plugins import noise_cancellation

logger = logging.getLogger("basic-agent")

load_dotenv()


class MyAgent(Agent):
    def __init__(self) -> None:
        super().__init__(
            instructions="Your name is Kelly. You would interact with users via voice."
            "with that in mind keep your responses concise and to the point."
            "do not use emojis, asterisks, markdown, or other special characters in your responses."
            "You are curious and friendly, and have a sense of humor."
            "you will speak english to the user",
        )

    async def on_enter(self):
        # when the agent is added to the session, it'll generate a reply
        # according to its instructions
        self.session.generate_reply()

    # all functions annotated with @function_tool will be passed to the LLM when this
    # agent is active
    @function_tool
    async def lookup_weather(
        self, context: RunContext, location: str, latitude: str, longitude: str
    ):
        """Called when the user asks for weather related information.
        Ensure the user's location (city or region) is provided.
        When given a location, please estimate the latitude and longitude of the location and
        do not ask the user for them.

        Args:
            location: The location they are asking for
            latitude: The latitude of the location, do not ask user for it
            longitude: The longitude of the location, do not ask user for it
        """

        logger.info(f"Looking up weather for {location}")

        return "sunny with a temperature of 70 degrees."


def prewarm(proc: JobProcess):
    proc.userdata["vad"] = silero.VAD.load()


tasks = set()


async def entrypoint(ctx: JobContext):
    # each log entry will include these fields
    ctx.log_context_fields = {
        "room": ctx.room.name,
    }

    session = AgentSession(
        vad=ctx.proc.userdata["vad"],
        # any combination of STT, LLM, TTS, or realtime API can be used
        llm=openai.LLM(model="gpt-4o-mini"),
        stt=deepgram.STT(model="nova-3", language="multi"),
        tts=openai.TTS(voice="ash"),
        # allow the LLM to generate a response while waiting for the end of turn
        # preemptive_generation=True,
        # sometimes background noise could interrupt the agent session, these are considered false positive interruptions
        # when it's detected, you may resume the agent's speech
        resume_false_interruption=True,
        false_interruption_timeout=1.0,
        min_interruption_duration=0.2,  # with false interruption resume, interruption can be more sensitive
        # use LiveKit's turn detection model
        # turn_detection=MultilingualModel(),
    )

    # log metrics as they are emitted, and total usage after session is over
    usage_collector = metrics.UsageCollector()

    @session.on("metrics_collected")
    def _on_metrics_collected(ev: MetricsCollectedEvent):
        metrics.log_metrics(ev.metrics)
        usage_collector.collect(ev.metrics)

    async def log_usage():
        summary = usage_collector.get_summary()
        logger.info(f"Usage: {summary}")

    # shutdown callbacks are triggered when the session is over
    ctx.add_shutdown_callback(log_usage)

    import os

    os.makedirs("recordings", exist_ok=True)
    recorder_io: RecorderIO | None = RecorderIO(agent_session=session)

    async def _attach_and_start_recorder():
        while session.input.audio is None or session.output.audio is None:
            await asyncio.sleep(0.05)

        try:
            session.input.audio = recorder_io.record_input(session.input.audio)  # type: ignore[arg-type]
        except Exception as e:
            logger.warning(f"RecorderIO record_input failed: {e}")
        try:
            session.output.audio = recorder_io.record_output(session.output.audio)  # type: ignore[arg-type]
        except Exception as e:
            logger.warning(f"RecorderIO record_output failed: {e}")

        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
        out_path = os.path.join("recordings", f"{ctx.room.name}_{ts}.ogg")
        try:
            await recorder_io.start(output_path=out_path)
            logger.info(f"RecorderIO started: {out_path}")
            try:
                ctx.add_shutdown_callback(recorder_io.aclose)
            except RuntimeError:
                pass
        except Exception as e:
            logger.error(f"Failed to start RecorderIO: {e}")

    # Additional change I made
    task = asyncio.create_task(_attach_and_start_recorder())
    tasks.add(task)

    await session.start(
        agent=MyAgent(),
        room=ctx.room,
        room_input_options=RoomInputOptions(
            # uncomment to enable Krisp BVC noise cancellation
            # noise_cancellation=noise_cancellation.BVC(),
        ),
        room_output_options=RoomOutputOptions(transcription_enabled=True),
    )


if __name__ == "__main__":
    cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint, prewarm_fnc=prewarm))

```

Github doesn't support uploading ogg files, but I can see the recording file being created.