### PR TITLE
feat(voice/run_result): OTEL tracing of judge

### DIFF
--- a/livekit-agents/livekit/agents/voice/run_result.py
+++ b/livekit-agents/livekit/agents/voice/run_result.py
@@ -894,7 +894,7 @@ class ChatMessageAssert:
 
         arguments: str | None = None
         usage: llm.CompletionUsage | None = None
-          
+
         extra_kwargs = {}
         excluded_models_temperature = ["gpt-5"]  # Add model names here to exclude temperature
 


### PR DESCRIPTION
This PR enhances the OpenTelemetry tracing for the LLM-as-a-judge functionality in Livekit to provide:
- The model name (so e.g. LangFuse can estimate price)
- The token counting (so e.g. LangFuse can estimate price)
- A named parent span (so e.g. its clear that it is a span not part of a regular conversation with the agent) - before this PR it was an unnamed parent span (see screenshots below for comparison)
- The LLM-as-a-judge results (shared via the already existing OTEL attributes for function call results)

_____

**Before this PR:**

<img width="1137" height="737" alt="image" src="https://github.com/user-attachments/assets/161b4d23-9dab-465a-b426-a3bc89c49887" />

_____

**After this PR:**

<img width="1150" height="893" alt="image" src="https://github.com/user-attachments/assets/78da9220-02d1-4193-8bb3-23f3d097e92f" />


