### PR TITLE
Add OVHcloud AI Endpoints provider

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
@@ -17,7 +17,7 @@
 Support for OpenAI Realtime API, LLM, TTS, and STT APIs.
 
 Also includes support for a large number of OpenAI-compatible APIs including Azure OpenAI, Cerebras,
-Fireworks, Perplexity, Telnyx, xAI, Ollama, DeepSeek, and OpenRouter.
+Fireworks, Perplexity, Telnyx, xAI, Ollama, DeepSeek, OpenRouter, and OVHcloud AI Endpoints.
 
 See https://docs.livekit.io/agents/integrations/openai/ and
 https://docs.livekit.io/agents/integrations/llm/ for more information.

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -607,6 +607,50 @@ class LLM(llm.LLM):
         )
 
     @staticmethod
+    def with_ovhcloud(
+        *,
+        model: str = "gpt-oss-120b",
+        api_key: str | None = None,
+        base_url: str = "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1",
+        client: openai.AsyncClient | None = None,
+        user: NotGivenOr[str] = NOT_GIVEN,
+        temperature: NotGivenOr[float] = NOT_GIVEN,
+        parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
+        tool_choice: ToolChoice = "auto",
+        reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
+        safety_identifier: NotGivenOr[str] = NOT_GIVEN,
+        prompt_cache_key: NotGivenOr[str] = NOT_GIVEN,
+        top_p: NotGivenOr[float] = NOT_GIVEN,
+    ) -> LLM:
+        """
+        Create a new instance of OVHcloud AI Endpoints LLM.
+
+        ``api_key`` must be set to your OVHcloud AI Endpoints API key, either using the argument or by setting
+        the ``OVHCLOUD_API_KEY`` environmental variable.
+        """
+
+        api_key = api_key or os.environ.get("OVHCLOUD_API_KEY")
+        if api_key is None:
+            raise ValueError(
+                "OVHcloud AI Endpoints API key is required, either as argument or set OVHCLOUD_API_KEY environmental variable"  # noqa: E501
+            )
+
+        return LLM(
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            client=client,
+            user=user,
+            temperature=temperature,
+            parallel_tool_calls=parallel_tool_calls,
+            tool_choice=tool_choice,
+            reasoning_effort=reasoning_effort,
+            safety_identifier=safety_identifier,
+            prompt_cache_key=prompt_cache_key,
+            top_p=top_p,
+        )
+
+    @staticmethod
     def with_perplexity(
         *,
         model: str | PerplexityChatModels = "llama-3.1-sonar-small-128k-chat",

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -254,6 +254,38 @@ class STT(stt.STT):
             use_realtime=False,
         )
 
+    @staticmethod
+    def with_ovhcloud(
+        *,
+        model: str = "whisper-large-v3-turbo",
+        api_key: NotGivenOr[str] = NOT_GIVEN,
+        base_url: str = "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1",
+        client: openai.AsyncClient | None = None,
+        language: str = "en",
+        detect_language: bool = False,
+        prompt: NotGivenOr[str] = NOT_GIVEN,
+    ) -> STT:
+        """
+        Create a new instance of OVHcloud AI Endpoints STT.
+
+        ``api_key`` must be set to your OVHcloud AI Endpoints API key, either using the argument or by setting
+        the ``OVHCLOUD_API_KEY`` environmental variable.
+        """
+        ovhcloud_api_key = api_key if is_given(api_key) else os.environ.get("OVHCLOUD_API_KEY")
+        if not ovhcloud_api_key:
+            raise ValueError("OVHcloud AI Endpoints API key is required")
+
+        return STT(
+            model=model,
+            api_key=ovhcloud_api_key,
+            base_url=base_url,
+            client=client,
+            language=language,
+            detect_language=detect_language,
+            prompt=prompt,
+            use_realtime=False,
+        )
+
     def stream(
         self,
         *,


### PR DESCRIPTION
Hi team,
You will find in this PR the integration of OVHcloud AI Endpoints, the inference provider of OVHcloud (the cloud leader in Europe).

I edited the openai plugin to integrate a new function `with_ovhcloud`, like other providers such as OpenRouter, Groq, Together, etc...

Let me know if it's okay for you!
The docs will be updated when this PR is merged.

Best regards!