### PR TITLE
fix record.exc_info is not pickable when using LogQueueHandler

### DIFF
--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -668,7 +668,9 @@ class RichLoggingHandler(logging.Handler):
             right = visible - left
             return s[:left] + "…" + s[-right:]
 
-        has_exc = bool(record.exc_info and record.exc_info != (None, None, None))
+        has_exc = bool(
+            (record.exc_info and record.exc_info != (None, None, None)) or record.exc_text
+        )
 
         if has_exc:
             exc_info, exc_text = record.exc_info, record.exc_text

--- a/livekit-agents/livekit/agents/ipc/log_queue.py
+++ b/livekit-agents/livekit/agents/ipc/log_queue.py
@@ -93,8 +93,7 @@ class LogQueueHandler(logging.Handler):
             record.message = msg
             record.msg = msg
             record.args = None
-            if record.exc_info is not None:
-                record.exc_info = (record.exc_info[0], record.exc_info[1], None)  # type: ignore
+            record.exc_info = None
             # pass formatted exc_text since stack trace is not pickleable
             record.exc_text = record.exc_text
             record.stack_info = None


### PR DESCRIPTION
fix issue introduced in https://github.com/livekit/agents/pull/4128, `record.exc_info[0]` or `record.exc_info[1]` can be unpickeable in some cases.