### PR TITLE
fix: guard against negative sleep duration in voice agent scheduling

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1095,9 +1095,9 @@ class AgentActivity(RecognitionHooks):
                     continue
                 self._current_speech = speech
                 if self.min_consecutive_speech_delay > 0.0:
-                    await asyncio.sleep(
-                        self.min_consecutive_speech_delay - (time.time() - last_playout_ts)
-                    )
+                    delay = self.min_consecutive_speech_delay - (time.time() - last_playout_ts)
+                    if delay > 0:
+                        await asyncio.sleep(delay)
                     # check again if speech is done after sleep delay
                     if speech.done():
                         # skip done speech (interrupted during delay)


### PR DESCRIPTION
## Problem

In `_scheduling_task` inside `agent_activity.py`, the sleep duration for `min_consecutive_speech_delay` is computed as:

```python
await asyncio.sleep(
    self.min_consecutive_speech_delay - (time.time() - last_playout_ts)
)
```

When the elapsed time since the last playout exceeds `min_consecutive_speech_delay`, this expression produces a negative value. Although `asyncio.sleep` silently treats negative durations as zero, the code's intent is clearly to only delay when not enough time has passed — passing a negative value is semantically wrong and makes the logic harder to follow.

## Fix

Compute the remaining delay into a local variable and only call `asyncio.sleep` when it is positive. This makes the intent explicit and avoids relying on `asyncio.sleep`'s undocumented handling of negative values.

```python
delay = self.min_consecutive_speech_delay - (time.time() - last_playout_ts)
if delay > 0:
    await asyncio.sleep(delay)
```

## Testing

This is a minimal, behavior-preserving change — the runtime behavior is identical because `asyncio.sleep` already clamps negatives to zero. The guard simply makes the intent explicit and avoids any future risk if that implementation detail ever changes.