### PR TITLE
fix(google-stt): reconnect stream on server-initiated closure from VoiceActivityTimeout

### DIFF
--- a/livekit-plugins/livekit-plugins-google/README.md
+++ b/livekit-plugins/livekit-plugins-google/README.md
@@ -19,6 +19,27 @@ To use the STT and TTS API, you'll need to enable the respective services for yo
 - Cloud Speech-to-Text API
 - Cloud Text-to-Speech API
 
+## Google STT — Voice Activity Timeouts
+
+`speech_start_timeout` and `speech_end_timeout` control Google's server-side stream lifecycle, **not** VAD or endpointing. When a timeout fires, Google closes the gRPC stream; the plugin automatically reconnects if the session is still active.
+
+| Parameter | What it does |
+|---|---|
+| `speech_start_timeout` | Google closes the stream if no speech begins within this many seconds |
+| `speech_end_timeout` | Google closes the stream if silence lasts this many seconds after speech ends |
+
+Because reconnecting adds a small overhead, set `speech_end_timeout` to the minimum silence you're willing to accept before the stream resets (e.g. `0.5`–`1.0` seconds). This can reduce perceived latency for short utterances like "hi" with `chirp_3`, at the cost of a reconnect between turns.
+
+```python
+stt = google.STT(
+    model="chirp_3",
+    speech_start_timeout=10.0,  # close stream if user doesn't speak within 10s
+    speech_end_timeout=0.8,     # close stream 800ms after speech ends, then reconnect
+)
+```
+
+> **Note:** These parameters only work with V2 API models (e.g. `chirp_3`). They are silently ignored for V1 models.
+
 ## Live API model support
 
 LiveKit supports both Gemini Live API on both Gemini Developer API as well as Vertex AI. However, be aware they have slightly different behavior and use different model names.

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -182,8 +182,11 @@ class STT(stt.STT):
             credentials_info(dict): the credentials info to use for recognition (default: None)
             credentials_file(str): the credentials file to use for recognition (default: None)
             keywords(List[tuple[str, float]]): list of keywords to recognize (default: None)
-            speech_start_timeout(float): maximum seconds to wait for speech to begin before timeout (default: None)
-            speech_end_timeout(float): seconds of silence before marking utterance as complete (default: None)
+            speech_start_timeout(float): seconds to wait before Google closes the stream if no speech begins.
+                The stream auto-reconnects if audio is still being received. (default: None)
+            speech_end_timeout(float): seconds of silence after speech before Google closes the stream.
+                The stream auto-reconnects if audio is still being received, reducing perceived
+                latency for short utterances at the cost of a reconnect per turn. (default: None)
             endpointing_sensitivity(EndpointingSensitivity): controls the trade-off between latency
                 and accuracy when detecting end-of-speech. Only supported with chirp_3.
                 Options: ENDPOINTING_SENSITIVITY_STANDARD (default),
@@ -875,7 +878,11 @@ class SpeechStream(stt.SpeechStream):
                             if task != wait_reconnect_task:
                                 task.result()
                         if wait_reconnect_task not in done:
-                            break
+                            # Google closed the stream server-side (e.g. speech_end_timeout fired).
+                            # Reconnect if the input channel is still open (more audio expected).
+                            if self._input_ch.closed:
+                                break
+                            logger.debug("Google STT stream closed by server, reconnecting...")
                         self._reconnect_event.clear()
                     finally:
                         should_stop.set()


### PR DESCRIPTION
## What

Fixes #4804 — follow-up to #4361.

PR #4361 added `speech_start_timeout` / `speech_end_timeout` to the Google STT plugin. This PR fixes two issues that were reported in [this comment](https://github.com/livekit/agents/issues/4804#issuecomment-4122032421):

### Bug: stream dies after first turn

When `speech_end_timeout` fires, Google closes the gRPC stream server-side. The reconnect loop in `SpeechStream._run()` treated this as a normal end-of-stream and broke out — killing the `SpeechStream` permanently after the first turn.

**Root cause** (`stt.py` ~line 877):
```python
if wait_reconnect_task not in done:
    break  # ← exited the while loop when Google closed the stream
```

**Fix:** check `self._input_ch.closed`. If the input channel is still open, the stream was closed server-side — reconnect. Only break when the client has explicitly closed the input.

```python
if wait_reconnect_task not in done:
    if self._input_ch.closed:
        break
    logger.debug("Google STT stream closed by server, reconnecting...")
self._reconnect_event.clear()
```

### Docs: misleading descriptions

The docstrings and PR description called `speech_end_timeout` "seconds of silence before marking utterance as complete" — implying VAD/endpointing behavior. These params actually control **stream lifetime**: Google closes the gRPC stream when the timeout fires. Updated docstrings and README to reflect this accurately.

## Changes

- `livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py` — reconnect on server-initiated stream closure; corrected docstrings
- `livekit-plugins/livekit-plugins-google/README.md` — new "Voice Activity Timeouts" section with correct usage guidance
- `tests/test_plugin_google_stt.py` — two new tests covering the reconnect vs. stop branching

## Test plan

- [x] All 17 existing + new Google STT tests pass (`uv run pytest tests/test_plugin_google_stt.py`)
- [x] `ruff check` and `ruff format` pass with no issues
- [ ] Manual: `google.STT(model="chirp_3", speech_end_timeout=0.5)` survives multiple turns without dying after turn 1