### PR TITLE
Fix wrong "timestamp" parameter in livekit-plugins-spitch stt.py

### DIFF
--- a/livekit-plugins/livekit-plugins-spitch/livekit/plugins/spitch/stt.py
+++ b/livekit-plugins/livekit-plugins-spitch/livekit/plugins/spitch/stt.py
@@ -71,7 +71,7 @@ class STT(stt.STT):
                 language=config.language,  # type: ignore
                 content=data,
                 timeout=httpx.Timeout(30, connect=conn_options.timeout),
-                timestamp=True if "mansa" in model else None,
+                timestamp="word" if "mansa" in model else "none",
             )
 
             return stt.SpeechEvent(


### PR DESCRIPTION
Using the Spitch plugin against their latest API endpoint is currently broken. The plugin returns this error: 

```
livekit.agents._exceptions.APIStatusError: Error code: 400 - {'detail': 'invalid timestamp value'} (status_code=400, request_id=None, body={'detail': 'invalid timestamp value'}, retryable=False)
```

According to the official Spitch documentation, the "timestamp" parameter of the transcribe method must be a string, one of ["word", "sentence", "none"]. (See https://github.com/spi-tch/spitch-python/blob/main/src/spitch/types/speech_transcribe_params.py#L22)

This small change fixes the plugin. Spitch endpoint successfully returns transcriptions.
<!-- devin-review-badge-begin -->

---

<a href="https://livekit.devinenterprise.com/review/livekit/agents/pull/4702">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
