### PR TITLE
fix(google realtime): support gemini-3.1-flash-live-preview

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/api_proto.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/api_proto.py
@@ -15,10 +15,19 @@ LiveAPIModels = Literal[
     # VertexAI models
     "gemini-live-2.5-flash-native-audio",  # GA https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-live-api#live-2.5-flash
     # Gemini API models
-    "gemini-3.1-flash-live-preview",
+    "gemini-3.1-flash-live-preview",  # https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-live-preview
     "gemini-2.5-flash-native-audio-preview-12-2025",  # https://ai.google.dev/gemini-api/docs/models#gemini-2.5-flash-live
     "gemini-2.5-flash-native-audio-preview-09-2025",  # https://ai.google.dev/gemini-api/docs/models#gemini-2.5-flash-live
 ]
+
+# Models that reject send_client_content after the first model turn.
+# These models require send_realtime_input for all mid-session text input.
+# See: https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-live-preview#migrating
+RESTRICTED_CLIENT_CONTENT_MODELS: frozenset[str] = frozenset(
+    {
+        "gemini-3.1-flash-live-preview",
+    }
+)
 
 Voice = Literal[
     "Achernar",

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -927,14 +927,20 @@ class RealtimeSession(llm.RealtimeSession):
                     # Otherwise, silently drop to prevent 1007 errors.
                     if self._opts.model in RESTRICTED_CLIENT_CONTENT_MODELS:
                         if self._opts.reconnect_on_update:
-                            logger.debug("restricted model: reconnecting to apply LiveClientContent update")
+                            logger.debug(
+                                "restricted model: reconnecting to apply LiveClientContent update"
+                            )
                             self._mark_restart_needed()
                         else:
-                            logger.debug("restricted model: dropping LiveClientContent (not supported mid-session)")
+                            logger.debug(
+                                "restricted model: dropping LiveClientContent (not supported mid-session)"
+                            )
                     else:
                         await session.send_client_content(
                             turns=msg.turns,  # type: ignore
-                            turn_complete=msg.turn_complete if msg.turn_complete is not None else True,
+                            turn_complete=msg.turn_complete
+                            if msg.turn_complete is not None
+                            else True,
                         )
                 elif isinstance(msg, types.LiveClientToolResponse) and msg.function_responses:
                     await session.send_tool_response(function_responses=msg.function_responses)

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -25,7 +25,12 @@ from livekit.agents.types import (
     NotGivenOr,
 )
 from livekit.agents.utils import audio as audio_utils, images, is_given
-from livekit.plugins.google.realtime.api_proto import ClientEvents, LiveAPIModels, Voice
+from livekit.plugins.google.realtime.api_proto import (
+    RESTRICTED_CLIENT_CONTENT_MODELS,
+    ClientEvents,
+    LiveAPIModels,
+    Voice,
+)
 
 from ..log import logger
 from ..utils import create_tools_config, get_tool_results_for_realtime
@@ -150,6 +155,7 @@ class _RealtimeOptions:
     tool_response_scheduling: NotGivenOr[types.FunctionResponseScheduling] = NOT_GIVEN
     thinking_config: NotGivenOr[types.ThinkingConfig] = NOT_GIVEN
     session_resumption: NotGivenOr[types.SessionResumptionConfig] = NOT_GIVEN
+    reconnect_on_update: bool = False
     credentials: google.auth.credentials.Credentials | None = None
 
 
@@ -218,6 +224,7 @@ class RealtimeModel(llm.RealtimeModel):
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
         http_options: NotGivenOr[types.HttpOptions] = NOT_GIVEN,
         thinking_config: NotGivenOr[types.ThinkingConfig] = NOT_GIVEN,
+        reconnect_on_update: bool = False,
         credentials: google.auth.credentials.Credentials | None = None,
     ) -> None:
         """
@@ -257,6 +264,10 @@ class RealtimeModel(llm.RealtimeModel):
             tool_response_scheduling (FunctionResponseScheduling, optional): The scheduling for tool response. Default scheduling is WHEN_IDLE.
             session_resumption (SessionResumptionConfig, optional): The configuration for session resumption. Defaults to None.
             thinking_config (ThinkingConfig, optional): Native audio thinking configuration.
+            reconnect_on_update (bool, optional): For models that restrict mid-session
+                send_client_content (e.g. gemini-3.1-flash-live-preview), reconnect the session
+                when update_instructions() or update_chat_ctx() is called. Without this,
+                updates are silently dropped. Defaults to False.
             conn_options (APIConnectOptions, optional): The configuration for the API connection. Defaults to DEFAULT_API_CONNECT_OPTIONS.
 
         Raises:
@@ -363,6 +374,7 @@ class RealtimeModel(llm.RealtimeModel):
             http_options=http_options,
             thinking_config=thinking_config,
             session_resumption=session_resumption,
+            reconnect_on_update=reconnect_on_update,
             credentials=credentials,
         )
 
@@ -701,12 +713,19 @@ class RealtimeSession(llm.RealtimeSession):
             self._in_user_activity = False
 
         # Gemini requires the last message to end with user's turn
-        # so we need to add a placeholder user turn in order to trigger a new generation
-        turns = []
-        if is_given(instructions):
-            turns.append(types.Content(parts=[types.Part(text=instructions)], role="model"))
-        turns.append(types.Content(parts=[types.Part(text=".")], role="user"))
-        self._send_client_event(types.LiveClientContent(turns=turns, turn_complete=True))
+        # so we need to add a placeholder user turn in order to trigger a new generation.
+        # Restricted client_content models (e.g. gemini-3.1-flash-live-preview) reject send_client_content
+        # after the first model turn and require send_realtime_input for text input.
+        # See: https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-live-preview#migrating
+        if self._opts.model in RESTRICTED_CLIENT_CONTENT_MODELS:
+            prompt = instructions if is_given(instructions) else "."
+            self._send_client_event(types.LiveClientRealtimeInput(text=prompt))
+        else:
+            turns = []
+            if is_given(instructions):
+                turns.append(types.Content(parts=[types.Part(text=instructions)], role="model"))
+            turns.append(types.Content(parts=[types.Part(text=".")], role="user"))
+            self._send_client_event(types.LiveClientContent(turns=turns, turn_complete=True))
 
         def _on_timeout() -> None:
             if not fut.done():
@@ -811,6 +830,10 @@ class RealtimeSession(llm.RealtimeSession):
                                 f"update_instructions() to set system-level context instead."
                             )
 
+                        # For restricted client_content models (e.g. gemini-3.1-flash-live-preview),
+                        # history_config.initial_history_in_client_content=True is set in
+                        # _build_connect_config, which allows send_client_content for initial
+                        # history seeding before the first model turn.
                         turns_dict, _ = self._chat_ctx.copy(
                             exclude_function_call=True,
                             exclude_handoff=True,
@@ -898,10 +921,21 @@ class RealtimeSession(llm.RealtimeSession):
                     ):
                         break
                 if isinstance(msg, types.LiveClientContent):
-                    await session.send_client_content(
-                        turns=msg.turns,  # type: ignore
-                        turn_complete=msg.turn_complete if msg.turn_complete is not None else True,
-                    )
+                    # Restricted client_content models reject send_client_content after the first model turn.
+                    # With reconnect_on_update=True, trigger a reconnect so updates take
+                    # effect via system_instruction/history in the new session setup.
+                    # Otherwise, silently drop to prevent 1007 errors.
+                    if self._opts.model in RESTRICTED_CLIENT_CONTENT_MODELS:
+                        if self._opts.reconnect_on_update:
+                            logger.debug("restricted model: reconnecting to apply LiveClientContent update")
+                            self._mark_restart_needed()
+                        else:
+                            logger.debug("restricted model: dropping LiveClientContent (not supported mid-session)")
+                    else:
+                        await session.send_client_content(
+                            turns=msg.turns,  # type: ignore
+                            turn_complete=msg.turn_complete if msg.turn_complete is not None else True,
+                        )
                 elif isinstance(msg, types.LiveClientToolResponse) and msg.function_responses:
                     await session.send_tool_response(function_responses=msg.function_responses)
                 elif isinstance(msg, types.LiveClientRealtimeInput):
@@ -1069,6 +1103,11 @@ class RealtimeSession(llm.RealtimeSession):
         if is_given(self._opts.context_window_compression):
             conf.context_window_compression = self._opts.context_window_compression
 
+        # Restricted client_content models require history_config to allow send_client_content
+        # for initial context history seeding on connect.
+        if self._opts.model in RESTRICTED_CLIENT_CONTENT_MODELS:
+            conf.history_config = types.HistoryConfig(initial_history_in_client_content=True)
+
         return conf
 
     def _start_new_generation(self) -> None:
@@ -1121,6 +1160,20 @@ class RealtimeSession(llm.RealtimeSession):
         self.emit("generation_created", generation_event)
 
     def _handle_server_content(self, server_content: types.LiveServerContent) -> None:
+        # Restricted client_content models (e.g. gemini-3.1-flash-live-preview) may send an empty
+        # server_content with only usage_metadata before the first model_turn.
+        # Skip these to avoid dropping the first generation's audio.
+        has_content = (
+            server_content.model_turn
+            or server_content.output_transcription
+            or server_content.input_transcription
+            or server_content.turn_complete is not None
+            or server_content.generation_complete is not None
+            or server_content.interrupted is not None
+        )
+        if not has_content:
+            return
+
         current_gen = self._current_generation
         if not current_gen:
             logger.warning("received server content but no active generation.")


### PR DESCRIPTION
Adds working support for gemini-3.1-flash-live-preview.

Gemini 3.1 changed how send_client_content works. It's now only allowed for initial history seeding (with history_config.initial_history_in_client_content=true).

After the first model turn, all text input must go through send_realtime_input. This broke generate_reply, and any mid-session LiveClientContent (from update_instructions, update_chat_ctx, etc.) gets rejected with a 1007 error.

What this PR does:

- Introduces RESTRICTED_CLIENT_CONTENT_MODELS set in api_proto.py to identify models with this limitation - generate_reply() uses LiveClientRealtimeInput(text=...) instead of LiveClientContent for these models
- _send_task drops LiveClientContent events mid-session to prevent 1007 crashes. With reconnect_on_update=True, it triggers a reconnect instead so updates take effect via the new session's setup config
- _build_connect_config adds history_config.initial_history_in_client_content=True so initial history seeding still works on connect/reconnect
- _handle_server_content skips empty server_content that 3.1 sends (only usage_metadata, no actual content) - without this the first generation's audio gets dropped, thx #5234 
- Adds reconnect_on_update parameter to RealtimeModel — opt-in reconnect when update_instructions/update_chat_ctx is called on restricted models. Off by default since it interrupts the session.

Tested locally: greeting via generate_reply, bidirectional audio, function tool calling, update_instructions and update_chat_ctx with reconnect all work.

Known limitation: mid-session update_instructions and update_chat_ctx require a reconnect on 3.1 - there's no way around this since the model simply doesn't accept send_client_content after the first turn. Google's migration guide confirms this is by design.
<img width="908" height="183" alt="image" src="https://github.com/user-attachments/assets/8654f8a7-f4db-4daa-b374-f3c4b018d013" />


Ref: https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-live-preview#migrating
Related: #5234