### PR TITLE
docs: clarify Gemini 3.1 instruction updates

### DIFF
--- a/livekit-plugins/livekit-plugins-google/README.md
+++ b/livekit-plugins/livekit-plugins-google/README.md
@@ -37,7 +37,7 @@ And these on Vertex AI:
 
 Gemini 3.1 Live does not allow system instructions to be changed after the
 session has started. Calls such as `AgentSession.update_instructions()` and
-`session.generate_reply(instructions=...)` are ignored for
+`session.generate_reply(instructions=...)` will throw an error for
 `gemini-3.1-flash-live-preview`.
 
 For dynamic behavior with Gemini 3.1, a new session must be created with the

--- a/livekit-plugins/livekit-plugins-google/README.md
+++ b/livekit-plugins/livekit-plugins-google/README.md
@@ -33,6 +33,18 @@ And these on Vertex AI:
 
 - gemini-live-2.5-flash-native-audio
 
+### Gemini 3.1 instructions
+
+Gemini 3.1 Live does not allow system instructions to be changed after the
+session has started. Calls such as `AgentSession.update_instructions()` and
+`session.generate_reply(instructions=...)` are ignored for
+`gemini-3.1-flash-live-preview`.
+
+For dynamic behavior with Gemini 3.1, prefer starting a new session with the
+updated instructions. For turn-specific context, include the extra context in
+the user message or a tool result before the model responds instead of relying
+on mid-session instruction updates.
+
 References:
 
 - [Gemini API Models](https://ai.google.dev/gemini-api/docs/models)

--- a/livekit-plugins/livekit-plugins-google/README.md
+++ b/livekit-plugins/livekit-plugins-google/README.md
@@ -33,15 +33,15 @@ And these on Vertex AI:
 
 - gemini-live-2.5-flash-native-audio
 
-### Gemini 3.1 instructions
+### Gemini 3.1 compatibility
 
 Gemini 3.1 Live does not allow system instructions to be changed after the
 session has started. Calls such as `AgentSession.update_instructions()` and
 `session.generate_reply(instructions=...)` are ignored for
 `gemini-3.1-flash-live-preview`.
 
-For dynamic behavior with Gemini 3.1, prefer starting a new session with the
-updated instructions. For turn-specific context, include the extra context in
+For dynamic behavior with Gemini 3.1, a new session must be created with the
+updated instructions. For turn-specific context, consider including the extra context in
 the user message or a tool result before the model responds instead of relying
 on mid-session instruction updates.
 

--- a/livekit-plugins/livekit-plugins-google/README.md
+++ b/livekit-plugins/livekit-plugins-google/README.md
@@ -36,9 +36,9 @@ And these on Vertex AI:
 ### Gemini 3.1 compatibility
 
 Gemini 3.1 Live does not allow system instructions to be changed after the
-session has started. Calls such as `AgentSession.update_instructions()` and
-`session.generate_reply(instructions=...)` will throw an error for
-`gemini-3.1-flash-live-preview`.
+session has started. `AgentSession.update_instructions()` is ignored for
+`gemini-3.1-flash-live-preview`, while
+`session.generate_reply(instructions=...)` will throw an error.
 
 For dynamic behavior with Gemini 3.1, a new session must be created with the
 updated instructions. For turn-specific context, consider including the extra context in

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -233,6 +233,9 @@ class RealtimeModel(llm.RealtimeModel):
 
         Args:
             instructions (str, optional): Initial system instructions for the model. Defaults to "".
+                Gemini 3.1 Live models do not support mid-session instruction updates;
+                start a new session with updated instructions, or pass turn-specific context
+                in user/tool content before the model responds.
             api_key (str, optional): Google Gemini API key. If None, will attempt to read from the environment variable GOOGLE_API_KEY.
             modalities (list[Modality], optional): Modalities to use, such as ["TEXT", "AUDIO"]. Defaults to ["AUDIO"].
             model (str, optional): The name of the model to use. Defaults to "gemini-2.5-flash-native-audio-preview-12-2025" or "gemini-live-2.5-flash-native-audio" (vertexai).


### PR DESCRIPTION
## Summary\n- Document that Gemini 3.1 Live cannot update instructions mid-session\n- Clarify that per-turn instructions via generate_reply are ignored for this model\n- Suggest starting a new session or passing turn-specific context in user/tool content\n\nFixes #5496\n\n## Tests\n- python3 -m py_compile livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py