### PR TITLE
fix(plugins/sarvam): shorten TTS WS pool duration to 50s and refresh on get

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -468,8 +468,12 @@ class TTS(tts.TTS):
         self._pool = utils.ConnectionPool[aiohttp.ClientWebSocketResponse](
             connect_cb=self._connect_ws,
             close_cb=self._close_ws,
-            max_session_duration=3600,  # 1 hour
-            mark_refreshed_on_get=False,
+            # Sarvam's server closes the WebSocket after 60 s of inactivity
+            # (https://docs.sarvam.ai/api-reference-docs/api-guides-tutorials/text-to-speech/streaming-api/web-socket),
+            # so the pool must recycle connections well before that threshold and
+            # treat each get() as a refresh, mirroring Cartesia / Neuphonic / Murf / AsyncAI.
+            max_session_duration=50,
+            mark_refreshed_on_get=True,
         )
 
     async def _connect_ws(self, timeout: float) -> aiohttp.ClientWebSocketResponse:


### PR DESCRIPTION
## Summary

Fixes #5681.

The Sarvam TTS plugin configures its WebSocket `ConnectionPool` with `max_session_duration=3600` (1 hour) and `mark_refreshed_on_get=False`. Sarvam's server, however, [closes idle WebSockets after 60 seconds](https://docs.sarvam.ai/api-reference-docs/api-guides-tutorials/text-to-speech/streaming-api/web-socket), so the pool routinely hands out connections that are already dead, producing:

```
livekit.plugins.sarvam.log: Error in send task: Cannot write to closing transport
livekit.agents: failed to synthesize speech: Send task failed: Cannot write to closing transport, retrying in 0.1s
```

on nearly every turn after a conversation pause longer than 60 s, which translates to 2–6 seconds of silence per call.

## Fix

Align the pool config with the other streaming-WS TTS plugins (Cartesia, Neuphonic, Murf, AsyncAI) that don't have this issue:

```diff
-    max_session_duration=3600,  # 1 hour
-    mark_refreshed_on_get=False,
+    # Sarvam's server closes the WebSocket after 60 s of inactivity, so the
+    # pool must recycle connections well before that threshold and treat each
+    # get() as a refresh.
+    max_session_duration=50,
+    mark_refreshed_on_get=True,
```

`50s` (instead of the 300s used by other plugins) keeps a safety margin below Sarvam's 60s idle cutoff. `mark_refreshed_on_get=True` ensures an actively used connection isn't recycled mid-conversation.

## Out of scope (follow-up)

The issue also mentions Sarvam's `{"type": "ping"}` keepalive frame as the most robust long-term solution (similar to pipecat-ai/pipecat#3730). That's a larger change — happy to follow up with a dedicated PR adding a keepalive task if this minimal fix is accepted first.

## Test plan

- [x] Config matches the pattern used by Cartesia / Neuphonic / Murf / AsyncAI plugins in the same repo
- [ ] Sarvam-authenticated end-to-end test with a long-pause conversation — needs a Sarvam API key to run; if maintainers can run it I'd appreciate the confirmation, otherwise the analytical comparison with peer plugins is the strongest signal pre-merge
