### PR TITLE
Upgrading Cartesia TTS default to Sonic 3

### DIFF
--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -251,7 +251,7 @@ class TTS(tts.TTS):
         and emotion. If any parameter is not provided, the existing value will be retained.
 
         Args:
-            model (TTSModels, optional): The Cartesia TTS model to use. Defaults to "sonic-2".
+            model (TTSModels, optional): The Cartesia TTS model to use. Defaults to "sonic-3".
             language (str, optional): The language code for synthesis. Defaults to "en".
             voice (str | list[float], optional): The voice ID or embedding array.
             speed (TTSVoiceSpeed | float, optional): Voice Control - Speed (https://docs.cartesia.ai/user-guides/voice-control)


### PR DESCRIPTION
Admittedly this is on us for not being on top of this, but Sonic 3 has been stable in production with the broad majority of our customers for quite a while, upgrading the Cartesia TTS utility in LiveKit Agents to reflect this.