### PR TITLE
feat(inference): add InferenceWebsocket

### DIFF
--- a/livekit-agents/livekit/agents/inference/_ws.py
+++ b/livekit-agents/livekit/agents/inference/_ws.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from types import TracebackType
+from typing import overload
+
+import aiohttp
+
+from .._exceptions import (
+    APIConnectionError,
+    APIStatusError,
+    APITimeoutError,
+    create_api_error_from_http,
+)
+from ..log import logger
+from ._utils import create_access_token, get_inference_headers
+
+_WS_CLOSE_TYPES = frozenset(
+    {
+        aiohttp.WSMsgType.CLOSED,
+        aiohttp.WSMsgType.CLOSE,
+        aiohttp.WSMsgType.CLOSING,
+    }
+)
+
+_PAYLOAD_TO_WS_TYPE: dict[type[str] | type[bytes], aiohttp.WSMsgType] = {
+    str: aiohttp.WSMsgType.TEXT,
+    bytes: aiohttp.WSMsgType.BINARY,
+}
+
+
+class InferenceWebSocket:
+    """Context manager that connects to a LiveKit inference WebSocket endpoint.
+
+    Handles URL scheme conversion (http->ws), authentication, connection timeout,
+    error wrapping, and provides recv iterators with automatic close detection.
+
+    Usage::
+
+        async with InferenceWebSocket(
+            session=http_session,
+            base_url="https://agent-gateway.livekit.cloud/v1",
+            path="/stt?model=deepgram/nova-3",
+            api_key=api_key,
+            api_secret=api_secret,
+            timeout=10.0,
+        ) as iws:
+            await iws.send(session_create_json)
+            ...
+    """
+
+    def __init__(
+        self,
+        *,
+        session: aiohttp.ClientSession,
+        base_url: str,
+        path: str,
+        api_key: str,
+        api_secret: str,
+        timeout: float,
+    ) -> None:
+        self._session = session
+        self._base_url = base_url
+        self._path = path
+        self._api_key = api_key
+        self._api_secret = api_secret
+        self._timeout = timeout
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._closing = False
+
+    async def __aenter__(self) -> InferenceWebSocket:
+        base_url = self._base_url
+        if base_url.startswith(("http://", "https://")):
+            base_url = base_url.replace("http", "ws", 1)
+
+        headers = {
+            **get_inference_headers(),
+            "Authorization": f"Bearer {create_access_token(self._api_key, self._api_secret)}",
+        }
+
+        try:
+            self._ws = await asyncio.wait_for(
+                self._session.ws_connect(f"{base_url}{self._path}", headers=headers),
+                self._timeout,
+            )
+        except aiohttp.ClientResponseError as e:
+            if e.status == 429:
+                raise APIStatusError(
+                    f"inference quota exceeded: {e.message}",
+                    status_code=e.status,
+                    retryable=False,
+                ) from e
+            raise create_api_error_from_http(e.message, status=e.status) from e
+        except asyncio.TimeoutError as e:
+            raise APITimeoutError("inference websocket connection timed out") from e
+        except aiohttp.ClientConnectorError as e:
+            raise APIConnectionError(
+                f"failed to connect to inference websocket at {self._path}"
+            ) from e
+
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        if self._ws is not None and not self._ws.closed:
+            await self._ws.close()
+        self._ws = None
+
+    @property
+    def ws(self) -> aiohttp.ClientWebSocketResponse:
+        assert self._ws is not None, "InferenceWebSocket not connected"
+        return self._ws
+
+    @property
+    def closed(self) -> bool:
+        return self._ws is None or self._ws.closed
+
+    def mark_closing(self) -> None:
+        """Signal that a graceful close has been initiated by the caller.
+
+        After calling this, the recv iterators will return cleanly when the
+        server closes the WebSocket instead of raising ``APIStatusError``.
+        """
+        self._closing = True
+
+    @overload
+    async def send(self, data: str) -> None: ...
+
+    @overload
+    async def send(self, data: bytes) -> None: ...
+
+    async def send(self, data: str | bytes) -> None:
+        if isinstance(data, str):
+            await self.ws.send_str(data)
+        else:
+            await self.ws.send_bytes(data)
+
+    @overload
+    def recv(self, payload_type: type[str]) -> AsyncIterator[str]: ...
+
+    @overload
+    def recv(self, payload_type: type[bytes]) -> AsyncIterator[bytes]: ...
+
+    async def recv(self, payload_type: type[str] | type[bytes] = str) -> AsyncIterator[str | bytes]:
+        """Yield payloads from the WebSocket.
+
+        Args:
+            payload_type: ``str`` for text frames, ``bytes`` for binary frames.
+
+        Handles CLOSED/CLOSE/CLOSING detection: returns cleanly if
+        ``mark_closing()`` was called or the session is closed,
+        otherwise raises ``APIStatusError``.
+        """
+        expected_ws_type = _PAYLOAD_TO_WS_TYPE[payload_type]
+        ws = self.ws
+        while True:
+            msg = await ws.receive()
+            if msg.type in _WS_CLOSE_TYPES:
+                if self._closing or self._session.closed:
+                    return
+                raise APIStatusError(
+                    message="inference websocket connection closed unexpectedly",
+                    status_code=ws.close_code or -1,
+                    body=f"{msg.data=} {msg.extra=}",
+                )
+
+            if msg.type != expected_ws_type:
+                logger.warning("unexpected inference websocket message type %s", msg.type)
+                continue
+
+            yield msg.data

--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -944,6 +944,17 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
         return msg.model_dump_json()
 
     async def _run(self) -> None:
+        async def wait_worker_tasks(tasks: list[asyncio.Task[None]]) -> None:
+            done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+
+            for task in done:
+                task.result()
+
+            if pending:
+                done, _ = await asyncio.wait(pending)
+                for task in done:
+                    task.result()
+
         async def send_task(
             iws: InferenceWebSocket, input_ch: aio.Chan[npt.NDArray[np.int16]]
         ) -> None:
@@ -1079,11 +1090,12 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                     asyncio.create_task(send_task(iws, data_ch)),
                     asyncio.create_task(recv_task(iws)),
                 ]
+                worker_tasks_done = asyncio.create_task(wait_worker_tasks(tasks))
                 wait_reconnect_task = asyncio.create_task(self._reconnect_event.wait())
 
                 try:
                     done, _ = await asyncio.wait(
-                        [*tasks, wait_reconnect_task],
+                        (worker_tasks_done, wait_reconnect_task),
                         return_when=asyncio.FIRST_COMPLETED,
                     )
 
@@ -1097,7 +1109,7 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                     self._reconnect_event.clear()
                 finally:
                     iws.mark_closing()
-                    await aio.gracefully_cancel(*tasks, wait_reconnect_task)
+                    await aio.gracefully_cancel(worker_tasks_done, *tasks, wait_reconnect_task)
 
 
 # endregion

--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -49,8 +49,8 @@ from ._utils import (
     STAGING_INFERENCE_URL,
     create_access_token,
     get_default_inference_url,
-    get_inference_headers,
 )
+from ._ws import InferenceWebSocket
 
 SAMPLE_RATE = 16000
 THRESHOLD = 0.5
@@ -929,13 +929,24 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
             self._opts.min_frames = math.ceil(min_interruption_duration * _FRAMES_PER_SECOND)
         self._reconnect_event.set()
 
-    async def _run(self) -> None:
-        closing_ws = False
+    def _build_session_create_message(self) -> str:
+        settings = InterruptionWSSessionCreateSettings(
+            sample_rate=self._opts.sample_rate,
+            num_channels=1,
+            threshold=self._opts.threshold,
+            min_frames=self._model._opts.min_frames,
+            encoding="s16le",
+        )
+        msg = InterruptionWSSessionCreateMessage(
+            type=InterruptionWSMessageType.SESSION_CREATE,
+            settings=settings,
+        )
+        return msg.model_dump_json()
 
+    async def _run(self) -> None:
         async def send_task(
-            ws: aiohttp.ClientWebSocketResponse, input_ch: aio.Chan[npt.NDArray[np.int16]]
+            iws: InferenceWebSocket, input_ch: aio.Chan[npt.NDArray[np.int16]]
         ) -> None:
-            nonlocal closing_ws
             timeout_ns = int(self._opts.inference_timeout * 1e9)
 
             async for audio_data in input_ch:
@@ -955,43 +966,21 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                 await self._num_requests.increment()
                 created_at = perf_counter_ns()
                 header = struct.pack("<Q", created_at)  # 8 bytes
-                await ws.send_bytes(header + audio_data.tobytes())
+                await iws.send(header + audio_data.tobytes())
                 self._cache[created_at] = InterruptionCacheEntry(
                     created_at=created_at,
                     speech_input=audio_data,
                 )
 
-            closing_ws = True
-            msg = InterruptionWSSessionCloseMessage(
+            iws.mark_closing()
+            close_msg = InterruptionWSSessionCloseMessage(
                 type=InterruptionWSMessageType.SESSION_CLOSE,
             )
-            await ws.send_str(msg.model_dump_json())
+            await iws.send(close_msg.model_dump_json())
 
-        async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
-            nonlocal closing_ws
-
-            while True:
-                ws_msg = await ws.receive()
-                if ws_msg.type in (
-                    aiohttp.WSMsgType.CLOSED,
-                    aiohttp.WSMsgType.CLOSE,
-                    aiohttp.WSMsgType.CLOSING,
-                ):
-                    if closing_ws or self._session.closed:
-                        return
-                    raise APIStatusError(
-                        message=f"LiveKit Adaptive Interruption connection closed unexpectedly: {ws_msg.data}",
-                        status_code=ws.close_code or -1,
-                        body=f"{ws_msg.data=} {ws_msg.extra=}",
-                    )
-
-                if ws_msg.type != aiohttp.WSMsgType.TEXT:
-                    logger.warning(
-                        "unexpected LiveKit Adaptive Interruption message type %s", ws_msg.type
-                    )
-                    continue
-
-                data = json.loads(ws_msg.data)
+        async def recv_task(iws: InferenceWebSocket) -> None:
+            async for raw_data in iws.recv(str):
+                data = json.loads(raw_data)
                 msg: AnyInterruptionWSMessage = InterruptionWSMessage.validate_python(data)
 
                 match msg:
@@ -1068,24 +1057,33 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                             data,
                         )
 
-        ws: aiohttp.ClientWebSocketResponse | None = None
-
         while True:
             data_ch = aio.Chan[npt.NDArray[np.int16]]()
-            try:
-                closing_ws = False
-                ws = await self._connect_ws()
+            async with InferenceWebSocket(
+                session=self._session,
+                base_url=self._opts.base_url,
+                path="/bargein",
+                api_key=self._opts.api_key,
+                api_secret=self._opts.api_secret,
+                timeout=self._conn_options.timeout,
+            ) as iws:
+                try:
+                    await iws.send(self._build_session_create_message())
+                except Exception as e:
+                    raise APIConnectionError(
+                        "failed to send session.create to adaptive interruption"
+                    ) from e
+
                 tasks = [
                     asyncio.create_task(self._forward_data(data_ch)),
-                    asyncio.create_task(send_task(ws, data_ch)),
-                    asyncio.create_task(recv_task(ws)),
+                    asyncio.create_task(send_task(iws, data_ch)),
+                    asyncio.create_task(recv_task(iws)),
                 ]
-                tasks_group = asyncio.gather(*tasks)
                 wait_reconnect_task = asyncio.create_task(self._reconnect_event.wait())
 
                 try:
                     done, _ = await asyncio.wait(
-                        (tasks_group, wait_reconnect_task),
+                        [*tasks, wait_reconnect_task],
                         return_when=asyncio.FIRST_COMPLETED,
                     )
 
@@ -1098,74 +1096,8 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
 
                     self._reconnect_event.clear()
                 finally:
-                    closing_ws = True
-                    if ws is not None and not ws.closed:
-                        await ws.close()
-                        ws = None
+                    iws.mark_closing()
                     await aio.gracefully_cancel(*tasks, wait_reconnect_task)
-                    tasks_group.cancel()
-                    try:
-                        tasks_group.exception()
-                    except asyncio.CancelledError:
-                        pass
-            finally:
-                closing_ws = True
-                if ws is not None and not ws.closed:
-                    await ws.close()
-
-    async def _connect_ws(self) -> aiohttp.ClientWebSocketResponse:
-        """Connect to the LiveKit Adaptive Interruption WebSocket."""
-        settings = InterruptionWSSessionCreateSettings(
-            sample_rate=self._opts.sample_rate,
-            num_channels=1,
-            threshold=self._opts.threshold,
-            min_frames=self._model._opts.min_frames,
-            encoding="s16le",
-        )
-
-        base_url = self._opts.base_url
-        if base_url.startswith(("http://", "https://")):
-            base_url = base_url.replace("http", "ws", 1)
-        headers = {
-            **get_inference_headers(),
-            "Authorization": f"Bearer {create_access_token(self._opts.api_key, self._opts.api_secret)}",
-        }
-        try:
-            ws = await asyncio.wait_for(
-                self._session.ws_connect(f"{base_url}/bargein", headers=headers),
-                self._conn_options.timeout,
-            )
-        except (
-            aiohttp.ClientConnectorError,
-            asyncio.TimeoutError,
-            aiohttp.ClientResponseError,
-        ) as e:
-            if isinstance(e, aiohttp.ClientResponseError) and e.status == 429:
-                raise APIStatusError(
-                    "LiveKit Adaptive Interruption quota exceeded",
-                    status_code=e.status,
-                    retryable=False,
-                ) from e
-            elif isinstance(e, asyncio.TimeoutError):
-                raise APIConnectionError(
-                    "failed to connect to LiveKit Adaptive Interruption: timeout",
-                    retryable=False,
-                ) from e
-            raise APIConnectionError("failed to connect to LiveKit Adaptive Interruption") from e
-
-        try:
-            msg = InterruptionWSSessionCreateMessage(
-                type=InterruptionWSMessageType.SESSION_CREATE,
-                settings=settings,
-            )
-            await ws.send_str(msg.model_dump_json())
-        except Exception as e:
-            await ws.close()
-            raise APIConnectionError(
-                "failed to send session.create message to LiveKit Adaptive Interruption"
-            ) from e
-
-        return ws
 
 
 # endregion

--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -14,13 +14,7 @@ from typing_extensions import Required
 from livekit import rtc
 
 from .. import stt, utils
-from .._exceptions import (
-    APIConnectionError,
-    APIError,
-    APIStatusError,
-    APITimeoutError,
-    create_api_error_from_http,
-)
+from .._exceptions import APIError
 from ..language import LanguageCode
 from ..log import logger
 from ..types import (
@@ -31,7 +25,8 @@ from ..types import (
     TimedString,
 )
 from ..utils import is_given
-from ._utils import create_access_token, get_default_inference_url, get_inference_headers
+from ._utils import get_default_inference_url
+from ._ws import InferenceWebSocket
 
 DeepgramModels = Literal[
     "deepgram/nova-3",
@@ -485,7 +480,7 @@ class SpeechStream(stt.SpeechStream):
 
         self._speaking = False
         self._speech_duration: float = 0
-        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._iws: InferenceWebSocket | None = None
 
     def update_options(
         self,
@@ -508,7 +503,8 @@ class SpeechStream(stt.SpeechStream):
             self._opts.extra_kwargs.update(extra)
 
         has_update = is_given(model) or is_given(language) or is_given(extra)
-        if has_update and self._ws is not None and not self._ws.closed:
+        iws = self._iws
+        if has_update and iws is not None and not iws.closed:
             settings: dict[str, Any] = {}
             if is_given(model):
                 settings["model"] = model
@@ -524,107 +520,15 @@ class SpeechStream(stt.SpeechStream):
 
     async def _send_session_update(self, msg: dict[str, Any]) -> None:
         try:
-            if self._ws is not None and not self._ws.closed:
-                await self._ws.send_str(json.dumps(msg))
+            iws = self._iws
+            if iws is not None and not iws.closed:
+                await iws.send(json.dumps(msg))
         except Exception:
             logger.debug("failed to send session.update, ws may be closing")
 
-    async def _run(self) -> None:
-        """Main loop for streaming transcription."""
-        closing_ws = False
-
-        @utils.log_exceptions(logger=logger)
-        async def send_task(ws: aiohttp.ClientWebSocketResponse) -> None:
-            nonlocal closing_ws
-
-            audio_bstream = utils.audio.AudioByteStream(
-                sample_rate=self._opts.sample_rate,
-                num_channels=1,
-                samples_per_channel=self._opts.sample_rate // 20,  # 50ms
-            )
-
-            async for ev in self._input_ch:
-                frames: list[rtc.AudioFrame] = []
-                if isinstance(ev, rtc.AudioFrame):
-                    frames.extend(audio_bstream.push(ev.data))
-                elif isinstance(ev, self._FlushSentinel):
-                    frames.extend(audio_bstream.flush())
-
-                for frame in frames:
-                    self._speech_duration += frame.duration
-                    audio_bytes = frame.data.tobytes()
-                    base64_audio = base64.b64encode(audio_bytes).decode("utf-8")
-                    audio_msg = {
-                        "type": "input_audio",
-                        "audio": base64_audio,
-                    }
-                    await ws.send_str(json.dumps(audio_msg))
-
-            closing_ws = True
-            finalize_msg = {
-                "type": "session.finalize",
-            }
-            await ws.send_str(json.dumps(finalize_msg))
-
-        @utils.log_exceptions(logger=logger)
-        async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
-            nonlocal closing_ws
-            while True:
-                msg = await ws.receive()
-                if msg.type in (
-                    aiohttp.WSMsgType.CLOSED,
-                    aiohttp.WSMsgType.CLOSE,
-                    aiohttp.WSMsgType.CLOSING,
-                ):
-                    if closing_ws or self._session.closed:
-                        return
-                    raise APIStatusError(
-                        message="LiveKit Inference STT connection closed unexpectedly"
-                    )
-
-                if msg.type != aiohttp.WSMsgType.TEXT:
-                    logger.warning("unexpected LiveKit Inference STT message type %s", msg.type)
-                    continue
-
-                data = json.loads(msg.data)
-                msg_type = data.get("type")
-                if msg_type == "session.created":
-                    pass
-                elif msg_type == "interim_transcript":
-                    self._process_transcript(data, is_final=False)
-                elif msg_type == "final_transcript":
-                    self._process_transcript(data, is_final=True)
-                elif msg_type == "session.finalized":
-                    pass
-                elif msg_type == "session.closed":
-                    pass
-                elif msg_type == "error":
-                    raise APIError(f"LiveKit Inference STT returned error: {msg.data}")
-                else:
-                    logger.warning(
-                        "received unexpected message from LiveKit Inference STT: %s", data
-                    )
-
-        ws: aiohttp.ClientWebSocketResponse | None = None
-        try:
-            ws = await self._connect_ws()
-            self._ws = ws
-            tasks = [
-                asyncio.create_task(send_task(ws)),
-                asyncio.create_task(recv_task(ws)),
-            ]
-            try:
-                await asyncio.gather(*tasks)
-            finally:
-                await utils.aio.gracefully_cancel(*tasks)
-        finally:
-            self._ws = None
-            if ws is not None:
-                await ws.close()
-
-    async def _connect_ws(self) -> aiohttp.ClientWebSocketResponse:
-        """Connect to the LiveKit Inference STT WebSocket."""
+    def _build_session_create_params(self) -> dict[str, Any]:
         params: dict[str, Any] = {
+            "type": "session.create",
             "settings": {
                 "sample_rate": str(self._opts.sample_rate),
                 "encoding": self._opts.encoding,
@@ -650,30 +554,84 @@ class SpeechStream(stt.SpeechStream):
                 "timeout": self._opts.conn_options.timeout,
                 "retries": self._opts.conn_options.max_retry,
             }
+        return params
 
-        base_url = self._opts.base_url
-        if base_url.startswith(("http://", "https://")):
-            base_url = base_url.replace("http", "ws", 1)
-        headers = {
-            **get_inference_headers(),
-            "Authorization": f"Bearer {create_access_token(self._opts.api_key, self._opts.api_secret)}",
-        }
-        try:
-            ws = await asyncio.wait_for(
-                self._session.ws_connect(
-                    f"{base_url}/stt?model={self._opts.model}", headers=headers
-                ),
-                self._conn_options.timeout,
-            )
-            params["type"] = "session.create"
-            await ws.send_str(json.dumps(params))
-        except aiohttp.ClientResponseError as e:
-            raise create_api_error_from_http(e.message, status=e.status) from e
-        except asyncio.TimeoutError as e:
-            raise APITimeoutError("LiveKit Inference STT connection timed out.") from e
-        except aiohttp.ClientConnectorError as e:
-            raise APIConnectionError("failed to connect to LiveKit Inference STT") from e
-        return ws
+    async def _run(self) -> None:
+        """Main loop for streaming transcription."""
+
+        async with InferenceWebSocket(
+            session=self._session,
+            base_url=self._opts.base_url,
+            path=f"/stt?model={self._opts.model}",
+            api_key=self._opts.api_key,
+            api_secret=self._opts.api_secret,
+            timeout=self._conn_options.timeout,
+        ) as iws:
+            await iws.send(json.dumps(self._build_session_create_params()))
+            self._iws = iws
+
+            @utils.log_exceptions(logger=logger)
+            async def send_task() -> None:
+                audio_bstream = utils.audio.AudioByteStream(
+                    sample_rate=self._opts.sample_rate,
+                    num_channels=1,
+                    samples_per_channel=self._opts.sample_rate // 20,  # 50ms
+                )
+
+                async for ev in self._input_ch:
+                    frames: list[rtc.AudioFrame] = []
+                    if isinstance(ev, rtc.AudioFrame):
+                        frames.extend(audio_bstream.push(ev.data))
+                    elif isinstance(ev, self._FlushSentinel):
+                        frames.extend(audio_bstream.flush())
+
+                    for frame in frames:
+                        self._speech_duration += frame.duration
+                        audio_bytes = frame.data.tobytes()
+                        base64_audio = base64.b64encode(audio_bytes).decode("utf-8")
+                        audio_msg = {
+                            "type": "input_audio",
+                            "audio": base64_audio,
+                        }
+                        await iws.send(json.dumps(audio_msg))
+
+                iws.mark_closing()
+                await iws.send(json.dumps({"type": "session.finalize"}))
+
+            @utils.log_exceptions(logger=logger)
+            async def recv_task() -> None:
+                async for data in iws.recv(str):
+                    parsed = json.loads(data)
+                    msg_type = parsed.get("type")
+                    if msg_type == "session.created":
+                        pass
+                    elif msg_type == "interim_transcript":
+                        self._process_transcript(parsed, is_final=False)
+                    elif msg_type == "final_transcript":
+                        self._process_transcript(parsed, is_final=True)
+                    elif msg_type in ("session.finalized", "session.closed"):
+                        pass
+                    elif msg_type == "error":
+                        raise APIError(
+                            f"LiveKit Inference STT returned error: {json.dumps(parsed)}"
+                        )
+                    else:
+                        logger.warning(
+                            "received unexpected message from LiveKit Inference STT: %s",
+                            parsed,
+                        )
+
+            try:
+                tasks = [
+                    asyncio.create_task(send_task()),
+                    asyncio.create_task(recv_task()),
+                ]
+                try:
+                    await asyncio.gather(*tasks)
+                finally:
+                    await utils.aio.gracefully_cancel(*tasks)
+            finally:
+                self._iws = None
 
     def _process_transcript(self, data: dict, is_final: bool) -> None:
         request_id = data.get("request_id", self._request_id)


### PR DESCRIPTION
A new websocket helper that:
- provides a context manager for lifetime management
- recv loop that yields valid payloads, handles close detection internally via mark_closing()

Design decisions:
- It still leaves task orchestration and session creation to the caller
- It does not handle retry or stream class-level abstraction (`RecognizeStream` and `InterruptionStreamBase` already handle them differently in _main_task)

Usage:
```python
async with InferenceWebSocket(
      session=http_session,
      base_url="https://agent-gateway.livekit.cloud/v1",
      path="/stt?model=deepgram/nova-3",
      api_key=api_key,
      api_secret=api_secret,
      timeout=10.0,
  ) as iws:
      await iws.send(session_create_data)
      async def send_coro():
          ...
      
     async def recv_coro():
          async for raw_data in iws.recv(str):
              ...

      tasks = [
          asyncio.create_task(...),
          asyncio.create_task(...),
      ]
      try:
          await asyncio.gather(*tasks)
      finally:
          await aio.cancel_and_wait(*tasks)
```