### PR TITLE
feat(gemini3) use low latency thinking_level by default for gemini 3 models

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -50,6 +50,7 @@ def _is_gemini_3_model(model: str) -> bool:
     """Check if model is Gemini 3 series"""
     return "gemini-3" in model.lower() or model.lower().startswith("gemini-3")
 
+
 def _is_gemini_3_flash_model(model: str) -> bool:
     """Check if model is Gemini 3 Flash"""
     return "gemini-3-flash" in model.lower() or model.lower().startswith("gemini-3-flash")


### PR DESCRIPTION
The default thinking_level is now "minimal" for Gemini 3 Flash models and "low" for other Gemini 3 models because [the API defaults to "high" when unspecified](https://ai.google.dev/gemini-api/docs/gemini-3)
