### PR TITLE
fix: resource cleanup improvements in session teardown

### DIFF
--- a/livekit-agents/livekit/agents/utils/http_context.py
+++ b/livekit-agents/livekit/agents/utils/http_context.py
@@ -55,5 +55,7 @@ async def _close_http_ctx() -> None:
     val = _ContextVar.get(None)
     if val is not None:
         logger.debug("http_session(): closing the httpclient ctx")
-        await val().close()
+        session = val()
+        if not session.closed:
+            await session.close()
         _ContextVar.set(None)

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -557,7 +557,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                     room_input_options=room_input_options,
                     room_output_options=room_output_options,
                 )
-                room_options = copy.copy(room_options)  # shadow copy is enough
+                room_options = copy.copy(room_options)  # shallow copy is enough
 
                 if self.input.audio is not None:
                     if room_options.audio_input:
@@ -828,6 +828,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
             if self._forward_audio_atask is not None:
                 await utils.aio.cancel_and_wait(self._forward_audio_atask)
+
+            if self._forward_video_atask is not None:
+                await utils.aio.cancel_and_wait(self._forward_video_atask)
 
             if self._recorder_io:
                 await self._recorder_io.aclose()

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -183,6 +183,7 @@ class RoomIO:
     async def aclose(self) -> None:
         self._room.off("participant_connected", self._on_participant_connected)
         self._room.off("connection_state_changed", self._on_connection_state_changed)
+        self._room.off("participant_disconnected", self._on_participant_disconnected)
         self._agent_session.off("agent_state_changed", self._on_agent_state_changed)
         self._agent_session.off("user_input_transcribed", self._on_user_input_transcribed)
         self._agent_session.off("close", self._on_agent_session_close)


### PR DESCRIPTION
- Cancel video forwarding task during AgentSession close to prevent leaked async tasks
- Unregister participant_disconnected event handler in RoomIO.aclose() to prevent callbacks on stale objects
- Add session.closed check in _close_http_ctx to avoid creating a new session just to immediately close it
- Fix "shadow copy" → "shallow copy" comment typo