### PR TITLE
add instruction on error-handling

### DIFF
--- a/examples/drive-thru/database.py
+++ b/examples/drive-thru/database.py
@@ -44,6 +44,8 @@ COMMON_INSTRUCTIONS = (
     "E.g: a hamburger isn't a cheeseburger\n"
     "Do not ask for size unless the item has more than one size option specified. \n"
     "If an item does not require a size according to the menu, **NEVER** ask the customer to choose one or mention size at all. \n"
+    "\n\n"
+    "If there is any error from the tool, you should inform the customer and ask them to try again."
 )
 
 


### PR DESCRIPTION
Previously, there was no instruction on how to handle generic errors. The model saw no reason to inform the user about the issue and thus failed the test.