### PR TITLE
fix: correctness and performance improvements

### DIFF
--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -379,11 +379,14 @@ class ChatContext:
 
         new_items = self._items[-max_items:]
         # chat_ctx shouldn't start with function_call or function_call_output
-        while new_items and new_items[0].type in [
+        start = 0
+        while start < len(new_items) and new_items[start].type in [
             "function_call",
             "function_call_output",
         ]:
-            new_items.pop(0)
+            start += 1
+        if start > 0:
+            new_items = new_items[start:]
 
         if instructions:
             new_items.insert(0, instructions)

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1080,9 +1080,9 @@ class AgentActivity(RecognitionHooks):
                     continue
                 self._current_speech = speech
                 if self.min_consecutive_speech_delay > 0.0:
-                    await asyncio.sleep(
-                        self.min_consecutive_speech_delay - (time.time() - last_playout_ts)
-                    )
+                    delay = self.min_consecutive_speech_delay - (time.time() - last_playout_ts)
+                    if delay > 0:
+                        await asyncio.sleep(delay)
                     # check again if speech is done after sleep delay
                     if speech.done():
                         # skip done speech (interrupted during delay)
@@ -1093,7 +1093,7 @@ class AgentActivity(RecognitionHooks):
                 self._current_speech = None
                 last_playout_ts = time.time()
 
-            # if we're draining/pasuing and there are no more speech tasks, we can exit.
+            # if we're draining/pausing and there are no more speech tasks, we can exit.
             # only speech tasks can bypass draining to create a tool response (see `_schedule_speech`)  # noqa: E501
 
             blocked_handles: list[SpeechHandle] = []

--- a/livekit-agents/livekit/agents/voice/background_audio.py
+++ b/livekit-agents/livekit/agents/voice/background_audio.py
@@ -349,7 +349,7 @@ class BackgroundAudioPlayer:
 
                 if volume != 1.0:
                     data = np.frombuffer(frame.data, dtype=np.int16).astype(np.float32)
-                    data *= 10 ** (np.log10(volume))
+                    data *= volume
                     np.clip(data, -32768, 32767, out=data)
                     yield rtc.AudioFrame(
                         data=data.astype(np.int16).tobytes(),

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -681,7 +681,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
             self._api = api.LiveKitAPI(
                 self._ws_url, self._api_key, self._api_secret, session=self._http_session
             )
-            self._close_future = asyncio.Future(loop=self._loop)
+            self._close_future = asyncio.Future()
 
             @utils.log_exceptions(logger=logger)
             async def _load_task() -> None:


### PR DESCRIPTION
- Remove deprecated loop parameter from asyncio.Future() in worker.py (deprecated since Python 3.8, removed in 3.10+)
- Guard against negative sleep duration in agent_activity speech playout delay calculation
- Simplify redundant volume formula: 10^(log10(v)) is just v
- Fix O(n²) chat context truncation: replace while/pop(0) with index-based slicing
- Fix "pasuing" → "pausing" typo in comment