### PR TITLE
fix: reduce overly eager call ending behavior

### DIFF
--- a/livekit-agents/livekit/agents/beta/tools/end_call.py
+++ b/livekit-agents/livekit/agents/beta/tools/end_call.py
@@ -13,7 +13,6 @@ Ends the current call and disconnects immediately.
 
 Call when:
 - The user clearly indicates they are done (e.g., “that’s all, bye”).
-- The agent determines the conversation is complete and should end.
 
 Do not call when:
 - The user asks to pause, hold, or transfer.


### PR DESCRIPTION
the line "The agent determines the conversation is complete and should end." was causing the agent to hang up even though the user clearly did not

this is due to the agent making an assessment that the conversation is complete, without getting a clear user signal that's what they want