### PR TITLE
Fix stale playout state across multi-step voice turns

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3480,13 +3480,20 @@ class AgentActivity(RecognitionHooks):
             self._false_interruption_timer.cancel()
 
         def _on_false_interruption() -> None:
+            paused_speech = self._paused_speech
             if (
-                self._paused_speech is None
-                or (self._current_speech and self._current_speech is not self._paused_speech.handle)
-                or (self._paused_speech.generation_step != self._paused_speech.handle.num_steps)
+                paused_speech is None
+                or (self._current_speech and self._current_speech is not paused_speech.handle)
+                or (paused_speech.generation_step != paused_speech.handle.num_steps)
             ):
                 # already new speech is scheduled, do nothing
                 self._paused_speech = None
+                if (
+                    paused_speech is not None
+                    and (audio_output := self._session.output.audio)
+                    and audio_output.can_pause
+                ):
+                    audio_output.resume()
                 return
 
             resumed = False
@@ -3494,13 +3501,13 @@ class AgentActivity(RecognitionHooks):
                 self._session.options.interruption["resume_false_interruption"]
                 and (audio_output := self._session.output.audio)
                 and audio_output.can_pause
-                and not self._paused_speech.handle.done()
+                and not paused_speech.handle.done()
             ):
                 self._session._update_agent_state(
-                    self._paused_speech.agent_state,
-                    otel_context=self._paused_speech.handle._agent_turn_context,
+                    paused_speech.agent_state,
+                    otel_context=paused_speech.handle._agent_turn_context,
                 )
-                if self._audio_recognition and self._paused_speech.agent_state == "speaking":
+                if self._audio_recognition and paused_speech.agent_state == "speaking":
                     self._audio_recognition.on_start_of_agent_speech(started_at=time.time())
                 if self.interruption_enabled:
                     self._interruption_by_audio_activity_enabled = False

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -8,7 +8,7 @@ import time
 from collections.abc import AsyncIterable, Coroutine, Sequence
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from opentelemetry import context as otel_context, trace
 
@@ -131,6 +131,7 @@ class _PreemptiveGeneration:
 @dataclass
 class _PausedSpeechInfo:
     handle: SpeechHandle
+    generation_step: int
     agent_state: AgentState
     timeout: float
 
@@ -1614,6 +1615,9 @@ class AgentActivity(RecognitionHooks):
             and not self._current_speech.interrupted
             and self._current_speech.allow_interruptions
         ):
+            current_speech = self._current_speech
+            current_generation_playout_active = current_speech.current_generation_playout_active
+
             # reset the false interruption timer
             if self._false_interruption_timer:
                 self._false_interruption_timer.cancel()
@@ -1621,7 +1625,8 @@ class AgentActivity(RecognitionHooks):
 
             # only interrupt if not already interrupting
             if (
-                self._audio_recognition
+                current_generation_playout_active
+                and self._audio_recognition
                 and not self._audio_recognition._endpointing.overlapping
                 and self._session.agent_state == "speaking"
             ):
@@ -1633,7 +1638,7 @@ class AgentActivity(RecognitionHooks):
                 assert (timeout := interruption_options["false_interruption_timeout"]) is not None
                 assert (audio_output := self._session.output.audio) is not None
 
-                self._update_paused_speech(self._current_speech, timeout)
+                self._update_paused_speech(current_speech, timeout)
                 audio_output.pause()
                 self._session._update_agent_state("listening")
                 if self._audio_recognition:
@@ -1646,7 +1651,7 @@ class AgentActivity(RecognitionHooks):
                 if self._rt_session is not None:
                     self._rt_session.interrupt()
 
-                self._current_speech.interrupt()
+                current_speech.interrupt()
 
     # region recognition hooks
 
@@ -2114,6 +2119,42 @@ class AgentActivity(RecognitionHooks):
             if self.interruption_enabled:
                 self._restore_interruption_by_audio_activity()
 
+    def _on_generation_playout_started(
+        self, *, speech_handle: SpeechHandle, started_at: float
+    ) -> None:
+        speech_handle._mark_current_generation_playout_started()
+        self._session._update_agent_state(
+            "speaking",
+            start_time=started_at,
+            otel_context=speech_handle._agent_turn_context,
+        )
+        if self._audio_recognition:
+            self._audio_recognition.on_start_of_agent_speech(started_at=started_at)
+        if self.interruption_enabled:
+            self._interruption_by_audio_activity_enabled = False
+
+    def _on_generation_playout_finished(
+        self,
+        *,
+        speech_handle: SpeechHandle,
+        next_state: Literal["thinking", "listening"],
+        ignore_user_transcript_until: float | None = None,
+        notify_audio_recognition: bool = True,
+        restore_interruption_by_audio_activity: bool = True,
+    ) -> None:
+        speech_handle._mark_current_generation_playout_finished()
+
+        if self._session.agent_state != "speaking":
+            return
+
+        self._session._update_agent_state(next_state)
+        if notify_audio_recognition and self._audio_recognition:
+            self._audio_recognition.on_end_of_agent_speech(
+                ignore_user_transcript_until=ignore_user_transcript_until or time.time()
+            )
+        if restore_interruption_by_audio_activity and self.interruption_enabled:
+            self._restore_interruption_by_audio_activity()
+
     @utils.log_exceptions(logger=logger)
     async def _tts_task(
         self,
@@ -2211,15 +2252,10 @@ class AgentActivity(RecognitionHooks):
             except BaseException:
                 return
 
-            self._session._update_agent_state(
-                "speaking",
-                start_time=started_speaking_at,
-                otel_context=speech_handle._agent_turn_context,
+            self._on_generation_playout_started(
+                speech_handle=speech_handle,
+                started_at=started_speaking_at,
             )
-            if self._audio_recognition:
-                self._audio_recognition.on_start_of_agent_speech(started_at=started_speaking_at)
-            if self.interruption_enabled:
-                self._interruption_by_audio_activity_enabled = False
 
         audio_out: _AudioOutput | None = None
         tts_gen_data: _TTSGenerationData | None = None
@@ -2334,14 +2370,11 @@ class AgentActivity(RecognitionHooks):
             speech_handle._item_added([msg])
             self._session._conversation_item_added(msg)
 
-        if self._session.agent_state == "speaking":
-            self._session._update_agent_state("listening")
-            if self._audio_recognition:
-                self._audio_recognition.on_end_of_agent_speech(
-                    ignore_user_transcript_until=time.time()
-                )
-            if self.interruption_enabled:
-                self._restore_interruption_by_audio_activity()
+        self._on_generation_playout_finished(
+            speech_handle=speech_handle,
+            next_state="listening",
+            ignore_user_transcript_until=time.time(),
+        )
 
         if audio_out is not None and not audio_out.first_frame_fut.done():
             audio_out.first_frame_fut.cancel()
@@ -2566,17 +2599,10 @@ class AgentActivity(RecognitionHooks):
                     started_speaking_at - user_metrics["stopped_speaking_at"]
                 )
             self._session._early_assistant_metrics = early_metrics
-
-            self._session._update_agent_state(
-                "speaking",
-                start_time=started_speaking_at,
-                otel_context=speech_handle._agent_turn_context,
+            self._on_generation_playout_started(
+                speech_handle=speech_handle,
+                started_at=started_speaking_at,
             )
-
-            if self._audio_recognition:
-                self._audio_recognition.on_start_of_agent_speech(started_at=started_speaking_at)
-            if self.interruption_enabled:
-                self._interruption_by_audio_activity_enabled = False
 
         audio_out: _AudioOutput | None = None
         if audio_output is not None:
@@ -2704,15 +2730,18 @@ class AgentActivity(RecognitionHooks):
             current_span.set_attribute(trace_types.ATTR_RESPONSE_TEXT, forwarded_text)
 
         if not speech_handle.interrupted and len(tool_output.output) > 0:
-            self._session._update_agent_state("thinking")
-        elif self._session.agent_state == "speaking":
-            self._session._update_agent_state("listening")
-            if self._audio_recognition:
-                self._audio_recognition.on_end_of_agent_speech(
-                    ignore_user_transcript_until=time.time()
-                )
-            if self.interruption_enabled:
-                self._restore_interruption_by_audio_activity()
+            self._on_generation_playout_finished(
+                speech_handle=speech_handle,
+                next_state="thinking",
+                notify_audio_recognition=False,
+                restore_interruption_by_audio_activity=False,
+            )
+        else:
+            self._on_generation_playout_finished(
+                speech_handle=speech_handle,
+                next_state="listening",
+                ignore_user_transcript_until=time.time(),
+            )
 
         if audio_out is not None and not audio_out.first_frame_fut.done():
             audio_out.first_frame_fut.cancel()
@@ -2744,7 +2773,7 @@ class AgentActivity(RecognitionHooks):
                     extra={"speech_id": speech_handle.id},
                 )
 
-            speech_handle._num_steps += 1
+            speech_handle._advance_step()
 
             new_calls: list[llm.FunctionCall] = []
             new_fnc_outputs: list[llm.FunctionCallOutput] = []
@@ -3029,15 +3058,10 @@ class AgentActivity(RecognitionHooks):
             except BaseException:
                 return
 
-            self._session._update_agent_state(
-                "speaking",
-                start_time=started_speaking_at,
-                otel_context=speech_handle._agent_turn_context,
+            self._on_generation_playout_started(
+                speech_handle=speech_handle,
+                started_at=started_speaking_at,
             )
-            if self._audio_recognition:
-                self._audio_recognition.on_start_of_agent_speech(started_at=started_speaking_at)
-            if self.interruption_enabled:
-                self._interruption_by_audio_activity_enabled = False
 
         tasks: list[asyncio.Task[Any]] = []
         tees: list[utils.aio.itertools.Tee[Any]] = []
@@ -3210,16 +3234,14 @@ class AgentActivity(RecognitionHooks):
             await speech_handle.wait_if_not_interrupted(
                 [asyncio.ensure_future(audio_output.wait_for_playout())]
             )
-            self._session._update_agent_state("listening")
-            if self._audio_recognition:
-                self._audio_recognition.on_end_of_agent_speech(
-                    ignore_user_transcript_until=time.time()
-                )
-            if self.interruption_enabled:
-                self._restore_interruption_by_audio_activity()
-            current_span.set_attribute(
-                trace_types.ATTR_SPEECH_INTERRUPTED, speech_handle.interrupted
-            )
+
+        self._on_generation_playout_finished(
+            speech_handle=speech_handle,
+            next_state="listening",
+            ignore_user_transcript_until=time.time(),
+        )
+
+        current_span.set_attribute(trace_types.ATTR_SPEECH_INTERRUPTED, speech_handle.interrupted)
 
         stopped_speaking_at = time.time()
 
@@ -3324,7 +3346,7 @@ class AgentActivity(RecognitionHooks):
         # important: no agent output should be used after this point
 
         if len(tool_output.output) > 0:
-            speech_handle._num_steps += 1
+            speech_handle._advance_step()
 
             new_fnc_outputs: list[llm.FunctionCallOutput] = []
             generate_tool_reply: bool = False
@@ -3430,11 +3452,16 @@ class AgentActivity(RecognitionHooks):
         ``agent_state`` captured at first pause is preserved, so the resume
         path restores the correct state even across multiple calls.
         """
-        if self._paused_speech and self._paused_speech.handle is speech_handle:
+        if (
+            self._paused_speech
+            and self._paused_speech.handle is speech_handle
+            and self._paused_speech.generation_step == speech_handle.num_steps
+        ):
             self._paused_speech.timeout = timeout
         else:
             self._paused_speech = _PausedSpeechInfo(
                 handle=speech_handle,
+                generation_step=speech_handle.num_steps,
                 agent_state=self._session.agent_state,
                 timeout=timeout,
             )
@@ -3453,8 +3480,10 @@ class AgentActivity(RecognitionHooks):
             self._false_interruption_timer.cancel()
 
         def _on_false_interruption() -> None:
-            if self._paused_speech is None or (
-                self._current_speech and self._current_speech is not self._paused_speech.handle
+            if (
+                self._paused_speech is None
+                or (self._current_speech and self._current_speech is not self._paused_speech.handle)
+                or (self._paused_speech.generation_step != self._paused_speech.handle.num_steps)
             ):
                 # already new speech is scheduled, do nothing
                 self._paused_speech = None

--- a/livekit-agents/livekit/agents/voice/speech_handle.py
+++ b/livekit-agents/livekit/agents/voice/speech_handle.py
@@ -41,6 +41,7 @@ class SpeechHandle:
         self._done_fut = asyncio.Future[None]()
         self._scheduled_fut = asyncio.Future[None]()
         self._authorize_event = asyncio.Event()
+        self._current_generation_playout_active = False
 
         self._generations: list[asyncio.Future[None]] = []
 
@@ -130,6 +131,10 @@ class SpeechHandle:
             )
 
         self._allow_interruptions = value
+
+    @property
+    def current_generation_playout_active(self) -> bool:
+        return self._current_generation_playout_active
 
     @property
     def chat_items(self) -> list[llm.ChatItem]:
@@ -250,6 +255,16 @@ class SpeechHandle:
         fut = asyncio.Future[None]()
         self._generations.append(fut)
         self._authorize_event.set()
+
+    def _mark_current_generation_playout_started(self) -> None:
+        self._current_generation_playout_active = True
+
+    def _mark_current_generation_playout_finished(self) -> None:
+        self._current_generation_playout_active = False
+
+    def _advance_step(self) -> None:
+        self._num_steps += 1
+        self._current_generation_playout_active = False
 
     def _clear_authorization(self) -> None:
         self._authorize_event.clear()

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -19,7 +19,7 @@ from livekit.agents.llm import (
 )
 from livekit.agents.llm.chat_context import ChatContext, ChatMessage
 from livekit.agents.voice.agent_activity import AgentActivity
-from livekit.agents.voice.events import FunctionToolsExecutedEvent
+from livekit.agents.voice.events import AgentFalseInterruptionEvent, FunctionToolsExecutedEvent
 from livekit.agents.voice.io import PlaybackFinishedEvent
 from livekit.agents.voice.speech_handle import SpeechHandle
 
@@ -828,6 +828,66 @@ async def test_unknown_function_call() -> None:
     ]
     assert len(error_outputs) == 1
     assert "Unknown function: nonexistent_tool" in error_outputs[0].output
+
+
+async def test_silent_tool_call_pause_state_does_not_leak_into_tool_reply() -> None:
+    speed = 5.0
+    actions = FakeActions()
+    actions.add_user_speech(0.1, 0.2, "What's the weather in Tokyo?", stt_delay=0.05)
+
+    # Silent tool-call step: no spoken preamble/audio before the function call.
+    actions.add_llm(
+        content="",
+        tool_calls=[
+            FunctionToolCall(
+                name="get_weather",
+                arguments='{"location": "Tokyo"}',
+                call_id="1",
+            )
+        ],
+        ttft=0.05,
+        duration=1.0,
+    )
+
+    # VAD-only speech starts during the silent tool-call generation and remains
+    # active after the tool reply starts.
+    actions.add_user_speech(0.85, 2.0, "", stt_delay=0.05)
+
+    actions.add_llm(
+        content="The weather in Tokyo is sunny today.",
+        input="The weather in Tokyo is sunny today.",
+        ttft=0.0,
+        duration=0.0,
+    )
+    actions.add_tts(0.5, ttfb=0.0, duration=0.0)
+
+    session = create_session(
+        actions,
+        speed_factor=speed,
+        can_pause_audio=True,
+        turn_handling={"interruption": {"false_interruption_timeout": 0.2 / speed}},
+    )
+    agent = MyAgent()
+
+    agent_state_events: list[AgentStateChangedEvent] = []
+    false_interruption_events: list[AgentFalseInterruptionEvent] = []
+
+    session.on("agent_state_changed", agent_state_events.append)
+    session.on("agent_false_interruption", false_interruption_events.append)
+
+    await asyncio.wait_for(
+        run_session(session, agent, drain_delay=0.8 / speed),
+        timeout=SESSION_TIMEOUT,
+    )
+
+    transitions = [(ev.old_state, ev.new_state) for ev in agent_state_events]
+    silent_step_finished = transitions.index(("speaking", "listening"))
+
+    # Before the fix this is ("listening", "thinking") because the pause state
+    # captured during the silent tool-call step leaks into the tool reply.
+    assert transitions[silent_step_finished + 1] == ("listening", "speaking")
+    assert false_interruption_events
+    assert false_interruption_events[-1].resumed is True
 
 
 async def test_speech_handle_advance_step_resets_playout_state() -> None:

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -6,6 +6,7 @@ import pytest
 
 from livekit.agents import (
     Agent,
+    AgentSession,
     AgentStateChangedEvent,
     ConversationItemAddedEvent,
     MetricsCollectedEvent,
@@ -17,8 +18,10 @@ from livekit.agents.llm import (
     FunctionToolCall,
 )
 from livekit.agents.llm.chat_context import ChatContext, ChatMessage
+from livekit.agents.voice.agent_activity import AgentActivity
 from livekit.agents.voice.events import FunctionToolsExecutedEvent
 from livekit.agents.voice.io import PlaybackFinishedEvent
+from livekit.agents.voice.speech_handle import SpeechHandle
 
 from .fake_session import FakeActions, create_session, run_session
 
@@ -824,6 +827,38 @@ async def test_unknown_function_call() -> None:
     ]
     assert len(error_outputs) == 1
     assert "Unknown function: nonexistent_tool" in error_outputs[0].output
+
+
+async def test_speech_handle_advance_step_resets_playout_state() -> None:
+    speech_handle = SpeechHandle.create()
+
+    speech_handle._mark_current_generation_playout_started()
+    assert speech_handle.current_generation_playout_active is True
+
+    speech_handle._advance_step()
+
+    assert speech_handle.current_generation_playout_active is False
+
+
+async def test_paused_speech_info_refreshes_after_handle_step_advances() -> None:
+    session: AgentSession[None] = AgentSession(aec_warmup_duration=None)
+    activity = AgentActivity(Agent(instructions="You are a helpful assistant."), session)
+    speech_handle = SpeechHandle.create()
+
+    session._agent_state = "thinking"
+    activity._update_paused_speech(speech_handle, timeout=0)
+    assert activity._paused_speech is not None
+    assert activity._paused_speech.generation_step == 1
+    assert activity._paused_speech.agent_state == "thinking"
+
+    speech_handle._mark_current_generation_playout_started()
+    speech_handle._advance_step()
+    session._agent_state = "speaking"
+
+    activity._update_paused_speech(speech_handle, timeout=1)
+    assert activity._paused_speech is not None
+    assert activity._paused_speech.generation_step == 2
+    assert activity._paused_speech.agent_state == "speaking"
 
 
 # helpers

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -23,6 +23,7 @@ from livekit.agents.voice.events import FunctionToolsExecutedEvent
 from livekit.agents.voice.io import PlaybackFinishedEvent
 from livekit.agents.voice.speech_handle import SpeechHandle
 
+from .fake_io import FakeAudioOutput
 from .fake_session import FakeActions, create_session, run_session
 
 
@@ -859,6 +860,25 @@ async def test_paused_speech_info_refreshes_after_handle_step_advances() -> None
     assert activity._paused_speech is not None
     assert activity._paused_speech.generation_step == 2
     assert activity._paused_speech.agent_state == "speaking"
+
+
+async def test_stale_paused_speech_cleanup_resumes_audio_output() -> None:
+    session: AgentSession[None] = AgentSession(aec_warmup_duration=None)
+    session.output.audio = audio_output = FakeAudioOutput(can_pause=True)
+    activity = AgentActivity(Agent(instructions="You are a helpful assistant."), session)
+    speech_handle = SpeechHandle.create()
+
+    activity._current_speech = speech_handle
+    activity._update_paused_speech(speech_handle, timeout=0)
+    audio_output.pause()
+    assert audio_output._paused_at is not None
+
+    speech_handle._advance_step()
+    activity._start_false_interruption_timer(timeout=0)
+    await asyncio.sleep(0.01)
+
+    assert activity._paused_speech is None
+    assert audio_output._paused_at is None
 
 
 # helpers


### PR DESCRIPTION
This PR fixes a bug where paused-speech state could become stale across generation steps within a single `SpeechHandle`. The key changes are:

1. New `current_generation_playout_active` flag on `SpeechHandle` — tracks whether the current generation's audio is actively playing, reset on each step advance.
2. New `generation_step` field on `_PausedSpeechInfo` — ensures paused speech is only applied/resumed if it matches the current generation step.
3. Centralized `_on_generation_playout_started` / `_on_generation_playout_finished` — extracts duplicated playout lifecycle logic (state updates, audio recognition notifications, interruption toggling) into two reusable methods.

The audio-interruption condition now also gates on `current_generation_playout_active`, preventing interruptions when the agent isn't actually playing audio for the current generation.