### PR TITLE
fix(aws): Handle nested schema in Nova Sonic tool parameter extraction

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -448,15 +448,9 @@ class RealtimeSession(  # noqa: F811
             for name, f in self.tools.function_tools.items():
                 if llm.tool_context.is_function_tool(f):
                     description = llm.tool_context.get_function_info(f).description
-                    # Robust schema extraction for MCP tool compatibility:
-                    # - internally_tagged=True returns flat: {"name", "parameters", "type"}
-                    # - Other sources may use nested: {"type": "function", "function": {...}}
-                    # Handle both formats safely with fallback
-                    schema = llm.utils.build_legacy_openai_schema(f, internally_tagged=True)
-                    func_schema = schema.get("function", schema)
-                    input_schema = func_schema.get(
-                        "parameters", {"type": "object", "properties": {}}
-                    )
+                    input_schema = llm.utils.build_legacy_openai_schema(f, internally_tagged=True)[
+                        "parameters"
+                    ]
                 elif llm.tool_context.is_raw_function_tool(f):
                     description = llm.tool_context.get_raw_function_info(f).raw_schema.get(
                         "description"


### PR DESCRIPTION
## Summary
Fixes tool parameter extraction for Amazon Nova Sonic realtime models. Tool calls were receiving empty `{}` parameters due to incorrect schema access.

## Problem
`build_legacy_openai_schema()` returns a nested structure:
{'type': 'function', 'function': {'name': '...', 'parameters': {...}}}The existing code directly accessed `schema["parameters"]`, which returns `None` when the schema has the nested `function` key, causing all tool parameters to be empty.

## Solution
Safely extract parameters by checking for the nested `function` key:
schema = llm.utils.build_legacy_openai_schema(f, internally_tagged=True)
func_schema = schema.get("function", schema)
input_schema = func_schema.get("parameters", {"type": "object", "properties": {}})This handles both flat and nested schema formats with proper fallback.

## Testing
Tested with function tools using the LiveKit Agents framework. Tools now receive correct parameter schemas instead of empty objects.

## Checklist
- [x] Ran `ruff check --fix` - all checks passed
- [x] Ran `ruff format` - code formatted
- [x] Handles both flat and nested schema structures
- [x] Includes fallback for raw function tools