### PR TITLE
fix: end Runway realtime sessions on shutdown

### DIFF
--- a/livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py
+++ b/livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py
@@ -78,6 +78,7 @@ class AvatarSession(BaseAvatarSession):
         self._avatar_participant_name = avatar_participant_name or _AVATAR_AGENT_NAME
         self._http_session: aiohttp.ClientSession | None = None
         self._conn_options = conn_options
+        self._room: rtc.Room | None = None
         self._end_session_task: asyncio.Task[None] | None = None
 
     def _ensure_http_session(self) -> aiohttp.ClientSession:
@@ -95,6 +96,7 @@ class AvatarSession(BaseAvatarSession):
         livekit_api_secret: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
         await super().start(agent_session, room)
+        self._room = room
 
         livekit_url = livekit_url or (os.getenv("LIVEKIT_URL") or NOT_GIVEN)
         livekit_api_key = livekit_api_key or (os.getenv("LIVEKIT_API_KEY") or NOT_GIVEN)
@@ -123,11 +125,7 @@ class AvatarSession(BaseAvatarSession):
 
         @agent_session.on("close")
         def _on_agent_session_close(_: Any) -> None:
-            if self._end_session_task is None:
-                self._end_session_task = asyncio.create_task(
-                    self._end_runway_realtime_session(room),
-                    name="runway_end_realtime_session",
-                )
+            self._ensure_end_session_task()
 
         agent_session.output.audio = DataStreamAudioOutput(
             room=room,
@@ -191,6 +189,19 @@ class AvatarSession(BaseAvatarSession):
 
         raise APIConnectionError("Failed to start Runway Avatar Session after all retries")
 
+    def _ensure_end_session_task(self) -> asyncio.Task[None] | None:
+        if self._end_session_task is not None:
+            return self._end_session_task
+
+        if self._room is None:
+            return None
+
+        self._end_session_task = asyncio.create_task(
+            self._end_runway_realtime_session(self._room),
+            name="runway_end_realtime_session",
+        )
+        return self._end_session_task
+
     async def _end_runway_realtime_session(self, room: rtc.Room) -> None:
         if not room.isconnected():
             logger.warning("could not end Runway realtime session; room is disconnected")
@@ -210,5 +221,5 @@ class AvatarSession(BaseAvatarSession):
             )
 
     async def aclose(self) -> None:
-        if self._end_session_task is not None:
-            await asyncio.shield(self._end_session_task)
+        if end_session_task := self._ensure_end_session_task():
+            await asyncio.shield(end_session_task)

--- a/livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py
+++ b/livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 
 import aiohttp
@@ -116,8 +117,8 @@ class AvatarSession(BaseAvatarSession):
         )
 
         logger.debug("starting Runway avatar session")
-        session_id = await self._create_session(livekit_url, livekit_token, room.name)
-        job_ctx.add_shutdown_callback(lambda: self._cancel_runway_realtime_session(session_id))
+        await self._create_session(livekit_url, livekit_token, room.name)
+        job_ctx.add_shutdown_callback(lambda: self._end_runway_realtime_session(room))
 
         agent_session.output.audio = DataStreamAudioOutput(
             room=room,
@@ -126,7 +127,7 @@ class AvatarSession(BaseAvatarSession):
             sample_rate=SAMPLE_RATE,
         )
 
-    async def _create_session(self, livekit_url: str, livekit_token: str, room_name: str) -> str:
+    async def _create_session(self, livekit_url: str, livekit_token: str, room_name: str) -> None:
         assert self._api_key is not None
         assert isinstance(self._api_url, str)
 
@@ -162,15 +163,7 @@ class AvatarSession(BaseAvatarSession):
                             status_code=response.status,
                             body=text,
                         )
-                    payload = await response.json()
-                    session_id = payload.get("id") if isinstance(payload, dict) else None
-                    if not isinstance(session_id, str):
-                        raise APIStatusError(
-                            "Runway API response missing session id",
-                            status_code=response.status,
-                            body=str(payload),
-                        )
-                    return session_id
+                    return
 
             except Exception as error:
                 if isinstance(error, APIStatusError):
@@ -189,34 +182,16 @@ class AvatarSession(BaseAvatarSession):
 
         raise APIConnectionError("Failed to start Runway Avatar Session after all retries")
 
-    async def _cancel_runway_realtime_session(self, session_id: str) -> None:
-        assert self._api_key is not None
-        assert isinstance(self._api_url, str)
-
+    async def _end_runway_realtime_session(self, room: rtc.Room) -> None:
         try:
-            async with self._ensure_http_session().delete(
-                f"{self._api_url}/v1/realtime_sessions/{session_id}",
-                headers={
-                    "Authorization": f"Bearer {self._api_key}",
-                    "X-Runway-Version": API_VERSION,
-                },
-                timeout=aiohttp.ClientTimeout(total=self._conn_options.timeout),
-            ) as response:
-                if response.ok:
-                    logger.debug(
-                        "cancelled Runway realtime session",
-                        extra={"session_id": session_id},
-                    )
-                else:
-                    logger.warning(
-                        "could not cancel Runway realtime session",
-                        extra={
-                            "session_id": session_id,
-                            "status": response.status,
-                        },
-                    )
+            await room.local_participant.publish_data(
+                json.dumps({"type": "END_CALL"}).encode("utf-8"),
+                reliable=True,
+                destination_identities=[self._avatar_participant_identity],
+            )
+            logger.debug("sent Runway realtime session end call")
         except Exception as exc:
             logger.warning(
-                "error cancelling Runway realtime session",
-                extra={"session_id": session_id, "error": str(exc)},
+                "error ending Runway realtime session",
+                extra={"error": str(exc)},
             )

--- a/livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py
+++ b/livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py
@@ -19,6 +19,7 @@ from livekit.agents import (
     get_job_context,
     utils,
 )
+from livekit.agents.utils import is_given
 from livekit.agents.voice.avatar import AvatarSession as BaseAvatarSession, DataStreamAudioOutput
 from livekit.agents.voice.room_io import ATTRIBUTE_PUBLISH_ON_BEHALF
 
@@ -79,6 +80,7 @@ class AvatarSession(BaseAvatarSession):
         self._http_session: aiohttp.ClientSession | None = None
         self._conn_options = conn_options
         self._room: rtc.Room | None = None
+        self._realtime_session_id: str | None = None
         self._end_session_task: asyncio.Task[None] | None = None
 
     def _ensure_http_session(self) -> aiohttp.ClientSession:
@@ -135,9 +137,6 @@ class AvatarSession(BaseAvatarSession):
         )
 
     async def _create_session(self, livekit_url: str, livekit_token: str, room_name: str) -> None:
-        assert self._api_key is not None
-        assert isinstance(self._api_url, str)
-
         body: dict[str, object] = {
             "model": "gwm1_avatars",
             "avatar": self._avatar,
@@ -149,7 +148,7 @@ class AvatarSession(BaseAvatarSession):
             },
         }
 
-        if self._max_duration:
+        if is_given(self._max_duration):
             body["maxDuration"] = self._max_duration
 
         for attempt in range(self._conn_options.max_retry):
@@ -170,10 +169,14 @@ class AvatarSession(BaseAvatarSession):
                             status_code=response.status,
                             body=text,
                         )
+                    payload = await response.json()
+                    session_id = payload.get("id") if isinstance(payload, dict) else None
+                    if isinstance(session_id, str):
+                        self._realtime_session_id = session_id
                     return
 
             except Exception as error:
-                if isinstance(error, APIStatusError):
+                if isinstance(error, APIStatusError) and not error.retryable:
                     raise
 
                 if isinstance(error, APIConnectionError):
@@ -203,21 +206,63 @@ class AvatarSession(BaseAvatarSession):
         return self._end_session_task
 
     async def _end_runway_realtime_session(self, room: rtc.Room) -> None:
-        if not room.isconnected():
-            logger.warning("could not end Runway realtime session; room is disconnected")
+        # Preferred path: data-channel END_CALL while the room is still connected.
+        # The Runway worker handles this message and shuts the session down through
+        # the normal "user ended call" lifecycle (COMPLETED, not CANCELLED).
+        if room.isconnected():
+            try:
+                await room.local_participant.publish_data(
+                    json.dumps({"type": "END_CALL"}).encode("utf-8"),
+                    reliable=True,
+                    destination_identities=[self._avatar_participant_identity],
+                )
+                logger.debug("sent Runway realtime session end call")
+                return
+            except Exception as exc:
+                logger.warning(
+                    "error ending Runway realtime session via data channel",
+                    extra={"error": str(exc)},
+                )
+
+        # Fallback for hard shutdowns where the room is already disconnected
+        # (e.g. aclose() registered as a job shutdown callback runs after
+        # room.disconnect()): cancel the session via API so we don't keep
+        # billing until maxDuration.
+        await self._cancel_runway_realtime_session()
+
+    async def _cancel_runway_realtime_session(self) -> None:
+        session_id = self._realtime_session_id
+        if session_id is None:
+            logger.warning("could not cancel Runway realtime session; no session id available")
             return
 
         try:
-            await room.local_participant.publish_data(
-                json.dumps({"type": "END_CALL"}).encode("utf-8"),
-                reliable=True,
-                destination_identities=[self._avatar_participant_identity],
-            )
-            logger.debug("sent Runway realtime session end call")
+            async with self._ensure_http_session().delete(
+                f"{self._api_url}/v1/realtime_sessions/{session_id}",
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "X-Runway-Version": API_VERSION,
+                },
+                timeout=aiohttp.ClientTimeout(total=self._conn_options.timeout),
+            ) as response:
+                if response.ok:
+                    logger.debug(
+                        "cancelled Runway realtime session",
+                        extra={"session_id": session_id},
+                    )
+                else:
+                    logger.warning(
+                        "could not cancel Runway realtime session",
+                        extra={
+                            "session_id": session_id,
+                            "status": response.status,
+                            "body": await response.text(),
+                        },
+                    )
         except Exception as exc:
             logger.warning(
-                "error ending Runway realtime session",
-                extra={"error": str(exc)},
+                "error cancelling Runway realtime session",
+                extra={"session_id": session_id, "error": str(exc)},
             )
 
     async def aclose(self) -> None:

--- a/livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py
+++ b/livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+from typing import Any
 
 import aiohttp
 
@@ -77,6 +78,7 @@ class AvatarSession(BaseAvatarSession):
         self._avatar_participant_name = avatar_participant_name or _AVATAR_AGENT_NAME
         self._http_session: aiohttp.ClientSession | None = None
         self._conn_options = conn_options
+        self._end_session_task: asyncio.Task[None] | None = None
 
     def _ensure_http_session(self) -> aiohttp.ClientSession:
         if self._http_session is None:
@@ -118,7 +120,14 @@ class AvatarSession(BaseAvatarSession):
 
         logger.debug("starting Runway avatar session")
         await self._create_session(livekit_url, livekit_token, room.name)
-        job_ctx.add_shutdown_callback(lambda: self._end_runway_realtime_session(room))
+
+        @agent_session.on("close")
+        def _on_agent_session_close(_: Any) -> None:
+            if self._end_session_task is None:
+                self._end_session_task = asyncio.create_task(
+                    self._end_runway_realtime_session(room),
+                    name="runway_end_realtime_session",
+                )
 
         agent_session.output.audio = DataStreamAudioOutput(
             room=room,
@@ -183,6 +192,10 @@ class AvatarSession(BaseAvatarSession):
         raise APIConnectionError("Failed to start Runway Avatar Session after all retries")
 
     async def _end_runway_realtime_session(self, room: rtc.Room) -> None:
+        if not room.isconnected():
+            logger.warning("could not end Runway realtime session; room is disconnected")
+            return
+
         try:
             await room.local_participant.publish_data(
                 json.dumps({"type": "END_CALL"}).encode("utf-8"),
@@ -195,3 +208,7 @@ class AvatarSession(BaseAvatarSession):
                 "error ending Runway realtime session",
                 extra={"error": str(exc)},
             )
+
+    async def aclose(self) -> None:
+        if self._end_session_task is not None:
+            await asyncio.shield(self._end_session_task)


### PR DESCRIPTION
Gracefully end Runway realtime sessions when the LiveKit job shuts down by sending the normal `END_CALL` data-channel message to the avatar participant. This follows the same lifecycle as a user-ended call, so conversations can complete cleanly instead of being cancelled through the API.

The worker-side trusted-agent-disconnect handling still provides defense in depth for hard disconnects or missed cleanup.

Verify:
- `uv run ruff format livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py`
- `uv run ruff check livekit-plugins/livekit-plugins-runway/livekit/plugins/runway/avatar.py`
- `make type-check`
- `uv run pytest tests/test_agent_session.py -k "test_interruption_before_speaking"`