### PR TITLE
feat: add service_tier parameter to Responses API LLM

### DIFF
--- a/.github/next-release/changeset-service-tier-param.md
+++ b/.github/next-release/changeset-service-tier-param.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-openai": patch
+---
+
+Add service_tier parameter to Responses API LLM for parity with Chat Completions LLM

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -141,6 +141,7 @@ class _LLMOptions:
     store: NotGivenOr[bool]
     reasoning: NotGivenOr[Reasoning]
     metadata: NotGivenOr[dict[str, str]]
+    service_tier: NotGivenOr[str]
     use_websocket: bool
 
 
@@ -160,6 +161,7 @@ class LLM(llm.LLM):
         tool_choice: NotGivenOr[ToolChoice | Literal["auto", "required", "none"]] = NOT_GIVEN,
         store: NotGivenOr[bool] = NOT_GIVEN,
         metadata: NotGivenOr[dict[str, str]] = NOT_GIVEN,
+        service_tier: NotGivenOr[str] = NOT_GIVEN,
         timeout: httpx.Timeout | None = None,
     ) -> None:
         """
@@ -189,6 +191,7 @@ class LLM(llm.LLM):
             store=store,
             metadata=metadata,
             reasoning=reasoning,
+            service_tier=service_tier,
             use_websocket=use_websocket,
         )
         self._client = client
@@ -281,6 +284,9 @@ class LLM(llm.LLM):
 
         if is_given(self._opts.reasoning):
             extra["reasoning"] = self._opts.reasoning
+
+        if is_given(self._opts.service_tier):
+            extra["service_tier"] = self._opts.service_tier
 
         parallel_tool_calls = (
             parallel_tool_calls if is_given(parallel_tool_calls) else self._opts.parallel_tool_calls


### PR DESCRIPTION
## Summary

The Chat Completions LLM (`openai.LLM`) already supports the `service_tier` parameter for configuring priority/flex/default processing per-request. The Responses API LLM (`openai.responses.LLM`) is missing this parameter despite the OpenAI Responses API [supporting it](https://platform.openai.com/docs/api-reference/responses/create).

This PR adds `service_tier` to the Responses LLM for parity.

## Changes

**`livekit-plugins/livekit-plugins-openai/.../responses/llm.py`** (1 file, 6 lines):
- Add `service_tier: NotGivenOr[str]` to `_LLMOptions`
- Add `service_tier` parameter to `LLM.__init__()`
- Pass `service_tier` through in `chat()` via extra kwargs

## Usage

```python
from livekit.plugins.openai import responses

llm = responses.LLM(
    model="gpt-5.4",
    service_tier="priority",  # now supported
)
```

## Backward Compatible

- Defaults to `NOT_GIVEN` — no impact on existing code
- Matches the existing pattern used by the Chat Completions LLM