### PR TITLE
feat(agents): add first-run diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,32 @@ python myagent.py start
 
 Runs the agent with production-ready optimizations.
 
+### Checking your setup
+
+```shell
+python agent.py doctor
+```
+
+Runs local diagnostics without starting a worker. Replace `agent.py` with your agent entrypoint. Use this first when setup fails or before deploying to confirm required packages, environment variables, credentials, and downloadable model files are in place.
+
+Useful options:
+
+- `--json`: output a machine-readable report for CI or support tickets.
+- `--online`: include a safe LiveKit network connectivity check.
+- `--deep`: run plugin-declared checks that are safe to execute.
+- `--strict`: exit non-zero on warnings as well as errors.
+
+### CLI modes
+
+| Command | Use for | Requires LiveKit server | Notes |
+| --- | --- | --- | --- |
+| `console` | Local terminal testing | Yes for the default Cloud Inference examples | Uses local audio or text input; fastest way to iterate on agent behavior. |
+| `dev` | Development with clients | Yes | Starts a worker with dev defaults and auto-reload. |
+| `start` | Production workers | Yes | Runs with production defaults. |
+| `connect` | Attach an agent to a room | Yes | Creates or joins the room and simulates a job for that room. |
+| `download-files` | Preload plugin assets | No | Downloads files required by registered plugins, such as local model assets. |
+| `doctor` | Diagnose setup issues | No by default | Add `--online` for network and credential checks. |
+
 ## Contributing
 
 The Agents framework is under active development in a rapidly evolving field. We welcome and appreciate contributions of any kind, be it feedback, bugfixes, features, new plugins and tools, or better documentation. You can file issues under this repo, open a PR, or chat with us in the [LiveKit community](https://docs.livekit.io/intro/community/).

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,15 @@ session = AgentSession(
 
 **Note:** Realtime models (e.g., `openai.realtime.RealtimeModel`) are not supported by LiveKit Inference and must use the plugin directly. See the [Real-time Models](#-real-time-models) examples in `voice_agents/`.
 
+### Choosing model access
+
+| Option | Choose when | Credentials |
+| --- | --- | --- |
+| LiveKit Cloud Inference | You want the default examples to work with one LiveKit Cloud project and a unified model API. | `LIVEKIT_API_KEY` and `LIVEKIT_API_SECRET` |
+| Provider plugin | You need provider-specific features, models, or account controls. | Provider API key, such as `OPENAI_API_KEY` |
+| Realtime model | You need a provider's realtime speech-to-speech API. | Provider API key |
+| Self-hosted model | You run model services in your own infrastructure. | Your service URL and any service-specific credentials |
+
 ## 📁 Example Categories
 
 ### 🎙️ [Voice Agents](./voice_agents/)
@@ -54,7 +63,7 @@ To run the examples, you'll need:
 
 - A [LiveKit Cloud](https://cloud.livekit.io) account or a local [LiveKit server](https://github.com/livekit/livekit)
 - API keys for the model providers you want to use in a `.env` file
-- Python 3.9 or higher
+- Python 3.10 or higher
 - [uv](https://docs.astral.sh/uv/)
 
 ### Environment file
@@ -84,6 +93,14 @@ uv sync --all-extras --dev
 
 ### Running an individual example
 
+Check your setup before running an example:
+
+```bash
+uv run examples/voice_agents/basic_agent.py doctor
+```
+
+Use `--json` for machine-readable output, `--online` for a safe LiveKit network check, `--deep` for plugin-declared checks, and `--strict` to fail on warnings.
+
 Run an example agent:
 
 ```bash
@@ -93,6 +110,17 @@ uv run examples/voice_agents/basic_agent.py console
 Your agent is now running in the console.
 
 For frontend support, use the [Agents playground](https://agents-playground.livekit.io) or the [starter apps](https://docs.livekit.io/agents/start/frontend/#starter-apps).
+
+### CLI modes
+
+| Command | Use for |
+| --- | --- |
+| `console` | Test the agent locally in the terminal. |
+| `dev` | Run a development worker for LiveKit clients with auto-reload. |
+| `start` | Run a production worker. |
+| `connect` | Attach the agent to a specific LiveKit room. |
+| `download-files` | Download plugin assets before first run or container startup. |
+| `doctor` | Diagnose local setup, credentials, and optional online checks. |
 
 ## 📖 Additional Resources
 

--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -1513,6 +1513,7 @@ def _run_console(
         server=server,
         mode="console",
         console=c,
+        console_audio=mode == "audio",
         input_device=input_device,
         output_device=output_device,
     )
@@ -1534,7 +1535,8 @@ def _run_console(
         # c.print(f"Importing from {import_data.module_data.extra_sys_path}")
         # c.print(" ")
 
-        c._validate_device_or_raise(input_device=input_device, output_device=output_device)
+        if mode == "audio":
+            c._validate_device_or_raise(input_device=input_device, output_device=output_device)
 
         exit_triggered = False
 
@@ -1697,11 +1699,11 @@ def _apply_cli_server_options(
     api_secret: str | None = None,
 ) -> None:
     update_kwargs: dict[str, Any] = {}
-    if url is not None:
+    if url:
         update_kwargs["ws_url"] = url
-    if api_key is not None:
+    if api_key:
         update_kwargs["api_key"] = api_key
-    if api_secret is not None:
+    if api_secret:
         update_kwargs["api_secret"] = api_secret
 
     if update_kwargs:
@@ -1715,6 +1717,7 @@ def _diagnostic_context(
     online: bool = False,
     deep: bool = False,
     strict: bool = False,
+    console_audio: bool = True,
     input_device: str | int | None = None,
     output_device: str | int | None = None,
 ) -> DiagnosticContext:
@@ -1726,6 +1729,7 @@ def _diagnostic_context(
         env=os.environ.copy(),
         registered_plugins=tuple(Plugin.registered_plugins),
         server=server,
+        console_audio=console_audio,
         input_device=input_device,
         output_device=output_device,
     )
@@ -1736,6 +1740,7 @@ def _run_preflight(
     server: AgentServer,
     mode: Literal["console", "dev", "start", "connect"],
     console: AgentsConsole | None,
+    console_audio: bool = True,
     input_device: str | int | None = None,
     output_device: str | int | None = None,
 ) -> None:
@@ -1743,6 +1748,7 @@ def _run_preflight(
         _diagnostic_context(
             server,
             mode=mode,
+            console_audio=console_audio,
             input_device=input_device,
             output_device=output_device,
         )

--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -1710,6 +1710,20 @@ def _apply_cli_server_options(
         server.update_options(**update_kwargs)
 
 
+def _resolved_livekit_api_options(
+    server: AgentServer,
+    *,
+    url: str | None = None,
+    api_key: str | None = None,
+    api_secret: str | None = None,
+) -> tuple[str, str, str]:
+    return (
+        str(url or server._ws_url or ""),
+        str(api_key or server._api_key or ""),
+        str(api_secret or server._api_secret or ""),
+    )
+
+
 def _diagnostic_context(
     server: AgentServer,
     *,
@@ -2053,9 +2067,14 @@ def _build_cli(server: AgentServer) -> typer.Typer:
         _configure_logger(c, log_level.value)
         _apply_cli_server_options(server, url=url, api_key=api_key, api_secret=api_secret)
         _run_preflight(server=server, mode="connect", console=c)
-        resolved_url = str(getattr(server, "_ws_url", "") or "")
-        resolved_api_key = str(getattr(server, "_api_key", "") or "")
-        resolved_api_secret = str(getattr(server, "_api_secret", "") or "")
+        resolved_url, resolved_api_key, resolved_api_secret = _resolved_livekit_api_options(
+            server,
+            url=url,
+            api_key=api_key,
+            api_secret=api_secret,
+        )
+        if not (resolved_url and resolved_api_key and resolved_api_secret):
+            raise CLIError("LiveKit credentials are required for connect mode")
 
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)

--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -39,6 +39,14 @@ from livekit import api, rtc
 
 from .. import llm
 from .._exceptions import CLIError
+from ..diagnostics import (
+    DiagnosticContext,
+    DiagnosticSeverity,
+    build_diagnostics_table,
+    collect_diagnostics,
+    diagnostic_report_to_json,
+    report_exit_code,
+)
 from ..job import JobExecutorType
 from ..log import logger
 from ..plugin import Plugin
@@ -1501,6 +1509,13 @@ def _run_console(
     c.record = record
 
     _configure_logger(c, log_level)
+    _run_preflight(
+        server=server,
+        mode="console",
+        console=c,
+        input_device=input_device,
+        output_device=output_device,
+    )
     c.print("Starting console mode 🚀", tag="Agents")
 
     if c.record:
@@ -1592,6 +1607,17 @@ def _run_worker(server: AgentServer, args: proto.CliArgs, jupyter: bool = False)
             signal.signal(sig, _handle_exit)
 
     _configure_logger(c, args.log_level)
+    _apply_cli_server_options(
+        server,
+        url=args.url,
+        api_key=args.api_key,
+        api_secret=args.api_secret,
+    )
+    _run_preflight(
+        server=server,
+        mode="dev" if args.devmode else "start",
+        console=c,
+    )
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
@@ -1663,6 +1689,79 @@ class LogLevel(str, enum.Enum):
     critical = "CRITICAL"
 
 
+def _apply_cli_server_options(
+    server: AgentServer,
+    *,
+    url: str | None = None,
+    api_key: str | None = None,
+    api_secret: str | None = None,
+) -> None:
+    update_kwargs: dict[str, Any] = {}
+    if url is not None:
+        update_kwargs["ws_url"] = url
+    if api_key is not None:
+        update_kwargs["api_key"] = api_key
+    if api_secret is not None:
+        update_kwargs["api_secret"] = api_secret
+
+    if update_kwargs:
+        server.update_options(**update_kwargs)
+
+
+def _diagnostic_context(
+    server: AgentServer,
+    *,
+    mode: Literal["doctor", "console", "dev", "start", "connect"] = "doctor",
+    online: bool = False,
+    deep: bool = False,
+    strict: bool = False,
+    input_device: str | int | None = None,
+    output_device: str | int | None = None,
+) -> DiagnosticContext:
+    return DiagnosticContext(
+        mode=mode,
+        online=online,
+        deep=deep,
+        strict=strict,
+        env=os.environ.copy(),
+        registered_plugins=tuple(Plugin.registered_plugins),
+        server=server,
+        input_device=input_device,
+        output_device=output_device,
+    )
+
+
+def _run_preflight(
+    *,
+    server: AgentServer,
+    mode: Literal["console", "dev", "start", "connect"],
+    console: AgentsConsole | None,
+    input_device: str | int | None = None,
+    output_device: str | int | None = None,
+) -> None:
+    report = collect_diagnostics(
+        _diagnostic_context(
+            server,
+            mode=mode,
+            input_device=input_device,
+            output_device=output_device,
+        )
+    )
+    blocking = [result for result in report.results if result.severity == DiagnosticSeverity.FATAL]
+    notable = [result for result in report.results if result.severity != DiagnosticSeverity.OK]
+
+    if notable:
+        if console is None:
+            Console().print(build_diagnostics_table(report))
+        else:
+            console.print(build_diagnostics_table(report))
+
+    # Preflight only blocks on fatal setup errors. Non-fatal errors still surface
+    # in the table but should not prevent an otherwise valid worker from starting.
+    if blocking:
+        raise typer.Exit(code=1)
+
+
 def _build_cli(server: AgentServer) -> typer.Typer:
     app = typer.Typer(rich_markup_mode="rich")
 
@@ -1676,6 +1775,45 @@ def _build_cli(server: AgentServer) -> typer.Typer:
 
     _start_log_default = LogLevel(ServerEnvOption.getvalue(server.log_level, False))
     _dev_log_default = LogLevel(ServerEnvOption.getvalue(server.log_level, True))
+
+    @app.command()
+    def doctor(
+        *,
+        json_output: Annotated[
+            bool,
+            typer.Option("--json", help="Emit a stable JSON diagnostics report."),
+        ] = False,
+        online: Annotated[
+            bool,
+            typer.Option(help="Run safe online connectivity checks."),
+        ] = False,
+        deep: Annotated[
+            bool,
+            typer.Option(help="Run plugin-declared deep checks that are safe to execute."),
+        ] = False,
+        strict: Annotated[
+            bool,
+            typer.Option(help="Return a failing exit code for warnings."),
+        ] = False,
+    ) -> None:
+        """
+        Run [bold]LiveKit Agents[/bold] first-run diagnostics.
+        """
+        report = collect_diagnostics(
+            _diagnostic_context(
+                server,
+                mode="doctor",
+                online=online,
+                deep=deep,
+                strict=strict,
+            )
+        )
+        if json_output:
+            typer.echo(diagnostic_report_to_json(report))
+        else:
+            Console().print(build_diagnostics_table(report))
+
+        raise typer.Exit(code=report_exit_code(report))
 
     @app.command()
     def console(
@@ -1907,6 +2045,11 @@ def _build_cli(server: AgentServer) -> typer.Typer:
 
         c = AgentsConsole.get_instance()
         _configure_logger(c, log_level.value)
+        _apply_cli_server_options(server, url=url, api_key=api_key, api_secret=api_secret)
+        _run_preflight(server=server, mode="connect", console=c)
+        resolved_url = str(getattr(server, "_ws_url", "") or "")
+        resolved_api_key = str(getattr(server, "_api_key", "") or "")
+        resolved_api_secret = str(getattr(server, "_api_secret", "") or "")
 
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
@@ -1917,7 +2060,9 @@ def _build_cli(server: AgentServer) -> typer.Typer:
             nonlocal _task
 
             async def simulate_job() -> None:
-                async with api.LiveKitAPI(url, api_key, api_secret) as lk_api:
+                async with api.LiveKitAPI(
+                    resolved_url, resolved_api_key, resolved_api_secret
+                ) as lk_api:
                     room_request = api.ListRoomsRequest(names=[room])
                     active_room = await lk_api.room.list_rooms(room_request)
 

--- a/livekit-agents/livekit/agents/diagnostics/__init__.py
+++ b/livekit-agents/livekit/agents/diagnostics/__init__.py
@@ -72,6 +72,7 @@ class DiagnosticContext:
     env: Mapping[str, str] = field(default_factory=lambda: os.environ.copy())
     registered_plugins: Sequence[Any] = ()
     server: Any | None = None
+    console_audio: bool = True
     input_device: str | int | None = None
     output_device: str | int | None = None
 
@@ -167,7 +168,7 @@ def collect_diagnostics(context: DiagnosticContext) -> DiagnosticReport:
         *_check_plugins(context),
     ]
 
-    if context.mode == "console":
+    if context.mode == "console" and context.console_audio:
         results.extend(_check_audio_devices(context))
 
     if context.mode == "start":
@@ -386,16 +387,7 @@ def _plugin_metadata_results(context: DiagnosticContext, plugin: Any) -> list[Di
         ]
 
     if info is None:
-        return [
-            DiagnosticResult(
-                id=f"plugins.{plugin_id}.metadata",
-                category=DiagnosticCategory.PLUGIN,
-                severity=DiagnosticSeverity.WARN,
-                message="Plugin does not expose diagnostic metadata",
-                fix_hint="Update the plugin to return PluginDiagnosticInfo from diagnostic_info().",
-                details={"plugin": plugin_id},
-            )
-        ]
+        return []
 
     results = [
         DiagnosticResult(

--- a/livekit-agents/livekit/agents/diagnostics/__init__.py
+++ b/livekit-agents/livekit/agents/diagnostics/__init__.py
@@ -1,0 +1,650 @@
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Literal
+from urllib.parse import urlparse
+
+from rich.table import Table
+
+DiagnosticMode = Literal["doctor", "console", "dev", "start", "connect"]
+
+
+class DiagnosticSeverity(str, Enum):
+    """Severity levels returned by first-run diagnostics."""
+
+    OK = "ok"
+    WARN = "warn"
+    ERROR = "error"
+    FATAL = "fatal"
+
+
+class DiagnosticCategory(str, Enum):
+    """High-level area covered by a diagnostic result."""
+
+    ENVIRONMENT = "environment"
+    LIVEKIT = "livekit"
+    AUDIO = "audio"
+    PLUGIN = "plugin"
+    DOWNLOADS = "downloads"
+    NETWORK = "network"
+    DEPLOYMENT = "deployment"
+
+
+class PluginCapability(str, Enum):
+    """Capabilities that a LiveKit Agents plugin can advertise to diagnostics."""
+
+    LLM = "llm"
+    STT = "stt"
+    TTS = "tts"
+    REALTIME = "realtime"
+    VAD = "vad"
+    AVATAR = "avatar"
+    NOISE_CANCELLATION = "noise_cancellation"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class PluginDiagnosticInfo:
+    """Static diagnostic metadata exposed by a plugin without side effects."""
+
+    required_env_vars: Sequence[str] = ()
+    optional_env_vars: Sequence[str] = ()
+    capabilities: Sequence[PluginCapability | str] = ()
+    downloadable_files: Sequence[str] = ()
+    docs_url: str | None = None
+    notes: str | None = None
+
+
+@dataclass(frozen=True)
+class DiagnosticContext:
+    """Inputs available to diagnostics for one CLI mode or preflight run."""
+
+    mode: DiagnosticMode = "doctor"
+    online: bool = False
+    deep: bool = False
+    strict: bool = False
+    env: Mapping[str, str] = field(default_factory=lambda: os.environ.copy())
+    registered_plugins: Sequence[Any] = ()
+    server: Any | None = None
+    input_device: str | int | None = None
+    output_device: str | int | None = None
+
+
+@dataclass(frozen=True)
+class DiagnosticResult:
+    """Single diagnostic finding with a user-facing message and optional fix."""
+
+    id: str
+    category: DiagnosticCategory | str
+    severity: DiagnosticSeverity | str
+    message: str
+    fix_hint: str | None = None
+    docs_url: str | None = None
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        category = self.category.value if isinstance(self.category, Enum) else self.category
+        severity = self.severity.value if isinstance(self.severity, Enum) else self.severity
+        return {
+            "id": self.id,
+            "category": category,
+            "severity": severity,
+            "message": self.message,
+            "fix_hint": self.fix_hint,
+            "docs_url": self.docs_url,
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class DiagnosticCheck:
+    """Callable deep diagnostic check provided by a plugin."""
+
+    id: str
+    category: DiagnosticCategory
+    run: Callable[[DiagnosticContext], DiagnosticResult]
+
+
+@dataclass(frozen=True)
+class DiagnosticReport:
+    """Collected diagnostics and rendering metadata for a single run."""
+
+    results: Sequence[DiagnosticResult]
+    mode: DiagnosticMode = "doctor"
+    strict: bool = False
+    online: bool = False
+    deep: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        result_dicts = [result.to_dict() for result in self.results]
+        counts = {
+            severity.value: sum(
+                1 for result in self.results if _severity_value(result.severity) == severity.value
+            )
+            for severity in DiagnosticSeverity
+        }
+        plugins: list[dict[str, Any]] = []
+        for result in self.results:
+            if result.id == "plugins.registered":
+                raw_plugins = result.details.get("plugins", [])
+                if isinstance(raw_plugins, list):
+                    plugins = [plugin for plugin in raw_plugins if isinstance(plugin, dict)]
+                break
+
+        return {
+            "schema_version": 1,
+            "mode": self.mode,
+            "strict": self.strict,
+            "online": self.online,
+            "deep": self.deep,
+            "exit_code": report_exit_code(self),
+            "summary": {
+                "ok": counts[DiagnosticSeverity.OK.value],
+                "warnings": counts[DiagnosticSeverity.WARN.value],
+                "errors": counts[DiagnosticSeverity.ERROR.value],
+                "fatal": counts[DiagnosticSeverity.FATAL.value],
+                "exit_code": report_exit_code(self),
+            },
+            "plugins": plugins,
+            "results": result_dicts,
+        }
+
+
+_LIVEKIT_REQUIRED_MODES = {"console", "dev", "start", "connect"}
+
+
+def collect_diagnostics(context: DiagnosticContext) -> DiagnosticReport:
+    results = [
+        _check_python_version(),
+        _check_entrypoint(context),
+        *_check_livekit_credentials(context),
+        *_check_plugins(context),
+    ]
+
+    if context.mode == "console":
+        results.extend(_check_audio_devices(context))
+
+    if context.mode == "start":
+        results.extend(_check_deployment(context))
+
+    if context.online:
+        results.append(_check_livekit_tcp_connectivity(context))
+
+    return DiagnosticReport(
+        results=results,
+        mode=context.mode,
+        strict=context.strict,
+        online=context.online,
+        deep=context.deep,
+    )
+
+
+def diagnostic_report_to_json(report: DiagnosticReport) -> str:
+    return json.dumps(report.to_dict(), default=str, sort_keys=True)
+
+
+def report_exit_code(report: DiagnosticReport) -> int:
+    severities = {_severity_value(result.severity) for result in report.results}
+    if DiagnosticSeverity.FATAL.value in severities or DiagnosticSeverity.ERROR.value in severities:
+        return 1
+    if report.strict and DiagnosticSeverity.WARN.value in severities:
+        return 1
+    return 0
+
+
+def build_diagnostics_table(report: DiagnosticReport) -> Table:
+    table = Table(title="LiveKit Agents diagnostics")
+    table.add_column("Severity", no_wrap=True)
+    table.add_column("Category", no_wrap=True)
+    table.add_column("Check")
+    table.add_column("Message")
+    table.add_column("Fix")
+
+    for result in report.results:
+        table.add_row(
+            _severity_value(result.severity),
+            _category_value(result.category),
+            result.id,
+            result.message,
+            result.fix_hint or "",
+        )
+
+    return table
+
+
+def _check_python_version() -> DiagnosticResult:
+    version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    supported = (3, 10) <= sys.version_info[:2] < (3, 15)
+    if supported:
+        return DiagnosticResult(
+            id="python.version",
+            category=DiagnosticCategory.ENVIRONMENT,
+            severity=DiagnosticSeverity.OK,
+            message=f"Python {version} is supported",
+            details={"version": version},
+        )
+
+    return DiagnosticResult(
+        id="python.version",
+        category=DiagnosticCategory.ENVIRONMENT,
+        severity=DiagnosticSeverity.FATAL,
+        message=f"Python {version} is outside the supported range >=3.10,<3.15",
+        fix_hint="Use Python 3.10, 3.11, 3.12, 3.13, or 3.14.",
+        details={"version": version},
+    )
+
+
+def _check_entrypoint(context: DiagnosticContext) -> DiagnosticResult:
+    server = context.server
+    has_entrypoint = bool(getattr(server, "_entrypoint_fnc", None))
+    if has_entrypoint:
+        return DiagnosticResult(
+            id="agent.entrypoint",
+            category=DiagnosticCategory.ENVIRONMENT,
+            severity=DiagnosticSeverity.OK,
+            message="RTC session entrypoint is registered",
+        )
+
+    return DiagnosticResult(
+        id="agent.entrypoint",
+        category=DiagnosticCategory.ENVIRONMENT,
+        severity=DiagnosticSeverity.FATAL,
+        message="No RTC session entrypoint has been registered",
+        fix_hint="Register one with @server.rtc_session(...) before calling cli.run_app(server).",
+        docs_url="https://docs.livekit.io/agents/start/voice-ai/",
+    )
+
+
+def _check_livekit_credentials(context: DiagnosticContext) -> list[DiagnosticResult]:
+    required = context.mode in _LIVEKIT_REQUIRED_MODES
+    missing_severity = DiagnosticSeverity.FATAL if required else DiagnosticSeverity.ERROR
+    results: list[DiagnosticResult] = []
+
+    credentials = {
+        "LIVEKIT_URL": _resolved_value(context, "_ws_url", "LIVEKIT_URL"),
+        "LIVEKIT_API_KEY": _resolved_value(context, "_api_key", "LIVEKIT_API_KEY"),
+        "LIVEKIT_API_SECRET": _resolved_value(context, "_api_secret", "LIVEKIT_API_SECRET"),
+    }
+
+    missing = [name for name, value in credentials.items() if not value]
+    if missing:
+        results.append(
+            DiagnosticResult(
+                id="livekit.credentials",
+                category=DiagnosticCategory.LIVEKIT,
+                severity=missing_severity,
+                message=f"Missing LiveKit credential environment variables: {', '.join(missing)}",
+                fix_hint="Set LIVEKIT_URL, LIVEKIT_API_KEY, and LIVEKIT_API_SECRET, or pass CLI options.",
+                docs_url="https://docs.livekit.io/agents/start/voice-ai/",
+                details={"missing": missing},
+            )
+        )
+    else:
+        results.append(
+            DiagnosticResult(
+                id="livekit.credentials",
+                category=DiagnosticCategory.LIVEKIT,
+                severity=DiagnosticSeverity.OK,
+                message="LiveKit credentials are configured",
+                details={"env_vars": list(credentials.keys())},
+            )
+        )
+
+    url = credentials["LIVEKIT_URL"]
+    if url:
+        valid = _valid_ws_url(url)
+        results.append(
+            DiagnosticResult(
+                id="livekit.url",
+                category=DiagnosticCategory.LIVEKIT,
+                severity=DiagnosticSeverity.OK if valid else missing_severity,
+                message=(
+                    "LiveKit URL uses a WebSocket scheme"
+                    if valid
+                    else "LiveKit URL must start with ws:// or wss://"
+                ),
+                fix_hint=None
+                if valid
+                else "Use the WebSocket URL for your LiveKit server or Cloud project.",
+                docs_url=None
+                if valid
+                else "https://docs.livekit.io/home/get-started/api-primitives/",
+                details={"url": _redact_url(url)},
+            )
+        )
+
+    return results
+
+
+def _check_plugins(context: DiagnosticContext) -> list[DiagnosticResult]:
+    results: list[DiagnosticResult] = [
+        DiagnosticResult(
+            id="plugins.registered",
+            category=DiagnosticCategory.PLUGIN,
+            severity=DiagnosticSeverity.OK,
+            message=f"{len(context.registered_plugins)} plugin(s) registered",
+            details={
+                "plugins": [
+                    {
+                        "title": getattr(plugin, "title", type(plugin).__name__),
+                        "version": getattr(plugin, "version", ""),
+                        "package": getattr(plugin, "package", ""),
+                    }
+                    for plugin in context.registered_plugins
+                ]
+            },
+        )
+    ]
+
+    for plugin in context.registered_plugins:
+        results.extend(_plugin_metadata_results(context, plugin))
+
+        if context.deep:
+            results.extend(_plugin_deep_results(context, plugin))
+
+    return results
+
+
+def _plugin_metadata_results(context: DiagnosticContext, plugin: Any) -> list[DiagnosticResult]:
+    plugin_id = _plugin_id(plugin)
+    try:
+        info = plugin.diagnostic_info()
+    except Exception as exc:
+        return [
+            DiagnosticResult(
+                id=f"plugins.{plugin_id}.metadata",
+                category=DiagnosticCategory.PLUGIN,
+                severity=DiagnosticSeverity.ERROR,
+                message=f"Plugin diagnostic metadata failed: {exc}",
+                fix_hint="Check the plugin diagnostic_info() implementation.",
+                details={"plugin": plugin_id},
+            )
+        ]
+
+    if info is None:
+        return [
+            DiagnosticResult(
+                id=f"plugins.{plugin_id}.metadata",
+                category=DiagnosticCategory.PLUGIN,
+                severity=DiagnosticSeverity.WARN,
+                message="Plugin does not expose diagnostic metadata",
+                fix_hint="Update the plugin to return PluginDiagnosticInfo from diagnostic_info().",
+                details={"plugin": plugin_id},
+            )
+        ]
+
+    results = [
+        DiagnosticResult(
+            id=f"plugins.{plugin_id}.capabilities",
+            category=DiagnosticCategory.PLUGIN,
+            severity=DiagnosticSeverity.OK,
+            message="Plugin diagnostic metadata is available",
+            docs_url=info.docs_url,
+            details={
+                "plugin": plugin_id,
+                "capabilities": [
+                    capability.value if isinstance(capability, Enum) else capability
+                    for capability in info.capabilities
+                ],
+                "optional_env_vars": list(info.optional_env_vars),
+                "notes": info.notes,
+            },
+        )
+    ]
+
+    missing_env = [name for name in info.required_env_vars if not context.env.get(name)]
+    if missing_env:
+        results.append(
+            DiagnosticResult(
+                id=f"plugins.{plugin_id}.env",
+                category=DiagnosticCategory.PLUGIN,
+                severity=DiagnosticSeverity.WARN,
+                message=f"Plugin may need missing environment variables: {', '.join(missing_env)}",
+                fix_hint="Set the provider key or pass credentials explicitly when constructing the plugin client.",
+                docs_url=info.docs_url,
+                details={"plugin": plugin_id, "missing": missing_env},
+            )
+        )
+    elif info.required_env_vars:
+        results.append(
+            DiagnosticResult(
+                id=f"plugins.{plugin_id}.env",
+                category=DiagnosticCategory.PLUGIN,
+                severity=DiagnosticSeverity.OK,
+                message="Required plugin environment variables are set",
+                docs_url=info.docs_url,
+                details={"plugin": plugin_id, "env_vars": list(info.required_env_vars)},
+            )
+        )
+
+    if info.downloadable_files:
+        results.append(
+            DiagnosticResult(
+                id=f"plugins.{plugin_id}.downloads",
+                category=DiagnosticCategory.DOWNLOADS,
+                severity=DiagnosticSeverity.WARN,
+                message="Plugin may require local model or asset downloads",
+                fix_hint="Run `python your_agent.py download-files` before the first run.",
+                docs_url=info.docs_url,
+                details={"plugin": plugin_id, "files": list(info.downloadable_files)},
+            )
+        )
+
+    return results
+
+
+def _plugin_deep_results(context: DiagnosticContext, plugin: Any) -> list[DiagnosticResult]:
+    plugin_id = _plugin_id(plugin)
+    try:
+        checks = plugin.diagnostics()
+    except Exception as exc:
+        return [
+            DiagnosticResult(
+                id=f"plugins.{plugin_id}.diagnostics",
+                category=DiagnosticCategory.PLUGIN,
+                severity=DiagnosticSeverity.ERROR,
+                message=f"Plugin diagnostics failed: {exc}",
+                fix_hint="Check the plugin diagnostics() implementation.",
+                details={"plugin": plugin_id},
+            )
+        ]
+
+    results: list[DiagnosticResult] = []
+    for check in checks:
+        try:
+            results.append(check.run(context))
+        except Exception as exc:
+            results.append(
+                DiagnosticResult(
+                    id=check.id,
+                    category=check.category,
+                    severity=DiagnosticSeverity.ERROR,
+                    message=f"Diagnostic check failed: {exc}",
+                    fix_hint="Check the plugin diagnostic check implementation.",
+                    details={"plugin": plugin_id},
+                )
+            )
+
+    return results
+
+
+def _check_audio_devices(context: DiagnosticContext) -> list[DiagnosticResult]:
+    try:
+        import sounddevice as sd  # type: ignore
+    except Exception as exc:
+        return [
+            DiagnosticResult(
+                id="audio.sounddevice",
+                category=DiagnosticCategory.AUDIO,
+                severity=DiagnosticSeverity.FATAL,
+                message=f"Unable to import sounddevice: {exc}",
+                fix_hint="Install the audio dependencies for livekit-agents.",
+            )
+        ]
+
+    checks: list[tuple[str, str | int | None, str]] = [
+        ("audio.input_device", context.input_device, "input"),
+        ("audio.output_device", context.output_device, "output"),
+    ]
+    results: list[DiagnosticResult] = []
+    for check_id, device, kind in checks:
+        if device is None:
+            continue
+        try:
+            sd.query_devices(device, kind=kind)
+        except Exception:
+            results.append(
+                DiagnosticResult(
+                    id=check_id,
+                    category=DiagnosticCategory.AUDIO,
+                    severity=DiagnosticSeverity.FATAL,
+                    message=f"Unable to access the {kind} audio device",
+                    fix_hint="Run `python your_agent.py console --list-devices` to inspect devices.",
+                    details={"device": device},
+                )
+            )
+        else:
+            results.append(
+                DiagnosticResult(
+                    id=check_id,
+                    category=DiagnosticCategory.AUDIO,
+                    severity=DiagnosticSeverity.OK,
+                    message=f"{kind.capitalize()} audio device is accessible",
+                    details={"device": device},
+                )
+            )
+
+    return results
+
+
+def _check_deployment(context: DiagnosticContext) -> list[DiagnosticResult]:
+    server = context.server
+    results: list[DiagnosticResult] = []
+    drain_timeout = getattr(server, "_drain_timeout", None)
+    if isinstance(drain_timeout, int) and drain_timeout <= 0:
+        results.append(
+            DiagnosticResult(
+                id="deployment.drain_timeout",
+                category=DiagnosticCategory.DEPLOYMENT,
+                severity=DiagnosticSeverity.WARN,
+                message="drain_timeout is disabled or non-positive",
+                fix_hint="Use a positive drain timeout so active jobs can finish during shutdown.",
+                details={"drain_timeout": drain_timeout},
+            )
+        )
+
+    prometheus_dir = getattr(server, "_prometheus_multiproc_dir", None)
+    if prometheus_dir and not os.path.isdir(prometheus_dir):
+        results.append(
+            DiagnosticResult(
+                id="deployment.prometheus_multiproc_dir",
+                category=DiagnosticCategory.DEPLOYMENT,
+                severity=DiagnosticSeverity.WARN,
+                message="Prometheus multiprocess directory does not exist yet",
+                fix_hint="Ensure the process can create and clean this directory on startup.",
+                details={"path": prometheus_dir},
+            )
+        )
+
+    return results
+
+
+def _check_livekit_tcp_connectivity(context: DiagnosticContext) -> DiagnosticResult:
+    url = _resolved_value(context, "_ws_url", "LIVEKIT_URL")
+    if not url or not _valid_ws_url(url):
+        return DiagnosticResult(
+            id="network.livekit_tcp",
+            category=DiagnosticCategory.NETWORK,
+            severity=DiagnosticSeverity.WARN,
+            message="Skipping online connectivity check because LIVEKIT_URL is missing or invalid",
+            fix_hint="Set LIVEKIT_URL to a ws:// or wss:// URL before using --online.",
+        )
+
+    parsed = urlparse(url)
+    host = parsed.hostname
+    port = parsed.port or (443 if parsed.scheme == "wss" else 80)
+    if not host:
+        return DiagnosticResult(
+            id="network.livekit_tcp",
+            category=DiagnosticCategory.NETWORK,
+            severity=DiagnosticSeverity.ERROR,
+            message="Unable to resolve a hostname from LIVEKIT_URL",
+            details={"url": _redact_url(url)},
+        )
+
+    try:
+        with socket.create_connection((host, port), timeout=3):
+            pass
+    except OSError as exc:
+        return DiagnosticResult(
+            id="network.livekit_tcp",
+            category=DiagnosticCategory.NETWORK,
+            severity=DiagnosticSeverity.ERROR,
+            message=f"Unable to open a TCP connection to {host}:{port}: {exc}",
+            fix_hint="Check network access, DNS, proxy settings, and the LiveKit URL.",
+            details={"host": host, "port": port},
+        )
+
+    return DiagnosticResult(
+        id="network.livekit_tcp",
+        category=DiagnosticCategory.NETWORK,
+        severity=DiagnosticSeverity.OK,
+        message=f"TCP connectivity to {host}:{port} succeeded",
+        details={"host": host, "port": port},
+    )
+
+
+def _resolved_value(context: DiagnosticContext, server_attr: str, env_key: str) -> str:
+    server_value = getattr(context.server, server_attr, None)
+    if server_value:
+        return str(server_value)
+    return context.env.get(env_key, "")
+
+
+def _valid_ws_url(url: str) -> bool:
+    parsed = urlparse(url)
+    return parsed.scheme in {"ws", "wss"} and bool(parsed.netloc)
+
+
+def _redact_url(url: str) -> str:
+    parsed = urlparse(url)
+    if not parsed.password:
+        return url
+    netloc = parsed.netloc.replace(parsed.password, "***")
+    return parsed._replace(netloc=netloc).geturl()
+
+
+def _plugin_id(plugin: Any) -> str:
+    package = getattr(plugin, "package", "") or getattr(plugin, "title", "")
+    return str(package or type(plugin).__name__).replace(".", "_").replace("-", "_")
+
+
+def _severity_value(severity: DiagnosticSeverity | str) -> str:
+    return severity.value if isinstance(severity, Enum) else severity
+
+
+def _category_value(category: DiagnosticCategory | str) -> str:
+    return category.value if isinstance(category, Enum) else category
+
+
+__all__ = [
+    "DiagnosticCategory",
+    "DiagnosticCheck",
+    "DiagnosticContext",
+    "DiagnosticMode",
+    "DiagnosticReport",
+    "DiagnosticResult",
+    "DiagnosticSeverity",
+    "PluginCapability",
+    "PluginDiagnosticInfo",
+    "build_diagnostics_table",
+    "collect_diagnostics",
+    "diagnostic_report_to_json",
+    "report_exit_code",
+]

--- a/livekit-agents/livekit/agents/diagnostics/__init__.py
+++ b/livekit-agents/livekit/agents/diagnostics/__init__.py
@@ -156,7 +156,7 @@ class DiagnosticReport:
         }
 
 
-_LIVEKIT_REQUIRED_MODES = {"console", "dev", "start", "connect"}
+_LIVEKIT_REQUIRED_MODES = {"dev", "start", "connect"}
 
 
 def collect_diagnostics(context: DiagnosticContext) -> DiagnosticReport:
@@ -263,7 +263,12 @@ def _check_entrypoint(context: DiagnosticContext) -> DiagnosticResult:
 
 def _check_livekit_credentials(context: DiagnosticContext) -> list[DiagnosticResult]:
     required = context.mode in _LIVEKIT_REQUIRED_MODES
-    missing_severity = DiagnosticSeverity.FATAL if required else DiagnosticSeverity.ERROR
+    if required:
+        missing_severity = DiagnosticSeverity.FATAL
+    elif context.mode == "console":
+        missing_severity = DiagnosticSeverity.WARN
+    else:
+        missing_severity = DiagnosticSeverity.ERROR
     results: list[DiagnosticResult] = []
 
     credentials = {
@@ -274,13 +279,26 @@ def _check_livekit_credentials(context: DiagnosticContext) -> list[DiagnosticRes
 
     missing = [name for name, value in credentials.items() if not value]
     if missing:
+        if context.mode == "console":
+            message = (
+                "LiveKit credentials are not configured; console mode can still run local agents"
+            )
+            fix_hint = (
+                "Set LIVEKIT_URL, LIVEKIT_API_KEY, and LIVEKIT_API_SECRET if this agent uses "
+                "LiveKit Cloud services."
+            )
+        else:
+            message = f"Missing LiveKit credential environment variables: {', '.join(missing)}"
+            fix_hint = (
+                "Set LIVEKIT_URL, LIVEKIT_API_KEY, and LIVEKIT_API_SECRET, or pass CLI options."
+            )
         results.append(
             DiagnosticResult(
                 id="livekit.credentials",
                 category=DiagnosticCategory.LIVEKIT,
                 severity=missing_severity,
-                message=f"Missing LiveKit credential environment variables: {', '.join(missing)}",
-                fix_hint="Set LIVEKIT_URL, LIVEKIT_API_KEY, and LIVEKIT_API_SECRET, or pass CLI options.",
+                message=message,
+                fix_hint=fix_hint,
                 docs_url="https://docs.livekit.io/agents/start/voice-ai/",
                 details={"missing": missing},
             )

--- a/livekit-agents/livekit/agents/diagnostics/__init__.py
+++ b/livekit-agents/livekit/agents/diagnostics/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import socket
 import sys
 from collections.abc import Callable, Mapping, Sequence
@@ -44,6 +45,7 @@ class PluginCapability(str, Enum):
     TTS = "tts"
     REALTIME = "realtime"
     VAD = "vad"
+    TURN_DETECTOR = "turn_detector"
     AVATAR = "avatar"
     NOISE_CANCELLATION = "noise_cancellation"
     UNKNOWN = "unknown"
@@ -79,7 +81,12 @@ class DiagnosticContext:
 
 @dataclass(frozen=True)
 class DiagnosticResult:
-    """Single diagnostic finding with a user-facing message and optional fix."""
+    """Single diagnostic finding with a user-facing message and optional fix.
+
+    ``details`` is included in ``doctor --json`` output. Keep it free of
+    secret values; credential-like keys are defensively redacted during
+    serialization.
+    """
 
     id: str
     category: DiagnosticCategory | str
@@ -99,7 +106,7 @@ class DiagnosticResult:
             "message": self.message,
             "fix_hint": self.fix_hint,
             "docs_url": self.docs_url,
-            "details": dict(self.details),
+            "details": _redact_details(self.details),
         }
 
 
@@ -121,6 +128,7 @@ class DiagnosticReport:
     strict: bool = False
     online: bool = False
     deep: bool = False
+    plugins: Sequence[Mapping[str, Any]] = ()
 
     def to_dict(self) -> dict[str, Any]:
         result_dicts = [result.to_dict() for result in self.results]
@@ -130,13 +138,6 @@ class DiagnosticReport:
             )
             for severity in DiagnosticSeverity
         }
-        plugins: list[dict[str, Any]] = []
-        for result in self.results:
-            if result.id == "plugins.registered":
-                raw_plugins = result.details.get("plugins", [])
-                if isinstance(raw_plugins, list):
-                    plugins = [plugin for plugin in raw_plugins if isinstance(plugin, dict)]
-                break
 
         return {
             "schema_version": 1,
@@ -152,7 +153,7 @@ class DiagnosticReport:
                 "fatal": counts[DiagnosticSeverity.FATAL.value],
                 "exit_code": report_exit_code(self),
             },
-            "plugins": plugins,
+            "plugins": [dict(plugin) for plugin in self.plugins],
             "results": result_dicts,
         }
 
@@ -179,6 +180,7 @@ def collect_diagnostics(context: DiagnosticContext) -> DiagnosticReport:
 
     return DiagnosticReport(
         results=results,
+        plugins=_registered_plugin_summaries(context.registered_plugins),
         mode=context.mode,
         strict=context.strict,
         online=context.online,
@@ -221,22 +223,31 @@ def build_diagnostics_table(report: DiagnosticReport) -> Table:
 
 def _check_python_version() -> DiagnosticResult:
     version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
-    supported = (3, 10) <= sys.version_info[:2] < (3, 15)
-    if supported:
+    if sys.version_info[:2] < (3, 10):  # noqa: UP036 - diagnostics reports stale runtimes.
         return DiagnosticResult(
             id="python.version",
             category=DiagnosticCategory.ENVIRONMENT,
-            severity=DiagnosticSeverity.OK,
-            message=f"Python {version} is supported",
+            severity=DiagnosticSeverity.FATAL,
+            message=f"Python {version} is below the supported range >=3.10",
+            fix_hint="Use Python 3.10 or newer.",
+            details={"version": version},
+        )
+
+    if sys.version_info[:2] >= (3, 15):
+        return DiagnosticResult(
+            id="python.version",
+            category=DiagnosticCategory.ENVIRONMENT,
+            severity=DiagnosticSeverity.WARN,
+            message=f"Python {version} is newer than the currently tested range",
+            fix_hint="Use Python 3.10, 3.11, 3.12, 3.13, or 3.14 if you hit runtime issues.",
             details={"version": version},
         )
 
     return DiagnosticResult(
         id="python.version",
         category=DiagnosticCategory.ENVIRONMENT,
-        severity=DiagnosticSeverity.FATAL,
-        message=f"Python {version} is outside the supported range >=3.10,<3.15",
-        fix_hint="Use Python 3.10, 3.11, 3.12, 3.13, or 3.14.",
+        severity=DiagnosticSeverity.OK,
+        message=f"Python {version} is supported",
         details={"version": version},
     )
 
@@ -348,16 +359,7 @@ def _check_plugins(context: DiagnosticContext) -> list[DiagnosticResult]:
             category=DiagnosticCategory.PLUGIN,
             severity=DiagnosticSeverity.OK,
             message=f"{len(context.registered_plugins)} plugin(s) registered",
-            details={
-                "plugins": [
-                    {
-                        "title": getattr(plugin, "title", type(plugin).__name__),
-                        "version": getattr(plugin, "version", ""),
-                        "package": getattr(plugin, "package", ""),
-                    }
-                    for plugin in context.registered_plugins
-                ]
-            },
+            details={"plugins": _registered_plugin_summaries(context.registered_plugins)},
         )
     ]
 
@@ -537,7 +539,7 @@ def _check_deployment(context: DiagnosticContext) -> list[DiagnosticResult]:
     server = context.server
     results: list[DiagnosticResult] = []
     drain_timeout = getattr(server, "_drain_timeout", None)
-    if isinstance(drain_timeout, int) and drain_timeout <= 0:
+    if drain_timeout is not None and drain_timeout <= 0:
         results.append(
             DiagnosticResult(
                 id="deployment.drain_timeout",
@@ -563,6 +565,17 @@ def _check_deployment(context: DiagnosticContext) -> list[DiagnosticResult]:
         )
 
     return results
+
+
+def _registered_plugin_summaries(plugins: Sequence[Any]) -> list[dict[str, Any]]:
+    return [
+        {
+            "title": getattr(plugin, "title", type(plugin).__name__),
+            "version": getattr(plugin, "version", ""),
+            "package": getattr(plugin, "package", ""),
+        }
+        for plugin in plugins
+    ]
 
 
 def _check_livekit_tcp_connectivity(context: DiagnosticContext) -> DiagnosticResult:
@@ -611,7 +624,7 @@ def _check_livekit_tcp_connectivity(context: DiagnosticContext) -> DiagnosticRes
 
 
 def _resolved_value(context: DiagnosticContext, server_attr: str, env_key: str) -> str:
-    server_value = getattr(context.server, server_attr, None)
+    server_value = getattr(context.server, server_attr) if context.server is not None else None
     if server_value:
         return str(server_value)
     return context.env.get(env_key, "")
@@ -624,10 +637,43 @@ def _valid_ws_url(url: str) -> bool:
 
 def _redact_url(url: str) -> str:
     parsed = urlparse(url)
-    if not parsed.password:
+    if not parsed.username and not parsed.password:
         return url
-    netloc = parsed.netloc.replace(parsed.password, "***")
+
+    host = parsed.hostname or ""
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+
+    if parsed.port is not None:
+        host = f"{host}:{parsed.port}"
+
+    netloc = f"***:***@{host}"
     return parsed._replace(netloc=netloc).geturl()
+
+
+_SECRET_DETAIL_KEY_RE = re.compile(
+    r"(api[_-]?key|secret|token|password|credential|authorization|passphrase|bearer|connection[_-]?string)",
+    re.IGNORECASE,
+)
+
+
+def _redact_details(value: Any, *, key: str = "") -> Any:
+    if key and _SECRET_DETAIL_KEY_RE.search(key):
+        return "***"
+
+    if isinstance(value, Mapping):
+        return {
+            str(item_key): _redact_details(item_value, key=str(item_key))
+            for item_key, item_value in value.items()
+        }
+
+    if isinstance(value, list):
+        return [_redact_details(item) for item in value]
+
+    if isinstance(value, tuple):
+        return [_redact_details(item) for item in value]
+
+    return value
 
 
 def _plugin_id(plugin: Any) -> str:

--- a/livekit-agents/livekit/agents/plugin.py
+++ b/livekit-agents/livekit/agents/plugin.py
@@ -6,6 +6,7 @@ from abc import ABC
 from typing import Literal
 
 from . import utils
+from .diagnostics import DiagnosticCheck, PluginDiagnosticInfo
 
 EventTypes = Literal["plugin_registered",]
 
@@ -38,6 +39,18 @@ class Plugin(ABC):  # noqa: B024
     # plugin can implement an optional download_files method
     def download_files(self) -> None:  # noqa: B027
         pass
+
+    # plugin can implement optional diagnostic metadata for first-run checks
+    def diagnostic_info(self) -> PluginDiagnosticInfo | None:  # noqa: B027
+        """Return static first-run diagnostic metadata for this plugin."""
+
+        return None
+
+    # plugin can implement optional safe deep diagnostic checks
+    def diagnostics(self) -> list[DiagnosticCheck]:  # noqa: B027
+        """Return side-effect-safe deep diagnostic checks for this plugin."""
+
+        return []
 
     @property
     def package(self) -> str:

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/__init__.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/__init__.py
@@ -24,6 +24,7 @@ from .version import __version__
 __all__ = ["STT", "TTS", "ChunkedStream", "__version__"]
 
 from livekit.agents import Plugin
+from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
 
 from .log import logger
 
@@ -31,6 +32,13 @@ from .log import logger
 class CartesiaPlugin(Plugin):
     def __init__(self) -> None:
         super().__init__(__name__, __version__, __package__, logger)
+
+    def diagnostic_info(self) -> PluginDiagnosticInfo:
+        return PluginDiagnosticInfo(
+            capabilities=[PluginCapability.STT, PluginCapability.TTS],
+            required_env_vars=["CARTESIA_API_KEY"],
+            docs_url="https://docs.livekit.io/agents/integrations/tts/cartesia/",
+        )
 
 
 Plugin.register_plugin(CartesiaPlugin())

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/__init__.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/__init__.py
@@ -17,6 +17,8 @@
 See https://docs.livekit.io/agents/integrations/tts/cartesia/ for more information.
 """
 
+from typing import TYPE_CHECKING
+
 from .stt import STT
 from .tts import TTS, ChunkedStream
 from .version import __version__
@@ -24,16 +26,20 @@ from .version import __version__
 __all__ = ["STT", "TTS", "ChunkedStream", "__version__"]
 
 from livekit.agents import Plugin
-from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
 
 from .log import logger
+
+if TYPE_CHECKING:
+    from livekit.agents.diagnostics import PluginDiagnosticInfo
 
 
 class CartesiaPlugin(Plugin):
     def __init__(self) -> None:
         super().__init__(__name__, __version__, __package__, logger)
 
-    def diagnostic_info(self) -> PluginDiagnosticInfo:
+    def diagnostic_info(self) -> "PluginDiagnosticInfo":
+        from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
+
         return PluginDiagnosticInfo(
             capabilities=[PluginCapability.STT, PluginCapability.TTS],
             required_env_vars=["CARTESIA_API_KEY"],

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/__init__.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/__init__.py
@@ -19,6 +19,8 @@ Support for speech-to-text with [Deepgram](https://deepgram.com/).
 See https://docs.livekit.io/agents/integrations/stt/deepgram/ for more information.
 """
 
+from typing import TYPE_CHECKING
+
 from .stt import STT, SpeechStream
 from .stt_v2 import SpeechStreamv2, STTv2
 from .tts import TTS
@@ -28,16 +30,20 @@ __all__ = ["STT", "SpeechStream", "STTv2", "SpeechStreamv2", "__version__", "TTS
 
 
 from livekit.agents import Plugin
-from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
 
 from .log import logger
+
+if TYPE_CHECKING:
+    from livekit.agents.diagnostics import PluginDiagnosticInfo
 
 
 class DeepgramPlugin(Plugin):
     def __init__(self) -> None:
         super().__init__(__name__, __version__, __package__, logger)
 
-    def diagnostic_info(self) -> PluginDiagnosticInfo:
+    def diagnostic_info(self) -> "PluginDiagnosticInfo":
+        from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
+
         return PluginDiagnosticInfo(
             capabilities=[PluginCapability.STT, PluginCapability.TTS],
             required_env_vars=["DEEPGRAM_API_KEY"],

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/__init__.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/__init__.py
@@ -28,6 +28,7 @@ __all__ = ["STT", "SpeechStream", "STTv2", "SpeechStreamv2", "__version__", "TTS
 
 
 from livekit.agents import Plugin
+from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
 
 from .log import logger
 
@@ -35,6 +36,13 @@ from .log import logger
 class DeepgramPlugin(Plugin):
     def __init__(self) -> None:
         super().__init__(__name__, __version__, __package__, logger)
+
+    def diagnostic_info(self) -> PluginDiagnosticInfo:
+        return PluginDiagnosticInfo(
+            capabilities=[PluginCapability.STT, PluginCapability.TTS],
+            required_env_vars=["DEEPGRAM_API_KEY"],
+            docs_url="https://docs.livekit.io/agents/integrations/stt/deepgram/",
+        )
 
 
 Plugin.register_plugin(DeepgramPlugin())

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/__init__.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/__init__.py
@@ -17,6 +17,8 @@
 See https://docs.livekit.io/agents/integrations/tts/elevenlabs/ for more information.
 """
 
+from typing import TYPE_CHECKING
+
 from .models import STTRealtimeSampleRates, TTSEncoding, TTSModels
 from .stt import STT, SpeechStream
 from .tts import DEFAULT_VOICE_ID, TTS, PronunciationDictionaryLocator, Voice, VoiceSettings
@@ -37,16 +39,20 @@ __all__ = [
 ]
 
 from livekit.agents import Plugin
-from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
 
 from .log import logger
+
+if TYPE_CHECKING:
+    from livekit.agents.diagnostics import PluginDiagnosticInfo
 
 
 class ElevenLabsPlugin(Plugin):
     def __init__(self) -> None:
         super().__init__(__name__, __version__, __package__, logger)
 
-    def diagnostic_info(self) -> PluginDiagnosticInfo:
+    def diagnostic_info(self) -> "PluginDiagnosticInfo":
+        from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
+
         return PluginDiagnosticInfo(
             capabilities=[PluginCapability.STT, PluginCapability.TTS],
             required_env_vars=["ELEVEN_API_KEY"],

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/__init__.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/__init__.py
@@ -37,6 +37,7 @@ __all__ = [
 ]
 
 from livekit.agents import Plugin
+from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
 
 from .log import logger
 
@@ -44,6 +45,13 @@ from .log import logger
 class ElevenLabsPlugin(Plugin):
     def __init__(self) -> None:
         super().__init__(__name__, __version__, __package__, logger)
+
+    def diagnostic_info(self) -> PluginDiagnosticInfo:
+        return PluginDiagnosticInfo(
+            capabilities=[PluginCapability.STT, PluginCapability.TTS],
+            required_env_vars=["ELEVEN_API_KEY"],
+            docs_url="https://docs.livekit.io/agents/integrations/tts/elevenlabs/",
+        )
 
 
 Plugin.register_plugin(ElevenLabsPlugin())

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
@@ -23,6 +23,8 @@ See https://docs.livekit.io/agents/integrations/openai/ and
 https://docs.livekit.io/agents/integrations/llm/ for more information.
 """
 
+from typing import TYPE_CHECKING
+
 from . import realtime, responses, tools
 from .embeddings import EmbeddingData, create_embeddings
 from .llm import LLM, LLMStream
@@ -56,16 +58,20 @@ __all__ = [
 ]
 
 from livekit.agents import Plugin
-from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
 
 from .log import logger
+
+if TYPE_CHECKING:
+    from livekit.agents.diagnostics import PluginDiagnosticInfo
 
 
 class OpenAIPlugin(Plugin):
     def __init__(self) -> None:
         super().__init__(__name__, __version__, __package__, logger)
 
-    def diagnostic_info(self) -> PluginDiagnosticInfo:
+    def diagnostic_info(self) -> "PluginDiagnosticInfo":
+        from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
+
         return PluginDiagnosticInfo(
             capabilities=[
                 PluginCapability.LLM,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
 ]
 
 from livekit.agents import Plugin
+from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
 
 from .log import logger
 
@@ -63,6 +64,25 @@ from .log import logger
 class OpenAIPlugin(Plugin):
     def __init__(self) -> None:
         super().__init__(__name__, __version__, __package__, logger)
+
+    def diagnostic_info(self) -> PluginDiagnosticInfo:
+        return PluginDiagnosticInfo(
+            capabilities=[
+                PluginCapability.LLM,
+                PluginCapability.STT,
+                PluginCapability.TTS,
+                PluginCapability.REALTIME,
+            ],
+            required_env_vars=["OPENAI_API_KEY"],
+            optional_env_vars=[
+                "OPENAI_ORG_ID",
+                "OPENAI_PROJECT_ID",
+                "AZURE_OPENAI_API_KEY",
+                "AZURE_OPENAI_ENDPOINT",
+                "OPENAI_API_VERSION",
+            ],
+            docs_url="https://docs.livekit.io/agents/integrations/openai/",
+        )
 
 
 Plugin.register_plugin(OpenAIPlugin())

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/__init__.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/__init__.py
@@ -17,22 +17,28 @@
 See https://docs.livekit.io/agents/build/turns/vad/ for more information.
 """
 
+from typing import TYPE_CHECKING
+
 from .vad import VAD, VADStream
 from .version import __version__
 
 __all__ = ["VAD", "VADStream", "__version__"]
 
 from livekit.agents import Plugin
-from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
 
 from .log import logger
+
+if TYPE_CHECKING:
+    from livekit.agents.diagnostics import PluginDiagnosticInfo
 
 
 class SileroPlugin(Plugin):
     def __init__(self) -> None:
         super().__init__(__name__, __version__, __package__, logger)
 
-    def diagnostic_info(self) -> PluginDiagnosticInfo:
+    def diagnostic_info(self) -> "PluginDiagnosticInfo":
+        from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
+
         return PluginDiagnosticInfo(
             capabilities=[PluginCapability.VAD],
             downloadable_files=["Silero VAD model"],

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/__init__.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/__init__.py
@@ -23,6 +23,7 @@ from .version import __version__
 __all__ = ["VAD", "VADStream", "__version__"]
 
 from livekit.agents import Plugin
+from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
 
 from .log import logger
 
@@ -30,6 +31,13 @@ from .log import logger
 class SileroPlugin(Plugin):
     def __init__(self) -> None:
         super().__init__(__name__, __version__, __package__, logger)
+
+    def diagnostic_info(self) -> PluginDiagnosticInfo:
+        return PluginDiagnosticInfo(
+            capabilities=[PluginCapability.VAD],
+            downloadable_files=["Silero VAD model"],
+            docs_url="https://docs.livekit.io/agents/build/turns/vad/",
+        )
 
 
 Plugin.register_plugin(SileroPlugin())

--- a/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/base.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/base.py
@@ -8,12 +8,11 @@ import re
 import time
 import unicodedata
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from huggingface_hub import errors
 
 from livekit.agents import LanguageCode, Plugin, llm
-from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
 from livekit.agents.inference_runner import _InferenceRunner
 from livekit.agents.ipc.inference_executor import InferenceExecutor
 from livekit.agents.job import get_job_context
@@ -25,6 +24,9 @@ from .version import __version__
 
 MAX_HISTORY_TOKENS = 128
 MAX_HISTORY_TURNS = 6
+
+if TYPE_CHECKING:
+    from livekit.agents.diagnostics import PluginDiagnosticInfo
 
 
 def _download_from_hf_hub(repo_id: str, filename: str, **kwargs: Any) -> str:
@@ -198,8 +200,10 @@ class EOUPlugin(Plugin):
         self._runner_class._download_files()
 
     def diagnostic_info(self) -> PluginDiagnosticInfo:
+        from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
+
         return PluginDiagnosticInfo(
-            capabilities=[PluginCapability.VAD],
+            capabilities=[PluginCapability.TURN_DETECTOR],
             downloadable_files=["LiveKit turn detector model"],
             docs_url="https://docs.livekit.io/agents/build/turns/turn-detector/",
         )

--- a/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/base.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/base.py
@@ -13,6 +13,7 @@ from typing import Any
 from huggingface_hub import errors
 
 from livekit.agents import LanguageCode, Plugin, llm
+from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
 from livekit.agents.inference_runner import _InferenceRunner
 from livekit.agents.ipc.inference_executor import InferenceExecutor
 from livekit.agents.job import get_job_context
@@ -195,6 +196,13 @@ class EOUPlugin(Plugin):
 
     def download_files(self) -> None:
         self._runner_class._download_files()
+
+    def diagnostic_info(self) -> PluginDiagnosticInfo:
+        return PluginDiagnosticInfo(
+            capabilities=[PluginCapability.VAD],
+            downloadable_files=["LiveKit turn detector model"],
+            docs_url="https://docs.livekit.io/agents/build/turns/turn-detector/",
+        )
 
 
 class EOUModelBase(ABC):

--- a/makefile
+++ b/makefile
@@ -89,9 +89,12 @@ unit-tests:
 		tests/test_aio.py \
 		tests/test_audio_decoder.py \
 		tests/test_chat_ctx.py \
+		tests/test_cli_doctor.py \
 		tests/test_config.py \
 		tests/test_connection_pool.py \
 		tests/test_debounce.py \
+		tests/test_plugin_diagnostics.py \
+		tests/test_plugin_diagnostic_metadata.py \
 		tests/test_google_thought_signatures.py \
 		tests/test_inference_stt_fallback.py \
 		tests/test_inference_tts_fallback.py \

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
+import asyncio
 import builtins
 import json
 from collections.abc import Iterator
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 import typer
 from typer.testing import CliRunner
 
-from livekit.agents.cli.cli import _apply_cli_server_options, _build_cli, _run_preflight
+from livekit.agents.cli.cli import (
+    _apply_cli_server_options,
+    _build_cli,
+    _ExitCli,
+    _resolved_livekit_api_options,
+    _run_preflight,
+)
 from livekit.agents.diagnostics import (
     DiagnosticCategory,
     DiagnosticCheck,
@@ -215,6 +224,27 @@ def test_doctor_online_runs_safe_livekit_tcp_check(
     )
 
 
+def test_doctor_online_reports_livekit_tcp_failure(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def create_connection(address: tuple[str, int], timeout: float) -> object:
+        raise OSError("network unreachable")
+
+    monkeypatch.setattr(
+        "livekit.agents.diagnostics.socket.create_connection",
+        create_connection,
+    )
+    app = _build_cli(_make_server())
+
+    result = runner.invoke(app, ["doctor", "--online", "--json"], env=_valid_env())
+
+    assert result.exit_code == 1
+    report = json.loads(result.output)
+    tcp_result = next(item for item in report["results"] if item["id"] == "network.livekit_tcp")
+    assert tcp_result["severity"] == "error"
+    assert tcp_result["details"] == {"host": "diagnostics-test.livekit.cloud", "port": 443}
+
+
 def test_doctor_deep_runs_plugin_declared_checks(runner: CliRunner) -> None:
     Plugin.register_plugin(DeepCheckPlugin())
     app = _build_cli(_make_server())
@@ -288,3 +318,81 @@ def test_cli_server_options_ignore_empty_strings() -> None:
     assert server._ws_url == "wss://configured.livekit.cloud"
     assert server._api_key == "configured-key"
     assert server._api_secret == "configured-secret"
+
+
+def test_cli_server_options_override_constructor_values() -> None:
+    server = AgentServer(
+        ws_url="wss://constructor.livekit.cloud",
+        api_key="constructor-key",
+        api_secret="constructor-secret",
+    )
+
+    _apply_cli_server_options(
+        server,
+        url="wss://cli.livekit.cloud",
+        api_key="cli-key",
+        api_secret="cli-secret",
+    )
+
+    assert server._ws_url == "wss://cli.livekit.cloud"
+    assert server._api_key == "cli-key"
+    assert server._api_secret == "cli-secret"
+
+
+def test_resolved_livekit_api_options_prefers_cli_values() -> None:
+    server = AgentServer(
+        ws_url="wss://constructor.livekit.cloud",
+        api_key="constructor-key",
+        api_secret="constructor-secret",
+    )
+
+    assert _resolved_livekit_api_options(
+        server,
+        url="wss://cli.livekit.cloud",
+        api_key="cli-key",
+        api_secret="cli-secret",
+    ) == ("wss://cli.livekit.cloud", "cli-key", "cli-secret")
+
+
+def test_connect_uses_env_credentials_for_livekit_api(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    server = _make_server()
+    captured: dict[str, str] = {}
+
+    class _Rooms:
+        async def list_rooms(self, request: object) -> SimpleNamespace:
+            return SimpleNamespace(rooms=[SimpleNamespace(name="room")])
+
+    class _LiveKitAPI:
+        def __init__(self, url: str, api_key: str, api_secret: str) -> None:
+            captured["url"] = url
+            captured["api_key"] = api_key
+            captured["api_secret"] = api_secret
+            self.room = _Rooms()
+
+        async def __aenter__(self) -> _LiveKitAPI:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+    async def run(*, devmode: bool, unregistered: bool) -> None:
+        server.emit("worker_started")
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        raise _ExitCli()
+
+    monkeypatch.setattr("livekit.agents.cli.cli.api.LiveKitAPI", _LiveKitAPI)
+    monkeypatch.setattr(server, "run", run)
+    monkeypatch.setattr(server, "simulate_job", AsyncMock())
+    app = _build_cli(server)
+
+    result = runner.invoke(app, ["connect", "--room", "test-room"], env=_valid_env())
+
+    assert result.exit_code == 0
+    assert captured == {
+        "url": "wss://diagnostics-test.livekit.cloud",
+        "api_key": "api-key",
+        "api_secret": "api-secret",
+    }

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from livekit.agents.cli.cli import _build_cli
+from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
+from livekit.agents.plugin import Plugin
+from livekit.agents.worker import AgentServer
+
+
+async def _entrypoint(ctx: Any) -> None:
+    pass
+
+
+def _make_server(*, registered: bool = True) -> AgentServer:
+    server = AgentServer()
+    if registered:
+        server.rtc_session(_entrypoint)
+    return server
+
+
+class MissingEnvPlugin(Plugin):
+    def __init__(self) -> None:
+        super().__init__(
+            title="Missing Env Plugin",
+            version="1.2.3",
+            package="livekit.plugins.missing_env",
+        )
+
+    def diagnostic_info(self) -> PluginDiagnosticInfo:
+        return PluginDiagnosticInfo(
+            capabilities=[PluginCapability.STT],
+            required_env_vars=["MISSING_ENV_PLUGIN_API_KEY"],
+        )
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def restore_plugins() -> Iterator[None]:
+    previous = list(Plugin.registered_plugins)
+    Plugin.registered_plugins.clear()
+    yield
+    Plugin.registered_plugins[:] = previous
+
+
+@pytest.fixture(autouse=True)
+def clear_livekit_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ("LIVEKIT_URL", "LIVEKIT_API_KEY", "LIVEKIT_API_SECRET"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _valid_env() -> dict[str, str]:
+    return {
+        "LIVEKIT_URL": "wss://diagnostics-test.livekit.cloud",
+        "LIVEKIT_API_KEY": "api-key",
+        "LIVEKIT_API_SECRET": "api-secret",
+    }
+
+
+def test_doctor_reports_missing_env(runner: CliRunner) -> None:
+    app = _build_cli(_make_server())
+
+    result = runner.invoke(app, ["doctor", "--json"], env={})
+
+    assert result.exit_code == 1
+    report = json.loads(result.output)
+    assert any(
+        result["id"] == "livekit.credentials"
+        and set(result["details"]["missing"])
+        == {"LIVEKIT_URL", "LIVEKIT_API_KEY", "LIVEKIT_API_SECRET"}
+        for result in report["results"]
+    )
+
+
+def test_doctor_reports_invalid_url(runner: CliRunner) -> None:
+    app = _build_cli(_make_server())
+
+    result = runner.invoke(
+        app,
+        ["doctor", "--json"],
+        env={
+            **_valid_env(),
+            "LIVEKIT_URL": "not-a-url",
+        },
+    )
+
+    assert result.exit_code == 1
+    report = json.loads(result.output)
+    assert any(
+        result["id"] == "livekit.url"
+        and result["severity"] == "error"
+        and "ws:// or wss://" in result["message"]
+        for result in report["results"]
+    )
+
+
+def test_doctor_reports_unregistered_entrypoint(runner: CliRunner) -> None:
+    app = _build_cli(_make_server(registered=False))
+
+    result = runner.invoke(app, ["doctor"], env=_valid_env())
+
+    assert result.exit_code == 1
+    assert "entrypoint" in result.output.lower()
+    assert "registered" in result.output.lower()
+
+
+def test_doctor_json_outputs_report_schema_and_success_exit_code(runner: CliRunner) -> None:
+    app = _build_cli(_make_server())
+
+    result = runner.invoke(app, ["doctor", "--json"], env=_valid_env())
+
+    assert result.exit_code == 0
+    report = json.loads(result.output)
+    assert report["schema_version"] == 1
+    assert report["mode"] == "doctor"
+    assert report["exit_code"] == 0
+    assert report["summary"]["errors"] == 0
+    assert isinstance(report["plugins"], list)
+    assert isinstance(report["results"], list)
+    assert all("id" in result for result in report["results"])
+
+
+def test_doctor_strict_treats_warnings_as_failures(runner: CliRunner) -> None:
+    Plugin.register_plugin(MissingEnvPlugin())
+    app = _build_cli(_make_server())
+
+    non_strict = runner.invoke(app, ["doctor"], env=_valid_env())
+    strict = runner.invoke(app, ["doctor", "--strict"], env=_valid_env())
+
+    assert non_strict.exit_code == 0
+    assert strict.exit_code == 1
+    assert "plugin" in strict.output

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,14 +1,24 @@
 from __future__ import annotations
 
+import builtins
 import json
 from collections.abc import Iterator
 from typing import Any
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
-from livekit.agents.cli.cli import _build_cli
-from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
+from livekit.agents.cli.cli import _apply_cli_server_options, _build_cli, _run_preflight
+from livekit.agents.diagnostics import (
+    DiagnosticCategory,
+    DiagnosticCheck,
+    DiagnosticContext,
+    DiagnosticResult,
+    DiagnosticSeverity,
+    PluginCapability,
+    PluginDiagnosticInfo,
+)
 from livekit.agents.plugin import Plugin
 from livekit.agents.worker import AgentServer
 
@@ -37,6 +47,37 @@ class MissingEnvPlugin(Plugin):
             capabilities=[PluginCapability.STT],
             required_env_vars=["MISSING_ENV_PLUGIN_API_KEY"],
         )
+
+
+class DeepCheckPlugin(Plugin):
+    def __init__(self) -> None:
+        super().__init__(
+            title="Deep Check Plugin",
+            version="1.2.3",
+            package="livekit.plugins.deep_check",
+        )
+
+    def diagnostic_info(self) -> PluginDiagnosticInfo:
+        return PluginDiagnosticInfo()
+
+    def diagnostics(self) -> list[DiagnosticCheck]:
+        def run(ctx: DiagnosticContext) -> DiagnosticResult:
+            assert ctx.deep
+            return DiagnosticResult(
+                id="plugins.deep_check.self_test",
+                category=DiagnosticCategory.PLUGIN,
+                severity=DiagnosticSeverity.OK,
+                message="deep check ran",
+                details={"plugin": self.package},
+            )
+
+        return [
+            DiagnosticCheck(
+                id="plugins.deep_check.self_test",
+                category=DiagnosticCategory.PLUGIN,
+                run=run,
+            )
+        ]
 
 
 @pytest.fixture
@@ -139,3 +180,111 @@ def test_doctor_strict_treats_warnings_as_failures(runner: CliRunner) -> None:
     assert non_strict.exit_code == 0
     assert strict.exit_code == 1
     assert "plugin" in strict.output
+
+
+def test_doctor_online_runs_safe_livekit_tcp_check(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _Socket:
+        def __enter__(self) -> _Socket:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    calls: list[tuple[tuple[str, int], float]] = []
+
+    def create_connection(address: tuple[str, int], timeout: float) -> _Socket:
+        calls.append((address, timeout))
+        return _Socket()
+
+    monkeypatch.setattr(
+        "livekit.agents.diagnostics.socket.create_connection",
+        create_connection,
+    )
+    app = _build_cli(_make_server())
+
+    result = runner.invoke(app, ["doctor", "--online", "--json"], env=_valid_env())
+
+    assert result.exit_code == 0
+    assert calls == [(("diagnostics-test.livekit.cloud", 443), 3)]
+    report = json.loads(result.output)
+    assert any(
+        item["id"] == "network.livekit_tcp" and item["severity"] == "ok"
+        for item in report["results"]
+    )
+
+
+def test_doctor_deep_runs_plugin_declared_checks(runner: CliRunner) -> None:
+    Plugin.register_plugin(DeepCheckPlugin())
+    app = _build_cli(_make_server())
+
+    result = runner.invoke(app, ["doctor", "--deep", "--json"], env=_valid_env())
+
+    assert result.exit_code == 0
+    report = json.loads(result.output)
+    assert any(
+        item["id"] == "plugins.deep_check.self_test" and item["severity"] == "ok"
+        for item in report["results"]
+    )
+
+
+def test_preflight_text_console_skips_audio_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name, value in _valid_env().items():
+        monkeypatch.setenv(name, value)
+
+    original_import = builtins.__import__
+
+    def import_guard(name: str, *args: object, **kwargs: object) -> object:
+        if name == "sounddevice":
+            raise AssertionError("text console preflight should not import sounddevice")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_guard)
+
+    _run_preflight(
+        server=_make_server(),
+        mode="console",
+        console=None,
+        console_audio=False,
+    )
+
+
+def test_preflight_audio_console_blocks_missing_sounddevice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name, value in _valid_env().items():
+        monkeypatch.setenv(name, value)
+
+    original_import = builtins.__import__
+
+    def import_guard(name: str, *args: object, **kwargs: object) -> object:
+        if name == "sounddevice":
+            raise ImportError("missing sounddevice")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_guard)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        _run_preflight(
+            server=_make_server(),
+            mode="console",
+            console=None,
+            console_audio=True,
+        )
+
+    assert exc_info.value.exit_code == 1
+
+
+def test_cli_server_options_ignore_empty_strings() -> None:
+    server = AgentServer(
+        ws_url="wss://configured.livekit.cloud",
+        api_key="configured-key",
+        api_secret="configured-secret",
+    )
+
+    _apply_cli_server_options(server, url="", api_key="", api_secret="")
+
+    assert server._ws_url == "wss://configured.livekit.cloud"
+    assert server._api_key == "configured-key"
+    assert server._api_secret == "configured-secret"

--- a/tests/test_drain_timeout.py
+++ b/tests/test_drain_timeout.py
@@ -27,11 +27,21 @@ from livekit.agents.ipc.supervised_proc import SupervisedProc
 from livekit.agents.utils import aio
 from livekit.agents.worker import AgentServer
 
-_CLI_ARGS = CliArgs(log_level="ERROR", url=None, api_key=None, api_secret=None)
+_CLI_ARGS = CliArgs(
+    log_level="ERROR",
+    url="wss://diagnostics-test.livekit.cloud",
+    api_key="api-key",
+    api_secret="api-secret",
+)
+
+
+async def _entrypoint(ctx: object) -> None:
+    pass
 
 
 def _make_server(drain_timeout: int = 1) -> AgentServer:
     server = AgentServer(drain_timeout=drain_timeout)
+    server.rtc_session(_entrypoint)
     return server
 
 

--- a/tests/test_plugin_diagnostic_metadata.py
+++ b/tests/test_plugin_diagnostic_metadata.py
@@ -83,7 +83,7 @@ def test_local_model_plugin_diagnostic_metadata() -> None:
     turn_detector_info = base.EOUPlugin(english._EUORunnerEn).diagnostic_info()
 
     assert turn_detector_info.required_env_vars == ()
-    assert set(turn_detector_info.capabilities) == {PluginCapability.VAD}
+    assert set(turn_detector_info.capabilities) == {PluginCapability.TURN_DETECTOR}
     assert turn_detector_info.downloadable_files == ["LiveKit turn detector model"]
     assert (
         turn_detector_info.docs_url == "https://docs.livekit.io/agents/build/turns/turn-detector/"

--- a/tests/test_plugin_diagnostic_metadata.py
+++ b/tests/test_plugin_diagnostic_metadata.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import importlib
+from collections.abc import Iterator
+
+import pytest
+
+from livekit.agents.diagnostics import PluginCapability, PluginDiagnosticInfo
+from livekit.agents.plugin import Plugin
+
+
+@pytest.fixture(autouse=True)
+def restore_plugins() -> Iterator[None]:
+    previous = list(Plugin.registered_plugins)
+    yield
+    Plugin.registered_plugins[:] = previous
+
+
+def _plugin_info(module_name: str, class_name: str) -> PluginDiagnosticInfo:
+    module = importlib.import_module(module_name)
+    plugin = getattr(module, class_name)()
+    info = plugin.diagnostic_info()
+    assert info is not None
+    return info
+
+
+def test_provider_plugin_diagnostic_metadata() -> None:
+    cases = [
+        (
+            "livekit.plugins.openai",
+            "OpenAIPlugin",
+            {"OPENAI_API_KEY"},
+            {
+                PluginCapability.LLM,
+                PluginCapability.STT,
+                PluginCapability.TTS,
+                PluginCapability.REALTIME,
+            },
+        ),
+        (
+            "livekit.plugins.deepgram",
+            "DeepgramPlugin",
+            {"DEEPGRAM_API_KEY"},
+            {PluginCapability.STT, PluginCapability.TTS},
+        ),
+        (
+            "livekit.plugins.cartesia",
+            "CartesiaPlugin",
+            {"CARTESIA_API_KEY"},
+            {PluginCapability.STT, PluginCapability.TTS},
+        ),
+        (
+            "livekit.plugins.elevenlabs",
+            "ElevenLabsPlugin",
+            {"ELEVEN_API_KEY"},
+            {PluginCapability.STT, PluginCapability.TTS},
+        ),
+    ]
+
+    for module_name, class_name, required_env_vars, capabilities in cases:
+        info = _plugin_info(module_name, class_name)
+
+        assert set(info.required_env_vars) == required_env_vars
+        assert set(info.capabilities) == capabilities
+        assert not info.downloadable_files
+        assert info.docs_url is not None
+        assert info.docs_url.startswith("https://docs.livekit.io/")
+
+    openai_info = _plugin_info("livekit.plugins.openai", "OpenAIPlugin")
+    assert "AZURE_OPENAI_API_KEY" in openai_info.optional_env_vars
+
+
+def test_local_model_plugin_diagnostic_metadata() -> None:
+    silero_info = _plugin_info("livekit.plugins.silero", "SileroPlugin")
+
+    assert silero_info.required_env_vars == ()
+    assert set(silero_info.capabilities) == {PluginCapability.VAD}
+    assert silero_info.downloadable_files == ["Silero VAD model"]
+    assert silero_info.docs_url == "https://docs.livekit.io/agents/build/turns/vad/"
+
+    english = importlib.import_module("livekit.plugins.turn_detector.english")
+    base = importlib.import_module("livekit.plugins.turn_detector.base")
+    turn_detector_info = base.EOUPlugin(english._EUORunnerEn).diagnostic_info()
+
+    assert turn_detector_info.required_env_vars == ()
+    assert set(turn_detector_info.capabilities) == {PluginCapability.VAD}
+    assert turn_detector_info.downloadable_files == ["LiveKit turn detector model"]
+    assert (
+        turn_detector_info.docs_url == "https://docs.livekit.io/agents/build/turns/turn-detector/"
+    )

--- a/tests/test_plugin_diagnostics.py
+++ b/tests/test_plugin_diagnostics.py
@@ -10,6 +10,7 @@ from livekit.agents.diagnostics import (
     DiagnosticCategory,
     DiagnosticCheck,
     DiagnosticContext,
+    DiagnosticMode,
     DiagnosticResult,
     DiagnosticSeverity,
     PluginCapability,
@@ -36,11 +37,18 @@ def _make_server() -> AgentServer:
     return server
 
 
-def _context(*, strict: bool = False, deep: bool = False) -> DiagnosticContext:
+def _context(
+    *,
+    mode: DiagnosticMode = "doctor",
+    strict: bool = False,
+    deep: bool = False,
+    env: dict[str, str] | None = None,
+) -> DiagnosticContext:
     return DiagnosticContext(
+        mode=mode,
         strict=strict,
         deep=deep,
-        env={},
+        env=env or {},
         registered_plugins=tuple(Plugin.registered_plugins),
         server=_make_server(),
     )
@@ -146,3 +154,45 @@ def test_plugin_diagnostics_exception_becomes_plugin_error_without_crashing() ->
     assert report_exit_code(report) == 1
     assert "livekit.plugins.exploding" in serialized
     assert "provider self-test exploded" in serialized
+
+
+def test_console_mode_missing_livekit_credentials_is_non_blocking_warning() -> None:
+    server = AgentServer()
+    server.rtc_session(_entrypoint)
+
+    report = collect_diagnostics(
+        DiagnosticContext(
+            mode="console",
+            env={},
+            registered_plugins=(),
+            server=server,
+        )
+    )
+    payload = _report_dict(report)
+
+    credentials = next(
+        result for result in payload["results"] if result["id"] == "livekit.credentials"
+    )
+    assert credentials["severity"] == "warn"
+    assert report_exit_code(report) == 0
+
+
+def test_worker_modes_missing_livekit_credentials_remain_fatal() -> None:
+    server = AgentServer()
+    server.rtc_session(_entrypoint)
+
+    report = collect_diagnostics(
+        DiagnosticContext(
+            mode="dev",
+            env={},
+            registered_plugins=(),
+            server=server,
+        )
+    )
+    payload = _report_dict(report)
+
+    credentials = next(
+        result for result in payload["results"] if result["id"] == "livekit.credentials"
+    )
+    assert credentials["severity"] == "fatal"
+    assert report_exit_code(report) == 1

--- a/tests/test_plugin_diagnostics.py
+++ b/tests/test_plugin_diagnostics.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from livekit.agents.diagnostics import (
+    DiagnosticCategory,
+    DiagnosticCheck,
+    DiagnosticContext,
+    DiagnosticResult,
+    DiagnosticSeverity,
+    PluginCapability,
+    PluginDiagnosticInfo,
+    collect_diagnostics,
+    diagnostic_report_to_json,
+    report_exit_code,
+)
+from livekit.agents.plugin import Plugin
+from livekit.agents.worker import AgentServer
+
+
+async def _entrypoint(ctx: Any) -> None:
+    pass
+
+
+def _make_server() -> AgentServer:
+    server = AgentServer(
+        ws_url="wss://diagnostics-test.livekit.cloud",
+        api_key="api-key",
+        api_secret="api-secret",
+    )
+    server.rtc_session(_entrypoint)
+    return server
+
+
+def _context(*, strict: bool = False, deep: bool = False) -> DiagnosticContext:
+    return DiagnosticContext(
+        strict=strict,
+        deep=deep,
+        env={},
+        registered_plugins=tuple(Plugin.registered_plugins),
+        server=_make_server(),
+    )
+
+
+class MissingEnvPlugin(Plugin):
+    def __init__(self) -> None:
+        super().__init__(
+            title="Missing Env Plugin",
+            version="1.2.3",
+            package="livekit.plugins.missing_env",
+        )
+
+    def diagnostic_info(self) -> PluginDiagnosticInfo:
+        return PluginDiagnosticInfo(
+            capabilities=[PluginCapability.STT],
+            required_env_vars=["MISSING_ENV_PLUGIN_API_KEY"],
+        )
+
+    def diagnostics(self) -> list[DiagnosticCheck]:
+        def run(ctx: DiagnosticContext) -> DiagnosticResult:
+            assert isinstance(ctx, DiagnosticContext)
+            return DiagnosticResult(
+                id="plugins.missing_env.self_test",
+                category=DiagnosticCategory.PLUGIN,
+                severity=DiagnosticSeverity.WARN,
+                message="optional provider token is not configured",
+                details={"plugin": self.package},
+            )
+
+        return [
+            DiagnosticCheck(
+                id="plugins.missing_env.self_test",
+                category=DiagnosticCategory.PLUGIN,
+                run=run,
+            )
+        ]
+
+
+class ExplodingPlugin(Plugin):
+    def __init__(self) -> None:
+        super().__init__(
+            title="Exploding Plugin",
+            version="9.9.9",
+            package="livekit.plugins.exploding",
+        )
+
+    def diagnostic_info(self) -> PluginDiagnosticInfo:
+        return PluginDiagnosticInfo()
+
+    def diagnostics(self) -> list[DiagnosticCheck]:
+        raise RuntimeError("provider self-test exploded")
+
+
+@pytest.fixture(autouse=True)
+def restore_plugins() -> Iterator[None]:
+    previous = list(Plugin.registered_plugins)
+    Plugin.registered_plugins.clear()
+    yield
+    Plugin.registered_plugins[:] = previous
+
+
+def _report_dict(report: Any) -> dict[str, Any]:
+    return json.loads(diagnostic_report_to_json(report))
+
+
+def test_diagnostic_report_to_json_schema_and_exit_code() -> None:
+    Plugin.register_plugin(MissingEnvPlugin())
+
+    report = collect_diagnostics(_context())
+    payload = _report_dict(report)
+    serialized = json.dumps(payload)
+
+    assert payload["schema_version"] == 1
+    assert payload["mode"] == "doctor"
+    assert payload["exit_code"] == 0
+    assert isinstance(payload["results"], list)
+    assert all("id" in result for result in payload["results"])
+    assert report_exit_code(report) == 0
+    assert "livekit.plugins.missing_env" in serialized
+    assert "MISSING_ENV_PLUGIN_API_KEY" in serialized
+
+
+def test_strict_mode_makes_warnings_fail() -> None:
+    Plugin.register_plugin(MissingEnvPlugin())
+
+    report = collect_diagnostics(_context(strict=True))
+    payload = _report_dict(report)
+
+    assert any(result["severity"] == "warn" for result in payload["results"])
+    assert payload["exit_code"] == 1
+    assert report_exit_code(report) == 1
+
+
+def test_plugin_diagnostics_exception_becomes_plugin_error_without_crashing() -> None:
+    Plugin.register_plugin(ExplodingPlugin())
+
+    report = collect_diagnostics(_context(deep=True))
+    payload = _report_dict(report)
+    serialized = json.dumps(payload)
+
+    assert any(result["severity"] == "error" for result in payload["results"])
+    assert report_exit_code(report) == 1
+    assert "livekit.plugins.exploding" in serialized
+    assert "provider self-test exploded" in serialized

--- a/tests/test_plugin_diagnostics.py
+++ b/tests/test_plugin_diagnostics.py
@@ -6,11 +6,13 @@ from typing import Any
 
 import pytest
 
+import livekit.agents.diagnostics as diagnostics_mod
 from livekit.agents.diagnostics import (
     DiagnosticCategory,
     DiagnosticCheck,
     DiagnosticContext,
     DiagnosticMode,
+    DiagnosticReport,
     DiagnosticResult,
     DiagnosticSeverity,
     PluginCapability,
@@ -112,6 +114,23 @@ class LegacyPlugin(Plugin):
         )
 
 
+class _FakeVersionInfo(tuple):
+    def __new__(cls, major: int, minor: int, micro: int) -> _FakeVersionInfo:
+        return super().__new__(cls, (major, minor, micro, "final", 0))
+
+    @property
+    def major(self) -> int:
+        return self[0]
+
+    @property
+    def minor(self) -> int:
+        return self[1]
+
+    @property
+    def micro(self) -> int:
+        return self[2]
+
+
 @pytest.fixture(autouse=True)
 def restore_plugins() -> Iterator[None]:
     previous = list(Plugin.registered_plugins)
@@ -139,6 +158,104 @@ def test_diagnostic_report_to_json_schema_and_exit_code() -> None:
     assert report_exit_code(report) == 0
     assert "livekit.plugins.missing_env" in serialized
     assert "MISSING_ENV_PLUGIN_API_KEY" in serialized
+
+
+def test_diagnostic_report_plugins_are_schema_state_not_result_side_effect() -> None:
+    report = DiagnosticReport(
+        results=[],
+        plugins=[
+            {
+                "title": "Schema Plugin",
+                "version": "1.0.0",
+                "package": "livekit.plugins.schema",
+            }
+        ],
+    )
+
+    payload = _report_dict(report)
+
+    assert payload["plugins"] == [
+        {
+            "title": "Schema Plugin",
+            "version": "1.0.0",
+            "package": "livekit.plugins.schema",
+        }
+    ]
+
+
+def test_diagnostic_result_details_redact_credential_like_keys() -> None:
+    report = DiagnosticReport(
+        results=[
+            DiagnosticResult(
+                id="test.redaction",
+                category=DiagnosticCategory.ENVIRONMENT,
+                severity=DiagnosticSeverity.ERROR,
+                message="redaction test",
+                details={
+                    "api_key": "secret-key",
+                    "authorization": "Bearer secret-token",
+                    "credential": "secret-credential",
+                    "connection_string": "postgres://user:pass@example.com/db",
+                    "nested": {"password": "secret-password"},
+                    "safe": "visible",
+                },
+            )
+        ]
+    )
+
+    payload = _report_dict(report)
+    details = payload["results"][0]["details"]
+
+    assert details["api_key"] == "***"
+    assert details["authorization"] == "***"
+    assert details["credential"] == "***"
+    assert details["connection_string"] == "***"
+    assert details["nested"]["password"] == "***"
+    assert details["safe"] == "visible"
+
+
+def test_python_newer_than_tested_range_warns_without_blocking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(diagnostics_mod.sys, "version_info", _FakeVersionInfo(3, 15, 0))
+
+    report = collect_diagnostics(_context())
+    payload = _report_dict(report)
+
+    python_result = next(
+        result for result in payload["results"] if result["id"] == "python.version"
+    )
+    assert python_result["severity"] == "warn"
+    assert report_exit_code(report) == 0
+
+
+def test_python_below_supported_range_is_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(diagnostics_mod.sys, "version_info", _FakeVersionInfo(3, 9, 18))
+
+    report = collect_diagnostics(_context())
+    payload = _report_dict(report)
+
+    python_result = next(
+        result for result in payload["results"] if result["id"] == "python.version"
+    )
+    assert python_result["severity"] == "fatal"
+    assert report_exit_code(report) == 1
+
+
+def test_livekit_url_redacts_userinfo_credentials() -> None:
+    report = collect_diagnostics(
+        DiagnosticContext(
+            env={
+                "LIVEKIT_URL": "wss://api-key:api-secret@example.livekit.cloud",
+                "LIVEKIT_API_KEY": "api-key",
+                "LIVEKIT_API_SECRET": "api-secret",
+            },
+        )
+    )
+    payload = _report_dict(report)
+
+    livekit_url = next(result for result in payload["results"] if result["id"] == "livekit.url")
+    assert livekit_url["details"]["url"] == "wss://***:***@example.livekit.cloud"
 
 
 def test_strict_mode_makes_warnings_fail() -> None:
@@ -197,6 +314,24 @@ def test_console_mode_missing_livekit_credentials_is_non_blocking_warning() -> N
     assert credentials["severity"] == "warn"
 
 
+def test_console_mode_invalid_livekit_url_is_non_blocking_warning() -> None:
+    server = AgentServer()
+    server.rtc_session(_entrypoint)
+
+    report = collect_diagnostics(
+        DiagnosticContext(
+            mode="console",
+            env={"LIVEKIT_URL": "not-a-url"},
+            registered_plugins=(),
+            server=server,
+        )
+    )
+    payload = _report_dict(report)
+
+    livekit_url = next(result for result in payload["results"] if result["id"] == "livekit.url")
+    assert livekit_url["severity"] == "warn"
+
+
 def test_worker_modes_missing_livekit_credentials_remain_fatal() -> None:
     server = AgentServer()
     server.rtc_session(_entrypoint)
@@ -216,3 +351,23 @@ def test_worker_modes_missing_livekit_credentials_remain_fatal() -> None:
     )
     assert credentials["severity"] == "fatal"
     assert report_exit_code(report) == 1
+
+
+def test_start_mode_warns_on_float_non_positive_drain_timeout() -> None:
+    server = _make_server()
+    server._drain_timeout = 0.0
+
+    report = collect_diagnostics(
+        DiagnosticContext(
+            mode="start",
+            env={},
+            registered_plugins=(),
+            server=server,
+        )
+    )
+    payload = _report_dict(report)
+
+    assert any(
+        result["id"] == "deployment.drain_timeout" and result["severity"] == "warn"
+        for result in payload["results"]
+    )

--- a/tests/test_plugin_diagnostics.py
+++ b/tests/test_plugin_diagnostics.py
@@ -103,6 +103,15 @@ class ExplodingPlugin(Plugin):
         raise RuntimeError("provider self-test exploded")
 
 
+class LegacyPlugin(Plugin):
+    def __init__(self) -> None:
+        super().__init__(
+            title="Legacy Plugin",
+            version="0.1.0",
+            package="livekit.plugins.legacy",
+        )
+
+
 @pytest.fixture(autouse=True)
 def restore_plugins() -> Iterator[None]:
     previous = list(Plugin.registered_plugins)
@@ -154,6 +163,18 @@ def test_plugin_diagnostics_exception_becomes_plugin_error_without_crashing() ->
     assert report_exit_code(report) == 1
     assert "livekit.plugins.exploding" in serialized
     assert "provider self-test exploded" in serialized
+
+
+def test_plugin_without_diagnostic_metadata_does_not_warn_or_fail_strict() -> None:
+    Plugin.register_plugin(LegacyPlugin())
+
+    report = collect_diagnostics(_context(strict=True))
+    payload = _report_dict(report)
+
+    assert report_exit_code(report) == 0
+    assert all(result["severity"] != "warn" for result in payload["results"])
+    assert all("legacy.metadata" not in result["id"] for result in payload["results"])
+    assert any(plugin["package"] == "livekit.plugins.legacy" for plugin in payload["plugins"])
 
 
 def test_console_mode_missing_livekit_credentials_is_non_blocking_warning() -> None:

--- a/tests/test_plugin_diagnostics.py
+++ b/tests/test_plugin_diagnostics.py
@@ -174,7 +174,6 @@ def test_console_mode_missing_livekit_credentials_is_non_blocking_warning() -> N
         result for result in payload["results"] if result["id"] == "livekit.credentials"
     )
     assert credentials["severity"] == "warn"
-    assert report_exit_code(report) == 0
 
 
 def test_worker_modes_missing_livekit_credentials_remain_fatal() -> None:


### PR DESCRIPTION
## Summary
- Add a structured diagnostics layer for first-run checks, with stable JSON output and Rich table rendering.
- Add `python agent.py doctor` with `--json`, `--online`, `--deep`, and `--strict`.
- Run lightweight preflight diagnostics before `console`, `dev`, `start`, and `connect`; only fatal results block startup.
- Add backwards-compatible plugin diagnostic metadata/hooks and initial metadata for OpenAI, Deepgram, Cartesia, ElevenLabs, Silero, and Turn Detector.
- Document the first-run workflow in the root README and examples README.

The default doctor path is intentionally side-effect-free: it does not create rooms, call model providers, download files, mutate env, or write local files. `--online` only does a safe LiveKit URL/connectivity check, and `--deep` only runs checks that plugins explicitly expose.

A few compatibility edges are pinned by tests: legacy plugins stay quiet, plugin metadata imports are lazy so plugin import remains compatible with older agents installs, `console --text` skips audio-device preflight, empty CLI credential strings do not clear `AgentServer` values, credential-like details are redacted in JSON output, and Python versions newer than the tested range warn instead of blocking.

## Non-goals
- `doctor` does not validate provider tokens by calling provider APIs.
- `doctor` does not download model files or create LiveKit rooms.
- The plugin metadata is declarative; dynamic provider health checks can be added later behind explicit deep checks.

## Tests
- `uv run --extra mcp pytest tests/test_cli_doctor.py tests/test_plugin_diagnostics.py tests/test_plugin_diagnostic_metadata.py tests/test_drain_timeout.py`
  - `35 passed`
- `make check`
- `git diff --check`
- `LIVEKIT_URL=wss://diagnostics-test.livekit.cloud LIVEKIT_API_KEY=api-key LIVEKIT_API_SECRET=api-secret uv run examples/voice_agents/basic_agent.py doctor --json`