### PR TITLE
fix AttributeError in NVIDIA Riva STT

### DIFF
--- a/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py
+++ b/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py
@@ -286,9 +286,9 @@ class SpeechStream(stt.SpeechStream):
             text=transcript,
             words=[
                 TimedString(
-                    text=word.get("word", ""),
-                    start_time=word.get("start_time", 0) + self.start_time_offset,
-                    end_time=word.get("end_time", 0) + self.start_time_offset,
+                    text=getattr(word, "word", ""),
+                    start_time=getattr(word, "start_time", 0) + self.start_time_offset,
+                    end_time=getattr(word, "end_time", 0) + self.start_time_offset,
                 )
                 for word in words
             ]


### PR DESCRIPTION
I'm getting `AttributeError` here

https://github.com/livekit/agents/blob/80861211bad66a584c7ba84e6cd0666d2485f372/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py#L289-L291

The safer way is to use `getattr()`, which I see that it is already used in a few lines earlier

https://github.com/livekit/agents/blob/80861211bad66a584c7ba84e6cd0666d2485f372/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py#L278-L279

Pinging @chenghao-mou for review since it looks like you made the last commit to the file. Thank you!