### PR TITLE
fix(dep): pin bithuman

### DIFF
--- a/livekit-plugins/livekit-plugins-bithuman/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-bithuman/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 
-dependencies = ["livekit-agents>=1.5.9", "bithuman>=0.5.25"]
+dependencies = ["livekit-agents>=1.5.9", "bithuman>=0.5.25,<1.12"]
 
 [project.urls]
 Documentation = "https://docs.livekit.io"

--- a/uv.lock
+++ b/uv.lock
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bithuman", specifier = ">=0.5.25" },
+    { name = "bithuman", specifier = ">=0.5.25,<1.12" },
     { name = "livekit-agents", editable = "livekit-agents" },
 ]
 


### PR DESCRIPTION
pin bithuman to the last version that has compatible packages for 3.12. 

Their recent releases only support 3.11 and 3.13 for some reason in some platforms.