### PR TITLE
fix(assemblyai): use cumulative words text for PREFLIGHT_TRANSCRIPT

### DIFF
--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -540,7 +540,7 @@ class SpeechStream(stt.SpeechStream):
             )
             self._event_ch.send_nowait(interim_event)
 
-        if utterance:
+        if utterance and timed_words:
             if self._last_preflight_start_time == 0.0:
                 self._last_preflight_start_time = start_time
 
@@ -555,12 +555,19 @@ class SpeechStream(stt.SpeechStream):
                 len(utterance_words), 1
             )
 
+            # Use the cumulative words text (same as INTERIM) instead of the
+            # chunk-based utterance field.  Both INTERIM and PREFLIGHT events
+            # flow through on_interim_transcript in the framework and are
+            # rendered in replacement mode (is_delta_stream=False).  Using the
+            # chunk-based utterance here would cause the displayed text to
+            # regress/jump when the shorter chunk overwrites the longer
+            # cumulative text for the same segment ID.  See #4779.
             final_event = stt.SpeechEvent(
                 type=stt.SpeechEventType.PREFLIGHT_TRANSCRIPT,
                 alternatives=[
                     stt.SpeechData(
                         language=language,
-                        text=utterance,
+                        text=interim_text,
                         start_time=self._last_preflight_start_time,
                         end_time=end_time,
                         words=utterance_words,


### PR DESCRIPTION
## Summary

Fixes #4779

- **Root cause**: The `PREFLIGHT_TRANSCRIPT` event was emitting the chunk-based `utterance` field as its text, while `INTERIM_TRANSCRIPT` used the cumulative `words` array. Both events flow through `on_interim_transcript` in the framework and are rendered in replacement mode (`is_delta_stream=False`), so the shorter chunk text from PREFLIGHT would overwrite the longer cumulative text on the same segment ID, causing visible text regression/jumping on the client.

- **Fix**: Use `interim_text` (built from the cumulative `words` array) for the `PREFLIGHT_TRANSCRIPT` text field, matching the behavior of `INTERIM_TRANSCRIPT`. Also added a guard to require `timed_words` to be non-empty before entering the utterance block, since `interim_text` is only defined within the `timed_words` scope.

## Test plan

- [ ] Verify `ruff check` and `ruff format` pass (confirmed locally)
- [ ] Manual test: set up a voice agent with `AssemblyAISTT` in streaming mode, speak continuously for 10+ seconds, and confirm the transcription text on the client only grows or is replaced by the final transcript (never shrinks mid-utterance)
- [ ] Verify existing `test_plugin_assemblyai_stt.py` tests pass