### PR TITLE
fix: strip empty {} entries from anyOf/oneOf in strict JSON schema

### DIFF
--- a/livekit-agents/livekit/agents/llm/_strict.py
+++ b/livekit-agents/livekit/agents/llm/_strict.py
@@ -75,21 +75,26 @@ def _ensure_strict_json_schema(
     if is_dict(items):
         json_schema["items"] = _ensure_strict_json_schema(items, path=(*path, "items"), root=root)
 
-    # unions
-    any_of = json_schema.get("anyOf")
-    if is_list(any_of):
-        json_schema["anyOf"] = [
-            _ensure_strict_json_schema(variant, path=(*path, "anyOf", str(i)), root=root)
-            for i, variant in enumerate(any_of)
-        ]
-
-    # unions (oneOf)
-    one_of = json_schema.get("oneOf")
-    if is_list(one_of):
-        json_schema["oneOf"] = [
-            _ensure_strict_json_schema(variant, path=(*path, "oneOf", str(i)), root=root)
-            for i, variant in enumerate(one_of)
-        ]
+    # unions (anyOf / oneOf)
+    # Strip empty schema objects ({}) — they are JSON Schema's identity element
+    # for anyOf (match anything) and cause OpenAI strict mode to reject the schema.
+    # Common when Union[..., Any] or ForwardRef patterns produce bare {} entries.
+    for union_key in ("anyOf", "oneOf"):
+        variants = json_schema.get(union_key)
+        if is_list(variants):
+            variants = [v for v in variants if v != {}]
+            if len(variants) == 1:
+                json_schema.update(
+                    _ensure_strict_json_schema(variants[0], path=(*path, union_key, "0"), root=root)
+                )
+                json_schema.pop(union_key, None)
+            elif len(variants) >= 2:
+                json_schema[union_key] = [
+                    _ensure_strict_json_schema(variant, path=(*path, union_key, str(i)), root=root)
+                    for i, variant in enumerate(variants)
+                ]
+            else:
+                json_schema.pop(union_key, None)
 
     # intersections
     all_of = json_schema.get("allOf")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,5 +1,6 @@
 import enum
-from typing import Literal
+import json
+from typing import Any, Literal
 
 import pytest
 from pydantic import BaseModel, Field
@@ -447,3 +448,52 @@ class TestStrictJsonSchema:
         status = schema["properties"]["status"]
         assert None not in status["enum"], f"enum should not contain None: {status}"
         assert "null" not in status.get("type", []), f"type should not contain 'null': {status}"
+
+
+class _OpenEnumModel(BaseModel):
+    """Simulates a codegen'd "open enum" pattern (e.g. Fern Python SDK).
+    Union[Literal["a", "b"], Any] produces an anyOf with a bare {} entry."""
+
+    preference: Literal["a", "b"] | Any | None = None
+
+
+class _NestedOpenEnumModel(BaseModel):
+    items: list[_OpenEnumModel]
+
+
+def _has_empty_schema(schema: object) -> bool:
+    """Recursively check if any dict in the schema tree is an empty {}."""
+    if isinstance(schema, dict):
+        if schema == {}:
+            return True
+        return any(_has_empty_schema(v) for v in schema.values())
+    if isinstance(schema, list):
+        return any(_has_empty_schema(v) for v in schema)
+    return False
+
+
+class TestEmptySchemaStripping:
+    """Test that empty {} entries are stripped from anyOf/oneOf."""
+
+    def test_open_enum_strips_empty_anyof(self):
+        schema = to_strict_json_schema(_OpenEnumModel)
+        assert not _has_empty_schema(schema), (
+            f"schema should not contain empty {{}}: {json.dumps(schema, indent=2)}"
+        )
+
+    def test_nested_open_enum_strips_empty_anyof(self):
+        schema = to_strict_json_schema(_NestedOpenEnumModel)
+        assert not _has_empty_schema(schema), (
+            f"nested schema should not contain empty {{}}: {json.dumps(schema, indent=2)}"
+        )
+
+    def test_single_variant_after_strip_is_unwrapped(self):
+        """When stripping {} leaves a single variant, anyOf should be unwrapped."""
+        schema = to_strict_json_schema(_OpenEnumModel)
+        pref = schema["properties"]["preference"]
+        # After stripping {}, the union should be simplified (no single-element anyOf)
+        any_of = pref.get("anyOf")
+        if any_of is not None:
+            assert len(any_of) != 1, (
+                f"single-element anyOf should be unwrapped: {json.dumps(pref, indent=2)}"
+            )


### PR DESCRIPTION
## Summary
- Strip empty `{}` schema objects from `anyOf`/`oneOf` arrays in `_ensure_strict_json_schema`
- Unwrap single-element `anyOf`/`oneOf` after stripping (analogous to existing `allOf` handling)
- Fix ruff lint violations from #5134

Fixes #5130
Supersedes #5134

## Context

When a Pydantic model field is typed as `Union[Literal[...], Any]` (common in codegen clients like Fern for forward-compatible "open enums"), `model_json_schema()` produces an `anyOf` containing a bare `{}` entry. OpenAI's strict mode rejects schemas containing `{}` because it lacks a type field.

`{}` is the JSON Schema identity element for `anyOf` (matches anything), so removing it is semantically neutral.

## Changes

- **`livekit-agents/livekit/agents/llm/_strict.py`**: Unified `anyOf`/`oneOf` handling into a single loop that filters `{}` entries and unwraps single-variant unions
- **`tests/test_tools.py`**: Added `TestEmptySchemaStripping` with tests for open enum models, nested models, and single-variant unwrapping

## Test plan
- [x] `uv run pytest tests/test_tools.py` — all 27 tests pass
- [x] `ruff check` and `ruff format` pass
- [ ] CI green

Based on work by @guoyangzhen in #5134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)