### PR TITLE
Improve error handling and developer experience

### DIFF
--- a/livekit-agents/livekit/agents/__init__.py
+++ b/livekit-agents/livekit/agents/__init__.py
@@ -27,6 +27,7 @@ from ._exceptions import (
     APIStatusError,
     APITimeoutError,
     AssignmentTimeoutError,
+    create_api_error_from_http,
 )
 from .job import (
     AutoSubscribe,
@@ -175,6 +176,7 @@ __all__ = [
     "APIError",
     "APIStatusError",
     "APITimeoutError",
+    "create_api_error_from_http",
     "APIConnectOptions",
     "NotGiven",
     "NOT_GIVEN",

--- a/livekit-agents/livekit/agents/_exceptions.py
+++ b/livekit-agents/livekit/agents/_exceptions.py
@@ -39,7 +39,10 @@ class APIError(Exception):
         self.retryable = retryable
 
     def __str__(self) -> str:
-        return f"{self.message} (body={self.body}, retryable={self.retryable})"
+        return self.message
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.message!r}, body={self.body!r}, retryable={self.retryable!r})"
 
 
 class APIStatusError(APIError):
@@ -71,13 +74,13 @@ class APIStatusError(APIError):
         self.status_code = status_code
         self.request_id = request_id
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return (
-            f"{self.message} "
-            f"(status_code={self.status_code}, "
-            f"request_id={self.request_id}, "
-            f"body={self.body}, "
-            f"retryable={self.retryable})"
+            f"{self.__class__.__name__}({self.message!r}, "
+            f"status_code={self.status_code!r}, "
+            f"request_id={self.request_id!r}, "
+            f"body={self.body!r}, "
+            f"retryable={self.retryable!r})"
         )
 
 
@@ -97,3 +100,35 @@ class APITimeoutError(APIConnectionError):
 
 class CLIError(Exception):
     pass
+
+
+def create_api_error_from_http(
+    message: str = "",
+    *,
+    status: int,
+    request_id: str | None = None,
+    body: object | None = None,
+) -> APIStatusError:
+    """Create an APIStatusError from an HTTP status code.
+
+    When the message carries extra detail beyond the standard reason phrase,
+    both the message and the reason are shown. Otherwise just the reason.
+    """
+    from http import HTTPStatus
+
+    try:
+        reason = HTTPStatus(status).phrase
+    except ValueError:
+        reason = f"HTTP {status}"
+
+    if message and message != reason:
+        display = f"{message} ({status} {reason})"
+    else:
+        display = f"{reason} ({status})"
+
+    return APIStatusError(
+        message=display,
+        status_code=status,
+        request_id=request_id,
+        body=body,
+    )

--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -1397,7 +1397,7 @@ def _run_console(
             console_worker.shutdown()
             console_worker.join()
 
-    except CLIError as e:
+    except (CLIError, ValueError) as e:
         c.print(" ")
         c.print(f"[error]{e}")
         c.print(" ")
@@ -1748,7 +1748,7 @@ def _build_cli(server: AgentServer) -> typer.Typer:
         except KeyboardInterrupt:
             logger.warning("exiting forcefully")
             os._exit(1)
-        except CLIError as e:
+        except (CLIError, ValueError) as e:
             c.print(" ")
             c.print(f"[error]{e}")
             c.print(" ")

--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -14,7 +14,13 @@ from typing_extensions import Required
 from livekit import rtc
 
 from .. import stt, utils
-from .._exceptions import APIConnectionError, APIError, APIStatusError
+from .._exceptions import (
+    APIConnectionError,
+    APIError,
+    APIStatusError,
+    APITimeoutError,
+    create_api_error_from_http,
+)
 from ..log import logger
 from ..types import (
     DEFAULT_API_CONNECT_OPTIONS,
@@ -372,7 +378,7 @@ class STT(stt.STT):
         conn_options: APIConnectOptions,
     ) -> stt.SpeechEvent:
         raise NotImplementedError(
-            "LiveKit STT does not support batch recognition, use stream() instead"
+            "LiveKit Inference STT does not support batch recognition, use stream() instead"
         )
 
     def stream(
@@ -493,10 +499,12 @@ class SpeechStream(stt.SpeechStream):
                 ):
                     if closing_ws or self._session.closed:
                         return
-                    raise APIStatusError(message="LiveKit STT connection closed unexpectedly")
+                    raise APIStatusError(
+                        message="LiveKit Inference STT connection closed unexpectedly"
+                    )
 
                 if msg.type != aiohttp.WSMsgType.TEXT:
-                    logger.warning("unexpected LiveKit STT message type %s", msg.type)
+                    logger.warning("unexpected LiveKit Inference STT message type %s", msg.type)
                     continue
 
                 data = json.loads(msg.data)
@@ -512,9 +520,11 @@ class SpeechStream(stt.SpeechStream):
                 elif msg_type == "session.closed":
                     pass
                 elif msg_type == "error":
-                    raise APIError(f"LiveKit STT returned error: {msg.data}")
+                    raise APIError(f"LiveKit Inference STT returned error: {msg.data}")
                 else:
-                    logger.warning("received unexpected message from LiveKit STT: %s", data)
+                    logger.warning(
+                        "received unexpected message from LiveKit Inference STT: %s", data
+                    )
 
         ws: aiohttp.ClientWebSocketResponse | None = None
 
@@ -551,7 +561,7 @@ class SpeechStream(stt.SpeechStream):
                     await ws.close()
 
     async def _connect_ws(self) -> aiohttp.ClientWebSocketResponse:
-        """Connect to the LiveKit STT WebSocket."""
+        """Connect to the LiveKit Inference STT WebSocket."""
         params: dict[str, Any] = {
             "settings": {
                 "sample_rate": str(self._opts.sample_rate),
@@ -594,14 +604,12 @@ class SpeechStream(stt.SpeechStream):
             )
             params["type"] = "session.create"
             await ws.send_str(json.dumps(params))
-        except (
-            aiohttp.ClientConnectorError,
-            asyncio.TimeoutError,
-            aiohttp.ClientResponseError,
-        ) as e:
-            if isinstance(e, aiohttp.ClientResponseError) and e.status == 429:
-                raise APIStatusError("LiveKit STT quota exceeded", status_code=e.status) from e
-            raise APIConnectionError("failed to connect to LiveKit STT") from e
+        except aiohttp.ClientResponseError as e:
+            raise create_api_error_from_http(e.message, status=e.status) from e
+        except asyncio.TimeoutError as e:
+            raise APITimeoutError("LiveKit Inference STT connection timed out.") from e
+        except aiohttp.ClientConnectorError as e:
+            raise APIConnectionError("failed to connect to LiveKit Inference STT") from e
         return ws
 
     def _process_transcript(self, data: dict, is_final: bool) -> None:

--- a/livekit-agents/livekit/agents/inference/tts.py
+++ b/livekit-agents/livekit/agents/inference/tts.py
@@ -12,7 +12,13 @@ import aiohttp
 from typing_extensions import NotRequired
 
 from .. import tokenize, tts, utils
-from .._exceptions import APIConnectionError, APIError, APIStatusError, APITimeoutError
+from .._exceptions import (
+    APIConnectionError,
+    APIError,
+    APIStatusError,
+    APITimeoutError,
+    create_api_error_from_http,
+)
 from ..log import logger
 from ..types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, APIConnectOptions, NotGivenOr
 from ..utils import is_given
@@ -407,14 +413,12 @@ class TTS(tts.TTS):
                 session.ws_connect(f"{base_url}/tts?model={self._opts.model}", headers=headers),
                 timeout,
             )
-        except (
-            aiohttp.ClientConnectorError,
-            asyncio.TimeoutError,
-            aiohttp.ClientResponseError,
-        ) as e:
-            if isinstance(e, aiohttp.ClientResponseError) and e.status == 429:
-                raise APIStatusError("LiveKit TTS quota exceeded", status_code=e.status) from e
-            raise APIConnectionError("failed to connect to LiveKit TTS") from e
+        except aiohttp.ClientResponseError as e:
+            raise create_api_error_from_http(e.message, status=e.status) from e
+        except asyncio.TimeoutError as e:
+            raise APITimeoutError("LiveKit Inference TTS connection timed out.") from e
+        except aiohttp.ClientConnectorError as e:
+            raise APIConnectionError("failed to connect to LiveKit Inference TTS") from e
 
         params: dict[str, Any] = {
             "type": "session.create",
@@ -450,7 +454,9 @@ class TTS(tts.TTS):
             await ws.send_str(json.dumps(params))
         except Exception as e:
             await ws.close()
-            raise APIConnectionError("failed to send session.create message to LiveKit TTS") from e
+            raise APIConnectionError(
+                "failed to send session.create message to LiveKit Inference TTS"
+            ) from e
 
         return ws
 
@@ -601,7 +607,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                     output_emitter.end_input()
                     break
                 elif data.get("type") == "error":
-                    raise APIError(f"LiveKit TTS returned error: {msg.data}")
+                    raise APIError(f"LiveKit Inference TTS returned error: {msg.data}")
                 else:
                     logger.warning("unexpected message %s", data)
 
@@ -624,9 +630,10 @@ class SynthesizeStream(tts.SynthesizeStream):
             raise APITimeoutError() from None
 
         except aiohttp.ClientResponseError as e:
-            raise APIStatusError(
-                message=e.message, status_code=e.status, request_id=None, body=None
-            ) from None
+            raise create_api_error_from_http(e.message, status=e.status) from None
+
+        except APIError:
+            raise
 
         except Exception as e:
             raise APIConnectionError() from e

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -233,8 +233,7 @@ class LLMStream(ABC):
                 else:
                     self._emit_error(e, recoverable=True)
                     logger.warning(
-                        f"failed to generate LLM completion, retrying in {retry_interval}s",  # noqa: E501
-                        exc_info=e,
+                        f"failed to generate LLM completion: {e}, retrying in {retry_interval}s",  # noqa: E501
                         extra={
                             "llm": self._llm._label,
                             "attempt": i + 1,

--- a/livekit-agents/livekit/agents/stt/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/stt/fallback_adapter.py
@@ -192,6 +192,7 @@ class FallbackAdapter(
                         AvailabilityChangedEvent(stt=stt, available=True),
                     )
                 except Exception:
+                    logger.debug(f"{stt.label} recovery attempt failed", exc_info=True)
                     return
 
             stt_status.recovering_synthesize_task = asyncio.create_task(_recover_stt_task(stt))

--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -192,8 +192,7 @@ class STT(
                 else:
                     self._emit_error(e, recoverable=True)
                     logger.warning(
-                        f"failed to recognize speech, retrying in {retry_interval}s",
-                        exc_info=e,
+                        f"failed to recognize speech: {e}, retrying in {retry_interval}s",
                         extra={
                             "tts": self._label,
                             "attempt": i + 1,
@@ -330,8 +329,7 @@ class RecognizeStream(ABC):
 
                     retry_interval = self._conn_options._interval_for_retry(self._num_retries)
                     logger.warning(
-                        f"failed to recognize speech, retrying in {retry_interval}s",
-                        exc_info=e,
+                        f"failed to recognize speech: {e}, retrying in {retry_interval}s",
                         extra={
                             "tts": self._stt._label,
                             "attempt": self._num_retries,

--- a/livekit-agents/livekit/agents/tts/tts.py
+++ b/livekit-agents/livekit/agents/tts/tts.py
@@ -303,8 +303,7 @@ class ChunkedStream(ABC):
                 else:
                     self._emit_error(e, recoverable=True)
                     logger.warning(
-                        f"failed to synthesize speech, retrying in {retry_interval}s",
-                        exc_info=e,
+                        f"failed to synthesize speech: {e}, retrying in {retry_interval}s",
                         extra={"tts": self._tts._label, "attempt": i + 1, "streamed": False},
                     )
 
@@ -486,8 +485,7 @@ class SynthesizeStream(ABC):
                 else:
                     self._emit_error(e, recoverable=True)
                     logger.warning(
-                        f"failed to synthesize speech, retrying in {retry_interval}s",
-                        exc_info=e,
+                        f"failed to synthesize speech: {e}, retrying in {retry_interval}s",
                         extra={"tts": self._tts._label, "attempt": i + 1, "streamed": True},
                     )
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -178,13 +178,16 @@ class AgentActivity(RecognitionHooks):
         llm_model = self.llm
 
         if mode == "vad" and not vad_model:
-            logger.warning("turn_detection is set to 'vad', but no VAD model is provided")
+            logger.warning(
+                "turn_detection is set to 'vad', but no VAD model is provided. "
+                "Pass a VAD instance, e.g. Agent(vad=silero.VAD.load())"
+            )
             mode = None
 
         if mode == "stt" and not stt_model:
             logger.warning(
-                "turn_detection is set to 'stt', but no STT model is provided, "
-                "ignoring the turn_detection setting"
+                "turn_detection is set to 'stt', but no STT model is provided. "
+                "Pass an STT instance, e.g. Agent(stt=deepgram.STT())"
             )
             mode = None
 
@@ -643,7 +646,11 @@ class AgentActivity(RecognitionHooks):
 
             self._cancel_preemptive_generation()
 
-            await self._on_exit_task
+            try:
+                await self._on_exit_task
+            except Exception:
+                pass  # already logged by @log_exceptions
+
             await self._pause_scheduling_task()
 
     async def _pause_scheduling_task(

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -307,7 +307,7 @@ class _ParticipantLegacyTranscriptionOutput:
                 await self._room.local_participant.publish_transcription(transcription)
         except Exception as e:
             if self._room.isconnected():
-                logger.warning("failed to publish transcription", exc_info=e)
+                logger.warning("failed to publish agent transcription to room", exc_info=e)
 
     def _on_track_published(
         self, track: rtc.RemoteTrackPublication, participant: rtc.RemoteParticipant
@@ -442,7 +442,7 @@ class _ParticipantStreamTranscriptionOutput:
                     await tmp_writer.write(text)
                     await tmp_writer.aclose()
         except Exception as e:
-            logger.warning("failed to publish transcription", exc_info=e)
+            logger.warning("failed to publish agent transcription to room", exc_info=e)
 
     async def _flush_task(self, writer: rtc.TextStreamWriter | None) -> None:
         attributes = {ATTRIBUTE_TRANSCRIPTION_FINAL: "true"}
@@ -459,7 +459,7 @@ class _ParticipantStreamTranscriptionOutput:
                     await tmp_writer.write(self._latest_text)
                     await tmp_writer.aclose()
         except Exception as e:
-            logger.warning("failed to publish transcription", exc_info=e)
+            logger.warning("failed to publish agent transcription to room", exc_info=e)
 
     def flush(self) -> None:
         if self._participant_identity is None or not self._capturing:

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -596,14 +596,14 @@ class AgentServer(utils.EventEmitter[EventTypes]):
             self._load_task: asyncio.Task[None] | None = None
 
             if not self._ws_url:
-                raise ValueError("ws_url is required, or add LIVEKIT_URL in your environment")
+                raise ValueError("ws_url is required, or set LIVEKIT_URL environment variable")
 
             if not self._api_key:
-                raise ValueError("api_key is required, or add LIVEKIT_API_KEY in your environment")
+                raise ValueError("api_key is required, or set LIVEKIT_API_KEY environment variable")
 
             if not self._api_secret:
                 raise ValueError(
-                    "api_secret is required, or add LIVEKIT_API_SECRET in your environment"
+                    "api_secret is required, or set LIVEKIT_API_SECRET environment variable"
                 )
 
             self._prometheus_server: telemetry.http_server.HttpServer | None = None

--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
@@ -98,7 +98,10 @@ class LLM(llm.LLM):
         )
         anthropic_api_key = api_key if is_given(api_key) else os.environ.get("ANTHROPIC_API_KEY")
         if not anthropic_api_key:
-            raise ValueError("Anthropic API key is required")
+            raise ValueError(
+                "Anthropic API key is required, either as argument or set"
+                " ANTHROPIC_API_KEY environment variable"
+            )
 
         self._client = client or anthropic.AsyncClient(
             api_key=anthropic_api_key,

--- a/livekit-plugins/livekit-plugins-asyncai/livekit/plugins/asyncai/tts.py
+++ b/livekit-plugins/livekit-plugins-asyncai/livekit/plugins/asyncai/tts.py
@@ -110,7 +110,10 @@ class TTS(tts.TTS):
         )
         async_api_key = api_key or os.environ.get("ASYNCAI_API_KEY")
         if not async_api_key:
-            raise ValueError("ASYNCAI_API_KEY must be set")
+            raise ValueError(
+                "AsyncAI API key is required, either as argument or set"
+                " ASYNCAI_API_KEY environment variable"
+            )
 
         self._opts = _TTSOptions(
             model=model,

--- a/livekit-plugins/livekit-plugins-avatartalk/livekit/plugins/avatartalk/api.py
+++ b/livekit-plugins/livekit-plugins-avatartalk/livekit/plugins/avatartalk/api.py
@@ -24,7 +24,10 @@ class AvatarTalkAPI:
         self._api_url = api_url or DEFAULT_API_URL
         avatartalk_api_key = api_key or os.getenv("AVATARTALK_API_KEY")
         if avatartalk_api_key is None:
-            raise AvatarTalkException("AVATARTALK_API_KEY must be set")
+            raise AvatarTalkException(
+                "AvatarTalk API key is required, either as argument or set"
+                " AVATARTALK_API_KEY environment variable"
+            )
 
         self._api_key = avatartalk_api_key
         self._headers = {"Authorization": f"Bearer {self._api_key}"}

--- a/livekit-plugins/livekit-plugins-cambai/livekit/plugins/cambai/tts.py
+++ b/livekit-plugins/livekit-plugins-cambai/livekit/plugins/cambai/tts.py
@@ -25,6 +25,7 @@ from livekit.agents import (
     APIConnectOptions,
     APIStatusError,
     APITimeoutError,
+    create_api_error_from_http,
     tts,
     utils,
 )
@@ -241,12 +242,7 @@ class ChunkedStream(tts.ChunkedStream):
         except asyncio.TimeoutError as e:
             raise APITimeoutError() from e
         except aiohttp.ClientResponseError as e:
-            raise APIStatusError(
-                message=e.message,
-                status_code=e.status,
-                request_id=None,
-                body=None,
-            ) from e
+            raise create_api_error_from_http(e.message, status=e.status) from e
         except Exception as e:
             if isinstance(e, (APIStatusError, APIConnectionError, APITimeoutError)):
                 raise

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/stt.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/stt.py
@@ -101,7 +101,10 @@ class STT(stt.STT):
 
         cartesia_api_key = api_key or os.environ.get("CARTESIA_API_KEY")
         if not cartesia_api_key:
-            raise ValueError("CARTESIA_API_KEY must be set")
+            raise ValueError(
+                "Cartesia API key is required, either as argument or set"
+                " CARTESIA_API_KEY environment variable"
+            )
 
         self._opts = STTOptions(
             model=model,

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -136,7 +136,10 @@ class TTS(tts.TTS):
         )
         cartesia_api_key = api_key or os.environ.get("CARTESIA_API_KEY")
         if not cartesia_api_key:
-            raise ValueError("CARTESIA_API_KEY must be set")
+            raise ValueError(
+                "Cartesia API key is required, either as argument or set"
+                " CARTESIA_API_KEY environment variable"
+            )
 
         if isinstance(emotion, str):
             emotion = [emotion]

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -148,7 +148,10 @@ class STT(stt.STT):
 
         deepgram_api_key = api_key if is_given(api_key) else os.environ.get("DEEPGRAM_API_KEY")
         if not deepgram_api_key:
-            raise ValueError("Deepgram API key is required")
+            raise ValueError(
+                "Deepgram API key is required, either as argument or set"
+                " DEEPGRAM_API_KEY environment variable"
+            )
         self._api_key = deepgram_api_key
 
         model = _validate_model(model, language)

--- a/livekit-plugins/livekit-plugins-groq/livekit/plugins/groq/tts.py
+++ b/livekit-plugins/livekit-plugins-groq/livekit/plugins/groq/tts.py
@@ -86,7 +86,10 @@ class TTS(tts.TTS):
 
         groq_api_key = api_key if is_given(api_key) else os.getenv("GROQ_API_KEY")
         if not groq_api_key:
-            raise ValueError("GROQ_API_KEY is not set")
+            raise ValueError(
+                "Groq API key is required, either as argument or set"
+                " GROQ_API_KEY environment variable"
+            )
 
         self._opts = _TTSOptions(
             model=model,

--- a/livekit-plugins/livekit-plugins-inworld/livekit/plugins/inworld/tts.py
+++ b/livekit-plugins/livekit-plugins-inworld/livekit/plugins/inworld/tts.py
@@ -855,7 +855,10 @@ class TTS(tts.TTS):
 
         key = api_key if is_given(api_key) else os.getenv("INWORLD_API_KEY")
         if not key:
-            raise ValueError("Inworld API key required. Set INWORLD_API_KEY or provide api_key.")
+            raise ValueError(
+                "Inworld API key is required, either as argument or set"
+                " INWORLD_API_KEY environment variable"
+            )
 
         self._authorization = f"Basic {key}"
         self._base_url = base_url

--- a/livekit-plugins/livekit-plugins-lmnt/livekit/plugins/lmnt/tts.py
+++ b/livekit-plugins/livekit-plugins-lmnt/livekit/plugins/lmnt/tts.py
@@ -23,8 +23,8 @@ import aiohttp
 from livekit.agents import (
     APIConnectionError,
     APIConnectOptions,
-    APIStatusError,
     APITimeoutError,
+    create_api_error_from_http,
     tts,
     utils,
 )
@@ -113,8 +113,8 @@ class TTS(tts.TTS):
         api_key = api_key or os.environ.get("LMNT_API_KEY")
         if not api_key:
             raise ValueError(
-                "LMNT API key is required. "
-                "Set it via environment variable or pass it as an argument."
+                "LMNT API key is required, either as argument or set"
+                " LMNT_API_KEY environment variable"
             )
 
         if not language:
@@ -253,11 +253,6 @@ class ChunkedStream(tts.ChunkedStream):
         except asyncio.TimeoutError:
             raise APITimeoutError() from None
         except aiohttp.ClientResponseError as e:
-            raise APIStatusError(
-                message=e.message,
-                status_code=e.status,
-                request_id=None,
-                body=None,
-            ) from None
+            raise create_api_error_from_http(e.message, status=e.status) from None
         except Exception as e:
             raise APIConnectionError() from e

--- a/livekit-plugins/livekit-plugins-minimax/livekit/plugins/minimax/tts.py
+++ b/livekit-plugins/livekit-plugins-minimax/livekit/plugins/minimax/tts.py
@@ -229,7 +229,10 @@ class TTS(tts.TTS):
 
         minimax_api_key = api_key or os.environ.get("MINIMAX_API_KEY")
         if not minimax_api_key:
-            raise ValueError("MINIMAX_API_KEY must be set")
+            raise ValueError(
+                "MiniMax API key is required, either as argument or set"
+                " MINIMAX_API_KEY environment variable"
+            )
 
         if not (0.5 <= speed <= 2.0):
             raise ValueError(f"speed must be between 0.5 and 2.0, but got {speed}")

--- a/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/llm.py
+++ b/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/llm.py
@@ -55,7 +55,13 @@ class LLM(llm.LLM):
             temperature=temperature,
             max_completion_tokens=max_completion_tokens,
         )
-        self._client = Mistral(api_key=api_key or os.environ.get("MISTRAL_API_KEY"))
+        mistral_api_key = api_key or os.environ.get("MISTRAL_API_KEY")
+        if not mistral_api_key:
+            raise ValueError(
+                "Mistral API key is required, either as argument or set"
+                " MISTRAL_API_KEY environment variable"
+            )
+        self._client = Mistral(api_key=mistral_api_key)
 
     @property
     def model(self) -> str:

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -148,6 +148,12 @@ class LLM(llm.LLM):
             extra_headers=extra_headers,
             extra_query=extra_query,
         )
+        if is_given(api_key) and not api_key:
+            raise ValueError(
+                "OpenAI API key is required, either as argument or set"
+                " OPENAI_API_KEY environment variable"
+            )
+
         self._provider_fmt = _provider_fmt or "openai"
         self._strict_tool_schema = _strict_tool_schema
         self._owns_client = client is None

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -130,6 +130,12 @@ class STT(stt.STT):
         if is_given(noise_reduction_type):
             self._opts.noise_reduction_type = noise_reduction_type
 
+        if is_given(api_key) and not api_key:
+            raise ValueError(
+                "OpenAI API key is required, either as argument or set"
+                " OPENAI_API_KEY environment variable"
+            )
+
         self._client = client or openai.AsyncClient(
             max_retries=0,
             api_key=api_key if is_given(api_key) else None,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -85,6 +85,12 @@ class TTS(tts.TTS):
             response_format=response_format if is_given(response_format) else "mp3",
         )
 
+        if is_given(api_key) and not api_key:
+            raise ValueError(
+                "OpenAI API key is required, either as argument or set"
+                " OPENAI_API_KEY environment variable"
+            )
+
         self._client = client or openai.AsyncClient(
             max_retries=0,
             api_key=api_key if is_given(api_key) else None,

--- a/livekit-plugins/livekit-plugins-simplismart/livekit/plugins/simplismart/tts.py
+++ b/livekit-plugins/livekit-plugins-simplismart/livekit/plugins/simplismart/tts.py
@@ -10,8 +10,8 @@ from livekit.agents import (
     DEFAULT_API_CONNECT_OPTIONS,
     APIConnectionError,
     APIConnectOptions,
-    APIStatusError,
     APITimeoutError,
+    create_api_error_from_http,
     tts,
     utils,
 )
@@ -136,8 +136,6 @@ class ChunkedStream(tts.ChunkedStream):
         except asyncio.TimeoutError:
             raise APITimeoutError() from None
         except aiohttp.ClientResponseError as e:
-            raise APIStatusError(
-                message=e.message, status_code=e.status, request_id=None, body=None
-            ) from None
+            raise create_api_error_from_http(e.message, status=e.status) from None
         except Exception as e:
             raise APIConnectionError() from e

--- a/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/tts.py
+++ b/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/tts.py
@@ -24,8 +24,8 @@ import aiohttp
 from livekit.agents import (
     APIConnectionError,
     APIConnectOptions,
-    APIStatusError,
     APITimeoutError,
+    create_api_error_from_http,
     tts,
     utils,
 )
@@ -96,7 +96,10 @@ class TTS(tts.TTS):
 
         api_key = api_key or os.environ.get("SMALLEST_API_KEY")
         if not api_key:
-            raise ValueError("SMALLEST_API_KEY must be set")
+            raise ValueError(
+                "Smallest.ai API key is required, either as argument or set"
+                " SMALLEST_API_KEY environment variable"
+            )
 
         if (consistency or similarity or enhancement) and model == "lightning":
             logger.warning(
@@ -223,9 +226,7 @@ class ChunkedStream(tts.ChunkedStream):
         except asyncio.TimeoutError:
             raise APITimeoutError() from None
         except aiohttp.ClientResponseError as e:
-            raise APIStatusError(
-                message=e.message, status_code=e.status, request_id=None, body=None
-            ) from None
+            raise create_api_error_from_http(e.message, status=e.status) from None
         except Exception as e:
             raise APIConnectionError() from e
 


### PR DESCRIPTION
- Clean HTTP error messages via `create_api_error_from_http` helper (e.g. `Unauthorized (401)` instead of raw stacktraces)
- Remove stacktraces from STT/TTS/LLM retry warnings
- API errors on unrecoverable session close show clean one-liner
- Standardize API key validation messages across all plugins
- Fix inference TTS streaming path swallowing auth errors
- Prevent `on_exit` callback errors from crashing session shutdown
- Improve fallback adapter, transcription, and turn detection log messages