### PR TITLE
fix(amd): make detection thresholds configurable and fix short-greeting voicemail misclassification

### DIFF
--- a/livekit-agents/livekit/agents/voice/amd/classifier.py
+++ b/livekit-agents/livekit/agents/voice/amd/classifier.py
@@ -96,11 +96,18 @@ def _state_guard(method: Callable[..., Any]) -> Callable[..., Any]:
 
 
 class _AMDClassifier(EventEmitter[Literal["amd_result"]]):
-    def __init__(self, llm: LLM):
+    def __init__(
+        self,
+        llm: LLM,
+        *,
+        human_speech_threshold: float = HUMAN_SPEECH_THRESHOLD,
+        human_silence_threshold: float = HUMAN_SILENCE_THRESHOLD,
+        machine_silence_threshold: float = MACHINE_SILENCE_THRESHOLD,
+    ):
         super().__init__()
-        self._human_speech_threshold = HUMAN_SPEECH_THRESHOLD
-        self._human_silence_threshold = HUMAN_SILENCE_THRESHOLD
-        self._machine_silence_threshold = MACHINE_SILENCE_THRESHOLD
+        self._human_speech_threshold = human_speech_threshold
+        self._human_silence_threshold = human_silence_threshold
+        self._machine_silence_threshold = machine_silence_threshold
 
         self._input_ch: aio.Chan[str] = aio.Chan()
         self._classify_task: asyncio.Task[None] | None = None
@@ -164,15 +171,23 @@ class _AMDClassifier(EventEmitter[Literal["amd_result"]]):
             if self._silence_timer is not None:
                 self._silence_timer.cancel()
                 self._silence_timer = None
-            self._silence_timer = asyncio.get_running_loop().call_later(
-                max(0, self._human_silence_threshold - silence_duration),
-                functools.partial(
-                    self._silence_timer_callback,
-                    category=AMDCategory.HUMAN,
-                    reason="short_greeting",
-                    speech_duration=speech_duration,
-                ),
-            )
+            if self._classify_task is not None:
+                # Transcript text was already received — delegate to the LLM instead
+                # of blindly classifying as HUMAN based on duration alone
+                self._silence_timer = asyncio.get_running_loop().call_later(
+                    max(0, self._machine_silence_threshold - silence_duration),
+                    functools.partial(self._silence_timer_callback, speech_duration=speech_duration),
+                )
+            else:
+                self._silence_timer = asyncio.get_running_loop().call_later(
+                    max(0, self._human_silence_threshold - silence_duration),
+                    functools.partial(
+                        self._silence_timer_callback,
+                        category=AMDCategory.HUMAN,
+                        reason="short_greeting",
+                        speech_duration=speech_duration,
+                    ),
+                )
             return
 
         if self._classify_task is None:

--- a/livekit-agents/livekit/agents/voice/amd/detector.py
+++ b/livekit-agents/livekit/agents/voice/amd/detector.py
@@ -11,6 +11,9 @@ from ...llm import LLM as _LLM
 from ...log import logger
 from ...telemetry import trace_types, tracer
 from .classifier import (
+    HUMAN_SILENCE_THRESHOLD,
+    HUMAN_SPEECH_THRESHOLD,
+    MACHINE_SILENCE_THRESHOLD,
     AMDCategory,
     AMDResult,
     _AMDClassifier,
@@ -52,6 +55,18 @@ class AMD:
             agent speech immediately when a machine is detected.
         ivr_detection: If ``True`` (default), automatically start IVR
             navigation when a ``machine-ivr`` result is returned.
+        human_speech_threshold: Maximum speech duration (in seconds) for the
+            short-greeting fast path. Greetings shorter than this threshold
+            are classified as ``human`` without an LLM call, **unless**
+            transcript text has already arrived, in which case the LLM is
+            consulted regardless of duration. Defaults to ``2.5``.
+        human_silence_threshold: Silence duration (in seconds) required after
+            a short greeting before the ``human`` verdict is emitted.
+            Defaults to ``0.5``.
+        machine_silence_threshold: Silence duration (in seconds) required
+            after a long greeting (or a short greeting with available
+            transcript) before the LLM-based verdict is emitted.
+            Defaults to ``1.5``.
     """
 
     def __init__(
@@ -61,6 +76,9 @@ class AMD:
         llm: LLM | LLMModels | str | None = None,
         interrupt_on_machine: bool = True,
         ivr_detection: bool = True,
+        human_speech_threshold: float = HUMAN_SPEECH_THRESHOLD,
+        human_silence_threshold: float = HUMAN_SILENCE_THRESHOLD,
+        machine_silence_threshold: float = MACHINE_SILENCE_THRESHOLD,
     ) -> None:
         self._llm_config = llm
         self._session: AgentSession | None = session
@@ -69,6 +87,9 @@ class AMD:
         self._closed = False
         self._interrupt_on_machine = interrupt_on_machine
         self._ivr_detection = ivr_detection
+        self._human_speech_threshold = human_speech_threshold
+        self._human_silence_threshold = human_silence_threshold
+        self._machine_silence_threshold = machine_silence_threshold
         self._span: trace.Span | None = None
 
     @property
@@ -188,7 +209,13 @@ class AMD:
             return
 
         self._session = session
-        self._classifier = self._resolve_classifier(self._llm_config, session)
+        self._classifier = self._resolve_classifier(
+            self._llm_config,
+            session,
+            human_speech_threshold=self._human_speech_threshold,
+            human_silence_threshold=self._human_silence_threshold,
+            machine_silence_threshold=self._machine_silence_threshold,
+        )
         if self._classifier is None:
             raise ValueError(
                 "AMD classifier could not be resolved, please provide a compatible model"
@@ -264,14 +291,23 @@ class AMD:
     def _resolve_classifier(
         llm: LLM | LLMModels | str | None,
         session: AgentSession,
+        *,
+        human_speech_threshold: float = HUMAN_SPEECH_THRESHOLD,
+        human_silence_threshold: float = HUMAN_SILENCE_THRESHOLD,
+        machine_silence_threshold: float = MACHINE_SILENCE_THRESHOLD,
     ) -> _AMDClassifier | None:
+        kwargs = {
+            "human_speech_threshold": human_speech_threshold,
+            "human_silence_threshold": human_silence_threshold,
+            "machine_silence_threshold": machine_silence_threshold,
+        }
         if isinstance(llm, str):
-            return _AMDClassifier(_InferenceLLM(llm))
+            return _AMDClassifier(_InferenceLLM(llm), **kwargs)
         if isinstance(llm, _LLM):
-            return _AMDClassifier(llm)
+            return _AMDClassifier(llm, **kwargs)
 
         if (candidate := session.llm) is not None and isinstance(candidate, _LLM):
-            return _AMDClassifier(candidate)
+            return _AMDClassifier(candidate, **kwargs)
 
         return None
 


### PR DESCRIPTION
Fixes #5477

## Problem

The AMD classifier's short-greeting fast path (`on_user_speech_ended`) emitted a `HUMAN` verdict unconditionally whenever speech duration was <= `HUMAN_SPEECH_THRESHOLD` (2.5 s) followed by >= `HUMAN_SILENCE_THRESHOLD` (0.5 s) of silence -- even when transcript text had already been delivered via `push_text()` (meaning an LLM classification was already in flight).

This caused voicemail greetings that paused mid-sentence (e.g. ~2.33 s speech / 528 ms silence) to be misclassified as `HUMAN` regardless of what the transcript said.

## Solution

Two changes:

**1. Make detection thresholds configurable**

`HUMAN_SPEECH_THRESHOLD`, `HUMAN_SILENCE_THRESHOLD`, and `MACHINE_SILENCE_THRESHOLD` are now keyword arguments on both `_AMDClassifier` and the public `AMD` class, so callers can tune detection behaviour without patching module-level constants.

**2. Fix the short-greeting fast path**

When `_classify_task` is already running at the time `on_user_speech_ended` is called (indicating that transcript text has arrived), the fast-path HUMAN verdict is skipped. Instead the code falls through to the LLM path using `machine_silence_threshold`, so the LLM can classify the greeting from the available transcript.

## Testing

The fix is consistent with the existing flow: `push_text()` already creates `_classify_task`, so detecting `_classify_task is not None` reliably indicates that transcript evidence is available. No new runtime dependencies are introduced.