### PR TITLE
fix(elevenlabs): handle empty words in _to_timed_words

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -877,6 +877,9 @@ def _to_timed_words(
     timestamps = start_times_ms + [start_times_ms[-1] + durations_ms[-1]]  # N+1
 
     words = split_words(text, ignore_punctuation=False, split_character=True)
+    if not words:
+        return [], text
+
     timed_words = []
     _, start_indices, _ = zip(*words, strict=False)
     end = 0


### PR DESCRIPTION
## Summary

`_to_timed_words` crashes with `ValueError: not enough values to unpack (expected 3, got 0)` when `split_words()` returns an empty list. The `zip(*words)` call on an empty list produces no values to unpack.

This bubbles up as `APIStatusError: Could not synthesize` in the TTS stream, causing silence for the user.

**Fix:** Add an early return when `words` is empty, matching the existing guard for empty `text` on the line above.

## Crash path

```
tts.py:881  _to_timed_words → _, start_indices, _ = zip(*words)  # words is []
tts.py:724  _recv_loop → timed_words, _ = _to_timed_words(...)
tts.py:471  _run → raise APIStatusError("Could not synthesize") from e
```

## Sentry trace

```
ValueError: not enough values to unpack (expected 3, got 0)
  File "livekit/plugins/elevenlabs/tts.py", line 861, in _to_timed_words
    _, start_indices, _ = zip(*words, strict=False)
```