### PR TITLE
fix: replace bare except with except BaseException in channel put

### DIFF
--- a/livekit-agents/livekit/agents/utils/aio/channel.py
+++ b/livekit-agents/livekit/agents/utils/aio/channel.py
@@ -76,7 +76,7 @@ class Chan(Generic[T]):
                 await p
             except ChanClosed:
                 raise
-            except:
+            except BaseException:
                 p.cancel()
                 with contextlib.suppress(ValueError):
                     self._puts.remove(p)


### PR DESCRIPTION
Replace bare `except:` with `except BaseException:` in `channel.py`'s `put()` method. `BaseException` is correct here because `asyncio.CancelledError` (a `BaseException` subclass) needs to trigger the future cleanup, while making the catch explicit.