### PR TITLE
Add support for GPT-Realtime-2.0

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -75,6 +75,7 @@ from .generation import (
     remove_instructions,
     update_instructions,
 )
+from .io import PlaybackFinishedEvent
 from .speech_handle import DEFAULT_INPUT_DETAILS, InputDetails, SpeechHandle
 from .turn import EndpointingOptions, TurnDetectionMode
 
@@ -3012,6 +3013,8 @@ class AgentActivity(RecognitionHooks):
             2. _TextOutput.first_text_fut (None)
             """
             nonlocal started_speaking_at, started_forwarding_at
+            if started_speaking_at is not None:
+                return
             try:
                 started_speaking_at = fut.result() or time.time()
                 started_forwarding_at = (
@@ -3048,12 +3051,6 @@ class AgentActivity(RecognitionHooks):
             forward_tasks: list[asyncio.Task[Any]] = []
             try:
                 async for msg in generation_ev.message_stream:
-                    if len(forward_tasks) > 0:
-                        logger.warning(
-                            "expected to receive only one message generation from the realtime API"
-                        )
-                        break
-
                     msg_modalities = await msg.modalities
                     tts_text_input: AsyncIterable[str] | None = None
                     if "audio" not in msg_modalities and self.tts:
@@ -3241,59 +3238,92 @@ class AgentActivity(RecognitionHooks):
             msg.metrics = assistant_metrics
             return msg
 
-        msg_gen, text_out, audio_out = (
-            message_outputs[0] if len(message_outputs) > 0 else (None, None, None)
-        )  # there should be only one message
+        partial_idx: int | None = None
+        playback_ev: PlaybackFinishedEvent | None = None
 
-        forwarded_text = text_out.text if text_out else ""
         if speech_handle.interrupted:
             await utils.aio.cancel_and_wait(*tasks)
 
-            if msg_gen and audio_output is not None:
+            if message_outputs and audio_output is not None:
                 audio_output.clear_buffer()
-
                 playback_ev = await audio_output.wait_for_playout()
-                playback_position = playback_ev.playback_position
-                if (
-                    audio_out is not None
-                    and audio_out.first_frame_fut.done()
-                    and not audio_out.first_frame_fut.cancelled()
-                ):
-                    # playback_ev is valid only if the first frame was already played
-                    if playback_ev.synchronized_transcript is not None:
-                        forwarded_text = playback_ev.synchronized_transcript
-                else:
-                    forwarded_text = ""
-                    playback_position = 0
 
-                # truncate server-side message (if supported)
-                if self.llm.capabilities.message_truncation:
-                    msg_modalities = await msg_gen.modalities
-                    self._rt_session.truncate(
-                        message_id=msg_gen.message_id,
-                        modalities=msg_modalities,
-                        audio_end_ms=int(playback_position * 1000),
-                        audio_transcript=forwarded_text,
-                    )
+                if playback_ev.interrupted:
+                    for idx, (_, _, audio_out_i) in enumerate(message_outputs):
+                        if (
+                            audio_out_i is not None
+                            and audio_out_i.first_frame_fut.done()
+                            and not audio_out_i.first_frame_fut.cancelled()
+                        ):
+                            partial_idx = idx
 
-        elif read_transcript_from_tts and text_out and not text_out.text:
+                    if (
+                        partial_idx is not None
+                        and self.llm.capabilities.message_truncation
+                    ):
+                        msg_gen, text_out, _ = message_outputs[partial_idx]
+                        transcript = playback_ev.synchronized_transcript or (
+                            text_out.text if text_out else ""
+                        )
+                        msg_modalities = await msg_gen.modalities
+                        self._rt_session.truncate(
+                            message_id=msg_gen.message_id,
+                            modalities=msg_modalities,
+                            audio_end_ms=int(playback_ev.playback_position * 1000),
+                            audio_transcript=transcript,
+                        )
+        elif read_transcript_from_tts and any(
+            text_out is not None and not text_out.text
+            for _, text_out, _ in message_outputs
+        ):
             logger.warning(
                 "`use_tts_aligned_transcript` is enabled but no agent transcript was returned from tts"
             )
 
-        if msg_gen and forwarded_text:
+        trace_text_parts: list[str] = []
+        for idx, (msg_gen, text_out, audio_out) in enumerate(message_outputs):
+            if msg_gen is None:
+                continue
+
+            if audio_output is not None:
+                started_playing = (
+                    audio_out is not None
+                    and audio_out.first_frame_fut.done()
+                    and not audio_out.first_frame_fut.cancelled()
+                )
+                if not started_playing:
+                    continue
+
+            if idx == partial_idx and playback_ev is not None:
+                forwarded_text = playback_ev.synchronized_transcript or (
+                    text_out.text if text_out else ""
+                )
+                item_interrupted = True
+            else:
+                forwarded_text = text_out.text if text_out else ""
+                item_interrupted = False
+
+            if not forwarded_text:
+                continue
+
+            trace_text_parts.append(forwarded_text)
             msg = _create_assistant_message(
                 message_id=msg_gen.message_id,
                 forwarded_text=forwarded_text,
-                interrupted=speech_handle.interrupted,
+                interrupted=item_interrupted,
             )
             self._agent._chat_ctx._upsert_item(msg)
             speech_handle._item_added([msg])
             self._session._conversation_item_added(msg)
-            current_span.set_attribute(trace_types.ATTR_RESPONSE_TEXT, forwarded_text)
 
-        if audio_out is not None and not audio_out.first_frame_fut.done():
-            audio_out.first_frame_fut.cancel()
+        if trace_text_parts:
+            current_span.set_attribute(
+                trace_types.ATTR_RESPONSE_TEXT, " ".join(trace_text_parts)
+            )
+
+        for _, _, audio_out in message_outputs:
+            if audio_out is not None and not audio_out.first_frame_fut.done():
+                audio_out.first_frame_fut.cancel()
 
         for tee in tees:
             await tee.aclose()

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3048,9 +3048,10 @@ class AgentActivity(RecognitionHooks):
             nonlocal read_transcript_from_tts
             assert isinstance(self.llm, llm.RealtimeModel)
 
-            forward_tasks: list[asyncio.Task[Any]] = []
+            msg_tasks: list[asyncio.Task[Any]] = []
             try:
                 async for msg in generation_ev.message_stream:
+                    msg_tasks = []
                     msg_modalities = await msg.modalities
                     tts_text_input: AsyncIterable[str] | None = None
                     if "audio" not in msg_modalities and self.tts:
@@ -3090,7 +3091,7 @@ class AgentActivity(RecognitionHooks):
                                 tr_text_input = timed_texts
                                 read_transcript_from_tts = True
 
-                            tasks.append(tts_task)
+                            msg_tasks.append(tts_task)
                             realtime_audio_result = tts_gen_data.audio_ch
                         elif "audio" in msg_modalities:
                             realtime_audio = self._agent.realtime_audio_output_node(
@@ -3117,7 +3118,7 @@ class AgentActivity(RecognitionHooks):
                                 audio_output=audio_output,
                                 tts_output=realtime_audio_result,
                             )
-                            forward_tasks.append(forward_task)
+                            msg_tasks.append(forward_task)
                             audio_out.first_frame_fut.add_done_callback(
                                 partial(_on_first_frame, audio_out=audio_out)
                             )
@@ -3131,16 +3132,22 @@ class AgentActivity(RecognitionHooks):
                             text_output=text_output,
                             source=tr_node_result,
                         )
-                        forward_tasks.append(forward_task)
+                        msg_tasks.append(forward_task)
 
                     if not audio_out and text_out:
                         text_out.first_text_fut.add_done_callback(_on_first_frame)
 
                     outputs.append((msg, text_out, audio_out))
 
-                await asyncio.gather(*forward_tasks)
+                    await asyncio.gather(*msg_tasks)
+                    msg_tasks.clear()
+
+                    if audio_output is not None and audio_out is not None:
+                        await audio_output.wait_for_playout()
+                        if not audio_out.first_frame_fut.done():
+                            audio_out.first_frame_fut.cancel()
             finally:
-                await utils.aio.cancel_and_wait(*forward_tasks)
+                await utils.aio.cancel_and_wait(*msg_tasks)
 
         message_outputs: list[
             tuple[MessageGeneration, _TextOutput | None, _AudioOutput | None]
@@ -3257,10 +3264,7 @@ class AgentActivity(RecognitionHooks):
                         ):
                             partial_idx = idx
 
-                    if (
-                        partial_idx is not None
-                        and self.llm.capabilities.message_truncation
-                    ):
+                    if partial_idx is not None and self.llm.capabilities.message_truncation:
                         msg_gen, text_out, _ = message_outputs[partial_idx]
                         transcript = playback_ev.synchronized_transcript or (
                             text_out.text if text_out else ""
@@ -3273,8 +3277,7 @@ class AgentActivity(RecognitionHooks):
                             audio_transcript=transcript,
                         )
         elif read_transcript_from_tts and any(
-            text_out is not None and not text_out.text
-            for _, text_out, _ in message_outputs
+            text_out is not None and not text_out.text for _, text_out, _ in message_outputs
         ):
             logger.warning(
                 "`use_tts_aligned_transcript` is enabled but no agent transcript was returned from tts"
@@ -3317,9 +3320,7 @@ class AgentActivity(RecognitionHooks):
             self._session._conversation_item_added(msg)
 
         if trace_text_parts:
-            current_span.set_attribute(
-                trace_types.ATTR_RESPONSE_TEXT, " ".join(trace_text_parts)
-            )
+            current_span.set_attribute(trace_types.ATTR_RESPONSE_TEXT, " ".join(trace_text_parts))
 
         for _, _, audio_out in message_outputs:
             if audio_out is not None and not audio_out.first_frame_fut.done():

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -100,7 +100,6 @@ class _ParticipantAudioOutput(io.AudioOutput):
         await super().capture_frame(frame)
 
         if self._flush_task and not self._flush_task.done():
-            logger.error("capture_frame called while flush is in progress")
             await self._flush_task
 
         for f in self._audio_bstream.push(frame.data):

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import time
 
@@ -116,12 +117,15 @@ class _ParticipantAudioOutput(io.AudioOutput):
         if not self._pushed_duration:
             return
 
-        if self._flush_task and not self._flush_task.done():
-            # shouldn't happen if only one active speech handle at a time
-            logger.error("flush called while playback is in progress")
-            self._flush_task.cancel()
+        prior_task = self._flush_task
 
-        self._flush_task = asyncio.create_task(self._wait_for_playout())
+        async def _serialized_playout() -> None:
+            if prior_task is not None and not prior_task.done():
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await prior_task
+            await self._wait_for_playout()
+
+        self._flush_task = asyncio.create_task(_serialized_playout())
 
     def clear_buffer(self) -> None:
         self._audio_bstream.clear()

--- a/livekit-agents/livekit/agents/voice/transcription/synchronizer.py
+++ b/livekit-agents/livekit/agents/voice/transcription/synchronizer.py
@@ -197,6 +197,8 @@ class _SegmentSynchronizerImpl:
         if self.closed:
             logger.warning("_SegmentSynchronizerImpl.end_audio_input called after close")
             return
+        if self._audio_data.done:
+            return
 
         self._audio_data.done = True
         self._audio_data.sr_stream.end_input()
@@ -225,6 +227,8 @@ class _SegmentSynchronizerImpl:
     def end_text_input(self) -> None:
         if self.closed:
             logger.warning("_SegmentSynchronizerImpl.end_text_input called after close")
+            return
+        if self._text_data.done:
             return
 
         self._text_data.done = True
@@ -454,6 +458,9 @@ class TranscriptSynchronizer:
         self._impl = _SegmentSynchronizerImpl(options=self._opts, next_in_chain=next_in_chain_text)
         self._rotate_segment_atask: asyncio.Task[None] | None = None
 
+        self._pending_impls: list[_SegmentSynchronizerImpl] = []
+        self._aclose_tasks: list[asyncio.Task[None]] = []
+
     @property
     def audio_output(self) -> _SyncedAudioOutput:
         return self._audio_output
@@ -469,6 +476,14 @@ class TranscriptSynchronizer:
     async def aclose(self) -> None:
         self._closed = True
         await self.barrier()
+        for impl in self._pending_impls:
+            with contextlib.suppress(Exception):
+                await impl.aclose()
+        self._pending_impls.clear()
+        for task in self._aclose_tasks:
+            with contextlib.suppress(Exception):
+                await task
+        self._aclose_tasks.clear()
         await self._impl.aclose()
 
     def set_enabled(self, enabled: bool) -> None:
@@ -528,6 +543,22 @@ class TranscriptSynchronizer:
             self._rotate_segment_task(self._rotate_segment_atask)
         )
 
+    def _advance_segment(self) -> None:
+        """Move the active impl to the pending queue and install a fresh
+        active impl, without closing the moved impl. The pending impl
+        will receive its playback_started/playback_finished events from
+        _SyncedAudioOutput in capture order, then be closed.
+        """
+        if self._closed:
+            return
+
+        self._pending_impls.append(self._impl)
+        self._impl = _SegmentSynchronizerImpl(
+            options=self._opts, next_in_chain=self._text_output._next_in_chain
+        )
+        if self._paused:
+            self._impl.pause()
+
     async def barrier(self) -> None:
         if self._rotate_segment_atask is None:
             return
@@ -576,12 +607,13 @@ class _SyncedAudioOutput(io.AudioOutput):
             return
 
         if self._synchronizer._impl.audio_input_ended:
-            # this should not happen if `on_playback_finished` is called after each flush
-            logger.warning(
-                "_SegmentSynchronizerImpl audio marked as ended in capture audio, rotating segment"
-            )
-            self._synchronizer.rotate_segment()
-            await self._synchronizer.barrier()
+            # The active impl had its audio input ended (typically because
+            # the prior item's flush() has run but its text flush hasn't
+            # yet); advance to a fresh impl so this frame doesn't push
+            # into a closed sr_stream. _advance_segment moves the prior
+            # impl to pending (it stays alive to receive its playback
+            # events and finish forwarding any in-flight text).
+            self._synchronizer._advance_segment()
 
         self._synchronizer._impl.push_audio(frame)
 
@@ -598,15 +630,29 @@ class _SyncedAudioOutput(io.AudioOutput):
             return
 
         self._synchronizer._impl.end_audio_input()
+        if self._synchronizer._impl.text_input_ended:
+            self._synchronizer._advance_segment()
 
     def clear_buffer(self) -> None:
         self._next_in_chain.clear_buffer()
+
+    def _impl_for_playback_started(self) -> _SegmentSynchronizerImpl:
+        # Audio playback events arrive in capture order. Find the oldest
+        # impl that hasn't received its playback_started yet. Falls back
+        # to the active impl when there's nothing pending (e.g. before
+        # the first segment has been advanced).
+        for pending in self._synchronizer._pending_impls:
+            if not pending._start_fut.is_set():
+                return pending
+        return self._synchronizer._impl
 
     # this is going to be automatically called by the next_in_chain
     def on_playback_started(self, *, created_at: float) -> None:
         super().on_playback_started(created_at=created_at)
         if self._synchronizer.enabled:
-            self._synchronizer._impl.on_playback_started(start_time=created_at)
+            self._impl_for_playback_started().on_playback_started(
+                start_time=created_at
+            )
 
     def on_playback_finished(
         self,
@@ -623,16 +669,28 @@ class _SyncedAudioOutput(io.AudioOutput):
             )
             return
 
-        self._synchronizer._impl.mark_playback_finished(
-            playback_position=playback_position, interrupted=interrupted
-        )
-        super().on_playback_finished(
-            playback_position=playback_position,
-            interrupted=interrupted,
-            synchronized_transcript=self._synchronizer._impl.synchronized_transcript,
-        )
+        if self._synchronizer._pending_impls:
+            target = self._synchronizer._pending_impls.pop(0)
+            target.mark_playback_finished(
+                playback_position=playback_position, interrupted=interrupted
+            )
+            super().on_playback_finished(
+                playback_position=playback_position,
+                interrupted=interrupted,
+                synchronized_transcript=target.synchronized_transcript,
+            )
+            self._synchronizer._aclose_tasks.append(asyncio.create_task(target.aclose()))
+        else:
+            self._synchronizer._impl.mark_playback_finished(
+                playback_position=playback_position, interrupted=interrupted
+            )
+            super().on_playback_finished(
+                playback_position=playback_position,
+                interrupted=interrupted,
+                synchronized_transcript=self._synchronizer._impl.synchronized_transcript,
+            )
+            self._synchronizer.rotate_segment()
 
-        self._synchronizer.rotate_segment()
         self._pushed_duration = 0.0
 
     def on_attached(self) -> None:
@@ -688,12 +746,11 @@ class _SyncedTextOutput(io.TextOutput):
 
         self._capturing = True
         if self._synchronizer._impl.text_input_ended:
-            # this should not happen if `on_playback_finished` is called after each flush
-            logger.warning(
-                "_SegmentSynchronizerImpl text marked as ended in capture text, rotating segment"
-            )
-            self._synchronizer.rotate_segment()
-            await self._synchronizer.barrier()
+            # Mirror of the audio fallback: text input on the active impl
+            # was ended (the prior item's text flush() ran but its audio
+            # flush hasn't yet); advance so this text doesn't push into
+            # a closed word_stream.
+            self._synchronizer._advance_segment()
 
         self._synchronizer._impl.push_text(text)
 
@@ -708,6 +765,8 @@ class _SyncedTextOutput(io.TextOutput):
 
         self._capturing = False
         self._synchronizer._impl.end_text_input()
+        if self._synchronizer._impl.audio_input_ended:
+            self._synchronizer._advance_segment()
 
     def on_attached(self) -> None:
         super().on_attached()

--- a/livekit-agents/livekit/agents/voice/transcription/synchronizer.py
+++ b/livekit-agents/livekit/agents/voice/transcription/synchronizer.py
@@ -150,6 +150,7 @@ class _SegmentSynchronizerImpl:
 
         self._out_ch = utils.aio.Chan[TimedString]()
         self._close_future = asyncio.Future[None]()
+        self._inputs_done_fut = asyncio.Future[None]()
 
         self._main_atask = asyncio.create_task(self._main_task())
         self._main_atask.add_done_callback(lambda _: self._out_ch.close())
@@ -203,6 +204,7 @@ class _SegmentSynchronizerImpl:
         self._audio_data.done = True
         self._audio_data.sr_stream.end_input()
         self._reestimate_speed()
+        self._maybe_mark_inputs_done()
 
     def push_text(self, text: str) -> None:
         if self.closed:
@@ -235,6 +237,7 @@ class _SegmentSynchronizerImpl:
         self._text_data.word_stream.end_input()
 
         self._reestimate_speed()
+        self._maybe_mark_inputs_done()
 
     def pause(self) -> None:
         if self.closed:
@@ -277,23 +280,25 @@ class _SegmentSynchronizerImpl:
         if pushed_speaking_units > 0:
             self._speed_on_speaking_unit = pushed_hyphens / pushed_speaking_units
 
-    def mark_playback_finished(self, *, playback_position: float, interrupted: bool) -> None:
+    def _maybe_mark_inputs_done(self) -> None:
+        if self._text_data.done and self._audio_data.done and not self._inputs_done_fut.done():
+            self._inputs_done_fut.set_result(None)
+
+    async def wait_inputs_done(self) -> None:
+        await asyncio.shield(self._inputs_done_fut)
+
+    def mark_playback_finished(self, *, playback_position: float, interrupted: bool) -> bool:
         if self.closed:
             logger.warning("_SegmentSynchronizerImpl.playback_finished called after close")
-            return
+            return True
 
         self._interrupted = interrupted
-        if not self._text_data.done or not self._audio_data.done:
-            logger.warning(
-                "_SegmentSynchronizerImpl.playback_finished called before text/audio input is done",
-                extra={"text_done": self._text_data.done, "audio_done": self._audio_data.done},
-            )
-            return
-
-        # if the playback of the segment is done and were not interrupted, make sure the whole
-        # transcript is sent. (In case we're late)
         if not interrupted:
+            # If playback finished before the text stream drained, release the remaining words
+            # as soon as they arrive so the upstream playback_finished event can include them.
             self._playback_completed = True
+
+        return interrupted or self._inputs_done_fut.done()
 
     @property
     def synchronized_transcript(self) -> str:
@@ -400,6 +405,8 @@ class _SegmentSynchronizerImpl:
             return
 
         self._close_future.set_result(None)
+        if not self._inputs_done_fut.done():
+            self._inputs_done_fut.set_result(None)
         if self._start_wall_time is None:
             # avoid assertion error in _main_task if playback completed
             self._start_wall_time = time.time()
@@ -459,6 +466,7 @@ class TranscriptSynchronizer:
         self._rotate_segment_atask: asyncio.Task[None] | None = None
 
         self._pending_impls: list[_SegmentSynchronizerImpl] = []
+        self._finalizing_impls: list[_SegmentSynchronizerImpl] = []
         self._aclose_tasks: list[asyncio.Task[None]] = []
 
     @property
@@ -480,7 +488,11 @@ class TranscriptSynchronizer:
             with contextlib.suppress(Exception):
                 await impl.aclose()
         self._pending_impls.clear()
-        for task in self._aclose_tasks:
+        for impl in self._finalizing_impls:
+            with contextlib.suppress(Exception):
+                await impl.aclose()
+        self._finalizing_impls.clear()
+        for task in list(self._aclose_tasks):
             with contextlib.suppress(Exception):
                 await task
         self._aclose_tasks.clear()
@@ -522,15 +534,7 @@ class TranscriptSynchronizer:
         except Exception:
             logger.exception("failed to close segment synchronizer impl during rotation")
 
-        # always create a new impl even if aclose() failed, to avoid leaving
-        # self._impl pointing to a closed impl which causes the agent to get stuck
-        self._impl = _SegmentSynchronizerImpl(
-            options=self._opts, next_in_chain=self._text_output._next_in_chain
-        )
-
-        # apply the current pause state to the new impl
-        if self._paused:
-            self._impl.pause()
+        self._replace_active_impl()
 
     def rotate_segment(self) -> None:
         if self._closed:
@@ -543,6 +547,15 @@ class TranscriptSynchronizer:
             self._rotate_segment_task(self._rotate_segment_atask)
         )
 
+    def _replace_active_impl(self) -> None:
+        # Always create a new impl even if the previous impl failed to close, to
+        # avoid leaving self._impl pointing to a closed impl which gets output stuck.
+        self._impl = _SegmentSynchronizerImpl(
+            options=self._opts, next_in_chain=self._text_output._next_in_chain
+        )
+        if self._paused:
+            self._impl.pause()
+
     def _advance_segment(self) -> None:
         """Move the active impl to the pending queue and install a fresh
         active impl, without closing the moved impl. The pending impl
@@ -552,12 +565,27 @@ class TranscriptSynchronizer:
         if self._closed:
             return
 
-        self._pending_impls.append(self._impl)
-        self._impl = _SegmentSynchronizerImpl(
-            options=self._opts, next_in_chain=self._text_output._next_in_chain
+        if self._impl not in self._finalizing_impls:
+            self._pending_impls.append(self._impl)
+        self._replace_active_impl()
+
+    def _iter_live_impls(self) -> tuple[_SegmentSynchronizerImpl, ...]:
+        return (
+            *self._pending_impls,
+            *self._finalizing_impls,
+            self._impl,
         )
-        if self._paused:
-            self._impl.pause()
+
+    def _track_aclose_task(self, task: asyncio.Task[None]) -> None:
+        self._aclose_tasks.append(task)
+
+        def _remove_task(_: asyncio.Task[None]) -> None:
+            with contextlib.suppress(ValueError):
+                self._aclose_tasks.remove(task)
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                task.exception()
+
+        task.add_done_callback(_remove_task)
 
     async def barrier(self) -> None:
         if self._rotate_segment_atask is None:
@@ -621,10 +649,13 @@ class _SyncedAudioOutput(io.AudioOutput):
         super().flush()
         self._next_in_chain.flush()
 
+        pushed_duration = self._pushed_duration
+        self._pushed_duration = 0.0
+
         if not self._synchronizer.enabled:
             return
 
-        if not self._pushed_duration:
+        if not pushed_duration:
             # in case there is no audio after text was pushed, rotate the segment
             self._synchronizer.rotate_segment()
             return
@@ -650,9 +681,7 @@ class _SyncedAudioOutput(io.AudioOutput):
     def on_playback_started(self, *, created_at: float) -> None:
         super().on_playback_started(created_at=created_at)
         if self._synchronizer.enabled:
-            self._impl_for_playback_started().on_playback_started(
-                start_time=created_at
-            )
+            self._impl_for_playback_started().on_playback_started(start_time=created_at)
 
     def on_playback_finished(
         self,
@@ -671,27 +700,101 @@ class _SyncedAudioOutput(io.AudioOutput):
 
         if self._synchronizer._pending_impls:
             target = self._synchronizer._pending_impls.pop(0)
-            target.mark_playback_finished(
-                playback_position=playback_position, interrupted=interrupted
-            )
-            super().on_playback_finished(
+            self._schedule_playback_finished(
+                target,
                 playback_position=playback_position,
                 interrupted=interrupted,
-                synchronized_transcript=target.synchronized_transcript,
             )
-            self._synchronizer._aclose_tasks.append(asyncio.create_task(target.aclose()))
         else:
-            self._synchronizer._impl.mark_playback_finished(
-                playback_position=playback_position, interrupted=interrupted
-            )
-            super().on_playback_finished(
+            target = self._synchronizer._impl
+            self._schedule_playback_finished(
+                target,
                 playback_position=playback_position,
                 interrupted=interrupted,
-                synchronized_transcript=self._synchronizer._impl.synchronized_transcript,
+                replace_active=True,
             )
-            self._synchronizer.rotate_segment()
 
         self._pushed_duration = 0.0
+
+    def _schedule_playback_finished(
+        self,
+        target: _SegmentSynchronizerImpl,
+        *,
+        playback_position: float,
+        interrupted: bool,
+        replace_active: bool = False,
+    ) -> None:
+        self._synchronizer._finalizing_impls.append(target)
+        ready = target.mark_playback_finished(
+            playback_position=playback_position, interrupted=interrupted
+        )
+        if ready:
+            if replace_active and self._synchronizer._impl is target:
+                self._synchronizer._replace_active_impl()
+                replace_active = False
+            self._emit_playback_finished(
+                target,
+                playback_position=playback_position,
+                interrupted=interrupted,
+            )
+            task = asyncio.create_task(
+                self._close_finished_impl(target, replace_active=replace_active)
+            )
+        else:
+            task = asyncio.create_task(
+                self._finish_playback_when_ready(
+                    target,
+                    playback_position=playback_position,
+                    interrupted=interrupted,
+                    replace_active=replace_active,
+                )
+            )
+        self._synchronizer._track_aclose_task(task)
+
+    def _emit_playback_finished(
+        self,
+        target: _SegmentSynchronizerImpl,
+        *,
+        playback_position: float,
+        interrupted: bool,
+    ) -> None:
+        super().on_playback_finished(
+            playback_position=playback_position,
+            interrupted=interrupted,
+            synchronized_transcript=target.synchronized_transcript,
+        )
+
+    @utils.log_exceptions(logger=logger)
+    async def _finish_playback_when_ready(
+        self,
+        target: _SegmentSynchronizerImpl,
+        *,
+        playback_position: float,
+        interrupted: bool,
+        replace_active: bool,
+    ) -> None:
+        await target.wait_inputs_done()
+        target.mark_playback_finished(playback_position=playback_position, interrupted=interrupted)
+        self._emit_playback_finished(
+            target,
+            playback_position=playback_position,
+            interrupted=interrupted,
+        )
+        await self._close_finished_impl(target, replace_active=replace_active)
+
+    @utils.log_exceptions(logger=logger)
+    async def _close_finished_impl(
+        self, target: _SegmentSynchronizerImpl, *, replace_active: bool
+    ) -> None:
+        try:
+            if replace_active and self._synchronizer._impl is target:
+                self._synchronizer._replace_active_impl()
+            await target.aclose()
+        finally:
+            with contextlib.suppress(ValueError):
+                self._synchronizer._finalizing_impls.remove(target)
+            with contextlib.suppress(ValueError):
+                self._synchronizer._pending_impls.remove(target)
 
     def on_attached(self) -> None:
         super().on_attached()
@@ -705,15 +808,17 @@ class _SyncedAudioOutput(io.AudioOutput):
         super().pause()
         # track pause state at synchronizer level so it persists across segment rotations
         self._synchronizer._paused = True
-        if not self._synchronizer._impl.closed:
-            self._synchronizer._impl.pause()
+        for impl in self._synchronizer._iter_live_impls():
+            if not impl.closed:
+                impl.pause()
 
     def resume(self) -> None:
         super().resume()
         # track pause state at synchronizer level so it persists across segment rotations
         self._synchronizer._paused = False
-        if not self._synchronizer._impl.closed:
-            self._synchronizer._impl.resume()
+        for impl in self._synchronizer._iter_live_impls():
+            if not impl.closed:
+                impl.resume()
 
 
 class _SyncedTextOutput(io.TextOutput):

--- a/makefile
+++ b/makefile
@@ -105,6 +105,7 @@ unit-tests:
 		tests/test_recording.py \
 		tests/test_tokenizer.py \
 		tests/test_transcription_filter.py \
+		tests/test_transcript_synchronizer.py \
 		tests/test_tools.py \
 		tests/test_aio_itertools.py \
 		tests/test_room.py \

--- a/tests/test_transcript_synchronizer.py
+++ b/tests/test_transcript_synchronizer.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import asyncio
+import time
+
+from livekit import rtc
+from livekit.agents.voice import io
+from livekit.agents.voice.transcription.synchronizer import TranscriptSynchronizer
+
+
+class _ManualAudioOutput(io.AudioOutput):
+    def __init__(self) -> None:
+        super().__init__(
+            label="ManualAudioOutput",
+            capabilities=io.AudioOutputCapabilities(pause=True),
+        )
+        self._pushed_duration = 0.0
+        self._started = False
+
+    async def capture_frame(self, frame: rtc.AudioFrame) -> None:
+        await super().capture_frame(frame)
+        self._pushed_duration += frame.duration
+        if not self._started:
+            self._started = True
+            self.on_playback_started(created_at=time.time())
+
+    def flush(self) -> None:
+        super().flush()
+
+    def clear_buffer(self) -> None:
+        if self._pushed_duration:
+            self.finish(interrupted=True)
+
+    def finish(self, *, interrupted: bool = False) -> None:
+        playback_position = self._pushed_duration
+        self._pushed_duration = 0.0
+        self._started = False
+        self.on_playback_finished(
+            playback_position=playback_position,
+            interrupted=interrupted,
+        )
+
+
+class _CapturingTextOutput(io.TextOutput):
+    def __init__(self) -> None:
+        super().__init__(label="CapturingTextOutput", next_in_chain=None)
+        self._current_text = ""
+        self.messages: list[str] = []
+
+    async def capture_text(self, text: str) -> None:
+        self._current_text += text
+
+    def flush(self) -> None:
+        self.messages.append(self._current_text)
+        self._current_text = ""
+
+
+def _audio_frame(duration: float = 0.02) -> rtc.AudioFrame:
+    sample_rate = 16000
+    samples = int(sample_rate * duration)
+    return rtc.AudioFrame(
+        data=b"\x00\x00" * samples,
+        sample_rate=sample_rate,
+        num_channels=1,
+        samples_per_channel=samples,
+    )
+
+
+async def test_empty_audio_flush_after_advance_does_not_end_fresh_segment() -> None:
+    audio_output = _ManualAudioOutput()
+    text_output = _CapturingTextOutput()
+    synchronizer = TranscriptSynchronizer(
+        next_in_chain_audio=audio_output,
+        next_in_chain_text=text_output,
+    )
+
+    try:
+        await synchronizer.audio_output.capture_frame(_audio_frame())
+        await synchronizer.text_output.capture_text("hello")
+        synchronizer.audio_output.flush()
+        synchronizer.text_output.flush()
+
+        assert len(synchronizer._pending_impls) == 1
+        assert not synchronizer._impl.audio_input_ended
+
+        synchronizer.audio_output.flush()
+        await synchronizer.barrier()
+
+        assert not synchronizer._impl.audio_input_ended
+    finally:
+        await synchronizer.aclose()
+
+
+async def test_playback_finished_waits_for_text_input_before_emitting_transcript() -> None:
+    audio_output = _ManualAudioOutput()
+    text_output = _CapturingTextOutput()
+    synchronizer = TranscriptSynchronizer(
+        next_in_chain_audio=audio_output,
+        next_in_chain_text=text_output,
+        speed=100.0,
+    )
+    playback_events: list[io.PlaybackFinishedEvent] = []
+    synchronizer.audio_output.on("playback_finished", playback_events.append)
+
+    try:
+        await synchronizer.audio_output.capture_frame(_audio_frame())
+        await synchronizer.text_output.capture_text("hello")
+        synchronizer.audio_output.flush()
+        audio_output.finish()
+
+        waiter = asyncio.create_task(synchronizer.audio_output.wait_for_playout())
+        await asyncio.sleep(0)
+
+        assert not waiter.done()
+        assert playback_events == []
+
+        synchronizer.text_output.flush()
+        playback_ev = await asyncio.wait_for(waiter, timeout=1.0)
+
+        assert playback_ev.synchronized_transcript == "hello"
+        assert playback_events == [playback_ev]
+    finally:
+        await synchronizer.aclose()
+
+
+async def test_pause_resume_applies_to_pending_segments() -> None:
+    audio_output = _ManualAudioOutput()
+    text_output = _CapturingTextOutput()
+    synchronizer = TranscriptSynchronizer(
+        next_in_chain_audio=audio_output,
+        next_in_chain_text=text_output,
+    )
+
+    try:
+        await synchronizer.audio_output.capture_frame(_audio_frame())
+        await synchronizer.text_output.capture_text("hello")
+        synchronizer.audio_output.flush()
+        synchronizer.text_output.flush()
+
+        pending = synchronizer._pending_impls[0]
+
+        synchronizer.audio_output.pause()
+        assert not pending._output_enabled_ev.is_set()
+
+        synchronizer.audio_output.resume()
+        assert pending._output_enabled_ev.is_set()
+    finally:
+        await synchronizer.aclose()


### PR DESCRIPTION
## Summary

Update realtime agent output handling for Realtime 2.0 responses and fix transcript synchronization races around overlapping segment lifecycle events.

Realtime 2.0 can produce multiple message items for a single response. The Agents output stack exposes playback through a shared `AudioOutput` segment contract, so this PR forwards realtime message outputs sequentially through the sink. That keeps playback-start/playback-finished events attributable to the correct message and avoids adding or truncating the wrong assistant item during interruption.

This PR also hardens `TranscriptSynchronizer` segment handling when audio/text flush timing is not perfectly aligned.

  ## Changes

  - Support multiple realtime message items in one generation.
  - Forward each realtime message’s audio/text output to completion before starting the next message’s sink forwarding.
  - Wait for per-message audio playout before registering the next message’s playback listener.
  - Preserve existing single-message realtime behavior for current providers.
  - Fix transcript synchronizer stale-duration handling by resetting per-segment pushed audio duration during flush.
  - Keep pending/finalizing transcript segment impls alive until their text/audio inputs are complete.
  - Emit interrupted or already-ready playback-finished events synchronously to preserve existing state transition ordering.
  - Delay non-interrupted synced playback-finished events only when needed to include complete synchronized transcript text.
  - Apply pause/resume to active, pending, and finalizing transcript segments.
  - Add focused regression tests for transcript segment advancement, delayed text completion, and pause/resume behavior.

  ## Compatibility

This is intended to be public-API compatible. It does not change the `AudioOutput` or `TextOutput` interfaces or event payload shapes.

Existing realtime models emitted a single message item per response, so the sequential forwarding path preserves prior behavior while correctly handling the new Realtime 2.0 multi-message response shape.

The transcript synchronizer changes are internal lifecycle fixes. The main observable timing change is that a non-interrupted synced `playback_finished` event may wait for text/audio inputs to complete when playback finishes before transcript input drains. Interrupted and already-ready playback events remain synchronous.

  ## Testing

  - `make check`
  - `make unit-tests`
  - `uv run pytest tests/test_agent_session.py tests/test_transcript_synchronizer.py -q`
  - `git diff --check`

  `make unit-tests` result: 635 passed, 2 skipped