### PR TITLE
fix(elevenlabs): add validation warnings for out-of-range VoiceSettings

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -69,7 +69,7 @@ class VoiceSettings:
     stability: float  # [0.0 - 1.0]
     similarity_boost: float  # [0.0 - 1.0]
     style: NotGivenOr[float] = NOT_GIVEN  # [0.0 - 1.0]
-    speed: NotGivenOr[float] = NOT_GIVEN  # [0.8 - 1.2]
+    speed: NotGivenOr[float] = NOT_GIVEN  # [0.7 - 1.2]
     use_speaker_boost: NotGivenOr[bool] = NOT_GIVEN
 
 
@@ -90,6 +90,30 @@ DEFAULT_VOICE_ID = "bIHbv24MWmeRgasZH58o"
 API_BASE_URL_V1 = "https://api.elevenlabs.io/v1"
 AUTHORIZATION_HEADER = "xi-api-key"
 WS_INACTIVITY_TIMEOUT = 180
+
+
+def _validate_voice_settings(settings: VoiceSettings) -> None:
+    """Log warnings for VoiceSettings parameters outside documented ElevenLabs API ranges."""
+    if not (0.0 <= settings.stability <= 1.0):
+        logger.warning(
+            "voice_settings.stability must be between 0.0 and 1.0",
+            extra={"stability": settings.stability},
+        )
+    if not (0.0 <= settings.similarity_boost <= 1.0):
+        logger.warning(
+            "voice_settings.similarity_boost must be between 0.0 and 1.0",
+            extra={"similarity_boost": settings.similarity_boost},
+        )
+    if is_given(settings.style) and not (0.0 <= settings.style <= 1.0):
+        logger.warning(
+            "voice_settings.style must be between 0.0 and 1.0",
+            extra={"style": settings.style},
+        )
+    if is_given(settings.speed) and not (0.7 <= settings.speed <= 1.2):
+        logger.warning(
+            "voice_settings.speed must be between 0.7 and 1.2",
+            extra={"speed": settings.speed},
+        )
 
 
 class TTS(tts.TTS):
@@ -173,6 +197,10 @@ class TTS(tts.TTS):
                 "auto_mode is enabled, it expects full sentences or phrases, "
                 "please provide a SentenceTokenizer instead of a WordTokenizer."
             )
+
+        if is_given(voice_settings):
+            _validate_voice_settings(voice_settings)
+
         self._opts = _TTSOptions(
             voice_id=voice_id,
             voice_settings=voice_settings,
@@ -250,6 +278,7 @@ class TTS(tts.TTS):
             changed = True
 
         if is_given(voice_settings):
+            _validate_voice_settings(voice_settings)
             self._opts.voice_settings = voice_settings
             changed = True
 


### PR DESCRIPTION
Closes #4774

## Summary

- Add `_validate_voice_settings()` that logs warnings when `VoiceSettings` params are outside their documented ElevenLabs API ranges — follows the same pattern as Cartesia's `_check_generation_config()`
- Call validation from both `TTS.__init__()` and `TTS.update_options()`
- Fix speed range comment: `[0.8 - 1.2]` -> `[0.7 - 1.2]` per ElevenLabs API docs

## Motivation

Out-of-range `VoiceSettings` values (e.g. `speed=0.5`) get sent straight to the 11labs API which silently clamps them. The voice fails and there's nothing in the logs to indicate why. The Cartesia plugin already handles this with `_check_generation_config()` — this brings the ElevenLabs plugin to the same level.

Warnings are non-blocking (`logger.warning` with `extra={}`) so values still pass through.

## Validated Ranges

| Parameter | Range |
|-----------|-------|
| `stability` | 0.0 - 1.0 |
| `similarity_boost` | 0.0 - 1.0 |
| `style` | 0.0 - 1.0 |
| `speed` | 0.7 - 1.2 |