### PR TITLE
feat(llm): add remove_by_id helper to ChatContext

### DIFF
--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -415,6 +415,20 @@ class ChatContext:
     def index_by_id(self, item_id: str) -> int | None:
         return next((i for i, item in enumerate(self.items) if item.id == item_id), None)
 
+    def remove_by_id(self, item_id: str) -> ChatItem | None:
+        """Remove the first item with the given id.
+
+        Args:
+            item_id: The id of the item to remove.
+
+        Returns:
+            The removed ChatItem, or None if no item with that id exists.
+        """
+        idx = self.index_by_id(item_id)
+        if idx is None:
+            return None
+        return self._items.pop(idx)
+
     def copy(
         self,
         *,


### PR DESCRIPTION
Fixes #5085

Add a `remove_by_id` method to `ChatContext` that removes the first item matching the given id and returns the removed `ChatItem` (or `None` if not found).

This follows the existing pattern of `get_by_id` and `index_by_id` methods and aligns with Python conventions like `dict.pop()` and `list.pop()`.