### PR TITLE
fix: catch TimeoutError from drain() so aclose() always runs

### DIFF
--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -1622,7 +1622,10 @@ def _run_worker(server: AgentServer, args: proto.CliArgs, jupyter: bool = False)
         try:
             exit_triggered = False  # allow a new _ExitCLI raise
             if not args.devmode:
-                loop.run_until_complete(server.drain())
+                try:
+                    loop.run_until_complete(server.drain())
+                except asyncio.TimeoutError:
+                    logger.warning("drain timed out, forcing shutdown")
 
             loop.run_until_complete(server.aclose())
 

--- a/tests/test_drain_timeout.py
+++ b/tests/test_drain_timeout.py
@@ -1,15 +1,15 @@
 """Tests that server.aclose() is always called during shutdown, even when
 server.drain() raises TimeoutError.
 
-Currently, _run_worker (cli.py) does not catch TimeoutError from drain(),
-which means aclose() is skipped — stuck child processes are never killed
-and become orphaned until the pod is force-terminated.
+Previously, _run_worker (cli.py) did not catch TimeoutError from drain(),
+which meant aclose() was skipped — stuck child processes were never killed
+and became orphaned until the pod was force-terminated.
 
 The drain() docstring explicitly documents this behavior:
   "When timeout isn't None, it will raise asyncio.TimeoutError if the
    processes didn't finish in time."
 
-But _run_worker's except clause only catches _ExitCli, not TimeoutError.
+The fix catches asyncio.TimeoutError around drain() so aclose() always runs.
 """
 
 from __future__ import annotations
@@ -23,14 +23,16 @@ from livekit.agents.cli.cli import _ExitCli, _run_worker
 from livekit.agents.cli.proto import CliArgs
 from livekit.agents.worker import AgentServer
 
+_CLI_ARGS = CliArgs(log_level="ERROR", url=None, api_key=None, api_secret=None)
+
 
 def _make_server(drain_timeout: int = 1) -> AgentServer:
     server = AgentServer(drain_timeout=drain_timeout)
     return server
 
 
-class TestDrainTimeoutSkipsAclose:
-    """When drain() raises TimeoutError, _run_worker does not call aclose()."""
+class TestDrainTimeout:
+    """Verify that aclose() is called regardless of drain() outcome."""
 
     def test_aclose_called_when_drain_succeeds(self) -> None:
         """Baseline: when drain completes normally, aclose IS called."""
@@ -41,24 +43,19 @@ class TestDrainTimeoutSkipsAclose:
             patch.object(server, "aclose", new_callable=AsyncMock) as mock_aclose,
             patch.object(server, "run", new_callable=AsyncMock),
         ):
-            _run_worker(
-                server,
-                args=CliArgs(log_level="ERROR", url=None, api_key=None, api_secret=None),
-            )
+            _run_worker(server, args=_CLI_ARGS)
 
         mock_drain.assert_awaited_once()
         mock_aclose.assert_awaited_once()
 
-    def test_aclose_skipped_when_drain_times_out(self) -> None:
-        """BUG: when drain raises TimeoutError, aclose is never called.
-
-        This means stuck child processes are never sent ShutdownRequest
-        and never SIGKILL'd. They become orphaned until K8s force-kills
-        the pod.
+    def test_aclose_called_when_drain_times_out(self) -> None:
+        """When drain raises TimeoutError, aclose must still be called.
 
         The TimeoutError originates from asyncio.wait_for() inside
         AgentServer.drain() (worker.py) when a child process doesn't
-        exit within drain_timeout seconds.
+        exit within drain_timeout seconds. Without catching it,
+        stuck child processes are never sent ShutdownRequest and never
+        SIGKILL'd — they become orphaned until the pod is force-killed.
         """
         server = _make_server()
 
@@ -72,22 +69,14 @@ class TestDrainTimeoutSkipsAclose:
             patch.object(server, "aclose", new_callable=AsyncMock) as mock_aclose,
             patch.object(server, "run", new_callable=AsyncMock),
         ):
-            with pytest.raises(asyncio.TimeoutError):
-                _run_worker(
-                    server,
-                    args=CliArgs(log_level="ERROR", url=None, api_key=None, api_secret=None),
-                )
+            _run_worker(server, args=_CLI_ARGS)
 
-        # BUG: aclose was never called because TimeoutError is not caught
-        mock_aclose.assert_not_awaited()
+        mock_aclose.assert_awaited_once()
 
     def test_drain_raises_timeout_from_stuck_process(self) -> None:
-        """Demonstrates that drain() itself raises TimeoutError via
-        asyncio.wait_for when a child process won't exit.
-
-        This exercises the real AgentServer.drain() code path rather than
-        mocking it, confirming that the TimeoutError originates from
-        worker.py:868.
+        """Exercises real AgentServer.drain() with a stuck process,
+        confirming TimeoutError originates from asyncio.wait_for in
+        worker.py.
         """
         server = _make_server(drain_timeout=1)
 
@@ -115,8 +104,10 @@ class TestDrainTimeoutSkipsAclose:
             with pytest.raises(asyncio.TimeoutError):
                 asyncio.get_event_loop().run_until_complete(server.drain())
 
-    def test_aclose_skipped_on_any_non_exitcli_exception(self) -> None:
-        """The same bug applies to ANY exception type that isn't _ExitCli."""
+    def test_aclose_skipped_on_non_exitcli_non_timeout_exception(self) -> None:
+        """Other exceptions from drain() still propagate (only TimeoutError
+        is caught by the fix).
+        """
         server = _make_server()
 
         with (
@@ -130,16 +121,13 @@ class TestDrainTimeoutSkipsAclose:
             patch.object(server, "run", new_callable=AsyncMock),
         ):
             with pytest.raises(RuntimeError):
-                _run_worker(
-                    server,
-                    args=CliArgs(log_level="ERROR", url=None, api_key=None, api_secret=None),
-                )
+                _run_worker(server, args=_CLI_ARGS)
 
         mock_aclose.assert_not_awaited()
 
-    def test_exitcli_is_caught_but_aclose_still_skipped(self) -> None:
-        """When drain() raises _ExitCli (second SIGTERM), it is caught
-        but aclose() is still not called — the handler calls os._exit(1).
+    def test_exitcli_during_drain_forces_exit(self) -> None:
+        """When drain() raises _ExitCli (second SIGTERM), the handler
+        calls os._exit(1) for a forceful shutdown.
         """
         server = _make_server()
 
@@ -154,10 +142,7 @@ class TestDrainTimeoutSkipsAclose:
             patch.object(server, "run", new_callable=AsyncMock),
             patch("os._exit") as mock_exit,
         ):
-            _run_worker(
-                server,
-                args=CliArgs(log_level="ERROR", url=None, api_key=None, api_secret=None),
-            )
+            _run_worker(server, args=_CLI_ARGS)
 
         mock_aclose.assert_not_awaited()
         mock_exit.assert_called_once_with(1)


### PR DESCRIPTION
## Bug

When `server.drain()` raises `TimeoutError` (its [documented behavior](https://github.com/livekit/agents/blob/490198ae2/livekit-agents/livekit/agents/worker.py#L843) when child processes don't exit within `drain_timeout`), `_run_worker` does not catch it:

```python
# cli.py _run_worker shutdown sequence
try:
    if not args.devmode:
        loop.run_until_complete(server.drain())   # <-- raises TimeoutError
    loop.run_until_complete(server.aclose())       # <-- never reached
except _ExitCli:
    ...
```

`except _ExitCli` does not catch `TimeoutError`, so `server.aclose()` is skipped entirely. This means:

- Stuck child processes are never sent `ShutdownRequest`
- Stuck child processes are never SIGKILL'd
- They become orphaned until the pod is force-terminated (e.g. by Kubernetes)
- The unhandled `TimeoutError` propagates to `typer`, which renders a Rich traceback to stderr — in production (no TTY, JSON logging), each line of the Rich output becomes a separate log entry in the log aggregator

## Observed impact

We observed this in production during a rolling deploy. A child process was stuck after a LiveKit room disconnected during `wait_for_participant()`. The drain timeout expired after 600s, `aclose()` was never called, and the pod had to be SIGKILL'd by Kubernetes. The Rich traceback produced ~200 fragmented log entries in Datadog.

## This PR

Adds tests that reproduce the bug using real `AgentServer` and `_run_worker` code:

- `test_aclose_called_when_drain_succeeds` — baseline: aclose runs when drain succeeds
- `test_aclose_skipped_when_drain_times_out` — **the bug**: TimeoutError skips aclose
- `test_drain_raises_timeout_from_stuck_process` — exercises real `AgentServer.drain()` with a stuck process, confirming TimeoutError originates from `asyncio.wait_for` in `worker.py`
- `test_aclose_skipped_on_any_non_exitcli_exception` — same bug for any non-_ExitCli exception
- `test_exitcli_is_caught_but_aclose_still_skipped` — documents the _ExitCli/os._exit path

## Suggested fix

```python
try:
    if not args.devmode:
        try:
            loop.run_until_complete(server.drain())
        except TimeoutError:
            logger.warning("drain timed out, forcing shutdown")
    loop.run_until_complete(server.aclose())
except _ExitCli:
    ...
```

Happy to add the fix + update the tests to validate it in this PR if you'd like.