### PR TITLE
Add Proactive Session Recycling for Nova Sonic resume

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -567,6 +567,10 @@ class RealtimeSession(  # noqa: F811
 
         # Step 3: Cancel background tasks
         # Tasks are blocked on channel recv() and won't exit naturally
+        # Note: You may see AWS CRT errors about cancelled futures or completed streams.
+        # These are expected and harmless - they're from the C library cleaning up the old HTTP/2 connection.
+        logger.info("[SESSION] Closing old session (AWS CRT errors are expected and harmless)")
+
         if self._audio_input_task and not self._audio_input_task.done():
             logger.debug("[SESSION] Cancelling audio input task...")
             self._audio_input_task.cancel()


### PR DESCRIPTION
## Add Proactive Session Recycling for Nova Sonic

### Problem
Nova Sonic sessions fail after ~8 minutes due to AWS-imposed session limits. Additionally, when AWS temporary credentials expire and refresh mid-session, the HTTP/2 connection breaks with ValidationException errors.

### Solution
Implement proactive session recycling that:
- Monitors session duration and credential expiry
- Gracefully transitions to a new session before limits are reached
- Preserves conversation state (chat history, tools, instructions)
- Waits for natural conversation boundaries to avoid interrupting audio

### Key Features
- **Automatic recycling** before 8-minute AWS limit or credential expiry (whichever comes first)
- **Seamless transitions** - waits for assistant to finish speaking and 1 second of silence
- **Zero data loss** - preserves full chat context, tool definitions, and pending tool results
- **Configurable** - set LK_SESSION_MAX_DURATION env var for testing (default: 6 minutes)

### Technical Details
- Added _done_fut to track generation completion
- Recreate tool results channel on recycle (fixes tool calls after transition)
- Ensure chat history starts with USER message (Nova Sonic requirement)
- Track audio END_TURN events to detect natural completion points
- Drain pending tool results before closing old session

### Testing
Tested with:
- ✅ Nova Sonic 1.0 (audio-only)
- ✅ Nova Sonic 2.0 (audio + text)
- ✅ SSO credentials (1-hour expiry)
- ✅ EC2 instance credentials (12-hour expiry)
- ✅ Tool calls before and after recycle
- ✅ Multiple consecutive recycles
- ✅ Barge-in during and after recycle

### Breaking Changes
None - feature is transparent to users.