### PR TITLE
fix(openai): preserve non-instruction system messages in update_chat_ctx for realtime models

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -27,6 +27,7 @@ from livekit.agents.types import (
     NotGivenOr,
 )
 from livekit.agents.utils import is_given
+from livekit.agents.voice.generation import remove_instructions
 from openai.types import realtime
 from openai.types.beta.realtime.session import (
     InputAudioNoiseReduction,
@@ -1120,9 +1121,11 @@ class RealtimeSession(
         async with self._update_chat_ctx_lock:
             chat_ctx = chat_ctx.copy(
                 exclude_handoff=True,
-                exclude_instructions=True,
                 exclude_config_update=True,
             )
+            # only remove the instructions but keep other system messages
+            remove_instructions(chat_ctx)
+
             events = self._create_update_chat_ctx_events(chat_ctx)
             futs: list[asyncio.Future[None]] = []
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model_beta.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model_beta.py
@@ -27,6 +27,7 @@ from livekit.agents.types import (
     NotGivenOr,
 )
 from livekit.agents.utils import is_given
+from livekit.agents.voice.generation import remove_instructions
 from openai.types.beta.realtime import (
     ConversationItem,
     ConversationItemContent,
@@ -964,6 +965,13 @@ class RealtimeSessionBeta(
 
     async def update_chat_ctx(self, chat_ctx: llm.ChatContext) -> None:
         async with self._update_chat_ctx_lock:
+            chat_ctx = chat_ctx.copy(
+                exclude_handoff=True,
+                exclude_config_update=True,
+            )
+            # only remove the instructions but keep other system messages
+            remove_instructions(chat_ctx)
+
             events = self._create_update_chat_ctx_events(chat_ctx)
             futs: list[asyncio.Future[None]] = []
 


### PR DESCRIPTION
preserves non-instruction system messages (e.g. context summaries) in `update_chat_ctx` for OpenAI realtime, instead of stripping all system messages.

fix https://github.com/livekit/agents/issues/4875