### PR TITLE
feat(avatar): add playback_started RPC for remote avatar workers

### DIFF
--- a/examples/avatar_agents/audio_wave/agent_worker.py
+++ b/examples/avatar_agents/audio_wave/agent_worker.py
@@ -1,8 +1,8 @@
 import logging
+import os
 from dataclasses import asdict, dataclass
 
 import httpx
-from bithuman.runtime import os
 from dotenv import load_dotenv
 
 from livekit import api, rtc

--- a/examples/avatar_agents/audio_wave/agent_worker.py
+++ b/examples/avatar_agents/audio_wave/agent_worker.py
@@ -1,26 +1,23 @@
-import argparse
 import logging
-import sys
 from dataclasses import asdict, dataclass
-from functools import partial
 
 import httpx
+from bithuman.runtime import os
 from dotenv import load_dotenv
 
 from livekit import api, rtc
-from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli
+from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli, inference
 from livekit.agents.voice.avatar import DataStreamAudioOutput
-from livekit.agents.voice.io import PlaybackFinishedEvent
+from livekit.agents.voice.io import PlaybackFinishedEvent, PlaybackStartedEvent
 from livekit.agents.voice.room_io import ATTRIBUTE_PUBLISH_ON_BEHALF
-from livekit.plugins import openai
+from livekit.plugins import silero
 
 load_dotenv()
 
 logger = logging.getLogger("avatar-example")
-logger.setLevel(logging.INFO)
 
-server = AgentServer()
 AVATAR_IDENTITY = "avatar_worker"
+AVATAR_DISPATCHER_URL = os.getenv("AVATAR_DISPATCHER_URL", "http://localhost:8089/launch")
 
 
 @dataclass
@@ -58,31 +55,34 @@ async def launch_avatar(ctx: JobContext, avatar_dispatcher_url: str, avatar_iden
     logger.info("Avatar handshake completed")
 
 
-async def entrypoint(ctx: JobContext, avatar_dispatcher_url: str):
+server = AgentServer()
+
+
+@server.rtc_session()
+async def entrypoint(ctx: JobContext):
     await ctx.connect()
 
     agent = Agent(instructions="Talk to me!")
     session = AgentSession(
-        llm=openai.realtime.RealtimeModel(),
-        # stt=deepgram.STT(),
-        # llm=openai.LLM(model="gpt-4.1-mini"),
-        # tts=cartesia.TTS(),
+        stt=inference.STT("deepgram/nova-3"),
+        llm=inference.LLM("google/gemini-2.5-flash"),
+        tts=inference.TTS("cartesia/sonic-3"),
+        vad=silero.VAD.load(),
         resume_false_interruption=False,
     )
 
-    await launch_avatar(ctx, avatar_dispatcher_url, AVATAR_IDENTITY)
+    await launch_avatar(ctx, AVATAR_DISPATCHER_URL, AVATAR_IDENTITY)
     session.output.audio = DataStreamAudioOutput(
         ctx.room,
         destination_identity=AVATAR_IDENTITY,
         # (optional) wait for the avatar to publish video track before generating a reply
         wait_remote_track=rtc.TrackKind.KIND_VIDEO,
+        # the example avatar_runner uses AvatarRunner which sends lk.playback_started
+        wait_playback_start=True,
     )
 
     # start agent with room input and room text output
-    await session.start(
-        agent=agent,
-        room=ctx.room,
-    )
+    await session.start(agent=agent, room=ctx.room)
 
     @session.output.audio.on("playback_finished")
     def on_playback_finished(ev: PlaybackFinishedEvent) -> None:
@@ -95,12 +95,16 @@ async def entrypoint(ctx: JobContext, avatar_dispatcher_url: str):
             },
         )
 
+    @session.output.audio.on("playback_started")
+    def on_playback_started(ev: PlaybackStartedEvent) -> None:
+        # the avatar should notify when the audio playback is started
+        logger.info(
+            "playback_started",
+            extra={"created_at": ev.created_at},
+        )
+
+    await session.generate_reply(instructions="say hello to the user")
+
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--avatar-url", type=str, default="http://localhost:8089/launch")
-    args, remaining_args = parser.parse_known_args()
-    sys.argv = sys.argv[:1] + remaining_args
-
-    server.rtc_session(partial(entrypoint, avatar_dispatcher_url=args.avatar_url))
     cli.run_app(server)

--- a/examples/avatar_agents/audio_wave/avatar_runner.py
+++ b/examples/avatar_agents/audio_wave/avatar_runner.py
@@ -20,6 +20,7 @@ from livekit.agents.voice.avatar import (
     DataStreamAudioReceiver,
     VideoGenerator,
 )
+from livekit.agents.voice.remote_session import TOPIC_SESSION_MESSAGES
 
 sys.path.insert(0, str(Path(__file__).parent))
 from wave_viz import WaveformVisualizer
@@ -164,7 +165,12 @@ async def main(api_url: str, api_token: str):
         # ignore transcription from the room
         pass
 
+    def on_session_messages_received(reader: rtc.ByteStreamReader, participant_identity: str):
+        # ignore session messages from the room
+        pass
+
     room.register_text_stream_handler(TOPIC_TRANSCRIPTION, on_transcription_received)
+    room.register_byte_stream_handler(TOPIC_SESSION_MESSAGES, on_session_messages_received)
 
     should_stop = asyncio.Event()
 

--- a/livekit-agents/livekit/agents/voice/avatar/_datastream_io.py
+++ b/livekit-agents/livekit/agents/voice/avatar/_datastream_io.py
@@ -5,7 +5,7 @@ import json
 import math
 import time
 from collections.abc import AsyncIterator, Callable
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from typing import Any
 
 from livekit import rtc
@@ -18,7 +18,13 @@ from ._types import AudioReceiver, AudioSegmentEnd
 
 RPC_CLEAR_BUFFER = "lk.clear_buffer"
 RPC_PLAYBACK_FINISHED = "lk.playback_finished"
+RPC_PLAYBACK_STARTED = "lk.playback_started"
 AUDIO_STREAM_TOPIC = "lk.audio_stream"
+
+
+@dataclass
+class _PlaybackStartedEvent:
+    pass
 
 
 class DataStreamAudioOutput(AudioOutput):
@@ -27,6 +33,7 @@ class DataStreamAudioOutput(AudioOutput):
     """  # noqa: E501
 
     _playback_finished_handlers: dict[str, Callable[[rtc.RpcInvocationData], str]] = {}
+    _playback_started_handlers: dict[str, Callable[[rtc.RpcInvocationData], str]] = {}
 
     def __init__(
         self,
@@ -36,6 +43,7 @@ class DataStreamAudioOutput(AudioOutput):
         sample_rate: int | None = None,
         wait_remote_track: rtc.TrackKind.ValueType | None = None,
         clear_buffer_timeout: float | None = 2.0,
+        wait_playback_start: bool = False,
     ):
         super().__init__(
             label="DataStreamIO",
@@ -46,6 +54,7 @@ class DataStreamAudioOutput(AudioOutput):
         self._room = room
         self._destination_identity = destination_identity
         self._wait_remote_track = wait_remote_track
+        self._wait_playback_start = wait_playback_start
         self._stream_writer: rtc.ByteStreamWriter | None = None
         self._pushed_duration: float = 0.0
         self._tasks: set[asyncio.Task[Any]] = set()
@@ -67,6 +76,12 @@ class DataStreamAudioOutput(AudioOutput):
                     caller_identity=self._destination_identity,
                     handler=self._handle_playback_finished,
                 )
+                if self._wait_playback_start:
+                    self._register_playback_started_rpc(
+                        self._room,
+                        caller_identity=self._destination_identity,
+                        handler=self._handle_playback_started,
+                    )
                 self._start_atask = asyncio.create_task(self._start_task())
 
         self._room_connected_fut = asyncio.Future[None]()
@@ -89,6 +104,12 @@ class DataStreamAudioOutput(AudioOutput):
                 caller_identity=self._destination_identity,
                 handler=self._handle_playback_finished,
             )
+            if self._wait_playback_start:
+                self._register_playback_started_rpc(
+                    self._room,
+                    caller_identity=self._destination_identity,
+                    handler=self._handle_playback_started,
+                )
             logger.debug(
                 "waiting for the remote participant",
                 extra={"identity": self._destination_identity},
@@ -135,9 +156,10 @@ class DataStreamAudioOutput(AudioOutput):
                 },
             )
             self._pushed_duration = 0.0
-            # Not ideal since frame isn't actually playing yet
-            # potentially we need another RPC for this
-            self.on_playback_started(created_at=time.time())
+            if not self._wait_playback_start:
+                # approximate the playback_started time; the frame isn't actually playing yet,
+                # used when the remote avatar doesn't send lk.playback_started notifications
+                self.on_playback_started(created_at=time.time())
 
         await self._stream_writer.write(bytes(frame.data))
         self._pushed_duration += frame.duration
@@ -227,6 +249,20 @@ class DataStreamAudioOutput(AudioOutput):
         )
         return "ok"
 
+    def _handle_playback_started(self, data: rtc.RpcInvocationData) -> str:
+        if data.caller_identity != self._destination_identity:
+            logger.warning(
+                "playback started event received from unexpected participant",
+                extra={
+                    "caller_identity": data.caller_identity,
+                    "expected_identity": self._destination_identity,
+                },
+            )
+            return "reject"
+
+        self.on_playback_started(created_at=time.time())
+        return "ok"
+
     def _handle_connection_state_changed(self, state: rtc.ConnectionState) -> None:
         if self._room.isconnected() and not self._room_connected_fut.done():
             self._room_connected_fut.set_result(None)
@@ -264,6 +300,39 @@ class DataStreamAudioOutput(AudioOutput):
             )
             return "reject"
 
+    @classmethod
+    def _register_playback_started_rpc(
+        cls,
+        room: rtc.Room,
+        *,
+        caller_identity: str,
+        handler: Callable[[rtc.RpcInvocationData], str],
+    ) -> None:
+        cls._playback_started_handlers[caller_identity] = handler
+
+        if (
+            rpc_handler := room.local_participant._rpc_handlers.get(RPC_PLAYBACK_STARTED)
+        ) and rpc_handler == cls._playback_started_rpc_handler:
+            return
+
+        room.local_participant.register_rpc_method(
+            RPC_PLAYBACK_STARTED, cls._playback_started_rpc_handler
+        )
+
+    @classmethod
+    def _playback_started_rpc_handler(cls, data: rtc.RpcInvocationData) -> str:
+        if handler := cls._playback_started_handlers.get(data.caller_identity):
+            return handler(data)
+        else:
+            logger.warning(
+                "playback started event received from unexpected participant",
+                extra={
+                    "caller_identity": data.caller_identity,
+                    "expected_identities": list(cls._playback_started_handlers.keys()),
+                },
+            )
+            return "reject"
+
 
 class DataStreamAudioReceiver(AudioReceiver):
     """
@@ -295,7 +364,7 @@ class DataStreamAudioReceiver(AudioReceiver):
         self._current_reader: rtc.ByteStreamReader | None = None
         self._current_reader_cleared: bool = False
 
-        self._playback_finished_ch = utils.aio.Chan[PlaybackFinishedEvent]()
+        self._rpc_send_ch = utils.aio.Chan[PlaybackFinishedEvent | _PlaybackStartedEvent]()
         self._rpc_max_retries = rpc_max_retries
 
         self._main_atask: asyncio.Task | None = None
@@ -353,9 +422,12 @@ class DataStreamAudioReceiver(AudioReceiver):
         self._room.register_byte_stream_handler(AUDIO_STREAM_TOPIC, _handle_stream_received)
 
     def notify_playback_finished(self, playback_position: float, interrupted: bool) -> None:
-        self._playback_finished_ch.send_nowait(
+        self._rpc_send_ch.send_nowait(
             PlaybackFinishedEvent(playback_position=playback_position, interrupted=interrupted)
         )
+
+    def notify_playback_started(self) -> None:
+        self._rpc_send_ch.send_nowait(_PlaybackStartedEvent())
 
     async def _main_task(self) -> None:
         tasks = [
@@ -367,37 +439,49 @@ class DataStreamAudioReceiver(AudioReceiver):
         except Exception as error:
             self._exception = error
         finally:
-            self._playback_finished_ch.close()
+            self._rpc_send_ch.close()
             self._data_ch.close()
             await utils.aio.cancel_and_wait(*tasks)
 
     @utils.log_exceptions(logger=logger)
     async def _send_task(self) -> None:
-        async for event in self._playback_finished_ch:
+        async for event in self._rpc_send_ch:
             assert self._remote_participant is not None
+
+            if isinstance(event, PlaybackFinishedEvent):
+                method = RPC_PLAYBACK_FINISHED
+                payload = json.dumps(asdict(event))
+            else:
+                method = RPC_PLAYBACK_STARTED
+                payload = ""
 
             retry_count = 0  # TODO: use retry logic in rust
             while retry_count < self._rpc_max_retries:
-                logger.debug(
-                    f"notifying playback finished: {event.playback_position:.3f}s, "
-                    f"interrupted: {event.interrupted}"
-                )
+                logger.debug(f"notifying {method}", extra={"payload": payload})
                 try:
                     await self._room.local_participant.perform_rpc(
                         destination_identity=self._remote_participant.identity,
-                        method=RPC_PLAYBACK_FINISHED,
-                        payload=json.dumps(asdict(event)),
+                        method=method,
+                        payload=payload,
                     )
                     break
                 except rtc.RpcError as e:
+                    if e.code == rtc.RpcError.ErrorCode.UNSUPPORTED_METHOD:
+                        # remote participant didn't register this method; skip retry
+                        if method == RPC_PLAYBACK_STARTED:
+                            logger.error(
+                                "remote participant didn't register lk.playback_started RPC"
+                            )
+                            break
+
                     if retry_count == self._rpc_max_retries - 1:
                         logger.error(
-                            f"failed to notify playback finished after {retry_count + 1} retries",
+                            f"failed to call {method} after {retry_count + 1} retries",
                             exc_info=e,
                         )
                         raise
                     retry_count += 1
-                    logger.warning("failed to notify the agent playback finished, retrying...")
+                    logger.warning(f"failed to call {method}, retrying...")
                     await asyncio.sleep(0.1)
 
     @utils.log_exceptions(logger=logger)
@@ -464,7 +548,7 @@ class DataStreamAudioReceiver(AudioReceiver):
 
     async def aclose(self) -> None:
         self._closing = True
-        self._playback_finished_ch.close()
+        self._rpc_send_ch.close()
         self._data_ch.close()
         self._stream_reader_changed.set()
         if self._main_atask:

--- a/livekit-agents/livekit/agents/voice/avatar/_queue_io.py
+++ b/livekit-agents/livekit/agents/voice/avatar/_queue_io.py
@@ -23,13 +23,19 @@ class QueueAudioOutput(
     AudioOutput implementation that sends audio frames through a queue.
     """
 
-    def __init__(self, *, sample_rate: int | None = None):
+    def __init__(
+        self,
+        *,
+        sample_rate: int | None = None,
+        wait_playback_start: bool = False,
+    ):
         super().__init__(
             label="DebugQueueIO",
             next_in_chain=None,
             sample_rate=sample_rate,
             capabilities=AudioOutputCapabilities(pause=False),
         )
+        self._wait_playback_start = wait_playback_start
         self._data_ch = utils.aio.Chan[rtc.AudioFrame | AudioSegmentEnd]()
         self._capturing = False
 
@@ -38,9 +44,8 @@ class QueueAudioOutput(
         await super().capture_frame(frame)
         if not self._capturing:
             self._capturing = True
-            # Not ideal since frame isn't actually playing yet
-            # potentially we need another RPC/hook for this
-            self.on_playback_started(created_at=time.time())
+            if not self._wait_playback_start:
+                self.on_playback_started(created_at=time.time())
 
         await self._data_ch.send(frame)
 
@@ -65,6 +70,12 @@ class QueueAudioOutput(
 
     def notify_playback_finished(self, playback_position: float, interrupted: bool) -> None:
         self.on_playback_finished(playback_position=playback_position, interrupted=interrupted)
+
+    def notify_playback_started(self) -> None:
+        if not self._wait_playback_start:
+            # already fired eagerly in capture_frame; avoid double-firing
+            return
+        self.on_playback_started(created_at=time.time())
 
     def __aiter__(self) -> AsyncIterator[rtc.AudioFrame | AudioSegmentEnd]:
         return self._data_ch

--- a/livekit-agents/livekit/agents/voice/avatar/_runner.py
+++ b/livekit-agents/livekit/agents/voice/avatar/_runner.py
@@ -153,6 +153,13 @@ class AvatarRunner:
 
             await self._av_sync.push(frame)
             if isinstance(frame, rtc.AudioFrame):
+                if self._playback_position == 0.0 and frame.duration > 0.0:
+                    notify_task = self._audio_recv.notify_playback_started()
+                    if asyncio.iscoroutine(notify_task):
+                        task = asyncio.create_task(notify_task)
+                        self._tasks.add(task)
+                        task.add_done_callback(self._tasks.discard)
+
                 self._playback_position += frame.duration
 
     def _on_clear_buffer(self) -> None:

--- a/livekit-agents/livekit/agents/voice/avatar/_types.py
+++ b/livekit-agents/livekit/agents/voice/avatar/_types.py
@@ -28,6 +28,10 @@ class AudioReceiver(ABC, rtc.EventEmitter[Literal["clear_buffer"]]):
         """Notify the sender that playback has finished"""
 
     @abstractmethod
+    def notify_playback_started(self) -> None | Coroutine[None, None, None]:
+        """Notify the sender that playback has started"""
+
+    @abstractmethod
     def __aiter__(self) -> AsyncIterator[rtc.AudioFrame | AudioSegmentEnd]:
         """Continuously stream out audio frames or AudioSegmentEnd when the stream ends"""
 

--- a/livekit-agents/livekit/agents/voice/transcription/synchronizer.py
+++ b/livekit-agents/livekit/agents/voice/transcription/synchronizer.py
@@ -171,16 +171,24 @@ class _SegmentSynchronizerImpl:
     def text_input_ended(self) -> bool:
         return self._text_data.done
 
+    def on_playback_started(self, start_time: float) -> None:
+        if self.closed:
+            logger.warning("_SegmentSynchronizerImpl.on_playback_started called after close")
+            return
+
+        if self._start_fut.is_set():
+            logger.warning(
+                "_SegmentSynchronizerImpl.on_playback_started called after start_fut is set"
+            )
+            return
+
+        self._start_wall_time = start_time
+        self._start_fut.set()
+
     def push_audio(self, frame: rtc.AudioFrame) -> None:
         if self.closed:
             logger.warning("_SegmentSynchronizerImpl.push_audio called after close")
             return
-
-        # the first audio frame we receive marks the start of the sync
-        # see `TranscriptSynchronizer` docstring
-        if self._start_wall_time is None and frame.duration > 0:
-            self._start_wall_time = time.time()
-            self._start_fut.set()
 
         self._audio_data.sr_stream.push_frame(frame)
         self._audio_data.pushed_duration += frame.duration
@@ -397,7 +405,7 @@ class TranscriptSynchronizer:
     Synchronizes text with audio playback timing.
 
     This class is responsible for synchronizing text with audio playback timing.
-    It currently assumes that the first push_audio is starting the audio playback of a segment.
+    It starts sending transcription when AudioOutput.on_playback_started is called.
     """
 
     def __init__(
@@ -588,6 +596,11 @@ class _SyncedAudioOutput(io.AudioOutput):
         self._next_in_chain.clear_buffer()
 
     # this is going to be automatically called by the next_in_chain
+    def on_playback_started(self, *, created_at: float) -> None:
+        super().on_playback_started(created_at=created_at)
+        if self._synchronizer.enabled:
+            self._synchronizer._impl.on_playback_started(start_time=created_at)
+
     def on_playback_finished(
         self,
         *,

--- a/livekit-plugins/livekit-plugins-bithuman/livekit/plugins/bithuman/avatar.py
+++ b/livekit-plugins/livekit-plugins-bithuman/livekit/plugins/bithuman/avatar.py
@@ -269,7 +269,10 @@ class AvatarSession(BaseAvatarSession):
             audio_channels=1,
         )
 
-        audio_buffer = QueueAudioOutput(sample_rate=runtime.settings.INPUT_SAMPLE_RATE)
+        audio_buffer = QueueAudioOutput(
+            sample_rate=runtime.settings.INPUT_SAMPLE_RATE,
+            wait_playback_start=True,
+        )
         # create avatar runner
         self._avatar_runner = AvatarRunner(
             room=room,
@@ -336,6 +339,7 @@ class AvatarSession(BaseAvatarSession):
         agent_session.output.audio = DataStreamAudioOutput(
             room=room,
             destination_identity=self._avatar_participant_identity,
+            wait_playback_start=False,
         )
 
     async def _start_cloud_agent(

--- a/livekit-plugins/livekit-plugins-liveavatar/livekit/plugins/liveavatar/avatar.py
+++ b/livekit-plugins/livekit-plugins-liveavatar/livekit/plugins/liveavatar/avatar.py
@@ -158,7 +158,7 @@ class AvatarSession(BaseAvatarSession):
         def on_agent_session_close(ev: Any) -> None:
             self._msg_ch.close()
 
-        self._audio_buffer = QueueAudioOutput(sample_rate=SAMPLE_RATE)
+        self._audio_buffer = QueueAudioOutput(sample_rate=SAMPLE_RATE, wait_playback_start=True)
         await self._audio_buffer.start()
         self._audio_buffer.on("clear_buffer", self._on_clear_buffer)  # type: ignore[arg-type]
 
@@ -372,3 +372,4 @@ class AvatarSession(BaseAvatarSession):
     def _handle_agent_speak_started(self, event: dict) -> None:
         self._avatar_speaking = True
         self._avatar_interrupted = False
+        self._audio_buffer.notify_playback_started()

--- a/uv.lock
+++ b/uv.lock
@@ -2917,7 +2917,6 @@ requires-dist = [{ name = "livekit-agents", editable = "livekit-agents" }]
 
 [[package]]
 name = "livekit-plugins-telnyx"
-version = "0.1.0"
 source = { editable = "livekit-plugins/livekit-plugins-telnyx" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Adds `lk.playback_started` RPC so remote avatar workers (e.g. `AvatarRunner`) can notify the agent session when playback actually begins, instead of approximating it the instant a frame is queued.
- Introduces a `wait_playback_start` opt-in on `DataStreamAudioOutput` / `QueueAudioOutput`. When false (default), behavior matches before: `on_playback_started` fires eagerly on first captured frame. When true, the event is deferred until the remote sends the RPC.
- If the avatar service is built on `AvatarRunner`, just upgrade `livekit-agents` and set `wait_playback_start=True` in the plugin will enable this feature.
