### PR TITLE
fix(nvidia): add retry logic for Riva STT sequence timeout errors

### DIFF
--- a/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py
+++ b/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py
@@ -185,15 +185,43 @@ class SpeechStream(stt.SpeechStream):
                 break
 
     def _recognition_worker(self, config: riva.client.StreamingRecognitionConfig) -> None:
+        max_retries = 3
+        retry_count = 0
+
         try:
-            audio_generator = self._audio_chunk_generator()
+            while retry_count < max_retries:
+                try:
+                    audio_generator = self._audio_chunk_generator()
 
-            response_generator = self._asr_service.streaming_response_generator(
-                audio_generator, config
-            )
+                    response_generator = self._asr_service.streaming_response_generator(
+                        audio_generator, config
+                    )
 
-            for response in response_generator:
-                self._handle_response(response)
+                    for response in response_generator:
+                        self._handle_response(response)
+                        retry_count = 0  # Reset on successful response
+
+                    # Normal completion, exit the retry loop
+                    break
+
+                except Exception as e:
+                    error_msg = str(e).lower()
+                    if "start flag" in error_msg or "sequence" in error_msg:
+                        retry_count += 1
+                        if retry_count < max_retries:
+                            logger.warning(
+                                f"Riva sequence timeout detected, recreating ASR service "
+                                f"(attempt {retry_count}/{max_retries}): {e}"
+                            )
+                            self._asr_service = riva.client.ASRService(self._auth)
+                            continue
+                        else:
+                            logger.error(
+                                f"Max retries ({max_retries}) exceeded for Riva sequence timeout"
+                            )
+                            raise
+                    else:
+                        raise
 
         except Exception:
             logger.exception("Error in NVIDIA recognition thread")


### PR DESCRIPTION
## Summary
- Adds retry logic (max 3 attempts) when Riva STT encounters sequence timeout errors
- Detects errors related to missing START flag or sequence issues that occur after audio pauses
- Automatically recreates the ASR service connection to get a fresh sequence on timeout

## Background
When there are pauses in audio, Riva's server-side `max_sequence_idle_microseconds` timeout expires and releases the sequence. Subsequent audio chunks then fail with an `INVALID_ARGUMENT` error about missing START flag. This fix handles that gracefully by retrying with a fresh connection.

## Test plan
- [ ] Test with NVIDIA Riva STT in scenarios with audio pauses
- [ ] Verify retry logic triggers on sequence timeout errors
- [ ] Confirm normal operation is unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of NVIDIA speech-to-text service by implementing automatic retry logic for transient errors, reducing the likelihood of recognition failures due to temporary glitches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->