### PR TITLE
fix(aws): wait for stream ready before sending audio start event

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -982,22 +982,23 @@ class RealtimeSession(  # noqa: F811
                 await self._send_raw_event(event)
                 await asyncio.sleep(0.01)
 
-            # Step 3: Create audio input task (sends AUDIO contentStart immediately)
-            self._audio_input_task = asyncio.create_task(
-                self._process_audio_input(), name="RealtimeSession._process_audio_input"
-            )
-
+            # Step 3: Start response reader first (calls await_output, sets _stream_ready)
             self._response_task = asyncio.create_task(
                 self._process_responses(), name="RealtimeSession._process_responses"
             )
 
-            # Step 4: Allow audio contentStart to be sent before unblocking
+            # Step 4: Start audio input (waits for _stream_ready before sending audio_content_start)
+            self._audio_input_task = asyncio.create_task(
+                self._process_audio_input(), name="RealtimeSession._process_audio_input"
+            )
+
+            # Step 5: Allow audio contentStart to be sent before unblocking
             # interactive text (generate_reply). This avoids sending AUDIO and TEXT
             # interactive contentStart events simultaneously.
             await asyncio.sleep(0.05)
             self._is_sess_active.set()
 
-            # Step 5: If we popped a user message from history, send it as
+            # Step 6: If we popped a user message from history, send it as
             # interactive text now to trigger Nova Sonic to respond.
             if interactive_user_text:
                 await self._stream_ready.wait()
@@ -1916,6 +1917,11 @@ class RealtimeSession(  # noqa: F811
     @utils.log_exceptions(logger=logger)
     async def _process_audio_input(self) -> None:
         """Background task that feeds audio and tool results into the Bedrock stream."""
+        # Wait for the bidirectional stream to be fully established (HTTP 200)
+        # before sending audio_content_start_event. Without this, under load
+        # Bedrock may not have finished processing chat history, causing:
+        # ValidationException: "Chat history should be sent completely before streaming audio."
+        await self._stream_ready.wait()
         await self._send_raw_event(self._event_builder.create_audio_content_start_event())
         logger.info("Starting audio input processing loop")
 


### PR DESCRIPTION
**Problem**
Under load, _process_audio_input sends audio_content_start_event before Bedrock confirms it has finished processing chat history. This causes:
```
ValidationException: "Chat history should be sent completely before streaming audio."
```
The root cause is a race condition in initialize_streams: the _process_audio_input task was created before _process_responses, and immediately fired off the audio start event without waiting for the stream to be established.

**Changes**
- Added await self._stream_ready.wait() in _process_audio_input before sending audio_content_start_event
- Swapped task creation order in initialize_streams so _process_responses (which calls await_output and sets _stream_ready) starts before _process_audio_input

**Testing**
No behavior change on the happy path. The fix only adds a gate that ensures the stream is ready before audio begins, which was already the implicit assumption.