### PR TITLE
support streaming events from RunResult

### DIFF
--- a/livekit-agents/livekit/agents/voice/run_result.py
+++ b/livekit-agents/livekit/agents/voice/run_result.py
@@ -147,7 +147,7 @@ class RunResult(Generic[Run_T]):
         return val
 
     def __aiter__(self) -> AsyncIterator[RunEvent]:
-        # NOTE: the order of FunctionCallEvent and FunctionCallOutputEvent may not be the same as that in final result
+        # NOTE: the order of FunctionCallEvent may not be the same as that in final result
         return self
 
     def _agent_handoff(


### PR DESCRIPTION
split from https://github.com/livekit/agents/pull/4337, use it with 
```python
    async for ev in session.run(user_input=ctx.text):
        ...
```