### PR TITLE
feat(google): add response_mime_type and response_schema params

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -81,7 +81,7 @@ class _LLMOptions:
     http_options: NotGivenOr[types.HttpOptions]
     seed: NotGivenOr[int]
     response_mime_type: NotGivenOr[str]
-    response_schema: NotGivenOr[types.SchemaUnion | type[llm_utils.ResponseFormatT]]
+    response_schema: NotGivenOr[types.SchemaUnion | type]
     safety_settings: NotGivenOr[list[types.SafetySettingOrDict]]
 
 
@@ -324,11 +324,17 @@ class LLM(llm.LLM):
             )
 
         if is_given(response_format):
-            extra["response_schema"] = to_response_format(response_format)
+            if isinstance(response_format, (dict, types.Schema)):
+                extra["response_schema"] = response_format
+            else:
+                extra["response_schema"] = to_response_format(response_format)
             extra["response_mime_type"] = "application/json"
         else:
             if is_given(self._opts.response_schema):
-                extra["response_schema"] = to_response_format(self._opts.response_schema)
+                if isinstance(self._opts.response_schema, (dict, types.Schema)):
+                    extra["response_schema"] = self._opts.response_schema
+                else:
+                    extra["response_schema"] = to_response_format(self._opts.response_schema)
                 extra["response_mime_type"] = (
                     self._opts.response_mime_type
                     if is_given(self._opts.response_mime_type)


### PR DESCRIPTION
Add instance-level output format control to the Google GenAI LLM plugin. Previously, structured output could only be configured per-call via the chat() method's response_format parameter. In scenarios where the LLM is consistently used to produce JSON responses (e.g. extracting structured data, building tool-calling pipelines), having to pass response_format on every chat() call is repetitive and error-prone.

In our scenario, the agent's prompt requires the model to output JSON, which is then parsed in the tts_node to let the agent read out the content, and send an RPC to the frontend, so we need instance-level control over the JSON output.

With these two new __init__ parameters:
- response_mime_type: controls the output MIME type (e.g. "application/json") without requiring a schema, useful for free-form JSON output.
- response_schema: constrains the JSON output to a specific structure (Pydantic model or Google SchemaUnion), automatically sets mime type to "application/json" if not explicitly provided.

The chat() response_format parameter still takes precedence when provided, preserving full backward compatibility.