### PR TITLE
fix: wording in missing required argument error

### DIFF
--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -422,7 +422,7 @@ def prepare_function_arguments(
                         args_dict[param_name] = param.default
                     else:
                         raise ValueError(
-                            f"Received None for required parameter '{param_name} ;"
+                            f"Received no value for required parameter '{param_name}': "
                             "this argument cannot be None and no default is available."
                         )
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -393,7 +393,7 @@ class TestToolExecution:
         with pytest.raises(ValueError, match="validation error"):
             prepare_function_arguments(fnc=mock_tool_1, json_arguments='{"opt_arg2": "test2"}')
 
-        with pytest.raises(ValueError, match="Received None for required parameter"):
+        with pytest.raises(ValueError, match="Received no value for required parameter"):
             prepare_function_arguments(fnc=mock_tool_2, json_arguments='{"arg1": null}')
 
         with pytest.raises(ValueError, match="validation error"):


### PR DESCRIPTION
The punctuation in the original error is wonky and I tweaked the wording to be more friendly to pass through to LLM agents who are more likely thinking in terms of `null` / "missing values" when filling out tool schemas than Python `None`.

You may disagree with the removal of `None` here. Understand if so.