### PR TITLE
feat (google STT): support profanity filter

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -155,7 +155,7 @@ class STT(stt.STT):
             enable_voice_activity_events(bool): whether to enable voice activity events (default: False)
             model(SpeechModels): the model to use for recognition default: "latest_long"
             location(str): the location to use for recognition default: "global"
-            profanity_filter (bool): whether to filter out profanities default: False
+            profanity_filter(bool): whether to filter out profanities default: False
             sample_rate(int): the sample rate of the audio default: 16000
             min_confidence_threshold(float): minimum confidence threshold for recognition
             (default: 0.65)


### PR DESCRIPTION
it was entertaining testing this PR.

[docs](https://docs.cloud.google.com/speech-to-text/docs/profanity-filter)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a profanity filter option to Google Speech-to-Text, allowing automatic profanity filtering to be enabled or disabled for transcriptions.
  * Profanity filter setting now applies across initial recognition and live streaming transcriptions and can be updated at runtime.

* **Documentation**
  * Updated parameter documentation and usage notes to include the new profanity filter configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->