### PR TITLE
fix(google): set tool_response_scheduling to IMMEDIATELY by default

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -184,7 +184,7 @@ class RealtimeModel(llm.RealtimeModel):
             realtime_input_config (RealtimeInputConfig, optional): The configuration for realtime input. Defaults to None.
             context_window_compression (ContextWindowCompressionConfig, optional): The configuration for context window compression. Defaults to None.
             tool_behavior (Behavior, optional): The behavior for tool call. Default behavior is BLOCK in Gemini Realtime API.
-            tool_response_scheduling (FunctionResponseScheduling, optional): The scheduling for tool response. Default scheduling is WHEN_IDLE.
+            tool_response_scheduling (FunctionResponseScheduling, optional): The scheduling for tool response. Defaults to IMMEDIATELY to ensure Gemini generates a response after tool execution in voice mode.
             session_resumption (SessionResumptionConfig, optional): The configuration for session resumption. Defaults to None.
             thinking_config (ThinkingConfig, optional): Native audio thinking configuration.
             conn_options (APIConnectOptions, optional): The configuration for the API connection. Defaults to DEFAULT_API_CONNECT_OPTIONS.
@@ -196,6 +196,8 @@ class RealtimeModel(llm.RealtimeModel):
             input_audio_transcription = types.AudioTranscriptionConfig()
         if not is_given(output_audio_transcription):
             output_audio_transcription = types.AudioTranscriptionConfig()
+        if not is_given(tool_response_scheduling):
+            tool_response_scheduling = types.FunctionResponseScheduling.IMMEDIATELY
 
         server_turn_detection = True
         if (


### PR DESCRIPTION
## Summary

This PR fixes an issue where Gemini Live would not generate a response after tool execution in voice mode.

**Root Cause Analysis:** The default `tool_response_scheduling` in Gemini's API is `WHEN_IDLE`, which means Gemini waits until it's "idle" before processing tool responses. However, in voice mode, Gemini is never truly idle because it's continuously processing audio input. This causes Gemini to wait indefinitely before generating a response after receiving tool results.

**Fix:** Set `tool_response_scheduling` to `IMMEDIATELY` by default, ensuring Gemini generates a response immediately after receiving tool results.

## Review & Testing Checklist for Human

- [ ] **Test with actual Gemini Live + tool calls**: The fix is based on code analysis, not actual testing. Please verify this resolves the reported issue where tool calls execute but no response follows.
- [ ] **Verify no regressions with multiple tool calls**: Ensure `IMMEDIATELY` scheduling doesn't cause issues with rapid successive tool calls or parallel tool execution.
- [ ] **Confirm understanding of Gemini API behavior**: The analysis assumes `WHEN_IDLE` never triggers in voice mode - this should be validated against Gemini API documentation or Google support.

**Recommended test plan:**
1. Create a Gemini Live agent with tools (as in the original issue report)
2. Trigger a tool call via voice
3. Verify the agent responds after tool execution completes

### Notes

- Link to Devin run: https://livekit.devinenterprise.com/sessions/44168cc226ec4a389d58d89464bb5380
- Requested by: @s-hamdananwar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool responses in voice interactions now execute immediately after tool execution for improved response timing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->