### PR TITLE
fix(google): capture usage_metadata before early continues in streaming

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -464,6 +464,20 @@ class LLMStream(llm.LLMStream):
                         request_id=request_id,
                     )
 
+                if response.usage_metadata is not None:
+                    usage = response.usage_metadata
+                    self._event_ch.send_nowait(
+                        llm.ChatChunk(
+                            id=request_id,
+                            usage=llm.CompletionUsage(
+                                completion_tokens=usage.candidates_token_count or 0,
+                                prompt_tokens=usage.prompt_token_count or 0,
+                                prompt_cached_tokens=usage.cached_content_token_count or 0,
+                                total_tokens=usage.total_token_count or 0,
+                            ),
+                        )
+                    )
+
                 if not response.candidates:
                     continue
 
@@ -492,20 +506,6 @@ class LLMStream(llm.LLMStream):
                     if chat_chunk is not None:
                         retryable = False
                         self._event_ch.send_nowait(chat_chunk)
-
-                if response.usage_metadata is not None:
-                    usage = response.usage_metadata
-                    self._event_ch.send_nowait(
-                        llm.ChatChunk(
-                            id=request_id,
-                            usage=llm.CompletionUsage(
-                                completion_tokens=usage.candidates_token_count or 0,
-                                prompt_tokens=usage.prompt_token_count or 0,
-                                prompt_cached_tokens=usage.cached_content_token_count or 0,
-                                total_tokens=usage.total_token_count or 0,
-                            ),
-                        )
-                    )
 
             if not response_generated:
                 raise APIStatusError(


### PR DESCRIPTION
## Summary

- Fix `prompt_tokens: 0, completion_tokens: 0` in LLM metrics for Gemini streaming requests
- Move the `usage_metadata` check before the two `continue` statements in `LLMStream._run` so token counts are always captured
- In Gemini's streaming API, the final chunk typically carries `usage_metadata` with complete token counts but has empty `candidates` or `content.parts`, causing the existing code to skip the usage check entirely

## Details

In `livekit-plugins-google/livekit/plugins/google/llm.py`, the streaming loop has two early `continue` statements:

1. `if not response.candidates: continue`
2. `if not candidate.content or not candidate.content.parts: continue`

Both skip past the `usage_metadata` check at the end of the loop body. Since Gemini's final streaming chunk often has a `finish_reason` but empty content, the usage data (which is only fully populated on this last chunk) is never captured.

The fix moves the `usage_metadata` check to immediately after the `prompt_feedback` check, before any `continue` statements.

## Test plan

- [ ] Existing tests pass
- [ ] Lint and type checks pass
- [ ] Manual verification: run a Gemini streaming session and confirm LLM metrics show non-zero `prompt_tokens`, `completion_tokens`, and `tokens_per_second`

🤖 Generated with [Claude Code](https://claude.com/claude-code)