### PR TITLE
feat(stt): expose turn_detection mode to STT streams

### DIFF
--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -7,7 +7,10 @@ from collections.abc import AsyncIterable, AsyncIterator
 from dataclasses import dataclass, field
 from enum import Enum, unique
 from types import TracebackType
-from typing import Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Generic, Literal, TypeVar
+
+if TYPE_CHECKING:
+    from ..voice.audio_recognition import TurnDetectionMode
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -295,7 +298,7 @@ class RecognizeStream(ABC):
         self._resampler: rtc.AudioResampler | None = None
 
         self._start_time_offset: float = 0.0
-        self._turn_detection: str | None = None
+        self._turn_detection: TurnDetectionMode | None = None
 
     @property
     def start_time_offset(self) -> float:
@@ -308,17 +311,18 @@ class RecognizeStream(ABC):
         self._start_time_offset = value
 
     @property
-    def turn_detection(self) -> str | None:
-        """The turn detection mode set by the voice pipeline, if any.
+    def turn_detection(self) -> TurnDetectionMode | None:
+        """The turn detection configuration set by the voice pipeline, if any.
 
         Automatically set by the framework when the stream is used within
-        an AgentSession. Possible values: "stt", "vad", "realtime_llm",
-        "manual", or None if not configured.
+        an AgentSession. Possible values: a string mode ("stt", "vad",
+        "realtime_llm", "manual"), a _TurnDetector instance (e.g.
+        EnglishModel), or None if not configured.
         """
         return self._turn_detection
 
     @turn_detection.setter
-    def turn_detection(self, value: str | None) -> None:
+    def turn_detection(self, value: TurnDetectionMode | None) -> None:
         self._turn_detection = value
 
     @abstractmethod

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -30,8 +30,9 @@ if TYPE_CHECKING:
 class ModelSettings:
     tool_choice: NotGivenOr[llm.ToolChoice] = NOT_GIVEN
     """The tool choice to use when calling the LLM."""
-    turn_detection: str | None = None
-    """The resolved turn detection mode ("stt", "vad", "realtime_llm", "manual"), or None."""
+    turn_detection: TurnDetectionMode | None = None
+    """The turn detection configuration. A string mode ("stt", "vad", "realtime_llm",
+    "manual"), a _TurnDetector instance (e.g. EnglishModel), or None if not set."""
 
 
 class Agent:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -681,7 +681,8 @@ class AudioRecognition:
         if task is not None:
             await aio.cancel_and_wait(task)
 
-        node = stt_node(audio_input, ModelSettings(turn_detection=self._turn_detection_mode))
+        turn_detection: TurnDetectionMode | None = self._turn_detection_mode or self._turn_detector
+        node = stt_node(audio_input, ModelSettings(turn_detection=turn_detection))
         if asyncio.iscoroutine(node):
             node = await node
 


### PR DESCRIPTION
## Summary

- Thread the `turn_detection` mode (`"stt"`, `"vad"`, `"realtime_llm"`, `"manual"`) from `AudioRecognition` through `ModelSettings` to `RecognizeStream`
- Add a `turn_detection` property on `RecognizeStream` (following the existing `start_time_offset` pattern) so any STT plugin can read the active turn detection mode
- Add `turn_detection` field to `ModelSettings` and populate it in `AudioRecognition._stt_task`

## Motivation

STT plugins currently have no way to know what `turn_detection` mode the user configured at the Agent/AgentSession level. This information stops at `AudioRecognition` and is never passed to the STT stream.

Exposing this value enables plugins to adapt their default behavior based on the turn detection strategy — for example, adjusting end-of-turn parameter defaults when a 3rd-party turn detector is handling turn detection.

## Changes

- **`ModelSettings`** (`voice/agent.py`): Added `turn_detection: str | None = None` field
- **`AudioRecognition._stt_task`** (`voice/audio_recognition.py`): Populate `turn_detection` from `self._turn_detection_mode` when constructing `ModelSettings`
- **`RecognizeStream`** (`stt/stt.py`): Added `turn_detection` property/setter (defaults to `None`)
- **`Agent.default.stt_node`** (`voice/agent.py`): Set `stream.turn_detection` from `model_settings.turn_detection`

## Non-breaking

All changes use default values (`None`), so existing plugins, custom `stt_node` overrides, and `ModelSettings()` calls continue to work without modification.
