### PR TITLE
fix: end Runway realtime sessions on shutdown

### DIFF
--- a/livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py
+++ b/livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py
@@ -116,7 +116,8 @@ class AvatarSession(BaseAvatarSession):
         )
 
         logger.debug("starting Runway avatar session")
-        await self._create_session(livekit_url, livekit_token, room.name)
+        session_id = await self._create_session(livekit_url, livekit_token, room.name)
+        job_ctx.add_shutdown_callback(lambda: self._cancel_runway_realtime_session(session_id))
 
         agent_session.output.audio = DataStreamAudioOutput(
             room=room,
@@ -125,7 +126,7 @@ class AvatarSession(BaseAvatarSession):
             sample_rate=SAMPLE_RATE,
         )
 
-    async def _create_session(self, livekit_url: str, livekit_token: str, room_name: str) -> None:
+    async def _create_session(self, livekit_url: str, livekit_token: str, room_name: str) -> str:
         assert self._api_key is not None
         assert isinstance(self._api_url, str)
 
@@ -161,7 +162,15 @@ class AvatarSession(BaseAvatarSession):
                             status_code=response.status,
                             body=text,
                         )
-                    return
+                    payload = await response.json()
+                    session_id = payload.get("id") if isinstance(payload, dict) else None
+                    if not session_id or not isinstance(session_id, str):
+                        raise APIStatusError(
+                            "Runway API response missing session id",
+                            status_code=response.status,
+                            body=str(payload),
+                        )
+                    return session_id
 
             except Exception as error:
                 if isinstance(error, APIStatusError):
@@ -179,3 +188,35 @@ class AvatarSession(BaseAvatarSession):
                     await asyncio.sleep(self._conn_options.retry_interval)
 
         raise APIConnectionError("Failed to start Runway Avatar Session after all retries")
+
+    async def _cancel_runway_realtime_session(self, session_id: str) -> None:
+        assert self._api_key is not None
+        assert isinstance(self._api_url, str)
+
+        try:
+            async with self._ensure_http_session().delete(
+                f"{self._api_url}/v1/realtime_sessions/{session_id}",
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "X-Runway-Version": API_VERSION,
+                },
+                timeout=aiohttp.ClientTimeout(total=self._conn_options.timeout),
+            ) as response:
+                if response.ok:
+                    logger.debug(
+                        "cancelled Runway realtime session",
+                        extra={"session_id": session_id},
+                    )
+                else:
+                    logger.warning(
+                        "could not cancel Runway realtime session",
+                        extra={
+                            "session_id": session_id,
+                            "status": response.status,
+                        },
+                    )
+        except Exception as exc:
+            logger.warning(
+                "error cancelling Runway realtime session",
+                extra={"session_id": session_id, "error": str(exc)},
+            )

--- a/livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py
+++ b/livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py
@@ -164,7 +164,7 @@ class AvatarSession(BaseAvatarSession):
                         )
                     payload = await response.json()
                     session_id = payload.get("id") if isinstance(payload, dict) else None
-                    if not session_id or not isinstance(session_id, str):
+                    if not isinstance(session_id, str):
                         raise APIStatusError(
                             "Runway API response missing session id",
                             status_code=response.status,


### PR DESCRIPTION
End Runway realtime sessions through the normal LiveKit data-channel lifecycle when the LiveKit job shuts down, so conversations complete cleanly instead of being marked cancelled.

Verify:
- `uv run ruff format livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py`
- `uv run ruff check livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py`
- `make type-check`