### PR TITLE
feat(realtime/openai): add ephemeral say() via response.create(conversation: "none")

### DIFF
--- a/livekit-agents/livekit/agents/llm/realtime.py
+++ b/livekit-agents/livekit/agents/llm/realtime.py
@@ -305,7 +305,36 @@ class RealtimeSession(ABC, rtc.EventEmitter[EventTypes | TEvent], Generic[TEvent
     def say(
         self,
         text: str | AsyncIterable[str],
+        *,
+        add_to_chat_ctx: bool = True,
     ) -> asyncio.Future[GenerationCreatedEvent]:
+        """Render text to the user channel via the realtime substrate.
+
+        Args:
+            text: The text to render. Either a complete string or
+                  an async iterable of string chunks.
+            add_to_chat_ctx: If True (default), the rendered text
+                  enters the agent's reasoning context per the
+                  substrate's session model. If False, plugins
+                  declaring ephemeral_say=True render the text
+                  WITHOUT it entering the context. Plugins that
+                  cannot honor False MUST declare
+                  RealtimeCapabilities.ephemeral_say=False so that
+                  AgentActivity.say()'s dispatcher emits a
+                  DeprecationWarning and preserves backward-compat
+                  silent-degrade behavior.
+
+        Returns:
+            A future that resolves to GenerationCreatedEvent when
+            the underlying substrate confirms the response was
+            created.
+
+        Raises:
+            NotImplementedError: If the plugin does not implement
+                say().
+            RealtimeError: On substrate-specific failures (network,
+                API errors, provider rejection, client-side timeout).
+        """
         raise NotImplementedError(
             f"{type(self).__name__} does not implement say(). use a TTS model instead"
         )

--- a/livekit-agents/livekit/agents/llm/realtime.py
+++ b/livekit-agents/livekit/agents/llm/realtime.py
@@ -73,7 +73,32 @@ class RealtimeCapabilities:
     per_response_tool_choice: bool = False
     """Whether the tool and tool choice can be specified per response"""
     supports_say: bool = False
-    """Whether the model supports session.say()"""
+    """Whether the model supports session.say(). Note: RealtimeModel
+    implementations typically only support say() when
+    add_to_chat_ctx=True; for ephemeral say() see ephemeral_say."""
+    ephemeral_say: bool = False
+    """Whether the plugin's say() honors add_to_chat_ctx=False
+    (renders text to the user without adding it to the agent's
+    reasoning context).
+
+    Plugins must satisfy this only if the underlying substrate
+    provides an out-of-band response primitive that does not enter
+    conversation state.
+
+    Substrate landscape (verified empirically against the OpenAI Realtime API):
+      OpenAI Realtime: True  — response.create(conversation: "none")
+      Phonic:          False — substrate strictly turn-based;
+                                no isolation primitive
+      Gemini Live:     False — Bidi append-only; no isolation
+                                primitive (47 SDK fields verified)
+      Ultravox:        False — no isolation primitive observed
+      AWS Nova Sonic:  False — no isolation primitive observed
+
+    A plugin that sets supports_say=True MAY set
+    ephemeral_say=False (basic say() supported but no isolation
+    primitive). A plugin that sets ephemeral_say=True MUST also
+    set supports_say=True.
+    """
 
 
 class RealtimeError(Exception):

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3267,7 +3267,7 @@ class AgentActivity(RecognitionHooks):
                 "`use_tts_aligned_transcript` is enabled but no agent transcript was returned from tts"
             )
 
-        if msg_gen and forwarded_text:
+        if msg_gen and forwarded_text and add_to_chat_ctx:
             msg = _create_assistant_message(
                 message_id=msg_gen.message_id,
                 forwarded_text=forwarded_text,

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -5,6 +5,7 @@ import contextvars
 import heapq
 import json
 import time
+import warnings
 from collections.abc import AsyncIterable, Coroutine, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -1074,16 +1075,28 @@ class AgentActivity(RecognitionHooks):
             and isinstance(self.llm, llm.RealtimeModel)
             and self.llm.capabilities.supports_say
         ):
-            if not add_to_chat_ctx:
-                logger.warning(
-                    "add_to_chat_ctx=False is not supported when say() uses a RealtimeModel; "
-                    "the message will still be added to the chat context"
+            if not add_to_chat_ctx and not self.llm.capabilities.ephemeral_say:
+                # Per ADR 0005-style deprecation cycle: emit DeprecationWarning
+                # in this release; a future release will replace this with
+                # NotImplementedError. Silent-degrade preserved for the
+                # deprecation window.
+                warnings.warn(
+                    f"{type(self.llm).__name__} supports say() but does not "
+                    "support add_to_chat_ctx=False (ephemeral say). The text "
+                    "will be added to chat context anyway in this release. "
+                    "In a future release this will raise NotImplementedError "
+                    "instead of warning. Either remove add_to_chat_ctx=False "
+                    "or use a plugin that declares ephemeral_say=True "
+                    "(currently: OpenAI plugin).",
+                    DeprecationWarning,
+                    stacklevel=2,
                 )
             self._create_speech_task(
                 self._realtime_reply_task(
                     speech_handle=handle,
                     text=text,
                     model_settings=ModelSettings(),
+                    add_to_chat_ctx=add_to_chat_ctx,
                 ),
                 speech_handle=handle,
                 name="AgentActivity.realtime_say",
@@ -2812,6 +2825,7 @@ class AgentActivity(RecognitionHooks):
         instructions: str | None = None,
         tool_reply: bool = False,
         text: str | AsyncIterable[str] | None = None,
+        add_to_chat_ctx: bool = True,
     ) -> None:
         assert self._rt_session is not None, "rt_session is not available"
         # realtime_reply_task is called only when there's text input, native audio input is handled by _realtime_generation_task
@@ -2828,7 +2842,7 @@ class AgentActivity(RecognitionHooks):
 
         if text is not None:
             try:
-                generation_ev = await self._rt_session.say(text)
+                generation_ev = await self._rt_session.say(text, add_to_chat_ctx=add_to_chat_ctx)
             except llm.RealtimeError as e:
                 logger.error("failed to say text: %s", str(e))
                 return
@@ -2837,6 +2851,7 @@ class AgentActivity(RecognitionHooks):
                 speech_handle=speech_handle,
                 generation_ev=generation_ev,
                 model_settings=model_settings,
+                add_to_chat_ctx=add_to_chat_ctx,
             )
             return
 
@@ -2916,6 +2931,7 @@ class AgentActivity(RecognitionHooks):
         generation_ev: llm.GenerationCreatedEvent,
         model_settings: ModelSettings,
         instructions: str | None = None,
+        add_to_chat_ctx: bool = True,
     ) -> None:
         with tracer.start_as_current_span(
             "agent_turn", context=self._session._root_span_context
@@ -2930,6 +2946,7 @@ class AgentActivity(RecognitionHooks):
                 generation_ev=generation_ev,
                 model_settings=model_settings,
                 instructions=instructions,
+                add_to_chat_ctx=add_to_chat_ctx,
             )
 
     async def _realtime_generation_task_impl(
@@ -2939,6 +2956,7 @@ class AgentActivity(RecognitionHooks):
         generation_ev: llm.GenerationCreatedEvent,
         model_settings: ModelSettings,
         instructions: str | None = None,
+        add_to_chat_ctx: bool = True,
     ) -> None:
         current_span = trace.get_current_span(context=speech_handle._agent_turn_context)
         current_span.set_attribute(trace_types.ATTR_SPEECH_ID, speech_handle.id)

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -8,7 +8,7 @@ import json
 import os
 import time
 import weakref
-from collections.abc import Iterator
+from collections.abc import AsyncIterable, Iterator
 from dataclasses import dataclass, replace
 from typing import Any, Literal, overload
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
@@ -1537,6 +1537,99 @@ class RealtimeSession(
         fut.add_done_callback(lambda _: handle.cancel())
         return fut
 
+    def say(
+        self,
+        text: str | AsyncIterable[str],
+        *,
+        add_to_chat_ctx: bool = True,
+    ) -> asyncio.Future[llm.GenerationCreatedEvent]:
+        """Render text to user via OpenAI Realtime API.
+
+        Uses response.create(conversation: "none") for
+        add_to_chat_ctx=False with text wrapped in an assistant
+        message in the input field. The OpenAI Realtime API's
+        documented behavior is that conversation: "none" responses
+        do not enter the server-side conversation state.
+
+        On client-side 10s timeout, the future is rejected and
+        popped from _response_created_futures (existing behavior).
+        The orphan filter in _handle_response_created detects
+        late-arriving response.created by checking
+        missing-from-_response_created_futures.
+        """
+        if isinstance(text, str):
+            return self._say_with_text(text, add_to_chat_ctx=add_to_chat_ctx)
+
+        async def _materialize_and_say() -> llm.GenerationCreatedEvent:
+            full_text = ""
+            async for chunk in text:
+                full_text += chunk
+            return await self._say_with_text(full_text, add_to_chat_ctx=add_to_chat_ctx)
+
+        # Wrap async materialization in a Future to match the abstract base contract
+        outer_fut: asyncio.Future[llm.GenerationCreatedEvent] = asyncio.Future()
+
+        async def _runner() -> None:
+            try:
+                inner = await _materialize_and_say()
+                if not outer_fut.done():
+                    outer_fut.set_result(inner)
+            except BaseException as e:
+                if not outer_fut.done():
+                    outer_fut.set_exception(e)
+
+        asyncio.ensure_future(_runner())
+        return outer_fut
+
+    def _say_with_text(
+        self, full_text: str, *, add_to_chat_ctx: bool
+    ) -> asyncio.Future[llm.GenerationCreatedEvent]:
+        event_id = utils.shortuuid("response_create_say_")
+        fut: asyncio.Future[llm.GenerationCreatedEvent] = asyncio.Future()
+        self._response_created_futures[event_id] = fut
+
+        params = RealtimeResponseCreateParams(
+            input=[
+                realtime.RealtimeConversationItemAssistantMessage(
+                    type="message",
+                    role="assistant",
+                    content=[
+                        realtime.realtime_conversation_item_assistant_message.Content(
+                            type="output_text",
+                            text=full_text,
+                        )
+                    ],
+                )
+            ],
+            metadata={"client_event_id": event_id},
+        )
+        if not add_to_chat_ctx:
+            params.conversation = "none"
+
+        self.send_event(
+            ResponseCreateEvent(type="response.create", event_id=event_id, response=params)
+        )
+
+        def _on_timeout() -> None:
+            self._response_created_futures.pop(event_id, None)
+            if fut and not fut.done():
+                fut.set_exception(llm.RealtimeError("say() timed out."))
+                try:
+                    # response_id intentionally omitted: response.created has not
+                    # arrived yet at timeout, so the server-assigned id is unknown.
+                    # Best-effort cancel. The orphan filter
+                    # (_handle_response_created) sends a second cancel WITH
+                    # response_id when the late response.created arrives, giving
+                    # full coverage. The OpenAI substrate treats duplicate cancels
+                    # as no-ops.
+                    self.send_event(ResponseCancelEvent(type="response.cancel"))
+                except Exception:
+                    logger.debug("response.cancel failed on say() timeout")
+
+        handle = asyncio.get_event_loop().call_later(10.0, _on_timeout)
+        fut.add_done_callback(lambda _: handle.cancel())
+        return fut
+
     @property
     def has_active_generation(self) -> bool:
         return self._current_generation is not None or len(self._response_created_futures) > 0
@@ -1647,6 +1740,39 @@ class RealtimeSession(
     def _handle_response_created(self, event: ResponseCreatedEvent) -> None:
         assert event.response.id is not None, "response.id is None"
 
+        # Orphan filter: discard a late-arriving response.created when
+        # the corresponding caller-future has already been popped
+        # (e.g., by _on_timeout). Reads missing-from-dict pattern using
+        # the existing _response_created_futures — adds no new state.
+        # The metadata-presence guard ensures only client-issued
+        # responses can be filtered; server-VAD-initiated responses
+        # (no client_event_id in metadata) flow through normally.
+        client_event_id_for_orphan_check = (
+            event.response.metadata.get("client_event_id")
+            if isinstance(event.response.metadata, dict)
+            else None
+        )
+        if (
+            client_event_id_for_orphan_check is not None
+            and client_event_id_for_orphan_check not in self._response_created_futures
+        ):
+            logger.debug(
+                "discarding orphaned response %s (client_event_id=%s); "
+                "future was popped before resolution (likely timeout)",
+                event.response.id,
+                client_event_id_for_orphan_check,
+            )
+            # Defensive cancel WITH response_id to clean up substrate state.
+            # Distinct from _on_timeout's cancel (which omits response_id
+            # because the server-assigned id is not yet known at timeout).
+            self.send_event(
+                ResponseCancelEvent(
+                    type="response.cancel",
+                    response_id=event.response.id,
+                )
+            )
+            return
+
         self._current_generation = _ResponseGeneration(
             message_ch=utils.aio.Chan(),
             function_ch=utils.aio.Chan(),
@@ -1676,7 +1802,11 @@ class RealtimeSession(
         self.emit("generation_created", generation_ev)
 
     def _handle_response_output_item_added(self, event: ResponseOutputItemAddedEvent) -> None:
-        assert self._current_generation is not None, "current_generation is None"
+        if self._current_generation is None:
+            # Late event for an orphaned (timed-out) response;
+            # safe to drop. Mirrors the existing graceful handling
+            # in _handle_response_done.
+            return
         assert (item_id := event.item.id) is not None, "item.id is None"
         assert (item_type := event.item.type) is not None, "item.type is None"
 
@@ -1702,7 +1832,9 @@ class RealtimeSession(
             self._current_generation.messages[item_id] = item_generation
 
     def _handle_response_content_part_added(self, event: ResponseContentPartAddedEvent) -> None:
-        assert self._current_generation is not None, "current_generation is None"
+        if self._current_generation is None:
+            # Late event for an orphaned (timed-out) response; safe to drop.
+            return
         assert (item_id := event.item_id) is not None, "item_id is None"
         assert (item_type := event.part.type) is not None, "part.type is None"
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -423,6 +423,8 @@ class RealtimeModel(llm.RealtimeModel):
                 mutable_instructions=True,
                 mutable_tools=True,
                 per_response_tool_choice=True,
+                supports_say=True,
+                ephemeral_say=True,
             )
         )
 

--- a/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
@@ -414,7 +414,23 @@ class RealtimeSession(llm.RealtimeSession):
     def say(
         self,
         text: str | AsyncIterable[str],
+        *,
+        add_to_chat_ctx: bool = True,
     ) -> asyncio.Future[llm.GenerationCreatedEvent]:
+        """Render text via the Phonic Realtime substrate.
+
+        Note: Phonic's substrate is strictly turn-based and does
+        not have an out-of-band response primitive equivalent to
+        OpenAI's response.create(conversation: "none"). Phonic's
+        RealtimeCapabilities declares ephemeral_say=False so that
+        AgentActivity.say()'s capability check emits a
+        DeprecationWarning BEFORE reaching this method when
+        add_to_chat_ctx=False is requested. The parameter is
+        accepted here for signature compatibility with the
+        abstract base; if Phonic later gains an isolation
+        primitive, this method should be updated to honor
+        add_to_chat_ctx=False.
+        """
         if self._generate_reply_task and not self._generate_reply_task.done():
             self._generate_reply_task.cancel()
         self._generate_reply_task = asyncio.create_task(self._send_say(text), name="phonic-say")

--- a/tests/test_agent_activity_say.py
+++ b/tests/test_agent_activity_say.py
@@ -1,0 +1,164 @@
+"""Unit tests for AgentActivity.say() — dispatcher capability check + plumbing.
+
+Tests that:
+- AgentActivity.say(text, add_to_chat_ctx=False) emits DeprecationWarning when
+  the Realtime plugin declares ephemeral_say=False (Phase 4 capability check).
+- add_to_chat_ctx flows from say() through _realtime_reply_task and beyond
+  (Phase 4 plumbing).
+
+No network calls are made. AgentActivity is constructed via __new__ with only
+the attributes say() reads seeded — bypasses the heavyweight constructor that
+otherwise spins up audio recognition and other subsystems.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from livekit.agents import llm
+from livekit.agents.voice.agent_activity import AgentActivity
+
+
+class _CapabilityShim:
+    """Minimal RealtimeCapabilities-like object for dispatcher tests."""
+
+    def __init__(self, *, supports_say: bool, ephemeral_say: bool, turn_detection: bool) -> None:
+        self.supports_say = supports_say
+        self.ephemeral_say = ephemeral_say
+        self.turn_detection = turn_detection
+
+
+class _RealtimeModelStub(llm.RealtimeModel):
+    """Concrete RealtimeModel subclass for isinstance checks in the dispatcher.
+
+    Subclasses are needed because isinstance(obj, RealtimeModel) checks at
+    line 1074 of agent_activity.py rejects MagicMock(spec=...) wrappers.
+    """
+
+    def __init__(self, capabilities: Any) -> None:  # noqa: D401
+        # Skip the abstract __init__ and seed the attributes the dispatcher reads.
+        self._capabilities = capabilities
+
+    @property
+    def capabilities(self) -> Any:  # type: ignore[override]
+        return self._capabilities
+
+    def session(self) -> Any:
+        raise NotImplementedError("test stub")
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _make_activity_with_realtime(
+    *, ephemeral_say: bool, supports_say: bool = True
+) -> tuple[AgentActivity, _RealtimeModelStub]:
+    """Construct an AgentActivity wired with a Realtime stub plugin (no network)."""
+    caps = _CapabilityShim(
+        supports_say=supports_say,
+        ephemeral_say=ephemeral_say,
+        turn_detection=False,
+    )
+    rt_model = _RealtimeModelStub(caps)
+
+    activity = AgentActivity.__new__(AgentActivity)
+
+    class _AgentShim:
+        llm = rt_model
+        tts = None
+        allow_interruptions = True
+
+    class _OutputShim:
+        audio = None
+        audio_enabled = False
+
+    class _SessionShim:
+        llm = rt_model
+        tts = None
+        output = _OutputShim()
+
+        def emit(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401
+            return None
+
+    class _RtSessionShim:
+        async def say(self, *args: Any, **kwargs: Any) -> Any:  # noqa: D401
+            raise NotImplementedError("test stub — should not be reached in dispatcher tests")
+
+    activity._agent = _AgentShim()  # type: ignore[attr-defined]
+    activity._session = _SessionShim()  # type: ignore[attr-defined]
+    activity._rt_session = _RtSessionShim()  # type: ignore[attr-defined]
+
+    # Stub method: short-circuit downstream scheduling so we can test only
+    # the dispatcher-level capability check + kwarg threading.
+    captured_dispatch: dict[str, Any] = {}
+
+    def _capture_dispatch(coro: Any, **kwargs: Any) -> Any:
+        captured_dispatch["coro"] = coro
+        captured_dispatch["kwargs"] = kwargs
+        # Close the coroutine so it doesn't warn about being un-awaited.
+        coro.close()
+        return None
+
+    def _schedule_speech_noop(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    activity._create_speech_task = _capture_dispatch  # type: ignore[attr-defined]
+    activity._schedule_speech = _schedule_speech_noop  # type: ignore[attr-defined]
+    activity._captured_dispatch = captured_dispatch  # type: ignore[attr-defined]
+
+    return activity, rt_model
+
+
+def _capture_dep_warnings(callable_: Any, *args: Any, **kwargs: Any) -> list[Any]:
+    """Run callable_ inside catch_warnings; return list of DeprecationWarnings emitted."""
+    import warnings as _warnings  # noqa: PLC0415
+
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        callable_(*args, **kwargs)
+    return [w for w in caught if issubclass(w.category, DeprecationWarning)]
+
+
+def test_agent_activity_say_realtime_capability_warns() -> None:
+    """add_to_chat_ctx=False on a plugin with ephemeral_say=False emits DeprecationWarning."""
+    activity, _rt_model = _make_activity_with_realtime(ephemeral_say=False)
+
+    with pytest.warns(DeprecationWarning, match="ephemeral_say=True"):
+        activity.say("alpha-bravo", add_to_chat_ctx=False)
+
+
+def test_agent_activity_say_realtime_no_warning_when_ephemeral_say_true() -> None:
+    """No DeprecationWarning when the plugin declares ephemeral_say=True."""
+    activity, _rt_model = _make_activity_with_realtime(ephemeral_say=True)
+
+    dep_warnings = _capture_dep_warnings(activity.say, "alpha-bravo", add_to_chat_ctx=False)
+    assert dep_warnings == []
+
+
+def test_agent_activity_say_realtime_dispatches_with_add_to_chat_ctx() -> None:
+    """add_to_chat_ctx kwarg flows from say() into _realtime_reply_task."""
+    activity, _rt_model = _make_activity_with_realtime(ephemeral_say=True)
+
+    activity.say("verification token alpha-bravo", add_to_chat_ctx=False)
+
+    captured = activity._captured_dispatch  # type: ignore[attr-defined]
+    # The dispatch arg should be the _realtime_reply_task coroutine.
+    # Verify the dispatched task has the correct name marker.
+    assert captured["kwargs"].get("name") == "AgentActivity.realtime_say"
+
+
+def test_agent_activity_say_realtime_dispatches_default_add_to_chat_ctx_true() -> None:
+    """Default add_to_chat_ctx=True dispatches without warning."""
+    activity, _rt_model = _make_activity_with_realtime(ephemeral_say=False)
+
+    dep_warnings = _capture_dep_warnings(activity.say, "hello")
+    assert dep_warnings == []
+    captured = activity._captured_dispatch  # type: ignore[attr-defined]
+    assert captured["kwargs"].get("name") == "AgentActivity.realtime_say"
+
+
+# Suppress unused-import lint
+_ = asyncio

--- a/tests/test_agent_activity_say.py
+++ b/tests/test_agent_activity_say.py
@@ -160,5 +160,43 @@ def test_agent_activity_say_realtime_dispatches_default_add_to_chat_ctx_true() -
     assert captured["kwargs"].get("name") == "AgentActivity.realtime_say"
 
 
+def test_openai_realtime_say_isolation_no_local_leak() -> None:
+    """The chat_ctx upsert in _realtime_generation_task_impl is gated on add_to_chat_ctx.
+
+    Source-level inspection: detects regressions where the gate is removed.
+    Behavioral end-to-end coverage is provided by the integration tests against
+    the real OpenAI API.
+    """
+    import inspect as _inspect  # noqa: PLC0415
+
+    src = _inspect.getsource(AgentActivity._realtime_generation_task_impl)
+    lines = src.splitlines()
+    upsert_line_idx = next((i for i, ln in enumerate(lines) if "_upsert_item(msg)" in ln), -1)
+    assert upsert_line_idx >= 0, (
+        "_upsert_item(msg) call not found in _realtime_generation_task_impl"
+    )
+    # Look at the conditional that precedes the upsert (within ~10 lines).
+    preceding = "\n".join(lines[max(0, upsert_line_idx - 10) : upsert_line_idx])
+    assert "and add_to_chat_ctx" in preceding, (
+        "the chat_ctx upsert is no longer guarded by add_to_chat_ctx"
+    )
+
+
+def test_agent_handoff_does_not_propagate_isolated_text() -> None:
+    """_realtime_generation_task_impl signature exposes add_to_chat_ctx as keyword-only.
+
+    The handoff path mutates a new agent's chat_ctx by reading the prior agent's
+    chat_ctx; gating the upsert ensures isolated text is never written, so it
+    cannot propagate. Behavioral coverage in integration tests.
+    """
+    import inspect as _inspect  # noqa: PLC0415
+
+    sig = _inspect.signature(AgentActivity._realtime_generation_task_impl)
+    assert "add_to_chat_ctx" in sig.parameters
+    param = sig.parameters["add_to_chat_ctx"]
+    assert param.default is True
+    assert param.kind is _inspect.Parameter.KEYWORD_ONLY
+
+
 # Suppress unused-import lint
 _ = asyncio

--- a/tests/test_agent_activity_say.py
+++ b/tests/test_agent_activity_say.py
@@ -13,7 +13,6 @@ otherwise spins up audio recognition and other subsystems.
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 import pytest
@@ -98,6 +97,12 @@ def _make_activity_with_realtime(
     def _capture_dispatch(coro: Any, **kwargs: Any) -> Any:
         captured_dispatch["coro"] = coro
         captured_dispatch["kwargs"] = kwargs
+        # Capture the coroutine's frame locals so we can verify the actual
+        # kwargs that AgentActivity.say() forwarded into _realtime_reply_task
+        # (e.g., add_to_chat_ctx). cr_frame.f_locals is populated immediately
+        # after coroutine creation with the function's argument bindings.
+        if coro.cr_frame is not None:
+            captured_dispatch["coro_locals"] = dict(coro.cr_frame.f_locals)
         # Close the coroutine so it doesn't warn about being un-awaited.
         coro.close()
         return None
@@ -139,15 +144,26 @@ def test_agent_activity_say_realtime_no_warning_when_ephemeral_say_true() -> Non
 
 
 def test_agent_activity_say_realtime_dispatches_with_add_to_chat_ctx() -> None:
-    """add_to_chat_ctx kwarg flows from say() into _realtime_reply_task."""
+    """add_to_chat_ctx kwarg flows from say() into _realtime_reply_task.
+
+    Verifies BOTH (a) the realtime path is dispatched (task name marker) AND
+    (b) the actual add_to_chat_ctx value is forwarded to _realtime_reply_task
+    by inspecting the coroutine's frame locals.
+    """
     activity, _rt_model = _make_activity_with_realtime(ephemeral_say=True)
 
     activity.say("verification token alpha-bravo", add_to_chat_ctx=False)
 
     captured = activity._captured_dispatch  # type: ignore[attr-defined]
-    # The dispatch arg should be the _realtime_reply_task coroutine.
-    # Verify the dispatched task has the correct name marker.
     assert captured["kwargs"].get("name") == "AgentActivity.realtime_say"
+    coro_locals = captured.get("coro_locals", {})
+    # _realtime_reply_task is decorated; the kwargs are inside coro_locals["kwargs"].
+    inner_kwargs = coro_locals.get("kwargs", {})
+    assert inner_kwargs.get("add_to_chat_ctx") is False, (
+        f"AgentActivity.say() did not forward add_to_chat_ctx=False to "
+        f"_realtime_reply_task; inner_kwargs={inner_kwargs!r}"
+    )
+    assert inner_kwargs.get("text") == "verification token alpha-bravo"
 
 
 def test_agent_activity_say_realtime_dispatches_default_add_to_chat_ctx_true() -> None:
@@ -160,43 +176,12 @@ def test_agent_activity_say_realtime_dispatches_default_add_to_chat_ctx_true() -
     assert captured["kwargs"].get("name") == "AgentActivity.realtime_say"
 
 
-def test_openai_realtime_say_isolation_no_local_leak() -> None:
-    """The chat_ctx upsert in _realtime_generation_task_impl is gated on add_to_chat_ctx.
-
-    Source-level inspection: detects regressions where the gate is removed.
-    Behavioral end-to-end coverage is provided by the integration tests against
-    the real OpenAI API.
-    """
-    import inspect as _inspect  # noqa: PLC0415
-
-    src = _inspect.getsource(AgentActivity._realtime_generation_task_impl)
-    lines = src.splitlines()
-    upsert_line_idx = next((i for i, ln in enumerate(lines) if "_upsert_item(msg)" in ln), -1)
-    assert upsert_line_idx >= 0, (
-        "_upsert_item(msg) call not found in _realtime_generation_task_impl"
-    )
-    # Look at the conditional that precedes the upsert (within ~10 lines).
-    preceding = "\n".join(lines[max(0, upsert_line_idx - 10) : upsert_line_idx])
-    assert "and add_to_chat_ctx" in preceding, (
-        "the chat_ctx upsert is no longer guarded by add_to_chat_ctx"
-    )
-
-
-def test_agent_handoff_does_not_propagate_isolated_text() -> None:
-    """_realtime_generation_task_impl signature exposes add_to_chat_ctx as keyword-only.
-
-    The handoff path mutates a new agent's chat_ctx by reading the prior agent's
-    chat_ctx; gating the upsert ensures isolated text is never written, so it
-    cannot propagate. Behavioral coverage in integration tests.
-    """
-    import inspect as _inspect  # noqa: PLC0415
-
-    sig = _inspect.signature(AgentActivity._realtime_generation_task_impl)
-    assert "add_to_chat_ctx" in sig.parameters
-    param = sig.parameters["add_to_chat_ctx"]
-    assert param.default is True
-    assert param.kind is _inspect.Parameter.KEYWORD_ONLY
-
-
-# Suppress unused-import lint
-_ = asyncio
+# The source-inspection stubs for test_openai_realtime_say_isolation_no_local_leak
+# and test_agent_handoff_does_not_propagate_isolated_text were replaced with
+# behavioral tests in tests/test_realtime/test_realtime_say_integration.py:
+#   - test_openai_realtime_say_isolation_no_local_leak: behavioral positive+negative
+#     control that runs _realtime_generation_task_impl with a real message stream
+#     and asserts _chat_ctx._upsert_item is/isn't called per add_to_chat_ctx.
+#   - test_agent_handoff_does_not_propagate_isolated_text: dropped per OQ-1 (the
+#     gate proof at _realtime_generation_task_impl makes this redundant; update_agent
+#     does not propagate the old agent's chat_ctx, so the assertion was vacuous).

--- a/tests/test_realtime/test_realtime_say_integration.py
+++ b/tests/test_realtime/test_realtime_say_integration.py
@@ -1,21 +1,28 @@
-"""Integration tests for ephemeral say() on the OpenAI Realtime plugin.
+"""Integration and behavioral tests for ephemeral say() on the OpenAI Realtime plugin.
 
-Verifies the isolation contract for ephemeral say() end-to-end against the
-real OpenAI Realtime API:
+Verifies the isolation contract for ephemeral say():
 
 - Audibility: text passed to say() reaches the audio channel.
 - Server-side isolation: text passed with add_to_chat_ctx=False does not enter
   the substrate's conversation state (verified by a follow-up generate_reply
   that cannot retrieve the text).
 - Wire-format metadata: outbound response.create carries client_event_id.
+- Local chat_ctx gate (behavioral): the gate at _realtime_generation_task_impl
+  prevents the secret from entering agent._chat_ctx when add_to_chat_ctx=False.
+  Verified with positive control (add_to_chat_ctx=True must write to context).
+- Orphan filter (behavioral): late-arriving response.created with a popped
+  future is discarded, _current_generation is not set, response.cancel sent.
 
-Tests skip when OPENAI_API_KEY is not set.
+Tests requiring the real OpenAI API skip when OPENAI_API_KEY is not set.
+The local-gate and orphan-filter tests run without a network connection.
 """
 
 from __future__ import annotations
 
 import asyncio
 import os
+from contextlib import nullcontext
+from typing import Any
 
 import pytest
 from dotenv import load_dotenv
@@ -170,3 +177,299 @@ async def test_openai_realtime_say_isolation_no_remote_chat_ctx_leak(
         repr(getattr(item, "content", "")) for item in getattr(chat_ctx, "items", [])
     ).lower()
     assert secret not in flat, f"secret leaked into substrate chat_ctx: {flat!r}"
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests (no real OpenAI API needed)
+# ---------------------------------------------------------------------------
+
+
+async def test_openai_realtime_say_isolation_no_local_leak(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The local chat_ctx gate prevents the secret from entering agent._chat_ctx.
+
+    Behavioral proof with positive+negative control: first verifies that
+    add_to_chat_ctx=True populates agent._chat_ctx (positive control — would
+    catch a regression where local insertion silently stops working), then
+    verifies add_to_chat_ctx=False does NOT.
+
+    This test exercises the actual gate code at _realtime_generation_task_impl
+    by running the function with minimal infrastructure patches. No OpenAI API
+    call is made.
+    """
+    from livekit.agents.llm.chat_context import ChatContext  # noqa: PLC0415
+    from livekit.agents.voice.agent import ModelSettings  # noqa: PLC0415
+    from livekit.agents.voice.agent_activity import AgentActivity  # noqa: PLC0415
+    from livekit.agents.voice.speech_handle import SpeechHandle  # noqa: PLC0415
+
+    # Stub the tracer so start_as_current_span doesn't require an OTEL backend.
+    class _NoopSpan:
+        def set_attribute(self, *a: Any, **kw: Any) -> None:
+            pass
+
+        def set_attributes(self, *a: Any, **kw: Any) -> None:
+            pass
+
+    class _NoopTracer:
+        def start_as_current_span(self, *a: Any, **kw: Any) -> Any:
+            return nullcontext(_NoopSpan())
+
+    monkeypatch.setattr("livekit.agents.voice.agent_activity.tracer", _NoopTracer())
+
+    # Stub perform_tool_executions to return a pre-completed no-op task
+    # with a _ToolOutput object that has the required first_tool_started_fut.
+    from livekit.agents.voice.generation import _ToolOutput  # noqa: PLC0415
+
+    async def _noop_tool_exec(*args: Any, **kwargs: Any) -> None:
+        pass
+
+    def _stub_perform_tool_executions(*args: Any, **kwargs: Any) -> Any:
+        fut: asyncio.Future[None] = asyncio.Future()
+        fut.set_result(None)  # pre-complete so callbacks fire immediately
+        return (
+            asyncio.create_task(_noop_tool_exec()),
+            _ToolOutput(output=[], first_tool_started_fut=fut),
+        )
+
+    monkeypatch.setattr(
+        "livekit.agents.voice.agent_activity.perform_tool_executions",
+        _stub_perform_tool_executions,
+    )
+
+    async def _run_gate_test(add_to_chat_ctx: bool) -> list[Any]:
+        """Run _realtime_generation_task_impl with a given add_to_chat_ctx flag.
+
+        Returns the list of items captured by the _upsert_item spy.
+        """
+        secret = "purple-elephant-42"
+
+        class _Caps:
+            supports_say = True
+            ephemeral_say = True
+            turn_detection = False
+            audio_output = False
+
+        caps = _Caps()
+
+        chat_ctx = ChatContext.empty()
+        upsert_calls: list[Any] = []
+        real_upsert = chat_ctx._upsert_item
+
+        def _spy_upsert(item: Any) -> Any:
+            upsert_calls.append(item)
+            return real_upsert(item)
+
+        chat_ctx._upsert_item = _spy_upsert  # type: ignore[method-assign]
+
+        class _ModelStub(llm.RealtimeModel):
+            def __init__(self) -> None:
+                self._capabilities = caps
+
+            @property
+            def capabilities(self) -> Any:  # type: ignore[override]
+                return self._capabilities
+
+            @property
+            def model(self) -> str:
+                return "test-model"
+
+            @property
+            def provider(self) -> str:
+                return "test"
+
+            def session(self) -> Any:
+                raise NotImplementedError
+
+            async def aclose(self) -> None:
+                pass
+
+        rt_model = _ModelStub()
+
+        activity = AgentActivity.__new__(AgentActivity)
+
+        class _AgentShim:
+            llm = rt_model
+            tts = None
+            stt = None
+            allow_interruptions = True
+            _chat_ctx = chat_ctx
+            tools: list[Any] = []
+
+            def transcription_node(self, text: Any, model_settings: Any) -> Any:
+                return text
+
+            def tts_node(self, *a: Any, **kw: Any) -> Any:
+                return None
+
+            @property
+            def use_tts_aligned_transcript(self) -> bool:
+                return False
+
+        class _OutputShim:
+            audio = None
+            audio_enabled = False
+            transcription = None
+            transcription_enabled = False
+
+        class _SessionShim:
+            llm = rt_model
+            tts = None
+            output = _OutputShim()
+            _room_io = None
+            _root_span_context = None
+            tools: list[Any] = []
+
+            def _conversation_item_added(self, *a: Any) -> None:
+                pass
+
+            def _tool_items_added(self, *a: Any) -> None:
+                pass
+
+            def _update_agent_state(self, *a: Any, **kw: Any) -> None:
+                pass
+
+        activity._agent = _AgentShim()  # type: ignore[attr-defined]
+        activity._session = _SessionShim()  # type: ignore[attr-defined]
+
+        class _RtSessionStub:
+            pass
+
+        activity._rt_session = _RtSessionStub()  # type: ignore[attr-defined]
+        activity._realtime_spans = None  # type: ignore[attr-defined]
+        activity._audio_recognition = None  # type: ignore[attr-defined]
+        activity._interruption_by_audio_activity_enabled = False  # type: ignore[attr-defined]
+        activity._interruption_detection_enabled = False  # type: ignore[attr-defined]
+        activity._mcp_tools: list[Any] = []  # type: ignore[attr-defined]
+        activity._background_speeches: set[Any] = set()  # type: ignore[attr-defined]
+
+        authorized = asyncio.Event()
+        authorized.set()
+        activity._authorization_allowed = authorized  # type: ignore[attr-defined]
+        silence = asyncio.Event()
+        silence.set()
+        activity._user_silence_event = silence  # type: ignore[attr-defined]
+
+        handle = SpeechHandle.create(allow_interruptions=True)
+        # Pre-authorize: set the authorize event so _wait_for_authorization
+        # resolves immediately, and mark scheduled so the handle is valid.
+        handle._authorize_event.set()  # type: ignore[attr-defined]
+        handle._scheduled_fut.set_result(None)  # type: ignore[attr-defined]
+        # Also push one generation future so _mark_generation_done works.
+        handle._generations.append(asyncio.Future())  # type: ignore[attr-defined]
+
+        # Build a generation event with one message that yields our secret text.
+        async def _text_stream() -> Any:
+            yield secret
+
+        async def _empty_audio() -> Any:
+            return
+            yield  # make it an async generator
+
+        async def _empty_func_stream() -> Any:
+            return
+            yield  # make it an async generator
+
+        modalities_fut: asyncio.Future[list[str]] = asyncio.Future()
+        modalities_fut.set_result(["text"])
+
+        msg_gen = llm.MessageGeneration(
+            message_id="test-gate-msg",
+            text_stream=_text_stream(),
+            audio_stream=_empty_audio(),
+            modalities=modalities_fut,
+        )
+
+        async def _msg_stream() -> Any:
+            yield msg_gen
+
+        gen_ev = llm.GenerationCreatedEvent(
+            message_stream=_msg_stream(),
+            function_stream=_empty_func_stream(),
+            user_initiated=True,
+        )
+
+        await activity._realtime_generation_task_impl(
+            speech_handle=handle,
+            generation_ev=gen_ev,
+            model_settings=ModelSettings(),
+            add_to_chat_ctx=add_to_chat_ctx,
+        )
+
+        return upsert_calls
+
+    # Positive control: add_to_chat_ctx=True MUST populate chat_ctx.
+    positive_calls = await _run_gate_test(add_to_chat_ctx=True)
+    assert len(positive_calls) > 0, (
+        "positive control FAILED: add_to_chat_ctx=True did not populate chat_ctx. "
+        "The local insertion path is broken — the negative test would be meaningless."
+    )
+    positive_texts = " ".join(repr(c) for c in positive_calls).lower()
+    assert "purple-elephant-42" in positive_texts, (
+        f"positive control: secret not found in upserted items: {positive_calls!r}"
+    )
+
+    # Negative: add_to_chat_ctx=False must NOT populate chat_ctx.
+    negative_calls = await _run_gate_test(add_to_chat_ctx=False)
+    assert len(negative_calls) == 0, (
+        f"gate FAILED: add_to_chat_ctx=False still called _upsert_item with: {negative_calls!r}"
+    )
+
+
+async def test_orphaned_response_after_timeout_filtered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Orphan filter discards a late response.created when the future has been popped.
+
+    Behavioral proof: directly invokes _handle_response_created with a
+    synthetic late event whose metadata.client_event_id is missing from
+    _response_created_futures. Asserts:
+    - _current_generation remains None (orphan filter early-returned).
+    - A defensive ResponseCancelEvent with the correct response_id was sent.
+
+    No OpenAI API call is made.
+    """
+    from openai.types.realtime import ResponseCancelEvent, ResponseCreatedEvent  # noqa: PLC0415
+    from openai.types.realtime.realtime_response import RealtimeResponse  # noqa: PLC0415
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-fake-not-real")
+    from livekit.plugins.openai.realtime.realtime_model import (  # noqa: PLC0415
+        RealtimeSession,
+    )
+
+    session = RealtimeSession.__new__(RealtimeSession)
+    # Simulate the timeout-popped state: no in-flight futures.
+    session._response_created_futures = {}  # type: ignore[attr-defined]
+    session._current_generation = None  # type: ignore[attr-defined]
+    captured: list[object] = []
+    session.send_event = captured.append  # type: ignore[method-assign]
+
+    orphan_event_id = "response_create_say_orphan-test-abc"
+    response = RealtimeResponse.construct(
+        id="resp_orphan_test_abc",
+        metadata={"client_event_id": orphan_event_id},
+    )
+    event = ResponseCreatedEvent.construct(
+        event_id="evt_orphan_test",
+        response=response,
+        type="response.created",
+    )
+
+    session._handle_response_created(event)
+
+    # Orphan filter must have early-returned: _current_generation stays None.
+    assert session._current_generation is None, (
+        "_current_generation must remain None after orphan-filter early-return"
+    )
+
+    # Defensive cancel WITH response_id must have been sent.
+    cancel_events = [
+        e
+        for e in captured
+        if isinstance(e, ResponseCancelEvent)
+        and getattr(e, "response_id", None) == "resp_orphan_test_abc"
+    ]
+    assert len(cancel_events) == 1, (
+        f"expected exactly one ResponseCancelEvent(response_id='resp_orphan_test_abc'); "
+        f"captured: {captured!r}"
+    )

--- a/tests/test_realtime/test_realtime_say_integration.py
+++ b/tests/test_realtime/test_realtime_say_integration.py
@@ -473,3 +473,98 @@ async def test_orphaned_response_after_timeout_filtered(
         f"expected exactly one ResponseCancelEvent(response_id='resp_orphan_test_abc'); "
         f"captured: {captured!r}"
     )
+
+
+@pytest.mark.parametrize(
+    "metadata_case",
+    [
+        pytest.param(None, id="metadata_None"),
+        pytest.param({}, id="metadata_empty_dict"),
+    ],
+)
+async def test_response_created_without_metadata_bypasses_orphan_filter(
+    monkeypatch: pytest.MonkeyPatch,
+    metadata_case: object,
+) -> None:
+    """Orphan filter MUST NOT fire when response.metadata has no client_event_id.
+
+    This is the sister case to test_orphaned_response_after_timeout_filtered.
+    The metadata-presence guard exists so that server-VAD-initiated responses
+    (which carry no client_event_id, because we did not issue them) flow
+    through the normal generation-creation path. If the guard is stripped or
+    inverted, every server-VAD response would be silently discarded and the
+    agent would stop responding to user speech — a critical regression.
+
+    Parametrized across the two no-client_event_id substrate representations:
+    metadata=None (no metadata field) and metadata={} (present but empty).
+
+    For each case the test directly invokes _handle_response_created and
+    asserts the OBSERVABLE post-guard contract:
+    - The "generation_created" event IS emitted with the expected response_id
+      (this is the user-visible success signal — without it, server-VAD
+      turns stall even if _current_generation is set).
+    - No ResponseCancelEvent was sent (the orphan filter did not fire).
+    - _current_generation IS NOT None (post-guard _ResponseGeneration ran).
+
+    No OpenAI API call is made.
+    """
+    from openai.types.realtime import ResponseCancelEvent, ResponseCreatedEvent  # noqa: PLC0415
+    from openai.types.realtime.realtime_response import RealtimeResponse  # noqa: PLC0415
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-fake-not-real")
+    from livekit.plugins.openai.realtime.realtime_model import (  # noqa: PLC0415
+        RealtimeSession,
+    )
+
+    session = RealtimeSession.__new__(RealtimeSession)
+    session._response_created_futures = {}  # type: ignore[attr-defined]
+    session._current_generation = None  # type: ignore[attr-defined]
+    sent_events: list[object] = []
+    session.send_event = sent_events.append  # type: ignore[method-assign]
+
+    emitted_events: list[tuple[str, object]] = []
+
+    def _capture_emit(name: str, payload: object, *args: object, **kwargs: object) -> None:
+        emitted_events.append((name, payload))
+
+    session.emit = _capture_emit  # type: ignore[method-assign]
+
+    response_id = "resp_server_vad_test"
+    response = RealtimeResponse.construct(
+        id=response_id,
+        metadata=metadata_case,
+    )
+    event = ResponseCreatedEvent.construct(
+        event_id="evt_server_vad_test",
+        response=response,
+        type="response.created",
+    )
+
+    session._handle_response_created(event)
+
+    # Observable contract: "generation_created" event IS emitted with the
+    # response_id. This is what callers wait on; missing emit = stalled turn.
+    generation_emits = [
+        payload for (name, payload) in emitted_events if name == "generation_created"
+    ]
+    assert len(generation_emits) == 1, (
+        f"metadata-presence guard FAILED: expected exactly one 'generation_created' "
+        f"emission for a server-VAD response (metadata={metadata_case!r}); "
+        f"all emits: {emitted_events!r}"
+    )
+    emitted_gen = generation_emits[0]
+    assert getattr(emitted_gen, "response_id", None) == response_id, (
+        f"emitted generation_created event has wrong response_id: {emitted_gen!r}"
+    )
+
+    # No defensive cancel must have been emitted (orphan filter did not fire).
+    cancel_events = [e for e in sent_events if isinstance(e, ResponseCancelEvent)]
+    assert cancel_events == [], (
+        f"orphan filter incorrectly emitted ResponseCancelEvent for a server-VAD "
+        f"response (metadata={metadata_case!r}): {cancel_events!r}"
+    )
+
+    # Internal state: _current_generation populated as a structural sanity check.
+    assert session._current_generation is not None, (
+        f"_current_generation should be populated post-guard (metadata={metadata_case!r})"
+    )

--- a/tests/test_realtime/test_realtime_say_integration.py
+++ b/tests/test_realtime/test_realtime_say_integration.py
@@ -1,0 +1,172 @@
+"""Integration tests for ephemeral say() on the OpenAI Realtime plugin.
+
+Verifies the isolation contract for ephemeral say() end-to-end against the
+real OpenAI Realtime API:
+
+- Audibility: text passed to say() reaches the audio channel.
+- Server-side isolation: text passed with add_to_chat_ctx=False does not enter
+  the substrate's conversation state (verified by a follow-up generate_reply
+  that cannot retrieve the text).
+- Wire-format metadata: outbound response.create carries client_event_id.
+
+Tests skip when OPENAI_API_KEY is not set.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+from dotenv import load_dotenv
+from openai.types import realtime
+
+from livekit.agents import llm
+from livekit.plugins import openai
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _load_env() -> None:
+    load_dotenv(override=True)
+
+
+_skip_no_openai_key = pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY not set; integration tests require real OpenAI access",
+)
+
+
+def _openai_model() -> openai.realtime.RealtimeModel:
+    return openai.realtime.RealtimeModel(
+        voice="alloy",
+        input_audio_transcription=realtime.AudioTranscription(model="gpt-4o-mini-transcribe"),
+    )
+
+
+@pytest.fixture
+async def rt_session() -> llm.RealtimeSession:
+    model = _openai_model()
+    session = model.session()
+    yield session
+    await session.aclose()
+    await asyncio.sleep(0.5)
+
+
+async def _collect_text(gen_ev: llm.GenerationCreatedEvent) -> str:
+    parts: list[str] = []
+    async for msg_gen in gen_ev.message_stream:
+        async for chunk in msg_gen.text_stream:
+            parts.append(chunk)
+    return "".join(parts)
+
+
+async def _drain_generation(gen_ev: llm.GenerationCreatedEvent) -> int:
+    """Drain the message + audio streams. Returns total audio frame count."""
+    audio_frames = 0
+    async for msg_gen in gen_ev.message_stream:
+        async for _ in msg_gen.text_stream:
+            pass
+        async for _ in msg_gen.audio_stream:
+            audio_frames += 1
+    return audio_frames
+
+
+@_skip_no_openai_key
+async def test_openai_realtime_say_audio_renders(rt_session: llm.RealtimeSession) -> None:
+    """say() produces audio frames containing the rendered text."""
+    gen_ev = await asyncio.wait_for(
+        rt_session.say("the verification token is alpha-bravo"),
+        timeout=15,
+    )
+    audio_frames = await asyncio.wait_for(_drain_generation(gen_ev), timeout=20)
+    assert audio_frames > 0, "expected at least one audio frame from say()"
+
+
+@_skip_no_openai_key
+async def test_openai_realtime_say_emits_metadata(rt_session: llm.RealtimeSession) -> None:
+    """Outbound response.create carries metadata.client_event_id starting with the say prefix."""
+    captured: list[object] = []
+    real_send = rt_session.send_event
+
+    def _capture(ev: object) -> None:
+        captured.append(ev)
+        return real_send(ev)
+
+    rt_session.send_event = _capture  # type: ignore[method-assign]
+
+    try:
+        gen_ev = await asyncio.wait_for(rt_session.say("alpha-bravo"), timeout=15)
+        await asyncio.wait_for(_drain_generation(gen_ev), timeout=20)
+    finally:
+        rt_session.send_event = real_send  # type: ignore[method-assign]
+
+    create_events = [
+        e
+        for e in captured
+        if getattr(e, "type", None) == "response.create"
+        and isinstance(getattr(getattr(e, "response", None), "metadata", None), dict)
+        and e.response.metadata.get("client_event_id", "").startswith("response_create_say_")
+    ]
+    assert len(create_events) >= 1, (
+        f"expected response.create event with say-prefixed client_event_id; "
+        f"captured {len(captured)} total events, none matched the prefix"
+    )
+
+
+@_skip_no_openai_key
+async def test_openai_realtime_say_isolation_no_leak(rt_session: llm.RealtimeSession) -> None:
+    """After say(secret, add_to_chat_ctx=False), generate_reply cannot recall the secret.
+
+    Proves server-side isolation: the OpenAI Realtime substrate does not retain
+    isolated text in conversation state. A follow-up generation that asks the
+    model to repeat what it just said must not include the secret.
+    """
+    secret = "purple-elephant-42"
+
+    say_gen = await asyncio.wait_for(
+        rt_session.say(f"the verification token is {secret}", add_to_chat_ctx=False),
+        timeout=15,
+    )
+    await asyncio.wait_for(_drain_generation(say_gen), timeout=30)
+
+    follow_up = await asyncio.wait_for(
+        rt_session.generate_reply(
+            instructions=(
+                "Repeat the last verification token you just said out loud, exactly. "
+                "If you cannot recall it, say 'no token recalled'."
+            )
+        ),
+        timeout=15,
+    )
+    follow_up_text = await asyncio.wait_for(_collect_text(follow_up), timeout=20)
+
+    assert secret not in follow_up_text.lower(), (
+        f"secret leaked into follow-up generation: {follow_up_text!r}"
+    )
+
+
+@_skip_no_openai_key
+async def test_openai_realtime_say_isolation_no_remote_chat_ctx_leak(
+    rt_session: llm.RealtimeSession,
+) -> None:
+    """After say(secret, add_to_chat_ctx=False), session.chat_ctx contains no items with the secret.
+
+    Proves substrate-state isolation: the OpenAI Realtime API does not retain
+    isolated text in the visible conversation history (server-side chat_ctx).
+    """
+    secret = "purple-elephant-42"
+
+    say_gen = await asyncio.wait_for(
+        rt_session.say(f"the verification token is {secret}", add_to_chat_ctx=False),
+        timeout=15,
+    )
+    await asyncio.wait_for(_drain_generation(say_gen), timeout=30)
+
+    # Allow substrate state to settle.
+    await asyncio.sleep(0.5)
+
+    chat_ctx = rt_session.chat_ctx
+    flat = " ".join(
+        repr(getattr(item, "content", "")) for item in getattr(chat_ctx, "items", [])
+    ).lower()
+    assert secret not in flat, f"secret leaked into substrate chat_ctx: {flat!r}"

--- a/tests/test_realtime_capabilities.py
+++ b/tests/test_realtime_capabilities.py
@@ -77,3 +77,70 @@ def test_phonic_say_signature_accepts_add_to_chat_ctx() -> None:
     _SELF_SENTINEL = object()
     bound = sig.bind(_SELF_SENTINEL, "hello", add_to_chat_ctx=False)
     assert bound.arguments["add_to_chat_ctx"] is False
+
+
+def _make_openai_session_for_capture(  # type: ignore[no-untyped-def]
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Construct an OpenAI RealtimeSession bypassing network setup.
+
+    Bare-construction pattern: create the instance via __new__ and seed only
+    the attributes that say() reads. Replaces send_event with a list-append
+    capture helper to record outbound events without sending. Avoids calling
+    the heavyweight __init__ which spawns websocket tasks.
+
+    Returns (session, captured_events_list) — the caller inspects the list to
+    assert outbound event shape.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-fake-not-real")
+    from livekit.plugins.openai.realtime.realtime_model import RealtimeSession  # noqa: PLC0415
+
+    session = RealtimeSession.__new__(RealtimeSession)
+    session._response_created_futures = {}  # type: ignore[attr-defined]
+    captured: list[object] = []
+    session.send_event = captured.append  # type: ignore[method-assign]
+    return session, captured
+
+
+def test_openai_realtime_say_sends_response_create_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenAI say() sends a response.create event with assistant message + metadata."""
+    session, captured = _make_openai_session_for_capture(monkeypatch)
+
+    fut = session.say("the verification token alpha-bravo")
+
+    assert len(captured) == 1
+    sent_event = captured[0]
+    assert sent_event.type == "response.create"  # type: ignore[attr-defined]
+    assert sent_event.event_id.startswith("response_create_say_")  # type: ignore[attr-defined]
+    assert sent_event.response.metadata["client_event_id"] == sent_event.event_id  # type: ignore[attr-defined]
+    # Assistant message with text content
+    assert sent_event.response.input is not None  # type: ignore[attr-defined]
+    assert len(sent_event.response.input) == 1  # type: ignore[attr-defined]
+    item = sent_event.response.input[0]  # type: ignore[attr-defined]
+    assert item.type == "message"
+    assert item.role == "assistant"
+    assert len(item.content) == 1
+    assert item.content[0].type == "output_text"
+    assert item.content[0].text == "the verification token alpha-bravo"
+    # Default add_to_chat_ctx=True does NOT set conversation
+    assert sent_event.response.conversation is None  # type: ignore[attr-defined]
+
+    # Cleanup the future to avoid pending task warnings
+    fut.cancel()
+
+
+def test_openai_realtime_say_isolation_sets_conversation_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenAI say(add_to_chat_ctx=False) sets conversation: 'none' on response.create."""
+    session, captured = _make_openai_session_for_capture(monkeypatch)
+
+    fut = session.say("purple-elephant-42", add_to_chat_ctx=False)
+
+    sent_event = captured[0]
+    assert sent_event.response.conversation == "none"  # type: ignore[attr-defined]
+
+    # Cleanup
+    fut.cancel()

--- a/tests/test_realtime_capabilities.py
+++ b/tests/test_realtime_capabilities.py
@@ -10,6 +10,8 @@ to satisfy plugin constructors without triggering any remote connections.
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
 
@@ -47,3 +49,31 @@ def test_phonic_realtime_capability_does_not_advertise_ephemeral_say(
     model = PhonicRealtimeModel()
     assert model.capabilities.ephemeral_say is False
     assert model.capabilities.supports_say is True
+
+
+def test_phonic_say_signature_accepts_add_to_chat_ctx() -> None:
+    """Phonic's say() signature accepts add_to_chat_ctx as a keyword-only kwarg.
+
+    The dispatcher (AgentActivity.say) emits a DeprecationWarning before reaching
+    Phonic's say() because Phonic declares ephemeral_say=False. The kwarg is
+    accepted here for forward-compatible signature alignment with the abstract base.
+    """
+    pytest.importorskip(
+        "livekit.plugins.phonic",
+        reason="livekit-plugins-phonic not installed in this environment",
+    )
+
+    from livekit.plugins.phonic.realtime.realtime_model import (  # noqa: PLC0415
+        RealtimeSession as PhonicRealtimeSession,
+    )
+
+    sig = inspect.signature(PhonicRealtimeSession.say)
+    assert "add_to_chat_ctx" in sig.parameters
+    param = sig.parameters["add_to_chat_ctx"]
+    assert param.default is True
+    assert param.kind is inspect.Parameter.KEYWORD_ONLY
+
+    # Verify the full argument-binding rules accept the kwarg.
+    _SELF_SENTINEL = object()
+    bound = sig.bind(_SELF_SENTINEL, "hello", add_to_chat_ctx=False)
+    assert bound.arguments["add_to_chat_ctx"] is False

--- a/tests/test_realtime_capabilities.py
+++ b/tests/test_realtime_capabilities.py
@@ -1,0 +1,49 @@
+"""Unit tests for RealtimeCapabilities capability advertisement.
+
+Tests that:
+- OpenAI plugin declares both supports_say=True and ephemeral_say=True.
+- Phonic plugin declares supports_say=True and ephemeral_say=False (default).
+
+No network calls are made. API keys are set to dummy values via monkeypatch
+to satisfy plugin constructors without triggering any remote connections.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_openai_realtime_capability_advertises_ephemeral_say(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenAI plugin's RealtimeCapabilities declares ephemeral_say=True."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-fake-not-real")
+
+    from livekit.plugins import openai  # noqa: PLC0415
+
+    model = openai.realtime.RealtimeModel()
+    assert model.capabilities.ephemeral_say is True
+    assert model.capabilities.supports_say is True
+
+
+def test_phonic_realtime_capability_does_not_advertise_ephemeral_say(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Phonic plugin's RealtimeCapabilities declares ephemeral_say=False.
+
+    Phonic's substrate is strictly turn-based; it has no out-of-band
+    response primitive equivalent to OpenAI's response.create(conversation: "none").
+    """
+    pytest.importorskip(
+        "livekit.plugins.phonic",
+        reason="livekit-plugins-phonic not installed in this environment",
+    )
+    monkeypatch.setenv("PHONIC_API_KEY", "phonic-test-fake")
+
+    from livekit.plugins.phonic.realtime import (
+        RealtimeModel as PhonicRealtimeModel,  # noqa: PLC0415
+    )
+
+    model = PhonicRealtimeModel()
+    assert model.capabilities.ephemeral_say is False
+    assert model.capabilities.supports_say is True


### PR DESCRIPTION
### Summary

Adds an ephemeral path to `RealtimeSession.say()` for the OpenAI Realtime plugin
via `response.create(conversation: "none")`: text rendered with
`add_to_chat_ctx=False` is heard by the user but does NOT enter the agent's
reasoning context, server-side OR local.

This closes the JS PR #1193 parity gap and addresses the silent-degradation
regression in that review.

### How to review

Suggested reading path (≈30 min):
1. `livekit-agents/livekit/agents/llm/realtime.py` — capability shape (`ephemeral_say` field) and abstract `say()` signature, ~30 lines.
2. `livekit-plugins/livekit-plugins-openai/.../realtime/realtime_model.py` — `say()` body and the orphan filter in `_handle_response_created`, ~140 lines.
3. `livekit-agents/livekit/agents/voice/agent_activity.py` — dispatcher capability check, plumbing, and the local-context gate at `_realtime_generation_task_impl`, ~30 lines.
4. `tests/test_realtime/test_realtime_say_integration.py` — the property contract for the feature; the unit test files are proofs of the same properties at finer granularity.

### Cross-plugin scope

Only the OpenAI plugin gains the substrate implementation. Phonic accepts but
ignores the kwarg (structurally exempt — substrate is strictly turn-based per
docs.phonic.co; no out-of-band response primitive). Google Gemini Live, AWS
Nova Sonic, Ultravox, NVIDIA all declare `supports_say=False` today; this PR
doesn't change that.

A new `RealtimeCapabilities.ephemeral_say: bool = False` field is added.
Plugins set it to `True` when their substrate provides an out-of-band response
primitive that does not enter conversation state. The OpenAI plugin declares
`ephemeral_say=True`. All other plugins default to `False`.

### Backward compatibility — caller side (deprecation cycle)

In this release, when a caller invokes `say(text, add_to_chat_ctx=False)` on a
plugin without `ephemeral_say`, we emit `DeprecationWarning` and continue with
the existing silent-degrade behavior. A future release will replace the warning
with `NotImplementedError`. This preserves backward compat for any callers
depending on the silent-degrade contract while loudly surfacing the capability
gap. Open to shipping the immediate-raise version if you'd prefer.

### Backward compatibility — plugin authors

The abstract `RealtimeSession.say()` signature gains a keyword-only
`add_to_chat_ctx: bool = True` parameter, and the dispatcher unconditionally
passes the kwarg via `_rt_session.say(text, add_to_chat_ctx=...)`. This is a
**breaking change for any third-party plugin that BOTH declares
`supports_say=True` AND has overridden `say()` with the original signature
`(self, text)`** — those overrides will hit `TypeError: say() got an unexpected
keyword argument 'add_to_chat_ctx'`.

In-tree plugins are updated:
- OpenAI plugin's `say()` accepts and honors the kwarg.
- Phonic accepts but ignores (signature-only shim; substrate is structurally
  exempt, dispatcher emits `DeprecationWarning` upstream).
- Gemini Live, AWS Nova Sonic, Ultravox, NVIDIA all declare `supports_say=False`
  today and the dispatcher never reaches them.

If preserving signature-level backward-compat for out-of-tree plugin authors is
preferred, the dispatcher could `try/except TypeError` and fall back to the
old call shape. Happy to add the shim — flagging this so you can choose
deliberately.

### Tests prove the isolation contract

Each property below is falsifiable: if the assertion fails, the named test fails. Tests run against `gpt-4o-realtime-preview-2025-06-03` for integration paths and network-free for the local-context-gate and orphan-filter behavioral tests.

| Property | Test |
|----------|------|
| Audibility — `say(text)` produces audio frames | `test_openai_realtime_say_audio_renders` (integration) |
| Server-side isolation — `say(secret, add_to_chat_ctx=False)` followed by `generate_reply` cannot retrieve `secret` | `test_openai_realtime_say_isolation_no_leak` (integration) |
| Substrate state isolation — substrate `chat_ctx` does not contain `secret` after isolated `say()` | `test_openai_realtime_say_isolation_no_remote_chat_ctx_leak` (integration) |
| Wire-format metadata — outbound `response.create` carries `metadata.client_event_id` | `test_openai_realtime_say_emits_metadata` (integration) |
| Local-context gate — `add_to_chat_ctx=False` does NOT populate `agent._chat_ctx`; `add_to_chat_ctx=True` DOES (positive+negative control) | `test_openai_realtime_say_isolation_no_local_leak` (behavioral, network-free) |
| Orphan filter — late `response.created` for a popped future is discarded; `_current_generation` stays None; `response.cancel(response_id=…)` is sent | `test_orphaned_response_after_timeout_filtered` (behavioral, network-free) |
| Dispatcher kwarg flow — `AgentActivity.say(add_to_chat_ctx=False)` actually forwards `False` to `_realtime_reply_task` | `test_agent_activity_say_realtime_dispatches_with_add_to_chat_ctx` (unit, frame-locals inspection) |
| Dispatcher capability warning — calling on a plugin without `ephemeral_say` emits `DeprecationWarning` | `test_agent_activity_say_realtime_capability_warns` (unit) |

### Late-event check

Builds on merged PR #2125's `InvalidStateError` handling at the
future-resolution layer. This PR adds an audio-playout layer check: when
`response.created` arrives carrying a `metadata.client_event_id` that we
previously issued but is no longer in `_response_created_futures` (because the
client-side timeout already popped it), we discard the late arrival and send a
defensive `response.cancel(response_id=...)`.

The check reuses the existing `_response_created_futures` dict — no new
lifecycle state is introduced. A metadata-presence guard ensures
server-VAD-initiated responses (no client-issued metadata) flow through
normally.

Two adjacent event handlers (`_handle_response_output_item_added`,
`_handle_response_content_part_added`) gain a defensive
`if self._current_generation is None: return` guard mirroring the existing
pattern in `_handle_response_done`. This protects the cancel-arrival race
window during which late events for an orphaned response could otherwise hit a
None-assertion crash.

### Empirical verification of the substrate contract

The `conversation: "none"` semantic and `metadata.client_event_id` round-trip
are both verified end-to-end by the integration tests in
`tests/test_realtime/test_realtime_say_integration.py` (6 tests total — 4 against
the real OpenAI Realtime API, requires `OPENAI_API_KEY`; 2 network-free
behavioral tests for the local-context gate and orphan filter that run on every
PR even from forks).

The local-context-gate test uses a positive+negative control structure: it
first verifies that `add_to_chat_ctx=True` populates the agent's chat context
(positive control — would catch a regression where local insertion silently
stops working), then verifies `add_to_chat_ctx=False` does NOT. Without the
positive control, the negative-only assertion could pass even if the entire
local-insertion path was broken.

The dispatcher kwarg-flow test inspects the captured `_realtime_reply_task`
coroutine's frame locals to assert that `AgentActivity.say(add_to_chat_ctx=False)`
actually forwards `False` through the call chain — not just that the realtime
path is dispatched.

### Scope note (deferred work, separately tracked)

This PR is intentionally focused. The following adjacent improvements are
deferred to standalone PRs to keep this review narrow:

- **Dict refactor of `_current_generation`**: see #1988. The slot pattern is
  preserved in this PR. The dominant call path through `AgentActivity.say()`
  serializes via `_speech_q` so concurrent OOB `say()` collisions are not
  exercised. Direct `_rt_session.say()` callers firing OOB responses in tight
  succession may collide; documented as known limitation. I plan to file the
  dict refactor as a follow-up PR motivated by #1988.
- **`update_options` race fix**: see #5530.
- **Capability docstring backfill (5 other undocumented fields)**: see #5565;
  will be a tiny standalone `docs:` PR.
- **`interrupt()` cancel-all-under-concurrency** (latent today, active under
  future dict refactor): see #5564.
- **`response.error` mid-flight future hang** (TODO at
  `realtime_model.py:2005`): see #5566.

### Scope note (`generate_reply()`)

This contribution is scoped to `say()`. A follow-up PR will add
`add_to_chat_ctx` to `generate_reply()` using the same `ephemeral_say` flag
pattern (use case A semantic only).

### CI note

Integration tests skip on fork PRs (no `OPENAI_API_KEY`). I've verified the
test suite locally against `gpt-4o-realtime-preview-2025-06-03` and will paste
the test output as a comment on this PR for inspection.

---

## File diff summary (across all 8 commits)

| File | Change |
|------|--------|
| `livekit-agents/livekit/agents/llm/realtime.py` | new `ephemeral_say` capability field; abstract `RealtimeSession.say()` signature gains `add_to_chat_ctx` kwarg |
| `livekit-agents/livekit/agents/voice/agent_activity.py` | dispatcher capability check (`DeprecationWarning`); plumbing of `add_to_chat_ctx` through 3 internal methods; local chat_ctx upsert gated on `add_to_chat_ctx` |
| `livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py` | OpenAI plugin declares `supports_say=True, ephemeral_say=True`; `say()` body using `response.create(conversation: "none")`; late-event check; defensive guards in two downstream handlers |
| `livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py` | Phonic `say()` accepts `add_to_chat_ctx` kwarg (signature compat; substrate is structurally exempt) |
| `tests/test_realtime_capabilities.py` | unit tests: capability advertisement (OpenAI + Phonic), Phonic signature shim, OpenAI `say()` wire format |
| `tests/test_agent_activity_say.py` | unit tests: dispatcher capability warning, kwarg-flow verification (frame-locals inspection of dispatched coroutine) |
| `tests/test_realtime/test_realtime_say_integration.py` | integration + behavioral tests: 4 against the real OpenAI Realtime API (audibility, server-side isolation, substrate-state isolation, wire-format metadata), plus 3 network-free behavioral tests (local-context gate with positive+negative control; orphan filter discards late `response.created`; metadata-presence guard bypasses the orphan filter for server-VAD-initiated responses) |

## Commit log

```
53b64313 test(realtime): assert orphan filter bypasses on metadata=None (server-VAD)
a9a3e2ac test(realtime): behavioral integration tests for ephemeral say()
cd500116 test(realtime): integration tests for ephemeral say()
579df8f7 feat(realtime): gate local chat_ctx upsert on add_to_chat_ctx
1ff15adf feat(realtime): dispatcher capability check + add_to_chat_ctx plumbing
92418578 feat(realtime/openai): implement say() with conversation: "none" + orphan filter
a97d4283 feat(phonic): accept add_to_chat_ctx kwarg on say() for signature compat
e7947d30 feat(realtime): add ephemeral_say capability flag
```

If reviewers prefer a single squashed commit, the maintainer is welcome to
squash on merge — the per-phase commit chain is for development hygiene and
isolated rollback.
