### PR TITLE
fix: ruff and mypy issues in livekit-plugins-browser

### DIFF
--- a/examples/browser_agent.py
+++ b/examples/browser_agent.py
@@ -6,7 +6,6 @@ from livekit.agents import AgentServer, AutoSubscribe, JobContext, cli
 from livekit.plugins.browser import (
     AudioData,
     BrowserContext,
-    BrowserPage,
     BrowserSession,
     PaintData,
 )

--- a/livekit-plugins/livekit-plugins-browser/livekit/plugins/browser/__init__.py
+++ b/livekit-plugins/livekit-plugins-browser/livekit/plugins/browser/__init__.py
@@ -3,16 +3,19 @@
 Support for Chromium Embedded Framework (CEF).
 """
 
-import sys
-
 from livekit.agents import Plugin
+
+# Re-export from livekit-browser for convenience
+from livekit.browser import (  # type: ignore[import-untyped]
+    AudioData,
+    BrowserContext,
+    BrowserPage,
+    PaintData,
+)
 
 from .log import logger
 from .session import BrowserSession
 from .version import __version__
-
-# Re-export from livekit-browser for convenience
-from livekit.browser import BrowserContext, BrowserPage, AudioData, PaintData
 
 __all__ = [
     "AudioData",
@@ -24,7 +27,7 @@ __all__ = [
 
 
 class BrowserPlugin(Plugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(__name__, __version__, __package__, logger)
 
     def download_files(self) -> None:


### PR DESCRIPTION
## Summary
- Fix ruff lint errors (import sorting, unused imports) in browser plugin and example
- Fix all mypy type errors (missing annotations, union-attr, import-untyped)
- Align with other plugin conventions

## Test plan
- [x] `ruff check` passes
- [x] `mypy` passes with 0 errors