### PR TITLE
Add control flag for voice activity interruption for barge-in

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1111,7 +1111,7 @@ class AgentActivity(RecognitionHooks):
         self._schedule_speech(handle, SpeechHandle.SPEECH_PRIORITY_NORMAL)
 
     def _interrupt_by_audio_activity(self) -> None:
-        # barge-in holds off interruptions only if there is no realtime session
+        # barge-in only works if there is no realtime session
         if not self._allow_interruption_by_audio_activity and self._rt_session is None:
             return
 


### PR DESCRIPTION
**Background**

This is the third piece for barge-in detection and it adds a control flag for `_interrupt_by_audio_activity`:
- when agent is speaking, barge-in detector will disable this, but allow STT to continue transcribing user speeches;
- only re-enable it when the detector identifies barge-in

**Changes**
- Added a new flag `_allow_interruption_by_audio_activity` and set to True by default;
- Allow update to that flag via `update_options`;
- Only works with non-realtime agent sessions