### PR TITLE
feat: adopt current OTEL cached token conventions

### DIFF
--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -321,15 +321,18 @@ class LLMStream(ABC):
             )
 
             # set gen_ai attributes
-            self._llm_request_span.set_attributes(
-                {
-                    trace_types.ATTR_GEN_AI_OPERATION_NAME: "chat",
-                    trace_types.ATTR_GEN_AI_REQUEST_MODEL: self._llm.model,
-                    trace_types.ATTR_GEN_AI_PROVIDER_NAME: self._llm.provider,
-                    trace_types.ATTR_GEN_AI_USAGE_INPUT_TOKENS: metrics.prompt_tokens,
-                    trace_types.ATTR_GEN_AI_USAGE_OUTPUT_TOKENS: metrics.completion_tokens,
-                },
-            )
+            gen_ai_attrs: dict[str, str | int] = {
+                trace_types.ATTR_GEN_AI_OPERATION_NAME: "chat",
+                trace_types.ATTR_GEN_AI_REQUEST_MODEL: self._llm.model,
+                trace_types.ATTR_GEN_AI_PROVIDER_NAME: self._llm.provider,
+                trace_types.ATTR_GEN_AI_USAGE_INPUT_TOKENS: metrics.prompt_tokens,
+                trace_types.ATTR_GEN_AI_USAGE_OUTPUT_TOKENS: metrics.completion_tokens,
+            }
+            if metrics.prompt_cached_tokens:
+                gen_ai_attrs[trace_types.ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] = (
+                    metrics.prompt_cached_tokens
+                )
+            self._llm_request_span.set_attributes(gen_ai_attrs)
             if completion_start_time:
                 self._llm_request_span.set_attribute(
                     trace_types.ATTR_LANGFUSE_COMPLETION_START_TIME, f'"{completion_start_time}"'

--- a/livekit-agents/livekit/agents/telemetry/trace_types.py
+++ b/livekit-agents/livekit/agents/telemetry/trace_types.py
@@ -69,15 +69,14 @@ ATTR_GEN_AI_PROVIDER_NAME = "gen_ai.provider.name"
 ATTR_GEN_AI_REQUEST_MODEL = "gen_ai.request.model"
 ATTR_GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
 ATTR_GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
+ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read.input_tokens"
+ATTR_GEN_AI_USAGE_DETAILS_OUTPUT_AUDIO_TOKENS = "gen_ai.usage.details.output_audio_tokens" 
+# The following two experimental fields have recently been adopted by
+# pydantic (https://github.com/open-telemetry/semantic-conventions/issues/1959#issuecomment-3135486259) 
+# and LangFuse (https://github.com/langfuse/langfuse/pull/13110) to support audio token counting.
+ATTR_GEN_AI_USAGE_DETAILS_INPUT_AUDIO_TOKENS = "gen_ai.usage.details.input_audio_tokens" # pydantic proposed  https://github.com/open-telemetry/semantic-conventions/issues/1959#issuecomment-3135486259
+ATTR_GEN_AI_USAGE_DETAILS_CACHE_AUDIO_READ_TOKENS = "gen_ai.usage.details.cache_audio_read_tokens" # pddantic proposed https://github.com/open-telemetry/semantic-conventions/issues/1959#issuecomment-3135486259
 
-# Unofficial OpenTelemetry GenAI attributes, these are namespaces recognised by LangFuse
-# https://langfuse.com/integrations/native/opentelemetry#usage
-# but not yet in the official OpenTelemetry specification.
-ATTR_GEN_AI_USAGE_INPUT_TEXT_TOKENS = "gen_ai.usage.input_text_tokens"
-ATTR_GEN_AI_USAGE_INPUT_AUDIO_TOKENS = "gen_ai.usage.input_audio_tokens"
-ATTR_GEN_AI_USAGE_INPUT_CACHED_TOKENS = "gen_ai.usage.input_cached_tokens"
-ATTR_GEN_AI_USAGE_OUTPUT_TEXT_TOKENS = "gen_ai.usage.output_text_tokens"
-ATTR_GEN_AI_USAGE_OUTPUT_AUDIO_TOKENS = "gen_ai.usage.output_audio_tokens"
 
 # OpenTelemetry GenAI event names (for structured logging)
 EVENT_GEN_AI_SYSTEM_MESSAGE = "gen_ai.system.message"

--- a/livekit-agents/livekit/agents/telemetry/trace_types.py
+++ b/livekit-agents/livekit/agents/telemetry/trace_types.py
@@ -70,12 +70,12 @@ ATTR_GEN_AI_REQUEST_MODEL = "gen_ai.request.model"
 ATTR_GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
 ATTR_GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
 ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read.input_tokens"
-ATTR_GEN_AI_USAGE_DETAILS_OUTPUT_AUDIO_TOKENS = "gen_ai.usage.details.output_audio_tokens" 
+ATTR_GEN_AI_USAGE_DETAILS_OUTPUT_AUDIO_TOKENS = "gen_ai.usage.details.output_audio_tokens"
 # The following two experimental fields have recently been adopted by
-# pydantic (https://github.com/open-telemetry/semantic-conventions/issues/1959#issuecomment-3135486259) 
+# pydantic (https://github.com/open-telemetry/semantic-conventions/issues/1959#issuecomment-3135486259)
 # and LangFuse (https://github.com/langfuse/langfuse/pull/13110) to support audio token counting.
-ATTR_GEN_AI_USAGE_DETAILS_INPUT_AUDIO_TOKENS = "gen_ai.usage.details.input_audio_tokens" # pydantic proposed  https://github.com/open-telemetry/semantic-conventions/issues/1959#issuecomment-3135486259
-ATTR_GEN_AI_USAGE_DETAILS_CACHE_AUDIO_READ_TOKENS = "gen_ai.usage.details.cache_audio_read_tokens" # pddantic proposed https://github.com/open-telemetry/semantic-conventions/issues/1959#issuecomment-3135486259
+ATTR_GEN_AI_USAGE_DETAILS_INPUT_AUDIO_TOKENS = "gen_ai.usage.details.input_audio_tokens"  # pydantic proposed  https://github.com/open-telemetry/semantic-conventions/issues/1959#issuecomment-3135486259
+ATTR_GEN_AI_USAGE_DETAILS_CACHE_AUDIO_READ_TOKENS = "gen_ai.usage.details.cache_audio_read_tokens"  # pddantic proposed https://github.com/open-telemetry/semantic-conventions/issues/1959#issuecomment-3135486259
 
 
 # OpenTelemetry GenAI event names (for structured logging)

--- a/livekit-agents/livekit/agents/telemetry/utils.py
+++ b/livekit-agents/livekit/agents/telemetry/utils.py
@@ -26,22 +26,42 @@ def record_exception(span: trace.Span, exception: Exception) -> None:
 
 
 def record_realtime_metrics(span: trace.Span, ev: RealtimeModelMetrics) -> None:
+    """Set OpenTelemetry GenAI usage attributes for Langfuse-compatible OTEL ingestion.
+
+    Uses text token counts for top-level ``gen_ai.usage.input_tokens`` and
+    ``gen_ai.usage.output_tokens`` (from ``input_token_details.text_tokens`` and
+    ``output_token_details.text_tokens``). OpenAI Realtime reports those text counts
+    inclusive of cached text; cache read for pricing breakdown is
+    ``gen_ai.usage.cache_read.input_tokens`` from ``cached_tokens_details.text_tokens``.
+    Audio tokens use ``gen_ai.usage.details.*`` keys.
+    """
     model_name = ev.metadata.model_name if ev.metadata else None
     model_provider = ev.metadata.model_provider if ev.metadata else None
+
+    cached = ev.input_token_details.cached_tokens_details
+    cache_read_text = cached.text_tokens if cached else 0
+    cache_read_audio = cached.audio_tokens if cached else 0
 
     attrs: dict[str, str | int] = {
         trace_types.ATTR_GEN_AI_OPERATION_NAME: "chat",
         trace_types.ATTR_GEN_AI_PROVIDER_NAME: model_provider or "unknown",
         trace_types.ATTR_GEN_AI_REQUEST_MODEL: model_name or "unknown",
         trace_types.ATTR_REALTIME_MODEL_METRICS: ev.model_dump_json(),
-        trace_types.ATTR_GEN_AI_USAGE_INPUT_TOKENS: ev.input_tokens,
-        trace_types.ATTR_GEN_AI_USAGE_OUTPUT_TOKENS: ev.output_tokens,
-        trace_types.ATTR_GEN_AI_USAGE_INPUT_TEXT_TOKENS: ev.input_token_details.text_tokens,
-        trace_types.ATTR_GEN_AI_USAGE_INPUT_AUDIO_TOKENS: ev.input_token_details.audio_tokens,
-        trace_types.ATTR_GEN_AI_USAGE_INPUT_CACHED_TOKENS: ev.input_token_details.cached_tokens,
-        trace_types.ATTR_GEN_AI_USAGE_OUTPUT_TEXT_TOKENS: ev.output_token_details.text_tokens,
-        trace_types.ATTR_GEN_AI_USAGE_OUTPUT_AUDIO_TOKENS: ev.output_token_details.audio_tokens,
+        trace_types.ATTR_GEN_AI_USAGE_INPUT_TOKENS: ev.input_token_details.text_tokens,
+        trace_types.ATTR_GEN_AI_USAGE_OUTPUT_TOKENS: ev.output_token_details.text_tokens,
     }
+    if cache_read_text:
+        attrs[trace_types.ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] = cache_read_text
+    if ev.input_token_details.audio_tokens:
+        attrs[trace_types.ATTR_GEN_AI_USAGE_DETAILS_INPUT_AUDIO_TOKENS] = (
+            ev.input_token_details.audio_tokens
+        )
+    if cache_read_audio:
+        attrs[trace_types.ATTR_GEN_AI_USAGE_DETAILS_CACHE_AUDIO_READ_TOKENS] = cache_read_audio
+    if ev.output_token_details.audio_tokens:
+        attrs[trace_types.ATTR_GEN_AI_USAGE_DETAILS_OUTPUT_AUDIO_TOKENS] = (
+            ev.output_token_details.audio_tokens
+        )
     if ev.ttft != -1:
         completion_start_time = ev.timestamp + ev.ttft
         # This attribute is used by LangFuse to calculate "time to first token metric"

--- a/livekit-agents/livekit/agents/voice/run_result.py
+++ b/livekit-agents/livekit/agents/voice/run_result.py
@@ -964,15 +964,15 @@ class ChatMessageAssert:
         current_span.set_attribute(trace_types.ATTR_FUNCTION_TOOL_OUTPUT, reason)
 
         if usage:
-            current_span.set_attributes(
-                {
-                    trace_types.ATTR_GEN_AI_USAGE_INPUT_TOKENS: usage.prompt_tokens,
-                    trace_types.ATTR_GEN_AI_USAGE_OUTPUT_TOKENS: usage.completion_tokens,
-                    trace_types.ATTR_GEN_AI_USAGE_INPUT_TEXT_TOKENS: usage.prompt_tokens,
-                    trace_types.ATTR_GEN_AI_USAGE_OUTPUT_TEXT_TOKENS: usage.completion_tokens,
-                    trace_types.ATTR_GEN_AI_USAGE_INPUT_CACHED_TOKENS: usage.prompt_cached_tokens,
-                }
-            )
+            judge_attrs: dict[str, int] = {
+                trace_types.ATTR_GEN_AI_USAGE_INPUT_TOKENS: usage.prompt_tokens,
+                trace_types.ATTR_GEN_AI_USAGE_OUTPUT_TOKENS: usage.completion_tokens,
+            }
+            if usage.prompt_cached_tokens:
+                judge_attrs[trace_types.ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] = (
+                    usage.prompt_cached_tokens
+                )
+            current_span.set_attributes(judge_attrs)
 
         if not success:
             self._raise(f"Judgement failed: {reason}")

--- a/tests/test_record_realtime_metrics_otel.py
+++ b/tests/test_record_realtime_metrics_otel.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from livekit.agents.metrics.base import Metadata, RealtimeModelMetrics
+from livekit.agents.telemetry import trace_types
+from livekit.agents.telemetry.utils import record_realtime_metrics
+
+
+def test_record_realtime_metrics_sets_langfuse_otel_usage_keys() -> None:
+    span = MagicMock()
+    span.is_recording.return_value = True
+
+    ev = RealtimeModelMetrics(
+        request_id="req-1",
+        timestamp=0.0,
+        input_token_details=RealtimeModelMetrics.InputTokenDetails(
+            text_tokens=120,
+            audio_tokens=5,
+            cached_tokens=32,
+            cached_tokens_details=RealtimeModelMetrics.CachedTokenDetails(
+                text_tokens=30,
+                audio_tokens=2,
+            ),
+        ),
+        output_token_details=RealtimeModelMetrics.OutputTokenDetails(
+            text_tokens=40,
+            audio_tokens=7,
+        ),
+        metadata=Metadata(model_name="gpt-realtime", model_provider="openai"),
+    )
+
+    record_realtime_metrics(span, ev)
+
+    span.set_attributes.assert_called_once()
+    attrs = span.set_attributes.call_args[0][0]
+
+    assert attrs[trace_types.ATTR_GEN_AI_USAGE_INPUT_TOKENS] == 120
+    assert attrs[trace_types.ATTR_GEN_AI_USAGE_OUTPUT_TOKENS] == 40
+    assert attrs[trace_types.ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] == 30
+    assert attrs[trace_types.ATTR_GEN_AI_USAGE_DETAILS_INPUT_AUDIO_TOKENS] == 5
+    assert attrs[trace_types.ATTR_GEN_AI_USAGE_DETAILS_CACHE_AUDIO_READ_TOKENS] == 2
+    assert attrs[trace_types.ATTR_GEN_AI_USAGE_DETAILS_OUTPUT_AUDIO_TOKENS] == 7
+
+
+def test_record_realtime_metrics_omits_zero_breakdown() -> None:
+    span = MagicMock()
+    span.is_recording.return_value = True
+
+    ev = RealtimeModelMetrics(
+        request_id="req-2",
+        timestamp=0.0,
+        input_token_details=RealtimeModelMetrics.InputTokenDetails(
+            text_tokens=10,
+            audio_tokens=0,
+            cached_tokens_details=None,
+        ),
+        output_token_details=RealtimeModelMetrics.OutputTokenDetails(
+            text_tokens=3,
+            audio_tokens=0,
+        ),
+    )
+
+    record_realtime_metrics(span, ev)
+
+    attrs = span.set_attributes.call_args[0][0]
+    assert trace_types.ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS not in attrs
+    assert trace_types.ATTR_GEN_AI_USAGE_DETAILS_INPUT_AUDIO_TOKENS not in attrs
+    assert trace_types.ATTR_GEN_AI_USAGE_DETAILS_CACHE_AUDIO_READ_TOKENS not in attrs
+    assert trace_types.ATTR_GEN_AI_USAGE_DETAILS_OUTPUT_AUDIO_TOKENS not in attrs


### PR DESCRIPTION
## Context
Today, when we emit the `gen_ai.usage.input_tokens`  metric, we calculate this already correctly in LiveKit (as defined by https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/) however two gaps exist in LiveKit today:

- The cached text token count is emited to a custom namespace not recognised by OTEL or major providers like LangFuse or Pydantic (see "## Removed trace type constants (not in the OTEL spec)" section below)
- Audio token counting is not part of official OTEL syntax, but recently   LangFuse https://github.com/langfuse/langfuse/pull/13110  and pydantic https://github.com/open-telemetry/semantic-conventions/issues/1959#issuecomment-3135486259 have adopted a convention for this that would be useful LiveKit to follow, as it allows cost estimation of gpt-realtime in LangFuse. LangFuse has [recently merged a fix](https://github.com/langfuse/langfuse/pull/13110) on their side to correctly map values stored in the convention used in this PR to their internal cost modelling .

## Summary

Aligns realtime and related LLM spans with **current OpenTelemetry GenAI usage conventions** and **Langfuse OTEL ingestion** ([langfuse#13110](https://github.com/langfuse/langfuse/pull/13110)): top-level `gen_ai.usage.input_tokens` / `output_tokens` represent **text** counts; **cache read** uses the standard dotted key; **audio** breakdowns use `gen_ai.usage.details.*` so backends can normalize usage without double-counting cache or mixing modalities.

Internal metrics (`RealtimeModelMetrics`, `ModelUsageCollector`, Prometheus counters) are unchanged—only **trace attributes** and `trace_types` constants are updated.

## Attribute mapping

Realtime spans (`record_realtime_metrics`) now set:

| Intent | OTEL / Langfuse-oriented attribute | Source on `RealtimeModelMetrics` |
|--------|-----------------------------------|----------------------------------|
| Top-level input (text-only, inclusive of cached text) | `gen_ai.usage.input_tokens` | `input_token_details.text_tokens` |
| Top-level output (text-only) | `gen_ai.usage.output_tokens` | `output_token_details.text_tokens` |
| Cached **text** (cache read) | `gen_ai.usage.cache_read.input_tokens` | `cached_tokens_details.text_tokens` (if non-zero) |
| Input audio (non-cached) | `gen_ai.usage.details.input_audio_tokens` | `input_token_details.audio_tokens` |
| Cached audio read | `gen_ai.usage.details.cache_audio_read_tokens` | `cached_tokens_details.audio_tokens` |
| Output audio | `gen_ai.usage.details.output_audio_tokens` | `output_token_details.audio_tokens` |

*`gen_ai.usage.cache_creation.input_tokens` is not set until a provider exposes cache-creation counts in our metrics model.*

## Removed trace type constants (not in the OTEL spec)

These **`ATTR_GEN_AI_USAGE_*` aliases were removed** because their string keys were **informal** (LiveKit/Langfuse-style flat names) and **not** defined in [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/):

| Removed constant | Removed attribute key |
|------------------|------------------------|
| `ATTR_GEN_AI_USAGE_INPUT_TEXT_TOKENS` | `gen_ai.usage.input_text_tokens` |
| `ATTR_GEN_AI_USAGE_INPUT_AUDIO_TOKENS` | `gen_ai.usage.input_audio_tokens` |
| `ATTR_GEN_AI_USAGE_INPUT_CACHED_TOKENS` | `gen_ai.usage.input_cached_tokens` |
| `ATTR_GEN_AI_USAGE_OUTPUT_TEXT_TOKENS` | `gen_ai.usage.output_text_tokens` |
| `ATTR_GEN_AI_USAGE_OUTPUT_AUDIO_TOKENS` | `gen_ai.usage.output_audio_tokens` |

Top-level **`gen_ai.usage.input_tokens`** and **`gen_ai.usage.output_tokens`** remain; they now map to **text** token fields only on realtime spans, consistent with semconv + Langfuse normalization.

## Other call sites

- **Cascaded LLM spans** (`llm.py`): set `gen_ai.usage.cache_read.input_tokens` when `prompt_cached_tokens > 0`.
- **Eval judge spans** (`run_result.py`): same cache-read key; redundant duplicate text keys removed.

## Tests

- Unit tests assert the attribute dict produced by `record_realtime_metrics` (including omission of zero breakdowns).

---

**Breaking note:** External code that imported the five removed `ATTR_GEN_AI_USAGE_*` names must switch to the new constants (`ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS`, `ATTR_GEN_AI_USAGE_DETAILS_*`, etc.).