### PR TITLE
bump livekit sdk to 1.1.1

### DIFF
--- a/livekit-agents/pyproject.toml
+++ b/livekit-agents/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "typer>=0.15.1",
     "click~=8.1",
     "certifi>=2025.6.15",
-    "livekit==1.1.0",
+    "livekit==1.1.1",
     "livekit-api>=1.0.7,<2",
     "livekit-protocol>=1.1,<2",
     "livekit-blingfire~=1.1,<2",


### PR DESCRIPTION
## Summary
- Update `livekit` dependency from 1.1.0 to 1.1.1 in livekit-agents