### PR TITLE
voice: add opt-in audio turn detector hook

### DIFF
--- a/examples/voice_agents/README.md
+++ b/examples/voice_agents/README.md
@@ -23,6 +23,7 @@ session = AgentSession(
 ### 🚀 Getting Started
 
 - [`basic_agent.py`](./basic_agent.py) - A fundamental voice agent using LiveKit Inference with metrics collection
+- [`audio_turn_detector.py`](./audio_turn_detector.py) - Using a custom audio-native turn detector with buffered current-turn PCM
 
 ### 🛠️ Tool Integration & Function Calling
 

--- a/examples/voice_agents/audio_turn_detector.py
+++ b/examples/voice_agents/audio_turn_detector.py
@@ -1,0 +1,113 @@
+import logging
+
+from dotenv import load_dotenv
+
+from livekit.agents import (
+    Agent,
+    AgentServer,
+    AgentSession,
+    AudioTurnContext,
+    AudioTurnDetector,
+    JobContext,
+    JobProcess,
+    TurnHandlingOptions,
+    cli,
+    inference,
+)
+from livekit.agents.utils.audio import calculate_audio_duration
+from livekit.plugins import silero
+
+logger = logging.getLogger("audio-turn-detector")
+logger.setLevel(logging.INFO)
+
+load_dotenv()
+
+
+class HeuristicAudioTurnDetector(AudioTurnDetector):
+    """Example audio-native turn detector.
+
+    This intentionally uses a simple duration heuristic so the example stays dependency-free.
+    A production detector can inspect ``turn_ctx.audio`` and run any external model there.
+    """
+
+    def __init__(
+        self,
+        *,
+        short_utterance_seconds: float = 0.8,
+        long_utterance_seconds: float = 1.8,
+    ) -> None:
+        self._short_utterance_seconds = short_utterance_seconds
+        self._long_utterance_seconds = long_utterance_seconds
+
+    @property
+    def model(self) -> str:
+        return "heuristic-audio-turn-detector"
+
+    @property
+    def provider(self) -> str:
+        return "examples"
+
+    async def unlikely_threshold(self, language) -> float | None:
+        return 0.5
+
+    async def supports_language(self, language) -> bool:
+        return True
+
+    async def predict_end_of_turn_audio(
+        self, turn_ctx: AudioTurnContext, *, timeout: float | None = None
+    ) -> float:
+        duration = calculate_audio_duration(turn_ctx.audio)
+        logger.info(
+            "audio turn detector evaluated current turn",
+            extra={
+                "duration_seconds": round(duration, 3),
+                "language": turn_ctx.language,
+                "transcript": turn_ctx.transcript,
+            },
+        )
+
+        if not turn_ctx.transcript.strip():
+            return 0.0
+        if duration <= self._short_utterance_seconds:
+            return 0.95
+        if duration >= self._long_utterance_seconds:
+            return 0.15
+        return 0.55
+
+
+server = AgentServer()
+
+
+def prewarm(proc: JobProcess) -> None:
+    proc.userdata["vad"] = silero.VAD.load()
+
+
+server.setup_fnc = prewarm
+
+
+@server.rtc_session()
+async def entrypoint(ctx: JobContext) -> None:
+    session = AgentSession(
+        stt=inference.STT("deepgram/nova-3", language="multi"),
+        llm=inference.LLM("openai/gpt-4.1-mini"),
+        tts=inference.TTS("cartesia/sonic-3"),
+        vad=ctx.proc.userdata["vad"],
+        turn_handling=TurnHandlingOptions(
+            turn_detection=HeuristicAudioTurnDetector(),
+            endpointing={
+                "min_delay": 0.05,
+                "max_delay": 0.6,
+            },
+        ),
+    )
+
+    await session.start(
+        agent=Agent(
+            instructions=("You are a concise voice assistant. Reply briefly and naturally.")
+        ),
+        room=ctx.room,
+    )
+
+
+if __name__ == "__main__":
+    cli.run_app(server)

--- a/livekit-agents/livekit/agents/__init__.py
+++ b/livekit-agents/livekit/agents/__init__.py
@@ -113,6 +113,8 @@ from .voice.run_result import (
     mock_tools,
 )
 from .voice.turn import (
+    AudioTurnContext,
+    AudioTurnDetector,
     EndpointingOptions,
     InterruptionOptions,
     PreemptiveGenerationOptions,
@@ -236,6 +238,8 @@ __all__ = [
     "AMDCategory",
     "AMDPredictionEvent",
     "TurnHandlingOptions",
+    "AudioTurnContext",
+    "AudioTurnDetector",
     "EndpointingOptions",
     "InterruptionOptions",
     "PreemptiveGenerationOptions",

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -7,7 +7,7 @@ import time
 from collections import deque
 from collections.abc import AsyncIterable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, TypeGuard, cast
 
 from opentelemetry import trace
 from opentelemetry.sdk.trace import ReadableSpan
@@ -33,7 +33,12 @@ from . import io
 from ._utils import _set_participant_attributes
 from .endpointing import BaseEndpointing
 from .events import UserTurnExceededEvent
-from .turn import TurnDetectionMode as TurnDetectionMode
+from .turn import (
+    AudioTurnContext,
+    AudioTurnDetector,
+    TurnDetectionMode as TurnDetectionMode,
+    _TurnDetector,
+)
 
 if TYPE_CHECKING:
     from .agent_session import AgentSession
@@ -41,6 +46,19 @@ if TYPE_CHECKING:
 MIN_LANGUAGE_DETECTION_LENGTH = 5
 # Mirrors turn_detector.base.MAX_HISTORY_TURNS for tracing
 _EOU_MAX_HISTORY_TURNS = 6
+
+
+def _copy_audio_frame(frame: rtc.AudioFrame) -> rtc.AudioFrame:
+    return rtc.AudioFrame(
+        data=bytes(frame.data),
+        sample_rate=frame.sample_rate,
+        num_channels=frame.num_channels,
+        samples_per_channel=frame.samples_per_channel,
+    )
+
+
+def _is_audio_turn_detector(detector: object) -> TypeGuard[AudioTurnDetector]:
+    return hasattr(detector, "predict_end_of_turn_audio")
 
 
 @dataclass
@@ -156,6 +174,7 @@ class AudioRecognition:
         self._end_of_turn_task: asyncio.Task[None] | None = None
         self._endpointing: BaseEndpointing = endpointing
         self._turn_detector = turn_detection if not isinstance(turn_detection, str) else None
+        self._audio_turn_detector_enabled = _is_audio_turn_detector(self._turn_detector)
         self._stt = stt
         self._vad = vad
         self._stt_model = stt_model
@@ -178,6 +197,7 @@ class AudioRecognition:
         self._audio_interim_transcript = ""
         # used for STTs that support preflight mode, so it could start preemptive generation earlier
         self._audio_preflight_transcript = ""
+        self._turn_audio_frames: list[rtc.AudioFrame] = []
         self._last_language: LanguageCode | None = None
 
         self._stt_pipeline: _STTPipeline | None = None
@@ -237,6 +257,7 @@ class AudioRecognition:
 
         if is_given(turn_detection):
             self._turn_detector = turn_detection if not isinstance(turn_detection, str) else None
+            self._audio_turn_detector_enabled = _is_audio_turn_detector(self._turn_detector)
 
             mode = turn_detection if isinstance(turn_detection, str) else None
             if self._turn_detection_mode != mode:
@@ -546,6 +567,8 @@ class AudioRecognition:
             self._input_started_at = time.time() - frame.duration
 
         self._sample_rate = frame.sample_rate
+        if self._audio_turn_detector_enabled:
+            self._turn_audio_frames.append(_copy_audio_frame(frame))
         if not skip_stt and self._stt_pipeline is not None:
             self._stt_pipeline.audio_ch.send_nowait(frame)
 
@@ -698,6 +721,7 @@ class AudioRecognition:
         self._speech_start_time = None
         self._last_speaking_time = None
         self._vad_speech_started = False
+        self._turn_audio_frames = []
         self._user_turn_committed = False
 
         # end any in-progress user_turn span so the next speech starts a fresh one
@@ -1114,9 +1138,27 @@ class AudioRecognition:
                         end_of_turn_probability = 0.0
                         unlikely_threshold: float | None = None
                         try:
-                            end_of_turn_probability = await turn_detector.predict_end_of_turn(
-                                chat_ctx
-                            )
+                            if _is_audio_turn_detector(turn_detector):
+                                if not self._turn_audio_frames:
+                                    logger.debug(
+                                        "audio turn detector skipped because no turn audio was buffered"
+                                    )
+                                else:
+                                    end_of_turn_probability = (
+                                        await turn_detector.predict_end_of_turn_audio(
+                                            AudioTurnContext(
+                                                audio=list(self._turn_audio_frames),
+                                                transcript=self._audio_transcript,
+                                                chat_ctx=chat_ctx.copy(),
+                                                language=self._last_language,
+                                            )
+                                        )
+                                    )
+                            else:
+                                text_turn_detector = cast(_TurnDetector, turn_detector)
+                                end_of_turn_probability = (
+                                    await text_turn_detector.predict_end_of_turn(chat_ctx)
+                                )
                             unlikely_threshold = await turn_detector.unlikely_threshold(
                                 self._last_language
                             )
@@ -1218,6 +1260,7 @@ class AudioRecognition:
                 # clear the transcript if the user turn was committed
                 self._audio_transcript = ""
                 self._final_transcript_confidence = []
+                self._turn_audio_frames = []
                 self._last_final_transcript_time = None
                 # concurrent user speech might have changed it
                 # only reset if there is no new speech

--- a/livekit-agents/livekit/agents/voice/turn.py
+++ b/livekit-agents/livekit/agents/voice/turn.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Literal, Protocol
 
 from typing_extensions import TypedDict
+
+from livekit import rtc
 
 from ..language import LanguageCode
 from ..llm import ChatContext
@@ -28,7 +31,45 @@ class _TurnDetector(Protocol):
     ) -> float: ...
 
 
-TurnDetectionMode = Literal["stt", "vad", "realtime_llm", "manual"] | _TurnDetector
+@dataclass(slots=True)
+class AudioTurnContext:
+    """Current-turn audio and conversation context for audio-native detectors.
+
+    Attributes:
+        audio: Buffered audio frames for the current user turn.
+        transcript: The current turn transcript accumulated from STT.
+        chat_ctx: Conversation context with the current user transcript appended.
+        language: The most recent detected language, if available from STT.
+    """
+
+    audio: list[rtc.AudioFrame]
+    transcript: str
+    chat_ctx: ChatContext
+    language: LanguageCode | None = None
+
+
+class AudioTurnDetector(Protocol):
+    """Protocol for custom audio-native turn detectors."""
+
+    @property
+    def model(self) -> str:
+        return "unknown"
+
+    @property
+    def provider(self) -> str:
+        return "unknown"
+
+    async def unlikely_threshold(self, language: LanguageCode | None) -> float | None: ...
+    async def supports_language(self, language: LanguageCode | None) -> bool: ...
+
+    async def predict_end_of_turn_audio(
+        self, turn_ctx: AudioTurnContext, *, timeout: float | None = None
+    ) -> float: ...
+
+
+TurnDetectionMode = (
+    Literal["stt", "vad", "realtime_llm", "manual"] | _TurnDetector | AudioTurnDetector
+)
 """
 The mode of turn detection to use.
 
@@ -36,7 +77,8 @@ The mode of turn detection to use.
 - "vad": use VAD to detect the start and end of the user's turn
 - "realtime_llm": use server-side turn detection provided by the realtime LLM
 - "manual": manually manage the turn detection
-- _TurnDetector: use the default mode with the provided turn detector
+- _TurnDetector: use a text/chat-context turn detector
+- AudioTurnDetector: use an audio-native turn detector
 
 (default) If not provided, automatically choose the best mode based on
     available models (realtime_llm -> vad -> stt -> manual)

--- a/tests/test_audio_turn_detection.py
+++ b/tests/test_audio_turn_detection.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from contextlib import suppress
+
+from livekit.agents import Agent, AudioTurnContext, ConversationItemAddedEvent
+from livekit.agents.utils.audio import calculate_audio_duration
+from livekit.agents.voice.transcription.synchronizer import _SyncedAudioOutput
+
+from .fake_io import FakeAudioInput
+from .fake_session import FakeActions, create_session
+from .fake_stt import FakeSTT
+
+SESSION_TIMEOUT = 60.0
+
+
+class _FakeAudioTurnDetector:
+    def __init__(self, *, probability: float, threshold: float = 0.5) -> None:
+        self._probability = probability
+        self._threshold = threshold
+        self.contexts: list[AudioTurnContext] = []
+
+    @property
+    def model(self) -> str:
+        return "fake-audio-turn-detector"
+
+    @property
+    def provider(self) -> str:
+        return "tests"
+
+    async def unlikely_threshold(self, language) -> float | None:
+        return self._threshold
+
+    async def supports_language(self, language) -> bool:
+        return True
+
+    async def predict_end_of_turn_audio(
+        self, turn_ctx: AudioTurnContext, *, timeout: float | None = None
+    ) -> float:
+        self.contexts.append(
+            AudioTurnContext(
+                audio=list(turn_ctx.audio),
+                transcript=turn_ctx.transcript,
+                chat_ctx=turn_ctx.chat_ctx.copy(),
+                language=turn_ctx.language,
+            )
+        )
+        return self._probability
+
+
+async def _run_session_with_streamed_audio(
+    session,
+    agent: Agent,
+    *,
+    frame_duration: float = 0.02,
+    drain_delay: float = 0.2,
+) -> float:
+    stt = session.stt
+    audio_input = session.input.audio
+    assert isinstance(stt, FakeSTT)
+    assert isinstance(audio_input, FakeAudioInput)
+
+    transcription_sync = None
+    if isinstance(session.output.audio, _SyncedAudioOutput):
+        transcription_sync = session.output.audio._synchronizer
+
+    stop_audio = asyncio.Event()
+
+    async def _pump_audio() -> None:
+        while not stop_audio.is_set():
+            audio_input.push(frame_duration)
+            await asyncio.sleep(frame_duration)
+
+    await session.start(agent)
+    audio_task = asyncio.create_task(_pump_audio())
+    t_origin = time.time()
+
+    try:
+        await stt.fake_user_speeches_done
+        await asyncio.sleep(drain_delay)
+        await session.drain()
+        await session.aclose()
+    finally:
+        stop_audio.set()
+        audio_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await audio_task
+        if transcription_sync is not None:
+            await transcription_sync.aclose()
+
+    return t_origin
+
+
+async def test_audio_turn_detector_receives_audio_context() -> None:
+    speed = 5.0
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 1.5, "Hello there", stt_delay=0.2)
+    actions.add_llm("Hi there!", ttft=0.1, duration=0.3)
+    actions.add_tts(1.0, ttfb=0.1, duration=0.2)
+
+    detector = _FakeAudioTurnDetector(probability=0.95)
+    session = create_session(actions, speed_factor=speed)
+    session.update_options(turn_detection=detector)
+
+    await asyncio.wait_for(
+        _run_session_with_streamed_audio(session, Agent(instructions="You are helpful.")),
+        timeout=SESSION_TIMEOUT,
+    )
+
+    assert len(detector.contexts) == 1
+    turn_ctx = detector.contexts[0]
+    assert turn_ctx.transcript == "Hello there"
+    assert turn_ctx.chat_ctx.items[-1].type == "message"
+    assert turn_ctx.chat_ctx.items[-1].role == "user"
+    assert turn_ctx.chat_ctx.items[-1].text_content == "Hello there"
+    assert calculate_audio_duration(turn_ctx.audio) >= 0.25
+
+
+async def test_audio_turn_detector_controls_endpointing_delay() -> None:
+    async def _run_turn(probability: float) -> float:
+        speed = 5.0
+        actions = FakeActions()
+        actions.add_user_speech(0.5, 1.5, "hello", stt_delay=0.2)
+        actions.add_llm("hi", ttft=0.1, duration=0.2)
+        actions.add_tts(0.5, ttfb=0.1, duration=0.2)
+
+        detector = _FakeAudioTurnDetector(probability=probability, threshold=0.5)
+        session = create_session(actions, speed_factor=speed)
+        session.update_options(
+            endpointing_opts={"min_delay": 0.05, "max_delay": 0.25},
+            turn_detection=detector,
+        )
+
+        conversation_events: list[ConversationItemAddedEvent] = []
+        session.on("conversation_item_added", conversation_events.append)
+
+        t_origin = await _run_session_with_streamed_audio(
+            session, Agent(instructions="You are helpful.")
+        )
+        user_event = next(
+            ev for ev in conversation_events if ev.item.type == "message" and ev.item.role == "user"
+        )
+        return user_event.created_at - t_origin
+
+    fast_commit_time = await asyncio.wait_for(_run_turn(0.95), timeout=SESSION_TIMEOUT)
+    slow_commit_time = await asyncio.wait_for(_run_turn(0.05), timeout=SESSION_TIMEOUT)
+
+    assert slow_commit_time - fast_commit_time >= 0.12
+
+
+async def test_audio_turn_detector_buffer_resets_between_turns() -> None:
+    speed = 5.0
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 1.5, "First turn", stt_delay=0.2)
+    actions.add_llm("first response", ttft=0.1, duration=0.2)
+    actions.add_tts(0.4, ttfb=0.1, duration=0.2)
+    actions.add_user_speech(2.8, 3.8, "Second turn", stt_delay=0.2)
+    actions.add_llm("second response", ttft=0.1, duration=0.2)
+    actions.add_tts(0.4, ttfb=0.1, duration=0.2)
+
+    detector = _FakeAudioTurnDetector(probability=0.95)
+    session = create_session(actions, speed_factor=speed)
+    session.update_options(turn_detection=detector)
+
+    await asyncio.wait_for(
+        _run_session_with_streamed_audio(session, Agent(instructions="You are helpful.")),
+        timeout=SESSION_TIMEOUT,
+    )
+
+    assert [ctx.transcript for ctx in detector.contexts] == ["First turn", "Second turn"]
+    first_duration = calculate_audio_duration(detector.contexts[0].audio)
+    second_duration = calculate_audio_duration(detector.contexts[1].audio)
+
+    assert first_duration < 0.6
+    assert second_duration < 0.6


### PR DESCRIPTION
## Summary

This PR adds an opt-in extension point for audio-native turn detectors in `livekit-agents`.

Today, custom turn detectors operate on chat or transcript context only. This change adds:
- `AudioTurnContext`, a public container for buffered current-turn audio plus transcript and chat context
- `AudioTurnDetector`, a public protocol for audio-native end-of-turn detectors
- current-turn PCM buffering in `AudioRecognition`
- audio-detector invocation in the existing end-of-utterance path before endpointing and commit
- a focused example agent and unit coverage for the new hook

## Motivation

Some turn detectors operate directly on audio rather than text. Those detectors cannot currently plug into the existing custom turn-detection API because only `ChatContext` is exposed to custom detectors.

This PR adds the minimal generic hook needed to support that class of detector without introducing any provider-specific dependency.

## Scope

- no default behavior change
- existing text/chat-context turn detectors continue to work unchanged
- no built-in vendor or model integration is added in this PR
- audio is exposed as buffered current-turn frames; model-specific preprocessing remains the responsibility of the detector implementation

## Validation

- `make check`
- `uv run pytest tests/test_agent_session.py tests/test_audio_recognition_handoff.py tests/test_audio_turn_detection.py -q`
- `uv run python -m py_compile examples/voice_agents/audio_turn_detector.py`
- `uv run examples/voice_agents/audio_turn_detector.py --help`

## Notes

This draft intentionally keeps the change generic and provider-agnostic. A follow-up plugin PR can implement a concrete detector on top of this hook.

This is also intended as a narrower, lower-risk framing of audio-based turn detection than the earlier feature request in #3094.
