### PR TITLE
fix(turn-detector): relax transformers upper bound to allow 5.x

### DIFF
--- a/livekit-plugins/livekit-plugins-turn-detector/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-turn-detector/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "livekit-agents>=1.5.0",
-    "transformers>=4.47.1,<=4.57.1",  # transformers 4.57.2 has a bug with local_files_only=True
+    "transformers>=4.47.1,!=4.57.2,!=4.57.3",  # 4.57.2-4.57.3 have a bug with local_files_only=True (huggingface/transformers#42369)
     "numpy>=1.26",
     "onnxruntime>=1.18",
     "jinja2",


### PR DESCRIPTION
Replace the <=4.57.1 cap with targeted excludes for 4.57.2 and 4.57.3, which had a local_files_only=True regression (huggingface/transformers#42369). The bug was fixed in 4.57.4 (huggingface/transformers#42880), so versions 4.57.4+ and 5.x are safe.

The <=4.57.1 cap blocks the entire dependency tree from upgrading to transformers 5.x, which includes a security fix for PVE-2026-85102 (insecure deserialization in Trainer._load_rng_state).

Fixes livekit/agents#5173