### PR TITLE
feat(stt): forward session VAD events to STT plugins

### DIFF
--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -7,7 +7,10 @@ from collections.abc import AsyncIterable, AsyncIterator
 from dataclasses import dataclass, field
 from enum import Enum, unique
 from types import TracebackType
-from typing import Any, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
+
+if TYPE_CHECKING:
+    from .. import vad as _vad
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -275,6 +278,15 @@ class STT(
 
     def prewarm(self) -> None:
         """Pre-warm connection to the STT service"""
+        pass
+
+    def on_vad_event(self, ev: _vad.VADEvent) -> None:
+        """Receive VAD events from the session-level VAD, when one is attached.
+
+        Default implementation is a no-op. Plugins may override this to react to
+        external VAD signals — for example, to call `finalize()` on END_OF_SPEECH
+        when running in an externally-driven turn detection mode.
+        """
         pass
 
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -880,6 +880,14 @@ class AudioRecognition:
 
     @utils.log_exceptions(logger=logger)
     async def _on_vad_event(self, ev: vad.VADEvent) -> None:
+        # Forward to the active STT plugin so it can react to session-level VAD
+        # (e.g. call finalize() on END_OF_SPEECH for externally-driven modes).
+        if (stt_inst := self._session.stt) is not None:
+            try:
+                stt_inst.on_vad_event(ev)
+            except Exception:
+                logger.exception("error forwarding VAD event to STT")
+
         if ev.type == vad.VADEventType.START_OF_SPEECH:
             speech_start_time = time.time() - ev.speech_duration - ev.inference_duration
             if not self._vad_speech_started:


### PR DESCRIPTION
Currently STT providers do not recieve any external VAD events (e.g. from Silero VAD).

The proposal is to add STT.on_vad_event() hook and have AudioRecognition forward VAD events to the active STT instance, enabling plugins to react to session-level VAD (e.g. finalize on END_OF_SPEECH for externally- driven turn detection modes).

Example code:
```
class STT(stt.STT):

    ...

    def on_vad_event(self, ev: vad.VADEvent) -> None:
        """Auto-finalize when the session VAD reports end of speech.

        Only acts when running in EXTERNAL turn detection mode — other modes
        either delegate end-of-utterance handling to the Speechmatics service
        (ADAPTIVE, SMART_TURN, FIXED) or expect the caller to manage turns
        explicitly.
        """
        if ev.type != vad.VADEventType.END_OF_SPEECH:
            return
        if self._stt_options.turn_detection_mode != TurnDetectionMode.EXTERNAL:
            return
        self.finalize()

    ...

```