### PR TITLE
fix(google): do not pass in scheduling parameter by default

### DIFF
--- a/livekit-plugins/livekit-plugins-google/README.md
+++ b/livekit-plugins/livekit-plugins-google/README.md
@@ -33,3 +33,4 @@ And these on Vertex AI:
 
 - gemini-2.0-flash-exp
 - gemini-live-2.5-flash-preview-native-audio
+- gemini-live-2.5-flash-preview-native-audio-09-2025

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/api_proto.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/api_proto.py
@@ -9,6 +9,7 @@ LiveAPIModels = Literal[
     # VertexAI models
     "gemini-2.0-flash-exp",
     "gemini-live-2.5-flash-preview-native-audio",
+    "gemini-live-2.5-flash-preview-native-audio-09-2025",
     # Gemini API models
     "gemini-2.0-flash-live-001",
     "gemini-live-2.5-flash-preview",

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
@@ -108,10 +108,11 @@ def get_tool_results_for_realtime(
             res = types.FunctionResponse(
                 name=msg.name,
                 response={"output": msg.output},
-                scheduling=tool_response_scheduling
-                if is_given(tool_response_scheduling)
-                else types.FunctionResponseScheduling.WHEN_IDLE,
             )
+            if is_given(tool_response_scheduling):
+                # vertexai currently doesn't support the scheduling parameter, gemini api defaults to idle
+                # it's the user's responsibility to avoid this parameter when using vertexai
+                res.scheduling = tool_response_scheduling
             if not vertexai:
                 # vertexai does not support id in FunctionResponse
                 # see: https://github.com/googleapis/python-genai/blob/85e00bc/google/genai/_live_converters.py#L1435


### PR DESCRIPTION
since VertexAI doesn't support it. fixes #3784