### PR TITLE
fix room io audio output deadlock

### DIFF
--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -142,6 +142,8 @@ class _ParticipantAudioOutput(io.AudioOutput):
                     await self._playback_enabled.wait()
 
                 await self._audio_source.wait_for_playout()
+                # avoid deadlock when clear_buffer called before capture_frame
+                await asyncio.sleep(0)
 
         wait_for_playout = asyncio.create_task(_wait_buffered_audio())
         await asyncio.wait(


### PR DESCRIPTION
potentially fix https://github.com/livekit/agents/issues/3637

cannot reproduce the issue in #3637, but the while loop in https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/voice/room_io/_output.py#L139-L144 may cause a deadlock if `wait_for_playout` is called before any frame captured after previous `clear_queue`