### PR TITLE
fix(deepgram): expose close code and reason on unexpected disconnects

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -463,7 +463,8 @@ class SpeechStream(stt.SpeechStream):
                 while True:
                     await ws.send_str(SpeechStream._KEEPALIVE_MSG)
                     await asyncio.sleep(5)
-            except Exception:
+            except Exception as e:
+                logger.warning(f"Deepgram keepalive task exited: {e}")
                 return
 
         @utils.log_exceptions(logger=logger)
@@ -516,7 +517,10 @@ class SpeechStream(stt.SpeechStream):
                         return
 
                     # this will trigger a reconnection, see the _run loop
-                    raise APIStatusError(message="deepgram connection closed unexpectedly")
+                    raise APIStatusError(
+                        message=f"deepgram connection closed unexpectedly: "
+                        f"code={ws.close_code}, reason={msg.extra if msg.extra else 'no reason provided'}"
+                    )
 
                 if msg.type != aiohttp.WSMsgType.TEXT:
                     logger.warning("unexpected deepgram message type %s", msg.type)


### PR DESCRIPTION
Improves debuggability of Deepgram STT connection failures:

- Include WebSocket close code and reason in error messages (e.g. `code=1008, reason=NET-0001`)
- Add warning log when keepalive task exits unexpectedly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages and logging to provide more detailed information when connection failures occur, improving diagnostics and troubleshooting capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->