### PR TITLE
feat: add missing OpenTelemetry GenAI attributes (gen_ai.provider.name, gen_ai.operation.name)

### DIFF
--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -196,7 +196,13 @@ class LLMStream(ABC):
 
     async def _main_task(self) -> None:
         self._llm_request_span = trace.get_current_span()
-        self._llm_request_span.set_attribute(trace_types.ATTR_GEN_AI_REQUEST_MODEL, self._llm.model)
+        self._llm_request_span.set_attributes(
+            {
+                trace_types.ATTR_GEN_AI_OPERATION_NAME: "chat",
+                trace_types.ATTR_GEN_AI_PROVIDER_NAME: self._llm.provider,
+                trace_types.ATTR_GEN_AI_REQUEST_MODEL: self._llm.model,
+            }
+        )
 
         for i in range(self._conn_options.max_retry + 1):
             try:

--- a/livekit-agents/livekit/agents/telemetry/trace_types.py
+++ b/livekit-agents/livekit/agents/telemetry/trace_types.py
@@ -60,6 +60,7 @@ ATTR_REALTIME_MODEL_METRICS = "lk.realtime_model_metrics"
 # OpenTelemetry GenAI attributes
 # OpenTelemetry specification: https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/
 ATTR_GEN_AI_OPERATION_NAME = "gen_ai.operation.name"
+ATTR_GEN_AI_PROVIDER_NAME = "gen_ai.provider.name"
 ATTR_GEN_AI_REQUEST_MODEL = "gen_ai.request.model"
 ATTR_GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
 ATTR_GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"

--- a/livekit-agents/livekit/agents/telemetry/utils.py
+++ b/livekit-agents/livekit/agents/telemetry/utils.py
@@ -27,8 +27,11 @@ def record_exception(span: trace.Span, exception: Exception) -> None:
 
 def record_realtime_metrics(span: trace.Span, ev: RealtimeModelMetrics) -> None:
     model_name = ev.metadata.model_name if ev.metadata else None
+    model_provider = ev.metadata.model_provider if ev.metadata else None
 
     attrs: dict[str, str | int] = {
+        trace_types.ATTR_GEN_AI_OPERATION_NAME: "chat",
+        trace_types.ATTR_GEN_AI_PROVIDER_NAME: model_provider or "unknown",
         trace_types.ATTR_GEN_AI_REQUEST_MODEL: model_name or "unknown",
         trace_types.ATTR_REALTIME_MODEL_METRICS: ev.model_dump_json(),
         trace_types.ATTR_GEN_AI_USAGE_INPUT_TOKENS: ev.input_tokens,

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2335,7 +2335,13 @@ class AgentActivity(RecognitionHooks):
         assert self._rt_session is not None, "rt_session is not available"
         assert isinstance(self.llm, llm.RealtimeModel), "llm is not a realtime model"
 
-        current_span.set_attribute(trace_types.ATTR_GEN_AI_REQUEST_MODEL, self.llm.model)
+        current_span.set_attributes(
+            {
+                trace_types.ATTR_GEN_AI_OPERATION_NAME: "chat",
+                trace_types.ATTR_GEN_AI_PROVIDER_NAME: self.llm.provider,
+                trace_types.ATTR_GEN_AI_REQUEST_MODEL: self.llm.model,
+            }
+        )
         if self._realtime_spans is not None and generation_ev.response_id:
             self._realtime_spans[generation_ev.response_id] = current_span
 


### PR DESCRIPTION
## Summary
- Adds the required `gen_ai.provider.name` and `gen_ai.operation.name` attributes to LLM and realtime model spans as specified by [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/#spans)
- These attributes enable proper detection by observability platforms like Datadog's LLM Observability service
- Adds `ATTR_GEN_AI_PROVIDER_NAME` constant to trace_types.py

## Changes
- **trace_types.py**: Add `ATTR_GEN_AI_PROVIDER_NAME = "gen_ai.provider.name"` constant
- **llm.py**: Set `gen_ai.operation.name` ("chat") and `gen_ai.provider.name` on LLM request spans
- **agent_activity.py**: Set attributes on realtime model spans
- **utils.py**: Include attributes when recording realtime metrics

## Test plan
- [ ] Verify spans now include `gen_ai.operation.name` and `gen_ai.provider.name` attributes
- [ ] Test with Datadog LLM Observability to confirm spans are properly detected

Fixes #4639

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://livekit.devinenterprise.com/review/livekit/agents/pull/4759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
