### PR TITLE
fix(mcp): Error message based on text attribute instead of str(part)

### DIFF
--- a/livekit-agents/livekit/agents/llm/mcp.py
+++ b/livekit-agents/livekit/agents/llm/mcp.py
@@ -108,7 +108,10 @@ class MCPServer(ABC):
             tool_result = await self._client.call_tool(name, raw_arguments)
 
             if tool_result.isError:
-                error_str = "\n".join(str(part) for part in tool_result.content)
+                error_str = "\n".join(
+                    part.text if hasattr(part, "text") else str(part)
+                    for part in tool_result.content
+                )
                 raise ToolError(error_str)
 
             # TODO(theomonnom): handle images & binary messages


### PR DESCRIPTION
It fixes the following issue: https://github.com/livekit/agents/issues/4503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message reporting for tool execution: error text now prefers the tool’s provided textual content when available, and falls back to previous formatting otherwise—making tool errors clearer and more informative for end users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->