### PR TITLE
Conditional message truncation based on LLM capabilitities

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2181,14 +2181,15 @@ class AgentActivity(RecognitionHooks):
                         forwarded_text = ""
                         playback_position = 0
 
-                    # truncate server-side message
-                    msg_modalities = await msg_gen.modalities
-                    self._rt_session.truncate(
-                        message_id=msg_gen.message_id,
-                        modalities=msg_modalities,
-                        audio_end_ms=int(playback_position * 1000),
-                        audio_transcript=forwarded_text,
-                    )
+                    # truncate server-side message (if supported)
+                    if self.llm.capabilities.message_truncation:
+                        msg_modalities = await msg_gen.modalities
+                        self._rt_session.truncate(
+                            message_id=msg_gen.message_id,
+                            modalities=msg_modalities,
+                            audio_end_ms=int(playback_position * 1000),
+                            audio_transcript=forwarded_text,
+                        )
 
                 msg: llm.ChatMessage | None = None
                 if forwarded_text:


### PR DESCRIPTION
## Fix: Respect `message_truncation` capability before calling `truncate()`

### Problem
The voice agent activity code unconditionally calls `truncate()` on realtime sessions during interruptions, even when the underlying model doesn't support message truncation. This causes unnecessary warnings in logs:

```
{"message": "truncate is not supported by the Google Realtime API.", "level": "WARNING", ...}
```

### Root Cause
The `RealtimeCapabilities` class includes a `message_truncation` flag that providers correctly set:
- OpenAI Realtime API: `message_truncation=True`
- Google Realtime API: `message_truncation=False`
- AWS Bedrock Realtime: `message_truncation=False`

However, `agent_activity.py` was ignoring this capability flag and calling `truncate()` unconditionally.

### Solution
Added a capability check before calling `truncate()`:

```python
# truncate server-side message (if supported)
if self.llm.capabilities.message_truncation:
    msg_modalities = await msg_gen.modalities
    self._rt_session.truncate(...)
```

### Testing
Tested with Google Realtime API - warning no longer appears during interruptions, and interruption handling continues to work correctly.
