### PR TITLE
feat(xai): support model selection in realtime, default to grok-voice-think-fast-1.0

### DIFF
--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/__init__.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/__init__.py
@@ -4,7 +4,7 @@ from . import realtime, responses
 from .stt import STT
 from .tools import FileSearch, WebSearch, XSearch
 from .tts import TTS
-from .types import STTLanguages, TTSLanguages
+from .types import GrokRealtimeModels, GrokVoices, STTLanguages, TTSLanguages
 from .version import __version__
 
 __all__ = [
@@ -17,6 +17,8 @@ __all__ = [
     "TTS",
     "TTSLanguages",
     "FileSearch",
+    "GrokRealtimeModels",
+    "GrokVoices",
     "__version__",
 ]
 

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/realtime/realtime_model.py
@@ -27,9 +27,11 @@ from livekit.plugins import openai
 
 from ..log import logger
 from ..tools import XAITool
-from ..types import GrokVoices
+from ..types import GrokRealtimeModels, GrokVoices
 
 XAI_BASE_URL = "wss://api.x.ai/v1/realtime"
+
+XAI_DEFAULT_MODEL: GrokRealtimeModels = "grok-voice-think-fast-1.0"
 
 XAI_DEFAULT_INPUT_AUDIO_TRANSCRIPTION = AudioTranscription()
 
@@ -47,6 +49,7 @@ class RealtimeModel(openai.realtime.RealtimeModel):
     def __init__(
         self,
         *,
+        model: NotGivenOr[GrokRealtimeModels | str] = NOT_GIVEN,
         voice: NotGivenOr[GrokVoices | str | None] = "Ara",
         api_key: str | None = None,
         base_url: NotGivenOr[str] = NOT_GIVEN,
@@ -65,7 +68,7 @@ class RealtimeModel(openai.realtime.RealtimeModel):
         resolved_voice = voice if is_given(voice) else "Ara"
         super().__init__(
             base_url=base_url if is_given(base_url) else XAI_BASE_URL,
-            model="grok-4-1-fast-non-reasoning",
+            model=model if is_given(model) else XAI_DEFAULT_MODEL,
             voice=resolved_voice,  # type: ignore[arg-type]
             api_key=api_key,
             modalities=["audio"],

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/types.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/types.py
@@ -36,6 +36,11 @@ GrokVoices = Literal[
     "Sal",
 ]
 
+GrokRealtimeModels = Literal[
+    "grok-voice-think-fast-1.0",
+    "grok-voice-fast-1.0",
+]
+
 TTSLanguages = Literal[
     "auto",
     "en",


### PR DESCRIPTION
x.ai deprecated grok-voice-fast-1.0 and recommends grok-voice-think-fast-1.0 as the new flagship voice model, selectable via the model query param on the realtime websocket (see https://docs.x.ai/developers/model-capabilities/audio/voice-agent). This patch adds a model kwarg to xai.realtime.RealtimeModel, defaults it to grok-voice-think-fast-1.0, and exposes a GrokRealtimeModels literal with both the new and legacy ids; the parent openai realtime client already forwards model as a ws query param so the resulting url matches the x.ai docs exactly.