### PR TITLE
fix: heartbeat

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -407,7 +407,7 @@ class SpeechStreamv2(stt.SpeechStream):
                 self._session.ws_connect(
                     _to_deepgram_url(live_config, base_url=self._opts.endpoint_url, websocket=True),
                     headers={"Authorization": f"Token {self._api_key}"},
-                    heartbeat=30.0
+                    heartbeat=30.0,
                 ),
                 self._conn_options.timeout,
             )


### PR DESCRIPTION
The new deepgram api requires WS pings otherwise it will close the connection.

https://developers.deepgram.com/docs/flux/flux-nova-3-comparison#connection-management