### PR TITLE
fix(pipeline): surface validation error details in tool execution

### DIFF
--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -555,15 +555,21 @@ async def _execute_tools_task(
                 )
 
             except (ValidationError, ValueError) as e:
-                logger.exception(
-                    f"tried to call AI function `{fnc_call.name}` with invalid arguments",
+                # Surface argument validation errors to the LLM so it can self-correct.
+                # Without this, the LLM only sees "An internal error occurred" and has
+                # no signal about what was wrong with its arguments.
+                logger.warning(
+                    f"invalid arguments for AI function `{fnc_call.name}`: {e}",
                     extra={
                         "function": fnc_call.name,
                         "arguments": fnc_call.arguments,
                         "speech_id": speech_handle.id,
                     },
                 )
-                _tool_completed(make_tool_output(fnc_call=fnc_call, output=None, exception=e))
+                tool_error = ToolError(f"Error parsing arguments for `{fnc_call.name}`: {e}")
+                _tool_completed(
+                    make_tool_output(fnc_call=fnc_call, output=None, exception=tool_error)
+                )
                 continue
 
             if not tool_output.first_tool_started_fut.done():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -653,3 +653,48 @@ class TestExecuteFunctionCallValidationErrors:
         assert result.fnc_call_out.is_error is True
         # Should contain error details, not generic message
         assert "An internal error occurred" not in result.fnc_call_out.output
+
+
+class TestVoicePathValidationErrors:
+    """Test that the voice path's make_tool_output surfaces ToolError details."""
+
+    def test_tool_error_surfaces_message(self):
+        """When a ToolError is passed to make_tool_output, the error message should
+        appear in FunctionCallOutput.output with is_error=True."""
+        from livekit.agents.llm import FunctionCall, ToolError
+        from livekit.agents.voice.generation import make_tool_output
+
+        fnc_call = FunctionCall(
+            name="test_fn",
+            arguments="{}",
+            call_id="test-call-voice-1",
+        )
+        tool_error = ToolError("Error parsing arguments for `test_fn`: missing field 'arg1'")
+
+        result = make_tool_output(fnc_call=fnc_call, output=None, exception=tool_error)
+
+        assert result.fnc_call_out is not None
+        assert result.fnc_call_out.is_error is True
+        assert "missing field 'arg1'" in result.fnc_call_out.output
+        assert "An internal error occurred" not in result.fnc_call_out.output
+
+    def test_raw_value_error_hides_message(self):
+        """When a raw ValueError (not ToolError) is passed to make_tool_output,
+        the output is the generic 'An internal error occurred' message.
+        This demonstrates why wrapping in ToolError matters."""
+        from livekit.agents.llm import FunctionCall
+        from livekit.agents.voice.generation import make_tool_output
+
+        fnc_call = FunctionCall(
+            name="test_fn",
+            arguments="{}",
+            call_id="test-call-voice-2",
+        )
+        raw_error = ValueError("missing field 'arg1'")
+
+        result = make_tool_output(fnc_call=fnc_call, output=None, exception=raw_error)
+
+        assert result.fnc_call_out is not None
+        assert result.fnc_call_out.is_error is True
+        # Raw ValueError produces the generic message - this is the behavior we're fixing
+        assert result.fnc_call_out.output == "An internal error occurred"


### PR DESCRIPTION
## Summary

- Wraps `ValidationError`/`ValueError` in `ToolError` in `voice/generation.py`'s `_execute_tools_task`, matching the pattern established by #5193 for the realtime path
- Changes `logger.exception` to `logger.warning` to match the realtime path convention
- Without this fix, the LLM only sees `"An internal error occurred"` instead of the actual validation error details when tool argument parsing fails in the voice path

## Context

#5193 fixed this for the realtime path (`llm/utils.py`), but the equivalent pipeline code in `voice/generation.py` was not updated.

Fixes #5164 (voice path)

## Test plan

- [x] Added unit tests verifying `ToolError` surfaces message in `make_tool_output` while raw `ValueError` produces generic message
- [x] Existing `TestExecuteFunctionCallValidationErrors` tests still pass
- [x] `make check` passes (format, lint, type-check)
- [ ] Install package from this branch and manually test in a real application

🤖 Generated with [Claude Code](https://claude.com/claude-code)