### PR TITLE
feat: add preflight transcript via utterance

### DIFF
--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -64,7 +64,7 @@ class STT(stt.STT):
         api_key: NotGivenOr[str] = NOT_GIVEN,
         sample_rate: int = 16000,
         encoding: Literal["pcm_s16le", "pcm_mulaw"] = "pcm_s16le",
-        speech_model: Literal[
+        model: Literal[
             "universal-streaming-english", "universal-streaming-multilingual"
         ] = "universal-streaming-english",
         end_of_turn_confidence_threshold: NotGivenOr[float] = NOT_GIVEN,
@@ -90,7 +90,7 @@ class STT(stt.STT):
             sample_rate=sample_rate,
             buffer_size_seconds=buffer_size_seconds,
             encoding=encoding,
-            speech_model=speech_model,
+            speech_model=model,
             end_of_turn_confidence_threshold=end_of_turn_confidence_threshold,
             min_end_of_turn_silence_when_confident=min_end_of_turn_silence_when_confident,
             max_turn_silence=max_turn_silence,


### PR DESCRIPTION
added utterance as a preflight transcript as per @longcw guidance, docs: https://www.assemblyai.com/docs/api-reference/streaming-api/streaming-api#receive.receiveTurn.utterance

the utterance is emitted if a short pause is detected and all words have been finalised, so that it can be used for preemptive generation

one issue I did notice though is that the preemptive generation validation is an absolute comparison so even though no words have changed, if the final transcript includes an extra comma it cancels, is this intended or could it be edited to first lowercase the text and strip punc and compare just words? 