### PR TITLE
Fix: Add reconnection support for ElevenLabs STT WebSocket disconnect…

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
@@ -413,7 +413,7 @@ class SpeechStream(stt.SpeechStream):
                     # Reset speaking state on reconnection
                     self._speaking = False
                     # Add exponential backoff
-                    await asyncio.sleep(min(2 ** reconnect_attempt, 10))
+                    await asyncio.sleep(min(2**reconnect_attempt, 10))
 
                 reconnect_attempt += 1
                 if reconnect_attempt > max_reconnect_attempts:


### PR DESCRIPTION
…ions

- Add retryable=True to APIStatusError when connection closes unexpectedly
   - Implement exponential backoff for reconnection attempts (max 5 attempts)
   - Reset _speaking state on reconnection to prevent state corruption
   - Add logging for reconnection attempts
   - Reset reconnection counter after successful reconnection

   Fixes #4609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ElevenLabs speech-to-text stability with automatic reconnection when streams close unexpectedly.
  * Added exponential backoff between reconnect attempts to reduce transient failures.
  * Enforced a configurable max reconnect limit to avoid indefinite retry loops.
  * Restored and maintained proper speaking/state handling across reconnects.
  * Marked certain disconnects as retryable so transient issues are retried intelligently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->