### PR TITLE
fix 11labs tts hang after update_options in tool call

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -583,10 +583,6 @@ class _Connection:
                 if isinstance(msg, _SynthesizeContent):
                     is_new_context = msg.context_id not in self._active_contexts
 
-                    # If not current and this is a new context, ignore it
-                    if not self._is_current and is_new_context:
-                        continue
-
                     if is_new_context:
                         voice_settings = (
                             _strip_nones(dataclasses.asdict(self._opts.voice_settings))


### PR DESCRIPTION
when there is a tool call without text message but calls the `tts.update_options`, the connection associated with the tts stream will be marked as not current, the flush message will be ignored so there is no final message sent from the TTS service. 