### PR TITLE
feat(core): allow skip_reply when calling commit_user_turn

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1032,15 +1032,15 @@ class AgentActivity(RecognitionHooks):
             self._rt_session.clear_audio()
 
     def commit_user_turn(
-        self, *, transcript_timeout: float, stt_flush_duration: float
+        self, *, transcript_timeout: float, stt_flush_duration: float, skip_reply: bool = False
     ) -> asyncio.Future[str]:
-        skip_reply: bool = False
         if self._rt_session is not None:
-            # commit audio buffer and trigger response generation
+            # commit audio buffer and conditionally trigger response generation
+            self._rt_session.commit_audio()
+            if not skip_reply:
+                self._session.generate_reply()
             # `skip_reply` prevents duplicate reply from _on_user_turn_completed
             # but keeps flushing STT transcript into the chat context
-            self._rt_session.commit_audio()
-            self._session.generate_reply()
             skip_reply = True
 
         assert self._audio_recognition is not None
@@ -1530,6 +1530,12 @@ class AgentActivity(RecognitionHooks):
                         self._session._conversation_item_added(user_message)
                     return
                 self._rt_session.commit_audio()
+
+        if info.skip_reply:
+            if info.new_transcript != "":
+                self._agent._chat_ctx.items.append(user_message)
+                self._session._conversation_item_added(user_message)
+            return
 
         if (current_speech := self._current_speech) is not None:
             if not current_speech.allow_interruptions:

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1082,7 +1082,11 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         self._activity.clear_user_turn()
 
     def commit_user_turn(
-        self, *, transcript_timeout: float = 2.0, stt_flush_duration: float = 2.0
+        self,
+        *,
+        transcript_timeout: float = 2.0,
+        stt_flush_duration: float = 2.0,
+        skip_reply: bool = False,
     ) -> asyncio.Future[str]:
         """Commit the user turn and generate a reply.
 
@@ -1095,6 +1099,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 Increase this value if the STT is slow to respond.
             stt_flush_duration (float, optional): The duration of the silence to be appended to the STT
                 to flush the buffer and generate the final transcript.
+            skip_reply (bool, optional): Whether to skip the reply generation after committing the user turn.
 
         Returns:
             asyncio.Future[str]: A future that resolves with the audio transcript.
@@ -1106,7 +1111,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             raise RuntimeError("AgentSession isn't running")
 
         return self._activity.commit_user_turn(
-            transcript_timeout=transcript_timeout, stt_flush_duration=stt_flush_duration
+            transcript_timeout=transcript_timeout,
+            stt_flush_duration=stt_flush_duration,
+            skip_reply=skip_reply,
         )
 
     def update_agent(self, agent: Agent) -> None:


### PR DESCRIPTION
Expose skip_reply at session level for both realtime and cascading agents when calling commit_user_turn.

closes #5026

This can be tested with a RPC:

```
    @ctx.room.local_participant.register_rpc_method("commit_user_turn")
    async def on_commit_user_turn(data: rtc.RpcInvocationData) -> str:
        skip_reply = data.payload == "skip_reply"
        logger.info(f"RPC commit_user_turn called, skip_reply={skip_reply}")
        fut = session.commit_user_turn(skip_reply=skip_reply)
        transcript = await fut
        logger.info(f"Committed transcript: {transcript}")
        return transcript
```