### PR TITLE
feat(openai): add gpt-5.4-mini to model registry

### DIFF
--- a/.github/next-release/changeset-gpt-5-4-mini.md
+++ b/.github/next-release/changeset-gpt-5-4-mini.md
@@ -1,0 +1,6 @@
+---
+"livekit-agents": patch
+"livekit-plugins-openai": patch
+---
+
+Add `gpt-5.4-mini` to the OpenAI model registry.

--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -103,6 +103,7 @@ OpenAIModels = Literal[
     "openai/gpt-5.2-chat-latest",
     "openai/gpt-5.3-chat-latest",
     "openai/gpt-5.4",
+    "openai/gpt-5.4-mini",
     "openai/gpt-oss-120b",
 ]
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -20,6 +20,7 @@ TTSVoices = Literal[
 DalleModels = Literal["dall-e-2", "dall-e-3"]
 ChatModels = Literal[
     "gpt-5.4",
+    "gpt-5.4-mini",
     "gpt-5.3-chat-latest",
     "gpt-5.2",
     "gpt-5.2-chat-latest",
@@ -312,6 +313,7 @@ SambaNovaChatModels = Literal[
 def _supports_reasoning_effort(model: ChatModels | str) -> bool:
     return model in [
         "gpt-5.4",
+        "gpt-5.4-mini",
         "gpt-5.2",
         "gpt-5.1",
         "gpt-5",


### PR DESCRIPTION
## Summary

Adds `gpt-5.4-mini` to the OpenAI model registry so it can be selected via both the `livekit-plugins-openai` plugin (`openai.LLM(model="gpt-5.4-mini")`) and the unified `inference.LLM` interface (`model="openai/gpt-5.4-mini"`).

The model is also added to `_supports_reasoning_effort()` — it falls through to the default `reasoning_effort="minimal"` branch, matching the other `-mini` variants.