### PR TITLE
feat(google): add streaming support for Gemini TTS models

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
@@ -53,6 +53,8 @@ class _TTSOptions:
     custom_pronunciations: CustomPronunciations | None
     enable_ssml: bool
     use_markup: bool
+    model_name: str | None
+    prompt: str | None
 
 
 class TTS(tts.TTS):
@@ -63,6 +65,8 @@ class TTS(tts.TTS):
         gender: NotGivenOr[Gender | str] = NOT_GIVEN,
         voice_name: NotGivenOr[str] = NOT_GIVEN,
         voice_cloning_key: NotGivenOr[str] = NOT_GIVEN,
+        model_name: NotGivenOr[str] = NOT_GIVEN,
+        prompt: NotGivenOr[str] = NOT_GIVEN,
         sample_rate: int = 24000,
         pitch: int = 0,
         effects_profile_id: str = "",
@@ -90,6 +94,8 @@ class TTS(tts.TTS):
             gender (Gender | str, optional): Voice gender ("male", "female", "neutral"). Default is "neutral".
             voice_name (str, optional): Specific voice name. Default is an empty string.
             voice_cloning_key (str, optional): Voice clone key. Created via https://cloud.google.com/text-to-speech/docs/chirp3-instant-custom-voice
+            model_name (str, optional): Model name for TTS (e.g., "gemini-2.5-flash-tts"). Enables Gemini TTS models with streaming support.
+            prompt (str, optional): Style prompt for Gemini TTS models. Controls tone, style, and speaking characteristics. Only applied to first input chunk in streaming mode.
             sample_rate (int, optional): Audio sample rate in Hz. Default is 24000.
             location (str, optional): Location for the TTS client. Default is "global".
             pitch (float, optional): Speaking pitch, ranging from -20.0 to 20.0 semitones relative to the original pitch. Default is 0.
@@ -128,6 +134,8 @@ class TTS(tts.TTS):
             language_code=lang,
             ssml_gender=ssml_gender,
         )
+        if is_given(model_name):
+            voice_params.model_name = model_name
         if is_given(voice_cloning_key):
             voice_params.voice_clone = texttospeech.VoiceCloneParams(
                 voice_cloning_key=voice_cloning_key,
@@ -152,12 +160,14 @@ class TTS(tts.TTS):
             custom_pronunciations=pronunciations,
             enable_ssml=enable_ssml,
             use_markup=use_markup,
+            model_name=model_name if is_given(model_name) else None,
+            prompt=prompt if is_given(prompt) else None,
         )
         self._streams = weakref.WeakSet[SynthesizeStream]()
 
     @property
     def model(self) -> str:
-        return "Chirp3"
+        return self._opts.model_name or "Chirp3"
 
     @property
     def provider(self) -> str:
@@ -169,6 +179,8 @@ class TTS(tts.TTS):
         language: NotGivenOr[SpeechLanguages | str] = NOT_GIVEN,
         gender: NotGivenOr[Gender | str] = NOT_GIVEN,
         voice_name: NotGivenOr[str] = NOT_GIVEN,
+        model_name: NotGivenOr[str] = NOT_GIVEN,
+        prompt: NotGivenOr[str] = NOT_GIVEN,
         speaking_rate: NotGivenOr[float] = NOT_GIVEN,
         volume_gain_db: NotGivenOr[float] = NOT_GIVEN,
     ) -> None:
@@ -179,6 +191,8 @@ class TTS(tts.TTS):
             language (SpeechLanguages | str, optional): Language code (e.g., "en-US").
             gender (Gender | str, optional): Voice gender ("male", "female", "neutral").
             voice_name (str, optional): Specific voice name.
+            model_name (str, optional): Model name for TTS (e.g., "gemini-2.5-flash-tts").
+            prompt (str, optional): Style prompt for Gemini TTS models.
             speaking_rate (float, optional): Speed of speech.
             volume_gain_db (float, optional): Volume gain in decibels.
         """
@@ -189,6 +203,9 @@ class TTS(tts.TTS):
             params["ssml_gender"] = _gender_from_str(str(gender))
         if is_given(voice_name):
             params["name"] = voice_name
+        if is_given(model_name):
+            params["model_name"] = model_name
+            self._opts.model_name = model_name
 
         if params:
             self._opts.voice = texttospeech.VoiceSelectionParams(**params)
@@ -197,6 +214,8 @@ class TTS(tts.TTS):
             self._opts.speaking_rate = speaking_rate
         if is_given(volume_gain_db):
             self._opts.volume_gain_db = volume_gain_db
+        if is_given(prompt):
+            self._opts.prompt = prompt
 
     def _ensure_client(self) -> texttospeech.TextToSpeechAsyncClient:
         api_endpoint = "texttospeech.googleapis.com"
@@ -370,15 +389,17 @@ class SynthesizeStream(tts.SynthesizeStream):
             try:
                 yield texttospeech.StreamingSynthesizeRequest(streaming_config=streaming_config)
 
+                is_first_input = True
                 async for input in input_stream:
                     self._mark_started()
-                    yield (
-                        texttospeech.StreamingSynthesizeRequest(
-                            input=texttospeech.StreamingSynthesisInput(markup=input.token)
-                            if self._opts.use_markup
-                            else texttospeech.StreamingSynthesisInput(text=input.token)
-                        )
+                    # prompt is only supported in the first input chunk (for Gemini TTS)
+                    synthesis_input = texttospeech.StreamingSynthesisInput(
+                        markup=input.token if self._opts.use_markup else None,
+                        text=None if self._opts.use_markup else input.token,
+                        prompt=self._opts.prompt if is_first_input else None,
                     )
+                    is_first_input = False
+                    yield texttospeech.StreamingSynthesizeRequest(input=synthesis_input)
 
             except Exception:
                 logger.exception("an error occurred while streaming input to google TTS")

--- a/livekit-plugins/livekit-plugins-google/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-google/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
     "google-auth >= 2, < 3",
     "google-cloud-speech >= 2, < 3",
-    "google-cloud-texttospeech >= 2.27, < 3",
+    "google-cloud-texttospeech >= 2.32, < 3",
     "google-genai >= v1.47.0",
     "livekit-agents>=1.3.6",
 ]


### PR DESCRIPTION
## Summary
Add streaming support for Gemini TTS via Google Cloud TTS API's `model_name` parameter.

Fixes #3864

## Motivation
My company is launching a product using Gemini TTS in the next two weeks.   
We initially implemented a separate module internally to work around the streaming limitation.  
However, I noticed the discussion in #3864 about potentially integrating Gemini streaming into `google.TTS` rather than keeping it separate, so I decided to implement it this way to contribute back to the community.

I'm a big fan of LiveKit Agents and would love to see this feature land. If there are any concerns about backward compatibility, additional testing needs, or code style adjustments, I'm more than willing to iterate and do the work required to get this merged.

## Approach
This PR adds Gemini TTS streaming support through the **Cloud TTS API** (not the Gemini AI API).
- The existing `beta.GeminiTTS` uses `google.genai` (no streaming)
- This enhancement uses `google.cloud.texttospeech` with `model_name` parameter (streaming supported)

Both approaches can coexist - users can choose based on their needs:
- Use `beta.GeminiTTS` for Gemini AI API with instruction-based style control
- Use `TTS(model_name="gemini-2.5-flash-tts")` for streaming support

## Backward Compatibility
- All new parameters have default values (`NOT_GIVEN`)
- Existing code using `google.TTS()` continues to work unchanged
- The `model` property returns `"Chirp3"` when `model_name` is not set
- No breaking changes

## Changes
- Add `model_name` parameter to TTS for Gemini model support (e.g., `gemini-2.5-flash-tts`)
- Add `prompt` parameter for style control (applied to first input chunk only per Google TTS API spec)
- Update `model` property to return actual model name when set
- Update `update_options()` to support dynamic model/prompt changes

## Usage Example
from livekit.plugins.google import TTS


# Gemini TTS with streaming
tts = TTS(
    model_name="gemini-2.5-flash-tts",
    voice_name="zephyr",
    language="ko-KR",
    prompt="Speak in a friendly, conversational tone",
)

## Testing
Tested with `gemini-2.5-flash-tts` model and zephyr voice in our production environment.

---

Happy to address any feedback or make adjustments as needed!
