### PR TITLE
fix(worker): ensure safe iteration over process pool during job joining

### DIFF
--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -541,7 +541,7 @@ class Worker(utils.EventEmitter[EventTypes]):
         await self._update_worker_status()
 
         async def _join_jobs() -> None:
-            for proc in self._proc_pool.processes:
+            for proc in list(self._proc_pool.processes):
                 if proc.running_job:
                     await proc.join()
 


### PR DESCRIPTION
If elements are removed during the iteration process, a race condition may occur here, causing the program to exit prematurely.

Use list() to snapshot processes during iteration to prevent race conditions when joining running jobs in Worker.drain().