### PR TITLE
continue instead of return in InferenceProcExecutor loop

### DIFF
--- a/livekit-agents/livekit/agents/ipc/inference_proc_executor.py
+++ b/livekit-agents/livekit/agents/ipc/inference_proc_executor.py
@@ -70,7 +70,7 @@ class InferenceProcExecutor(SupervisedProc):
                         "received unexpected inference response",
                         extra={"request_id": msg.request_id},
                     )
-                    return
+                    continue
 
                 with contextlib.suppress(asyncio.InvalidStateError):
                     fut.set_result(msg)


### PR DESCRIPTION
If the intention was to return immediately, we can close this. 

Reported by detail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where message processing would unexpectedly stop when encountering invalid request identifiers. The system now continues handling subsequent messages, improving reliability and resilience in message queue handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->