### PR TITLE
Chore: AssemblyAI add dynamic keyterms + return language code + normalize preemptive generation validation

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1393,7 +1393,8 @@ class AgentActivity(RecognitionHooks):
             # otherwise invalidate the preemptive generation
 
             if (
-                (preemptive.info.new_transcript or "").lower() == (user_message.text_content or "").lower()
+                (preemptive.info.new_transcript or "").lower()
+                == (user_message.text_content or "").lower()
                 and preemptive.chat_ctx.is_equivalent(temp_mutable_chat_ctx)
                 and preemptive.tools == self.tools
                 and preemptive.tool_choice == self._tool_choice

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -385,7 +385,7 @@ class SpeechStream(stt.SpeechStream):
             utterance = data.get("utterance", "")
             transcript = data.get("transcript", "")
             confidence = words[-1].get("confidence", 0.0) if words else 0.0
-            
+
             # language_code is only returned with utterances, so track it for final transcript
             if "language_code" in data:
                 self._current_language_code = data["language_code"]
@@ -394,7 +394,9 @@ class SpeechStream(stt.SpeechStream):
                 interim_text = " ".join(word.get("text", "") for word in words)
                 interim_event = stt.SpeechEvent(
                     type=stt.SpeechEventType.INTERIM_TRANSCRIPT,
-                    alternatives=[stt.SpeechData(language="en", text=interim_text, confidence=confidence)],
+                    alternatives=[
+                        stt.SpeechData(language="en", text=interim_text, confidence=confidence)
+                    ],
                 )
                 self._event_ch.send_nowait(interim_event)
 
@@ -402,7 +404,11 @@ class SpeechStream(stt.SpeechStream):
                 final_event = stt.SpeechEvent(
                     type=stt.SpeechEventType.PREFLIGHT_TRANSCRIPT,
                     alternatives=[
-                        stt.SpeechData(language=self._current_language_code, text=utterance, confidence=confidence)
+                        stt.SpeechData(
+                            language=self._current_language_code,
+                            text=utterance,
+                            confidence=confidence,
+                        )
                     ],
                 )
                 self._event_ch.send_nowait(final_event)
@@ -414,7 +420,11 @@ class SpeechStream(stt.SpeechStream):
                 final_event = stt.SpeechEvent(
                     type=stt.SpeechEventType.FINAL_TRANSCRIPT,
                     alternatives=[
-                        stt.SpeechData(language=self._current_language_code, text=transcript, confidence=confidence)
+                        stt.SpeechData(
+                            language=self._current_language_code,
+                            text=transcript,
+                            confidence=confidence,
+                        )
                     ],
                 )
                 self._event_ch.send_nowait(final_event)


### PR DESCRIPTION
Hi team!

Added dynamic keyterms updating without closing the stream, sends a message with type "UpdateConfiguration" https://www.assemblyai.com/docs/api-reference/streaming-api/streaming-api#send.sendUpdateConfiguration

Language code is returned when "Language_detection" is True (set now by default), and we pass this in the preflight and final transcripts, its only returned with utterances so we store it when we get it
https://www.assemblyai.com/docs/api-reference/streaming-api/streaming-api#receive.receiveTurn.language_code

Also normalized the preemptive generation text in agent_activity before validation, so we only compare if there are new words and not any changes in casing or punctuation.
