### PR TITLE
fix: surface Deepgram TTS websocket errors

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
@@ -11,6 +11,7 @@ import aiohttp
 from livekit.agents import (
     APIConnectionError,
     APIConnectOptions,
+    APIError,
     APIStatusError,
     APITimeoutError,
     tokenize,
@@ -344,10 +345,12 @@ class SynthesizeStream(tts.SynthesizeStream):
                         break
                     elif mtype == "Warning":
                         logger.warning("Deepgram warning: %s", resp.get("warn_msg"))
+                    elif mtype in ("Error", "error"):
+                        raise APIError(message="Deepgram TTS returned error", body=resp)
                     elif mtype == "Metadata":
                         pass
                     else:
-                        logger.debug("Unknown message type: %s", resp)
+                        logger.warning("Unknown Deepgram message type: %s", resp)
 
         async with self._tts._pool.connection(timeout=self._conn_options.timeout) as ws:
             self._acquire_time = self._tts._pool.last_acquire_time

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
@@ -292,6 +292,8 @@ class SynthesizeStream(tts.SynthesizeStream):
             await asyncio.gather(*tasks)
         except asyncio.TimeoutError:
             raise APITimeoutError() from None
+        except APIError:
+            raise
         except aiohttp.ClientResponseError as e:
             raise APIStatusError(
                 message=e.message, status_code=e.status, request_id=request_id, body=None


### PR DESCRIPTION
## Summary

Surface server-sent Deepgram TTS websocket error frames instead of treating them as unknown debug-only messages.

## Changes

- Handle `Error`/`error` Deepgram TTS websocket message types by raising `APIError`
- Promote unknown Deepgram websocket message types from debug to warning visibility

## Testing

- `python3 -m compileall -q livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py`
- `uv run python -m compileall -q livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py`
- `uv run ruff check livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py`

Fixes livekit/agents#5719
