### PR TITLE
fix(voice): make function call history preservation configurable in AgentTask

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -700,6 +700,7 @@ class AgentTask(Agent, Generic[TaskResult_T]):
         llm: NotGivenOr[llm.LLM | llm.RealtimeModel | None] = NOT_GIVEN,
         tts: NotGivenOr[tts.TTS | None] = NOT_GIVEN,
         mcp_servers: NotGivenOr[list[mcp.MCPServer] | None] = NOT_GIVEN,
+        preserve_function_call_history: bool = False,
         # deprecated
         turn_detection: NotGivenOr[TurnDetectionMode | None] = NOT_GIVEN,
         allow_interruptions: NotGivenOr[bool] = NOT_GIVEN,
@@ -733,6 +734,7 @@ class AgentTask(Agent, Generic[TaskResult_T]):
         self.__fut = asyncio.Future[TaskResult_T]()
         self.__inactive_ev = asyncio.Event()
         self.__inactive_ev.set()  # set when the agent is not awaited or activity is closed
+        self._preserve_function_call_history = preserve_function_call_history
 
         self._old_agent: Agent | None = None
 
@@ -892,7 +894,9 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                     run_state._watch_handle(speech_handle)
 
                 merged_chat_ctx = old_agent.chat_ctx.merge(
-                    self.chat_ctx, exclude_function_call=True, exclude_instructions=True
+                    self.chat_ctx,
+                    exclude_function_call=not self._preserve_function_call_history,
+                    exclude_instructions=True,
                 )
                 # set the chat_ctx directly, `session._update_activity` will sync it to the rt_session if needed
                 old_agent._chat_ctx.items[:] = merged_chat_ctx.items


### PR DESCRIPTION
## Summary
- Adds `preserve_function_call_history` parameter to `AgentTask.__init__()` (default `False` for backward compatibility)
- When `True`, function call and function call output items from the sub-task's chat context are retained when merging back to the parent agent
- Previously, `exclude_function_call=True` was hardcoded, unconditionally stripping all tool call history

## Root Cause
In `AgentTask.__await_impl`, the merge call:
```python
old_agent.chat_ctx.merge(self.chat_ctx, exclude_function_call=True, ...)
```
unconditionally strips all function_call items. Users who need tool call results for context continuity (e.g., MCP tool responses, API lookups) had no way to preserve them.

## Test Plan
- [x] Default behavior unchanged (`preserve_function_call_history=False`)
- [x] New parameter correctly inverts `exclude_function_call` flag
- [x] Backward compatible — no changes to existing call sites

Fixes #5284