### PR TITLE
playback started call for DataStreamAudioOutput and QueueAudioOutput

### DIFF
--- a/livekit-agents/livekit/agents/voice/avatar/_datastream_io.py
+++ b/livekit-agents/livekit/agents/voice/avatar/_datastream_io.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import math
+import time
 from collections.abc import AsyncIterator
 from dataclasses import asdict
 from typing import Any, Callable, Union
@@ -134,6 +135,10 @@ class DataStreamAudioOutput(AudioOutput):
                 },
             )
             self._pushed_duration = 0.0
+            # Not ideal since frame isn't actually playing yet
+            # potentially we need another RPC for this
+            self.on_playback_started(created_at=time.time())
+
         await self._stream_writer.write(bytes(frame.data))
         self._pushed_duration += frame.duration
 

--- a/livekit-agents/livekit/agents/voice/avatar/_queue_io.py
+++ b/livekit-agents/livekit/agents/voice/avatar/_queue_io.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import AsyncIterator
 from typing import Literal, Union
 
@@ -16,7 +17,7 @@ logger = logging.getLogger(__name__)
 class QueueAudioOutput(
     AudioOutput,
     AudioReceiver,
-    rtc.EventEmitter[Literal["playback_finished", "clear_buffer"]],
+    rtc.EventEmitter[Literal["clear_buffer"]],
 ):
     """
     AudioOutput implementation that sends audio frames through a queue.
@@ -37,6 +38,9 @@ class QueueAudioOutput(
         await super().capture_frame(frame)
         if not self._capturing:
             self._capturing = True
+            # Not ideal since frame isn't actually playing yet
+            # potentially we need another RPC/hook for this
+            self.on_playback_started(created_at=time.time())
 
         await self._data_ch.send(frame)
 


### PR DESCRIPTION
Bugs introduced by #4131 and it should close #4568 affecting version 1.3.11

- Avatar services use `DataStreamAudioOutput` and `QueueAudioOutput` where first frame future was never resolved, leading to agent messages missed in context and session hooks.
- Tested with liveavatar locally.

More details:

We have 7 AudioOutput subsclasses:

- [x] DataStreamAudioOutput
- [x] ConsoleAudioOutput
- [ ] _ParticipantAudioOutput
- [x] FakeAudioOutput
- [ ] RecorderAudioOutput
- [ ] _SyncedAudioOutput
- [x] QueueAudioOutput

Internal classes and the recorder will not fire `on_playback_started` events since other output on the chain should take care of that. We don't put this in the base class because we want to make sure it is only fired as close to the device as possible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice avatar playback now emits a start event with timestamp information when playback begins.

* **Changes**
  * Modified observable audio events in queue playback system; certain events are no longer publicly available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->