### PR TITLE
feat(assemblyai): expose session ID from Begin event

### DIFF
--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -277,6 +277,21 @@ class SpeechStream(stt.SpeechStream):
         self._speech_duration: float = 0
         self._last_preflight_start_time: float = 0
         self._config_update_queue: asyncio.Queue[dict] = asyncio.Queue()
+        self._session_id: str | None = None
+        self._expires_at: int | None = None
+
+    @property
+    def session_id(self) -> str | None:
+        """The AssemblyAI session ID. Set when the WebSocket connection is established
+        (before any speech events). None until the connection completes.
+        Share this with the AssemblyAI team when reporting issues."""
+        return self._session_id
+
+    @property
+    def expires_at(self) -> int | None:
+        """Unix timestamp when the AssemblyAI session expires. Set alongside session_id
+        when the WebSocket connection is established."""
+        return self._expires_at
 
     def update_options(
         self,
@@ -487,6 +502,16 @@ class SpeechStream(stt.SpeechStream):
 
     def _process_stream_event(self, data: dict) -> None:
         message_type = data.get("type")
+
+        if message_type == "Begin":
+            self._session_id = data.get("id")
+            self._expires_at = data.get("expires_at")
+            logger.info(
+                "AssemblyAI session started id=%s expires_at=%s",
+                self._session_id,
+                self._expires_at,
+            )
+            return
 
         if message_type == "SpeechStarted":
             self._event_ch.send_nowait(stt.SpeechEvent(type=stt.SpeechEventType.START_OF_SPEECH))


### PR DESCRIPTION
## Summary

- Parses the `Begin` event from the AssemblyAI WebSocket connection, which was previously silently dropped
- Exposes `session_id` and `expires_at` as properties on `SpeechStream`
- Logs the session ID at `INFO` level on connect for easy debugging

## Motivation

The AssemblyAI streaming API sends a `Begin` event when a session starts containing a unique session ID. Exposing this makes it easy for users to share the session ID with the AssemblyAI team when reporting transcription issues.

## Usage

```python
stream = stt.stream()

async for event in stream:
    # session_id is set before any speech events arrive
    print(stream.session_id)   # e.g. "676d673c-83fc-4d8a-bd95-bfe23b1c5a50"
    print(stream.expires_at)   # e.g. 1773775624
    ...
```

The session ID is also automatically logged:
```
AssemblyAI session started id=676d673c-83fc-4d8a-bd95-bfe23b1c5a50 expires_at=1773775624
```

## Test plan

- [ ] Verify `session_id` and `expires_at` are `None` before connection
- [ ] Verify both properties are populated after the first event from a live stream
- [ ] Verify session ID appears in logs at INFO level on connect