### PR TITLE
allow 499 retry

### DIFF
--- a/livekit-agents/livekit/agents/llm/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/fallback_adapter.py
@@ -259,7 +259,7 @@ class FallbackLLMStream(LLMStream):
                         self._event_ch.send_nowait(result)
 
                     return
-                except Exception:  # exceptions already logged inside _try_synthesize
+                except Exception:  # exceptions already logged inside _try_generate
                     if llm_status.available:
                         llm_status.available = False
                         self._fallback_adapter.emit(

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/gemini_tts.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/gemini_tts.py
@@ -235,7 +235,7 @@ class ChunkedStream(tts.ChunkedStream):
                 "gemini tts: client error",
                 status_code=e.code,
                 body=f"{e.message} {e.status}",
-                retryable=False if e.code != 429 else True,
+                retryable=True if e.code in {429, 499} else False,
             ) from e
         except ServerError as e:
             raise APIStatusError(

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -515,7 +515,7 @@ class LLMStream(llm.LLMStream):
                 status_code=e.code,
                 body=f"{e.message} {e.status}",
                 request_id=request_id,
-                retryable=False if e.code != 429 else True,
+                retryable=True if e.code in {429, 499} else False,
             ) from e
         except ServerError as e:
             raise APIStatusError(


### PR DESCRIPTION
This allows retry on 499 errors w/ Google LLM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error retry logic for Google services to properly handle transient failures, treating both rate-limiting and temporary service unavailability responses as retryable conditions to improve reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->