### PR TITLE
fix(voice): block new user turns immediately on update_agent() to prevent transition delay

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -118,6 +118,7 @@ class AgentActivity(RecognitionHooks):
         self._started = False
         self._closed = False
         self._scheduling_paused = True
+        self._new_turns_blocked = False
 
         self._current_speech: SpeechHandle | None = None
         self._speech_q: list[tuple[int, float, SpeechHandle]] = []
@@ -1401,7 +1402,7 @@ class AgentActivity(RecognitionHooks):
             # user_initiated generations are directly handled inside _realtime_reply_task
             return
 
-        if self._scheduling_paused:
+        if self._scheduling_paused or self._new_turns_blocked:
             # TODO(theomonnom): should we "forward" this new turn to the next agent?
             logger.warning("skipping new realtime generation, the speech scheduling is not running")
             return
@@ -1663,6 +1664,7 @@ class AgentActivity(RecognitionHooks):
         if (
             not self._session.options.preemptive_generation
             or self._scheduling_paused
+            or self._new_turns_blocked
             or (self._current_speech is not None and not self._current_speech.interrupted)
             or not isinstance(self.llm, llm.LLM)
         ):
@@ -1699,7 +1701,7 @@ class AgentActivity(RecognitionHooks):
         # IMPORTANT: This method is sync to avoid it being cancelled by the AudioRecognition
         # We explicitly create a new task here
 
-        if self._scheduling_paused:
+        if self._scheduling_paused or self._new_turns_blocked:
             self._cancel_preemptive_generation()
             logger.warning(
                 "skipping user input, speech scheduling is paused",
@@ -1800,7 +1802,7 @@ class AgentActivity(RecognitionHooks):
             if self._rt_session is not None:
                 self._rt_session.interrupt()
 
-        if self._scheduling_paused:
+        if self._scheduling_paused or self._new_turns_blocked:
             logger.warning(
                 "skipping on_user_turn_completed, speech scheduling is paused",
                 extra={"user_input": info.new_transcript},
@@ -1833,7 +1835,7 @@ class AgentActivity(RecognitionHooks):
         elif self.llm is None:
             return  # skip response if no llm is set
 
-        if self._scheduling_paused:
+        if self._scheduling_paused or self._new_turns_blocked:
             logger.warning(
                 "skipping reply to user input, speech scheduling is paused",
                 extra={"user_input": info.new_transcript},

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -759,6 +759,7 @@ class AgentActivity(RecognitionHooks):
             return
 
         self._scheduling_paused = False
+        self._new_turns_blocked = False
         self._scheduling_atask = asyncio.create_task(
             self._scheduling_task(), name="_scheduling_task"
         )

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1245,11 +1245,10 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         self._agent = agent
 
         if self._started:
-            # immediately pause the old activity's scheduling to prevent new user turns
-            # from being accepted during the transition window (before drain() runs)
-            if self._activity is not None and not self._activity._scheduling_paused:
-                self._activity._scheduling_paused = True
-                self._activity._wake_up_scheduling_task()
+            # immediately block the old activity from accepting new user turns
+            # during the transition window (before drain() formally pauses scheduling)
+            if self._activity is not None:
+                self._activity._new_turns_blocked = True
 
             self._update_activity_atask = task = asyncio.create_task(
                 self._update_activity_task(self._update_activity_atask, self._agent),

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1245,6 +1245,12 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         self._agent = agent
 
         if self._started:
+            # immediately pause the old activity's scheduling to prevent new user turns
+            # from being accepted during the transition window (before drain() runs)
+            if self._activity is not None and not self._activity._scheduling_paused:
+                self._activity._scheduling_paused = True
+                self._activity._wake_up_scheduling_task()
+
             self._update_activity_atask = task = asyncio.create_task(
                 self._update_activity_task(self._update_activity_atask, self._agent),
                 name="_update_activity_task",


### PR DESCRIPTION
## Summary

**Bug**: When `update_agent()` is called, the old agent can still accept and process new user turns (including ambient noise) during the transition window, delaying the new agent's `on_enter()` by seconds.

**Root cause**: The async transition task (`drain()` → `_pause_scheduling_task()`) doesn't run immediately, leaving a window where the old activity's scheduling task accepts new turns and triggers full LLM → TTS pipeline.

**Fix**: Introduce a lightweight `_new_turns_blocked` flag that is set synchronously in `update_agent()` to immediately block new user turns, while keeping `_scheduling_paused` untouched for `_pause_scheduling_task()` to function correctly.

This avoids the issue where directly setting `_scheduling_paused = True` would cause `_pause_scheduling_task()` to early-return and skip `await asyncio.shield(self._scheduling_atask)`, which is needed to wait for in-flight speech tasks to complete.

### Changes

- **`agent_activity.py`**: Add `_new_turns_blocked` flag, checked at all user-turn entry points (`_on_generation_created`, `on_preemptive_generation`, `on_end_of_turn`, `_on_user_turn_completed`, `_on_user_input_complete`)
- **`agent_session.py`**: `update_agent()` sets `_new_turns_blocked = True` instead of `_scheduling_paused = True`

### What is NOT changed (intentionally)

- `_pause_scheduling_task()` early-return guard — must only check `_scheduling_paused`
- `_schedule_speech(force=True)` — tool responses during drain still work
- `_scheduling_task` exit condition — only exits on formal pause signal
- `say()`/`generate_reply()` routing — programmatic speech still routes to current activity during transition

## Test plan

- [ ] Call `session.update_agent(new_agent)` while there is ambient noise — new agent's `on_enter()` should fire promptly without the old agent processing a stray turn
- [ ] Verify `drain()` properly awaits in-flight speech tasks before completing the transition
- [ ] Verify normal agent transitions still work correctly
- [ ] Verify that in-progress turns at the time of `update_agent()` complete without interruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)