### PR TITLE
fix: avoid blocking event loop with unconditional psutil call in _load_task

### DIFF
--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -705,7 +705,10 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                     )
 
                     telemetry.metrics._update_worker_load(self._worker_load)
-                    telemetry.metrics._update_child_proc_count()
+                    if self._prometheus_multiproc_dir:
+                        await asyncio.get_event_loop().run_in_executor(
+                            None, telemetry.metrics._update_child_proc_count
+                        )
 
                     load_threshold = ServerEnvOption.getvalue(self._load_threshold, devmode)
                     default_num_idle_processes = ServerEnvOption.getvalue(


### PR DESCRIPTION
## Summary

- Re-add the `if self._prometheus_multiproc_dir:` guard that was accidentally dropped during the AgentServer refactor in PR #4108 (v1.3.6)
- Move `_update_child_proc_count()` to `run_in_executor` so it never blocks the event loop

## Problem

Since v1.3.6, `telemetry.metrics._update_child_proc_count()` runs **unconditionally every 0.5s on the main event loop**. This function calls `psutil.Process(os.getpid()).children(recursive=True)`, a synchronous syscall that walks the entire process tree.

This blocks the same event loop thread that runs `_recv_task` — the WebSocket receiver that processes `availability` requests from LiveKit Cloud. With multiple child processes, this call can take several milliseconds per invocation, delaying the processing of incoming job dispatch messages and increasing the time delta between cloud dispatch and `request_fnc` invocation.

### History of the guard

| Version | Behavior |
|---------|----------|
| **v1.2.6** | Lazy — used `set_function()`, only evaluated on Prometheus scrape |
| **v1.2.16** (PR #3565) | Guarded with `if self._prometheus_multiproc_dir:` |
| **v1.3.6** (PR #4108) | Guard accidentally dropped — now unconditional |
| **This PR** | Guard restored + moved off the event loop via `run_in_executor` |
