### PR TITLE
use default voice accessible to free tier users

### DIFF
--- a/examples/other/text-to-speech/elevenlabs_tts.py
+++ b/examples/other/text-to-speech/elevenlabs_tts.py
@@ -45,8 +45,8 @@ server = AgentServer()
 async def entrypoint(job: JobContext):
     # Using LiveKit inference for TTS, to use elevenlabs with your own API key, you can change it to:
     # from livekit.plugins import elevenlabs
-    # tts_11labs = elevenlabs.TTS(model="elevenlabs/eleven_multilingual_v2", voice_id="l7kNoIfnJKPg7779LI2t")
-    tts_11labs = inference.TTS("elevenlabs/eleven_multilingual_v2", voice="l7kNoIfnJKPg7779LI2t")
+    # tts_11labs = elevenlabs.TTS(model="elevenlabs/eleven_multilingual_v2", voice_id="hpp4J3VqNfWAUOO0d1Us")
+    tts_11labs = inference.TTS("elevenlabs/eleven_multilingual_v2", voice="hpp4J3VqNfWAUOO0d1Us")
 
     source = rtc.AudioSource(tts_11labs.sample_rate, tts_11labs.num_channels)
     track = rtc.LocalAudioTrack.create_audio_track("agent-mic", source)


### PR DESCRIPTION
The voice was recently updated to a Pro Cloned Voice in this PR [here](https://github.com/livekit/agents/pull/5010), stemming from this community [thread](https://community.livekit.io/t/new-default-elevenlabs-voices/459/4?u=cwilson). For users using LiveKit Inference, the Pro Cloned Voice is not available in LiveKit Inference, so the agent will not generate speech. For users using their own API key through the plugin, Pro Cloned Voices are not accessible to Eleven Labs free tier users and not available to any user unless the voice is added to their library on the Eleven Labs dashboard. Failure to meet either requirement results in the agent not generating speech.

I changed the voice to an Eleven Labs default voice, which is available through both LiveKit Inference. The voice is also available via the plugin for Eleven Labs free tier users and without requiring Eleven Labs dashboard configuration. 