### PR TITLE
fix: update gemini response schema key for JSON format handling

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -261,7 +261,7 @@ class LLM(llm.LLM):
                 extra["tool_config"] = gemini_tool_choice
 
         if is_given(response_format):
-            extra["response_schema"] = to_response_format(response_format)  # type: ignore
+            extra["response_json_schema"] = to_response_format(response_format)  # type: ignore
             extra["response_mime_type"] = "application/json"
 
         if is_given(self._opts.temperature):


### PR DESCRIPTION
According to the official documentation, it should be `response_json_schema`

https://ai.google.dev/gemini-api/docs/structured-output

<img width="877" height="240" alt="image" src="https://github.com/user-attachments/assets/83339fa4-d267-45ac-96d3-a4bd2fc96f8a" />
