### PR TITLE
add remove() to ChatContext (#5085)

### DIFF
--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -415,6 +415,32 @@ class ChatContext:
     def index_by_id(self, item_id: str) -> int | None:
         return next((i for i, item in enumerate(self.items) if item.id == item_id), None)
 
+    def remove(self, items: ChatItem | str | Sequence[ChatItem | str]) -> list[ChatItem]:
+        """Remove items from the chat context by ChatItem or item ID.
+        Args:
+            items: A single ChatItem, item ID string, or a sequence of either.
+
+        Returns:
+            List of removed ChatItem objects.
+        """
+        if isinstance(items, str) or not isinstance(items, Sequence):
+            items = [items]
+
+        ids_to_remove: set[str] = set()
+        for item in items:
+            ids_to_remove.add(item if isinstance(item, str) else item.id)
+
+        removed: list[ChatItem] = []
+        kept: list[ChatItem] = []
+        for item in self._items:
+            if item.id in ids_to_remove:
+                removed.append(item)
+            else:
+                kept.append(item)
+
+        self._items = kept
+        return removed
+
     def copy(
         self,
         *,

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -438,7 +438,7 @@ class ChatContext:
             else:
                 kept.append(item)
 
-        self._items = kept
+        self._items[:] = kept
         return removed
 
     def copy(


### PR DESCRIPTION
Fixes #5085

`ChatContext` has `get_by_id()` and `index_by_id()` but no public way to remove items — users end up accessing `_items` directly.

This adds `remove()` that takes a ChatItem, ID string, or a list of either. Returns the removed items. API based on @tinalenguyen's suggestion in the issue.