### PR TITLE
fix(google): pause audio input during synchronous tool execution on t…

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -495,6 +495,11 @@ class RealtimeSession(llm.RealtimeSession):
         self._session_lock = asyncio.Lock()
         self._num_retries = 0
 
+        # true while synchronous tool call is in flight for 3.1 only
+        # Audio frames dropped here to prevent server from thinking incoming audio is a
+        # new turn and cancelling the pending tool call
+        self._tool_call_pending = False
+
     async def _close_active_session(self) -> None:
         async with self._session_lock:
             if self._active_session:
@@ -672,6 +677,8 @@ class RealtimeSession(llm.RealtimeSession):
         return self._session_resumption_handle
 
     def push_audio(self, frame: rtc.AudioFrame) -> None:
+        if self._tool_call_pending:
+            return
         for f in self._resample_audio(frame):
             for nf in self._bstream.write(f.data.tobytes()):
                 realtime_input = types.LiveClientRealtimeInput(
@@ -816,6 +823,7 @@ class RealtimeSession(llm.RealtimeSession):
             await self._close_active_session()
 
             self._session_should_close.clear()
+            self._tool_call_pending = False  # reset if previous session ended mid-tool-call
             config = self._build_connect_config()
             session = None
             try:
@@ -937,6 +945,7 @@ class RealtimeSession(llm.RealtimeSession):
                     )
                 elif isinstance(msg, types.LiveClientToolResponse) and msg.function_responses:
                     await session.send_tool_response(function_responses=msg.function_responses)
+                    self._tool_call_pending = False
                 elif isinstance(msg, types.LiveClientRealtimeInput):
                     if msg.audio:
                         await session.send_realtime_input(audio=msg.audio)
@@ -1294,6 +1303,13 @@ class RealtimeSession(llm.RealtimeSession):
                 )
             )
         self._mark_current_generation_done()
+        is_blocking = (
+            not is_given(self._opts.tool_behavior)
+            or self._opts.tool_behavior == types.Behavior.BLOCKING
+        )
+        if is_blocking:
+            self._tool_call_pending = True
+            self._bstream.clear()
 
     def _handle_tool_call_cancellation(
         self, tool_call_cancellation: types.LiveServerToolCallCancellation
@@ -1302,6 +1318,7 @@ class RealtimeSession(llm.RealtimeSession):
             "server cancelled tool calls",
             extra={"function_call_ids": tool_call_cancellation.ids},
         )
+        self._tool_call_pending = False
 
     def _handle_usage_metadata(self, usage_metadata: types.UsageMetadata) -> None:
         current_gen = self._current_generation


### PR DESCRIPTION
Gemini 3.1 live model

Gemini 3.1 forces synchronous tool calling, which means the model blocks until tool responses arrive. The plugin's _send_task was constantly forwarding microphone audio while tools executed, which caused the server to think of incoming audio as a new turn and cancel the pending tool call after ~12s. This caused duplicate tool execution with already-resolved call_ids as well as corrupted conversation state.

1. Adds a _tool_call_pending flag (for Gemini 3.1 only) that drops push_audio frames from the moment a toolCall is received until send_tool_response is flushed. 
2. Also clears the flag on tool_call_cancellation so the session never stalls. No behavior change for Gemini 2.5 models.