### PR TITLE
fix: prevent compounding retries between SDK and framework retry layers

### DIFF
--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -201,6 +201,7 @@ class LLM(llm.LLM):
         self._client = openai.AsyncClient(
             api_key=create_access_token(self._opts.api_key, self._opts.api_secret),
             base_url=self._opts.base_url,
+            max_retries=0,
             http_client=httpx.AsyncClient(
                 timeout=httpx.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
                 follow_redirects=True,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -14,7 +14,9 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import warnings
 from dataclasses import asdict, dataclass
 from typing import Any, Literal
 from urllib.parse import urlparse
@@ -57,6 +59,7 @@ from .models import (
 )
 from .utils import AsyncAzureADTokenProvider
 
+logger = logging.getLogger(__name__)
 lk_oai_debug = int(os.getenv("LK_OPENAI_DEBUG", 0))
 
 Verbosity = Literal["low", "medium", "high"]
@@ -155,13 +158,22 @@ class LLM(llm.LLM):
                 " OPENAI_API_KEY environment variable"
             )
 
+        if is_given(max_retries) and max_retries > 0:
+            warnings.warn(
+                "max_retries is deprecated for openai.LLM and will be ignored. "
+                "Retries are handled by the framework via APIConnectOptions.max_retry. "
+                "Setting max_retries on the SDK client causes compounding retries.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         self._provider_fmt = _provider_fmt or "openai"
         self._strict_tool_schema = _strict_tool_schema
         self._owns_client = client is None
         self._client = client or openai.AsyncClient(
             api_key=api_key if is_given(api_key) else None,
             base_url=base_url if is_given(base_url) else None,
-            max_retries=max_retries if is_given(max_retries) else 0,
+            max_retries=0,
             http_client=httpx.AsyncClient(
                 timeout=timeout
                 if timeout


### PR DESCRIPTION
## Summary

Fixes a bug where **two independent retry layers compound multiplicatively**, causing far more HTTP requests than expected with most retries invisible in logs.

### The problem

The framework's `LLMStream._main_task()` in `llm.py` implements retry logic controlled by `APIConnectOptions` (default: `max_retry=3`, `timeout=10s`). Separately, the OpenAI SDK client has its own built-in retry mechanism (`max_retries`, SDK default: 2).

When both layers are active, each framework-level retry triggers the `_run()` method, which makes an API call through the OpenAI SDK. If that call times out, the SDK silently retries internally before surfacing the error back to the framework, which then retries again. This produces **multiplicative** behavior:

| Layer | Attempts | Visible in logs? |
|---|---|---|
| Framework (`_main_task`) | 1 initial + 3 retries = **4** | Yes |
| OpenAI SDK (per framework attempt) | 1 initial + 2 retries = **3** | **No** |
| **Total HTTP requests** | **4 × 3 = 12** | Only 3 retry log lines |

A user expecting 3 retries over ~30s instead sees 3 logged retries, each taking ~30s (3 × 10s timeout silently inside the SDK), for a total wait of **~120s with 12 actual HTTP requests**.

### The fix

- **`inference/llm.py`**: Add `max_retries=0` to the `openai.AsyncClient` constructor. This was the only client in the codebase that did not set this, causing it to silently use the OpenAI SDK's default of 2 retries. Every other client (`openai/llm.py`, `openai/stt.py`, `openai/tts.py`, `openai/responses/llm.py`) already had `max_retries=0`.

- **`openai/llm.py`**: Always set `max_retries=0` on the SDK client regardless of user input. Previously, passing `max_retries=N` would enable SDK-level retries that compound with the framework's retries. Now emits a `DeprecationWarning` when a non-zero value is passed, guiding users to configure retries exclusively through `APIConnectOptions.max_retry`.

### How to configure retries (before and after this fix)

```python
# Correct way to configure retries — unchanged by this PR
from livekit.agents.types import APIConnectOptions

agent = Agent(
    ...,
    llm=openai.LLM(model="gpt-4.1"),
    conn_options=APIConnectOptions(
        max_retry=3,        # number of retries (framework-level, with logging)
        retry_interval=2.0, # seconds between retries
        timeout=10.0,       # per-attempt timeout
    ),
)
```

## Test plan

- [ ] Verify `inference.LLM` no longer triggers SDK-level retries (only framework retries visible in logs)
- [ ] Verify `openai.LLM(max_retries=3)` emits a `DeprecationWarning` and does not pass the value to the SDK client
- [ ] Verify default behavior (no `max_retries` arg) continues to work with `max_retries=0` on the SDK client
- [ ] Confirm linter passes (`make lint` ✅)


Made with [Cursor](https://cursor.com)