### PR TITLE
chore(mypy): enable mypy cache in type checking

### DIFF
--- a/scripts/check_types.py
+++ b/scripts/check_types.py
@@ -16,11 +16,6 @@ EXCLUDED_PLUGINS = [
     "rtzr",
 ]
 
-# Stub packages that mypy --install-types pulls in but that break our type checking
-EXCLUDED_STUBS = [
-    "scipy-stubs",
-]
-
 _TYPES_MARKER = ".mypy_cache/.types_installed"
 
 
@@ -68,6 +63,8 @@ def ensure_types_installed(repo_root: Path, pkg_args: list[str]) -> None:
     # Ensure pip is available (required for mypy --install-types)
     _run_or_exit(["uv", "pip", "install", "pip"], repo_root, "pip install")
 
+    # mypy --install-types installs type stubs but also runs the type checker (doubled runtime)
+    # https://github.com/python/mypy/issues/10600
     _run_or_exit(
         [
             "uv",
@@ -81,9 +78,6 @@ def ensure_types_installed(repo_root: Path, pkg_args: list[str]) -> None:
         repo_root,
         "mypy install types",
     )
-
-    # Remove stubs that break our type checking
-    _run_or_exit(["uv", "pip", "uninstall", *EXCLUDED_STUBS], repo_root, "pip uninstall stubs")
 
     marker.parent.mkdir(parents=True, exist_ok=True)
     marker.touch()

--- a/uv.lock
+++ b/uv.lock
@@ -4320,7 +4320,7 @@ name = "pyzmq"
 version = "26.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "python_full_version < '3.14' and implementation_name == 'pypy'" },
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/11/b9213d25230ac18a71b39b3723494e57adebe36e066397b961657b3b41c1/pyzmq-26.4.0.tar.gz", hash = "sha256:4bd13f85f80962f91a651a7356fe0472791a5f7a92f227822b5acf44795c626d", size = 278293, upload-time = "2025-04-04T12:05:44.049Z" }
 wheels = [


### PR DESCRIPTION
This makes subsequent runs much faster: 3s vs 34s by caching mypy type dependencies.

Also removed the `scipy-stubs` workaround since it doesn't seem to cause any issues anymore in either 3.10 or 3.14.