### PR TITLE
fix(deepgram): include word confidence for stt v2 alternatives

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Look at the `examples/` directory to get a sense of all the different features a
 
 ## Typechecking, linting and formatting
 
-The CI validates this but to do checks locally see the following example commmands:
+The CI validates this but to do checks locally see the following example commands:
 
 ### Typechecking
 
@@ -102,7 +102,7 @@ uv pip install pip && uv run mypy --install-types --non-interactive \
 uv run ruff check --output-format=github .
 ```
 
-### Formating
+### Formatting
 
 ```bash
 uv run ruff format .

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -550,6 +550,7 @@ def _parse_transcription(
                 text=word.get("word", ""),
                 start_time=word.get("start", 0) + start_time_offset,
                 end_time=word.get("end", 0) + start_time_offset,
+                confidence=word["confidence"],
                 start_time_offset=start_time_offset,
             )
             for word in words


### PR DESCRIPTION
I noticed Deepgram STT v2 word confidence wasn't set on the word level, even though it is used to set the overall combined confidence.

Tested running locally with a STT node.