### PR TITLE
Revert "require CanManageAgentSession grant for remote session (#5487)"

### DIFF
--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -5,7 +5,6 @@ import struct
 import time
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Mapping, Sequence
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from google.protobuf.duration_pb2 import Duration
@@ -58,38 +57,34 @@ if TYPE_CHECKING:
 TOPIC_SESSION_MESSAGES = "lk.agent.session"
 
 
-@dataclass(frozen=True, slots=True)
-class IncomingMessage:
-    message: agent_pb.AgentSessionMessage
-    sender_identity: str | None = None
-
-
 class SessionTransport(ABC):
     @abstractmethod
     async def start(self) -> None: ...
     @abstractmethod
-    async def send_message(
-        self,
-        msg: agent_pb.AgentSessionMessage,
-        *,
-        destination_identity: str | None = None,
-    ) -> None:
-        """Send a message. When ``destination_identity`` is None, broadcast to every authorized peer."""
-
+    async def send_message(self, msg: agent_pb.AgentSessionMessage) -> None: ...
     @abstractmethod
     async def close(self) -> None: ...
     @abstractmethod
-    def __aiter__(self) -> AsyncIterator[IncomingMessage]: ...
+    def __aiter__(self) -> AsyncIterator[agent_pb.AgentSessionMessage]: ...
     @abstractmethod
-    async def __anext__(self) -> IncomingMessage: ...
+    async def __anext__(self) -> agent_pb.AgentSessionMessage: ...
 
 
 class RoomSessionTransport(SessionTransport):
-    def __init__(self, room: rtc.Room) -> None:
+    def __init__(self, room: rtc.Room, remote_identity: str | None = None) -> None:
         self._room = room
-        self._recv_ch: utils.aio.Chan[IncomingMessage] = utils.aio.Chan()
+        self._remote_identity = remote_identity
+        self._recv_ch: utils.aio.Chan[agent_pb.AgentSessionMessage] = utils.aio.Chan()
         self._handler_registered = False
         self._tasks: set[asyncio.Task[None]] = set()
+
+    @property
+    def remote_identity(self) -> str | None:
+        return self._remote_identity
+
+    @remote_identity.setter
+    def remote_identity(self, value: str | None) -> None:
+        self._remote_identity = value
 
     async def start(self) -> None:
         if self._handler_registered:
@@ -97,29 +92,14 @@ class RoomSessionTransport(SessionTransport):
         self._room.register_byte_stream_handler(TOPIC_SESSION_MESSAGES, self._on_byte_stream)
         self._handler_registered = True
 
-    def _can_manage(self, identity: str) -> bool:
-        participant = self._room.remote_participants.get(identity)
-        return participant is not None and participant.permissions.can_manage_agent_session
-
-    def _authorized_identities(self) -> list[str]:
-        return [
-            identity
-            for identity, participant in self._room.remote_participants.items()
-            if participant.permissions.can_manage_agent_session
-        ]
-
     def _on_byte_stream(self, reader: rtc.ByteStreamReader, participant_identity: str) -> None:
-        if not self._can_manage(participant_identity):
-            logger.debug(
-                "ignoring session message from participant without can_manage_agent_session grant",
-                extra={"participant": participant_identity},
-            )
+        if self._remote_identity and participant_identity != self._remote_identity:
             return
-        task = asyncio.create_task(self._read_stream(reader, participant_identity))
+        task = asyncio.create_task(self._read_stream(reader))
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
 
-    async def _read_stream(self, reader: rtc.ByteStreamReader, sender_identity: str) -> None:
+    async def _read_stream(self, reader: rtc.ByteStreamReader) -> None:
         try:
             chunks: list[bytes] = []
             async for chunk in reader:
@@ -127,30 +107,18 @@ class RoomSessionTransport(SessionTransport):
             data = b"".join(chunks)
             msg = agent_pb.AgentSessionMessage()
             msg.ParseFromString(data)
-            self._recv_ch.send_nowait(IncomingMessage(message=msg, sender_identity=sender_identity))
+            self._recv_ch.send_nowait(msg)
         except utils.aio.ChanClosed:
             pass
         except Exception as e:
             logger.warning("failed to read binary stream message", exc_info=e)
 
-    async def send_message(
-        self,
-        msg: agent_pb.AgentSessionMessage,
-        *,
-        destination_identity: str | None = None,
-    ) -> None:
+    async def send_message(self, msg: agent_pb.AgentSessionMessage) -> None:
         if self._recv_ch.closed or not self._room.isconnected():
             return
-        if destination_identity is not None:
-            if not self._can_manage(destination_identity):
-                return
-            dest = [destination_identity]
-        else:
-            dest = self._authorized_identities()
-            if not dest:
-                return
         try:
             data = msg.SerializeToString()
+            dest = [self._remote_identity] if self._remote_identity else None
             writer = await self._room.local_participant.stream_bytes(
                 name=utils.shortuuid("AS_"),
                 topic=TOPIC_SESSION_MESSAGES,
@@ -174,10 +142,10 @@ class RoomSessionTransport(SessionTransport):
                 pass
             self._handler_registered = False
 
-    def __aiter__(self) -> AsyncIterator[IncomingMessage]:
+    def __aiter__(self) -> AsyncIterator[agent_pb.AgentSessionMessage]:
         return self._recv_ch.__aiter__()
 
-    async def __anext__(self) -> IncomingMessage:
+    async def __anext__(self) -> agent_pb.AgentSessionMessage:
         return await self._recv_ch.__anext__()
 
 
@@ -205,12 +173,7 @@ class TcpSessionTransport(SessionTransport):
         self._writer = writer
         self._loop = asyncio.get_running_loop()
 
-    async def send_message(
-        self,
-        msg: agent_pb.AgentSessionMessage,
-        *,
-        destination_identity: str | None = None,
-    ) -> None:
+    async def send_message(self, msg: agent_pb.AgentSessionMessage) -> None:
         if self._closed or self._writer is None:
             return
         data = msg.SerializeToString()
@@ -237,10 +200,10 @@ class TcpSessionTransport(SessionTransport):
             except (ConnectionError, OSError):
                 pass
 
-    def __aiter__(self) -> AsyncIterator[IncomingMessage]:
+    def __aiter__(self) -> AsyncIterator[agent_pb.AgentSessionMessage]:
         return self
 
-    async def __anext__(self) -> IncomingMessage:
+    async def __anext__(self) -> agent_pb.AgentSessionMessage:
         if self._closed or self._reader is None:
             raise StopAsyncIteration
 
@@ -261,7 +224,7 @@ class TcpSessionTransport(SessionTransport):
 
         msg = agent_pb.AgentSessionMessage()
         msg.ParseFromString(data)
-        return IncomingMessage(message=msg)
+        return msg
 
 
 _AGENT_STATE_MAP: dict[AgentState, agent_pb.AgentState] = {
@@ -446,11 +409,10 @@ class SessionHost:
 
     async def _recv_loop(self) -> None:
         try:
-            async for incoming in self._transport:
-                msg = incoming.message
+            async for msg in self._transport:
                 if msg.HasField("request"):
                     if self._session is not None:
-                        self._tasks.create_task(self._handle_request_safe(incoming))
+                        self._tasks.create_task(self._handle_request_safe(msg.request))
                 else:
                     msg_type = msg.WhichOneof("message")
                     if msg_type:
@@ -611,19 +573,9 @@ class SessionHost:
             )
         )
 
-    async def _send_response(
-        self, incoming: IncomingMessage, response: agent_pb.SessionResponse
-    ) -> None:
-        response.request_id = incoming.message.request.request_id
-        await self._transport.send_message(
-            agent_pb.AgentSessionMessage(response=response),
-            destination_identity=incoming.sender_identity,
-        )
-
-    async def _handle_request_safe(self, incoming: IncomingMessage) -> None:
-        req = incoming.message.request
+    async def _handle_request_safe(self, req: agent_pb.SessionRequest) -> None:
         try:
-            await self._handle_request(incoming)
+            await self._handle_request(req)
         except Exception:
             logger.warning(
                 "error handling session request",
@@ -631,44 +583,55 @@ class SessionHost:
                 extra={"request_id": req.request_id},
             )
             try:
-                await self._send_response(
-                    incoming, agent_pb.SessionResponse(error="internal error")
+                resp = agent_pb.AgentSessionMessage(
+                    response=agent_pb.SessionResponse(
+                        request_id=req.request_id,
+                        error="internal error",
+                    )
                 )
+                await self._transport.send_message(resp)
             except Exception:
                 pass
 
-    async def _handle_request(self, incoming: IncomingMessage) -> None:
+    async def _handle_request(self, req: agent_pb.SessionRequest) -> None:
         assert self._session is not None
-        req = incoming.message.request
 
         if req.HasField("ping"):
-            await self._send_response(
-                incoming, agent_pb.SessionResponse(pong=agent_pb.SessionResponse.Pong())
+            resp = agent_pb.AgentSessionMessage(
+                response=agent_pb.SessionResponse(
+                    request_id=req.request_id,
+                    pong=agent_pb.SessionResponse.Pong(),
+                )
             )
+            await self._transport.send_message(resp)
 
         elif req.HasField("get_chat_history"):
             items = [_chat_item_to_proto(item) for item in self._session.history.items]
-            await self._send_response(
-                incoming,
-                agent_pb.SessionResponse(
-                    get_chat_history=agent_pb.SessionResponse.GetChatHistoryResponse(items=items),
-                ),
+            resp = agent_pb.AgentSessionMessage(
+                response=agent_pb.SessionResponse(
+                    request_id=req.request_id,
+                    get_chat_history=agent_pb.SessionResponse.GetChatHistoryResponse(
+                        items=items,
+                    ),
+                )
             )
+            await self._transport.send_message(resp)
 
         elif req.HasField("get_agent_info"):
             agent = self._session.current_agent
             items = [_chat_item_to_proto(item) for item in agent.chat_ctx.items]
-            await self._send_response(
-                incoming,
-                agent_pb.SessionResponse(
+            resp = agent_pb.AgentSessionMessage(
+                response=agent_pb.SessionResponse(
+                    request_id=req.request_id,
                     get_agent_info=agent_pb.SessionResponse.GetAgentInfoResponse(
                         id=agent.id,
                         instructions=agent.instructions,
                         tools=_tool_names(agent.tools),
                         chat_ctx=items,
                     ),
-                ),
+                )
             )
+            await self._transport.send_message(resp)
 
         elif req.HasField("run_input"):
             items_list: list[agent_pb.ChatContext.ChatItem] = []
@@ -697,13 +660,16 @@ class SessionHost:
                     except Exception as e:
                         error = str(e)
 
-            await self._send_response(
-                incoming,
-                agent_pb.SessionResponse(
+            resp = agent_pb.AgentSessionMessage(
+                response=agent_pb.SessionResponse(
+                    request_id=req.request_id,
                     error=error,
-                    run_input=agent_pb.SessionResponse.RunInputResponse(items=items_list),
-                ),
+                    run_input=agent_pb.SessionResponse.RunInputResponse(
+                        items=items_list,
+                    ),
+                )
             )
+            await self._transport.send_message(resp)
 
         elif req.HasField("get_session_state"):
             agent = self._session.current_agent
@@ -711,22 +677,25 @@ class SessionHost:
             started_at = self._session._started_at or time.time()
             created_at.FromNanoseconds(int(started_at * 1e9))
 
-            await self._send_response(
-                incoming,
-                agent_pb.SessionResponse(
+            resp = agent_pb.AgentSessionMessage(
+                response=agent_pb.SessionResponse(
+                    request_id=req.request_id,
                     get_session_state=agent_pb.SessionResponse.GetSessionStateResponse(
                         agent_state=_AGENT_STATE_MAP.get(
-                            self._session.agent_state, agent_pb.AS_IDLE
+                            self._session.agent_state,
+                            agent_pb.AS_IDLE,
                         ),
                         user_state=_USER_STATE_MAP.get(
-                            self._session.user_state, agent_pb.US_LISTENING
+                            self._session.user_state,
+                            agent_pb.US_LISTENING,
                         ),
                         agent_id=agent.id,
                         options=_serialize_options(self._session.options),
                         created_at=created_at,
                     ),
-                ),
+                )
             )
+            await self._transport.send_message(resp)
 
         elif req.HasField("get_rtc_stats"):
             from google.protobuf.struct_pb2 import Struct
@@ -752,40 +721,43 @@ class SessionHost:
                     st.update(d)
                     subscriber_stats.append(st)
 
-            await self._send_response(
-                incoming,
-                agent_pb.SessionResponse(
+            resp = agent_pb.AgentSessionMessage(
+                response=agent_pb.SessionResponse(
+                    request_id=req.request_id,
                     get_rtc_stats=agent_pb.SessionResponse.GetRTCStatsResponse(
                         publisher_stats=publisher_stats,
                         subscriber_stats=subscriber_stats,
                     ),
-                ),
+                )
             )
+            await self._transport.send_message(resp)
 
         elif req.HasField("get_session_usage"):
             created_at = Timestamp()
             created_at.FromNanoseconds(int(time.time() * 1e9))
 
-            await self._send_response(
-                incoming,
-                agent_pb.SessionResponse(
+            resp = agent_pb.AgentSessionMessage(
+                response=agent_pb.SessionResponse(
+                    request_id=req.request_id,
                     get_session_usage=agent_pb.SessionResponse.GetSessionUsageResponse(
                         usage=_session_usage_to_proto(self._session.usage),
                         created_at=created_at,
                     ),
-                ),
+                )
             )
+            await self._transport.send_message(resp)
 
         elif req.HasField("get_framework_info"):
-            await self._send_response(
-                incoming,
-                agent_pb.SessionResponse(
+            resp = agent_pb.AgentSessionMessage(
+                response=agent_pb.SessionResponse(
+                    request_id=req.request_id,
                     get_framework_info=agent_pb.SessionResponse.GetFrameworkInfoResponse(
                         sdk="python",
                         sdk_version=__version__,
                     ),
-                ),
+                )
             )
+            await self._transport.send_message(resp)
 
 
 def _session_usage_to_proto(usage: AgentSessionUsage) -> agent_pb.AgentSessionUsage:

--- a/tests/test_session_host.py
+++ b/tests/test_session_host.py
@@ -23,7 +23,7 @@ from livekit.agents.voice.events import (
     UserStateChangedEvent,
 )
 from livekit.agents.voice.remote_session import (
-    IncomingMessage,
+    RoomSessionTransport,
     SessionHost,
     SessionTransport,
     _chat_item_to_proto,
@@ -42,34 +42,27 @@ class InMemoryTransport(SessionTransport):
 
     def __init__(self) -> None:
         self.sent: list[agent_pb.AgentSessionMessage] = []
-        self.destinations: list[str | None] = []
-        self._inbound: asyncio.Queue[IncomingMessage] = asyncio.Queue()
+        self._inbound: asyncio.Queue[agent_pb.AgentSessionMessage] = asyncio.Queue()
         self._closed = False
 
     async def start(self) -> None:
         pass
 
-    async def send_message(
-        self,
-        msg: agent_pb.AgentSessionMessage,
-        *,
-        destination_identity: str | None = None,
-    ) -> None:
+    async def send_message(self, msg: agent_pb.AgentSessionMessage) -> None:
         if self._closed:
             return
         self.sent.append(msg)
-        self.destinations.append(destination_identity)
 
     async def close(self) -> None:
         self._closed = True
 
-    def inject(self, msg: agent_pb.AgentSessionMessage, sender_identity: str | None = None) -> None:
-        self._inbound.put_nowait(IncomingMessage(message=msg, sender_identity=sender_identity))
+    def inject(self, msg: agent_pb.AgentSessionMessage) -> None:
+        self._inbound.put_nowait(msg)
 
-    def __aiter__(self) -> AsyncIterator[IncomingMessage]:
+    def __aiter__(self) -> AsyncIterator[agent_pb.AgentSessionMessage]:
         return self
 
-    async def __anext__(self) -> IncomingMessage:
+    async def __anext__(self) -> agent_pb.AgentSessionMessage:
         if self._closed:
             raise StopAsyncIteration
         try:
@@ -241,6 +234,26 @@ class TestSessionUsageToProto:
         )
         pb = _session_usage_to_proto(usage)
         assert len(pb.model_usage) == 3
+
+
+# ---------------------------------------------------------------------------
+# RoomSessionTransport
+# ---------------------------------------------------------------------------
+
+
+class TestRoomSessionTransport:
+    def test_remote_identity_property(self) -> None:
+        room = MagicMock()
+        transport = RoomSessionTransport(room, remote_identity="user-1")
+        assert transport.remote_identity == "user-1"
+
+        transport.remote_identity = "user-2"
+        assert transport.remote_identity == "user-2"
+
+    def test_remote_identity_none(self) -> None:
+        room = MagicMock()
+        transport = RoomSessionTransport(room)
+        assert transport.remote_identity is None
 
 
 # ---------------------------------------------------------------------------
@@ -453,9 +466,7 @@ class TestSessionHostRequests:
             request_id="req-1",
             ping=agent_pb.SessionRequest.Ping(),
         )
-        await host._handle_request(
-            IncomingMessage(message=agent_pb.AgentSessionMessage(request=req))
-        )
+        await host._handle_request(req)
 
         assert len(transport.sent) == 1
         resp = transport.sent[0].response
@@ -475,9 +486,7 @@ class TestSessionHostRequests:
             request_id="req-2",
             get_chat_history=agent_pb.SessionRequest.GetChatHistory(),
         )
-        await host._handle_request(
-            IncomingMessage(message=agent_pb.AgentSessionMessage(request=req))
-        )
+        await host._handle_request(req)
 
         assert len(transport.sent) == 1
         resp = transport.sent[0].response
@@ -498,9 +507,7 @@ class TestSessionHostRequests:
             request_id="req-3",
             get_agent_info=agent_pb.SessionRequest.GetAgentInfo(),
         )
-        await host._handle_request(
-            IncomingMessage(message=agent_pb.AgentSessionMessage(request=req))
-        )
+        await host._handle_request(req)
 
         assert len(transport.sent) == 1
         resp = transport.sent[0].response
@@ -522,9 +529,7 @@ class TestSessionHostRequests:
             request_id="req-4",
             get_session_state=agent_pb.SessionRequest.GetSessionState(),
         )
-        await host._handle_request(
-            IncomingMessage(message=agent_pb.AgentSessionMessage(request=req))
-        )
+        await host._handle_request(req)
 
         assert len(transport.sent) == 1
         resp = transport.sent[0].response
@@ -547,9 +552,7 @@ class TestSessionHostRequests:
             request_id="req-5",
             get_session_usage=agent_pb.SessionRequest.GetSessionUsage(),
         )
-        await host._handle_request(
-            IncomingMessage(message=agent_pb.AgentSessionMessage(request=req))
-        )
+        await host._handle_request(req)
 
         assert len(transport.sent) == 1
         resp = transport.sent[0].response
@@ -570,9 +573,7 @@ class TestSessionHostRequests:
             request_id="req-err",
             get_chat_history=agent_pb.SessionRequest.GetChatHistory(),
         )
-        await host._handle_request_safe(
-            IncomingMessage(message=agent_pb.AgentSessionMessage(request=req))
-        )
+        await host._handle_request_safe(req)
 
         assert len(transport.sent) == 1
         resp = transport.sent[0].response


### PR DESCRIPTION
## Summary
- Reverts commit 2de7aa09e which added `CanManageAgentSession` permission checks to the remote session transport
- Restores the previous `remote_identity`-based filtering behavior in `RoomSessionTransport`
- Removes the `IncomingMessage` wrapper and `_send_response` helper, reverting to direct `AgentSessionMessage` passing

## Test plan
- [ ] Verify remote session connections work without `CanManageAgentSession` grants
- [ ] Run `test_session_host.py` tests


Made with [Cursor](https://cursor.com)