### PR TITLE
fix: Add default google tts model selection for backward compatibility

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
@@ -132,8 +132,9 @@ class TTS(tts.TTS):
         if not is_given(model_name):
             # chirp3 voice name format: <locale>-<model>-<voice>
             # only chirp 3 model can support voice cloning
-            if is_given(voice_cloning_key) or (
-                is_given(voice_name) and "chirp" in voice_name.lower()
+            if not is_given(prompt) and (
+                is_given(voice_cloning_key)
+                or (is_given(voice_name) and "chirp" in voice_name.lower())
             ):
                 model_name = "chirp_3"
                 logger.debug(


### PR DESCRIPTION
This PR automatically selects the model name based on `prompt`, `voice_name` or `voice_cloning_key`.

<!-- devin-review-badge-begin -->

---

<a href="https://livekit.devinenterprise.com/review/livekit/agents/pull/4731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
