### PR TITLE
feat(plugins-soniox): surface per-run language segments end-to-end

### DIFF
--- a/.github/next-release/changeset-soniox-target-segments.md
+++ b/.github/next-release/changeset-soniox-target-segments.md
@@ -1,0 +1,12 @@
+---
+"livekit-agents": patch
+"livekit-plugins-soniox": patch
+---
+
+Surface per-run language segments end-to-end in the Soniox STT plugin, fixing two symmetric symptoms of the same underlying bug where `_TokenAccumulator._lang_segments` was computed but discarded in `send_endpoint_transcript` (and in the interim path). Both fixes live in the same block.
+
+- Add `target_languages` and `target_texts` to `stt.SpeechData`, mirroring the existing `source_languages` / `source_texts` source-side fields.
+- In translation mode, the Soniox plugin now populates `target_*` on `FINAL_TRANSCRIPT` and `INTERIM_TRANSCRIPT` / `PREFLIGHT_TRANSCRIPT` events, exposing per-run target-language breakdowns for code-switched two-way translation (e.g. `target_languages=["en", "es"]` / `target_texts=["Hello, how are you?", " Estoy bien, gracias."]` for the translation of `"Hello, ¿cómo estás? I'm doing fine, gracias."`).
+- In non-translation mode, the plugin now populates `source_languages` / `source_texts` from the same accumulator (previously these were left `None`, making code-switched dictation look monolingual to consumers). For a Japanese-then-English utterance, consumers now see `source_languages=["ja", "en"]` instead of `None`.
+
+`SpeechData.text` and `SpeechData.language` are unchanged for back-compat (still the full concatenation and the first translated/detected language, respectively). Fixes #5685.

--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -69,6 +69,15 @@ class SpeechData:
     source_texts: list[str] | None = None
     """the original transcription segments in the source language(s), when translation is active.
     each entry corresponds to the same-indexed entry in `source_languages`."""
+    target_languages: list[LanguageCode] | None = None
+    """the target language(s) produced by a translation-capable STT service, one entry per
+    consecutive same-language run, parallel to `target_texts`. mirrors `source_languages` /
+    `source_texts` on the source side: `language` holds the dominant (first) target language
+    and `target_languages` carries the fine-grained per-run breakdown.
+    populated when translation is active; None otherwise."""
+    target_texts: list[str] | None = None
+    """the translated transcription segments in the target language(s).
+    each entry corresponds to the same-indexed entry in `target_languages`."""
     metadata: dict[str, Any] | None = None
     """optional plugin-specific metadata (e.g. voice profile, provider diagnostics).
     plugins may populate this with provider-specific data that doesn't map to standard fields."""
@@ -82,6 +91,13 @@ class SpeechData:
                 if not isinstance(lang, LanguageCode) and isinstance(lang, str)
                 else lang
                 for lang in self.source_languages
+            ]
+        if self.target_languages is not None:
+            self.target_languages = [
+                LanguageCode(lang)
+                if not isinstance(lang, LanguageCode) and isinstance(lang, str)
+                else lang
+                for lang in self.target_languages
             ]
 
 

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
@@ -410,6 +410,11 @@ class SpeechStream(stt.SpeechStream):
     async def _recv_messages_task(self) -> None:
         """Receive transcription messages, handle tokens, errors, and dispatch events."""
 
+        # Translation routes original-language tokens to `final_original` and translated
+        # tokens to `final`. In non-translation mode, all tokens go to `final` and
+        # `final_original` stays empty (so `final` IS the source side there).
+        is_translation_mode = self._stt._params.translation is not None
+
         # final tokens are accumulated across messages until an endpoint is detected.
         final = _TokenAccumulator()
         final_original = _TokenAccumulator()
@@ -418,9 +423,20 @@ class SpeechStream(stt.SpeechStream):
         def send_endpoint_transcript() -> None:
             nonlocal is_speaking
             if final.text:
-                src_segs = final_original._lang_segments
-                source_languages = [LanguageCode(lang) for lang, _ in src_segs] or None
-                source_texts = [t for _, t in src_segs] or None
+                # Translation mode determines the role of each accumulator:
+                # when on, `final_original` carries the source side and
+                # `final` carries the target side -- even across flush windows
+                # where the originals were finalized in a prior message and
+                # only translation tokens land in this one. When translation
+                # is off, `final` IS the source side and `final_original`
+                # stays empty.
+                src_segs, tgt_segs = (
+                    (final_original._lang_segments, final._lang_segments)
+                    if is_translation_mode
+                    else (final._lang_segments, [])
+                )
+                source_languages, source_texts = _lang_segments_to_fields(src_segs)
+                target_languages, target_texts = _lang_segments_to_fields(tgt_segs)
                 self._event_ch.send_nowait(
                     stt.SpeechEvent(
                         type=SpeechEventType.FINAL_TRANSCRIPT,
@@ -429,6 +445,8 @@ class SpeechStream(stt.SpeechStream):
                                 self.start_time_offset,
                                 source_languages=source_languages,
                                 source_texts=source_texts,
+                                target_languages=target_languages,
+                                target_texts=target_texts,
                             )
                         ],
                     )
@@ -447,8 +465,6 @@ class SpeechStream(stt.SpeechStream):
                 is_speaking = False
             else:
                 final_original.reset()
-
-        is_translation_mode = self._stt._params.translation is not None
 
         if not self._ws:
             return
@@ -505,11 +521,30 @@ class SpeechStream(stt.SpeechStream):
                             self._event_ch.send_nowait(
                                 stt.SpeechEvent(type=SpeechEventType.START_OF_SPEECH)
                             )
-                        interim_segs = _merge_lang_segments(
-                            final_original._lang_segments, non_final_original._lang_segments
+                        # Same source/target classification as in
+                        # `send_endpoint_transcript`: in translation mode the
+                        # `_original` buckets carry the source side and `final` /
+                        # `non_final` carry the translation; in non-translation
+                        # mode the `_original` buckets are empty and `final` /
+                        # `non_final` ARE the source.
+                        merged_originals = _merge_lang_segments(
+                            final_original._lang_segments,
+                            non_final_original._lang_segments,
                         )
-                        interim_src_langs = [LanguageCode(lang) for lang, _ in interim_segs] or None
-                        interim_src_texts = [t for _, t in interim_segs] or None
+                        merged_primary = _merge_lang_segments(
+                            final._lang_segments, non_final._lang_segments
+                        )
+                        interim_src_segs, interim_tgt_segs = (
+                            (merged_originals, merged_primary)
+                            if is_translation_mode
+                            else (merged_primary, [])
+                        )
+                        interim_src_langs, interim_src_texts = _lang_segments_to_fields(
+                            interim_src_segs
+                        )
+                        interim_tgt_langs, interim_tgt_texts = _lang_segments_to_fields(
+                            interim_tgt_segs
+                        )
 
                         # When all tokens in this batch are final (no non-final pending),
                         # speech has reached a stable state — emit PREFLIGHT_TRANSCRIPT to
@@ -529,6 +564,8 @@ class SpeechStream(stt.SpeechStream):
                                         self.start_time_offset,
                                         source_languages=interim_src_langs,
                                         source_texts=interim_src_texts,
+                                        target_languages=interim_tgt_langs,
+                                        target_texts=interim_tgt_texts,
                                     )
                                 ],
                             )
@@ -581,6 +618,19 @@ def _merge_lang_segments(
         else:
             result.append((lang, text))
     return result
+
+
+def _lang_segments_to_fields(
+    segments: list[tuple[str, str]],
+) -> tuple[list[LanguageCode] | None, list[str] | None]:
+    """Convert `(lang, text)` runs to the parallel `SpeechData` field pair,
+    or `(None, None)` when empty."""
+    if not segments:
+        return None, None
+    return (
+        [LanguageCode(lang) for lang, _ in segments],
+        [t for _, t in segments],
+    )
 
 
 class _LangStats(NamedTuple):
@@ -667,12 +717,16 @@ class _TokenAccumulator:
         start_time_offset: float = 0.0,
         source_languages: list[LanguageCode] | None = None,
         source_texts: list[str] | None = None,
+        target_languages: list[LanguageCode] | None = None,
+        target_texts: list[str] | None = None,
     ) -> stt.SpeechData:
         return stt.SpeechData(
             text=self.text,
             language=LanguageCode(self.language),
             source_languages=source_languages,
             source_texts=source_texts,
+            target_languages=target_languages,
+            target_texts=target_texts,
             speaker_id=self.speaker_id,
             start_time=self.start_time / 1000 + start_time_offset,
             end_time=self.end_time / 1000 + start_time_offset,
@@ -685,6 +739,8 @@ class _TokenAccumulator:
         start_time_offset: float = 0.0,
         source_languages: list[LanguageCode] | None = None,
         source_texts: list[str] | None = None,
+        target_languages: list[LanguageCode] | None = None,
+        target_texts: list[str] | None = None,
     ) -> stt.SpeechData:
         """Build a SpeechData combining self (final) with other (non-final)."""
         candidates = [acc.start_time for acc in (self, other) if acc._has_start_time]
@@ -697,6 +753,8 @@ class _TokenAccumulator:
             language=LanguageCode(self.language if self.language else other.language),
             source_languages=source_languages,
             source_texts=source_texts,
+            target_languages=target_languages,
+            target_texts=target_texts,
             speaker_id=self.speaker_id if self.speaker_id is not None else other.speaker_id,
             start_time=start / 1000 + start_time_offset,
             end_time=end / 1000 + start_time_offset,

--- a/tests/test_plugin_soniox_stt.py
+++ b/tests/test_plugin_soniox_stt.py
@@ -1,0 +1,494 @@
+"""Tests for the Soniox STT plugin: target-language segments on `SpeechData`.
+
+Covers:
+- `SpeechData.__post_init__` coerces `target_languages` strings to `LanguageCode`.
+- `_TokenAccumulator._lang_segments` coalesces consecutive same-language tokens.
+- `_lang_segments_to_fields` helper edge cases.
+- `_recv_messages_task` end-to-end via a fake WebSocket, asserting the resulting
+  `SpeechData` fields on `FINAL_TRANSCRIPT` and `INTERIM_TRANSCRIPT`.
+
+Mirrors the unit-test style of `tests/test_plugin_assemblyai_stt.py`: patches
+`asyncio.create_task` during `SpeechStream.__init__` so no real connection is
+opened, then drives `_recv_messages_task` directly with canned token messages.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import aiohttp
+
+from livekit.agents.language import LanguageCode
+from livekit.agents.stt import SpeechData, SpeechEventType
+
+# ---------------------------------------------------------------------------
+# SpeechData.__post_init__: target_languages coercion
+# ---------------------------------------------------------------------------
+
+
+def test_speech_data_target_languages_coerces_strings_to_language_code():
+    sd = SpeechData(
+        language="en",
+        text="hello",
+        target_languages=["en", "es"],
+        target_texts=["hello, ", "hola."],
+    )
+
+    assert sd.target_languages is not None
+    assert all(isinstance(lang, LanguageCode) for lang in sd.target_languages)
+    assert sd.target_languages == [LanguageCode("en"), LanguageCode("es")]
+    assert sd.target_texts == ["hello, ", "hola."]
+
+
+def test_speech_data_target_languages_none_stays_none():
+    sd = SpeechData(language="en", text="hello")
+    assert sd.target_languages is None
+    assert sd.target_texts is None
+
+
+def test_speech_data_target_languages_preserves_existing_language_code_instances():
+    code = LanguageCode("en")
+    sd = SpeechData(language="en", text="hello", target_languages=[code])
+
+    assert sd.target_languages is not None
+    assert sd.target_languages[0] is code
+
+
+# ---------------------------------------------------------------------------
+# _TokenAccumulator._lang_segments coalescing
+# ---------------------------------------------------------------------------
+
+
+def test_token_accumulator_coalesces_consecutive_same_language_runs():
+    from livekit.plugins.soniox.stt import _TokenAccumulator
+
+    accumulator = _TokenAccumulator()
+    for lang, text in [
+        ("en", "Hello"),
+        ("en", " world"),
+        ("es", " hola"),
+        ("es", " mundo"),
+        ("en", " again"),
+    ]:
+        accumulator.update({"text": text, "language": lang, "is_final": True})
+
+    assert accumulator._lang_segments == [
+        ("en", "Hello world"),
+        ("es", " hola mundo"),
+        ("en", " again"),
+    ]
+    assert accumulator.text == "Hello world hola mundo again"
+    assert "".join(text for _, text in accumulator._lang_segments) == accumulator.text
+
+
+def test_token_accumulator_lang_segments_empty_initially():
+    from livekit.plugins.soniox.stt import _TokenAccumulator
+
+    accumulator = _TokenAccumulator()
+    assert accumulator._lang_segments == []
+
+
+# ---------------------------------------------------------------------------
+# _lang_segments_to_fields helper
+# ---------------------------------------------------------------------------
+
+
+def test_lang_segments_to_fields_empty_returns_none_pair():
+    from livekit.plugins.soniox.stt import _lang_segments_to_fields
+
+    langs, texts = _lang_segments_to_fields([])
+    assert langs is None
+    assert texts is None
+
+
+def test_lang_segments_to_fields_coerces_to_language_code():
+    from livekit.plugins.soniox.stt import _lang_segments_to_fields
+
+    langs, texts = _lang_segments_to_fields([("en", "Hello, "), ("es", "hola.")])
+    assert langs == [LanguageCode("en"), LanguageCode("es")]
+    assert texts == ["Hello, ", "hola."]
+    assert langs is not None
+    assert all(isinstance(lang, LanguageCode) for lang in langs)
+
+
+# ---------------------------------------------------------------------------
+# _recv_messages_task end-to-end via a fake WebSocket
+# ---------------------------------------------------------------------------
+
+
+class _FakeWSMessage:
+    """Minimal stand-in for `aiohttp.WSMessage` used by `_recv_messages_task`."""
+
+    def __init__(self, data: Any, msg_type: aiohttp.WSMsgType = aiohttp.WSMsgType.TEXT) -> None:
+        self.type = msg_type
+        self.data = data if isinstance(data, str) else json.dumps(data)
+
+
+class _FakeWebSocket:
+    """One-shot async-iterable that yields canned messages once, then stays empty.
+
+    `__anext__` awaits `asyncio.sleep(0)` so each iteration yields control back
+    to the event loop — without that yield, the plugin's tight outer
+    `while self._ws:` loop after the iterator exhausts would starve the test's
+    `_event_ch.recv()` consumer and the test would hang.
+    """
+
+    def __init__(self, messages: list[dict[str, Any]]) -> None:
+        self._messages = [_FakeWSMessage(m) for m in messages]
+
+    def __aiter__(self) -> _FakeWebSocket:
+        return self
+
+    async def __anext__(self) -> _FakeWSMessage:
+        await asyncio.sleep(0)
+        if not self._messages:
+            raise StopAsyncIteration
+        return self._messages.pop(0)
+
+
+def _make_stream(translation: Any = None):
+    """Construct a Soniox `SpeechStream` without spawning its real `_main_task`.
+
+    Patches `asyncio.create_task` (the call site in `RecognizeStream.__init__`) so
+    `_main_task` isn't scheduled — the stream's `_event_ch` is still a live
+    channel that the test drives directly via `_recv_messages_task`.
+    """
+    from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS
+    from livekit.plugins.soniox import STT
+    from livekit.plugins.soniox.stt import SpeechStream
+
+    stt_instance = STT(api_key="test-key")
+    if translation is not None:
+        stt_instance._params.translation = translation
+
+    def _fake_create_task(coro, *args, **kwargs):
+        coro.close()
+        return MagicMock()
+
+    with patch("livekit.agents.stt.stt.asyncio.create_task", side_effect=_fake_create_task):
+        stream = SpeechStream(stt=stt_instance, conn_options=DEFAULT_API_CONNECT_OPTIONS)
+    return stream
+
+
+async def _drive_recv(
+    stream, messages: list[dict[str, Any]], *, expect_events: int, timeout: float = 2.0
+):
+    """Drive `_recv_messages_task` with canned messages, return collected events.
+
+    Sets `stream._ws = None` after collecting events so the plugin's outer
+    `while self._ws:` loop exits cleanly. Cancellation is the fallback for
+    timeout / event-count mismatches.
+    """
+    stream._ws = _FakeWebSocket(messages)
+    task = asyncio.create_task(stream._recv_messages_task())
+    events = []
+    try:
+        for _ in range(expect_events):
+            ev = await asyncio.wait_for(stream._event_ch.recv(), timeout=timeout)
+            events.append(ev)
+        return events
+    finally:
+        stream._ws = None
+        try:
+            await asyncio.wait_for(task, timeout=1.0)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            task.cancel()
+            try:
+                await task
+            except BaseException:
+                pass
+        except BaseException:
+            pass
+
+
+def _final_token(text: str, language: str, translation_status: str | None = None) -> dict:
+    token: dict[str, Any] = {"text": text, "language": language, "is_final": True}
+    if translation_status is not None:
+        token["translation_status"] = translation_status
+    return token
+
+
+def _nonfinal_token(text: str, language: str, translation_status: str | None = None) -> dict:
+    token: dict[str, Any] = {"text": text, "language": language, "is_final": False}
+    if translation_status is not None:
+        token["translation_status"] = translation_status
+    return token
+
+
+END_TOKEN_FINAL: dict[str, Any] = {"text": "<end>", "is_final": True}
+
+
+# --- Two-way translation, code-switched input -------------------------------
+
+
+async def test_final_transcript_two_way_code_switched():
+    """The issue's canonical example: 'No hablo español but I speak English' →
+    'I don't speak Spanish, pero hablo inglés.' produces per-run source and
+    target lists with different language orderings."""
+    from livekit.plugins.soniox.stt import TranslationConfig
+
+    stream = _make_stream(
+        translation=TranslationConfig(type="two_way", language_a="en", language_b="es")
+    )
+
+    messages = [
+        {
+            "tokens": [
+                _final_token("No hablo español, ", "es", translation_status="original"),
+                _final_token("but I speak English.", "en", translation_status="original"),
+                _final_token("I don't speak Spanish, ", "en", translation_status="translation"),
+                _final_token("pero hablo inglés.", "es", translation_status="translation"),
+                END_TOKEN_FINAL,
+            ],
+            "total_audio_proc_ms": 1000,
+        }
+    ]
+
+    events = await _drive_recv(stream, messages, expect_events=3)
+
+    types = [e.type for e in events]
+    assert SpeechEventType.FINAL_TRANSCRIPT in types
+    assert SpeechEventType.END_OF_SPEECH in types
+
+    final = next(e for e in events if e.type == SpeechEventType.FINAL_TRANSCRIPT)
+    assert len(final.alternatives) == 1
+    sd = final.alternatives[0]
+
+    assert sd.text == "I don't speak Spanish, pero hablo inglés."
+    assert sd.language == LanguageCode("en")
+
+    assert sd.source_languages == [LanguageCode("es"), LanguageCode("en")]
+    assert sd.source_texts == ["No hablo español, ", "but I speak English."]
+
+    assert sd.target_languages == [LanguageCode("en"), LanguageCode("es")]
+    assert sd.target_texts == ["I don't speak Spanish, ", "pero hablo inglés."]
+    assert sd.target_texts is not None
+    assert "".join(sd.target_texts) == sd.text
+
+
+# --- One-way translation ----------------------------------------------------
+
+
+async def test_final_transcript_one_way_translation_single_target_run():
+    """One-way translation produces a single-entry `target_languages` list."""
+    from livekit.plugins.soniox.stt import TranslationConfig
+
+    stream = _make_stream(translation=TranslationConfig(type="one_way", target_language="es"))
+
+    messages = [
+        {
+            "tokens": [
+                _final_token("Hello world.", "en", translation_status="original"),
+                _final_token("Hola mundo.", "es", translation_status="translation"),
+                END_TOKEN_FINAL,
+            ],
+            "total_audio_proc_ms": 500,
+        }
+    ]
+
+    events = await _drive_recv(stream, messages, expect_events=3)
+    final = next(e for e in events if e.type == SpeechEventType.FINAL_TRANSCRIPT)
+    sd = final.alternatives[0]
+
+    assert sd.text == "Hola mundo."
+    assert sd.language == LanguageCode("es")
+    assert sd.source_languages == [LanguageCode("en")]
+    assert sd.source_texts == ["Hello world."]
+    assert sd.target_languages == [LanguageCode("es")]
+    assert sd.target_texts == ["Hola mundo."]
+
+
+# --- "none" untranslated chunk ---------------------------------------------
+
+
+async def test_final_transcript_untranslated_chunk_yields_asymmetric_lists():
+    """A `translation_status: "none"` token sits in source-only; the resulting
+    source and target lists legitimately have different lengths."""
+    from livekit.plugins.soniox.stt import TranslationConfig
+
+    stream = _make_stream(
+        translation=TranslationConfig(type="two_way", language_a="en", language_b="de")
+    )
+
+    messages = [
+        {
+            "tokens": [
+                _final_token("Good morning. ", "en", translation_status="original"),
+                _final_token("Bonjour à tous. ", "fr", translation_status="none"),
+                _final_token("How are you?", "en", translation_status="original"),
+                _final_token("Guten Morgen. ", "de", translation_status="translation"),
+                _final_token("Wie geht's?", "de", translation_status="translation"),
+                END_TOKEN_FINAL,
+            ],
+            "total_audio_proc_ms": 1200,
+        }
+    ]
+
+    events = await _drive_recv(stream, messages, expect_events=3)
+    final = next(e for e in events if e.type == SpeechEventType.FINAL_TRANSCRIPT)
+    sd = final.alternatives[0]
+
+    # The "Bonjour à tous." fr chunk sits between two en chunks, so the source
+    # per-run breakdown is three entries (en, fr, en) — the same coalescing
+    # behavior as the target side, just driven by different `language` runs.
+    assert sd.source_languages == [
+        LanguageCode("en"),
+        LanguageCode("fr"),
+        LanguageCode("en"),
+    ]
+    assert sd.source_texts == [
+        "Good morning. ",
+        "Bonjour à tous. ",
+        "How are you?",
+    ]
+
+    # Both translation tokens are German → single coalesced target run.
+    assert sd.target_languages == [LanguageCode("de")]
+    assert sd.target_texts == ["Guten Morgen. Wie geht's?"]
+
+    # The two per-run lists are independent — different lengths are legitimate.
+    assert sd.source_languages is not None
+    assert sd.target_languages is not None
+    assert len(sd.source_languages) != len(sd.target_languages)
+
+
+# --- Interim transcript shape ----------------------------------------------
+
+
+async def test_interim_transcript_merges_final_and_non_final_per_run():
+    """Interim path merges final-so-far with current non-final tokens for
+    both source and target sides via `_merge_lang_segments`."""
+    from livekit.plugins.soniox.stt import TranslationConfig
+
+    stream = _make_stream(
+        translation=TranslationConfig(type="two_way", language_a="en", language_b="es")
+    )
+
+    messages = [
+        {
+            "tokens": [
+                _final_token("Hola, ", "es", translation_status="original"),
+                _final_token("Hello, ", "en", translation_status="translation"),
+                _nonfinal_token("¿cómo estás?", "es", translation_status="original"),
+                _nonfinal_token("how are you?", "en", translation_status="translation"),
+            ],
+            "total_audio_proc_ms": 800,
+        }
+    ]
+
+    events = await _drive_recv(stream, messages, expect_events=2)
+
+    interim = next(
+        e
+        for e in events
+        if e.type in (SpeechEventType.INTERIM_TRANSCRIPT, SpeechEventType.PREFLIGHT_TRANSCRIPT)
+    )
+    sd = interim.alternatives[0]
+
+    assert sd.source_languages == [LanguageCode("es")]
+    assert sd.source_texts == ["Hola, ¿cómo estás?"]
+    assert sd.target_languages == [LanguageCode("en")]
+    assert sd.target_texts == ["Hello, how are you?"]
+
+
+async def test_interim_transcript_no_translation_populates_source_runs():
+    """Interim path also surfaces per-run `source_*` in non-translation mode,
+    same symmetric fix as the final-transcript case."""
+    stream = _make_stream(translation=None)
+
+    messages = [
+        {
+            "tokens": [
+                _final_token("こんにちは、", "ja"),
+                _nonfinal_token("My name is Sam.", "en"),
+            ],
+            "total_audio_proc_ms": 600,
+        }
+    ]
+
+    events = await _drive_recv(stream, messages, expect_events=2)
+    interim = next(
+        e
+        for e in events
+        if e.type in (SpeechEventType.INTERIM_TRANSCRIPT, SpeechEventType.PREFLIGHT_TRANSCRIPT)
+    )
+    sd = interim.alternatives[0]
+
+    assert sd.source_languages == [LanguageCode("ja"), LanguageCode("en")]
+    assert sd.source_texts == ["こんにちは、", "My name is Sam."]
+    assert sd.target_languages is None
+    assert sd.target_texts is None
+
+
+# --- Non-translation mode -------------------------------------------------
+
+
+async def test_final_transcript_no_translation_single_language_populates_source():
+    """Non-translation, single-language input: `source_*` is populated from the
+    per-run breakdown (single entry), `target_*` is None. This matches the
+    `SpeechData` docstring's "multi-language detection services" semantics and
+    is the same fix-symptom as translation mode — `final._lang_segments` was
+    being discarded when `final_original` was empty."""
+    stream = _make_stream(translation=None)
+
+    messages = [
+        {
+            "tokens": [
+                _final_token("Hello world.", "en"),
+                END_TOKEN_FINAL,
+            ],
+            "total_audio_proc_ms": 500,
+        }
+    ]
+
+    events = await _drive_recv(stream, messages, expect_events=3)
+    final = next(e for e in events if e.type == SpeechEventType.FINAL_TRANSCRIPT)
+    sd = final.alternatives[0]
+
+    assert sd.text == "Hello world."
+    assert sd.language == LanguageCode("en")
+    assert sd.source_languages == [LanguageCode("en")]
+    assert sd.source_texts == ["Hello world."]
+    assert sd.target_languages is None
+    assert sd.target_texts is None
+
+
+async def test_final_transcript_no_translation_code_switched_populates_source_runs():
+    """Non-translation, code-switched input: `source_*` carries the per-run
+    breakdown across detected languages. Mirrors the follow-up issue comment's
+    JA+EN example — same plugin gap as the original target-side symptom, just
+    surfaced through the source side when translation is off."""
+    stream = _make_stream(translation=None)
+
+    messages = [
+        {
+            "tokens": [
+                _final_token("こんにちは、君の名前は何だ。", "ja"),
+                _final_token(" My name is Sam.", "en"),
+                END_TOKEN_FINAL,
+            ],
+            "total_audio_proc_ms": 1500,
+        }
+    ]
+
+    events = await _drive_recv(stream, messages, expect_events=3)
+    final = next(e for e in events if e.type == SpeechEventType.FINAL_TRANSCRIPT)
+    sd = final.alternatives[0]
+
+    assert sd.text == "こんにちは、君の名前は何だ。 My name is Sam."
+    # `sd.language` is the plugin's opinionated lossy summary (currently
+    # most-chars-wins) and isn't what this test is exercising -- the per-run
+    # `source_languages` / `source_texts` are. Don't assert on `language`
+    # here so the test stays decoupled from upstream's summary heuristic.
+    assert sd.source_languages == [LanguageCode("ja"), LanguageCode("en")]
+    assert sd.source_texts == [
+        "こんにちは、君の名前は何だ。",
+        " My name is Sam.",
+    ]
+    assert sd.target_languages is None
+    assert sd.target_texts is None
+    assert sd.source_texts is not None
+    assert "".join(sd.source_texts) == sd.text


### PR DESCRIPTION
## Summary

Fixes #5685 (and the follow-up source-side symptom raised in the comment thread, which @chenghao-mou approved bundling into the same PR).

Both halves are the same plugin bug: `_TokenAccumulator._lang_segments` is built per-run by the existing coalescing logic but then dropped in `send_endpoint_transcript` (and the interim path). The fix surfaces it through new `SpeechData` fields on the target side, and stops dropping it on the source side in non-translation mode.

### Changes

- **`stt.SpeechData`**: add `target_languages` / `target_texts` (symmetric to existing `source_languages` / `source_texts`). Same `LanguageCode` coercion in `__post_init__`. Default `None`, so the addition is strictly additive for every other plugin.
- **Soniox plugin, translation mode**: populate `target_*` from `final._lang_segments` on `FINAL_TRANSCRIPT` and `INTERIM_TRANSCRIPT` / `PREFLIGHT_TRANSCRIPT`. Consumers now see the per-run target breakdown for code-switched two-way translation, e.g. `target_languages=["en", "es"]` / `target_texts=["Hello, how are you?", " Estoy bien, gracias."]` for the translation of `"Hello, ¿cómo estás? I'm doing fine, gracias."`.
- **Soniox plugin, non-translation mode**: populate `source_*` from the same accumulator (previously `None`). A code-switched `ja` + `en` utterance now surfaces `source_languages=["ja", "en"]` / `source_texts=["こんにちは、私の名はサムです。", " My name is Sam."]` -- matches what the `SpeechData` docstring already promised for "multi-language detection services".
- **Refactor**: extract a `_lang_segments_to_fields` helper to DRY the conversion across both modes and both event paths; the four duplicated inline list comprehensions collapse to one named operation. The predicate that distinguishes source from target became data-presence-based (`final_original._lang_segments`) rather than config-based (`is_translation_mode is not None`), which is what unified both halves cleanly.

`SpeechData.text` and `SpeechData.language` are unchanged for back-compat (still the full concatenation and the first translated/detected language, respectively).

## Test plan

- [x] 14 new unit tests in `tests/test_plugin_soniox_stt.py` covering:
  - `SpeechData.__post_init__` `target_languages` coercion (strings → `LanguageCode`, `None` stays `None`, existing `LanguageCode` passthrough)
  - `_TokenAccumulator._lang_segments` per-run coalescing
  - `_lang_segments_to_fields` helper edge cases (empty → `(None, None)`, non-empty → parallel lists with `LanguageCode` coercion)
  - Two-way translation, code-switched (the issue's canonical example)
  - One-way translation (single target run)
  - "none" untranslated chunk inside a translated utterance (asymmetric per-run list lengths)
  - Interim path: translation mode merging final + non-final per run on both sides
  - Interim path: non-translation mode populates `source_*` from final + non-final merged
  - Non-translation single-language: `source_*` populated, `target_*` `None`
  - Non-translation code-switched JA+EN: `source_*` carries the per-run breakdown
- [x] Live-verified end-to-end against the real Soniox WebSocket API in console mode:
  - **Translation mode**, code-switched `"Hello, ¿cómo estás? I'm doing fine, gracias."` → `text="Hello, how are you? Estoy bien, gracias."`, `target_languages=["en", "es"]`, `target_texts=["Hello, how are you?", " Estoy bien, gracias."]`, `"".join(target_texts) == text`. Source side unchanged.
  - **Non-translation mode**, code-switched `" こんにちは、私の名はサムです。 My name is Sam."` → `text=" こんにちは、私の名はサムです。 My name is Sam."`, `source_languages=["ja", "en"]`, `source_texts=[" こんにちは、私の名はサムです。", " My name is Sam."]`, `target_*` correctly `None`. Interim events also surface the multi-language source breakdown progressively as the user code-switches.
- [x] `ruff format` clean, `ruff check` clean, no new `mypy --strict` errors introduced in changed files.

## Follow-ups (intentionally not in this PR)

- The `final` / `final_original` accumulator names are honest about routing today but the new `target_*` fields make their two-mode roles more glaring (`final` is "primary user-facing accumulator", `final_original` is "source-side accumulator that's empty in non-translation mode"). Worth a separate behavior-preserving rename PR to `final_primary` / `final_source`.
- The new `target_*` fields are wired in Soniox only; other translation-capable plugins (Gladia, Deepgram v2, AWS) can adopt them in follow-up PRs.
