### PR TITLE
expose elevenlabs TTS error message

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -662,7 +662,7 @@ class _Connection:
                 if error := data.get("error"):
                     logger.error(
                         "elevenlabs tts returned error",
-                        extra={"context_id": context_id, "error": error},
+                        extra={"context_id": context_id, "error": error, "data": data},
                     )
                     if context_id is not None:
                         if ctx and not ctx.waiter.done():


### PR DESCRIPTION
related to https://github.com/livekit/agents/issues/4135

elevenlabs TTS may return an error message without contextId first, then close the connection.