### PR TITLE
fix(cartesia): Move API key from Query Params to Headers

### DIFF
--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/stt.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/stt.py
@@ -37,7 +37,7 @@ from livekit.agents.types import NOT_GIVEN, NotGivenOr
 from livekit.agents.utils import is_given
 from livekit.agents.voice.io import TimedString
 
-from .constants import API_VERSION, REQUEST_ID_HEADER, USER_AGENT
+from .constants import API_AUTH_HEADER, API_VERSION, REQUEST_ID_HEADER, USER_AGENT
 from .log import logger
 from .models import STTEncoding, STTLanguages, STTModels
 
@@ -330,7 +330,6 @@ class SpeechStream(stt.SpeechStream):
             "sample_rate": str(self._opts.sample_rate),
             "encoding": self._opts.encoding,
             "cartesia_version": API_VERSION,
-            "api_key": self._opts.api_key,
         }
 
         if self._opts.language:
@@ -343,7 +342,13 @@ class SpeechStream(stt.SpeechStream):
 
         try:
             ws = await asyncio.wait_for(
-                self._session.ws_connect(ws_url, headers={"User-Agent": USER_AGENT}),
+                self._session.ws_connect(
+                    ws_url,
+                    headers={
+                        "User-Agent": USER_AGENT,
+                        API_AUTH_HEADER: self._opts.api_key,
+                    },
+                ),
                 self._conn_options.timeout,
             )
             c_request_id = ws._response.headers.get(REQUEST_ID_HEADER)

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -208,11 +208,16 @@ class TTS(tts.TTS):
 
     async def _connect_ws(self, timeout: float) -> aiohttp.ClientWebSocketResponse:
         session = self._ensure_session()
-        url = self._opts.get_ws_url(
-            f"/tts/websocket?api_key={self._opts.api_key}&cartesia_version={self._opts.api_version}"
-        )
+        url = self._opts.get_ws_url(f"/tts/websocket?cartesia_version={self._opts.api_version}")
         ws = await asyncio.wait_for(
-            session.ws_connect(url, headers={"User-Agent": USER_AGENT}), timeout
+            session.ws_connect(
+                url,
+                headers={
+                    "User-Agent": USER_AGENT,
+                    API_AUTH_HEADER: self._opts.api_key,
+                },
+            ),
+            timeout,
         )
         c_request_id = ws._response.headers.get(REQUEST_ID_HEADER)
         logger.debug(


### PR DESCRIPTION
Moves the Cartesia API key from inside the WebSocket URL (`wss://api.cartesia.ai?api_key=sk_abc`) to the `X-API-Key` header for both TTS and STT streaming connections.

This is to avoid accidentally exposing API keys since URLs are commonly logged.

Testing:

- [x] Created an agent using Cartesia TTS + STT
- [x] API key appears in headers now rather than the URL
