### PR TITLE
Update Letta voice API integration to use new endpoint

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -783,7 +783,7 @@ class LLM(llm.LLM):
     def with_letta(
         *,
         agent_id: str,
-        base_url: str = "https://api.letta.com/v1/voice-beta",
+        base_url: str = "https://api.letta.com/v1/chat/completions",
         api_key: str | None = None,
     ) -> LLM:
         """
@@ -791,7 +791,7 @@ class LLM(llm.LLM):
 
         Args:
             agent_id (str): The Letta agent ID (must be prefixed with 'agent-').
-            base_url (str): The URL of the Letta server (e.g., from ngrok or Letta Cloud).
+            base_url (str): The URL of the Letta server (e.g., http://localhost:8283/v1/chat/completions for local or https://api.letta.com/v1/chat/completions for cloud).
             api_key (str | None, optional): Optional API key for authentication, required if
                                             the Letta server enforces auth.
 
@@ -799,7 +799,6 @@ class LLM(llm.LLM):
             LLM: A configured LLM instance for interacting with the given Letta agent.
         """
 
-        base_url = f"{base_url}/{agent_id}"
         parsed = urlparse(base_url)
         if parsed.scheme not in {"http", "https"}:
             raise ValueError(f"Invalid URL scheme: '{parsed.scheme}'. Must be 'http' or 'https'.")
@@ -813,7 +812,7 @@ class LLM(llm.LLM):
             )
 
         return LLM(
-            model="letta-fast",
+            model=agent_id,
             api_key=api_key,
             base_url=base_url,
             client=None,


### PR DESCRIPTION
## Summary
- Updated `with_letta()` method to use the new `/v1/chat/completions` endpoint instead of the legacy `/v1/voice-beta/<AGENT_ID>` endpoint
- Agent ID is now passed as the `model` parameter instead of being appended to the base URL
- Updated default base URL and documentation to reflect new API structure

## Background
The Letta voice API has migrated to an OpenAI-compatible streaming chat completions endpoint. The legacy `/v1/voice-beta/<AGENT_ID>` endpoint has been deprecated in favor of the standard `/v1/chat/completions` endpoint where the agent ID is specified via the `model` parameter.

Reference: https://docs.letta.com/guides/voice/overview

👾 Generated with [Letta Code](https://letta.com)