### PR TITLE
Update xAI WebSocket URL for TTS service

### DIFF
--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/tts.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/tts.py
@@ -41,7 +41,7 @@ from .types import GrokVoices, TTSLanguages
 SAMPLE_RATE = 24000
 NUM_CHANNELS = 1
 
-XAI_WEBSOCKET_URL = "wss://api.x.ai/v1/realtime/audio/speech"
+XAI_WEBSOCKET_URL = "wss://api.x.ai/v1/tts"
 DEFAULT_VOICE = "ara"
 
 


### PR DESCRIPTION
Correct xAI TTS WebSocket URL
https://docs.x.ai/developers/model-capabilities/audio/text-to-speech#streaming-tts-websocket