### PR TITLE
fix(baseten): correct metadata and response field names for STT

### DIFF
--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/stt.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/stt.py
@@ -315,13 +315,11 @@ class SpeechStream(stt.SpeechStream):
                         for segment in segments
                     ]
                     start_time = (
-                        next((s.get("start_time", 0.0) for s in segments), 0.0)
-                        + self.start_time_offset
-                    )
+                        segments[0].get("start_time", 0.0) if segments else 0.0
+                    ) + self.start_time_offset
                     end_time = (
-                        next((s.get("end_time", 0.0) for s in segments), 0.0)
-                        + self.start_time_offset
-                    )
+                        segments[-1].get("end_time", 0.0) if segments else 0.0
+                    ) + self.start_time_offset
 
                     if not is_final:
                         if text:


### PR DESCRIPTION
## Summary
- Fix metadata field names to match Baseten server schema (`vad_params`, `streaming_whisper_params`)
- Fix response parsing to use correct timing field names (`start_time`, `end_time` instead of `start`, `end`)

## Changes
1. **Metadata structure** - Updated to match Baseten's expected schema:
   - `streaming_vad_config` → `vad_params`
   - `streaming_params` + `whisper_params` → `streaming_whisper_params` (combined)

2. **Response timing fields** - Fixed to match Baseten's actual response format:
   - `segment.get("start")` → `segment.get("start_time")`
   - `segment.get("end")` → `segment.get("end_time")`

## Test plan
- [x] Verified WebSocket connection succeeds (no more 1011 Internal Server Error)
- [x] Verified transcription works with correct timing information
- [x] Confirmed `start_time_offset` is correctly applied to timestamps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected timing alignment in speech-to-text transcripts so segment and overall timestamps are accurate and consistent.

* **New Features**
  * Added option to specify audio language for transcription.
  * Added word-level timestamps so individual words can be shown with timing information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->