### PR TITLE
check recorder_io in make_session_report

### DIFF
--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -256,8 +256,8 @@ class JobContext:
             room_id=self.job.room.sid,
             room=self.job.room.name,
             options=session.options,
-            audio_recording_path=recorder_io.output_path,
-            audio_recording_started_at=recorder_io.recording_started_at,
+            audio_recording_path=recorder_io.output_path if recorder_io else None,
+            audio_recording_started_at=recorder_io.recording_started_at if recorder_io else None,
             events=session._recorded_events,
             enable_user_data_training=True,  # TODO
             chat_history=session.history.copy(),


### PR DESCRIPTION
encountered this error:
```
\venv\Lib\site-packages\livekit\agents\ipc\job_proc_lazy_main.py", line 314, in _run_job_task  
                                         await self._job_ctx._on_session_end()                                                                                                    
\venv\Lib\site-packages\livekit\agents\job.py", line 174, in _on_session_end                   
                                         report = self.make_session_report(session)                                                                                               
\venv\Lib\site-packages\livekit\agents\job.py", line 259, in make_session_report               
                                         audio_recording_path=recorder_io.output_path,                                                                                            
                                                              ^^^^^^^^^^^^^^^^^^^^^^^                                                                                             
                                     AttributeError: 'NoneType' object has no attribute 'output_path'   
```