### PR TITLE
feat(mistral): migrate LLM to Conversations API with provider tools support

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
@@ -1,17 +1,109 @@
 from __future__ import annotations
 
-from typing import Literal
+import base64
+from dataclasses import dataclass
+from typing import Any
 
 from livekit.agents import llm
 
-from .openai import to_chat_ctx as openai_to_chat_ctx
+from .utils import group_tool_calls
 
 
-def to_chat_ctx(
-    chat_ctx: llm.ChatContext, *, inject_dummy_user_message: bool = True
-) -> tuple[list[dict], Literal[None]]:
-    messages, _ = openai_to_chat_ctx(chat_ctx, inject_dummy_user_message=inject_dummy_user_message)
+@dataclass
+class MistralFormatData:
+    instructions: str | None
 
-    if inject_dummy_user_message and (not messages or messages[-1]["role"] not in ["user", "tool"]):
-        messages.append({"role": "user", "content": ""})
-    return messages, None
+
+def to_conversations_ctx(
+    chat_ctx: llm.ChatContext,
+) -> tuple[list[dict], MistralFormatData]:
+    """Convert ChatContext to Mistral Conversations API entry format.
+
+    Returns:
+        A tuple of (entries, instructions) where instructions is the extracted
+        system/developer message content (or None if absent).
+    """
+    item_groups = group_tool_calls(chat_ctx)
+    entries: list[dict[str, Any]] = []
+    instructions: str | None = None
+
+    for group in item_groups:
+        if not group.message and not group.tool_calls and not group.tool_outputs:
+            continue
+
+        if group.message:
+            item = group.message
+            if isinstance(item, llm.ChatMessage) and item.role in ("system", "developer"):
+                text_parts = [c for c in item.content if isinstance(c, str)]
+                instructions = "\n".join(text_parts) if text_parts else None
+                continue
+
+            entry = _to_entry(item)
+            if entry is not None:
+                entries.append(entry)
+
+        for tool_call in group.tool_calls:
+            entries.append(
+                {
+                    "type": "function.call",
+                    "tool_call_id": tool_call.call_id,
+                    "name": tool_call.name,
+                    "arguments": tool_call.arguments,
+                }
+            )
+
+        for tool_output in group.tool_outputs:
+            entries.append(
+                {
+                    "type": "function.result",
+                    "tool_call_id": tool_output.call_id,
+                    "result": tool_output.output,
+                }
+            )
+
+    return entries, MistralFormatData(instructions=instructions)
+
+
+def _to_entry(item: llm.ChatItem) -> dict[str, Any] | None:
+    if not isinstance(item, llm.ChatMessage):
+        return None
+
+    content = _build_content(item)
+
+    if item.role == "user":
+        return {"type": "message.input", "role": "user", "content": content}
+    elif item.role == "assistant":
+        return {"type": "message.output", "role": "assistant", "content": content}
+
+    return None
+
+
+def _build_content(msg: llm.ChatMessage) -> str | list[dict[str, Any]]:
+    list_content: list[dict[str, Any]] = []
+    text_content = ""
+
+    for content in msg.content:
+        if isinstance(content, str):
+            if text_content:
+                text_content += "\n"
+            text_content += content
+        elif isinstance(content, llm.ImageContent):
+            list_content.append(_to_image_content(content))
+
+    if not list_content:
+        return text_content
+
+    if text_content:
+        list_content.append({"type": "text", "text": text_content})
+
+    return list_content
+
+
+def _to_image_content(image: llm.ImageContent) -> dict[str, Any]:
+    img = llm.utils.serialize_image(image)
+    if img.external_url:
+        return {"type": "image_url", "image_url": img.external_url}
+
+    assert img.data_bytes is not None
+    b64_data = base64.b64encode(img.data_bytes).decode("utf-8")
+    return {"type": "image_url", "image_url": f"data:{img.mime_type};base64,{b64_data}"}

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -663,8 +663,8 @@ class ChatContext:
 
     @overload
     def to_provider_format(
-        self, format: Literal["mistralai"], *, inject_dummy_user_message: bool = True
-    ) -> tuple[list[dict], Literal[None]]: ...
+        self, format: Literal["mistralai"]
+    ) -> tuple[list[dict], _provider_format.mistralai.MistralFormatData]: ...
 
     @overload
     def to_provider_format(self, format: str, **kwargs: Any) -> tuple[list[dict], Any]: ...
@@ -698,7 +698,7 @@ class ChatContext:
         elif format == "anthropic":
             return _provider_format.anthropic.to_chat_ctx(self, **kwargs)
         elif format == "mistralai":
-            return _provider_format.mistralai.to_chat_ctx(self, **kwargs)
+            return _provider_format.mistralai.to_conversations_ctx(self)
         else:
             raise ValueError(f"Unsupported provider format: {format}")
 

--- a/livekit-plugins/livekit-plugins-mistralai/README.md
+++ b/livekit-plugins/livekit-plugins-mistralai/README.md
@@ -82,10 +82,25 @@ from livekit.plugins import mistralai
 
 llm = mistralai.LLM()
 
-# With custom temperature/max. tokens
+# With all available options
 llm = mistralai.LLM(
     model="mistral-large-latest",
     temperature=0.7,
-    max_completion_tokens=150
+    top_p=0.9,
+    max_completion_tokens=150,
+    presence_penalty=0.1,
+    frequency_penalty=0.1,
+    random_seed=42,
+    tool_choice="auto",
+)
+
+# With provider tools
+agent = Agent(
+    llm=llm,
+    tools=[
+        mistralai.tools.WebSearch(),
+        mistralai.tools.CodeInterpreter(),
+        mistralai.tools.DocumentLibrary(library_ids=["<your-library-id>"]),
+    ]
 )
 ```

--- a/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/__init__.py
+++ b/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/__init__.py
@@ -2,13 +2,14 @@
 
 from livekit.agents import Plugin
 
+from . import tools
 from .llm import LLM
 from .log import logger
 from .stt import STT
 from .tts import TTS
 from .version import __version__
 
-__all__ = ["LLM", "STT", "TTS", "__version__"]
+__all__ = ["LLM", "STT", "TTS", "tools", "__version__"]
 
 
 class MistralAIPlugin(Plugin):

--- a/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/llm.py
+++ b/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/llm.py
@@ -253,6 +253,9 @@ class LLMStream(llm.LLMStream):
         self._received_conversation_id: str | None = None
 
     async def _run(self) -> None:
+        self._emitted_tool_calls = set()
+        self._provider_tool_args = {}
+        self._received_conversation_id = None
         retryable = True
 
         try:
@@ -262,13 +265,17 @@ class LLMStream(llm.LLMStream):
                 if isinstance(tool, MistralTool):
                     tools_list.append(tool.to_dict())
 
+            start_kwargs: dict[str, Any] = {}
+            if tools_list:
+                start_kwargs["tools"] = tools_list
+
             if self._conversation_id is None:
                 async_response = await self._client.beta.conversations.start_stream_async(
                     inputs=entries,
                     model=self._model,
                     instructions=extra_data.instructions,
-                    tools=tools_list or None,
                     timeout_ms=int(self._conn_options.timeout * 1000),
+                    **start_kwargs,
                     **self._extra_kwargs,
                 )
             else:

--- a/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/llm.py
+++ b/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/llm.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import json
 import os
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any
 
 from livekit.agents import APIConnectionError, APIStatusError, APITimeoutError, llm
 from livekit.agents.llm import (
     ChatChunk,
     ChatContext,
+    ChatItem,
     ToolChoice,
     utils as llm_utils,
 )
@@ -21,12 +21,22 @@ from livekit.agents.types import (
 from livekit.agents.utils import is_given, shortuuid
 from mistralai.client import Mistral
 from mistralai.client.models import (
-    ChatCompletionStreamRequestMessageTypedDict,
-    CompletionResponseStreamChoice,
-    ToolTypedDict,
+    CompletionArgs,
+    ConversationEvents,
+    FunctionCallEvent,
+    MessageOutputEvent,
+    ResponseDoneEvent,
+    ResponseErrorEvent,
+    ResponseStartedEvent,
+    TextChunk,
+    ToolExecutionDeltaEvent,
+    ToolExecutionDoneEvent,
+    ToolExecutionStartedEvent,
 )
 
+from .log import logger
 from .models import ChatModels
+from .tools import MistralTool
 
 DEFAULT_MODEL: ChatModels = "ministral-8b-latest"
 
@@ -36,6 +46,16 @@ class _LLMOptions:
     model: ChatModels | str
     max_completion_tokens: int | None
     temperature: float | None
+
+
+@dataclass
+class _PendingFunctionCall:
+    """Accumulates streamed function call deltas."""
+
+    id: str
+    name: str
+    tool_call_id: str
+    arguments: str = ""
 
 
 class LLM(llm.LLM):
@@ -50,14 +70,17 @@ class LLM(llm.LLM):
         """
         Create a new instance of MistralAI LLM.
 
+        Uses the Mistral Conversations API, which supports both function tools
+        and provider tools (web search, document library, code interpreter).
+
         Args:
             client: Optional pre-configured MistralAI client instance.
-            api_key: Your Mistral AI API key. If not provided, will use the MISTRAL_API_KEY environment variable.
-            model: The Mistral AI model to use for completions, default is "ministral-8b-latest".
+            api_key: Your Mistral AI API key.
+                If not provided, will use the MISTRAL_API_KEY environment variable.
+            model: The Mistral AI model to use, default is "ministral-8b-latest".
             max_completion_tokens: The max. number of tokens the LLM can output.
             temperature: The temperature to use the LLM with.
         """
-
         resolved_model = model if is_given(model) else DEFAULT_MODEL
         resolved_max_completion_tokens = (
             max_completion_tokens if is_given(max_completion_tokens) else None
@@ -74,6 +97,9 @@ class LLM(llm.LLM):
         if not client and not mistral_api_key:
             raise ValueError("Mistral AI API key is required. Set MISTRAL_API_KEY or pass api_key")
         self._client = client or Mistral(api_key=mistral_api_key)
+        self._conversation_id: str | None = None
+        self._prev_chat_ctx: ChatContext | None = None
+        self._pending_tool_calls: set[str] = set()
 
     @property
     def model(self) -> str:
@@ -117,29 +143,52 @@ class LLM(llm.LLM):
         extra_kwargs: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
     ) -> LLMStream:
         extra: dict[str, Any] = {}
-
         if is_given(extra_kwargs):
             extra.update(extra_kwargs)
+
+        completion_args: dict[str, Any] = {}
         if is_given(parallel_tool_calls):
-            extra["parallel_tool_calls"] = parallel_tool_calls
+            completion_args["parallel_tool_calls"] = parallel_tool_calls
         if is_given(tool_choice):
-            extra["tool_choice"] = tool_choice
+            completion_args["tool_choice"] = tool_choice
         if is_given(response_format):
-            extra["response_format"] = response_format
+            completion_args["response_format"] = response_format
         if self._opts.max_completion_tokens is not None:
-            extra["max_tokens"] = self._opts.max_completion_tokens
+            completion_args["max_tokens"] = self._opts.max_completion_tokens
         if self._opts.temperature is not None:
-            extra["temperature"] = self._opts.temperature
+            completion_args["temperature"] = self._opts.temperature
+        if completion_args:
+            extra["completion_args"] = CompletionArgs(**completion_args)
+
+        input_chat_ctx = chat_ctx
+        conversation_id: str | None = None
+        if self._prev_chat_ctx is not None and self._conversation_id:
+            n = len(self._prev_chat_ctx.items)
+            if ChatContext(items=chat_ctx.items[:n]).is_equivalent(
+                self._prev_chat_ctx
+            ) and self._pending_tool_calls_completed(chat_ctx.items[n:]):
+                input_chat_ctx = ChatContext(items=chat_ctx.items[n:])
+                conversation_id = self._conversation_id
 
         return LLMStream(
             self,
             model=self._opts.model,
             client=self._client,
-            chat_ctx=chat_ctx,
+            chat_ctx=input_chat_ctx,
+            full_chat_ctx=chat_ctx,
+            conversation_id=conversation_id,
             tools=tools or [],
             conn_options=conn_options,
             extra_kwargs=extra,
         )
+
+    def _pending_tool_calls_completed(self, items: list[ChatItem]) -> bool:
+        """Check that all pending function calls from the previous response have results."""
+        if not self._pending_tool_calls:
+            return True
+
+        completed = {item.call_id for item in items if isinstance(item, llm.FunctionCallOutput)}
+        return all(call_id in completed for call_id in self._pending_tool_calls)
 
 
 class LLMStream(llm.LLMStream):
@@ -150,6 +199,8 @@ class LLMStream(llm.LLMStream):
         model: str | ChatModels,
         client: Mistral,
         chat_ctx: ChatContext,
+        full_chat_ctx: ChatContext,
+        conversation_id: str | None,
         tools: list[llm.Tool],
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
         extra_kwargs: dict[str, Any],
@@ -157,34 +208,56 @@ class LLMStream(llm.LLMStream):
         super().__init__(llm_v, chat_ctx=chat_ctx, tools=tools, conn_options=conn_options)
         self._model = model
         self._client = client
-        self._llm = llm_v
+        self._mistral_llm = llm_v
+        self._full_chat_ctx = full_chat_ctx.copy()
+        self._conversation_id = conversation_id
         self._extra_kwargs = extra_kwargs
         self._tool_ctx = llm.ToolContext(tools)
+        self._emitted_tool_calls: set[str] = set()
+        self._provider_tool_args: dict[str, str] = {}  # id -> accumulated arguments
 
     async def _run(self) -> None:
-        # current function call that we're waiting for full completion (args are streamed)
-        # (defined inside the _run method to make sure the state is reset for each run/attempt)
         retryable = True
 
         try:
-            messages, _ = self._chat_ctx.to_provider_format(format="mistralai")
-            tools = self._tool_ctx.parse_function_tools("openai", strict=True)
+            entries, extra_data = self._chat_ctx.to_provider_format(format="mistralai")
+            tools_list = self._tool_ctx.parse_function_tools("openai", strict=True)
+            for tool in self._tool_ctx.provider_tools:
+                if isinstance(tool, MistralTool):
+                    tools_list.append(tool.to_dict())
 
-            async_response = await self._client.chat.stream_async(
-                messages=cast(list[ChatCompletionStreamRequestMessageTypedDict], messages),
-                tools=cast(list[ToolTypedDict], tools),
-                model=self._model,
-                timeout_ms=int(self._conn_options.timeout * 1000),
-                **self._extra_kwargs,
-            )
+            if self._conversation_id is None:
+                async_response = await self._client.beta.conversations.start_stream_async(
+                    inputs=entries,
+                    model=self._model,
+                    instructions=extra_data.instructions,
+                    tools=tools_list or None,
+                    timeout_ms=int(self._conn_options.timeout * 1000),
+                    **self._extra_kwargs,
+                )
+            else:
+                # the server already has its own outputs (message.output, function.call),
+                # so we only send function results and new user messages.
+                async_response = await self._client.beta.conversations.append_stream_async(
+                    conversation_id=self._conversation_id,
+                    inputs=[
+                        e for e in entries if e.get("type") in ("function.result", "message.input")
+                    ],
+                    timeout_ms=int(self._conn_options.timeout * 1000),
+                    **self._extra_kwargs,
+                )
+
+            pending_fnc_calls: dict[str, _PendingFunctionCall] = {}
+
             async for ev in async_response:
-                if not ev.data.choices:
-                    continue
-                choice = ev.data.choices[0]
-                chat_chunk = self._parse_choice(ev.data.id, choice)
-                if chat_chunk is not None:
+                chunks = self._parse_event(ev, pending_fnc_calls)
+                for chat_chunk in chunks:
                     retryable = False
                     self._event_ch.send_nowait(chat_chunk)
+
+            # store current state for next call's diff
+            self._mistral_llm._prev_chat_ctx = self._full_chat_ctx
+            self._mistral_llm._pending_tool_calls = self._emitted_tool_calls
 
         except APITimeoutError:
             raise APITimeoutError(retryable=retryable) from None
@@ -199,25 +272,102 @@ class LLMStream(llm.LLMStream):
         except Exception as e:
             raise APIConnectionError(retryable=retryable) from e
 
-    def _parse_choice(self, id: str, choice: CompletionResponseStreamChoice) -> ChatChunk | None:
-        chunk = llm.ChatChunk(id=id)
-        if choice.delta.content and isinstance(choice.delta.content, str):
-            # TODO: support thinking chunks
-            chunk.delta = llm.ChoiceDelta(content=choice.delta.content, role="assistant")
+    def _flush_pending_fnc_calls(self, pending: dict[str, _PendingFunctionCall]) -> list[ChatChunk]:
+        """Emit completed FunctionToolCalls from the pending buffer."""
+        chunks: list[ChatChunk] = []
+        for fnc in pending.values():
+            delta = llm.ChoiceDelta(role="assistant")
+            delta.tool_calls.append(
+                llm.FunctionToolCall(
+                    name=fnc.name,
+                    arguments=fnc.arguments,
+                    call_id=fnc.tool_call_id,
+                )
+            )
+            chunks.append(ChatChunk(id=fnc.id, delta=delta))
+            self._emitted_tool_calls.add(fnc.tool_call_id)
+        pending.clear()
+        return chunks
 
-        if choice.delta.tool_calls:
-            if not chunk.delta:
-                chunk.delta = llm.ChoiceDelta(role="assistant")
+    def _parse_event(
+        self,
+        ev: ConversationEvents,
+        pending_fnc_calls: dict[str, _PendingFunctionCall],
+    ) -> list[ChatChunk]:
+        data = ev.data
+        chunks: list[ChatChunk] = []
 
-            for tool in choice.delta.tool_calls:
-                arguments = tool.function.arguments
-                if not isinstance(arguments, str):
-                    arguments = json.dumps(arguments)
-                call_id = tool.id or shortuuid("tool_call_")
+        if isinstance(data, ResponseStartedEvent):
+            self._mistral_llm._conversation_id = data.conversation_id
+            return chunks
 
-                chunk.delta.tool_calls.append(
-                    llm.FunctionToolCall(
-                        name=tool.function.name, arguments=arguments, call_id=call_id
+        if isinstance(data, FunctionCallEvent):
+            # accumulate arguments across delta events
+            call_id = data.tool_call_id or shortuuid("tool_call_")
+            if call_id not in pending_fnc_calls:
+                pending_fnc_calls[call_id] = _PendingFunctionCall(
+                    id=data.id,
+                    name=data.name,
+                    tool_call_id=call_id,
+                )
+            pending_fnc_calls[call_id].arguments += data.arguments
+            return chunks
+
+        # any non-FunctionCallEvent flushes pending function calls
+        chunks.extend(self._flush_pending_fnc_calls(pending_fnc_calls))
+
+        if isinstance(data, MessageOutputEvent):
+            content = data.content
+            if isinstance(content, str):
+                text = content
+            elif isinstance(content, TextChunk):
+                text = content.text
+            else:
+                return chunks
+
+            if text:
+                chunks.append(
+                    ChatChunk(
+                        id=data.id,
+                        delta=llm.ChoiceDelta(content=text, role="assistant"),
                     )
                 )
-        return chunk if chunk.delta else None
+            return chunks
+
+        if isinstance(data, ResponseDoneEvent):
+            usage = data.usage
+            chunks.append(
+                ChatChunk(
+                    id=shortuuid("done_"),
+                    usage=llm.CompletionUsage(
+                        completion_tokens=usage.completion_tokens or 0,
+                        prompt_tokens=usage.prompt_tokens or 0,
+                        total_tokens=usage.total_tokens or 0,
+                    ),
+                )
+            )
+            return chunks
+
+        if isinstance(data, ResponseErrorEvent):
+            raise APIStatusError(
+                data.message,
+                status_code=data.code,
+                request_id=None,
+                body=None,
+                retryable=False,
+            )
+
+        if isinstance(data, ToolExecutionStartedEvent):
+            self._provider_tool_args[data.id] = data.arguments
+
+        elif isinstance(data, ToolExecutionDeltaEvent):
+            self._provider_tool_args[data.id] += data.arguments
+
+        elif isinstance(data, ToolExecutionDoneEvent):
+            args = self._provider_tool_args.pop(data.id, "")
+            logger.debug(
+                "executed provider tool",
+                extra={"function": data.name, "arguments": args, "info": data.info},
+            )
+
+        return chunks

--- a/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/llm.py
+++ b/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/llm.py
@@ -139,6 +139,9 @@ class LLM(llm.LLM):
     ) -> None:
         if is_given(model):
             self._opts.model = model
+            self._conversation_id = None
+            self._prev_chat_ctx = None
+            self._pending_tool_calls = set()
         if is_given(max_completion_tokens):
             self._opts.max_completion_tokens = max_completion_tokens
         if is_given(temperature):

--- a/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/llm.py
+++ b/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/llm.py
@@ -10,7 +10,6 @@ from livekit.agents.llm import (
     ChatContext,
     ChatItem,
     ToolChoice,
-    utils as llm_utils,
 )
 from livekit.agents.types import (
     DEFAULT_API_CONNECT_OPTIONS,
@@ -46,6 +45,11 @@ class _LLMOptions:
     model: ChatModels | str
     max_completion_tokens: int | None
     temperature: float | None
+    top_p: float | None
+    presence_penalty: float | None
+    frequency_penalty: float | None
+    random_seed: int | None
+    tool_choice: ToolChoice | None
 
 
 @dataclass
@@ -61,11 +65,17 @@ class _PendingFunctionCall:
 class LLM(llm.LLM):
     def __init__(
         self,
+        *,
         client: Mistral | None = None,
         api_key: NotGivenOr[str] = NOT_GIVEN,
         model: NotGivenOr[ChatModels | str] = NOT_GIVEN,
-        max_completion_tokens: NotGivenOr[int] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
+        top_p: NotGivenOr[float] = NOT_GIVEN,
+        presence_penalty: NotGivenOr[float] = NOT_GIVEN,
+        frequency_penalty: NotGivenOr[float] = NOT_GIVEN,
+        random_seed: NotGivenOr[int] = NOT_GIVEN,
+        tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
+        max_completion_tokens: NotGivenOr[int] = NOT_GIVEN,
     ) -> None:
         """
         Create a new instance of MistralAI LLM.
@@ -78,19 +88,26 @@ class LLM(llm.LLM):
             api_key: Your Mistral AI API key.
                 If not provided, will use the MISTRAL_API_KEY environment variable.
             model: The Mistral AI model to use, default is "ministral-8b-latest".
-            max_completion_tokens: The max. number of tokens the LLM can output.
             temperature: The temperature to use the LLM with.
+            top_p: Nucleus sampling parameter.
+            presence_penalty: Penalize new tokens based on their presence in the text so far.
+            frequency_penalty: Penalize new tokens based on their frequency in the text so far.
+            random_seed: Random seed for reproducibility.
+            tool_choice: Default tool choice strategy ("auto", "required", "none").
+            max_completion_tokens: The max. number of tokens the LLM can output.
         """
-        resolved_model = model if is_given(model) else DEFAULT_MODEL
-        resolved_max_completion_tokens = (
-            max_completion_tokens if is_given(max_completion_tokens) else None
-        )
-        resolved_temperature = temperature if is_given(temperature) else None
         super().__init__()
         self._opts = _LLMOptions(
-            model=resolved_model,
-            max_completion_tokens=resolved_max_completion_tokens,
-            temperature=resolved_temperature,
+            model=model if is_given(model) else DEFAULT_MODEL,
+            temperature=temperature if is_given(temperature) else None,
+            top_p=top_p if is_given(top_p) else None,
+            presence_penalty=presence_penalty if is_given(presence_penalty) else None,
+            frequency_penalty=frequency_penalty if is_given(frequency_penalty) else None,
+            random_seed=random_seed if is_given(random_seed) else None,
+            tool_choice=tool_choice if is_given(tool_choice) else None,
+            max_completion_tokens=max_completion_tokens
+            if is_given(max_completion_tokens)
+            else None,
         )
 
         mistral_api_key = api_key if is_given(api_key) else os.environ.get("MISTRAL_API_KEY")
@@ -115,21 +132,28 @@ class LLM(llm.LLM):
         model: NotGivenOr[ChatModels | str] = NOT_GIVEN,
         max_completion_tokens: NotGivenOr[int] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
+        top_p: NotGivenOr[float] = NOT_GIVEN,
+        presence_penalty: NotGivenOr[float] = NOT_GIVEN,
+        frequency_penalty: NotGivenOr[float] = NOT_GIVEN,
+        random_seed: NotGivenOr[int] = NOT_GIVEN,
+        tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
     ) -> None:
-        """
-        Update the LLM options.
-
-        Args:
-            model: The model to use for completions
-            max_completion_tokens: The max. number of tokens the LLM can output.
-            temperature: The temperature to use the LLM with.
-        """
         if is_given(model):
             self._opts.model = model
         if is_given(max_completion_tokens):
             self._opts.max_completion_tokens = max_completion_tokens
         if is_given(temperature):
             self._opts.temperature = temperature
+        if is_given(top_p):
+            self._opts.top_p = top_p
+        if is_given(presence_penalty):
+            self._opts.presence_penalty = presence_penalty
+        if is_given(frequency_penalty):
+            self._opts.frequency_penalty = frequency_penalty
+        if is_given(random_seed):
+            self._opts.random_seed = random_seed
+        if is_given(tool_choice):
+            self._opts.tool_choice = tool_choice
 
     def chat(
         self,
@@ -139,7 +163,6 @@ class LLM(llm.LLM):
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
-        response_format: NotGivenOr[type[llm_utils.ResponseFormatT]] = NOT_GIVEN,
         extra_kwargs: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
     ) -> LLMStream:
         extra: dict[str, Any] = {}
@@ -147,16 +170,26 @@ class LLM(llm.LLM):
             extra.update(extra_kwargs)
 
         completion_args: dict[str, Any] = {}
-        if is_given(parallel_tool_calls):
-            completion_args["parallel_tool_calls"] = parallel_tool_calls
-        if is_given(tool_choice):
-            completion_args["tool_choice"] = tool_choice
-        if is_given(response_format):
-            completion_args["response_format"] = response_format
         if self._opts.max_completion_tokens is not None:
             completion_args["max_tokens"] = self._opts.max_completion_tokens
         if self._opts.temperature is not None:
             completion_args["temperature"] = self._opts.temperature
+        if self._opts.top_p is not None:
+            completion_args["top_p"] = self._opts.top_p
+        if self._opts.presence_penalty is not None:
+            completion_args["presence_penalty"] = self._opts.presence_penalty
+        if self._opts.frequency_penalty is not None:
+            completion_args["frequency_penalty"] = self._opts.frequency_penalty
+        if self._opts.random_seed is not None:
+            completion_args["random_seed"] = self._opts.random_seed
+
+        resolved_tool_choice = tool_choice if is_given(tool_choice) else self._opts.tool_choice
+        if resolved_tool_choice is not None:
+            has_provider_tools = any(isinstance(t, MistralTool) for t in (tools or []))
+            if isinstance(resolved_tool_choice, dict) or resolved_tool_choice == "required":
+                completion_args["tool_choice"] = "auto" if has_provider_tools else "required"
+            elif resolved_tool_choice in ("auto", "none"):
+                completion_args["tool_choice"] = resolved_tool_choice
         if completion_args:
             extra["completion_args"] = CompletionArgs(**completion_args)
 

--- a/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/llm.py
+++ b/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/llm.py
@@ -85,8 +85,7 @@ class LLM(llm.LLM):
 
         Args:
             client: Optional pre-configured MistralAI client instance.
-            api_key: Your Mistral AI API key.
-                If not provided, will use the MISTRAL_API_KEY environment variable.
+            api_key: Your Mistral AI API key. If not provided, will use the MISTRAL_API_KEY environment variable.
             model: The Mistral AI model to use, default is "ministral-8b-latest".
             temperature: The temperature to use the LLM with.
             top_p: Nucleus sampling parameter.
@@ -247,7 +246,8 @@ class LLMStream(llm.LLMStream):
         self._extra_kwargs = extra_kwargs
         self._tool_ctx = llm.ToolContext(tools)
         self._emitted_tool_calls: set[str] = set()
-        self._provider_tool_args: dict[str, str] = {}  # id -> accumulated arguments
+        self._provider_tool_args: dict[str, str] = {}
+        self._received_conversation_id: str | None = None
 
     async def _run(self) -> None:
         retryable = True
@@ -269,8 +269,6 @@ class LLMStream(llm.LLMStream):
                     **self._extra_kwargs,
                 )
             else:
-                # the server already has its own outputs (message.output, function.call),
-                # so we only send function results and new user messages.
                 async_response = await self._client.beta.conversations.append_stream_async(
                     conversation_id=self._conversation_id,
                     inputs=[
@@ -288,7 +286,10 @@ class LLMStream(llm.LLMStream):
                     retryable = False
                     self._event_ch.send_nowait(chat_chunk)
 
-            # store current state for next call's diff
+            for chat_chunk in self._flush_pending_fnc_calls(pending_fnc_calls):
+                self._event_ch.send_nowait(chat_chunk)
+
+            self._mistral_llm._conversation_id = self._received_conversation_id
             self._mistral_llm._prev_chat_ctx = self._full_chat_ctx
             self._mistral_llm._pending_tool_calls = self._emitted_tool_calls
 
@@ -331,7 +332,7 @@ class LLMStream(llm.LLMStream):
         chunks: list[ChatChunk] = []
 
         if isinstance(data, ResponseStartedEvent):
-            self._mistral_llm._conversation_id = data.conversation_id
+            self._received_conversation_id = data.conversation_id
             return chunks
 
         if isinstance(data, FunctionCallEvent):
@@ -394,6 +395,8 @@ class LLMStream(llm.LLMStream):
             self._provider_tool_args[data.id] = data.arguments
 
         elif isinstance(data, ToolExecutionDeltaEvent):
+            if data.id not in self._provider_tool_args:
+                self._provider_tool_args[data.id] = ""
             self._provider_tool_args[data.id] += data.arguments
 
         elif isinstance(data, ToolExecutionDoneEvent):

--- a/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/stt.py
+++ b/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/stt.py
@@ -83,11 +83,6 @@ class STT(stt.STT):
                 When not provided, Silero VAD is auto-loaded with default settings. Only used with realtime models.
         """
         resolved_model = model if is_given(model) else DEFAULT_MODEL
-        resolved_language = LanguageCode(language) if is_given(language) else None
-        resolved_context_bias = context_bias if is_given(context_bias) else None
-        resolved_target_streaming_delay_ms = (
-            target_streaming_delay_ms if is_given(target_streaming_delay_ms) else None
-        )
         is_realtime = _is_realtime(resolved_model)
         super().__init__(
             capabilities=stt.STTCapabilities(
@@ -99,9 +94,11 @@ class STT(stt.STT):
         )
         self._opts = _STTOptions(
             model=resolved_model,
-            language=resolved_language,
-            context_bias=resolved_context_bias,
-            target_streaming_delay_ms=resolved_target_streaming_delay_ms,
+            language=LanguageCode(language) if is_given(language) else None,
+            context_bias=context_bias if is_given(context_bias) else None,
+            target_streaming_delay_ms=target_streaming_delay_ms
+            if is_given(target_streaming_delay_ms)
+            else None,
         )
 
         if is_realtime and vad is None:

--- a/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/tools.py
+++ b/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/tools.py
@@ -1,0 +1,45 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+from livekit.agents import ProviderTool
+
+
+class MistralTool(ProviderTool, ABC):
+    @abstractmethod
+    def to_dict(self) -> dict[str, Any]: ...
+
+
+@dataclass
+class WebSearch(MistralTool):
+    """Enable web search tool to access up-to-date information from the internet."""
+
+    def __post_init__(self) -> None:
+        super().__init__(id="mistral_web_search")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"type": "web_search"}
+
+
+@dataclass
+class DocumentLibrary(MistralTool):
+    """Enable document library tool to search uploaded document collections."""
+
+    library_ids: list[str]
+
+    def __post_init__(self) -> None:
+        super().__init__(id="mistral_document_library")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"type": "document_library", "library_ids": self.library_ids}
+
+
+@dataclass
+class CodeInterpreter(MistralTool):
+    """Enable the code interpreter tool to write and execute Python code."""
+
+    def __post_init__(self) -> None:
+        super().__init__(id="mistral_code_interpreter")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"type": "code_interpreter"}

--- a/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/tts.py
+++ b/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/tts.py
@@ -37,7 +37,7 @@ SAMPLE_RATE: int = 24000
 NUM_CHANNELS: int = 1
 
 RESPONSE_FORMAT = Literal["mp3", "wav", "pcm", "opus", "flac"]
-DEFAULT_RESPONSE_FORMAT: RESPONSE_FORMAT = "pcm"
+DEFAULT_RESPONSE_FORMAT: RESPONSE_FORMAT = "mp3"
 
 
 @dataclass
@@ -67,7 +67,7 @@ class TTS(tts.TTS):
             model: The Mistral AI model to use for text-to-speech, default is "voxtral-mini-tts-latest".
             voice: The voice ID to use for synthesis. Mutually exclusive with ``ref_audio``. Defaults to ``en_paul_neutral`` when neither is given.
             ref_audio: Base64-encoded audio sample (3–25 s) for zero-shot voice cloning. Mutually exclusive with ``voice``.
-            response_format: The audio format of synthesized speech, between ``mp3``, ``wav``, ``pcm``, ``opus`` or ``flac``. Defaults to ``pcm``.
+            response_format: The audio format of synthesized speech, between ``mp3``, ``wav``, ``pcm``, ``opus`` or ``flac``. Defaults to ``mp3``.
         """
         if is_given(voice) and is_given(ref_audio):
             raise ValueError("Only one of 'voice' or 'ref_audio' may be provided, not both")
@@ -114,7 +114,7 @@ class TTS(tts.TTS):
             model: The model to use for text-to-speech. Clears ``ref_audio``.
             voice: The voice ID to use for synthesis.
             ref_audio: Base64-encoded audio sample for zero-shot voice cloning. Clears ``voice``.
-            response_format: The audio format of synthesized speech, between ``mp3``, ``wav``, ``pcm``, ``opus`` or ``flac``. Defaults to ``pcm``.
+            response_format: The audio format of synthesized speech, between ``mp3``, ``wav``, ``pcm``, ``opus`` or ``flac``. Defaults to ``mp3``.
         """
         if is_given(voice) and is_given(ref_audio):
             raise ValueError("Only one of 'voice' or 'ref_audio' may be provided, not both")

--- a/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/tts.py
+++ b/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/tts.py
@@ -72,24 +72,18 @@ class TTS(tts.TTS):
         if is_given(voice) and is_given(ref_audio):
             raise ValueError("Only one of 'voice' or 'ref_audio' may be provided, not both")
 
-        resolved_model = model if is_given(model) else DEFAULT_MODEL
-        resolved_voice = (
-            voice if is_given(voice) else (None if is_given(ref_audio) else DEFAULT_VOICE)
-        )
-        resolved_ref_audio = ref_audio if is_given(ref_audio) else None
-        resolved_response_format = (
-            response_format if is_given(response_format) else DEFAULT_RESPONSE_FORMAT
-        )
         super().__init__(
             capabilities=tts.TTSCapabilities(streaming=False),
             sample_rate=SAMPLE_RATE,
             num_channels=NUM_CHANNELS,
         )
         self._opts = _TTSOptions(
-            model=resolved_model,
-            voice=resolved_voice,
-            ref_audio=resolved_ref_audio,
-            response_format=resolved_response_format,
+            model=model if is_given(model) else DEFAULT_MODEL,
+            voice=voice if is_given(voice) else (None if is_given(ref_audio) else DEFAULT_VOICE),
+            ref_audio=ref_audio if is_given(ref_audio) else None,
+            response_format=response_format
+            if is_given(response_format)
+            else DEFAULT_RESPONSE_FORMAT,
         )
 
         mistral_api_key = api_key if is_given(api_key) else os.environ.get("MISTRAL_API_KEY")


### PR DESCRIPTION
## Summary

- Migrates the Mistral AI LLM plugin from the [Chat Completions API](https://docs.mistral.ai/studio-api/conversations/chat-completion) to the [Conversations API](https://docs.mistral.ai/studio-api/agents/agents-api#conversations),
enabling support for Mistral's built-in provider tools: [Web Search](https://docs.mistral.ai/studio-api/agents/agent-tools/websearch), [Code Interpreter](https://docs.mistral.ai/studio-api/agents/agent-tools/code_interpreter), and [Document Library](https://docs.mistral.ai/studio-api/knowledge-rag/libraries)
- Adds `MistralTool` base class with `WebSearch`, `CodeInterpreter`, and `DocumentLibrary` provider tool definitions
- Extends LLM constructor with full completion parameter support (`top_p`, `presence_penalty`, `frequency_penalty`, `random_seed`, `tool_choice`)
- Switches default TTS response format from `pcm` to `mp3`

## Details

### Conversations API migration

The Conversations API is stateful — the server retains conversation history across calls. This enables:

- **First call:** `start_stream_async()` sends the full context, model, instructions, and tools
- **Subsequent calls:** `append_stream_async()` sends only new client-originated entries (`function.result`, `message.input`), avoiding redundant re-transmission of the full history

Context diffing uses `ChatContext.is_equivalent()` (following the OpenAI Responses API pattern) to detect whether the new context extends the previous one. If it diverges, the conversation is reset with a fresh `start_stream_async()`.

A pending tool call verification safeguard ensures all function calls from the previous response have results before attempting to append.

### Streaming event handling

The Conversations API uses typed SSE events instead of choice deltas.

| Event | Handling |
|---|---|
| `ResponseStartedEvent` | Captures `conversation_id` for stateful tracking |
| `MessageOutputEvent` | Emits `ChatChunk` with text content |
| `FunctionCallEvent` | Accumulated in `_PendingFunctionCall` buffer, flushed as complete `FunctionToolCall` on next non-function event (since arguments are sent delta-wise incrementally) |
| `ToolExecution{Started,Delta,Done}Event` | Provider tool execution (server-side) — arguments accumulated silently, logged once on completion |
| `ResponseDoneEvent` | Extracts token usage |
| `ResponseErrorEvent` | Raises `APIStatusError` |

### Provider format converter

Replaces the old `to_chat_ctx()` (which delegated to OpenAI format) with `to_conversations_ctx()` that produces Mistral's flat entry format:

- System/developer messages → extracted as `instructions` string (returned via `MistralFormatData`)
- User messages → `{"type": "message.input", ...}`
- Assistant messages → `{"type": "message.output", ...}`
- Function calls → `{"type": "function.call", ...}`
- Function results → `{"type": "function.result", ...}`

### LLM completion parameters

The LLM constructor and `update_options()` now accept the full set of `CompletionArgs` parameters supported by the Conversations API: `temperature`, `top_p`, `max_completion_tokens`, `presence_penalty`, `frequency_penalty`, `random_seed`, and `tool_choice`.

### TTS default response format

Switches the default TTS response format from `pcm` back to `mp3`, since it is the most reliable default for most setups.

### Usage

```python
from livekit.plugins import mistralai

llm = mistralai.LLM(model="mistral-medium-latest")

# With provider tools
agent = Agent(
    llm=llm,
    tools=[
        mistralai.tools.WebSearch(),
        mistralai.tools.CodeInterpreter(),
        mistralai.tools.DocumentLibrary(library_ids=["<your-library-id>"]),
    ],
)