### PR TITLE
Add full OpenRouter provider preferences schema

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
@@ -27,7 +27,10 @@ from . import realtime, responses, tools
 from .embeddings import EmbeddingData, create_embeddings
 from .llm import LLM, LLMStream
 from .models import (
+    OpenRouterMaxPrice,
+    OpenRouterPercentiles,
     OpenRouterProviderPreferences,
+    OpenRouterSortOption,
     OpenRouterWebPlugin,
     STTModels,
     TTSModels,
@@ -42,7 +45,10 @@ __all__ = [
     "TTS",
     "LLM",
     "LLMStream",
+    "OpenRouterMaxPrice",
+    "OpenRouterPercentiles",
     "OpenRouterProviderPreferences",
+    "OpenRouterSortOption",
     "OpenRouterWebPlugin",
     "STTModels",
     "TTSModels",

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Literal, TypedDict
 
@@ -329,6 +331,31 @@ class OpenRouterWebPlugin:
     id: str = "web"
 
 
+class OpenRouterSortOption(TypedDict, total=False):
+    """OpenRouter advanced sorting configuration with partition support."""
+
+    by: Literal["price", "throughput", "latency"]
+    partition: Literal["model", "none"]
+
+
+class OpenRouterPercentiles(TypedDict, total=False):
+    """Performance percentile thresholds for OpenRouter provider preferences."""
+
+    p50: float
+    p75: float
+    p90: float
+    p99: float
+
+
+class OpenRouterMaxPrice(TypedDict, total=False):
+    """Maximum acceptable pricing for OpenRouter provider preferences."""
+
+    prompt: float
+    completion: float
+    request: float
+    image: float
+
+
 class OpenRouterProviderPreferences(TypedDict, total=False):
     """OpenRouter provider routing preferences."""
 
@@ -338,6 +365,12 @@ class OpenRouterProviderPreferences(TypedDict, total=False):
     data_collection: Literal["allow", "deny"]
     only: list[str]
     ignore: list[str]
-    quantizations: list[str]
-    sort: Literal["price", "throughput", "latency"]
-    max_price: dict[str, float]
+    quantizations: list[
+        Literal["int4", "int8", "fp4", "fp6", "fp8", "fp16", "bf16", "fp32", "unknown"]
+    ]
+    sort: Literal["price", "throughput", "latency"] | OpenRouterSortOption
+    max_price: OpenRouterMaxPrice
+    zdr: bool
+    enforce_distillable_text: bool
+    preferred_min_throughput: float | OpenRouterPercentiles
+    preferred_max_latency: float | OpenRouterPercentiles


### PR DESCRIPTION
## Summary
- Expand `OpenRouterProviderPreferences` to cover the complete [OpenRouter provider routing API](https://openrouter.ai/docs/guides/routing/provider-selection)
- Add `OpenRouterSortOption` for [advanced sorting with partition](https://openrouter.ai/docs/guides/routing/provider-selection#advanced-sorting-with-partition) (`partition: "model" | "none"`)
- Add `OpenRouterPercentiles` for performance threshold fields (`p50`/`p75`/`p90`/`p99`)
- Add `OpenRouterMaxPrice` with typed pricing fields (`prompt`, `completion`, `request`, `image`)
- Add missing provider preference fields: `preferred_min_throughput`, `preferred_max_latency`, `zdr`, `enforce_distillable_text`
- Type `quantizations` with specific literal values instead of `list[str]`

## Test plan
- [x] `ruff check --fix` passes
- [x] `ruff format` passes
- [x] `mypy` passes (no new errors; 54 pre-existing errors unrelated to this change)
- [x] Type-only change (TypedDicts) — no runtime behavior to test