### PR TITLE
fix: preserve completed tool results in chat context after interruption

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2164,6 +2164,26 @@ class AgentActivity(RecognitionHooks):
 
         if speech_handle.interrupted:
             await utils.aio.cancel_and_wait(exe_task)
+
+            # Preserve completed tool results in chat context even after interruption.
+            # This prevents the LLM from re-calling the same tools on the next turn
+            # when the user interrupts mid-speech but tools have already completed.
+            if len(tool_output.output) > 0:
+                preserved_messages: list[llm.FunctionCall | llm.FunctionCallOutput] = []
+                for completed_out in tool_output.output:
+                    if completed_out.fnc_call_out is not None:
+                        preserved_messages.append(completed_out.fnc_call)
+                        preserved_messages.append(completed_out.fnc_call_out)
+
+                if preserved_messages:
+                    self._agent._chat_ctx.insert(preserved_messages)
+                    self._session._tool_items_added(preserved_messages)
+                    logger.debug(
+                        "preserved %d tool result(s) in chat context after interruption",
+                        len(preserved_messages) // 2,
+                        extra={"speech_id": speech_handle.id},
+                    )
+
             return
 
         # wait for the tool execution to complete
@@ -2652,6 +2672,27 @@ class AgentActivity(RecognitionHooks):
 
         if speech_handle.interrupted:
             await utils.aio.cancel_and_wait(exe_task)
+
+            # Preserve completed tool results in chat context even after interruption.
+            # This prevents the LLM from re-calling the same tools on the next turn
+            # when the user interrupts mid-speech but tools have already completed.
+            # Note: in the realtime path, fnc_call is already added to chat_ctx
+            # by _tool_execution_started_cb, so we only add fnc_call_out here.
+            if len(tool_output.output) > 0:
+                preserved_count = 0
+                for completed_out in tool_output.output:
+                    if completed_out.fnc_call_out is not None:
+                        self._agent._chat_ctx.items.append(completed_out.fnc_call_out)
+                        self._session._tool_items_added([completed_out.fnc_call_out])
+                        preserved_count += 1
+
+                if preserved_count > 0:
+                    logger.debug(
+                        "preserved %d tool result(s) in chat context after interruption",
+                        preserved_count,
+                        extra={"speech_id": speech_handle.id},
+                    )
+
             return
 
         # wait for the tool execution to complete


### PR DESCRIPTION
## Summary

Fixes #3702

When a user interrupts the agent mid-speech, any tool calls that had already completed were being discarded from the chat context. On the next turn, the LLM would re-call the same tools — wasting time, API calls, and creating a poor user experience.

This PR preserves completed `FunctionCall` + `FunctionCallOutput` pairs in the agent's `_chat_ctx` even after interruption, so the LLM can reference those results on the next turn without re-executing.

## Problem

In `_pipeline_reply_task` (and `_realtime_pipeline_reply_task`), when `speech_handle.interrupted` is true:

1. `cancel_and_wait(exe_task)` is called — which internally waits for in-flight tool tasks to finish (via the `CancelledError` handler in `_execute_tools_task`)
2. At this point, `tool_output.output` may contain completed results
3. But the code immediately `return`s — those results are thrown away
4. On the next user turn, the LLM has no memory of the tool results, so it calls the same tool again

This is especially problematic for:
- **Slow tools** (API lookups, database queries) that take several seconds
- **Stateful tools** (reservations, payments) where re-execution has side effects
- **Real-time voice agents** where latency from duplicate calls degrades UX

## Changes

**Stateless LLM pipeline** (`_pipeline_reply_task`):
- After `cancel_and_wait(exe_task)`, iterates `tool_output.output`
- For each completed output, inserts both `fnc_call` and `fnc_call_out` into `self._agent._chat_ctx` via `insert()`
- Notifies the session via `_tool_items_added()`

**Realtime LLM pipeline** (`_realtime_pipeline_reply_task`):
- Same pattern, but since `_tool_execution_started_cb` already adds `fnc_call` to the chat context in the realtime path, only `fnc_call_out` is added
- Uses `items.append()` consistent with the existing realtime path pattern

Both paths include debug logging to track when tool results are preserved.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Interrupted, tools completed | Results discarded, LLM re-calls | Results preserved in chat_ctx |
| Interrupted, no tools completed | Clean return | Clean return (unchanged) |
| Not interrupted | Normal flow | Normal flow (unchanged) |

## Test plan

- [ ] Interrupted speech with completed tools → results appear in `_chat_ctx` on next turn
- [ ] Interrupted speech with no completed tools → clean return, no change
- [ ] Non-interrupted path → behavior unchanged
- [ ] Realtime pipeline: only `fnc_call_out` added (not duplicate `fnc_call`)
- [ ] Existing test suite passes without regressions