### PR TITLE
feat(elevenlabs): add eleven_v3 model support with HTTP streaming fallback

### DIFF
--- a/examples/eleven_v3_example.py
+++ b/examples/eleven_v3_example.py
@@ -1,0 +1,45 @@
+"""
+Example demonstrating ElevenLabs eleven_v3 TTS model usage with LiveKit Agents.
+
+The eleven_v3 model doesn't support WebSocket streaming, so the plugin automatically
+uses HTTP streaming with chunked transfer encoding instead.
+
+To compare latency between models:
+- Set USE_V3 = True  → Uses eleven_v3 with HTTP streaming (new)
+- Set USE_V3 = False → Uses eleven_turbo_v2_5 with WebSocket (existing)
+
+Look for the "tts_ttfb" metric in the console to compare TTS latency.
+"""
+
+from livekit.agents import AgentServer, JobContext, cli
+from livekit.agents.voice import Agent, AgentSession
+from livekit.plugins import elevenlabs, openai, silero
+
+server = AgentServer()
+
+
+@server.rtc_session()
+async def entrypoint(ctx: JobContext):
+    # Toggle between models to compare latency:
+    # - eleven_v3: Uses HTTP streaming (our new implementation)
+    # - eleven_turbo_v2_5: Uses WebSocket streaming (existing)
+    
+    USE_V3 = True  # Set to False to test eleven_turbo_v2_5
+    
+    agent = Agent(
+        instructions="You are a helpful voice assistant. Keep responses very short - 1 sentence max.",
+        stt=openai.STT(),  # OpenAI Whisper
+        llm=openai.LLM(model="gpt-4o"),  # Faster than gpt-4o-mini for streaming
+        tts=elevenlabs.TTS(
+            model="eleven_v3" if USE_V3 else "eleven_turbo_v2_5",
+            voice_id="EXAVITQu4vr4xnSDxMaL",
+        ),
+        vad=silero.VAD.load(),
+    )
+
+    session = AgentSession()
+    await session.start(agent=agent, room=ctx.room)
+
+
+if __name__ == "__main__":
+    cli.run_app(server)

--- a/examples/eleven_v3_example.py
+++ b/examples/eleven_v3_example.py
@@ -23,9 +23,9 @@ async def entrypoint(ctx: JobContext):
     # Toggle between models to compare latency:
     # - eleven_v3: Uses HTTP streaming (our new implementation)
     # - eleven_turbo_v2_5: Uses WebSocket streaming (existing)
-    
+
     USE_V3 = True  # Set to False to test eleven_turbo_v2_5
-    
+
     agent = Agent(
         instructions="You are a helpful voice assistant. Keep responses very short - 1 sentence max.",
         stt=openai.STT(),  # OpenAI Whisper

--- a/livekit-plugins/livekit-plugins-elevenlabs/README.md
+++ b/livekit-plugins/livekit-plugins-elevenlabs/README.md
@@ -13,3 +13,13 @@ pip install livekit-plugins-elevenlabs
 ## Pre-requisites
 
 You'll need an API key from ElevenLabs. It can be set as an environment variable: `ELEVEN_API_KEY`
+
+## Supported Models
+
+All ElevenLabs TTS models are supported, including:
+- `eleven_v3` - Most expressive model with emotion and delivery control
+- `eleven_turbo_v2_5` - Fast, high-quality multilingual model (default)
+- `eleven_flash_v2_5`, `eleven_flash_v2` - Ultra-fast models
+- And more...
+
+**Note:** The `eleven_v3` model uses HTTP streaming instead of WebSocket for compatibility, as it doesn't support WebSocket connections. The plugin automatically handles this difference. Aligned transcripts are not yet supported for `eleven_v3`.

--- a/livekit-plugins/livekit-plugins-elevenlabs/README.md
+++ b/livekit-plugins/livekit-plugins-elevenlabs/README.md
@@ -22,4 +22,4 @@ All ElevenLabs TTS models are supported, including:
 - `eleven_flash_v2_5`, `eleven_flash_v2` - Ultra-fast models
 - And more...
 
-**Note:** The `eleven_v3` model uses HTTP streaming instead of WebSocket for compatibility, as it doesn't support WebSocket connections. The plugin automatically handles this difference. Aligned transcripts are not yet supported for `eleven_v3`.
+**Note:** The `eleven_v3` model uses HTTP streaming instead of WebSocket for compatibility, as it doesn't support WebSocket connections. The plugin automatically handles this difference.

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -300,6 +300,7 @@ class TTS(tts.TTS):
     def stream(
         self, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
     ) -> SynthesizeStream | HTTPSynthesizeStream:
+        stream: SynthesizeStream | HTTPSynthesizeStream
         if self._opts.model in NON_WEBSOCKET_MODELS:
             stream = HTTPSynthesizeStream(tts=self, conn_options=conn_options)
         else:

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -705,8 +705,9 @@ class HTTPSynthesizeStream(tts.SynthesizeStream):
                         if timed_words:
                             output_emitter.push_timed_transcript(timed_words)
 
-                        start_times_ms = start_times_ms[-len(text_buffer) :]
-                        durations_ms = durations_ms[-len(text_buffer) :]
+                        remaining = len(text_buffer)
+                        start_times_ms = start_times_ms[-remaining:] if remaining else []
+                        durations_ms = durations_ms[-remaining:] if remaining else []
 
             except (json.JSONDecodeError, KeyError) as e:
                 logger.warning(f"[HTTPSynthesizeStream] Failed to parse response line: {e}")
@@ -777,8 +778,9 @@ class HTTPSynthesizeStream(tts.SynthesizeStream):
                                 text_buffer, start_times_ms, durations_ms
                             )
                             output_emitter.push_timed_transcript(timed_words)
-                            start_times_ms = start_times_ms[-len(text_buffer) :]
-                            durations_ms = durations_ms[-len(text_buffer) :]
+                            remaining = len(text_buffer)
+                            start_times_ms = start_times_ms[-remaining:] if remaining else []
+                            durations_ms = durations_ms[-remaining:] if remaining else []
 
                 except (json.JSONDecodeError, KeyError) as e:
                     logger.warning(f"Failed to parse timestamp response: {e}")
@@ -1027,8 +1029,9 @@ class _Connection:
                             stream._text_buffer, stream._start_times_ms, stream._durations_ms
                         )
                         emitter.push_timed_transcript(timed_words)
-                        stream._start_times_ms = stream._start_times_ms[-len(stream._text_buffer) :]
-                        stream._durations_ms = stream._durations_ms[-len(stream._text_buffer) :]
+                        remaining = len(stream._text_buffer)
+                        stream._start_times_ms = stream._start_times_ms[-remaining:] if remaining else []
+                        stream._durations_ms = stream._durations_ms[-remaining:] if remaining else []
 
                 if data.get("audio"):
                     b64data = base64.b64decode(data["audio"])

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -1030,8 +1030,12 @@ class _Connection:
                         )
                         emitter.push_timed_transcript(timed_words)
                         remaining = len(stream._text_buffer)
-                        stream._start_times_ms = stream._start_times_ms[-remaining:] if remaining else []
-                        stream._durations_ms = stream._durations_ms[-remaining:] if remaining else []
+                        stream._start_times_ms = (
+                            stream._start_times_ms[-remaining:] if remaining else []
+                        )
+                        stream._durations_ms = (
+                            stream._durations_ms[-remaining:] if remaining else []
+                        )
 
                 if data.get("audio"):
                     b64data = base64.b64decode(data["audio"])

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -601,6 +601,8 @@ class HTTPSynthesizeStream(tts.SynthesizeStream):
 
         except asyncio.TimeoutError as e:
             raise APITimeoutError() from e
+        except APIError:
+            raise
         except aiohttp.ClientResponseError as e:
             raise APIStatusError(
                 message=e.message,

--- a/tests/test_elevenlabs_v3.py
+++ b/tests/test_elevenlabs_v3.py
@@ -108,10 +108,9 @@ class TestElevenLabsV3Support:
 
     @patch.dict("os.environ", {"ELEVEN_API_KEY": "test-key"})
     def test_alignment_capability_for_v3(self):
-        """Test that eleven_v3 doesn't support alignment yet (uses HTTP streaming)"""
-        # Alignment not yet supported for HTTP streaming models
+        """Test that eleven_v3 supports alignment via HTTP /stream/with-timestamps endpoint"""
         tts_with_alignment = elevenlabs.TTS(model="eleven_v3", sync_alignment=True)
-        assert tts_with_alignment.capabilities.aligned_transcript is False
+        assert tts_with_alignment.capabilities.aligned_transcript is True
 
         tts_without_alignment = elevenlabs.TTS(model="eleven_v3", sync_alignment=False)
         assert tts_without_alignment.capabilities.aligned_transcript is False

--- a/tests/test_elevenlabs_v3.py
+++ b/tests/test_elevenlabs_v3.py
@@ -1,0 +1,155 @@
+"""Tests for ElevenLabs eleven_v3 TTS model support"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from livekit.plugins import elevenlabs
+
+
+class TestElevenLabsV3Support:
+    """Test that eleven_v3 model uses HTTP streaming instead of WebSocket"""
+
+    @pytest.fixture
+    def mock_http_session(self):
+        """Mock HTTP session for testing"""
+        session = MagicMock()
+        session.post = AsyncMock()
+        return session
+
+    def test_eleven_v3_in_non_websocket_models(self):
+        """Verify eleven_v3 is marked as a non-WebSocket model"""
+        from livekit.plugins.elevenlabs.tts import NON_WEBSOCKET_MODELS
+
+        assert "eleven_v3" in NON_WEBSOCKET_MODELS
+
+    @patch.dict("os.environ", {"ELEVEN_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_returns_http_stream_for_v3(self):
+        """Test that stream() returns HTTPSynthesizeStream for eleven_v3"""
+        from livekit.plugins.elevenlabs.tts import HTTPSynthesizeStream
+
+        tts = elevenlabs.TTS(model="eleven_v3")
+        stream = tts.stream()
+
+        assert isinstance(stream, HTTPSynthesizeStream)
+        assert tts.model == "eleven_v3"
+
+        await stream.aclose()
+        await tts.aclose()
+
+    @patch.dict("os.environ", {"ELEVEN_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_returns_websocket_stream_for_other_models(self):
+        """Test that stream() returns SynthesizeStream for non-v3 models"""
+        from livekit.plugins.elevenlabs.tts import SynthesizeStream
+
+        tts = elevenlabs.TTS(model="eleven_turbo_v2_5")
+        stream = tts.stream()
+
+        assert isinstance(stream, SynthesizeStream)
+        assert tts.model == "eleven_turbo_v2_5"
+
+        await stream.aclose()
+        await tts.aclose()
+
+    @patch.dict("os.environ", {"ELEVEN_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_model_update_to_v3_changes_stream_type(self):
+        """Test that updating to eleven_v3 changes the stream type"""
+        from livekit.plugins.elevenlabs.tts import HTTPSynthesizeStream, SynthesizeStream
+
+        tts = elevenlabs.TTS(model="eleven_turbo_v2_5")
+        stream1 = tts.stream()
+        assert isinstance(stream1, SynthesizeStream)
+        await stream1.aclose()
+
+        tts.update_options(model="eleven_v3")
+        stream2 = tts.stream()
+        assert isinstance(stream2, HTTPSynthesizeStream)
+        await stream2.aclose()
+        await tts.aclose()
+
+    @patch.dict("os.environ", {"ELEVEN_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_synthesize_works_for_v3(self):
+        """Test that synthesize() still works for eleven_v3"""
+        from livekit.plugins.elevenlabs.tts import ChunkedStream
+
+        tts = elevenlabs.TTS(model="eleven_v3")
+        stream = tts.synthesize("Hello world")
+
+        assert isinstance(stream, ChunkedStream)
+        await stream.aclose()
+        await tts.aclose()
+
+    @patch.dict("os.environ", {"ELEVEN_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_all_tts_models_are_supported(self):
+        """Test that all model types can be instantiated"""
+        models = [
+            "eleven_monolingual_v1",
+            "eleven_multilingual_v1",
+            "eleven_multilingual_v2",
+            "eleven_turbo_v2",
+            "eleven_turbo_v2_5",
+            "eleven_flash_v2_5",
+            "eleven_flash_v2",
+            "eleven_v3",
+        ]
+
+        for model in models:
+            tts = elevenlabs.TTS(model=model)
+            assert tts.model == model
+            stream = tts.stream()
+            assert stream is not None
+            await stream.aclose()
+            await tts.aclose()
+
+    @patch.dict("os.environ", {"ELEVEN_API_KEY": "test-key"})
+    def test_alignment_capability_for_v3(self):
+        """Test that eleven_v3 doesn't support alignment yet (uses HTTP streaming)"""
+        # Alignment not yet supported for HTTP streaming models
+        tts_with_alignment = elevenlabs.TTS(model="eleven_v3", sync_alignment=True)
+        assert tts_with_alignment.capabilities.aligned_transcript is False
+
+        tts_without_alignment = elevenlabs.TTS(model="eleven_v3", sync_alignment=False)
+        assert tts_without_alignment.capabilities.aligned_transcript is False
+
+    @patch.dict("os.environ", {"ELEVEN_API_KEY": "test-key"})
+    def test_with_timestamps_url_generation(self):
+        """Test that with-timestamps endpoint is used when sync_alignment is enabled"""
+        from livekit.plugins.elevenlabs.tts import _synthesize_url, _TTSOptions
+
+        opts = _TTSOptions(
+            api_key="test",
+            voice_id="voice123",
+            model="eleven_v3",
+            base_url="https://api.elevenlabs.io/v1",
+            encoding="mp3_22050_32",
+            sample_rate=22050,
+            streaming_latency=0,
+            word_tokenizer=None,
+            chunk_length_schedule=[],
+            enable_ssml_parsing=False,
+            enable_logging=True,
+            inactivity_timeout=180,
+            sync_alignment=True,
+            apply_text_normalization="auto",
+            preferred_alignment="normalized",
+            auto_mode=True,
+            voice_settings=None,
+            language=None,
+            pronunciation_dictionary_locators=None,
+        )
+
+        url_with_timestamps = _synthesize_url(opts, with_timestamps=True)
+        assert "stream/with-timestamps" in url_with_timestamps
+
+        url_without_timestamps = _synthesize_url(opts, with_timestamps=False)
+        assert "stream/with-timestamps" not in url_without_timestamps
+        assert "/stream?" in url_without_timestamps
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Adds support for ElevenLabs eleven_v3 TTS model by implementing HTTP streaming fallback. The plugin automatically detects when eleven_v3 is used and routes to the HTTP /stream endpoint instead of WebSocket.

## Changes

- Add HTTPSynthesizeStream class for HTTP-based streaming
- Automatically detect and route eleven_v3 to HTTP streaming
- Add comprehensive test coverage (8 unit tests)
- Include example demonstrating usage

## Implementation

```python
tts = elevenlabs.TTS(model="eleven_v3")
stream = tts.stream()  # Automatically uses HTTP streaming
```

Other models continue using WebSocket unchanged.

## Limitations

HTTP streaming has higher latency (~1.5s TTFB) compared to WebSocket models (~300ms) due to text buffering requirements. This is an ElevenLabs API limitation since eleven_v3 doesn't support WebSocket connections.

Fixes 403 errors when using eleven_v3.
