### PR TITLE
fix(eou): only reset speech/speaking time when no new speech

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -669,9 +669,12 @@ class AudioRecognition:
                 # clear the transcript if the user turn was committed
                 self._audio_transcript = ""
                 self._final_transcript_confidence = []
-                self._last_speaking_time = None
                 self._last_final_transcript_time = None
-                self._speech_start_time = None
+                # concurrent user speech might have changed it
+                # only reset if there is no new speech
+                if self._last_speaking_time == last_speaking_time:
+                    self._speech_start_time = None
+                    self._last_speaking_time = None
 
             self._user_turn_committed = False
 


### PR DESCRIPTION
Only resets user speech-related timestamps when there is no new speech when committing a turn, by comparing the captured `last_speaking_time` and the latest `self._last_speaking_time`