### PR TITLE
fix(warm_transfer): don't fall back to env var when sip_connection is set

### DIFF
--- a/livekit-agents/livekit/agents/beta/workflows/warm_transfer.py
+++ b/livekit-agents/livekit/agents/beta/workflows/warm_transfer.py
@@ -119,11 +119,13 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
 
         self._sip_call_to = sip_call_to
         self._sip_connection = sip_connection if is_given(sip_connection) else None
-        self._sip_trunk_id = (
-            sip_trunk_id
-            if is_given(sip_trunk_id)
-            else os.getenv("LIVEKIT_SIP_OUTBOUND_TRUNK", None)
-        )
+        if is_given(sip_trunk_id):
+            self._sip_trunk_id = sip_trunk_id
+        elif self._sip_connection is not None:
+            # explicit sip_connection: don't override with the env var trunk
+            self._sip_trunk_id = None
+        else:
+            self._sip_trunk_id = os.getenv("LIVEKIT_SIP_OUTBOUND_TRUNK", None)
         if self._sip_trunk_id is None and self._sip_connection is None:
             raise ValueError(
                 "`LIVEKIT_SIP_OUTBOUND_TRUNK` environment variable, `sip_trunk_id`,"


### PR DESCRIPTION
## Summary

When `sip_connection` was explicitly passed to `WarmTransferTask` but `sip_trunk_id` was not, `__init__` still fell back to the `LIVEKIT_SIP_OUTBOUND_TRUNK` env var. `_dial_human_agent` then set both `sip_trunk_id` and `trunk` on `CreateSIPParticipantRequest`, and the server prioritizes `sip_trunk_id` — so the inline `SIPOutboundConfig` was silently ignored whenever the env var happened to be set in the environment.

## Fix

Only fall back to `LIVEKIT_SIP_OUTBOUND_TRUNK` when neither `sip_trunk_id` nor `sip_connection` was explicitly provided.