### PR TITLE
fix(anthropic): raise default httpx read timeout for streaming; add configurable timeout param

### DIFF
--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
@@ -75,6 +75,7 @@ class LLM(llm.LLM):
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
         caching: NotGivenOr[Literal["ephemeral"]] = NOT_GIVEN,
+        timeout: httpx.Timeout | None = None,
         _strict_tool_schema: bool = True,
     ) -> None:
         """
@@ -88,6 +89,12 @@ class LLM(llm.LLM):
         base_url (str, optional): The base URL for the Anthropic API. Defaults to None.
         user (str, optional): The user for the Anthropic API. Defaults to None.
         client (anthropic.AsyncClient | None): The Anthropic client to use. Defaults to None.
+        timeout (httpx.Timeout | None): HTTP timeout configuration for the underlying httpx client.
+            Defaults to ``httpx.Timeout(5.0, read=30.0)``, which keeps a tight connect timeout
+            while allowing up to 30 s between streamed chunks — long enough for Claude's
+            adaptive-thinking phases without masking genuine network stalls.
+            Pass a custom ``httpx.Timeout`` to override (e.g. ``httpx.Timeout(5.0, read=60.0)``
+            for very large contexts or extended thinking budgets).
         temperature (float, optional): The temperature for the Anthropic API. Defaults to None.
         parallel_tool_calls (bool, optional): Whether to parallelize tool calls. Defaults to None.
         tool_choice (ToolChoice, optional): The tool choice for the Anthropic API. Defaults to "auto".
@@ -118,7 +125,7 @@ class LLM(llm.LLM):
             api_key=anthropic_api_key,
             base_url=base_url if is_given(base_url) else None,
             http_client=httpx.AsyncClient(
-                timeout=5.0,
+                timeout=timeout or httpx.Timeout(5.0, read=30.0),
                 follow_redirects=True,
                 limits=httpx.Limits(
                     max_connections=1000,

--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
@@ -75,7 +75,7 @@ class LLM(llm.LLM):
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
         caching: NotGivenOr[Literal["ephemeral"]] = NOT_GIVEN,
-        timeout: httpx.Timeout | None = None,
+        timeout: NotGivenOr[httpx.Timeout] = NOT_GIVEN
         _strict_tool_schema: bool = True,
     ) -> None:
         """

--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
@@ -75,7 +75,7 @@ class LLM(llm.LLM):
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
         caching: NotGivenOr[Literal["ephemeral"]] = NOT_GIVEN,
-        timeout: NotGivenOr[httpx.Timeout] = NOT_GIVEN
+        timeout: NotGivenOr[httpx.Timeout] = NOT_GIVEN,
         _strict_tool_schema: bool = True,
     ) -> None:
         """

--- a/tests/test_plugin_anthropic.py
+++ b/tests/test_plugin_anthropic.py
@@ -1,0 +1,59 @@
+"""Unit tests for the Anthropic LLM plugin that do not require a real API key or network."""
+
+from __future__ import annotations
+
+import httpx
+
+
+def _make_llm(**kwargs):
+    from livekit.plugins.anthropic import LLM
+
+    return LLM(api_key="sk-ant-test", **kwargs)
+
+
+class TestHttpxTimeoutDefaults:
+    def test_default_read_timeout_is_generous(self) -> None:
+        """Default read timeout must accommodate adaptive-thinking pauses (≥30 s)."""
+        llm = _make_llm()
+        read = llm._client._client.timeout.read
+        assert read >= 30.0, f"read timeout {read}s is too short for adaptive thinking"
+
+    def test_default_connect_timeout_remains_tight(self) -> None:
+        """Connect timeout should stay short so genuine connection failures surface fast."""
+        llm = _make_llm()
+        connect = llm._client._client.timeout.connect
+        assert connect <= 10.0, f"connect timeout {connect}s is unexpectedly long"
+
+    def test_default_timeout_is_split(self) -> None:
+        """Default must be an httpx.Timeout object, not a flat scalar."""
+        llm = _make_llm()
+        t = llm._client._client.timeout
+        assert isinstance(t, httpx.Timeout)
+        assert t.read != t.connect, "read and connect timeouts should differ in the default"
+
+
+class TestHttpxTimeoutCustom:
+    def test_custom_timeout_honored(self) -> None:
+        """A caller-supplied httpx.Timeout is passed through to the httpx client."""
+        custom = httpx.Timeout(3.0, read=120.0)
+        llm = _make_llm(timeout=custom)
+        t = llm._client._client.timeout
+        assert t.read == 120.0
+        assert t.connect == 3.0
+
+    def test_none_timeout_uses_default(self) -> None:
+        """Passing timeout=None must fall back to the built-in default."""
+        llm = _make_llm(timeout=None)
+        assert llm._client._client.timeout.read >= 30.0
+
+    def test_explicit_client_bypasses_timeout_param(self) -> None:
+        """When a pre-built client= is supplied, timeout= is ignored (client wins)."""
+        import anthropic
+
+        tight_client = anthropic.AsyncClient(
+            api_key="sk-ant-test",
+            http_client=httpx.AsyncClient(timeout=httpx.Timeout(1.0)),
+        )
+        # timeout= argument should have no effect here
+        llm = _make_llm(client=tight_client, timeout=httpx.Timeout(5.0, read=999.0))
+        assert llm._client._client.timeout.read == 1.0


### PR DESCRIPTION
## Summary

Fixes #5508.

The Anthropic LLM plugin used `httpx.AsyncClient(timeout=5.0)`, which sets **all** httpx sub-timeouts — including the per-chunk SSE read timeout — to 5 seconds. Claude's adaptive-thinking phases routinely pause for 10–30 s before emitting the first content chunk, so the 5 s read timeout fires during normal usage and raises `APIConnectionError`, killing voice sessions mid-turn.

### Changes

- **Default split timeout**: `httpx.Timeout(5.0, read=30.0)` — connect stays at 5 s (genuine TCP failures surface fast) while the per-chunk read window is 30 s (covers standard thinking budgets with headroom).
- **New `timeout` constructor parameter**: `timeout: httpx.Timeout | None = None` lets callers supply a custom timeout without constructing a whole `anthropic.AsyncClient` — e.g. `httpx.Timeout(5.0, read=60.0)` for extended thinking or very large contexts. Aligns with the pattern already used by the OpenAI plugin.
- **Six unit tests** in `tests/test_plugin_anthropic.py` cover the default split, tight connect value, custom timeout pass-through, and `client=` precedence over `timeout=`.

### Before / after

```python
# Before — all sub-timeouts at 5 s, kills thinking phases
httpx.AsyncClient(timeout=5.0, ...)

# After — tight connect, generous read
httpx.AsyncClient(timeout=timeout or httpx.Timeout(5.0, read=30.0), ...)
```

### Usage (new parameter)

```python
# Default (30 s read) — sufficient for most models
llm = anthropic.LLM(model="claude-sonnet-4-6")

# Extended thinking or very large contexts
llm = anthropic.LLM(
    model="claude-opus-4-6",
    timeout=httpx.Timeout(5.0, read=60.0),
)
```

## Test plan

- [x] `uv run pytest tests/test_plugin_anthropic.py -v` — 6/6 pass
- [x] `uv run ruff check` — no errors
- [x] `uv run ruff format --check` — no changes needed