### PR TITLE
Allow users to pick BVCTelephony at runtime

### DIFF
--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -14,7 +14,7 @@ from ...log import logger
 from ...utils import aio, log_exceptions
 from ..io import AudioInput, VideoInput
 from ._pre_connect_audio import PreConnectAudioHandler
-from .types import NoiseCancellationSelector
+from .types import NoiseCancellationParams, NoiseCancellationSelector
 
 T = TypeVar("T", bound=Union[rtc.AudioFrame, rtc.VideoFrame])
 
@@ -229,7 +229,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
     @override
     def _create_stream(self, track: rtc.Track, participant: rtc.Participant) -> rtc.AudioStream:
         noise_cancellation = (
-            self._noise_cancellation(participant, track)
+            self._noise_cancellation(NoiseCancellationParams(participant, track))
             if callable(self._noise_cancellation)
             else self._noise_cancellation
         )

--- a/livekit-agents/livekit/agents/voice/room_io/types.py
+++ b/livekit-agents/livekit/agents/voice/room_io/types.py
@@ -37,8 +37,15 @@ TextInputCallback = Callable[
     ["AgentSession", TextInputEvent], Optional[Coroutine[None, None, None]]
 ]
 
+
+@dataclass
+class NoiseCancellationParams:
+    participant: rtc.Participant
+    track: rtc.Track
+
+
 NoiseCancellationSelector = Callable[
-    [rtc.Participant, rtc.Track], Optional[rtc.NoiseCancellationOptions]
+    [NoiseCancellationParams], Optional[rtc.NoiseCancellationOptions]
 ]
 
 


### PR DESCRIPTION
We've run into an issue with builder agents where our standard approach of leaving a comment telling you to use BVCTelephony if you're doing SIP won't cut it. We need to pick the right model at runtime. 

It's a rough edge anyways. It's better that our default "just work",  and it's good to have an option that is runtime flexible.

There are multiple challenges to make this work:

1. The option is configured prior to connection (so you don't know what kind of participant will be on the other end)
2. You can't change the NC model later without tearing down and recreating the stream
3. The models are in a plugin that's not a default dependency of the agents SDK

This PR solves it by allowing users to specify a selector function for the model, which is called at runtime just before creating the stream and is given the remote participant and the remote track. While I'm only currently using it for choosing BVC vs BVC telephony according to the participant kind, this approach provides additional flexibility for users to pick appropriate models based on other attributes of the remote participant or track.

There may be other ways to solve this but this seemed like a good option - I'm interested in what others think. Also I added this to the new RoomOptions/AudioInputOptions only, instead of the deprecated RoomInputOptions

A working implementation for the intended usecase looks like this:

```
room_options=room_io.RoomOptions(
    audio_input=room_io.AudioInputOptions(
        noise_cancellation=lambda params: noise_cancellation.BVCTelephony() if params.participant.kind == rtc.ParticipantKind.PARTICIPANT_KIND_SIP else noise_cancellation.BVC()
    )
),
```