### PR TITLE
Set _speech_start_time when VAD START_OF_SPEECH activates

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -535,6 +535,7 @@ class AudioRecognition:
             with trace.use_span(self._ensure_user_turn_span()):
                 self._hooks.on_end_of_speech(ev)
 
+            self._vad_speech_started = False
             self._speaking = False
 
             if self._vad_base_turn_detection or (


### PR DESCRIPTION
This image attempts to convey the issue. I have plotted where the ChatMessage was (determined by [MetricsReport](https://github.com/livekit/agents/blob/89f94d36db6ec289729b1280bd904b0981cba498/livekit-agents/livekit/agents/llm/chat_context.py#L111-L112) and the box that shows it is designated across the whole span) vs where I believe it should be (on the right).

<img width="1073" height="157" alt="Screenshot 2026-03-06 at 10 01 29 AM" src="https://github.com/user-attachments/assets/af40ab56-b18e-41e6-b76b-4cbab06a10f7" />

Basically it should align with this custom span I added that represents the vad start of speech.

<img width="597" height="234" alt="image" src="https://github.com/user-attachments/assets/f96bb9ca-9465-49c0-b62c-a12b6d4592c4" />

I believe the reason this is happening is b/c we're setting `_speech_start_time` during [INFERENCE_DONE](https://github.com/livekit/agents/blob/89f94d36db6ec289729b1280bd904b0981cba498/livekit-agents/livekit/agents/voice/audio_recognition.py#L523).  When VAD picks up speech ([even though it doesn't match up with the activation](https://github.com/livekit/agents/blob/89f94d36db6ec289729b1280bd904b0981cba498/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py#L472-L474)) `_speech_start_time` is set. Instead it should be reset when a START_OF_SPEECH event occurs. This would align it with the activation threshold and also a few other places

[here](https://github.com/livekit/agents/blob/89f94d36db6ec289729b1280bd904b0981cba498/livekit-agents/livekit/agents/voice/agent_activity.py#L1292)
and [here](https://github.com/livekit/agents/blob/89f94d36db6ec289729b1280bd904b0981cba498/livekit-agents/livekit/agents/voice/audio_recognition.py#L510).

We're not removing the INFERENCE_DONE branch b/c it would handle the case where no other START_OF_SPEECH event comes. I'm open to removing that too though.
