### PR TITLE
fix(mcp): refresh tools on list_changed notification

### DIFF
--- a/livekit-agents/livekit/agents/llm/mcp.py
+++ b/livekit-agents/livekit/agents/llm/mcp.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlparse
 
+import anyio
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from typing_extensions import Self
 
@@ -46,6 +47,9 @@ from .tool_context import (
 
 MCPTool = RawFunctionTool
 _ToolListChangedCallback = Callable[[], None]
+_ReloadFailedCallback = Callable[[BaseException], None]
+
+_RELOAD_RETRY_DELAYS: tuple[float, ...] = (1.0, 2.0, 4.0)
 
 
 @dataclass
@@ -89,6 +93,7 @@ class MCPServer(ABC):
         self._cache_dirty = True
         self._lk_tools: list[MCPTool] | None = None
         self._tool_list_changed_callbacks: set[_ToolListChangedCallback] = set()
+        self._reload_failed_callbacks: set[_ReloadFailedCallback] = set()
 
         self._client_task: asyncio.Task[None] | None = None
         self._closing_ev = asyncio.Event()
@@ -144,6 +149,12 @@ class MCPServer(ABC):
             self._closing_ev.clear()
 
     async def _handle_message(self, message: Any) -> None:
+        if isinstance(message, Exception):
+            # Match the MCP SDK default handler so cancellation propagates through
+            # bursts of incoming notifications.
+            await anyio.lowlevel.checkpoint()
+            return
+
         if isinstance(message, mcp.types.ServerNotification) and isinstance(
             message.root, mcp.types.ToolListChangedNotification
         ):
@@ -164,6 +175,19 @@ class MCPServer(ABC):
 
     def _remove_tool_list_changed_callback(self, callback: _ToolListChangedCallback) -> None:
         self._tool_list_changed_callbacks.discard(callback)
+
+    def _add_reload_failed_callback(self, callback: _ReloadFailedCallback) -> None:
+        self._reload_failed_callbacks.add(callback)
+
+    def _remove_reload_failed_callback(self, callback: _ReloadFailedCallback) -> None:
+        self._reload_failed_callbacks.discard(callback)
+
+    def _notify_reload_failed(self, error: BaseException) -> None:
+        for callback in list(self._reload_failed_callbacks):
+            try:
+                callback(error)
+            except Exception:
+                logger.exception("error in MCP reload failed callback")
 
     async def list_tools(self) -> list[MCPTool]:
         if self._client is None:
@@ -538,12 +562,39 @@ class MCPToolset(Toolset):
         try:
             while self._reload_requested:
                 self._reload_requested = False
-                await self.setup(reload=True)
-                self._notify_tools_changed()
+                await self._reload_tools_with_retry()
         except asyncio.CancelledError:
             raise
-        except Exception:
-            logger.exception("failed to reload MCP tools after tools/list_changed notification")
+
+    async def _reload_tools_with_retry(self) -> None:
+        last_exc: BaseException | None = None
+        for attempt, delay in enumerate((0.0,) + _RELOAD_RETRY_DELAYS):
+            if delay:
+                try:
+                    await asyncio.sleep(delay)
+                except asyncio.CancelledError:
+                    raise
+            try:
+                await self.setup(reload=True)
+                self._notify_tools_changed()
+                return
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                last_exc = exc
+                logger.warning(
+                    "failed to reload MCP tools (attempt %d/%d): %s",
+                    attempt + 1,
+                    len(_RELOAD_RETRY_DELAYS) + 1,
+                    exc,
+                )
+
+        assert last_exc is not None
+        logger.exception(
+            "giving up reloading MCP tools after tools/list_changed notification",
+            exc_info=last_exc,
+        )
+        self._mcp_server._notify_reload_failed(last_exc)
 
     async def aclose(self) -> None:
         try:

--- a/livekit-agents/livekit/agents/llm/mcp.py
+++ b/livekit-agents/livekit/agents/llm/mcp.py
@@ -91,6 +91,7 @@ class MCPServer(ABC):
         )
 
         self._cache_dirty = True
+        self._cache_generation = 0
         self._lk_tools: list[MCPTool] | None = None
         self._tool_list_changed_callbacks: set[_ToolListChangedCallback] = set()
         self._reload_failed_callbacks: set[_ReloadFailedCallback] = set()
@@ -105,6 +106,7 @@ class MCPServer(ABC):
 
     def invalidate_cache(self) -> None:
         self._cache_dirty = True
+        self._cache_generation += 1
 
     async def initialize(self) -> None:
         if self._client_task and not self._client_task.done():
@@ -196,6 +198,7 @@ class MCPServer(ABC):
         if not self._cache_dirty and self._lk_tools is not None:
             return self._lk_tools
 
+        cache_generation = self._cache_generation
         tools = await self._client.list_tools()
         lk_tools = [
             self._make_function_tool(tool.name, tool.description, tool.inputSchema, tool.meta)
@@ -203,7 +206,7 @@ class MCPServer(ABC):
         ]
 
         self._lk_tools = lk_tools
-        self._cache_dirty = False
+        self._cache_dirty = cache_generation != self._cache_generation
         return lk_tools
 
     def _make_function_tool(

--- a/livekit-agents/livekit/agents/llm/mcp.py
+++ b/livekit-agents/livekit/agents/llm/mcp.py
@@ -151,10 +151,12 @@ class MCPServer(ABC):
             self._closing_ev.clear()
 
     async def _handle_message(self, message: Any) -> None:
+        # Always yield to the loop, matching the MCP SDK default handler. Without
+        # this, a burst of notifications starves the receive loop of cancellation
+        # points.
+        await anyio.lowlevel.checkpoint()
+
         if isinstance(message, Exception):
-            # Match the MCP SDK default handler so cancellation propagates through
-            # bursts of incoming notifications.
-            await anyio.lowlevel.checkpoint()
             return
 
         if isinstance(message, mcp.types.ServerNotification) and isinstance(
@@ -553,6 +555,14 @@ class MCPToolset(Toolset):
         return [tool for tool in tools if self._tool_filter(tool)]
 
     def _request_tools_reload(self) -> None:
+        # Guard against snapshot-iteration races: MCPServer._handle_tool_list_changed
+        # snapshots its callback set, then fires each. If aclose() unsubscribed us
+        # between the snapshot and this call, the listening flag is already False
+        # and we must not spawn a reload task against a server that may be tearing
+        # down.
+        if not self._listening_for_tool_changes:
+            return
+
         self._reload_requested = True
         if self._reload_task is not None and not self._reload_task.done():
             return

--- a/livekit-agents/livekit/agents/llm/mcp.py
+++ b/livekit-agents/livekit/agents/llm/mcp.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 from abc import ABC, abstractmethod
-from collections.abc import Awaitable, Callable
-from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from collections.abc import Awaitable, Callable, Sequence
+from contextlib import AbstractAsyncContextManager, asynccontextmanager, suppress
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
@@ -45,6 +45,7 @@ from .tool_context import (
 )
 
 MCPTool = RawFunctionTool
+_ToolListChangedCallback = Callable[[], None]
 
 
 @dataclass
@@ -87,6 +88,7 @@ class MCPServer(ABC):
 
         self._cache_dirty = True
         self._lk_tools: list[MCPTool] | None = None
+        self._tool_list_changed_callbacks: set[_ToolListChangedCallback] = set()
 
         self._client_task: asyncio.Task[None] | None = None
         self._closing_ev = asyncio.Event()
@@ -122,6 +124,7 @@ class MCPServer(ABC):
                     read_timeout_seconds=timedelta(seconds=self._read_timeout)
                     if self._read_timeout
                     else None,
+                    message_handler=self._handle_message,
                 ) as client:
                     await client.initialize()
                     self._client = client
@@ -139,6 +142,28 @@ class MCPServer(ABC):
             self._client = None
             self._lk_tools = None
             self._closing_ev.clear()
+
+    async def _handle_message(self, message: Any) -> None:
+        if isinstance(message, mcp.types.ServerNotification) and isinstance(
+            message.root, mcp.types.ToolListChangedNotification
+        ):
+            self._handle_tool_list_changed()
+
+    def _handle_tool_list_changed(self) -> None:
+        self.invalidate_cache()
+        # Refetch from toolset tasks instead of the MCP receive loop, which must stay free
+        # to deliver the list_tools() response.
+        for callback in list(self._tool_list_changed_callbacks):
+            try:
+                callback()
+            except Exception:
+                logger.exception("error in MCP tool list changed callback")
+
+    def _add_tool_list_changed_callback(self, callback: _ToolListChangedCallback) -> None:
+        self._tool_list_changed_callbacks.add(callback)
+
+    def _remove_tool_list_changed_callback(self, callback: _ToolListChangedCallback) -> None:
+        self._tool_list_changed_callbacks.discard(callback)
 
     async def list_tools(self) -> list[MCPTool]:
         if self._client is None:
@@ -444,6 +469,10 @@ class MCPToolset(Toolset):
         self._mcp_server = mcp_server
         self._initialized = False
         self._lock = asyncio.Lock()
+        self._reload_requested = False
+        self._reload_task: asyncio.Task[None] | None = None
+        self._listening_for_tool_changes = False
+        self._tool_filter: Callable[[MCPTool], bool] | None = None
 
     async def setup(self, *, reload: bool = False) -> Self:
         """Initialize the MCP server connection and fetch available tools.
@@ -461,27 +490,74 @@ class MCPToolset(Toolset):
             if not reload and self._initialized:
                 return self
 
+            # Register before the first list_tools() call so a concurrent list_changed
+            # notification queues a reload instead of leaving the initial result stale.
+            if not self._listening_for_tool_changes:
+                self._mcp_server._add_tool_list_changed_callback(self._request_tools_reload)
+                self._listening_for_tool_changes = True
+
             if not self._mcp_server.initialized:
                 await self._mcp_server.initialize()
             elif reload:
                 self._mcp_server.invalidate_cache()
 
             tools = await self._mcp_server.list_tools()
-            self._tools = tools
+            self._tools = self._apply_filter(tools)
             self._initialized = True
             return self
 
     def filter_tools(self, filter_fn: Callable[[MCPTool], bool]) -> Self:
         """Filter the toolset's tools in-place using a predicate."""
-        self._tools = [
-            tool for tool in self._tools if isinstance(tool, MCPTool) and filter_fn(tool)
-        ]
+        if self._tool_filter is None:
+            self._tool_filter = filter_fn
+        else:
+            previous_filter = self._tool_filter
+            self._tool_filter = lambda tool: previous_filter(tool) and filter_fn(tool)
+
+        self._tools = self._apply_filter(
+            [tool for tool in self._tools if isinstance(tool, MCPTool)]
+        )
         return self
+
+    def _apply_filter(self, tools: Sequence[MCPTool]) -> list[MCPTool]:
+        if self._tool_filter is None:
+            return list(tools)
+
+        return [tool for tool in tools if self._tool_filter(tool)]
+
+    def _request_tools_reload(self) -> None:
+        self._reload_requested = True
+        if self._reload_task is not None and not self._reload_task.done():
+            return
+
+        self._reload_task = asyncio.create_task(
+            self._reload_tools(), name=f"{type(self).__name__}._reload_tools"
+        )
+
+    async def _reload_tools(self) -> None:
+        try:
+            while self._reload_requested:
+                self._reload_requested = False
+                await self.setup(reload=True)
+                self._notify_tools_changed()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("failed to reload MCP tools after tools/list_changed notification")
 
     async def aclose(self) -> None:
         try:
+            if self._listening_for_tool_changes:
+                self._mcp_server._remove_tool_list_changed_callback(self._request_tools_reload)
+                self._listening_for_tool_changes = False
+            if self._reload_task is not None and self._reload_task is not asyncio.current_task():
+                self._reload_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await self._reload_task
+
             await super().aclose()
             await self._mcp_server.aclose()
         finally:
             self._initialized = False
             self._tools = []
+            self._reload_requested = False

--- a/livekit-agents/livekit/agents/llm/tool_context.py
+++ b/livekit-agents/livekit/agents/llm/tool_context.py
@@ -63,6 +63,7 @@ class Toolset:
         self._id = id
         self._tools: Sequence[Tool | Toolset] = list(tools) if tools is not None else []
         self._tools.extend(find_function_tools(self))
+        self._tools_changed_callbacks: set[Callable[[Toolset], None]] = set()
 
     @property
     def id(self) -> str:
@@ -93,6 +94,19 @@ class Toolset:
         toolsets = [tool for tool in self._tools if isinstance(tool, Toolset)]
         if toolsets:
             await asyncio.gather(*(toolset.aclose() for toolset in toolsets))
+
+    def _add_tools_changed_callback(self, callback: Callable[[Toolset], None]) -> None:
+        self._tools_changed_callbacks.add(callback)
+
+    def _remove_tools_changed_callback(self, callback: Callable[[Toolset], None]) -> None:
+        self._tools_changed_callbacks.discard(callback)
+
+    def _notify_tools_changed(self) -> None:
+        for callback in list(self._tools_changed_callbacks):
+            try:
+                callback(self)
+            except Exception:
+                logger.exception("error in tools_changed callback")
 
 
 # Used by ToolChoice

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -433,6 +433,13 @@ class AgentActivity(RecognitionHooks):
         cannot interleave their writes to ``_chat_ctx`` and ``rt_session``.
         """
         async with self._refresh_lock:
+            # Re-check after acquiring: a publish queued behind the lock could be
+            # awoken by a cancelled refresh task right as _close_session is about
+            # to await rt_session.aclose(). Writing to a closing session yields
+            # noisy errors out to the caller.
+            if self._closed:
+                return
+
             tools = self.tools
             tool_ctx = llm.ToolContext(tools)
             tool_names = set(get_fnc_tool_names(tools))
@@ -486,8 +493,13 @@ class AgentActivity(RecognitionHooks):
 
         for server in mcp_servers:
             if server not in self._mcp_reload_failed_callbacks:
-                server._add_reload_failed_callback(self._on_mcp_reload_failed)
-                self._mcp_reload_failed_callbacks[server] = self._on_mcp_reload_failed
+                # Bind the source server at registration time so the bridge can
+                # tag the ErrorEvent with the actual failing component. Without
+                # this, listeners couldn't tell which MCP server went stale when
+                # an agent has multiple servers.
+                bound_cb = partial(self._on_mcp_reload_failed, server)
+                server._add_reload_failed_callback(bound_cb)
+                self._mcp_reload_failed_callbacks[server] = bound_cb
 
     def _clear_toolset_change_subscriptions(self) -> None:
         for toolset, ts_cb in list(self._toolset_changed_callbacks.items()):
@@ -498,11 +510,11 @@ class AgentActivity(RecognitionHooks):
             server._remove_reload_failed_callback(fail_cb)
         self._mcp_reload_failed_callbacks.clear()
 
-    def _on_mcp_reload_failed(self, error: BaseException) -> None:
+    def _on_mcp_reload_failed(self, server: mcp.MCPServer, error: BaseException) -> None:
         if self._closed:
             return
         try:
-            self._session.emit("error", ErrorEvent(error=error, source=self._agent))
+            self._session.emit("error", ErrorEvent(error=error, source=server))
         except Exception:
             logger.exception("error while emitting MCP reload-failed event")
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -5,7 +5,7 @@ import contextvars
 import heapq
 import json
 import time
-from collections.abc import AsyncIterable, Coroutine, Sequence
+from collections.abc import AsyncIterable, Callable, Coroutine, Sequence
 from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any
@@ -177,6 +177,10 @@ class AgentActivity(RecognitionHooks):
 
         self._drain_blocked_tasks: list[asyncio.Task[Any]] = []
         self._mcp_tools: list[mcp.MCPToolset] = []
+        self._toolset_changed_callbacks: dict[llm.Toolset, Callable[[llm.Toolset], None]] = {}
+        self._toolset_refresh_task: asyncio.Task[None] | None = None
+        self._toolset_refresh_pending = False
+        self._tool_names_snapshot: set[str] = set()
 
         self._on_enter_task: asyncio.Task | None = None
         self._on_exit_task: asyncio.Task | None = None
@@ -423,6 +427,82 @@ class AgentActivity(RecognitionHooks):
         if isinstance(self.llm, llm.LLM):
             # for realtime LLM, we assume the server will remove unvalid tool messages
             await self.update_chat_ctx(self._agent._chat_ctx.copy(tools=tools))
+
+        self._sync_toolset_change_subscriptions()
+        self._tool_names_snapshot = set(get_fnc_tool_names(self.tools))
+
+    def _sync_toolset_change_subscriptions(self) -> None:
+        toolsets = set(llm.ToolContext(self.tools).toolsets)
+
+        for toolset in list(self._toolset_changed_callbacks):
+            if toolset not in toolsets:
+                callback = self._toolset_changed_callbacks.pop(toolset)
+                toolset._remove_tools_changed_callback(callback)
+
+        for toolset in toolsets:
+            if toolset in self._toolset_changed_callbacks:
+                continue
+
+            def _on_tools_changed(changed_toolset: llm.Toolset) -> None:
+                self._request_toolset_refresh(changed_toolset)
+
+            toolset._add_tools_changed_callback(_on_tools_changed)
+            self._toolset_changed_callbacks[toolset] = _on_tools_changed
+
+    def _clear_toolset_change_subscriptions(self) -> None:
+        for toolset, callback in list(self._toolset_changed_callbacks.items()):
+            toolset._remove_tools_changed_callback(callback)
+        self._toolset_changed_callbacks.clear()
+
+    def _request_toolset_refresh(self, toolset: llm.Toolset) -> None:
+        if self._closed:
+            return
+
+        self._toolset_refresh_pending = True
+        if self._toolset_refresh_task is not None and not self._toolset_refresh_task.done():
+            return
+
+        self._toolset_refresh_task = asyncio.create_task(
+            self._refresh_tools_from_toolsets(),
+            name=f"AgentActivity.refresh_tools.{toolset.id}",
+        )
+
+    async def _refresh_tools_from_toolsets(self) -> None:
+        try:
+            while self._toolset_refresh_pending and not self._closed:
+                self._toolset_refresh_pending = False
+                await self._apply_toolset_refresh()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("failed to refresh tools after toolset update")
+
+    async def _apply_toolset_refresh(self) -> None:
+        tools = self.tools
+        tool_ctx = llm.ToolContext(tools)
+        tool_names = set(get_fnc_tool_names(tools))
+        tools_added = sorted(tool_names - self._tool_names_snapshot) or None
+        tools_removed = sorted(self._tool_names_snapshot - tool_names) or None
+
+        config_update: llm.AgentConfigUpdate | None = None
+        if tools_added or tools_removed:
+            config_update = llm.AgentConfigUpdate(
+                tools_added=tools_added,
+                tools_removed=tools_removed,
+                agent_id=self._agent.id,
+            )
+            config_update._tools = tool_ctx.flatten()
+
+        if self._rt_session is not None:
+            await self._rt_session.update_tools(tool_ctx.flatten())
+
+        if isinstance(self.llm, llm.LLM):
+            await self.update_chat_ctx(self._agent._chat_ctx.copy(tools=tools))
+
+        if config_update is not None:
+            self._agent._chat_ctx.insert(config_update)
+
+        self._tool_names_snapshot = tool_names
 
     async def update_chat_ctx(
         self, chat_ctx: llm.ChatContext, *, exclude_invalid_function_calls: bool = True
@@ -706,6 +786,9 @@ class AgentActivity(RecognitionHooks):
                 return_exceptions=True,
             )
 
+        self._tool_names_snapshot = set(get_fnc_tool_names(self.tools))
+        self._sync_toolset_change_subscriptions()
+
         if isinstance(self.llm, llm.RealtimeModel):
             rt_reused = reuse_resources is not None and reuse_resources.rt_session is not None
             if rt_reused:
@@ -952,6 +1035,10 @@ class AgentActivity(RecognitionHooks):
             self._interruption_detector.off("metrics_collected", self._on_metrics_collected)
             self._interruption_detector.off("error", self._on_error)
             self._interruption_detector.off("overlapping_speech", self._on_overlap_speech_ended)
+
+        self._clear_toolset_change_subscriptions()
+        if self._toolset_refresh_task is not None:
+            await utils.aio.cancel_and_wait(self._toolset_refresh_task)
 
         if self._rt_session is not None:
             await self._rt_session.aclose()

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -178,9 +178,15 @@ class AgentActivity(RecognitionHooks):
         self._drain_blocked_tasks: list[asyncio.Task[Any]] = []
         self._mcp_tools: list[mcp.MCPToolset] = []
         self._toolset_changed_callbacks: dict[llm.Toolset, Callable[[llm.Toolset], None]] = {}
+        self._mcp_reload_failed_callbacks: dict[mcp.MCPServer, Callable[[BaseException], None]] = {}
         self._toolset_refresh_task: asyncio.Task[None] | None = None
         self._toolset_refresh_pending = False
         self._tool_names_snapshot: set[str] = set()
+        # Serializes _publish_tools_change between the public update_tools API and the
+        # background refresh task triggered by toolset change notifications. Cannot
+        # reuse self._lock because that one is held across long operations like
+        # _close_session, which would deadlock the cancel_and_wait of the refresh task.
+        self._refresh_lock = asyncio.Lock()
 
         self._on_enter_task: asyncio.Task | None = None
         self._on_exit_task: asyncio.Task | None = None
@@ -402,34 +408,53 @@ class AgentActivity(RecognitionHooks):
             )
 
     async def update_tools(self, tools: list[llm.Tool | llm.Toolset]) -> None:
-        # Compute tool diff before updating
-        old_tool_names = set(get_fnc_tool_names(self._agent._tools))
-        new_tool_names = set(get_fnc_tool_names(tools))
-        tools_added = list(new_tool_names - old_tool_names) or None
-        tools_removed = list(old_tool_names - new_tool_names) or None
-
         tools = list({tool.id: tool for tool in tools}.values())
         self._agent._tools = tools
 
-        # Record the configuration change
-        config_update = llm.AgentConfigUpdate(
-            tools_added=tools_added,
-            tools_removed=tools_removed,
-            agent_id=self._agent.id,
-        )
-        # Store full tool definitions in-memory (not serialized)
-        config_update._tools = llm.ToolContext(tools).flatten()
-        self._agent._chat_ctx.insert(config_update)
-
-        if self._rt_session is not None:
-            await self._rt_session.update_tools(llm.ToolContext(self.tools).flatten())
-
-        if isinstance(self.llm, llm.LLM):
-            # for realtime LLM, we assume the server will remove unvalid tool messages
-            await self.update_chat_ctx(self._agent._chat_ctx.copy(tools=tools))
-
+        await self._publish_tools_change()
         self._sync_toolset_change_subscriptions()
-        self._tool_names_snapshot = set(get_fnc_tool_names(self.tools))
+
+    async def _publish_tools_change(self) -> None:
+        """Push the current tool set to the realtime session and chat context.
+
+        Reads ``self.tools``, diffs against ``self._tool_names_snapshot``, updates
+        the realtime session (when present), updates the chat context (for
+        non-realtime LLMs), and inserts an ``AgentConfigUpdate`` describing the
+        diff. The snapshot is advanced last, so a transient failure mid-publish
+        leaves the previous snapshot in place and the next refresh retries.
+
+        Serialized via ``self._refresh_lock`` so the public ``update_tools`` API
+        and the background refresh task triggered by toolset change notifications
+        cannot interleave their writes to ``_chat_ctx`` and ``rt_session``.
+        """
+        async with self._refresh_lock:
+            tools = self.tools
+            tool_ctx = llm.ToolContext(tools)
+            tool_names = set(get_fnc_tool_names(tools))
+            tools_added = sorted(tool_names - self._tool_names_snapshot) or None
+            tools_removed = sorted(self._tool_names_snapshot - tool_names) or None
+
+            config_update: llm.AgentConfigUpdate | None = None
+            if tools_added or tools_removed:
+                config_update = llm.AgentConfigUpdate(
+                    tools_added=tools_added,
+                    tools_removed=tools_removed,
+                    agent_id=self._agent.id,
+                )
+                # Store full tool definitions in-memory (not serialized)
+                config_update._tools = tool_ctx.flatten()
+
+            if self._rt_session is not None:
+                await self._rt_session.update_tools(tool_ctx.flatten())
+
+            if isinstance(self.llm, llm.LLM):
+                # for realtime LLM, we assume the server will remove unvalid tool messages
+                await self.update_chat_ctx(self._agent._chat_ctx.copy(tools=tools))
+
+            if config_update is not None:
+                self._agent._chat_ctx.insert(config_update)
+
+            self._tool_names_snapshot = tool_names
 
     def _sync_toolset_change_subscriptions(self) -> None:
         toolsets = set(llm.ToolContext(self.tools).toolsets)
@@ -440,19 +465,41 @@ class AgentActivity(RecognitionHooks):
                 toolset._remove_tools_changed_callback(callback)
 
         for toolset in toolsets:
-            if toolset in self._toolset_changed_callbacks:
-                continue
+            if toolset not in self._toolset_changed_callbacks:
+                toolset._add_tools_changed_callback(self._request_toolset_refresh)
+                self._toolset_changed_callbacks[toolset] = self._request_toolset_refresh
 
-            def _on_tools_changed(changed_toolset: llm.Toolset) -> None:
-                self._request_toolset_refresh(changed_toolset)
+        # Bridge MCP-specific reload failures (after retries are exhausted) onto
+        # the session-level error event so operators can react.
+        from ..llm.mcp import MCPToolset
 
-            toolset._add_tools_changed_callback(_on_tools_changed)
-            self._toolset_changed_callbacks[toolset] = _on_tools_changed
+        mcp_servers = {ts._mcp_server for ts in toolsets if isinstance(ts, MCPToolset)}
+        for server in list(self._mcp_reload_failed_callbacks):
+            if server not in mcp_servers:
+                fail_cb = self._mcp_reload_failed_callbacks.pop(server)
+                server._remove_reload_failed_callback(fail_cb)
+
+        for server in mcp_servers:
+            if server not in self._mcp_reload_failed_callbacks:
+                server._add_reload_failed_callback(self._on_mcp_reload_failed)
+                self._mcp_reload_failed_callbacks[server] = self._on_mcp_reload_failed
 
     def _clear_toolset_change_subscriptions(self) -> None:
-        for toolset, callback in list(self._toolset_changed_callbacks.items()):
-            toolset._remove_tools_changed_callback(callback)
+        for toolset, ts_cb in list(self._toolset_changed_callbacks.items()):
+            toolset._remove_tools_changed_callback(ts_cb)
         self._toolset_changed_callbacks.clear()
+
+        for server, fail_cb in list(self._mcp_reload_failed_callbacks.items()):
+            server._remove_reload_failed_callback(fail_cb)
+        self._mcp_reload_failed_callbacks.clear()
+
+    def _on_mcp_reload_failed(self, error: BaseException) -> None:
+        if self._closed:
+            return
+        try:
+            self._session.emit("error", ErrorEvent(error=error, source=self._agent))
+        except Exception:
+            logger.exception("error while emitting MCP reload-failed event")
 
     def _request_toolset_refresh(self, toolset: llm.Toolset) -> None:
         if self._closed:
@@ -471,38 +518,11 @@ class AgentActivity(RecognitionHooks):
         try:
             while self._toolset_refresh_pending and not self._closed:
                 self._toolset_refresh_pending = False
-                await self._apply_toolset_refresh()
+                await self._publish_tools_change()
         except asyncio.CancelledError:
             raise
         except Exception:
             logger.exception("failed to refresh tools after toolset update")
-
-    async def _apply_toolset_refresh(self) -> None:
-        tools = self.tools
-        tool_ctx = llm.ToolContext(tools)
-        tool_names = set(get_fnc_tool_names(tools))
-        tools_added = sorted(tool_names - self._tool_names_snapshot) or None
-        tools_removed = sorted(self._tool_names_snapshot - tool_names) or None
-
-        config_update: llm.AgentConfigUpdate | None = None
-        if tools_added or tools_removed:
-            config_update = llm.AgentConfigUpdate(
-                tools_added=tools_added,
-                tools_removed=tools_removed,
-                agent_id=self._agent.id,
-            )
-            config_update._tools = tool_ctx.flatten()
-
-        if self._rt_session is not None:
-            await self._rt_session.update_tools(tool_ctx.flatten())
-
-        if isinstance(self.llm, llm.LLM):
-            await self.update_chat_ctx(self._agent._chat_ctx.copy(tools=tools))
-
-        if config_update is not None:
-            self._agent._chat_ctx.insert(config_update)
-
-        self._tool_names_snapshot = tool_names
 
     async def update_chat_ctx(
         self, chat_ctx: llm.ChatContext, *, exclude_invalid_function_calls: bool = True

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -408,20 +408,25 @@ class AgentActivity(RecognitionHooks):
             )
 
     async def update_tools(self, tools: list[llm.Tool | llm.Toolset]) -> None:
+        if self._closed:
+            return
+
         tools = list({tool.id: tool for tool in tools}.values())
         self._agent._tools = tools
 
-        await self._publish_tools_change()
+        await self._publish_tools_change(record_noop=True)
         self._sync_toolset_change_subscriptions()
 
-    async def _publish_tools_change(self) -> None:
+    async def _publish_tools_change(self, *, record_noop: bool = False) -> None:
         """Push the current tool set to the realtime session and chat context.
 
         Reads ``self.tools``, diffs against ``self._tool_names_snapshot``, updates
         the realtime session (when present), updates the chat context (for
         non-realtime LLMs), and inserts an ``AgentConfigUpdate`` describing the
-        diff. The snapshot is advanced last, so a transient failure mid-publish
-        leaves the previous snapshot in place and the next refresh retries.
+        diff. ``record_noop`` preserves the public update_tools() audit trail even
+        when the requested tool set is unchanged. The snapshot is advanced last, so
+        a transient failure mid-publish leaves the previous snapshot in place and
+        the next refresh retries.
 
         Serialized via ``self._refresh_lock`` so the public ``update_tools`` API
         and the background refresh task triggered by toolset change notifications
@@ -435,7 +440,7 @@ class AgentActivity(RecognitionHooks):
             tools_removed = sorted(self._tool_names_snapshot - tool_names) or None
 
             config_update: llm.AgentConfigUpdate | None = None
-            if tools_added or tools_removed:
+            if tools_added or tools_removed or record_noop:
                 config_update = llm.AgentConfigUpdate(
                     tools_added=tools_added,
                     tools_removed=tools_removed,
@@ -1060,8 +1065,9 @@ class AgentActivity(RecognitionHooks):
         if self._toolset_refresh_task is not None:
             await utils.aio.cancel_and_wait(self._toolset_refresh_task)
 
-        if self._rt_session is not None:
-            await self._rt_session.aclose()
+        async with self._refresh_lock:
+            if self._rt_session is not None:
+                await self._rt_session.aclose()
 
         if self._realtime_spans is not None:
             self._realtime_spans.clear()

--- a/makefile
+++ b/makefile
@@ -99,6 +99,7 @@ unit-tests:
 		tests/test_ivr_activity.py \
 		tests/test_langgraph.py \
 		tests/test_language.py \
+		tests/test_mcp.py \
 		tests/test_schema_gemini.py \
 		tests/test_tts_fallback.py \
 		tests/test_stt_fallback.py \

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -48,6 +48,48 @@ async def _wait_for(predicate: Callable[[], bool], *, timeout: float = 1.0) -> N
         await asyncio.sleep(0.01)
 
 
+def _patch_reload_backoff_to_instant(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the 1s/2s/4s reload backoff with zero waits for fast tests."""
+    from livekit.agents.llm import mcp as mcp_module
+
+    monkeypatch.setattr(mcp_module, "_RELOAD_RETRY_DELAYS", (0.0, 0.0, 0.0))
+
+
+def _make_test_activity(
+    *,
+    toolset: MCPToolset,
+    rt_session: _FakeRealtimeSession | None,
+    chat_ctx: ChatContext | None = None,
+    session: SimpleNamespace | None = None,
+    closed: bool = False,
+) -> AgentActivity:
+    """Construct an AgentActivity bypassing __init__ for unit tests.
+
+    Initializes only the attributes touched by the toolset-refresh / publish-tools
+    paths. Tests that exercise close paths (which touch stt/tts/vad/etc.) should
+    extend the returned object themselves.
+    """
+    activity = object.__new__(AgentActivity)
+    activity._session = session or SimpleNamespace(tools=[], llm=None)
+    activity._agent = SimpleNamespace(
+        id="agent",
+        tools=[toolset],
+        _tools=[toolset],
+        _chat_ctx=chat_ctx if chat_ctx is not None else ChatContext.empty(),
+        llm=object(),
+    )
+    activity._mcp_tools = []
+    activity._rt_session = rt_session
+    activity._closed = closed
+    activity._toolset_changed_callbacks = {}
+    activity._mcp_reload_failed_callbacks = {}
+    activity._toolset_refresh_task = None
+    activity._toolset_refresh_pending = False
+    activity._tool_names_snapshot = set(ToolContext([toolset]).function_tools)
+    activity._refresh_lock = asyncio.Lock()
+    return activity
+
+
 class _FakeMCPServer(MCPServer):
     def __init__(self, tools: list[str]) -> None:
         super().__init__(client_session_timeout_seconds=5)
@@ -55,6 +97,9 @@ class _FakeMCPServer(MCPServer):
         self.list_tools_calls = 0
         self.invalidate_cache_calls = 0
         self.fail_list_tools = False
+        # When > 0, list_tools fails this many calls and then succeeds. Decremented
+        # on each failing call. Useful for scripting transient-failure scenarios.
+        self.fail_list_tools_remaining = 0
         self._fake_initialized = False
         self.block_list_tools: asyncio.Event | None = None
         self.list_tools_started: asyncio.Event | None = None
@@ -81,6 +126,9 @@ class _FakeMCPServer(MCPServer):
             self.block_list_tools = None
         if self.fail_list_tools:
             raise RuntimeError("list_tools failed")
+        if self.fail_list_tools_remaining > 0:
+            self.fail_list_tools_remaining -= 1
+            raise RuntimeError("list_tools transient failure")
         tool_names = self.list_tools_response_names or self.tool_names
         self.list_tools_response_names = None
         return [_make_mcp_tool(name) for name in tool_names]
@@ -194,22 +242,7 @@ async def test_agent_activity_refreshes_realtime_tools_after_toolset_reload() ->
 
     rt_session = _FakeRealtimeSession()
     chat_ctx = ChatContext.empty()
-    activity = object.__new__(AgentActivity)
-    activity._session = SimpleNamespace(tools=[], llm=None)
-    activity._agent = SimpleNamespace(
-        id="agent",
-        tools=[toolset],
-        _tools=[toolset],
-        _chat_ctx=chat_ctx,
-        llm=object(),
-    )
-    activity._mcp_tools = []
-    activity._rt_session = rt_session
-    activity._closed = False
-    activity._toolset_changed_callbacks = {}
-    activity._toolset_refresh_task = None
-    activity._toolset_refresh_pending = False
-    activity._tool_names_snapshot = {"alpha"}
+    activity = _make_test_activity(toolset=toolset, rt_session=rt_session, chat_ctx=chat_ctx)
     activity._sync_toolset_change_subscriptions()
 
     server.tool_names = ["beta"]
@@ -236,28 +269,17 @@ async def test_agent_activity_unsubscribes_toolset_before_realtime_close() -> No
         await asyncio.sleep(0.05)
 
     rt_session = _FakeRealtimeSession(on_close=_notify_during_close)
-    activity = object.__new__(AgentActivity)
-    activity._session = SimpleNamespace(tools=[], llm=None, stt=None, tts=None, vad=None)
-    activity._agent = SimpleNamespace(
-        id="agent",
-        tools=[toolset],
-        _tools=[toolset],
-        _chat_ctx=ChatContext.empty(),
-        llm=object(),
-        stt=object(),
-        tts=object(),
-        vad=object(),
+    activity = _make_test_activity(
+        toolset=toolset,
+        rt_session=rt_session,
+        session=SimpleNamespace(tools=[], llm=None, stt=None, tts=None, vad=None),
     )
-    activity._mcp_tools = []
-    activity._rt_session = rt_session
+    activity._agent.stt = object()
+    activity._agent.tts = object()
+    activity._agent.vad = object()
     activity._realtime_spans = None
     activity._audio_recognition = None
     activity._interruption_detector = None
-    activity._closed = False
-    activity._toolset_changed_callbacks = {}
-    activity._toolset_refresh_task = None
-    activity._toolset_refresh_pending = False
-    activity._tool_names_snapshot = {"alpha"}
     activity._cancel_speech_pause_task = None
 
     async def _cancel_speech_pause(**kwargs: Any) -> None:
@@ -283,22 +305,7 @@ async def test_agent_activity_keeps_snapshot_when_realtime_tool_update_fails() -
 
     rt_session = _FakeRealtimeSession()
     rt_session.fail_update = True
-    activity = object.__new__(AgentActivity)
-    activity._session = SimpleNamespace(tools=[], llm=None)
-    activity._agent = SimpleNamespace(
-        id="agent",
-        tools=[toolset],
-        _tools=[toolset],
-        _chat_ctx=ChatContext.empty(),
-        llm=object(),
-    )
-    activity._mcp_tools = []
-    activity._rt_session = rt_session
-    activity._closed = False
-    activity._toolset_changed_callbacks = {}
-    activity._toolset_refresh_task = None
-    activity._toolset_refresh_pending = False
-    activity._tool_names_snapshot = {"alpha"}
+    activity = _make_test_activity(toolset=toolset, rt_session=rt_session)
     activity._sync_toolset_change_subscriptions()
 
     server.tool_names = ["beta"]
@@ -349,18 +356,195 @@ async def test_mcp_toolset_keeps_filter_after_tool_list_reload() -> None:
 @pytest.mark.asyncio
 async def test_mcp_toolset_keeps_existing_tools_when_reload_fails(
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _patch_reload_backoff_to_instant(monkeypatch)
+
     server = _FakeMCPServer(["alpha"])
     toolset = MCPToolset(id="test_mcp", mcp_server=server)
 
     await toolset.setup()
+    initial_calls = server.list_tools_calls
     assert _tool_names(toolset) == {"alpha"}
 
     server.fail_list_tools = True
     server._handle_tool_list_changed()
 
-    await _wait_for(lambda: server.list_tools_calls >= 2)
+    # Reload retries 4 times total (initial attempt + 3 backoff retries) before
+    # giving up. Each calls list_tools once.
+    await _wait_for(lambda: server.list_tools_calls >= initial_calls + 4)
     assert _tool_names(toolset) == {"alpha"}
-    assert "failed to reload MCP tools" in caplog.text
+    assert "giving up reloading MCP tools" in caplog.text
 
     await toolset.aclose()
+
+
+@pytest.mark.asyncio
+async def test_mcp_toolset_retries_reload_with_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_reload_backoff_to_instant(monkeypatch)
+
+    server = _FakeMCPServer(["alpha"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+    await toolset.setup()
+    initial_calls = server.list_tools_calls
+
+    failure_callback_calls: list[BaseException] = []
+    server._add_reload_failed_callback(failure_callback_calls.append)
+
+    # Fail twice, then succeed on the third retry (total: 1 fail + 1 fail + success).
+    server.fail_list_tools_remaining = 2
+    server.tool_names = ["beta"]
+    server._handle_tool_list_changed()
+
+    await _wait_for(lambda: _tool_names(toolset) == {"beta"})
+    # 2 transient failures + 1 success.
+    assert server.list_tools_calls == initial_calls + 3
+    assert failure_callback_calls == []
+
+    await toolset.aclose()
+
+
+@pytest.mark.asyncio
+async def test_mcp_toolset_emits_terminal_error_after_retry_exhaustion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_reload_backoff_to_instant(monkeypatch)
+
+    server = _FakeMCPServer(["alpha"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+    await toolset.setup()
+
+    failures: list[BaseException] = []
+    server._add_reload_failed_callback(failures.append)
+
+    server.fail_list_tools = True
+    server._handle_tool_list_changed()
+
+    await _wait_for(lambda: len(failures) == 1)
+    assert isinstance(failures[0], RuntimeError)
+    assert _tool_names(toolset) == {"alpha"}
+
+    await toolset.aclose()
+
+
+@pytest.mark.asyncio
+async def test_agent_activity_emits_session_error_on_terminal_reload_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_reload_backoff_to_instant(monkeypatch)
+
+    server = _FakeMCPServer(["alpha"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+    await toolset.setup()
+
+    rt_session = _FakeRealtimeSession()
+    activity = _make_test_activity(toolset=toolset, rt_session=rt_session)
+
+    emitted: list[tuple[str, Any]] = []
+
+    def _emit(event_name: str, payload: Any) -> None:
+        emitted.append((event_name, payload))
+
+    activity._session.emit = _emit  # type: ignore[attr-defined]
+    activity._sync_toolset_change_subscriptions()
+
+    server.fail_list_tools = True
+    server._handle_tool_list_changed()
+
+    from livekit.agents.voice.events import ErrorEvent
+
+    await _wait_for(
+        lambda: any(name == "error" and isinstance(p, ErrorEvent) for name, p in emitted)
+    )
+    error_events = [p for name, p in emitted if name == "error"]
+    assert len(error_events) == 1
+    assert isinstance(error_events[0].error, RuntimeError)
+
+    activity._clear_toolset_change_subscriptions()
+    await toolset.aclose()
+
+
+@pytest.mark.asyncio
+async def test_publish_tools_change_serializes_under_concurrent_callers() -> None:
+    server = _FakeMCPServer(["alpha"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+    await toolset.setup()
+
+    rt_session = _FakeRealtimeSession()
+
+    block = asyncio.Event()
+    started = asyncio.Event()
+    enter_count = 0
+    concurrent_observed = False
+    original_update = rt_session.update_tools
+
+    async def _slow_update(tools: list[Any]) -> None:
+        nonlocal enter_count, concurrent_observed
+        enter_count += 1
+        if enter_count > 1:
+            concurrent_observed = True
+        started.set()
+        await block.wait()
+        await original_update(tools)
+        enter_count -= 1
+
+    rt_session.update_tools = _slow_update  # type: ignore[assignment]
+
+    activity = _make_test_activity(toolset=toolset, rt_session=rt_session)
+    activity._sync_toolset_change_subscriptions()
+
+    # First publish blocks inside rt_session.update_tools.
+    first = asyncio.create_task(activity._publish_tools_change())
+    await started.wait()
+
+    # Second publish should be queued on the lock, not enter rt_session.update_tools yet.
+    second = asyncio.create_task(activity._publish_tools_change())
+    await asyncio.sleep(0.05)
+    assert enter_count == 1, "second publish must wait for the first to release the lock"
+
+    block.set()
+    await asyncio.gather(first, second)
+    assert concurrent_observed is False
+
+    activity._clear_toolset_change_subscriptions()
+    await toolset.aclose()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_ignores_unrelated_messages() -> None:
+    """Exception-typed messages and non-tool-list notifications must not touch
+    the cache or fire tool-list-changed callbacks. Matches the MCP SDK default
+    handler behavior, which absorbs exceptions silently."""
+    server = _FakeMCPServer(["alpha"])
+    callback_calls = 0
+
+    def _callback() -> None:
+        nonlocal callback_calls
+        callback_calls += 1
+
+    server._cache_dirty = False
+    server._add_tool_list_changed_callback(_callback)
+
+    # Exception-typed message: no raise, no cache invalidation, no callback.
+    await server._handle_message(RuntimeError("transport hiccup"))
+    assert server._cache_dirty is False
+    assert callback_calls == 0
+    assert server.invalidate_cache_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_handle_message_lets_cancellation_propagate() -> None:
+    """The checkpoint() in the Exception branch is a cooperative cancel point;
+    a cancellation scheduled before the task runs must surface at that await
+    instead of being swallowed by a no-await early return."""
+    server = _FakeMCPServer(["alpha"])
+
+    async def _runner() -> None:
+        await server._handle_message(RuntimeError("transport hiccup"))
+
+    task = asyncio.create_task(_runner())
+    task.cancel()  # marked before the task gets a chance to run
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mcp")
+import mcp.types as mcp_types
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+from mcp.client.streamable_http import GetSessionIdCallback
+from mcp.shared.message import SessionMessage
+
+from livekit.agents.llm import AgentConfigUpdate, ChatContext, ToolContext, function_tool
+from livekit.agents.llm.mcp import MCPServer, MCPTool, MCPToolset
+from livekit.agents.voice.agent_activity import AgentActivity
+
+
+def _make_mcp_tool(name: str) -> MCPTool:
+    @function_tool(
+        raw_schema={
+            "name": name,
+            "description": f"{name} test tool",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+            },
+        }
+    )
+    async def _tool(raw_arguments: dict[str, Any]) -> str:
+        return name
+
+    return _tool
+
+
+def _tool_names(toolset: MCPToolset) -> set[str]:
+    return set(ToolContext([toolset]).function_tools)
+
+
+async def _wait_for(predicate: Callable[[], bool], *, timeout: float = 1.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not predicate():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError("condition was not met before timeout")
+        await asyncio.sleep(0.01)
+
+
+class _FakeMCPServer(MCPServer):
+    def __init__(self, tools: list[str]) -> None:
+        super().__init__(client_session_timeout_seconds=5)
+        self.tool_names = tools
+        self.list_tools_calls = 0
+        self.invalidate_cache_calls = 0
+        self.fail_list_tools = False
+        self._fake_initialized = False
+        self.block_list_tools: asyncio.Event | None = None
+        self.list_tools_started: asyncio.Event | None = None
+        self.list_tools_response_names: list[str] | None = None
+
+    @property
+    def initialized(self) -> bool:
+        return self._fake_initialized
+
+    async def initialize(self) -> None:
+        self._fake_initialized = True
+
+    def invalidate_cache(self) -> None:
+        self.invalidate_cache_calls += 1
+        super().invalidate_cache()
+
+    async def list_tools(self) -> list[MCPTool]:
+        self.list_tools_calls += 1
+        if self.list_tools_started is not None:
+            self.list_tools_started.set()
+            self.list_tools_started = None
+        if self.block_list_tools is not None:
+            await self.block_list_tools.wait()
+            self.block_list_tools = None
+        if self.fail_list_tools:
+            raise RuntimeError("list_tools failed")
+        tool_names = self.list_tools_response_names or self.tool_names
+        self.list_tools_response_names = None
+        return [_make_mcp_tool(name) for name in tool_names]
+
+    async def aclose(self) -> None:
+        self._fake_initialized = False
+
+    def client_streams(
+        self,
+    ) -> AbstractAsyncContextManager[
+        tuple[
+            MemoryObjectReceiveStream[SessionMessage | Exception],
+            MemoryObjectSendStream[SessionMessage],
+        ]
+        | tuple[
+            MemoryObjectReceiveStream[SessionMessage | Exception],
+            MemoryObjectSendStream[SessionMessage],
+            GetSessionIdCallback,
+        ]
+    ]:
+        raise NotImplementedError
+
+
+class _FakeRealtimeSession:
+    def __init__(self, on_close: Callable[[], Awaitable[None]] | None = None) -> None:
+        self.tool_updates: list[set[str]] = []
+        self.on_close = on_close
+        self.closing = False
+        self.updated_while_closing = False
+        self.fail_update = False
+
+    async def update_tools(self, tools: list[Any]) -> None:
+        if self.fail_update:
+            raise RuntimeError("update_tools failed")
+        if self.closing:
+            self.updated_while_closing = True
+        self.tool_updates.append({tool.info.name for tool in tools if isinstance(tool, MCPTool)})
+
+    async def aclose(self) -> None:
+        self.closing = True
+        if self.on_close is not None:
+            await self.on_close()
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_invalidates_cache_on_tool_list_changed_notification() -> None:
+    server = _FakeMCPServer(["alpha"])
+    callback_calls = 0
+
+    def _callback() -> None:
+        nonlocal callback_calls
+        callback_calls += 1
+
+    server._cache_dirty = False
+    server._add_tool_list_changed_callback(_callback)
+
+    await server._handle_message(
+        mcp_types.ServerNotification(root=mcp_types.ToolListChangedNotification())
+    )
+
+    assert server._cache_dirty is True
+    assert server.invalidate_cache_calls == 1
+    assert callback_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_mcp_toolset_reloads_tools_after_tool_list_changed_notification() -> None:
+    server = _FakeMCPServer(["alpha"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+
+    await toolset.setup()
+    assert _tool_names(toolset) == {"alpha"}
+
+    server.tool_names = ["beta", "gamma"]
+    server._handle_tool_list_changed()
+
+    await _wait_for(lambda: _tool_names(toolset) == {"beta", "gamma"})
+    assert server.list_tools_calls >= 2
+
+    await toolset.aclose()
+
+
+@pytest.mark.asyncio
+async def test_mcp_toolset_does_not_miss_notification_during_initial_list_tools() -> None:
+    server = _FakeMCPServer(["alpha"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+    server.block_list_tools = asyncio.Event()
+    server.list_tools_started = asyncio.Event()
+    server.list_tools_response_names = ["alpha"]
+
+    setup_task = asyncio.create_task(toolset.setup())
+    await server.list_tools_started.wait()
+
+    server.tool_names = ["beta"]
+    server._handle_tool_list_changed()
+    server.block_list_tools.set()
+
+    await setup_task
+
+    await _wait_for(lambda: _tool_names(toolset) == {"beta"})
+    assert server.list_tools_calls >= 2
+
+    await toolset.aclose()
+
+
+@pytest.mark.asyncio
+async def test_agent_activity_refreshes_realtime_tools_after_toolset_reload() -> None:
+    server = _FakeMCPServer(["alpha"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+    await toolset.setup()
+
+    rt_session = _FakeRealtimeSession()
+    chat_ctx = ChatContext.empty()
+    activity = object.__new__(AgentActivity)
+    activity._session = SimpleNamespace(tools=[], llm=None)
+    activity._agent = SimpleNamespace(
+        id="agent",
+        tools=[toolset],
+        _tools=[toolset],
+        _chat_ctx=chat_ctx,
+        llm=object(),
+    )
+    activity._mcp_tools = []
+    activity._rt_session = rt_session
+    activity._closed = False
+    activity._toolset_changed_callbacks = {}
+    activity._toolset_refresh_task = None
+    activity._toolset_refresh_pending = False
+    activity._tool_names_snapshot = {"alpha"}
+    activity._sync_toolset_change_subscriptions()
+
+    server.tool_names = ["beta"]
+    server._handle_tool_list_changed()
+
+    await _wait_for(lambda: rt_session.tool_updates[-1:] == [{"beta"}])
+    config_updates = [item for item in chat_ctx.items if isinstance(item, AgentConfigUpdate)]
+    assert config_updates[-1].tools_added == ["beta"]
+    assert config_updates[-1].tools_removed == ["alpha"]
+
+    activity._clear_toolset_change_subscriptions()
+    await toolset.aclose()
+
+
+@pytest.mark.asyncio
+async def test_agent_activity_unsubscribes_toolset_before_realtime_close() -> None:
+    server = _FakeMCPServer(["alpha"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+    await toolset.setup()
+
+    async def _notify_during_close() -> None:
+        server.tool_names = ["beta"]
+        server._handle_tool_list_changed()
+        await asyncio.sleep(0.05)
+
+    rt_session = _FakeRealtimeSession(on_close=_notify_during_close)
+    activity = object.__new__(AgentActivity)
+    activity._session = SimpleNamespace(tools=[], llm=None, stt=None, tts=None, vad=None)
+    activity._agent = SimpleNamespace(
+        id="agent",
+        tools=[toolset],
+        _tools=[toolset],
+        _chat_ctx=ChatContext.empty(),
+        llm=object(),
+        stt=object(),
+        tts=object(),
+        vad=object(),
+    )
+    activity._mcp_tools = []
+    activity._rt_session = rt_session
+    activity._realtime_spans = None
+    activity._audio_recognition = None
+    activity._interruption_detector = None
+    activity._closed = False
+    activity._toolset_changed_callbacks = {}
+    activity._toolset_refresh_task = None
+    activity._toolset_refresh_pending = False
+    activity._tool_names_snapshot = {"alpha"}
+    activity._cancel_speech_pause_task = None
+
+    async def _cancel_speech_pause(**kwargs: Any) -> None:
+        return None
+
+    activity._cancel_speech_pause = _cancel_speech_pause
+    activity._lock = asyncio.Lock()
+    activity._sync_toolset_change_subscriptions()
+
+    async with activity._lock:
+        await activity._close_session()
+
+    assert rt_session.updated_while_closing is False
+    assert rt_session.tool_updates == []
+    assert activity._toolset_changed_callbacks == {}
+
+
+@pytest.mark.asyncio
+async def test_agent_activity_keeps_snapshot_when_realtime_tool_update_fails() -> None:
+    server = _FakeMCPServer(["alpha"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+    await toolset.setup()
+
+    rt_session = _FakeRealtimeSession()
+    rt_session.fail_update = True
+    activity = object.__new__(AgentActivity)
+    activity._session = SimpleNamespace(tools=[], llm=None)
+    activity._agent = SimpleNamespace(
+        id="agent",
+        tools=[toolset],
+        _tools=[toolset],
+        _chat_ctx=ChatContext.empty(),
+        llm=object(),
+    )
+    activity._mcp_tools = []
+    activity._rt_session = rt_session
+    activity._closed = False
+    activity._toolset_changed_callbacks = {}
+    activity._toolset_refresh_task = None
+    activity._toolset_refresh_pending = False
+    activity._tool_names_snapshot = {"alpha"}
+    activity._sync_toolset_change_subscriptions()
+
+    server.tool_names = ["beta"]
+    server._handle_tool_list_changed()
+
+    await _wait_for(
+        lambda: activity._toolset_refresh_task is not None and activity._toolset_refresh_task.done()
+    )
+    assert activity._tool_names_snapshot == {"alpha"}
+    assert [
+        item for item in activity._agent._chat_ctx.items if isinstance(item, AgentConfigUpdate)
+    ] == []
+
+    activity._clear_toolset_change_subscriptions()
+    await toolset.aclose()
+
+
+@pytest.mark.asyncio
+async def test_mcp_toolset_unregisters_tool_list_changed_callback_on_close() -> None:
+    server = _FakeMCPServer(["alpha"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+
+    await toolset.setup()
+    assert len(server._tool_list_changed_callbacks) == 1
+
+    await toolset.aclose()
+
+    assert server._tool_list_changed_callbacks == set()
+
+
+@pytest.mark.asyncio
+async def test_mcp_toolset_keeps_filter_after_tool_list_reload() -> None:
+    server = _FakeMCPServer(["alpha", "beta"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+
+    await toolset.setup()
+    toolset.filter_tools(lambda tool: tool.info.name.startswith("a"))
+    assert _tool_names(toolset) == {"alpha"}
+
+    server.tool_names = ["alpha2", "beta2"]
+    server._handle_tool_list_changed()
+
+    await _wait_for(lambda: _tool_names(toolset) == {"alpha2"})
+
+    await toolset.aclose()
+
+
+@pytest.mark.asyncio
+async def test_mcp_toolset_keeps_existing_tools_when_reload_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    server = _FakeMCPServer(["alpha"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+
+    await toolset.setup()
+    assert _tool_names(toolset) == {"alpha"}
+
+    server.fail_list_tools = True
+    server._handle_tool_list_changed()
+
+    await _wait_for(lambda: server.list_tools_calls >= 2)
+    assert _tool_names(toolset) == {"alpha"}
+    assert "failed to reload MCP tools" in caplog.text
+
+    await toolset.aclose()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -625,8 +625,58 @@ async def test_agent_activity_emits_session_error_on_terminal_reload_failure(
     error_events = [p for name, p in emitted if name == "error"]
     assert len(error_events) == 1
     assert isinstance(error_events[0].error, RuntimeError)
+    # The bridge must tag the event with the failing MCP server, not the agent —
+    # otherwise downstream listeners can't tell which server went stale when an
+    # agent owns multiple MCP servers.
+    assert error_events[0].source is server
 
     activity._clear_toolset_change_subscriptions()
+    await toolset.aclose()
+
+
+@pytest.mark.asyncio
+async def test_agent_activity_skips_session_error_after_close() -> None:
+    """A reload-failed callback firing after _on_mcp_reload_failed sees _closed=True
+    must not emit a session error event."""
+    server = _FakeMCPServer(["alpha"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+    await toolset.setup()
+
+    activity = _make_test_activity(toolset=toolset, rt_session=None)
+    emitted: list[Any] = []
+    activity._session.emit = lambda name, payload: emitted.append((name, payload))  # type: ignore[attr-defined]
+    activity._sync_toolset_change_subscriptions()
+
+    activity._closed = True
+    bound_cb = next(iter(activity._mcp_reload_failed_callbacks.values()))
+    bound_cb(RuntimeError("simulated terminal failure"))
+
+    assert emitted == []
+
+    activity._clear_toolset_change_subscriptions()
+    await toolset.aclose()
+
+
+@pytest.mark.asyncio
+async def test_publish_tools_change_skips_after_close() -> None:
+    """If _close_session has already flipped _closed=True while a publish was
+    queued behind _refresh_lock, the publish must bail out instead of writing
+    to a closing rt_session."""
+    server = _FakeMCPServer(["alpha"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+    await toolset.setup()
+
+    rt_session = _FakeRealtimeSession()
+    activity = _make_test_activity(toolset=toolset, rt_session=rt_session)
+    # Snapshot before close so the diff would be non-empty if publish ran.
+    activity._tool_names_snapshot = set()
+    activity._closed = True
+
+    await activity._publish_tools_change()
+
+    assert rt_session.tool_updates == []
+    assert activity._tool_names_snapshot == set()
+
     await toolset.aclose()
 
 
@@ -671,8 +721,48 @@ async def test_publish_tools_change_serializes_under_concurrent_callers() -> Non
     block.set()
     await asyncio.gather(first, second)
     assert concurrent_observed is False
+    # Both publishes saw the same {alpha} tool set; snapshot must end matching.
+    assert activity._tool_names_snapshot == {"alpha"}
 
     activity._clear_toolset_change_subscriptions()
+    await toolset.aclose()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_checkpoints_for_notifications() -> None:
+    """The hoisted checkpoint() must run for ServerNotification messages too,
+    not just Exception-typed ones — otherwise a burst of notifications starves
+    the receive loop of cancellation points."""
+    server = _FakeMCPServer(["alpha"])
+
+    async def _runner() -> None:
+        await server._handle_message(
+            mcp_types.ServerNotification(root=mcp_types.ToolListChangedNotification())
+        )
+
+    task = asyncio.create_task(_runner())
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_request_tools_reload_skips_after_unsubscribe() -> None:
+    """Snapshot-iteration race: MCPServer._handle_tool_list_changed snapshots
+    its callback set, then fires each one. If aclose() removed our callback in
+    between, _request_tools_reload must not spawn a reload task."""
+    server = _FakeMCPServer(["alpha"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+    await toolset.setup()
+
+    # Simulate the race: server already removed our callback (aclose path), but
+    # we still receive the call from a stale snapshot iteration.
+    server._remove_tool_list_changed_callback(toolset._request_tools_reload)
+    toolset._listening_for_tool_changes = False
+
+    toolset._request_tools_reload()
+    assert toolset._reload_task is None
+
     await toolset.aclose()
 
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -152,6 +152,45 @@ class _FakeMCPServer(MCPServer):
         raise NotImplementedError
 
 
+class _BaseCacheMCPServer(MCPServer):
+    def client_streams(
+        self,
+    ) -> AbstractAsyncContextManager[
+        tuple[
+            MemoryObjectReceiveStream[SessionMessage | Exception],
+            MemoryObjectSendStream[SessionMessage],
+        ]
+        | tuple[
+            MemoryObjectReceiveStream[SessionMessage | Exception],
+            MemoryObjectSendStream[SessionMessage],
+            GetSessionIdCallback,
+        ]
+    ]:
+        raise NotImplementedError
+
+
+class _BlockingListToolsClient:
+    def __init__(self, responses: list[list[str]]) -> None:
+        self.responses = responses
+        self.calls = 0
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def list_tools(self) -> SimpleNamespace:
+        self.calls += 1
+        self.started.set()
+        await self.release.wait()
+        names = self.responses.pop(0)
+        return SimpleNamespace(
+            tools=[
+                SimpleNamespace(
+                    name=name, description=f"{name} test tool", inputSchema={}, meta=None
+                )
+                for name in names
+            ]
+        )
+
+
 class _FakeRealtimeSession:
     def __init__(self, on_close: Callable[[], Awaitable[None]] | None = None) -> None:
         self.tool_updates: list[set[str]] = []
@@ -192,6 +231,34 @@ async def test_mcp_server_invalidates_cache_on_tool_list_changed_notification() 
     assert server._cache_dirty is True
     assert server.invalidate_cache_calls == 1
     assert callback_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_keeps_cache_dirty_when_notification_arrives_during_list_tools() -> None:
+    server = _BaseCacheMCPServer(client_session_timeout_seconds=5)
+    client = _BlockingListToolsClient([["alpha"], ["beta"]])
+    server._client = client  # type: ignore[assignment]
+
+    first_list_task = asyncio.create_task(server.list_tools())
+    await client.started.wait()
+
+    server._handle_tool_list_changed()
+    client.release.set()
+    first_tools = await first_list_task
+
+    assert {tool.info.name for tool in first_tools} == {"alpha"}
+    assert server._cache_dirty is True
+
+    client.started = asyncio.Event()
+    client.release = asyncio.Event()
+    second_list_task = asyncio.create_task(server.list_tools())
+    await client.started.wait()
+    client.release.set()
+    second_tools = await second_list_task
+
+    assert {tool.info.name for tool in second_tools} == {"beta"}
+    assert client.calls == 2
+    assert server._cache_dirty is False
 
 
 @pytest.mark.asyncio
@@ -298,6 +365,60 @@ async def test_agent_activity_unsubscribes_toolset_before_realtime_close() -> No
 
 
 @pytest.mark.asyncio
+async def test_agent_activity_close_waits_for_in_flight_tool_publish() -> None:
+    server = _FakeMCPServer(["alpha"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+    await toolset.setup()
+
+    rt_session = _FakeRealtimeSession()
+    block_update = asyncio.Event()
+    update_started = asyncio.Event()
+    original_update = rt_session.update_tools
+
+    async def _slow_update(tools: list[Any]) -> None:
+        update_started.set()
+        await block_update.wait()
+        await original_update(tools)
+
+    rt_session.update_tools = _slow_update  # type: ignore[assignment]
+    activity = _make_test_activity(
+        toolset=toolset,
+        rt_session=rt_session,
+        session=SimpleNamespace(tools=[], llm=None, stt=None, tts=None, vad=None),
+    )
+    activity._agent.stt = object()
+    activity._agent.tts = object()
+    activity._agent.vad = object()
+    activity._realtime_spans = None
+    activity._audio_recognition = None
+    activity._interruption_detector = None
+    activity._cancel_speech_pause_task = None
+
+    async def _cancel_speech_pause(**kwargs: Any) -> None:
+        return None
+
+    activity._cancel_speech_pause = _cancel_speech_pause
+    activity._lock = asyncio.Lock()
+
+    publish_task = asyncio.create_task(activity._publish_tools_change())
+    await update_started.wait()
+
+    async def _close_activity() -> None:
+        async with activity._lock:
+            await activity._close_session()
+
+    close_task = asyncio.create_task(_close_activity())
+    await asyncio.sleep(0.05)
+    assert rt_session.closing is False
+
+    block_update.set()
+    await asyncio.gather(publish_task, close_task)
+
+    assert rt_session.closing is True
+    await toolset.aclose()
+
+
+@pytest.mark.asyncio
 async def test_agent_activity_keeps_snapshot_when_realtime_tool_update_fails() -> None:
     server = _FakeMCPServer(["alpha"])
     toolset = MCPToolset(id="test_mcp", mcp_server=server)
@@ -320,6 +441,49 @@ async def test_agent_activity_keeps_snapshot_when_realtime_tool_update_fails() -
     ] == []
 
     activity._clear_toolset_change_subscriptions()
+    await toolset.aclose()
+
+
+@pytest.mark.asyncio
+async def test_update_tools_records_noop_config_update() -> None:
+    server = _FakeMCPServer(["alpha"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+    await toolset.setup()
+
+    chat_ctx = ChatContext.empty()
+    activity = _make_test_activity(toolset=toolset, rt_session=None, chat_ctx=chat_ctx)
+    activity._tool_names_snapshot = set(ToolContext([toolset]).function_tools)
+
+    await activity.update_tools([toolset])
+
+    config_updates = [item for item in chat_ctx.items if isinstance(item, AgentConfigUpdate)]
+    assert len(config_updates) == 1
+    assert config_updates[0].tools_added is None
+    assert config_updates[0].tools_removed is None
+
+    await toolset.aclose()
+
+
+@pytest.mark.asyncio
+async def test_update_tools_after_close_is_noop() -> None:
+    server = _FakeMCPServer(["alpha"])
+    toolset = MCPToolset(id="test_mcp", mcp_server=server)
+    await toolset.setup()
+
+    chat_ctx = ChatContext.empty()
+    activity = _make_test_activity(
+        toolset=toolset,
+        rt_session=None,
+        chat_ctx=chat_ctx,
+        closed=True,
+    )
+    previous_tools = activity._agent._tools
+
+    await activity.update_tools([])
+
+    assert activity._agent._tools is previous_tools
+    assert [item for item in chat_ctx.items if isinstance(item, AgentConfigUpdate)] == []
+
     await toolset.aclose()
 
 


### PR DESCRIPTION
Fixes #5378.

## Why

MCP servers can advertise new or removed tools at runtime via `notifications/tools/list_changed`. Today `MCPServer` ignores that notification, so an agent keeps using the stale tool list for the rest of the session — calls to removed tools fail and newly added tools are invisible until restart.

## What changed

- `MCPServer` listens for `notifications/tools/list_changed`, invalidates its cached `list_tools()` result, and fans out to subscribed toolsets.
- `MCPServer.list_tools()` keeps the cache dirty if a notification arrives while a fetch is in flight, so direct callers refetch instead of treating an older snapshot as clean.
- `MCPToolset` reloads tools in a background task: coalesces duplicate notifications, retries up to 4 attempts with 1s/2s/4s exponential backoff, preserves user `filter_tools` predicates across reloads, and unregisters on close.
- On terminal reload failure, the toolset fires a callback that `AgentActivity` bridges to `AgentSession.emit("error", ...)`, so operators can detect that the agent's tool view has gone stale.
- `AgentActivity` subscribes to `Toolset` changes, refreshes the realtime session and chat context under `_refresh_lock`, and inserts an `AgentConfigUpdate` describing the diff. The public `update_tools()` path still records a no-op `AgentConfigUpdate` when the requested tool set is unchanged.
- `_close_session` cancels refresh tasks and takes `_refresh_lock` before closing realtime resources, so an in-flight tool publish cannot race with realtime close.
- The publish path is extracted into `_publish_tools_change`, used by both `update_tools()` and background refresh.
- `_handle_message` passes `Exception`-typed messages through `anyio.lowlevel.checkpoint()`, matching the MCP SDK default handler so cooperative cancellation propagates.

No public API changes; new callbacks are internal plumbing.

## Test plan

### Automated

- `uv run --extra mcp pytest tests/test_mcp.py`
  - `19 passed`
- `uv run ruff check livekit-agents/livekit/agents/voice/agent_activity.py livekit-agents/livekit/agents/llm/mcp.py tests/test_mcp.py`
- `make check`
- Earlier branch run: `uv run --extra mcp pytest tests/test_tools.py`
  - `37 passed`
- Earlier branch run: `make unit-tests`
  - `626 passed, 2 skipped`; `tests/test_room.py` setup failed locally because this machine does not have the `livekit-server` binary on PATH.

New coverage in `tests/test_mcp.py` includes:

- notification during initial `list_tools()` does not get missed
- notification during base `MCPServer.list_tools()` keeps the cache dirty
- toolset reload retries transient failures and surfaces terminal failures
- realtime/chat-context refresh serializes concurrent publishers
- close waits for an in-flight tool publish before closing realtime resources
- public no-op `update_tools()` still records an audit `AgentConfigUpdate`
- post-close `update_tools()` is a no-op
- subscriptions are removed on close
- `Exception`-typed MCP messages preserve cancellation behavior

### End-to-end smoke against a real subprocess MCP server

Wrote a minimal MCP stdio server (using `mcp.server.lowlevel.Server` + `ServerSession.send_tool_list_changed`) that mutates its tool list 1s after start, then drove `MCPServerStdio` + `MCPToolset` against it in three modes (`_RELOAD_RETRY_DELAYS` patched to 0/0.1/0.1 for speed):

```
=== scenario: happy ===
  initial: ['echo']
  after_change_observed: True
  final: ['ping', 'shout']
  reload_failures: []

=== scenario: retry ===
  initial: ['echo']
  after_change_observed: True
  final: ['ping', 'shout']
  reload_failures: []

=== scenario: terminal ===
  initial: ['echo']
  after_change_observed: True
  final: ['echo']
  reload_failures: ['McpError']
```

## Notes

- `tests/test_mcp.py` is added to the `unit-tests` make target so it runs in CI.
- Reload uses bounded retry (4 attempts, 1s/2s/4s backoff). On exhaustion the previous tool set is preserved and the failure surfaces via `AgentSession`'s error event.
- `_refresh_lock` is separate from `self._lock` because `_close_session` holds `self._lock` while cancelling refresh tasks; using one lock for both would deadlock.
- The reload-failure `ErrorEvent` is tagged with `source=<MCPServer>` (not the agent) so listeners with multiple MCP servers can identify which one went stale.
- The error event is one-shot per terminal failure; there is no paired "recovered" event when the next reload succeeds. Operators who need recovery confirmation should poll the agent's tool list. Tracked as a follow-up if it becomes painful in practice.
- `_publish_tools_change` re-checks `_closed` after acquiring `_refresh_lock` so a publish queued behind the lock cannot wake into a closing realtime session. `_request_tools_reload` bails if the toolset has already unsubscribed, closing a snapshot-iteration race in `MCPServer._handle_tool_list_changed`.
- `anyio.lowlevel.checkpoint()` runs at the top of `_handle_message` for every message (not just `Exception`-typed), matching the MCP SDK default handler so notification bursts don't starve the receive loop of cancellation points.
