### PR TITLE
fix(chat_ctx): preserve conversation order in merge() for realtime mo…

### DIFF
--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -405,7 +405,11 @@ class ChatContext:
         exclude_instructions: bool = False,
         exclude_config_update: bool = False,
     ) -> ChatContext:
-        """Add messages from `other_chat_ctx` into this one, avoiding duplicates, and keep items sorted by created_at."""
+        """Add messages from `other_chat_ctx` into this one, avoiding duplicates.
+
+        New items are appended in the order they appear in `other_chat_ctx`, preserving
+        the natural conversation order.
+        """
         existing_ids = {item.id for item in self._items}
 
         for item in other_chat_ctx.items:
@@ -426,8 +430,7 @@ class ChatContext:
                 continue
 
             if item.id not in existing_ids:
-                idx = self.find_insertion_index(created_at=item.created_at)
-                self._items.insert(idx, item)
+                self._items.append(item)
                 existing_ids.add(item.id)
 
         return self


### PR DESCRIPTION
…dels

ChatContext.merge() was using find_insertion_index() to re-sort items by created_at when merging a completed AgentTask's context back into the TaskGroup. This broke conversation ordering for realtime models (e.g. Gemini native audio) where the assistant message's created_at is set to started_speaking_at -- which can be earlier than the user message's created_at (transcript finalisation time) even though the assistant is responding to that user message.

Fix: replace find_insertion_index() + insert() with append() in merge(), preserving the natural insertion order from other_chat_ctx. This is safe because merge() is only called in one place (AgentTask.__await_impl__), where other_chat_ctx is always a superset of self and new items are already in correct conversation order from prior append() calls.

Also add two regression tests:
- test_merge_preserves_conversation_order_over_timestamps: directly replicates the Gemini timing scenario.
- test_merge_deduplicates_existing_items: confirms deduplication still works correctly after the change.