### PR TITLE
Add Loop Option for Thinking Sound in `BackgroundAudioPlayer`

### DIFF
--- a/livekit-agents/livekit/agents/voice/background_audio.py
+++ b/livekit-agents/livekit/agents/voice/background_audio.py
@@ -69,6 +69,7 @@ class BackgroundAudioPlayer:
         thinking_sound: NotGivenOr[
             AudioSource | AudioConfig | list[AudioConfig] | None
         ] = NOT_GIVEN,
+        loop_thinking_sound: bool = False,
         stream_timeout_ms: int = 200,
     ) -> None:
         """
@@ -93,10 +94,14 @@ class BackgroundAudioPlayer:
                 The sound to be played when the associated agent enters a “thinking” state. This can be a single
                 sound source or a list of AudioConfig objects (with volume and probability settings).
 
+            loop_thinking_sound (bool, optional):
+                Wether to loop the thinking sound or not. Defaults to False.
+
         """  # noqa: E501
 
         self._ambient_sound = ambient_sound if is_given(ambient_sound) else None
         self._thinking_sound = thinking_sound if is_given(thinking_sound) else None
+        self._loop_thinking_sound = loop_thinking_sound
 
         self._audio_source = rtc.AudioSource(48000, 1, queue_size_ms=_AUDIO_SOURCE_BUFFER_MS)
         self._audio_mixer = rtc.AudioMixer(
@@ -321,7 +326,8 @@ class BackgroundAudioPlayer:
 
             assert self._thinking_sound is not None
             self._thinking_handle = self.play(
-                cast(Union[AudioSource, AudioConfig, list[AudioConfig]], self._thinking_sound)
+                cast(Union[AudioSource, AudioConfig, list[AudioConfig]], self._thinking_sound),
+                loop=self._loop_thinking_sound,
             )
 
         elif self._thinking_handle:


### PR DESCRIPTION
This PR adds a `loop_thinking_sound` parameter to the `BackgroundAudioPlayer` class, enabling the thinking sound to loop continuously during the agent's thinking state rather than playing once.

## Changes Made

- Added `loop_thinking_sound: bool = False` parameter to `BackgroundAudioPlayer.__init__()`
- Pass the loop parameter to the internal `play()` function when playing thinking sounds
- Updated docstring to document the new parameter

```python
# Usage example
bg_player = BackgroundAudioPlayer(
    thinking_sound=AudioConfig(
        source="thinking.wav",
        volume=0.5
    ),
    loop_thinking_sound=True  # New parameter
)
```

## Problem Statement

### Current Limitation

Currently, the thinking sound plays **only once** when the agent enters the thinking state, regardless of how long the LLM takes to respond. While this works well for short utterances like "hmm" or "uhh", it creates significant friction for developers who want to use **continuous ambient sounds** during thinking (e.g., typing sounds, soft music, processing indicators).

### Developer Pain Point

Without looping support, developers must:

1. **Manually calculate worst-case TTFT** for their LLM (e.g., GPT-4o-mini ~2.5s)
2. **Stretch or concatenate audio clips** to match this duration
3. **Repeat this process** for every sound effect they want to test
4. **Re-do the work** if they switch LLMs with different TTFT characteristics

**Example scenario:**
```
LLM TTFT: 1.05s
Audio clip: 0.2s
Expected behavior: Play 5 times (1.05s / 0.2s ≈ 5)
Actual behavior: Plays once, then silence
```

This creates a frustrating trial-and-error workflow that significantly slows down experimentation with thinking sound effects.

## Impact on Development

### Before This Change ❌
```python
# Developer has to pre-process audio
# 1. Take 200ms clip
# 2. Manually concatenate it 12+ times to get ~2.5s
# 3. Export as new file
# 4. Repeat for every sound effect variation

bg_player = BackgroundAudioPlayer(
    thinking_sound=AudioConfig(
        source="thinking_stretched_2500ms.wav",  # Pre-processed
        volume=0.5
    )
)
```

### After This Change ✅
```python
# Developer can use short, natural loops
bg_player = BackgroundAudioPlayer(
    thinking_sound=AudioConfig(
        source="thinking.wav",  # Original 200ms clip
        volume=0.5
    ),
    loop_thinking_sound=True  # Automatically loops
)
```