### PR TITLE
agent server otel metrics

### DIFF
--- a/livekit-agents/livekit/agents/telemetry/metrics.py
+++ b/livekit-agents/livekit/agents/telemetry/metrics.py
@@ -11,6 +11,10 @@ import psutil
 from .. import utils
 
 _meter = metrics_api.get_meter("livekit-agent-server")
+_METRIC_EXPORT_ENDPOINT_ENV_VARS = (
+    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+)
 
 PROC_INITIALIZE_TIME = prometheus_client.Histogram(
     "lk_agents_proc_initialize_duration_seconds",
@@ -60,11 +64,26 @@ class _AgentServerMetricsState:
 
 
 _agent_server_metrics_state = _AgentServerMetricsState()
+_worker_meter_provider_owned = False
+
+
+def _otel_metrics_configured() -> bool:
+    return any(os.environ.get(env_var) for env_var in _METRIC_EXPORT_ENDPOINT_ENV_VARS)
+
+
+def worker_observability_metrics_enabled() -> bool:
+    current_meter_provider = metrics_api.get_meter_provider()
+    return _otel_metrics_configured() or isinstance(current_meter_provider, SdkMeterProvider)
 
 
 def setup_worker_observability_metrics() -> None:
+    global _worker_meter_provider_owned
+
     current_meter_provider = metrics_api.get_meter_provider()
     if isinstance(current_meter_provider, SdkMeterProvider):
+        return
+
+    if not _otel_metrics_configured():
         return
 
     metric_exporter = OTLPMetricExporter()
@@ -76,6 +95,17 @@ def setup_worker_observability_metrics() -> None:
         metric_readers=[reader],
     )
     metrics_api.set_meter_provider(meter_provider)
+    _worker_meter_provider_owned = True
+
+
+def shutdown_worker_observability_metrics() -> None:
+    global _worker_meter_provider_owned
+
+    meter_provider = metrics_api.get_meter_provider()
+    if _worker_meter_provider_owned and isinstance(meter_provider, SdkMeterProvider):
+        meter_provider.force_flush()
+        meter_provider.shutdown()
+        _worker_meter_provider_owned = False
 
 
 def _node_attrs() -> dict[str, str]:

--- a/livekit-agents/livekit/agents/telemetry/metrics.py
+++ b/livekit-agents/livekit/agents/telemetry/metrics.py
@@ -11,6 +11,7 @@ from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from .. import utils
 
 _meter = metrics_api.get_meter("livekit-agent-server")
+_METRIC_GROUP = "agent_server"
 _METRIC_EXPORT_ENDPOINT_ENV_VARS = (
     "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
     "OTEL_EXPORTER_OTLP_ENDPOINT",
@@ -109,7 +110,11 @@ def shutdown_worker_observability_metrics() -> None:
 
 
 def _metric_attrs(metric_name: str) -> dict[str, str]:
-    return {"nodename": utils.nodename(), "metric_name": metric_name}
+    return {
+        "nodename": utils.nodename(),
+        "metric_name": metric_name,
+        "livekit.metric_group": _METRIC_GROUP,
+    }
 
 
 def _observe_child_process_count() -> list[metrics_api.Observation]:

--- a/livekit-agents/livekit/agents/telemetry/metrics.py
+++ b/livekit-agents/livekit/agents/telemetry/metrics.py
@@ -1,9 +1,12 @@
 import os
 
+from opentelemetry import metrics as metrics_api
 import prometheus_client
 import psutil
 
 from .. import utils
+
+_meter = metrics_api.get_meter("livekit-server")
 
 PROC_INITIALIZE_TIME = prometheus_client.Histogram(
     "lk_agents_proc_initialize_duration_seconds",
@@ -35,12 +38,56 @@ CPU_LOAD_GAUGE = prometheus_client.Gauge(
     ["nodename"],
 )
 
+OTEL_PROC_INITIALIZE_TIME = _meter.create_histogram(
+    "lk.agents.server.proc_initialize_time",
+    unit="s",
+    description="Time taken to initialize a worker process",
+)
+OTEL_RUNNING_JOB_COUNTER = _meter.create_up_down_counter(
+    "lk.agents.server.active_job_count",
+    description="Active jobs on the agent server",
+)
+
+
+class _AgentServerMetricsState:
+    def __init__(self) -> None:
+        self.child_process_count = 0
+        self.worker_load = 0.0
+
+
+_agent_server_metrics_state = _AgentServerMetricsState()
+
+
+def _node_attrs() -> dict[str, str]:
+    return {"nodename": utils.nodename()}
+
+
+def _observe_child_process_count() -> list[metrics_api.Observation]:
+    return [metrics_api.Observation(_agent_server_metrics_state.child_process_count, attributes=_node_attrs())]
+
+
+def _observe_worker_load() -> list[metrics_api.Observation]:
+    return [metrics_api.Observation(_agent_server_metrics_state.worker_load, attributes=_node_attrs())]
+
+
+_meter.create_observable_gauge(
+    "lk.agents.server.child_process_count",
+    callbacks=[lambda options: _observe_child_process_count()],
+    description="Child process count on the agent server",
+)
+_meter.create_observable_gauge(
+    "lk.agents.server.worker_load",
+    callbacks=[lambda options: _observe_worker_load()],
+    description="Worker load percentage",
+)
+
 
 # Note: set_function() is not supported in multiprocess mode.# We need to update this metric explicitly.
 def _update_child_proc_count() -> None:
     """Update child process count metric. Must be called periodically in the main process."""
     try:
         count = len(psutil.Process(os.getpid()).children(recursive=True))
+        _agent_server_metrics_state.child_process_count = count
         CHILD_PROC_GAUGE.labels(nodename=utils.nodename()).set(count)
     except Exception:
         # Process might not exist anymore or access denied
@@ -48,16 +95,20 @@ def _update_child_proc_count() -> None:
 
 
 def _update_worker_load(worker_load: float) -> None:
+    _agent_server_metrics_state.worker_load = worker_load
     CPU_LOAD_GAUGE.labels(nodename=utils.nodename()).set(worker_load)
 
 
 def job_started() -> None:
     RUNNING_JOB_GAUGE.labels(nodename=utils.nodename()).inc()
+    OTEL_RUNNING_JOB_COUNTER.add(1, attributes=_node_attrs())
 
 
 def job_ended() -> None:
     RUNNING_JOB_GAUGE.labels(nodename=utils.nodename()).dec()
+    OTEL_RUNNING_JOB_COUNTER.add(-1, attributes=_node_attrs())
 
 
 def proc_initialized(*, time_elapsed: float) -> None:
     PROC_INITIALIZE_TIME.labels(nodename=utils.nodename()).observe(time_elapsed)
+    OTEL_PROC_INITIALIZE_TIME.record(time_elapsed, attributes=_node_attrs())

--- a/livekit-agents/livekit/agents/telemetry/metrics.py
+++ b/livekit-agents/livekit/agents/telemetry/metrics.py
@@ -1,12 +1,16 @@
 import os
 
 from opentelemetry import metrics as metrics_api
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 import prometheus_client
 import psutil
 
 from .. import utils
 
-_meter = metrics_api.get_meter("livekit-server")
+_meter = metrics_api.get_meter("livekit-agent-server")
 
 PROC_INITIALIZE_TIME = prometheus_client.Histogram(
     "lk_agents_proc_initialize_duration_seconds",
@@ -56,6 +60,22 @@ class _AgentServerMetricsState:
 
 
 _agent_server_metrics_state = _AgentServerMetricsState()
+
+
+def setup_worker_observability_metrics() -> None:
+    current_meter_provider = metrics_api.get_meter_provider()
+    if isinstance(current_meter_provider, SdkMeterProvider):
+        return
+
+    metric_exporter = OTLPMetricExporter()
+    reader = PeriodicExportingMetricReader(metric_exporter, export_interval_millis=30000)
+    meter_provider = SdkMeterProvider(
+        resource=Resource.create(
+            {SERVICE_NAME: os.environ.get("OTEL_SERVICE_NAME", "livekit-agent-server")}
+        ),
+        metric_readers=[reader],
+    )
+    metrics_api.set_meter_provider(meter_provider)
 
 
 def _node_attrs() -> dict[str, str]:

--- a/livekit-agents/livekit/agents/telemetry/metrics.py
+++ b/livekit-agents/livekit/agents/telemetry/metrics.py
@@ -1,12 +1,12 @@
 import os
 
+import prometheus_client
+import psutil
 from opentelemetry import metrics as metrics_api
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-import prometheus_client
-import psutil
 
 from .. import utils
 
@@ -108,16 +108,26 @@ def shutdown_worker_observability_metrics() -> None:
         _worker_meter_provider_owned = False
 
 
-def _node_attrs() -> dict[str, str]:
-    return {"nodename": utils.nodename()}
+def _metric_attrs(metric_name: str) -> dict[str, str]:
+    return {"nodename": utils.nodename(), "metric_name": metric_name}
 
 
 def _observe_child_process_count() -> list[metrics_api.Observation]:
-    return [metrics_api.Observation(_agent_server_metrics_state.child_process_count, attributes=_node_attrs())]
+    return [
+        metrics_api.Observation(
+            _agent_server_metrics_state.child_process_count,
+            attributes=_metric_attrs("child_process_count"),
+        )
+    ]
 
 
 def _observe_worker_load() -> list[metrics_api.Observation]:
-    return [metrics_api.Observation(_agent_server_metrics_state.worker_load, attributes=_node_attrs())]
+    return [
+        metrics_api.Observation(
+            _agent_server_metrics_state.worker_load,
+            attributes=_metric_attrs("worker_load"),
+        )
+    ]
 
 
 _meter.create_observable_gauge(
@@ -151,14 +161,17 @@ def _update_worker_load(worker_load: float) -> None:
 
 def job_started() -> None:
     RUNNING_JOB_GAUGE.labels(nodename=utils.nodename()).inc()
-    OTEL_RUNNING_JOB_COUNTER.add(1, attributes=_node_attrs())
+    OTEL_RUNNING_JOB_COUNTER.add(1, attributes=_metric_attrs("active_job_count"))
 
 
 def job_ended() -> None:
     RUNNING_JOB_GAUGE.labels(nodename=utils.nodename()).dec()
-    OTEL_RUNNING_JOB_COUNTER.add(-1, attributes=_node_attrs())
+    OTEL_RUNNING_JOB_COUNTER.add(-1, attributes=_metric_attrs("active_job_count"))
 
 
 def proc_initialized(*, time_elapsed: float) -> None:
     PROC_INITIALIZE_TIME.labels(nodename=utils.nodename()).observe(time_elapsed)
-    OTEL_PROC_INITIALIZE_TIME.record(time_elapsed, attributes=_node_attrs())
+    OTEL_PROC_INITIALIZE_TIME.record(
+        time_elapsed,
+        attributes=_metric_attrs("proc_initialize_time"),
+    )

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -755,7 +755,10 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                     self._worker_load = await self._invoke_load_fnc()
 
                     telemetry.metrics._update_worker_load(self._worker_load)
-                    if self._prometheus_multiproc_dir or telemetry.metrics.worker_observability_metrics_enabled():
+                    if (
+                        self._prometheus_multiproc_dir
+                        or telemetry.metrics.worker_observability_metrics_enabled()
+                    ):
                         await asyncio.get_event_loop().run_in_executor(
                             None, telemetry.metrics._update_child_proc_count
                         )

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -755,7 +755,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                     self._worker_load = await self._invoke_load_fnc()
 
                     telemetry.metrics._update_worker_load(self._worker_load)
-                    if self._prometheus_multiproc_dir:
+                    if self._prometheus_multiproc_dir or telemetry.metrics.worker_observability_metrics_enabled():
                         await asyncio.get_event_loop().run_in_executor(
                             None, telemetry.metrics._update_child_proc_count
                         )
@@ -980,6 +980,8 @@ class AgentServer(utils.EventEmitter[EventTypes]):
 
             if self._prometheus_server:
                 await self._prometheus_server.aclose()
+
+            telemetry.metrics.shutdown_worker_observability_metrics()
 
             await self._api.aclose()  # type: ignore
 

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -34,6 +34,20 @@ import aiohttp
 import jwt
 from aiohttp import web
 from google.protobuf.json_format import MessageToDict
+from opentelemetry import metrics as metrics_api
+from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.sdk.metrics import (
+    Counter as SdkCounter,
+    Histogram as SdkHistogram,
+    MeterProvider as SdkMeterProvider,
+    ObservableCounter as SdkObservableCounter,
+    ObservableGauge as SdkObservableGauge,
+    ObservableUpDownCounter as SdkObservableUpDownCounter,
+    UpDownCounter as SdkUpDownCounter,
+)
+from opentelemetry.sdk.metrics.export import AggregationTemporality, PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 
 from livekit import api, rtc
 from livekit.protocol import agent, models
@@ -60,6 +74,31 @@ ASSIGNMENT_TIMEOUT = 7.5
 UPDATE_STATUS_INTERVAL = 2.5
 UPDATE_LOAD_INTERVAL = 0.5
 HEARTBEAT_INTERVAL = 30
+
+
+def _setup_worker_observability_metrics(observability_url: str) -> None:
+    current_meter_provider = metrics_api.get_meter_provider()
+    if isinstance(current_meter_provider, SdkMeterProvider):
+        return
+
+    metric_exporter = OTLPMetricExporter(
+        endpoint=f"{observability_url}/observability/metrics/otlp/v0",
+        compression=Compression.Gzip,
+        preferred_temporality={
+            SdkCounter: AggregationTemporality.DELTA,
+            SdkUpDownCounter: AggregationTemporality.DELTA,
+            SdkHistogram: AggregationTemporality.DELTA,
+            SdkObservableCounter: AggregationTemporality.DELTA,
+            SdkObservableUpDownCounter: AggregationTemporality.DELTA,
+            SdkObservableGauge: AggregationTemporality.DELTA,
+        },
+    )
+    reader = PeriodicExportingMetricReader(metric_exporter, export_interval_millis=30000)
+    meter_provider = SdkMeterProvider(
+        resource=Resource.create({SERVICE_NAME: "livekit-agents"}),
+        metric_readers=[reader],
+    )
+    metrics_api.set_meter_provider(meter_provider)
 
 
 def _default_setup_fnc(proc: JobProcess) -> Any:
@@ -686,6 +725,9 @@ class AgentServer(utils.EventEmitter[EventTypes]):
             os.environ["LIVEKIT_URL"] = self._ws_url
             os.environ["LIVEKIT_API_KEY"] = self._api_key
             os.environ["LIVEKIT_API_SECRET"] = self._api_secret
+
+            if otel_metrics_export_url := os.environ.get("AGENT_SERVER_OTEL_METRICS_EXPORT_URL"):
+                _setup_worker_observability_metrics(observability_url=otel_metrics_export_url)
 
             logger.info(
                 "starting worker",

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -34,20 +34,6 @@ import aiohttp
 import jwt
 from aiohttp import web
 from google.protobuf.json_format import MessageToDict
-from opentelemetry import metrics as metrics_api
-from opentelemetry.exporter.otlp.proto.http import Compression
-from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
-from opentelemetry.sdk.metrics import (
-    Counter as SdkCounter,
-    Histogram as SdkHistogram,
-    MeterProvider as SdkMeterProvider,
-    ObservableCounter as SdkObservableCounter,
-    ObservableGauge as SdkObservableGauge,
-    ObservableUpDownCounter as SdkObservableUpDownCounter,
-    UpDownCounter as SdkUpDownCounter,
-)
-from opentelemetry.sdk.metrics.export import AggregationTemporality, PeriodicExportingMetricReader
-from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 
 from livekit import api, rtc
 from livekit.protocol import agent, models
@@ -74,31 +60,6 @@ ASSIGNMENT_TIMEOUT = 7.5
 UPDATE_STATUS_INTERVAL = 2.5
 UPDATE_LOAD_INTERVAL = 0.5
 HEARTBEAT_INTERVAL = 30
-
-
-def _setup_worker_observability_metrics(observability_url: str) -> None:
-    current_meter_provider = metrics_api.get_meter_provider()
-    if isinstance(current_meter_provider, SdkMeterProvider):
-        return
-
-    metric_exporter = OTLPMetricExporter(
-        endpoint=f"{observability_url}/observability/metrics/otlp/v0",
-        compression=Compression.Gzip,
-        preferred_temporality={
-            SdkCounter: AggregationTemporality.DELTA,
-            SdkUpDownCounter: AggregationTemporality.DELTA,
-            SdkHistogram: AggregationTemporality.DELTA,
-            SdkObservableCounter: AggregationTemporality.DELTA,
-            SdkObservableUpDownCounter: AggregationTemporality.DELTA,
-            SdkObservableGauge: AggregationTemporality.DELTA,
-        },
-    )
-    reader = PeriodicExportingMetricReader(metric_exporter, export_interval_millis=30000)
-    meter_provider = SdkMeterProvider(
-        resource=Resource.create({SERVICE_NAME: "livekit-agents"}),
-        metric_readers=[reader],
-    )
-    metrics_api.set_meter_provider(meter_provider)
 
 
 def _default_setup_fnc(proc: JobProcess) -> Any:
@@ -726,8 +687,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
             os.environ["LIVEKIT_API_KEY"] = self._api_key
             os.environ["LIVEKIT_API_SECRET"] = self._api_secret
 
-            if otel_metrics_export_url := os.environ.get("AGENT_SERVER_OTEL_METRICS_EXPORT_URL"):
-                _setup_worker_observability_metrics(observability_url=otel_metrics_export_url)
+            telemetry.metrics.setup_worker_observability_metrics()
 
             logger.info(
                 "starting worker",


### PR DESCRIPTION
Complementary otel setup for Agent Server metrics. 

It's enabled when either  `  "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" | "OTEL_EXPORTER_OTLP_ENDPOINT"` env var is set

The only thing I did not understood quite is multiproc prometheus setup, as agent server has only 1 process and the load_task is running there. Would appreciate help there!

Lmk if we should default to livekit o11y url

related issue: https://github.com/livekit/agents/issues/5443