### PR TITLE
feat(cli): add --reload-dir to dev for extra watch directories

### DIFF
--- a/.github/next-release/changeset-reload-dir.md
+++ b/.github/next-release/changeset-reload-dir.md
@@ -1,0 +1,8 @@
+---
+"livekit-agents": minor
+---
+
+Add `--reload-dir` (repeatable) and `LIVEKIT_RELOAD_DIRS` to `dev` so the watcher
+restarts the worker on edits inside additional, user-supplied directories.
+Auto-discovery of the entrypoint, `livekit.agents`, and editable plugins is
+unchanged; the new flag is purely additive.

--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -1816,7 +1816,32 @@ def _build_cli(server: AgentServer) -> typer.Typer:
                 envvar="LIVEKIT_API_SECRET",
             ),
         ] = None,
+        reload_dir: Annotated[
+            list[pathlib.Path] | None,  # noqa: UP007
+            typer.Option(
+                "--reload-dir",
+                envvar="LIVEKIT_RELOAD_DIRS",
+                help=(
+                    "Additional directory to watch for .py changes (repeatable). "
+                    "Watched recursively; avoid huge trees. "
+                    "Env var LIVEKIT_RELOAD_DIRS is split on os.pathsep."
+                ),
+            ),
+        ] = None,
     ) -> None:
+        c = AgentsConsole.get_instance()
+        _configure_logger(c, log_level.value)
+
+        resolved_reload_dirs: list[pathlib.Path] = []
+        for p in reload_dir or []:
+            rp = pathlib.Path(p).expanduser().resolve()
+            if not rp.exists():
+                c.print(" ")
+                c.print(f"[error]--reload-dir path does not exist: {p}")
+                c.print(" ")
+                raise typer.Exit(code=1)
+            resolved_reload_dirs.append(rp)
+
         args = proto.CliArgs(
             log_level=log_level.value,
             url=url,
@@ -1824,10 +1849,8 @@ def _build_cli(server: AgentServer) -> typer.Typer:
             api_secret=api_secret,
             devmode=True,
             reload=reload,
+            reload_dirs=resolved_reload_dirs,
         )
-
-        c = AgentsConsole.get_instance()
-        _configure_logger(c, log_level.value)
 
         term_program = os.environ.get("TERM_PROGRAM")
 
@@ -1836,6 +1859,8 @@ def _build_cli(server: AgentServer) -> typer.Typer:
             args.reload = False
 
         if not args.reload:
+            if resolved_reload_dirs:
+                c.print("[error]--reload-dir provided but auto-reload is disabled; ignoring.")
             _run_worker(server=server, args=args)
             return
 

--- a/livekit-agents/livekit/agents/cli/proto.py
+++ b/livekit-agents/livekit/agents/cli/proto.py
@@ -1,6 +1,7 @@
 from __future__ import annotations  # noqa: I001
 
 import io
+import pathlib
 import socket
 from dataclasses import dataclass, field
 from typing import ClassVar
@@ -22,6 +23,10 @@ class CliArgs:
 
     devmode: bool = False
     reload: bool = False
+
+    # extra directories supplied by the user via `--reload-dir` / LIVEKIT_RELOAD_DIRS;
+    # unioned with the auto-discovered watch paths inside WatchServer.
+    reload_dirs: list[pathlib.Path] = field(default_factory=list)
 
     # simulate_job: str | None = None
 

--- a/livekit-agents/livekit/agents/cli/watcher.py
+++ b/livekit-agents/livekit/agents/cli/watcher.py
@@ -83,9 +83,14 @@ class WatchServer:
         self._close_fut = asyncio.Future[None]()
 
     async def run(self) -> None:
-        watch_paths = _find_watchable_paths(self._main_file)
-        for pth in watch_paths:
+        auto_paths = _find_watchable_paths(self._main_file)
+        user_paths = list(self._cli_args.reload_dirs)
+        watch_paths = [*auto_paths, *user_paths]
+
+        for pth in auto_paths:
             logger.log(DEV_LEVEL, f"Watching {pth}")
+        for pth in user_paths:
+            logger.log(DEV_LEVEL, f"Watching {pth} (user)")
 
         self._pch = await utils.aio.duplex_unix._AsyncDuplex.open(self._mp_pch)
         read_ipc_task = self._loop.create_task(self._read_ipc_task())

--- a/tests/test_reload_dir.py
+++ b/tests/test_reload_dir.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import pathlib
+import pickle
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import watchfiles
+from typer.testing import CliRunner
+
+from livekit.agents.cli import proto
+from livekit.agents.cli.cli import _build_cli
+from livekit.agents.cli.watcher import WatchServer
+from livekit.agents.worker import AgentServer, ServerOptions
+
+
+def _make_server() -> AgentServer:
+    async def _fake_entrypoint(ctx: Any) -> None:
+        pass
+
+    opts = ServerOptions(entrypoint_fnc=_fake_entrypoint)
+    return AgentServer.from_server_options(opts)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch) -> Any:
+    # Remove iTerm2 carve-out for parsing-focused tests; the carve-out has its own tests.
+    monkeypatch.delenv("TERM_PROGRAM", raising=False)
+    return _build_cli(_make_server())
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — new logic
+# ---------------------------------------------------------------------------
+
+
+class TestReloadDirParsing:
+    """Scenarios covering how `--reload-dir` and LIVEKIT_RELOAD_DIRS land on CliArgs."""
+
+    @patch("livekit.agents.cli.cli._run_worker")
+    def test_default_no_flag_no_env(
+        self, mock_run_worker: MagicMock, runner: CliRunner, app: Any
+    ) -> None:
+        result = runner.invoke(app, ["dev", "--no-reload"])
+        assert result.exit_code == 0, result.output
+        args: proto.CliArgs = mock_run_worker.call_args.kwargs["args"]
+        assert args.reload_dirs == []
+
+    @patch("livekit.agents.cli.cli._run_worker")
+    def test_repeated_flag_accumulates(
+        self,
+        mock_run_worker: MagicMock,
+        runner: CliRunner,
+        app: Any,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        result = runner.invoke(
+            app,
+            ["dev", "--no-reload", "--reload-dir", str(a), "--reload-dir", str(b)],
+        )
+        assert result.exit_code == 0, result.output
+        args: proto.CliArgs = mock_run_worker.call_args.kwargs["args"]
+        assert args.reload_dirs == [a.resolve(), b.resolve()]
+
+    @patch("livekit.agents.cli.cli._run_worker")
+    def test_env_var_pathsep_split(
+        self,
+        mock_run_worker: MagicMock,
+        runner: CliRunner,
+        app: Any,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        env_value = os.pathsep.join([str(a), str(b)])
+        result = runner.invoke(
+            app,
+            ["dev", "--no-reload"],
+            env={"LIVEKIT_RELOAD_DIRS": env_value},
+        )
+        assert result.exit_code == 0, result.output
+        args: proto.CliArgs = mock_run_worker.call_args.kwargs["args"]
+        assert args.reload_dirs == [a.resolve(), b.resolve()]
+
+    @patch("livekit.agents.cli.cli._run_worker")
+    def test_flag_overrides_env(
+        self,
+        mock_run_worker: MagicMock,
+        runner: CliRunner,
+        app: Any,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        flag_dir = tmp_path / "flag"
+        env_dir = tmp_path / "env"
+        flag_dir.mkdir()
+        env_dir.mkdir()
+        result = runner.invoke(
+            app,
+            ["dev", "--no-reload", "--reload-dir", str(flag_dir)],
+            env={"LIVEKIT_RELOAD_DIRS": str(env_dir)},
+        )
+        assert result.exit_code == 0, result.output
+        args: proto.CliArgs = mock_run_worker.call_args.kwargs["args"]
+        assert args.reload_dirs == [flag_dir.resolve()]
+
+    @patch("livekit.agents.cli.cli._run_worker")
+    def test_relative_path_resolved_to_absolute(
+        self,
+        mock_run_worker: MagicMock,
+        runner: CliRunner,
+        app: Any,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["dev", "--no-reload", "--reload-dir", "sub"])
+        assert result.exit_code == 0, result.output
+        args: proto.CliArgs = mock_run_worker.call_args.kwargs["args"]
+        assert args.reload_dirs == [sub.resolve()]
+        assert args.reload_dirs[0].is_absolute()
+
+    @patch("livekit.agents.cli.cli._run_worker")
+    def test_symlink_resolved(
+        self,
+        mock_run_worker: MagicMock,
+        runner: CliRunner,
+        app: Any,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        real = tmp_path / "real"
+        link = tmp_path / "link"
+        real.mkdir()
+        link.symlink_to(real)
+        result = runner.invoke(app, ["dev", "--no-reload", "--reload-dir", str(link)])
+        assert result.exit_code == 0, result.output
+        args: proto.CliArgs = mock_run_worker.call_args.kwargs["args"]
+        # .resolve() collapses the symlink to the real path
+        assert args.reload_dirs == [real.resolve()]
+
+    @patch("livekit.agents.cli.cli._run_worker")
+    def test_missing_path_flag_fails_fast(
+        self,
+        mock_run_worker: MagicMock,
+        runner: CliRunner,
+        app: Any,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        bogus = tmp_path / "does_not_exist"
+        result = runner.invoke(app, ["dev", "--no-reload", "--reload-dir", str(bogus)])
+        assert result.exit_code == 1
+        assert "does not exist" in result.output
+        mock_run_worker.assert_not_called()
+
+    @patch("livekit.agents.cli.cli._run_worker")
+    def test_missing_path_env_fails_fast(
+        self,
+        mock_run_worker: MagicMock,
+        runner: CliRunner,
+        app: Any,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        bogus = tmp_path / "does_not_exist"
+        result = runner.invoke(
+            app,
+            ["dev", "--no-reload"],
+            env={"LIVEKIT_RELOAD_DIRS": str(bogus)},
+        )
+        assert result.exit_code == 1
+        assert "does not exist" in result.output
+        mock_run_worker.assert_not_called()
+
+
+class TestCliArgsPickle:
+    """CliArgs crosses the watchfiles fork boundary; pickling must round-trip."""
+
+    def test_default_round_trip(self) -> None:
+        args = proto.CliArgs(log_level="DEBUG", url=None)
+        restored = pickle.loads(pickle.dumps(args))
+        assert restored.reload_dirs == []
+
+    def test_non_empty_round_trip(self, tmp_path: pathlib.Path) -> None:
+        paths = [tmp_path / "a", tmp_path / "b"]
+        args = proto.CliArgs(log_level="DEBUG", url=None, reload_dirs=paths)
+        restored = pickle.loads(pickle.dumps(args))
+        assert restored.reload_dirs == paths
+
+
+# ---------------------------------------------------------------------------
+# Regression tests — old logic affected by the change
+# ---------------------------------------------------------------------------
+
+
+class TestRegressionDefaults:
+    """Pin existing behavior so the additive change stays additive."""
+
+    @patch("livekit.agents.cli.cli._run_worker")
+    def test_dev_no_reload_carries_no_reload_dirs(
+        self, mock_run_worker: MagicMock, runner: CliRunner, app: Any
+    ) -> None:
+        # No flag, no env -> reload_dirs stays empty (BC contract).
+        result = runner.invoke(app, ["dev", "--no-reload"])
+        assert result.exit_code == 0
+        args: proto.CliArgs = mock_run_worker.call_args.kwargs["args"]
+        assert args.reload_dirs == []
+        assert args.reload is False
+        assert args.devmode is True
+
+
+class TestRegressionITerm2Carveout:
+    """The iTerm2 force-disable path is unaffected and now warns when --reload-dir was set."""
+
+    @patch("livekit.agents.cli.cli._run_worker")
+    def test_iterm2_disables_reload(
+        self,
+        mock_run_worker: MagicMock,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("TERM_PROGRAM", "iTerm.app")
+        app = _build_cli(_make_server())
+        result = runner.invoke(app, ["dev"])  # default --reload=True
+        assert result.exit_code == 0
+        args: proto.CliArgs = mock_run_worker.call_args.kwargs["args"]
+        assert args.reload is False
+        # The "Auto-reload is not supported" message goes through the AgentsConsole;
+        # CliRunner's captured stdout does not include rich-styled markup, so we just
+        # assert the worker was called single-process (no WatchServer constructed).
+        mock_run_worker.assert_called_once()
+
+    @patch("livekit.agents.cli.cli._run_worker")
+    def test_iterm2_with_reload_dir_warns_and_runs_single_process(
+        self,
+        mock_run_worker: MagicMock,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        monkeypatch.setenv("TERM_PROGRAM", "iTerm.app")
+        extra = tmp_path / "extra"
+        extra.mkdir()
+        app = _build_cli(_make_server())
+        result = runner.invoke(app, ["dev", "--reload-dir", str(extra)])
+        assert result.exit_code == 0
+        args: proto.CliArgs = mock_run_worker.call_args.kwargs["args"]
+        # The reload_dirs still travel on CliArgs (so they survive a hypothetical
+        # later re-enable), but reload is force-disabled and no WatchServer runs.
+        assert args.reload is False
+        assert args.reload_dirs == [extra.resolve()]
+        mock_run_worker.assert_called_once()
+
+    @patch("livekit.agents.cli.cli._run_worker")
+    def test_no_reload_with_reload_dir_runs_single_process(
+        self,
+        mock_run_worker: MagicMock,
+        runner: CliRunner,
+        app: Any,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        extra = tmp_path / "extra"
+        extra.mkdir()
+        result = runner.invoke(app, ["dev", "--no-reload", "--reload-dir", str(extra)])
+        assert result.exit_code == 0
+        args: proto.CliArgs = mock_run_worker.call_args.kwargs["args"]
+        assert args.reload is False
+        assert args.reload_dirs == [extra.resolve()]
+        mock_run_worker.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Watcher integration — path union and PythonFilter still in effect
+# ---------------------------------------------------------------------------
+
+
+class TestWatchServerPathUnion:
+    """Pin the watcher's contract: auto-discovered + user paths, PythonFilter intact."""
+
+    def test_run_unions_user_paths_and_keeps_python_filter(self, tmp_path: pathlib.Path) -> None:
+        captured: dict[str, Any] = {}
+
+        async def _fake_arun_process(*paths: Any, **kwargs: Any) -> int:
+            captured["paths"] = paths
+            captured["watch_filter"] = kwargs.get("watch_filter")
+            captured["target"] = kwargs.get("target")
+            return 0
+
+        extra = tmp_path / "extra"
+        extra.mkdir()
+        cli_args = proto.CliArgs(
+            log_level="DEBUG",
+            url=None,
+            devmode=True,
+            reload=True,
+            reload_dirs=[extra],
+        )
+
+        async def _go() -> None:
+            loop = asyncio.get_running_loop()
+            ws = WatchServer(
+                worker_runner=lambda *a, **kw: None,
+                server=_make_server(),
+                main_file=tmp_path,
+                cli_args=cli_args,
+                loop=loop,
+            )
+
+            with patch("watchfiles.arun_process", side_effect=_fake_arun_process):
+                run_task = loop.create_task(ws.run())
+                # Wait for the fake arun_process to be called (it returns immediately,
+                # which then triggers ws.aclose() inside the run-task).
+                for _ in range(50):
+                    await asyncio.sleep(0)
+                    if "paths" in captured:
+                        break
+                # Make sure the run task settles cleanly within the test timeout.
+                await asyncio.wait_for(run_task, timeout=2.0)
+
+        asyncio.run(_go())
+
+        assert "paths" in captured, "watchfiles.arun_process was never called"
+        # User-supplied dir must appear in the path list passed to watchfiles.
+        assert extra in captured["paths"], f"expected user dir {extra!r} in {captured['paths']!r}"
+        # The Python filter must still be in effect — pin this so a future cleanup
+        # cannot silently drop it and re-enable restart-storms on .git churn etc.
+        assert isinstance(captured["watch_filter"], watchfiles.filters.PythonFilter)
+
+
+class TestPythonFilterCoversIgnoredDirs:
+    """Sanity-pin the negative case: changes that must not trigger reloads."""
+
+    def test_filter_drops_non_python_and_ignored_dirs(self, tmp_path: pathlib.Path) -> None:
+        f = watchfiles.filters.PythonFilter()
+        change = watchfiles.Change.modified
+
+        # Positive: a regular .py file inside a user-supplied dir is observed.
+        assert f(change, str(tmp_path / "foo.py"))
+
+        # Negative: non-.py files are dropped.
+        assert not f(change, str(tmp_path / "notes.txt"))
+
+        # Negative: ignored dirs (the source of restart storms) are dropped.
+        assert not f(change, str(tmp_path / ".git" / "HEAD"))
+        assert not f(change, str(tmp_path / ".venv" / "x.py"))
+        assert not f(change, str(tmp_path / "__pycache__" / "x.cpython-311.pyc"))
+        assert not f(change, str(tmp_path / "node_modules" / "x.py"))


### PR DESCRIPTION
## Problem

`dev`-mode auto-reload only watches the entrypoint, `livekit.agents`, and editable plugins. Edits to *other* packages the agent imports (shared utility code mounted editable in monorepos) are silently ignored — the worker keeps holding stale module objects with no warning.

## Solution

Add repeatable `--reload-dir` (and `LIVEKIT_RELOAD_DIRS`, `os.pathsep`-split) to `dev`. Resolved paths are unioned with the auto-discovered list and passed to the existing `watchfiles.arun_process`. Auto-discovery is unchanged; omitting the flag preserves identical behavior.

```mermaid
flowchart LR
    F["--reload-dir / LIVEKIT_RELOAD_DIRS"] --> CA[CliArgs.reload_dirs]
    AD[_find_watchable_paths<br/>main + livekit.agents + plugins] --> U[union]
    CA --> U
    U --> AP["watchfiles.arun_process(*paths,<br/>watch_filter=PythonFilter())"]
```

Naming mirrors uvicorn's `--reload-dir` so muscle memory transfers.

### Notes worth flagging

- Missing path fails fast (exit 1, clear error). Silent skip would re-create the gap this PR closes.
- `PythonFilter` is retained, so `.git/`, `.venv/`, `__pycache__/`, `node_modules/`, and non-`.py` files don't trigger reloads — even inside user-supplied dirs.
- The flag does **not** split on commas (`A,B` → single path). Only the env var splits on `os.pathsep`. Help text calls this out.
- No allowlist gating (`/`, `~`, paths above `cwd`): hard-rejecting outside `cwd` would break the very monorepo workflow this is for, and `PythonFilter` already drops the dangerous dirs.

## Test plan

`tests/test_reload_dir.py` — 16 scenarios:

- [x] Defaults, repeated flag, env-var split, flag-overrides-env
- [x] Relative + `~` paths, symlink resolution
- [x] Missing path (flag + env) → exit 1
- [x] `CliArgs` pickle round-trip
- [x] iTerm2 carve-out preserved (with and without `--reload-dir`)
- [x] `WatchServer.run()` unions auto + user paths, keeps `PythonFilter`
- [x] `PythonFilter` drops `.git/HEAD`, `.venv/*.py`, etc.
- [x] `tests/test_cli_log_level.py` (25 cases) still passes

Manual: `dev --help` shows the flag + env-var; `dev --reload-dir /tmp/extra` logs `Watching /tmp/extra (user)`; bad path → exit 1.

Changeset: `.github/next-release/changeset-reload-dir.md` (livekit-agents minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)