### PR TITLE
fix(async_toolset): respect allow_interruptions when cancelling tool calls

### DIFF
--- a/livekit-agents/livekit/agents/llm/async_toolset.py
+++ b/livekit-agents/livekit/agents/llm/async_toolset.py
@@ -12,6 +12,7 @@ from ..llm.tool_context import (
     FunctionTool,
     RawFunctionTool,
     Tool,
+    ToolError,
     Toolset,
     function_tool,
 )
@@ -195,6 +196,10 @@ class AsyncToolset(Toolset):
     async def cancel(self, call_id: str) -> bool:
         task = self._running_tasks.get(call_id)
         if task is not None:
+            if not task.ctx.speech_handle.allow_interruptions:
+                raise ToolError(
+                    f"Tool call {call_id} is not cancellable because interruptions are disallowed"
+                )
             await utils.aio.cancel_and_wait(task.exe_task)
             return True
         return False

--- a/livekit-agents/livekit/agents/llm/async_toolset.py
+++ b/livekit-agents/livekit/agents/llm/async_toolset.py
@@ -370,7 +370,14 @@ class AsyncToolset(Toolset):
             return None
 
         if self._on_duplicate_call == "replace":
-            await asyncio.gather(*[self.cancel(fnc_call.call_id) for fnc_call in running_fnc_calls])
+            results = await asyncio.gather(
+                *[self.cancel(fnc_call.call_id) for fnc_call in running_fnc_calls],
+                return_exceptions=True,
+            )
+            exceptions = [result for result in results if isinstance(result, Exception)]
+            if exceptions:
+                error_messages = "\n".join([str(e) for e in exceptions])
+                raise ToolError(f"Failed to cancel duplicate tool calls: {error_messages}")
             return None
 
         if self._on_duplicate_call == "reject":


### PR DESCRIPTION
## Summary
- When the LLM invokes `cancel_task` against a running async tool whose `SpeechHandle` has `allow_interruptions=False`, `AsyncToolset.cancel()` now raises a `ToolError` instead of silently cancelling the task.
- This surfaces the disallowed-interruption state back to the LLM as a tool error, keeping cancellation behavior consistent with the speech handle's interruption policy.