### PR TITLE
fix: update_instructions() now reflected in tool call response generation

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2272,6 +2272,15 @@ class AgentActivity(RecognitionHooks):
             if fnc_executed_ev._reply_required:
                 chat_ctx.items.extend(tool_messages)
 
+                # refresh instructions in chat_ctx so that any update_instructions()
+                # calls made inside tool functions are reflected in the tool response
+                # generation (fixes #4242)
+                update_instructions(
+                    chat_ctx,
+                    instructions=self._agent._instructions,
+                    add_if_missing=False,
+                )
+
                 tool_response_task = self._create_speech_task(
                     self._pipeline_reply_task(
                         speech_handle=speech_handle,


### PR DESCRIPTION
## Summary

- Fixes #4242: when `update_instructions()` is called inside a function tool, the updated instructions are now used for the subsequent tool response generation
- Before this fix, the chat context was snapshotted before tool execution, so any instruction updates made during tool execution were lost for the current turn's response
- The fix refreshes the instructions in `chat_ctx` from `agent._instructions` right before generating the tool response

## Context

Maintainer @longcw confirmed this is unexpected behavior:
> "it makes sense to add a `update_instructions` for this turn in a function tool"
> "no, it's not expected"

## Changes

In `agent_activity.py`, added a call to `update_instructions()` to refresh the chat context's instructions from the agent's current `_instructions` before the recursive `_pipeline_reply_task` call that generates the tool response. This ensures that any `update_instructions()` calls made inside function tools are reflected in the LLM's response generation for the current turn.

## Test plan

- [ ] Verify that calling `agent.update_instructions()` inside a `@function_tool` updates the instructions used for the current turn's response
- [ ] Verify that normal (non-tool) instruction updates continue to work as before
- [ ] Verify that instructions persist correctly across multiple tool call steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)