### PR TITLE
feat(mistral): add connectors provider tool & fix realtime STT custom headers

### DIFF
--- a/livekit-plugins/livekit-plugins-mistralai/README.md
+++ b/livekit-plugins/livekit-plugins-mistralai/README.md
@@ -101,6 +101,7 @@ agent = Agent(
         mistralai.tools.WebSearch(),
         mistralai.tools.CodeInterpreter(),
         mistralai.tools.DocumentLibrary(library_ids=["<your-library-id>"]),
+        mistralai.tools.Connector(connector_id="<your_connector_id>")
     ]
 )
 ```

--- a/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/stt.py
+++ b/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/stt.py
@@ -124,10 +124,18 @@ class STT(stt.STT):
 
     async def _connect_ws(self, timeout: float) -> RealtimeConnection:
         rt = RealtimeTranscription(self._client.sdk_configuration)
+        http_headers = None
+        cfg = self._client.sdk_configuration
+        client_headers = getattr(cfg.async_client, "headers", None) or getattr(
+            cfg.client, "headers", None
+        )
+        if client_headers:
+            http_headers = dict(client_headers)
         return await asyncio.wait_for(
             rt.connect(
                 model=self._opts.model,
                 target_streaming_delay_ms=self._opts.target_streaming_delay_ms,
+                http_headers=http_headers,
             ),
             timeout=timeout,
         )

--- a/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/tools.py
+++ b/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/tools.py
@@ -52,7 +52,7 @@ class Connector(MistralTool):
     connector_id: str
 
     def __post_init__(self) -> None:
-        super().__init__(id=f"mistral_connector_${self.connector_id}")
+        super().__init__(id=f"mistral_connector_{self.connector_id}")
 
     def to_dict(self) -> dict[str, Any]:
         return {"type": "connector", "connector_id": self.connector_id}

--- a/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/tools.py
+++ b/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/tools.py
@@ -43,3 +43,16 @@ class CodeInterpreter(MistralTool):
 
     def to_dict(self) -> dict[str, Any]:
         return {"type": "code_interpreter"}
+
+
+@dataclass
+class Connector(MistralTool):
+    """Enable the connector tool"""
+
+    connector_id: str
+
+    def __post_init__(self) -> None:
+        super().__init__(id=f"mistral_connector_${self.connector_id}")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"type": "connector", "connector_id": self.connector_id}


### PR DESCRIPTION
## Summary

Adds support for Mistral [Connectors](https://docs.mistral.ai/studio-api/knowledge-rag/connectors) (e.g. Google Calendar, Notion, etc.) as a provider tool, and fixes custom HTTP headers not being forwarded to the realtime STT websocket.

## Changes

### New `Connector` tool (`tools.py`)

Introduces `mistralai.tools.Connector(connector_id="...")`, following the same pattern as the existing `WebSearch`, `CodeInterpreter` & `DocumentLibrary` tools. Serialises to `{"type": "connector", "connector_id": "..."}`.

### Fix STT websocket headers (`stt.py`)

Custom HTTP headers set on the `Mistral` client (e.g. for auth proxies) were not being passed through to the realtime transcription websocket. The fix extracts headers from the client's HTTP client and forwards them via the `http_headers` parameter of `rt.connect()`.

## Usage

```python
agent = Agent(
    llm=mistralai.LLM(),
    tools=[
        mistralai.tools.Connector(connector_id="google_calendar")
    ]
)
```