### PR TITLE
Fix RoomIO teardown listener cleanup

### DIFF
--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -126,6 +126,7 @@ class _ParticipantInputStream(Generic[T], ABC):
             await aio.cancel_and_wait(self._forward_atask)
 
         self._room.off("track_subscribed", self._on_track_available)
+        self._room.off("track_unpublished", self._on_track_unavailable)
         self._room.off("token_refreshed", self._on_token_refreshed)
         self._data_ch.close()
 

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -217,6 +217,7 @@ class _ParticipantLegacyTranscriptionOutput:
         self._room.on("track_published", self._on_track_published)
         self._room.on("local_track_published", self._on_local_track_published)
         self._flush_task: asyncio.Task[None] | None = None
+        self._closed = False
 
         self._reset_state()
         self.set_participant(participant)
@@ -283,6 +284,16 @@ class _ParticipantLegacyTranscriptionOutput:
             self._publish_transcription(self._current_id, self._pushed_text, final=True)
         )
         self._reset_state()
+
+    async def aclose(self) -> None:
+        if self._closed:
+            return
+
+        self._closed = True
+        self._room.off("track_published", self._on_track_published)
+        self._room.off("local_track_published", self._on_local_track_published)
+        if self._flush_task:
+            await self._flush_task
 
     async def _publish_transcription(self, id: str, text: str, final: bool) -> None:
         if self._participant_identity is None or self._track_id is None:
@@ -365,6 +376,7 @@ class _ParticipantStreamTranscriptionOutput:
         self._room.on("track_published", self._on_track_published)
         self._room.on("local_track_published", self._on_local_track_published)
         self._flush_atask: asyncio.Task[None] | None = None
+        self._closed = False
 
         self._reset_state()
         self.set_participant(participant)
@@ -470,6 +482,22 @@ class _ParticipantStreamTranscriptionOutput:
         self._writer = None
         self._flush_atask = asyncio.create_task(self._flush_task(curr_writer))
 
+    async def aclose(self) -> None:
+        if self._closed:
+            return
+
+        self._closed = True
+        self._room.off("track_published", self._on_track_published)
+        self._room.off("local_track_published", self._on_local_track_published)
+
+        if self._flush_atask:
+            await self._flush_atask
+
+        if self._writer:
+            writer = self._writer
+            self._writer = None
+            await writer.aclose()
+
     def _on_track_published(
         self, track: rtc.RemoteTrackPublication, participant: rtc.RemoteParticipant
     ) -> None:
@@ -519,6 +547,7 @@ class _ParticipantTranscriptionOutput(io.TextOutput):
                 participant=participant,
             ),
         ]
+        self.__closed = False
 
     def set_participant(self, participant: rtc.Participant | str | None) -> None:
         for source in self.__outputs:
@@ -536,3 +565,10 @@ class _ParticipantTranscriptionOutput(io.TextOutput):
 
         if self.next_in_chain:
             self.next_in_chain.flush()
+
+    async def aclose(self) -> None:
+        if self.__closed:
+            return
+
+        self.__closed = True
+        await asyncio.gather(*[source.aclose() for source in self.__outputs])

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -202,6 +202,7 @@ class RoomIO:
     async def aclose(self) -> None:
         self._room.off("participant_connected", self._on_participant_connected)
         self._room.off("connection_state_changed", self._on_connection_state_changed)
+        self._room.off("participant_disconnected", self._on_participant_disconnected)
         self._agent_session.off("agent_state_changed", self._on_agent_state_changed)
         self._agent_session.off("user_input_transcribed", self._on_user_input_transcribed)
         self._agent_session.off("close", self._on_agent_session_close)
@@ -234,6 +235,11 @@ class RoomIO:
 
         if self._tr_synchronizer:
             await self._tr_synchronizer.aclose()
+
+        if self._user_tr_output:
+            await self._user_tr_output.aclose()
+        if self._agent_tr_output:
+            await self._agent_tr_output.aclose()
 
         if self._audio_output:
             await self._audio_output.aclose()

--- a/tests/test_room_io_teardown.py
+++ b/tests/test_room_io_teardown.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from livekit import rtc
+from livekit.agents.voice.room_io._input import _ParticipantInputStream
+from livekit.agents.voice.room_io._output import _ParticipantTranscriptionOutput
+from livekit.agents.voice.room_io.room_io import RoomIO
+
+
+class _FakeRoom:
+    def __init__(self) -> None:
+        self._events: dict[str, list[object]] = defaultdict(list)
+        self.remote_participants: dict[str, object] = {}
+        self.local_participant = SimpleNamespace(identity="local")
+        self.name = "test-room"
+
+    def on(self, event: str, callback: object) -> None:
+        self._events[event].append(callback)
+
+    def off(self, event: str, callback: object) -> None:
+        callbacks = self._events[event]
+        callbacks.remove(callback)
+        if not callbacks:
+            self._events.pop(event, None)
+
+    def listener_count(self, event: str) -> int:
+        return len(self._events.get(event, []))
+
+    def isconnected(self) -> bool:
+        return True
+
+    def register_text_stream_handler(self, topic: str, callback: object) -> None:
+        self.on(f"text:{topic}", callback)
+
+    def unregister_text_stream_handler(self, topic: str) -> None:
+        self._events.pop(f"text:{topic}", None)
+
+
+class _NoopAudioInputStream(_ParticipantInputStream[rtc.AudioFrame]):
+    def __init__(self, room: _FakeRoom) -> None:
+        super().__init__(room, track_source=rtc.TrackSource.SOURCE_MICROPHONE)
+
+    def _create_stream(
+        self, track: rtc.RemoteTrack, participant: rtc.Participant
+    ) -> rtc.AudioStream:
+        raise AssertionError("_create_stream should not be called in teardown tests")
+
+
+class _FakeWriter:
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    async def aclose(self, attributes: dict[str, str] | None = None) -> None:
+        self.close_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_participant_input_stream_aclose_unregisters_track_unpublished() -> None:
+    room = _FakeRoom()
+    stream = _NoopAudioInputStream(room)
+
+    assert room.listener_count("track_subscribed") == 1
+    assert room.listener_count("track_unpublished") == 1
+    assert room.listener_count("token_refreshed") == 1
+
+    await stream.aclose()
+
+    assert room.listener_count("track_subscribed") == 0
+    assert room.listener_count("track_unpublished") == 0
+    assert room.listener_count("token_refreshed") == 0
+
+
+@pytest.mark.asyncio
+async def test_transcription_output_aclose_unregisters_and_closes_resources() -> None:
+    room = _FakeRoom()
+    output = _ParticipantTranscriptionOutput(room=room, participant=None)
+    legacy_output, stream_output = output._ParticipantTranscriptionOutput__outputs
+
+    legacy_output._flush_task = asyncio.create_task(asyncio.sleep(0))
+    writer = _FakeWriter()
+    stream_output._writer = writer
+
+    assert room.listener_count("track_published") == 2
+    assert room.listener_count("local_track_published") == 2
+
+    await output.aclose()
+    await output.aclose()
+
+    assert room.listener_count("track_published") == 0
+    assert room.listener_count("local_track_published") == 0
+    assert legacy_output._flush_task is not None and legacy_output._flush_task.done()
+    assert writer.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_roomio_aclose_unregisters_disconnect_and_closes_transcription_outputs() -> None:
+    room = _FakeRoom()
+    agent_session = SimpleNamespace(
+        off=MagicMock(),
+        input=SimpleNamespace(audio=None, video=None),
+        output=SimpleNamespace(audio=None, transcription=None),
+    )
+    room_io = RoomIO(agent_session, room)
+
+    room.on("participant_connected", room_io._on_participant_connected)
+    room.on("connection_state_changed", room_io._on_connection_state_changed)
+    room.on("participant_disconnected", room_io._on_participant_disconnected)
+
+    order: list[str] = []
+
+    async def _mark(name: str) -> None:
+        order.append(name)
+
+    async def _close_sync() -> None:
+        await _mark("sync")
+
+    async def _close_user() -> None:
+        await _mark("user")
+
+    async def _close_agent() -> None:
+        await _mark("agent")
+
+    room_io._tr_synchronizer = SimpleNamespace(aclose=AsyncMock(side_effect=_close_sync))
+    room_io._user_tr_output = SimpleNamespace(aclose=AsyncMock(side_effect=_close_user))
+    room_io._agent_tr_output = SimpleNamespace(aclose=AsyncMock(side_effect=_close_agent))
+
+    assert room.listener_count("participant_disconnected") == 1
+
+    await room_io.aclose()
+
+    assert room.listener_count("participant_connected") == 0
+    assert room.listener_count("connection_state_changed") == 0
+    assert room.listener_count("participant_disconnected") == 0
+    assert order == ["sync", "user", "agent"]
+    room_io._tr_synchronizer.aclose.assert_awaited_once()
+    room_io._user_tr_output.aclose.assert_awaited_once()
+    room_io._agent_tr_output.aclose.assert_awaited_once()


### PR DESCRIPTION
## Problem
Long-lived RoomIO users can recreate and tear down input/output helpers multiple times against the same `rtc.Room`. A few room event handlers were registered on startup but never removed on `aclose()`, and the transcription helpers also had no explicit teardown path. Because the room event emitter stores bound methods strongly, old `RoomIO` / input / transcription objects can remain reachable after shutdown instead of being released promptly.

This patch fixes the missing cleanup in the Python `voice/room_io` implementation. `aclose()` is already the teardown boundary for these objects elsewhere in this package, so this change is meant to make that existing contract complete rather than expand its scope.

## What changed
- unregister `participant_disconnected` in `RoomIO.aclose()`
- unregister `track_unpublished` in `_ParticipantInputStream.aclose()`
- add explicit `aclose()` support to the transcription helpers so they unregister `track_published` / `local_track_published` and finish any pending flush/writer work safely
- close the RoomIO-managed user and agent transcription outputs during `RoomIO.aclose()`
- preserve the existing shutdown ordering by closing the transcript synchronizer before the transcription outputs

## Scope / quick audit
I did a follow-up grep across `livekit-agents/livekit/agents/voice/room_io` after this change. The room-level registrations in that package now have matching teardown paths, and I did not spot another obvious unmatched `on(...)` / `off(...)` pair in `room_io`.

## Testing
- `uv run pytest tests/test_room_io_teardown.py`
- `uv run ruff check livekit-agents/livekit/agents/voice/room_io/_input.py livekit-agents/livekit/agents/voice/room_io/_output.py livekit-agents/livekit/agents/voice/room_io/room_io.py tests/test_room_io_teardown.py`
- `uv run ruff format --check livekit-agents/livekit/agents/voice/room_io/_input.py livekit-agents/livekit/agents/voice/room_io/_output.py livekit-agents/livekit/agents/voice/room_io/room_io.py tests/test_room_io_teardown.py`
