### PR TITLE
Security: Fragile Monkeypatching of asyncio Internals

### DIFF
--- a/livekit-agents/livekit/agents/utils/aio/debug.py
+++ b/livekit-agents/livekit/agents/utils/aio/debug.py
@@ -1,22 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-import time
-from asyncio.base_events import _format_handle  # type: ignore
-from typing import Any
-
-from ...log import logger
 
 
 def hook_slow_callbacks(slow_duration: float) -> None:
-    _run = asyncio.events.Handle._run
-
-    def instrumented(self: Any) -> Any:
-        start = time.monotonic()
-        val = _run(self)
-        dt = time.monotonic() - start
-        if dt >= slow_duration:
-            logger.warning("Running %s took too long: %.2f seconds", _format_handle(self), dt)
-        return val
-
-    asyncio.events.Handle._run = instrumented  # type: ignore
+    loop = asyncio.get_event_loop()
+    loop.slow_callback_duration = slow_duration
+    loop.set_debug(True)


### PR DESCRIPTION
## Problem

The `hook_slow_callbacks` function in `livekit.agents.utils.aio.debug` monkeypatches the private method `asyncio.events.Handle._run`. Relying on private internal APIs of the Python standard library is fragile and can lead to unexpected crashes or behavior changes when Python is updated. In a production environment, this could lead to service instability.

**Severity**: `medium`
**File**: `livekit-agents/livekit/agents/utils/aio/debug.py`

## Solution

Avoid monkeypatching private members of the `asyncio` module. Use official debugging tools like `loop.set_debug(True)` or custom event loop policies if monitoring callback duration is necessary.

## Changes

- `livekit-agents/livekit/agents/utils/aio/debug.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
