### PR TITLE
AGT-2328: negative threshold in silero

### DIFF
--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py
@@ -107,7 +107,7 @@ class VAD(agents.vad.VAD):
             sample_rate (Literal[8000, 16000]): Sample rate for the inference (only 8KHz and 16KHz are supported).
             onnx_file_path (Path | str | None): Path to the ONNX model file. If not provided, the default model will be loaded. This can be helpful if you want to use a previous version of the silero model.
             force_cpu (bool): Force the use of CPU for inference.
-            deactivation_threshold (float): Negative threshold (noise or exit threshold). If model's current state is SPEECH, values BELOW this value are considered as NON-SPEECH. Default is activation_threshold - 0.15.
+            deactivation_threshold (float): Negative threshold (noise or exit threshold). If model's current state is SPEECH, values BELOW this value are considered as NON-SPEECH. Default is max(activation_threshold - 0.15, 0.01).
             padding_duration (float | None): **Deprecated**. Use `prefix_padding_duration` instead.
 
         Returns:
@@ -125,6 +125,9 @@ class VAD(agents.vad.VAD):
             )
             prefix_padding_duration = padding_duration
 
+        if is_given(deactivation_threshold) and deactivation_threshold <= 0:
+            raise ValueError("deactivation_threshold must be greater than 0")
+
         session = onnx_model.new_inference_session(force_cpu, onnx_file_path=onnx_file_path or None)
         opts = _VADOptions(
             min_speech_duration=min_speech_duration,
@@ -132,7 +135,7 @@ class VAD(agents.vad.VAD):
             prefix_padding_duration=prefix_padding_duration,
             max_buffered_speech=max_buffered_speech,
             activation_threshold=activation_threshold,
-            deactivation_threshold=deactivation_threshold or activation_threshold - 0.15,
+            deactivation_threshold=deactivation_threshold or max(activation_threshold - 0.15, 0.01),
             sample_rate=sample_rate,
         )
         return cls(session=session, opts=opts)
@@ -181,6 +184,7 @@ class VAD(agents.vad.VAD):
         prefix_padding_duration: NotGivenOr[float] = NOT_GIVEN,
         max_buffered_speech: NotGivenOr[float] = NOT_GIVEN,
         activation_threshold: NotGivenOr[float] = NOT_GIVEN,
+        deactivation_threshold: NotGivenOr[float] = NOT_GIVEN,
     ) -> None:
         """
         Update the VAD options.
@@ -204,6 +208,8 @@ class VAD(agents.vad.VAD):
             self._opts.max_buffered_speech = max_buffered_speech
         if is_given(activation_threshold):
             self._opts.activation_threshold = activation_threshold
+        if is_given(deactivation_threshold):
+            self._opts.deactivation_threshold = deactivation_threshold
 
         for stream in self._streams:
             stream.update_options(
@@ -212,6 +218,7 @@ class VAD(agents.vad.VAD):
                 prefix_padding_duration=prefix_padding_duration,
                 max_buffered_speech=max_buffered_speech,
                 activation_threshold=activation_threshold,
+                deactivation_threshold=deactivation_threshold,
             )
 
 
@@ -235,6 +242,7 @@ class VADStream(agents.vad.VADStream):
         prefix_padding_duration: NotGivenOr[float] = NOT_GIVEN,
         max_buffered_speech: NotGivenOr[float] = NOT_GIVEN,
         activation_threshold: NotGivenOr[float] = NOT_GIVEN,
+        deactivation_threshold: NotGivenOr[float] = NOT_GIVEN,
     ) -> None:
         """
         Update the VAD options.
@@ -247,6 +255,7 @@ class VADStream(agents.vad.VADStream):
             prefix_padding_duration (float): Duration of padding to add to the beginning of each speech chunk.
             max_buffered_speech (float): Maximum duration of speech to keep in the buffer (in seconds).
             activation_threshold (float): Threshold to consider a frame as speech.
+            deactivation_threshold (float): Negative threshold (noise or exit threshold). If model's current state is SPEECH, values BELOW this value are considered as NON-SPEECH.
         """  # noqa: E501
         old_max_buffered_speech = self._opts.max_buffered_speech
 
@@ -260,6 +269,8 @@ class VADStream(agents.vad.VADStream):
             self._opts.max_buffered_speech = max_buffered_speech
         if is_given(activation_threshold):
             self._opts.activation_threshold = activation_threshold
+        if is_given(deactivation_threshold):
+            self._opts.deactivation_threshold = deactivation_threshold
 
         if self._input_sample_rate:
             assert self._speech_buffer is not None
@@ -459,7 +470,7 @@ class VADStream(agents.vad.VADStream):
                 )
 
                 if p >= self._opts.activation_threshold or (
-                    pub_speaking and p >= self._opts.deactivation_threshold
+                    pub_speaking and p > self._opts.deactivation_threshold
                 ):
                     speech_threshold_duration += window_duration
                     silence_threshold_duration = 0.0


### PR DESCRIPTION
Allow speech to non-speech threshold in silero, same as the negative threshold in [silero](https://github.com/snakers4/silero-vad/blob/d5b52843f79c97810940534f3433e162470af83d/src/silero_vad/utils_vad.py#L272).