### PR TITLE
telemetry: emit OTel span events for developer-role messages

### DIFF
--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -281,6 +281,11 @@ def _setup_cloud_tracer(
 def _chat_ctx_to_otel_events(chat_ctx: ChatContext) -> list[tuple[str, Attributes]]:
     role_to_event = {
         "system": trace_types.EVENT_GEN_AI_SYSTEM_MESSAGE,
+        # OpenAI's `developer` role is the successor to `system` on the
+        # Chat Completions API and carries equivalent instructional content,
+        # so surface it as the system-message span event rather than dropping
+        # it on the floor.
+        "developer": trace_types.EVENT_GEN_AI_SYSTEM_MESSAGE,
         "user": trace_types.EVENT_GEN_AI_USER_MESSAGE,
         "assistant": trace_types.EVENT_GEN_AI_ASSISTANT_MESSAGE,
     }


### PR DESCRIPTION
`_chat_ctx_to_otel_events` only mapped `system`, `user`, and `assistant` roles, so `ChatContext` items with `role="developer"` were silently dropped from the OpenTelemetry span events and invisible to any downstream tracer.

This patch maps `developer` to `EVENT_GEN_AI_SYSTEM_MESSAGE` since OpenAI's `developer` role is the successor to `system` on the Chat Completions API and carries equivalent instructional content.

Fixes #5398