### PR TITLE
fix(aws): set aws_credentials_identity_resolver as value instead of tuple

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
@@ -190,7 +190,7 @@ class SpeechStream(stt.SpeechStream):
                 config_kwargs["aws_session_token"] = self._credentials.session_token
             else:
                 config_kwargs["aws_credentials_identity_resolver"] = (
-                    EnvironmentCredentialsResolver(),
+                    EnvironmentCredentialsResolver()
                 )
 
             client: TranscribeStreamingClient = TranscribeStreamingClient(


### PR DESCRIPTION
reverts an accidental change as part of #4248