### PR TITLE
feat(rime): add WebSocket streaming TTS support

### DIFF
--- a/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
+++ b/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
@@ -485,6 +485,10 @@ class SynthesizeStream(tts.SynthesizeStream):
                         "Rime ws closed unexpectedly",
                         request_id=request_id,
                     )
+                if msg.type == aiohttp.WSMsgType.ERROR:
+                    raise APIConnectionError(
+                        f"Rime ws error: {ws.exception()}"
+                    )
                 if msg.type != aiohttp.WSMsgType.TEXT:
                     logger.warning("unexpected Rime ws message type %s", msg.type)
                     continue

--- a/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
+++ b/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
@@ -124,8 +124,7 @@ class TTS(tts.TTS):
     def __init__(
         self,
         *,
-        base_url: str = RIME_BASE_URL,
-        ws_base_url: str = RIME_WS_BASE_URL,
+        base_url: NotGivenOr[str] = NOT_GIVEN,
         model: TTSModels | str = "arcana",
         speaker: NotGivenOr[ArcanaVoices | str] = NOT_GIVEN,
         lang: TTSLangs | str = "eng",
@@ -146,6 +145,13 @@ class TTS(tts.TTS):
         segment: NotGivenOr[str] = NOT_GIVEN,
         tokenizer: NotGivenOr[tokenize.SentenceTokenizer] = NOT_GIVEN,
     ) -> None:
+        if is_given(base_url):
+            # Infer streaming mode from URL prefix; an explicit use_websocket=True still wins.
+            use_websocket = use_websocket or base_url.startswith(("ws://", "wss://"))
+            resolved_base_url = base_url
+        else:
+            resolved_base_url = RIME_WS_BASE_URL if use_websocket else RIME_BASE_URL
+
         super().__init__(
             capabilities=tts.TTSCapabilities(
                 streaming=use_websocket,
@@ -186,8 +192,7 @@ class TTS(tts.TTS):
                 phonemize_between_brackets=phonemize_between_brackets,
             )
         self._session = http_session
-        self._base_url = base_url
-        self._ws_base_url = ws_base_url
+        self._base_url = resolved_base_url
         self._use_websocket = use_websocket
         self._segment = segment if is_given(segment) else "bySentence"
 
@@ -230,7 +235,7 @@ class TTS(tts.TTS):
         encoded = {
             k: ("true" if v else "false") if isinstance(v, bool) else v for k, v in params.items()
         }
-        return f"{self._ws_base_url}/ws3?{urlencode(encoded)}"
+        return f"{self._base_url}/ws3?{urlencode(encoded)}"
 
     async def _connect_ws(self, timeout: float) -> aiohttp.ClientWebSocketResponse:
         session = self._ensure_session()

--- a/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
+++ b/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
@@ -227,7 +227,11 @@ class TTS(tts.TTS):
             "segment": self._segment,
             **_model_params(self._opts),
         }
-        return f"{self._ws_base_url}/ws3?{urlencode(params)}"
+        encoded = {
+            k: ("true" if v else "false") if isinstance(v, bool) else v
+            for k, v in params.items()
+        }
+        return f"{self._ws_base_url}/ws3?{urlencode(encoded)}"
 
     async def _connect_ws(self, timeout: float) -> aiohttp.ClientWebSocketResponse:
         session = self._ensure_session()

--- a/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
+++ b/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
@@ -281,6 +281,10 @@ class TTS(tts.TTS):
     def synthesize(
         self, text: str, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
     ) -> ChunkedStream:
+        if self._use_websocket:
+            raise RuntimeError(
+                "Rime TTS one-shot synthesize requires use_websocket=False at construction time"
+            )
         return ChunkedStream(tts=self, input_text=text, conn_options=conn_options)
 
     def update_options(

--- a/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
+++ b/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
@@ -486,9 +486,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                         request_id=request_id,
                     )
                 if msg.type == aiohttp.WSMsgType.ERROR:
-                    raise APIConnectionError(
-                        f"Rime ws error: {ws.exception()}"
-                    )
+                    raise APIConnectionError(f"Rime ws error: {ws.exception()}")
                 if msg.type != aiohttp.WSMsgType.TEXT:
                     logger.warning("unexpected Rime ws message type %s", msg.type)
                     continue

--- a/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
+++ b/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
@@ -259,7 +259,8 @@ class TTS(tts.TTS):
             await ws.close()
 
     def prewarm(self) -> None:
-        self._pool.prewarm()
+        if self._use_websocket:
+            self._pool.prewarm()
 
     def stream(
         self, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS

--- a/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
+++ b/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
@@ -434,6 +434,7 @@ class SynthesizeStream(tts.SynthesizeStream):
 
         sent_stream = self._tts._sentence_tokenizer.stream()
         input_sent_event = asyncio.Event()
+        empty_input = False
 
         async def _input_task() -> None:
             async for data in self._input_ch:
@@ -444,6 +445,7 @@ class SynthesizeStream(tts.SynthesizeStream):
             sent_stream.end_input()
 
         async def _send_task(ws: aiohttp.ClientWebSocketResponse) -> None:
+            nonlocal empty_input
             sent_count = 0
             async for ev in sent_stream:
                 pkt = {"text": ev.token + " ", "contextId": context_id}
@@ -451,14 +453,17 @@ class SynthesizeStream(tts.SynthesizeStream):
                 await ws.send_str(json.dumps(pkt))
                 input_sent_event.set()
                 sent_count += 1
-            # Empty input: server returns notReady, never emits done — fail fast.
             if sent_count == 0:
-                raise APIError("Rime WS: no text was provided to synthesize")
-            # Per-utterance flush — eos would close the pooled WS.
+                empty_input = True
+                input_sent_event.set()
+                output_emitter.end_input()
+                return
             await ws.send_str(json.dumps({"operation": "flush", "contextId": context_id}))
 
         async def _recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
             await input_sent_event.wait()
+            if empty_input:
+                return
             while True:
                 msg = await ws.receive(timeout=self._conn_options.timeout)
                 if msg.type in (

--- a/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
+++ b/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
@@ -15,16 +15,22 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import json
 import os
+import weakref
 from dataclasses import dataclass, replace
+from urllib.parse import urlencode
 
 import aiohttp
 
 from livekit.agents import (
     APIConnectionError,
     APIConnectOptions,
+    APIError,
     APIStatusError,
     APITimeoutError,
+    tokenize,
     tts,
     utils,
 )
@@ -34,6 +40,7 @@ from livekit.agents.types import (
     NotGivenOr,
 )
 from livekit.agents.utils import is_given
+from livekit.agents.voice.io import TimedString
 
 from .langs import TTSLangs
 from .log import logger
@@ -43,6 +50,8 @@ from .models import ArcanaVoices, DefaultMistVoice, TTSModels
 ARCANA_MODEL_TIMEOUT = 60 * 4
 MIST_MODEL_TIMEOUT = 30
 RIME_BASE_URL = "https://users.rime.ai/v1/rime-tts"
+RIME_WS_BASE_URL = "wss://users-ws.rime.ai"
+NUM_CHANNELS = 1
 
 
 @dataclass
@@ -73,9 +82,6 @@ class _MistOptions:
     phonemize_between_brackets: NotGivenOr[bool] = NOT_GIVEN
 
 
-NUM_CHANNELS = 1
-
-
 def _is_mist_model(model: TTSModels | str) -> bool:
     return "mist" in model
 
@@ -86,11 +92,40 @@ def _timeout_for_model(model: TTSModels | str) -> int:
     return MIST_MODEL_TIMEOUT
 
 
+def _model_params(opts: _TTSOptions) -> dict[str, object]:
+    """Per-model option fields shared between the HTTP body and the WS query string."""
+    params: dict[str, object] = {}
+    if opts.model == "arcana" and opts.arcana_options is not None:
+        ao = opts.arcana_options
+        if is_given(ao.lang):
+            params["lang"] = ao.lang
+        if is_given(ao.repetition_penalty):
+            params["repetition_penalty"] = ao.repetition_penalty
+        if is_given(ao.temperature):
+            params["temperature"] = ao.temperature
+        if is_given(ao.top_p):
+            params["top_p"] = ao.top_p
+        if is_given(ao.max_tokens):
+            params["max_tokens"] = ao.max_tokens
+    elif _is_mist_model(opts.model) and opts.mist_options is not None:
+        mo = opts.mist_options
+        if is_given(mo.lang):
+            params["lang"] = mo.lang
+        if is_given(mo.speed_alpha):
+            params["speedAlpha"] = mo.speed_alpha
+        if is_given(mo.pause_between_brackets):
+            params["pauseBetweenBrackets"] = mo.pause_between_brackets
+        if is_given(mo.phonemize_between_brackets):
+            params["phonemizeBetweenBrackets"] = mo.phonemize_between_brackets
+    return params
+
+
 class TTS(tts.TTS):
     def __init__(
         self,
         *,
         base_url: str = RIME_BASE_URL,
+        ws_base_url: str = RIME_WS_BASE_URL,
         model: TTSModels | str = "arcana",
         speaker: NotGivenOr[ArcanaVoices | str] = NOT_GIVEN,
         lang: TTSLangs | str = "eng",
@@ -107,10 +142,14 @@ class TTS(tts.TTS):
         phonemize_between_brackets: NotGivenOr[bool] = NOT_GIVEN,
         api_key: NotGivenOr[str] = NOT_GIVEN,
         http_session: aiohttp.ClientSession | None = None,
+        use_websocket: bool = False,
+        segment: NotGivenOr[str] = NOT_GIVEN,
+        tokenizer: NotGivenOr[tokenize.SentenceTokenizer] = NOT_GIVEN,
     ) -> None:
         super().__init__(
             capabilities=tts.TTSCapabilities(
-                streaming=False,
+                streaming=use_websocket,
+                aligned_transcript=use_websocket,
             ),
             sample_rate=sample_rate,
             num_channels=NUM_CHANNELS,
@@ -148,8 +187,22 @@ class TTS(tts.TTS):
             )
         self._session = http_session
         self._base_url = base_url
+        self._ws_base_url = ws_base_url
+        self._use_websocket = use_websocket
+        self._segment = segment if is_given(segment) else "bySentence"
 
         self._total_timeout = _timeout_for_model(model)
+
+        self._streams: weakref.WeakSet[SynthesizeStream] = weakref.WeakSet()
+        self._sentence_tokenizer = (
+            tokenizer if is_given(tokenizer) else tokenize.blingfire.SentenceTokenizer()
+        )
+        self._pool = utils.ConnectionPool[aiohttp.ClientWebSocketResponse](
+            connect_cb=self._connect_ws,
+            close_cb=self._close_ws,
+            max_session_duration=300,
+            mark_refreshed_on_get=True,
+        )
 
     @property
     def model(self) -> str:
@@ -164,6 +217,58 @@ class TTS(tts.TTS):
             self._session = utils.http_context.http_session()
 
         return self._session
+
+    def _ws_url(self) -> str:
+        params: dict[str, object] = {
+            "speaker": self._opts.speaker,
+            "modelId": self._opts.model,
+            "audioFormat": "pcm",
+            "samplingRate": self._sample_rate,
+            "segment": self._segment,
+            **_model_params(self._opts),
+        }
+        return f"{self._ws_base_url}/ws3?{urlencode(params)}"
+
+    async def _connect_ws(self, timeout: float) -> aiohttp.ClientWebSocketResponse:
+        session = self._ensure_session()
+        return await asyncio.wait_for(
+            session.ws_connect(
+                self._ws_url(), headers={"Authorization": f"Bearer {self._api_key}"}
+            ),
+            timeout,
+        )
+
+    async def _close_ws(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        try:
+            await ws.send_str(json.dumps({"operation": "eos"}))
+            try:
+                await asyncio.wait_for(ws.receive(), timeout=1.0)
+            except asyncio.TimeoutError:
+                pass
+        except Exception as e:
+            logger.warning(f"Error during Rime WS close sequence: {e}")
+        finally:
+            await ws.close()
+
+    def prewarm(self) -> None:
+        self._pool.prewarm()
+
+    def stream(
+        self, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
+    ) -> SynthesizeStream:
+        if not self._use_websocket:
+            raise RuntimeError(
+                "Rime TTS streaming requires use_websocket=True at construction time"
+            )
+        s = SynthesizeStream(tts=self, conn_options=conn_options)
+        self._streams.add(s)
+        return s
+
+    async def aclose(self) -> None:
+        for s in list(self._streams):
+            await s.aclose()
+        self._streams.clear()
+        await self._pool.aclose()
 
     def synthesize(
         self, text: str, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
@@ -189,6 +294,8 @@ class TTS(tts.TTS):
         phonemize_between_brackets: NotGivenOr[bool] = NOT_GIVEN,
         base_url: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
+        # WS URL is bound at pool connect; invalidate if any URL-affecting param changed.
+        prev_ws_url = self._ws_url() if self._use_websocket else None
         if is_given(base_url):
             self._base_url = base_url
         if is_given(model):
@@ -231,6 +338,9 @@ class TTS(tts.TTS):
             if is_given(phonemize_between_brackets):
                 self._opts.mist_options.phonemize_between_brackets = phonemize_between_brackets
 
+        if prev_ws_url is not None and self._ws_url() != prev_ws_url:
+            self._pool.invalidate()
+
 
 class ChunkedStream(tts.ChunkedStream):
     """Synthesize using the chunked api endpoint"""
@@ -245,38 +355,18 @@ class ChunkedStream(tts.ChunkedStream):
             "speaker": self._opts.speaker,
             "text": self._input_text,
             "modelId": self._opts.model,
+            **_model_params(self._opts),
         }
         format = "audio/pcm"
-        if self._opts.model == "arcana":
-            arcana_opts = self._opts.arcana_options
-            assert arcana_opts is not None
-            if is_given(arcana_opts.repetition_penalty):
-                payload["repetition_penalty"] = arcana_opts.repetition_penalty
-            if is_given(arcana_opts.temperature):
-                payload["temperature"] = arcana_opts.temperature
-            if is_given(arcana_opts.top_p):
-                payload["top_p"] = arcana_opts.top_p
-            if is_given(arcana_opts.max_tokens):
-                payload["max_tokens"] = arcana_opts.max_tokens
-            if is_given(arcana_opts.lang):
-                payload["lang"] = arcana_opts.lang
-            if is_given(arcana_opts.sample_rate):
-                payload["samplingRate"] = arcana_opts.sample_rate
-        elif _is_mist_model(self._opts.model):
+        if self._opts.model == "arcana" and self._opts.arcana_options is not None:
+            if is_given(self._opts.arcana_options.sample_rate):
+                payload["samplingRate"] = self._opts.arcana_options.sample_rate
+        elif _is_mist_model(self._opts.model) and self._opts.mist_options is not None:
             mist_opts = self._opts.mist_options
-            assert mist_opts is not None
-            if is_given(mist_opts.lang):
-                payload["lang"] = mist_opts.lang
             if is_given(mist_opts.sample_rate):
                 payload["samplingRate"] = mist_opts.sample_rate
-            if is_given(mist_opts.speed_alpha):
-                payload["speedAlpha"] = mist_opts.speed_alpha
             if self._opts.model == "mistv2" and is_given(mist_opts.reduce_latency):
                 payload["reduceLatency"] = mist_opts.reduce_latency
-            if is_given(mist_opts.pause_between_brackets):
-                payload["pauseBetweenBrackets"] = mist_opts.pause_between_brackets
-            if is_given(mist_opts.phonemize_between_brackets):
-                payload["phonemizeBetweenBrackets"] = mist_opts.phonemize_between_brackets
 
         try:
             async with self._tts._ensure_session().post(
@@ -316,3 +406,106 @@ class ChunkedStream(tts.ChunkedStream):
             ) from None
         except Exception as e:
             raise APIConnectionError() from e
+
+
+class SynthesizeStream(tts.SynthesizeStream):
+    """One stream = one utterance. Server-side bySentence segmentation by default;
+    pass segment="immediate" on the TTS to disable server buffering when the agent
+    is already feeding sentence-tokenized text."""
+
+    def __init__(self, *, tts: TTS, conn_options: APIConnectOptions) -> None:
+        super().__init__(tts=tts, conn_options=conn_options)
+        self._tts: TTS = tts
+
+    async def _run(self, output_emitter: tts.AudioEmitter) -> None:
+        request_id = utils.shortuuid()
+        context_id = utils.shortuuid()
+        output_emitter.initialize(
+            request_id=request_id,
+            sample_rate=self._tts.sample_rate,
+            num_channels=NUM_CHANNELS,
+            mime_type="audio/pcm",
+            stream=True,
+        )
+        output_emitter.start_segment(segment_id=context_id)
+
+        sent_stream = self._tts._sentence_tokenizer.stream()
+
+        async def _input_task() -> None:
+            async for data in self._input_ch:
+                if isinstance(data, self._FlushSentinel):
+                    sent_stream.flush()
+                    continue
+                sent_stream.push_text(data)
+            sent_stream.end_input()
+
+        async def _send_task(ws: aiohttp.ClientWebSocketResponse) -> None:
+            sent_count = 0
+            async for ev in sent_stream:
+                pkt = {"text": ev.token + " ", "contextId": context_id}
+                self._mark_started()
+                await ws.send_str(json.dumps(pkt))
+                sent_count += 1
+            # Empty input: server returns notReady, never emits done — fail fast.
+            if sent_count == 0:
+                raise APIError("Rime WS: no text was provided to synthesize")
+            # Per-utterance flush — eos would close the pooled WS.
+            await ws.send_str(json.dumps({"operation": "flush", "contextId": context_id}))
+
+        async def _recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
+            while True:
+                msg = await ws.receive(timeout=self._conn_options.timeout)
+                if msg.type in (
+                    aiohttp.WSMsgType.CLOSE,
+                    aiohttp.WSMsgType.CLOSED,
+                    aiohttp.WSMsgType.CLOSING,
+                ):
+                    raise APIStatusError(
+                        "Rime ws closed unexpectedly",
+                        request_id=request_id,
+                    )
+                if msg.type != aiohttp.WSMsgType.TEXT:
+                    logger.warning("unexpected Rime ws message type %s", msg.type)
+                    continue
+                data = json.loads(msg.data)
+                t = data.get("type")
+                if t == "chunk":
+                    output_emitter.push(base64.b64decode(data["data"]))
+                elif t == "timestamps":
+                    wt = data.get("word_timestamps") or {}
+                    words = wt.get("words") or []
+                    starts = wt.get("start") or []
+                    ends = wt.get("end") or []
+                    for w, s, e in zip(words, starts, ends, strict=False):
+                        output_emitter.push_timed_transcript(
+                            TimedString(text=w + " ", start_time=s, end_time=e)
+                        )
+                elif t == "done":
+                    output_emitter.end_input()
+                    break
+                elif t == "error":
+                    msg_text = data.get("message", "(no message)")
+                    raise APIError(f"Rime ws error: {msg_text}")
+
+        try:
+            async with self._tts._pool.connection(timeout=self._conn_options.timeout) as ws:
+                tasks = [
+                    asyncio.create_task(_input_task()),
+                    asyncio.create_task(_send_task(ws)),
+                    asyncio.create_task(_recv_task(ws)),
+                ]
+                try:
+                    await asyncio.gather(*tasks)
+                finally:
+                    await sent_stream.aclose()
+                    await utils.aio.gracefully_cancel(*tasks)
+        except asyncio.TimeoutError:
+            raise APITimeoutError() from None
+        except aiohttp.ClientResponseError as e:
+            raise APIStatusError(
+                message=e.message, status_code=e.status, request_id=None, body=None
+            ) from None
+        except APIError:
+            raise
+        except Exception as e:
+            raise APIConnectionError(f"Rime WS error: {e}") from e

--- a/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
+++ b/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
@@ -430,6 +430,7 @@ class SynthesizeStream(tts.SynthesizeStream):
         output_emitter.start_segment(segment_id=context_id)
 
         sent_stream = self._tts._sentence_tokenizer.stream()
+        input_sent_event = asyncio.Event()
 
         async def _input_task() -> None:
             async for data in self._input_ch:
@@ -445,6 +446,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                 pkt = {"text": ev.token + " ", "contextId": context_id}
                 self._mark_started()
                 await ws.send_str(json.dumps(pkt))
+                input_sent_event.set()
                 sent_count += 1
             # Empty input: server returns notReady, never emits done — fail fast.
             if sent_count == 0:
@@ -453,6 +455,7 @@ class SynthesizeStream(tts.SynthesizeStream):
             await ws.send_str(json.dumps({"operation": "flush", "contextId": context_id}))
 
         async def _recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
+            await input_sent_event.wait()
             while True:
                 msg = await ws.receive(timeout=self._conn_options.timeout)
                 if msg.type in (
@@ -497,6 +500,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                 try:
                     await asyncio.gather(*tasks)
                 finally:
+                    input_sent_event.set()
                     await sent_stream.aclose()
                     await utils.aio.gracefully_cancel(*tasks)
         except asyncio.TimeoutError:

--- a/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
+++ b/livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
@@ -228,8 +228,7 @@ class TTS(tts.TTS):
             **_model_params(self._opts),
         }
         encoded = {
-            k: ("true" if v else "false") if isinstance(v, bool) else v
-            for k, v in params.items()
+            k: ("true" if v else "false") if isinstance(v, bool) else v for k, v in params.items()
         }
         return f"{self._ws_base_url}/ws3?{urlencode(encoded)}"
 

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -433,13 +433,6 @@ STREAM_TTS = [
     ),
     pytest.param(
         lambda: {
-            "tts": rime.TTS(use_websocket=True),
-            "proxy-upstream": "users-ws.rime.ai:443",
-        },
-        id="rime",
-    ),
-    pytest.param(
-        lambda: {
             "tts": tts.StreamAdapter(tts=inworld.TTS()),
             "proxy-upstream": "api.inworld.ai:443",
         },

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -433,6 +433,13 @@ STREAM_TTS = [
     ),
     pytest.param(
         lambda: {
+            "tts": rime.TTS(use_websocket=True),
+            "proxy-upstream": "users-ws.rime.ai:443",
+        },
+        id="rime",
+    ),
+    pytest.param(
+        lambda: {
             "tts": tts.StreamAdapter(tts=inworld.TTS()),
             "proxy-upstream": "api.inworld.ai:443",
         },


### PR DESCRIPTION
### Summary

Adds opt-in WebSocket streaming to the Rime TTS plugin via a new `use_websocket=True` constructor argument. The existing HTTP `synthesize` path is unchanged and remains the default. When enabled, the plugin sets `streaming=True` and `aligned_transcript=True` during construction, opens a long-lived pooled WebSocket to Rime's `/ws3` endpoint, and emits word-level timestamps via `push_timed_transcript`.

### New constructor arguments

- `use_websocket: bool = False` — opt into the streaming path. Off by default so existing consumers see no behavior change.
- `ws_base_url: str = "wss://users-ws.rime.ai"` — overridable for self-hosted deployments, parallel to the existing `base_url`.
- `segment: NotGivenOr[str] = NOT_GIVEN` — passed to Rime as a connect-time query param. Defaults to `"bySentence"` (server-side sentence buffering, mirrors `StreamAdapter` semantics). Pass `"immediate"` if the consumer is already feeding sentence-tokenized text and wants to skip server-side buffering.
- `tokenizer: NotGivenOr[tokenize.SentenceTokenizer] = NOT_GIVEN` — overridable client-side sentence tokenizer. Defaults to `tokenize.blingfire.SentenceTokenizer()`. Mirrors the hook Cartesia exposes.

### Implementation

The streaming class is similar to the implementation in the Cartesia plugin: single-context JSON-envelope WebSocket, base64 PCM audio frames, `weakref.WeakSet[SynthesizeStream]` for cleanup, `utils.ConnectionPool[aiohttp.ClientWebSocketResponse]` with `max_session_duration=300` and `mark_refreshed_on_get=True`. Word timestamps are pushed as `TimedString`.

Connection lifecycle:

- `_connect_ws` opens the pooled WebSocket using the URL built from current options. Connect-time errors propagate to the outer `_run` exception block, which classifies `aiohttp.ClientResponseError` (covering `WSServerHandshakeError`) as `APIStatusError` with the HTTP status code preserved.
- `_close_ws` follows the graceful-shutdown pattern in the Deepgram plugin: send the `eos` operation, wait one second for the server's ack, suppress-and-log any send or recv errors during teardown so they don't mask the original cause that evicted the connection from the pool.
- `update_options` invalidates the pool when the WebSocket URL changes, computed via a before/after `_ws_url()` diff. This automatically handles model swaps, speaker swaps, and any per-model option that participates in the URL.

A small `_model_params(opts)` helper consolidates the per-model option walking shared between the WebSocket query string and the HTTP JSON body.

Routes through `/ws3`, which accepts every model the plugin supports (`mistv2`, `mistv3`, `arcana`). The older `/ws2` endpoint is not wired in.

### Validating

- [x] `update_options` mid-session: model swap drops the existing pooled connection and reconnects with the new URL. Verified by observing two distinct `_connect_ws` calls and matching audio output.
- [x] Error propagation: invalid API key surfaces as `APIStatusError(status_code=401)` with the server message preserved, rather than a generic `APIConnectionError`.
- [x] Empty-input fast-fail: `tts.stream()` followed by `end_input()` with no `push_text()` raises `APIError` immediately at the protocol layer rather than hanging on the receive timeout.
- [x] Pool reuse: streams created within the `max_session_duration` window share the same WebSocket — no new handshake.
- [x] HTTP path unchanged: with `use_websocket=False` (default), `synthesize()` behavior is identical to before; `_run` payload assembly continues to use the same `_model_params` helper plus HTTP-only fields (`samplingRate`, `reduceLatency` for `mistv2`).
