### PR TITLE
feat(stt): add keyterms parameter in Elevenlabs STT plugin

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
@@ -109,7 +109,7 @@ class STT(stt.STT):
                 be selected based on parameters provided.
             keyterms (NotGivenOr[list[str]]): A list of keywords or phrases to bias the transcription towards.
                 Each keyterm can contain at most 5 words and must be less than 50 characters.
-                Maximum of 100 keyterms. Only supported for Scribe v1 and v2 batch recognition
+                Maximum of 100 keyterms. Only supported for Scribe v2 batch recognition
                 (not realtime streaming). Usage incurs additional costs.
         """
 


### PR DESCRIPTION
# Summary

- Add keyterms parameter to ElevenLabs STT plugin for batch recognition, allowing users to bias transcription towards specific words or phrases (e.g. product names, technical terms)
- Supported on Scribe v2 models only (not realtime streaming), matching the ElevenLabs API specification
- Also exposed via update_options() for runtime updates

Related Elevenlabs API Docs :
- https://elevenlabs.io/docs/api-reference/speech-to-text/convert#request.body.keyterms.keyterms
