### PR TITLE
fix: suppress expected STT failover input-ended errors

### DIFF
--- a/livekit-agents/livekit/agents/stt/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/stt/fallback_adapter.py
@@ -314,6 +314,11 @@ class FallbackRecognizeStream(RecognizeStream):
                             main_stream.push_frame(data)
                         elif isinstance(data, self._FlushSentinel):
                             main_stream.flush()
+                    except RuntimeError as e:
+                        if "input ended" not in str(e):
+                            logger.exception(
+                                "error happened in forwarding input", extra={"streamed": True}
+                            )
                     except Exception:
                         logger.exception(
                             "error happened in forwarding input", extra={"streamed": True}

--- a/livekit-agents/livekit/agents/stt/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/stt/fallback_adapter.py
@@ -308,17 +308,16 @@ class FallbackRecognizeStream(RecognizeStream):
                     except Exception:
                         pass
 
-                if main_stream is not None:
+                if (
+                    main_stream is not None
+                    and not main_stream._input_ch.closed
+                    and not main_stream._event_ch.closed
+                ):
                     try:
                         if isinstance(data, rtc.AudioFrame):
                             main_stream.push_frame(data)
                         elif isinstance(data, self._FlushSentinel):
                             main_stream.flush()
-                    except RuntimeError as e:
-                        if "input ended" not in str(e):
-                            logger.exception(
-                                "error happened in forwarding input", extra={"streamed": True}
-                            )
                     except Exception:
                         logger.exception(
                             "error happened in forwarding input", extra={"streamed": True}


### PR DESCRIPTION
## Summary

Suppresses expected `RuntimeError("... input ended")` races from the STT `FallbackAdapter` forwarder during failover, while preserving error logging for unexpected forwarding failures.

## Testing

- `uv run ruff check livekit-agents/livekit/agents/stt/fallback_adapter.py`
- `uv run pytest tests/test_stt_fallback.py -q`

Fixes #5736