### PR TITLE
fix: `AgentHandoff` unable to serialize and then deserialize [ONE-LINER]

### DIFF
--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -198,7 +198,7 @@ class FunctionCallOutput(BaseModel):
 class AgentHandoff(BaseModel):
     id: str = Field(default_factory=lambda: utils.shortuuid("item_"))
     type: Literal["agent_handoff"] = Field(default="agent_handoff")
-    old_agent_id: str | None
+    old_agent_id: str | None = None
     new_agent_id: str
     created_at: float = Field(default_factory=time.time)
 

--- a/tests/test_chat_ctx.py
+++ b/tests/test_chat_ctx.py
@@ -50,6 +50,18 @@ def test_dict():
     print(ChatContext.from_dict(chat_ctx.to_dict()).items)
 
 
+def test_chat_ctx_can_be_serialized_and_deserialized_with_defaults():
+    from livekit.agents.llm import AgentHandoff, ChatContext, ChatMessage
+
+    items = [
+        AgentHandoff(new_agent_id="default_agent", old_agent_id=None),
+        ChatMessage(role="user", content=["Hello, world!"]),
+        ChatMessage(role="assistant", content=["Hi there!"]),
+    ]
+    chat_ctx = ChatContext(items)
+    assert chat_ctx.is_equivalent(ChatContext.from_dict(chat_ctx.to_dict()))
+
+
 async def test_summarize():
     from livekit.agents import ChatContext
 


### PR DESCRIPTION
The root cause of this problem:
- `AgentHandoff` serializes excluding `None` values by default
- `AgentHandoff` deserializes **requiring** `None` value for `old_agent_id`
- You get `old_agent_id is missing` error

The fix is to assign a default `None` value to `AgentHandoff.old_agent_id`

---

I've included a unittest for this case.
