### PR TITLE
feat(workflows): expose dtmf and ringing_timeout on WarmTransferTask

### DIFF
--- a/.github/next-release/changeset-warm-transfer-sip-params.md
+++ b/.github/next-release/changeset-warm-transfer-sip-params.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Add `dtmf` and `ringing_timeout` parameters to `WarmTransferTask`. `dtmf` sends DTMF tones once the human agent answers (e.g. to dial an extension or navigate an IVR); `ringing_timeout` bounds how long to wait for an answer before falling back to the caller conversation. Both are passed through to the underlying `CreateSIPParticipantRequest`.

--- a/examples/warm-transfer/warm_transfer.py
+++ b/examples/warm-transfer/warm_transfer.py
@@ -63,6 +63,11 @@ class SupportAgent(Agent):
                 sip_trunk_id=SIP_TRUNK_ID,
                 sip_number=SIP_NUMBER,
                 chat_ctx=self.chat_ctx,
+                # to reach an extension behind an IVR, pass DTMF tones to send once
+                # answered, e.g. dtmf="wwww1234#" (each `w` pauses ~0.5s):
+                # dtmf=SUPERVISOR_EXTENSION,
+                # give up if the supervisor doesn't pick up within 25s:
+                # ringing_timeout=25,
                 # add extra instructions for summarization
                 # you can also customize the entire instructions by overriding the `get_instructions` method
                 extra_instructions=SUMMARY_INSTRUCTIONS,

--- a/livekit-agents/livekit/agents/beta/workflows/warm_transfer.py
+++ b/livekit-agents/livekit/agents/beta/workflows/warm_transfer.py
@@ -45,6 +45,8 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
         sip_connection: NotGivenOr[api.SIPOutboundConfig] = NOT_GIVEN,
         sip_number: NotGivenOr[str] = NOT_GIVEN,
         sip_headers: NotGivenOr[dict[str, str]] = NOT_GIVEN,
+        dtmf: NotGivenOr[str | None] = NOT_GIVEN,
+        ringing_timeout: NotGivenOr[float | None] = NOT_GIVEN,
         hold_audio: NotGivenOr[AudioSource | AudioConfig | list[AudioConfig] | None] = NOT_GIVEN,
         instructions: NotGivenOr[InstructionParts | Instructions | str] = NOT_GIVEN,
         chat_ctx: NotGivenOr[llm.ChatContext] = NOT_GIVEN,
@@ -72,6 +74,13 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
                 saved trunk. Use this when you need to specify a custom hostname,
                 transport, or authentication credentials directly, bypassing the
                 trunk-based configuration.
+            dtmf: DTMF tones to send once the human agent's call is answered, e.g. to dial
+                an extension or navigate an IVR menu (``"1234#"``). Insert ``w`` characters
+                to pause ~0.5s each before/between digits (``"wwww1234#"`` waits ~2s, useful
+                when the destination plays a greeting before accepting input).
+            ringing_timeout: How long to wait, in seconds, for the human agent to answer
+                before giving up on the call. When the timeout elapses the task completes
+                with a ``ToolError`` and the caller conversation resumes.
             hold_audio: Audio played to the caller while they are on hold during the
                     transfer.
             extra_instructions: Extra instructions to append to the base instructions
@@ -136,6 +145,8 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
             sip_number if is_given(sip_number) else os.getenv("LIVEKIT_SIP_NUMBER", "")
         )
         self._sip_headers = sip_headers if is_given(sip_headers) else {}
+        self._dtmf = dtmf if is_given(dtmf) else None
+        self._ringing_timeout = ringing_timeout if is_given(ringing_timeout) else None
 
         # background audio and io
         self._background_audio = BackgroundAudioPlayer()
@@ -327,7 +338,10 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
             wait_until_answered=True,
             sip_number=self._sip_number or None,
             headers=self._sip_headers,
+            dtmf=self._dtmf or "",
         )
+        if self._ringing_timeout is not None:
+            sip_request.ringing_timeout.FromNanoseconds(int(self._ringing_timeout * 1e9))
         if self._sip_connection is not None:
             sip_request.trunk.CopyFrom(self._sip_connection)
         await job_ctx.api.sip.create_sip_participant(sip_request)


### PR DESCRIPTION
### What

Adds two optional constructor parameters to `WarmTransferTask`:

- **`dtmf: str | None`** — DTMF tones to send once the human agent's call is answered, e.g. to dial an extension or navigate an IVR menu (`"1234#"`, or `"wwww1234#"` to pause ~2s first). Passed through to `CreateSIPParticipantRequest.dtmf`.
- **`ringing_timeout: float | None`** — seconds to wait for the human agent to answer before giving up; passed through to `CreateSIPParticipantRequest.ringing_timeout` (as a protobuf `Duration`). On timeout the task completes with a `ToolError` and the caller conversation resumes.

Also adds usage hints to `examples/warm-transfer/warm_transfer.py` and a changeset.

### Why

`WarmTransferTask` dials the human agent via `CreateSIPParticipantRequest` inside `_dial_human_agent`, but never exposed the request's `dtmf` / `ringing_timeout` fields. Warm-transferring to a destination behind an extension or IVR (common for PBX/desk-phone transfers), or bounding the ring time before falling back to the caller, currently requires subclassing the task and copy-pasting all of `_dial_human_agent` just to set those fields — brittle against upstream changes to that method.

Per @davidzhao's note on #5716, scoped to `dtmf` + `ringing_timeout`; happy to expose more `CreateSIPParticipantRequest` fields (`max_call_duration`, `play_dialtone`, `krisp_enabled`, `media_encryption`, …) in a follow-up if wanted.

Closes #5716

### Checks

- `ruff format` / `ruff check` — pass
- `python scripts/check_types.py` — pass