### PR TITLE
feat(rtzr): add keyword boosting to streaming STT

### DIFF
--- a/livekit-plugins/livekit-plugins-rtzr/README.md
+++ b/livekit-plugins/livekit-plugins-rtzr/README.md
@@ -48,8 +48,25 @@ session = AgentSession(
 )
 ```
 
+Keyword boosting (Streaming STT only, sommers_ko model only):
+
+```python
+stt = rtzr.STT(
+    model="sommers_ko",
+    keywords=[
+        "키워드",
+        ("부스팅", 3.5),
+        "키위드:-1.0",
+    ],
+)
+```
+
+Rules:
+- Use list entries as `keyword` or `keyword:score`, or use `(keyword, score)` tuples.
+- Score must be between -5.0 and 5.0, up to 100 keywords, each <= 20 chars.
+- Keywords must be written in Korean pronunciation (Hangul and spaces only); non-Korean input will error.
+
 Notes:
 - The WebSocket streaming endpoint accepts raw PCM frames when `encoding=LINEAR16`.
 - The plugin relies on the server-side endpointing (EPD). You do not need to send finalize messages.
 - When the pipeline closes the stream, the plugin sends `EOS` to end the session.
-

--- a/livekit-plugins/livekit-plugins-rtzr/livekit/plugins/rtzr/stt.py
+++ b/livekit-plugins/livekit-plugins-rtzr/livekit/plugins/rtzr/stt.py
@@ -53,6 +53,7 @@ class _STTOptions:
     noise_threshold: float = 0.60
     active_threshold: float = 0.80
     use_punctuation: bool = False
+    keywords: list[str] | list[tuple[str, float]] | None = None
 
 
 class STT(stt.STT):
@@ -75,6 +76,7 @@ class STT(stt.STT):
         noise_threshold: float = 0.60,
         active_threshold: float = 0.80,
         use_punctuation: bool = False,
+        keywords: list[str] | list[tuple[str, float]] | None = None,
         http_session: aiohttp.ClientSession | None = None,
     ) -> None:
         super().__init__(
@@ -95,7 +97,10 @@ class STT(stt.STT):
             noise_threshold=noise_threshold,
             active_threshold=active_threshold,
             use_punctuation=use_punctuation,
+            keywords=keywords,
         )
+        if keywords and model != "sommers_ko":
+            logger.warning("RTZR keyword boosting is only supported with sommers_ko model")
         self._client = RTZROpenAPIClient(http_session=http_session)
 
     async def aclose(self) -> None:
@@ -139,6 +144,7 @@ class SpeechStream(stt.SpeechStream):
             noise_threshold=self._stt._params.noise_threshold,
             active_threshold=self._stt._params.active_threshold,
             use_punctuation=self._stt._params.use_punctuation,
+            keywords=self._stt._params.keywords,
         )
 
         try:


### PR DESCRIPTION
### Description

Added RTZR keyword boosting support by exposing keywords in the STT interface and passing it to the streaming config.
Implemented keyword serialization/validation for WebSocket (keyword or keyword:score, (keyword, score) tuples).
Documented usage, limits, and Hangul-only requirement in plugin README.

### Changes

rtzrapi.py
stt.py
README.md

### Notes
Keyword boosting is only supported for sommers_ko and requires Hangul-only keywords; non-Korean input errors.
