### PR TITLE
feat: add service_tier parameter to Responses API LLM

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -43,6 +43,8 @@ from openai.types.shared_params import ResponsesModel
 from ..log import logger
 from ..models import _supports_reasoning_effort
 
+ServiceTier = Literal["auto", "default", "flex", "scale", "priority"]
+
 OPENAI_RESPONSES_WS_URL = "wss://api.openai.com/v1/responses"
 
 
@@ -141,7 +143,7 @@ class _LLMOptions:
     store: NotGivenOr[bool]
     reasoning: NotGivenOr[Reasoning]
     metadata: NotGivenOr[dict[str, str]]
-    service_tier: NotGivenOr[str]
+    service_tier: NotGivenOr[ServiceTier]
     use_websocket: bool
 
 
@@ -161,7 +163,7 @@ class LLM(llm.LLM):
         tool_choice: NotGivenOr[ToolChoice | Literal["auto", "required", "none"]] = NOT_GIVEN,
         store: NotGivenOr[bool] = NOT_GIVEN,
         metadata: NotGivenOr[dict[str, str]] = NOT_GIVEN,
-        service_tier: NotGivenOr[str] = NOT_GIVEN,
+        service_tier: NotGivenOr[ServiceTier] = NOT_GIVEN,
         timeout: httpx.Timeout | None = None,
     ) -> None:
         """


### PR DESCRIPTION
## Summary

The Chat Completions LLM (`openai.LLM`) already supports the `service_tier` parameter for configuring priority/flex/default processing per-request. The Responses API LLM (`openai.responses.LLM`) is missing this parameter despite the OpenAI Responses API [supporting it](https://platform.openai.com/docs/api-reference/responses/create).

This PR adds `service_tier` to the Responses LLM for parity.

## Changes

**`livekit-plugins/livekit-plugins-openai/.../responses/llm.py`** (1 file):
- Add `service_tier: NotGivenOr[str]` to `_LLMOptions`
- Add `service_tier` parameter to `LLM.__init__()`
- Pass `service_tier` through in `chat()` via extra kwargs

## Usage

\`\`\`python
from livekit.plugins.openai import responses

llm = responses.LLM(
    model="gpt-5.4",
    service_tier="priority",  # now supported
)
\`\`\`

## Backward Compatible

- Defaults to \`NOT_GIVEN\` — no impact on existing code
- Matches the existing pattern used by the Chat Completions LLM (\`NotGivenOr[str]\`)