### PR TITLE
fix: correct sample count calculation in AudioByteStream.flush() for multi-channel audio

### DIFF
--- a/livekit-agents/livekit/agents/utils/audio.py
+++ b/livekit-agents/livekit/agents/utils/audio.py
@@ -138,7 +138,7 @@ class AudioByteStream:
         if len(self._buf) == 0:
             return []
 
-        if len(self._buf) % (2 * self._num_channels) != 0:
+        if len(self._buf) % self._bytes_per_sample != 0:
             logger.warning("AudioByteStream: incomplete frame during flush, dropping")
             return []
 
@@ -147,7 +147,7 @@ class AudioByteStream:
                 data=self._buf.copy(),
                 sample_rate=self._sample_rate,
                 num_channels=self._num_channels,
-                samples_per_channel=len(self._buf) // 2,
+                samples_per_channel=len(self._buf) // self._bytes_per_sample,
             )
         ]
         self._buf.clear()


### PR DESCRIPTION
The `flush()` method used hardcoded `2` instead of `self._bytes_per_sample` for sample calculations, causing:
- **Stereo audio**: 2x incorrect sample count (reported 50 instead of 25 for 100 bytes)
- **4-channel audio**: 4x incorrect sample count  
- **AudioFrame creation failures** due to metadata validation errors