### PR TITLE
Add GPT-5.4 to OpenAI plugin

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -124,7 +124,7 @@ class LLM(llm.LLM):
         super().__init__()
 
         if not is_given(reasoning_effort) and _supports_reasoning_effort(model):
-            if model in ["gpt-5.1", "gpt-5.2"]:
+            if model in ["gpt-5.1", "gpt-5.2", "gpt-5.4"]:
                 reasoning_effort = "none"
             else:
                 reasoning_effort = "minimal"

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -19,6 +19,7 @@ TTSVoices = Literal[
 ]
 DalleModels = Literal["dall-e-2", "dall-e-3"]
 ChatModels = Literal[
+    "gpt-5.4",
     "gpt-5.2",
     "gpt-5.2-chat-latest",
     "gpt-5.1",
@@ -309,6 +310,7 @@ SambaNovaChatModels = Literal[
 
 def _supports_reasoning_effort(model: ChatModels | str) -> bool:
     return model in [
+        "gpt-5.4",
         "gpt-5.2",
         "gpt-5.1",
         "gpt-5",

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -170,7 +170,7 @@ class LLM(llm.LLM):
         super().__init__()
 
         if not is_given(reasoning) and _supports_reasoning_effort(model):
-            if model in ["gpt-5.1", "gpt-5.2"]:
+            if model in ["gpt-5.1", "gpt-5.2", "gpt-5.4"]:
                 reasoning = Reasoning(effort="none")
             else:
                 reasoning = Reasoning(effort="minimal")


### PR DESCRIPTION
## Summary
- Add `gpt-5.4` to `ChatModels` type literal
- Add `gpt-5.4` to `_supports_reasoning_effort()` list
- Default reasoning effort to `"none"` for gpt-5.4 in both `llm.py` and `responses/llm.py` (matching gpt-5.1/5.2 behavior)