### PR TITLE
fix(voice): skip pipeline reply when handoff is in progress

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2504,7 +2504,12 @@ class AgentActivity(RecognitionHooks):
                 draining = True
 
             tool_messages = new_calls + new_fnc_outputs
-            if fnc_executed_ev._reply_required:
+            if fnc_executed_ev._reply_required and not fnc_executed_ev._handoff_required:
+                # Skip follow-up LLM call when a handoff is in progress (#5150).
+                # Creating a pipeline reply task after update_agent() races against the
+                # handoff: the old agent sends tool results back to the LLM, receives an
+                # empty response, and loops — preventing on_enter() from firing on the
+                # new agent. When handing off, the old agent has no more work to do.
                 chat_ctx.items.extend(tool_messages)
 
                 # refresh instructions in chat_ctx so that any update_instructions()


### PR DESCRIPTION
## Summary

Fixes #5150 — agent handoff fails when a tool returning `Agent` runs in parallel with a reply-producing tool (pipeline path).

**Root cause:** In `agent_activity.py`, the pipeline path creates a `_pipeline_reply_task` whenever `fnc_executed_ev._reply_required` is `True`. When `update_agent()` (handoff) is triggered by one parallel tool call while another sets `_reply_required=True`, the old agent still creates a pipeline reply task. This races against the handoff:

1. Old agent sends tool results back to LLM
2. LLM returns an empty/stub response (since the agent is being replaced)
3. Old agent loops — `on_enter()` on the new agent never fires

**Fix:** Guard `_pipeline_reply_task` creation with `not fnc_executed_ev._handoff_required`. When a handoff is in flight the old agent has no further reply responsibility — that passes to the new agent.

```python
# Before
if fnc_executed_ev._reply_required:

# After
if fnc_executed_ev._reply_required and not fnc_executed_ev._handoff_required:
    # Skip follow-up LLM call when a handoff is in progress (#5150).
    # Creating a pipeline reply task after update_agent() races against the
    # handoff: the old agent sends tool results back to the LLM, receives an
    # empty response, and loops — preventing on_enter() from firing on the
    # new agent. When handing off, the old agent has no more work to do.
```

## Test plan

- [ ] Reproduce #5150: parallel tool calls where one triggers `update_agent()` and the other sets `_reply_required=True`
- [ ] Verify `on_enter()` fires on the new agent after handoff
- [ ] Verify single-tool handoff (no parallel tools) still works correctly
- [ ] Verify non-handoff reply path (`_reply_required=True`, `_handoff_required=False`) is unaffected