### PR TITLE
(liveavatar): change avatar mode from CUSTOM to LITE

### DIFF
--- a/livekit-plugins/livekit-plugins-liveavatar/livekit/plugins/liveavatar/api.py
+++ b/livekit-plugins/livekit-plugins-liveavatar/livekit/plugins/liveavatar/api.py
@@ -64,7 +64,7 @@ class LiveAvatarAPI:
         }
 
         payload = {
-            "mode": "CUSTOM",
+            "mode": "LITE",
             "avatar_id": avatar_id,
             "is_sandbox": is_sandbox,
             "livekit_config": livekit_config,


### PR DESCRIPTION
`"CUSTOM"` will not be supported in the future, was renamed to `"LITE"`
<!-- devin-review-badge-begin -->

---

<a href="https://livekit.devinenterprise.com/review/livekit/agents/pull/4748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
