### PR TITLE
feat: expose service_tier in CompletionUsage from OpenAI Responses API

### DIFF
--- a/.github/next-release/changeset-service-tier-response.md
+++ b/.github/next-release/changeset-service-tier-response.md
@@ -1,0 +1,6 @@
+---
+"livekit-agents": patch
+"livekit-plugins-openai": patch
+---
+
+Expose service_tier in CompletionUsage from OpenAI Responses API and Chat Completions

--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -375,6 +375,7 @@ class LLMStream(llm.LLMStream):
                                 prompt_tokens=chunk.usage.prompt_tokens,
                                 prompt_cached_tokens=cached_tokens or 0,
                                 total_tokens=chunk.usage.total_tokens,
+                                service_tier=getattr(chunk, "service_tier", None),
                             ),
                         )
                         self._event_ch.send_nowait(usage_chunk)

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -45,6 +45,9 @@ class CompletionUsage(BaseModel):
     """The number of tokens read from the cache."""
     total_tokens: int
     """The total number of tokens used (completion + prompt tokens)."""
+    service_tier: str | None = None
+    """The service tier used for processing the request (e.g. 'default', 'priority', 'flex').
+    Returned by providers that support tiered processing (e.g. OpenAI)."""
 
 
 class FunctionToolCall(BaseModel):

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -521,6 +521,7 @@ class LLMStream(llm.LLMStream):
                     if usage.input_tokens_details
                     else 0,
                     total_tokens=usage.total_tokens,
+                    service_tier=getattr(event.response, "service_tier", None),
                 ),
             )
         return chunk


### PR DESCRIPTION
## Summary

OpenAI returns `service_tier` (e.g. `"default"`, `"priority"`, `"flex"`) in every API response, indicating the processing tier that was actually used to serve the request. This is important for accurate cost tracking since priority tier has different billing rates.

Currently, both the Responses API plugin and the Chat Completions inference layer parse usage data but ignore `service_tier`. This PR adds it to `CompletionUsage` so downstream consumers can access it.

## Changes

- **`livekit-agents/livekit/agents/llm/llm.py`**: Add `service_tier: str | None = None` field to `CompletionUsage`
- **`livekit-plugins/livekit-plugins-openai/.../responses/llm.py`**: Read `event.response.service_tier` in `_handle_response_completed` and pass it to `CompletionUsage`
- **`livekit-agents/livekit/agents/inference/llm.py`**: Read `chunk.service_tier` in Chat Completions stream and pass it to `CompletionUsage`

## Why

- OpenAI's [Priority Processing](https://platform.openai.com/docs/guides/priority-processing) bills at a premium rate
- When `service_tier` is configured at the project level, some requests may be downgraded to `"default"` under ramp rate limits
- Without this field, there's no way to know which tier was actually used for billing reconciliation
- The field is already present on both the OpenAI `Response` object and `ChatCompletionChunk` — just not being read

## Design Note

`service_tier` is semantically response metadata rather than token usage. Placing it on `CompletionUsage` is a pragmatic choice — `CompletionUsage` is the object that flows through the metrics/usage collection pipeline (`ModelUsageCollector`, session reports, etc.), so it propagates automatically with zero changes to the pipeline.

If the maintainers prefer cleaner separation, this could be moved to `ChatChunk` directly — happy to refactor if that's the preferred approach.

## Backward Compatible

- `service_tier` defaults to `None` — no impact on existing code
- Providers that don't support it simply leave it as `None`

## Related

- JS equivalent: livekit/agents-js#1205