### PR TITLE
remove shortcut inference STT model name

### DIFF
--- a/examples/voice_agents/langfuse_trace.py
+++ b/examples/voice_agents/langfuse_trace.py
@@ -83,7 +83,12 @@ class Kelly(Agent):
                     inference.LLM("google/gemini-2.5-flash"),
                 ]
             ),
-            stt=FallbackSTTAdapter(stt=[inference.STT("deepgram"), inference.STT("cartesia")]),
+            stt=FallbackSTTAdapter(
+                stt=[
+                    inference.STT("deepgram/nova-3"),
+                    inference.STT("cartesia/ink-whisper"),
+                ]
+            ),
             tts=FallbackTTSAdapter(
                 tts=[
                     inference.TTS("cartesia"),

--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -27,7 +27,6 @@ from ..utils import is_given
 from ._utils import create_access_token
 
 DeepgramModels = Literal[
-    "deepgram",
     "deepgram/nova-3",
     "deepgram/nova-3-general",
     "deepgram/nova-3-medical",
@@ -37,14 +36,8 @@ DeepgramModels = Literal[
     "deepgram/nova-2-conversationalai",
     "deepgram/nova-2-phonecall",
 ]
-CartesiaModels = Literal[
-    "cartesia",
-    "cartesia/ink-whisper",
-]
-AssemblyAIModels = Literal[
-    "assemblyai",
-    "assemblyai/universal-streaming",
-]
+CartesiaModels = Literal["cartesia/ink-whisper",]
+AssemblyAIModels = Literal["assemblyai/universal-streaming",]
 
 
 class CartesiaOptions(TypedDict, total=False):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * STT model selection now requires specifying exact model versions (e.g., "deepgram/nova-3" instead of "deepgram"). Update your agent configurations accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->