### PR TITLE
feat(openai): emit interim input audio transcription deltas from Realtime API

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1798,6 +1798,9 @@ class RealtimeSession(
     def _handle_conversion_item_input_audio_transcription_failed(
         self, event: ConversationItemInputAudioTranscriptionFailedEvent
     ) -> None:
+        # clean up accumulated delta state on failure
+        self._input_transcriptions.pop(event.item_id, None)
+
         logger.error(
             f"{self._realtime_model._provider_label} failed to transcribe input audio",
             extra={"error": event.error},

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -48,6 +48,7 @@ from openai.types.realtime import (
     ConversationItemDeletedEvent,
     ConversationItemDeleteEvent,
     ConversationItemInputAudioTranscriptionCompletedEvent,
+    ConversationItemInputAudioTranscriptionDeltaEvent,
     ConversationItemInputAudioTranscriptionFailedEvent,
     ConversationItemTruncateEvent,
     InputAudioBufferAppendEvent,
@@ -818,6 +819,7 @@ class RealtimeSession(
             SAMPLE_RATE, NUM_CHANNELS, samples_per_channel=SAMPLE_RATE // 10
         )
         self._pushed_duration_s: float = 0  # duration of audio pushed to the OpenAI Realtime API
+        self._input_transcriptions: dict[str, str] = {}  # accumulated transcript per item_id
 
     def send_event(self, event: RealtimeClientEvent | dict[str, Any]) -> None:
         with contextlib.suppress(utils.aio.channel.ChanClosed):
@@ -1064,10 +1066,9 @@ class RealtimeSession(
                             ConversationItemDeletedEvent.construct(**event)
                         )
                     elif event["type"] == "conversation.item.input_audio_transcription.delta":
-                        # currently incoming transcripts are transcribed only after the user stops speaking
-                        # it's not very useful to emit these as the transcribe process takes place within ~100ms
-                        # when they handle streaming transcriptions, we'll handle it then.
-                        pass
+                        self._handle_conversion_item_input_audio_transcription_delta(
+                            ConversationItemInputAudioTranscriptionDeltaEvent.construct(**event)
+                        )
                     elif event["type"] == "conversation.item.input_audio_transcription.completed":
                         self._handle_conversion_item_input_audio_transcription_completed(
                             ConversationItemInputAudioTranscriptionCompletedEvent.construct(**event)
@@ -1751,10 +1752,33 @@ class RealtimeSession(
             else:
                 fut.set_result(None)
 
+    def _handle_conversion_item_input_audio_transcription_delta(
+        self, event: ConversationItemInputAudioTranscriptionDeltaEvent
+    ) -> None:
+        delta = event.delta or ""
+        if not delta:
+            return
+
+        accumulated = self._input_transcriptions.get(event.item_id, "")
+        accumulated += delta
+        self._input_transcriptions[event.item_id] = accumulated
+
+        self.emit(
+            "input_audio_transcription_completed",
+            llm.InputTranscriptionCompleted(
+                item_id=event.item_id,
+                transcript=accumulated,
+                is_final=False,
+            ),
+        )
+
     def _handle_conversion_item_input_audio_transcription_completed(
         self, event: ConversationItemInputAudioTranscriptionCompletedEvent
     ) -> None:
         confidence = calculate_confidence_from_logprobs(event.logprobs)
+
+        # clean up accumulated delta state
+        self._input_transcriptions.pop(event.item_id, None)
 
         if remote_item := self._remote_chat_ctx.get(event.item_id):
             assert isinstance(remote_item.item, llm.ChatMessage)

--- a/tests/test_realtime/test_realtime.py
+++ b/tests/test_realtime/test_realtime.py
@@ -226,19 +226,42 @@ async def test_vad_speech_events(rt_session: llm.RealtimeSession):
 @pytest.mark.parametrize("rt_session", REALTIME_MODELS, indirect=True)
 async def test_input_audio_transcription(rt_session: llm.RealtimeSession):
     transcripts: list[str] = []
-    transcript_received = asyncio.Event()
+    final_received = asyncio.Event()
 
     def on_transcript(ev: llm.InputTranscriptionCompleted):
         transcripts.append(ev.transcript)
-        transcript_received.set()
+        if ev.is_final:
+            final_received.set()
 
     rt_session.on("input_audio_transcription_completed", on_transcript)
     await _push_speech(rt_session, "weather_question")
     rt_session.commit_audio()
 
-    await asyncio.wait_for(transcript_received.wait(), timeout=15)
+    await asyncio.wait_for(final_received.wait(), timeout=15)
     full = " ".join(transcripts).lower()
     assert "weather" in full or "paris" in full
+
+
+@pytest.mark.parametrize("rt_session", REALTIME_MODELS, indirect=True)
+async def test_input_audio_transcription_interim(rt_session: llm.RealtimeSession):
+    interim_transcripts: list[str] = []
+    final_transcript: list[str] = []
+    final_received = asyncio.Event()
+
+    def on_transcript(ev: llm.InputTranscriptionCompleted):
+        if ev.is_final:
+            final_transcript.append(ev.transcript)
+            final_received.set()
+        else:
+            interim_transcripts.append(ev.transcript)
+
+    rt_session.on("input_audio_transcription_completed", on_transcript)
+    await _push_speech(rt_session, "weather_question")
+    rt_session.commit_audio()
+
+    await asyncio.wait_for(final_received.wait(), timeout=15)
+    assert len(final_transcript) == 1
+    assert len(interim_transcripts) > 0, "expected interim transcription deltas before final"
 
 
 # -- Chat context --


### PR DESCRIPTION
## Summary                                 
                                      
The OpenAI Realtime API sends `conversation.item.input_audio_transcription.delta` events with                    
streaming transcription text as the user speaks, but the plugin currently drops them with `pass`.
This PR handles those deltas by accumulating text per item and emitting                                          
`input_audio_transcription_completed` with `is_final=False`, matching the pattern already used                   
by the Google Gemini realtime plugin.                                                                            
                                                                                                                 
The `.completed` event continues to emit `is_final=True` as before, and cleans up accumulated                    
state.                                                                                                           
                                                                                                                 
- Accumulate delta text per `item_id` in `RealtimeSession._input_transcriptions`                                 
- Emit `InputTranscriptionCompleted(is_final=False)` on each delta
- Clean up state on `.completed`                                                                                 
- Fix existing `test_input_audio_transcription` to wait for `is_final=True` (interims now fire first)
- Add `test_input_audio_transcription_interim` asserting interim events arrive before final                      
                                                                                                                 
## Context                                                                                                       
                                                                                                                 
The same plugin's `openai.STT` class (in `stt.py`) already handles these deltas via its own                      
WebSocket connection. This brings parity to the `RealtimeModel` path so that `AgentSession`'s
`user_input_transcribed` event receives streaming transcripts in realtime mode.                                  
                                                                                                                 
## Test plan                                                                                                     
                                                                                                                 
- [x] `make check` passes (format, lint, type-check)                                                             
- [x] All 18 existing OpenAI realtime tests pass
- [x] New `test_input_audio_transcription_interim` validates interim deltas arrive before final                  
 