### PR TITLE
feat(openai): expose max_output_tokens on Responses API LLM

### DIFF
--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/responses/llm.py
@@ -32,6 +32,7 @@ class LLM(openai.responses.LLM):
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
         timeout: httpx.Timeout | None = None,
         reasoning: NotGivenOr[Reasoning] = NOT_GIVEN,
+        max_output_tokens: NotGivenOr[int] = NOT_GIVEN,
     ) -> None:
         """
         This automatically infers the following arguments from their corresponding environment variables if they are not provided:
@@ -68,6 +69,7 @@ class LLM(openai.responses.LLM):
             parallel_tool_calls=parallel_tool_calls,
             tool_choice=tool_choice,
             reasoning=reasoning,
+            max_output_tokens=max_output_tokens,
         )
         self._azure_client = azure_client
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -144,6 +144,7 @@ class _LLMOptions:
     reasoning: NotGivenOr[Reasoning]
     metadata: NotGivenOr[dict[str, str]]
     service_tier: NotGivenOr[ServiceTier]
+    max_output_tokens: NotGivenOr[int]
     use_websocket: bool
 
 
@@ -164,6 +165,7 @@ class LLM(llm.LLM):
         store: NotGivenOr[bool] = NOT_GIVEN,
         metadata: NotGivenOr[dict[str, str]] = NOT_GIVEN,
         service_tier: NotGivenOr[ServiceTier] = NOT_GIVEN,
+        max_output_tokens: NotGivenOr[int] = NOT_GIVEN,
         timeout: httpx.Timeout | None = None,
     ) -> None:
         """
@@ -194,6 +196,7 @@ class LLM(llm.LLM):
             metadata=metadata,
             reasoning=reasoning,
             service_tier=service_tier,
+            max_output_tokens=max_output_tokens,
             use_websocket=use_websocket,
         )
         self._client = client
@@ -289,6 +292,9 @@ class LLM(llm.LLM):
 
         if is_given(self._opts.service_tier):
             extra["service_tier"] = self._opts.service_tier
+
+        if is_given(self._opts.max_output_tokens):
+            extra["max_output_tokens"] = self._opts.max_output_tokens
 
         parallel_tool_calls = (
             parallel_tool_calls if is_given(parallel_tool_calls) else self._opts.parallel_tool_calls

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/responses/llm.py
@@ -27,6 +27,7 @@ class LLM(openai.responses.LLM):
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
         timeout: httpx.Timeout | None = None,
         reasoning: NotGivenOr[Reasoning] = NOT_GIVEN,
+        max_output_tokens: NotGivenOr[int] = NOT_GIVEN,
     ) -> None:
         api_key = api_key or os.environ.get("XAI_API_KEY")
         if api_key is None:
@@ -44,4 +45,5 @@ class LLM(openai.responses.LLM):
             tool_choice=tool_choice,
             reasoning=reasoning,
             timeout=timeout,
+            max_output_tokens=max_output_tokens,
         )


### PR DESCRIPTION
## Summary

Adds `max_output_tokens` as a first-class constructor argument on the OpenAI, Azure, and xAI Responses API LLM wrappers — mirroring how `service_tier` is handled today (#5346).

The underlying `/v1/responses` endpoint accepts `max_output_tokens` natively (see `openai.types.responses.response_create_params`), but the plugins previously required callers to reach for `extra_kwargs` on every `chat()` call to set it. This PR makes it a plain constructor arg so a bound can be set once at LLM construction time.

### Changes
- `livekit-plugins-openai/.../responses/llm.py`: add `max_output_tokens: NotGivenOr[int]` to `_LLMOptions` and the `LLM.__init__` signature; forward it into `extra` so it reaches both the HTTP (`client.responses.create`) and WebSocket (`response.create`) paths.
- `livekit-plugins-azure/.../responses/llm.py`: thread the new arg through to `openai.responses.LLM.__init__`.
- `livekit-plugins-xai/.../responses/llm.py`: thread the new arg through to `openai.responses.LLM.__init__`.

### Usage

```python
from livekit.plugins import openai

llm = openai.responses.LLM(
    model="gpt-4.1",
    max_output_tokens=1024,
)
```

## Motivation

All sibling chat-completions LLMs (`openai.LLM`, `anthropic.LLM`, `google.LLM`, `aws.LLM`, `mistralai.LLM`, `groq.LLM`) already expose a first-class `max_completion_tokens` / `max_tokens` / `max_output_tokens` argument. The Responses variants were the only remaining path that forced callers into `extra_kwargs`. This brings them in line.

## Test plan

- [x] `ast.parse` passes on all three modified files
- [x] `make check` (format + lint + type-check)
- [x] Smoke test: instantiate `openai.responses.LLM(model="gpt-4.1", max_output_tokens=64)` and verify the response honors the cap in both `use_websocket=True` and `use_websocket=False` modes