### PR TITLE
docs(agents): document realtime capabilities

### DIFF
--- a/livekit-agents/livekit/agents/llm/realtime.py
+++ b/livekit-agents/livekit/agents/llm/realtime.py
@@ -59,11 +59,17 @@ class RealtimeModelError(BaseModel):
 @dataclass
 class RealtimeCapabilities:
     message_truncation: bool
+    """Whether generated assistant messages can be truncated after interruption"""
     turn_detection: bool
+    """Whether the model emits server-side speech start and stop events for turn taking"""
     user_transcription: bool
+    """Whether the model emits user audio transcription events"""
     auto_tool_reply_generation: bool
+    """Whether the model automatically generates a reply after receiving tool results"""
     audio_output: bool
+    """Whether the model can produce audio output directly"""
     manual_function_calls: bool
+    """Whether pre-existing function call items in the chat context are honored"""
     mutable_chat_context: bool = False
     """Whether the chat context can be updated mid-session"""
     mutable_instructions: bool = False
@@ -73,7 +79,11 @@ class RealtimeCapabilities:
     per_response_tool_choice: bool = False
     """Whether the tool and tool choice can be specified per response"""
     supports_say: bool = False
-    """Whether the model supports session.say()"""
+    """Whether session.say() can use the realtime session directly, without TTS.
+
+    When used through a RealtimeModel, add_to_chat_ctx=False is ignored and the
+    message is still added to the chat context.
+    """
 
 
 class RealtimeError(Exception):

--- a/livekit-agents/livekit/agents/llm/realtime.py
+++ b/livekit-agents/livekit/agents/llm/realtime.py
@@ -69,7 +69,7 @@ class RealtimeCapabilities:
     audio_output: bool
     """Whether the model can produce audio output directly"""
     manual_function_calls: bool
-    """Whether pre-existing function call items in the chat context are honored"""
+    """Whether function call items already in the chat context can be resumed"""
     mutable_chat_context: bool = False
     """Whether the chat context can be updated mid-session"""
     mutable_instructions: bool = False


### PR DESCRIPTION
## Summary
- Add docstrings for the previously undocumented `RealtimeCapabilities` fields.
- Clarify that realtime-backed `session.say()` ignores `add_to_chat_ctx=False` and still adds the message to chat context.
- Clarify that `manual_function_calls` means function call items already in chat context can be resumed.
- Keep the change documentation-only: no defaults, provider declarations, or runtime behavior changed.

Closes #5565.

## Verification
- Checked each capability docstring against the corresponding `capabilities.<field>` usage in `agent_activity.py` and `agent.py`.
- `make check`
- `git diff --check`