### PR TITLE
fix(voice): wait_for_playout resolves on interrupt instead of deadlocking

### DIFF
--- a/livekit-agents/livekit/agents/voice/events.py
+++ b/livekit-agents/livekit/agents/voice/events.py
@@ -84,8 +84,15 @@ class RunContext(Generic[Userdata_T]):
         Unlike `SpeechHandle.wait_for_playout`, which waits for the full
         assistant turn to complete (including all function tools),
         this method only waits for the assistant's spoken response prior running
-        this tool to finish playing."""
-        await self.speech_handle._wait_for_generation(step_idx=self._initial_step_idx)
+        this tool to finish playing.
+
+        Returns as soon as the speech is interrupted (``speech_handle.interrupted``
+        is ``True``) instead of blocking until the generation is torn down.
+        """
+        sh = self.speech_handle
+        if not sh._generations:
+            raise RuntimeError("cannot use wait_for_playout: no active generation is running.")
+        await sh._race_against_interrupt(sh._generations[self._initial_step_idx])
 
 
 EventTypes = Literal[

--- a/livekit-agents/livekit/agents/voice/speech_handle.py
+++ b/livekit-agents/livekit/agents/voice/speech_handle.py
@@ -159,7 +159,13 @@ class SpeechHandle:
         This method waits until the assistant has fully finished speaking,
         including any finalization steps beyond initial response generation.
         This is appropriate to call when you want to ensure the speech output
-        has entirely played out, including any tool calls and response follow-ups."""
+        has entirely played out, including any tool calls and response follow-ups.
+
+        Returns as soon as the speech is interrupted (``self.interrupted`` is
+        ``True``) instead of blocking until the underlying generation is torn
+        down. Callers that want to ignore interrupts can check ``self.interrupted``
+        on return and decide whether to proceed.
+        """
 
         # raise an error to avoid developer mistakes
         from .agent import _get_activity_task_info
@@ -179,7 +185,7 @@ class SpeechHandle:
                     "To wait for the assistant’s spoken response prior to running this tool, use `RunContext.wait_for_playout()` instead."
                 )
 
-        await asyncio.shield(self._done_fut)
+        await self._race_against_interrupt(self._done_fut)
 
     def __await__(self) -> Generator[None, None, SpeechHandle]:
         async def _await_impl() -> SpeechHandle:
@@ -207,6 +213,25 @@ class SpeechHandle:
             with contextlib.suppress(asyncio.CancelledError):
                 gather_fut.cancel()
                 await gather_fut
+
+    async def _race_against_interrupt(self, playout_fut: asyncio.Future[None]) -> None:
+        """Wait for ``playout_fut`` or interruption, whichever happens first.
+
+        Returns as soon as either future resolves; callers can read
+        ``self.interrupted`` to distinguish between completion and interruption.
+        Mirrors ``wait_if_not_interrupted`` but accepts a single playout future
+        instead of an arbitrary list.
+        """
+        playout_aw = asyncio.ensure_future(asyncio.shield(playout_fut))
+        interrupt_aw = asyncio.ensure_future(asyncio.shield(self._interrupt_fut))
+        try:
+            await asyncio.wait({playout_aw, interrupt_aw}, return_when=asyncio.FIRST_COMPLETED)
+        finally:
+            for aw in (playout_aw, interrupt_aw):
+                if not aw.done():
+                    aw.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await aw
 
     def _cancel(self) -> SpeechHandle:
         if self.done():

--- a/tests/test_speech_handle_interruption.py
+++ b/tests/test_speech_handle_interruption.py
@@ -1,0 +1,89 @@
+"""Regression tests for SpeechHandle / RunContext playout-wait interruption.
+
+Guards against the deadlock described in livekit/agents#5359, where
+``SpeechHandle.wait_for_playout()`` and ``RunContext.wait_for_playout()``
+awaited only on the playout-completion future and ignored the interrupt
+future. When ``interrupt()`` fired, callers blocked until the
+``INTERRUPTION_TIMEOUT`` (~5s) hard-killed the surrounding tasks.
+
+Both methods now race the playout future against ``_interrupt_fut`` using
+``asyncio.wait(FIRST_COMPLETED)`` (the same primitive already used by
+``SpeechHandle.wait_if_not_interrupted``). The wait returns promptly on
+interrupt; callers can inspect ``speech_handle.interrupted`` to decide how
+to proceed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+from livekit.agents.llm import FunctionCall
+from livekit.agents.voice.events import RunContext
+from livekit.agents.voice.speech_handle import SpeechHandle
+
+
+async def test_speech_handle_wait_for_playout_returns_on_interrupt() -> None:
+    """wait_for_playout must unblock when interrupted, not hang on _done_fut.
+
+    Regression test for https://github.com/livekit/agents/issues/5359.
+    Pre-fix this hung on ``_done_fut`` for INTERRUPTION_TIMEOUT (~5s); the
+    1.0s deadline below would fire and the test would raise TimeoutError.
+    """
+    sh = SpeechHandle.create()
+
+    async def _interrupt_after_delay() -> None:
+        await asyncio.sleep(0.05)
+        sh._cancel()
+
+    interrupt_task = asyncio.create_task(_interrupt_after_delay())
+    try:
+        await asyncio.wait_for(sh.wait_for_playout(), timeout=1.0)
+    finally:
+        await interrupt_task
+
+    assert sh.interrupted
+    assert not sh.done()
+
+
+async def test_run_context_wait_for_playout_returns_on_interrupt() -> None:
+    """RunContext.wait_for_playout must unblock when the speech is interrupted.
+
+    Regression test for https://github.com/livekit/agents/issues/5359.
+    """
+    sh = SpeechHandle.create()
+    sh._authorize_generation()
+
+    fc = FunctionCall(call_id="call_test", arguments="{}", name="noop")
+    ctx = RunContext(session=MagicMock(), speech_handle=sh, function_call=fc)
+
+    async def _interrupt_after_delay() -> None:
+        await asyncio.sleep(0.05)
+        sh._cancel()
+
+    interrupt_task = asyncio.create_task(_interrupt_after_delay())
+    try:
+        await asyncio.wait_for(ctx.wait_for_playout(), timeout=1.0)
+    finally:
+        await interrupt_task
+        sh._mark_done()
+
+    assert sh.interrupted
+
+
+async def test_speech_handle_wait_for_playout_returns_normally_on_completion() -> None:
+    """Sanity check: a non-interrupted playout still resolves on _done_fut."""
+    sh = SpeechHandle.create()
+
+    async def _complete_after_delay() -> None:
+        await asyncio.sleep(0.05)
+        sh._mark_done()
+
+    completion_task = asyncio.create_task(_complete_after_delay())
+    try:
+        await asyncio.wait_for(sh.wait_for_playout(), timeout=1.0)
+    finally:
+        await completion_task
+
+    assert not sh.interrupted
+    assert sh.done()


### PR DESCRIPTION
# PR Description: fix(voice): wait_for_playout resolves on interrupt instead of deadlocking

Closes #5359.

## Summary

`SpeechHandle.wait_for_playout()` and `RunContext.wait_for_playout()` awaited `_done_fut` (or `_wait_for_generation`) only. When `interrupt()` fired, `_interrupt_fut` resolved but the wait did not, so callers blocked until the 5s `INTERRUPTION_TIMEOUT` hard-killed the surrounding tasks. In a tool preamble flow that meant scheduling paused, the worker drained, and subsequent user input was dropped.

This PR races the existing wait against `_interrupt_fut` in both paths, using the same primitive `SpeechHandle.wait_if_not_interrupted()` already uses. The wait now returns as soon as either future resolves. Callers that need to distinguish completion from interruption read `speech_handle.interrupted` on return.

## Deviation from #5359's proposed solution (read this first)

The issue author proposed raising `InterruptedError` when the interrupt wins the race. I started there and the test suite caught a real problem: the SDK already has internal callers (notably `agent_activity.py:2079`) that `await speech_handle.interrupt()` and rely on `wait_for_playout` returning so cleanup can proceed. Raising broke seven unrelated tests, all of them about correct interrupt/handoff/drain handling.

I switched to a return-early semantic for three reasons:

1. **Contract consistency.** The existing primitive `SpeechHandle.wait_if_not_interrupted()` (which this fix lifts the race pattern from) returns. It does not raise. The two `wait_for_playout` paths now match it.
2. **Backward compatibility.** Every existing caller of `wait_for_playout` continues to compile and behave the same way on the non-interrupt path. The interrupt path was previously a 5s deadlock; it is now an immediate return. No public signature change.
3. **Opt-in raising is one line.** A tool author who wants raise-on-interrupt writes:
   ```python
   await ctx.wait_for_playout()
   if ctx.speech_handle.interrupted:
       raise InterruptedError("...")
   ```
   That keeps the framework default conservative and lets each call site decide its own error semantics.

If the maintainers prefer raising as the default, I am happy to follow that direction as a separate PR with the necessary callsite adjustments inside the SDK. I think return-early is the right call here, but the choice is reasonable either way and I do not want to assume.

## Changes

- `livekit-agents/livekit/agents/voice/speech_handle.py` — `wait_for_playout()` now races `_done_fut` against `_interrupt_fut` with `asyncio.wait(FIRST_COMPLETED)`. Cancels the losing future. Returns either way; `self.interrupted` is true if the interrupt won.
- `livekit-agents/livekit/agents/voice/events.py` — `RunContext.wait_for_playout()` applies the same race against `_interrupt_fut`.
- `tests/test_speech_handle_interruption.py` — three deterministic unit tests, ~0.35s total runtime. Two cover the regression: `SpeechHandle.wait_for_playout` and `RunContext.wait_for_playout` both resolve under their 1.0s timeout when `_cancel()` fires. The third covers the no-interrupt case to confirm the happy path is unchanged.

Diff is intentionally minimal. No public signatures changed. `INTERRUPTION_TIMEOUT` is unchanged: it remains the right backstop for cases where the race itself misbehaves.

## Test plan

- New unit tests pass on this branch, fail on baseline `main` with `TimeoutError` (confirmed via stash/pop cycle). The two regression tests are the bug-shape proof.
- `ruff check` and `ruff format` clean.
- Full `pytest` suite green on this branch except for two pre-existing failures (`test_events_and_metrics`, `test_aclose_handles_precancelled_tasks_gracefully`) that also fail on the stashed baseline and are unrelated to this change. Happy to triage either as a separate issue if it would be useful.

## Notes for reviewers

- The primitive being lifted (`wait_if_not_interrupted`) is in the same file at line 201. I cited it in the implementation rather than refactoring into a shared helper, to keep the diff scoped. Happy to refactor if you prefer a shared private helper.
- The `__await__` path on `SpeechHandle` (so `await speech_handle` works) routes through `wait_for_playout`, so this fix incidentally makes `await speech_handle` interruptable as well. That matches expectation, and it is what `agent_activity.py:2079` was already implicitly relying on.
