### PR TITLE
fix(recorder): guard against empty agent speech frames

### DIFF
--- a/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
+++ b/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
@@ -478,7 +478,8 @@ class RecorderAudioOutput(io.AudioOutput):
             if pause_pos <= playback_position:
                 buf.append(_create_silence_frame(pause_dur, sample_rate, num_channels))
 
-        if buf and sum(f.duration for f in buf) > 0.0:
+        buf = [f for f in buf if f.duration > 0.0]
+        if buf:
             if trailing_silence_duration > 0.0:
                 buf.append(
                     _create_silence_frame(trailing_silence_duration, sample_rate, num_channels)


### PR DESCRIPTION
`buf` might contain an empty frame from split, so this PR guards against spurious buffer writes.