### PR TITLE
fix: reuse BytesIO buffer to avoid reallocation in StreamBuffer

### DIFF
--- a/livekit-agents/livekit/agents/utils/codecs/decoder.py
+++ b/livekit-agents/livekit/agents/utils/codecs/decoder.py
@@ -98,7 +98,13 @@ class StreamBuffer:
                 if data:
                     # shrink the buffer to remove already-read data
                     remaining = self._buffer.read()
-                    self._buffer = io.BytesIO(remaining)
+
+                    # Reuse the same buffer instead of reallocating
+                    self._buffer.seek(0)
+                    self._buffer.truncate()
+                    self._buffer.write(remaining)
+                    self._buffer.seek(0)
+
                     return data
 
                 if self._eof:


### PR DESCRIPTION
This PR reduces memory churn in `StreamBuffer.read()` by reusing the existing `BytesIO` buffer instead of reallocating a new one after each read.