### PR TITLE
fix: empty transcript blocks commit_user_turn until timeout

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -721,6 +721,7 @@ class AudioRecognition:
             ):
                 self._last_language = language
 
+            self._final_transcript_received.set()
             if not transcript:
                 return
 
@@ -745,7 +746,6 @@ class AudioRecognition:
             transcript_changed = self._audio_transcript != self._audio_preflight_transcript
             self._audio_interim_transcript = ""
             self._audio_preflight_transcript = ""
-            self._final_transcript_received.set()
 
             if not self._vad or self._last_speaking_time is None:
                 # vad disabled, use stt timestamp


### PR DESCRIPTION
## Summary

- When using manual turn detection, `commit_user_turn` waits for `_final_transcript_received` to be set after flushing the STT buffer with silence
- If the STT returns a `FINAL_TRANSCRIPT` with empty text (e.g. the user turn was silence), `_on_stt_event` returned early before setting the event, causing `commit_user_turn` to block until `transcript_timeout`
- Move `_final_transcript_received.set()` before the empty transcript guard so the wait unblocks regardless of transcript content
