### PR TITLE
fix(openai): only reuse previous_response_id when pending tool calls are completed

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -14,7 +14,7 @@ import openai
 from livekit.agents import APIConnectionError, APIStatusError, APITimeoutError, llm, utils
 from livekit.agents.inference.llm import drop_unsupported_params
 from livekit.agents.llm import ToolChoice
-from livekit.agents.llm.chat_context import ChatContext
+from livekit.agents.llm.chat_context import ChatContext, ChatItem
 from livekit.agents.llm.tool_context import (
     Tool,
 )
@@ -199,6 +199,7 @@ class LLM(llm.LLM):
         self._parallel_generation: bool = False
         self._prev_resp_id = ""
         self._prev_chat_ctx: ChatContext | None = None
+        self._pending_tool_calls = set[str]()  # tool call ids that are pending for a response
 
         if use_websocket:
             resolved_api_key = api_key if is_given(api_key) else os.environ.get("OPENAI_API_KEY")
@@ -308,7 +309,9 @@ class LLM(llm.LLM):
             and self._prev_resp_id
         ):
             n = len(self._prev_chat_ctx.items)
-            if ChatContext(items=chat_ctx.items[:n]).is_equivalent(self._prev_chat_ctx):
+            if ChatContext(items=chat_ctx.items[:n]).is_equivalent(
+                self._prev_chat_ctx
+            ) and self._pending_tool_calls_completed(chat_ctx.items[n:]):
                 # send only the new items appended since the last response
                 input_chat_ctx = ChatContext(items=chat_ctx.items[n:])
                 extra["previous_response_id"] = self._prev_resp_id
@@ -324,6 +327,15 @@ class LLM(llm.LLM):
             extra_kwargs=extra,
             full_chat_ctx=chat_ctx,
         )
+
+    def _pending_tool_calls_completed(self, items: list[ChatItem]) -> bool:
+        if not self._pending_tool_calls:
+            return True
+
+        completed_tool_calls = {
+            item.call_id for item in items if item.type == "function_call_output"
+        }
+        return all(call_id in completed_tool_calls for call_id in self._pending_tool_calls)
 
 
 class LLMStream(llm.LLMStream):
@@ -345,6 +357,8 @@ class LLMStream(llm.LLMStream):
         self._strict_tool_schema = strict_tool_schema
         self._response_id: str = ""
         self._response_completed: bool = False
+        self._pending_tool_calls = set[str]()
+
         self._client = client
         self._llm: LLM = llm
         self._extra_kwargs = drop_unsupported_params(model, extra_kwargs)
@@ -494,6 +508,7 @@ class LLMStream(llm.LLMStream):
         self._response_completed = True
         self._llm._prev_chat_ctx = self._full_chat_ctx
         self._llm._prev_resp_id = self._response_id
+        self._llm._pending_tool_calls = self._pending_tool_calls
 
         chunk = None
         if usage := event.response.usage:
@@ -527,6 +542,7 @@ class LLMStream(llm.LLMStream):
                     ],
                 ),
             )
+            self._pending_tool_calls.add(event.item.call_id)
         return chunk
 
     def _handle_response_output_text_delta(


### PR DESCRIPTION
fix https://github.com/livekit/agents/issues/5092