### PR TITLE
blingfire: add version constraints for pybind

### DIFF
--- a/livekit-plugins/livekit-blingfire/pyproject.toml
+++ b/livekit-plugins/livekit-blingfire/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "pybind11"]
+requires = ["setuptools>=61.0", "pybind11>=2.13.6,<3.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel.macos]

--- a/livekit-plugins/livekit-blingfire/setup.py
+++ b/livekit-plugins/livekit-blingfire/setup.py
@@ -19,6 +19,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pybind11
 import setuptools
 from setuptools import Extension
 from setuptools.command.build_ext import build_ext
@@ -48,6 +49,7 @@ class CMakeBuild(build_ext):
             f"-DPYTHON_EXECUTABLE={sys.executable}",
             "-DCMAKE_BUILD_TYPE=Release",
             "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
+            f"-Dpybind11_DIR={pybind11.get_cmake_dir()}",
         ]
 
         print(f"cmake_args: {cmake_args}")


### PR DESCRIPTION
`pybind` [recently updated](https://github.com/pybind/pybind11/releases/tag/v3.0.0) to v3.0.0 which includes breaking changes that are incompatible with the existing implementation of blingfire. This PR fixes `pybind11` to `>=2.13.6,<3.0` which ensures v2 is used.