### PR TITLE
Allow for Cartesia TTS language auto-detection

### DIFF
--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -178,12 +178,16 @@ class TTS(tts.TTS):
             self._stream_pacer = text_pacing
 
         if word_timestamps:
-            if "preview" not in self._opts.model and (self._opts.language is not None and self._opts.language not in {
-                "en",
-                "de",
-                "es",
-                "fr",
-            }):
+            if "preview" not in self._opts.model and (
+                self._opts.language is not None
+                and self._opts.language
+                not in {
+                    "en",
+                    "de",
+                    "es",
+                    "fr",
+                }
+            ):
                 # https://docs.cartesia.ai/api-reference/tts/compare-tts-endpoints
                 logger.warning(
                     "word_timestamps is only supported for languages en, de, es, and fr with `sonic` models"


### PR DESCRIPTION
Currently the Cartesia TTS plugin sets default language to `en` and does not allow for language to be unset or set to `None`.

It's not 100% clear in the Cartesia docs, but they do allow for auto-detection of languages. Current behavior is causing undesirable accents for us in multi-lingual scenarios.
1. https://docs.cartesia.ai/api-reference/tts/websocket - note language is not a required field
2. Their playground specifically says to omit language for auto-detection
<img width="725" height="392" alt="image" src="https://github.com/user-attachments/assets/80f74e16-a844-4a1d-96d1-e1efb3dc7659" />

This PR allows for language to be set to `None` to enable auto-detection. I feel `None` should be the default, but left it as `en` for backward compatibility. The language option is set and passed through websockets as `None` rather than not set in case there is a need to `update_options` language setting between auto-detection vs constrained.