### PR TITLE
fix(voice): cancel realtime generation when speech is interrupted

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2888,18 +2888,24 @@ class AgentActivity(RecognitionHooks):
                     ori_tools = self._rt_session.tools.flatten()
                     await self._rt_session.update_tools(llm.ToolContext(tools).flatten())
 
+            generate_reply_fut = self._rt_session.generate_reply(
+                instructions=instructions or NOT_GIVEN,
+                tool_choice=(model_settings.tool_choice if per_response_tool_choice else NOT_GIVEN),
+                tools=(
+                    llm.ToolContext(tools).flatten()
+                    if per_response_tool_choice and tools is not None
+                    else NOT_GIVEN
+                ),
+            )
+            await speech_handle.wait_if_not_interrupted([generate_reply_fut])
+            if speech_handle.interrupted:
+                # cancel the pending generation; the plugin emits response.cancel
+                if not generate_reply_fut.done():
+                    generate_reply_fut.cancel()
+                return
+
             try:
-                generation_ev = await self._rt_session.generate_reply(
-                    instructions=instructions or NOT_GIVEN,
-                    tool_choice=(
-                        model_settings.tool_choice if per_response_tool_choice else NOT_GIVEN
-                    ),
-                    tools=(
-                        llm.ToolContext(tools).flatten()
-                        if per_response_tool_choice and tools is not None
-                        else NOT_GIVEN
-                    ),
-                )
+                generation_ev = generate_reply_fut.result()
             except llm.RealtimeError as e:
                 logger.error(
                     "failed to generate a reply%s: %s",

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2905,7 +2905,7 @@ class AgentActivity(RecognitionHooks):
                 return
 
             try:
-                generation_ev = generate_reply_fut.result()
+                generation_ev = await generate_reply_fut
             except llm.RealtimeError as e:
                 logger.error(
                     "failed to generate a reply%s: %s",

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -2116,7 +2116,7 @@ class RealtimeSession(  # noqa: F811
                     if self._pending_generation_fut is fut:
                         self._pending_generation_fut = None
 
-            asyncio.create_task(_send_text())
+            send_task = asyncio.create_task(_send_text())
 
             # Set timeout from model configuration
             def _on_timeout() -> None:
@@ -2130,7 +2130,17 @@ class RealtimeSession(  # noqa: F811
             timeout_handle = asyncio.get_running_loop().call_later(
                 self._realtime_model._generate_reply_timeout, _on_timeout
             )
-            fut.add_done_callback(lambda _: timeout_handle.cancel())
+
+            def _on_fut_done(f: asyncio.Future[llm.GenerationCreatedEvent]) -> None:
+                timeout_handle.cancel()
+                is_current = self._pending_generation_fut is fut
+                if is_current:
+                    self._pending_generation_fut = None
+                if f.cancelled() and is_current and not send_task.done():
+                    # external cancel before the text was sent: drop the send
+                    send_task.cancel()
+
+            fut.add_done_callback(_on_fut_done)
 
             return fut
 

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -717,7 +717,11 @@ class RealtimeSession(llm.RealtimeSession):
             logger.warning(
                 "generate_reply called while another generation is pending, cancelling previous."
             )
-            self._pending_generation_fut.cancel("Superseded by new generate_reply call")
+            # clear the slot before cancelling so the done callback doesn't treat it
+            # as an external cancellation and signal the server.
+            old_fut = self._pending_generation_fut
+            self._pending_generation_fut = None
+            old_fut.cancel("Superseded by new generate_reply call")
 
         fut = asyncio.Future[llm.GenerationCreatedEvent]()
         self._pending_generation_fut = fut
@@ -749,7 +753,17 @@ class RealtimeSession(llm.RealtimeSession):
                     self._pending_generation_fut = None
 
         timeout_handle = asyncio.get_event_loop().call_later(5.0, _on_timeout)
-        fut.add_done_callback(lambda _: timeout_handle.cancel())
+
+        def _on_fut_done(f: asyncio.Future[llm.GenerationCreatedEvent]) -> None:
+            timeout_handle.cancel()
+            is_current = self._pending_generation_fut is fut
+            if is_current:
+                self._pending_generation_fut = None
+            if f.cancelled() and is_current:
+                # external cancel: signal interrupt to Gemini via activity_start
+                self.interrupt()
+
+        fut.add_done_callback(_on_fut_done)
 
         return fut
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1532,7 +1532,15 @@ class RealtimeSession(
                 fut.set_exception(llm.RealtimeError("generate_reply timed out."))
 
         handle = asyncio.get_event_loop().call_later(10.0, _on_timeout)
-        fut.add_done_callback(lambda _: handle.cancel())
+
+        def _on_fut_done(f: asyncio.Future[llm.GenerationCreatedEvent]) -> None:
+            handle.cancel()
+            self._response_created_futures.pop(event_id, None)
+            if f.cancelled():
+                # response.create was already sent; cancel the response server-side
+                self.send_event(ResponseCancelEvent(type="response.cancel"))
+
+        fut.add_done_callback(_on_fut_done)
         return fut
 
     @property

--- a/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
@@ -474,12 +474,17 @@ class RealtimeSession(llm.RealtimeSession):
         )
         if self._generate_reply_task and not self._generate_reply_task.done():
             self._generate_reply_task.cancel()
-        self._generate_reply_task = asyncio.create_task(self._send_generate_reply(payload))
+        send_task = asyncio.create_task(self._send_generate_reply(payload))
+        self._generate_reply_task = send_task
 
         self._close_current_generation(interrupted=False)
 
         if self._pending_generate_reply_fut and not self._pending_generate_reply_fut.done():
-            self._pending_generate_reply_fut.cancel()
+            # clear the slot first so the done callback doesn't see this as an
+            # external cancellation of the currently-pending generation.
+            old_fut = self._pending_generate_reply_fut
+            self._pending_generate_reply_fut = None
+            old_fut.cancel()
 
         fut = asyncio.Future[llm.GenerationCreatedEvent]()
         self._pending_generate_reply_fut = fut
@@ -489,7 +494,18 @@ class RealtimeSession(llm.RealtimeSession):
                 fut.set_exception(llm.RealtimeError("generate_reply timed out."))
 
         handle = asyncio.get_event_loop().call_later(10.0, _on_timeout)
-        fut.add_done_callback(lambda _: handle.cancel())
+
+        def _on_fut_done(f: asyncio.Future[llm.GenerationCreatedEvent]) -> None:
+            handle.cancel()
+            is_current = self._pending_generate_reply_fut is fut
+            if is_current:
+                self._pending_generate_reply_fut = None
+            if f.cancelled() and is_current:
+                # external cancel: drop the queued send if it hasn't gone out yet
+                if not send_task.done():
+                    send_task.cancel()
+
+        fut.add_done_callback(_on_fut_done)
         return fut
 
     async def _send_generate_reply(self, payload: GenerateReplyPayload) -> None:

--- a/livekit-plugins/livekit-plugins-ultravox/livekit/plugins/ultravox/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-ultravox/livekit/plugins/ultravox/realtime/realtime_model.py
@@ -490,7 +490,11 @@ class RealtimeSession(
             logger.warning(
                 "generate_reply called while another generation is pending, cancelling previous."
             )
-            self._pending_generation_fut.cancel("Superseded by new generate_reply call")
+            # clear the slot before cancelling so the done callback doesn't treat it
+            # as an external cancellation and signal the server.
+            old_fut = self._pending_generation_fut
+            self._pending_generation_fut = None
+            old_fut.cancel("Superseded by new generate_reply call")
 
         # Record epoch for server-event gating
         self._pending_generation_epoch = time.perf_counter()
@@ -522,7 +526,21 @@ class RealtimeSession(
                     self._pending_generation_epoch = None
 
         timeout_handle = asyncio.get_event_loop().call_later(5.0, _on_timeout)
-        fut.add_done_callback(lambda _: timeout_handle.cancel())
+
+        def _on_fut_done(f: asyncio.Future[llm.GenerationCreatedEvent]) -> None:
+            timeout_handle.cancel()
+            is_current = self._pending_generation_fut is fut
+            if is_current:
+                self._pending_generation_fut = None
+                self._pending_generation_epoch = None
+            if f.cancelled() and is_current:
+                # external cancel: send a deferred barge-in so Ultravox does not
+                # produce a response (or interrupts one already in progress).
+                self._send_client_event(
+                    UserTextMessageEvent(text="", urgency="immediate", defer_response=True)
+                )
+
+        fut.add_done_callback(_on_fut_done)
 
         return fut
 

--- a/tests/test_realtime/test_realtime.py
+++ b/tests/test_realtime/test_realtime.py
@@ -312,6 +312,28 @@ async def test_interrupt(rt_session: llm.RealtimeSession):
     assert got_chunk
 
 
+@pytest.mark.parametrize("rt_session", OPENAI_AND_AZURE, indirect=True)
+async def test_generate_reply_cancellation(rt_session: llm.RealtimeSession):
+    """Cancelling the generate_reply future before response.created arrives
+    should cancel the in-flight response server-side so a subsequent
+    generate_reply does not conflict with an active response."""
+    fut = rt_session.generate_reply(
+        instructions="Write a very long essay about the history of computing."
+    )
+    fut.cancel()
+    assert fut.cancelled()
+
+    # Brief wait so the response.cancel reaches the server before the next call.
+    await asyncio.sleep(1.0)
+
+    gen_ev = await asyncio.wait_for(
+        rt_session.generate_reply(instructions="Say exactly: pineapple"),
+        timeout=15,
+    )
+    text = await asyncio.wait_for(_collect_text(gen_ev), timeout=15)
+    assert "pineapple" in text.lower()
+
+
 # -- Function tools --
 
 


### PR DESCRIPTION
## Summary

`session.interrupt()` was a silent no-op when fired before the realtime server had emitted `response.created`. The local `SpeechHandle` was marked interrupted, but `_realtime_reply_task` had already passed its auth-wait block and continued to call `rt_session.generate_reply()`, after which the server produced a response the agent then discarded. Reported in #5642 ([comment](https://github.com/livekit/agents/issues/5642#issuecomment-4417273612)).

Two changes fix it:

- **Activity-side race.** `_realtime_reply_task` now races the `generate_reply` future against `speech_handle._interrupt_fut` via `wait_if_not_interrupted`. On interrupt, the future is cancelled and the task returns.
- **Plugin-side cancel propagation.** Each realtime plugin's `generate_reply` future now wires an `add_done_callback` that, on cancellation, cleans up tracking state and signals the server (or drops the queued send) where the API supports it:
  - OpenAI (and xAI by inheritance): emits `response.cancel`. 
  - Google: calls `interrupt()` to send `activity_start` to Gemini.
  - Phonic: cancels the queued send task (Phonic has no programmatic server-side cancel).
  - Ultravox: sends a deferred barge-in (`urgency=immediate, defer_response=True`).
  - AWS Nova (experimental): cancels the queued send task (Nova handles in-progress interruption automatically).

Added `test_generate_reply_cancellation` in `tests/test_realtime/test_realtime.py` (parameterized over OpenAI/Azure) which cancels a `generate_reply` future immediately and verifies a subsequent `generate_reply` does not hit `conversation_already_has_active_response`.

Fixes #5642