### PR TITLE
close log_handler when process initialize failed

### DIFF
--- a/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
@@ -80,6 +80,7 @@ def proc_main(args: ProcStartArgs) -> None:
     try:
         client.initialize()
     except Exception:
+        log_handler.close()
         return  # initialization failed, exit (initialize will send an error to the worker)
 
     client.run()


### PR DESCRIPTION
fix memory leak when `prewarm` failed. 

The `LogQueueHandler` creates a non-daemon thread that blocks forever on queue.get(). When `client.initialize()` failed, the early return in `proc_main()` skipped calling `log_handler.close()`. This prevented the child process from exiting, causing `self._proc.join()` to block forever in the parent.