### PR TITLE
Fix GPT-5.1 reasoning_effort

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -119,7 +119,7 @@ class LLM(llm.LLM):
 
         if not is_given(reasoning_effort) and _supports_reasoning_effort(model):
             if model == "gpt-5.1":
-                reasoning_effort = None
+                reasoning_effort = "none"
             else:
                 reasoning_effort = "minimal"
 


### PR DESCRIPTION
With latest version, default `gpt-5.1` raises the following error:
```
Unsupported value: 'reasoning_effort' does not support null with this model. Supported values are: 'none', 'low', 'medium', and 'high'.\", 'type': 'invalid_request_error', 'param': 'reasoning_effort', 'code': 'unsupported_value'
```