### PR TITLE
feat: expose provider request ids on STT/TTS/LLM spans for debugging

### DIFF
--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -181,7 +181,7 @@ class LLMStream(ABC):
         self._tee_aiter = aio.itertools.tee(self._event_ch, 2)
         self._event_aiter, monitor_aiter = self._tee_aiter
         self._current_attempt_has_error = False
-        self._provider_context_ids: list[str] = []
+        self._provider_request_ids: list[str] = []
         self._metrics_task = asyncio.create_task(
             self._metrics_monitor_task(monitor_aiter), name="LLM._metrics_task"
         )
@@ -218,16 +218,16 @@ class LLMStream(ABC):
                     attempt_span.set_attribute(trace_types.ATTR_RETRY_COUNT, i)
                     # Reset per-attempt context ids; the monitor task populates
                     # this as ChatChunks arrive.
-                    self._provider_context_ids = []
+                    self._provider_request_ids = []
                     try:
                         await self._run()
                     except Exception as e:
                         telemetry_utils.record_exception(attempt_span, e)
                         raise
                     finally:
-                        if self._provider_context_ids:
+                        if self._provider_request_ids:
                             attempt_span.set_attribute(
-                                trace_types.ATTR_PROVIDER_CONTEXT_IDS, self._provider_context_ids
+                                trace_types.ATTR_PROVIDER_REQUEST_IDS, self._provider_request_ids
                             )
                     return
             except APIError as e:
@@ -291,8 +291,8 @@ class LLMStream(ABC):
 
         async for ev in event_aiter:
             request_id = ev.id
-            if request_id and request_id not in self._provider_context_ids:
-                self._provider_context_ids.append(request_id)
+            if request_id and request_id not in self._provider_request_ids:
+                self._provider_request_ids.append(request_id)
             if ttft == -1.0:
                 ttft = time.perf_counter() - start_time
                 completion_start_time = datetime.now(timezone.utc).isoformat()

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -181,6 +181,7 @@ class LLMStream(ABC):
         self._tee_aiter = aio.itertools.tee(self._event_ch, 2)
         self._event_aiter, monitor_aiter = self._tee_aiter
         self._current_attempt_has_error = False
+        self._provider_context_ids: list[str] = []
         self._metrics_task = asyncio.create_task(
             self._metrics_monitor_task(monitor_aiter), name="LLM._metrics_task"
         )
@@ -215,11 +216,20 @@ class LLMStream(ABC):
             try:
                 with tracer.start_as_current_span("llm_request_run") as attempt_span:
                     attempt_span.set_attribute(trace_types.ATTR_RETRY_COUNT, i)
+                    # Reset per-attempt context ids; the monitor task populates
+                    # this as ChatChunks arrive.
+                    self._provider_context_ids = []
                     try:
-                        return await self._run()
+                        await self._run()
                     except Exception as e:
                         telemetry_utils.record_exception(attempt_span, e)
                         raise
+                    finally:
+                        if self._provider_context_ids:
+                            attempt_span.set_attribute(
+                                trace_types.ATTR_PROVIDER_CONTEXT_IDS, self._provider_context_ids
+                            )
+                    return
             except APIError as e:
                 # 499 (Client Closed Request) - close gracefully without raising
                 if isinstance(e, APIStatusError) and e.status_code == 499:
@@ -281,6 +291,8 @@ class LLMStream(ABC):
 
         async for ev in event_aiter:
             request_id = ev.id
+            if request_id and request_id not in self._provider_context_ids:
+                self._provider_context_ids.append(request_id)
             if ttft == -1.0:
                 ttft = time.perf_counter() - start_time
                 completion_start_time = datetime.now(timezone.utc).isoformat()

--- a/livekit-agents/livekit/agents/telemetry/trace_types.py
+++ b/livekit-agents/livekit/agents/telemetry/trace_types.py
@@ -3,7 +3,7 @@ ATTR_AGENT_LABEL = "lk.agent_label"
 ATTR_START_TIME = "lk.start_time"
 ATTR_END_TIME = "lk.end_time"
 ATTR_RETRY_COUNT = "lk.retry_count"
-ATTR_PROVIDER_CONTEXT_IDS = "lk.provider_context_ids"
+ATTR_PROVIDER_REQUEST_IDS = "lk.provider_request_ids"
 """Provider-known correlation ids associated with this span (list[str]).
 
 Populated by STT/TTS plugins when the id is either sent to the provider

--- a/livekit-agents/livekit/agents/telemetry/trace_types.py
+++ b/livekit-agents/livekit/agents/telemetry/trace_types.py
@@ -3,6 +3,12 @@ ATTR_AGENT_LABEL = "lk.agent_label"
 ATTR_START_TIME = "lk.start_time"
 ATTR_END_TIME = "lk.end_time"
 ATTR_RETRY_COUNT = "lk.retry_count"
+ATTR_PROVIDER_CONTEXT_IDS = "lk.provider_context_ids"
+"""Provider-known correlation ids associated with this span (list[str]).
+
+Populated by STT/TTS plugins when the id is either sent to the provider
+(e.g. WS context_id) or returned by it (e.g. response request_id / session_id),
+so it can be cross-referenced with the provider's logs for debugging."""
 
 
 ATTR_PARTICIPANT_ID = "lk.participant_id"

--- a/livekit-agents/livekit/agents/tts/tts.py
+++ b/livekit-agents/livekit/agents/tts/tts.py
@@ -739,6 +739,7 @@ class AudioEmitter:
         self._started = False
         self._num_segments = 0
         self._audio_durations: list[float] = []  # track durations per segment
+        self._provider_context_ids: list[str] = []  # deduped provider-known segment ids
 
     def pushed_duration(self, idx: int = -1) -> float:
         return (
@@ -802,6 +803,15 @@ class AudioEmitter:
                 "start_segment() can only be called when SynthesizeStream is initialized "
                 "with stream=True"
             )
+
+        if segment_id and segment_id not in self._provider_context_ids:
+            # expose the provider's per-segment context id on the current tts_request_run span
+            self._provider_context_ids.append(segment_id)
+            current_span = trace.get_current_span()
+            if current_span.is_recording():
+                current_span.set_attribute(
+                    trace_types.ATTR_PROVIDER_CONTEXT_IDS, self._provider_context_ids
+                )
 
         return self.__start_segment(segment_id=segment_id)
 

--- a/livekit-agents/livekit/agents/tts/tts.py
+++ b/livekit-agents/livekit/agents/tts/tts.py
@@ -804,10 +804,10 @@ class AudioEmitter:
                 "with stream=True"
             )
 
-        self.note_provider_request_id(segment_id)
+        self._note_provider_request_id(segment_id)
         return self.__start_segment(segment_id=segment_id)
 
-    def note_provider_request_id(self, context_id: str) -> None:
+    def _note_provider_request_id(self, context_id: str) -> None:
         """Record a provider-known id for this stream on the current span.
 
         Exposed on the `tts_request_run` span as `lk.provider_request_ids` so users

--- a/livekit-agents/livekit/agents/tts/tts.py
+++ b/livekit-agents/livekit/agents/tts/tts.py
@@ -739,7 +739,7 @@ class AudioEmitter:
         self._started = False
         self._num_segments = 0
         self._audio_durations: list[float] = []  # track durations per segment
-        self._provider_context_ids: list[str] = []  # deduped provider-known segment ids
+        self._provider_request_ids: list[str] = []  # deduped provider-known segment ids
 
     def pushed_duration(self, idx: int = -1) -> float:
         return (
@@ -804,25 +804,25 @@ class AudioEmitter:
                 "with stream=True"
             )
 
-        self.note_provider_context_id(segment_id)
+        self.note_provider_request_id(segment_id)
         return self.__start_segment(segment_id=segment_id)
 
-    def note_provider_context_id(self, context_id: str) -> None:
+    def note_provider_request_id(self, context_id: str) -> None:
         """Record a provider-known id for this stream on the current span.
 
-        Exposed on the `tts_request_run` span as `lk.provider_context_ids` so users
+        Exposed on the `tts_request_run` span as `lk.provider_request_ids` so users
         can correlate traces with the provider's server-side logs for debugging.
         `start_segment()` calls this automatically; plugins can also call it when
         the provider-known id becomes available later (e.g. from a response
         message's `request_id`/`session_id` field after start_segment).
         """
-        if not context_id or context_id in self._provider_context_ids:
+        if not context_id or context_id in self._provider_request_ids:
             return
-        self._provider_context_ids.append(context_id)
+        self._provider_request_ids.append(context_id)
         current_span = trace.get_current_span()
         if current_span.is_recording():
             current_span.set_attribute(
-                trace_types.ATTR_PROVIDER_CONTEXT_IDS, self._provider_context_ids
+                trace_types.ATTR_PROVIDER_REQUEST_IDS, self._provider_request_ids
             )
 
     def __start_segment(self, *, segment_id: str) -> None:

--- a/livekit-agents/livekit/agents/tts/tts.py
+++ b/livekit-agents/livekit/agents/tts/tts.py
@@ -804,16 +804,26 @@ class AudioEmitter:
                 "with stream=True"
             )
 
-        if segment_id and segment_id not in self._provider_context_ids:
-            # expose the provider's per-segment context id on the current tts_request_run span
-            self._provider_context_ids.append(segment_id)
-            current_span = trace.get_current_span()
-            if current_span.is_recording():
-                current_span.set_attribute(
-                    trace_types.ATTR_PROVIDER_CONTEXT_IDS, self._provider_context_ids
-                )
-
+        self.note_provider_context_id(segment_id)
         return self.__start_segment(segment_id=segment_id)
+
+    def note_provider_context_id(self, context_id: str) -> None:
+        """Record a provider-known id for this stream on the current span.
+
+        Exposed on the `tts_request_run` span as `lk.provider_context_ids` so users
+        can correlate traces with the provider's server-side logs for debugging.
+        `start_segment()` calls this automatically; plugins can also call it when
+        the provider-known id becomes available later (e.g. from a response
+        message's `request_id`/`session_id` field after start_segment).
+        """
+        if not context_id or context_id in self._provider_context_ids:
+            return
+        self._provider_context_ids.append(context_id)
+        current_span = trace.get_current_span()
+        if current_span.is_recording():
+            current_span.set_attribute(
+                trace_types.ATTR_PROVIDER_CONTEXT_IDS, self._provider_context_ids
+            )
 
     def __start_segment(self, *, segment_id: str) -> None:
         if not self._started:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -185,6 +185,7 @@ class AudioRecognition:
         self._agent_speaking: bool = False
 
         self._user_turn_span: trace.Span | None = None
+        self._stt_context_ids: list[str] = []
         self._closing = asyncio.Event()
 
         self._vad_speech_started: bool = False
@@ -677,6 +678,12 @@ class AudioRecognition:
         return self._audio_transcript
 
     async def _on_stt_event(self, ev: stt.SpeechEvent) -> None:
+        # Collect provider-known STT ids for this user turn. The actual attribute
+        # is written once when the user_turn span ends (see _on_end_of_turn), to
+        # avoid ordering issues with span creation.
+        if ev.request_id and ev.request_id not in self._stt_context_ids:
+            self._stt_context_ids.append(ev.request_id)
+
         if (
             self._turn_detection_mode == "manual"
             and self._user_turn_committed
@@ -1037,8 +1044,13 @@ class AudioRecognition:
                         trace_types.ATTR_END_OF_TURN_DELAY: end_of_turn_delay or 0,
                     }
                 )
+                if self._stt_context_ids:
+                    user_turn_span.set_attribute(
+                        trace_types.ATTR_PROVIDER_CONTEXT_IDS, self._stt_context_ids
+                    )
                 user_turn_span.end()
                 self._user_turn_span = None
+                self._stt_context_ids = []
 
                 # clear the transcript if the user turn was committed
                 self._audio_transcript = ""

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -185,7 +185,7 @@ class AudioRecognition:
         self._agent_speaking: bool = False
 
         self._user_turn_span: trace.Span | None = None
-        self._stt_context_ids: list[str] = []
+        self._stt_request_ids: list[str] = []
         self._closing = asyncio.Event()
 
         self._vad_speech_started: bool = False
@@ -681,8 +681,8 @@ class AudioRecognition:
         # Collect provider-known STT ids for this user turn. The actual attribute
         # is written once when the user_turn span ends (see _on_end_of_turn), to
         # avoid ordering issues with span creation.
-        if ev.request_id and ev.request_id not in self._stt_context_ids:
-            self._stt_context_ids.append(ev.request_id)
+        if ev.request_id and ev.request_id not in self._stt_request_ids:
+            self._stt_request_ids.append(ev.request_id)
 
         if (
             self._turn_detection_mode == "manual"
@@ -1044,13 +1044,13 @@ class AudioRecognition:
                         trace_types.ATTR_END_OF_TURN_DELAY: end_of_turn_delay or 0,
                     }
                 )
-                if self._stt_context_ids:
+                if self._stt_request_ids:
                     user_turn_span.set_attribute(
-                        trace_types.ATTR_PROVIDER_CONTEXT_IDS, self._stt_context_ids
+                        trace_types.ATTR_PROVIDER_REQUEST_IDS, self._stt_request_ids
                     )
                 user_turn_span.end()
                 self._user_turn_span = None
-                self._stt_context_ids = []
+                self._stt_request_ids = []
 
                 # clear the transcript if the user turn was committed
                 self._audio_transcript = ""

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -517,6 +517,7 @@ class SpeechStream(stt.SpeechStream):
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
             nonlocal closing_ws
             current_text = ""
+            current_item_id = ""
             last_interim_at: float = 0
             connected_at = time.time()
             item_audio_timing: dict[str, dict[str, int]] = {}
@@ -546,6 +547,7 @@ class SpeechStream(stt.SpeechStream):
                     msg_type = data.get("type")
                     if msg_type == "input_audio_buffer.speech_started":
                         item_id = data.get("item_id", "")
+                        current_item_id = item_id
                         audio_start_ms = data.get("audio_start_ms", 0)
                         item_audio_timing[item_id] = {"start_ms": audio_start_ms}
 
@@ -557,12 +559,16 @@ class SpeechStream(stt.SpeechStream):
 
                     elif msg_type == "conversation.item.input_audio_transcription.delta":
                         delta = data.get("delta", "")
+                        item_id = data.get("item_id", "") or current_item_id
+                        if item_id:
+                            current_item_id = item_id
                         if delta:
                             current_text += delta
                             if time.time() - last_interim_at > _delta_transcript_interval:
                                 self._event_ch.send_nowait(
                                     stt.SpeechEvent(
                                         type=stt.SpeechEventType.INTERIM_TRANSCRIPT,
+                                        request_id=current_item_id,
                                         alternatives=[
                                             stt.SpeechData(
                                                 text=current_text,
@@ -582,6 +588,7 @@ class SpeechStream(stt.SpeechStream):
                             self._event_ch.send_nowait(
                                 stt.SpeechEvent(
                                     type=stt.SpeechEventType.FINAL_TRANSCRIPT,
+                                    request_id=item_id,
                                     alternatives=[
                                         stt.SpeechData(
                                             text=transcript,

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -1313,8 +1313,10 @@ class SpeechStream(stt.SpeechStream):
         transcript_data = data.get("data", {})
         transcript_text = transcript_data.get("transcript", "")
         language = LanguageCode(transcript_data.get("language_code", ""))
-        request_id = transcript_data.get("request_id", "")
         self._maybe_set_server_request_id(transcript_data)
+        # Prefer the per-message request_id from the server; fall back to the
+        # session-wide server request_id captured from an earlier message.
+        request_id = transcript_data.get("request_id") or self._server_request_id or ""
 
         if not transcript_text:
             self._logger.debug("Received empty transcript", extra=self._build_log_context())

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -1325,13 +1325,13 @@ class SpeechStream(stt.SpeechStream):
         try:
             # Create usage event with proper metrics extraction
             metrics = transcript_data.get("metrics", {})
-            request_data = {
-                "original_id": request_id,
-                "processing_latency": metrics.get("processing_latency", 0.0),
-            }
+            # request_data = {
+            #     "original_id": request_id,
+            #     "processing_latency": metrics.get("processing_latency", 0.0),
+            # }
             usage_event = stt.SpeechEvent(
                 type=stt.SpeechEventType.RECOGNITION_USAGE,
-                request_id=json.dumps(request_data),
+                request_id=request_id,
                 recognition_usage=stt.RecognitionUsage(
                     audio_duration=metrics.get("audio_duration", 0.0),
                 ),

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -1020,7 +1020,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                 # Expose the server-assigned request id on the tts_request_run span so
                 # users can correlate traces with Sarvam's logs for debugging. Deduped
                 # internally, so calling on every message is fine.
-                output_emitter.note_provider_request_id(self._server_request_id)
+                output_emitter._note_provider_request_id(self._server_request_id)
 
             if not msg_type:
                 logger.warning(

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -1016,6 +1016,11 @@ class SynthesizeStream(tts.SynthesizeStream):
             resp = json.loads(msg_data)
             msg_type = resp.get("type")
             self._maybe_set_server_request_id(resp)
+            if self._server_request_id:
+                # Expose the server-assigned request id on the tts_request_run span so
+                # users can correlate traces with Sarvam's logs for debugging. Deduped
+                # internally, so calling on every message is fine.
+                output_emitter.note_provider_context_id(self._server_request_id)
 
             if not msg_type:
                 logger.warning(

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -1020,7 +1020,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                 # Expose the server-assigned request id on the tts_request_run span so
                 # users can correlate traces with Sarvam's logs for debugging. Deduped
                 # internally, so calling on every message is fine.
-                output_emitter.note_provider_context_id(self._server_request_id)
+                output_emitter.note_provider_request_id(self._server_request_id)
 
             if not msg_type:
                 logger.warning(

--- a/livekit-plugins/livekit-plugins-upliftai/livekit/plugins/upliftai/tts.py
+++ b/livekit-plugins/livekit-plugins-upliftai/livekit/plugins/upliftai/tts.py
@@ -509,8 +509,7 @@ class SynthesizeStream(tts.SynthesizeStream):
             self._mark_started()
 
             # Synthesize
-            request_id = str(uuid.uuid4())
-            audio_queue = await self._tts._client.synthesize(full_text, request_id)
+            audio_queue = await self._tts._client.synthesize(full_text, segment_id)
 
             # Stream audio
             while True:


### PR DESCRIPTION

Adds a new span attribute `lk.provider_request_ids` (list[str], deduped) on the `user_turn` (STT), `tts_request_run` (TTS), and `llm_request_run` (LLM) spans for debugging/reporting STT or TTS issues to the provider.


### Supported plugins (id actually known to the provider)

#### For LLM, the id comes from `ChatChunk.id`.


#### TTS streaming (`tts_request_run` attribute populated)
- **asyncai** — context_id echoed back
- **cartesia** — context_id echoed back
- **elevenlabs** — context_id sent on every WS message
- **inworld** — server-returned contextId
- **minimax** — server-returned session_id
- **murf** — context_id echoed back
- **neuphonic** — context_id sent in every message
- **sarvam** (updated in this PR) — server request_id via `note_provider_request_id()`
- **upliftai** (updated in this PR) — reuses the outbound requestId as segment_id
- **inference (LiveKit gateway)** — server-returned session_id

#### STT (`user_turn` attribute populated when present)
- **deepgram** — `metadata["request_id"]`
- **google** — from response metadata
- **gladia** — session id from init response
- **mistralai** — `session.request_id`
- **cartesia** — server request_id (falls back to local UUID if absent)
- **sarvam** — per-message request_id (with fallback to session-wide server id; fallback added in this PR)
- **openai realtime** (updated in this PR) — `item_id` from completion event
- **inference (LiveKit gateway)** — server request_id (present when gateway includes it)