### PR TITLE
chore(docs): ditch the v0 docs and promote v1 docs to main path

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: S3 Upload
         run: |
-          aws s3 sync docs/ s3://livekit-docs/python
+          aws s3 sync --delete docs/ s3://livekit-docs/python
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_DEPLOY_AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_DEPLOY_AWS_API_SECRET }}


### PR DESCRIPTION
We had previously removed links to old v0 reference documentation, but content was still hosted at `docs.livekit.io/reference/python` while v1 docs were at `docs.livekit.io/reference/python/v1`.

This Promotes v1 documentation to the base path (`docs.livekit.io/reference/python`) and removes logic for automated deployment of legacy docs.
<!-- devin-review-badge-begin -->

---

<a href="https://livekit.devinenterprise.com/review/livekit/agents/pull/4695">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
