### PR TITLE
Unprompted STT Reconnection at startup

### DIFF
--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -335,7 +335,7 @@ class SpeechStream(stt.SpeechStream):
             self._opts.model = model
         if is_given(language):
             self._opts.language = language
-        self._reconnect_event.set()            
+        self._reconnect_event.set()
 
     async def _run(self) -> None:
         """Main loop for streaming transcription."""


### PR DESCRIPTION
Addressing an issue that was causing the LiveKit Inference STT to reconnect immediately after the initial connection. Note, this erroneous behavior does not impact functionality, it may delay startup a bit but the agent is fully functional. 