### PR TITLE
Update codec config, MIME mapping, and interruption handling

### DIFF
--- a/livekit-agents/livekit/agents/utils/codecs/decoder.py
+++ b/livekit-agents/livekit/agents/utils/codecs/decoder.py
@@ -59,6 +59,8 @@ def _mime_to_av_format(mime: str | None) -> str | None:
         "audio/ogg": "ogg",
         "audio/webm": "webm",
         "audio/mp4": "mp4",
+        "audio/mulaw": "mulaw",
+        "audio/alaw": "alaw",
     }
     return _TABLE.get(mime)
 

--- a/livekit-agents/livekit/agents/utils/codecs/decoder.py
+++ b/livekit-agents/livekit/agents/utils/codecs/decoder.py
@@ -59,8 +59,6 @@ def _mime_to_av_format(mime: str | None) -> str | None:
         "audio/ogg": "ogg",
         "audio/webm": "webm",
         "audio/mp4": "mp4",
-        "audio/mulaw": "mulaw",
-        "audio/alaw": "alaw",
     }
     return _TABLE.get(mime)
 

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -62,7 +62,29 @@ ALLOWED_OUTPUT_AUDIO_CODECS: set[str] = {
     "flac",
     "aac",
     "wav",
+    "linear16",
+    "mulaw",
+    "alaw",
 }
+
+_CODEC_TO_MIME: dict[str, str] = {
+    "mp3": "audio/mp3",
+    "wav": "audio/wav",
+    "opus": "audio/opus",
+    "flac": "audio/flac",
+    "aac": "audio/aac",
+    "linear16": "audio/pcm",
+    "mulaw": "audio/pcm",
+    "alaw": "audio/pcm",
+}
+
+
+def _codec_to_mime_type(codec: str) -> str:
+    """Map a Sarvam output_audio_codec value to the MIME type the framework decoder expects."""
+    mime = _CODEC_TO_MIME.get(codec)
+    if mime is None:
+        raise ValueError(f"Unsupported output_audio_codec: {codec}")
+    return mime
 
 
 # Supported languages in BCP-47 format
@@ -699,7 +721,7 @@ class ChunkedStream(tts.ChunkedStream):
             "Content-Type": "application/json",
             "User-Agent": USER_AGENT,
         }
-        mime_type = f"audio/{self._opts.output_audio_codec}"
+        mime_type = _codec_to_mime_type(self._opts.output_audio_codec)
         try:
             async with self._tts._ensure_session().post(
                 url=self._opts.base_url,
@@ -765,7 +787,7 @@ class SynthesizeStream(tts.SynthesizeStream):
         request_id = utils.shortuuid()
         self._client_request_id = request_id
         self._server_request_id = None
-        mime_type = f"audio/{self._opts.output_audio_codec}"
+        mime_type = _codec_to_mime_type(self._opts.output_audio_codec)
         output_emitter.initialize(
             request_id=request_id,
             sample_rate=self._opts.speech_sample_rate,
@@ -835,29 +857,29 @@ class SynthesizeStream(tts.SynthesizeStream):
             extra={**self._build_log_context(), "user-agent": USER_AGENT},
         )
 
+        input_sent_event = asyncio.Event()
+
         async def send_task(ws: aiohttp.ClientWebSocketResponse) -> None:
             try:
-                # Send initial config
                 data: dict[str, object] = {
                     "target_language_code": self._opts.target_language_code,
                     "speaker": self._opts.speaker,
                     "pace": self._opts.pace,
                     "model": self._opts.model,
                     "speech_sample_rate": self._opts.speech_sample_rate,
+                    "output_audio_codec": self._opts.output_audio_codec,
+                    "output_audio_bitrate": self._opts.output_audio_bitrate,
+                    "min_buffer_size": self._opts.min_buffer_size,
+                    "max_chunk_length": self._opts.max_chunk_length,
                 }
                 if self._opts.model == "bulbul:v2":
                     data["pitch"] = self._opts.pitch
                     data["loudness"] = self._opts.loudness
                     data["enable_preprocessing"] = self._opts.enable_preprocessing
-                    data["output_audio_codec"] = self._opts.output_audio_codec
                     if self._opts.enable_cached_responses is not None:
                         data["enable_cached_responses"] = self._opts.enable_cached_responses
                 if self._opts.model in ("bulbul:v3", "bulbul:v3-beta"):
                     data["temperature"] = self._opts.temperature
-                    data["output_audio_bitrate"] = self._opts.output_audio_bitrate
-                    data["min_buffer_size"] = self._opts.min_buffer_size
-                    data["max_chunk_length"] = self._opts.max_chunk_length
-                    data["output_audio_codec"] = self._opts.output_audio_codec
                 if self._opts.model == "bulbul:v3" and self._opts.dict_id is not None:
                     data["dict_id"] = self._opts.dict_id
                 config_msg = {"type": "config", "data": data}
@@ -866,10 +888,8 @@ class SynthesizeStream(tts.SynthesizeStream):
                 )
                 await ws.send_str(json.dumps(config_msg))
 
-                # Count text chunks sent
                 started = False
                 text_chunks_sent = 0
-                # Send text chunks
                 async for word in word_stream:
                     if not started:
                         self._mark_started()
@@ -878,17 +898,32 @@ class SynthesizeStream(tts.SynthesizeStream):
                     await ws.send_str(json.dumps(text_msg))
                     text_chunks_sent += 1
 
-                # Send flush signal
                 flush_msg = {"type": "flush"}
                 await ws.send_str(json.dumps(flush_msg))
+                input_sent_event.set()
 
+            except (ConnectionResetError, RuntimeError) as e:
+                err_str = str(e).lower()
+                if "closing" in err_str or "closed" in err_str:
+                    logger.debug(
+                        "WebSocket transport closing during send (likely interruption)",
+                        extra=self._build_log_context(),
+                    )
+                    return
+                logger.error(
+                    f"Error in send task: {e}", extra=self._build_log_context(), exc_info=True
+                )
+                raise APIConnectionError(f"Send task failed: {e}") from e
             except Exception as e:
                 logger.error(
                     f"Error in send task: {e}", extra=self._build_log_context(), exc_info=True
                 )
                 raise APIConnectionError(f"Send task failed: {e}") from e
+            finally:
+                input_sent_event.set()
 
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
+            await input_sent_event.wait()
             try:
                 while True:
                     msg = await ws.receive(timeout=self._conn_options.timeout)
@@ -936,7 +971,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                     if msg.type == aiohttp.WSMsgType.TEXT:
                         success = await self._handle_websocket_message(msg.data, output_emitter)
                         if not success:
-                            break  # Stop processing on error or completion
+                            break
 
                     elif msg.type == aiohttp.WSMsgType.ERROR:
                         error_msg = f"WebSocket error: {msg.data}"
@@ -946,13 +981,26 @@ class SynthesizeStream(tts.SynthesizeStream):
             except asyncio.TimeoutError as e:
                 logger.error("WebSocket received timeout", extra=self._build_log_context())
                 raise APITimeoutError("WebSocket receive timeout") from e
+            except (APIStatusError, APIConnectionError, APITimeoutError):
+                raise
+            except ConnectionResetError as e:
+                err_str = str(e).lower()
+                if "closing" in err_str or "closed" in err_str:
+                    logger.debug(
+                        "WebSocket transport closing during receive (likely interruption)",
+                        extra=self._build_log_context(),
+                    )
+                    return
+                logger.error(
+                    f"Error in receive task: {e}", extra=self._build_log_context(), exc_info=True
+                )
+                raise
             except Exception as e:
                 logger.error(
                     f"Error in receive task: {e}", extra=self._build_log_context(), exc_info=True
                 )
                 raise
 
-        # Use connection pool for WebSocket management
         try:
             async with self._tts._pool.connection(timeout=self._conn_options.timeout) as ws:
                 self._acquire_time = self._tts._pool.last_acquire_time
@@ -972,15 +1020,8 @@ class SynthesizeStream(tts.SynthesizeStream):
                     logger.info(
                         "WebSocket session completed successfully", extra=self._build_log_context()
                     )
-                except Exception as e:
-                    logger.error(
-                        f"WebSocket session failed: {e}",
-                        extra=self._build_log_context(),
-                        exc_info=True,
-                    )
-                    raise
                 finally:
-                    # Gracefully cancel tasks
+                    input_sent_event.set()
                     await utils.aio.gracefully_cancel(*tasks)
                     self._send_task = None
                     self._recv_task = None
@@ -1150,51 +1191,12 @@ class SynthesizeStream(tts.SynthesizeStream):
             self._server_request_id = str(request_id)
 
     async def aclose(self) -> None:
-        """Close the stream and cleanup resources."""
-        logger.debug("Starting TTS stream cleanup", extra=self._build_log_context())
+        """Close the stream and cleanup resources.
 
-        self._connection_state = ConnectionState.DISCONNECTED
-
-        # Cancel running tasks first
-        tasks_to_cancel = []
-        for task_attr in ["_send_task", "_recv_task"]:
-            task = getattr(self, task_attr, None)
-            if task and not task.done():
-                tasks_to_cancel.append(task)
-
-        if tasks_to_cancel:
-            for task in tasks_to_cancel:
-                task.cancel()
-            try:
-                await asyncio.gather(*tasks_to_cancel, return_exceptions=True)
-            except Exception as e:
-                logger.warning(f"Error cancelling tasks: {e}", extra=self._build_log_context())
-
-        # Close WebSocket connection
-        if self._ws_conn and not self._ws_conn.closed:
-            try:
-                await self._ws_conn.close()
-                logger.debug("WebSocket connection closed", extra=self._build_log_context())
-            except Exception as e:
-                logger.warning(f"Error closing WebSocket: {e}", extra=self._build_log_context())
-
-        # Close channels
-        for channel_name, channel in [("segments", self._segments_ch), ("input", self._input_ch)]:
-            try:
-                if hasattr(channel, "closed") and not channel.closed:
-                    if hasattr(channel, "close"):
-                        channel.close()
-                    logger.debug(f"{channel_name} channel closed", extra=self._build_log_context())
-            except Exception as e:
-                logger.warning(
-                    f"Error closing {channel_name} channel: {e}", extra=self._build_log_context()
-                )
-
-        # Call parent cleanup
-        try:
-            await super().aclose()
-        except Exception as e:
-            logger.warning(f"Error in parent cleanup: {e}", extra=self._build_log_context())
-        finally:
-            self._client_request_id = None
-            self._server_request_id = None
+        The base class cancels ``_run`` (and therefore all child tasks
+        spawned inside ``_run_ws``).  The ``ConnectionPool`` context manager
+        handles WebSocket cleanup on cancellation.  We only need to close
+        the segments channel so that ``_process_segments`` unblocks.
+        """
+        self._segments_ch.close()
+        await super().aclose()

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -868,9 +868,6 @@ class SynthesizeStream(tts.SynthesizeStream):
                     "model": self._opts.model,
                     "speech_sample_rate": self._opts.speech_sample_rate,
                     "output_audio_codec": self._opts.output_audio_codec,
-                    "output_audio_bitrate": self._opts.output_audio_bitrate,
-                    "min_buffer_size": self._opts.min_buffer_size,
-                    "max_chunk_length": self._opts.max_chunk_length,
                 }
                 if self._opts.model == "bulbul:v2":
                     data["pitch"] = self._opts.pitch
@@ -880,6 +877,9 @@ class SynthesizeStream(tts.SynthesizeStream):
                         data["enable_cached_responses"] = self._opts.enable_cached_responses
                 if self._opts.model in ("bulbul:v3", "bulbul:v3-beta"):
                     data["temperature"] = self._opts.temperature
+                    data["output_audio_bitrate"] = self._opts.output_audio_bitrate
+                    data["min_buffer_size"] = self._opts.min_buffer_size
+                    data["max_chunk_length"] = self._opts.max_chunk_length
                 if self._opts.model == "bulbul:v3" and self._opts.dict_id is not None:
                     data["dict_id"] = self._opts.dict_id
                 config_msg = {"type": "config", "data": data}

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -74,8 +74,8 @@ _CODEC_TO_MIME: dict[str, str] = {
     "flac": "audio/flac",
     "aac": "audio/aac",
     "linear16": "audio/pcm",
-    "mulaw": "audio/pcm",
-    "alaw": "audio/pcm",
+    "mulaw": "audio/mulaw",
+    "alaw": "audio/alaw",
 }
 
 
@@ -887,6 +887,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                     "Sending TTS config", extra={**self._build_log_context(), "config": config_msg}
                 )
                 await ws.send_str(json.dumps(config_msg))
+                input_sent_event.set()
 
                 started = False
                 text_chunks_sent = 0
@@ -900,7 +901,6 @@ class SynthesizeStream(tts.SynthesizeStream):
 
                 flush_msg = {"type": "flush"}
                 await ws.send_str(json.dumps(flush_msg))
-                input_sent_event.set()
 
             except (ConnectionResetError, RuntimeError) as e:
                 err_str = str(e).lower()

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -784,6 +784,7 @@ class SynthesizeStream(tts.SynthesizeStream):
         self._ws_conn: aiohttp.ClientWebSocketResponse | None = None
 
     async def _run(self, output_emitter: tts.AudioEmitter) -> None:
+        self._segments_ch = utils.aio.Chan[tokenize.SentenceStream]()
         request_id = utils.shortuuid()
         self._client_request_id = request_id
         self._server_request_id = None

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -53,8 +53,19 @@ USER_AGENT = f"Livekit/{livekit_version} Python/{platform.python_version()}"
 SARVAM_TTS_BASE_URL = "https://api.sarvam.ai/text-to-speech"
 SARVAM_TTS_WS_URL = "wss://api.sarvam.ai/text-to-speech/ws"
 
-# Sarvam TTS WebSocket connections idle out after 60 seconds. Send a ping every
-# 30 seconds to keep pooled connections alive between requests.
+# Sarvam TTS WebSocket connections idle out after 60 seconds. We defend against
+# this on two layers:
+#
+# 1. Protocol-level: aiohttp ``heartbeat`` sends WebSocket PING frames every
+#    ``_WS_HEARTBEAT_INTERVAL`` seconds and auto-handles PONGs even while no
+#    application-level ``receive()`` is in flight. This is what actually keeps
+#    the TCP connection alive while it sits idle in the pool.
+# 2. Application-level: ``_keepalive_loop`` sends a Sarvam-defined
+#    ``{"type": "ping"}`` JSON message every ``_KEEPALIVE_INTERVAL`` seconds.
+#    This guards against a server-side application idle timer that may not be
+#    reset by protocol-level pings, and serves as a fast detector for stale
+#    pooled connections.
+_WS_HEARTBEAT_INTERVAL: float = 20.0
 _KEEPALIVE_INTERVAL: float = 30.0
 
 # Sarvam TTS specific models and speakers
@@ -575,6 +586,13 @@ class TTS(tts.TTS):
                 session.ws_connect(
                     ws_url,
                     headers=headers,
+                    # Send protocol-level WebSocket PING frames every
+                    # ``_WS_HEARTBEAT_INTERVAL`` seconds. aiohttp handles the
+                    # PONG accounting on its own and will close the connection
+                    # locally if the server stops responding -- this is what
+                    # actually keeps the TCP connection alive while it sits
+                    # idle in the pool (no ``receive()`` call to auto-pong).
+                    heartbeat=_WS_HEARTBEAT_INTERVAL,
                 ),
                 timeout,
             )
@@ -594,8 +612,16 @@ class TTS(tts.TTS):
         await ws.close()
 
     def _start_keepalive(self, ws: aiohttp.ClientWebSocketResponse) -> None:
-        """Spawn a background task that keeps ``ws`` alive with periodic pings."""
+        """Spawn a background task that keeps ``ws`` alive with periodic pings.
+
+        Idempotent: if a live keepalive task is already registered for ``ws``
+        the call is a no-op. Callers that need a fresh task must invoke
+        ``_stop_keepalive`` first.
+        """
         if _KEEPALIVE_INTERVAL <= 0:
+            return
+        existing = self._ws_keepalive_tasks.get(id(ws))
+        if existing is not None and not existing.done():
             return
         task = asyncio.create_task(self._keepalive_loop(ws), name="sarvam-tts-ws-keepalive")
         self._ws_keepalive_tasks[id(ws)] = task
@@ -610,24 +636,71 @@ class TTS(tts.TTS):
             await task
 
     async def _keepalive_loop(self, ws: aiohttp.ClientWebSocketResponse) -> None:
-        """Send a ping every ``_KEEPALIVE_INTERVAL`` seconds while ``ws`` is open."""
+        """Keep a pooled WebSocket alive while it sits idle.
+
+        This loop does two things in lockstep:
+
+        1. Actively calls ``ws.receive()`` so that aiohttp can process
+           server-initiated PONG frames (and any other messages). aiohttp
+           only resets its internal "PONG not received" timer when a PONG
+           is read via ``receive()`` -- without an active reader, the
+           protocol-level heartbeat will tear the connection down even
+           though the server is happily replying.
+
+        2. Sends a Sarvam-defined ``{"type": "ping"}`` JSON message
+           whenever ``receive()`` times out (i.e. nothing has come in for
+           ``_KEEPALIVE_INTERVAL`` seconds). This resets Sarvam's
+           server-side application idle timer (documented as 60 s).
+
+        Any CLOSE/CLOSED/CLOSING/ERROR message from the server, or any
+        write failure, evicts the connection from the pool so the next
+        checkout creates a fresh one instead of handing the dead one out.
+        """
         try:
             while not ws.closed:
-                await asyncio.sleep(_KEEPALIVE_INTERVAL)
-                if ws.closed:
-                    return
                 try:
-                    await ws.send_str(json.dumps({"type": "ping"}))
-                except asyncio.CancelledError:
-                    raise
-                except Exception as e:
-                    # Connection is no longer writable; let the pool discover
-                    # this on the next checkout and replace it.
+                    msg = await asyncio.wait_for(ws.receive(), timeout=_KEEPALIVE_INTERVAL)
+                except asyncio.TimeoutError:
+                    # No incoming message within the interval -- send our
+                    # app-level ping to reset Sarvam's idle timer.
+                    if ws.closed:
+                        return
+                    try:
+                        await ws.send_str(json.dumps({"type": "ping"}))
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as e:
+                        logger.debug(
+                            "Sarvam TTS keepalive ping failed; evicting connection from pool",
+                            extra={"error": str(e)},
+                        )
+                        with contextlib.suppress(Exception):
+                            self._pool.remove(ws)
+                        return
+                    continue
+
+                # We received something. CLOSE/CLOSED/CLOSING/ERROR means
+                # the server tore the connection down -- evict and exit.
+                if msg.type in (
+                    aiohttp.WSMsgType.CLOSE,
+                    aiohttp.WSMsgType.CLOSED,
+                    aiohttp.WSMsgType.CLOSING,
+                    aiohttp.WSMsgType.ERROR,
+                ):
                     logger.debug(
-                        "Sarvam TTS keepalive ping failed; connection will be replaced on next use",
-                        extra={"error": str(e)},
+                        "Sarvam TTS WebSocket closed while idle in pool; evicting connection",
+                        extra={
+                            "msg_type": str(msg.type),
+                            "close_code": ws.close_code,
+                        },
                     )
+                    with contextlib.suppress(Exception):
+                        self._pool.remove(ws)
                     return
+                # Otherwise -- PONG, TEXT, BINARY, etc. -- discard. We are
+                # idle in the pool so any unsolicited TTS traffic from a
+                # previous request is no longer relevant. The act of
+                # receiving has already reset aiohttp's heartbeat.
         except asyncio.CancelledError:
             pass
 
@@ -1013,11 +1086,20 @@ class SynthesizeStream(tts.SynthesizeStream):
             except (ConnectionResetError, RuntimeError) as e:
                 err_str = str(e).lower()
                 if "closing" in err_str or "closed" in err_str:
+                    # The transport is dead -- almost always a stale pooled
+                    # connection that the server already closed (60s idle
+                    # timeout). Raise so the pool evicts it via the
+                    # ``async with`` __aexit__; the framework will retry
+                    # against a fresh connection. Real user interruptions
+                    # propagate as ``CancelledError``, not this branch.
                     logger.debug(
-                        "WebSocket transport closing during send (likely interruption)",
+                        "Sarvam TTS WebSocket transport closed before send "
+                        "completed; pool will replace this connection",
                         extra=self._build_log_context(),
                     )
-                    return
+                    raise APIConnectionError(
+                        "Sarvam TTS WebSocket transport closed before send completed"
+                    ) from e
                 logger.error(
                     f"Error in send task: {e}", extra=self._build_log_context(), exc_info=True
                 )
@@ -1094,11 +1176,19 @@ class SynthesizeStream(tts.SynthesizeStream):
             except ConnectionResetError as e:
                 err_str = str(e).lower()
                 if "closing" in err_str or "closed" in err_str:
+                    # Same reasoning as ``send_task``: the transport is dead
+                    # (typically a stale pooled connection). Raise so the
+                    # pool evicts it and the framework retries against a
+                    # fresh connection. Real interruptions surface as
+                    # ``CancelledError``.
                     logger.debug(
-                        "WebSocket transport closing during receive (likely interruption)",
+                        "Sarvam TTS WebSocket transport closed during"
+                        " receive; pool will replace this connection",
                         extra=self._build_log_context(),
                     )
-                    return
+                    raise APIConnectionError(
+                        "Sarvam TTS WebSocket transport closed during receive"
+                    ) from e
                 logger.error(
                     f"Error in receive task: {e}", extra=self._build_log_context(), exc_info=True
                 )
@@ -1111,28 +1201,47 @@ class SynthesizeStream(tts.SynthesizeStream):
 
         try:
             async with self._tts._pool.connection(timeout=self._conn_options.timeout) as ws:
-                self._acquire_time = self._tts._pool.last_acquire_time
-                self._connection_reused = self._tts._pool.last_connection_reused
-                self._ws_conn = ws
-                self._connection_state = ConnectionState.CONNECTED
-
-                logger.info("WebSocket connected successfully", extra=self._build_log_context())
-
-                self._send_task = asyncio.create_task(send_task(ws))
-                self._recv_task = asyncio.create_task(recv_task(ws))
-
-                tasks = [self._send_task, self._recv_task]
+                # Pause the keepalive task while we own the connection so its
+                # ping frames don't interleave with config / text / flush
+                # traffic. The task was started either by ``_connect_ws`` (for
+                # a fresh connection) or by the previous ``_run_ws`` invocation
+                # that returned this connection to the pool.
+                await self._tts._stop_keepalive(ws)
+                keepalive_should_resume = False
 
                 try:
-                    await asyncio.gather(*tasks)
-                    logger.info(
-                        "WebSocket session completed successfully", extra=self._build_log_context()
-                    )
+                    self._acquire_time = self._tts._pool.last_acquire_time
+                    self._connection_reused = self._tts._pool.last_connection_reused
+                    self._ws_conn = ws
+                    self._connection_state = ConnectionState.CONNECTED
+
+                    logger.info("WebSocket connected successfully", extra=self._build_log_context())
+
+                    self._send_task = asyncio.create_task(send_task(ws))
+                    self._recv_task = asyncio.create_task(recv_task(ws))
+
+                    tasks = [self._send_task, self._recv_task]
+
+                    try:
+                        await asyncio.gather(*tasks)
+                        logger.info(
+                            "WebSocket session completed successfully",
+                            extra=self._build_log_context(),
+                        )
+                        keepalive_should_resume = True
+                    finally:
+                        input_sent_event.set()
+                        await utils.aio.gracefully_cancel(*tasks)
+                        self._send_task = None
+                        self._recv_task = None
                 finally:
-                    input_sent_event.set()
-                    await utils.aio.gracefully_cancel(*tasks)
-                    self._send_task = None
-                    self._recv_task = None
+                    # Resume the keepalive only when the session completed
+                    # cleanly. On exception the pool will discard the
+                    # connection via ``remove(conn)`` and ``_close_ws`` will
+                    # run, so restarting here would be wasted work (and the
+                    # task would be cancelled immediately anyway).
+                    if keepalive_should_resume:
+                        self._tts._start_keepalive(ws)
 
         except (aiohttp.ClientConnectorError, asyncio.TimeoutError) as e:
             self._connection_state = ConnectionState.FAILED

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -444,8 +444,8 @@ class TTS(tts.TTS):
     def __init__(
         self,
         *,
-        target_language_code: SarvamTTSLanguages | str,
-        model: SarvamTTSModels | str = "bulbul:v2",
+        target_language_code: SarvamTTSLanguages | str = "en-IN",
+        model: SarvamTTSModels | str = "bulbul:v3",
         speaker: SarvamTTSSpeakers | str | None = None,
         speech_sample_rate: int = 22050,
         num_channels: int = 1,  # Sarvam output is mono WAV

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass, replace
 from typing import Literal
 
 import aiohttp
+import numpy as np
 
 from livekit.agents import (
     DEFAULT_API_CONNECT_OPTIONS,
@@ -74,9 +75,13 @@ _CODEC_TO_MIME: dict[str, str] = {
     "flac": "audio/flac",
     "aac": "audio/aac",
     "linear16": "audio/pcm",
-    "mulaw": "audio/mulaw",
-    "alaw": "audio/alaw",
+    # G.711 telephony codecs are decoded to linear 16-bit PCM in this plugin
+    # before being pushed to the AudioEmitter, so they advertise audio/pcm.
+    "mulaw": "audio/pcm",
+    "alaw": "audio/pcm",
 }
+
+_TELEPHONY_CODECS: frozenset[str] = frozenset({"mulaw", "alaw"})
 
 
 def _codec_to_mime_type(codec: str) -> str:
@@ -85,6 +90,55 @@ def _codec_to_mime_type(codec: str) -> str:
     if mime is None:
         raise ValueError(f"Unsupported output_audio_codec: {codec}")
     return mime
+
+
+def _build_mulaw_table() -> np.ndarray:
+    """Build an ITU-T G.711 mu-law to linear 16-bit PCM lookup table."""
+    table = np.zeros(256, dtype=np.int16)
+    for i in range(256):
+        u = (~i) & 0xFF
+        sign = -1 if (u & 0x80) else 1
+        exponent = (u >> 4) & 0x07
+        mantissa = u & 0x0F
+        sample = ((mantissa << 3) + 0x84) << exponent
+        table[i] = sign * (sample - 0x84)
+    return table
+
+
+def _build_alaw_table() -> np.ndarray:
+    """Build an ITU-T G.711 A-law to linear 16-bit PCM lookup table.
+
+    Note: A-law sign convention is inverted relative to mu-law -- when the
+    sign bit of the XOR'd byte is set, the sample is positive.
+    """
+    table = np.zeros(256, dtype=np.int16)
+    for i in range(256):
+        a = i ^ 0x55
+        sign = 1 if (a & 0x80) else -1
+        exponent = (a >> 4) & 0x07
+        mantissa = a & 0x0F
+        if exponent == 0:
+            sample = (mantissa << 4) + 8
+        else:
+            sample = ((mantissa << 4) + 0x108) << (exponent - 1)
+        table[i] = sign * sample
+    return table
+
+
+_MULAW_TABLE: np.ndarray = _build_mulaw_table()
+_ALAW_TABLE: np.ndarray = _build_alaw_table()
+
+
+def _decode_telephony(codec: str, data: bytes) -> bytes:
+    """Decode 8-bit G.711 mu-law/A-law samples to little-endian linear 16-bit PCM."""
+    if codec == "mulaw":
+        table = _MULAW_TABLE
+    elif codec == "alaw":
+        table = _ALAW_TABLE
+    else:
+        raise ValueError(f"_decode_telephony does not support codec: {codec}")
+    pcm = table[np.frombuffer(data, dtype=np.uint8)]
+    return pcm.astype("<i2").tobytes()
 
 
 # Supported languages in BCP-47 format
@@ -756,6 +810,8 @@ class ChunkedStream(tts.ChunkedStream):
                 # handle multiple audio chunks
                 for b64 in audios:
                     wav_bytes = base64.b64decode(b64)
+                    if self._opts.output_audio_codec in _TELEPHONY_CODECS:
+                        wav_bytes = _decode_telephony(self._opts.output_audio_codec, wav_bytes)
                     output_emitter.push(wav_bytes)
         except asyncio.TimeoutError as e:
             raise APITimeoutError("Sarvam TTS API request timed out") from e
@@ -1108,6 +1164,8 @@ class SynthesizeStream(tts.SynthesizeStream):
                 return True
 
             audio_bytes = base64.b64decode(audio_data)
+            if self._opts.output_audio_codec in _TELEPHONY_CODECS:
+                audio_bytes = _decode_telephony(self._opts.output_audio_codec, audio_bytes)
             output_emitter.push(audio_bytes)
 
             return True

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import enum
 import json
 import os
@@ -51,6 +52,10 @@ USER_AGENT = f"Livekit/{livekit_version} Python/{platform.python_version()}"
 
 SARVAM_TTS_BASE_URL = "https://api.sarvam.ai/text-to-speech"
 SARVAM_TTS_WS_URL = "wss://api.sarvam.ai/text-to-speech/ws"
+
+# Sarvam TTS WebSocket connections idle out after 60 seconds. Send a ping every
+# 30 seconds to keep pooled connections alive between requests.
+_KEEPALIVE_INTERVAL: float = 30.0
 
 # Sarvam TTS specific models and speakers
 SarvamTTSModels = Literal["bulbul:v2", "bulbul:v3-beta", "bulbul:v3"]
@@ -540,6 +545,10 @@ class TTS(tts.TTS):
         )
         self._session = http_session
         self._streams = weakref.WeakSet[SynthesizeStream]()
+        # Maps id(ws) -> background keepalive task that pings the server while
+        # the connection sits idle in the pool. Sarvam closes idle connections
+        # after 60 s; pinging every 30 s keeps them alive for reuse.
+        self._ws_keepalive_tasks: dict[int, asyncio.Task[None]] = {}
 
         self._pool = utils.ConnectionPool[aiohttp.ClientWebSocketResponse](
             connect_cb=self._connect_ws,
@@ -562,7 +571,7 @@ class TTS(tts.TTS):
         logger.info("Connecting to Sarvam TTS WebSocket")
 
         try:
-            return await asyncio.wait_for(
+            ws = await asyncio.wait_for(
                 session.ws_connect(
                     ws_url,
                     headers=headers,
@@ -577,8 +586,50 @@ class TTS(tts.TTS):
             )
             raise APIConnectionError(f"WebSocket connection failed: {e}") from e
 
+        self._start_keepalive(ws)
+        return ws
+
     async def _close_ws(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        await self._stop_keepalive(ws)
         await ws.close()
+
+    def _start_keepalive(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        """Spawn a background task that keeps ``ws`` alive with periodic pings."""
+        if _KEEPALIVE_INTERVAL <= 0:
+            return
+        task = asyncio.create_task(self._keepalive_loop(ws), name="sarvam-tts-ws-keepalive")
+        self._ws_keepalive_tasks[id(ws)] = task
+
+    async def _stop_keepalive(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        """Cancel the keepalive task associated with ``ws`` (if any)."""
+        task = self._ws_keepalive_tasks.pop(id(ws), None)
+        if task is None or task.done():
+            return
+        task.cancel()
+        with contextlib.suppress(BaseException):
+            await task
+
+    async def _keepalive_loop(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        """Send a ping every ``_KEEPALIVE_INTERVAL`` seconds while ``ws`` is open."""
+        try:
+            while not ws.closed:
+                await asyncio.sleep(_KEEPALIVE_INTERVAL)
+                if ws.closed:
+                    return
+                try:
+                    await ws.send_str(json.dumps({"type": "ping"}))
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    # Connection is no longer writable; let the pool discover
+                    # this on the next checkout and replace it.
+                    logger.debug(
+                        "Sarvam TTS keepalive ping failed; connection will be replaced on next use",
+                        extra={"error": str(e)},
+                    )
+                    return
+        except asyncio.CancelledError:
+            pass
 
     @property
     def model(self) -> str:


### PR DESCRIPTION
- Always send output_audio_codec in WebSocket config (was only in
  model-specific branches, silently omitted for unmatched models)
- Add _codec_to_mime_type() mapping so linear16/mulaw/alaw correctly
  resolve to audio/pcm instead of invalid MIME types
- Expand ALLOWED_OUTPUT_AUDIO_CODECS to include linear16, mulaw, alaw
- Guard send_task and recv_task against ConnectionResetError during
  barge-in so transport-closing errors are suppressed, not re-raised
- Add input_sent_event coordination between send/recv tasks to prevent
  recv from starting before config is sent
- Simplify aclose() to delegate to base class, avoiding race with
  ConnectionPool cleanup