### PR TITLE
Increase read_bufsize in minimax tts plugin

### DIFF
--- a/livekit-plugins/livekit-plugins-minimax/livekit/plugins/minimax/tts.py
+++ b/livekit-plugins/livekit-plugins-minimax/livekit/plugins/minimax/tts.py
@@ -538,6 +538,8 @@ class ChunkedStream(tts.ChunkedStream):
                 },
                 json=msg,
                 timeout=aiohttp.ClientTimeout(total=30, sock_connect=self._conn_options.timeout),
+                # large read_bufsize to avoid `ValueError: Chunk too big`
+                read_bufsize=10 * 1024 * 1024,
             ) as resp:
                 resp.raise_for_status()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a "Chunk too big" error that could occur when using minimax text-to-speech streaming by optimizing the internal buffer size for HTTP responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->