### PR TITLE
feat(beta/tools): add speak_to_ivr tool auto-injected with ivr_detection

### DIFF
--- a/livekit-agents/livekit/agents/beta/tools/__init__.py
+++ b/livekit-agents/livekit/agents/beta/tools/__init__.py
@@ -1,7 +1,9 @@
 from .end_call import EndCallTool
 from .send_dtmf import send_dtmf_events
+from .speak_to_ivr import speak_to_ivr
 
 __all__ = [
     "EndCallTool",
     "send_dtmf_events",
+    "speak_to_ivr",
 ]

--- a/livekit-agents/livekit/agents/beta/tools/speak_to_ivr.py
+++ b/livekit-agents/livekit/agents/beta/tools/speak_to_ivr.py
@@ -1,0 +1,17 @@
+from ... import StopResponse, function_tool
+from ...voice.events import RunContext
+
+
+@function_tool
+async def speak_to_ivr(ctx: RunContext, text: str) -> None:
+    """
+    Speak a specific phrase to the IVR using voice.
+
+    Use when the IVR asks you to say something verbally rather than press keys —
+    e.g., your name, "yes", "no", or any spoken menu option.
+    After speaking, yields the turn back to the IVR to listen for its reply.
+    """
+    handle = ctx.session.say(text, allow_interruptions=False)
+    await ctx.wait_for_playout()
+    await handle
+    raise StopResponse()

--- a/livekit-agents/livekit/agents/voice/ivr/ivr_activity.py
+++ b/livekit-agents/livekit/agents/voice/ivr/ivr_activity.py
@@ -38,8 +38,9 @@ class IVRActivity:
     @property
     def tools(self) -> list[llm.FunctionTool | llm.RawFunctionTool]:
         from ...beta.tools.send_dtmf import send_dtmf_events
+        from ...beta.tools.speak_to_ivr import speak_to_ivr
 
-        return [send_dtmf_events]
+        return [send_dtmf_events, speak_to_ivr]
 
     def _on_user_input_transcribed(self, ev: UserInputTranscribedEvent) -> None:
         if not ev.is_final:


### PR DESCRIPTION
## Problem

`ivr_detection=True` automatically injects `send_dtmf_events` for key presses, but provides no equivalent for verbal responses. IVR systems use both modalities: pressing digits and saying phrases ("say your name", "say yes or no", "say your account number"). Without a built-in tool, every developer building an IVR agent must implement the same boilerplate:

```python
@function_tool()
async def speak_to_ivr(self, context: RunContext, text: str) -> None:
    handle = self.session.say(text, allow_interruptions=False)
    await context.wait_for_playout()
    await handle
    raise StopResponse()
```

And then instruct the agent via system prompt to always call it after every verbal response. This is the same class of problem as the missing `StopResponse` in `send_dtmf_events` — the tool exists conceptually but the correct behavior isn't encoded by default.

## Fix

Add `speak_to_ivr` as a built-in `function_tool` in `beta/tools/` and auto-inject it alongside `send_dtmf_events` via `IVRActivity.tools`. The tool calls `session.say()` with `allow_interruptions=False` (appropriate for IVR contexts where the agent must finish speaking before the IVR processes the response), waits for playout, and raises `StopResponse()` to yield the turn back to the IVR.

`send_dtmf_events` and `speak_to_ivr` are symmetric IVR interaction primitives — key presses and verbal responses. Both should be available out of the box when `ivr_detection=True`.

## Impact

- No breaking changes. `speak_to_ivr` is additive.
- Agents using `ivr_detection=True` will now have `speak_to_ivr` available automatically. Agents that already define their own equivalent tool should remove it to avoid duplication.