### PR TITLE
feat(soniox): add language_hints_strict option for STT

### DIFF
--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
@@ -89,6 +89,7 @@ class STTOptions:
     model: str | None = "stt-rt-preview"
 
     language_hints: list[str] | None = None
+    language_hints_strict: bool = False
     context: ContextObject | str | None = None
 
     num_channels: int = 1
@@ -214,6 +215,7 @@ class SpeechStream(stt.SpeechStream):
             "enable_endpoint_detection": enable_endpoint_detection,
             "sample_rate": self._stt._params.sample_rate,
             "language_hints": self._stt._params.language_hints,
+            "language_hints_strict": self._stt._params.language_hints_strict,
             "context": context,
             "enable_speaker_diarization": self._stt._params.enable_speaker_diarization,
             "enable_language_identification": self._stt._params.enable_language_identification,


### PR DESCRIPTION
Add support for the language_hints_strict parameter in the Soniox STT plugin. When enabled, transcription is restricted to only the languages specified in language_hints, rather than using them as soft hints for language detection.

  Reference: https://soniox.com/docs/stt/concepts/language-restrictions