### PR TITLE
fix: misleading conn_options handling in StreamAdapters

### DIFF
--- a/livekit-agents/livekit/agents/stt/stream_adapter.py
+++ b/livekit-agents/livekit/agents/stt/stream_adapter.py
@@ -9,11 +9,6 @@ from ..types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, APIConnectOptions, N
 from ..vad import VAD, VADEventType
 from .stt import STT, RecognizeStream, SpeechEvent, SpeechEventType, STTCapabilities
 
-# already a retry mechanism in STT.recognize, don't retry in stream adapter
-DEFAULT_STREAM_ADAPTER_API_CONNECT_OPTIONS = APIConnectOptions(
-    max_retry=0, timeout=DEFAULT_API_CONNECT_OPTIONS.timeout
-)
-
 
 class StreamAdapter(STT):
     def __init__(self, *, stt: STT, vad: VAD) -> None:
@@ -84,7 +79,11 @@ class StreamAdapterWrapper(RecognizeStream):
         language: NotGivenOr[str],
         conn_options: APIConnectOptions,
     ) -> None:
-        super().__init__(stt=stt, conn_options=DEFAULT_STREAM_ADAPTER_API_CONNECT_OPTIONS)
+        adapter_conn_options = APIConnectOptions(
+            timeout=conn_options.timeout,
+            max_retry=0,
+        )
+        super().__init__(stt=stt, conn_options=adapter_conn_options)
         self._vad = vad
         self._wrapped_stt = wrapped_stt
         self._wrapped_stt_conn_options = conn_options

--- a/livekit-agents/livekit/agents/tts/stream_adapter.py
+++ b/livekit-agents/livekit/agents/tts/stream_adapter.py
@@ -16,11 +16,6 @@ from .tts import (
     TTSCapabilities,
 )
 
-# already a retry mechanism in TTS.synthesize, don't retry in stream adapter
-DEFAULT_STREAM_ADAPTER_API_CONNECT_OPTIONS = APIConnectOptions(
-    max_retry=0, timeout=DEFAULT_API_CONNECT_OPTIONS.timeout
-)
-
 
 class StreamAdapter(TTS):
     def __init__(
@@ -79,7 +74,11 @@ class StreamAdapterWrapper(SynthesizeStream):
     _tts_request_span_name: ClassVar[str] = "tts_stream_adapter"
 
     def __init__(self, *, tts: StreamAdapter, conn_options: APIConnectOptions) -> None:
-        super().__init__(tts=tts, conn_options=DEFAULT_STREAM_ADAPTER_API_CONNECT_OPTIONS)
+        adapter_conn_options = APIConnectOptions(
+            timeout=conn_options.timeout,
+            max_retry=0,
+        )
+        super().__init__(tts=tts, conn_options=adapter_conn_options)
         self._tts: StreamAdapter = tts
         self._wrapped_tts_conn_options = conn_options
 


### PR DESCRIPTION
StreamAdapter.stream(conn_options=…) previously ignored caller-provided options for the adapter’s own connection, always overriding them with hardcoded defaults.