### PR TITLE
fix(recorder): use libopus when possible

### DIFF
--- a/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
+++ b/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
@@ -146,9 +146,24 @@ class RecorderIO:
         self._output_path.parent.mkdir(parents=True, exist_ok=True)
 
         container = av.open(self._output_path, mode="w", format="ogg")
-        stream: av.AudioStream = container.add_stream(
-            "opus", rate=self._sample_rate, layout="stereo"
-        )  # type: ignore
+
+        # prefer libopus; fallback to native opus only if necessary
+        try:
+            av.Codec("libopus", "w")
+            codec_name = "libopus"
+        except av.codec.codec.UnknownCodecError:
+            logger.trace("libopus codec is not available, using opus")
+            codec_name = "opus"
+
+        stream: av.AudioStream = container.add_stream(  # type: ignore
+            codec_name,
+            rate=self._sample_rate,
+            layout="stereo",
+        )
+
+        # native ffmpeg opus encoder is experimental
+        if codec_name == "opus":
+            stream.codec_context.options["strict"] = "-2"
 
         in_resampler: rtc.AudioResampler | None = None
         out_resampler: rtc.AudioResampler | None = None

--- a/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
+++ b/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
 
 WRITE_INTERVAL = 2.5
+FFMPEG_STRICT_LEVEL = "experimental"
 
 
 class RecorderIO:
@@ -163,7 +164,7 @@ class RecorderIO:
 
         # native ffmpeg opus encoder is experimental
         if codec_name == "opus":
-            stream.codec_context.options["strict"] = "-2"
+            stream.codec_context.options["strict"] = FFMPEG_STRICT_LEVEL
 
         in_resampler: rtc.AudioResampler | None = None
         out_resampler: rtc.AudioResampler | None = None


### PR DESCRIPTION
Use libopus in pyav when possible or fall back to opus, so that PyAV bundled ffmpeg works correctly. This closes #4347 and AGT-2774