### PR TITLE
fix: clear _hist buffer in MovingAverage.reset() to prevent stale averages

### DIFF
--- a/livekit-agents/livekit/agents/utils/moving_average.py
+++ b/livekit-agents/livekit/agents/utils/moving_average.py
@@ -21,6 +21,7 @@ class MovingAverage:
         return self._sum / self.size()
 
     def reset(self) -> None:
+        self._hist = [0.0] * len(self._hist)
         self._count = 0
         self._sum = 0
 


### PR DESCRIPTION
Closes #5521

## Problem
`MovingAverage.reset()` resets `_count` and `_sum` to zero but does not clear the `_hist` ring-buffer. After a reset, once the window fills again, the eviction path subtracts stale pre-reset values from `_sum`, producing incorrect moving averages.

## Fix
Clear `_hist` in `reset()` by replacing with a zero-initialized list of the same length.

## Changes
- `livekit-agents/livekit/agents/utils/moving_average.py`: added `self._hist = [0.0] * len(self._hist)` as first line of `reset()`