### PR TITLE
fix(soniox): expose max_endpoint_delay_ms in STTOptions

### DIFF
--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
@@ -121,6 +121,7 @@ class STTOptions:
 
     client_reference_id: str | None = None
     translation: TranslationConfig | None = None
+    max_endpoint_delay_ms: int | None = None
 
 
 class STT(stt.STT):
@@ -260,6 +261,8 @@ class SpeechStream(stt.SpeechStream):
                 translation_dict["language_a"] = tr.language_a
                 translation_dict["language_b"] = tr.language_b
             config["translation"] = translation_dict
+        if self._stt._params.max_endpoint_delay_ms is not None:
+            config["max_endpoint_delay_ms"] = self._stt._params.max_endpoint_delay_ms
         # Connect to the Soniox Speech-to-Text API.
         ws = await asyncio.wait_for(
             self._ensure_session().ws_connect(self._stt._base_url),


### PR DESCRIPTION
## Summary
- Adds `max_endpoint_delay_ms` field to `STTOptions` dataclass (`int | None`, defaults to `None`)
- Passes the value through to the WebSocket config in `SpeechStream._connect_ws()` when set

Closes #5248

## Test plan
- [x] `ruff format` — no changes needed
- [x] `ruff check` — all checks passed
- [x] `mypy` — no issues found