### PR TITLE
feat(anam): add avatarModel config support

### DIFF
--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/api.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/api.py
@@ -70,13 +70,18 @@ class AnamAPI:
         Returns:
             The created session token (a JWT string).
         """
+        persona_config_payload = {
+            "type": "ephemeral",
+            "name": persona_config.name,
+            "avatarId": persona_config.avatarId,
+            "llmId": "CUSTOMER_CLIENT_V1",
+        }
+
+        if persona_config.avatarModel:
+            persona_config_payload["avatarModel"] = persona_config.avatarModel
+
         payload = {
-            "personaConfig": {
-                "type": "ephemeral",
-                "name": persona_config.name,
-                "avatarId": persona_config.avatarId,
-                "llmId": "CUSTOMER_CLIENT_V1",
-            },
+            "personaConfig": persona_config_payload,
         }
         payload["environment"] = {
             "livekitUrl": livekit_url,

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
@@ -7,3 +7,4 @@ class PersonaConfig:
 
     name: str
     avatarId: str
+    avatarModel: str | None = None


### PR DESCRIPTION
Updates the Anam plugin to allow passthrough of Avatar Model on session creation, allowing users to access pre release models.

### Summary
---
- Adds optional avatarModel field to Anam personaConfig defaults to None
- If defined passes through to session-token request, else falls back to default (None) current stable model