### PR TITLE
Sarvam's WebSocket API decoder format mismatch

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -707,7 +707,7 @@ class SynthesizeStream(tts.SynthesizeStream):
             request_id=request_id,
             sample_rate=self._opts.speech_sample_rate,
             num_channels=1,
-            mime_type="audio/wav",
+            mime_type="audio/mp3",
             stream=True,
             frame_size_ms=50,
         )


### PR DESCRIPTION
## Summary
Fix mime_type mismatch in Sarvam TTS WebSocket streaming path. The `SynthesizeStream` class was declaring `audio/wav` but Sarvam's WebSocket API actually returns MP3 audio, causing the LiveKit WAV decoder to fail on MPEG bytes.

## Changes
- Changed `mime_type` from `"audio/wav"` to `"audio/mp3"` in `SynthesizeStream._run()`

## Notes
- The HTTP REST path (`ChunkedStream`) correctly handles WAV format
- The WebSocket path was incorrectly assuming the same format without verification
- This aligns with how other plugins (AWS, Resemble) handle MP3 streams