### PR TITLE
fix(anthropic): use passed client parameter instead of always creating new one (fixes #4129)

### DIFF
--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
@@ -100,7 +100,7 @@ class LLM(llm.LLM):
         if not anthropic_api_key:
             raise ValueError("Anthropic API key is required")
 
-        self._client = anthropic.AsyncClient(
+        self._client = client or anthropic.AsyncClient(
             api_key=anthropic_api_key,
             base_url=base_url if is_given(base_url) else None,
             http_client=httpx.AsyncClient(


### PR DESCRIPTION
fix(anthropic): use passed client parameter instead of always creating new one (fixes #4129)  