### PR TITLE
docs: clarify RunResult.events testing surface

### DIFF
--- a/livekit-agents/livekit/agents/voice/run_result.py
+++ b/livekit-agents/livekit/agents/voice/run_result.py
@@ -79,7 +79,17 @@ class RunResult(Generic[Run_T]):
 
     @property
     def events(self) -> list[RunEvent]:
-        """List of all recorded events generated during the run."""
+        """
+        List of recorded run events in chronological order.
+
+        This surface is intended for assertions in tests. Events may include
+        `ChatMessageEvent`, `FunctionCallEvent`,
+        `FunctionCallOutputEvent`, and `AgentHandoffEvent`.
+
+        Use `RunResult.events` when validating what happened in a run instead
+        of depending on lower-level session internals, room state, or raw media
+        artifacts.
+        """
         return self._recorded_items
 
     @functools.cached_property


### PR DESCRIPTION
Fixes #5410

Documents `RunResult.events` as a small, testing-oriented surface, enumerates the event types it contains, and clarifies that callers should use it for run assertions instead of depending on lower-level session internals or raw media artifacts.