### PR TITLE
allow tests on external PRs when triggered by members

### DIFF
--- a/.github/workflows/test-stt.yml
+++ b/.github/workflows/test-stt.yml
@@ -121,10 +121,10 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'test-stt.yml',
-              ref: '${{ steps.pr-info.outputs.branch }}',
+              ref: 'main',
               inputs: {
                 pr_number: '${{ steps.pr-info.outputs.pr_number }}',
-                branch: '${{ steps.pr-info.outputs.branch }}'
+                branch: 'refs/pull/${{ steps.pr-info.outputs.pr_number }}/head'
               }
             });
 


### PR DESCRIPTION
This allow us to trigger STT tests with a `/test-stt` comment on PRs.

This requires us to verify that there is no malicious code (e.g. API exfiltration) before triggering it.