### PR TITLE
fix(soniox): emit PREFLIGHT_TRANSCRIPT for preemptive LLM generation

### DIFF
--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
@@ -499,7 +499,7 @@ class SpeechStream(stt.SpeechStream):
                             else:
                                 non_final.update(token)
 
-                        # 2) emit START_OF_SPEECH + interim for remaining content.
+                        # 2) emit START_OF_SPEECH + transcript for remaining content.
                         if final.text or non_final.text:
                             if not is_speaking:
                                 is_speaking = True
@@ -513,9 +513,19 @@ class SpeechStream(stt.SpeechStream):
                                 LanguageCode(lang) for lang, _ in interim_segs
                             ] or None
                             interim_src_texts = [t for _, t in interim_segs] or None
+
+                            # When all tokens in this batch are final (no non-final pending),
+                            # speech has reached a stable state — emit PREFLIGHT_TRANSCRIPT to
+                            # allow preemptive LLM generation. This mirrors Deepgram v2's
+                            # EagerEndOfTurn behavior.
+                            event_type = (
+                                SpeechEventType.PREFLIGHT_TRANSCRIPT
+                                if final.text and not non_final.text
+                                else SpeechEventType.INTERIM_TRANSCRIPT
+                            )
                             self._event_ch.send_nowait(
                                 stt.SpeechEvent(
-                                    type=SpeechEventType.INTERIM_TRANSCRIPT,
+                                    type=event_type,
                                     alternatives=[
                                         final.merged_speech_data(
                                             non_final,


### PR DESCRIPTION
Fixes #5536

## Problem

The Soniox STT plugin only emits `INTERIM_TRANSCRIPT` events, so `AgentSession`'s preemptive LLM generation never fires when using Soniox for STT-driven end-of-turn detection. Users pay full LLM TTFT in wall-clock time after every turn, which is too high for real-time voice use cases.

## Solution

When a Soniox token batch contains **only final tokens** (no non-final/speculative tokens pending), speech has reached a stable state — this indicates a likely pause, analogous to Deepgram v2's `EagerEndOfTurn` signal. In that case, emit `PREFLIGHT_TRANSCRIPT` instead of `INTERIM_TRANSCRIPT`.

This allows `AgentSession` to start speculative LLM generation. If the user resumes speaking, the next batch will contain non-final tokens, triggering a regular `INTERIM_TRANSCRIPT` that aborts the preemptive generation — the same abort path used by Deepgram v2's `TurnResumed` event.

The change is minimal: one conditional in the event-type selection within `_recv_messages_task`.

## Testing

Tested by code review against the Deepgram v2 pattern (`EagerEndOfTurn` → `PREFLIGHT_TRANSCRIPT`). The logic mirrors that behavior using the token finality heuristic native to Soniox's streaming API.