### PR TITLE
Fix: Propagate ws_url in AgentServer.from_server_options

### DIFF
--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -374,6 +374,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
             initialize_process_timeout=options.initialize_process_timeout,
             permissions=options.permissions,
             max_retry=options.max_retry,
+            ws_url=options.ws_url,
             api_key=options.api_key,
             api_secret=options.api_secret,
             host=options.host,


### PR DESCRIPTION
## Summary
This PR fixes a bug where the `ws_url` parameter from `WorkerOptions` was not being passed to the `AgentServer` constructor in `AgentServer.from_server_options()`. This caused runtime errors when `ws_url` was provided in `WorkerOptions` but not set in the environment variables.

## Changes
- Updated `AgentServer.from_server_options` in `livekit/agents/worker.py` to explicitly pass `ws_url=options.ws_url` to the `AgentServer` constructor.

## Testing
- Ran linting (`ruff check`), formatting (`ruff format`), and type checking (`mypy`) as per `CONTRIBUTING.md`.
- Ran the following script to verify the fix:

```python
import os
import asyncio
from livekit.agents import AgentServer, WorkerOptions, JobContext

async def test_ws_url_propagation():
    # Clear environment variables to ensure we're testing WorkerOptions
    for key in ['LIVEKIT_URL', 'LIVEKIT_API_KEY', 'LIVEKIT_API_SECRET']:
        os.environ.pop(key, None)

    async def entrypoint(ctx: JobContext):
        pass

    worker_options = WorkerOptions(
        entrypoint_fnc=entrypoint,
        ws_url='wss://test-server.livekit.cloud',
        api_key='test-api-key',
        api_secret='test-api-secret',
    )

    # This should work without environment variables
    server = AgentServer.from_server_options(worker_options)
    
    # Verify that the ws_url was correctly set on the server instance
    assert server._ws_url == 'wss://test-server.livekit.cloud'
    print("✅ ws_url propagated correctly!")

if __name__ == '__main__':
    asyncio.run(test_ws_url_propagation())
```