### PR TITLE
fix(cartesia): handle flush_done message in TTS _recv_task

### DIFF
--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -510,7 +510,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                     )
                     raise APIError(f"Cartesia returned error: {data}")
                 elif data.get("type") == "flush_done":
-                    logger.debug("Received flush_done acknowledgment from Cartesia TTS")
+                    pass
                 else:
                     logger.warning("unexpected message %s", data)
 


### PR DESCRIPTION
## Summary

- The Cartesia TTS WebSocket now returns `flush_done` messages (e.g. `{'type': 'flush_done', 'context_id': '...', 'status_code': 206, 'done': False, 'data': '', 'flush_id': 2, 'flush_done': True}`), but `_recv_task` in `tts.py` does not handle them.
- Because all fields in the message are falsy (`data=""`, `done=False`, `word_timestamps=None`, `type!="error"`), the message falls through the entire if/elif chain into the `else` branch, producing noisy warning logs: `unexpected message {...}`.
- The STT plugin already handles this message type correctly in `_process_stream_event` ([stt.py#L436](https://github.com/livekit/agents/blob/9c260cbe3a44aedeed0244c90aa98d32030fbd6e/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/stt.py#L436)). This PR adds the same handling to the TTS side.

## Changes

**File:** `livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py`

Added an `elif data.get("type") == "flush_done"` branch before the final `else` in `_recv_task`, logging the message at `debug` level — consistent with the STT plugin's approach.