### PR TITLE
fix: preserve 'type' field in TaskGroup JSON schema enum items

### DIFF
--- a/livekit-agents/livekit/agents/beta/workflows/task_group.py
+++ b/livekit-agents/livekit/agents/beta/workflows/task_group.py
@@ -170,7 +170,7 @@ class TaskGroup(AgentTask[TaskGroupResult]):
                 list[str],
                 Field(
                     description="The IDs of the tasks requested",
-                    json_schema_extra={"items": {"enum": list(task_ids)}},
+                    json_schema_extra={"items": {"type": "string", "enum": list(task_ids)}},
                 ),
             ],
         ) -> None:


### PR DESCRIPTION
## Summary

Fixes #5044 — The `json_schema_extra` override in `task_group.py` (line 173) replaces the `items` sub-schema entirely, dropping `"type": "string"`. This causes Gemini API to reject the schema with a 400 `INVALID_ARGUMENT` error since it requires explicit `type` on every schema node.

- Adds `"type": "string"` alongside `"enum"` in the `items` sub-schema
- The Google plugin (`_GeminiJsonSchema._simplify()`) has a downstream workaround that infers `type` from enum values, so this may not reproduce on 1.4.x with the Google plugin (per @davidzhao's question) — but the source schema should still be correct
- One-line fix, no behavioral change for providers that already tolerate missing `type`

## Test plan

- [ ] Verify generated JSON schema for `out_of_scope` tool includes `{"type": "array", "items": {"type": "string", "enum": [...]}}` 
- [ ] Confirm Gemini API no longer returns 400 when using TaskGroup workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)