### PR TITLE
Restore Python 3.14 support by updating livekit-blingfire to 1.1

### DIFF
--- a/livekit-agents/pyproject.toml
+++ b/livekit-agents/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "A powerful framework for building realtime voice AI agents"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.9,<3.15"
 authors = [{ name = "LiveKit", email = "hello@livekit.io" }]
 keywords = ["webrtc", "realtime", "audio", "video", "livekit", "agents", "AI"]
 classifiers = [
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
@@ -32,7 +33,7 @@ dependencies = [
     "livekit==1.0.23",
     "livekit-api>=1.0.7,<2",
     "livekit-protocol>=1.1,<2",
-    "livekit-blingfire~=1.0",
+    "livekit-blingfire~=1.1,<2",
     "protobuf>=3",
     "pyjwt>=2.0",
     "types-protobuf>=4",


### PR DESCRIPTION
## Summary
Enables Python 3.14 support by updating the `livekit-blingfire` dependency to version 1.1+, which includes Python 3.14 wheels.

## Background
Issue #3618 reported that Python 3.14.0 installation was failing due to `livekit-blingfire==1.0.0` not having wheels for Python 3.14 (`cp314`). PRs #3921 and #3942 added a temporary `<3.14` requirement to the `requires-python` field to prevent user confusion while the dependency was being updated.

## Resolution
- `livekit-blingfire` 1.1.0 was released with Python 3.14 support via PR #4265
- Included in `livekit-agents@1.3.7` (released December 16, 2025)
- The dependency has been tested in production for over a month

## Changes
- Updated `livekit-blingfire` from `~=1.0` to `>=1.1,<2` to allow Python 3.14 support
- Removed `<3.14` upper bound from `requires-python`
- Added `<3.15` upper bound for future Python compatibility
- Added Python 3.14 classifier

## Testing
- `livekit-blingfire>=1.1,<2` is backward compatible (minor version bump per semver)
- Already deployed in production since livekit-agents@1.3.7 (December 16, 2025)
- CI/CD will verify Python 3.14 compatibility

Closes #3618
<!-- devin-review-badge-begin -->

---

<a href="https://livekit.devinenterprise.com/review/livekit/agents/pull/4710">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
