### PR TITLE
feat(aws): add auto language detection and mid-stream language switch…

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
@@ -428,7 +428,7 @@ class SpeechStream(stt.SpeechStream):
             confidence = items[0].confidence or 0.0
 
         return stt.SpeechData(
-            language=LanguageCode(resp.language_code or self._opts.language),
+            language=LanguageCode(resp.language_code or self._opts.language or "en-US"),
             start_time=(resp.start_time or 0.0) + self.start_time_offset,
             end_time=(resp.end_time or 0.0) + self.start_time_offset,
             text=resp.alternatives[0].transcript if resp.alternatives else "",

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
@@ -138,6 +138,12 @@ class STT(stt.STT):
         if not is_given(region):
             region = os.getenv("AWS_REGION") or DEFAULT_REGION
 
+        if identify_language and identify_multiple_languages:
+            raise ValueError(
+                "identify_language and identify_multiple_languages are mutually exclusive. "
+                "Set only one to True."
+            )
+
         # When auto language detection is enabled, language_code must not be set
         lang: LanguageCode | None = None
         if not identify_language and not identify_multiple_languages:
@@ -427,12 +433,20 @@ class SpeechStream(stt.SpeechStream):
         if resp.alternatives and (items := resp.alternatives[0].items):
             confidence = items[0].confidence or 0.0
 
+        detected_lang = resp.language_code or self._opts.language or "en-US"
+
+        # Populate source_languages when language identification is active
+        source_languages = None
+        if (self._opts.identify_language or self._opts.identify_multiple_languages) and resp.language_code:
+            source_languages = [LanguageCode(resp.language_code)]
+
         return stt.SpeechData(
-            language=LanguageCode(resp.language_code or self._opts.language or "en-US"),
+            language=LanguageCode(detected_lang),
             start_time=(resp.start_time or 0.0) + self.start_time_offset,
             end_time=(resp.end_time or 0.0) + self.start_time_offset,
             text=resp.alternatives[0].transcript if resp.alternatives else "",
             confidence=confidence,
+            source_languages=source_languages,
             words=[
                 TimedString(
                     text=item.content,

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
@@ -435,20 +435,12 @@ class SpeechStream(stt.SpeechStream):
 
         detected_lang = resp.language_code or self._opts.language or "en-US"
 
-        # Populate source_languages when language identification is active
-        source_languages = None
-        if (
-            self._opts.identify_language or self._opts.identify_multiple_languages
-        ) and resp.language_code:
-            source_languages = [LanguageCode(resp.language_code)]
-
         return stt.SpeechData(
             language=LanguageCode(detected_lang),
             start_time=(resp.start_time or 0.0) + self.start_time_offset,
             end_time=(resp.end_time or 0.0) + self.start_time_offset,
             text=resp.alternatives[0].transcript if resp.alternatives else "",
             confidence=confidence,
-            source_languages=source_languages,
             words=[
                 TimedString(
                     text=item.content,

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
@@ -437,7 +437,9 @@ class SpeechStream(stt.SpeechStream):
 
         # Populate source_languages when language identification is active
         source_languages = None
-        if (self._opts.identify_language or self._opts.identify_multiple_languages) and resp.language_code:
+        if (
+            self._opts.identify_language or self._opts.identify_multiple_languages
+        ) and resp.language_code:
             source_languages = [LanguageCode(resp.language_code)]
 
         return stt.SpeechData(

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
@@ -438,8 +438,7 @@ class SpeechStream(stt.SpeechStream):
         # Populate source_languages when language identification is active
         source_languages: list[LanguageCode] | None = None
         if (
-            self._opts.identify_language
-            or self._opts.identify_multiple_languages
+            self._opts.identify_language or self._opts.identify_multiple_languages
         ) and resp.language_code:
             source_languages = [LanguageCode(resp.language_code)]
 

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
@@ -293,7 +293,7 @@ class SpeechStream(stt.SpeechStream):
                 if self._opts.language:
                     live_config["language_code"] = self._opts.language
 
-            filtered_config = {}
+            filtered_config: dict[str, Any] = {}
             for k, v in live_config.items():
                 if isinstance(v, bool):
                     filtered_config[k] = v

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
@@ -73,7 +73,7 @@ class Credentials:
 @dataclass
 class STTOptions:
     sample_rate: int
-    language: LanguageCode
+    language: LanguageCode | None
     encoding: str
     vocabulary_name: NotGivenOr[str]
     session_id: NotGivenOr[str]
@@ -86,6 +86,12 @@ class STTOptions:
     partial_results_stability: NotGivenOr[str]
     language_model_name: NotGivenOr[str]
     region: str
+    identify_language: bool
+    identify_multiple_languages: bool
+    language_options: NotGivenOr[str]
+    preferred_language: NotGivenOr[str]
+    vocabulary_names: NotGivenOr[str]
+    vocabulary_filter_names: NotGivenOr[str]
 
 
 class STT(stt.STT):
@@ -94,7 +100,7 @@ class STT(stt.STT):
         *,
         region: NotGivenOr[str] = NOT_GIVEN,
         sample_rate: int = 24000,
-        language: str = "en-US",
+        language: str | None = "en-US",
         encoding: str = "pcm",
         vocabulary_name: NotGivenOr[str] = NOT_GIVEN,
         session_id: NotGivenOr[str] = NOT_GIVEN,
@@ -107,6 +113,12 @@ class STT(stt.STT):
         partial_results_stability: NotGivenOr[str] = NOT_GIVEN,
         language_model_name: NotGivenOr[str] = NOT_GIVEN,
         credentials: NotGivenOr[Credentials] = NOT_GIVEN,
+        identify_language: bool = False,
+        identify_multiple_languages: bool = False,
+        language_options: NotGivenOr[str] = NOT_GIVEN,
+        preferred_language: NotGivenOr[str] = NOT_GIVEN,
+        vocabulary_names: NotGivenOr[str] = NOT_GIVEN,
+        vocabulary_filter_names: NotGivenOr[str] = NOT_GIVEN,
     ):
         super().__init__(
             capabilities=stt.STTCapabilities(
@@ -126,8 +138,13 @@ class STT(stt.STT):
         if not is_given(region):
             region = os.getenv("AWS_REGION") or DEFAULT_REGION
 
+        # When auto language detection is enabled, language_code must not be set
+        lang: LanguageCode | None = None
+        if not identify_language and not identify_multiple_languages:
+            lang = LanguageCode(language) if language else LanguageCode("en-US")
+
         self._config = STTOptions(
-            language=LanguageCode(language),
+            language=lang,
             sample_rate=sample_rate,
             encoding=encoding,
             vocabulary_name=vocabulary_name,
@@ -141,6 +158,12 @@ class STT(stt.STT):
             partial_results_stability=partial_results_stability,
             language_model_name=language_model_name,
             region=region,
+            identify_language=identify_language,
+            identify_multiple_languages=identify_multiple_languages,
+            language_options=language_options,
+            preferred_language=preferred_language,
+            vocabulary_names=vocabulary_names,
+            vocabulary_filter_names=vocabulary_filter_names,
         )
 
         self._credentials = credentials if is_given(credentials) else None
@@ -231,7 +254,6 @@ class SpeechStream(stt.SpeechStream):
             )
 
             live_config = {
-                "language_code": self._opts.language,
                 "media_sample_rate_hertz": self._opts.sample_rate,
                 "media_encoding": self._opts.encoding,
                 "vocabulary_name": self._opts.vocabulary_name,
@@ -245,7 +267,40 @@ class SpeechStream(stt.SpeechStream):
                 "partial_results_stability": self._opts.partial_results_stability,
                 "language_model_name": self._opts.language_model_name,
             }
-            filtered_config = {k: v for k, v in live_config.items() if v and is_given(v)}
+
+            # Auto language detection is mutually exclusive with language_code
+            if self._opts.identify_language:
+                live_config["identify_language"] = True
+                if is_given(self._opts.language_options):
+                    live_config["language_options"] = self._opts.language_options
+                if is_given(self._opts.preferred_language):
+                    live_config["preferred_language"] = self._opts.preferred_language
+                if is_given(self._opts.vocabulary_names):
+                    live_config["vocabulary_names"] = self._opts.vocabulary_names
+                if is_given(self._opts.vocabulary_filter_names):
+                    live_config["vocabulary_filter_names"] = self._opts.vocabulary_filter_names
+            elif self._opts.identify_multiple_languages:
+                live_config["identify_multiple_languages"] = True
+                if is_given(self._opts.language_options):
+                    live_config["language_options"] = self._opts.language_options
+                if is_given(self._opts.preferred_language):
+                    live_config["preferred_language"] = self._opts.preferred_language
+                if is_given(self._opts.vocabulary_names):
+                    live_config["vocabulary_names"] = self._opts.vocabulary_names
+                if is_given(self._opts.vocabulary_filter_names):
+                    live_config["vocabulary_filter_names"] = self._opts.vocabulary_filter_names
+            else:
+                if self._opts.language:
+                    live_config["language_code"] = self._opts.language
+
+            filtered_config = {}
+            for k, v in live_config.items():
+                if isinstance(v, bool):
+                    filtered_config[k] = v
+                elif isinstance(v, (int, float)):
+                    filtered_config[k] = v
+                elif v is not None and is_given(v):
+                    filtered_config[k] = v
 
             tasks: list[asyncio.Task[Any]] = []
 

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
@@ -435,12 +435,21 @@ class SpeechStream(stt.SpeechStream):
 
         detected_lang = resp.language_code or self._opts.language or "en-US"
 
+        # Populate source_languages when language identification is active
+        source_languages: list[LanguageCode] | None = None
+        if (
+            self._opts.identify_language
+            or self._opts.identify_multiple_languages
+        ) and resp.language_code:
+            source_languages = [LanguageCode(resp.language_code)]
+
         return stt.SpeechData(
             language=LanguageCode(detected_lang),
             start_time=(resp.start_time or 0.0) + self.start_time_offset,
             end_time=(resp.end_time or 0.0) + self.start_time_offset,
             text=resp.alternatives[0].transcript if resp.alternatives else "",
             confidence=confidence,
+            source_languages=source_languages,
             words=[
                 TimedString(
                     text=item.content,


### PR DESCRIPTION
<h2>Summary</h2>
<p>Adds support for Amazon Transcribe's automatic language identification parameters to the <code>livekit-plugins-aws</code> STT plugin, enabling auto language detection and mid-stream language switching without requiring users to manually specify a <code>language_code</code>.</p>
<h2>Changes</h2>
<h3>6 new parameters added to <code>STTOptions</code> and <code>STT.__init__()</code>:</h3>
<ul>
<li><code>identify_language</code> — detect the dominant language for the stream</li>
<li><code>identify_multiple_languages</code> — detect language switches mid-stream</li>
<li><code>language_options</code> — comma-separated list of expected language codes (2–12 required)</li>
<li><code>preferred_language</code> — bias detection toward a specific language</li>
<li><code>vocabulary_names</code> — custom vocabularies per language</li>
<li><code>vocabulary_filter_names</code> — vocabulary filters per language</li>
</ul>
<p>All default to disabled (<code>False</code> / <code>NOT_GIVEN</code>), preserving full backward compatibility.</p>
<h3>Conditional config building in <code>SpeechStream._run()</code>:</h3>
<p><code>language_code</code> and <code>identify_language</code>/<code>identify_multiple_languages</code> are mutually exclusive per the AWS API. The config builder now conditionally sends one or the other:</p>
<pre><code class="language-python">if self._opts.identify_language:
    live_config["identify_language"] = True
    ...
elif self._opts.identify_multiple_languages:
    live_config["identify_multiple_languages"] = True
    ...
else:
    live_config["language_code"] = self._opts.language
</code></pre>
<h3>Bug fix: <code>filtered_config</code> boolean handling</h3>
<p>The original filter <code>{k: v for k, v in live_config.items() if v and is_given(v)}</code> silently drops <code>False</code> booleans. Replaced with explicit type checking that correctly preserves booleans, numbers, and <code>NOT_GIVEN</code> values.</p>
<h2>Usage</h2>
<pre><code class="language-python"># Existing behavior — unchanged
stt = STT(language="en-US")

# Single language auto-detection
stt = STT(identify_language=True, language_options="en-US,es-US,fr-FR")

# Multi-language mid-stream switching
stt = STT(
    identify_multiple_languages=True,
    language_options="en-US,es-US,fr-FR,de-DE,ja-JP,ko-KR,zh-HK,pt-BR,hi-IN,vi-VN,pl-PL,ru-RU",
)
</code></pre>
<h2>Test Results</h2>
<p>Tested with <code>identify_multiple_languages=True</code> and 12 language codes. All 12 configured languages were successfully detected across test sessions with mid-stream switching:</p>

Language | Code | Detected
-- | -- | --
English | en-US | ✅
Spanish | es-US | ✅
French | fr-FR | ✅
German | de-DE | ✅
Japanese | ja-JP | ✅
Korean | ko-KR | ✅
Cantonese | zh-HK | ✅
Portuguese | pt-BR | ✅
Hindi | hi-IN | ✅
Vietnamese | vi-VN | ✅
Polish | pl-PL | ✅
Russian | ru-RU | ✅


<p>Sample output showing mid-stream language switching in a single session:</p>
<pre><code>[FINAL] [en-US] Good afternoon, everyone. Welcome to day 4.
[FINAL] [zh-HK] 你聽緊嘅係SBS電台廣東話節目
[FINAL] [vi-VN] Xin kính chào quý vị và các bạn
[FINAL] [pt-BR] Nós estamos aqui de azul hoje porque azul é a cor mais celebrando
[FINAL] [pl-PL] Dzień dobry, przy mikrofonie Joanna Borkowska Surucić
</code></pre>
<h2>Backward Compatibility</h2>
<p>All new parameters default to disabled. Existing code continues to work without any changes.</p>
<hr>