### PR TITLE
examples: add Synap persistent memory integration

### DIFF
--- a/examples/other/synap_memory.py
+++ b/examples/other/synap_memory.py
@@ -9,6 +9,7 @@ cross-session memory via Synap (https://maximem.ai):
 
 Install: pip install maximem-synap-livekit-agents
 Get an API key at synap.maximem.ai
+Open source: https://github.com/maximem-ai/maximem_synap_sdk/tree/main/packages/integrations
 """
 
 import os

--- a/examples/other/synap_memory.py
+++ b/examples/other/synap_memory.py
@@ -11,11 +11,11 @@ Install: pip install maximem-synap-livekit-agents
 Get an API key at synap.maximem.ai
 """
 
-import asyncio
 import os
 
+from dotenv import load_dotenv
 from livekit.agents import Agent, AgentSession, ChatContext, RoomInputOptions
-from livekit.plugins import openai
+from livekit.plugins import deepgram, openai, silero
 
 from maximem_synap import MaximemSynapSDK
 from synap_livekit_agents import (
@@ -25,8 +25,12 @@ from synap_livekit_agents import (
     synap_store_tool,
 )
 
+load_dotenv()
+
 sdk = MaximemSynapSDK(api_key=os.environ["SYNAP_API_KEY"])
 
+# In production, derive USER_ID from the room participant identity or JWT claims
+# so each caller gets their own Synap memory namespace.
 USER_ID = "demo-user-001"
 CUSTOMER_ID = "demo-customer"
 
@@ -48,6 +52,7 @@ async def entrypoint(ctx):
             "Use synap_search to recall user preferences when relevant. "
             "Use synap_store to save important new facts the user mentions."
         ),
+        chat_ctx=chat_ctx,
         tools=[
             synap_search_tool(sdk=sdk, user_id=USER_ID, customer_id=CUSTOMER_ID),
             synap_store_tool(sdk=sdk, user_id=USER_ID, customer_id=CUSTOMER_ID),
@@ -56,7 +61,9 @@ async def entrypoint(ctx):
 
     session = AgentSession(
         llm=openai.LLM(model="gpt-4o"),
-        chat_ctx=chat_ctx,
+        stt=deepgram.STT(),
+        tts=openai.TTS(),
+        vad=silero.VAD.load(),
     )
 
     # 2. Automatically record every user transcription and assistant response

--- a/examples/other/synap_memory.py
+++ b/examples/other/synap_memory.py
@@ -1,0 +1,75 @@
+"""Synap memory integration for LiveKit Agents.
+
+Demonstrates three patterns for giving a LiveKit voice agent persistent,
+cross-session memory via Synap (https://maximem.ai):
+
+1. preload_synap_context  — inject long-term memory before the call starts
+2. attach_synap_recording — record every turn automatically
+3. synap_search_tool      — LLM-callable tool for explicit memory search
+
+Install: pip install maximem-synap-livekit-agents
+Get an API key at synap.maximem.ai
+"""
+
+import asyncio
+import os
+
+from livekit.agents import Agent, AgentSession, ChatContext, RoomInputOptions
+from livekit.plugins import openai
+
+from maximem_synap import MaximemSynapSDK
+from synap_livekit_agents import (
+    attach_synap_recording,
+    preload_synap_context,
+    synap_search_tool,
+    synap_store_tool,
+)
+
+sdk = MaximemSynapSDK(api_key=os.environ["SYNAP_API_KEY"])
+
+USER_ID = "demo-user-001"
+CUSTOMER_ID = "demo-customer"
+
+
+async def entrypoint(ctx):
+    chat_ctx = ChatContext()
+
+    # 1. Inject long-term memory before the first LLM turn
+    await preload_synap_context(
+        chat_ctx,
+        sdk,
+        user_id=USER_ID,
+        customer_id=CUSTOMER_ID,
+    )
+
+    agent = Agent(
+        instructions=(
+            "You are a helpful voice assistant with long-term memory. "
+            "Use synap_search to recall user preferences when relevant. "
+            "Use synap_store to save important new facts the user mentions."
+        ),
+        tools=[
+            synap_search_tool(sdk=sdk, user_id=USER_ID, customer_id=CUSTOMER_ID),
+            synap_store_tool(sdk=sdk, user_id=USER_ID, customer_id=CUSTOMER_ID),
+        ],
+    )
+
+    session = AgentSession(
+        llm=openai.LLM(model="gpt-4o"),
+        chat_ctx=chat_ctx,
+    )
+
+    # 2. Automatically record every user transcription and assistant response
+    attach_synap_recording(session, sdk, user_id=USER_ID, customer_id=CUSTOMER_ID)
+
+    await session.start(
+        agent=agent,
+        room=ctx.room,
+        room_input_options=RoomInputOptions(),
+    )
+
+
+if __name__ == "__main__":
+    from livekit.agents import cli, WorkerOptions
+
+    cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))

--- a/examples/other/synap_memory.py
+++ b/examples/other/synap_memory.py
@@ -3,9 +3,10 @@
 Demonstrates three patterns for giving a LiveKit voice agent persistent,
 cross-session memory via Synap (https://maximem.ai):
 
-1. preload_synap_context  — inject long-term memory before the call starts
-2. attach_synap_recording — record every turn automatically
-3. synap_search_tool      — LLM-callable tool for explicit memory search
+1. preload_synap_context    — inject long-term memory before the call starts
+2. attach_synap_recording   — record every turn automatically
+3. synap_search_tool /
+   synap_store_tool         — LLM-callable tools for explicit memory search and store
 
 Install: pip install maximem-synap-livekit-agents
 Get an API key at synap.maximem.ai
@@ -23,7 +24,7 @@ from synap_livekit_agents import (
     synap_store_tool,
 )
 
-from livekit.agents import Agent, AgentSession, ChatContext, RoomInputOptions
+from livekit.agents import Agent, AgentSession, ChatContext
 from livekit.plugins import deepgram, openai, silero
 
 load_dotenv()
@@ -37,6 +38,8 @@ CUSTOMER_ID = "demo-customer"
 
 
 async def entrypoint(ctx):
+    await ctx.connect()
+
     chat_ctx = ChatContext()
 
     # 1. Inject long-term memory before the first LLM turn
@@ -73,7 +76,6 @@ async def entrypoint(ctx):
     await session.start(
         agent=agent,
         room=ctx.room,
-        room_input_options=RoomInputOptions(),
     )
 
 

--- a/examples/other/synap_memory.py
+++ b/examples/other/synap_memory.py
@@ -14,9 +14,6 @@ Get an API key at synap.maximem.ai
 import os
 
 from dotenv import load_dotenv
-from livekit.agents import Agent, AgentSession, ChatContext, RoomInputOptions
-from livekit.plugins import deepgram, openai, silero
-
 from maximem_synap import MaximemSynapSDK
 from synap_livekit_agents import (
     attach_synap_recording,
@@ -24,6 +21,9 @@ from synap_livekit_agents import (
     synap_search_tool,
     synap_store_tool,
 )
+
+from livekit.agents import Agent, AgentSession, ChatContext, RoomInputOptions
+from livekit.plugins import deepgram, openai, silero
 
 load_dotenv()
 
@@ -77,6 +77,6 @@ async def entrypoint(ctx):
 
 
 if __name__ == "__main__":
-    from livekit.agents import cli, WorkerOptions
+    from livekit.agents import WorkerOptions, cli
 
     cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))

--- a/examples/other/synap_memory.py
+++ b/examples/other/synap_memory.py
@@ -24,7 +24,7 @@ from synap_livekit_agents import (
     synap_store_tool,
 )
 
-from livekit.agents import Agent, AgentSession, ChatContext
+from livekit.agents import Agent, AgentSession, ChatContext, JobContext
 from livekit.plugins import deepgram, openai, silero
 
 load_dotenv()
@@ -37,7 +37,7 @@ USER_ID = "demo-user-001"
 CUSTOMER_ID = "demo-customer"
 
 
-async def entrypoint(ctx):
+async def entrypoint(ctx: JobContext):
     await ctx.connect()
 
     chat_ctx = ChatContext()


### PR DESCRIPTION
Adds `examples/other/synap_memory.py` — a complete example showing how to give a LiveKit voice agent persistent, cross-session memory via [Synap](https://maximem.ai).

## What's demonstrated

Three integration patterns in one file:

1. **`preload_synap_context`** — injects the user's long-term memory as a system message into `ChatContext` before the session starts, so the LLM sees it on its first turn
2. **`attach_synap_recording`** — wires a `conversation_item_added` listener that records every user transcription and assistant response to Synap automatically
3. **LLM-callable tools** — `synap_search_tool` and `synap_store_tool` factory functions that return `FunctionTool` instances for explicit agent-driven memory access

## Error policy

- Read failures (preload, search) degrade silently — a Synap outage never prevents a call from starting or a tool call from returning
- Write failures (recording, store) are logged at ERROR but swallowed — a Synap write blip never tears down a live call

**Install:** `pip install maximem-synap-livekit-agents`
**PyPI:** https://pypi.org/project/maximem-synap-livekit-agents/
**Docs:** https://docs.maximem.ai/integrations/livekit-agents
**Open source:** Integration package source at [`maximem-ai/maximem_synap_sdk`](https://github.com/maximem-ai/maximem_synap_sdk/tree/main/packages/integrations) — contributions welcome