### PR TITLE
fix(transcription): seed _start_wall_time fallback in aclose

### DIFF
--- a/livekit-agents/livekit/agents/voice/transcription/synchronizer.py
+++ b/livekit-agents/livekit/agents/voice/transcription/synchronizer.py
@@ -392,6 +392,9 @@ class _SegmentSynchronizerImpl:
             return
 
         self._close_future.set_result(None)
+        if self._start_wall_time is None:
+            # avoid assertion error in _main_task if playback completed
+            self._start_wall_time = time.time()
         self._start_fut.set()  # avoid deadlock of main_task in case it never started
         self._output_enabled_ev.set()
         await self._text_data.word_stream.aclose()


### PR DESCRIPTION
## Summary
Followup to #5511.

After #5511 changed `_start_wall_time` to be set via the `on_playback_started` RPC instead of the first pushed audio frame, there is a case where `_playback_completed` can be set to `True` (via `mark_playback_finished`) without `on_playback_started` ever firing. 

Seed `_start_wall_time = time.time()` in `aclose` before signaling `_start_fut`. The value is never actually consumed in the playback-completed branch of `_main_task` (which just flushes remaining words), so this purely silences the assertion for the edge case.
