### PR TITLE
fix(openai realtime): reject pending response future on error event

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1993,6 +1993,14 @@ class RealtimeSession(
             f"{provider_label} returned an error: {event.error}",
             extra={"error": event.error},
         )
+
+        if (event_id := event.error.event_id) and (
+            fut := self._response_created_futures.pop(event_id, None)
+        ):
+            # set exception for the response future if it exists
+            if not fut.done():
+                fut.set_exception(llm.RealtimeError(event.error.message))
+
         self._emit_error(
             APIError(
                 message=f"{provider_label} returned an error",
@@ -2001,8 +2009,6 @@ class RealtimeSession(
             ),
             recoverable=True,
         )
-
-        # TODO: set exception for the response future if it exists
 
     def _emit_error(self, error: Exception, recoverable: bool) -> None:
         self.emit(


### PR DESCRIPTION
## Summary
- When OpenAI realtime sends an `error` event referencing the `event_id` of a `response.create` we issued, resolve the future created by `generate_reply()` with `llm.RealtimeError`.

Closes #5566.