### PR TITLE
Update readme to include mcp and skill information

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ agents that can see, hear, and understand.
 To install the core Agents library, along with plugins for popular model providers:
 
 ```bash
-pip install "livekit-agents[openai,silero,deepgram,cartesia,turn-detector]~=1.0"
+pip install "livekit-agents[openai,silero,deepgram,cartesia,turn-detector]~=1.4"
 ```
 
 ## Docs and guides


### PR DESCRIPTION
Adds a `Building with AI coding agents` subsection under `Docs and guides` recommending the LiveKit Docs MCP server and LiveKit Agent Skill as best practices for developers using AI coding assistants.  Also does a driveby update of the installation command to the current released version of the sdk. 

Open question: Should we also include the skill and the MCP server as links in the resources section in the table at the bottom of the readme?