### PR TITLE
fix: replace bare except with Exception in async put handling

### DIFF
--- a/livekit-agents/livekit/agents/utils/aio/channel.py
+++ b/livekit-agents/livekit/agents/utils/aio/channel.py
@@ -76,7 +76,7 @@ class Chan(Generic[T]):
                 await p
             except ChanClosed:
                 raise
-            except:
+            except Exception:
                 p.cancel()
                 with contextlib.suppress(ValueError):
                     self._puts.remove(p)


### PR DESCRIPTION
This prevents swallowing critical exceptions like KeyboardInterrupt and SystemExit while preserving existing cancellation behavior.