### PR TITLE
feat(inference): make STT/TTS reconnect retries replayable

### DIFF
--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -531,6 +531,9 @@ class SpeechStream(stt.SpeechStream):
 
     async def _run(self) -> None:
         """Main loop for streaming transcription."""
+        # reset per-session state since the gateway starts a fresh session on reconnect
+        self._speech_duration = 0
+        self._speaking = False
         closing_ws = False
 
         @utils.log_exceptions(logger=logger)

--- a/livekit-agents/livekit/agents/inference/tts.py
+++ b/livekit-agents/livekit/agents/inference/tts.py
@@ -396,6 +396,7 @@ class TTS(tts.TTS):
         self._pool = utils.ConnectionPool[aiohttp.ClientWebSocketResponse](
             connect_cb=self._connect_ws,
             close_cb=self._close_ws,
+            health_check_cb=self._check_ws_health,
             max_session_duration=300,
             mark_refreshed_on_get=True,
         )
@@ -484,6 +485,9 @@ class TTS(tts.TTS):
             ) from e
 
         return ws
+
+    async def _check_ws_health(self, ws: aiohttp.ClientWebSocketResponse) -> bool:
+        return not ws.closed
 
     async def _close_ws(self, ws: aiohttp.ClientWebSocketResponse) -> None:
         await ws.close()

--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import collections
 import time
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterable, AsyncIterator
@@ -310,6 +311,14 @@ class RecognizeStream(ABC):
         self._pushed_sr = 0
         self._resampler: rtc.AudioResampler | None = None
 
+        # input buffer for replay on reconnect
+        self._input_buffer: collections.deque[rtc.AudioFrame | RecognizeStream._FlushSentinel] = (
+            collections.deque()
+        )
+        self._input_buffer_duration: float = 0.0
+        self._max_buffer_duration: float = 10.0  # seconds of audio to retain
+        self._input_ended: bool = False
+
         self._start_time_offset: float = 0.0
 
     @property
@@ -338,6 +347,17 @@ class RecognizeStream(ABC):
                 metadata=Metadata(model_name=self._stt.model, model_provider=self._stt.provider),
             ),
         )
+
+    def _append_to_buffer(self, item: rtc.AudioFrame | RecognizeStream._FlushSentinel) -> None:
+        """Append a frame or flush sentinel to the input buffer, evicting old entries."""
+        self._input_buffer.append(item)
+        if isinstance(item, rtc.AudioFrame):
+            self._input_buffer_duration += item.duration
+        # evict oldest entries when over max duration
+        while self._input_buffer_duration > self._max_buffer_duration and self._input_buffer:
+            oldest = self._input_buffer.popleft()
+            if isinstance(oldest, rtc.AudioFrame):
+                self._input_buffer_duration -= oldest.duration
 
     @abstractmethod
     async def _run(self) -> None: ...
@@ -375,6 +395,13 @@ class RecognizeStream(ABC):
                         },
                     )
                     await asyncio.sleep(retry_interval)
+
+                    # replay buffered input into a fresh channel for retry
+                    self._input_ch = aio.Chan[rtc.AudioFrame | RecognizeStream._FlushSentinel]()
+                    for item in self._input_buffer:
+                        self._input_ch.send_nowait(item)
+                    if self._input_ended:
+                        self._input_ch.close()
 
                 self._num_retries += 1
 
@@ -443,8 +470,10 @@ class RecognizeStream(ABC):
             frames = self._resampler.push(frame)
             for frame in frames:
                 self._input_ch.send_nowait(frame)
+                self._append_to_buffer(frame)
         else:
             self._input_ch.send_nowait(frame)
+            self._append_to_buffer(frame)
 
     def flush(self) -> None:
         """Mark the end of the current segment"""
@@ -454,13 +483,17 @@ class RecognizeStream(ABC):
         if self._resampler:
             for frame in self._resampler.flush():
                 self._input_ch.send_nowait(frame)
+                self._append_to_buffer(frame)
 
-        self._input_ch.send_nowait(self._FlushSentinel())
+        sentinel = self._FlushSentinel()
+        self._input_ch.send_nowait(sentinel)
+        self._append_to_buffer(sentinel)
 
     def end_input(self) -> None:
         """Mark the end of input, no more audio will be pushed"""
         self.flush()
         self._input_ch.close()
+        self._input_ended = True
 
     async def aclose(self) -> None:
         """Close ths stream immediately"""

--- a/livekit-agents/livekit/agents/tts/tts.py
+++ b/livekit-agents/livekit/agents/tts/tts.py
@@ -505,9 +505,9 @@ class SynthesizeStream(ABC):
                 pushed_duration = output_emitter.pushed_duration()
                 should_retry = (
                     e.retryable
-                    and pushed_duration == 0.0
                     and self._conn_options.max_retry > 0
                     and i < self._conn_options.max_retry
+                    and (pushed_duration == 0.0 or self._conn_options.tts_replay_on_partial)
                 )
 
                 if not should_retry:

--- a/livekit-agents/livekit/agents/types.py
+++ b/livekit-agents/livekit/agents/types.py
@@ -88,6 +88,9 @@ class APIConnectOptions:
     Timeout for connecting to the API in seconds.
     """
 
+    tts_replay_on_partial: bool = False
+    """If True, TTS will retry and replay all tokens even after partial audio was emitted."""
+
     def __post_init__(self) -> None:
         if self.max_retry < 0:
             raise ValueError("max_retry must be greater than or equal to 0")

--- a/livekit-agents/livekit/agents/utils/connection_pool.py
+++ b/livekit-agents/livekit/agents/utils/connection_pool.py
@@ -25,6 +25,7 @@ class ConnectionPool(Generic[T]):
         mark_refreshed_on_get: bool = False,
         connect_cb: Callable[[float], Awaitable[T]] | None = None,
         close_cb: Callable[[T], Awaitable[None]] | None = None,
+        health_check_cb: Callable[[T], Awaitable[bool]] | None = None,
         connect_timeout: float = 10.0,
     ) -> None:
         """Initialize the connection wrapper.
@@ -34,11 +35,13 @@ class ConnectionPool(Generic[T]):
             mark_refreshed_on_get: If True, the session will be marked as fresh when get() is called. only used when max_session_duration is set.
             connect_cb: Optional async callback to create new connections
             close_cb: Optional async callback to close connections
+            health_check_cb: Optional async callback to verify a pooled connection is still alive
         """  # noqa: E501
         self._max_session_duration = max_session_duration
         self._mark_refreshed_on_get = mark_refreshed_on_get
         self._connect_cb = connect_cb
         self._close_cb = close_cb
+        self._health_check_cb = health_check_cb
         self._connections: dict[T, float] = {}  # conn -> connected_at timestamp
         self._available: set[T] = set()
         self._connect_timeout = connect_timeout
@@ -107,16 +110,29 @@ class ConnectionPool(Generic[T]):
             while self._available:
                 conn = self._available.pop()
                 if (
-                    self._max_session_duration is None
-                    or now - self._connections[conn] <= self._max_session_duration
+                    self._max_session_duration is not None
+                    and now - self._connections[conn] > self._max_session_duration
                 ):
-                    if self._mark_refreshed_on_get:
-                        self._connections[conn] = now
-                    self.last_acquire_time = 0.0
-                    self.last_connection_reused = True
-                    return conn
-                # connection expired; mark it for resetting.
-                self.remove(conn)
+                    # connection expired; mark it for resetting.
+                    self.remove(conn)
+                    continue
+
+                # health check pooled connection before reuse
+                if self._health_check_cb is not None:
+                    try:
+                        healthy = await asyncio.wait_for(self._health_check_cb(conn), timeout=2.0)
+                        if not healthy:
+                            self.remove(conn)
+                            continue
+                    except Exception:
+                        self.remove(conn)
+                        continue
+
+                if self._mark_refreshed_on_get:
+                    self._connections[conn] = now
+                self.last_acquire_time = 0.0
+                self.last_connection_reused = True
+                return conn
 
             t0 = time.perf_counter()
             conn = await self._connect(timeout)

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 
 import pytest
@@ -8,6 +9,7 @@ from livekit.agents.utils import ConnectionPool
 class DummyConnection:
     def __init__(self, id):
         self.id = id
+        self.healthy = True
 
     def __repr__(self):
         return f"DummyConnection({self.id})"
@@ -81,3 +83,102 @@ async def test_get_expired():
 
     conn2 = await pool.get(timeout=10.0)
     assert conn2 is not conn, "Expected a new connection to be returned."
+
+
+@pytest.mark.asyncio
+async def test_health_check_healthy_connection():
+    """Health check passes — pooled connection is reused."""
+    dummy_connect = dummy_connect_factory()
+
+    async def health_check(conn: DummyConnection) -> bool:
+        return conn.healthy
+
+    pool = ConnectionPool(
+        max_session_duration=60,
+        connect_cb=dummy_connect,
+        health_check_cb=health_check,
+    )
+
+    conn1 = await pool.get(timeout=10.0)
+    pool.put(conn1)
+
+    conn2 = await pool.get(timeout=10.0)
+    assert conn1 is conn2, "Healthy connection should be reused."
+
+
+@pytest.mark.asyncio
+async def test_health_check_unhealthy_connection():
+    """Health check fails — pooled connection is removed and a new one is created."""
+    dummy_connect = dummy_connect_factory()
+
+    async def health_check(conn: DummyConnection) -> bool:
+        return conn.healthy
+
+    pool = ConnectionPool(
+        max_session_duration=60,
+        connect_cb=dummy_connect,
+        health_check_cb=health_check,
+    )
+
+    conn1 = await pool.get(timeout=10.0)
+    conn1.healthy = False
+    pool.put(conn1)
+
+    conn2 = await pool.get(timeout=10.0)
+    assert conn2 is not conn1, "Unhealthy connection should not be reused."
+
+
+@pytest.mark.asyncio
+async def test_health_check_timeout():
+    """Health check that times out causes connection to be removed."""
+    dummy_connect = dummy_connect_factory()
+
+    async def slow_health_check(conn: DummyConnection) -> bool:
+        await asyncio.sleep(10)  # longer than the 2s timeout
+        return True
+
+    pool = ConnectionPool(
+        max_session_duration=60,
+        connect_cb=dummy_connect,
+        health_check_cb=slow_health_check,
+    )
+
+    conn1 = await pool.get(timeout=10.0)
+    pool.put(conn1)
+
+    conn2 = await pool.get(timeout=10.0)
+    assert conn2 is not conn1, "Connection with timed-out health check should not be reused."
+
+
+@pytest.mark.asyncio
+async def test_health_check_exception():
+    """Health check that raises an exception causes connection to be removed."""
+    dummy_connect = dummy_connect_factory()
+
+    async def failing_health_check(conn: DummyConnection) -> bool:
+        raise RuntimeError("health check failed")
+
+    pool = ConnectionPool(
+        max_session_duration=60,
+        connect_cb=dummy_connect,
+        health_check_cb=failing_health_check,
+    )
+
+    conn1 = await pool.get(timeout=10.0)
+    pool.put(conn1)
+
+    conn2 = await pool.get(timeout=10.0)
+    assert conn2 is not conn1, "Connection with failing health check should not be reused."
+
+
+@pytest.mark.asyncio
+async def test_no_health_check_by_default():
+    """Without health_check_cb, connections are reused without checks."""
+    dummy_connect = dummy_connect_factory()
+    pool = ConnectionPool(max_session_duration=60, connect_cb=dummy_connect)
+
+    conn1 = await pool.get(timeout=10.0)
+    pool.put(conn1)
+
+    conn2 = await pool.get(timeout=10.0)
+    assert conn1 is conn2, "Without health check, connection should be reused."

--- a/tests/test_stt_reconnect.py
+++ b/tests/test_stt_reconnect.py
@@ -1,0 +1,217 @@
+"""Tests for STT RecognizeStream input buffering and replay on reconnect."""
+
+import pytest
+
+from livekit import rtc
+from livekit.agents._exceptions import APIError
+from livekit.agents.stt.stt import RecognizeStream, SpeechEventType
+from livekit.agents.types import APIConnectOptions
+
+from .fake_stt import FakeSTT
+
+
+def _make_audio_frame(
+    duration_ms: int = 100,
+    sample_rate: int = 16000,
+    num_channels: int = 1,
+) -> rtc.AudioFrame:
+    """Create a silent audio frame with the given duration."""
+    samples_per_channel = int(sample_rate * duration_ms / 1000)
+    data = b"\x00\x00" * samples_per_channel * num_channels
+    return rtc.AudioFrame(
+        data=data,
+        sample_rate=sample_rate,
+        num_channels=num_channels,
+        samples_per_channel=samples_per_channel,
+    )
+
+
+class TestInputBuffer:
+    """Tests for the input buffer append and eviction logic."""
+
+    @pytest.mark.asyncio
+    async def test_append_audio_frame(self):
+        """Audio frames are appended and duration is tracked."""
+        stream = FakeSTT(fake_transcript="hello").stream(
+            conn_options=APIConnectOptions(max_retry=0)
+        )
+        frame = _make_audio_frame(duration_ms=100)
+        stream._append_to_buffer(frame)
+
+        assert len(stream._input_buffer) == 1
+        assert stream._input_buffer[0] is frame
+        assert stream._input_buffer_duration == pytest.approx(frame.duration, abs=1e-6)
+        await stream.aclose()
+
+    @pytest.mark.asyncio
+    async def test_append_flush_sentinel(self):
+        """Flush sentinels are appended but don't affect duration."""
+        stream = FakeSTT(fake_transcript="hello").stream(
+            conn_options=APIConnectOptions(max_retry=0)
+        )
+        sentinel = RecognizeStream._FlushSentinel()
+        stream._append_to_buffer(sentinel)
+
+        assert len(stream._input_buffer) == 1
+        assert isinstance(stream._input_buffer[0], RecognizeStream._FlushSentinel)
+        assert stream._input_buffer_duration == 0.0
+        await stream.aclose()
+
+    @pytest.mark.asyncio
+    async def test_eviction_over_max_duration(self):
+        """Oldest frames are evicted when buffer exceeds max duration."""
+        stream = FakeSTT(fake_transcript="hello").stream(
+            conn_options=APIConnectOptions(max_retry=0)
+        )
+        stream._max_buffer_duration = 1.0  # 1 second max
+
+        # Push 15 frames of 100ms each = 1.5s total, should evict ~5 oldest
+        frames = []
+        for _ in range(15):
+            frame = _make_audio_frame(duration_ms=100)
+            frames.append(frame)
+            stream._append_to_buffer(frame)
+
+        assert stream._input_buffer_duration <= stream._max_buffer_duration
+        assert len(stream._input_buffer) < 15
+        # The most recent frames should still be in the buffer
+        assert stream._input_buffer[-1] is frames[-1]
+        await stream.aclose()
+
+    @pytest.mark.asyncio
+    async def test_eviction_preserves_sentinels_duration(self):
+        """When sentinels are evicted, duration doesn't go negative."""
+        stream = FakeSTT(fake_transcript="hello").stream(
+            conn_options=APIConnectOptions(max_retry=0)
+        )
+        stream._max_buffer_duration = 0.5
+
+        # Push sentinel + frames that exceed max
+        stream._append_to_buffer(RecognizeStream._FlushSentinel())
+        for _ in range(10):
+            stream._append_to_buffer(_make_audio_frame(duration_ms=100))
+
+        assert stream._input_buffer_duration >= 0.0
+        assert stream._input_buffer_duration <= stream._max_buffer_duration
+        await stream.aclose()
+
+
+class TestPushFrameBuffering:
+    """Tests that push_frame() and flush() populate the input buffer."""
+
+    @pytest.mark.asyncio
+    async def test_push_frame_buffers(self):
+        """push_frame() adds to both _input_ch and _input_buffer."""
+        stream = FakeSTT(fake_transcript="hello").stream(
+            conn_options=APIConnectOptions(max_retry=0)
+        )
+        frame = _make_audio_frame()
+
+        stream.push_frame(frame)
+        assert len(stream._input_buffer) == 1
+        assert isinstance(stream._input_buffer[0], rtc.AudioFrame)
+
+        await stream.aclose()
+
+    @pytest.mark.asyncio
+    async def test_flush_buffers_sentinel(self):
+        """flush() adds a FlushSentinel to _input_buffer."""
+        stream = FakeSTT(fake_transcript="hello").stream(
+            conn_options=APIConnectOptions(max_retry=0)
+        )
+        stream.push_frame(_make_audio_frame())
+        stream.flush()
+
+        sentinel_count = sum(
+            1 for item in stream._input_buffer if isinstance(item, RecognizeStream._FlushSentinel)
+        )
+        assert sentinel_count == 1
+
+        await stream.aclose()
+
+    @pytest.mark.asyncio
+    async def test_end_input_sets_flag(self):
+        """end_input() sets _input_ended flag."""
+        stream = FakeSTT(fake_transcript="hello").stream(
+            conn_options=APIConnectOptions(max_retry=0)
+        )
+        stream.push_frame(_make_audio_frame())
+        stream.end_input()
+
+        assert stream._input_ended is True
+        # wait for task completion
+        events = []
+        async for ev in stream:
+            events.append(ev)
+
+
+class TestReconnectReplay:
+    """Tests for channel replay during retry."""
+
+    @pytest.mark.asyncio
+    async def test_replay_on_retry(self):
+        """After a retryable error, the input buffer is replayed into a fresh channel."""
+        fail_count = 0
+
+        class FailOnceSpeechStream(RecognizeStream):
+            def __init__(self, *, stt, conn_options):
+                super().__init__(stt=stt, conn_options=conn_options)
+                self._frames_received: list[rtc.AudioFrame] = []
+
+            async def _run(self) -> None:
+                nonlocal fail_count
+                fail_count += 1
+                if fail_count == 1:
+                    # consume some input, then fail
+                    async for data in self._input_ch:
+                        if isinstance(data, rtc.AudioFrame):
+                            self._frames_received.append(data)
+                        if isinstance(data, RecognizeStream._FlushSentinel):
+                            break
+                    raise APIError("transient failure")
+                else:
+                    # on retry, should receive replayed frames
+                    count = 0
+                    async for data in self._input_ch:
+                        if isinstance(data, rtc.AudioFrame):
+                            count += 1
+                        if isinstance(data, RecognizeStream._FlushSentinel):
+                            break
+                    # emit a final transcript to indicate success
+                    from livekit.agents.stt.stt import SpeechData, SpeechEvent
+
+                    self._event_ch.send_nowait(
+                        SpeechEvent(
+                            type=SpeechEventType.FINAL_TRANSCRIPT,
+                            alternatives=[
+                                SpeechData(
+                                    text="test",
+                                    language="en",
+                                )
+                            ],
+                        )
+                    )
+                    async for _ in self._input_ch:
+                        pass
+
+        class FailOnceSTT(FakeSTT):
+            def stream(self, *, language=None, conn_options=None):
+                if conn_options is None:
+                    conn_options = APIConnectOptions()
+                return FailOnceSpeechStream(stt=self, conn_options=conn_options)
+
+        stt = FailOnceSTT(fake_transcript="test")
+        stream = stt.stream(conn_options=APIConnectOptions(max_retry=3, retry_interval=0.0))
+
+        # Push audio frames then end input
+        for _ in range(5):
+            stream.push_frame(_make_audio_frame())
+        stream.end_input()
+
+        events = []
+        async for ev in stream:
+            events.append(ev)
+
+        # Should have gotten a final transcript on the retry
+        assert fail_count == 2
+        assert any(ev.type == SpeechEventType.FINAL_TRANSCRIPT for ev in events)


### PR DESCRIPTION
## Summary
- Add bounded STT streaming input buffering and replay-on-retry so reconnects can resume from recent audio instead of restarting empty.
- Reset inference STT per-connection speech state on reconnect and add websocket health checks to pooled inference TTS connections.
- Add optional `APIConnectOptions.tts_replay_on_partial` and test coverage for connection pool health checks plus STT reconnect buffering/replay behavior.

## Test plan
- [x] `uv run ruff check livekit-agents/livekit/agents/stt/stt.py livekit-agents/livekit/agents/inference/stt.py livekit-agents/livekit/agents/utils/connection_pool.py livekit-agents/livekit/agents/inference/tts.py livekit-agents/livekit/agents/tts/tts.py livekit-agents/livekit/agents/types.py tests/test_connection_pool.py tests/test_stt_reconnect.py`
- [ ] `uv run pytest tests/test_stt_reconnect.py tests/test_connection_pool.py` *(blocked in this environment by `psutil` import failure from `tests/conftest.py`)*