### PR TITLE
fix turn-detector loading issue due to transformers 4.57.2

### DIFF
--- a/livekit-plugins/livekit-plugins-turn-detector/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-turn-detector/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "livekit-agents>=1.3.4",
-    "transformers>=4.47.1",
+    "transformers>=4.47.1,<=4.57.1",  # transformers 4.57.2 has a bug with local_files_only=True
     "numpy>=1.26",
     "onnxruntime>=1.18",
     "jinja2",


### PR DESCRIPTION
temporally fix turn detector loading issue introduced by transformers 4.57.2
```
Could not find model livekit/turn-detector with revision v0.4.1-intl. Make sure you have downloaded the model before running the agent. Use `python3 your_agent.py download-files` to download the models.
error initializing inference runner
Traceback (most recent call last):
  File "/Users/darryncampbell/temp/agent-starter-python/.venv/lib/python3.13/site-packages/livekit/agents/ipc/inference_proc_lazy_main.py", line 69, in initialize
    runner.initialize()
    ~~~~~~~~~~~~~~~~~^^
  File "/Users/darryncampbell/temp/agent-starter-python/.venv/lib/python3.13/site-packages/livekit/plugins/turn_detector/base.py", line 146, in initialize
    raise RuntimeError(
    ...<2 lines>...
    ) from None
RuntimeError: livekit-plugins-turn-detector initialization failed. Could not find model livekit/turn-detector with revision v0.4.1-intl.
```

related to https://github.com/huggingface/transformers/issues/42369

the issue was caused by this change https://github.com/huggingface/transformers/pull/42299/files#diff-85b29486a884f445b1014a26fecfb189141f2e6b09f4ae701ee758a754fddcc1R2102, we set `local_files_only=True` and the `pretrained_model_name_or_path` is the repo name `livekit/turn-detector`, it goes to `remote_files = os.listdir(pretrained_model_name_or_path)` which raises the file not found error