### PR TITLE
(openai realtime): add truncation param

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1074,7 +1074,7 @@ class RealtimeSession(
             self._realtime_model._opts.truncation = cast(
                 Union[RealtimeTruncation, None], truncation
             )
-            session.truncation = cast(Union[RealtimeTruncation, None], truncation)  # type: ignore
+            session.truncation = cast(Union[RealtimeTruncation, None], truncation)
             has_changes = True
 
         has_audio_config = False


### PR DESCRIPTION
Note: `RealtimeModelBeta` does not support the `truncation` parameter

https://platform.openai.com/docs/api-reference/realtime-client-events/session/update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added truncation configuration for OpenAI Realtime models. Users can set truncation when creating a model and update it during active sessions; changes propagate to sessions and the Realtime API for consistent message handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->