### PR TITLE
Update Phonic `generate_reply` timeout to 10 seconds

### DIFF
--- a/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
@@ -397,7 +397,7 @@ class RealtimeSession(llm.RealtimeSession):
             if not fut.done():
                 fut.set_exception(llm.RealtimeError("generate_reply timed out."))
 
-        handle = asyncio.get_event_loop().call_later(5.0, _on_timeout)
+        handle = asyncio.get_event_loop().call_later(10.0, _on_timeout)
         fut.add_done_callback(lambda _: handle.cancel())
         return fut
 


### PR DESCRIPTION
This ensures consistency with the OpenAI realtime model's timeout, which was also recently changed to 10 seconds.

We ran into a few of these `generate_reply` timed out errors while having unexpectedly high latency, so we think 10 seconds is a bit better. 