### PR TITLE
fix (mistral-ai): add flexibility for timestamps 

### DIFF
--- a/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/stt.py
+++ b/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/stt.py
@@ -130,7 +130,7 @@ class STT(stt.STT):
                 alternatives=[
                     stt.SpeechData(
                         text=resp.text,
-                        language=self._opts.language,
+                        language=self._opts.language if self._opts.language else "",
                         start_time=resp.segments[0].start if resp.segments else 0,
                         end_time=resp.segments[-1].end if resp.segments else 0,
                         words=[


### PR DESCRIPTION
`timestamp_granularities` and `language` can't be used in tandem. to use one, the other must be set to `None`