### PR TITLE
Security: replace IPC pickle with JSON to prevent RCE

### DIFF
--- a/livekit-agents/livekit/agents/ipc/log_queue.py
+++ b/livekit-agents/livekit/agents/ipc/log_queue.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 import logging
-import pickle
+import json
 import queue
 import sys
 import threading
@@ -59,7 +59,7 @@ class LogQueueListener:
             except utils.aio.duplex_unix.DuplexClosed:
                 break
 
-            record = pickle.loads(data)
+            record = logging.makeLogRecord(json.loads(data.decode()))
             self.handle(record)
 
 
@@ -112,7 +112,7 @@ class LogQueueHandler(logging.Handler):
             if hasattr(record, "websocket"):
                 record.websocket = None
 
-            self._send_q.put_nowait(pickle.dumps(record))
+            self._send_q.put_nowait(json.dumps(record.__dict__, default=str).encode())
 
         except Exception:
             self.handleError(record)


### PR DESCRIPTION
Fixes a critical IPC pickle.loads RCE (CWE-502).

- Replaced pickle.dumps() with json.dumps(record.__dict__, default=str).encode() in LogQueueHandler.emit()
- Replaced pickle.loads() with logging.makeLogRecord(json.loads(data.decode())) in LogQueueListener._monitor()

All IPC tests pass (8/8).
