### PR TITLE
Allow tool role for dummy user message

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/google.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/google.py
@@ -83,7 +83,8 @@ def to_chat_ctx(
             turn["role"] = "user"
 
     # Gemini requires the last message to end with user's turn before they can generate
-    if inject_dummy_user_message and current_role != "user":
+    # allow tool role since we update it to user in the previous step
+    if inject_dummy_user_message and current_role not in ("user", "tool"):
         turns.append({"role": "user", "parts": [{"text": "."}]})
 
     return turns, GoogleFormatData(system_messages=system_messages)


### PR DESCRIPTION
This should fix #3936 

Tool role is updated to user, but the `current_role` is not updated. This can lead to extra dummy user message after a tool message.