### PR TITLE
docs(google): note Gemini 3.1 instruction limitations

### DIFF
--- a/livekit-plugins/livekit-plugins-google/README.md
+++ b/livekit-plugins/livekit-plugins-google/README.md
@@ -33,6 +33,13 @@ And these on Vertex AI:
 
 - gemini-live-2.5-flash-native-audio
 
+### Gemini 3.1 Live compatibility
+
+`gemini-3.1-flash-live-preview` does not reliably apply mid-session system instruction
+updates sent with `AgentSession.update_instructions()`. When dynamic context changes during a
+session, prefer starting a new session with the updated instructions or pass the context as
+user-visible conversation content instead of relying on a system-instruction update.
+
 References:
 
 - [Gemini API Models](https://ai.google.dev/gemini-api/docs/models)

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -63,6 +63,10 @@ KNOWN_GEMINI_API_MODELS: frozenset[str] = frozenset(
 )
 
 
+def _is_gemini_31_live(model: str) -> bool:
+    return model.lower().startswith("gemini-3.1-") and "live" in model.lower()
+
+
 def _validate_model_api_match(model: str, use_vertexai: bool) -> None:
     """
     Validate that the model name matches the API being used.
@@ -484,6 +488,7 @@ class RealtimeSession(llm.RealtimeSession):
         self._in_user_activity = False
         self._session_lock = asyncio.Lock()
         self._num_retries = 0
+        self._logged_gemini_31_instruction_warning = False
 
     async def _close_active_session(self) -> None:
         async with self._session_lock:
@@ -556,6 +561,17 @@ class RealtimeSession(llm.RealtimeSession):
                     return
 
             # Active session exists — send mid-session system instruction update (no reconnect needed)
+            if (
+                _is_gemini_31_live(self._opts.model)
+                and not self._logged_gemini_31_instruction_warning
+            ):
+                logger.warning(
+                    "Gemini 3.1 Live does not reliably support mid-session instruction "
+                    "updates; prefer starting a new session with updated instructions or "
+                    "passing dynamic context as user-visible conversation content."
+                )
+                self._logged_gemini_31_instruction_warning = True
+
             logger.debug("Updating instructions mid-session")
             self._send_client_event(
                 types.LiveClientContent(


### PR DESCRIPTION
Fixes #5496

## Summary
- Document Gemini 3.1 Live limitations around mid-session instruction updates
- Log the limitation once per session when update_instructions() is used with Gemini 3.1 Live

## Tests
- uv run ruff check livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
- python3 -m py_compile livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py