### PR TITLE
chore(deepgram): update languages list per model family

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/models.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/models.py
@@ -1,4 +1,4 @@
-from typing import Literal, Union
+from typing import Literal
 
 DeepgramModels = Literal[
     "nova-general",
@@ -179,4 +179,4 @@ DeepgramNova2Languages = Literal[
     "zh-TW",
 ]
 
-DeepgramLanguages = Union[DeepgramNova3Languages, DeepgramNova2Languages]
+DeepgramLanguages = DeepgramNova3Languages | DeepgramNova2Languages


### PR DESCRIPTION
Align Deepgram language aliases with current model support

The Deepgram language list in the plugin was out of date. It also treated Nova-2 and Nova-3 as if they supported the same languages, which is no longer true based on the [current docs. ](https://developers.deepgram.com/docs/models-languages-overview)