### PR TITLE
fix(core): fix speech start time overriden by VAD SOS events

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -967,7 +967,8 @@ class AudioRecognition:
         if ev.type == vad.VADEventType.START_OF_SPEECH:
             speech_start_time = time.time() - ev.speech_duration - ev.inference_duration
             if not self._vad_speech_started:
-                self._speech_start_time = speech_start_time
+                if self._speech_start_time is None:
+                    self._speech_start_time = speech_start_time
                 self._vad_speech_started = True
 
             with trace.use_span(self._ensure_user_turn_span(start_time=speech_start_time)):

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -966,9 +966,12 @@ class AudioRecognition:
     async def _on_vad_event(self, ev: vad.VADEvent) -> None:
         if ev.type == vad.VADEventType.START_OF_SPEECH:
             speech_start_time = time.time() - ev.speech_duration - ev.inference_duration
+            # _vad_speech_started is now per-turn (not per-burst): it stays True across
+            # END_OF_SPEECH within the same uncommitted turn so that subsequent bursts
+            # do not overwrite the original turn's _speech_start_time. It is reset
+            # only when an EOU commits or the VAD stream closes.
             if not self._vad_speech_started:
-                if self._speech_start_time is None:
-                    self._speech_start_time = speech_start_time
+                self._speech_start_time = speech_start_time
                 self._vad_speech_started = True
 
             with trace.use_span(self._ensure_user_turn_span(start_time=speech_start_time)):
@@ -996,7 +999,6 @@ class AudioRecognition:
             with trace.use_span(self._ensure_user_turn_span()):
                 self._hooks.on_end_of_speech(ev)
 
-            self._vad_speech_started = False
             self._speaking = False
 
             if self._vad_base_turn_detection or (

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -204,7 +204,7 @@ class AudioRecognition:
         self._stt_request_ids: list[str] = []
         self._closing = asyncio.Event()
 
-        self._vad_speech_started: bool = False
+        self._turn_speech_started: bool = False
 
     def update_options(
         self,
@@ -966,13 +966,9 @@ class AudioRecognition:
     async def _on_vad_event(self, ev: vad.VADEvent) -> None:
         if ev.type == vad.VADEventType.START_OF_SPEECH:
             speech_start_time = time.time() - ev.speech_duration - ev.inference_duration
-            # _vad_speech_started is now per-turn (not per-burst): it stays True across
-            # END_OF_SPEECH within the same uncommitted turn so that subsequent bursts
-            # do not overwrite the original turn's _speech_start_time. It is reset
-            # only when an EOU commits or the VAD stream closes.
-            if not self._vad_speech_started:
+            if not self._turn_speech_started:
                 self._speech_start_time = speech_start_time
-                self._vad_speech_started = True
+                self._turn_speech_started = True
 
             with trace.use_span(self._ensure_user_turn_span(start_time=speech_start_time)):
                 self._hooks.on_start_of_speech(ev, speech_start_time=speech_start_time)
@@ -1159,7 +1155,7 @@ class AudioRecognition:
                 # only reset if there is no new speech
                 if self._last_speaking_time == last_speaking_time:
                     self._speech_start_time = None
-                    self._vad_speech_started = False
+                    self._turn_speech_started = False
                     self._last_speaking_time = None
 
             self._user_turn_committed = False
@@ -1226,7 +1222,7 @@ class AudioRecognition:
                 with trace.use_span(self._ensure_user_turn_span()):
                     self._hooks.on_end_of_speech(None)
                 self._speaking = False
-                self._vad_speech_started = False
+                self._turn_speech_started = False
 
     @utils.log_exceptions(logger=logger)
     async def _interruption_task(

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -653,6 +653,7 @@ class AudioRecognition:
         self._audio_preflight_transcript = ""
         self._final_transcript_confidence = []
         self._user_turn_committed = False
+        self._turn_speech_started = False
 
         # reset stt to clear the buffer from previous user turn
         stt = self._stt


### PR DESCRIPTION
Previously, it was overriden by VAD events such that turn start timestamps in Insights were misaligned to the last speaking span start time.

This closes AGT-2840.


Before:
<img width="3234" height="2054" alt="CleanShot 2026-05-07 at 11 46 42@2x" src="https://github.com/user-attachments/assets/542ae299-5164-4c53-b7fe-dbc63b83c2cd" />


After:
<img width="3042" height="1780" alt="CleanShot 2026-05-07 at 11 48 14@2x" src="https://github.com/user-attachments/assets/6b53a9cf-56ad-4ecf-9e65-7b9ac9eb1013" />

