### PR TITLE
feat(openai): add verbosity parameter support to LLM.with_azure()

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -191,6 +191,7 @@ class LLM(llm.LLM):
         timeout: httpx.Timeout | None = None,
         reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
         top_p: NotGivenOr[float] = NOT_GIVEN,
+        verbosity: NotGivenOr[Verbosity] = NOT_GIVEN,
     ) -> LLM:
         """
         This automatically infers the following arguments from their corresponding environment variables if they are not provided:
@@ -229,6 +230,7 @@ class LLM(llm.LLM):
             safety_identifier=safety_identifier,
             prompt_cache_key=prompt_cache_key,
             top_p=top_p,
+            verbosity=verbosity,
         )
 
     @staticmethod


### PR DESCRIPTION
Add verbosity parameter to the with_azure() static method to match the parameter support available in the main LLM constructor. This allows Azure OpenAI users to control response verbosity for reasoning models through the convenience method.

The verbosity parameter was already supported in the core LLM class but was missing from the Azure-specific method signature. #4069 