### PR TITLE
feat(google): add VertexRAGRetrieval provider tool

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tools.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tools.py
@@ -83,3 +83,40 @@ class ToolCodeExecution(GeminiTool):
         return types.Tool(
             code_execution=types.ToolCodeExecution(),
         )
+
+
+@dataclass
+class VertexRAGRetrieval(GeminiTool):
+    """Vertex AI RAG Engine retrieval tool for server-side grounding.
+
+    Enables single-pass retrieval during Gemini inference with no tool-call
+    round-trip.  Works like Google Search grounding but against your own
+    document corpus managed by Vertex AI RAG Engine.
+
+    Args:
+        rag_resources: RAG corpus resource names
+            (e.g. ``["projects/123/locations/us-central1/ragCorpora/456"]``).
+        similarity_top_k: Number of top results to retrieve.
+        vector_distance_threshold: Optional distance threshold for filtering.
+    """
+
+    rag_resources: list[str]
+    similarity_top_k: int = 3
+    vector_distance_threshold: float | None = None
+
+    def __post_init__(self) -> None:
+        super().__init__(id="gemini_vertex_rag_retrieval")
+
+    def to_tool_config(self) -> types.Tool:
+        return types.Tool(
+            retrieval=types.Retrieval(
+                vertex_rag_store=types.VertexRagStore(
+                    rag_resources=[
+                        types.VertexRagStoreRagResource(rag_corpus=corpus)
+                        for corpus in self.rag_resources
+                    ],
+                    similarity_top_k=self.similarity_top_k,
+                    vector_distance_threshold=self.vector_distance_threshold,
+                ),
+            )
+        )


### PR DESCRIPTION
## Summary

Adds a `VertexRAGRetrieval` provider tool that enables server-side retrieval via Vertex AI RAG Engine during Gemini inference. Retrieval happens in a single inference pass with no tool-call round-trip — critical for low-latency voice agents using native audio.

## Usage

```python
from livekit.plugins import google

agent = MyAgent(
    llm=google.realtime.RealtimeModel(
        model="gemini-live-2.5-flash-native-audio",
        vertexai=True,
    ),
    tools=[
        google.tools.VertexRAGRetrieval(
            rag_resources=["projects/123/locations/us-central1/ragCorpora/456"],
            similarity_top_k=3,
        ),
    ],
)
```

## Motivation

Vertex AI RAG Engine works like Google Search grounding — retrieval is handled server-side during inference. With function-calling RAG, Gemini native audio requires 2 inference passes (~3-5s). With server-side retrieval, it's a single pass (~0.5s).

The `Retrieval` / `VertexRagStore` types already exist in `google.genai.types` and the Gemini Live API supports them, but there was no provider tool wrapper to use them through the LiveKit agents framework.

## Changes

- Added `VertexRAGRetrieval` dataclass to `tools.py` following the same `GeminiTool` pattern as `GoogleSearch`, `FileSearch`, etc.

Closes #5221
