### PR TITLE
fix(voice): merge late STT segments into previous turn instead of creating phantom turns

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1652,6 +1652,16 @@ class AgentActivity(RecognitionHooks):
             created_at=time.time(),
         )
 
+    def on_user_turn_corrected(self) -> None:
+        """Called when a late STT segment was merged into the last user message.
+
+        Forces an interruption of the in-progress generation and re-generates
+        with the updated chat context so the agent responds to the full
+        transcript, not just the first segment.
+        """
+        self.interrupt(force=True)
+        self._session.generate_reply()
+
     def on_end_of_turn(self, info: _EndOfTurnInfo) -> bool:
         # IMPORTANT: This method is sync to avoid it being cancelled by the AudioRecognition
         # We explicitly create a new task here

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1652,16 +1652,6 @@ class AgentActivity(RecognitionHooks):
             created_at=time.time(),
         )
 
-    def on_user_turn_corrected(self) -> None:
-        """Called when a late STT segment was merged into the last user message.
-
-        Forces an interruption of the in-progress generation and re-generates
-        with the updated chat context so the agent responds to the full
-        transcript, not just the first segment.
-        """
-        self.interrupt(force=True)
-        self._session.generate_reply()
-
     def on_end_of_turn(self, info: _EndOfTurnInfo) -> bool:
         # IMPORTANT: This method is sync to avoid it being cancelled by the AudioRecognition
         # We explicitly create a new task here
@@ -1727,6 +1717,18 @@ class AgentActivity(RecognitionHooks):
 
         # interrupt all background speeches and wait for them to finish to update the chat context
         await asyncio.gather(*self._interrupt_background_speeches(force=False))
+
+        # append any late STT segments that arrived after the turn was committed
+        # but before the user message is created (avoids a race where the
+        # merge would target the wrong message in the chat context)
+        if self._audio_recognition:
+            late = self._audio_recognition.consume_pending_late_transcript()
+            if late:
+                info.new_transcript = f"{info.new_transcript} {late}"
+                logger.debug(
+                    "appended late STT transcript to turn",
+                    extra={"late_transcript": late, "full_transcript": info.new_transcript},
+                )
 
         user_message = llm.ChatMessage(
             role="user",

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -75,7 +75,6 @@ class RecognitionHooks(Protocol):
     def on_final_transcript(self, ev: stt.SpeechEvent, *, speaking: bool | None = None) -> None: ...
     def on_end_of_turn(self, info: _EndOfTurnInfo) -> bool: ...
     def on_preemptive_generation(self, info: _PreemptiveGenerationInfo) -> None: ...
-    def on_user_turn_corrected(self) -> None: ...
 
     def retrieve_chat_ctx(self) -> llm.ChatContext: ...
 
@@ -199,6 +198,8 @@ class AudioRecognition:
         # timestamp of the last turn commit — used to suppress phantom turns
         # from late STT segments arriving shortly after a turn was committed
         self._last_turn_committed_at: float | None = None
+        # late FINAL_TRANSCRIPT text stored here until consumed by the turn task
+        self._pending_late_transcript: str = ""
 
     def update_options(
         self,
@@ -569,6 +570,12 @@ class AudioRecognition:
             self._interruption_detection is not None and self._vad is not None
         )
 
+    def consume_pending_late_transcript(self) -> str:
+        """Return and clear any late STT text stored during the grace period."""
+        text = self._pending_late_transcript
+        self._pending_late_transcript = ""
+        return text
+
     def clear_user_turn(self) -> None:
         self._audio_transcript = ""
         self._audio_interim_transcript = ""
@@ -719,19 +726,13 @@ class AudioRecognition:
             if ev.type == stt.SpeechEventType.FINAL_TRANSCRIPT:
                 late_text = ev.alternatives[0].text if ev.alternatives else ""
                 if late_text:
-                    chat_ctx = self._hooks.retrieve_chat_ctx()
-                    for item in reversed(chat_ctx.items):
-                        if isinstance(item, llm.ChatMessage) and item.role == "user":
-                            for i in range(len(item.content) - 1, -1, -1):
-                                if isinstance(item.content[i], str):
-                                    item.content[i] = f"{item.content[i]} {late_text}"
-                                    break
-                            break
+                    self._pending_late_transcript = (
+                        f"{self._pending_late_transcript} {late_text}".strip()
+                    )
                     logger.debug(
-                        "merged late STT transcript into previous turn",
+                        "stored late STT transcript for pending turn",
                         extra={"late_transcript": late_text},
                     )
-                    self._hooks.on_user_turn_corrected()
             return
 
         # handle interruption detection
@@ -905,6 +906,7 @@ class AudioRecognition:
 
             self._speaking = True
             self._last_turn_committed_at = None  # new speech → reset phantom protection
+            self._pending_late_transcript = ""
 
             if self._end_of_turn_task is not None:
                 self._end_of_turn_task.cancel()

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -39,6 +39,11 @@ MIN_LANGUAGE_DETECTION_LENGTH = 5
 # Mirrors turn_detector.base.MAX_HISTORY_TURNS for tracing
 _EOU_MAX_HISTORY_TURNS = 6
 
+# grace period to wait for late STT transcripts before committing a turn.
+# some streaming STT providers segment long utterances internally and deliver the last
+# segment's FINAL_TRANSCRIPT after the endpointing delay, creating a phantom user turn.
+_STT_FLUSH_GRACE_PERIOD = 0.5
+
 
 @dataclass
 class _EndOfTurnInfo:
@@ -70,6 +75,7 @@ class RecognitionHooks(Protocol):
     def on_final_transcript(self, ev: stt.SpeechEvent, *, speaking: bool | None = None) -> None: ...
     def on_end_of_turn(self, info: _EndOfTurnInfo) -> bool: ...
     def on_preemptive_generation(self, info: _PreemptiveGenerationInfo) -> None: ...
+    def on_user_turn_corrected(self) -> None: ...
 
     def retrieve_chat_ctx(self) -> llm.ChatContext: ...
 
@@ -189,6 +195,10 @@ class AudioRecognition:
         self._closing = asyncio.Event()
 
         self._vad_speech_started: bool = False
+
+        # timestamp of the last turn commit — used to suppress phantom turns
+        # from late STT segments arriving shortly after a turn was committed
+        self._last_turn_committed_at: float | None = None
 
     def update_options(
         self,
@@ -688,6 +698,40 @@ class AudioRecognition:
             # and EOU task is done or this is an interim transcript
             return
 
+        # merge late STT segments arriving shortly after a turn commit while
+        # the user is not speaking — these are leftover segments from the
+        # previous utterance that would create phantom turns if processed
+        # normally.  instead of dropping them we append the text to the last
+        # user message in the chat context so the information is preserved.
+        if (
+            ev.type
+            in (
+                stt.SpeechEventType.FINAL_TRANSCRIPT,
+                stt.SpeechEventType.INTERIM_TRANSCRIPT,
+                stt.SpeechEventType.PREFLIGHT_TRANSCRIPT,
+            )
+            and not self._speaking
+            and self._last_turn_committed_at is not None
+            and time.time() - self._last_turn_committed_at < _STT_FLUSH_GRACE_PERIOD
+        ):
+            late_text = ev.alternatives[0].text if ev.alternatives else ""
+            if late_text:
+                chat_ctx = self._hooks.retrieve_chat_ctx()
+                # walk backwards to find the last user message and concat
+                for item in reversed(chat_ctx.items):
+                    if isinstance(item, llm.ChatMessage) and item.role == "user":
+                        for i in range(len(item.content) - 1, -1, -1):
+                            if isinstance(item.content[i], str):
+                                item.content[i] = f"{item.content[i]} {late_text}"
+                                break
+                        break
+                logger.debug(
+                    "merged late STT transcript into previous turn",
+                    extra={"late_transcript": late_text},
+                )
+                self._hooks.on_user_turn_corrected()
+            return
+
         # handle interruption detection
         # - hold the event until the ignore_user_transcript_until expires
         # - release only relevant events
@@ -858,6 +902,7 @@ class AudioRecognition:
                 self._hooks.on_start_of_speech(ev)
 
             self._speaking = True
+            self._last_turn_committed_at = None  # new speech → reset phantom protection
 
             if self._end_of_turn_task is not None:
                 self._end_of_turn_task.cancel()
@@ -1019,8 +1064,11 @@ class AudioRecognition:
 
                 # clear the transcript if the user turn was committed
                 self._audio_transcript = ""
+                self._audio_interim_transcript = ""
+                self._audio_preflight_transcript = ""
                 self._final_transcript_confidence = []
                 self._last_final_transcript_time = None
+                self._last_turn_committed_at = time.time()
                 # concurrent user speech might have changed it
                 # only reset if there is no new speech
                 if self._last_speaking_time == last_speaking_time:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -698,11 +698,12 @@ class AudioRecognition:
             # and EOU task is done or this is an interim transcript
             return
 
-        # merge late STT segments arriving shortly after a turn commit while
+        # handle late STT segments arriving shortly after a turn commit while
         # the user is not speaking — these are leftover segments from the
         # previous utterance that would create phantom turns if processed
-        # normally.  instead of dropping them we append the text to the last
-        # user message in the chat context so the information is preserved.
+        # normally.  interims/preflights are silently dropped (they are
+        # cumulative so merging would duplicate text); the final that follows
+        # carries the complete text and is merged into the previous turn.
         if (
             ev.type
             in (
@@ -715,22 +716,22 @@ class AudioRecognition:
             and self._last_turn_committed_at is not None
             and time.time() - self._last_turn_committed_at < _STT_FLUSH_GRACE_PERIOD
         ):
-            late_text = ev.alternatives[0].text if ev.alternatives else ""
-            if late_text:
-                chat_ctx = self._hooks.retrieve_chat_ctx()
-                # walk backwards to find the last user message and concat
-                for item in reversed(chat_ctx.items):
-                    if isinstance(item, llm.ChatMessage) and item.role == "user":
-                        for i in range(len(item.content) - 1, -1, -1):
-                            if isinstance(item.content[i], str):
-                                item.content[i] = f"{item.content[i]} {late_text}"
-                                break
-                        break
-                logger.debug(
-                    "merged late STT transcript into previous turn",
-                    extra={"late_transcript": late_text},
-                )
-                self._hooks.on_user_turn_corrected()
+            if ev.type == stt.SpeechEventType.FINAL_TRANSCRIPT:
+                late_text = ev.alternatives[0].text if ev.alternatives else ""
+                if late_text:
+                    chat_ctx = self._hooks.retrieve_chat_ctx()
+                    for item in reversed(chat_ctx.items):
+                        if isinstance(item, llm.ChatMessage) and item.role == "user":
+                            for i in range(len(item.content) - 1, -1, -1):
+                                if isinstance(item.content[i], str):
+                                    item.content[i] = f"{item.content[i]} {late_text}"
+                                    break
+                            break
+                    logger.debug(
+                        "merged late STT transcript into previous turn",
+                        extra={"late_transcript": late_text},
+                    )
+                    self._hooks.on_user_turn_corrected()
             return
 
         # handle interruption detection

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -710,6 +710,7 @@ class AudioRecognition:
                 stt.SpeechEventType.INTERIM_TRANSCRIPT,
                 stt.SpeechEventType.PREFLIGHT_TRANSCRIPT,
             )
+            and self._vad is not None
             and not self._speaking
             and self._last_turn_committed_at is not None
             and time.time() - self._last_turn_committed_at < _STT_FLUSH_GRACE_PERIOD

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -582,6 +582,8 @@ class AudioRecognition:
         self._audio_preflight_transcript = ""
         self._final_transcript_confidence = []
         self._user_turn_committed = False
+        self._pending_late_transcript = ""
+        self._last_turn_committed_at = None
 
         # reset stt to clear the buffer from previous user turn
         stt = self._stt

--- a/tests/test_stt_flush_grace_period.py
+++ b/tests/test_stt_flush_grace_period.py
@@ -1,0 +1,195 @@
+"""Tests for phantom turn suppression after turn commit.
+
+Verifies that late FINAL_TRANSCRIPT events from streaming STT providers
+are suppressed instead of creating phantom user turns.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from livekit.agents import (
+    Agent,
+    AgentSession,
+    ConversationItemAddedEvent,
+    EndpointingOptions,
+    InterruptionOptions,
+    TurnHandlingOptions,
+)
+from livekit.agents.voice.transcription.synchronizer import (
+    TranscriptSynchronizer,
+    _SyncedAudioOutput,
+)
+
+from .fake_io import FakeAudioInput, FakeAudioOutput, FakeTextOutput
+from .fake_llm import FakeLLM, FakeLLMResponse
+from .fake_stt import FakeSTT, FakeUserSpeech
+from .fake_tts import FakeTTS, FakeTTSResponse
+from .fake_vad import FakeVAD
+
+SESSION_TIMEOUT = 60.0
+
+
+class SimpleAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(instructions="You are a helpful assistant.")
+
+
+def _create_split_session(
+    *,
+    stt_speeches: list[FakeUserSpeech],
+    vad_speeches: list[FakeUserSpeech],
+    llm_responses: list[FakeLLMResponse],
+    tts_responses: list[FakeTTSResponse],
+    min_endpointing_delay: float = 0.1,
+    allow_interruptions: bool = True,
+) -> AgentSession:
+    """Create a session with separate STT and VAD speech configs."""
+    session = AgentSession[None](
+        vad=FakeVAD(
+            fake_user_speeches=vad_speeches,
+            min_silence_duration=0.1,
+            min_speech_duration=0.05,
+        ),
+        stt=FakeSTT(fake_user_speeches=stt_speeches),
+        llm=FakeLLM(fake_responses=llm_responses),
+        tts=FakeTTS(fake_responses=tts_responses),
+        turn_handling=TurnHandlingOptions(
+            endpointing=EndpointingOptions(
+                min_delay=min_endpointing_delay,
+                max_delay=6.0,
+            ),
+            interruption=InterruptionOptions(
+                enabled=allow_interruptions,
+                min_duration=0.0,
+                min_words=0,
+            ),
+        ),
+        aec_warmup_duration=None,
+    )
+
+    audio_input = FakeAudioInput()
+    audio_output = FakeAudioOutput()
+    transcription_output = FakeTextOutput()
+
+    transcript_sync = TranscriptSynchronizer(
+        next_in_chain_audio=audio_output,
+        next_in_chain_text=transcription_output,
+    )
+    session.input.audio = audio_input
+    session.output.audio = transcript_sync.audio_output
+    session.output.transcription = transcript_sync.text_output
+
+    return session
+
+
+async def _run_session(session: AgentSession, agent: Agent, *, drain_delay: float = 1.0) -> None:
+    stt = session.stt
+    audio_input = session.input.audio
+    assert isinstance(stt, FakeSTT)
+    assert isinstance(audio_input, FakeAudioInput)
+
+    transcription_sync: TranscriptSynchronizer | None = None
+    if isinstance(session.output.audio, _SyncedAudioOutput):
+        transcription_sync = session.output.audio._synchronizer
+
+    await session.start(agent)
+    audio_input.push(0.1)
+
+    await stt.fake_user_speeches_done
+    await asyncio.sleep(drain_delay)
+    await session.drain()
+    await session.aclose()
+
+    if transcription_sync is not None:
+        await transcription_sync.aclose()
+
+
+async def test_late_stt_transcript_suppressed() -> None:
+    """A late FINAL_TRANSCRIPT arriving after turn commit should not create a phantom turn.
+
+    Scenario: user says a long utterance. The STT provider delivers:
+      - segment 1 quickly (stt_delay=0.05s)
+      - segment 2 LATE (stt_delay=0.35s — arrives after the turn is committed)
+
+    The VAD sees one continuous speech for both segments.
+
+    With interruptions enabled the phantom would be processed as a real turn.
+    The fix suppresses it because it arrives within _STT_FLUSH_GRACE_PERIOD
+    after the turn commit and the user is not speaking (VAD).
+    """
+    # STT: two segments, second one arrives after the EOU commit
+    stt_speeches = [
+        FakeUserSpeech(
+            start_time=0.1,
+            end_time=0.3,
+            transcript="Hello world",
+            stt_delay=0.05,
+        ),
+        FakeUserSpeech(
+            start_time=0.35,
+            end_time=0.4,
+            transcript="how are you?",
+            stt_delay=0.35,  # arrives at 0.4 + 0.35 = 0.75s, after commit at ~0.6s
+        ),
+    ]
+
+    # VAD: one continuous speech covering both segments
+    vad_speeches = [
+        FakeUserSpeech(
+            start_time=0.1,
+            end_time=0.4,
+            transcript="",
+            stt_delay=0.0,
+        ),
+    ]
+
+    llm_responses = [
+        FakeLLMResponse(
+            input="Hello world",
+            content="I'm doing great!",
+            ttft=0.1,
+            duration=0.1,
+        ),
+    ]
+
+    tts_responses = [
+        FakeTTSResponse(
+            input="I'm doing great!",
+            audio_duration=0.5,
+            ttfb=0.05,
+            duration=0.1,
+        ),
+    ]
+
+    session = _create_split_session(
+        stt_speeches=stt_speeches,
+        vad_speeches=vad_speeches,
+        llm_responses=llm_responses,
+        tts_responses=tts_responses,
+        min_endpointing_delay=0.1,
+        allow_interruptions=True,
+    )
+    agent = SimpleAgent()
+
+    conversation_events: list[ConversationItemAddedEvent] = []
+    session.on("conversation_item_added", conversation_events.append)
+
+    await asyncio.wait_for(_run_session(session, agent), timeout=SESSION_TIMEOUT)
+
+    user_messages = [
+        ev
+        for ev in conversation_events
+        if ev.item.type == "message" and ev.item.role == "user"
+    ]
+
+    # key assertion: only ONE user message (no phantom turn)
+    assert len(user_messages) == 1, (
+        f"expected 1 user message but got {len(user_messages)}: "
+        f"{[m.item.text_content for m in user_messages]}"
+    )
+
+    # the late transcript should be merged into the first user message
+    transcript = user_messages[0].item.text_content or ""
+    assert "Hello world" in transcript
+    assert "how are you?" in transcript

--- a/tests/test_stt_flush_grace_period.py
+++ b/tests/test_stt_flush_grace_period.py
@@ -151,11 +151,23 @@ async def test_late_stt_transcript_suppressed() -> None:
             ttft=0.1,
             duration=0.1,
         ),
+        FakeLLMResponse(
+            input="Hello world how are you?",
+            content="I'm doing even better now!",
+            ttft=0.1,
+            duration=0.1,
+        ),
     ]
 
     tts_responses = [
         FakeTTSResponse(
             input="I'm doing great!",
+            audio_duration=0.5,
+            ttfb=0.05,
+            duration=0.1,
+        ),
+        FakeTTSResponse(
+            input="I'm doing even better now!",
             audio_duration=0.5,
             ttfb=0.05,
             duration=0.1,
@@ -186,8 +198,3 @@ async def test_late_stt_transcript_suppressed() -> None:
         f"expected 1 user message but got {len(user_messages)}: "
         f"{[m.item.text_content for m in user_messages]}"
     )
-
-    # the late transcript should be merged into the first user message
-    transcript = user_messages[0].item.text_content or ""
-    assert "Hello world" in transcript
-    assert "how are you?" in transcript

--- a/tests/test_stt_flush_grace_period.py
+++ b/tests/test_stt_flush_grace_period.py
@@ -178,9 +178,7 @@ async def test_late_stt_transcript_suppressed() -> None:
     await asyncio.wait_for(_run_session(session, agent), timeout=SESSION_TIMEOUT)
 
     user_messages = [
-        ev
-        for ev in conversation_events
-        if ev.item.type == "message" and ev.item.role == "user"
+        ev for ev in conversation_events if ev.item.type == "message" and ev.item.role == "user"
     ]
 
     # key assertion: only ONE user message (no phantom turn)


### PR DESCRIPTION
## Problem                                                                             
                                                                                                                                                                                                                                                                                                                            
  Streaming STT providers (e.g. ElevenLabs Scribe v2 realtime) segment long utterances internally. When a user pauses briefly mid-sentence, the STT delivers the last segment's `FINAL_TRANSCRIPT` **after** the turn has already been committed by the endpointing/EOU pipeline.
                                                                                                                                                                                                                                                                                                                            
  This late transcript is then processed as a brand-new user turn, causing:
  - The agent to generate **two consecutive responses** instead of one                                                                                                                                                                                                                                                      
  - In confirmation-awaiting flows, the orphan fragment to be misinterpreted as a confirmation, **skipping actual user validation**
                                                                                                                                                                                                                                                                                                                            
  Observed with ElevenLabs Scribe v2 realtime + Silero VAD + MultilingualModel turn detector + dynamic endpointing, but the root cause applies to any streaming STT that segments independently from the agent-side VAD/EOU pipeline.
                                                                                                                                                                                                                                                                                                                            
  ## Fix                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                            
  **`audio_recognition.py`** — detect late transcripts and store them for the pending turn:                                                                                                                                                                                                                                 
  - Record `_last_turn_committed_at` when a turn is committed in `_bounce_eou_task`                                                                                                                                                                                                                                         
  - In `_on_stt_event`, any transcript arriving within 0.5s of a commit while the user is not speaking (VAD) is identified as a late segment
  - `FINAL_TRANSCRIPT`: stored in `_pending_late_transcript` to be consumed by the turn processing task                                                                                                                                                                                                                     
  - `INTERIM_TRANSCRIPT` / `PREFLIGHT_TRANSCRIPT`: silently dropped (they are cumulative — each contains the full hypothesis, so merging would duplicate text; the final that follows carries the complete segment)
  - Guard: `self._vad is not None` ensures this only activates when VAD provides reliable speech boundaries                                                                                                                                                                                                                 
  - `_last_turn_committed_at` is reset on VAD `START_OF_SPEECH` so genuine new turns are never suppressed                                                                                                                                                                                                                   
  - `_audio_interim_transcript` and `_audio_preflight_transcript` are now properly cleared on turn commit (they were leaking across turns)                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                            
  **`agent_activity.py`** — consume the pending late text before creating the user message:                                                                                                                                                                                                                                 
  - In `_user_turn_completed_task`, calls `consume_pending_late_transcript()` and appends the text to `info.new_transcript` **before** the `ChatMessage` is created                                                                                                                                                         
  - This avoids mutating the chat context directly (which would target the wrong message due to async race between turn commit and message insertion)                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                            
  ## Design decisions                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                            
  - **No direct chat_ctx mutation**: the user message for the current turn is added to the chat context asynchronously, well after the turn is committed. Mutating the "last user message" during the grace period would modify a *previous* turn's message, corrupting the conversation history.                           
  - **No interrupt + regenerate**: force-interrupting and calling `generate_reply()` from the recognition layer would require the user message to already be in the chat context, which it isn't due to the same async race. The pending-text approach is simpler and race-free.                                            
  - **Only FINAL_TRANSCRIPT merged**: interim transcripts are cumulative (each contains the full hypothesis for the segment). Merging them would cause `"Hello world how how are how are you?"` instead of `"Hello world how are you?"`.                                                                                    
                                                                                                                                                                                                                                                                                                                            
  ## Test plan                            
                                                                                                                                                                                                                                                                                                                            
  - [x] New test `test_stt_flush_grace_period.py` — simulates split STT delivery with separate VAD/STT timings, verifies single user message (fails without fix, passes with)                                                                                                                                               
  - [x] All 69 existing tests pass (agent session, endpointing, handoff)                                                                                                                                                                                                                                                    
  - [ ] Manual test with ElevenLabs Scribe v2 realtime on long utterances with mid-sentence pauses                 