### PR TITLE
fix(cli): update log level width in console mode

### DIFF
--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -869,7 +869,7 @@ class RichLoggingHandler(logging.Handler):
 
         output = Table.grid(padding=(0, 1))
         output.add_column(style="log.time")
-        output.add_column(style="log.level", width=6, no_wrap=True)
+        output.add_column(style="log.level", width=8, no_wrap=True)
         output.add_column(style="log.name", width=MAX_NAME_WIDTH, no_wrap=True, overflow="ellipsis")
         output.add_column(ratio=1, style="log.message")
         output.add_column(style="log.extra", no_wrap=True)


### PR DESCRIPTION
before:
<img width="1552" height="410" alt="CleanShot 2026-03-25 at 11 15 22@2x" src="https://github.com/user-attachments/assets/1486eff4-3aaf-44a7-95df-aeb60faed34d" />

after:
<img width="1608" height="398" alt="CleanShot 2026-03-25 at 11 14 57@2x" src="https://github.com/user-attachments/assets/96f7ece7-0cd6-4721-adb4-d748cc0787e6" />
