### PR TITLE
(google realtime): replace deprecated mediaChunks

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -925,7 +925,9 @@ class RealtimeSession(llm.RealtimeSession):
                         types.LiveClientRealtimeInput,
                     ),
                 ):
-                    if not isinstance(msg, types.LiveClientRealtimeInput) or not (msg.audio or msg.video or msg.text):
+                    if not isinstance(msg, types.LiveClientRealtimeInput) or not (
+                        msg.audio or msg.video or msg.text
+                    ):
                         logger.debug(
                             f">>> sent {type(msg).__name__}",
                             extra={"content": msg.model_dump(exclude_defaults=True)},


### PR DESCRIPTION
`mediaChunks` is deprecated, use `audio`, `video` , and `text` instead

[reference](https://ai.google.dev/api/live#bidigeneratecontentrealtimeinput)