### PR TITLE
fix: accurate speech duration in VAD EOS

### DIFF
--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py
@@ -496,7 +496,9 @@ class VADStream(agents.vad.VADStream):
                                 samples_index=pub_current_sample,
                                 timestamp=pub_timestamp,
                                 silence_duration=pub_silence_duration,
-                                speech_duration=pub_speech_duration,
+                                speech_duration=max(
+                                    0.0, pub_speech_duration - silence_threshold_duration
+                                ),
                                 frames=[_copy_speech_buffer()],
                                 speaking=False,
                             )


### PR DESCRIPTION
https://github.com/livekit/agents/pull/3951#discussion_r2533060419