### PR TITLE
fix(llm): surface validation error details to LLM on function call argument failures

### DIFF
--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -17,6 +17,7 @@ from typing import (
     get_type_hints,
 )
 
+import pydantic
 from pydantic import BaseModel, TypeAdapter, create_model
 from pydantic.fields import Field, FieldInfo
 from pydantic_core import PydanticUndefined, from_json
@@ -28,7 +29,7 @@ from ..log import logger
 from ..utils import images
 from . import _strict
 from .chat_context import ChatContext, ImageContent
-from .tool_context import FunctionTool, RawFunctionTool
+from .tool_context import FunctionTool, RawFunctionTool, ToolError
 
 if TYPE_CHECKING:
     from ..voice.events import RunContext
@@ -596,6 +597,24 @@ async def execute_function_call(
             json_arguments=tool_call.arguments or "{}",
             call_ctx=call_ctx,
         )
+    except (pydantic.ValidationError, ValueError) as e:
+        # Surface argument validation errors to the LLM so it can self-correct.
+        # Without this, the LLM only sees "An internal error occurred" and has
+        # no signal about what was wrong with its arguments.
+        logger.warning(
+            f"invalid arguments for AI function `{tool_call.name}`: {e}",
+            extra={"call_id": tool_call.call_id, "arguments": tool_call.arguments},
+        )
+        tool_error = ToolError(f"Error parsing arguments for `{tool_call.name}`: {e}")
+        return make_function_call_output(fnc_call=fnc_call, output=None, exception=tool_error)
+    except Exception as e:
+        logger.exception(
+            f"exception preparing arguments for AI function `{tool_call.name}`",
+            extra={"call_id": tool_call.call_id, "arguments": tool_call.arguments},
+        )
+        return make_function_call_output(fnc_call=fnc_call, output=None, exception=e)
+
+    try:
         result = function_tool(*fnc_args, **fnc_kwargs)
         if asyncio.iscoroutine(result):
             result = await result

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -497,3 +497,89 @@ class TestEmptySchemaStripping:
             assert len(any_of) != 1, (
                 f"single-element anyOf should be unwrapped: {json.dumps(pref, indent=2)}"
             )
+
+
+class TestExecuteFunctionCallValidationErrors:
+    """Test that argument validation errors are surfaced to the LLM."""
+
+    @pytest.mark.asyncio
+    async def test_missing_required_arg_surfaces_error(self):
+        """When the LLM omits a required argument, the error details should be
+        returned as a ToolError (is_error=True) instead of 'An internal error occurred'."""
+        from livekit.agents.llm.llm import FunctionToolCall
+        from livekit.agents.llm.utils import execute_function_call
+
+        tool_ctx = ToolContext([mock_tool_1])
+        tool_call = FunctionToolCall(
+            name="mock_tool_1",
+            arguments="{}",  # missing required 'arg1'
+            call_id="test-call-1",
+        )
+
+        result = await execute_function_call(tool_call, tool_ctx)
+
+        assert result.fnc_call_out is not None
+        assert result.fnc_call_out.is_error is True
+        # The error message should contain details about what went wrong,
+        # NOT the generic "An internal error occurred"
+        assert "An internal error occurred" not in result.fnc_call_out.output
+        assert "arg1" in result.fnc_call_out.output
+
+    @pytest.mark.asyncio
+    async def test_wrong_type_arg_surfaces_error(self):
+        """When the LLM provides an argument with the wrong type, the validation
+        error details should be surfaced."""
+        from livekit.agents.llm.llm import FunctionToolCall
+        from livekit.agents.llm.utils import execute_function_call
+
+        tool_ctx = ToolContext([mock_tool_2])
+        tool_call = FunctionToolCall(
+            name="mock_tool_2",
+            arguments='{"arg1": 12345}',  # should be a MockOption string, not int
+            call_id="test-call-2",
+        )
+
+        result = await execute_function_call(tool_call, tool_ctx)
+
+        assert result.fnc_call_out is not None
+        assert result.fnc_call_out.is_error is True
+        assert "An internal error occurred" not in result.fnc_call_out.output
+
+    @pytest.mark.asyncio
+    async def test_valid_args_still_work(self):
+        """Verify that valid arguments still execute successfully."""
+        from livekit.agents.llm.llm import FunctionToolCall
+        from livekit.agents.llm.utils import execute_function_call
+
+        tool_ctx = ToolContext([mock_tool_1])
+        tool_call = FunctionToolCall(
+            name="mock_tool_1",
+            arguments='{"arg1": "hello"}',
+            call_id="test-call-3",
+        )
+
+        result = await execute_function_call(tool_call, tool_ctx)
+
+        assert result.fnc_call_out is not None
+        assert result.fnc_call_out.is_error is False
+        assert "arg1" in result.fnc_call_out.output
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_surfaces_error(self):
+        """When the LLM provides invalid JSON, the error should be surfaced."""
+        from livekit.agents.llm.llm import FunctionToolCall
+        from livekit.agents.llm.utils import execute_function_call
+
+        tool_ctx = ToolContext([mock_tool_1])
+        tool_call = FunctionToolCall(
+            name="mock_tool_1",
+            arguments="{not valid json}",
+            call_id="test-call-4",
+        )
+
+        result = await execute_function_call(tool_call, tool_ctx)
+
+        assert result.fnc_call_out is not None
+        assert result.fnc_call_out.is_error is True
+        # Should contain error details, not generic message
+        assert "An internal error occurred" not in result.fnc_call_out.output


### PR DESCRIPTION
## Problem

When the LLM makes a function call with invalid arguments (e.g., missing required fields, wrong types, invalid enum values, malformed JSON), `execute_function_call` catches all exceptions generically and returns `"An internal error occurred"` via `make_function_call_output`. This gives the LLM **zero feedback** about what was wrong with its arguments, so it has no signal to self-correct.

Fixes #5164

## Solution

Separate the argument preparation phase from the function execution phase in `execute_function_call`. During argument preparation, catch `pydantic.ValidationError` and `ValueError` specifically and convert them to a `ToolError` with the full error details. Since `ToolError` is already handled by `make_function_call_output` (surfacing the message to the LLM with `is_error=True`), this requires no changes to the output handling logic.

### Before
```
LLM calls tool with {"arg1": 12345} (wrong type) → "An internal error occurred"
LLM calls tool with {} (missing required arg) → "An internal error occurred"
```

### After
```
LLM calls tool with {"arg1": 12345} → "Error parsing arguments for \`my_tool\`: 1 validation error for ..."
LLM calls tool with {} → "Error parsing arguments for \`my_tool\`: ... Field required [type=missing, ...]"
```

## Changes

- **`livekit-agents/livekit/agents/llm/utils.py`**: Split the `try/except` in `execute_function_call` into two blocks — one for argument preparation (catches `ValidationError`/`ValueError` → `ToolError`) and one for function execution (unchanged behavior).
- **`tests/test_tools.py`**: Added `TestExecuteFunctionCallValidationErrors` with 4 test cases:
  - Missing required argument surfaces error details (not generic message)
  - Wrong type argument surfaces validation error
  - Valid arguments still execute successfully (regression check)
  - Invalid JSON surfaces parse error

## Testing

All 31 tests pass:
```
$ uv run pytest tests/test_tools.py -xvs
============================= 31 passed in 0.03s ===============================
```