### PR TITLE
Fix realtime compatibility with aws-sdk-bedrock-runtime 0.2.0 upgrade

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -1027,15 +1027,13 @@ class RealtimeSession(  # noqa: F811
                     ModelStreamErrorException,
                 ) as re:
                     logger.warning(
-                        f"Retryable error: {re}\nAttempting to recover...",
-                        exc_info=True
+                        f"Retryable error: {re}\nAttempting to recover...", exc_info=True
                     )
                     await self._restart_session(re)
                     break
                 except ModelTimeoutException as mte:
                     logger.warning(
-                        f"Model timeout error: {mte}\nAttempting to recover...",
-                        exc_info=True
+                        f"Model timeout error: {mte}\nAttempting to recover...", exc_info=True
                     )
                     await self._restart_session(mte)
                     break


### PR DESCRIPTION
**Description:**

This PR addresses compatibility issues introduced by the recent upgrade to `aws-sdk-bedrock-runtime>=0.2.0` in #4111.

### Changes

**API compatibility fixes:**
- Add required `service="bedrock"` parameter to `SigV4AuthScheme` 
- Update Config parameter names to match new SDK API:
  - `http_auth_scheme_resolver` → `auth_scheme_resolver`
  - `http_auth_schemes` → `auth_schemes`

**Performance improvement:**
- Add credential caching to `Boto3CredentialsResolver` to prevent fetching AWS credentials on every event
- Temporary credentials cached until 5 minutes before expiration
- Static credentials cached indefinitely

### Testing
Tested with realtime Bedrock sessions - credentials now load once instead of ~30 times per second.

### Related
Follows up on #4111 which upgraded the Bedrock SDK dependencies.
