### PR TITLE
feat(inference): propagate STT extra to SpeechData.metadata

### DIFF
--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -737,7 +737,7 @@ class SpeechStream(stt.SpeechStream):
         language = LanguageCode(data.get("language", self._opts.language or "en"))
         words = data.get("words", []) or []
         # The gateway carries provider-specific data on the `extra` field
-        # of the transcript message. We surface it on SpeechData.metadata 
+        # of the transcript message. We surface it on SpeechData.metadata
         extra = data.get("extra")
         metadata = extra if isinstance(extra, dict) and extra else None
         return stt.SpeechData(

--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -736,6 +736,10 @@ class SpeechStream(stt.SpeechStream):
     def _build_speech_data(self, data: dict) -> stt.SpeechData:
         language = LanguageCode(data.get("language", self._opts.language or "en"))
         words = data.get("words", []) or []
+        # The gateway carries provider-specific data on the `extra` field
+        # of the transcript message. We surface it on SpeechData.metadata 
+        extra = data.get("extra")
+        metadata = extra if isinstance(extra, dict) and extra else None
         return stt.SpeechData(
             language=language,
             start_time=self.start_time_offset + data.get("start", 0),
@@ -754,6 +758,7 @@ class SpeechStream(stt.SpeechStream):
                 )
                 for word in words
             ],
+            metadata=metadata,
         )
 
     def _process_preflight_transcript(self, data: dict) -> None:


### PR DESCRIPTION
## Summary

Five-line change in the inference STT plugin to plumb the gateway's per-transcript `extra` field onto the public `SpeechData.metadata` field that already exists upstream.

This unblocks consumers of provider-specific STT signals — most immediately, Inworld STT 1's voice profile (age, emotion, pitch, vocal style, accent, gender) which the gateway emits under \`extra[\"voice_profile\"]\`. The agent-gateway side returns this on \`MessageTranscribeResult.Extra\`; without this PR there's no client-side path to read it.

The change is generic, not Inworld-specific. xAI STT, which already emits \`extra[\"speech_final\"]\` from the gateway, will also start surfacing on \`SpeechData.metadata\` after this lands. That's purely additive — \`speech_final\` was already on the wire but invisible to clients.

## Test plan

- [ ] e2e Inworld STT scenario in livekit/e2e (depends on this PR) reads \`alt.metadata[\"voice_profile\"]\` and validates the structural shape.
- [ ] agent-starter-python Morgan demo logs \`stt voice_profile\` per turn and injects a system note for the LLM.