### PR TITLE
clear internal buffer of datastream io when interruption

### DIFF
--- a/livekit-agents/livekit/agents/voice/avatar/_datastream_io.py
+++ b/livekit-agents/livekit/agents/voice/avatar/_datastream_io.py
@@ -320,6 +320,11 @@ class DataStreamAudioReceiver(AudioReceiver):
 
             if self._current_reader:
                 self._current_reader_cleared = True
+
+            # clear the audio internal buffer
+            while not self._data_ch.empty():
+                self._data_ch.recv_nowait()
+
             self.emit("clear_buffer")
             return "ok"
 
@@ -417,7 +422,11 @@ class DataStreamAudioReceiver(AudioReceiver):
                     async for data in self._current_reader:
                         if self._current_reader_cleared:
                             # ignore the rest data of the current reader if clear_buffer was called
+                            while not self._data_ch.empty():
+                                self._data_ch.recv_nowait()
+                            bstream.clear()
                             break
+
                         for frame in bstream.push(data):
                             self._data_ch.send_nowait(frame)
 


### PR DESCRIPTION
if the consumer of the datastream io is slower than audio receiving, the audio frames in the buffer are still played after interruption