### PR TITLE
Rename e2ee to encryption in JobContext.connect

### DIFF
--- a/examples/voice_agents/realtime_turn_detector.py
+++ b/examples/voice_agents/realtime_turn_detector.py
@@ -3,8 +3,8 @@ import logging
 from dotenv import load_dotenv
 from google.genai import types  # noqa: F401
 
-from livekit.agents import Agent, AgentServer, AgentSession, JobContext, JobProcess, cli
-from livekit.plugins import deepgram, google, openai, silero  # noqa: F401
+from livekit.agents import Agent, AgentServer, AgentSession, JobContext, JobProcess, cli, inference
+from livekit.plugins import google, openai, silero  # noqa: F401
 from livekit.plugins.turn_detector.multilingual import MultilingualModel
 
 logger = logging.getLogger("realtime-turn-detector")
@@ -26,24 +26,24 @@ async def entrypoint(ctx: JobContext):
         allow_interruptions=True,
         turn_detection=MultilingualModel(),
         vad=ctx.proc.userdata["vad"],
-        stt=deepgram.STT(),
+        stt=inference.STT("deepgram/nova-3"),
         # To use OpenAI Realtime API
-        llm=openai.realtime.RealtimeModel(
-            voice="alloy",
-            # it's necessary to turn off turn detection in the OpenAI Realtime API in order to use
-            # LiveKit's turn detection model
-            turn_detection=None,
-            input_audio_transcription=None,  # we use Deepgram STT instead
-        ),
-        # To use Gemini Live API
-        # llm=google.realtime.RealtimeModel(
-        #     realtime_input_config=types.RealtimeInputConfig(
-        #         automatic_activity_detection=types.AutomaticActivityDetection(
-        #             disabled=True,
-        #         ),
-        #     ),
-        #     input_audio_transcription=None,
+        # llm=openai.realtime.RealtimeModel(
+        #     voice="alloy",
+        #     # it's necessary to turn off turn detection in the OpenAI Realtime API in order to use
+        #     # LiveKit's turn detection model
+        #     turn_detection=None,
+        #     input_audio_transcription=None,  # we use Deepgram STT instead
         # ),
+        # To use Gemini Live API
+        llm=google.realtime.RealtimeModel(
+            realtime_input_config=types.RealtimeInputConfig(
+                automatic_activity_detection=types.AutomaticActivityDetection(
+                    disabled=True,
+                ),
+            ),
+            input_audio_transcription=None,
+        ),
     )
     await session.start(agent=Agent(instructions="You are a helpful assistant."), room=ctx.room)
 

--- a/examples/voice_agents/realtime_turn_detector.py
+++ b/examples/voice_agents/realtime_turn_detector.py
@@ -3,8 +3,8 @@ import logging
 from dotenv import load_dotenv
 from google.genai import types  # noqa: F401
 
-from livekit.agents import Agent, AgentServer, AgentSession, JobContext, JobProcess, cli, inference
-from livekit.plugins import google, openai, silero  # noqa: F401
+from livekit.agents import Agent, AgentServer, AgentSession, JobContext, JobProcess, cli
+from livekit.plugins import deepgram, google, openai, silero  # noqa: F401
 from livekit.plugins.turn_detector.multilingual import MultilingualModel
 
 logger = logging.getLogger("realtime-turn-detector")
@@ -26,24 +26,24 @@ async def entrypoint(ctx: JobContext):
         allow_interruptions=True,
         turn_detection=MultilingualModel(),
         vad=ctx.proc.userdata["vad"],
-        stt=inference.STT("deepgram/nova-3"),
+        stt=deepgram.STT(),
         # To use OpenAI Realtime API
-        # llm=openai.realtime.RealtimeModel(
-        #     voice="alloy",
-        #     # it's necessary to turn off turn detection in the OpenAI Realtime API in order to use
-        #     # LiveKit's turn detection model
-        #     turn_detection=None,
-        #     input_audio_transcription=None,  # we use Deepgram STT instead
-        # ),
-        # To use Gemini Live API
-        llm=google.realtime.RealtimeModel(
-            realtime_input_config=types.RealtimeInputConfig(
-                automatic_activity_detection=types.AutomaticActivityDetection(
-                    disabled=True,
-                ),
-            ),
-            input_audio_transcription=None,
+        llm=openai.realtime.RealtimeModel(
+            voice="alloy",
+            # it's necessary to turn off turn detection in the OpenAI Realtime API in order to use
+            # LiveKit's turn detection model
+            turn_detection=None,
+            input_audio_transcription=None,  # we use Deepgram STT instead
         ),
+        # To use Gemini Live API
+        # llm=google.realtime.RealtimeModel(
+        #     realtime_input_config=types.RealtimeInputConfig(
+        #         automatic_activity_detection=types.AutomaticActivityDetection(
+        #             disabled=True,
+        #         ),
+        #     ),
+        #     input_audio_transcription=None,
+        # ),
     )
     await session.start(agent=Agent(instructions="You are a helpful assistant."), room=ctx.room)
 

--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -42,6 +42,7 @@ from .telemetry import _upload_session_report, otel_metrics
 from .telemetry.traces import _BufferingHandler, _setup_cloud_tracer, _shutdown_telemetry
 from .types import NotGivenOr
 from .utils import http_context, is_given, wait_for_participant
+from .utils.deprecation import deprecate_params
 from .utils.misc import is_cloud
 
 _JobContextVar = contextvars.ContextVar["JobContext"]("agents_job_context")
@@ -494,12 +495,15 @@ class JobContext:
 
         return await wait_for_participant(self._room, identity=identity, kind=kind)
 
+    @deprecate_params({"e2ee": "Use `encryption` instead."})
     async def connect(
         self,
         *,
-        e2ee: rtc.E2EEOptions | None = None,
+        encryption: rtc.E2EEOptions | None = None,
         auto_subscribe: AutoSubscribe = AutoSubscribe.SUBSCRIBE_ALL,
         rtc_config: rtc.RtcConfiguration | None = None,
+        # deprecated
+        e2ee: rtc.E2EEOptions | None = None,
     ) -> None:
         """Connect to the room. This method should be called only once.
 
@@ -512,8 +516,9 @@ class JobContext:
             if self._connected:
                 return
 
+            encryption = encryption or e2ee
             room_options = rtc.RoomOptions(
-                encryption=e2ee,
+                encryption=encryption,
                 auto_subscribe=auto_subscribe == AutoSubscribe.SUBSCRIBE_ALL,
                 rtc_config=rtc_config,
             )

--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -508,7 +508,7 @@ class JobContext:
         """Connect to the room. This method should be called only once.
 
         Args:
-            e2ee: End-to-end encryption options. If provided, the Agent will utilize end-to-end encryption. Note: clients will also need to handle E2EE.
+            encryption: End-to-end encryption options. If provided, the Agent will utilize end-to-end encryption. Note: clients will also need to handle E2EE.
             auto_subscribe: Whether to automatically subscribe to tracks. Default is AutoSubscribe.SUBSCRIBE_ALL.
             rtc_config: Custom RTC configuration to use when connecting to the room.
         """  # noqa: E501


### PR DESCRIPTION
## Summary
- Rename `e2ee` parameter to `encryption` in `JobContext.connect()` with backward-compatible deprecation via `@deprecate_params`