### PR TITLE
add can_update_own_metadata to simulate_job token

### DIFF
--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -909,7 +909,11 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                 api.AccessToken(self._api_key, self._api_secret)
                 .with_identity(agent_identity)
                 .with_kind("agent")
-                .with_grants(api.VideoGrants(room_join=True, room=room, agent=True))
+                .with_grants(
+                    api.VideoGrants(
+                        room_join=True, room=room, agent=True, can_update_own_metadata=True
+                    )
+                )
                 .to_jwt()
             )
             running_info = RunningJobInfo(


### PR DESCRIPTION
## Summary

When an agent is run in `connect` or `dev` mode, calling `ctx.agent.set_name()`, `ctx.agent.set_metadata()`, or `ctx.agent.set_attributes()` has no effect and does not raise an error.

## Steps to Reproduce

```python
# agent.py
from livekit.agents import AgentServer, JobContext, cli

server = AgentServer()

@server.rtc_session()
async def entrypoint(ctx: JobContext):
    await ctx.connect()
    await ctx.agent.set_name("new_name")
    print(ctx.agent.name)  # still prints original name, not "new_name"

if __name__ == "__main__":
    cli.run_app(server)
````

Run with:

```bash
python agent.py connect --room test-room
```

Expected result:
The participant name is updated to `"new_name"` in the room.

Actual result:
The name remains unchanged (default value is `""`), and no error is raised.

The same code works as expected when the job is started via:

```bash
python agent.py start
```

## Root Cause

`simulate_job()` in `worker.py` generates a local JWT for simulated jobs, but the token does not include `can_update_own_metadata`.

That permission is required for:

* `set_name()`
* `set_metadata()`
* `set_attributes()`

This is also consistent with the note in `participant.py`.

When the job is dispatched normally by the server, the generated token includes this grant automatically, which explains why the behavior differs between `connect`/`dev` mode and `start`.

## Proposed Fix

In `simulate_job()`, update:

```python
api.VideoGrants(room_join=True, room=room, agent=True)
```

to:

```python
api.VideoGrants(room_join=True, room=room, agent=True, can_update_own_metadata=True)
```

## Note

I am not sure whether omitting this grant in simulated/dev jobs was intentional, for example as a security boundary to prevent metadata updates in those modes.

If this behavior is intentional, please feel free to close the PR. In that case, I would appreciate a short note on the rationale so I can handle it appropriately on my side.