### PR TITLE
fix: pass API key via header in Neuphonic and Murf WebSocket TTS

### DIFF
--- a/.github/next-release/changeset-murf-ws-header-auth.md
+++ b/.github/next-release/changeset-murf-ws-header-auth.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-murf": patch
+---
+
+Pass API key via the `api-key` HTTP header on the WebSocket handshake instead of as a URL query parameter.

--- a/.github/next-release/changeset-neuphonic-ws-header-auth.md
+++ b/.github/next-release/changeset-neuphonic-ws-header-auth.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-neuphonic": patch
+---
+
+Drop redundant API key from WebSocket URL query string (it was already being sent via the X-API-KEY header).

--- a/livekit-plugins/livekit-plugins-murf/livekit/plugins/murf/tts.py
+++ b/livekit-plugins/livekit-plugins-murf/livekit/plugins/murf/tts.py
@@ -172,9 +172,10 @@ class TTS(tts.TTS):
     async def _connect_ws(self, timeout: float) -> aiohttp.ClientWebSocketResponse:
         session = self._ensure_session()
         url = self._opts.get_ws_url(
-            f"/v1/speech/stream-input?api-key={self._opts.api_key}&sample_rate={self._opts.sample_rate}&format={self._opts.encoding}&model={self._opts.model}"
+            f"/v1/speech/stream-input?sample_rate={self._opts.sample_rate}&format={self._opts.encoding}&model={self._opts.model}"
         )
-        return await asyncio.wait_for(session.ws_connect(url), timeout)
+        headers = {API_AUTH_HEADER: self._opts.api_key}
+        return await asyncio.wait_for(session.ws_connect(url, headers=headers), timeout)
 
     async def _close_ws(self, ws: aiohttp.ClientWebSocketResponse) -> None:
         await ws.close()

--- a/livekit-plugins/livekit-plugins-neuphonic/livekit/plugins/neuphonic/tts.py
+++ b/livekit-plugins/livekit-plugins-neuphonic/livekit/plugins/neuphonic/tts.py
@@ -138,7 +138,7 @@ class TTS(tts.TTS):
     async def _connect_ws(self, timeout: float) -> aiohttp.ClientWebSocketResponse:
         session = self._ensure_session()
         url = self._opts.get_ws_url(
-            f"/speak/en?api_key={self._opts.api_key}&speed={self._opts.speed}&lang_code={self._opts.lang_code.language}&sampling_rate={self._opts.sample_rate}&voice_id={self._opts.voice_id}"
+            f"/speak/en?speed={self._opts.speed}&lang_code={self._opts.lang_code.language}&sampling_rate={self._opts.sample_rate}&voice_id={self._opts.voice_id}"
         )
         if self._opts.jwt_token:
             url += f"&jwt_token={self._opts.jwt_token}"


### PR DESCRIPTION
## Description

Both `livekit-plugins-neuphonic` and `livekit-plugins-murf` were embedding the API key in the WebSocket URL query string without URL-encoding. Move the key onto the WS handshake header instead — both providers' SDKs/docs already support header auth.

## Changes

- **neuphonic**: drop `api_key=` from the WS URL; the existing `X-API-KEY` header was already redundantly set on the handshake. JWT-token URL handling is unchanged.
- **murf**: switch from the `?api-key=...` query param to the `api-key` header (matches Murf's official Python SDK and WS API reference).

## Testing

- `make check` (ruff lint + format-check) passes locally on both edited files.