### PR TITLE
re-export TurnDetection for xAI

### DIFF
--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/__init__.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/__init__.py
@@ -1,13 +1,10 @@
 """xAI plugin for LiveKit Agents"""
 
-from openai.types.beta.realtime.session import TurnDetection
-
 from . import realtime
 from .version import __version__
 
 __all__ = [
     "realtime",
-    "TurnDetection",
     "__version__",
 ]
 

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/realtime/__init__.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/realtime/__init__.py
@@ -1,3 +1,5 @@
+from openai.types.beta.realtime.session import TurnDetection
+
 from livekit.plugins.openai.realtime import RealtimeSession
 
 from .realtime_model import RealtimeModel
@@ -7,4 +9,5 @@ __all__ = [
     "GrokVoices",
     "RealtimeModel",
     "RealtimeSession",
+    "TurnDetection",
 ]


### PR DESCRIPTION
this would allow users to pass TurnDetection settings like so without importing from openai:

```
from livekit.agents import AgentSession
from livekit.plugins import xai

session = AgentSession(
    llm=xai.RealtimeModel(
        turn_detection=xai.TurnDetection(
            type="server_vad",
            threshold=0.5,
            prefix_padding_ms=300,
            silence_duration_ms=200,
            create_response=True,
            interrupt_response=True,
        )
    ),
)
```