### PR TITLE
fix (gemini filesearch): require only filestore names

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tools.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tools.py
@@ -50,9 +50,9 @@ class URLContext(GeminiTool):
 
 @dataclass
 class FileSearch(GeminiTool):
-    file_search_store_names: Optional[list[str]]
-    top_k: Optional[int]
-    metadata_filter: Optional[str]
+    file_search_store_names: list[str]
+    top_k: Optional[int] = None
+    metadata_filter: Optional[str] = None
 
     def to_tool_config(self) -> types.Tool:
         return types.Tool(


### PR DESCRIPTION
error will be thrown if `file_search_store_names` is not provided, rest are optional