### PR TITLE
docs(examples): expand env template

### DIFF
--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,3 +1,90 @@
-LIVEKIT_API_SECRET="<your livekit api secret>"
-LIVEKIT_API_KEY="<your livekit api key>"
-LIVEKIT_URL="<your livekit ws url>"
+# Required for most examples. Everything below this first block is optional and
+# only needed by specific examples.
+LIVEKIT_URL="wss://your-project.livekit.cloud"
+LIVEKIT_API_KEY="your_livekit_api_key"
+LIVEKIT_API_SECRET="your_livekit_api_secret"
+
+# Common model providers used by examples that instantiate provider plugins directly.
+# LiveKit Inference routes through LiveKit Cloud, so those examples only need the
+# LiveKit credentials above.
+# OPENAI_API_KEY="sk-..."
+# DEEPGRAM_API_KEY="..."
+# CARTESIA_API_KEY="..."
+# ELEVEN_API_KEY="..."
+# GOOGLE_API_KEY="..."
+# XAI_API_KEY="..."
+# PHONIC_API_KEY="..."
+# ULTRAVOX_API_KEY="..."
+# NVIDIA_API_KEY="..."
+# SPEECHMATICS_API_KEY="..."
+# SPEECHMATICS_RT_URL="wss://eu2.rt.speechmatics.com/v2"
+# RIME_API_KEY="..."
+# NEUPHONIC_API_KEY="..."
+# INWORLD_API_KEY="..."
+
+# AWS examples use the standard AWS SDK credential chain.
+# AWS_ACCESS_KEY_ID="..."
+# AWS_SECRET_ACCESS_KEY="..."
+# AWS_SESSION_TOKEN="..."
+# AWS_REGION="us-east-1"
+
+# Tracing and external tool integrations
+# LANGFUSE_PUBLIC_KEY="..."
+# LANGFUSE_SECRET_KEY="..."
+# LANGFUSE_HOST="https://cloud.langfuse.com"
+# ZAPIER_MCP_SERVER="..."
+
+# Avatar provider examples
+# ANAM_API_KEY="..."
+# ANAM_AVATAR_ID="..."
+# AVATARIO_API_KEY="..."
+# AVATARIO_AVATAR_ID="..."
+# AVATARTALK_API_KEY="..."
+# AVATARTALK_API_URL="..."
+# AVATARTALK_AVATAR="..."
+# AVATARTALK_EMOTION="..."
+# BEY_API_KEY="..."
+# BEY_AVATAR_ID="..."
+# BITHUMAN_API_SECRET="..."
+# BITHUMAN_MODEL_PATH="/path/to/model.imx"
+# DID_API_KEY="..."
+# DID_AGENT_ID="..."
+# KEYFRAME_API_KEY="..."
+# KEYFRAME_PERSONA_ID="..."
+# KEYFRAME_PERSONA_SLUG="public:luna"
+# LEMONSLICE_API_KEY="..."
+# LEMONSLICE_IMAGE_URL="https://example.com/avatar.png"
+# LIVEAVATAR_API_KEY="..."
+# LIVEAVATAR_AVATAR_ID="..."
+# RUNWAYML_API_SECRET="..."
+# RUNWAY_AVATAR_PRESET_ID="..."
+# RUNWAY_AVATAR_ID="..."
+# SIMLI_API_KEY="..."
+# SIMLI_FACE_ID="..."
+# TAVUS_API_KEY="..."
+# TAVUS_PERSONA_ID="..."
+# TAVUS_REPLICA_ID="..."
+# TRUGEN_API_KEY="..."
+# TRUGEN_AVATAR_ID="..."
+
+# Audio wave avatar local runner
+# AVATAR_DISPATCHER_URL="http://localhost:8089/launch"
+# Room access token generated for a specific room by the LiveKit CLI or SDK.
+# LIVEKIT_TOKEN="..."
+
+# SIP and telephony examples
+# LIVEKIT_SIP_OUTBOUND_TRUNK="ST_..."
+# LIVEKIT_SUPERVISOR_PHONE_NUMBER="+12003004000"
+# LIVEKIT_SIP_NUMBER="+15005006000"
+# SIP_OUTBOUND_TRUNK_ID="ST_..."
+
+# Optional dispatch-name overrides used by telephony examples
+# DTMF_AGENT_DISPATCH_NAME="my-telephony-agent"
+# BANK_IVR_DISPATCH_NAME="bank-ivr-agent"
+# PHONE_TREE_AGENT_DISPATCH_NAME="my-telephony-agent"
+
+# End-to-end encryption primitive example. Generate a strong shared value.
+# LIVEKIT_E2EE_KEY="shared-secret"
+
+# Front desk example
+# CAL_API_KEY="..."


### PR DESCRIPTION
## Summary
- Expand `examples/.env.example` beyond the three LiveKit credentials.
- Add commented placeholders for provider, avatar, tracing, SIP, and primitive-example variables used by examples.
- Clarify that LiveKit Inference examples only need LiveKit Cloud credentials, while direct provider plugins need provider keys.

## Tests
- `uv run python - <<'PY' ... dotenv_values('examples/.env.example') ... PY`
- `make check`
- `git diff --check`
- Claude reviewed the docs-only diff and found no incorrect env var names.
