### PR TITLE
feat(plugins-google): add cached_content option for explicit context caching

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -81,6 +81,7 @@ class _LLMOptions:
     http_options: NotGivenOr[types.HttpOptions]
     seed: NotGivenOr[int]
     safety_settings: NotGivenOr[list[types.SafetySettingOrDict]]
+    cached_content: NotGivenOr[str]
 
 
 BLOCKED_REASONS = [
@@ -117,6 +118,7 @@ class LLM(llm.LLM):
         http_options: NotGivenOr[types.HttpOptions] = NOT_GIVEN,
         seed: NotGivenOr[int] = NOT_GIVEN,
         safety_settings: NotGivenOr[list[types.SafetySettingOrDict]] = NOT_GIVEN,
+        cached_content: NotGivenOr[str] = NOT_GIVEN,
         credentials: google.auth.credentials.Credentials | None = None,
     ) -> None:
         """
@@ -148,6 +150,7 @@ class LLM(llm.LLM):
             http_options (HttpOptions, optional): The HTTP options to use for the session.
             seed (int, optional): Random seed for reproducible generation. Defaults to None.
             safety_settings (list[SafetySettingOrDict], optional): Safety settings for content filtering. Defaults to None.
+            cached_content (str, optional): Resource name of an explicit context cache to attach to every request from this LLM instance, e.g. ``"cachedContents/abc123"`` for the Gemini API or ``"projects/<project>/locations/<location>/cachedContents/abc123"`` for VertexAI. The cache must already exist — create it via ``client.caches.create(...)`` and pass the returned ``name``. Gemini rejects ``generateContent`` requests that combine ``cached_content`` with ``system_instruction``, ``tools``, or ``tool_config``, so when this option is set the plugin bakes those fields out of every outgoing request; the cache resource itself must contain whichever of them the model needs (typically the system prompt and the tool schemas). Useful for long-lived static prefixes where implicit caching is unreliable. See https://ai.google.dev/gemini-api/docs/caching for details and minimum prefix-token requirements. Defaults to None.
         """  # noqa: E501
         super().__init__()
         gcp_project = project if is_given(project) else os.environ.get("GOOGLE_CLOUD_PROJECT")
@@ -220,6 +223,7 @@ class LLM(llm.LLM):
             http_options=http_options,
             seed=seed,
             safety_settings=safety_settings,
+            cached_content=cached_content,
         )
         self._client = Client(
             api_key=gemini_api_key,
@@ -384,6 +388,9 @@ class LLM(llm.LLM):
         if is_given(self._opts.safety_settings):
             extra["safety_settings"] = self._opts.safety_settings
 
+        if is_given(self._opts.cached_content):
+            extra["cached_content"] = self._opts.cached_content
+
         return LLMStream(
             self,
             client=self._client,
@@ -430,8 +437,19 @@ class LLMStream(llm.LLMStream):
             turns = [types.Content.model_validate(turn) for turn in turns_dict]
             tool_context = llm.ToolContext(self._tools)
             tools_config = create_tools_config(tool_context, _only_single_type=True)
-            if tools_config:
+            # Gemini's API rejects `generateContent` requests that pass
+            # `cached_content` together with `system_instruction`, `tools`,
+            # or `tool_config` — those fields must live INSIDE the
+            # CachedContent resource, not on the request. The application
+            # bakes them into the cache via `client.caches.create(...)`;
+            # here we just suppress the duplicates on the outgoing request
+            # whenever a cache is attached.
+            using_cache = "cached_content" in self._extra_kwargs
+            if tools_config and not using_cache:
                 self._extra_kwargs["tools"] = tools_config
+            elif using_cache:
+                self._extra_kwargs.pop("tools", None)
+                self._extra_kwargs.pop("tool_config", None)
             http_options = self._llm._opts.http_options or types.HttpOptions(
                 timeout=int(self._conn_options.timeout * 1000)
             )
@@ -440,9 +458,13 @@ class LLMStream(llm.LLMStream):
             http_options.headers["x-goog-api-client"] = f"livekit-agents/{__version__}"
             config = types.GenerateContentConfig(
                 system_instruction=(
-                    [types.Part(text=content) for content in extra_data.system_messages]
-                    if extra_data.system_messages
-                    else None
+                    None
+                    if using_cache
+                    else (
+                        [types.Part(text=content) for content in extra_data.system_messages]
+                        if extra_data.system_messages
+                        else None
+                    )
                 ),
                 http_options=http_options,
                 **self._extra_kwargs,

--- a/tests/test_plugin_google_llm.py
+++ b/tests/test_plugin_google_llm.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from google.genai import types
 
-from livekit.plugins.google.llm import LLMStream
+from livekit.agents.llm import ChatContext, function_tool
+from livekit.plugins.google.llm import LLM, LLMStream
 
 
 @pytest.fixture
@@ -63,3 +64,177 @@ class TestParsePartFunctionCall:
         chunk = llm_stream._parse_part("test-id", part)
 
         assert chunk is None
+
+
+class TestCachedContentOption:
+    """Verify the ``cached_content`` constructor option propagates from
+    ``LLM.__init__`` through ``_LLMOptions`` and into the keyword
+    arguments handed to ``GenerateContentConfig`` for every request.
+
+    The propagation tests are ``async def`` because ``LLM.chat()`` builds
+    an ``LLMStream`` whose constructor schedules a metrics-monitoring
+    task on the running event loop. A sync test would raise
+    ``RuntimeError: no running event loop`` before reaching the
+    assertion.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cached_content_propagates_to_extra_kwargs(self) -> None:
+        llm = LLM(model="gemini-2.5-flash", api_key="test", cached_content="cachedContents/abc123")
+
+        stream = llm.chat(chat_ctx=ChatContext.empty())
+        try:
+            assert stream._extra_kwargs.get("cached_content") == "cachedContents/abc123"
+        finally:
+            await stream.aclose()
+
+    @pytest.mark.asyncio
+    async def test_cached_content_omitted_when_not_set(self) -> None:
+        """Backward compatibility: callers that don't pass
+        ``cached_content`` must produce a request config without the
+        field, so existing behaviour is unchanged."""
+        llm = LLM(model="gemini-2.5-flash", api_key="test")
+
+        stream = llm.chat(chat_ctx=ChatContext.empty())
+        try:
+            assert "cached_content" not in stream._extra_kwargs
+        finally:
+            await stream.aclose()
+
+    def test_cached_content_stored_on_opts(self) -> None:
+        llm = LLM(
+            model="gemini-2.5-flash",
+            api_key="test",
+            cached_content="projects/p/locations/us-central1/cachedContents/xyz",
+        )
+
+        assert llm._opts.cached_content == "projects/p/locations/us-central1/cachedContents/xyz"
+
+
+class TestCachedContentRequestSuppression:
+    """Gemini's API rejects ``generateContent`` requests that pass
+    ``cached_content`` together with ``system_instruction``, ``tools``,
+    or ``tool_config`` — those fields belong inside the CachedContent
+    resource. The plugin therefore strips them off the outgoing request
+    whenever a cache is attached. These tests run the LLMStream against
+    a stubbed ``generate_content_stream`` and assert on the
+    ``GenerateContentConfig`` it received.
+    """
+
+    @staticmethod
+    async def _single_response_async_iter():
+        """Emit one minimal-but-valid GenerateContentResponse so the
+        retry layer in livekit.agents.LLM doesn't treat the stream as
+        empty and re-issue the request three more times."""
+        yield types.GenerateContentResponse(
+            candidates=[
+                types.Candidate(
+                    content=types.Content(
+                        role="model",
+                        parts=[types.Part(text="ok")],
+                    ),
+                    finish_reason=types.FinishReason.STOP,
+                )
+            ],
+        )
+
+    @classmethod
+    def _patched_stream_capture(cls) -> tuple[AsyncMock, dict]:
+        captured: dict = {}
+
+        async def fake_stream(**kwargs):
+            captured["model"] = kwargs.get("model")
+            captured["contents"] = kwargs.get("contents")
+            captured["config"] = kwargs.get("config")
+            return cls._single_response_async_iter()
+
+        return AsyncMock(side_effect=fake_stream), captured
+
+    @pytest.mark.asyncio
+    async def test_request_omits_system_instruction_when_cached_content_set(self) -> None:
+        """With a cache attached, the outgoing request must carry
+        ``system_instruction=None`` — the system prompt lives in the
+        cache resource and re-sending it would make Gemini return 400."""
+        llm = LLM(
+            model="gemini-2.5-flash",
+            api_key="test",
+            cached_content="cachedContents/abc123",
+        )
+
+        chat_ctx = ChatContext.empty()
+        chat_ctx.add_message(role="system", content="system prompt that lives in cache")
+        chat_ctx.add_message(role="user", content="hi")
+
+        fake, captured = self._patched_stream_capture()
+        with patch.object(llm._client.aio.models, "generate_content_stream", fake):
+            stream = llm.chat(chat_ctx=chat_ctx)
+            try:
+                async for _ in stream:
+                    pass
+            finally:
+                await stream.aclose()
+
+        config = captured["config"]
+        assert config.system_instruction is None
+        assert config.cached_content == "cachedContents/abc123"
+
+    @pytest.mark.asyncio
+    async def test_request_omits_tools_when_cached_content_set(self) -> None:
+        """With a cache attached, the outgoing request must NOT include
+        ``tools`` even if the LLMStream was constructed with function
+        tools — the tool schemas belong inside the cache resource."""
+
+        @function_tool
+        async def example_tool(query: str) -> str:
+            """Look something up."""
+            return query
+
+        llm = LLM(
+            model="gemini-2.5-flash",
+            api_key="test",
+            cached_content="cachedContents/abc123",
+        )
+
+        fake, captured = self._patched_stream_capture()
+        with patch.object(llm._client.aio.models, "generate_content_stream", fake):
+            stream = llm.chat(chat_ctx=ChatContext.empty(), tools=[example_tool])
+            try:
+                async for _ in stream:
+                    pass
+            finally:
+                await stream.aclose()
+
+        config = captured["config"]
+        assert config.tools is None
+        assert config.tool_config is None
+        assert config.cached_content == "cachedContents/abc123"
+
+    @pytest.mark.asyncio
+    async def test_request_includes_system_instruction_and_tools_when_no_cache(self) -> None:
+        """Backward compatibility: without ``cached_content``, the
+        request still carries ``system_instruction`` and ``tools`` as
+        before. Suppression is gated strictly on the cache being set."""
+
+        @function_tool
+        async def example_tool(query: str) -> str:
+            """Look something up."""
+            return query
+
+        llm = LLM(model="gemini-2.5-flash", api_key="test")
+
+        chat_ctx = ChatContext.empty()
+        chat_ctx.add_message(role="system", content="system prompt sent on every request")
+        chat_ctx.add_message(role="user", content="hi")
+
+        fake, captured = self._patched_stream_capture()
+        with patch.object(llm._client.aio.models, "generate_content_stream", fake):
+            stream = llm.chat(chat_ctx=chat_ctx, tools=[example_tool])
+            try:
+                async for _ in stream:
+                    pass
+            finally:
+                await stream.aclose()
+
+        config = captured["config"]
+        assert config.system_instruction is not None
+        assert config.tools is not None and len(config.tools) >= 1


### PR DESCRIPTION
## Motivation

The Gemini plugin's `LLM` class supports many `GenerateContentConfig` options (thinking_config, retrieval_config, safety_settings, etc.) but not `cached_content`. The plugin already reads `cached_content_token_count` from response usage in `LLMStream._parse_part`, so cache hits surface in metrics — there's just no way to attach a `CachedContent` resource to outgoing requests.

## Change

Add `cached_content: NotGivenOr[str] = NOT_GIVEN` to `LLM.__init__`, propagated through `_LLMOptions` → `chat()` → `extra["cached_content"]` → `GenerateContentConfig` via `**self._extra_kwargs`.

### Request-side suppression

Gemini's API rejects `generateContent` requests that pass `cached_content` together with `system_instruction`, `tools`, or `tool_config` — those fields belong inside the `CachedContent` resource itself, and the API returns a 400 instructing callers to move them.

Without handling that, the parameter would 400 on any realistic agent. So `LLMStream._run` strips `system_instruction`, `tools`, and `tool_config` from the outgoing request whenever `cached_content` is attached. Behaviour is unchanged when `cached_content` is unset.

Cache lifecycle (creation, TTL refresh, deletion) and the choice of what to bake into the cache stay the application's responsibility.

## Compatibility

Default `NOT_GIVEN` keeps existing behaviour unchanged — verified by tests covering both the omission case (no key in `_extra_kwargs`) and the no-cache request path (`system_instruction` and `tools` propagate as before).

Works with both Gemini Developer API (`cachedContents/{id}`) and Vertex AI (`projects/{p}/locations/{l}/cachedContents/{id}`); the plugin passes the string through unmodified.

## Tests

`tests/test_plugin_google_llm.py` — 6 cases:

- **Propagation (3)** — `cached_content` round-trips through `_LLMOptions` and reaches `_extra_kwargs`; default `NOT_GIVEN` produces no key.
- **Suppression (3)** — patching `client.aio.models.generate_content_stream` to capture the `GenerateContentConfig`, the request omits `system_instruction` / `tools` / `tool_config` when `cached_content` is set, and includes them when it isn't (backward compat).

Existing google-plugin tests still pass. `ruff check` / `ruff format` clean.

## Refs

- #2359 (implicit caching reliability)
- https://ai.google.dev/gemini-api/docs/caching
