### PR TITLE
fix: pass prometheus_multiproc_dir in from_server_options initialization

### DIFF
--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -419,6 +419,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
             http_proxy=options.http_proxy,
             multiprocessing_context=options.multiprocessing_context,
             prometheus_port=options.prometheus_port if is_given(options.prometheus_port) else None,
+            prometheus_multiproc_dir=options.prometheus_multiproc_dir,
             setup_fnc=options.prewarm_fnc,
             load_fnc=options.load_fnc,
             log_level=options.log_level,


### PR DESCRIPTION
Currently, prometheus_multiproc_dir is not being passed to the AgentServer initialization in from_server_options. That means if you use WorkerOptions, the prometheus_multiproc_dir field will not be read.