### PR TITLE
Close TTS connections when closing the session

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -644,6 +644,7 @@ class AgentActivity(RecognitionHooks):
         if isinstance(self.llm, llm.LLM):
             self.llm.off("metrics_collected", self._on_metrics_collected)
             self.llm.off("error", self._on_error)
+            await self.llm.aclose()
 
         if isinstance(self.llm, llm.RealtimeModel) and self._rt_session is not None:
             self._rt_session.off("generation_created", self._on_generation_created)
@@ -659,6 +660,7 @@ class AgentActivity(RecognitionHooks):
         if isinstance(self.stt, stt.STT):
             self.stt.off("metrics_collected", self._on_metrics_collected)
             self.stt.off("error", self._on_error)
+            await self.stt.aclose()
 
         if isinstance(self.tts, tts.TTS):
             self.tts.off("metrics_collected", self._on_metrics_collected)

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -663,6 +663,7 @@ class AgentActivity(RecognitionHooks):
         if isinstance(self.tts, tts.TTS):
             self.tts.off("metrics_collected", self._on_metrics_collected)
             self.tts.off("error", self._on_error)
+            await self.tts.aclose()
 
         if isinstance(self.vad, vad.VAD):
             self.vad.off("metrics_collected", self._on_metrics_collected)


### PR DESCRIPTION
I have an agent that transfers to other agents, during testing I unexpectedly hit the Inference TTS quota. After digging around a bit I discovered that after every transfer, the number of TTS connections to my dev Inference service kept increasing.  

As far as I can tell, this only happens for TTS plugins that use a connection pool. 

I tested this change with TTS plugins that do **and** do not use a connection pool. In the case of TTS plugins that do not use a connection pool.

This doesn't happen for STT connections since those get closed [here](https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/voice/agent_activity.py#L676-L677) .

Feedback welcome, let me know if there's an alternative way to handle this situation. 

     