### PR TITLE
fix(openai): prepend session instructions in realtime generate_reply

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1466,6 +1466,11 @@ class RealtimeSession(
         fut = asyncio.Future[llm.GenerationCreatedEvent]()
         self._response_created_futures[event_id] = fut
 
+        if is_given(instructions) and self._instructions:
+            # in OpenAI realtime, the session-level instructions are completely replaced
+            # by the new instructions for this response
+            instructions = f"{self._instructions}\n{instructions}"
+
         params = RealtimeResponseCreateParams(
             instructions=instructions or None,
             metadata={"client_event_id": event_id},

--- a/tests/test_realtime/test_realtime.py
+++ b/tests/test_realtime/test_realtime.py
@@ -136,6 +136,17 @@ async def test_generate_reply_with_instructions(rt_session: llm.RealtimeSession)
     assert "pineapple" in text.lower()
 
 
+@pytest.mark.parametrize("rt_session", REALTIME_MODELS, indirect=True)
+async def test_generate_reply_preserves_session_instructions(rt_session: llm.RealtimeSession):
+    await rt_session.update_instructions("Your name is Kelly. Always respond in English.")
+    gen_ev = await asyncio.wait_for(
+        rt_session.generate_reply(instructions="Tell the user what your name is."),
+        timeout=15,
+    )
+    text = await asyncio.wait_for(_collect_text(gen_ev), timeout=15)
+    assert "kelly" in text.lower(), f"Expected 'kelly' in response, got: {text}"
+
+
 @pytest.mark.parametrize("rt_session", OPENAI_AND_AZURE, indirect=True)
 async def test_multiple_sequential_replies(rt_session: llm.RealtimeSession):
     for i in range(2):


### PR DESCRIPTION
## Summary
- In OpenAI realtime API, per-response `instructions` completely replace session-level instructions. This means when `generate_reply(instructions=...)` is called, the agent loses its system prompt.
- This fix prepends the session-level instructions to the per-response instructions so `generate_reply` behaves consistently with pipeline agents.
- Addresses https://github.com/livekit/agents/pull/5287#issuecomment-4207711957
