### PR TITLE
fix(room-io): preserve audio frame processors across stream transitions

### DIFF
--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -306,15 +306,28 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             frame_size_ms=self._frame_size_ms,
         )
 
+    def _close_selector_processor(self) -> None:
+        if isinstance(self._noise_cancellation, rtc.FrameProcessor):
+            return
+        if self._processor is not None:
+            self._processor._close()
+            self._processor = None
+
+    @override
+    def set_participant(self, participant: rtc.RemoteParticipant | str | None) -> None:
+        previous_processor = self._processor
+        super().set_participant(participant)
+        if self._stream is None and self._processor is previous_processor:
+            self._close_selector_processor()
+
     @override
     def _on_track_unavailable(
         self, publication: rtc.RemoteTrackPublication, participant: rtc.RemoteParticipant
     ) -> None:
         current_processor = self._processor
         super()._on_track_unavailable(publication, participant)
-        if self._stream is None and self._processor is current_processor and current_processor is not None:
-            current_processor._close()
-            self._processor = None
+        if self._stream is None and self._processor is current_processor:
+            self._close_selector_processor()
 
     @override
     async def _forward_task(

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -175,9 +175,6 @@ class _ParticipantInputStream(Generic[T], ABC):
             self._tasks.add(task)
             self._stream = None
             self._publication = None
-        if self._processor:
-            self._processor._close()
-            self._processor = None
 
     def _on_track_available(
         self,
@@ -291,10 +288,15 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             else self._noise_cancellation
         )
 
+        previous_processor = self._processor
+        next_processor: rtc.FrameProcessor[rtc.AudioFrame] | None = None
         if isinstance(noise_cancellation, rtc.FrameProcessor):
-            self._processor = noise_cancellation
-        elif callable(self._noise_cancellation):
-            self._processor = None
+            next_processor = noise_cancellation
+
+        if previous_processor is not None and previous_processor is not next_processor:
+            previous_processor._close()
+
+        self._processor = next_processor
 
         return rtc.AudioStream.from_track(
             track=track,
@@ -303,6 +305,16 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             noise_cancellation=noise_cancellation,
             frame_size_ms=self._frame_size_ms,
         )
+
+    @override
+    def _on_track_unavailable(
+        self, publication: rtc.RemoteTrackPublication, participant: rtc.RemoteParticipant
+    ) -> None:
+        current_processor = self._processor
+        super()._on_track_unavailable(publication, participant)
+        if self._stream is None and self._processor is current_processor and current_processor is not None:
+            current_processor._close()
+            self._processor = None
 
     @override
     async def _forward_task(

--- a/tests/test_room_io_noise_cancellation.py
+++ b/tests/test_room_io_noise_cancellation.py
@@ -102,6 +102,28 @@ def _make_audio_input_stream(
 
 
 @pytest.mark.asyncio
+async def test_direct_frame_processor_survives_initial_subscription() -> None:
+    room = _FakeRoom()
+    processor = _MockFrameProcessor()
+    stream = _make_audio_input_stream(room, noise_cancellation=processor)
+    stream.set_participant("test-user")
+
+    track, publication, participant = _make_track_available_args()
+
+    with patch("livekit.rtc.AudioStream.from_track", side_effect=lambda **kw: _MockAudioStream()):
+        stream._on_track_available(track, publication, participant)
+
+    assert stream._processor is processor
+    assert processor.close_calls == 0
+    assert len(processor.stream_info_calls) == 1
+    assert len(processor.credentials_calls) == 1
+
+    await stream.aclose()
+
+    assert processor.close_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_selector_frame_processor_receives_lifecycle_calls() -> None:
     """When a NoiseCancellationSelector returns a FrameProcessor, it should
     receive _on_stream_info_updated and _on_credentials_updated calls."""

--- a/tests/test_room_io_noise_cancellation.py
+++ b/tests/test_room_io_noise_cancellation.py
@@ -268,6 +268,62 @@ async def test_token_refresh_does_not_hit_closed_processor_after_track_unpublish
 
 
 @pytest.mark.asyncio
+async def test_set_participant_none_closes_selector_processor() -> None:
+    room = _FakeRoom()
+    processor = _MockFrameProcessor()
+    stream = _make_audio_input_stream(room, noise_cancellation=lambda _params: processor)
+    stream.set_participant("test-user")
+
+    track, publication, participant = _make_track_available_args()
+
+    with patch("livekit.rtc.AudioStream.from_track", side_effect=lambda **kw: _MockAudioStream()):
+        stream._on_track_available(track, publication, participant)
+
+    stream.set_participant(None)
+
+    assert processor.close_calls == 1
+    assert stream._processor is None
+
+    room._token = "refreshed-token"
+    room._server_url = "wss://refreshed.livekit.cloud"
+    stream._on_token_refreshed()
+
+    assert len(processor.credentials_calls) == 1
+
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_set_participant_without_available_track_closes_selector_processor() -> None:
+    room = _FakeRoom()
+    processor = _MockFrameProcessor()
+    stream = _make_audio_input_stream(room, noise_cancellation=lambda _params: processor)
+    stream.set_participant("test-user")
+
+    track, publication, participant = _make_track_available_args()
+
+    with patch("livekit.rtc.AudioStream.from_track", side_effect=lambda **kw: _MockAudioStream()):
+        stream._on_track_available(track, publication, participant)
+
+    next_participant = MagicMock()
+    next_participant.identity = "new-user"
+    next_participant.track_publications = {}
+
+    stream.set_participant(next_participant)
+
+    assert processor.close_calls == 1
+    assert stream._processor is None
+
+    room._token = "refreshed-token"
+    room._server_url = "wss://refreshed.livekit.cloud"
+    stream._on_token_refreshed()
+
+    assert len(processor.credentials_calls) == 1
+
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
 async def test_aclose_closes_active_processor() -> None:
     """aclose() must deterministically close an active FrameProcessor
     rather than relying on garbage collection."""


### PR DESCRIPTION
Fixes #5448

## Summary
- stop `_ParticipantInputStream._close_stream()` from closing the active frame processor during ordinary stream transitions
- close replaced per-track processors inside `_ParticipantAudioInputStream._create_stream()` and close orphaned processors when a track disappears without replacement
- add a regression test covering a direct `rtc.FrameProcessor` passed via `noise_cancellation` so it survives the initial subscription and still closes during final teardown

## Testing
- `.venv/bin/python -m pytest tests/test_room_io_noise_cancellation.py tests/test_room_io_teardown.py`
- `.venv/bin/ruff check livekit-agents/livekit/agents/voice/room_io/_input.py tests/test_room_io_noise_cancellation.py tests/test_room_io_teardown.py`