### PR TITLE
Security: Unvalidated OpenAI base URL override can leak credentials

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/utils.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/utils.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import ipaddress
 import os
 from collections.abc import Awaitable, Callable
+from urllib.parse import urlparse
 
 AsyncAzureADTokenProvider = Callable[[], str | Awaitable[str]]
 
@@ -9,6 +11,46 @@ AsyncAzureADTokenProvider = Callable[[], str | Awaitable[str]]
 def get_base_url(base_url: str | None) -> str:
     if not base_url:
         base_url = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+
+    parsed_url = urlparse(base_url)
+    hostname = parsed_url.hostname
+    if parsed_url.scheme.lower() != "https" or not hostname:
+        raise ValueError("OPENAI base URL must be a valid https URL")
+
+    allowed_hosts = {"api.openai.com"}
+    allowed_hosts.update(
+        host.strip().lower()
+        for host in os.getenv("OPENAI_ALLOWED_BASE_URL_HOSTS", "").split(",")
+        if host.strip()
+    )
+
+    normalized_hostname = hostname.lower()
+    if normalized_hostname not in allowed_hosts:
+        raise ValueError("OPENAI base URL host is not allowed")
+
+    allow_private_hosts = os.getenv("OPENAI_ALLOW_PRIVATE_BASE_URL", "").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+    if not allow_private_hosts:
+        if normalized_hostname in {"localhost", "localhost.localdomain"}:
+            raise ValueError("OPENAI base URL host is not allowed")
+        try:
+            ip_addr = ipaddress.ip_address(normalized_hostname)
+        except ValueError:
+            pass
+        else:
+            if (
+                ip_addr.is_private
+                or ip_addr.is_loopback
+                or ip_addr.is_link_local
+                or ip_addr.is_multicast
+                or ip_addr.is_reserved
+                or ip_addr.is_unspecified
+            ):
+                raise ValueError("OPENAI base URL host is not allowed")
+
     return base_url
 
 


### PR DESCRIPTION
## Problem

`get_base_url` returns caller/env-provided URLs without validation. If an attacker can influence this value, requests may be sent to attacker-controlled or internal hosts, potentially leaking bearer tokens and enabling SSRF-style access.

**Severity**: `high`
**File**: `livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/utils.py`

## Solution

Validate `base_url` against an allowlist of trusted hosts, require `https`, and block loopback/private-network destinations unless explicitly allowed for trusted deployments.

## Changes

- `livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/utils.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
