### PR TITLE
fix: acquire lock in _DefaultLoadCalc.get_load() to prevent race condition

### DIFF
--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -105,7 +105,7 @@ class _DefaultLoadCalc:
         if cls._instance is None:
             cls._instance = _DefaultLoadCalc()
 
-        return cls._instance._m_avg.get_avg()
+        return cls._instance._get_avg()
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- Fixed a race condition in `_DefaultLoadCalc.get_load()` where the shared `MovingAverage` object was accessed without acquiring the threading lock
- The background thread continuously modifies the moving average while `get_load()` reads it, causing potential inconsistent state reads
- Changed to use the existing `_get_avg()` method which properly acquires the lock before reading

## Details

The `get_load()` classmethod was directly calling `cls._instance._m_avg.get_avg()` without lock protection, while:
- The background thread acquires `self._lock` before calling `add_sample()`
- The instance method `_get_avg()` properly acquires `self._lock` before calling `get_avg()`

This inconsistency could cause workers to report incorrect CPU load values to the LiveKit server, potentially leading to incorrect job assignment decisions.

## Test plan

- [x] Verified the existing `_get_avg()` method properly acquires the lock
- [x] Confirmed the fix uses the locked method instead of direct access

🤖 Generated with [Claude Code](https://claude.com/claude-code)