### PR TITLE
Unify generate_reply and say code pattern

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -830,22 +830,12 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         )
 
         run_state = self._global_run_state
-        if self._activity.scheduling_paused:
-            if self._next_activity is None:
-                raise RuntimeError("AgentSession is closing, cannot use generate_reply()")
+        activity = self._next_activity if self._activity.scheduling_paused else self._activity
 
-            handle = self._next_activity._generate_reply(
-                user_message=user_message,
-                instructions=instructions,
-                tool_choice=tool_choice,
-                allow_interruptions=allow_interruptions,
-            )
-            if run_state:
-                run_state._watch_handle(handle)
+        if activity is None:
+            raise RuntimeError("AgentSession is closing, cannot use generate_reply()")
 
-            return handle
-
-        handle = self._activity._generate_reply(
+        handle = activity._generate_reply(
             user_message=user_message,
             instructions=instructions,
             tool_choice=tool_choice,


### PR DESCRIPTION
Just a small refactoring so that `say` and `generate_reply` use the same pattern.