### PR TITLE
add comments to agent side and inference side fallback adapters

### DIFF
--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -147,7 +147,7 @@ STTLanguages = Literal["multi", "en", "de", "es", "fr", "ja", "pt", "zh", "hi"]
 
 
 class FallbackModel(TypedDict, total=False):
-    """A fallback model with optional extra configuration.
+    """Inference Fallback Adapter: configuration for a fallback STT model that runs server-side in LiveKit Inference, providing automatic fallback between providers.
 
     Extra fields are passed through to the provider.
 

--- a/livekit-agents/livekit/agents/inference/tts.py
+++ b/livekit-agents/livekit/agents/inference/tts.py
@@ -77,7 +77,7 @@ def _parse_model_string(model: str) -> tuple[str, str | None]:
 
 
 class FallbackModel(TypedDict):
-    """A fallback model with optional extra configuration.
+    """Inference Fallback Adapter: configuration for a fallback TTS model that runs server-side in LiveKit Inference, providing automatic fallback between providers.
 
     Extra fields are passed through to the provider.
 

--- a/livekit-agents/livekit/agents/llm/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/fallback_adapter.py
@@ -34,6 +34,10 @@ class AvailabilityChangedEvent:
 class FallbackAdapter(
     LLM[Literal["llm_availability_changed"]],
 ):
+    """Agent Fallback Adapter for LLM. Manages multiple STT instances with automatic fallback
+    when the primary provider fails.
+    """
+
     def __init__(
         self,
         llm: list[LLM],

--- a/livekit-agents/livekit/agents/stt/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/stt/fallback_adapter.py
@@ -41,6 +41,10 @@ class _STTStatus:
 class FallbackAdapter(
     STT[Literal["stt_availability_changed"]],
 ):
+    """Agent Fallback Adapter for STT. Manages multiple STT instances with automatic fallback
+    when the primary provider fails.
+    """
+
     def __init__(
         self,
         stt: list[STT],

--- a/livekit-agents/livekit/agents/tts/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/tts/fallback_adapter.py
@@ -46,8 +46,8 @@ class AvailabilityChangedEvent:
 class FallbackAdapter(
     TTS[Literal["tts_availability_changed"]],
 ):
-    """
-    Manages multiple TTS instances, providing a fallback mechanism to ensure continuous TTS service.
+    """Agent Fallback Adapter for TTS. Manages multiple STT instances with automatic fallback
+    when the primary provider fails.
     """
 
     def __init__(


### PR DESCRIPTION
We're updating the docs to describe how users can write model fallbacks on the LiveKit Agent side and on the LiveKit Inference side. We would like the comments to make it easy to find the code for the agent side fallback and the inference side fallback. 