### PR TITLE
openai: add max_completion_tokens to with_azure()

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -210,6 +210,7 @@ class LLM(llm.LLM):
         reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
         top_p: NotGivenOr[float] = NOT_GIVEN,
         verbosity: NotGivenOr[Verbosity] = NOT_GIVEN,
+        max_completion_tokens: NotGivenOr[int] = NOT_GIVEN,
     ) -> LLM:
         """
         This automatically infers the following arguments from their corresponding environment variables if they are not provided:
@@ -249,6 +250,7 @@ class LLM(llm.LLM):
             prompt_cache_key=prompt_cache_key,
             top_p=top_p,
             verbosity=verbosity,
+            max_completion_tokens=max_completion_tokens,
         )
         llm._owns_client = True
         return llm


### PR DESCRIPTION
## Summary
- Add `max_completion_tokens` parameter to `LLM.with_azure()` static method, forwarding it to the `LLM` constructor
- This parameter was already supported by `LLM.__init__` and sent correctly to the Azure OpenAI API, but `with_azure()` didn't expose it

## Test plan
- [x] Verify `max_completion_tokens` is passed through `with_azure()` → `LLM.__init__` → `self._opts` → `chat.completions.create()`
- [x] Confirm Azure OpenAI API accepts `max_completion_tokens` (supported since api-version `2024-08-01-preview`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)