### PR TITLE
fix(google): only block generate_reply when instructions passed to immutable-context model

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -704,13 +704,12 @@ class RealtimeSession(llm.RealtimeSession):
     ) -> asyncio.Future[llm.GenerationCreatedEvent]:
         if is_given(tools):
             logger.warning("per-response tools is not supported by Google Realtime API, ignoring")
-        if not self._realtime_model.capabilities.mutable_chat_context:
-            logger.warning(
-                f"generate_reply is not compatible with '{self._opts.model}' and will be ignored."
-            )
+        if not self._realtime_model.capabilities.mutable_chat_context and is_given(instructions):
             fut = asyncio.Future[llm.GenerationCreatedEvent]()
             fut.set_exception(
-                llm.RealtimeError(f"generate_reply is not compatible with '{self._opts.model}'")
+                llm.RealtimeError(
+                    f"generate_reply with 'instructions' is not compatible with '{self._opts.model}'"
+                )
             )
             return fut
         if self._pending_generation_fut and not self._pending_generation_fut.done():


### PR DESCRIPTION
Models like gemini-3.1-flash-live-preview have mutable_chat_context=False because injecting a role=model turn via `instructions=` causes a 1007 error from the Google API.

The previous guard blocked all generate_reply calls for such models, but the role=model injection only happens when `instructions` is given (line 737). Calling generate_reply() or generate_reply(user_input=...) without instructions sends only a role=user placeholder turn, which works correctly on gemini-3.1.

Narrow the guard to raise only when instructions is provided.

Fixes: #5260