### PR TITLE
fix(tests): update preemptive_generation mock to use dict

### DIFF
--- a/makefile
+++ b/makefile
@@ -113,7 +113,8 @@ unit-tests:
 		tests/test_utils/test_bounded_dict.py \
 		tests/test_interruption/test_overlapping_speech_event.py \
 		tests/test_tool_search.py \
-		tests/test_tool_proxy.py
+		tests/test_tool_proxy.py \
+		tests/test_session_host.py
 
 # ============================================
 # Development Workflows

--- a/tests/test_session_host.py
+++ b/tests/test_session_host.py
@@ -444,7 +444,7 @@ class TestSessionHostRequests:
         options.interruption = MagicMock(__iter__=lambda s: iter([]))
         options.max_tool_steps = 5
         options.user_away_timeout = 30
-        options.preemptive_generation = False
+        options.preemptive_generation = {"enabled": False}
         options.min_consecutive_speech_delay = 0.5
         options.use_tts_aligned_transcript = True
         options.ivr_detection = False


### PR DESCRIPTION
## Summary
- Fix `test_session_host` mock that used a plain `bool` for `preemptive_generation`, which crashes with `TypeError` when `remote_session.py` calls `dict()` on it after #5428
- Add `test_session_host.py` to unit test suite

Follow-up to https://github.com/livekit/agents/pull/5428#discussion_r3090827999