### PR TITLE
fix(examples): update e2ee.py to use encryption kwarg and env var

### DIFF
--- a/examples/primitives/e2ee.py
+++ b/examples/primitives/e2ee.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from dotenv import load_dotenv
 
@@ -17,15 +18,14 @@ server = AgentServer()
 async def entrypoint(ctx: JobContext):
     e2ee_config = rtc.E2EEOptions(
         key_provider_options=rtc.KeyProviderOptions(
-            shared_key=b"my_shared_key",
-            # ratchet_salt=b"my_salt",
+            shared_key=os.environ["LIVEKIT_E2EE_KEY"].encode(),
         ),
         encryption_type=rtc.EncryptionType.GCM,
     )
 
     # Connect to the room with end-to-end encryption (E2EE)
     # Only clients possessing the same shared key will be able to decode the published tracks
-    await ctx.connect(e2ee=e2ee_config)
+    await ctx.connect(encryption=e2ee_config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Rename `e2ee=` to `encryption=` on `ctx.connect` to match the renamed kwarg from #5454
- Load shared key from `LIVEKIT_E2EE_KEY` env var instead of hardcoding it

Resolves DOCS-1278

🤖 Generated with [Claude Code](https://claude.com/claude-code)