### PR TITLE
chore: lock onnxruntime to <=1.23.1

### DIFF
--- a/livekit-plugins/livekit-plugins-silero/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-silero/pyproject.toml
@@ -24,7 +24,8 @@ classifiers = [
 ]
 dependencies = [
     "livekit-agents>=1.2.15",
-    "onnxruntime>=1.18",
+    # onnxruntime 1.23.2 is missing wheel on MacOS
+    "onnxruntime>=1.18,<=1.23.1",
     "numpy>=1.26",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2453,7 +2453,7 @@ dependencies = [
 requires-dist = [
     { name = "livekit-agents", editable = "livekit-agents" },
     { name = "numpy", specifier = ">=1.26" },
-    { name = "onnxruntime", specifier = ">=1.18" },
+    { name = "onnxruntime", specifier = ">=1.18,<=1.23.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
due to 1.23.2 missing wheel on MacOS