### PR TITLE
feat(assemblyai): log connection lifecycle, silence, and session correlators

### DIFF
--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -19,6 +19,7 @@ import asyncio
 import dataclasses
 import json
 import os
+import time
 import weakref
 from dataclasses import dataclass
 from typing import Literal
@@ -368,6 +369,9 @@ class SpeechStream(stt.SpeechStream):
                 samples_per_channel=samples_per_buffer,
             )
 
+            total_bytes_sent = 0
+            last_flow_log = time.monotonic()
+
             # forward inputs to AssemblyAI
             # if we receive a close message, signal it to AssemblyAI and break.
             # the recv task will then make sure to process the remaining audio and stop
@@ -379,19 +383,40 @@ class SpeechStream(stt.SpeechStream):
 
                 for frame in frames:
                     self._speech_duration += frame.duration
-                    await ws.send_bytes(frame.data.tobytes())
+                    frame_bytes = frame.data.tobytes()
+                    total_bytes_sent += len(frame_bytes)
+                    await ws.send_bytes(frame_bytes)
+
+                now = time.monotonic()
+                if now - last_flow_log >= 10.0:
+                    logger.debug(
+                        "AssemblyAI audio flow session=%s bytes_sent=%d",
+                        self._session_id,
+                        total_bytes_sent,
+                    )
+                    last_flow_log = now
 
             closing_ws = True
+            logger.debug("AssemblyAI sending close message session=%s", self._session_id)
             await ws.send_str(SpeechStream._CLOSE_MSG)
 
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
             nonlocal closing_ws
+            consecutive_timeouts = 0
             while True:
                 try:
                     msg = await asyncio.wait_for(ws.receive(), timeout=5)
+                    consecutive_timeouts = 0
                 except asyncio.TimeoutError:
                     if closing_ws:
                         break
+                    consecutive_timeouts += 1
+                    # 3 timeouts = 15s without any message from AAI
+                    if consecutive_timeouts == 3:
+                        logger.warning(
+                            "AssemblyAI no messages received for 15s session=%s",
+                            self._session_id,
+                        )
                     continue
 
                 if msg.type in (
@@ -402,6 +427,14 @@ class SpeechStream(stt.SpeechStream):
                     if closing_ws:  # close is expected, see SpeechStream.aclose
                         return
 
+                    logger.warning(
+                        "AssemblyAI WebSocket closed unexpectedly "
+                        "session=%s code=%s data=%s extra=%s",
+                        self._session_id,
+                        ws.close_code,
+                        msg.data,
+                        msg.extra,
+                    )
                     raise APIStatusError(
                         "AssemblyAI connection closed unexpectedly",
                         status_code=ws.close_code or -1,
@@ -409,13 +442,20 @@ class SpeechStream(stt.SpeechStream):
                     )
 
                 if msg.type != aiohttp.WSMsgType.TEXT:
-                    logger.error("unexpected AssemblyAI message type %s", msg.type)
+                    logger.error(
+                        "unexpected AssemblyAI message type=%s session=%s",
+                        msg.type,
+                        self._session_id,
+                    )
                     continue
 
                 try:
                     self._process_stream_event(json.loads(msg.data))
                 except Exception:
-                    logger.exception("failed to process AssemblyAI message")
+                    logger.exception(
+                        "failed to process AssemblyAI message session=%s",
+                        self._session_id,
+                    )
 
         async def send_config_task(ws: aiohttp.ClientWebSocketResponse) -> None:
             """Send config updates and control messages immediately, independent of audio."""
@@ -501,7 +541,16 @@ class SpeechStream(stt.SpeechStream):
             if v is not None
         }
         url = f"{self._base_url}/v3/ws?{urlencode(filtered_config)}"
+        logger.debug(
+            "connecting to AssemblyAI model=%s base_url=%s",
+            self._opts.speech_model,
+            self._base_url,
+        )
         ws = await self._session.ws_connect(url, headers=headers)
+        logger.debug(
+            "AssemblyAI WebSocket connected status=%s",
+            ws._response.status if ws._response is not None else None,
+        )
         return ws
 
     def _process_stream_event(self, data: dict) -> None:
@@ -525,13 +574,19 @@ class SpeechStream(stt.SpeechStream):
             audio_duration = data.get("audio_duration_seconds")
             session_duration = data.get("session_duration_seconds")
             logger.debug(
-                "AssemblyAI session terminated audio_duration=%ss session_duration=%ss",
+                "AssemblyAI session terminated session=%s audio_duration=%ss session_duration=%ss",
+                self._session_id,
                 audio_duration,
                 session_duration,
             )
             return
 
         if message_type != "Turn":
+            logger.debug(
+                "AssemblyAI unhandled message type=%s session=%s",
+                message_type,
+                self._session_id,
+            )
             return
         words = data.get("words", [])
         end_of_turn = data.get("end_of_turn", False)
@@ -585,7 +640,11 @@ class SpeechStream(stt.SpeechStream):
                 ],
             )
             self._event_ch.send_nowait(interim_event)
-            logger.debug("interim transcript end_of_turn_confidence=%s", end_of_turn_confidence)
+            logger.debug(
+                "interim transcript session=%s end_of_turn_confidence=%s",
+                self._session_id,
+                end_of_turn_confidence,
+            )
 
         if utterance:
             if self._last_preflight_start_time == 0.0:
@@ -617,7 +676,11 @@ class SpeechStream(stt.SpeechStream):
                 ],
             )
             self._event_ch.send_nowait(final_event)
-            logger.debug("preflight transcript end_of_turn_confidence=%s", end_of_turn_confidence)
+            logger.debug(
+                "preflight transcript session=%s end_of_turn_confidence=%s",
+                self._session_id,
+                end_of_turn_confidence,
+            )
             self._last_preflight_start_time = end_time
 
         if end_of_turn and (
@@ -638,14 +701,19 @@ class SpeechStream(stt.SpeechStream):
                 ],
             )
             self._event_ch.send_nowait(final_event)
-            logger.debug("final transcript end_of_turn_confidence=%s", end_of_turn_confidence)
+            logger.debug(
+                "final transcript session=%s end_of_turn_confidence=%s",
+                self._session_id,
+                end_of_turn_confidence,
+            )
 
             if words:
                 first_word_start = words[0].get("start", 0)
                 last_word_end = words[-1].get("end", 0)
                 logger.debug(
-                    "turn speech_duration=%.3fs (from word timestamps)",
+                    "turn speech_duration=%.3fs session=%s (from word timestamps)",
                     (last_word_end - first_word_start) / 1000,
+                    self._session_id,
                 )
 
             self._event_ch.send_nowait(stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH))

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -411,10 +411,12 @@ class SpeechStream(stt.SpeechStream):
                     if closing_ws:
                         break
                     consecutive_timeouts += 1
-                    # 3 timeouts = 15s without any message from AAI
-                    if consecutive_timeouts == 3:
+                    # First warning at 15s, then every 15s while silence continues.
+                    # `session=None` here means WS connected but AAI never sent `Begin`.
+                    if consecutive_timeouts % 3 == 0:
                         logger.warning(
-                            "AssemblyAI no messages received for 15s session=%s",
+                            "AssemblyAI no messages received for %ds session=%s",
+                            consecutive_timeouts * 5,
                             self._session_id,
                         )
                     continue

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -19,7 +19,6 @@ import asyncio
 import dataclasses
 import json
 import os
-import time
 import weakref
 from dataclasses import dataclass
 from typing import Literal
@@ -369,9 +368,6 @@ class SpeechStream(stt.SpeechStream):
                 samples_per_channel=samples_per_buffer,
             )
 
-            total_bytes_sent = 0
-            last_flow_log = time.monotonic()
-
             # forward inputs to AssemblyAI
             # if we receive a close message, signal it to AssemblyAI and break.
             # the recv task will then make sure to process the remaining audio and stop
@@ -383,18 +379,7 @@ class SpeechStream(stt.SpeechStream):
 
                 for frame in frames:
                     self._speech_duration += frame.duration
-                    frame_bytes = frame.data.tobytes()
-                    total_bytes_sent += len(frame_bytes)
-                    await ws.send_bytes(frame_bytes)
-
-                now = time.monotonic()
-                if now - last_flow_log >= 10.0:
-                    logger.debug(
-                        "AssemblyAI audio flow session=%s bytes_sent=%d",
-                        self._session_id,
-                        total_bytes_sent,
-                    )
-                    last_flow_log = now
+                    await ws.send_bytes(frame.data.tobytes())
 
             closing_ws = True
             logger.debug("AssemblyAI sending close message session=%s", self._session_id)


### PR DESCRIPTION
## Summary

Extends the DEBUG logging added in #5146.

- **WebSocket lifecycle** — `debug` before `ws_connect` (model + base_url; URL intentionally excluded since the query string contains customer `prompt` / `keyterms_prompt`) and after with the HTTP status.
- **Unexpected close** — `warning` with `session_id`, `close_code`, `msg.data`, `msg.extra` logged before the `APIStatusError` is raised, so the close code is visible even if the exception gets swallowed downstream.
- **Recv silence** — `warning` when no message arrives from AAI for 15s, and re-emitted every 15s while silence continues (with the actual elapsed duration). Makes the "interims keep arriving but no finals" vs "AAI went quiet" distinction explicit.
- **Session correlators** — `session=...` added to every existing debug/error/exception log in `_process_stream_event` and `recv_task` so logs can be cross-referenced with AAI-side logs.
- **Unhandled message types** — `debug` log for unknown `type` values, which were previously silently dropped.

No impact at default log levels — all new output is `debug` except the two `warning`-level anomaly signals.

## Test plan

- [x] `make format lint type-check` pass
- [x] Verify in a running agent session that:
  - `connecting to AssemblyAI model=... base_url=...` appears once at connect
  - `AssemblyAI WebSocket connected status=...` appears once
  - Existing interim/preflight/final logs now include `session=<id>`
  - Closing the WS server-side produces the unexpected-close warning