### PR TITLE
interrupt the same speech handle

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1423,8 +1423,8 @@ class AgentActivity(RecognitionHooks):
             if self._rt_session is not None:
                 self._rt_session.commit_audio()
 
-        if self._current_speech is not None:
-            if not self._current_speech.allow_interruptions:
+        if (current_speech := self._current_speech) is not None:
+            if not current_speech.allow_interruptions:
                 logger.warning(
                     "skipping reply to user input, current speech generation cannot be interrupted",
                     extra={"user_input": info.new_transcript},
@@ -1432,8 +1432,7 @@ class AgentActivity(RecognitionHooks):
                 return
             await self._interrupt_paused_speech(self._interrupt_paused_speech_task)
 
-            if self._current_speech:
-                await self._current_speech.interrupt()
+            await current_speech.interrupt()
 
             if self._rt_session is not None:
                 self._rt_session.interrupt()


### PR DESCRIPTION
This makes sure we interrupt the same speech handle, given there is a chance that `self._current_speech` might be changed during the await point. Potentially fix for #4443 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimization to improve performance and readability of voice agent activity handling. No user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->