### PR TITLE
feat(rime): expand update_options to accept all TTS parameters

### DIFF
--- a/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
+++ b/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
@@ -192,7 +192,6 @@ class TTS(tts.TTS):
         if is_given(speaker):
             self._opts.speaker = speaker
 
-    
         if self._opts.model == "arcana" and self._opts.arcana_options is not None:
             if is_given(repetition_penalty):
                 self._opts.arcana_options.repetition_penalty = repetition_penalty


### PR DESCRIPTION
The Rime TTS plugin currently allows updates only for model and speaker values through the update_options method. This creates limitations for applications that need to adjust TTS behavior during runtime. Voice agents often modify temperature, speed, stability, latency settings, or other Rime specific parameters based on conversation context or user preference. Since these values cannot be changed without recreating the full TTS instance.