### PR TITLE
feat(warm-transfer): add sip_number parameter for outbound caller ID

### DIFF
--- a/examples/warm-transfer/warm_transfer.py
+++ b/examples/warm-transfer/warm_transfer.py
@@ -23,6 +23,7 @@ load_dotenv()
 # ensure the following variables/env vars are set
 SIP_TRUNK_ID = os.getenv("LIVEKIT_SIP_OUTBOUND_TRUNK")  # "ST_abcxyz"
 SUPERVISOR_PHONE_NUMBER = os.getenv("LIVEKIT_SUPERVISOR_PHONE_NUMBER")  # "+12003004000"
+SIP_NUMBER = os.getenv("LIVEKIT_SIP_NUMBER")  # "+15005006000" - caller ID shown to supervisor
 
 
 class SupportAgent(Agent):
@@ -60,6 +61,7 @@ class SupportAgent(Agent):
             result = await WarmTransferTask(
                 target_phone_number=SUPERVISOR_PHONE_NUMBER,
                 sip_trunk_id=SIP_TRUNK_ID,
+                sip_number=SIP_NUMBER,
                 chat_ctx=self.chat_ctx,
                 # add extra instructions for summarization
                 # you can also customize the entire instructions by overriding the `get_instructions` method

--- a/livekit-agents/livekit/agents/beta/workflows/warm_transfer.py
+++ b/livekit-agents/livekit/agents/beta/workflows/warm_transfer.py
@@ -70,6 +70,7 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
         *,
         hold_audio: NotGivenOr[AudioSource | AudioConfig | list[AudioConfig] | None] = NOT_GIVEN,
         sip_trunk_id: NotGivenOr[str] = NOT_GIVEN,
+        sip_number: NotGivenOr[str] = NOT_GIVEN,
         extra_instructions: str = "",
         chat_ctx: NotGivenOr[llm.ChatContext] = NOT_GIVEN,
         turn_detection: NotGivenOr[TurnDetectionMode | None] = NOT_GIVEN,
@@ -107,6 +108,10 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
             raise ValueError(
                 "`LIVEKIT_SIP_OUTBOUND_TRUNK` environment variable or `sip_trunk_id` argument must be set"
             )
+
+        self._sip_number = (
+            sip_number if is_given(sip_number) else os.getenv("LIVEKIT_SIP_NUMBER", "")
+        )
 
         # background audio and io
         self._background_audio = BackgroundAudioPlayer()
@@ -302,6 +307,7 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
                 room_name=human_agent_room_name,
                 participant_identity=self._human_agent_identity,
                 wait_until_answered=True,
+                sip_number=self._sip_number or None,
             )
         )
 


### PR DESCRIPTION
Add optional sip_number parameter to WarmTransferTask that allows setting the caller ID for outbound calls to the human agent.

- Can be passed directly via sip_number parameter
- Falls back to LIVEKIT_SIP_NUMBER environment variable
- If not set, behaves as before (no caller ID override)