### PR TITLE
fix contextvar when using text mode in console

### DIFF
--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -1002,16 +1002,14 @@ def _text_mode(c: AgentsConsole) -> None:
             c.console.bell()
             continue
 
-        def _generate_with_context(
-            text: str, result_fut: asyncio.Future[list[RunEvent]]
-        ) -> list[RunEvent]:
+        def _generate_with_context(text: str, result_fut: asyncio.Future[list[RunEvent]]) -> None:
             async def _generate(text: str) -> list[RunEvent]:
                 sess = await c.io_session.run(user_input=text)  # type: ignore
                 return sess.events.copy()
 
             def _done_callback(task: asyncio.Task[list[RunEvent]]) -> None:
-                if task.exception():
-                    result_fut.set_exception(task.exception())
+                if exception := task.exception():
+                    result_fut.set_exception(exception)
                 else:
                     result_fut.set_result(task.result())
 


### PR DESCRIPTION
fix https://github.com/livekit/agents/issues/3969

When using `asyncio.run_coroutine_threadsafe()`, the coroutine has the context from the thread it's created, so `_generate(text)` created in main thread doesn't have the `_JobContextVar`. This fix uses  `c.io_loop.call_soon_threadsafe(..., context=c.io_context)` instead.
