### PR TITLE
Restore audio enabled flags after exit GetDtmfTask

### DIFF
--- a/livekit-agents/livekit/agents/beta/workflows/dtmf_inputs.py
+++ b/livekit-agents/livekit/agents/beta/workflows/dtmf_inputs.py
@@ -59,6 +59,7 @@ class GetDtmfTask(AgentTask[GetDtmfResult]):
 
         self._curr_dtmf_inputs: list[DtmfEvent] = []
         self._dtmf_reply_running: bool = False
+        self._external_audio_enabled: bool = True
 
         @function_tool
         async def confirm_inputs(inputs: list[DtmfEvent]) -> None:
@@ -184,10 +185,12 @@ class GetDtmfTask(AgentTask[GetDtmfResult]):
 
     async def on_enter(self) -> None:
         ctx = get_job_context()
+        self._external_audio_enabled = self.session.input.audio_enabled
 
         ctx.room.on("sip_dtmf_received", self._on_sip_dtmf_received)
         self.session.on("agent_state_changed", self._on_user_state_changed)
         self.session.on("agent_state_changed", self._on_agent_state_changed)
+        self.session.input.set_audio_enabled(True)
         self.session.generate_reply()
 
     async def on_exit(self) -> None:
@@ -196,4 +199,5 @@ class GetDtmfTask(AgentTask[GetDtmfResult]):
         ctx.room.off("sip_dtmf_received", self._on_sip_dtmf_received)
         self.session.off("agent_state_changed", self._on_user_state_changed)
         self.session.off("agent_state_changed", self._on_agent_state_changed)
+        self.session.input.set_audio_enabled(self._external_audio_enabled)
         self._generate_dtmf_reply.cancel()

--- a/livekit-agents/livekit/agents/beta/workflows/dtmf_inputs.py
+++ b/livekit-agents/livekit/agents/beta/workflows/dtmf_inputs.py
@@ -190,8 +190,9 @@ class GetDtmfTask(AgentTask[GetDtmfResult]):
         ctx.room.on("sip_dtmf_received", self._on_sip_dtmf_received)
         self.session.on("agent_state_changed", self._on_user_state_changed)
         self.session.on("agent_state_changed", self._on_agent_state_changed)
-        self.session.input.set_audio_enabled(True)
-        self.session.generate_reply()
+
+        handle = self.session.generate_reply()
+        handle.add_done_callback(lambda _: self.session.input.set_audio_enabled(True))
 
     async def on_exit(self) -> None:
         ctx = get_job_context()


### PR DESCRIPTION
For building an agentic IVR system, user may want to disable audio enabled flag globally to prevent user interrupting the DTMF collection task flow. However, since we also support voice input inside `GetDtmfTask`, we would like to enable audio to true inside the task and restore it's original state outside of the task.