### PR TITLE
Support custom auth schemes for MCP servers

### DIFF
--- a/livekit-agents/livekit/agents/llm/mcp.py
+++ b/livekit-agents/livekit/agents/llm/mcp.py
@@ -13,6 +13,7 @@ from urllib.parse import urlparse
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 
 try:
+    from httpx import Auth
     from mcp import ClientSession, stdio_client
     from mcp.client.sse import sse_client
     from mcp.client.stdio import StdioServerParameters
@@ -187,10 +188,12 @@ class MCPServerHTTP(MCPServer):
         timeout: float = 5,
         sse_read_timeout: float = 60 * 5,
         client_session_timeout_seconds: float = 5,
+        auth: Auth | None = None,
     ) -> None:
         super().__init__(client_session_timeout_seconds=client_session_timeout_seconds)
         self.url = url
         self.headers = headers
+        self.auth = auth
         self._timeout = timeout
         self._sse_read_timeout = sse_read_timeout
         self._allowed_tools = set(allowed_tools) if allowed_tools else None
@@ -236,6 +239,7 @@ class MCPServerHTTP(MCPServer):
                 headers=self.headers,
                 timeout=timedelta(seconds=self._timeout),
                 sse_read_timeout=timedelta(seconds=self._sse_read_timeout),
+                auth=self.auth,
             )
         else:
             return sse_client(  # type: ignore[no-any-return]
@@ -243,6 +247,7 @@ class MCPServerHTTP(MCPServer):
                 headers=self.headers,
                 timeout=self._timeout,
                 sse_read_timeout=self._sse_read_timeout,
+                auth=self.auth,
             )
 
     async def list_tools(self) -> list[MCPTool]:


### PR DESCRIPTION
This PR adds an `auth` param to the `MCPServerHTTP` class, which is passed through to the underlying `mcp` library.

Livekit supports providing a list of static headers to the MCP client which is useful for basic authentication schemes, but are often insufficient. In our case, our authentication tokens are short-lived and need to be refreshed periodically. Having a more flexible way to configure authentication makes this possible.

```py
session = agents.AgentSession(
    mcp_servers=[
        mcp.MCPServerHTTP(
            url="https://foo.bar/mcp/",
            auth=RefreshingAccessTokenAuth(),
        )
    ],
)
```