### PR TITLE
feat(aws-stt): add keep-alive and robust retry logic

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
@@ -1,3 +1,5 @@
+# ruff: noqa: F821 "aws_sdk_transcribe_streaming" already requires Python 3.12+
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -13,11 +15,34 @@
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
-import contextlib
 import os
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
-from typing import Any
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+
+from aws_sdk_transcribe_streaming.client import TranscribeStreamingClient
+from aws_sdk_transcribe_streaming.config import Config
+from aws_sdk_transcribe_streaming.models import (
+    AudioEvent,
+    AudioStream,
+    AudioStreamAudioEvent,
+    BadRequestException,
+    Result,
+    StartStreamTranscriptionInput,
+    TranscriptEvent,
+    TranscriptResultStream,
+    TranscriptResultStreamUnknown,
+)
+from smithy_aws_core.identity import (
+    AWSCredentialsIdentity,
+    ContainerCredentialsResolver,
+    EnvironmentCredentialsResolver,
+    IMDSCredentialsResolver,
+    StaticCredentialsResolver,
+)
+from smithy_core.aio.identity import ChainedIdentityResolver
+from smithy_http.aio.crt import AWSCRTHTTPClient
 
 from livekit import rtc
 from livekit.agents import (
@@ -29,37 +54,12 @@ from livekit.agents import (
 from livekit.agents.types import NOT_GIVEN, NotGivenOr
 from livekit.agents.utils import is_given
 from livekit.agents.voice.io import TimedString
+from livekit.plugins.aws.log import logger
+from livekit.plugins.aws.utils import DEFAULT_REGION
 
-from .log import logger
-from .utils import DEFAULT_REGION
-
-try:
-    from aws_sdk_transcribe_streaming.client import TranscribeStreamingClient
-    from aws_sdk_transcribe_streaming.config import Config
-    from aws_sdk_transcribe_streaming.models import (
-        AudioEvent,
-        AudioStream,
-        AudioStreamAudioEvent,
-        BadRequestException,
-        Result,
-        StartStreamTranscriptionInput,
-        TranscriptEvent,
-        TranscriptResultStream,
-    )
-    from smithy_aws_core.identity import (
-        AWSCredentialsIdentity,
-        ContainerCredentialsResolver,
-        EnvironmentCredentialsResolver,
-        IMDSCredentialsResolver,
-        StaticCredentialsResolver,
-    )
-    from smithy_core.aio.identity import ChainedIdentityResolver
+if TYPE_CHECKING:
     from smithy_core.aio.interfaces.eventstream import EventPublisher, EventReceiver
-    from smithy_http.aio.crt import AWSCRTHTTPClient
-
-    _AWS_SDK_AVAILABLE = True
-except ImportError:
-    _AWS_SDK_AVAILABLE = False
+_RecognitionIterator = AsyncIterator[rtc.AudioFrame | stt.RecognizeStream._FlushSentinel]
 
 
 @dataclass
@@ -87,6 +87,18 @@ class STTOptions:
     region: str
 
 
+class _StaticCredsResolver:
+    def __init__(self, creds: Credentials):
+        self._identity = AWSCredentialsIdentity(
+            access_key_id=creds.access_key_id,
+            secret_access_key=creds.secret_access_key,
+            session_token=creds.session_token,
+        )
+
+    async def get_identity(self, **kwargs: Any) -> AWSCredentialsIdentity:
+        return self._identity
+
+
 class STT(stt.STT):
     def __init__(
         self,
@@ -112,15 +124,8 @@ class STT(stt.STT):
                 streaming=True,
                 interim_results=True,
                 aligned_transcript="word",
-                offline_recognize=False,
-            )
+            ),
         )
-
-        if not _AWS_SDK_AVAILABLE:
-            raise ImportError(
-                "The 'aws_sdk_transcribe_streaming' package is not installed. "
-                "This implementation requires Python 3.12+ and the 'aws_sdk_transcribe_streaming' dependency."
-            )
 
         if not is_given(region):
             region = os.getenv("AWS_REGION") or DEFAULT_REGION
@@ -166,7 +171,9 @@ class STT(stt.STT):
         language: NotGivenOr[str] = NOT_GIVEN,
         conn_options: APIConnectOptions,
     ) -> stt.SpeechEvent:
-        raise NotImplementedError("Amazon Transcribe does not support single frame recognition")
+        raise NotImplementedError(
+            "Amazon Transcribe does not support single frame recognition",
+        )
 
     def stream(
         self,
@@ -183,6 +190,8 @@ class STT(stt.STT):
 
 
 class SpeechStream(stt.SpeechStream):
+    _KEEPALIVE_TIMEOUT_S = timedelta(seconds=10).total_seconds()
+
     def __init__(
         self,
         stt: STT,
@@ -190,150 +199,199 @@ class SpeechStream(stt.SpeechStream):
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
         credentials: Credentials | None = None,
     ) -> None:
-        super().__init__(stt=stt, conn_options=conn_options, sample_rate=opts.sample_rate)
+        super().__init__(
+            stt=stt,
+            conn_options=conn_options,
+            sample_rate=opts.sample_rate,
+        )
         self._opts = opts
-        self._credentials = credentials
         self._http_client = AWSCRTHTTPClient()
+        self._credentials = (
+            ChainedIdentityResolver(
+                resolvers=(
+                    StaticCredentialsResolver(),
+                    EnvironmentCredentialsResolver(),
+                    ContainerCredentialsResolver(http_client=self._http_client),
+                    IMDSCredentialsResolver(http_client=self._http_client),
+                ),
+            )
+            if credentials is None
+            else _StaticCredsResolver(credentials)
+        )
+        self._input_closed = False  # Track if input is genuinely done
 
     async def _run(self) -> None:
-        while True:
-            config_kwargs: dict[str, Any] = {"region": self._opts.region}
-            if self._credentials:
-                # Use a credentials resolver for explicit credentials
-                # for some reason, Config with direct values doesn't work
-                class StaticCredsResolver:
-                    def __init__(self, creds: Credentials):
-                        self._identity = AWSCredentialsIdentity(
-                            access_key_id=creds.access_key_id,
-                            secret_access_key=creds.secret_access_key,
-                            session_token=creds.session_token,
-                        )
+        """Main loop: run one streaming session, retry on transient failures.
 
-                    async def get_identity(self, **kwargs: Any) -> AWSCredentialsIdentity:
-                        return self._identity
+        Workflow:
+        - Reuse one `input_iterator` across reconnects (no dropped frames).
+        - Run `_run_single_session()`; on error call `_should_retry()`.
+        - Retry or raise; exit on clean completion.
 
-                config_kwargs["aws_credentials_identity_resolver"] = StaticCredsResolver(
-                    self._credentials
-                )
-            else:
-                config_kwargs["aws_credentials_identity_resolver"] = ChainedIdentityResolver(
-                    resolvers=(
-                        StaticCredentialsResolver(),
-                        EnvironmentCredentialsResolver(),
-                        ContainerCredentialsResolver(http_client=self._http_client),
-                        IMDSCredentialsResolver(http_client=self._http_client),
-                    )
-                )
+        Raises:
+            BaseException: Non-retryable session error.
+        """
+        input_iterator = aiter(self._input_ch)
 
-            client: TranscribeStreamingClient = TranscribeStreamingClient(
-                config=Config(**config_kwargs)
+        while not self._input_closed:
+            logger.info(
+                "session start: lang=%s vocab=%s",
+                self._opts.language,
+                self._opts.vocabulary_name,
             )
+            # 1. Spawn the session as a standalone Task
+            # This allows us to "join" it without a try/except block
+            session_task = asyncio.create_task(self._run_single_session(input_iterator))
 
-            live_config = {
-                "language_code": self._opts.language,
-                "media_sample_rate_hertz": self._opts.sample_rate,
-                "media_encoding": self._opts.encoding,
-                "vocabulary_name": self._opts.vocabulary_name,
-                "session_id": self._opts.session_id,
-                "vocab_filter_method": self._opts.vocab_filter_method,
-                "vocab_filter_name": self._opts.vocab_filter_name,
-                "show_speaker_label": self._opts.show_speaker_label,
-                "enable_channel_identification": self._opts.enable_channel_identification,
-                "number_of_channels": self._opts.number_of_channels,
-                "enable_partial_results_stabilization": self._opts.enable_partial_results_stabilization,
-                "partial_results_stability": self._opts.partial_results_stability,
-                "language_model_name": self._opts.language_model_name,
-            }
-            filtered_config = {k: v for k, v in live_config.items() if v and is_given(v)}
+            # 2. Wait for completion (Does not raise exception)
+            await asyncio.wait([session_task])
 
-            tasks: list[asyncio.Task[Any]] = []
+            # 3. Inspect the outcome
+            exc = session_task.exception()
+            if exc is None:
+                logger.info("session end")
+                break
 
-            try:
-                stream = await client.start_stream_transcription(
-                    input=StartStreamTranscriptionInput(**filtered_config)
+            # 4. Decision Logic: Retry or Crash?
+            if _should_retry(exc):
+                logger.warning("retry: %s", exc)
+                continue
+
+            logger.error("session fail: %s", exc)
+            raise exc
+
+    async def _run_single_session(self, input_iterator: _RecognitionIterator) -> None:
+        """Runs one AWS Transcribe streaming session (audio up, transcripts
+        down).
+
+        Starts Transcribe, and run `_send_audio_loop()` and `_receive_transcript_loop()`
+        concurrently in a TaskGroup.
+
+        Args:
+            input_iterator: Stream of LiveKit audio frames (shared across retries).
+        """
+        config = Config(
+            aws_credentials_identity_resolver=self._credentials,
+            region=self._opts.region,
+        )
+
+        client = TranscribeStreamingClient(config=config)
+
+        live_config = {
+            "language_code": self._opts.language,
+            "media_sample_rate_hertz": self._opts.sample_rate,
+            "media_encoding": self._opts.encoding,
+            "vocabulary_name": self._opts.vocabulary_name,
+            "session_id": self._opts.session_id,
+            "vocab_filter_method": self._opts.vocab_filter_method,
+            "vocab_filter_name": self._opts.vocab_filter_name,
+            "show_speaker_label": self._opts.show_speaker_label,
+            "enable_channel_identification": self._opts.enable_channel_identification,
+            "number_of_channels": self._opts.number_of_channels,
+            "enable_partial_results_stabilization": (
+                self._opts.enable_partial_results_stabilization
+            ),
+            "partial_results_stability": self._opts.partial_results_stability,
+            "language_model_name": self._opts.language_model_name,
+        }
+        stream = await client.start_stream_transcription(
+            input=StartStreamTranscriptionInput(
+                **{
+                    key: val
+                    for key, val in live_config.items()
+                    if is_given(val) and val is not None
+                },
+            ),
+        )
+        _, output_stream = await stream.await_output()
+
+        # TaskGroup raises ExceptionGroup if any child fails
+        async with asyncio.TaskGroup() as task_group:
+            task_group.create_task(self._send_audio_loop(input_iterator, stream.input_stream))
+            task_group.create_task(self._receive_transcript_loop(output_stream))
+
+    async def _send_audio_loop(
+        self,
+        input_iterator: _RecognitionIterator,
+        audio_stream: EventPublisher[AudioStream],
+    ) -> None:
+        """Sends audio frames to AWS; emits keep-alives; closes on end-of-
+        input.
+
+        Args:
+            input_iterator: Source of frames (rtc.AudioFrame; None means input ended).
+            audio_stream: AWS publisher for `AudioEvent` chunks.
+        """
+        # Prime the first read
+        read_task = asyncio.create_task(anext(input_iterator, None))
+        pending = {read_task}
+
+        try:
+            while True:
+                # Efficient wait: returns immediately on data, or after timeout
+                done, pending = await asyncio.wait(
+                    pending,
+                    timeout=self._KEEPALIVE_TIMEOUT_S,
+                    return_when=asyncio.FIRST_COMPLETED,
                 )
 
-                # Get the output stream
-                _, output_stream = await stream.await_output()
+                if read_task in done:
+                    frame = read_task.result()
 
-                async def input_generator(
-                    audio_stream: EventPublisher[AudioStream],
-                ) -> None:
-                    try:
-                        async for frame in self._input_ch:
-                            if isinstance(frame, rtc.AudioFrame):
-                                await audio_stream.send(
-                                    AudioStreamAudioEvent(
-                                        value=AudioEvent(audio_chunk=frame.data.tobytes())
-                                    )
-                                )
-                    finally:
-                        # Send empty frame to close (required by AWS Transcribe)
-                        try:
-                            await audio_stream.send(
-                                AudioStreamAudioEvent(value=AudioEvent(audio_chunk=b""))
-                            )
-                        except Exception:
-                            pass
-                        finally:
-                            with contextlib.suppress(Exception):
-                                await audio_stream.close()
+                    if frame is None:
+                        # if None (from `anext(input_iterator, None)` above)
+                        # `input_iterator` has done i.e. audio stream gracefully stopped
+                        logger.info("audio end-of-input")
+                        self._input_closed = True
+                        break
 
-                async def handle_transcript_events(
-                    output_stream: EventReceiver[TranscriptResultStream],
-                ) -> None:
-                    try:
-                        async for event in output_stream:
-                            if isinstance(event.value, TranscriptEvent):
-                                self._process_transcript_event(event.value)
-                    except BadRequestException as e:
-                        if (
-                            e.message
-                            and "complete signal was sent without the preceding empty frame"
-                            in e.message
-                        ):
-                            # This can happen during cancellation if the empty frame wasn't sent in time
-                            logger.warning(
-                                "AWS Transcribe stream closed with empty frame error (this is usually harmless)"
-                            )
-                        else:
-                            raise
-                    except concurrent.futures.InvalidStateError:
-                        logger.warning(
-                            "AWS Transcribe stream closed unexpectedly (InvalidStateError)"
+                    if isinstance(frame, rtc.AudioFrame):
+                        await audio_stream.send(
+                            AudioStreamAudioEvent(
+                                value=AudioEvent(audio_chunk=frame.data.tobytes()),
+                            ),
                         )
-                        pass
 
-                tasks = [
-                    asyncio.create_task(input_generator(stream.input_stream)),
-                    asyncio.create_task(handle_transcript_events(output_stream)),
-                ]
-                gather_future = asyncio.gather(*tasks)
-
-                await asyncio.shield(gather_future)
-            except BadRequestException as e:
-                if e.message and e.message.startswith("Your request timed out"):
-                    # AWS times out after 15s of inactivity, this tends to happen
-                    # at the end of the session, when the input is gone, we'll ignore it and
-                    # just treat it as a silent retry
-                    logger.info("restarting transcribe session")
-                    continue
+                    # Schedule next read immediately
+                    read_task = asyncio.create_task(anext(input_iterator, None))
+                    pending = {read_task}
                 else:
-                    raise e
-            finally:
-                if tasks:
-                    # Close input stream first
-                    await utils.aio.gracefully_cancel(tasks[0])
+                    # read_task not in done -> timeout reached
+                    # send PCM16 little-endian silent to keep the audio stream alive
+                    logger.debug("audio keep-alive")
+                    await audio_stream.send(
+                        AudioStreamAudioEvent(
+                            value=AudioEvent(audio_chunk=b"\x00\x00"),
+                        ),
+                    )
 
-                    # Wait for output stream to close cleanly
-                    try:
-                        await asyncio.wait_for(tasks[1], timeout=3.0)
-                    except (asyncio.TimeoutError, asyncio.CancelledError):
-                        await utils.aio.gracefully_cancel(tasks[1])
+        finally:
+            read_task.cancel()
 
-                # Ensure gather future is retrieved to avoid "exception never retrieved"
-                with contextlib.suppress(Exception):
-                    await gather_future
+            # Only signal clean close if we actually finished inputs
+            if self._input_closed:
+                await audio_stream.send(
+                    AudioStreamAudioEvent(value=AudioEvent(audio_chunk=b"")),
+                )
+
+    async def _receive_transcript_loop(
+        self,
+        output_stream: EventReceiver[TranscriptResultStream],
+    ) -> None:
+        """Reads AWS transcript events and forwards them for emission.
+
+        Args:
+            output_stream: AWS receiver for transcript result events.
+        """
+        logger.debug("recv start")
+
+        async for event in output_stream:
+            if isinstance(event, TranscriptResultStreamUnknown):
+                continue
+            if isinstance(event.value, TranscriptEvent):
+                self._process_transcript_event(event.value)
+
+        logger.info("recv end")
 
     def _process_transcript_event(self, transcript_event: TranscriptEvent) -> None:
         if not transcript_event.transcript or not transcript_event.transcript.results:
@@ -343,7 +401,7 @@ class SpeechStream(stt.SpeechStream):
         for resp in stream:
             if resp.start_time is not None and resp.start_time == 0.0:
                 self._event_ch.send_nowait(
-                    stt.SpeechEvent(type=stt.SpeechEventType.START_OF_SPEECH)
+                    stt.SpeechEvent(type=stt.SpeechEventType.START_OF_SPEECH),
                 )
 
             if resp.end_time is not None and resp.end_time > 0.0:
@@ -351,22 +409,31 @@ class SpeechStream(stt.SpeechStream):
                     self._event_ch.send_nowait(
                         stt.SpeechEvent(
                             type=stt.SpeechEventType.INTERIM_TRANSCRIPT,
-                            alternatives=[self._streaming_recognize_response_to_speech_data(resp)],
-                        )
+                            alternatives=[
+                                self._streaming_recognize_response_to_speech_data(resp),
+                            ],
+                        ),
                     )
 
                 else:
                     self._event_ch.send_nowait(
                         stt.SpeechEvent(
                             type=stt.SpeechEventType.FINAL_TRANSCRIPT,
-                            alternatives=[self._streaming_recognize_response_to_speech_data(resp)],
-                        )
+                            alternatives=[
+                                self._streaming_recognize_response_to_speech_data(resp),
+                            ],
+                        ),
                     )
 
             if not resp.is_partial:
-                self._event_ch.send_nowait(stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH))
+                self._event_ch.send_nowait(
+                    stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH),
+                )
 
-    def _streaming_recognize_response_to_speech_data(self, resp: Result) -> stt.SpeechData:
+    def _streaming_recognize_response_to_speech_data(
+        self,
+        resp: Result,
+    ) -> stt.SpeechData:
         confidence = 0.0
         if resp.alternatives and (items := resp.alternatives[0].items):
             confidence = items[0].confidence or 0.0
@@ -375,7 +442,7 @@ class SpeechStream(stt.SpeechStream):
             language=resp.language_code or self._opts.language,
             start_time=(resp.start_time or 0.0) + self.start_time_offset,
             end_time=(resp.end_time or 0.0) + self.start_time_offset,
-            text=resp.alternatives[0].transcript if resp.alternatives else "",
+            text=(resp.alternatives[0].transcript or "") if resp.alternatives else "",
             confidence=confidence,
             words=[
                 TimedString(
@@ -386,7 +453,29 @@ class SpeechStream(stt.SpeechStream):
                     confidence=item.confidence or 0.0,
                 )
                 for item in resp.alternatives[0].items
+                if item.content
             ]
             if resp.alternatives and resp.alternatives[0].items
             else None,
         )
+
+
+def _should_retry(exc: BaseException) -> bool:
+    """Returns True if the error is retryable (handles ExceptionGroup from
+    TaskGroup).
+
+    Args:
+      exc: Session exception (may be an ExceptionGroup).
+
+    Returns:
+      bool: Whether to reconnect and retry.
+    """
+    # Errors we expect from AWS timeouts or network drops
+    retry_types = (BadRequestException,)
+
+    if isinstance(exc, ExceptionGroup):
+        # Check if the group ONLY contains retryable errors
+        matched, remainder = exc.split(retry_types)
+        return matched is not None and remainder is None
+
+    return isinstance(exc, retry_types)


### PR DESCRIPTION
This PR refactors the Amazon Transcribe STT plugin to improve session stability, and billing efficiency.

### Changes & Improvements

- **Audio Keep-Alive**:
  - Old behavior: Let the stream time out after 15s of silence, incurring reconnection latency and repeated [minimum 15-second billing charges](https://docs.aws.amazon.com/transcribe/latest/dg/what-is.html#transcribe-pricing).
  - New behavior: Sends silent PCM frames every 10s to maintain a long-lived session, ensuring instant response and better cost efficiency.
- Replaced `asyncio.gather` with `asyncio.TaskGroup`: if either the send or receive loop fails for safer cleanup (please check the below notes).
- Moved the audio iterator outside the retry loop. If a network error occurs, the plugin reconnects without "forgetting" the buffered audio.

### Notes
- I removed runtime dependency checks, as the `aws_sdk_transcribe_streaming` SDK already requires Python 3.12+.
- I have tested this implementation for 2 weeks, no error so far.