### PR TITLE
Fix #4188: Prevent LogQueueListener crash when logging RpcError

### DIFF
--- a/livekit-agents/livekit/agents/ipc/log_queue.py
+++ b/livekit-agents/livekit/agents/ipc/log_queue.py
@@ -14,7 +14,7 @@ from ..utils.aio import duplex_unix
 
 def _safe_to_log(obj: Any) -> Any:
     """Safely convert an object to a pickleable format.
-    
+
     Handles RpcError and other objects that may not be directly pickleable
     by converting them to a dictionary representation.
     """
@@ -138,7 +138,7 @@ class LogQueueHandler(logging.Handler):
                     "thread", "threadName", "exc_info", "exc_text", "stack_info",
                     "getMessage", "websocket"
                 }
-                
+
                 # Check custom attributes that might contain RpcError
                 for attr_name in dir(record):
                     if attr_name.startswith("_") or attr_name in standard_attrs:

--- a/tests/test_log_queue_rpcerror.py
+++ b/tests/test_log_queue_rpcerror.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import logging
-import pickle
 import socket
-import threading
 import time
 
 from livekit.agents.ipc.log_queue import LogQueueHandler, LogQueueListener


### PR DESCRIPTION
- Add _safe_to_log() helper to convert RpcError objects to pickleable dicts
- Sanitize custom log record attributes before pickling
- Add regression tests to verify RpcError handling
- Prevents pickle.PicklingError when RpcError objects are in log extra fields