### PR TITLE
Remove Gemini 2.0 models from inference gateway types

### DIFF
--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -101,8 +101,6 @@ GoogleModels = Literal[
     "google/gemini-2.5-pro",
     "google/gemini-2.5-flash",
     "google/gemini-2.5-flash-lite",
-    "google/gemini-2.0-flash",
-    "google/gemini-2.0-flash-lite",
 ]
 
 KimiModels = Literal["moonshotai/kimi-k2-instruct"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Gemini 2.0 Flash and Gemini 2.0 Flash Lite models have been removed from the LiveKit inference gateway. This PR removes `"google/gemini-2.0-flash"` and `"google/gemini-2.0-flash-lite"` from the `GoogleModels` Literal type in `livekit-agents/livekit/agents/inference/llm.py` to match the current gateway availability.

Note: The Gemini 2.0 references in the Google and OpenAI *plugins* are left intact, as those access the models directly via provider APIs rather than through the inference gateway.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://live-kit.slack.com/archives/C07TWVC0W4A/p1773785238274849?thread_ts=1773785238.274849&cid=C07TWVC0W4A)

<div><a href="https://cursor.com/agents/bc-bfb8d54b-58fd-5e22-b542-2feee763a773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfb8d54b-58fd-5e22-b542-2feee763a773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

