### PR TITLE
fix(aws): keep toolConfig when tool_choice="none" to prevent ValidationException

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -158,8 +158,8 @@ class LLM(llm.LLM):
                     tool_config["toolChoice"] = {"any": {}}
                 elif tool_choice == "auto":
                     tool_config["toolChoice"] = {"auto": {}}
-                else:
-                    return None
+                # tool_choice="none" means no forced tool use; omit toolChoice but keep toolConfig
+                # so AWS does not raise ValidationException when tool use/result blocks are present
 
             return tool_config
 


### PR DESCRIPTION
## Summary

Fixes #5589.

When `tool_choice="none"` is passed to the AWS Bedrock LLM plugin (e.g. during agent handoff when `draining=True`), `_get_tool_config()` was hitting the `else: return None` branch, causing `toolConfig` to be omitted entirely from the `ConverseStream` request. AWS raises `ValidationException` when `toolUse`/`toolResult` content blocks exist in the message history but `toolConfig` is absent.

**Root cause:** The `else: return None` branch handled any unrecognized `tool_choice` value by removing tool config entirely. The string `"none"` is a valid `ToolChoice` value meaning "don't force tool use", but AWS has no equivalent `toolChoice` field value — the correct behavior is to include `toolConfig` (with the tools list) but omit the `toolChoice` constraint, which lets Bedrock default to its auto behavior.

**Fix:** Remove the `else: return None` branch so `tool_choice="none"` falls through without setting `toolConfig["toolChoice"]`, keeping the tools config intact.

## Changes

- `livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py`: removed `else: return None` in `_get_tool_config()`, replaced with a comment explaining the intent for `tool_choice="none"`

## Test plan

- [ ] Trigger an agent handoff where a tool returns both an agent object and a string result — the old agent should successfully generate its reply without `ValidationException`
- [ ] Call `session.generate_reply(tool_choice=None)` when the chat context contains tool call/result messages — should succeed
- [ ] Verify existing behavior: `tool_choice="auto"`, `tool_choice="required"`, and named tool choice still work correctly
- [ ] Verify no-tools scenario still returns `None` from `_get_tool_config()` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)