### PR TITLE
feat(assemblyai): add DEBUG-level diagnostic logging

### DIFF
--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -517,10 +517,21 @@ class SpeechStream(stt.SpeechStream):
             self._event_ch.send_nowait(stt.SpeechEvent(type=stt.SpeechEventType.START_OF_SPEECH))
             return
 
+        if message_type == "Termination":
+            audio_duration = data.get("audio_duration_seconds")
+            session_duration = data.get("session_duration_seconds")
+            logger.debug(
+                "AssemblyAI session terminated audio_duration=%ss session_duration=%ss",
+                audio_duration,
+                session_duration,
+            )
+            return
+
         if message_type != "Turn":
             return
         words = data.get("words", [])
         end_of_turn = data.get("end_of_turn", False)
+        end_of_turn_confidence = data.get("end_of_turn_confidence")
         turn_is_formatted = data.get("turn_is_formatted", False)
         utterance = data.get("utterance", "")
         transcript = data.get("transcript", "")
@@ -570,6 +581,7 @@ class SpeechStream(stt.SpeechStream):
                 ],
             )
             self._event_ch.send_nowait(interim_event)
+            logger.debug("interim transcript end_of_turn_confidence=%s", end_of_turn_confidence)
 
         if utterance:
             if self._last_preflight_start_time == 0.0:
@@ -601,6 +613,7 @@ class SpeechStream(stt.SpeechStream):
                 ],
             )
             self._event_ch.send_nowait(final_event)
+            logger.debug("preflight transcript end_of_turn_confidence=%s", end_of_turn_confidence)
             self._last_preflight_start_time = end_time
 
         if end_of_turn and (
@@ -621,6 +634,15 @@ class SpeechStream(stt.SpeechStream):
                 ],
             )
             self._event_ch.send_nowait(final_event)
+            logger.debug("final transcript end_of_turn_confidence=%s", end_of_turn_confidence)
+
+            if words:
+                first_word_start = words[0].get("start", 0)
+                last_word_end = words[-1].get("end", 0)
+                logger.debug(
+                    "turn speech_duration=%.3fs (from word timestamps)",
+                    (last_word_end - first_word_start) / 1000,
+                )
 
             self._event_ch.send_nowait(stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH))
 


### PR DESCRIPTION
## Summary

- Log `end_of_turn_confidence` on every Turn event (interim, preflight, final)
- Compute and log per-turn speech duration from word timestamps on final transcripts
- Parse and log the `Termination` event (`audio_duration_seconds`, `session_duration_seconds`), which was previously silently dropped

All logging is at `DEBUG` level — no impact on existing behavior. Users opt in via:
```python
logging.getLogger("livekit.plugins.assemblyai").setLevel(logging.DEBUG)
```

## Motivation

Customer feedback requested visibility into `end_of_turn_confidence` and actual speech duration. The existing `audio_duration` in `RECOGNITION_USAGE` includes all audio sent to the stream (silence + speech), so 20s silence + 1s speech reports as 21s. The new `speech_duration` log uses word timestamps to report actual speech time.

## Example output

```
DEBUG - AssemblyAI session started id=d172d20c-... expires_at=1773877040
DEBUG - interim transcript end_of_turn_confidence=0
DEBUG - interim transcript end_of_turn_confidence=1.0
DEBUG - preflight transcript end_of_turn_confidence=1.0
DEBUG - final transcript end_of_turn_confidence=1.0
DEBUG - turn speech_duration=1.407s (from word timestamps)
DEBUG - AssemblyAI session terminated audio_duration=16s session_duration=15s
```

## Test plan

- [x] Existing tests pass (`pytest tests/test_plugin_assemblyai_stt.py`)
- [x] Lint and format checks pass
- [x] Manually verified debug output with live agent session