### PR TITLE
allow updating the same agent that is running to apply changes in agent

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -928,7 +928,11 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             self._agent = agent
 
             if new_activity == "start":
-                if agent._activity is not None:
+                previous_agent = self._activity.agent if self._activity else None
+                if agent._activity is not None and (
+                    # allow updating the same agent that is running
+                    agent is not previous_agent or previous_activity != "close"
+                ):
                     raise RuntimeError("cannot start agent: an activity is already running")
 
                 self._next_activity = AgentActivity(agent, self)


### PR DESCRIPTION
allowing users to call `session.update_agent` on a running agent, useful to apply the changes made on the agent options (e.g. https://github.com/livekit/agents/pull/3765#discussion_r2500954011)