### PR TITLE
deepgram plugin: better websocket logs

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -589,7 +589,8 @@ class SpeechStream(stt.SpeechStream):
                 k: v for k, v in ws._response.headers.items() if k.startswith("dg-") or k == "Date"
             }
             logger.debug(
-                f"Established new Deepgram STT WebSocket connection with headers: {ws_headers}"
+                "Established new Deepgram STT WebSocket connection:",
+                extra={"headers": ws_headers},
             )
         except (aiohttp.ClientConnectorError, asyncio.TimeoutError) as e:
             raise APIConnectionError("failed to connect to deepgram") from e

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -415,7 +415,8 @@ class SpeechStreamv2(stt.SpeechStream):
                 k: v for k, v in ws._response.headers.items() if k.startswith("dg-") or k == "Date"
             }
             logger.debug(
-                f"Established new Deepgram STT WebSocket connection with headers: {ws_headers}"
+                "Established new Deepgram STT WebSocket connection:",
+                extra={"headers": ws_headers},
             )
         except (aiohttp.ClientConnectorError, asyncio.TimeoutError) as e:
             raise APIConnectionError("failed to connect to deepgram") from e

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
@@ -127,7 +127,8 @@ class TTS(tts.TTS):
             k: v for k, v in ws._response.headers.items() if k.startswith("dg-") or k == "Date"
         }
         logger.debug(
-            f"Established new Deepgram TTS WebSocket connection with headers: {ws_headers}"
+            "Established new Deepgram TTS WebSocket connection:",
+            extra={"headers": ws_headers},
         )
 
         return ws


### PR DESCRIPTION
Added websocket connection headers to debug log output for Deepgram's STT and TTS. The logs include the Deepgram request ID, the user's Deepgram project ID, and the datetime when the websocket was created.

Example `DEBUG` logs:
```
2025-11-12 22:01:50,201 - DEBUG livekit.plugins.deepgram - Established new Deepgram STT WebSocket connection: {"room": "mock_room", "headers": {"dg-project-id": "026a7490-d155-499f-9cf3-27fe20cf7e3e", "dg-request-id": "458b61b3-cb3e-486a-a121-436567ab4524", "Date": "Thu, 13 Nov 2025 04:01:49 GMT"}}
```