### PR TITLE
feat(assemblyai): warn when audio stops flowing to the WebSocket

### DIFF
--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -19,6 +19,7 @@ import asyncio
 import dataclasses
 import json
 import os
+import time
 import weakref
 from dataclasses import dataclass
 from typing import Literal
@@ -282,6 +283,7 @@ class SpeechStream(stt.SpeechStream):
         self._config_update_queue: asyncio.Queue[dict] = asyncio.Queue()
         self._session_id: str | None = None
         self._expires_at: int | None = None
+        self._last_frame_sent_at: float | None = None
 
     @property
     def session_id(self) -> str | None:
@@ -380,6 +382,7 @@ class SpeechStream(stt.SpeechStream):
                 for frame in frames:
                     self._speech_duration += frame.duration
                     await ws.send_bytes(frame.data.tobytes())
+                    self._last_frame_sent_at = time.time()
 
             closing_ws = True
             logger.debug("AssemblyAI sending close message session=%s", self._session_id)
@@ -404,6 +407,17 @@ class SpeechStream(stt.SpeechStream):
                             consecutive_timeouts * 5,
                             self._session_id,
                         )
+                        # If the send side is also idle, the stall is upstream
+                        # of this plugin (no audio reaching us). Otherwise
+                        # frames are flowing and the stall is downstream.
+                        if self._last_frame_sent_at is not None:
+                            send_idle_s = time.time() - self._last_frame_sent_at
+                            if send_idle_s >= 15:
+                                logger.warning(
+                                    "AssemblyAI no audio frames sent for %.0fs session=%s",
+                                    send_idle_s,
+                                    self._session_id,
+                                )
                     continue
 
                 if msg.type in (


### PR DESCRIPTION
## Summary

Complementary to #5476 (recv-side silence warning, now merged).

#5476 added a warning when AssemblyAI sends no messages for 15s+. That signal alone can't distinguish "AssemblyAI stalled" from "the plugin stopped receiving audio from upstream and is correctly silent." When a session appears wedged, both interpretations are on the table and the merged recv-side log alone can't separate them.

This PR adds the symmetric send-side warning: nested inside the existing `consecutive_timeouts % 3 == 0` block from #5476, if the plugin hasn't pushed an audio frame to the WebSocket in ≥15s, emit `AssemblyAI no audio frames sent for Ns session=<id>`. The two absence-of-activity warnings together disambiguate the stall location by elimination:

| send-stopped warning | recv-silence warning | Diagnosis |
|---|---|---|
| silent | firing | AssemblyAI stalled — frames flowing, no response |
| firing | firing | Upstream stalled — plugin got no audio |
| silent | silent | healthy |

## Implementation

- Adds `self._last_frame_sent_at: float | None = None`, set on every successful `ws.send_bytes(...)` in `send_task`.
- Reuses the 15s cadence established by #5476: inside the same `% 3 == 0` block, check `time.time() - _last_frame_sent_at` and warn when ≥15s.
- No separate watchdog coroutine. Overhead on the hot path is one `time.time()` assignment per audio frame.
- Guarded on `_last_frame_sent_at is not None` so the warning doesn't fire during the initial connect window before any audio has been sent.

## Impact

- Default log level: `warning`, only when the anomaly is real.
- Healthy sessions: silent (mirrors #5476's absence-is-the-signal approach).

## Test plan

- [x] \`make format lint type-check\` pass
- [ ] Healthy session: no send-stopped warning emitted
- [ ] Simulated upstream stall: both warnings fire at 15s, 30s, 45s
- [ ] Simulated AAI stall: recv-silence fires, send-stopped stays silent