### PR TITLE
remove shutdown models from google gemini live 

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/api_proto.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/api_proto.py
@@ -14,9 +14,7 @@ LiveAPIModels = Literal[
     "gemini-live-2.5-flash-preview-native-audio-09-2025",
     # Gemini API models
     "gemini-2.5-flash-native-audio-preview-12-2025",
-    "gemini-live-2.5-flash-preview",
     # deprecated Gemini API models
-    "gemini-2.0-flash-live-001",
     "gemini-2.5-flash-native-audio-preview-09-2025",
 ]
 


### PR DESCRIPTION
`gemini-2.0-flash-live-001` and `gemini-live-2.5-flash-preview` were shutdown on december 9

addresses #4414 

source: [gemini changelog](https://ai.google.dev/gemini-api/docs/changelog)

