### PR TITLE
fix(gemini live): use parameters instead of parameters_json_schema for raw schema function tools

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/google.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/google.py
@@ -121,6 +121,7 @@ def to_fnc_ctx(
     tool_ctx: llm.ToolContext,
     *,
     tool_behavior: TOOL_BEHAVIOR | None = None,
+    use_parameters_json_schema: bool = True,
 ) -> list[dict[str, Any]]:
     tools: list[dict[str, Any]] = []
     for tool in tool_ctx.function_tools.values():
@@ -129,8 +130,18 @@ def to_fnc_ctx(
             schema = {
                 "name": info.name,
                 "description": info.raw_schema.get("description", ""),
-                "parameters_json_schema": info.raw_schema.get("parameters", {}),
             }
+            if use_parameters_json_schema:
+                schema["parameters_json_schema"] = info.raw_schema.get("parameters", {})
+            else:
+                # Gemini Live doesn't support parameters_json_schema, use the simplified JSON Schema instead
+                # see: https://github.com/googleapis/python-genai/issues/1147
+                from livekit.plugins.google.utils import _GeminiJsonSchema
+
+                schema["parameters"] = (
+                    _GeminiJsonSchema(info.raw_schema.get("parameters", {})).simplify() or None
+                )
+
             if tool_behavior is not None:
                 schema["behavior"] = tool_behavior
             tools.append(schema)

--- a/livekit-agents/livekit/agents/llm/tool_context.py
+++ b/livekit-agents/livekit/agents/llm/tool_context.py
@@ -512,6 +512,7 @@ class ToolContext:
         format: Literal["google"],
         *,
         tool_behavior: _provider_format.google.TOOL_BEHAVIOR | None = None,
+        use_parameters_json_schema: bool = True,
     ) -> list[dict[str, Any]]: ...
 
     @overload

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -1055,7 +1055,11 @@ class RealtimeSession(llm.RealtimeSession):
     def _build_connect_config(self) -> types.LiveConnectConfig:
         temp = self._opts.temperature if is_given(self._opts.temperature) else None
 
-        tools_config = create_tools_config(self._tools, tool_behavior=self._opts.tool_behavior)
+        tools_config = create_tools_config(
+            self._tools,
+            tool_behavior=self._opts.tool_behavior,
+            use_parameters_json_schema=False,
+        )
         conf = types.LiveConnectConfig(
             response_modalities=self._opts.response_modalities,
             history_config=types.HistoryConfig(initial_history_in_client_content=True)

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
@@ -21,6 +21,7 @@ def create_tools_config(
     tool_ctx: llm.ToolContext,
     *,
     tool_behavior: NotGivenOr[types.Behavior] = NOT_GIVEN,
+    use_parameters_json_schema: bool = True,
     _only_single_type: bool = False,
 ) -> list[types.Tool]:
     gemini_tools: list[types.Tool] = []
@@ -28,7 +29,9 @@ def create_tools_config(
     function_tools = [
         types.FunctionDeclaration.model_validate(schema)
         for schema in tool_ctx.parse_function_tools(
-            "google", tool_behavior=tool_behavior.value if tool_behavior else None
+            "google",
+            tool_behavior=tool_behavior.value if tool_behavior else None,
+            use_parameters_json_schema=use_parameters_json_schema,
         )
     ]
     if function_tools:


### PR DESCRIPTION
## Summary

- Gemini Live doesn't accept `parameters_json_schema` on `FunctionDeclaration`, so this PR switches the realtime session to the `parameters` field (simplified via `_GeminiJsonSchema`).
- The regular Gemini LLM keeps using `parameters_json_schema` to preserve the richer JSON Schema features it supports.

Closes #5450

Ref: https://github.com/googleapis/python-genai/issues/1147