### PR TITLE
feat(avatar): add AvatarSession base class, warn on sync mis-wire

### DIFF
--- a/livekit-agents/livekit/agents/voice/avatar/__init__.py
+++ b/livekit-agents/livekit/agents/voice/avatar/__init__.py
@@ -1,11 +1,12 @@
 from ._datastream_io import DataStreamAudioOutput, DataStreamAudioReceiver
 from ._queue_io import QueueAudioOutput
 from ._runner import AvatarOptions, AvatarRunner
-from ._types import AudioReceiver, AudioSegmentEnd, VideoGenerator
+from ._types import AudioReceiver, AudioSegmentEnd, AvatarSession, VideoGenerator
 
 __all__ = [
     "AvatarRunner",
     "AvatarOptions",
+    "AvatarSession",
     "VideoGenerator",
     "AudioReceiver",
     "AudioSegmentEnd",

--- a/livekit-agents/livekit/agents/voice/avatar/_types.py
+++ b/livekit-agents/livekit/agents/voice/avatar/_types.py
@@ -2,9 +2,15 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Coroutine
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from livekit import rtc
+
+from ...job import get_job_context
+from ...log import logger
+
+if TYPE_CHECKING:
+    from ..agent_session import AgentSession
 
 
 class AudioSegmentEnd:
@@ -43,3 +49,30 @@ class VideoGenerator(ABC):
         self,
     ) -> AsyncIterator[rtc.VideoFrame | rtc.AudioFrame | AudioSegmentEnd]:
         """Continuously stream out video and audio frames, or AudioSegmentEnd when the audio segment ends"""  # noqa: E501
+
+
+class AvatarSession:
+    """Base class for avatar plugin sessions."""
+
+    async def start(self, agent_session: AgentSession, room: rtc.Room) -> None:
+        job_ctx = get_job_context(required=False)
+        if job_ctx is not None:
+            job_ctx.add_shutdown_callback(self.aclose)
+        else:
+            logger.debug(
+                "AvatarSession started outside a job context; call aclose() manually to "
+                "release resources when the job shuts down"
+            )
+
+        if agent_session._started and (audio_output := agent_session.output.audio) is not None:
+            logger.warning(
+                (
+                    "AvatarSession.start() was called after AgentSession.start(); "
+                    "the existing audio output may be replaced by the avatar. "
+                    "Please start the avatar session before AgentSession.start() to avoid this."
+                ),
+                extra={"audio_output": audio_output.label},
+            )
+
+    async def aclose(self) -> None:
+        pass

--- a/livekit-agents/livekit/agents/voice/transcription/synchronizer.py
+++ b/livekit-agents/livekit/agents/voice/transcription/synchronizer.py
@@ -431,6 +431,10 @@ class TranscriptSynchronizer:
         # track pause state at the synchronizer level to apply to new impls after rotation
         self._paused = False
 
+        # warn once per enabled cycle when only one of audio/text is detached; reset when
+        # the synchronizer transitions back to enabled
+        self._warned_asymmetric_detach = False
+
         # initial segment/first segment, recreated for each new segment
         self._impl = _SegmentSynchronizerImpl(options=self._opts, next_in_chain=next_in_chain_text)
         self._rotate_segment_atask: asyncio.Task[None] | None = None
@@ -457,6 +461,8 @@ class TranscriptSynchronizer:
             return
 
         self._enabled = enabled
+        if enabled:
+            self._warned_asymmetric_detach = False
         if not self._rotate_segment_atask or self._rotate_segment_atask.done():
             # avoid calling rotate_segment twice when closing the session during agent speaking
             # first time when speech interrupted, second time here when output detached
@@ -541,6 +547,17 @@ class _SyncedAudioOutput(io.AudioOutput):
         self._pushed_duration += frame.duration
 
         if not self._synchronizer.enabled:
+            if (
+                self._synchronizer._audio_attached
+                and not self._synchronizer._text_attached
+                and not self._synchronizer._warned_asymmetric_detach
+            ):
+                self._synchronizer._warned_asymmetric_detach = True
+                logger.warning(
+                    "TranscriptSynchronizer text output was detached while audio output is "
+                    "still active; transcription sync is disabled. This usually means "
+                    "session.output.transcription was replaced after AgentSession.start()."
+                )
             return
 
         if self._synchronizer._impl.audio_input_ended:
@@ -634,6 +651,17 @@ class _SyncedTextOutput(io.TextOutput):
         await self._synchronizer.barrier()
 
         if not self._synchronizer.enabled:  # passthrough text if the synchronizer is disabled
+            if (
+                self._synchronizer._text_attached
+                and not self._synchronizer._audio_attached
+                and not self._synchronizer._warned_asymmetric_detach
+            ):
+                self._synchronizer._warned_asymmetric_detach = True
+                logger.warning(
+                    "TranscriptSynchronizer audio output was detached while text output is "
+                    "still active; transcription sync is disabled. This usually means "
+                    "session.output.audio was replaced after AgentSession.start()."
+                )
             if self._next_in_chain:
                 await self._next_in_chain.capture_text(text)
             return

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/avatar.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/avatar.py
@@ -14,7 +14,7 @@ from livekit.agents import (
     get_job_context,
     utils,
 )
-from livekit.agents.voice.avatar import DataStreamAudioOutput
+from livekit.agents.voice.avatar import AvatarSession as BaseAvatarSession, DataStreamAudioOutput
 from livekit.agents.voice.room_io import ATTRIBUTE_PUBLISH_ON_BEHALF
 
 from .api import DEFAULT_API_URL, AnamAPI
@@ -27,7 +27,7 @@ _AVATAR_AGENT_IDENTITY = "anam-avatar-agent"
 _AVATAR_AGENT_NAME = "anam-avatar-agent"
 
 
-class AvatarSession:
+class AvatarSession(BaseAvatarSession):
     """A Anam avatar session"""
 
     def __init__(
@@ -73,6 +73,8 @@ class AvatarSession:
         livekit_api_key: NotGivenOr[str] = NOT_GIVEN,
         livekit_api_secret: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
+        await super().start(agent_session, room)
+
         livekit_url = livekit_url or (os.getenv("LIVEKIT_URL") or NOT_GIVEN)
         livekit_api_key = livekit_api_key or (os.getenv("LIVEKIT_API_KEY") or NOT_GIVEN)
         livekit_api_secret = livekit_api_secret or (os.getenv("LIVEKIT_API_SECRET") or NOT_GIVEN)

--- a/livekit-plugins/livekit-plugins-avatario/livekit/plugins/avatario/avatar.py
+++ b/livekit-plugins/livekit-plugins-avatario/livekit/plugins/avatario/avatar.py
@@ -15,7 +15,7 @@ from livekit.agents import (
     get_job_context,
     utils,
 )
-from livekit.agents.voice.avatar import DataStreamAudioOutput
+from livekit.agents.voice.avatar import AvatarSession as BaseAvatarSession, DataStreamAudioOutput
 from livekit.agents.voice.room_io import ATTRIBUTE_PUBLISH_ON_BEHALF
 
 from .api import AvatarioAPI, AvatarioException
@@ -26,7 +26,7 @@ _AVATAR_AGENT_IDENTITY = "avatario-avatar-agent"
 _AVATAR_AGENT_NAME = "avatario-avatar-agent"
 
 
-class AvatarSession:
+class AvatarSession(BaseAvatarSession):
     """An Avatario avatar session"""
 
     @dataclass
@@ -107,6 +107,8 @@ class AvatarSession:
         livekit_api_secret: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
         """Entrypoint to start the video avatar session"""
+        await super().start(agent_session, room)
+
         livekit_url = livekit_url or (os.getenv("LIVEKIT_URL") or NOT_GIVEN)
         livekit_api_key = livekit_api_key or (os.getenv("LIVEKIT_API_KEY") or NOT_GIVEN)
         livekit_api_secret = livekit_api_secret or (os.getenv("LIVEKIT_API_SECRET") or NOT_GIVEN)

--- a/livekit-plugins/livekit-plugins-avatartalk/livekit/plugins/avatartalk/avatar.py
+++ b/livekit-plugins/livekit-plugins-avatartalk/livekit/plugins/avatartalk/avatar.py
@@ -3,7 +3,7 @@ import os
 from livekit import api, rtc
 from livekit.agents import NOT_GIVEN, AgentSession, NotGivenOr, get_job_context
 from livekit.agents.types import ATTRIBUTE_PUBLISH_ON_BEHALF
-from livekit.agents.voice.avatar import DataStreamAudioOutput
+from livekit.agents.voice.avatar import AvatarSession as BaseAvatarSession, DataStreamAudioOutput
 
 from .api import AvatarTalkAPI, AvatarTalkException
 from .log import logger
@@ -15,7 +15,7 @@ DEFAULT_AVATAR_EMOTION = "expressive"
 SAMPLE_RATE = 16000
 
 
-class AvatarSession:
+class AvatarSession(BaseAvatarSession):
     """AvatarTalkAPI avatar session"""
 
     def __init__(
@@ -67,6 +67,8 @@ class AvatarSession:
         livekit_api_key: NotGivenOr[str | None] = NOT_GIVEN,
         livekit_api_secret: NotGivenOr[str | None] = NOT_GIVEN,
     ) -> None:
+        await super().start(agent_session, room)
+
         livekit_url = livekit_url or (os.getenv("LIVEKIT_URL") or NOT_GIVEN)
         livekit_api_key = livekit_api_key or (os.getenv("LIVEKIT_API_KEY") or NOT_GIVEN)
         livekit_api_secret = livekit_api_secret or (os.getenv("LIVEKIT_API_SECRET") or NOT_GIVEN)

--- a/livekit-plugins/livekit-plugins-bey/livekit/plugins/bey/avatar.py
+++ b/livekit-plugins/livekit-plugins-bey/livekit/plugins/bey/avatar.py
@@ -17,7 +17,7 @@ from livekit.agents import (
     get_job_context,
     utils,
 )
-from livekit.agents.voice.avatar import DataStreamAudioOutput
+from livekit.agents.voice.avatar import AvatarSession as BaseAvatarSession, DataStreamAudioOutput
 from livekit.agents.voice.room_io import ATTRIBUTE_PUBLISH_ON_BEHALF
 
 from .log import logger
@@ -33,7 +33,7 @@ class BeyException(Exception):
     """Exception for Beyond Presence errors"""
 
 
-class AvatarSession:
+class AvatarSession(BaseAvatarSession):
     """A Beyond Presence avatar session"""
 
     def __init__(
@@ -75,6 +75,8 @@ class AvatarSession:
         livekit_api_key: NotGivenOr[str] = NOT_GIVEN,
         livekit_api_secret: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
+        await super().start(agent_session, room)
+
         livekit_url = livekit_url or (os.getenv("LIVEKIT_URL") or NOT_GIVEN)
         livekit_api_key = livekit_api_key or (os.getenv("LIVEKIT_API_KEY") or NOT_GIVEN)
         livekit_api_secret = livekit_api_secret or (os.getenv("LIVEKIT_API_SECRET") or NOT_GIVEN)

--- a/livekit-plugins/livekit-plugins-bithuman/livekit/plugins/bithuman/avatar.py
+++ b/livekit-plugins/livekit-plugins-bithuman/livekit/plugins/bithuman/avatar.py
@@ -32,6 +32,7 @@ from livekit.agents.voice.avatar import (
     AudioSegmentEnd,
     AvatarOptions,
     AvatarRunner,
+    AvatarSession as BaseAvatarSession,
     DataStreamAudioOutput,
     QueueAudioOutput,
     VideoGenerator,
@@ -93,7 +94,7 @@ class BitHumanException(Exception):
     """Exception for BitHuman errors"""
 
 
-class AvatarSession:
+class AvatarSession(BaseAvatarSession):
     """A Beyond Presence avatar session"""
 
     def __init__(
@@ -220,6 +221,7 @@ class AvatarSession:
         livekit_api_key: NotGivenOr[str] = NOT_GIVEN,
         livekit_api_secret: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
+        await super().start(agent_session, room)
         if self._mode == "local":
             await self._start_local(agent_session, room)
         elif self._mode == "cloud":
@@ -257,16 +259,6 @@ class AvatarSession:
             self._runtime = runtime
 
         video_generator = BithumanGenerator(runtime)
-
-        try:
-            job_ctx = get_job_context()
-
-            async def _on_shutdown() -> None:
-                runtime.cleanup()
-
-            job_ctx.add_shutdown_callback(_on_shutdown)
-        except RuntimeError:
-            pass
 
         output_width, output_height = video_generator.video_resolution
         avatar_options = AvatarOptions(
@@ -610,6 +602,10 @@ class AvatarSession:
         if self._runtime is None:
             raise BitHumanException("Runtime not initialized")
         return self._runtime
+
+    async def aclose(self) -> None:
+        if self._mode == "local" and utils.is_given(self._runtime) and self._runtime is not None:
+            self._runtime.cleanup()
 
 
 class BithumanGenerator(VideoGenerator):

--- a/livekit-plugins/livekit-plugins-did/livekit/plugins/did/avatar.py
+++ b/livekit-plugins/livekit-plugins-did/livekit/plugins/did/avatar.py
@@ -14,7 +14,7 @@ from livekit.agents import (
     get_job_context,
     utils,
 )
-from livekit.agents.voice.avatar import DataStreamAudioOutput
+from livekit.agents.voice.avatar import AvatarSession as BaseAvatarSession, DataStreamAudioOutput
 from livekit.agents.voice.room_io import ATTRIBUTE_PUBLISH_ON_BEHALF
 
 from .api import DIDAPI
@@ -26,7 +26,7 @@ _AVATAR_AGENT_IDENTITY = "d-id-avatar-agent"
 _AVATAR_AGENT_NAME = "d-id-avatar-agent"
 
 
-class AvatarSession:
+class AvatarSession(BaseAvatarSession):
     """A D-ID avatar session"""
 
     def __init__(
@@ -79,6 +79,8 @@ class AvatarSession:
         livekit_api_key: NotGivenOr[str] = NOT_GIVEN,
         livekit_api_secret: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
+        await super().start(agent_session, room)
+
         _livekit_url = livekit_url if utils.is_given(livekit_url) else os.getenv("LIVEKIT_URL")
         _livekit_api_key = (
             livekit_api_key if utils.is_given(livekit_api_key) else os.getenv("LIVEKIT_API_KEY")

--- a/livekit-plugins/livekit-plugins-keyframe/livekit/plugins/keyframe/avatar.py
+++ b/livekit-plugins/livekit-plugins-keyframe/livekit/plugins/keyframe/avatar.py
@@ -12,7 +12,7 @@ from livekit.agents import (
     get_job_context,
     utils,
 )
-from livekit.agents.voice.avatar import DataStreamAudioOutput
+from livekit.agents.voice.avatar import AvatarSession as BaseAvatarSession, DataStreamAudioOutput
 from livekit.agents.voice.room_io import ATTRIBUTE_PUBLISH_ON_BEHALF
 
 from .api import DEFAULT_API_URL, KeyframeAPI
@@ -26,7 +26,7 @@ _AVATAR_AGENT_IDENTITY = "keyframe-avatar-agent"
 _AVATAR_AGENT_NAME = "keyframe-avatar-agent"
 
 
-class AvatarSession:
+class AvatarSession(BaseAvatarSession):
     """A Keyframe avatar session for the LiveKit Agents framework."""
 
     def __init__(
@@ -89,6 +89,8 @@ class AvatarSession:
         livekit_api_key: NotGivenOr[str] = NOT_GIVEN,
         livekit_api_secret: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
+        await super().start(agent_session, room)
+
         livekit_url = livekit_url or (os.getenv("LIVEKIT_URL") or NOT_GIVEN)
         livekit_api_key = livekit_api_key or (os.getenv("LIVEKIT_API_KEY") or NOT_GIVEN)
         livekit_api_secret = livekit_api_secret or (os.getenv("LIVEKIT_API_SECRET") or NOT_GIVEN)

--- a/livekit-plugins/livekit-plugins-lemonslice/livekit/plugins/lemonslice/avatar.py
+++ b/livekit-plugins/livekit-plugins-lemonslice/livekit/plugins/lemonslice/avatar.py
@@ -14,7 +14,7 @@ from livekit.agents import (
     NotGivenOr,
     get_job_context,
 )
-from livekit.agents.voice.avatar import DataStreamAudioOutput
+from livekit.agents.voice.avatar import AvatarSession as BaseAvatarSession, DataStreamAudioOutput
 from livekit.agents.voice.room_io import ATTRIBUTE_PUBLISH_ON_BEHALF
 
 from .api import LemonSliceAPI, LemonSliceException
@@ -24,7 +24,7 @@ _AVATAR_AGENT_IDENTITY = "lemonslice-avatar-agent"
 _AVATAR_AGENT_NAME = "lemonslice-avatar-agent"
 
 
-class AvatarSession:
+class AvatarSession(BaseAvatarSession):
     """A LemonSlice avatar session"""
 
     def __init__(
@@ -56,7 +56,7 @@ class AvatarSession:
         self._avatar_participant_identity = avatar_participant_identity or _AVATAR_AGENT_IDENTITY
         self._avatar_participant_name = avatar_participant_name or _AVATAR_AGENT_NAME
 
-    async def start(
+    async def start(  # type: ignore[override]
         self,
         agent_session: AgentSession,
         room: rtc.Room,
@@ -65,6 +65,8 @@ class AvatarSession:
         livekit_api_key: NotGivenOr[str] = NOT_GIVEN,
         livekit_api_secret: NotGivenOr[str] = NOT_GIVEN,
     ) -> str:
+        await super().start(agent_session, room)
+
         livekit_url = livekit_url or (os.getenv("LIVEKIT_URL") or NOT_GIVEN)
         livekit_api_key = livekit_api_key or (os.getenv("LIVEKIT_API_KEY") or NOT_GIVEN)
         livekit_api_secret = livekit_api_secret or (os.getenv("LIVEKIT_API_SECRET") or NOT_GIVEN)

--- a/livekit-plugins/livekit-plugins-liveavatar/livekit/plugins/liveavatar/avatar.py
+++ b/livekit-plugins/livekit-plugins-liveavatar/livekit/plugins/liveavatar/avatar.py
@@ -23,7 +23,11 @@ from livekit.agents import (
     utils,
 )
 from livekit.agents.utils import is_given
-from livekit.agents.voice.avatar import AudioSegmentEnd, QueueAudioOutput
+from livekit.agents.voice.avatar import (
+    AudioSegmentEnd,
+    AvatarSession as BaseAvatarSession,
+    QueueAudioOutput,
+)
 from livekit.agents.voice.room_io import ATTRIBUTE_PUBLISH_ON_BEHALF
 
 from .api import LiveAvatarAPI, LiveAvatarException
@@ -35,7 +39,7 @@ _AVATAR_AGENT_IDENTITY = "liveavatar-avatar-agent"
 _AVATAR_AGENT_NAME = "liveavatar-avatar-agent"
 
 
-class AvatarSession:
+class AvatarSession(BaseAvatarSession):
     """A LiveAvatar avatar session"""
 
     def __init__(
@@ -69,7 +73,7 @@ class AvatarSession:
         self._avatar_participant_identity = avatar_participant_identity or _AVATAR_AGENT_IDENTITY
         self._avatar_participant_name = avatar_participant_name or _AVATAR_AGENT_NAME
         self._tasks: set[asyncio.Task[Any]] = set()
-        self._main_atask: asyncio.Task | None
+        self._main_atask: asyncio.Task | None = None
         self._audio_resampler: rtc.AudioResampler | None = None
         self._session_data = None
         self._msg_ch = utils.aio.Chan[dict]()
@@ -89,6 +93,7 @@ class AvatarSession:
         livekit_api_key: NotGivenOr[str] = NOT_GIVEN,
         livekit_api_secret: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
+        await super().start(agent_session, room)
         self._agent_session = agent_session
         self._room = room
         livekit_url = livekit_url or (os.getenv("LIVEKIT_URL") or NOT_GIVEN)

--- a/livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py
+++ b/livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py
@@ -17,7 +17,7 @@ from livekit.agents import (
     get_job_context,
     utils,
 )
-from livekit.agents.voice.avatar import DataStreamAudioOutput
+from livekit.agents.voice.avatar import AvatarSession as BaseAvatarSession, DataStreamAudioOutput
 from livekit.agents.voice.room_io import ATTRIBUTE_PUBLISH_ON_BEHALF
 
 from .log import logger
@@ -33,7 +33,7 @@ class RunwayException(Exception):
     """Exception for Runway errors"""
 
 
-class AvatarSession:
+class AvatarSession(BaseAvatarSession):
     """A Runway Characters avatar session.
 
     Creates a realtime session backed by Runway's avatar inference pipeline.
@@ -91,6 +91,8 @@ class AvatarSession:
         livekit_api_key: NotGivenOr[str] = NOT_GIVEN,
         livekit_api_secret: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
+        await super().start(agent_session, room)
+
         livekit_url = livekit_url or (os.getenv("LIVEKIT_URL") or NOT_GIVEN)
         livekit_api_key = livekit_api_key or (os.getenv("LIVEKIT_API_KEY") or NOT_GIVEN)
         livekit_api_secret = livekit_api_secret or (os.getenv("LIVEKIT_API_SECRET") or NOT_GIVEN)

--- a/livekit-plugins/livekit-plugins-simli/livekit/plugins/simli/avatar.py
+++ b/livekit-plugins/livekit-plugins-simli/livekit/plugins/simli/avatar.py
@@ -15,7 +15,7 @@ from livekit.agents import (
     get_job_context,
     utils,
 )
-from livekit.agents.voice.avatar import DataStreamAudioOutput
+from livekit.agents.voice.avatar import AvatarSession as BaseAvatarSession, DataStreamAudioOutput
 from livekit.agents.voice.room_io import ATTRIBUTE_PUBLISH_ON_BEHALF
 
 from .log import logger
@@ -56,7 +56,7 @@ class SimliConfig:
         return result
 
 
-class AvatarSession:
+class AvatarSession(BaseAvatarSession):
     """A Simli avatar session"""
 
     def __init__(
@@ -90,6 +90,8 @@ class AvatarSession:
         livekit_api_key: NotGivenOr[str] = NOT_GIVEN,
         livekit_api_secret: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
+        await super().start(agent_session, room)
+
         livekit_url = livekit_url or (os.getenv("LIVEKIT_URL") or NOT_GIVEN)
         livekit_api_key = livekit_api_key or (os.getenv("LIVEKIT_API_KEY") or NOT_GIVEN)
         livekit_api_secret = livekit_api_secret or (os.getenv("LIVEKIT_API_SECRET") or NOT_GIVEN)

--- a/livekit-plugins/livekit-plugins-tavus/livekit/plugins/tavus/avatar.py
+++ b/livekit-plugins/livekit-plugins-tavus/livekit/plugins/tavus/avatar.py
@@ -14,7 +14,7 @@ from livekit.agents import (
     get_job_context,
     utils,
 )
-from livekit.agents.voice.avatar import DataStreamAudioOutput
+from livekit.agents.voice.avatar import AvatarSession as BaseAvatarSession, DataStreamAudioOutput
 from livekit.agents.voice.room_io import ATTRIBUTE_PUBLISH_ON_BEHALF
 
 from .api import TavusAPI, TavusException
@@ -25,7 +25,7 @@ _AVATAR_AGENT_IDENTITY = "tavus-avatar-agent"
 _AVATAR_AGENT_NAME = "tavus-avatar-agent"
 
 
-class AvatarSession:
+class AvatarSession(BaseAvatarSession):
     """A Tavus avatar session"""
 
     def __init__(
@@ -69,6 +69,8 @@ class AvatarSession:
         livekit_api_key: NotGivenOr[str] = NOT_GIVEN,
         livekit_api_secret: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
+        await super().start(agent_session, room)
+
         livekit_url = livekit_url or (os.getenv("LIVEKIT_URL") or NOT_GIVEN)
         livekit_api_key = livekit_api_key or (os.getenv("LIVEKIT_API_KEY") or NOT_GIVEN)
         livekit_api_secret = livekit_api_secret or (os.getenv("LIVEKIT_API_SECRET") or NOT_GIVEN)

--- a/livekit-plugins/livekit-plugins-trugen/livekit/plugins/trugen/avatar.py
+++ b/livekit-plugins/livekit-plugins-trugen/livekit/plugins/trugen/avatar.py
@@ -17,7 +17,7 @@ from livekit.agents import (
     get_job_context,
     utils,
 )
-from livekit.agents.voice.avatar import DataStreamAudioOutput
+from livekit.agents.voice.avatar import AvatarSession as BaseAvatarSession, DataStreamAudioOutput
 from livekit.agents.voice.room_io import ATTRIBUTE_PUBLISH_ON_BEHALF
 
 from .log import logger
@@ -32,7 +32,7 @@ class TrugenException(Exception):
     """Exception for TruGen.AI errors"""
 
 
-class AvatarSession:
+class AvatarSession(BaseAvatarSession):
     """TruGen Realtime Avatar Session"""
 
     def __init__(
@@ -80,6 +80,8 @@ class AvatarSession:
         livekit_api_key: NotGivenOr[str] = NOT_GIVEN,
         livekit_api_secret: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
+        await super().start(agent_session, room)
+
         if livekit_url is NOT_GIVEN:
             livekit_url = os.getenv("LIVEKIT_URL") or NOT_GIVEN
         if livekit_api_key is NOT_GIVEN:


### PR DESCRIPTION
## Summary
- New `voice.avatar.AvatarSession` base registers `aclose` as a job shutdown callback and warns when started after `AgentSession.start()` replaces the audio output.
- `TranscriptSynchronizer` logs a one-shot warning when audio or text is detached asymmetrically (covers external avatars and manual `session.output.audio`/`.transcription` replacement).
- All in-repo avatar plugins inherit from the base and call `super().start(agent_session, room)` first. 