### PR TITLE
fix pickling AgentServer for python 3.9

### DIFF
--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -332,6 +332,21 @@ class AgentServer(utils.EventEmitter[EventTypes]):
 
         self._lock = asyncio.Lock()
 
+    if sys.version_info < (3, 10):
+        # Python 3.9 cannot pickle asyncio.Lock, customize for pickle support
+        def __getstate__(self) -> dict[str, Any]:
+            """Custom pickle support - exclude unpickleable asyncio objects."""
+            state = self.__dict__.copy()
+            # remove unpickleable asyncio.Lock (will be recreated in __setstate__)
+            state.pop("_lock", None)
+            return state
+
+        def __setstate__(self, state: dict[str, Any]) -> None:
+            """Restore state and recreate asyncio.Lock."""
+            self.__dict__.update(state)
+            # recreate the lock
+            self._lock = asyncio.Lock()
+
     @overload
     def rtc_session(
         self,


### PR DESCRIPTION
`asyncio.Lock()` is not pickleable in python 3.9 with error `AttributeError: Can't pickle local object 'WeakSet.__init__.<locals>._remove'` (https://github.com/python/cpython/issues/74876). Actually the `WeakSet` is still not pickleable in later pythons, but it seems `asyncio.Lock` is fixed after python 3.10.

this causing `python agent.py dev` failed since AgentServer now is an arg of `watchfiles.arun_process` when watchfiles enabled.

in addition to this one, https://github.com/livekit/agents/pull/3842 is needed for running in python 3.9