### PR TITLE
Separate extra instructions from core agent instructions

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -64,6 +64,7 @@ from .generation import (
     _AudioOutput,
     _TextOutput,
     _TTSGenerationData,
+    add_extra_instructions,
     apply_instructions_modality,
     perform_audio_forwarding,
     perform_llm_inference,
@@ -949,11 +950,15 @@ class AgentActivity(RecognitionHooks):
             )
 
         elif isinstance(self.llm, llm.LLM):
-            # instructions used inside generate_reply are "extra" instructions.
-            # this matches the behavior of the Realtime API:
+            # generate_reply instructions are "extra" instructions that should be kept
+            # separate from the agent's core instructions. This matches the behavior of
+            # the Realtime API:
             # https://platform.openai.com/docs/api-reference/realtime-client-events/response/create
-            if instructions:
-                instructions = self._agent.instructions + "\n" + instructions
+            #
+            # By adding extra_instructions at the END of the chat context (instead of
+            # modifying the first system message), the model can better distinguish between
+            # "core behavior" and "one-off task instructions" as the context grows.
+            extra_instructions = instructions if instructions else None
 
             task = self._create_speech_task(
                 self._pipeline_reply_task(
@@ -961,7 +966,7 @@ class AgentActivity(RecognitionHooks):
                     chat_ctx=chat_ctx or self._agent._chat_ctx,
                     tools=tools,
                     new_message=user_message if is_given(user_message) else None,
-                    instructions=instructions or None,
+                    extra_instructions=extra_instructions,
                     model_settings=ModelSettings(
                         tool_choice=tool_choice
                         if utils.is_given(tool_choice) or self._tool_choice is None
@@ -1898,7 +1903,7 @@ class AgentActivity(RecognitionHooks):
         tools: list[llm.Tool | llm.Toolset],
         model_settings: ModelSettings,
         new_message: llm.ChatMessage | None = None,
-        instructions: str | Instructions | None = None,
+        extra_instructions: str | Instructions | None = None,
         _previous_user_metrics: llm.MetricsReport | None = None,
         _previous_tools_messages: Sequence[llm.FunctionCall | llm.FunctionCallOutput] | None = None,
     ) -> None:
@@ -1916,7 +1921,7 @@ class AgentActivity(RecognitionHooks):
                 tools=tools,
                 model_settings=model_settings,
                 new_message=new_message,
-                instructions=instructions,
+                extra_instructions=extra_instructions,
                 _previous_user_metrics=_previous_user_metrics,
                 _previous_tools_messages=_previous_tools_messages,
             )
@@ -1929,7 +1934,7 @@ class AgentActivity(RecognitionHooks):
         tools: list[llm.Tool | llm.Toolset],
         model_settings: ModelSettings,
         new_message: llm.ChatMessage | None = None,
-        instructions: str | Instructions | None = None,
+        extra_instructions: str | Instructions | None = None,
         _previous_user_metrics: llm.MetricsReport | None = None,
         _previous_tools_messages: Sequence[llm.FunctionCall | llm.FunctionCallOutput] | None = None,
     ) -> None:
@@ -1937,8 +1942,8 @@ class AgentActivity(RecognitionHooks):
 
         current_span = trace.get_current_span(context=speech_handle._agent_turn_context)
         current_span.set_attribute(trace_types.ATTR_SPEECH_ID, speech_handle.id)
-        if instructions is not None:
-            current_span.set_attribute(trace_types.ATTR_INSTRUCTIONS, instructions)
+        if extra_instructions is not None:
+            current_span.set_attribute(trace_types.ATTR_INSTRUCTIONS, extra_instructions)
         if new_message:
             current_span.set_attribute(trace_types.ATTR_USER_INPUT, new_message.text_content or "")
 
@@ -1957,14 +1962,24 @@ class AgentActivity(RecognitionHooks):
         if new_message is not None:
             chat_ctx.insert(new_message)
 
-        if instructions is not None:
-            try:
-                update_instructions(chat_ctx, instructions=instructions, add_if_missing=True)
-            except ValueError:
-                logger.exception("failed to update the instructions")
+        # Always ensure the agent's core instructions are set in the first system message.
+        # This happens regardless of whether extra_instructions are provided.
+        try:
+            update_instructions(
+                chat_ctx, instructions=self._agent.instructions, add_if_missing=True
+            )
+        except ValueError:
+            logger.exception("failed to update the instructions")
 
         # apply the correct variant of the instructions for the turn's input modality
         apply_instructions_modality(chat_ctx, modality=speech_handle.input_details.modality)
+
+        # If extra_instructions (from generate_reply) are provided, add them as a
+        # separate system message at the END of the context. This keeps the agent's
+        # core instructions separate from one-off task instructions, preventing the
+        # model from getting confused as the context grows larger.
+        if extra_instructions is not None:
+            add_extra_instructions(chat_ctx, instructions=extra_instructions)
 
         # TODO(theomonnom): since pause is closing STT/LLM/TTS, we have issues for SpeechHandle still in queue  # noqa: E501
         # I should implement a retry mechanism?

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -853,3 +853,46 @@ def remove_instructions(chat_ctx: ChatContext) -> None:
             chat_ctx.items.remove(msg)
         else:
             break
+
+
+EXTRA_INSTRUCTIONS_MESSAGE_ID = "lk.generate_reply.extra_instructions"
+"""
+The ID of the extra instructions message added at the end of the chat context.
+Used by generate_reply to keep task-specific instructions isolated from core agent instructions.
+"""
+
+
+def add_extra_instructions(
+    chat_ctx: ChatContext, *, instructions: str | Instructions
+) -> llm.ChatMessage:
+    """
+    Add extra instructions as a new system message at the END of the chat context.
+
+    This is used by generate_reply to add task-specific instructions that are kept
+    separate from the agent's core instructions. By placing these at the end of the
+    context (right before the LLM call), the model can better distinguish between
+    "core behavior" (defined at the start) and "one-off task instructions".
+
+    Returns:
+        The ChatMessage that was added to the context.
+    """
+    # Remove any existing extra instructions first
+    remove_extra_instructions(chat_ctx)
+
+    # Add the new extra instructions at the end
+    msg = llm.ChatMessage(
+        id=EXTRA_INSTRUCTIONS_MESSAGE_ID,
+        role="system",
+        content=[instructions],
+    )
+    chat_ctx.items.append(msg)
+    return msg
+
+
+def remove_extra_instructions(chat_ctx: ChatContext) -> None:
+    """Remove the extra instructions message from the chat context."""
+    while True:
+        if msg := chat_ctx.get_by_id(EXTRA_INSTRUCTIONS_MESSAGE_ID):
+            chat_ctx.items.remove(msg)
+        else:
+            break

--- a/tests/fake_llm.py
+++ b/tests/fake_llm.py
@@ -115,10 +115,24 @@ class FakeLLMStream(LLMStream):
         )
 
     def _get_index_text(self) -> str:
+        from livekit.agents.voice.generation import EXTRA_INSTRUCTIONS_MESSAGE_ID
+
         assert self.chat_ctx.items
         items = self.chat_ctx.items
 
-        # for generate_reply(instructions=...)
+        # for generate_reply(instructions=...) - check for extra instructions message at end
+        # (new pattern: separate system message with EXTRA_INSTRUCTIONS_MESSAGE_ID)
+        for item in reversed(items):
+            if (
+                item.type == "message"
+                and item.role == "system"
+                and item.id == EXTRA_INSTRUCTIONS_MESSAGE_ID
+            ):
+                # Found the extra instructions message, return the content as-is
+                # (the test passes the full key including "instructions:" prefix)
+                return item.text_content
+
+        # for generate_reply(instructions=...) - legacy pattern: appended to first system message
         for item in items:
             if item.type == "message" and item.role == "system":
                 contents = item.text_content.split("\n")


### PR DESCRIPTION
## Summary
Refactored how extra instructions from `generate_reply()` are handled to keep them separate from the agent's core instructions. Instead of concatenating extra instructions with core instructions in the first system message, they are now added as a distinct system message at the end of the chat context, matching the behavior of OpenAI's Realtime API.

## Key Changes
- **New function `add_extra_instructions()`**: Adds task-specific instructions as a separate system message at the end of the chat context with a dedicated message ID (`EXTRA_INSTRUCTIONS_MESSAGE_ID`)
- **New function `remove_extra_instructions()`**: Removes any existing extra instructions message before adding new ones
- **Refactored `_pipeline_reply_task_impl()`**: 
  - Now always ensures core agent instructions are set in the first system message
  - Applies modality-specific instruction variants
  - Adds extra instructions (if provided) as a separate message at the end
- **Updated parameter naming**: Changed `instructions` parameter to `extra_instructions` throughout the call chain to clarify intent
- **Updated test helper**: Modified `fake_llm.py` to check for the new extra instructions message pattern while maintaining backward compatibility with the legacy pattern

## Implementation Details
- Extra instructions are now isolated from core instructions, allowing the model to better distinguish between "core behavior" (defined at the start) and "one-off task instructions" as context grows
- The extra instructions message uses a consistent ID (`lk.generate_reply.extra_instructions`) for easy identification and removal
- Core instructions are always applied first, followed by modality-specific variants, then extra instructions—ensuring proper instruction hierarchy
- This change aligns with OpenAI's Realtime API design pattern for handling dynamic instructions

https://claude.ai/code/session_01Mnk2UKbXB4LFnzaTdw1Rgh