### PR TITLE
feat(cartesia): add LiveKit user agent to requests

### DIFF
--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/stt.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/stt.py
@@ -37,10 +37,12 @@ from livekit.agents.utils import is_given
 
 from .log import logger
 from .models import STTEncoding, STTLanguages, STTModels
+from .version import __version__
 
 API_AUTH_HEADER = "X-API-Key"
 API_VERSION_HEADER = "Cartesia-Version"
 API_VERSION = "2025-04-16"
+USER_AGENT = f"LiveKit Agents Cartesia Plugin/{__version__}"
 
 
 @dataclass
@@ -333,7 +335,7 @@ class SpeechStream(stt.SpeechStream):
 
         try:
             ws = await asyncio.wait_for(
-                self._session.ws_connect(ws_url),
+                self._session.ws_connect(ws_url, headers={"User-Agent": USER_AGENT}),
                 self._conn_options.timeout,
             )
         except (aiohttp.ClientConnectorError, asyncio.TimeoutError) as e:

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -47,12 +47,14 @@ from .models import (
     TTSVoiceSpeed,
     _is_sonic_3,
 )
+from .version import __version__
 
 API_AUTH_HEADER = "X-API-Key"
 API_VERSION_HEADER = "Cartesia-Version"
 API_VERSION = "2025-04-16"
 API_VERSION_WITH_EMBEDDINGS_AND_EXPERIMENTAL_CONTROLS = "2024-11-13"
 MODEL_ID_WITH_EMBEDDINGS_AND_EXPERIMENTAL_CONTROLS = "sonic-2-2025-03-07"
+USER_AGENT = f"LiveKit Agents Cartesia Plugin/{__version__}"
 
 
 @dataclass
@@ -182,7 +184,9 @@ class TTS(tts.TTS):
         url = self._opts.get_ws_url(
             f"/tts/websocket?api_key={self._opts.api_key}&cartesia_version={self._opts.api_version}"
         )
-        return await asyncio.wait_for(session.ws_connect(url), timeout)
+        return await asyncio.wait_for(
+            session.ws_connect(url, headers={"User-Agent": USER_AGENT}), timeout
+        )
 
     async def _close_ws(self, ws: aiohttp.ClientWebSocketResponse) -> None:
         await ws.close()
@@ -300,6 +304,7 @@ class ChunkedStream(tts.ChunkedStream):
                 headers={
                     API_AUTH_HEADER: self._opts.api_key,
                     API_VERSION_HEADER: API_VERSION,
+                    "User-Agent": USER_AGENT,
                 },
                 json=json,
                 timeout=aiohttp.ClientTimeout(total=30, sock_connect=self._conn_options.timeout),


### PR DESCRIPTION
It's helpful to see what requests are coming from LiveKit users and with what version, this PR adds a `User-Agent` header to Cartesia requests with a LiveKit identifier + version.