### PR TITLE
fix(agents): clear pending auto tool reply future on timeout

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3411,6 +3411,9 @@ class AgentActivity(RecognitionHooks):
                                 "timed out waiting for realtime auto tool reply from %s",
                                 llm_label,
                             )
+                        finally:
+                            if self._pending_auto_tool_reply_fut is auto_reply_fut:
+                                self._pending_auto_tool_reply_fut = None
 
                     task = asyncio.create_task(_wait_for_auto_tool_reply())
                     run_state._watch_handle(task)


### PR DESCRIPTION
## Summary
The timeout branch of `_wait_for_auto_tool_reply` (in `auto_tool_reply_generation` setup, added in #5702) leaves `self._pending_auto_tool_reply_fut` set to the stale future. A subsequent tool execution then short-circuits the wait-setup guard (`is None`), so `RunResult` is not held open for the next realtime auto reply.

Move the cleanup into a `finally` block. The success path is already cleared in `_on_generation_created`; the `is auto_reply_fut` guard keeps the finally a no-op there.

## Reproducing
A realtime model with `auto_tool_reply_generation=True` whose first auto-reply takes >5s — the run completes after the warning, then the next tool turn returns from `sess.run(...)` before the auto-reply.