### PR TITLE
fix(deepgram): prevent dangling WebSocket streams

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
@@ -93,7 +93,9 @@ class TTS(tts.TTS):
         self._session = http_session
         self._streams = weakref.WeakSet[SynthesizeStream]()
 
-        self._pool = utils.ConnectionPool[aiohttp.ClientWebSocketResponse](
+        self._pool = utils.ConnectionPool[
+            aiohttp.ClientWebSocketResponse
+        ](
             connect_cb=self._connect_ws,
             close_cb=self._close_ws,
             max_session_duration=300,  # 5 minutes (reduced from 1 hour to prevent dangling connections)


### PR DESCRIPTION
## Deepgram TTS Connection:
- **Reduced `max_session_duration` from 1 hour to 5 minutes**
  - Forces fresh connections and clears zombie connections faster
  
- **Added `heartbeat=30.0` to WebSocket connections**
  - Maintains connection health via ping/pong frames, preventing server-side timeouts while connection sits in pool


Continuing on [https://github.com/livekit/agents/pull/3608](url)