### PR TITLE
fix(stt): preserve aligned transcript in fallback adapter

### DIFF
--- a/livekit-agents/livekit/agents/stt/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/stt/fallback_adapter.py
@@ -68,11 +68,20 @@ class FallbackAdapter(
                 StreamAdapter(stt=t, vad=vad) if not t.capabilities.streaming else t for t in stt
             ]
 
+        aligned_vals = [t.capabilities.aligned_transcript for t in stt]
+        if any(v is False for v in aligned_vals):
+            merged_aligned: Literal["word", "chunk", False] = False
+        elif any(v == "chunk" for v in aligned_vals):
+            merged_aligned = "chunk"
+        else:
+            merged_aligned = "word"
+
         super().__init__(
             capabilities=STTCapabilities(
                 streaming=True,
                 interim_results=all(t.capabilities.interim_results for t in stt),
                 diarization=all(t.capabilities.diarization for t in stt),
+                aligned_transcript=merged_aligned,
             )
         )
 

--- a/tests/test_stt_fallback.py
+++ b/tests/test_stt_fallback.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Literal
 
 import pytest
 
@@ -51,6 +52,33 @@ class FallbackAdapterTester(FallbackAdapter):
         stt: STT,
     ) -> utils.aio.ChanReceiver[AvailabilityChangedEvent]:
         return self._availability_changed_ch[id(stt)]
+
+
+def _aligned_fake_stt(aligned_transcript: Literal["word", "chunk", False]) -> FakeSTT:
+    fake_stt = FakeSTT(fake_transcript="hello world")
+    fake_stt.capabilities.aligned_transcript = aligned_transcript
+    return fake_stt
+
+
+@pytest.mark.parametrize(
+    ("aligned_transcripts", "expected"),
+    [
+        (["word", "word"], "word"),
+        (["word", "chunk"], "chunk"),
+        (["word", False], False),
+    ],
+)
+async def test_stt_fallback_derives_common_aligned_transcript_capability(
+    aligned_transcripts: list[Literal["word", "chunk", False]],
+    expected: Literal["word", "chunk", False],
+) -> None:
+    fallback_adapter = FallbackAdapterTester(
+        [_aligned_fake_stt(aligned_transcript) for aligned_transcript in aligned_transcripts]
+    )
+
+    assert fallback_adapter.capabilities.aligned_transcript == expected
+
+    await fallback_adapter.aclose()
 
 
 async def test_stt_fallback() -> None:


### PR DESCRIPTION
## Summary

This fixes a bug where `stt.FallbackAdapter` drops `STTCapabilities.aligned_transcript` when rebuilding its merged capabilities.

As a result, downstream code sees `aligned_transcript=False` even when all wrapped STTs support aligned transcripts, which disables adaptive interruption handling.

## What changed

- Preserve a merged `aligned_transcript` capability in `stt.FallbackAdapter`
- Downgrade mixed `"word"` / `"chunk"` providers to `"chunk"` as the common
denominator
- Added regression coverage for:
  - all `"word"` -> `"word"`
  - mixed `"word"` / `"chunk"` -> `"chunk"`
  - any `False` -> `False`

## Why this belongs in `FallbackAdapter`

The individual STT plugins already report their own `aligned_transcript` capability correctly. The information was being lost when `FallbackAdapter` reconstructed `STTCapabilities`.
