### PR TITLE
fix: allow codec format specification via the user for Sarvam TTS

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -58,9 +58,6 @@ SarvamTTSOutputAudioBitrate = Literal["32k", "64k", "96k", "128k", "192k"]
 ALLOWED_OUTPUT_AUDIO_BITRATES: set[str] = {"32k", "64k", "96k", "128k", "192k"}
 ALLOWED_OUTPUT_AUDIO_CODECS: set[str] = {
     "mp3",
-    "linear16",
-    "mulaw",
-    "alaw",
     "opus",
     "flac",
     "aac",


### PR DESCRIPTION
## Description

PR #5086 changed the audio mime-type for Sarvam's TTS to `.wav` which breaks the streaming entirely since Sarvam streams in `mp3`. This PR is to let people choose their output formats.

References:

- Sarvam docs, [codecs enum](https://docs.sarvam.ai/api-reference-docs/text-to-speech/convert#request.body.output_audio_codec).

## Minimal working example:

```python3
from livekit import agents
from livekit.agents import AgentServer, AgentSession, Agent, room_io
from livekit.plugins import sarvam

class TestAgent(Agent):
    def __init__(self) -> None:
        super().__init__(
            instructions="Be a nice robot",
        )

server = AgentServer()

@server.rtc_session(agent_name="test-agent")
async def my_agent(ctx: agents.JobContext):
    session = AgentSession(
        stt="deepgram/nova-3:multi",
        llm="openai/gpt-4.1-mini",
        tts=sarvam.TTS(
            model="bulbul:v3",
            speaker="shubh",
            target_language_code="en-IN",
            pace=1.0,
            temperature=0.6,
            output_audio_codec="wav", # Literal["mp3", "linear16", "mulaw", "alaw", "opus", "flac", "aac", "wav",]
        ),
    )
    await session.start(
        room=ctx.room,
        agent=TestAgent(),
    )
    await session.generate_reply(
        instructions="Be nice."
    )


if __name__ == "__main__":
    agents.cli.run_app(server)
```

Note: For setting `opus` the `speech_sample_rate` needs to be changed. There are other relevant docs for that.