### PR TITLE
fix: prevent KeyboardInterrupt in child processes on Ctrl+C

### DIFF
--- a/livekit-agents/livekit/agents/ipc/inference_proc_lazy_main.py
+++ b/livekit-agents/livekit/agents/ipc/inference_proc_lazy_main.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from multiprocessing import current_process
 
-if current_process().name == "inference_proc":
+if current_process().name == "agents_inference_process":
     import signal
 
     # ignore signals in the jobs process (the parent process will handle them)


### PR DESCRIPTION
- Use process-wide `signal.signal(SIG_IGN)` instead of per-thread `pthread_sigmask` in `_mask_ctrl_c`, so children inherit `SIG_IGN` across `exec()` regardless of which thread forks
- Add refcounting for concurrent proc pool spawns
- Fix inference process name mismatch (`"inference_proc"` vs `"agents_inference_process"`)