### PR TITLE
fix(sarvam-tts): correct mime_type from audio/mp3 to audio/wav

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -667,7 +667,7 @@ class ChunkedStream(tts.ChunkedStream):
                     request_id=request_id or "unknown",
                     sample_rate=self._tts.sample_rate,
                     num_channels=self._tts.num_channels,
-                    mime_type="audio/mp3",
+                    mime_type="audio/wav",
                 )
                 # handle multiple audio chunks
                 for b64 in audios:
@@ -707,7 +707,7 @@ class SynthesizeStream(tts.SynthesizeStream):
             request_id=request_id,
             sample_rate=self._opts.speech_sample_rate,
             num_channels=1,
-            mime_type="audio/mp3",
+            mime_type="audio/wav",
             stream=True,
             frame_size_ms=50,
         )


### PR DESCRIPTION
## Summary

The Sarvam TTS API returns **WAV (RIFF) audio data**, but the plugin declares `mime_type="audio/mp3"` in both `ChunkedStream` (line 670) and `SynthesizeStream` (line 710). This causes the LiveKit audio decoder to attempt MP3 decoding on WAV data, resulting in:

```
av.error.InvalidDataError: Invalid data found when processing input: 'avcodec_send_packet()'
```

followed by:

```
APIError: no audio frames were pushed for text: <text>
```

This affects **all** Sarvam TTS models (`bulbul:v2`, `bulbul:v3-beta`, `bulbul:v3`).

## Root cause

Verified by calling the Sarvam REST API directly and inspecting the raw response:

```python
raw = base64.b64decode(audios[0])
raw[:4]  # b'RIFF' — WAV header, not MP3
```

All models and sample rates (8000, 16000, 22050, 24000) return RIFF/WAV audio.

## Fix

Change `mime_type="audio/mp3"` → `mime_type="audio/wav"` in both:
- `ChunkedStream._run()` (HTTP batch path)
- `SynthesizeStream._run()` (WebSocket streaming path)

## Test plan

- [x] Tested with `bulbul:v2` (anushka, en-IN) — audio decodes correctly
- [x] Tested with `bulbul:v3` (shubh, hi-IN) — audio decodes correctly
- [x] Tested with `bulbul:v3` (ritu, en-IN) — audio decodes correctly
- [x] Tested with `bulbul:v3` + temperature=0.3 — audio decodes correctly
- [x] Tested with `bulbul:v3` + enable_preprocessing=True — audio decodes correctly