### PR TITLE
Update stt.py - Deepgram plugin allows PT for Keyterms

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -766,11 +766,7 @@ def _validate_keyterms(
         )
 
     if is_given(keyterms) and (
-        (
-            model.startswith("nova-3")
-            and language == "multi"
-        )
-        or not model.startswith("nova-3")
+        (model.startswith("nova-3") and language == "multi") or not model.startswith("nova-3")
     ):
         raise ValueError(
             "Keyterm Prompting is only available for monolingual transcription using the Nova-3 Model. "


### PR DESCRIPTION
Deepgram plugin allows all mono-language options for the use of keyterms