### PR TITLE
Fix AudioByteStream buffer slicing performance issue

### DIFF
--- a/livekit-agents/livekit/agents/utils/audio.py
+++ b/livekit-agents/livekit/agents/utils/audio.py
@@ -104,7 +104,7 @@ class AudioByteStream:
         frames = []
         while len(self._buf) >= self._bytes_per_frame:
             frame_data = self._buf[: self._bytes_per_frame]
-            self._buf = self._buf[self._bytes_per_frame :]
+            del self._buf[: self._bytes_per_frame]
 
             frames.append(
                 rtc.AudioFrame(


### PR DESCRIPTION
The original implementation used slice assignment (`self._buf = self._buf[n:]`) which creates a new bytearray object and copies remaining data on each frame extraction.