### PR TITLE
fix: add missing 'properties' field in tool schema for functions with no parameters

### DIFF
--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -200,7 +200,9 @@ def build_legacy_openai_schema(
     info = function_tool.info
     schema = model.model_json_schema()
 
-    # Ensure 'required' field exists for compatibility with strict APIs like Groq
+    # Ensure 'properties' and 'required' fields exist for compatibility with strict APIs
+    if "properties" not in schema:
+        schema["properties"] = {}
     if "required" not in schema:
         schema["required"] = []
 
@@ -230,7 +232,9 @@ def build_strict_openai_schema(
     info = function_tool.info
     schema = _strict.to_strict_json_schema(model)
 
-    # Ensure 'required' field exists for compatibility with strict APIs
+    # Ensure 'properties' and 'required' fields exist for compatibility with strict APIs
+    if "properties" not in schema:
+        schema["properties"] = {}
     if "required" not in schema:
         schema["required"] = []
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,6 +5,8 @@ import pytest
 from livekit.agents import Agent
 from livekit.agents.llm import ProviderTool, Tool, ToolContext, Toolset, function_tool
 from livekit.agents.llm.utils import (
+    build_legacy_openai_schema,
+    build_strict_openai_schema,
     function_arguments_to_pydantic_model,
     prepare_function_arguments,
 )
@@ -392,3 +394,27 @@ class TestToolExecution:
             prepare_function_arguments(
                 fnc=agent.mock_tool_in_agent, json_arguments='{"opt_arg2": "test2"}'
             )
+
+
+class TestNoParametersSchema:
+    """Test that functions with no parameters generate valid JSON schema with properties field."""
+
+    def test_legacy_schema_no_parameters(self):
+        """Test legacy schema for function with no parameters."""
+        # mock_tool_3 has no parameters
+        legacy_schema = build_legacy_openai_schema(mock_tool_3)
+        params = legacy_schema["function"]["parameters"]
+        assert "properties" in params, "properties field missing in legacy schema"
+        assert params["properties"] == {}, "properties should be empty dict"
+        assert "required" in params, "required field missing in legacy schema"
+        assert params["required"] == [], "required should be empty list"
+
+    def test_strict_schema_no_parameters(self):
+        """Test strict schema for function with no parameters."""
+        # mock_tool_3 has no parameters
+        strict_schema = build_strict_openai_schema(mock_tool_3)
+        params = strict_schema["function"]["parameters"]
+        assert "properties" in params, "properties field missing in strict schema"
+        assert params["properties"] == {}, "properties should be empty dict"
+        assert "required" in params, "required field missing in strict schema"
+        assert params["required"] == [], "required should be empty list"


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                      
   
  Fixes an issue where function tools with no parameters generate an invalid JSON schema for strict APIs like Groq.                                                                                                                                               
                                                                                                                                                                                                                                                                
  ## Problem                             

  When a function tool has no parameters (only `ctx: RunContext`), the generated JSON schema includes `required: []` but is missing `properties: {}`. This causes Groq API to reject requests with:

  invalid JSON schema for tool X, tools[N].function.parameters: 'required' present but 'properties' is missing

  ## Root Cause

  The fix in commit 6bdec2f (released in v1.4.0) was incomplete. It added `required: []` for functions with no parameters but did not add `properties: {}`.

  ## Solution

  Ensure both `properties` and `required` fields are always present in the generated schema:
  - `properties: {}` for empty parameter lists
  - `required: []` for no required parameters

  ## Changes

  - Modified `build_legacy_openai_schema()` in `livekit/agents/llm/utils.py`
  - Modified `build_strict_openai_schema()` in `livekit/agents/llm/utils.py`
  - Added test case for functions with no parameters in `tests/test_tools.py`

  ## Testing

  - [x] Added new test case `test_legacy_schema_no_parameters` and `test_strict_schema_no_parameters`
  - [x] All existing tests pass (`uv run pytest tests/test_tools.py`)
  - [x] Code formatted with `uv run ruff format`
  - [x] Linter passes with `uv run ruff check`
  - [x] Type checker passes with `make type-check`

  ## Verification

  Tested with Groq API - no more schema validation errors for function tools with no parameters.

  ## Related
  - Follow-up to commit: 6bdec2f