### PR TITLE
bump livekit sdk to 1.1.2

### DIFF
--- a/livekit-agents/pyproject.toml
+++ b/livekit-agents/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "typer>=0.15.1",
     "click~=8.1",
     "certifi>=2025.6.15",
-    "livekit==1.1.1",
+    "livekit==1.1.2",
     "livekit-api>=1.0.7,<2",
     "livekit-protocol>=1.1,<2",
     "livekit-blingfire~=1.1,<2",

--- a/uv.lock
+++ b/uv.lock
@@ -1683,7 +1683,7 @@ wheels = [
 
 [[package]]
 name = "livekit"
-version = "1.1.0"
+version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1691,13 +1691,13 @@ dependencies = [
     { name = "protobuf" },
     { name = "types-protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/01/1cd6f00a95eaee890cb5826eac5f285c061428732ba2bf093259c0432570/livekit-1.1.0.tar.gz", hash = "sha256:6757a1e3edd67fb51e4a16e67099bc319b7221f3e68ae4164d4bda55cf0013e3", size = 319942, upload-time = "2026-02-16T22:00:10.466Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/9c/0a9b9e1f88226df372b9ccc58868ce9a1eb97c8bf5257463a643dda2a6da/livekit-1.1.2.tar.gz", hash = "sha256:ef826e94dd039767fcabc2f0d810b1b2335c9cf249f52320b6ab018b06d5ccd7", size = 320006, upload-time = "2026-02-17T01:18:46.828Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/98/d6f6a15befa841d5703e7fd33b8ebec38a90ed0f4865839c78a58327ec91/livekit-1.1.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:34ae7f9817718dd4f9ae0a694776670b21013efb060a6f3781d2e3c6b916502c", size = 9844068, upload-time = "2026-02-16T21:59:58.651Z" },
-    { url = "https://files.pythonhosted.org/packages/07/b6/0eb65d2486231fcf573ccab3b7b09ddbff62f20f39c6319505726417f066/livekit-1.1.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:138704b984590c047eeecfa283b6afd490d82c9b6e4bb7938e29ea177bcb4b48", size = 8651617, upload-time = "2026-02-16T22:00:00.798Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/01/e9dd6b51f1d81e0cfa14e0c276998816ec17b9101bcd2c2d1b815d680f0b/livekit-1.1.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:3a96f7a1517837b74ffebd994b193a19f8fefa139d763d6ac7db02b3ac79892b", size = 14085795, upload-time = "2026-02-16T22:00:03.47Z" },
-    { url = "https://files.pythonhosted.org/packages/66/fb/53178268715e79b7bf2eb7aabbc8c1a053220de93d32dba43213af589a17/livekit-1.1.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:eab38ca99b9328dafd9722e044a3e8b45c374fa43cd9e5008b601c4c8d36bc47", size = 11448814, upload-time = "2026-02-16T22:00:05.739Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/72/cb48e1923a1e9709fb8c6f9b6a62599d69e7413f625bff25eb4d800f4ee9/livekit-1.1.0-py3-none-win_amd64.whl", hash = "sha256:543547083d7470a2fd54b8cef96618665d274c25c406bfb6603ef1cdeff988f5", size = 10394470, upload-time = "2026-02-16T22:00:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/07/7b/1b2d448d8976b14794bfba3d003e1451c79afa77e6b9fa1593f19175ef90/livekit-1.1.2-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:78be23f3f6315354aaacee664eb19b793009bc06faa8184ad9c07cffbe8d7f74", size = 9844157, upload-time = "2026-02-17T01:18:34.036Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fb/19f7fc4a7df3b1385ba2e32b907c5a502fe01c10e6ee2fb76629c068667d/livekit-1.1.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:656f4d9e4692f3d7ab2e51b0bbf4ec03b356a487b7ff220576dab496e60f99f3", size = 8651703, upload-time = "2026-02-17T01:18:36.416Z" },
+    { url = "https://files.pythonhosted.org/packages/29/59/ac6a3987bfd11687f86156627a8c7f6a0047a72877748facbd427e63b157/livekit-1.1.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:a20e681d8a4929e27df69f818888ae649700c9d52a262abbec296c84937bc337", size = 14085891, upload-time = "2026-02-17T01:18:38.561Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a5/680548ef7bf5034144ae01f1f742a6c49e4428942b3119ac6553207fea9b/livekit-1.1.2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:0e4d8105a0c317b513a118b48340b5773239103cb6305768451ef99ac7567823", size = 11448902, upload-time = "2026-02-17T01:18:42.006Z" },
+    { url = "https://files.pythonhosted.org/packages/00/05/e484f8fc079c5de7690e58ed48f44e77436b8732c3050da742bdfca51a5c/livekit-1.1.2-py3-none-win_amd64.whl", hash = "sha256:dd4a436fa16de589353bfbabde91068ab64241afd05b04f21fb1f22bfe155dc0", size = 10394562, upload-time = "2026-02-17T01:18:44.589Z" },
 ]
 
 [[package]]
@@ -1914,7 +1914,7 @@ requires-dist = [
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "eval-type-backport" },
-    { name = "livekit", specifier = "==1.1.0" },
+    { name = "livekit", specifier = "==1.1.2" },
     { name = "livekit-api", specifier = ">=1.0.7,<2" },
     { name = "livekit-blingfire", specifier = "~=1.1,<2" },
     { name = "livekit-plugins-anam", marker = "extra == 'anam'", editable = "livekit-plugins/livekit-plugins-anam" },


### PR DESCRIPTION
## Summary
- Bump `livekit` dependency from 1.1.1 to 1.1.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)