### PR TITLE
feat: add update_options method to FallbackAdapter for STT instances

### DIFF
--- a/livekit-agents/livekit/agents/stt/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/stt/fallback_adapter.py
@@ -280,7 +280,7 @@ class FallbackAdapter(
                 except TypeError as e:
                     logger.warning(
                         f"Failed to update options for {stt.label}: {e}. "
-                        "Ensure kwargs are compatible with this provider's update_options signature."
+                        "Ensure options passed are compatible with this provider's update_options signature."
                     )
 
     def _on_metrics_collected(self, *args: Any, **kwargs: Any) -> None:


### PR DESCRIPTION
missing ```update_options``` method in STT ```FallbackAdapter``` that prevented runtime configuration changes from propagating to underlying STT providers. The STT FallbackAdapter class was missing the update_options method, causing calls to update STT settings (language, model, keywords, etc.) to fail silently when using the adapter. This affected all STT providers (Deepgram, OpenAI, Cartesia, Azure, etc.) when wrapped in the FallbackAdapter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic option updates for fallback speech-to-text so configuration changes propagate to all underlying recognizers at runtime.
* **Bug Fixes**
  * Safely handles providers that can't accept updated options by logging a warning instead of failing, preventing crashes or interruptions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->