### PR TITLE
feat(fishaudio): add speech-to-text support

### DIFF
--- a/livekit-plugins/livekit-plugins-fishaudio/README.md
+++ b/livekit-plugins/livekit-plugins-fishaudio/README.md
@@ -1,6 +1,6 @@
 # Fish Audio plugin for LiveKit Agents
 
-Support for voice synthesis with [Fish Audio](https://fish.audio/).
+Support for speech-to-text and voice synthesis with [Fish Audio](https://fish.audio/).
 
 - Docs: `https://docs.fish.audio/`
 
@@ -22,11 +22,28 @@ FISH_API_KEY=<your_api_key>
 
 ## Usage
 
+### Speech-to-text
+
 ```python
 from livekit.agents import AgentSession
 from livekit.plugins import fishaudio
 
-# Basic usage with env-based credentials
+stt = fishaudio.STT(language="en")
+
+session = AgentSession(
+    stt=stt,
+    # ... llm, tts, etc.
+)
+```
+
+To let Fish Audio auto-detect the spoken language, omit `language` or pass `language=None`.
+
+### Text-to-speech
+
+```python
+from livekit.agents import AgentSession
+from livekit.plugins import fishaudio
+
 tts = fishaudio.TTS()
 
 session = AgentSession(

--- a/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/__init__.py
+++ b/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/__init__.py
@@ -9,12 +9,16 @@ Environment variables used:
 from livekit.agents import Plugin
 
 from .log import logger
-from .models import LatencyMode, OutputFormat, TTSModels
+from .models import LatencyMode, OutputFormat, STTModels, TTSModels
+from .stt import STT, FishAudioSTT
 from .tts import TTS
 from .version import __version__
 
 __all__ = [
+    "STT",
+    "FishAudioSTT",
     "TTS",
+    "STTModels",
     "TTSModels",
     "OutputFormat",
     "LatencyMode",

--- a/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/__init__.py
+++ b/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/__init__.py
@@ -10,13 +10,12 @@ from livekit.agents import Plugin
 
 from .log import logger
 from .models import LatencyMode, OutputFormat, STTModels, TTSModels
-from .stt import STT, FishAudioSTT
+from .stt import STT
 from .tts import TTS
 from .version import __version__
 
 __all__ = [
     "STT",
-    "FishAudioSTT",
     "TTS",
     "STTModels",
     "TTSModels",

--- a/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/models.py
+++ b/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/models.py
@@ -1,5 +1,7 @@
 from typing import Literal
 
+STTModels = Literal["transcribe-1"]
+
 TTSModels = Literal["s1", "s2-pro"]
 
 OutputFormat = Literal["wav", "pcm", "mp3", "opus"]

--- a/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/stt.py
+++ b/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/stt.py
@@ -218,9 +218,6 @@ class STT(stt.STT):
         return form
 
 
-FishAudioSTT = STT
-
-
 def _normalize_language(language: NotGivenOr[str | None]) -> LanguageCode | None:
     if not is_given(language) or language is None:
         return None

--- a/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/stt.py
+++ b/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/stt.py
@@ -176,6 +176,8 @@ class STT(stt.STT):
                 error=exc,
             )
             raise APIConnectionError(str(exc)) from exc
+        except Exception as exc:
+            raise APIConnectionError() from exc
 
         event = _speech_event_from_response(
             payload,

--- a/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/stt.py
+++ b/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/stt.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import aiohttp
+
+from livekit.agents import (
+    APIConnectionError,
+    APIConnectOptions,
+    APIStatusError,
+    APITimeoutError,
+    LanguageCode,
+    stt,
+    utils,
+)
+from livekit.agents.types import NOT_GIVEN, NotGivenOr
+from livekit.agents.utils import is_given
+
+from .log import logger
+from .models import STTModels
+from .version import __version__
+
+DEFAULT_BASE_URL = "https://api.fish.audio"
+DEFAULT_STT_MODEL: STTModels = "transcribe-1"
+USER_AGENT = f"livekit-plugins-fishaudio/{__version__}"
+
+
+@dataclass
+class _STTOptions:
+    api_key: str
+    base_url: str
+    language: LanguageCode | None
+    ignore_timestamps: bool
+    model: STTModels | str
+
+
+class STT(stt.STT):
+    def __init__(
+        self,
+        *,
+        api_key: NotGivenOr[str] = NOT_GIVEN,
+        base_url: NotGivenOr[str] = NOT_GIVEN,
+        language: NotGivenOr[str | None] = NOT_GIVEN,
+        ignore_timestamps: bool = True,
+        http_session: aiohttp.ClientSession | None = None,
+    ) -> None:
+        """
+        Create a new instance of Fish Audio STT.
+
+        Args:
+            api_key (NotGivenOr[str]): Fish Audio API key. Reads ``FISH_API_KEY`` if unset.
+            base_url (NotGivenOr[str]): Custom base URL. Defaults to
+                ``https://api.fish.audio``.
+            language (NotGivenOr[str | None]): Optional spoken language hint. ``None``,
+                ``"auto"``, ``"multi"``, and ``""`` omit the language field and let Fish
+                Audio auto-detect.
+            ignore_timestamps (bool): Request plain transcription without timestamp details.
+                Set to ``False`` to preserve provider timestamp segments in metadata when
+                Fish Audio returns them. Defaults to ``True``.
+            http_session (aiohttp.ClientSession | None): Optional aiohttp session.
+        """
+        super().__init__(
+            capabilities=stt.STTCapabilities(
+                streaming=False,
+                interim_results=False,
+                aligned_transcript=False,
+                offline_recognize=True,
+            )
+        )
+
+        fish_api_key = api_key if is_given(api_key) else os.getenv("FISH_API_KEY")
+        if not fish_api_key:
+            raise ValueError(
+                "Fish Audio API key is required, either as argument or set "
+                "FISH_API_KEY environment variable"
+            )
+
+        self._opts = _STTOptions(
+            api_key=fish_api_key,
+            base_url=(base_url if is_given(base_url) else DEFAULT_BASE_URL).rstrip("/"),
+            language=_normalize_language(language),
+            ignore_timestamps=ignore_timestamps,
+            model=DEFAULT_STT_MODEL,
+        )
+        self._session = http_session
+
+    @property
+    def model(self) -> STTModels | str:
+        return self._opts.model
+
+    @property
+    def provider(self) -> str:
+        return "FishAudio"
+
+    def _ensure_session(self) -> aiohttp.ClientSession:
+        if not self._session:
+            self._session = utils.http_context.http_session()
+        return self._session
+
+    def update_options(
+        self,
+        *,
+        language: NotGivenOr[str | None] = NOT_GIVEN,
+        ignore_timestamps: NotGivenOr[bool] = NOT_GIVEN,
+    ) -> None:
+        if is_given(language):
+            self._opts.language = _normalize_language(language)
+        if is_given(ignore_timestamps):
+            self._opts.ignore_timestamps = ignore_timestamps
+
+    async def _recognize_impl(
+        self,
+        buffer: utils.AudioBuffer,
+        *,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        conn_options: APIConnectOptions,
+    ) -> stt.SpeechEvent:
+        request_language = (
+            _normalize_language(language) if is_given(language) else self._opts.language
+        )
+        form = self._build_form(
+            audio=utils.merge_frames(buffer).to_wav_bytes(),
+            language=request_language,
+        )
+
+        try:
+            async with self._ensure_session().post(
+                url=f"{self._opts.base_url}/v1/asr",
+                headers={
+                    "Authorization": f"Bearer {self._opts.api_key}",
+                    "User-Agent": USER_AGENT,
+                },
+                data=form,
+                timeout=aiohttp.ClientTimeout(total=conn_options.timeout),
+            ) as response:
+                request_id = response.headers.get("x-request-id", "")
+                payload = await _read_response(response)
+
+                if response.status >= 400:
+                    _log_stt_error(
+                        "Fish Audio STT request failed",
+                        request_id=request_id,
+                        provider=self.provider,
+                        model=self.model,
+                        language=request_language,
+                        status_code=response.status,
+                        body=payload,
+                    )
+                    raise APIStatusError(
+                        "Fish Audio ASR request failed",
+                        status_code=response.status,
+                        request_id=request_id,
+                        body=payload,
+                    )
+
+        except asyncio.TimeoutError as exc:
+            _log_stt_error(
+                "Fish Audio STT request timed out",
+                request_id="",
+                provider=self.provider,
+                model=self.model,
+                language=request_language,
+                error=exc,
+            )
+            raise APITimeoutError() from exc
+        except aiohttp.ClientError as exc:
+            _log_stt_error(
+                "Fish Audio STT connection error",
+                request_id="",
+                provider=self.provider,
+                model=self.model,
+                language=request_language,
+                error=exc,
+            )
+            raise APIConnectionError(str(exc)) from exc
+
+        event = _speech_event_from_response(
+            payload,
+            language=request_language,
+            request_id=request_id,
+        )
+        transcript = event.alternatives[0].text if event.alternatives else ""
+        logger.info(
+            "Fish Audio STT transcript: %s",
+            transcript,
+            extra={
+                "request_id": request_id,
+                "stt_provider": self.provider,
+                "stt_model": self.model,
+                "stt_language": str(request_language) if request_language else None,
+                "stt_duration": event.alternatives[0].end_time if event.alternatives else 0.0,
+            },
+        )
+        return event
+
+    def _build_form(
+        self,
+        *,
+        audio: bytes,
+        language: LanguageCode | None,
+    ) -> aiohttp.FormData:
+        form = aiohttp.FormData()
+        form.add_field(
+            "audio",
+            audio,
+            filename="audio.wav",
+            content_type="audio/wav",
+        )
+        if language is not None:
+            form.add_field("language", language.language)
+        form.add_field(
+            "ignore_timestamps",
+            "true" if self._opts.ignore_timestamps else "false",
+        )
+        return form
+
+
+FishAudioSTT = STT
+
+
+def _normalize_language(language: NotGivenOr[str | None]) -> LanguageCode | None:
+    if not is_given(language) or language is None:
+        return None
+    if language in ("", "auto", "multi"):
+        return None
+    return LanguageCode(language)
+
+
+async def _read_response(response: aiohttp.ClientResponse) -> dict[str, Any]:
+    try:
+        payload = await response.json()
+    except aiohttp.ContentTypeError:
+        return {"error": await response.text()}
+
+    if isinstance(payload, dict):
+        return payload
+    return {"response": payload}
+
+
+def _log_stt_error(
+    message: str,
+    *,
+    request_id: str,
+    provider: str,
+    model: str,
+    language: LanguageCode | None,
+    status_code: int | None = None,
+    body: dict[str, Any] | None = None,
+    error: BaseException | None = None,
+) -> None:
+    extra: dict[str, Any] = {
+        "request_id": request_id,
+        "stt_provider": provider,
+        "stt_model": model,
+        "stt_language": str(language) if language else None,
+    }
+    if status_code is not None:
+        extra["stt_status_code"] = status_code
+    if body is not None:
+        extra["stt_error_body"] = body
+    if error is not None:
+        extra["stt_error"] = repr(error)
+
+    logger.error(message, extra=extra)
+
+
+def _speech_event_from_response(
+    payload: dict[str, Any],
+    *,
+    language: LanguageCode | None,
+    request_id: str,
+) -> stt.SpeechEvent:
+    text = str(payload.get("text") or "")
+    duration = _coerce_float(payload.get("duration"))
+    segments = payload.get("segments") or []
+
+    return stt.SpeechEvent(
+        type=stt.SpeechEventType.FINAL_TRANSCRIPT,
+        request_id=request_id,
+        alternatives=[
+            stt.SpeechData(
+                language=language or LanguageCode(str(payload.get("language") or "")),
+                text=text,
+                start_time=0.0,
+                end_time=duration,
+                metadata={"segments": segments} if segments else None,
+            )
+        ],
+    )
+
+
+def _coerce_float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0

--- a/livekit-plugins/livekit-plugins-fishaudio/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-fishaudio/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "livekit-plugins-fishaudio"
 dynamic = ["version"]
-description = "Agent Framework plugin for voice synthesis with Fish Audio's API."
+description = "Agent Framework plugin for speech-to-text and voice synthesis with Fish Audio's API."
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10.0"

--- a/tests/test_plugin_fishaudio_stt.py
+++ b/tests/test_plugin_fishaudio_stt.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import aiohttp
+import pytest
+
+from livekit import rtc
+from livekit.agents import APIConnectOptions, stt
+from livekit.plugins import fishaudio
+
+
+class _FakeFishResponse:
+    def __init__(
+        self,
+        *,
+        status: int = 200,
+        payload: dict[str, object] | None = None,
+    ) -> None:
+        self.status = status
+        self.headers = {"x-request-id": "fish-request"}
+        self._payload = payload or {
+            "text": "hello, world",
+            "duration": 1.25,
+            "segments": [
+                {"text": "hello", "start": 0.0, "end": 0.6},
+                {"text": "world", "start": 0.6, "end": 1.25},
+            ],
+        }
+
+    async def __aenter__(self) -> _FakeFishResponse:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+    async def json(self) -> dict[str, object]:
+        return self._payload
+
+
+class _FakeFishSession:
+    def __init__(self, response: _FakeFishResponse | None = None) -> None:
+        self.posts: list[dict[str, object]] = []
+        self._response = response or _FakeFishResponse()
+
+    def post(self, **kwargs: object) -> _FakeFishResponse:
+        self.posts.append(kwargs)
+        return self._response
+
+
+def _audio_frame() -> rtc.AudioFrame:
+    return rtc.AudioFrame(
+        data=b"\0\0" * 160,
+        sample_rate=16000,
+        num_channels=1,
+        samples_per_channel=160,
+    )
+
+
+def _form_fields(form: aiohttp.FormData) -> dict[str, object]:
+    return {field[0]["name"]: field[2] for field in form._fields}
+
+
+async def test_fish_audio_stt_posts_wav_form_data_and_returns_transcript(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level("INFO", logger="livekit.plugins.fishaudio"):
+        fake_session = _FakeFishSession()
+        fish_stt = fishaudio.STT(
+            api_key="fish-key",
+            language="zh-CN",
+            ignore_timestamps=False,
+            http_session=fake_session,  # type: ignore[arg-type]
+        )
+
+        event = await fish_stt.recognize(
+            _audio_frame(),
+            conn_options=APIConnectOptions(max_retry=0),
+        )
+
+    assert "Fish Audio STT transcript: hello, world" in caplog.records[-1].getMessage()
+    assert caplog.records[-1].stt_provider == "FishAudio"
+    assert caplog.records[-1].stt_model == "transcribe-1"
+    assert caplog.records[-1].stt_language == "zh-CN"
+    assert caplog.records[-1].stt_duration == 1.25
+
+    assert event.type == stt.SpeechEventType.FINAL_TRANSCRIPT
+    assert event.request_id == "fish-request"
+    assert event.alternatives[0].text == "hello, world"
+    assert event.alternatives[0].language == "zh-CN"
+    assert event.alternatives[0].start_time == 0.0
+    assert event.alternatives[0].end_time == 1.25
+    assert event.alternatives[0].metadata == {
+        "segments": [
+            {"text": "hello", "start": 0.0, "end": 0.6},
+            {"text": "world", "start": 0.6, "end": 1.25},
+        ]
+    }
+
+    request = fake_session.posts[0]
+    assert request["url"] == "https://api.fish.audio/v1/asr"
+    assert request["headers"] == {
+        "Authorization": "Bearer fish-key",
+        "User-Agent": f"livekit-plugins-fishaudio/{fishaudio.__version__}",
+    }
+
+    form = request["data"]
+    assert isinstance(form, aiohttp.FormData)
+    fields = _form_fields(form)
+    assert fields["language"] == "zh"
+    assert fields["ignore_timestamps"] == "false"
+    assert fields["audio"][:4] == b"RIFF"
+
+
+def test_fish_audio_stt_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FISH_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="FISH_API_KEY"):
+        fishaudio.STT()
+
+
+async def test_fish_audio_stt_omits_auto_language() -> None:
+    fake_session = _FakeFishSession()
+    fish_stt = fishaudio.STT(
+        api_key="fish-key",
+        language="auto",
+        http_session=fake_session,  # type: ignore[arg-type]
+    )
+
+    await fish_stt.recognize(
+        _audio_frame(),
+        conn_options=APIConnectOptions(max_retry=0),
+    )
+
+    form = fake_session.posts[0]["data"]
+    assert isinstance(form, aiohttp.FormData)
+    fields = _form_fields(form)
+    assert "language" not in fields
+
+
+async def test_fish_audio_stt_logs_http_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    fake_session = _FakeFishSession(
+        _FakeFishResponse(
+            status=401,
+            payload={"message": "bad fish key", "code": 401},
+        )
+    )
+    fish_stt = fishaudio.STT(
+        api_key="fish-key",
+        http_session=fake_session,  # type: ignore[arg-type]
+    )
+
+    with (
+        caplog.at_level("ERROR", logger="livekit.plugins.fishaudio"),
+        pytest.raises(Exception, match="Fish Audio ASR request failed"),
+    ):
+        await fish_stt.recognize(
+            _audio_frame(),
+            conn_options=APIConnectOptions(max_retry=0),
+        )
+
+    assert "Fish Audio STT request failed" in caplog.records[-1].getMessage()
+    assert caplog.records[-1].request_id == "fish-request"
+    assert caplog.records[-1].stt_provider == "FishAudio"
+    assert caplog.records[-1].stt_model == "transcribe-1"
+    assert caplog.records[-1].stt_status_code == 401
+    assert caplog.records[-1].stt_error_body == {
+        "message": "bad fish key",
+        "code": 401,
+    }


### PR DESCRIPTION
Adds Speech-to-Text support to the Fish Audio plugin.

This implements a new `fishaudio.STT` provider using Fish Audio's `/v1/asr` endpoint, alongside the existing TTS support. The STT implementation uploads LiveKit audio buffers as WAV multipart form data, supports optional language hints, preserves returned timestamp segments in transcript metadata, and reports the Fish ASR model as `transcribe-1` for metrics/logging.

## Changes

- Add `livekit.plugins.fishaudio.STT`
- Add `FishAudioSTT` alias for explicit naming
- Add `STTModels = Literal["transcribe-1"]`
- Export STT symbols from the Fish Audio plugin package
- Update Fish Audio README with separate STT and TTS examples
- Update package description to mention STT support
- Add unit tests for:
  - multipart WAV form upload
  - transcript mapping
  - language auto-detection behavior
  - HTTP error handling/logging