### PR TITLE
Upgrade the default drive thru LLM model to gpt 5 mini

### DIFF
--- a/examples/drive-thru/agent.py
+++ b/examples/drive-thru/agent.py
@@ -426,7 +426,7 @@ async def drive_thru_agent(ctx: JobContext) -> None:
                 ],
             },
         ),
-        llm=inference.LLM("openai/gpt-4.1"),
+        llm=inference.LLM("openai/gpt-5-mini"),
         tts=inference.TTS("cartesia/sonic-3", voice="f786b574-daa5-4673-aa0c-cbe3e8534c02"),
         turn_detection=MultilingualModel(),
         vad=silero.VAD.load(),


### PR DESCRIPTION
- 5 mini is supposedly cheaper and better at function calling and instruction following: [Artificial Analysis Comparison](https://artificialanalysis.ai/models/comparisons/gpt-5-mini-vs-gpt-4-1)