### PR TITLE
fix(llm): handle double-encoded JSON tool arguments from providers

### DIFF
--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -386,8 +386,23 @@ def prepare_function_arguments(
 
     if isinstance(json_arguments, str):
         args_dict = from_json(json_arguments)
+        # some providers (e.g. Nova Sonic) double-encode tool arguments as nested
+        # JSON strings. unwrap until we reach a non-string value.
+        while isinstance(args_dict, str):
+            try:
+                args_dict = from_json(args_dict)
+            except Exception:
+                raise ValueError(
+                    f"function arguments decoded to a non-JSON string: {args_dict[:200]}"
+                ) from None
+
         if args_dict is None:
             args_dict = {}
+        elif not isinstance(args_dict, dict):
+            raise ValueError(
+                f"expected dict from function arguments, "
+                f"got {type(args_dict).__name__}: {json_arguments[:200]}"
+            )
     else:
         args_dict = json_arguments
 

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -1286,6 +1286,20 @@ class RealtimeSession(  # noqa: F811
         tool_name = event_data["event"]["toolUse"]["toolName"]
         args = event_data["event"]["toolUse"]["content"]
 
+        # Nova Sonic sometimes double-encodes tool arguments as a JSON string
+        # containing another JSON string (e.g. "\"{\\\"order_id\\\":\\\"1234\\\"}\"").
+        # Detect and unwrap so the framework receives a proper JSON object string.
+        if isinstance(args, str):
+            try:
+                import json
+
+                parsed = json.loads(args)
+                if isinstance(parsed, str):
+                    # Double-encoded: the outer parse gave us a string, try again
+                    args = parsed
+            except (json.JSONDecodeError, TypeError):
+                pass
+
         # Emit function call to LiveKit framework
         self._current_generation.function_ch.send_nowait(
             llm.FunctionCall(call_id=tool_use_id, name=tool_name, arguments=args)


### PR DESCRIPTION
## fix(llm): handle double-encoded JSON tool arguments from providers

### Problem

Nova Sonic intermittently double-encodes tool call arguments as a JSON string containing another JSON string:

```
// Expected
"content": "{\"order_id\":\"27422\"}"

// Actual (double-encoded)
"content": "\"{\\\"order_id\\\":\\\"27422\\\"}\""
```

When this happens, `from_json()` in `prepare_function_arguments` returns a Python string instead of a dict, causing:

```
TypeError: string indices must be integers, not 'str'
```

at `utils.py:404` when the code tries to access `args_dict[param_name]`.

### Changes

**`livekit-agents/livekit/agents/llm/utils.py`**
- Added a defensive unwrap loop in `prepare_function_arguments` that iterates `from_json` until the result is no longer a string
- If the unwrapped value is `None`, falls back to `{}`
- If the unwrapped value is a non-dict type (list, int, etc.), raises a clear `ValueError`
- Errors are caught by the existing `execute_function_call` error handler and surfaced back to the LLM as a `ToolError`

**`livekit-plugins/livekit-plugins-aws/.../realtime_model.py`**
- Added early unwrap of double-encoded arguments in `_handle_tool_output_content_event` before emitting the `FunctionCall`, so downstream code receives clean data

### Testing

Reproduced with Nova Sonic 2 using a single-parameter tool (`track_order(order_id: str)`). The double-encoding is intermittent and model-dependent. Verified that:
- Normal (single-encoded) arguments still work
- Double-encoded arguments are correctly unwrapped
- Non-JSON strings raise a clear `ValueError` (caught by existing error handler)