### PR TITLE
Temp workaround for langfuse otel traces

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -637,8 +637,7 @@ class AgentActivity(RecognitionHooks):
                 attributes={trace_types.ATTR_AGENT_LABEL: self.agent.label},
             )
             try:
-                with trace.use_span(span, end_on_exit=False):
-                    await self._start_session()
+                await self._start_session()
             finally:
                 span.end()
 
@@ -659,9 +658,8 @@ class AgentActivity(RecognitionHooks):
                 attributes={trace_types.ATTR_AGENT_LABEL: self._agent.label},
             )
             try:
-                with trace.use_span(span, end_on_exit=False):
-                    await self._pause_scheduling_task(blocked_tasks=blocked_tasks)
-                    await self._close_session()
+                await self._pause_scheduling_task(blocked_tasks=blocked_tasks)
+                await self._close_session()
             finally:
                 span.end()
 


### PR DESCRIPTION
<img width="345" height="330" alt="Screenshot 2025-11-18 at 15 28 13" src="https://github.com/user-attachments/assets/3e2c452e-a1c3-4824-81c3-f2173e78cb80" />

There seems to be a regression where Langfuse stops having a root span to group span. Previously, there would be an empty span at the root level:
<img width="413" height="480" alt="Screenshot 2025-11-18 at 15 29 47" src="https://github.com/user-attachments/assets/c1efbfa2-3899-461e-a665-23d9e9ed69b3" />

This PR adds one root span manually, so it still works:
<img width="441" height="819" alt="Screenshot 2025-11-18 at 15 30 12" src="https://github.com/user-attachments/assets/331901c8-6b92-4f1c-b7a8-3d93622ffc52" />

I suspect some part of the new code affected the Otel context, leading to dangling spans.
