### PR TITLE
fix: strip SSML tags from conversation messages

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -464,9 +464,40 @@ class Agent:
         async def transcription_node(
             agent: Agent, text: AsyncIterable[str | TimedString], model_settings: ModelSettings
         ) -> AsyncGenerator[str | TimedString, None]:
-            """Default implementation for `Agent.transcription_node`"""
+            """Default implementation for `Agent.transcription_node`
+
+            Strips SSML tags (e.g. ``<break time="1s"/>``) so they do not leak
+            into conversation messages shown to the user.
+            """
+            from .io import TimedString as _TimedString
+            from .transcription.filters import strip_ssml
+
+            buffer = ""
+
             async for delta in text:
-                yield delta
+                if isinstance(delta, _TimedString):
+                    # TimedString comes from TTS-aligned transcription which
+                    # has already been processed by the TTS engine, so SSML
+                    # tags should not be present.  Yield as-is to preserve
+                    # timing metadata.
+                    yield delta
+                    continue
+
+                # Buffer plain strings to handle SSML tags that may span chunks
+                buffer += delta
+                last_open = buffer.rfind("<")
+                if last_open != -1 and ">" not in buffer[last_open:]:
+                    # Potentially incomplete tag - yield text before it
+                    complete = buffer[:last_open]
+                    if complete:
+                        yield strip_ssml(complete)
+                    buffer = buffer[last_open:]
+                else:
+                    yield strip_ssml(buffer)
+                    buffer = ""
+
+            if buffer:
+                yield strip_ssml(buffer)
 
         @staticmethod
         async def realtime_audio_output_node(

--- a/livekit-agents/livekit/agents/voice/transcription/filters.py
+++ b/livekit-agents/livekit/agents/voice/transcription/filters.py
@@ -154,3 +154,42 @@ async def filter_emoji(text: AsyncIterable[str]) -> AsyncIterable[str]:
     async for chunk in text:
         filtered_chunk = EMOJI_PATTERN.sub("", chunk)
         yield filtered_chunk
+
+
+# Matches SSML tags: self-closing (e.g. <break time="1s"/>), opening (e.g. <speak>),
+# and closing (e.g. </prosody>). Uses a non-greedy match to handle multiple tags per chunk.
+SSML_TAG_PATTERN = re.compile(r"</?[a-zA-Z][^>]*?>")
+
+
+def strip_ssml(text: str) -> str:
+    """Strip SSML tags from a string, returning only the plain text content."""
+    return SSML_TAG_PATTERN.sub("", text)
+
+
+async def filter_ssml(text: AsyncIterable[str]) -> AsyncIterable[str]:
+    """
+    Filter out SSML tags (e.g. ``<break time="1s"/>``, ``<speak>``, ``</prosody>``)
+    from the text, keeping only the plain text content.
+
+    Handles incomplete tags that may span across streaming chunks by buffering
+    text after an unmatched ``<`` until the closing ``>`` arrives.
+    """
+    buffer = ""
+
+    async for chunk in text:
+        buffer += chunk
+
+        # check for a potential incomplete tag at the end of the buffer
+        last_open = buffer.rfind("<")
+        if last_open != -1 and ">" not in buffer[last_open:]:
+            # incomplete tag - yield everything before it and keep buffering
+            complete = buffer[:last_open]
+            if complete:
+                yield SSML_TAG_PATTERN.sub("", complete)
+            buffer = buffer[last_open:]
+        else:
+            yield SSML_TAG_PATTERN.sub("", buffer)
+            buffer = ""
+
+    if buffer:
+        yield SSML_TAG_PATTERN.sub("", buffer)

--- a/livekit-agents/livekit/agents/voice/transcription/text_transforms.py
+++ b/livekit-agents/livekit/agents/voice/transcription/text_transforms.py
@@ -2,15 +2,17 @@ import re
 from collections.abc import AsyncIterable, Callable, Sequence
 from typing import Literal
 
-from .filters import filter_emoji, filter_markdown
+from .filters import filter_emoji, filter_markdown, filter_ssml
 
 TextTransforms = (
-    Literal["filter_markdown", "filter_emoji"] | Callable[[AsyncIterable[str]], AsyncIterable[str]]
+    Literal["filter_markdown", "filter_emoji", "filter_ssml"]
+    | Callable[[AsyncIterable[str]], AsyncIterable[str]]
 )
 
 _BUILTIN_TRANSFORMS: dict[str, Callable[[AsyncIterable[str]], AsyncIterable[str]]] = {
     "filter_markdown": lambda text: filter_markdown(text),
     "filter_emoji": lambda text: filter_emoji(text),
+    "filter_ssml": lambda text: filter_ssml(text),
 }
 
 

--- a/tests/test_transcription_filter.py
+++ b/tests/test_transcription_filter.py
@@ -1,6 +1,11 @@
 import pytest
 
-from livekit.agents.voice.transcription.filters import filter_emoji, filter_markdown
+from livekit.agents.voice.transcription.filters import (
+    filter_emoji,
+    filter_markdown,
+    filter_ssml,
+    strip_ssml,
+)
 from livekit.agents.voice.transcription.text_transforms import _apply_text_transforms, replace
 
 MARKDOWN_INPUT = """# Mathematics and Markdown Guide
@@ -321,3 +326,90 @@ async def test_apply_text_transforms_with_callable():
     # invalid string transform
     with pytest.raises(ValueError, match="Invalid transform"):
         await _collect(_apply_text_transforms(_stream_text("text", 4), ["nonexistent"]))
+
+
+# SSML test data
+SSML_INPUT = (
+    'Hello, welcome to our service.<break time="1s"/>'
+    "We are glad to have you here."
+    '<break time="500ms" />'
+    "<speak>This is inside speak tags.</speak>"
+    ' And <prosody rate="slow">this is slow speech</prosody> done.'
+)
+
+SSML_EXPECTED_OUTPUT = (
+    "Hello, welcome to our service."
+    "We are glad to have you here."
+    "This is inside speak tags."
+    " And this is slow speech done."
+)
+
+
+@pytest.mark.parametrize("chunk_size", [1, 2, 3, 5, 7, 11, 50, 200])
+async def test_ssml_filter(chunk_size: int):
+    """Test SSML tag filtering with various chunk sizes."""
+
+    async def stream_text():
+        for i in range(0, len(SSML_INPUT), chunk_size):
+            yield SSML_INPUT[i : i + chunk_size]
+
+    result = ""
+    async for chunk in filter_ssml(stream_text()):
+        result += chunk
+
+    assert result == SSML_EXPECTED_OUTPUT, (
+        f"chunk_size={chunk_size}: expected {SSML_EXPECTED_OUTPUT!r}, got {result!r}"
+    )
+
+
+async def test_ssml_filter_no_tags():
+    """Plain text without SSML tags should pass through unchanged."""
+
+    plain = "Hello, this is a normal sentence without any tags."
+
+    async def stream_text():
+        yield plain
+
+    result = ""
+    async for chunk in filter_ssml(stream_text()):
+        result += chunk
+
+    assert result == plain
+
+
+async def test_ssml_filter_only_tags():
+    """Text consisting entirely of SSML tags should produce empty output."""
+
+    async def stream_text():
+        yield '<break time="1s"/><speak></speak>'
+
+    result = ""
+    async for chunk in filter_ssml(stream_text()):
+        result += chunk
+
+    assert result == ""
+
+
+async def test_ssml_filter_self_closing_variants():
+    """Test various self-closing SSML tag formats."""
+
+    input_text = 'Hello<break time="1s"/>world<break time="500ms" /> end'
+    expected = "Helloworld end"
+
+    async def stream_text():
+        yield input_text
+
+    result = ""
+    async for chunk in filter_ssml(stream_text()):
+        result += chunk
+
+    assert result == expected
+
+
+def test_strip_ssml():
+    """Test the synchronous strip_ssml helper."""
+    assert strip_ssml('Hello <break time="1s"/> world') == "Hello  world"
+    assert strip_ssml("<speak>text</speak>") == "text"
+    assert strip_ssml("no tags here") == "no tags here"
+    assert strip_ssml('<prosody rate="slow">slow</prosody>') == "slow"
+    assert strip_ssml("") == ""


### PR DESCRIPTION
## Summary

Fixes #4802

When using `session.say()` with SSML-tagged text (e.g. `<break time="1s"/>`), the TTS engine correctly processes the tags — it pauses as expected and does not read them aloud. However, the raw SSML tags leak into the conversation messages displayed to the user, which is not the expected UX.

This PR strips SSML tags before they reach the conversation transcript:

- **Default `transcription_node`** (`agent.py`): strips SSML tags from plain-string chunks while preserving `TimedString` pass-through (TTS-aligned transcription already excludes SSML). Buffers incomplete tags that may span streaming chunks.
- **`strip_ssml()` helper** (`filters.py`): synchronous utility for stripping SSML tags from a string.
- **`filter_ssml` async transform** (`filters.py`): streaming-aware SSML filter registered as `"filter_ssml"` in `TextTransforms`, following the same pattern as `filter_markdown` and `filter_emoji`.

## Test plan

- [x] Added `test_ssml_filter` parameterized across 8 chunk sizes (1, 2, 3, 5, 7, 11, 50, 200) to verify correct stripping regardless of how tags are split across stream boundaries
- [x] Added `test_ssml_filter_no_tags` — plain text passes through unchanged
- [x] Added `test_ssml_filter_only_tags` — all-SSML input produces empty output
- [x] Added `test_ssml_filter_self_closing_variants` — handles `<break time="1s"/>` and `<break time="500ms" />` formats
- [x] Added `test_strip_ssml` — unit tests for the synchronous helper