### PR TITLE
feat(azure): add lexicon_uri option to TTS

### DIFF
--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
@@ -111,6 +111,7 @@ class _TTSOptions:
     deployment_id: str | None
     prosody: NotGivenOr[ProsodyConfig]
     style: NotGivenOr[StyleConfig]
+    lexicon_uri: NotGivenOr[str]
     auth_token: str | None = None
 
     def get_endpoint_url(self) -> str:
@@ -132,6 +133,7 @@ class TTS(tts.TTS):
         sample_rate: int = 24000,
         prosody: NotGivenOr[ProsodyConfig] = NOT_GIVEN,
         style: NotGivenOr[StyleConfig] = NOT_GIVEN,
+        lexicon_uri: NotGivenOr[str] = NOT_GIVEN,
         speech_key: str | None = None,
         speech_region: str | None = None,
         speech_endpoint: str | None = None,
@@ -184,6 +186,7 @@ class TTS(tts.TTS):
             language=language,
             prosody=prosody,
             style=style,
+            lexicon_uri=lexicon_uri,
             auth_token=speech_auth_token,
         )
 
@@ -202,6 +205,7 @@ class TTS(tts.TTS):
         language: NotGivenOr[str] = NOT_GIVEN,
         prosody: NotGivenOr[ProsodyConfig] = NOT_GIVEN,
         style: NotGivenOr[StyleConfig] = NOT_GIVEN,
+        lexicon_uri: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
         if is_given(voice):
             self._opts.voice = voice
@@ -213,6 +217,8 @@ class TTS(tts.TTS):
         if is_given(style):
             style.validate()
             self._opts.style = style
+        if is_given(lexicon_uri):
+            self._opts.lexicon_uri = lexicon_uri
 
     def _ensure_session(self) -> aiohttp.ClientSession:
         if not self._session:
@@ -243,6 +249,10 @@ class ChunkedStream(tts.ChunkedStream):
             f'xml:lang="{lang}">'
         )
         ssml += f'<voice name="{self._opts.voice}">'
+
+        if is_given(self._opts.lexicon_uri):
+            ssml += f'<lexicon uri="{self._opts.lexicon_uri}"/>'
+
         if is_given(self._opts.style):
             degree = f' styledegree="{self._opts.style.degree}"' if self._opts.style.degree else ""
             ssml += f'<mstts:express-as style="{self._opts.style.style}"{degree}>'


### PR DESCRIPTION
Add support for custom lexicon files in Azure TTS
With the new option, users can specify a lexicon URI to customize pronunciation.

Azure documentation: https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-synthesis-markup-pronunciation#custom-lexicon