### PR TITLE
fix(core): render error message with full details in traceback

### DIFF
--- a/livekit-agents/livekit/agents/_exceptions.py
+++ b/livekit-agents/livekit/agents/_exceptions.py
@@ -74,6 +74,18 @@ class APIStatusError(APIError):
         self.status_code = status_code
         self.request_id = request_id
 
+    def __str__(self) -> str:
+        parts = [
+            f"message={self.message!r}",
+            f"status_code={self.status_code}",
+            f"retryable={self.retryable}",
+        ]
+        if self.request_id:
+            parts.append(f"request_id={self.request_id}")
+        if self.body:
+            parts.append(f"body={self.body}")
+        return ", ".join(parts)
+
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}({self.message!r}, "


### PR DESCRIPTION
APIStatusError was using APIError's `__str__` with minimal information in the traceback. This PR fixes that.

```
#before
livekit.agents._exceptions.APIStatusError: something went wrong
#after
livekit.agents._exceptions.APIStatusError: message='something went wrong', status_code=429, retryable=False, request_id=req_abc123, body={'error': 'rate limit exceeded'}
```