### PR TITLE
feat(assemblyai): warn when audio stops flowing to the WebSocket

### DIFF
--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -19,6 +19,7 @@ import asyncio
 import dataclasses
 import json
 import os
+import time
 import weakref
 from dataclasses import dataclass
 from typing import Literal
@@ -282,6 +283,7 @@ class SpeechStream(stt.SpeechStream):
         self._config_update_queue: asyncio.Queue[dict] = asyncio.Queue()
         self._session_id: str | None = None
         self._expires_at: int | None = None
+        self._last_frame_sent_at: float | None = None
 
     @property
     def session_id(self) -> str | None:
@@ -380,18 +382,36 @@ class SpeechStream(stt.SpeechStream):
                 for frame in frames:
                     self._speech_duration += frame.duration
                     await ws.send_bytes(frame.data.tobytes())
+                    self._last_frame_sent_at = time.time()
 
             closing_ws = True
             await ws.send_str(SpeechStream._CLOSE_MSG)
 
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
             nonlocal closing_ws
+            consecutive_timeouts = 0
             while True:
                 try:
                     msg = await asyncio.wait_for(ws.receive(), timeout=5)
+                    consecutive_timeouts = 0
                 except asyncio.TimeoutError:
                     if closing_ws:
                         break
+                    consecutive_timeouts += 1
+                    # Every 15s of recv silence, check whether the send side is
+                    # also idle. If frames are still flowing but no messages
+                    # arrive, the stall is downstream of this plugin; if
+                    # frames have stopped, the stall is upstream. Logging the
+                    # send-side silence makes that distinction explicit in
+                    # logs without needing external instrumentation.
+                    if consecutive_timeouts % 3 == 0 and self._last_frame_sent_at is not None:
+                        send_idle_s = time.time() - self._last_frame_sent_at
+                        if send_idle_s >= 15:
+                            logger.warning(
+                                "AssemblyAI no audio frames sent for %.0fs session=%s",
+                                send_idle_s,
+                                self._session_id,
+                            )
                     continue
 
                 if msg.type in (


### PR DESCRIPTION
## Summary

Complementary to #5476 (recv-side silence warning).

#5476 warns when AssemblyAI sends no messages for 15s+. That's half the diagnostic picture — it can't distinguish "AssemblyAI is stalled" from "the plugin stopped receiving audio from upstream and is correctly silent." When a session appears wedged, both interpretations are on the table and the current logs can't separate them.

This PR adds the symmetric send-side warning: if no audio frames have been written to the WebSocket for 15s+ while the recv loop is also silent, emit `AssemblyAI no audio frames sent for Ns session=<id>`, re-emitted every 15s while the drought continues.

Together, the two absence-of-activity signals answer the question by elimination:

| send-stopped warning | recv-silence warning | Diagnosis |
|---|---|---|
| silent | firing | AssemblyAI stalled — frames flowing, no response |
| firing | firing | Upstream stalled — plugin got no audio |
| silent | silent | healthy |

## Implementation

- Adds `self._last_frame_sent_at: float | None = None`, set on every successful `ws.send_bytes(...)` in `send_task`.
- In `recv_task`, tracks `consecutive_timeouts` in 5s ticks (matches the cadence #5476 introduces on the recv side). Every 3rd tick (15s), check `time.time() - _last_frame_sent_at` and warn if it exceeds 15s.
- No separate watchdog coroutine. Overhead on the hot path is one `time.time()` assignment per frame.
- Guarded on `_last_frame_sent_at is not None` so the warning doesn't fire during the initial connect window before any audio has been sent.

## Impact

- Default log level: `warning` only, and only when the anomaly is real.
- Healthy sessions: silent (by design — mirrors #5476's absence-is-the-signal approach).

## Relationship to #5476

This PR is self-contained and doesn't depend on #5476 being merged first — it introduces its own `consecutive_timeouts` counter in `recv_task`. If #5476 lands first, the counter line in this PR becomes a conflict trivially resolvable by keeping the existing one.

## Test plan

- [x] `make format lint type-check` pass
- [ ] Healthy session: no send-stopped warning emitted
- [ ] Simulated upstream stall (close `input_ch` while keeping WS open): send-stopped warning fires at 15s, 30s, 45s
- [ ] Simulated AAI stall (mock WS that accepts but never responds): recv-silence warning fires, send-stopped stays silent