### PR TITLE
Enable Deepgram Nova-3 multilingual keyterm prompting

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -772,10 +772,8 @@ def _validate_keyterms(
             "Base speech to text models. For Nova-3, use Keyterm Prompting."
         )
 
-    if is_given(keyterms) and (
-        (model.startswith("nova-3") and language == "multi") or not model.startswith("nova-3")
-    ):
+    if is_given(keyterms) and (not model.startswith("nova-3")):
         raise ValueError(
-            "Keyterm Prompting is only available for monolingual transcription using the Nova-3 Model. "
+            "Keyterm Prompting is only available for transcription using the Nova-3 Model. "
             "To boost recognition of keywords using another model, use the Keywords feature."
         )


### PR DESCRIPTION
__Description:__

Enable Deepgram's expansion of keyterm prompting to their Nova-3 multilingual model.

__Changes:__

Support `(model.startswith("nova-3") and language == "multi")` as a valid condition for keyterm usage, so `model=nova-3&language=multi` can be passed to Deepgram.

__Linting:__

Linted changed file:
```
ruff format livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
ruff check --fix livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
```