### PR TITLE
hotfix: import issue in `agent_worker.py`

### DIFF
--- a/examples/avatar_agents/keyframe/agent_worker.py
+++ b/examples/avatar_agents/keyframe/agent_worker.py
@@ -12,8 +12,9 @@ from livekit.agents import (
     WorkerOptions,
     cli,
     function_tool,
+    inference,
 )
-from livekit.plugins import inference, keyframe, silero
+from livekit.plugins import keyframe, silero
 from livekit.plugins.keyframe import Emotion
 from livekit.plugins.turn_detector.multilingual import MultilingualModel
 


### PR DESCRIPTION
In introducing the inference chain change, we imported `inference` from the wrong module. This hot-fix corrects that.