### PR TITLE
turn_detection: reduce max_endpointing_delay to 3s

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -158,7 +158,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         min_interruption_duration: float = 0.5,
         min_interruption_words: int = 0,
         min_endpointing_delay: float = 0.5,
-        max_endpointing_delay: float = 6.0,
+        max_endpointing_delay: float = 3.0,
         max_tool_steps: int = 3,
         video_sampler: NotGivenOr[_VideoSampler | None] = NOT_GIVEN,
         user_away_timeout: float | None = 15.0,
@@ -218,7 +218,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 or an EOU model) before it declares the user’s turn complete.
                 Default ``0.5`` s.
             max_endpointing_delay (float): Maximum time-in-seconds the agent
-                will wait before terminating the turn. Default ``6.0`` s.
+                will wait before terminating the turn. Default ``3.0`` s.
             max_tool_steps (int): Maximum consecutive tool calls per LLM turn.
                 Default ``3``.
             video_sampler (_VideoSampler, optional): Uses


### PR DESCRIPTION
Reducing max_endpointing_delay to 3s. This is based on some analysis that suggests intra-utterance pauses are typically << 6s. I have two datasets: (i) audio of call center / customer service calls, that has p95 for mid-turn pause of 2.5s, and (ii) audio of two channel conversations with p95 for mid-turn pause of 1.4s