### PR TITLE
fix: recover from truncated JSON in tool call arguments

### DIFF
--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -431,33 +431,69 @@ def prepare_function_arguments(
     fnc: FunctionTool | RawFunctionTool,
     json_arguments: str,  # raw function output from the LLM
     call_ctx: RunContext[Any] | None = None,
+    repair_json: bool = True,
 ) -> tuple[tuple[Any, ...], dict[str, Any]]:  # returns args, kwargs
     """
     Create the positional and keyword arguments to call a function tool from
     the raw function output from the LLM.
+
+    Args:
+        repair_json: When True (default), attempt to repair truncated JSON from
+            LLM streaming before raising. Repaired arguments are validated
+            against the tool's schema — if validation fails, the original parse
+            error is raised so the caller can retry the LLM call instead.
+            Set to False to always raise on malformed JSON without attempting
+            repair.
     """
 
     signature = inspect.signature(fnc)
     type_hints = get_type_hints(fnc, include_extras=True)
     try:
         args_dict = from_json(json_arguments)
-    except ValueError:
+    except ValueError as original_parse_error:
+        if not repair_json:
+            raise ValueError(
+                f"Failed to parse tool call arguments as JSON: "
+                f"{json_arguments[:200]!r}{'…' if len(json_arguments) > 200 else ''}"
+            ) from None
+
         # LLMs may return truncated JSON in streaming tool calls (e.g., EOF
         # while parsing a string). Attempt to repair the JSON before giving up.
         try:
             args_dict = _try_repair_json(json_arguments)
-            logger.warning(
-                "repaired truncated JSON in tool call arguments",
-                extra={
-                    "raw_arguments_preview": json_arguments[:200],
-                    "raw_arguments_length": len(json_arguments),
-                },
-            )
         except Exception:
             raise ValueError(
                 f"Failed to parse tool call arguments as JSON "
-                f"(and repair attempt failed): {json_arguments!r}"
+                f"(and repair attempt failed): "
+                f"{json_arguments[:200]!r}{'…' if len(json_arguments) > 200 else ''}"
             ) from None
+
+        # Validate repaired args against the tool's Pydantic schema before
+        # executing.  Repair can produce structurally valid JSON that is
+        # semantically incomplete — e.g. '{"arr": [{"a": 1' repairs to
+        # '{"arr": [{"a": 1}]}' but the tool may require a "b" field too.
+        # If validation fails, we re-raise so the caller can retry the LLM
+        # call rather than invoking the tool with wrong arguments.
+        if isinstance(fnc, FunctionTool):
+            try:
+                model_type = function_arguments_to_pydantic_model(fnc)
+                model_type.model_validate(args_dict)
+            except Exception:
+                raise ValueError(
+                    f"Repaired JSON failed schema validation for tool "
+                    f"'{fnc.id}'; raising so the caller can retry the "
+                    f"LLM call. Args preview: "
+                    f"{json_arguments[:200]!r}"
+                ) from original_parse_error
+
+        logger.warning(
+            "repaired truncated JSON in tool call arguments",
+            extra={
+                "tool_name": fnc.id,
+                "raw_arguments_preview": json_arguments[:200],
+                "raw_arguments_length": len(json_arguments),
+            },
+        )
 
     if isinstance(fnc, FunctionTool):
         model_type = function_arguments_to_pydantic_model(fnc)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -68,6 +68,16 @@ async def raw_tool_2() -> str:
     return "raw2"
 
 
+@function_tool
+async def mock_tool_required_fields(a: int, b: int) -> dict[str, int]:
+    """Test tool with two required fields.
+    Args:
+        a: First required integer
+        b: Second required integer
+    """
+    return {"a": a, "b": b}
+
+
 class DummyAgent(Agent):
     def __init__(self):
         super().__init__(instructions="You are a dummy agent.")
@@ -444,3 +454,35 @@ class TestTruncatedJsonRepair:
         result = _try_repair_json('{"path": "C:\\\\Users\\\\name\\')
         assert result is not None
         assert "path" in result
+
+    def test_repaired_json_rejected_when_schema_validation_fails(self):
+        """Repaired JSON that drops required fields must raise ValueError.
+
+        This is the exact scenario from the PR review: '{"a": 1' might have been
+        '{"a": 1, "b": 2}' but repair produces '{"a": 1}' — missing required "b".
+        The schema validation safety net catches this and raises so the caller
+        can retry the LLM call.
+        """
+        with pytest.raises(ValueError, match="schema validation"):
+            prepare_function_arguments(
+                fnc=mock_tool_required_fields,
+                json_arguments='{"a": 1',  # truncated; "b" is missing
+            )
+
+    def test_repair_disabled_raises_immediately(self):
+        """When repair_json=False, malformed JSON raises without attempting repair."""
+        with pytest.raises(ValueError, match="Failed to parse"):
+            prepare_function_arguments(
+                fnc=mock_tool_1,
+                json_arguments='{"arg1": "hello"',
+                repair_json=False,
+            )
+
+    def test_repair_succeeds_when_all_required_fields_present(self):
+        """Repair should succeed when all required fields are present in the
+        truncated JSON — only structural closers are missing."""
+        args, kwargs = prepare_function_arguments(
+            fnc=mock_tool_required_fields,
+            json_arguments='{"a": 1, "b": 2',  # just missing closing brace
+        )
+        assert args == (1, 2)


### PR DESCRIPTION
## Problem

LLMs (notably GPT-4.1 on Azure) sometimes return truncated JSON in streaming tool call arguments. When the streaming response is cut off before the JSON is complete, `from_json()` raises `ValueError: EOF while parsing a string`, causing tool calls to fail entirely.

From issue #4240, a real-world example of truncated output:

```json
{"success":true,"reason":"The message explicitly asks the user to confirm if their name is John Doe"}
```

Was received as:

```json
{"success":true,"reason":"The message explicitly asks the user
```

This affects ~10% of tool calls for some users, particularly with Azure GPT-4.1.

## Solution

Add a JSON repair fallback in `prepare_function_arguments()`:

1. **Fast path unchanged**: `pydantic_core.from_json()` is tried first
2. **On ValueError**: Attempt to repair the truncated JSON by closing open string literals, brackets, and braces
3. **Log warning**: When repair succeeds, log for observability
4. **Re-raise**: If repair also fails, raise with a descriptive error

The repair handles the most common truncation patterns:
- Unfinished string values (missing closing quote)
- Missing closing braces/brackets
- Combinations of the above

## Tests

Added `TestTruncatedJsonRepair` with 4 test cases:
- Truncated string value → repaired and parsed
- Missing closing brace → repaired  
- Valid JSON → unchanged (no regression)
- Completely invalid JSON → still raises ValueError

Fixes #4240