### PR TITLE
fix: raise on unexpected ElevenLabs websocket close

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -707,7 +707,10 @@ class _Connection:
                 ):
                     if not self._closed and len(self._context_data) > 0:
                         # websocket will be closed after all contexts are closed
-                        logger.warning("websocket closed unexpectedly")
+                        raise APIStatusError(
+                            "ElevenLabs websocket connection closed unexpectedly",
+                            status_code=self._ws.close_code or -1,
+                        )
                     break
 
                 if msg.type != aiohttp.WSMsgType.TEXT:


### PR DESCRIPTION
## Summary

Raise immediately when the ElevenLabs TTS websocket closes while contexts are still pending.

## Changes

- Convert unexpected websocket close events with active contexts into `APIStatusError`
- Preserve normal close behavior when there are no pending contexts

## Testing

- `python3 -m compileall -q livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py`
- `uv run python -m compileall -q livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py`
- `uv run ruff check livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py`
- `uv run pytest tests/test_plugin_elevenlabs_tts.py`

Fixes livekit/agents#5720
