### PR TITLE
fix(langgraph): tool-call leak and add FlushSentinel support in LangGraph adapter

### DIFF
--- a/livekit-plugins/livekit-plugins-langchain/livekit/plugins/langchain/langgraph.py
+++ b/livekit-plugins/livekit-plugins-langchain/livekit/plugins/langchain/langgraph.py
@@ -186,7 +186,7 @@ class LangGraphStream(llm.LLMStream, Generic[ContextT]):
         skipped since ChatChunk only carries text.
         """
         if isinstance(data, FlushSentinel):
-            self._event_ch.send_nowait(data)
+            self._event_ch.send_nowait(data)  # type: ignore[arg-type]
             return
 
         content = _extract_custom_content(data)
@@ -242,7 +242,7 @@ def _extract_custom_content(value: Any) -> str | None:
     if isinstance(value, BaseMessage) and isinstance(value.content, str):
         return value.content
     if isinstance(value, dict) and isinstance(value.get("content"), str):
-        return value["content"]
+        return value["content"]  # type: ignore[no-any-return]
     return None
 
 

--- a/tests/test_langgraph.py
+++ b/tests/test_langgraph.py
@@ -314,10 +314,12 @@ async def test_subgraph_messages_mode():
     chunk_sub = AIMessageChunk(content="sub", id="s1")
 
     # Exact shapes from LangGraph: (namespace_tuple, (message, metadata))
-    mock = MockGraph([
-        ((), (chunk_root, meta)),
-        (("node_2:abc123",), (chunk_sub, meta)),
-    ])
+    mock = MockGraph(
+        [
+            ((), (chunk_root, meta)),
+            (("node_2:abc123",), (chunk_sub, meta)),
+        ]
+    )
     adapter = LLMAdapter(mock, stream_mode="messages", subgraphs=True)
 
     chat_ctx = ChatContext()
@@ -333,11 +335,13 @@ async def test_subgraph_messages_mode():
 async def test_subgraph_custom_mode():
     """Test namespace stripping for custom mode with subgraphs=True."""
     # Exact shapes: (namespace_tuple, raw_value)
-    mock = MockGraph([
-        ((), "root_chunk"),
-        (("node_2:abc123",), "sub_chunk"),
-        (("node_2:abc123",), {"content": "sub_dict"}),
-    ])
+    mock = MockGraph(
+        [
+            ((), "root_chunk"),
+            (("node_2:abc123",), "sub_chunk"),
+            (("node_2:abc123",), {"content": "sub_dict"}),
+        ]
+    )
     adapter = LLMAdapter(mock, stream_mode="custom", subgraphs=True)
 
     chat_ctx = ChatContext()
@@ -357,12 +361,14 @@ async def test_subgraph_multi_mode():
     chunk = AIMessageChunk(content="msg", id="m1")
 
     # Exact shapes: (namespace_tuple, mode_string, data)
-    mock = MockGraph([
-        ((), "messages", (chunk, meta)),
-        ((), "custom", "custom_root"),
-        (("node_2:abc123",), "messages", (chunk, meta)),
-        (("node_2:abc123",), "custom", "custom_sub"),
-    ])
+    mock = MockGraph(
+        [
+            ((), "messages", (chunk, meta)),
+            ((), "custom", "custom_root"),
+            (("node_2:abc123",), "messages", (chunk, meta)),
+            (("node_2:abc123",), "custom", "custom_sub"),
+        ]
+    )
     adapter = LLMAdapter(mock, stream_mode=["messages", "custom"], subgraphs=True)
 
     chat_ctx = ChatContext()
@@ -401,11 +407,13 @@ async def test_flush_sentinel_custom_mode():
 async def test_flush_sentinel_multi_mode():
     """Test FlushSentinel passes through in multi stream mode."""
     sentinel = FlushSentinel()
-    mock = MockGraph([
-        ("custom", "before"),
-        ("custom", sentinel),
-        ("custom", "after"),
-    ])
+    mock = MockGraph(
+        [
+            ("custom", "before"),
+            ("custom", sentinel),
+            ("custom", "after"),
+        ]
+    )
     adapter = LLMAdapter(mock, stream_mode=["messages", "custom"])
 
     chat_ctx = ChatContext()


### PR DESCRIPTION
Sorry about the issue in #4768 -- the tool-call leak was caused by my earlier change in #4511.

## Custom and multi stream mode support

Re-implement `stream_mode` routing for `"messages"`, `"custom"`, and multi-mode lists.

The previous approach in #4511 used `_extract_message_chunk()` (originally from #3112) to normalize all stream items into chat chunks. That function was designed for messages-mode tuple normalization and could not generalize to custom mode's arbitrary payloads -- it ended up leaking tool-call outputs into the LLM input stream (#4768).

This PR reverts #4511 and re-implements with explicit namespace stripping + per-mode dispatch:
- `_send_message()` handles `(message, metadata)` tuples from messages mode
- `_send_custom()` extracts text from StreamWriter payloads via `_extract_custom_content()`

Separating the handlers by mode is easier to understand and maintain than a single extraction function trying to cover both modes.

## FlushSentinel support for custom stream mode

PR #3933 added `FlushSentinel` at the LLMNode/generation.py boundary to trigger immediate TTS playback. However, `FlushSentinel` cannot flow through `LLMStream._event_ch` (typed `Chan[ChatChunk]`) because `_metrics_monitor_task` crashes on `.id` access.

This PR forwards `FlushSentinel` directly through `_event_ch` in `_send_custom` and overrides `_metrics_monitor_task` in `LangGraphStream` to filter non-`ChatChunk` items before delegating to the base implementation.

Fixes #4768