### PR TITLE
fix: generate final LLM response when max_tool_steps is reached

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2182,12 +2182,14 @@ class AgentActivity(RecognitionHooks):
         # important: no agent output should be used after this point
 
         if len(tool_output.output) > 0:
-            if speech_handle.num_steps >= self._session.options.max_tool_steps + 1:
+            max_steps_reached = speech_handle.num_steps >= self._session.options.max_tool_steps + 1
+
+            if max_steps_reached:
                 logger.warning(
-                    "maximum number of function calls steps reached",
+                    "maximum number of function calls steps reached, "
+                    "generating final response with tool_choice='none'",
                     extra={"speech_id": speech_handle.id},
                 )
-                return
 
             speech_handle._num_steps += 1
 
@@ -2237,9 +2239,11 @@ class AgentActivity(RecognitionHooks):
                         tools=tools,
                         model_settings=ModelSettings(
                             # Avoid setting tool_choice to "required" or a specific function when
-                            # passing tool response back to the LLM
+                            # passing tool response back to the LLM.
+                            # Force tool_choice="none" when max steps reached to guarantee
+                            # a final text response instead of silently stopping.
                             tool_choice="none"
-                            if draining or model_settings.tool_choice == "none"
+                            if max_steps_reached or draining or model_settings.tool_choice == "none"
                             else "auto",
                         ),
                         # in case the current reply only generated tools (no speech), re-use the current user_metrics for the next


### PR DESCRIPTION
## Summary

When `max_tool_steps` is reached during a tool-calling loop, the agent currently silently stops — the `_pipeline_reply_task` returns without generating a final LLM response. This leaves users (both voice and text) with no feedback after potentially multiple tool executions.

This PR changes the behavior so that when the limit is hit, the last recursive call to `_pipeline_reply_task` uses `tool_choice="none"`, forcing the LLM to produce a text response using whatever tool results have been gathered so far, instead of silently returning.

## Problem

In `agent_activity.py`, the tool execution loop checks:

```python
if speech_handle.num_steps >= self._session.options.max_tool_steps + 1:
    logger.warning("maximum number of function calls steps reached")
    return  # <-- Silent stop. No response to user.
```

This means:
- The user asks a question requiring multiple tool calls
- The agent executes tools up to the limit
- When the limit is hit, it just stops — no "here's what I found" response
- The user sees silence (voice) or no message (text)

## Solution

Instead of a hard `return`, the fix:
1. Removes the early return
2. Captures `max_steps_reached` as a boolean flag
3. Adds `max_steps_reached` to the existing `tool_choice` condition
4. When max steps is reached, `tool_choice="none"` forces the LLM to respond with text only (no more tool calls)

The tool results from the final step are still added to the chat context, so the LLM can reference them in its response.

## Changes

**File:** `livekit-agents/livekit/agents/voice/agent_activity.py`

- Replaced the early `return` with a `max_steps_reached` flag
- Added `max_steps_reached` to the `tool_choice` condition alongside the existing `draining` and `model_settings.tool_choice == "none"` checks
- Updated the warning log message to indicate a final response will be generated
- No new dependencies, no API changes, fully backward compatible

## Before (current behavior)

```
User: "Search for restaurants near me and check their ratings"
Agent: [calls search tool] -> [calls ratings tool] -> [calls details tool] -> (max_tool_steps reached) -> SILENCE
```

## After (with this fix)

```
User: "Search for restaurants near me and check their ratings"
Agent: [calls search tool] -> [calls ratings tool] -> [calls details tool] -> (max_tool_steps reached) -> "I found several restaurants near you. Here are the top rated ones: ..."
```

## Testing

- The change is minimal and contained to the tool step limit logic
- The `tool_choice="none"` parameter is already used in the same code path for `draining` scenarios
- No new code paths are introduced — the existing `_pipeline_reply_task` recursive call is reused
- Backward compatible: agents with `max_tool_steps` set high enough to never hit the limit see no change
<!-- devin-review-badge-begin -->

---

<a href="https://livekit.devinenterprise.com/review/livekit/agents/pull/4747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
