### PR TITLE
fix: return error to LLM for unknown function calls in voice path

### DIFF
--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -488,6 +488,13 @@ async def _execute_tools_task(
                         "speech_id": speech_handle.id,
                     },
                 )
+                _tool_completed(
+                    make_tool_output(
+                        fnc_call=fnc_call,
+                        output=None,
+                        exception=ValueError(f"Unknown function: {fnc_call.name}"),
+                    )
+                )
                 continue
 
             if not isinstance(function_tool, (llm.FunctionTool, llm.RawFunctionTool)):
@@ -497,6 +504,13 @@ async def _execute_tools_task(
                         "function": fnc_call.name,
                         "speech_id": speech_handle.id,
                     },
+                )
+                _tool_completed(
+                    make_tool_output(
+                        fnc_call=fnc_call,
+                        output=None,
+                        exception=TypeError(f"Unknown tool type: {type(function_tool)}"),
+                    )
                 )
                 continue
 


### PR DESCRIPTION
Fixes #4933

The voice path in `generation.py` silently drops unknown function calls with `continue`, leaving `tool_output.output` empty. This causes the agent to stop responding since `agent_activity.py` only retriggers the LLM when tool outputs are present.

Now returns a `FunctionCallResult` with `is_error=True` via `make_tool_output`, matching the existing pattern in `llm/utils.py` and the validation error handler in the same function.