### PR TITLE
Update GroqAudioModels with new model names

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -141,7 +141,7 @@ GroqChatModels = Literal[
 ]
 
 GroqAudioModels = Literal[
-    "whisper-large-v3", "distil-whisper-large-v3-en", "whisper-large-v3-turbo"
+    "whisper-large-v3", "whisper-large-v3-turbo"
 ]
 
 DeepSeekChatModels = Literal[


### PR DESCRIPTION
Removing the deprecated 'distil-whisper-large-v3-en' model from the OpenAI list.