### PR TITLE
Strip parallel_tool_calls from extra_kwargs when no tools provided

### DIFF
--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -333,8 +333,9 @@ class LLMStream(llm.LLMStream):
                     },
                 )
             if not self._tools:
-                # remove tool_choice from extra_kwargs if no tools are provided
+                # remove tool_choice/parallel_tool_calls from extra_kwargs if no tools are provided
                 self._extra_kwargs.pop("tool_choice", None)
+                self._extra_kwargs.pop("parallel_tool_calls", None)
 
             if self._provider:
                 headers = self._extra_kwargs.setdefault("extra_headers", {})


### PR DESCRIPTION
## Summary

When no tools are provided to the LLM stream, `parallel_tool_calls` is now stripped from `extra_kwargs` alongside the existing `tool_choice` removal. Sending `parallel_tool_calls` without any tools can cause API errors, so this ensures both tool-related parameters are cleaned up consistently.