### PR TITLE
fix(example): reset the inactivity_task to none

### DIFF
--- a/examples/voice_agents/inactive_user.py
+++ b/examples/voice_agents/inactive_user.py
@@ -36,11 +36,12 @@ async def entrypoint(ctx: JobContext):
     async def user_presence_task():
         # try to ping the user 3 times, if we get no answer, close the session
         for _ in range(3):
-            await session.generate_reply(
+            handle = session.generate_reply(
                 instructions=(
                     "The user has been inactive. Politely check if the user is still present."
                 )
             )
+            await handle.wait_for_playout()
             await asyncio.sleep(10)
 
         session.shutdown()
@@ -55,6 +56,7 @@ async def entrypoint(ctx: JobContext):
         # ev.new_state: listening, speaking, ..
         if inactivity_task is not None:
             inactivity_task.cancel()
+            inactivity_task = None
 
     await session.start(agent=Agent(instructions="You are a helpful assistant."), room=ctx.room)
 


### PR DESCRIPTION
The main changes ensure that the system waits for the reply to finish playing before proceeding and that canceled inactivity tasks are properly cleaned up.

Session and user inactivity handling:

* Now waits for the reply to finish playing by awaiting `handle.wait_for_playout()` after generating a reply in the user presence task.
* Sets `inactivity_task` to `None` after canceling it in the `_user_state_changed` event handler to prevent potential issues with stale task references.