### PR TITLE
Reproduce Test Framework Instability

### DIFF
--- a/examples/healthcare/mock_patient_taskgroup_agent.py
+++ b/examples/healthcare/mock_patient_taskgroup_agent.py
@@ -1,27 +1,9 @@
-import json
-import time
 from dataclasses import dataclass
 from typing import Literal
 
 from livekit.agents import Agent, AgentTask
 from livekit.agents.beta.workflows import TaskGroup
 from livekit.agents.llm import function_tool
-
-DEBUG_LOG_PATH = "/Users/toubatbrian/Documents/agents-js/.cursor/debug-e6d38d.log"
-
-
-def _debug_log(*, run_id: str, hypothesis_id: str, location: str, message: str, data: dict) -> None:
-    payload = {
-        "sessionId": "e6d38d",
-        "runId": run_id,
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data,
-        "timestamp": int(time.time() * 1000),
-    }
-    with open(DEBUG_LOG_PATH, "a", encoding="utf-8") as f:
-        f.write(json.dumps(payload) + "\n")
 
 
 @dataclass
@@ -40,15 +22,6 @@ class VerifyIntentTask(AgentTask[str]):
         )
 
     async def on_enter(self) -> None:
-        # region agent log
-        _debug_log(
-            run_id="pre-fix",
-            hypothesis_id="H1",
-            location="mock_patient_taskgroup_agent.py:30",
-            message="VerifyIntentTask.on_enter entered",
-            data={"task": "verify_intent_task"},
-        )
-        # endregion
         await self.session.generate_reply(
             instructions=(
                 "Ask user if they want to schedule an appointment. That said, do not say anything more. Just one brief sentence is enough."
@@ -58,15 +31,6 @@ class VerifyIntentTask(AgentTask[str]):
 
     @function_tool()
     async def verify_intent(self, intent: Literal["schedule"]) -> None:
-        # region agent log
-        _debug_log(
-            run_id="pre-fix",
-            hypothesis_id="H2",
-            location="mock_patient_taskgroup_agent.py:50",
-            message="verify_intent tool executed",
-            data={"intent": intent},
-        )
-        # endregion
         self.session.userdata.verified_intent = intent
         self.complete(intent)
 
@@ -80,15 +44,6 @@ class IdentifyPatientTask(AgentTask[dict]):
         )
 
     async def on_enter(self) -> None:
-        # region agent log
-        _debug_log(
-            run_id="pre-fix",
-            hypothesis_id="H3",
-            location="mock_patient_taskgroup_agent.py:69",
-            message="IdentifyPatientTask.on_enter entered",
-            data={"verified_intent": self.session.userdata.verified_intent},
-        )
-        # endregion
         await self.session.generate_reply(
             instructions=(
                 "Ask for full name and date of birth, then call identify_patient immediately."

--- a/examples/healthcare/mock_patient_taskgroup_agent.py
+++ b/examples/healthcare/mock_patient_taskgroup_agent.py
@@ -1,0 +1,155 @@
+import json
+import time
+from dataclasses import dataclass
+from typing import Literal
+
+from livekit.agents import Agent, AgentTask
+from livekit.agents.beta.workflows import TaskGroup
+from livekit.agents.llm import function_tool
+
+DEBUG_LOG_PATH = "/Users/toubatbrian/Documents/agents-js/.cursor/debug-e6d38d.log"
+
+
+def _debug_log(*, run_id: str, hypothesis_id: str, location: str, message: str, data: dict) -> None:
+    payload = {
+        "sessionId": "e6d38d",
+        "runId": run_id,
+        "hypothesisId": hypothesis_id,
+        "location": location,
+        "message": message,
+        "data": data,
+        "timestamp": int(time.time() * 1000),
+    }
+    with open(DEBUG_LOG_PATH, "a", encoding="utf-8") as f:
+        f.write(json.dumps(payload) + "\n")
+
+
+@dataclass
+class UserData:
+    verified_intent: str | None = None
+    full_name: str | None = None
+    date_of_birth: str | None = None
+    preferred_date_time: str | None = None
+    status: str | None = None
+
+
+class VerifyIntentTask(AgentTask[str]):
+    def __init__(self) -> None:
+        super().__init__(
+            instructions=("Verify the user's intent to schedule a patient appointment.")
+        )
+
+    async def on_enter(self) -> None:
+        # region agent log
+        _debug_log(
+            run_id="pre-fix",
+            hypothesis_id="H1",
+            location="mock_patient_taskgroup_agent.py:30",
+            message="VerifyIntentTask.on_enter entered",
+            data={"task": "verify_intent_task"},
+        )
+        # endregion
+        await self.session.generate_reply(
+            instructions=(
+                "Ask user if they want to schedule an appointment. That said, do not say anything more. Just one brief sentence is enough."
+            ),
+            tool_choice="none",
+        )
+
+    @function_tool()
+    async def verify_intent(self, intent: Literal["schedule"]) -> None:
+        # region agent log
+        _debug_log(
+            run_id="pre-fix",
+            hypothesis_id="H2",
+            location="mock_patient_taskgroup_agent.py:50",
+            message="verify_intent tool executed",
+            data={"intent": intent},
+        )
+        # endregion
+        self.session.userdata.verified_intent = intent
+        self.complete(intent)
+
+
+class IdentifyPatientTask(AgentTask[dict]):
+    def __init__(self) -> None:
+        super().__init__(
+            instructions=(
+                "Ask for full name and date of birth, then call identify_patient immediately.",
+            ),
+        )
+
+    async def on_enter(self) -> None:
+        # region agent log
+        _debug_log(
+            run_id="pre-fix",
+            hypothesis_id="H3",
+            location="mock_patient_taskgroup_agent.py:69",
+            message="IdentifyPatientTask.on_enter entered",
+            data={"verified_intent": self.session.userdata.verified_intent},
+        )
+        # endregion
+        await self.session.generate_reply(
+            instructions=(
+                "Ask for full name and date of birth, then call identify_patient immediately."
+            ),
+            tool_choice="none",
+        )
+
+    @function_tool()
+    async def identify_patient(self, full_name: str, date_of_birth: str) -> None:
+        self.session.userdata.full_name = full_name
+        self.session.userdata.date_of_birth = date_of_birth
+        self.complete({"full_name": full_name, "date_of_birth": date_of_birth})
+
+
+class SchedulePatientVisitTask(AgentTask[dict]):
+    def __init__(self) -> None:
+        super().__init__(
+            instructions=("Ask for a preferred date and time, then call schedule_patient_visit.")
+        )
+
+    async def on_enter(self) -> None:
+        await self.session.generate_reply(
+            instructions=("Ask for a preferred date and time, then call schedule_patient_visit."),
+            tool_choice="none",
+        )
+
+    @function_tool()
+    async def schedule_patient_visit(self, preferred_date_time: str) -> None:
+        self.session.userdata.preferred_date_time = preferred_date_time
+        self.session.userdata.status = "scheduled"
+        self.complete(
+            {
+                "preferred_date_time": preferred_date_time,
+                "status": "scheduled",
+            }
+        )
+
+
+class MockPatientTaskGroupAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(
+            instructions=(
+                "You are a concise healthcare assistant. Help the user schedule a patient appointment."
+            )
+        )
+
+    async def on_enter(self) -> None:
+        task_group = TaskGroup(summarize_chat_ctx=True)
+        task_group.add(
+            lambda: VerifyIntentTask(),
+            id="verify_intent_task",
+            description="confirm user scheduling intent",
+        )
+        task_group.add(
+            lambda: IdentifyPatientTask(),
+            id="identify_patient_task",
+            description="collect patient identity details",
+        )
+        task_group.add(
+            lambda: SchedulePatientVisitTask(),
+            id="schedule_patient_visit_task",
+            description="schedule patient visit",
+        )
+        await task_group

--- a/examples/healthcare/test_mock_patient_taskgroup_agent.py
+++ b/examples/healthcare/test_mock_patient_taskgroup_agent.py
@@ -1,7 +1,5 @@
 import asyncio
-import json
 import os
-import time
 from pprint import pformat
 
 import pytest
@@ -12,22 +10,6 @@ os.environ.setdefault("LIVEKIT_EVALS_VERBOSE", "1")
 from livekit.agents import AgentSession, inference, llm
 
 from .mock_patient_taskgroup_agent import MockPatientTaskGroupAgent, UserData
-
-DEBUG_LOG_PATH = "/Users/toubatbrian/Documents/agents-js/.cursor/debug-e6d38d.log"
-
-
-def _debug_log(*, run_id: str, hypothesis_id: str, location: str, message: str, data: dict) -> None:
-    payload = {
-        "sessionId": "e6d38d",
-        "runId": run_id,
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data,
-        "timestamp": int(time.time() * 1000),
-    }
-    with open(DEBUG_LOG_PATH, "a", encoding="utf-8") as f:
-        f.write(json.dumps(payload) + "\n")
 
 
 def _pretty_events(events: list[object]) -> str:
@@ -82,19 +64,6 @@ async def test_taskgroup_handoff_visibility_with_delay() -> None:
             # Accessing `expect` triggers LIVEKIT_EVALS_VERBOSE debug output.
 
             event_types = [event.type for event in result.events]
-            # region agent log
-            _debug_log(
-                run_id="pre-fix",
-                hypothesis_id="H4",
-                location="test_mock_patient_taskgroup_agent.py:90",
-                message="run1 events captured",
-                data={
-                    "startup_delay": startup_delay,
-                    "delay_after_wait": delay_after_wait,
-                    "event_types": event_types,
-                },
-            )
-            # endregion
             print(
                 f"\nPython run #1 events (startup_delay={startup_delay}s, delay_after_wait={delay_after_wait}s):"
             )
@@ -103,7 +72,7 @@ async def test_taskgroup_handoff_visibility_with_delay() -> None:
             # The first run may either call a tool immediately or ask a follow-up question first.
             if "function_call" in event_types:
                 result.expect.contains_function_call(name="verify_intent")
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(2)
 
             try:
                 result2 = await sess.run(
@@ -113,19 +82,6 @@ async def test_taskgroup_handoff_visibility_with_delay() -> None:
                     f"\nPython run #2 events (startup_delay={startup_delay}s, delay_after_wait={delay_after_wait}s):"
                 )
                 print(_pretty_events(list(result2.events)))
-                # region agent log
-                _debug_log(
-                    run_id="pre-fix",
-                    hypothesis_id="H5",
-                    location="test_mock_patient_taskgroup_agent.py:112",
-                    message="run2 events captured",
-                    data={
-                        "startup_delay": startup_delay,
-                        "delay_after_wait": delay_after_wait,
-                        "event_types": [event.type for event in result2.events],
-                    },
-                )
-                # endregion
             except RuntimeError as e:
                 print(
                     f"\nPython run #2 raised RuntimeError "

--- a/examples/healthcare/test_mock_patient_taskgroup_agent.py
+++ b/examples/healthcare/test_mock_patient_taskgroup_agent.py
@@ -1,0 +1,148 @@
+import asyncio
+import json
+import os
+import time
+from pprint import pformat
+
+import pytest
+
+# Enable RunResult debug output in `run_result.py`.
+os.environ.setdefault("LIVEKIT_EVALS_VERBOSE", "1")
+
+from livekit.agents import AgentSession, inference, llm
+
+from .mock_patient_taskgroup_agent import MockPatientTaskGroupAgent, UserData
+
+DEBUG_LOG_PATH = "/Users/toubatbrian/Documents/agents-js/.cursor/debug-e6d38d.log"
+
+
+def _debug_log(*, run_id: str, hypothesis_id: str, location: str, message: str, data: dict) -> None:
+    payload = {
+        "sessionId": "e6d38d",
+        "runId": run_id,
+        "hypothesisId": hypothesis_id,
+        "location": location,
+        "message": message,
+        "data": data,
+        "timestamp": int(time.time() * 1000),
+    }
+    with open(DEBUG_LOG_PATH, "a", encoding="utf-8") as f:
+        f.write(json.dumps(payload) + "\n")
+
+
+def _pretty_events(events: list[object]) -> str:
+    rows: list[dict[str, object]] = []
+    for idx, event in enumerate(events):
+        row: dict[str, object] = {"index": idx, "type": getattr(event, "type", "<unknown>")}
+
+        item = getattr(event, "item", None)
+        if item is not None and hasattr(item, "model_dump"):
+            row["item"] = item.model_dump(
+                exclude_none=True,
+                exclude_defaults=True,
+                exclude={"id", "call_id", "created_at"},
+            )
+
+        old_agent = getattr(event, "old_agent", None)
+        new_agent = getattr(event, "new_agent", None)
+        if old_agent is not None or new_agent is not None:
+            row["handoff"] = {
+                "old_agent": type(old_agent).__name__ if old_agent is not None else None,
+                "new_agent": type(new_agent).__name__ if new_agent is not None else None,
+            }
+
+        rows.append(row)
+
+    return pformat(rows, width=100, compact=False, sort_dicts=False)
+
+
+def _llm_model() -> llm.LLM:
+    return inference.LLM(
+        model="openai/gpt-4.1",
+        extra_kwargs={"temperature": 0.2},
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY is required")
+async def test_taskgroup_handoff_visibility_with_delay() -> None:
+    async def run_first_turn(
+        *, startup_delay: float, delay_after_wait: float
+    ) -> tuple[list[str], list[object]]:
+        async with _llm_model() as model, AgentSession(llm=model, userdata=UserData()) as sess:
+            await sess.start(MockPatientTaskGroupAgent())
+            # Optionally give on_enter TaskGroup time to start first task.
+            if startup_delay > 0:
+                await asyncio.sleep(startup_delay)
+
+            result = await sess.run(user_input="Yes, please. Also who are you?")
+            if delay_after_wait > 0:
+                await asyncio.sleep(delay_after_wait)
+
+            # Accessing `expect` triggers LIVEKIT_EVALS_VERBOSE debug output.
+
+            event_types = [event.type for event in result.events]
+            # region agent log
+            _debug_log(
+                run_id="pre-fix",
+                hypothesis_id="H4",
+                location="test_mock_patient_taskgroup_agent.py:90",
+                message="run1 events captured",
+                data={
+                    "startup_delay": startup_delay,
+                    "delay_after_wait": delay_after_wait,
+                    "event_types": event_types,
+                },
+            )
+            # endregion
+            print(
+                f"\nPython run #1 events (startup_delay={startup_delay}s, delay_after_wait={delay_after_wait}s):"
+            )
+            print(_pretty_events(list(result.events)))
+
+            # The first run may either call a tool immediately or ask a follow-up question first.
+            if "function_call" in event_types:
+                result.expect.contains_function_call(name="verify_intent")
+            await asyncio.sleep(0.5)
+
+            try:
+                result2 = await sess.run(
+                    user_input="My name is Alice Johnson and my date of birth is 1991-04-11."
+                )
+                print(
+                    f"\nPython run #2 events (startup_delay={startup_delay}s, delay_after_wait={delay_after_wait}s):"
+                )
+                print(_pretty_events(list(result2.events)))
+                # region agent log
+                _debug_log(
+                    run_id="pre-fix",
+                    hypothesis_id="H5",
+                    location="test_mock_patient_taskgroup_agent.py:112",
+                    message="run2 events captured",
+                    data={
+                        "startup_delay": startup_delay,
+                        "delay_after_wait": delay_after_wait,
+                        "event_types": [event.type for event in result2.events],
+                    },
+                )
+                # endregion
+            except RuntimeError as e:
+                print(
+                    f"\nPython run #2 raised RuntimeError "
+                    f"(startup_delay={startup_delay}s, delay_after_wait={delay_after_wait}s): {e}"
+                )
+
+            return event_types, list(result.events)
+
+    no_delay_types, no_delay_events = await run_first_turn(startup_delay=1.0, delay_after_wait=0.0)
+    delayed_types, delayed_events = await run_first_turn(startup_delay=1.0, delay_after_wait=1.0)
+    cold_start_types, cold_start_events = await run_first_turn(
+        startup_delay=0.0, delay_after_wait=0.0
+    )
+
+    assert len(no_delay_events) > 0
+    assert len(delayed_events) > 0
+    assert len(cold_start_events) > 0
+    assert len(cold_start_types) > 0
+    assert len(no_delay_types) > 0
+    assert len(delayed_types) > 0

--- a/livekit-agents/livekit/agents/beta/workflows/task_group.py
+++ b/livekit-agents/livekit/agents/beta/workflows/task_group.py
@@ -60,7 +60,11 @@ class TaskGroup(AgentTask[TaskGroupResult]):
             return_exceptions (bool): Whether or not to directly propagate an error. When set to True, the exception is added to the results dictionary and the sequence continues. Defaults to False.
             on_task_completed (Callable[]): A callable that executes upon each task completion. The callback takes in a single argument of a TaskCompletedEvent.
         """
-        super().__init__(instructions="*empty*", chat_ctx=chat_ctx, llm=None)
+        super().__init__(
+            instructions="You are TaskGroup, orchestrate a sequence of multiple AgentTasks.",
+            chat_ctx=chat_ctx,
+            llm=NOT_GIVEN,
+        )
 
         self._summarize_chat_ctx = summarize_chat_ctx
         self._return_exceptions = return_exceptions


### PR DESCRIPTION
```shell
examples/healthcare/test_mock_patient_taskgroup_agent.py 
Python run #1 events (startup_delay=1.0s, delay_after_wait=0.0s):
[{'index': 0,
  'type': 'function_call',
  'item': {'arguments': '{"intent":"schedule"}', 'name': 'verify_intent'}},
 {'index': 1,
  'type': 'function_call_output',
  'item': {'name': 'verify_intent', 'output': '', 'is_error': False}}]

Python run #2 raised RuntimeError (startup_delay=1.0s, delay_after_wait=0.0s): AgentSession is closing, cannot use generate_reply()

Python run #1 events (startup_delay=1.0s, delay_after_wait=1.0s):
[{'index': 0,
  'type': 'function_call',
  'item': {'arguments': '{"intent":"schedule" }', 'name': 'verify_intent'}},
 {'index': 1,
  'type': 'function_call_output',
  'item': {'name': 'verify_intent', 'output': '', 'is_error': False}}]

Python run #2 raised RuntimeError (startup_delay=1.0s, delay_after_wait=1.0s): AgentSession is closing, cannot use generate_reply()

Python run #1 events (startup_delay=0.0s, delay_after_wait=0.0s):
[{'index': 0,
  'type': 'message',
  'item': {'role': 'assistant',
           'content': ['Hello! I am TaskGroup, an AI designed to coordinate and manage sequences '
                       'of tasks, each handled by specialized agents. My role is to break down '
                       'your requests into actionable steps, assign them to the right agents, and '
                       'ensure you get a clear, organized response.\n'
                       '\n'
                       'Would you like to proceed with a specific task or ask more about how I '
                       'work?'],
           'metrics': {'started_speaking_at': 1775260454.7678652,
                       'stopped_speaking_at': 1775260455.1389382,
                       'llm_node_ttft': 0.3061819998547435,
                       'llm_metadata': {'model_name': 'openai/gpt-4.1',
                                        'model_provider': 'livekit'}}}}]

Python run #2 events (startup_delay=0.0s, delay_after_wait=0.0s):
[{'index': 0,
  'type': 'function_call',
  'item': {'arguments': '{"intent":"schedule"}', 'name': 'verify_intent'}},
 {'index': 1,
  'type': 'function_call_output',
  'item': {'name': 'verify_intent', 'output': '', 'is_error': False}}]
```