### PR TITLE
fix: prevent _cancel_speech_pause from poisoning subsequent user turns

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2859,7 +2859,13 @@ class AgentActivity(RecognitionHooks):
         self, old_task: asyncio.Task[None] | None = None, *, interrupt: bool = True
     ) -> None:
         if old_task is not None:
-            await old_task
+            try:
+                await old_task
+            except Exception:
+                # Don't let a failed prior task poison subsequent turn completions.
+                # This can happen when _wait_for_generation raises because
+                # the paused speech had no active generation (race condition).
+                logger.debug("previous _cancel_speech_pause task failed, ignoring")
 
         if self._false_interruption_timer is not None:
             self._false_interruption_timer.cancel()
@@ -2874,8 +2880,11 @@ class AgentActivity(RecognitionHooks):
             and self._paused_speech.allow_interruptions
         ):
             self._paused_speech.interrupt()
-            # ensure the generation is done
-            await self._paused_speech._wait_for_generation()
+            # ensure the generation is done — but only if a generation
+            # was actually started; a paused speech that was never
+            # authorized won't have an active generation future.
+            if self._paused_speech._generations:
+                await self._paused_speech._wait_for_generation()
         self._paused_speech = None
 
         if self._session.options.resume_false_interruption and self._session.output.audio:


### PR DESCRIPTION
## Summary

Fixes a race condition where `_cancel_speech_pause` can permanently break user-turn processing, causing the assistant to silently stop replying.

## Problem

When a user interrupts paused speech that has **no active generation** (e.g., the generation was never authorized or was cancelled before starting), `_wait_for_generation()` raises:

```
RuntimeError: cannot use wait_for_generation: no active generation is running.
```

This error bubbles up from `_cancel_speech_pause` and poisons the `_cancel_speech_pause_task`. Since subsequent tasks chain on the prior task via `await old_task`, the RuntimeError re-raises in every subsequent call, permanently breaking user-turn completion.

**Impact**: User speech is transcribed (STT events arrive) but the turn is never committed to chat context and no assistant reply is generated — for the current turn *and all future turns*.

## Root Cause

In `_cancel_speech_pause`:

1. `await old_task` — re-raises any error from a previously failed task
2. `await self._paused_speech._wait_for_generation()` — raises `RuntimeError` if `self._generations` is empty

A paused speech handle with an empty `_generations` list triggers (2), which then triggers (1) on every subsequent call.

## Fix

Two changes to `_cancel_speech_pause`:

1. **Guard `_wait_for_generation()`**: Only call it when `self._paused_speech._generations` is non-empty. This prevents the RuntimeError from being raised in the first place.

2. **Catch errors from `await old_task`**: Wrap it in try/except so a single failed task doesn't permanently poison the task chain. The error is logged at debug level and subsequent turns can proceed normally.

## Testing

The fix is defensive — it prevents an uncaught exception from a known race condition. The scenario requires specific timing between STT events, pause/resume, and generation authorization that is difficult to unit-test deterministically. The fix follows the same defensive pattern used in `_mark_done()` (which uses `contextlib.suppress` for similar edge cases).

Closes #5100