### PR TITLE
feat(stt): back-date START_OF_SPEECH onset via server-provided timestamp

### DIFF
--- a/.github/next-release/changeset-stt-speech-start-time-fallback.md
+++ b/.github/next-release/changeset-stt-speech-start-time-fallback.md
@@ -1,6 +1,0 @@
----
-"livekit-agents": patch
-"livekit-plugins-assemblyai": patch
----
-
-Add `SpeechEvent.speech_start_time` so STT plugins can propagate server-provided speech onset time. The AssemblyAI plugin populates it from `SpeechStarted.timestamp`, letting the framework back-date `_speech_start_time` when local VAD doesn't fire for STT-detected speech (previously produced `speech_duration = 0.0s` exactly).

--- a/.github/next-release/changeset-stt-speech-start-time-fallback.md
+++ b/.github/next-release/changeset-stt-speech-start-time-fallback.md
@@ -1,0 +1,6 @@
+---
+"livekit-agents": patch
+"livekit-plugins-assemblyai": patch
+---
+
+Add `SpeechEvent.speech_start_time` so STT plugins can propagate server-provided speech onset time. The AssemblyAI plugin populates it from `SpeechStarted.timestamp`, letting the framework back-date `_speech_start_time` when local VAD doesn't fire for STT-detected speech (previously produced `speech_duration = 0.0s` exactly).

--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -314,6 +314,7 @@ class RecognizeStream(ABC):
         self._resampler: rtc.AudioResampler | None = None
 
         self._start_time_offset: float = 0.0
+        self._start_time: float = time.time()
 
     @property
     def start_time_offset(self) -> float:
@@ -324,6 +325,24 @@ class RecognizeStream(ABC):
         if value < 0:
             raise ValueError("start_time_offset must be non-negative")
         self._start_time_offset = value
+
+    @property
+    def start_time(self) -> float:
+        """Wall-clock anchor for the stream. Seeded to `time.time()` when the
+        stream is initialized (and re-seeded on each retry). Plugins may
+        override this via the setter to anchor it at a more accurate moment
+        (e.g., when the first audio frame is sent to the provider) so that
+        server-provided stream-relative timestamps (like
+        `SpeechEvent.speech_start_time`) can be converted to wall-clock
+        accurately.
+        """
+        return self._start_time
+
+    @start_time.setter
+    def start_time(self, value: float) -> None:
+        if value < 0:
+            raise ValueError("start_time must be non-negative")
+        self._start_time = value
 
     def _report_connection_acquired(self, acquire_time: float, connection_reused: bool) -> None:
         """Report connection timing as an STTMetrics event with zero usage."""
@@ -354,6 +373,7 @@ class RecognizeStream(ABC):
         while self._num_retries <= max_retries:
             try:
                 self._start_time_offset += time.time() - last_start_time
+                self._start_time = time.time()
                 last_start_time = time.time()
                 return await self._run()
             except APIError as e:

--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -94,6 +94,14 @@ class SpeechEvent:
     request_id: str = ""
     alternatives: list[SpeechData] = field(default_factory=list)
     recognition_usage: RecognitionUsage | None = None
+    speech_start_time: float | None = None
+    """Server-reported wall-clock time of speech onset, when available.
+    Populated by STT plugins that receive separate speech-onset signals with
+    timing (e.g. AssemblyAI SpeechStarted.timestamp). Used by the framework
+    to back-date _speech_start_time on START_OF_SPEECH events so speech
+    duration metrics remain accurate when SpeechStarted and the first
+    transcript arrive in the same network burst. None means the framework
+    falls back to message arrival time."""
 
 
 @dataclass

--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -95,13 +95,8 @@ class SpeechEvent:
     alternatives: list[SpeechData] = field(default_factory=list)
     recognition_usage: RecognitionUsage | None = None
     speech_start_time: float | None = None
-    """Server-reported wall-clock time of speech onset, when available.
-    Populated by STT plugins that receive separate speech-onset signals with
-    timing (e.g. AssemblyAI SpeechStarted.timestamp). Used by the framework
-    to back-date _speech_start_time on START_OF_SPEECH events so speech
-    duration metrics remain accurate when SpeechStarted and the first
-    transcript arrive in the same network burst. None means the framework
-    falls back to message arrival time."""
+    """server-reported wall-clock time of speech onset, when the provider sends
+    a separate speech-start signal carrying onset timing."""
 
 
 @dataclass

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1645,15 +1645,8 @@ class AgentActivity(RecognitionHooks):
     def on_start_of_speech(
         self,
         ev: vad.VADEvent | None,
-        speech_start_time: float | None = None,
+        speech_start_time: float,
     ) -> None:
-        # Prefer a caller-provided onset time (e.g. STT's back-dated
-        # server timestamp). Fall back to VAD-event back-dating or the
-        # current wall clock.
-        if speech_start_time is None:
-            speech_start_time = time.time()
-            if ev:
-                speech_start_time = speech_start_time - ev.speech_duration - ev.inference_duration
         self._session._update_user_state("speaking", last_speaking_time=speech_start_time)
         if self._audio_recognition:
             self._audio_recognition.on_start_of_speech(

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1642,10 +1642,18 @@ class AgentActivity(RecognitionHooks):
 
     # region recognition hooks
 
-    def on_start_of_speech(self, ev: vad.VADEvent | None) -> None:
-        speech_start_time = time.time()
-        if ev:
-            speech_start_time = speech_start_time - ev.speech_duration - ev.inference_duration
+    def on_start_of_speech(
+        self,
+        ev: vad.VADEvent | None,
+        speech_start_time: float | None = None,
+    ) -> None:
+        # Prefer a caller-provided onset time (e.g. STT's back-dated
+        # server timestamp). Fall back to VAD-event back-dating or the
+        # current wall clock.
+        if speech_start_time is None:
+            speech_start_time = time.time()
+            if ev:
+                speech_start_time = speech_start_time - ev.speech_duration - ev.inference_duration
         self._session._update_user_state("speaking", last_speaking_time=speech_start_time)
         if self._audio_recognition:
             self._audio_recognition.on_start_of_speech(

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -857,7 +857,7 @@ class AudioRecognition:
             if self._speech_start_time is None:
                 self._speech_start_time = ev.speech_start_time or time.time()
 
-            with trace.use_span(self._ensure_user_turn_span()):
+            with trace.use_span(self._ensure_user_turn_span(start_time=self._speech_start_time)):
                 self._hooks.on_start_of_speech(None, speech_start_time=self._speech_start_time)
 
             self._speaking = True

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -854,19 +854,18 @@ class AudioRecognition:
             self._run_eou_detection(chat_ctx)
 
         elif ev.type == stt.SpeechEventType.START_OF_SPEECH and self._turn_detection_mode == "stt":
-            # Back-date onset using server-provided timestamp when available.
-            # Some STT plugins (e.g. AssemblyAI) gate SpeechStarted behind the
-            # first partial, so without this the speaking window is effectively
-            # zero and speech_duration~=0 for turns where local VAD doesn't
-            # fire independently. Falls back to arrival time when unset.
-            stt_speech_start_time = ev.speech_start_time or time.time()
+            # Fallback onset for the edge case where the STT server detected
+            # speech but the local VAD did not. If local VAD fired first,
+            # _speech_start_time already holds its back-dated value and we
+            # preserve it. Otherwise we fill from the STT's server timestamp
+            # (or arrival time, if the plugin doesn't provide one).
+            if self._speech_start_time is None:
+                self._speech_start_time = ev.speech_start_time or time.time()
 
             with trace.use_span(self._ensure_user_turn_span()):
-                self._hooks.on_start_of_speech(None, speech_start_time=stt_speech_start_time)
+                self._hooks.on_start_of_speech(None, speech_start_time=self._speech_start_time)
 
             self._speaking = True
-            if self._speech_start_time is None:
-                self._speech_start_time = stt_speech_start_time
             self._last_speaking_time = time.time()
 
             if self._end_of_turn_task is not None:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -63,7 +63,9 @@ class _PreemptiveGenerationInfo:
 
 class RecognitionHooks(Protocol):
     def on_interruption(self, ev: inference.OverlappingSpeechEvent) -> None: ...
-    def on_start_of_speech(self, ev: vad.VADEvent | None) -> None: ...
+    def on_start_of_speech(
+        self, ev: vad.VADEvent | None, speech_start_time: float | None = None
+    ) -> None: ...
     def on_vad_inference_done(self, ev: vad.VADEvent) -> None: ...
     def on_end_of_speech(self, ev: vad.VADEvent | None) -> None: ...
     def on_interim_transcript(self, ev: stt.SpeechEvent, *, speaking: bool | None) -> None: ...
@@ -852,12 +854,19 @@ class AudioRecognition:
             self._run_eou_detection(chat_ctx)
 
         elif ev.type == stt.SpeechEventType.START_OF_SPEECH and self._turn_detection_mode == "stt":
+            # Back-date onset using server-provided timestamp when available.
+            # Some STT plugins (e.g. AssemblyAI) gate SpeechStarted behind the
+            # first partial, so without this the speaking window is effectively
+            # zero and speech_duration~=0 for turns where local VAD doesn't
+            # fire independently. Falls back to arrival time when unset.
+            stt_speech_start_time = ev.speech_start_time or time.time()
+
             with trace.use_span(self._ensure_user_turn_span()):
-                self._hooks.on_start_of_speech(None)
+                self._hooks.on_start_of_speech(None, speech_start_time=stt_speech_start_time)
 
             self._speaking = True
             if self._speech_start_time is None:
-                self._speech_start_time = time.time()
+                self._speech_start_time = stt_speech_start_time
             self._last_speaking_time = time.time()
 
             if self._end_of_turn_task is not None:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -852,11 +852,8 @@ class AudioRecognition:
             self._run_eou_detection(chat_ctx)
 
         elif ev.type == stt.SpeechEventType.START_OF_SPEECH and self._turn_detection_mode == "stt":
-            # Fallback onset for the edge case where the STT server detected
-            # speech but the local VAD did not. If local VAD fired first,
-            # _speech_start_time already holds its back-dated value and we
-            # preserve it. Otherwise we fill from the STT's server timestamp
-            # (or arrival time, if the plugin doesn't provide one).
+            # If the plugin provided a server onset timestamp, use it;
+            # otherwise fall back to message arrival time.
             if self._speech_start_time is None:
                 self._speech_start_time = ev.speech_start_time or time.time()
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -63,9 +63,7 @@ class _PreemptiveGenerationInfo:
 
 class RecognitionHooks(Protocol):
     def on_interruption(self, ev: inference.OverlappingSpeechEvent) -> None: ...
-    def on_start_of_speech(
-        self, ev: vad.VADEvent | None, speech_start_time: float | None = None
-    ) -> None: ...
+    def on_start_of_speech(self, ev: vad.VADEvent | None, speech_start_time: float) -> None: ...
     def on_vad_inference_done(self, ev: vad.VADEvent) -> None: ...
     def on_end_of_speech(self, ev: vad.VADEvent | None) -> None: ...
     def on_interim_transcript(self, ev: stt.SpeechEvent, *, speaking: bool | None) -> None: ...
@@ -880,7 +878,7 @@ class AudioRecognition:
                 self._vad_speech_started = True
 
             with trace.use_span(self._ensure_user_turn_span(start_time=speech_start_time)):
-                self._hooks.on_start_of_speech(ev)
+                self._hooks.on_start_of_speech(ev, speech_start_time=speech_start_time)
 
             self._speaking = True
 

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -19,6 +19,7 @@ import asyncio
 import dataclasses
 import json
 import os
+import time
 import weakref
 from dataclasses import dataclass
 from typing import Literal
@@ -282,6 +283,11 @@ class SpeechStream(stt.SpeechStream):
         self._config_update_queue: asyncio.Queue[dict] = asyncio.Queue()
         self._session_id: str | None = None
         self._expires_at: int | None = None
+        # Wall-clock time (time.time()) when the first audio frame was sent to
+        # the server. Used to convert the server's stream-relative timestamp
+        # (returned in SpeechStarted.timestamp) into a wall-clock time so the
+        # framework can back-date _speech_start_time on START_OF_SPEECH.
+        self._stream_wall_start: float | None = None
 
     @property
     def session_id(self) -> str | None:
@@ -378,6 +384,9 @@ class SpeechStream(stt.SpeechStream):
                     frames = audio_bstream.write(data.data.tobytes())
 
                 for frame in frames:
+                    if self._stream_wall_start is None:
+                        # Anchor wall-clock time at first audio frame sent.
+                        self._stream_wall_start = time.time()
                     self._speech_duration += frame.duration
                     await ws.send_bytes(frame.data.tobytes())
 
@@ -518,7 +527,22 @@ class SpeechStream(stt.SpeechStream):
             return
 
         if message_type == "SpeechStarted":
-            self._event_ch.send_nowait(stt.SpeechEvent(type=stt.SpeechEventType.START_OF_SPEECH))
+            # The server gates SpeechStarted behind the first partial with text
+            # (PR #15524), so it arrives ~750ms after actual speech onset. The
+            # `timestamp` field carries the server VAD's onset time in stream-
+            # relative ms. Convert to wall-clock by adding _stream_wall_start
+            # (recorded when the first audio frame was sent) so the framework
+            # records an accurate _speech_start_time instead of message arrival.
+            timestamp_ms = data.get("timestamp", 0)
+            speech_start_time: float | None = None
+            if timestamp_ms and self._stream_wall_start is not None:
+                speech_start_time = self._stream_wall_start + timestamp_ms / 1000
+            self._event_ch.send_nowait(
+                stt.SpeechEvent(
+                    type=stt.SpeechEventType.START_OF_SPEECH,
+                    speech_start_time=speech_start_time,
+                )
+            )
             return
 
         if message_type == "Termination":

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -283,11 +283,6 @@ class SpeechStream(stt.SpeechStream):
         self._config_update_queue: asyncio.Queue[dict] = asyncio.Queue()
         self._session_id: str | None = None
         self._expires_at: int | None = None
-        # Wall-clock time (time.time()) when the first audio frame was sent to
-        # the server. Used to convert the server's stream-relative timestamp
-        # (returned in SpeechStarted.timestamp) into a wall-clock time so the
-        # framework can back-date _speech_start_time on START_OF_SPEECH.
-        self._stream_wall_start: float | None = None
 
     @property
     def session_id(self) -> str | None:
@@ -362,14 +357,11 @@ class SpeechStream(stt.SpeechStream):
 
     async def _run(self) -> None:
         """Run a single websocket connection to AssemblyAI."""
-        # Reset on each (re)connection — the server's stream-relative timestamps
-        # restart at 0 with every new WebSocket, so the wall-clock anchor must
-        # also be re-captured from this connection's first frame.
-        self._stream_wall_start = None
         closing_ws = False
 
         async def send_task(ws: aiohttp.ClientWebSocketResponse) -> None:
             nonlocal closing_ws
+            anchored = False
 
             samples_per_buffer = self._opts.sample_rate // round(1 / self._opts.buffer_size_seconds)
             audio_bstream = utils.audio.AudioByteStream(
@@ -388,9 +380,13 @@ class SpeechStream(stt.SpeechStream):
                     frames = audio_bstream.write(data.data.tobytes())
 
                 for frame in frames:
-                    if self._stream_wall_start is None:
-                        # Anchor wall-clock time at first audio frame sent.
-                        self._stream_wall_start = time.time()
+                    if not anchored:
+                        # Anchor the stream's wall-clock to the moment just
+                        # before the first frame is sent — aligned with the
+                        # server's stream-relative zero used by
+                        # SpeechStarted.timestamp.
+                        self.start_time = time.time()
+                        anchored = True
                     self._speech_duration += frame.duration
                     await ws.send_bytes(frame.data.tobytes())
 
@@ -533,13 +529,13 @@ class SpeechStream(stt.SpeechStream):
         if message_type == "SpeechStarted":
             # SpeechStarted can arrive well after actual speech onset. The
             # `timestamp` field carries the server VAD's onset time in stream-
-            # relative ms. Convert to wall-clock by adding _stream_wall_start
-            # (recorded when the first audio frame was sent) so the framework
-            # records an accurate _speech_start_time instead of message arrival.
+            # relative ms. Convert to wall-clock by adding self.start_time
+            # (the stream's wall-clock anchor) so the framework records an
+            # accurate _speech_start_time instead of message arrival.
             timestamp_ms = data.get("timestamp")
             speech_start_time: float | None = None
-            if timestamp_ms is not None and self._stream_wall_start is not None:
-                speech_start_time = self._stream_wall_start + timestamp_ms / 1000
+            if timestamp_ms is not None:
+                speech_start_time = self.start_time + timestamp_ms / 1000
             self._event_ch.send_nowait(
                 stt.SpeechEvent(
                     type=stt.SpeechEventType.START_OF_SPEECH,

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -362,6 +362,10 @@ class SpeechStream(stt.SpeechStream):
 
     async def _run(self) -> None:
         """Run a single websocket connection to AssemblyAI."""
+        # Reset on each (re)connection — the server's stream-relative timestamps
+        # restart at 0 with every new WebSocket, so the wall-clock anchor must
+        # also be re-captured from this connection's first frame.
+        self._stream_wall_start = None
         closing_ws = False
 
         async def send_task(ws: aiohttp.ClientWebSocketResponse) -> None:
@@ -533,9 +537,9 @@ class SpeechStream(stt.SpeechStream):
             # relative ms. Convert to wall-clock by adding _stream_wall_start
             # (recorded when the first audio frame was sent) so the framework
             # records an accurate _speech_start_time instead of message arrival.
-            timestamp_ms = data.get("timestamp", 0)
+            timestamp_ms = data.get("timestamp")
             speech_start_time: float | None = None
-            if timestamp_ms and self._stream_wall_start is not None:
+            if timestamp_ms is not None and self._stream_wall_start is not None:
                 speech_start_time = self._stream_wall_start + timestamp_ms / 1000
             self._event_ch.send_nowait(
                 stt.SpeechEvent(

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -531,8 +531,7 @@ class SpeechStream(stt.SpeechStream):
             return
 
         if message_type == "SpeechStarted":
-            # The server gates SpeechStarted behind the first partial with text
-            # (PR #15524), so it arrives ~750ms after actual speech onset. The
+            # SpeechStarted can arrive well after actual speech onset. The
             # `timestamp` field carries the server VAD's onset time in stream-
             # relative ms. Convert to wall-clock by adding _stream_wall_start
             # (recorded when the first audio frame was sent) so the framework

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -1,5 +1,11 @@
 """Tests for AssemblyAI STT plugin configuration options."""
 
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+from livekit.agents.stt import SpeechEventType
 from livekit.agents.types import NOT_GIVEN
 
 
@@ -78,3 +84,103 @@ async def test_vad_threshold_partial_update():
 
     assert stt._opts.vad_threshold == 0.8
     assert stt._opts.max_turn_silence == 500
+
+
+# ---------------------------------------------------------------------------
+# SpeechStarted → speech_start_time conversion
+#
+# The plugin anchors the stream's wall-clock via the base-class `start_time`
+# property (which it overrides in send_task on the first ws.send_bytes). The
+# server emits SpeechStarted with a stream-relative `timestamp` in ms, which
+# the plugin converts to wall-clock by `self.start_time + timestamp_ms/1000`
+# and surfaces via `SpeechEvent.speech_start_time`.
+# ---------------------------------------------------------------------------
+
+
+def _make_stream_for_unit_test():
+    """Construct a SpeechStream without triggering the _main_task WebSocket
+    loop. Patches asyncio.create_task during __init__ so the stream doesn't
+    try to open a real connection; also closes the coroutines that would
+    otherwise be scheduled, to avoid un-awaited coroutine warnings."""
+    from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS
+    from livekit.plugins.assemblyai import STT
+    from livekit.plugins.assemblyai.stt import SpeechStream
+
+    stt = STT(api_key="test-key")
+
+    def _fake_create_task(coro, *args, **kwargs):
+        # Close the coroutine so we don't get RuntimeWarning about it never
+        # being awaited. Return a benign mock so callers that chain
+        # add_done_callback / cancel don't break.
+        coro.close()
+        task = MagicMock()
+        return task
+
+    with patch("livekit.agents.stt.stt.asyncio.create_task", side_effect=_fake_create_task):
+        stream = SpeechStream(
+            stt=stt,
+            opts=stt._opts,
+            conn_options=DEFAULT_API_CONNECT_OPTIONS,
+            api_key="test-key",
+            http_session=MagicMock(),
+            base_url="wss://streaming.assemblyai.com",
+        )
+    return stream
+
+
+async def test_speech_started_uses_start_time_anchor():
+    """The SpeechStarted handler converts server timestamp_ms to wall-clock
+    using self.start_time, and emits a SpeechEvent with the correct
+    speech_start_time."""
+    stream = _make_stream_for_unit_test()
+
+    # Override the stream anchor to a known value — simulates what send_task
+    # would do on the first ws.send_bytes.
+    anchor = 1_700_000_000.0
+    stream.start_time = anchor
+
+    # Simulate the server sending a SpeechStarted message 500ms into the stream.
+    stream._process_stream_event({"type": "SpeechStarted", "timestamp": 500})
+
+    ev = stream._event_ch.recv_nowait()
+    assert ev.type == SpeechEventType.START_OF_SPEECH
+    assert ev.speech_start_time == anchor + 0.5
+
+
+async def test_speech_started_timestamp_zero_still_anchored():
+    """A timestamp of 0 is a valid onset at stream start (not treated as
+    'missing field'). Tests the earlier fix for the `is not None` check."""
+    stream = _make_stream_for_unit_test()
+
+    anchor = 1_700_000_000.0
+    stream.start_time = anchor
+    stream._process_stream_event({"type": "SpeechStarted", "timestamp": 0})
+
+    ev = stream._event_ch.recv_nowait()
+    assert ev.type == SpeechEventType.START_OF_SPEECH
+    assert ev.speech_start_time == anchor
+
+
+async def test_speech_started_without_timestamp_leaves_field_none():
+    """If the server omits `timestamp` entirely, the plugin should emit
+    START_OF_SPEECH with speech_start_time=None so the framework falls back
+    to message-arrival time (pre-PR behavior)."""
+    stream = _make_stream_for_unit_test()
+
+    # Server sends SpeechStarted with no timestamp field.
+    stream._process_stream_event({"type": "SpeechStarted"})
+
+    ev = stream._event_ch.recv_nowait()
+    assert ev.type == SpeechEventType.START_OF_SPEECH
+    assert ev.speech_start_time is None
+
+
+async def test_start_time_has_default_before_plugin_override():
+    """Even without any plugin override, the base-class default
+    (time.time() seeded in __init__) is available for the SpeechStarted
+    conversion to use."""
+    stream = _make_stream_for_unit_test()
+
+    # start_time should already be a recent wall-clock value from the base
+    # class __init__, without any explicit override.
+    assert time.time() - stream.start_time < 5.0

--- a/tests/test_stt_base.py
+++ b/tests/test_stt_base.py
@@ -1,0 +1,115 @@
+"""Unit tests for base STT `RecognizeStream` fields (start_time, etc.)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from livekit.agents import APIConnectionError
+from livekit.agents.stt import (
+    STT,
+    RecognizeStream,
+    SpeechData,
+    SpeechEvent,
+    SpeechEventType,
+    STTCapabilities,
+)
+from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS
+from livekit.agents.utils.audio import AudioBuffer
+
+
+class _DummyStream(RecognizeStream):
+    """Minimal RecognizeStream for unit tests — does not hit the network."""
+
+    def __init__(
+        self,
+        *,
+        stt: STT,
+        fail_first_run: bool = False,
+    ) -> None:
+        super().__init__(stt=stt, conn_options=DEFAULT_API_CONNECT_OPTIONS)
+        self._fail_first_run = fail_first_run
+        self._run_count = 0
+
+    async def _run(self) -> None:
+        self._run_count += 1
+        if self._fail_first_run and self._run_count == 1:
+            raise APIConnectionError("fake failure to trigger retry")
+        # emit a final and exit so _main_task can complete normally
+        self._event_ch.send_nowait(
+            SpeechEvent(
+                type=SpeechEventType.FINAL_TRANSCRIPT,
+                alternatives=[SpeechData(language="", text="hello")],
+            )
+        )
+
+
+class _DummySTT(STT):
+    def __init__(self) -> None:
+        super().__init__(capabilities=STTCapabilities(streaming=True, interim_results=False))
+
+    async def _recognize_impl(self, buffer: AudioBuffer, *, language, conn_options) -> SpeechEvent:
+        raise NotImplementedError
+
+    def stream(self, *, language=None, conn_options=DEFAULT_API_CONNECT_OPTIONS) -> _DummyStream:
+        return _DummyStream(stt=self)
+
+
+async def test_start_time_seeded_on_init() -> None:
+    """start_time is initialized to approximately time.time() when the stream is created."""
+    stt = _DummySTT()
+    before = time.time()
+    stream = stt.stream()
+    after = time.time()
+
+    assert before <= stream.start_time <= after
+    await stream.aclose()
+
+
+async def test_start_time_setter_accepts_valid_values() -> None:
+    """Plugins can override start_time by assigning to the public property."""
+    stt = _DummySTT()
+    stream = stt.stream()
+
+    new_anchor = time.time() + 10.0
+    stream.start_time = new_anchor
+    assert stream.start_time == new_anchor
+
+    await stream.aclose()
+
+
+async def test_start_time_setter_rejects_negative() -> None:
+    """start_time setter validates non-negative, matching start_time_offset behavior."""
+    stt = _DummySTT()
+    stream = stt.stream()
+
+    with pytest.raises(ValueError, match="start_time must be non-negative"):
+        stream.start_time = -1.0
+
+    await stream.aclose()
+
+
+async def test_start_time_reseeded_on_retry() -> None:
+    """When _main_task retries after an APIError, start_time is re-seeded so plugin
+    overrides from the previous connection don't leak into the new one."""
+    stt = _DummySTT()
+    stream = _DummyStream(stt=stt, fail_first_run=True)
+
+    # Simulate a plugin overriding start_time during the first (failing) _run()
+    # by assigning a sentinel value before the task picks up.
+    sentinel = 1.0
+    stream.start_time = sentinel
+
+    # Let the main task run: it should retry past the first-run APIError, and
+    # on each attempt re-seed start_time to a fresh time.time() value before
+    # _run() is called.
+    await asyncio.wait_for(stream._task, timeout=5.0)
+
+    # After the retry, start_time must have been re-seeded (not equal to sentinel).
+    assert stream.start_time != sentinel
+    # And it should be a recent wall-clock value.
+    assert time.time() - stream.start_time < 5.0
+
+    await stream.aclose()


### PR DESCRIPTION
## Summary

When `turn_detection="stt"` is used alongside a local VAD plugin (e.g. Silero), the framework records `_speech_start_time` from whichever event handler — VAD or STT — sets it first.

When local VAD fires for the audio, this works fine — the VAD handler back-dates `_speech_start_time` via `time.time() - speech_duration - inference_duration` and the existing None-guard prevents the later STT `START_OF_SPEECH` event from overwriting it.

But when the local VAD does **not** fire for that audio (different model version, different acoustic threshold, different preprocessing — common at quiet/borderline volumes), `_speech_start_time` stays `None` until the STT `START_OF_SPEECH` arrives — at which point the framework falls back to `time.time()` at message arrival. If the STT's speech-onset signal and its first transcript arrive close together, the framework's `_speech_start_time` and `_last_speaking_time` end up pinned near the same wall-clock instant. Result: `MetricsReport.started_speaking_at ≈ stopped_speaking_at`, i.e. **`speech_duration ≈ 0s`** for any turn the local VAD missed.

This is unphysical (real audio was transcribed), breaks downstream analytics keyed on speech duration, and creates state inconsistency where a user turn commits without ever entering a meaningful "speaking" window.

## What this PR changes

### Framework

1. Adds an optional `speech_start_time: float | None = None` field on `SpeechEvent`. Plugins that receive a separate speech-onset signal with timing can populate it; when left `None` the framework's STT SOS handler falls back to `time.time()` at message arrival (its current behavior).
2. Updates the STT SOS handler in `audio_recognition.py` to set `_speech_start_time` from `ev.speech_start_time` **only when it's still `None`** (i.e. local VAD hasn't fired first). When VAD has already set it, the VAD-back-dated value is preserved.
3. Extends the `RecognitionHooks.on_start_of_speech` protocol with a required `speech_start_time: float` parameter and threads the authoritative onset through it from both SOS handlers. Each handler computes its own authoritative onset locally (VAD back-dates from the VAD event; STT reads `_speech_start_time`) and passes a concrete value in — no ambiguity about which input wins at call time. All downstream state — `DynamicEndpointing._utterance_started_at`, `_user_speaking_span.start_time`, `UserStateChangedEvent.created_at` — reads from that single value.
4. Simplifies `AgentActivity.on_start_of_speech` to drop its internal VAD-event back-dating and `time.time()` fallback, since the caller now always provides the authoritative onset.

### AssemblyAI plugin

5. Parses the `SpeechStarted.timestamp` field (stream-relative ms) that the plugin currently discards, converts it to wall-clock via a `_stream_wall_start` anchor recorded when the first audio frame is sent, and populates `SpeechEvent.speech_start_time` on the emitted `START_OF_SPEECH` event.

## Why this is a safe fallback

Strictly additive. Every turn where local VAD fires is unaffected — `_speech_start_time` is already set by the VAD handler (its back-date is more accurate, computed locally with no network delay), the None-guard preserves it, and the same value flows through the hook to every downstream consumer. The STT-provided timestamp is only consulted when `_speech_start_time` is still `None` at STT `START_OF_SPEECH` arrival, i.e. exactly the case where local VAD missed the audio the STT caught.

## Provider-side fallback (if you'd prefer not to add the field)

If a `SpeechEvent` schema change isn't desirable, the same outcome can be achieved without touching the framework: a plugin can pass through the back-dated time on the existing `SpeechData.start_time` field by attaching a synthetic `SpeechData` to the `START_OF_SPEECH` event's `alternatives` list. Functionally equivalent but semantically off (`SpeechData` is meant for transcription hypotheses, not event metadata), so the explicit field is preferred. Happy to switch if maintainers prefer to defer the schema change.

## Files changed

- `livekit-agents/livekit/agents/stt/stt.py` — new optional field on `SpeechEvent`
- `livekit-agents/livekit/agents/voice/audio_recognition.py` — tighten `RecognitionHooks.on_start_of_speech` to require `speech_start_time: float`; set `_speech_start_time` from `ev.speech_start_time` under the None-guard; pass `self._speech_start_time` to the hook at the STT SOS call site; pass the locally-computed back-date at the VAD SOS call site
- `livekit-agents/livekit/agents/voice/agent_activity.py` — accept the required `speech_start_time` kwarg on `AgentActivity.on_start_of_speech`; internal fallback logic removed
- `livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py` — anchor `_stream_wall_start` on first frame; parse `SpeechStarted.timestamp` and populate `SpeechEvent.speech_start_time`

## Test plan

- [x] `make format lint type-check` pass
- [ ] Unit/integration coverage for the new field — happy to add on request