### PR TITLE
fix: strip markdown emphasis adjacent to punctuation

### DIFF
--- a/.github/next-release/changeset-filter-markdown-punctuation.md
+++ b/.github/next-release/changeset-filter-markdown-punctuation.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Fix `filter_markdown` to strip `**bold**` and `*italic*` when the delimiters are adjacent to punctuation (e.g. `**name**!`, `**date**,`, `(**1**)`). The previous regexes used `(?<!\S)` / `(?!\S)` boundaries which rejected punctuation as a valid boundary, letting raw Markdown leak through to TTS.

--- a/livekit-agents/livekit/agents/voice/transcription/filters.py
+++ b/livekit-agents/livekit/agents/voice/transcription/filters.py
@@ -15,10 +15,11 @@ INLINE_PATTERNS = [
     (re.compile(r"!\[([^\]]*)\]\([^)]*\)"), r"\1"),
     # links: keep text part [text](url) -> text
     (re.compile(r"\[([^\]]*)\]\([^)]*\)"), r"\1"),
-    # bold: remove asterisks from **text** (not preceded/followed by non-whitespace)
-    (re.compile(r"(?<!\S)\*\*([^*]+?)\*\*(?!\S)"), r"\1"),
-    # italic: remove asterisks from *text* (not preceded/followed by non-whitespace)
-    (re.compile(r"(?<!\S)\*([^*]+?)\*(?!\S)"), r"\1"),
+    # bold: remove asterisks from **text** (word/asterisk boundaries, so
+    # punctuation like ``**bold**!`` still matches)
+    (re.compile(r"(?<![\w*])\*\*(?!\s)([^*\n]+?)(?<!\s)\*\*(?![\w*])"), r"\1"),
+    # italic: remove asterisks from *text* (word/asterisk boundaries)
+    (re.compile(r"(?<![\w*])\*(?!\s|\*)([^*\n]+?)(?<!\s)\*(?![\w*])"), r"\1"),
     # bold with underscores: remove underscores from __text__ (word boundaries)
     (re.compile(r"(?<!\w)__([^_]+?)__(?!\w)"), r"\1"),
     # italic with underscores: remove underscores from _text_ (word boundaries)

--- a/tests/test_transcription_filter.py
+++ b/tests/test_transcription_filter.py
@@ -150,6 +150,70 @@ async def test_markdown_filter(chunk_size: int):
     print("\n=== TEST COMPLETE ===")
 
 
+# --- emphasis adjacent to punctuation ---
+#
+# Regression tests for the case where ``**bold**`` / ``*italic*`` delimiters
+# are immediately followed (or preceded) by a punctuation character rather
+# than whitespace. Previously the patterns used ``(?<!\S)`` / ``(?!\S)``
+# boundaries which rejected punctuation as a valid boundary, causing
+# ``Hi **Frankie**!`` to leak through untouched to TTS.
+
+
+PUNCTUATION_BOUNDARY_CASES = [
+    # (input, expected)
+    ("Hi **Frankie**!", "Hi Frankie!"),
+    ("See **Dr. Smith**.", "See Dr. Smith."),
+    ("Scheduled for **Monday**, at 9am.", "Scheduled for Monday, at 9am."),
+    ("Press (**1**) to confirm.", "Press (1) to confirm."),
+    ('Try "**this**" first.', 'Try "this" first.'),
+    ("Options: **a**, **b**, or **c**?", "Options: a, b, or c?"),
+    ("He said *hello*!", "He said hello!"),
+    ("It was *amazing*, really.", "It was amazing, really."),
+]
+
+
+@pytest.mark.parametrize("text,expected", PUNCTUATION_BOUNDARY_CASES)
+@pytest.mark.parametrize("chunk_size", [1, 2, 3, 7, 50])
+async def test_punctuation_boundary(text: str, expected: str, chunk_size: int):
+    """Emphasis delimiters followed by punctuation are correctly stripped."""
+
+    async def stream():
+        for i in range(0, len(text), chunk_size):
+            yield text[i : i + chunk_size]
+
+    result = ""
+    async for chunk in filter_markdown(stream()):
+        result += chunk
+
+    assert result == expected
+
+
+# Must NOT mutate: the punctuation-boundary fix must still preserve
+# contexts where ``*`` is used for arithmetic, globs, or in-word.
+PUNCTUATION_BOUNDARY_PRESERVE_CASES = [
+    "2 * 3 = 6",
+    "Use *.py files",
+    "x**2 + y**2 = z**2",
+    "a ** b evaluated right-to-left",
+]
+
+
+@pytest.mark.parametrize("text", PUNCTUATION_BOUNDARY_PRESERVE_CASES)
+@pytest.mark.parametrize("chunk_size", [1, 3, 50])
+async def test_punctuation_boundary_no_false_positives(text: str, chunk_size: int):
+    """Non-markdown asterisk contexts are preserved."""
+
+    async def stream():
+        for i in range(0, len(text), chunk_size):
+            yield text[i : i + chunk_size]
+
+    result = ""
+    async for chunk in filter_markdown(stream()):
+        result += chunk
+
+    assert result == text
+
+
 # Emoji test data
 EMOJI_INPUT = """Hello! 😀 Welcome to our app! 🎉
 


### PR DESCRIPTION
The `filter_markdown` inline regexes for `**bold**` and `*italic*` used `(?<!\S)` / `(?!\S)` boundaries, rejecting punctuation as a valid boundary. As a result LLM output like `**Frankie**!`, `**date**,`, and `(**1**)` passed through untouched and reached TTS as raw markdown.

Replace the asterisk patterns with `\w`/`*`-based boundaries (already used correctly by the underscore patterns) and add guards against whitespace-adjacent inner text so `a ** b` style arithmetic is still preserved.

Add parametrized regression tests across common punctuation characters and chunk sizes, plus false-positive guards for `x**2`, `*.py`, and arithmetic expressions.

Addresses #5482