### PR TITLE
fix(voice): add merge_exclude_function_call parameter to AgentTask

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -700,6 +700,7 @@ class AgentTask(Agent, Generic[TaskResult_T]):
         llm: NotGivenOr[llm.LLM | llm.RealtimeModel | None] = NOT_GIVEN,
         tts: NotGivenOr[tts.TTS | None] = NOT_GIVEN,
         mcp_servers: NotGivenOr[list[mcp.MCPServer] | None] = NOT_GIVEN,
+        merge_exclude_function_call: bool = True,  # if True, exclude function calls when merging context to parent
         # deprecated
         turn_detection: NotGivenOr[TurnDetectionMode | None] = NOT_GIVEN,
         allow_interruptions: NotGivenOr[bool] = NOT_GIVEN,
@@ -733,6 +734,7 @@ class AgentTask(Agent, Generic[TaskResult_T]):
         self.__fut = asyncio.Future[TaskResult_T]()
         self.__inactive_ev = asyncio.Event()
         self.__inactive_ev.set()  # set when the agent is not awaited or activity is closed
+        self._merge_exclude_function_call = merge_exclude_function_call
 
         self._old_agent: Agent | None = None
 
@@ -892,7 +894,7 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                     run_state._watch_handle(speech_handle)
 
                 merged_chat_ctx = old_agent.chat_ctx.merge(
-                    self.chat_ctx, exclude_function_call=True, exclude_instructions=True
+                    self.chat_ctx, exclude_function_call=self._merge_exclude_function_call, exclude_instructions=True
                 )
                 # set the chat_ctx directly, `session._update_activity` will sync it to the rt_session if needed
                 old_agent._chat_ctx.items[:] = merged_chat_ctx.items


### PR DESCRIPTION
Fixes #5284

AgentTask was hardcoding exclude_function_call=True when merging sub-task chat context back to the parent agent, causing permanent loss of tool call history.

This breaks scenarios where:
- Tool calls retrieve critical data (MCP tools, API responses, etc.)
- Users switch between tasks and need context continuity
- Debugging requires full conversation history

Added merge_exclude_function_call parameter (defaults to True for backward compatibility) that controls whether function call history is preserved when merging contexts.

## Usage
```python
task = AgentTask(
    instructions="...",
    merge_exclude_function_call=False  # Preserve tool history
)
```

## Changes
- Added `merge_exclude_function_call: bool = True` parameter
- Stored as instance variable `self._merge_exclude_function_call`
- Used in merge call instead of hardcoded True
- Added inline documentation

## Verification
- [x] Syntax valid (Python compiles)
- [x] Backward compatible (defaults to True)
- [x] Documentation added
- [x] Minimal change (4 lines)