### PR TITLE
fix(core): make default user span time explicit

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -1267,7 +1267,8 @@ class AudioRecognition:
         if self._user_turn_span and self._user_turn_span.is_recording():
             return self._user_turn_span
 
-        start_time: float = start_time or time.time()
+        if start_time is None:
+            start_time = time.time()
         start_time_ns = int(start_time * 1_000_000_000)
         self._user_turn_span = tracer.start_span("user_turn", start_time=start_time_ns)
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -1267,10 +1267,11 @@ class AudioRecognition:
         if self._user_turn_span and self._user_turn_span.is_recording():
             return self._user_turn_span
 
-        start_time_ns = int(start_time * 1_000_000_000) if start_time else None
+        start_time: float = start_time or time.time()
+        start_time_ns = int(start_time * 1_000_000_000)
         self._user_turn_span = tracer.start_span("user_turn", start_time=start_time_ns)
 
-        if start_time is not None and self._user_turn_start is None:
+        if self._user_turn_start is None:
             self._user_turn_start = start_time
 
         if (room_io := self._session._room_io) and room_io.linked_participant:


### PR DESCRIPTION
tracer.start_span has a default value when start_time is None, so we need a default value for _user_turn_start as well to make sure they are consistent.