### PR TITLE
Close HttpServer client connections when draining

### DIFF
--- a/livekit-agents/livekit/agents/utils/http_server.py
+++ b/livekit-agents/livekit/agents/utils/http_server.py
@@ -38,4 +38,8 @@ class HttpServer:
     async def aclose(self) -> None:
         async with self._lock:
             self._server.close()
+            # This will close all persistent connections.
+            # The close_clients method is only available in Python versions >= 3.13
+            if hasattr(self._server, "close_clients"):
+                self._server.close_clients()
             await self._server.wait_closed()


### PR DESCRIPTION
### Summary
When the agent server is deployed with Telegraf scraping the /metrics endpoint with default configs, there is a persistent connection kept alive indefinitely. When a `SIGTERM`  command is sent, it is unable to shut down the agent server gracefully and it gets stuck in the "process exiting" stage. This PR fixes the issue by calling close_client. 

Unfortunately, `close_clients` is only available with Python versions >= 3.13. I haven't been able to identify a similar fix for versions 3.10 to 3.12 which LiveKit supports. 

An alternative fix is to set Telegraf configs to close and start new connections with each scrape:
```
  [inputs.prometheus.http_headers]
    Connection = "close"
```

### Tested via:
1. Run the agent server locally and expose a Prometheus port.
2. Run Telegraf locally with the /metrics endpoint as input.
3. Send a SIGTERM command to the agent server process. This would not stop the agent.
4. Stop the Telegraf service. This would stop the agent server as well. 
5. With this fix, the Telegraf service does not need to be stopped for the agent to exit. It does not affect the graceful shutdowns when there are active agent sessions