### PR TITLE
fix(console): set mock participant state to active

### DIFF
--- a/livekit-agents/livekit/agents/ipc/mock_room.py
+++ b/livekit-agents/livekit/agents/ipc/mock_room.py
@@ -25,6 +25,7 @@ def create_mock_room() -> Any:
     mock_remote_participant.identity = "mock_user"
     mock_remote_participant.sid = "PA_mock_user"
     mock_remote_participant.kind = rtc.ParticipantKind.PARTICIPANT_KIND_STANDARD
+    mock_remote_participant.state = rtc.ParticipantState.PARTICIPANT_STATE_ACTIVE
     MockRoom.remote_participants = {mock_remote_participant.sid: mock_remote_participant}
     return MockRoom
 


### PR DESCRIPTION
## Summary
- `wait_for_participant` was changed in #5271 to require `PARTICIPANT_STATE_ACTIVE`, but the mock participant in `create_mock_room` had no `state` set, so the call hangs in console mode.
- Set `state = PARTICIPANT_STATE_ACTIVE` on the mock remote participant.

Fixes the issue raised in https://github.com/livekit/agents/pull/5271#issuecomment-4374055785.