### PR TITLE
feat: enhance worker load management with reserved slots and effective load calculation

### DIFF
--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -692,9 +692,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                 while True:
                     await interval.tick()
 
-                    self._worker_load = await asyncio.get_event_loop().run_in_executor(
-                        None, self._run_load_fnc_sync
-                    )
+                    self._worker_load = await self._invoke_load_fnc()
 
                     telemetry.metrics._update_worker_load(self._worker_load)
                     telemetry.metrics._update_child_proc_count()
@@ -1140,14 +1138,18 @@ class AgentServer(utils.EventEmitter[EventTypes]):
         self._job_lifecycle_tasks.add(task)
         task.add_done_callback(self._job_lifecycle_tasks.discard)
 
-    def _run_load_fnc_sync(self) -> float:
+    async def _invoke_load_fnc(self) -> float:
         """Run load_fnc in executor. Uses signature to call with or without self."""
-        assert self._load_fnc is not None
-        signature = inspect.signature(self._load_fnc)
-        parameters = list(signature.parameters.values())
-        if len(parameters) == 0:
-            return self._load_fnc()  # type: ignore
-        return self._load_fnc(self)  # type: ignore
+
+        def load_fnc() -> float:
+            assert self._load_fnc is not None
+            signature = inspect.signature(self._load_fnc)
+            parameters = list(signature.parameters.values())
+            if len(parameters) == 0:
+                return self._load_fnc()  # type: ignore
+            return self._load_fnc(self)  # type: ignore
+
+        return await asyncio.get_event_loop().run_in_executor(None, load_fnc)
 
     async def _refresh_worker_load(self) -> None:
         """Refresh _worker_load by running load_fnc. Used before availability checks
@@ -1156,9 +1158,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
         if self._load_fnc is None:
             return
 
-        self._worker_load = await asyncio.get_event_loop().run_in_executor(
-            None, self._run_load_fnc_sync
-        )
+        self._worker_load = await self._invoke_load_fnc()
         telemetry.metrics._update_worker_load(self._worker_load)
 
     def _get_effective_load(self) -> float:


### PR DESCRIPTION
Closes #4884

This PR improves worker load management to avoid over-accepting concurrent jobs around availability checks.

**Key changes**

- **Refresh load on each availability decision**  
  Introduces `_refresh_worker_load()` to recompute `_worker_load` by calling `load_fnc` and updating telemetry. `_answer_availability()` now awaits this method before calling `_is_available()`, so availability decisions use up-to-date load instead of relying on the periodic (0.5s) refresh.

- **Reserved slots for accepted-but-not-launched jobs**  
  Adds `_reserved_slots` to track jobs we have answered “available” to but that have not yet been launched. In `_on_accept`, we increment `_reserved_slots` immediately when accepting and decrement it in a `finally` block, ensuring the slot is released whether the job launches successfully, times out, or errors. This means capacity accounting covers the entire window from “available” to actual launch.

- **Effective load for availability and status**  
  Adds `_get_effective_load()` to compute effective load as:
  `effective_load = _worker_load + _reserved_slots * job_load_estimate`, where `job_load_estimate` is `_worker_load / len(active_jobs)` when there are active jobs, or `1.0` when there are none. `_is_available()` now uses this effective load against `load_threshold` (with `math.isinf(load_threshold)` still treated as “always available”), and `_update_worker_status()` uses the same effective load to determine `WS_FULL` and log status changes. This keeps availability checks and status reporting consistent and prevents over-accepting when multiple requests arrive before jobs are actually running.

**Example behavior**

With `load_threshold = 1.0` and `load_fnc = len(active_jobs)`:

- First request: `_refresh_worker_load()` sets `load = 0`, `_reserved_slots = 0` → worker reports available; on accept, `_reserved_slots` becomes `1`.
- Second request arriving before the first job is launched: `_refresh_worker_load()` still sees `load = 0`, but effective load becomes `0 + 1×1 = 1`, so the worker is considered at capacity and will report unavailable.
- Once the first job launches or is rejected/times out, `_reserved_slots` is decremented and capacity is freed again.

This aligns the worker’s advertised availability with its real-world capacity during the small but important gap between accepting a job and it showing up as active.