### PR TITLE
fix(tests): update test_recording to use renamed observability_url parameter

### DIFF
--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -151,7 +151,7 @@ async def _call_upload(
     """Call _upload_session_report with sensible defaults."""
     await _upload_session_report(
         agent_name="test-agent",
-        cloud_hostname="test.livekit.cloud",
+        observability_url="test.livekit.cloud",
         report=report,
         tagger=tagger or _make_mock_tagger(),
         http_session=http_session or _make_mock_http(),
@@ -368,7 +368,7 @@ def test_setup_cloud_tracer_logger_provider_always_created() -> None:
         _setup_cloud_tracer(
             room_id="room-1",
             job_id="job-1",
-            cloud_hostname="test.livekit.cloud",
+            observability_url="test.livekit.cloud",
             enable_traces=False,
             enable_logs=False,
         )


### PR DESCRIPTION
## Problem

6 tests in `tests/test_recording.py` fail on main because `_setup_cloud_tracer()` and `_upload_session_report()` were refactored to accept `observability_url` instead of `cloud_hostname`, but the tests still use the old parameter name:

```
TypeError: _setup_cloud_tracer() got an unexpected keyword argument 'cloud_hostname'
TypeError: _upload_session_report() got an unexpected keyword argument 'cloud_hostname'
```

Failing tests:
- `test_upload_returns_early_when_none`
- `test_upload_transcript_only`
- `test_upload_session_report_sent_without_transcript`
- `test_upload_audio_only_no_file`
- `test_upload_evaluations_emitted_without_logs`
- `test_setup_cloud_tracer_logger_provider_always_created`

## Fix

Update both call sites in `test_recording.py` to use `observability_url` instead of `cloud_hostname`.