### PR TITLE
Fix/sarvam tts update options language code

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -463,7 +463,7 @@ class TTS(tts.TTS):
         if target_language_code is not None:
             if not target_language_code.strip():
                 raise ValueError("Target language code cannot be empty")
-            self._opts.target_language_code = target_language_code
+            self._opts.target_language_code = Language(target_language_code)
 
         if model is not None:
             if not model.strip():


### PR DESCRIPTION
## Summary

- Add `target_language_code` parameter to `TTS.update_options()` in the Sarvam plugin, with empty-string validation consistent with the constructor.

## Fix

The constructor accepts `target_language_code` but `update_options()` did not, making it impossible to switch the TTS language mid-session without accessing private attributes.