### PR TITLE
feat(assemblyai): add domain parameter for Medical Mode

### DIFF
--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -62,6 +62,7 @@ class STTOptions:
     vad_threshold: NotGivenOr[float] = NOT_GIVEN
     speaker_labels: NotGivenOr[bool] = NOT_GIVEN
     max_speakers: NotGivenOr[int] = NOT_GIVEN
+    domain: NotGivenOr[str] = NOT_GIVEN
 
 
 class STT(stt.STT):
@@ -87,6 +88,7 @@ class STT(stt.STT):
         vad_threshold: NotGivenOr[float] = NOT_GIVEN,
         speaker_labels: NotGivenOr[bool] = NOT_GIVEN,
         max_speakers: NotGivenOr[int] = NOT_GIVEN,
+        domain: NotGivenOr[str] = NOT_GIVEN,
         http_session: aiohttp.ClientSession | None = None,
         buffer_size_seconds: float = 0.05,
         base_url: str = "wss://streaming.assemblyai.com",
@@ -161,6 +163,7 @@ class STT(stt.STT):
             vad_threshold=vad_threshold,
             speaker_labels=speaker_labels,
             max_speakers=max_speakers,
+            domain=domain,
         )
         self._session = http_session
         self._streams = weakref.WeakSet[SpeechStream]()
@@ -483,6 +486,7 @@ class SpeechStream(stt.SpeechStream):
             if is_given(self._opts.speaker_labels)
             else None,
             "max_speakers": self._opts.max_speakers if is_given(self._opts.max_speakers) else None,
+            "domain": self._opts.domain if is_given(self._opts.domain) else None,
         }
 
         headers = {


### PR DESCRIPTION
## Summary

- Add `domain` parameter to the AssemblyAI STT plugin to support specialized recognition modes
- AssemblyAI's streaming API accepts a `domain` query parameter on the WebSocket connection URL to enable domain-specific recognition, such as Medical Mode (`medical-v1`)
- The parameter is added to `STTOptions`, `STT.__init__`, and the WebSocket connection config, following the same pattern as existing optional parameters

## Usage

```python
from livekit.plugins.assemblyai import STT

stt = STT(domain="medical-v1")
```

## Documentation

[AssemblyAI Streaming Medical Mode](https://www.assemblyai.com/docs/streaming/medical-mode)

## Test plan

- [ ] Verify `STT(domain="medical-v1")` passes `domain=medical-v1` as a query parameter on the WebSocket URL
- [ ] Verify `STT()` (without domain) does not include `domain` in the query parameters
- [ ] Verify compatibility with all streaming models: `u3-rt-pro`, `universal-streaming-english`, `universal-streaming-multilingual`

🤖 Generated with [Claude Code](https://claude.com/claude-code)