### PR TITLE
fix(google): add thought_signature support for Gemini 2.5 models

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -49,6 +49,18 @@ def _is_gemini_3_flash_model(model: str) -> bool:
     return "gemini-3-flash" in model.lower() or model.lower().startswith("gemini-3-flash")
 
 
+def _requires_thought_signatures(model: str) -> bool:
+    """Check if model requires thought_signature handling for multi-turn function calling.
+
+    Gemini 2.5+ models require thought signatures to be stored from responses and
+    passed back in subsequent requests for proper multi-turn function calling.
+    """
+    if _is_gemini_3_model(model):
+        return True
+    model_lower = model.lower()
+    return "gemini-2.5" in model_lower or model_lower.startswith("gemini-2.5")
+
+
 @dataclass
 class _LLMOptions:
     model: ChatModels | str
@@ -208,7 +220,7 @@ class LLM(llm.LLM):
             project=gcp_project,
             location=gcp_location,
         )
-        # Store thought_signatures for Gemini 3 multi-turn function calling
+        # Store thought_signatures for Gemini 2.5+ multi-turn function calling
         self._thought_signatures: dict[str, bytes] = {}
 
     @property
@@ -401,9 +413,9 @@ class LLMStream(llm.LLMStream):
         request_id = utils.shortuuid()
 
         try:
-            # Pass thought_signatures for Gemini 3 multi-turn function calling
+            # Pass thought_signatures for Gemini 2.5+ multi-turn function calling
             thought_sigs = (
-                self._llm._thought_signatures if _is_gemini_3_model(self._model) else None
+                self._llm._thought_signatures if _requires_thought_signatures(self._model) else None
             )
             turns_dict, extra_data = self._chat_ctx.to_provider_format(
                 format="google", thought_signatures=thought_sigs
@@ -535,9 +547,9 @@ class LLMStream(llm.LLMStream):
                 call_id=part.function_call.id or utils.shortuuid("function_call_"),
             )
 
-            # Store thought_signature for Gemini 3 multi-turn function calling
+            # Store thought_signature for Gemini 2.5+ multi-turn function calling
             if (
-                _is_gemini_3_model(self._model)
+                _requires_thought_signatures(self._model)
                 and hasattr(part, "thought_signature")
                 and part.thought_signature
             ):

--- a/tests/test_google_thought_signatures.py
+++ b/tests/test_google_thought_signatures.py
@@ -1,0 +1,88 @@
+import pytest
+
+from livekit.plugins.google.llm import (
+    _is_gemini_3_flash_model,
+    _is_gemini_3_model,
+    _requires_thought_signatures,
+)
+
+
+class TestGeminiModelDetection:
+    """Tests for Gemini model detection helper functions."""
+
+    @pytest.mark.parametrize(
+        "model,expected",
+        [
+            # Gemini 3 models - should return True
+            ("gemini-3-pro-preview", True),
+            ("gemini-3-flash-preview", True),
+            ("gemini-3-flash", True),
+            ("gemini-3-pro", True),
+            ("GEMINI-3-FLASH", True),  # case insensitive
+            # Gemini 2.5 models - should return False
+            ("gemini-2.5-flash", False),
+            ("gemini-2.5-pro-preview-05-06", False),
+            # Gemini 2.0 models - should return False
+            ("gemini-2.0-flash-001", False),
+            # Gemini 1.5 models - should return False
+            ("gemini-1.5-pro", False),
+            # Other models - should return False
+            ("gpt-4", False),
+            ("claude-3", False),
+        ],
+    )
+    def test_is_gemini_3_model(self, model: str, expected: bool):
+        assert _is_gemini_3_model(model) == expected
+
+    @pytest.mark.parametrize(
+        "model,expected",
+        [
+            # Gemini 3 Flash models - should return True
+            ("gemini-3-flash-preview", True),
+            ("gemini-3-flash", True),
+            ("GEMINI-3-FLASH", True),  # case insensitive
+            # Gemini 3 Pro models - should return False
+            ("gemini-3-pro-preview", False),
+            ("gemini-3-pro", False),
+            # Other models - should return False
+            ("gemini-2.5-flash", False),
+            ("gemini-2.0-flash-001", False),
+        ],
+    )
+    def test_is_gemini_3_flash_model(self, model: str, expected: bool):
+        assert _is_gemini_3_flash_model(model) == expected
+
+    @pytest.mark.parametrize(
+        "model,expected",
+        [
+            # Gemini 3 models - should return True (requires thought signatures)
+            ("gemini-3-pro-preview", True),
+            ("gemini-3-flash-preview", True),
+            ("gemini-3-flash", True),
+            ("gemini-3-pro", True),
+            ("GEMINI-3-FLASH", True),  # case insensitive
+            # Gemini 2.5 models - should return True (requires thought signatures)
+            ("gemini-2.5-flash", True),
+            ("gemini-2.5-pro-preview-05-06", True),
+            ("gemini-2.5-flash-preview-04-17", True),
+            ("gemini-2.5-flash-preview-05-20", True),
+            ("GEMINI-2.5-FLASH", True),  # case insensitive
+            # Gemini 2.0 models - should return False (does not require thought signatures)
+            ("gemini-2.0-flash-001", False),
+            ("gemini-2.0-flash-lite-preview-02-05", False),
+            ("gemini-2.0-pro-exp-02-05", False),
+            # Gemini 1.5 models - should return False
+            ("gemini-1.5-pro", False),
+            # Other models - should return False
+            ("gpt-4", False),
+            ("claude-3", False),
+        ],
+    )
+    def test_requires_thought_signatures(self, model: str, expected: bool):
+        """Test that thought_signature handling is enabled for Gemini 2.5+ models.
+
+        This is the critical fix for the thought_signature error that occurs when using
+        Gemini 2.5 Flash with multi-turn function calling. Google's API requires
+        thought_signatures to be stored and passed back in subsequent requests.
+        """
+        assert _requires_thought_signatures(model) == expected


### PR DESCRIPTION
Gemini 2.5 models require thought_signatures to be stored from API responses and passed back in subsequent requests for proper multi-turn function calling. Without this, Google's API returns 400 INVALID_ARGUMENT errors with "missing thought_signature".

This adds a new `_requires_thought_signatures()` helper function that returns True for both Gemini 2.5 and Gemini 3 models, extending the existing Gemini 3-only thought_signature handling to also cover Gemini 2.5.

Changes:
- Add `_requires_thought_signatures()` function
- Update thought_signature storage/retrieval to use new function
- Add comprehensive unit tests for model detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended multi-turn function calling support to Gemini 2.5 and Gemini 3 models for improved conversation handling.

* **Tests**
  * Added comprehensive test coverage for Gemini model variants and function calling behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->