### PR TITLE
fix(liveavatar): emit playback_finished on AudioSegmentEnd

### DIFF
--- a/livekit-plugins/livekit-plugins-liveavatar/livekit/plugins/liveavatar/avatar.py
+++ b/livekit-plugins/livekit-plugins-liveavatar/livekit/plugins/liveavatar/avatar.py
@@ -22,7 +22,7 @@ from livekit.agents import (
     utils,
 )
 from livekit.agents.utils import is_given
-from livekit.agents.voice.avatar import QueueAudioOutput
+from livekit.agents.voice.avatar import AudioSegmentEnd, QueueAudioOutput
 from livekit.agents.voice.room_io import ATTRIBUTE_PUBLISH_ON_BEHALF
 
 from .api import LiveAvatarAPI, LiveAvatarException
@@ -219,6 +219,14 @@ class AvatarSession:
 
                         self.send_event(msg)
                         self._playback_position += resampled_frame.duration
+                elif isinstance(audio_frame, AudioSegmentEnd):
+                    if self._audio_playing:
+                        self._audio_playing = False
+                        self._audio_buffer.notify_playback_finished(
+                            playback_position=self._playback_position,
+                            interrupted=False,
+                        )
+                        self._playback_position = 0.0
 
         async def _keep_alive_task() -> None:
             try:


### PR DESCRIPTION
Fixes issue where session.say() hangs when LiveAvatar is enabled. The _forward_audio loop now handles AudioSegmentEnd markers by calling notify_playback_finished, matching the pattern in AvatarRunner.

fixes #4668

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio playback handling to properly manage completion of audio segments, reducing potential playback issues and ensuring correct state transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->