### PR TITLE
Clarify that official noise cancellation filters require LiveKit Cloud

### DIFF
--- a/examples/voice_agents/README.md
+++ b/examples/voice_agents/README.md
@@ -36,7 +36,7 @@ session = AgentSession(
 
 > **Note:** Realtime models use provider plugins directly as they are not supported by LiveKit Inference. These examples require provider-specific API keys (e.g., `OPENAI_API_KEY`).
 
-- [`getting_started.py`](./getting_started.py) - OpenAI Realtime model with noise cancellation
+- Noise cancellation examples that use `livekit.plugins.noise_cancellation` require LiveKit Cloud.
 - [`weather_agent.py`](./weather_agent.py) - OpenAI Realtime API with function calls for weather information
 - [`realtime_video_agent.py`](./realtime_video_agent.py) - Google Gemini with multimodal video and voice capabilities
 - [`realtime_joke_teller.py`](./realtime_joke_teller.py) - Amazon Nova Sonic real-time model with function calls

--- a/examples/voice_agents/basic_agent.py
+++ b/examples/voice_agents/basic_agent.py
@@ -23,6 +23,7 @@ from livekit.plugins import silero
 from livekit.plugins.turn_detector.multilingual import MultilingualModel
 
 # uncomment to enable Krisp background voice/noise cancellation
+# requires LiveKit Cloud; leave disabled on self-hosted servers
 # from livekit.plugins import noise_cancellation
 
 logger = logging.getLogger("basic-agent")
@@ -134,6 +135,7 @@ async def entrypoint(ctx: JobContext) -> None:
         room_options=room_io.RoomOptions(
             audio_input=room_io.AudioInputOptions(
                 # uncomment to enable the Krisp BVC noise cancellation
+                # requires LiveKit Cloud
                 # noise_cancellation=noise_cancellation.BVC(),
             ),
         ),

--- a/examples/voice_agents/grok/grok_voice_agent_api.py
+++ b/examples/voice_agents/grok/grok_voice_agent_api.py
@@ -15,6 +15,7 @@ from livekit.plugins import silero, xai
 from livekit.plugins.turn_detector.multilingual import MultilingualModel
 
 # uncomment lines 18 and 66-68 to enable Krisp background voice/noise cancellation
+# requires LiveKit Cloud; leave disabled on self-hosted servers
 # from livekit.plugins import noise_cancellation
 
 logger = logging.getLogger("agent")
@@ -61,6 +62,7 @@ async def my_agent(ctx: JobContext):
         room=ctx.room,
         room_options=room_io.RoomOptions(
             audio_input=room_io.AudioInputOptions(
+                # The official Krisp filters require LiveKit Cloud.
                 # noise_cancellation=lambda params: noise_cancellation.BVCTelephony()
                 # if params.participant.kind == rtc.ParticipantKind.PARTICIPANT_KIND_SIP
                 # else noise_cancellation.BVC(),

--- a/examples/voice_agents/multi_agent.py
+++ b/examples/voice_agents/multi_agent.py
@@ -21,6 +21,7 @@ from livekit.agents.voice import MetricsCollectedEvent
 from livekit.plugins import deepgram, openai, silero
 
 # uncomment to enable Krisp BVC noise cancellation, currently supported on Linux and MacOS
+# requires LiveKit Cloud; leave disabled on self-hosted servers
 # from livekit.plugins import noise_cancellation
 
 ## The storyteller agent is a multi-agent that can handoff the session to another agent.

--- a/examples/warm-transfer/warm_transfer.py
+++ b/examples/warm-transfer/warm_transfer.py
@@ -105,7 +105,7 @@ async def entrypoint(ctx: JobContext):
         room=ctx.room,
         room_options=room_io.RoomOptions(
             audio_input=room_io.AudioInputOptions(
-                # enable Krisp BVC noise cancellation
+                # enable Krisp BVC noise cancellation (requires LiveKit Cloud)
                 noise_cancellation=noise_cancellation.BVCTelephony(),
             ),
             delete_room_on_close=False,  # keep the room open for the customer and supervisor

--- a/livekit-agents/livekit/agents/voice/room_io/types.py
+++ b/livekit-agents/livekit/agents/voice/room_io/types.py
@@ -72,6 +72,13 @@ class AudioInputOptions:
         | rtc.FrameProcessor[rtc.AudioFrame]
         | None
     ) = None
+    """Noise cancellation or audio processing for inbound audio.
+
+    Note:
+        The official ``livekit.plugins.noise_cancellation`` Krisp filters require
+        LiveKit Cloud. On self-hosted servers, leave this unset or use your own
+        ``rtc.FrameProcessor`` implementation instead.
+    """
     auto_gain_control: bool = True
     """Enable automatic gain control (AGC) on the input audio. Enabled by default."""
     pre_connect_audio: bool = True
@@ -255,6 +262,13 @@ class RoomInputOptions:
     noise_cancellation: rtc.NoiseCancellationOptions | rtc.FrameProcessor[rtc.AudioFrame] | None = (
         None
     )
+    """Noise cancellation or audio processing for inbound audio.
+
+    Note:
+        The official ``livekit.plugins.noise_cancellation`` Krisp filters require
+        LiveKit Cloud. On self-hosted servers, leave this unset or use your own
+        ``rtc.FrameProcessor`` implementation instead.
+    """
     text_input_cb: TextInputCallback = _default_text_input_cb
     participant_kinds: NotGivenOr[list[rtc.ParticipantKind.ValueType]] = NOT_GIVEN
     """Participant kinds accepted for auto subscription. If not provided,


### PR DESCRIPTION
## Summary
- document on `AudioInputOptions.noise_cancellation` and legacy `RoomInputOptions.noise_cancellation` that the official `livekit.plugins.noise_cancellation` Krisp filters require LiveKit Cloud
- add the same warning to the example snippets that currently suggest uncommenting `noise_cancellation.BVC()` or `BVCTelephony()`
- note the cloud-only requirement in the voice agents README next to the noise cancellation examples

## Why
`livekit-agents` itself does not construct `BVC()` automatically, so the clean upstream fix here is documentation and example guardrails.

Today the examples and type docs make it easy to assume the official noise cancellation plugin works on self-hosted LiveKit deployments. In practice, the official Krisp-backed filters are LiveKit Cloud-only, which leads users toward opaque runtime/auth errors instead of a clear constraint up front.

## Verification
- `uv run --group dev ruff check livekit-agents/livekit/agents/voice/room_io/types.py examples/voice_agents/basic_agent.py examples/voice_agents/multi_agent.py examples/voice_agents/grok/grok_voice_agent_api.py examples/warm-transfer/warm_transfer.py`
- `uv run python -m py_compile livekit-agents/livekit/agents/voice/room_io/types.py examples/voice_agents/basic_agent.py examples/voice_agents/multi_agent.py examples/voice_agents/grok/grok_voice_agent_api.py examples/warm-transfer/warm_transfer.py`