### PR TITLE
feat(background-audio): add several builtin audio clips

### DIFF
--- a/livekit-agents/livekit/agents/resources/city-ambience.ogg
+++ b/livekit-agents/livekit/agents/resources/city-ambience.ogg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:520910965ef316130ac7240d86fd985613769c85a22d629f3d9d316accb4623f
+size 393503

--- a/livekit-agents/livekit/agents/resources/crowded-room.ogg
+++ b/livekit-agents/livekit/agents/resources/crowded-room.ogg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a3c8c476f176b59cbcfedc212e65b4c8b0cb9b1b7555fcf09c4e7fadf8e867f
+size 318878

--- a/livekit-agents/livekit/agents/resources/forest-ambience.ogg
+++ b/livekit-agents/livekit/agents/resources/forest-ambience.ogg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6692987291acdec983db399e08d5a4dd55627bbdf1ac59b86e8988999facee5d
+size 399708

--- a/livekit-agents/livekit/agents/voice/background_audio.py
+++ b/livekit-agents/livekit/agents/voice/background_audio.py
@@ -27,7 +27,10 @@ atexit.register(_resource_stack.close)
 
 
 class BuiltinAudioClip(enum.Enum):
+    CITY_AMBIENCE = "city-ambience.ogg"
+    FOREST_AMBIENCE = "forest-ambience.ogg"
     OFFICE_AMBIENCE = "office-ambience.ogg"
+    CROWDED_ROOM = "crowded-room.ogg"
     KEYBOARD_TYPING = "keyboard-typing.ogg"
     KEYBOARD_TYPING2 = "keyboard-typing2.ogg"
     HOLD_MUSIC = "hold_music.ogg"


### PR DESCRIPTION
Just thought a few more builtin audio clips could be useful -- though I'm aware we don't need to boil the ocean. These clips are each around 300-400k and are looped. They were generated with 11Labs sound effects playground.