### PR TITLE
add interruption timeout to SpeechHandle

### DIFF
--- a/livekit-agents/livekit/agents/voice/speech_handle.py
+++ b/livekit-agents/livekit/agents/voice/speech_handle.py
@@ -187,8 +187,6 @@ class SpeechHandle:
                 )
                 for task in self._tasks:
                     task.cancel()
-                if self._generations:
-                    self._mark_generation_done()
                 self._mark_done()
 
             self._interrupt_timeout_handle = asyncio.get_event_loop().call_later(


### PR DESCRIPTION
add interruption timeout to SpeechHandle, cancel the tasks of the speech and mark it as done if it's not done before the timeout, to avoid any potential deadlock that waiting for the speech playout.