### PR TITLE
fix(stt): reset VAD when STT sends EOT

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -483,7 +483,11 @@ class AudioRecognition:
             with trace.use_span(self._ensure_user_turn_span()):
                 self._hooks.on_end_of_speech(None)
 
+            # STT EOT changes user state from speaking to listening without updating VAD internal states
+            # VAD EOS will also skip updating user state from listening (STT enforced) to listening (VAD detected)
+            # and user state won't be updated until a new VAD SOS is received
             # reset VAD so that incorrect end of turn from STT can be corrected by VAD interruption
+            # if user is still speaking (an immediate VAD SOS will interrupt the agent)
             if self._vad:
                 if self._speaking:
                     logger.warning(


### PR DESCRIPTION
This allows VAD to start interrupting if STT sends a premature EOT.

When turn_detection is set to STT, an EOT from STT will force to change user state from speaking to listening, while VAD internal state is unchanged. This would skip any path for VAD-based interruption (including adaptive interruption) unless VAD picks up a new SOS/EOS.