### PR TITLE
Document using Opik via OTLP in voice tracing example

### DIFF
--- a/examples/voice_agents/README.md
+++ b/examples/voice_agents/README.md
@@ -86,7 +86,7 @@ session = AgentSession(
 
 ### 📊 Tracing & Error Handling
 
-- [`langfuse_trace.py`](./langfuse_trace.py) - LangFuse integration for conversation tracing
+- [`langfuse_trace.py`](./langfuse_trace.py) - LangFuse integration for conversation tracing. It uses OpenTelemetry OTLP export, so you can also send traces to Opik by setting OTLP endpoint/headers ([Opik OTLP docs](https://www.comet.com/docs/opik/integrations/opentelemetry)).
 - [`error_callback.py`](./error_callback.py) - Error handling callback
 - [`session_close_callback.py`](./session_close_callback.py) - Session lifecycle management
 


### PR DESCRIPTION
## Summary
- update `examples/voice_agents/README.md` tracing section
- clarify that the existing OpenTelemetry OTLP tracing example can also export to Opik
- add a direct link to Opik OpenTelemetry integration docs

## Test Plan
- preview markdown locally
- verify the new link resolves to Opik OTLP docs
