### PR TITLE
fix(agents): bound AgentSession close cleanup

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -118,6 +118,7 @@ _RECORDING_ALL_OFF: RecordingOptions = {
 
 
 _AGENT_SESSION_CLOSE_TIMEOUT = 10.0
+_AGENT_TASK_CLOSE_UNWIND_LIMIT = 32
 
 
 class _CloseStepResult(Enum):
@@ -907,8 +908,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
     def shutdown(self, *, drain: bool = True) -> None:
         self._close_soon(error=None, drain=drain, reason=CloseReason.USER_INITIATED)
 
+    @staticmethod
     def _log_late_close_step_result(
-        self, task: asyncio.Future[object], *, step: str, reason: CloseReason
+        task: asyncio.Future[object], *, step: str, reason: CloseReason
     ) -> None:
         try:
             task.result()
@@ -921,8 +923,8 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 extra={"step": step, "reason": reason.value},
             )
 
+    @staticmethod
     def _log_background_close_step_result(
-        self,
         task: asyncio.Future[object],
         *,
         step: str,
@@ -977,7 +979,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             _cancel_background_step,
         )
         task.add_done_callback(
-            lambda t: self._log_background_close_step_result(
+            lambda t: AgentSession._log_background_close_step_result(
                 t,
                 step=step,
                 reason=reason,
@@ -1030,14 +1032,14 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             if not task.done():
                 task.cancel()
                 task.add_done_callback(
-                    lambda t: self._log_late_close_step_result(t, step=step, reason=reason)
+                    lambda t: AgentSession._log_late_close_step_result(t, step=step, reason=reason)
                 )
             raise
 
         if task not in done:
             task.cancel()
             task.add_done_callback(
-                lambda t: self._log_late_close_step_result(t, step=step, reason=reason)
+                lambda t: AgentSession._log_late_close_step_result(t, step=step, reason=reason)
             )
             logger.warning(
                 "agent session close step timed out",
@@ -1102,7 +1104,27 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                     self._amd = None
 
             activity = self._activity
+            agent_task_unwind_count = 0
+            agent_task_visited_activities: set[int] = set()
             while activity and isinstance(agent_task := activity.agent, AgentTask):
+                agent_task_unwind_count += 1
+                activity_id = id(activity)
+                if activity_id in agent_task_visited_activities:
+                    logger.warning(
+                        "agent session close stopped unwinding repeated nested agent task activity",
+                        extra={"reason": reason.value},
+                    )
+                    activity = None
+                    break
+
+                agent_task_visited_activities.add(activity_id)
+                if agent_task_unwind_count > _AGENT_TASK_CLOSE_UNWIND_LIMIT:
+                    logger.warning(
+                        "agent session close stopped unwinding nested agent tasks",
+                        extra={"reason": reason.value, "limit": _AGENT_TASK_CLOSE_UNWIND_LIMIT},
+                    )
+                    break
+
                 # notify AgentTask to complete and wait it to resume the parent agent
                 agent_task.cancel()
                 task_activity = activity
@@ -1157,6 +1179,8 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                     current_speech = activity.current_speech
 
                     async def _wait_for_current_speech() -> None:
+                        # Do not let the close-step timeout cancel the speech future before
+                        # activity.aclose() gets a chance to own speech teardown.
                         await asyncio.shield(current_speech)
 
                     await self._run_close_step(

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import asyncio
 import copy
 import time
-from collections.abc import AsyncIterable, Callable, Sequence
+from collections.abc import AsyncIterable, Awaitable, Callable, Sequence
 from contextlib import AbstractContextManager, nullcontext
 from contextvars import Token
 from dataclasses import dataclass
+from enum import Enum
 from types import TracebackType
 from typing import (
     TYPE_CHECKING,
@@ -114,6 +115,25 @@ _RECORDING_ALL_OFF: RecordingOptions = {
     "logs": False,
     "transcript": False,
 }
+
+
+_AGENT_SESSION_CLOSE_TIMEOUT = 10.0
+
+
+class _CloseStepResult(Enum):
+    COMPLETED = "completed"
+    FAILED = "failed"
+    TIMED_OUT = "timed_out"
+    SKIPPED = "skipped"
+    START_FAILED = "start_failed"
+    BACKGROUND = "background"
+
+    @property
+    def attempted(self) -> bool:
+        return self not in {
+            _CloseStepResult.SKIPPED,
+            _CloseStepResult.START_FAILED,
+        }
 
 
 def _resolve_recording_options(record: bool | RecordingOptions) -> RecordingOptions:
@@ -887,6 +907,162 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
     def shutdown(self, *, drain: bool = True) -> None:
         self._close_soon(error=None, drain=drain, reason=CloseReason.USER_INITIATED)
 
+    def _log_late_close_step_result(
+        self, task: asyncio.Future[object], *, step: str, reason: CloseReason
+    ) -> None:
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            return
+        except Exception as e:
+            logger.warning(
+                "agent session close step failed after timeout",
+                exc_info=e,
+                extra={"step": step, "reason": reason.value},
+            )
+
+    def _log_background_close_step_result(
+        self,
+        task: asyncio.Future[object],
+        *,
+        step: str,
+        reason: CloseReason,
+        timeout_handle: asyncio.TimerHandle,
+    ) -> None:
+        timeout_handle.cancel()
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            return
+        except Exception as e:
+            logger.warning(
+                "agent session background close step failed",
+                exc_info=e,
+                extra={"step": step, "reason": reason.value},
+            )
+
+    def _run_close_step_in_background(
+        self,
+        step: str,
+        awaitable_factory: Callable[[], Awaitable[object]],
+        *,
+        reason: CloseReason,
+    ) -> _CloseStepResult:
+        try:
+            task = asyncio.ensure_future(awaitable_factory())
+        except Exception as e:
+            logger.warning(
+                "agent session close step failed before starting",
+                exc_info=e,
+                extra={"step": step, "reason": reason.value},
+            )
+            return _CloseStepResult.START_FAILED
+
+        def _cancel_background_step() -> None:
+            if task.done():
+                return
+
+            task.cancel()
+            logger.warning(
+                "agent session background close step timed out",
+                extra={
+                    "step": step,
+                    "reason": reason.value,
+                    "timeout": _AGENT_SESSION_CLOSE_TIMEOUT,
+                },
+            )
+
+        timeout_handle = asyncio.get_running_loop().call_later(
+            _AGENT_SESSION_CLOSE_TIMEOUT,
+            _cancel_background_step,
+        )
+        task.add_done_callback(
+            lambda t: self._log_background_close_step_result(
+                t,
+                step=step,
+                reason=reason,
+                timeout_handle=timeout_handle,
+            )
+        )
+        logger.warning(
+            "agent session close deadline exceeded; running close step in background",
+            extra={"step": step, "reason": reason.value},
+        )
+        return _CloseStepResult.BACKGROUND
+
+    async def _run_close_step(
+        self,
+        step: str,
+        awaitable_factory: Callable[[], Awaitable[object]],
+        *,
+        deadline: float,
+        reason: CloseReason,
+        run_after_deadline: bool = False,
+    ) -> _CloseStepResult:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            if run_after_deadline:
+                return self._run_close_step_in_background(
+                    step,
+                    awaitable_factory,
+                    reason=reason,
+                )
+
+            logger.warning(
+                "agent session close deadline exceeded; skipping close step",
+                extra={"step": step, "reason": reason.value},
+            )
+            return _CloseStepResult.SKIPPED
+
+        try:
+            task = asyncio.ensure_future(awaitable_factory())
+        except Exception as e:
+            logger.warning(
+                "agent session close step failed before starting",
+                exc_info=e,
+                extra={"step": step, "reason": reason.value},
+            )
+            return _CloseStepResult.START_FAILED
+
+        try:
+            done, _ = await asyncio.wait({task}, timeout=remaining)
+        except asyncio.CancelledError:
+            if not task.done():
+                task.cancel()
+                task.add_done_callback(
+                    lambda t: self._log_late_close_step_result(t, step=step, reason=reason)
+                )
+            raise
+
+        if task not in done:
+            task.cancel()
+            task.add_done_callback(
+                lambda t: self._log_late_close_step_result(t, step=step, reason=reason)
+            )
+            logger.warning(
+                "agent session close step timed out",
+                extra={"step": step, "reason": reason.value, "timeout": remaining},
+            )
+            return _CloseStepResult.TIMED_OUT
+
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            logger.warning(
+                "agent session close step was cancelled",
+                extra={"step": step, "reason": reason.value},
+            )
+            return _CloseStepResult.FAILED
+        except Exception as e:
+            logger.warning(
+                "agent session close step failed",
+                exc_info=e,
+                extra={"step": step, "reason": reason.value},
+            )
+            return _CloseStepResult.FAILED
+
+        return _CloseStepResult.COMPLETED
+
     @utils.log_exceptions(logger=logger)
     async def _aclose_impl(
         self,
@@ -908,19 +1084,42 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             if not self._started:
                 return
 
+            close_deadline = time.monotonic() + _AGENT_SESSION_CLOSE_TIMEOUT
+
             self._closing = True
             self._cancel_user_away_timer()
             self._on_aec_warmup_expired()  # always clear aec warmup when closing the session
 
             if self._amd is not None:
-                await self._amd.aclose()
-                self._amd = None
+                amd_close = await self._run_close_step(
+                    "amd.aclose",
+                    self._amd.aclose,
+                    deadline=close_deadline,
+                    reason=reason,
+                    run_after_deadline=True,
+                )
+                if amd_close.attempted:
+                    self._amd = None
 
             activity = self._activity
             while activity and isinstance(agent_task := activity.agent, AgentTask):
                 # notify AgentTask to complete and wait it to resume the parent agent
                 agent_task.cancel()
-                await agent_task._wait_for_inactive()
+                task_activity = activity
+                inactive = await self._run_close_step(
+                    "agent_task.wait_for_inactive",
+                    agent_task._wait_for_inactive,
+                    deadline=close_deadline,
+                    reason=reason,
+                )
+                if inactive is not _CloseStepResult.COMPLETED:
+                    await self._run_close_step(
+                        "agent_task.activity.aclose",
+                        task_activity.aclose,
+                        deadline=close_deadline,
+                        reason=reason,
+                        run_after_deadline=True,
+                    )
 
                 if old_agent := agent_task._old_agent:
                     activity = old_agent._activity
@@ -929,17 +1128,43 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
             if activity is not None:
                 if not drain:
-                    try:
+
+                    async def _interrupt_activity() -> None:
                         # force interrupt speeches when closing the session
-                        await activity.interrupt(force=True)
-                    except RuntimeError:
-                        # uninterruptible speech
-                        pass
-                await activity.drain()
+                        try:
+                            await activity.interrupt(force=True)
+                        except RuntimeError:
+                            # uninterruptible speech
+                            pass
+
+                    await self._run_close_step(
+                        "activity.interrupt",
+                        _interrupt_activity,
+                        deadline=close_deadline,
+                        reason=reason,
+                        run_after_deadline=True,
+                    )
+
+                await self._run_close_step(
+                    "activity.drain",
+                    activity.drain,
+                    deadline=close_deadline,
+                    reason=reason,
+                )
 
                 # wait any uninterruptible speech to finish
                 if activity.current_speech:
-                    await activity.current_speech
+                    current_speech = activity.current_speech
+
+                    async def _wait_for_current_speech() -> None:
+                        await asyncio.shield(current_speech)
+
+                    await self._run_close_step(
+                        "activity.current_speech",
+                        _wait_for_current_speech,
+                        deadline=close_deadline,
+                        reason=reason,
+                    )
 
                 # detach the inputs and outputs
                 self.input.audio = None
@@ -957,8 +1182,17 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                         transcript_timeout=self._opts.session_close_transcript_timeout,
                     )
 
-                await activity.aclose()
-            self._activity = None
+                activity_close = await self._run_close_step(
+                    "activity.aclose",
+                    activity.aclose,
+                    deadline=close_deadline,
+                    reason=reason,
+                    run_after_deadline=True,
+                )
+                if activity_close.attempted:
+                    self._activity = None
+            else:
+                self._activity = None
 
             if self._agent_speaking_span:
                 self._agent_speaking_span.end()
@@ -969,19 +1203,50 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 self._user_speaking_span = None
 
             if self._forward_audio_atask is not None:
-                await utils.aio.cancel_and_wait(self._forward_audio_atask)
+                forward_audio_atask = self._forward_audio_atask
+                forward_audio_close = await self._run_close_step(
+                    "forward_audio.cancel",
+                    lambda: utils.aio.cancel_and_wait(forward_audio_atask),
+                    deadline=close_deadline,
+                    reason=reason,
+                    run_after_deadline=True,
+                )
+                if forward_audio_close.attempted:
+                    self._forward_audio_atask = None
 
             if self._recorder_io:
-                await self._recorder_io.aclose()
+                recorder_close = await self._run_close_step(
+                    "recorder_io.aclose",
+                    self._recorder_io.aclose,
+                    deadline=close_deadline,
+                    reason=reason,
+                    run_after_deadline=True,
+                )
+                if recorder_close.attempted:
+                    self._recorder_io = None
 
             if self._ivr_activity is not None:
-                await self._ivr_activity.aclose()
+                ivr_close = await self._run_close_step(
+                    "ivr_activity.aclose",
+                    self._ivr_activity.aclose,
+                    deadline=close_deadline,
+                    reason=reason,
+                    run_after_deadline=True,
+                )
+                if ivr_close.attempted:
+                    self._ivr_activity = None
 
             toolsets = [tool for tool in self._tools if isinstance(tool, llm.Toolset)]
             if toolsets:
-                await asyncio.gather(
-                    *(toolset.aclose() for toolset in toolsets),
-                    return_exceptions=True,
+                await self._run_close_step(
+                    "toolsets.aclose",
+                    lambda: asyncio.gather(
+                        *(toolset.aclose() for toolset in toolsets),
+                        return_exceptions=True,
+                    ),
+                    deadline=close_deadline,
+                    reason=reason,
+                    run_after_deadline=True,
                 )
 
             if self._session_span:
@@ -1000,13 +1265,27 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             self._root_span_context = None
 
             if self._session_host:
-                await self._session_host.aclose()
-                self._session_host = None
+                session_host_close = await self._run_close_step(
+                    "session_host.aclose",
+                    self._session_host.aclose,
+                    deadline=close_deadline,
+                    reason=reason,
+                    run_after_deadline=True,
+                )
+                if session_host_close.attempted:
+                    self._session_host = None
 
             # close room io after close event is emitted
             if self._room_io:
-                await self._room_io.aclose()
-                self._room_io = None
+                room_io_close = await self._run_close_step(
+                    "room_io.aclose",
+                    self._room_io.aclose,
+                    deadline=close_deadline,
+                    reason=reason,
+                    run_after_deadline=True,
+                )
+                if room_io_close.attempted:
+                    self._room_io = None
 
         logger.debug("session closed", extra={"reason": reason.value, "error": error})
 

--- a/makefile
+++ b/makefile
@@ -86,6 +86,7 @@ unit-tests:
 	@echo "$(BOLD)$(CYAN)Running unit tests...$(RESET)"
 	PYTHONPATH="$$PWD" uv run pytest \
 		tests/test_agent_session.py \
+		tests/test_agent_session_close.py \
 		tests/test_aio.py \
 		tests/test_audio_decoder.py \
 		tests/test_chat_ctx.py \

--- a/tests/test_agent_session_close.py
+++ b/tests/test_agent_session_close.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from livekit.agents import Agent, AgentSession, AgentTask
+from livekit.agents.voice import agent_session as agent_session_mod
+from livekit.agents.voice.events import CloseEvent, CloseReason
+
+TEST_CLOSE_TIMEOUT = 0.05
+
+
+class _FakeActivity:
+    def __init__(
+        self,
+        *,
+        agent: object | None = None,
+        drain_never_returns: bool = False,
+        drain_raises: BaseException | None = None,
+        current_speech: asyncio.Future[Any] | None = None,
+    ) -> None:
+        self.agent = agent or object()
+        self._audio_recognition = None
+        self.current_speech = current_speech
+        self.drain_never_returns = drain_never_returns
+        self.drain_raises = drain_raises
+        self.drain_cancelled = asyncio.Event()
+        self.aclose_called = asyncio.Event()
+
+    def interrupt(self, *, force: bool = False) -> asyncio.Future[None]:
+        fut: asyncio.Future[None] = asyncio.Future()
+        fut.set_result(None)
+        return fut
+
+    async def drain(self) -> None:
+        if self.drain_raises:
+            raise self.drain_raises
+
+        if not self.drain_never_returns:
+            return
+
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            self.drain_cancelled.set()
+            raise
+
+    async def aclose(self) -> None:
+        self.aclose_called.set()
+
+
+class _HangingCloser:
+    def __init__(self) -> None:
+        self.cancelled = asyncio.Event()
+
+    async def aclose(self, *args: object, **kwargs: object) -> None:
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            raise
+
+
+class _RaisingCloser:
+    async def aclose(self) -> None:
+        raise RuntimeError("close failed")
+
+
+class _FailingAgentTask(AgentTask[None]):
+    def __init__(self, old_agent: Agent) -> None:
+        super().__init__(instructions="task")
+        self._old_agent = old_agent
+
+    def cancel(self) -> None:
+        return None
+
+    async def _wait_for_inactive(self) -> None:
+        raise RuntimeError("inactive failed")
+
+
+@pytest.fixture(autouse=True)
+def _short_close_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(agent_session_mod, "_AGENT_SESSION_CLOSE_TIMEOUT", TEST_CLOSE_TIMEOUT)
+
+
+def _started_session() -> AgentSession:
+    session = AgentSession(aec_warmup_duration=None)
+    session._started = True
+    return session
+
+
+async def _close_session(session: AgentSession) -> list[CloseEvent]:
+    close_events: list[CloseEvent] = []
+    session.on("close", close_events.append)
+
+    await asyncio.wait_for(session.aclose(), timeout=1.0)
+
+    assert len(close_events) == 1
+    assert close_events[0].reason == CloseReason.USER_INITIATED
+    return close_events
+
+
+async def test_aclose_emits_close_when_activity_drain_hangs() -> None:
+    session = _started_session()
+    activity = _FakeActivity(drain_never_returns=True)
+    session._activity = activity
+
+    await _close_session(session)
+
+    await asyncio.wait_for(activity.drain_cancelled.wait(), timeout=1.0)
+    assert session._activity is None
+
+
+async def test_aclose_attempts_late_cleanup_after_drain_uses_deadline() -> None:
+    session = _started_session()
+    activity = _FakeActivity(drain_never_returns=True)
+    session._activity = activity
+
+    forward_cancelled = asyncio.Event()
+
+    async def forward_audio() -> None:
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            forward_cancelled.set()
+            raise
+
+    session._forward_audio_atask = asyncio.create_task(forward_audio())
+
+    await _close_session(session)
+
+    await asyncio.wait_for(forward_cancelled.wait(), timeout=1.0)
+    assert session._forward_audio_atask is None
+
+
+async def test_aclose_emits_close_when_current_speech_hangs() -> None:
+    session = _started_session()
+    current_speech: asyncio.Future[Any] = asyncio.Future()
+    activity = _FakeActivity(current_speech=current_speech)
+    session._activity = activity
+
+    await _close_session(session)
+
+    assert not current_speech.cancelled()
+
+
+async def test_aclose_emits_close_when_cleanup_step_raises() -> None:
+    session = _started_session()
+    session._recorder_io = _RaisingCloser()  # type: ignore[assignment]
+
+    await _close_session(session)
+
+    assert session._recorder_io is None
+
+
+async def test_aclose_closes_agent_task_activity_and_parent_when_unwind_fails() -> None:
+    session = _started_session()
+    parent_activity = _FakeActivity()
+    old_agent = Agent(instructions="old agent")
+    old_agent._activity = parent_activity
+    task_agent = _FailingAgentTask(old_agent)
+    child_activity = _FakeActivity(agent=task_agent)
+    session._activity = child_activity
+
+    await _close_session(session)
+
+    assert child_activity.aclose_called.is_set()
+    assert parent_activity.aclose_called.is_set()
+
+
+async def test_aclose_is_bounded_when_room_io_close_hangs() -> None:
+    session = _started_session()
+    room_io = _HangingCloser()
+    session._room_io = room_io  # type: ignore[assignment]
+
+    close_seen = asyncio.Event()
+    session.on("close", lambda _: close_seen.set())
+
+    close_task = asyncio.create_task(session.aclose())
+    await asyncio.wait_for(close_seen.wait(), timeout=1.0)
+    await asyncio.wait_for(close_task, timeout=1.0)
+
+    assert room_io.cancelled.is_set()
+    assert session._room_io is None
+
+
+async def test_timed_out_close_step_is_cancelled() -> None:
+    session = _started_session()
+    closer = _HangingCloser()
+    session._session_host = closer  # type: ignore[assignment]
+
+    await _close_session(session)
+
+    await asyncio.wait_for(closer.cancelled.wait(), timeout=1.0)
+    assert session._session_host is None

--- a/tests/test_agent_session_close.py
+++ b/tests/test_agent_session_close.py
@@ -28,6 +28,7 @@ class _FakeActivity:
         self.drain_raises = drain_raises
         self.drain_cancelled = asyncio.Event()
         self.aclose_called = asyncio.Event()
+        self.aclose_calls = 0
 
     def interrupt(self, *, force: bool = False) -> asyncio.Future[None]:
         fut: asyncio.Future[None] = asyncio.Future()
@@ -48,6 +49,7 @@ class _FakeActivity:
             raise
 
     async def aclose(self) -> None:
+        self.aclose_calls += 1
         self.aclose_called.set()
 
 
@@ -168,6 +170,37 @@ async def test_aclose_closes_agent_task_activity_and_parent_when_unwind_fails() 
 
     assert child_activity.aclose_called.is_set()
     assert parent_activity.aclose_called.is_set()
+
+
+async def test_aclose_bounds_cyclic_agent_task_unwind() -> None:
+    session = _started_session()
+    agent_a = Agent(instructions="agent a")
+    agent_b = Agent(instructions="agent b")
+    task_a = _FailingAgentTask(agent_a)
+    task_b = _FailingAgentTask(agent_b)
+    activity_a = _FakeActivity(agent=task_a)
+    activity_b = _FakeActivity(agent=task_b)
+    agent_a._activity = activity_b
+    agent_b._activity = activity_a
+    session._activity = activity_a
+
+    await _close_session(session)
+
+    assert activity_a.aclose_called.is_set()
+    assert activity_b.aclose_called.is_set()
+    assert activity_a.aclose_calls == 1
+    assert activity_b.aclose_calls == 1
+
+
+async def test_concurrent_aclose_emits_close_once() -> None:
+    session = _started_session()
+
+    close_events: list[CloseEvent] = []
+    session.on("close", close_events.append)
+
+    await asyncio.wait_for(asyncio.gather(session.aclose(), session.aclose()), timeout=1.0)
+
+    assert len(close_events) == 1
 
 
 async def test_aclose_is_bounded_when_room_io_close_hangs() -> None:


### PR DESCRIPTION
## Summary

This bounds `AgentSession` shutdown cleanup so a stuck close step does not prevent the session from emitting `CloseEvent`.

The motivating case is #5497: a participant can disconnect while the agent is still speaking, then cleanup can hang before downstream shutdown callbacks ever run. This PR does not try to prove the exact native/audio playout root cause. It makes the close path defensive: once session close starts, cleanup is best effort, but the close event still gets emitted within a bounded deadline.

Fixes #5497.

## Invariant

`aclose()` emits `CloseEvent` within `_AGENT_SESSION_CLOSE_TIMEOUT` regardless of which cleanup step blocks. Steps that still need to release resources after the shared deadline are started in the background with their own bounded timeout and logged failures.

## What changed

- Added an internal close timeout for `AgentSession` cleanup.
- Added a close-step helper that logs the step name and close reason, cancels timed-out work, and drains late exceptions so timed-out cleanup does not produce unhandled task warnings.
- Wrapped close steps that can block: AMD close, AgentTask unwind, activity interrupt/drain/current speech/activity close, forward audio cancellation, recorder/IVR/toolset close, session host close, and room IO close.
- Bound AgentTask unwind with a visited-activity guard and iteration cap so bad task chains cannot close the same activity repeatedly.
- Kept the timeout internal. There is no new public API in this PR.

`current_speech` is awaited through `asyncio.shield(...)` so the close timeout does not cancel the speech future before `activity.aclose()` owns speech teardown. Late-result callbacks avoid retaining the `AgentSession` instance after close.

## Testing

- `uv run pytest tests/test_agent_session_close.py`
  - `9 passed`
- `uv run ruff check livekit-agents/livekit/agents/voice/agent_session.py tests/test_agent_session_close.py`
- `make check`
- Earlier branch run: `PYTHONPATH="$PWD" uv run pytest tests/test_agent_session.py tests/test_agent_session_close.py -q`
  - `27 passed`
- Earlier branch run: `PYTHONPATH="$PWD" uv run pytest tests/test_ipc.py -q`
  - `8 passed`
- Earlier `make unit-tests`: `618 passed, 2 skipped`; `tests/test_room.py` setup failed locally because this machine does not have the `livekit-server` binary on PATH.