### PR TITLE
feat(turn-detector): LLM-based turn completion detector

### DIFF
--- a/examples/voice_agents/llm_turn_detector.py
+++ b/examples/voice_agents/llm_turn_detector.py
@@ -1,0 +1,36 @@
+"""Voice agent using LLMTurnDetector for end-of-turn classification.
+
+Run with:
+    OPENAI_API_KEY=... DEEPGRAM_API_KEY=... \
+        python examples/voice_agents/llm_turn_detector.py dev
+"""
+
+from __future__ import annotations
+
+from livekit.agents import Agent, AgentSession, JobContext, WorkerOptions, cli
+from livekit.plugins import deepgram, openai, silero
+from livekit.plugins.turn_detector import LLMTurnDetector
+
+
+async def entrypoint(ctx: JobContext) -> None:
+    await ctx.connect()
+
+    # A cheap model is usually plenty for turn-completion classification.
+    classifier_llm = openai.LLM(model="gpt-4o-mini")
+
+    session = AgentSession(
+        vad=silero.VAD.load(),
+        stt=deepgram.STT(),
+        llm=openai.LLM(model="gpt-4o-mini"),
+        tts=openai.TTS(),
+        turn_detection=LLMTurnDetector(llm=classifier_llm),
+    )
+
+    await session.start(
+        agent=Agent(instructions="You are a friendly assistant. Keep answers short."),
+        room=ctx.room,
+    )
+
+
+if __name__ == "__main__":
+    cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))

--- a/examples/voice_agents/llm_turn_detector.py
+++ b/examples/voice_agents/llm_turn_detector.py
@@ -1,29 +1,48 @@
 """Voice agent using LLMTurnDetector for end-of-turn classification.
 
+Demonstrates plugging ``LLMTurnDetector`` into an ``AgentSession`` so a small
+LLM decides when the user has finished speaking, instead of relying solely on
+VAD silence timeouts.
+
 Run with:
     OPENAI_API_KEY=... DEEPGRAM_API_KEY=... \
         python examples/voice_agents/llm_turn_detector.py dev
 """
 
-from __future__ import annotations
+from dotenv import load_dotenv
 
-from livekit.agents import Agent, AgentSession, JobContext, WorkerOptions, cli
+from livekit.agents import (
+    Agent,
+    AgentServer,
+    AgentSession,
+    JobContext,
+    JobProcess,
+    cli,
+)
 from livekit.plugins import deepgram, openai, silero
 from livekit.plugins.turn_detector import LLMTurnDetector
 
+load_dotenv()
 
+server = AgentServer()
+
+
+def prewarm(proc: JobProcess) -> None:
+    proc.userdata["vad"] = silero.VAD.load()
+
+
+server.setup_fnc = prewarm
+
+
+@server.rtc_session()
 async def entrypoint(ctx: JobContext) -> None:
-    await ctx.connect()
-
-    # A cheap model is usually plenty for turn-completion classification.
-    classifier_llm = openai.LLM(model="gpt-4o-mini")
-
     session = AgentSession(
-        vad=silero.VAD.load(),
+        vad=ctx.proc.userdata["vad"],
         stt=deepgram.STT(),
         llm=openai.LLM(model="gpt-4o-mini"),
         tts=openai.TTS(),
-        turn_detection=LLMTurnDetector(llm=classifier_llm),
+        # A cheap model is usually plenty for turn-completion classification.
+        turn_detection=LLMTurnDetector(llm=openai.LLM(model="gpt-4o-mini")),
     )
 
     await session.start(
@@ -33,4 +52,4 @@ async def entrypoint(ctx: JobContext) -> None:
 
 
 if __name__ == "__main__":
-    cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))
+    cli.run_app(server)

--- a/livekit-plugins/livekit-plugins-turn-detector/README.md
+++ b/livekit-plugins/livekit-plugins-turn-detector/README.md
@@ -69,3 +69,47 @@ The model requires <500MB of RAM and runs within a shared inference server, supp
 The plugin source code is licensed under the Apache-2.0 license.
 
 The end-of-turn model is licensed under the [LiveKit Model License](https://huggingface.co/livekit/turn-detector/blob/main/LICENSE).
+
+## LLM-based turn detection (opt-in)
+
+`LLMTurnDetector` is an alternative to the ONNX EOU model that uses any
+`livekit.agents.llm.LLM` to classify turn completion. Useful when you already
+pay for an LLM in the same conversation loop, want multilingual coverage
+without a language table, or need semantic reasoning over the full context.
+
+### Usage
+
+```python
+from livekit.agents import AgentSession
+from livekit.plugins import openai
+from livekit.plugins.turn_detector import LLMTurnDetector
+
+session = AgentSession(
+    turn_detection=LLMTurnDetector(llm=openai.LLM(model="gpt-4o-mini")),
+    # ... STT, TTS, LLM, etc.
+)
+```
+
+### Tradeoffs vs the ONNX EOU model
+
+| Dimension         | ONNX EOU                      | `LLMTurnDetector`             |
+|-------------------|-------------------------------|-------------------------------|
+| Cost per turn     | Free after download           | Paid LLM call                 |
+| Latency           | ~10–50 ms CPU                 | 200–800 ms typical            |
+| Setup             | Model download step           | Drop in any `llm.LLM`         |
+| Language coverage | Fixed language table          | Whatever your LLM supports    |
+| Reasoning quality | Classifier-only               | Full LLM semantics            |
+
+The ONNX detector remains the default for most deployments. Reach for
+`LLMTurnDetector` when its tradeoffs match your workload.
+
+### Configuration
+
+- `instructions`: override the default classification prompt (e.g., for
+  non-English voice apps or domain-specific tuning).
+- `unlikely_threshold` (default `0.5`): probability below which endpointing
+  treats the turn as likely-incomplete and waits longer.
+- `timeout` (default `1.5`): hard cap on the classifier call; on timeout the
+  detector returns a neutral probability rather than blocking the agent.
+- `max_history_turns` (default `6`): how many trailing chat messages are
+  included in the classifier prompt.

--- a/livekit-plugins/livekit-plugins-turn-detector/README.md
+++ b/livekit-plugins/livekit-plugins-turn-detector/README.md
@@ -44,6 +44,34 @@ session = AgentSession(
 )
 ```
 
+### LLM-based detector
+
+`LLMTurnDetector` is an additional turn-detection option that delegates the
+classification call to any `livekit.agents.llm.LLM` instance. It plugs into the
+same `turn_detection=` slot as the ONNX models above.
+
+```python
+from livekit.agents import AgentSession
+from livekit.plugins import openai
+from livekit.plugins.turn_detector import LLMTurnDetector
+
+session = AgentSession(
+    ...
+    turn_detection=LLMTurnDetector(llm=openai.LLM(model="gpt-4o-mini")),
+)
+```
+
+Configuration:
+
+- `instructions`: override the default classification prompt (e.g., for
+  domain-specific tuning).
+- `unlikely_threshold` (default `0.5`): probability below which endpointing
+  treats the turn as likely-incomplete and waits longer.
+- `timeout` (default `1.5`): hard cap on the classifier call; on timeout the
+  detector returns a neutral probability rather than blocking the agent.
+- `max_history_turns` (default `6`): how many trailing chat messages are
+  included in the classifier prompt.
+
 ## Running your agent
 
 This plugin requires model files. Before starting your agent for the first time, or when building Docker images for deployment, run the following command to download the model files:
@@ -69,47 +97,3 @@ The model requires <500MB of RAM and runs within a shared inference server, supp
 The plugin source code is licensed under the Apache-2.0 license.
 
 The end-of-turn model is licensed under the [LiveKit Model License](https://huggingface.co/livekit/turn-detector/blob/main/LICENSE).
-
-## LLM-based turn detection (opt-in)
-
-`LLMTurnDetector` is an alternative to the ONNX EOU model that uses any
-`livekit.agents.llm.LLM` to classify turn completion. Useful when you already
-pay for an LLM in the same conversation loop, want multilingual coverage
-without a language table, or need semantic reasoning over the full context.
-
-### Usage
-
-```python
-from livekit.agents import AgentSession
-from livekit.plugins import openai
-from livekit.plugins.turn_detector import LLMTurnDetector
-
-session = AgentSession(
-    turn_detection=LLMTurnDetector(llm=openai.LLM(model="gpt-4o-mini")),
-    # ... STT, TTS, LLM, etc.
-)
-```
-
-### Tradeoffs vs the ONNX EOU model
-
-| Dimension         | ONNX EOU                      | `LLMTurnDetector`             |
-|-------------------|-------------------------------|-------------------------------|
-| Cost per turn     | Free after download           | Paid LLM call                 |
-| Latency           | ~10–50 ms CPU                 | 200–800 ms typical            |
-| Setup             | Model download step           | Drop in any `llm.LLM`         |
-| Language coverage | Fixed language table          | Whatever your LLM supports    |
-| Reasoning quality | Classifier-only               | Full LLM semantics            |
-
-The ONNX detector remains the default for most deployments. Reach for
-`LLMTurnDetector` when its tradeoffs match your workload.
-
-### Configuration
-
-- `instructions`: override the default classification prompt (e.g., for
-  non-English voice apps or domain-specific tuning).
-- `unlikely_threshold` (default `0.5`): probability below which endpointing
-  treats the turn as likely-incomplete and waits longer.
-- `timeout` (default `1.5`): hard cap on the classifier call; on timeout the
-  detector returns a neutral probability rather than blocking the agent.
-- `max_history_turns` (default `6`): how many trailing chat messages are
-  included in the classifier prompt.

--- a/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/__init__.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/__init__.py
@@ -17,8 +17,8 @@
 See https://docs.livekit.io/agents/build/turns/turn-detector/ for more information.
 """
 
-from .version import __version__
 from .llm_based import LLMTurnDetector
+from .version import __version__
 
 __all__ = ["LLMTurnDetector", "english", "multilingual", "__version__"]
 

--- a/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/__init__.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/__init__.py
@@ -18,8 +18,9 @@ See https://docs.livekit.io/agents/build/turns/turn-detector/ for more informati
 """
 
 from .version import __version__
+from .llm_based import LLMTurnDetector
 
-__all__ = ["english", "multilingual", "__version__"]
+__all__ = ["LLMTurnDetector", "english", "multilingual", "__version__"]
 
 
 # Cleanup docs of unexported modules

--- a/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/__init__.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/__init__.py
@@ -23,8 +23,9 @@ from .base import EOUPlugin
 from .english import _EUORunnerEn
 from .multilingual import _EUORunnerMultilingual
 from .version import __version__
+from .llm_based import LLMTurnDetector
 
-__all__ = ["english", "multilingual", "__version__"]
+__all__ = ["LLMTurnDetector", "english", "multilingual", "__version__"]
 
 Plugin.register_plugin(EOUPlugin(_EUORunnerEn))
 Plugin.register_plugin(EOUPlugin(_EUORunnerMultilingual))

--- a/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/__init__.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/__init__.py
@@ -21,9 +21,9 @@ from livekit.agents import Plugin
 
 from .base import EOUPlugin
 from .english import _EUORunnerEn
+from .llm_based import LLMTurnDetector
 from .multilingual import _EUORunnerMultilingual
 from .version import __version__
-from .llm_based import LLMTurnDetector
 
 __all__ = ["LLMTurnDetector", "english", "multilingual", "__version__"]
 

--- a/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/llm_based.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/llm_based.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from livekit.agents import LanguageCode, llm
@@ -69,5 +70,52 @@ class LLMTurnDetector:
     async def predict_end_of_turn(
         self, chat_ctx: ChatContext, *, timeout: float | None = None
     ) -> float:
-        # Implemented in Task 3.
-        raise NotImplementedError
+        user_messages = [m for m in chat_ctx.messages() if m.role == "user"]
+        if not user_messages:
+            return 1.0
+
+        prompt_ctx = self._build_prompt_ctx(chat_ctx)
+        effective_timeout = timeout if timeout is not None else self._timeout
+
+        try:
+            response = await asyncio.wait_for(
+                self._llm.chat(chat_ctx=prompt_ctx).collect(),
+                timeout=effective_timeout,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "LLMTurnDetector: classifier timed out after %.2fs", effective_timeout
+            )
+            return _NEUTRAL_PROBABILITY
+        except Exception:
+            logger.warning("LLMTurnDetector: classifier call failed", exc_info=True)
+            return _NEUTRAL_PROBABILITY
+
+        return self._parse_probability(response.text or "")
+
+    def _build_prompt_ctx(self, chat_ctx: ChatContext) -> ChatContext:
+        messages = chat_ctx.messages()[-self._max_history_turns :]
+        lines: list[str] = []
+        for i, msg in enumerate(messages):
+            text = msg.text_content or ""
+            marker = "[CURRENT] " if i == len(messages) - 1 and msg.role == "user" else ""
+            lines.append(f"{marker}{msg.role}: {text}")
+        rendered = "\n".join(lines)
+
+        prompt_ctx = ChatContext.empty()
+        prompt_ctx.add_message(role="system", content=self._instructions)
+        prompt_ctx.add_message(role="user", content=rendered)
+        return prompt_ctx
+
+    def _parse_probability(self, content: str) -> float:
+        stripped = content.strip()
+        if not stripped:
+            logger.warning("LLMTurnDetector: empty response")
+            return _NEUTRAL_PROBABILITY
+        first = stripped[0]
+        if first == "1":
+            return _COMPLETE_PROBABILITY
+        if first == "0":
+            return _INCOMPLETE_PROBABILITY
+        logger.warning("LLMTurnDetector: unexpected response token %r", stripped[:16])
+        return _NEUTRAL_PROBABILITY

--- a/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/llm_based.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/llm_based.py
@@ -83,9 +83,7 @@ class LLMTurnDetector:
                 timeout=effective_timeout,
             )
         except asyncio.TimeoutError:
-            logger.warning(
-                "LLMTurnDetector: classifier timed out after %.2fs", effective_timeout
-            )
+            logger.warning("LLMTurnDetector: classifier timed out after %.2fs", effective_timeout)
             return _NEUTRAL_PROBABILITY
         except Exception:
             logger.warning("LLMTurnDetector: classifier call failed", exc_info=True)

--- a/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/llm_based.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/llm_based.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from livekit.agents import LanguageCode, llm
+from livekit.agents.llm import ChatContext
+
+__all__ = ["LLMTurnDetector"]
+
+
+class LLMTurnDetector:
+    """LLM-based end-of-turn classifier.
+
+    Implementation added across Tasks 2-10.
+    """
+
+    pass

--- a/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/llm_based.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/llm_based.py
@@ -1,15 +1,73 @@
 from __future__ import annotations
 
+import logging
+
 from livekit.agents import LanguageCode, llm
 from livekit.agents.llm import ChatContext
 
 __all__ = ["LLMTurnDetector"]
 
+logger = logging.getLogger("livekit.plugins.turn_detector.llm_based")
+
+_MAX_HISTORY_TURNS = 6
+_DEFAULT_TIMEOUT = 1.5
+_COMPLETE_PROBABILITY = 0.95
+_INCOMPLETE_PROBABILITY = 0.05
+_NEUTRAL_PROBABILITY = 0.5
+
+_DEFAULT_INSTRUCTIONS = """\
+You are a turn-completion classifier for a voice assistant. Given a transcribed
+conversation, decide whether the LAST user message represents a complete thought
+that the assistant should respond to, or whether the user is mid-sentence and
+likely to continue speaking.
+
+Reply with EXACTLY one token:
+- "1" if the user's turn is complete
+- "0" if the user appears cut off or still thinking
+
+Do not explain. Do not add punctuation."""
+
 
 class LLMTurnDetector:
-    """LLM-based end-of-turn classifier.
+    """Classify end-of-turn using a user-supplied LLM.
 
-    Implementation added across Tasks 2-10.
+    Implements the ``_TurnDetector`` Protocol from
+    ``livekit.agents.voice.turn``. Designed as a drop-in alternative to the
+    ONNX EOU model for users who would rather spend an LLM call than run a
+    dedicated classifier.
     """
 
-    pass
+    def __init__(
+        self,
+        llm: llm.LLM,
+        *,
+        instructions: str | None = None,
+        unlikely_threshold: float = _NEUTRAL_PROBABILITY,
+        timeout: float = _DEFAULT_TIMEOUT,
+        max_history_turns: int = _MAX_HISTORY_TURNS,
+    ) -> None:
+        self._llm = llm
+        self._instructions = instructions or _DEFAULT_INSTRUCTIONS
+        self._unlikely_threshold = unlikely_threshold
+        self._timeout = timeout
+        self._max_history_turns = max_history_turns
+
+    @property
+    def provider(self) -> str:
+        return "llm"
+
+    @property
+    def model(self) -> str:
+        return self._llm.model
+
+    async def unlikely_threshold(self, language: LanguageCode | None) -> float | None:
+        return self._unlikely_threshold
+
+    async def supports_language(self, language: LanguageCode | None) -> bool:
+        return True
+
+    async def predict_end_of_turn(
+        self, chat_ctx: ChatContext, *, timeout: float | None = None
+    ) -> float:
+        # Implemented in Task 3.
+        raise NotImplementedError

--- a/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/llm_based.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/llm_based.py
@@ -19,12 +19,24 @@ _NEUTRAL_PROBABILITY = 0.5
 _DEFAULT_INSTRUCTIONS = """\
 You are a turn-completion classifier for a voice assistant. Given a transcribed
 conversation, decide whether the LAST user message represents a complete thought
-that the assistant should respond to, or whether the user is mid-sentence and
-likely to continue speaking.
+the assistant should respond to, or whether the user is mid-sentence and likely
+to keep speaking.
 
 Reply with EXACTLY one token:
 - "1" if the user's turn is complete
-- "0" if the user appears cut off or still thinking
+- "0" if the user appears cut off, still thinking, or asked the assistant to wait
+
+Reply "0" when the user sounds cut off, truncated, or mid-sentence:
+- unfinished clauses or sentence fragments
+- trailing conjunctions, prepositions, or articles ("and", "but", "to", "the")
+- partial names, numbers, dates, phone numbers, or addresses
+- obvious STT fragments from interruption or carrier clipping
+- the user paused intentionally to think, remember, or look something up
+- the user explicitly asked you to wait or hold ("one sec", "give me a moment")
+
+Reply "1" only when the user's thought is actually complete and the assistant
+should respond now. If unsure, prefer "0" — a brief extra wait is cheaper than
+talking over the user.
 
 Do not explain. Do not add punctuation."""
 

--- a/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
@@ -117,3 +117,27 @@ async def test_predict_returns_low_probability_when_llm_says_zero():
     det = LLMTurnDetector(llm=fake)
     prob = await det.predict_end_of_turn(_ctx_with_user("so i was thinking that"))
     assert prob == pytest.approx(0.05)
+
+
+@pytest.mark.asyncio
+async def test_predict_tolerates_whitespace_around_token():
+    fake = _QueuedLLM([_Behavior(content=" 1 \n")])
+    det = LLMTurnDetector(llm=fake)
+    prob = await det.predict_end_of_turn(_ctx_with_user("done speaking"))
+    assert prob == pytest.approx(0.95)
+
+
+@pytest.mark.asyncio
+async def test_predict_returns_neutral_on_garbage():
+    fake = _QueuedLLM([_Behavior(content="yes definitely")])
+    det = LLMTurnDetector(llm=fake)
+    prob = await det.predict_end_of_turn(_ctx_with_user("finished"))
+    assert prob == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_predict_returns_neutral_on_empty_response():
+    fake = _QueuedLLM([_Behavior(content="")])
+    det = LLMTurnDetector(llm=fake)
+    prob = await det.predict_end_of_turn(_ctx_with_user("something"))
+    assert prob == pytest.approx(0.5)

--- a/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from livekit.agents import llm
+from livekit.agents.llm import ChatContext
+from livekit.plugins.turn_detector import LLMTurnDetector

--- a/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
@@ -163,3 +163,23 @@ async def test_predict_swallows_llm_exception():
     det = LLMTurnDetector(llm=fake)
     prob = await det.predict_end_of_turn(_ctx_with_user("anyone there"))
     assert prob == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_predict_returns_complete_for_empty_ctx():
+    fake = _QueuedLLM([])  # no behaviors — should never be called
+    det = LLMTurnDetector(llm=fake)
+    prob = await det.predict_end_of_turn(ChatContext.empty())
+    assert prob == pytest.approx(1.0)
+    assert fake.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_predict_returns_complete_when_only_assistant_messages():
+    ctx = ChatContext.empty()
+    ctx.add_message(role="assistant", content="hello, how can I help?")
+    fake = _QueuedLLM([])
+    det = LLMTurnDetector(llm=fake)
+    prob = await det.predict_end_of_turn(ctx)
+    assert prob == pytest.approx(1.0)
+    assert fake.calls == 0

--- a/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
@@ -6,4 +6,97 @@ import pytest
 
 from livekit.agents import llm
 from livekit.agents.llm import ChatContext
+from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS
 from livekit.plugins.turn_detector import LLMTurnDetector
+
+
+class _QueuedLLMStream(llm.LLMStream):
+    def __init__(self, fake_llm: _QueuedLLM, *, chat_ctx: ChatContext) -> None:
+        super().__init__(
+            fake_llm,
+            chat_ctx=chat_ctx,
+            tools=[],
+            conn_options=DEFAULT_API_CONNECT_OPTIONS,
+        )
+        self._fake_llm = fake_llm
+
+    async def _run(self) -> None:
+        behavior = self._fake_llm.next_behavior()
+        if behavior.sleep:
+            await asyncio.sleep(behavior.sleep)
+        if behavior.raise_exc is not None:
+            raise behavior.raise_exc
+        if behavior.content is not None:
+            self._event_ch.send_nowait(
+                llm.ChatChunk(
+                    id="1",
+                    delta=llm.ChoiceDelta(role="assistant", content=behavior.content),
+                )
+            )
+
+
+class _Behavior:
+    def __init__(
+        self,
+        content: str | None = None,
+        sleep: float = 0.0,
+        raise_exc: Exception | None = None,
+    ) -> None:
+        self.content = content
+        self.sleep = sleep
+        self.raise_exc = raise_exc
+
+
+class _QueuedLLM(llm.LLM):
+    """Fake LLM that returns queued behaviors in order."""
+
+    def __init__(self, behaviors: list[_Behavior]) -> None:
+        super().__init__()
+        self._behaviors = list(behaviors)
+        self.calls = 0
+
+    def next_behavior(self) -> _Behavior:
+        self.calls += 1
+        if not self._behaviors:
+            return _Behavior(content="")
+        return self._behaviors.pop(0)
+
+    @property
+    def model(self) -> str:
+        return "fake-llm"
+
+    def chat(
+        self,
+        *,
+        chat_ctx,
+        tools=None,
+        conn_options=DEFAULT_API_CONNECT_OPTIONS,
+        parallel_tool_calls=None,
+        tool_choice=None,
+        extra_kwargs=None,
+    ):
+        return _QueuedLLMStream(self, chat_ctx=chat_ctx)
+
+
+def _ctx_with_user(text: str) -> ChatContext:
+    ctx = ChatContext.empty()
+    ctx.add_message(role="user", content=text)
+    return ctx
+
+
+def test_provider_and_model_properties():
+    det = LLMTurnDetector(llm=_QueuedLLM([]))
+    assert det.provider == "llm"
+    assert det.model == "fake-llm"
+
+
+@pytest.mark.asyncio
+async def test_supports_language_always_true():
+    det = LLMTurnDetector(llm=_QueuedLLM([]))
+    assert await det.supports_language(None) is True
+
+
+@pytest.mark.asyncio
+async def test_unlikely_threshold_returns_ctor_value():
+    det = LLMTurnDetector(llm=_QueuedLLM([]), unlikely_threshold=0.7)
+    assert await det.unlikely_threshold(None) == 0.7

--- a/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
@@ -141,3 +141,17 @@ async def test_predict_returns_neutral_on_empty_response():
     det = LLMTurnDetector(llm=fake)
     prob = await det.predict_end_of_turn(_ctx_with_user("something"))
     assert prob == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_predict_returns_neutral_on_timeout():
+    # LLM sleeps 0.5s, but timeout is 0.05s
+    fake = _QueuedLLM([_Behavior(content="1", sleep=0.5)])
+    det = LLMTurnDetector(llm=fake, timeout=0.05)
+
+    start = asyncio.get_event_loop().time()
+    prob = await det.predict_end_of_turn(_ctx_with_user("hello there"))
+    elapsed = asyncio.get_event_loop().time() - start
+
+    assert prob == pytest.approx(0.5)
+    assert elapsed < 0.2, f"expected early timeout, elapsed={elapsed:.3f}"

--- a/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
@@ -226,3 +226,16 @@ async def test_prompt_trims_history_to_max_history_turns():
     assert "turn-8" in rendered
     assert "turn-9" in rendered
     assert "turn-6" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_custom_instructions_replace_default_system_prompt():
+    custom = "Custom classifier instructions for domain X."
+    fake = _CapturingLLM([_Behavior(content="1")])
+    det = LLMTurnDetector(llm=fake, instructions=custom)
+    await det.predict_end_of_turn(_ctx_with_user("sample"))
+
+    assert fake.captured_ctx is not None
+    system_msg = fake.captured_ctx.messages()[0]
+    assert system_msg.role == "system"
+    assert system_msg.text_content == custom

--- a/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
@@ -155,3 +155,11 @@ async def test_predict_returns_neutral_on_timeout():
 
     assert prob == pytest.approx(0.5)
     assert elapsed < 0.2, f"expected early timeout, elapsed={elapsed:.3f}"
+
+
+@pytest.mark.asyncio
+async def test_predict_swallows_llm_exception():
+    fake = _QueuedLLM([_Behavior(raise_exc=RuntimeError("provider down"))])
+    det = LLMTurnDetector(llm=fake)
+    prob = await det.predict_end_of_turn(_ctx_with_user("anyone there"))
+    assert prob == pytest.approx(0.5)

--- a/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
@@ -183,3 +183,46 @@ async def test_predict_returns_complete_when_only_assistant_messages():
     prob = await det.predict_end_of_turn(ctx)
     assert prob == pytest.approx(1.0)
     assert fake.calls == 0
+
+
+class _CapturingLLM(_QueuedLLM):
+    def __init__(self, behaviors: list[_Behavior]) -> None:
+        super().__init__(behaviors)
+        self.captured_ctx: ChatContext | None = None
+
+    def chat(
+        self,
+        *,
+        chat_ctx,
+        tools=None,
+        conn_options=DEFAULT_API_CONNECT_OPTIONS,
+        parallel_tool_calls=None,
+        tool_choice=None,
+        extra_kwargs=None,
+    ):
+        self.captured_ctx = chat_ctx
+        return super().chat(
+            chat_ctx=chat_ctx,
+            tools=tools,
+            conn_options=conn_options,
+        )
+
+
+@pytest.mark.asyncio
+async def test_prompt_trims_history_to_max_history_turns():
+    ctx = ChatContext.empty()
+    for i in range(10):
+        role = "user" if i % 2 == 0 else "assistant"
+        ctx.add_message(role=role, content=f"turn-{i}")
+
+    fake = _CapturingLLM([_Behavior(content="1")])
+    det = LLMTurnDetector(llm=fake, max_history_turns=3)
+    await det.predict_end_of_turn(ctx)
+
+    assert fake.captured_ctx is not None
+    rendered = fake.captured_ctx.messages()[-1].text_content or ""
+    # last 3 turns are turn-7 (assistant), turn-8 (user), turn-9 (assistant)
+    assert "turn-7" in rendered
+    assert "turn-8" in rendered
+    assert "turn-9" in rendered
+    assert "turn-6" not in rendered

--- a/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py
@@ -100,3 +100,20 @@ async def test_supports_language_always_true():
 async def test_unlikely_threshold_returns_ctor_value():
     det = LLMTurnDetector(llm=_QueuedLLM([]), unlikely_threshold=0.7)
     assert await det.unlikely_threshold(None) == 0.7
+
+
+@pytest.mark.asyncio
+async def test_predict_returns_high_probability_when_llm_says_one():
+    fake = _QueuedLLM([_Behavior(content="1")])
+    det = LLMTurnDetector(llm=fake)
+    prob = await det.predict_end_of_turn(_ctx_with_user("the meeting is at three"))
+    assert prob == pytest.approx(0.95)
+    assert fake.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_predict_returns_low_probability_when_llm_says_zero():
+    fake = _QueuedLLM([_Behavior(content="0")])
+    det = LLMTurnDetector(llm=fake)
+    prob = await det.predict_end_of_turn(_ctx_with_user("so i was thinking that"))
+    assert prob == pytest.approx(0.05)


### PR DESCRIPTION
## Summary

Adds `LLMTurnDetector` to `livekit-plugins-turn-detector` as an additional turn-detection option alongside the existing ONNX EOU models. It implements the existing `_TurnDetector` Protocol and plugs into the same `turn_detection=` slot — **zero changes to voice core**.

Inspired by [Pipecat's Filter Incomplete Turns](https://docs.pipecat.ai/api-reference/server/utilities/turn-management/filter-incomplete-turns) feature. Single-token `1` / `0` classifier today; richer multi-state prediction can follow if there's interest.

## Why

Today `livekit-plugins-turn-detector` ships the ONNX EOU model (English + multilingual). Some users want to drive turn classification through their own LLM instead — already paying for inference in the same loop, want semantic reasoning over full conversation context, or want language coverage that matches their LLM rather than a fixed threshold table. This PR adds that as another option in the family, not a replacement.

## Usage

```python
from livekit.agents import AgentSession
from livekit.plugins import openai
from livekit.plugins.turn_detector import LLMTurnDetector

session = AgentSession(
    ...
    turn_detection=LLMTurnDetector(llm=openai.LLM(model="gpt-4o-mini")),
)
```

## Design highlights

- Implements the existing `_TurnDetector` Protocol (`livekit-agents/livekit/agents/voice/turn.py`) — no core changes.
- Single-token `1` / `0` classifier prompt; parser only reads the first non-whitespace char so provider-specific formatting differences are tolerated.
- `1.5s` default timeout via `asyncio.wait_for`; on timeout returns a neutral `0.5` probability so endpointing falls back to default delay.
- **Never raises** — timeouts, LLM exceptions, and malformed responses all return `0.5`. Empty chat context short-circuits to `1.0`.
- Custom `instructions` kwarg lets users replace the default prompt (e.g. for non-English or domain-specific deployments).
- No new runtime dependencies — `livekit.agents.llm` is already a peer dep of the plugin.

## Configuration

| Argument | Default | Purpose |
|---|---|---|
| `llm` | required | Any `livekit.agents.llm.LLM` instance |
| `instructions` | `None` | Override the default classifier prompt |
| `unlikely_threshold` | `0.5` | Probability below which endpointing treats the turn as likely-incomplete |
| `timeout` | `1.5` | Hard cap on the classifier call |
| `max_history_turns` | `6` | How many trailing chat messages are included in the prompt |

## Test plan

- [x] 14 unit tests in `livekit-plugins/livekit-plugins-turn-detector/tests/test_llm_turn_detector.py` — all passing:
  - Property and language-helper methods.
  - Happy-path classification (`"1"` / `"0"` -> 0.95 / 0.05).
  - Whitespace tolerance, garbage input, empty response — all return 0.5.
  - Timeout returns 0.5 within the configured cap.
  - LLM exceptions swallowed.
  - Empty / assistant-only chat context short-circuits to 1.0.
  - `max_history_turns` slicing.
  - Custom `instructions` override.
- [x] `make lint`, `make type-check`, `make format` all clean.
- [ ] Manual smoke test with `examples/voice_agents/llm_turn_detector.py`.

## Non-goals (future work, separate PR)

- Multi-state prediction (extending `_TurnDetector` Protocol with short/long incomplete signals).
- Re-engagement prompts (agent says something like "take your time" after an incomplete turn).

Happy to iterate on defaults (timeout, threshold, prompt wording) or placement if maintainers have a different preference.