### PR TITLE
ensure playback_segments_count is consistent in the audio output chain

### DIFF
--- a/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
+++ b/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
@@ -423,6 +423,9 @@ class RecorderAudioOutput(io.AudioOutput):
         self._reset_pause_state()
 
     async def capture_frame(self, frame: rtc.AudioFrame) -> None:
+        if self.next_in_chain:
+            await self.next_in_chain.capture_frame(frame)
+
         await super().capture_frame(frame)
 
         if self.__recording_io.recording:
@@ -430,9 +433,6 @@ class RecorderAudioOutput(io.AudioOutput):
                 self.__started_time = time.time()
 
             self.__acc_frames.append(frame)
-
-        if self.next_in_chain:
-            await self.next_in_chain.capture_frame(frame)
 
     def flush(self) -> None:
         super().flush()


### PR DESCRIPTION
when `next_in_chain` is set in `AudioOutput`, `await self.next_in_chain.capture_frame(frame)` should be called before `await super().capture_frame(frame)` (in case the capture_frame of next_in_chain is waiting for some conditions) to make sure the audio outputs in the chain have the same playback_segments_count.

this fixes the issue when the agent has a greeting message using session.say or session.generate_reply in Agent.on_enter (or just after session started), it will stuck when closing if no participant joined the room.