### PR TITLE
fix watchfiles prevent agent prcoess exit on SIGTERM

### DIFF
--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -1469,6 +1469,9 @@ def _build_cli(server: AgentServer) -> typer.Typer:
             loop.run_until_complete(_run_loop())
         except _ExitCli:
             raise typer.Exit() from None
+        except KeyboardInterrupt:
+            logger.warning("exiting forcefully")
+            os._exit(1)
 
     @app.command()
     def download_files() -> None:


### PR DESCRIPTION
in dev mode with `reload` enabled, watchfiles will raise a `KeyboardInterrupt` on SIGTERM, but not sure why the process doesn't exit after `KeyboardInterrupt` exception, added a force exiting.