### PR TITLE
fix(voice): apply max_unrecoverable_errors tolerance to STT errors

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -403,6 +403,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         # unrecoverable error counts, reset after agent speaking
         self._llm_error_counts = 0
         self._tts_error_counts = 0
+        self._stt_error_counts = 0
 
         # aec warmup: disable interruptions while AEC warms up
         self._aec_warmup_remaining = aec_warmup_duration or 0.0
@@ -997,6 +998,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             self._agent_state = "initializing"
             self._llm_error_counts = 0
             self._tts_error_counts = 0
+            self._stt_error_counts = 0
             self._root_span_context = None
 
             if self._session_host:
@@ -1384,6 +1386,10 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             self._llm_error_counts += 1
             if self._llm_error_counts <= self.conn_options.max_unrecoverable_errors:
                 return
+        elif error.type == "stt_error":
+            self._stt_error_counts += 1
+            if self._stt_error_counts <= self.conn_options.max_unrecoverable_errors:
+                return
         elif error.type == "tts_error":
             self._tts_error_counts += 1
             if self._tts_error_counts <= self.conn_options.max_unrecoverable_errors:
@@ -1478,6 +1484,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         if state == "speaking":
             self._llm_error_counts = 0
             self._tts_error_counts = 0
+            self._stt_error_counts = 0
 
             if self._agent_speaking_span is None:
                 self._agent_speaking_span = tracer.start_span(


### PR DESCRIPTION
Fixes #5665

## Problem

`AgentSession._on_error` applies `max_unrecoverable_errors` tolerance for `llm_error` and `tts_error` but not `stt_error`, which causes the session to close immediately on the first non-recoverable STT error.

## Fix

Add `_stt_error_counts` following the same pattern as `_llm_error_counts` and `_tts_error_counts` — initialised in `__init__`, reset in `_aclose_impl` and when agent state transitions to `speaking`, and checked in `_on_error` before tearing down the session.