### PR TITLE
_setup_cloud_tracer still overrides TracerProviders due to checking the wrong base class

### DIFF
--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -162,9 +162,14 @@ def _setup_cloud_tracer(*, room_id: str, job_id: str, cloud_hostname: str) -> No
             "job_id": job_id,
         }
     )
-    # We check against trace_api.TracerProvider since it is the abstract base class
-    if not isinstance(tracer._tracer_provider, trace_api.TracerProvider):
-        # ⬇️ This is a sdk TracerProvider which inherits from trace_api.TracerProvider
+
+    # Check if a tracer provider is not set and set one up
+    # below shows how the ProxyTracerProvider is returned when none have been setup
+    # https://github.com/open-telemetry/opentelemetry-python/blob/0018c0030bac9bdce4487fe5fcb3ec6a542ec904/opentelemetry-api/src/opentelemetry/trace/__init__.py#L555
+    tracer_provider: trace_api.TracerProvider
+    if isinstance(
+        tracer._tracer_provider, (trace_api.ProxyTracerProvider, trace_api.NoOpTracerProvider)
+    ):
         tracer_provider = trace_sdk.TracerProvider(resource=resource)
         set_tracer_provider(tracer_provider)
     else:


### PR DESCRIPTION
`_setup_cloud_tracer` still overrides TracerProviders due to checking the wrong base class.
The previous [TracerProvider](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py#L1217) inherits from the abstract base class [TracerProvider](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-api/src/opentelemetry/trace/__init__.py#L191) which is intended to be the base class of all TracerProviders. Not all TracerProviders need to inherit from the sdk variant.

This specifically happens for the dd-trace [TracerProvider](https://github.com/DataDog/dd-trace-py/blob/1ada64f6638cc4eca358ad918b44a88e2b1330d9/ddtrace/internal/opentelemetry/trace.py#L55) which instead inherits from the abstract base class.

What happens is if you use livekit cloud and datadog open telemetry traces, the tracerprovider is being reset by the `_setup_cloud_tracer` function and you don't get those traces. This is similar to the previous bug [here](https://github.com/livekit/agents/pull/4060)

https://github.com/livekit/agents/pull/4060

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved telemetry plumbing for safer tracer provider handling and clearer API vs SDK separation.
  * More robust conditional attachment of span processors to avoid incompatible setups.
  * Enhanced shutdown and safety checks for telemetry to reduce errors during provider transitions.
  * Cleaner logging and provider setup behavior to improve reliability and observability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->