### PR TITLE
[codex] Handle non-JSON session report values

### DIFF
--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -48,6 +48,10 @@ from .utils.misc import is_cloud
 _JobContextVar = contextvars.ContextVar["JobContext"]("agents_job_context")
 
 
+def _serialize_session_report(report: SessionReport) -> str:
+    return json.dumps(report.to_dict(), indent=2, default=str)
+
+
 def _observability_url(livekit_url: str) -> str | None:
     """Return the observability endpoint, or None if observability is unavailable."""
     url = os.environ.get("LIVEKIT_OBSERVABILITY_URL")
@@ -266,7 +270,7 @@ class JobContext:
         # console recording, dump data to a local file
         if c.enabled and c.record:
             try:
-                report_json = json.dumps(report.to_dict(), indent=2)
+                report_json = _serialize_session_report(report)
 
                 import aiofiles
                 import aiofiles.os

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import inspect
+import json
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -11,6 +12,7 @@ import aiohttp
 import pytest
 
 from livekit.agents import Agent, AgentSession
+from livekit.agents.job import _serialize_session_report
 from livekit.agents.telemetry.traces import _upload_session_report
 from livekit.agents.voice.agent_session import (
     _RECORDING_ALL_OFF,
@@ -126,6 +128,18 @@ def _make_mock_http() -> MagicMock:
     mock_post_cm.__aenter__.return_value = mock_resp
     mock_http.post.return_value = mock_post_cm
     return mock_http
+
+
+def test_serialize_session_report_handles_non_json_event_values() -> None:
+    class NonSerializable:
+        pass
+
+    report = MagicMock()
+    report.to_dict.return_value = {"events": [{"interruption_detector": NonSerializable()}]}
+
+    payload = json.loads(_serialize_session_report(report))
+
+    assert "NonSerializable" in payload["events"][0]["interruption_detector"]
 
 
 def _observability_endpoint_arg(func: Any) -> dict[str, str]:


### PR DESCRIPTION
## Summary

- make local console session report serialization tolerate non-JSON event values
- add a regression test covering recorded events with arbitrary runtime objects

## Root cause

`console --record` writes `session_report.json` with `json.dumps(report.to_dict())`. Some recorded events can include SDK runtime objects, such as an adaptive interruption detector instance, which are not JSON serializable and caused the report save to fail at session shutdown.

## Validation

- `uv run ruff check livekit-agents/livekit/agents/job.py tests/test_recording.py`
- `uv run pytest tests/test_recording.py`
