### PR TITLE
fix(voice): skip reply speech task when handoff is required

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2504,7 +2504,7 @@ class AgentActivity(RecognitionHooks):
                 draining = True
 
             tool_messages = new_calls + new_fnc_outputs
-            if fnc_executed_ev._reply_required:
+            if fnc_executed_ev._reply_required and not fnc_executed_ev._handoff_required:
                 chat_ctx.items.extend(tool_messages)
 
                 # refresh instructions in chat_ctx so that any update_instructions()
@@ -3053,6 +3053,7 @@ class AgentActivity(RecognitionHooks):
 
             if (
                 fnc_executed_ev._reply_required
+                and not fnc_executed_ev._handoff_required
                 and not self.llm.capabilities.auto_tool_reply_generation
             ):
                 self._rt_session.interrupt()


### PR DESCRIPTION
## Summary

Fixes #5150

When parallel tool calls include both a handoff (returning an `Agent`) and a string-returning tool (`reply_required=True`), the agent loops forever because a speech task is created on the old agent racing with the handoff, preventing `SecondaryAgent.on_enter()` from ever being called.

The same bug class was already fixed on the Gemini Realtime path in #4691.

## Changes

Guard the `_pipeline_reply_task` creation (pipeline path, ~line 2507) and `_realtime_reply_task` creation (realtime/non-auto-reply path, ~line 3054) behind a `not _handoff_required` check so that when a handoff is in progress, no follow-up speech is generated on the departing agent.

```python
# Before (pipeline path):
if fnc_executed_ev._reply_required:

# After:
if fnc_executed_ev._reply_required and not fnc_executed_ev._handoff_required:
```

## Test plan
- [ ] Parallel tool calls with both handoff + string-returning tool: handoff completes correctly, `on_enter()` fires on new agent
- [ ] Parallel tool calls with only string-returning tools: reply speech still fires as expected
- [ ] Single tool call handoff: no regression
- [ ] Tool calls with `reply_required=False`: existing `elif` path still adds tool messages to chat context
