### PR TITLE
turn-detector: add turn detector v0.4.0-intl

### DIFF
--- a/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/models.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/models.py
@@ -3,7 +3,7 @@ from typing import Literal
 EOUModelType = Literal["en", "multilingual"]
 MODEL_REVISIONS: dict[EOUModelType, str] = {
     "en": "v1.2.2-en",
-    "multilingual": "v0.3.1-intl",
+    "multilingual": "v0.4.0-intl",
 }
 HG_MODEL = "livekit/turn-detector"
 ONNX_FILENAME = "model_q8.onnx"


### PR DESCRIPTION
Adding `v0.4.0-intl` for the turn detector model. This model:
* includes the changes from `v0.3.1-intl` by training on normalized data
* adds improvements by distillation of large 7B parameter model (param count is unchanged compared to v0.3 models)

<img width="568" height="495" alt="Screenshot 2025-10-30 at 1 51 54 PM" src="https://github.com/user-attachments/assets/169c45d8-554b-496e-94b1-a9f8cc01f609" />
