### PR TITLE
fix(sarvam-tts): wrap raw PCM in RIFF/WAVE header when wav codec returns headerless bytes

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -25,6 +25,7 @@ import enum
 import json
 import os
 import platform
+import struct
 import weakref
 from dataclasses import dataclass, replace
 from typing import Literal
@@ -54,6 +55,35 @@ SARVAM_TTS_WS_URL = "wss://api.sarvam.ai/text-to-speech/ws"
 # Sarvam TTS specific models and speakers
 SarvamTTSModels = Literal["bulbul:v2", "bulbul:v3-beta", "bulbul:v3"]
 SarvamTTSOutputAudioBitrate = Literal["32k", "64k", "96k", "128k", "192k"]
+
+def _pcm_to_wav(data: bytes, sample_rate: int, num_channels: int, bit_depth: int = 16) -> bytes:
+    """Wrap raw PCM bytes in a RIFF/WAVE container.
+
+    The Sarvam API may return raw PCM bytes for the ``wav`` codec instead of a
+    properly-headered WAV file.  This helper prepends the minimal RIFF/WAVE
+    header so downstream decoders can parse the audio correctly.
+    """
+    data_size = len(data)
+    byte_rate = sample_rate * num_channels * bit_depth // 8
+    block_align = num_channels * bit_depth // 8
+    header = struct.pack(
+        "<4sI4s4sIHHIIHH4sI",
+        b"RIFF",
+        36 + data_size,  # overall file size minus 8 bytes
+        b"WAVE",
+        b"fmt ",
+        16,  # PCM fmt chunk size
+        1,  # AudioFormat: PCM
+        num_channels,
+        sample_rate,
+        byte_rate,
+        block_align,
+        bit_depth,
+        b"data",
+        data_size,
+    )
+    return header + data
+
 
 ALLOWED_OUTPUT_AUDIO_BITRATES: set[str] = {"32k", "64k", "96k", "128k", "192k"}
 ALLOWED_OUTPUT_AUDIO_CODECS: set[str] = {
@@ -696,9 +726,19 @@ class ChunkedStream(tts.ChunkedStream):
                     mime_type=mime_type,
                 )
                 # handle multiple audio chunks
-                for b64 in audios:
-                    wav_bytes = base64.b64decode(b64)
-                    output_emitter.push(wav_bytes)
+                raw_chunks = [base64.b64decode(b64) for b64 in audios]
+                if self._opts.output_audio_codec == "wav":
+                    # Sarvam may return raw PCM without a RIFF/WAVE header for
+                    # the wav codec; detect this and wrap accordingly.
+                    all_bytes = b"".join(raw_chunks)
+                    if not all_bytes.startswith(b"RIFF"):
+                        all_bytes = _pcm_to_wav(
+                            all_bytes, self._tts.sample_rate, self._tts.num_channels
+                        )
+                    output_emitter.push(all_bytes)
+                else:
+                    for chunk in raw_chunks:
+                        output_emitter.push(chunk)
         except asyncio.TimeoutError as e:
             raise APITimeoutError("Sarvam TTS API request timed out") from e
         except aiohttp.ClientError as e:
@@ -724,6 +764,10 @@ class SynthesizeStream(tts.SynthesizeStream):
         self._send_task: asyncio.Task | None = None
         self._recv_task: asyncio.Task | None = None
         self._ws_conn: aiohttp.ClientWebSocketResponse | None = None
+
+        # Buffer raw PCM for wav codec (Sarvam streams raw PCM chunks that must
+        # be collected into a single RIFF/WAVE container before emitting).
+        self._wav_buffer: list[bytes] = []
 
     async def _run(self, output_emitter: tts.AudioEmitter) -> None:
         request_id = utils.shortuuid()
@@ -1023,7 +1067,12 @@ class SynthesizeStream(tts.SynthesizeStream):
                 return True
 
             audio_bytes = base64.b64decode(audio_data)
-            output_emitter.push(audio_bytes)
+            if self._opts.output_audio_codec == "wav":
+                # Buffer raw PCM; the complete WAV container will be pushed once
+                # the "final" event is received (see _handle_event_message).
+                self._wav_buffer.append(audio_bytes)
+            else:
+                output_emitter.push(audio_bytes)
 
             return True
 
@@ -1070,6 +1119,17 @@ class SynthesizeStream(tts.SynthesizeStream):
 
         if event_type == "final":
             logger.debug("Generation complete event received", extra=self._build_log_context())
+            if self._wav_buffer:
+                # All raw PCM chunks have been collected; emit as a complete WAV.
+                all_pcm = b"".join(self._wav_buffer)
+                self._wav_buffer.clear()
+                if not all_pcm.startswith(b"RIFF"):
+                    all_pcm = _pcm_to_wav(
+                        all_pcm,
+                        self._opts.speech_sample_rate,
+                        1,  # Sarvam always outputs mono
+                    )
+                output_emitter.push(all_pcm)
             output_emitter.end_input()
             return False  # Stop processing
         else:


### PR DESCRIPTION
## Summary

Fixes #5267.

When `output_audio_codec="wav"` is set, the Sarvam API can return raw PCM bytes without a RIFF/WAVE header. The plugin then calls `output_emitter.initialize(mime_type="audio/wav")`, which causes downstream decoders to expect a RIFF/WAVE header — crashing with `"Invalid WAV file: missing RIFF/WAVE"`.

### Root cause

`mime_type = f"audio/{self._opts.output_audio_codec}"` correctly signals `audio/wav`, but `base64.b64decode(b64)` yields raw PCM bytes when Sarvam omits the container header.

### Fix

Added a `_pcm_to_wav()` helper that prepends the standard RIFF/WAVE header (computed from `sample_rate`, `num_channels`, `bit_depth=16`) to raw PCM data.

**REST path (`Synthesize._run`):**
- Collect all base64-decoded chunks
- If bytes don't start with `b"RIFF"`, wrap them with `_pcm_to_wav()`
- Push the complete WAV to the emitter

**Streaming WebSocket path (`SynthesizeStream`):**
- When `output_audio_codec == "wav"`, buffer raw PCM chunks in `_wav_buffer` (instead of pushing individual chunks, which can't form valid standalone WAV frames)
- On `event_type == "final"`, assemble the buffer into a complete WAV and push before calling `output_emitter.end_input()`

The `b"RIFF"` check on the assembled bytes makes the fix safe for Sarvam API responses that do include a proper WAV header.

## Test plan

- [ ] `output_audio_codec="wav"` with `bulbul:v3` no longer raises `"Invalid WAV file: missing RIFF/WAVE"`
- [ ] `output_audio_codec="mp3"` (default) is unaffected
- [ ] Streaming path emits audio correctly after "final" event with wav codec
- [ ] `_pcm_to_wav()` produces a parseable WAV file (standard RIFF header verified)