### PR TITLE
add reasoning param for openai responses LLM

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -20,6 +20,7 @@ from livekit.agents.types import (
     NotGivenOr,
 )
 from livekit.agents.utils import is_given
+from openai.types import Reasoning
 from openai.types.responses import (
     ResponseCompletedEvent,
     ResponseCreatedEvent,
@@ -33,6 +34,8 @@ from openai.types.responses import (
 from openai.types.responses.response_stream_event import ResponseStreamEvent
 from openai.types.shared_params import ResponsesModel
 
+from ..models import _supports_reasoning_effort
+
 
 @dataclass
 class _LLMOptions:
@@ -42,6 +45,7 @@ class _LLMOptions:
     parallel_tool_calls: NotGivenOr[bool]
     tool_choice: NotGivenOr[ToolChoice | Literal["auto", "required", "none"]]
     store: NotGivenOr[bool]
+    reasoning: NotGivenOr[Reasoning]
     metadata: NotGivenOr[dict[str, str]]
 
 
@@ -56,6 +60,7 @@ class LLM(llm.LLM):
         user: NotGivenOr[str] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
+        reasoning: NotGivenOr[Reasoning] = NOT_GIVEN,
         tool_choice: NotGivenOr[ToolChoice | Literal["auto", "required", "none"]] = NOT_GIVEN,
         store: NotGivenOr[bool] = NOT_GIVEN,
         metadata: NotGivenOr[dict[str, str]] = NOT_GIVEN,
@@ -68,6 +73,13 @@ class LLM(llm.LLM):
         ``OPENAI_API_KEY`` environmental variable.
         """
         super().__init__()
+
+        if not is_given(reasoning) and _supports_reasoning_effort(model):
+            if model in ["gpt-5.1", "gpt-5.2"]:
+                reasoning = Reasoning(effort="none")
+            else:
+                reasoning = Reasoning(effort="minimal")
+
         self._opts = _LLMOptions(
             model=model,
             user=user,
@@ -76,6 +88,7 @@ class LLM(llm.LLM):
             tool_choice=tool_choice,
             store=store,
             metadata=metadata,
+            reasoning=reasoning,
         )
         self._client = client or openai.AsyncClient(
             api_key=api_key if is_given(api_key) else None,
@@ -118,6 +131,9 @@ class LLM(llm.LLM):
 
         if is_given(self._opts.user):
             extra["user"] = self._opts.user
+
+        if is_given(self._opts.reasoning):
+            extra["reasoning"] = self._opts.reasoning
 
         parallel_tool_calls = (
             parallel_tool_calls if is_given(parallel_tool_calls) else self._opts.parallel_tool_calls


### PR DESCRIPTION
to use:

```
from openai.types import Reasoning

llm=openai.responses.LLM(reasoning=Reasoning(effort="low", summary="low")
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Language model operations now support configurable reasoning effort levels for enhanced flexibility
  * Compatible models automatically receive optimized default reasoning settings to ensure reliable performance
  * Reasoning configuration seamlessly integrates with all chat interactions
  * Users can customize reasoning behavior to meet specific performance and resource requirements

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->