### PR TITLE
feat(Azure STT): add an option to use the lexical form of the transcription

### DIFF
--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
@@ -281,7 +281,7 @@ class SpeechStream(stt.SpeechStream):
                 detailed_result = json.loads(evt.result.json)
                 lexical = detailed_result.get("NBest", [{}])[0].get("Lexical", None)
             except Exception as e:
-                logger.warning("Error parsing detailed result", extra={"error": str(e)})
+                logger.warning("Error parsing detailed result", exc_info=e)
         result = lexical or text
         if not result:
             return
@@ -315,7 +315,7 @@ class SpeechStream(stt.SpeechStream):
                 detailed_result = json.loads(evt.result.json)
                 lexical = detailed_result.get("NBest", [{}])[0].get("Lexical", None)
             except Exception as e:
-                logger.warning("Error parsing detailed result", extra={"error": str(e)})
+                logger.warning("error parsing detailed result", exc_info=e)
         result = lexical or text
         if not result:
             return


### PR DESCRIPTION
This PR introduces optional support for returning Azure Speech-to-Text results in lexical format.

✨ **What’s new**
- A new flag has been added to STTOptions to control whether the Azure STT plugin returns **lexical** or **normalized** text.
- The option defaults to false, so the current behavior remains unchanged.
- When enabled, the STT plugin will return Azure’s lexical form directly in the transcription result.

🔄 **Backward compatibility**
- This change is fully backward-compatible.
- Existing users will see no behavior change unless the new option is explicitly enabled.

🧩 **Motivation**

Some downstream use cases (e.g. custom NLU pipelines, post-processing, or domain-specific text handling) require access to the **raw lexical transcription** provided by Azure, rather than the normalized output. This change makes that possible without affecting existing integrations.

⚙️ **Usage**
- The new option is exposed as an additional field in `STTOptions`.
- Default behavior remains identical to the current implementation.
- Enabling the option switches the Azure STT response to lexical format.