### PR TITLE
fix generate_reply timeout for gemini

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -589,8 +589,8 @@ class RealtimeSession(llm.RealtimeSession):
 
         # Gemini requires the last message to end with user's turn
         # so we need to add a placeholder user turn in order to trigger a new generation
+        turns = []
         if is_given(instructions):
-            turns = []
             turns.append(types.Content(parts=[types.Part(text=instructions)], role="model"))
         turns.append(types.Content(parts=[types.Part(text=".")], role="user"))
         self._send_client_event(types.LiveClientContent(turns=turns, turn_complete=True))


### PR DESCRIPTION
fix https://github.com/livekit/agents/issues/3560, two cases:

- `generate_reply` may be interrupted by user speech or background noise, the interrupted response was ignored, causing a `received server content but no active generation.` warning and a timeout error.
- when only `user_input` is set for `generate_reply` and it's called right after `session.start`, the Gemini session may not created yet, so the user message is added to the chat_ctx and synced to the API during connection, in that case after https://github.com/livekit/agents/pull/3898, `turn_complete = True` is not sent to the API so no response created.


fix https://github.com/livekit/agents/issues/3821 and https://github.com/livekit/agents/issues/4017
