### PR TITLE
Add GPT-5.4 and GPT-5.3 Chat Latest support

### DIFF
--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -80,6 +80,7 @@ OpenAIModels = Literal[
     "openai/gpt-5.1-chat-latest",
     "openai/gpt-5.2",
     "openai/gpt-5.2-chat-latest",
+    "openai/gpt-5.3-chat-latest",
     "openai/gpt-5.4",
     "openai/gpt-oss-120b",
 ]

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -20,6 +20,7 @@ TTSVoices = Literal[
 DalleModels = Literal["dall-e-2", "dall-e-3"]
 ChatModels = Literal[
     "gpt-5.4",
+    "gpt-5.3-chat-latest",
     "gpt-5.2",
     "gpt-5.2-chat-latest",
     "gpt-5.1",


### PR DESCRIPTION
## Summary
- Adds `openai/gpt-5.4` to the `OpenAIModels` Literal type in the inference module
- Adds `gpt-5.3-chat-latest` to `ChatModels` type in the OpenAI plugin
- Adds `openai/gpt-5.3-chat-latest` to the `OpenAIModels` Literal type in the inference module