### PR TITLE
Remove 'distil-whisper-large-v3-en' from STTModels

### DIFF
--- a/livekit-plugins/livekit-plugins-groq/livekit/plugins/groq/models.py
+++ b/livekit-plugins/livekit-plugins-groq/livekit/plugins/groq/models.py
@@ -5,7 +5,6 @@ from typing import Literal
 STTModels = Literal[
     "whisper-large-v3",
     "whisper-large-v3-turbo",
-    "distil-whisper-large-v3-en",
 ]
 
 LLMModels = Literal[


### PR DESCRIPTION
This PR removes distil-whisper-large-v3-en, which was shut down by Groq.