### PR TITLE
fix dynamic FieldInfo for pydantic 2.12

### DIFF
--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -324,14 +324,23 @@ def function_arguments_to_pydantic_model(func: Callable[..., Any]) -> type[BaseM
             continue
 
         default_value = param.default if param.default is not param.empty else ...
+        field_info: FieldInfo | None = None
         field_attrs: dict[str, Any] = {}
 
         # Annotated[str, Field(description="...")]
         if get_origin(type_hint) is Annotated:
             annotated_args = get_args(type_hint)
             type_hint = annotated_args[0]
-            field_info = next((x for x in annotated_args[1:] if isinstance(x, FieldInfo)), Field())
-            field_attrs = field_info.asdict()["attributes"]
+            annotated_field = next(
+                (x for x in annotated_args[1:] if isinstance(x, FieldInfo)), None
+            )
+            if annotated_field and hasattr(annotated_field, "asdict"):
+                # `asdict` is available after pydantic 2.12
+                field_attrs = annotated_field.asdict()["attributes"]
+            elif annotated_field:
+                field_attrs["default"] = annotated_field.default
+                field_attrs["description"] = annotated_field.description
+                field_info = annotated_field
 
         if (
             default_value is not ...
@@ -342,7 +351,13 @@ def function_arguments_to_pydantic_model(func: Callable[..., Any]) -> type[BaseM
         if field_attrs.get("description") is None:
             field_attrs["description"] = param_docs.get(param_name, None)
 
-        fields[param_name] = (type_hint, Field(**field_attrs))
+        if not field_info:
+            field_info = Field(**field_attrs)
+        else:
+            for k, v in field_attrs.items():
+                setattr(field_info, k, v)
+
+        fields[param_name] = (type_hint, field_info)
 
     return create_model(model_name, **fields)
 


### PR DESCRIPTION
fix https://github.com/livekit/agents/issues/4051

changing the attr of FieldInfo dynamically is not supported since pydantic 2.12

ref: https://docs.pydantic.dev/latest/api/fields/#pydantic.fields.FieldInfo
> The FieldInfo class is meant to expose information about a field in a Pydantic model or dataclass. FieldInfo instances shouldn't be instantiated directly, nor mutated.
>
> If you need to derive a new model from another one and are willing to alter FieldInfo instances, refer to this [dynamic model example](https://docs.pydantic.dev/2.12/examples/dynamic_models/).