### PR TITLE
frontdesk: fix tz crash on deploy + survive failed startup

### DIFF
--- a/examples/frontdesk/agent.py
+++ b/examples/frontdesk/agent.py
@@ -204,7 +204,13 @@ server = AgentServer()
 
 
 async def on_session_end(ctx: JobContext) -> None:
-    report = ctx.make_session_report()
+    # `on_session_end` runs even if the job crashed before the AgentSession
+    # started (e.g. a bad timezone, a calendar fault) — make_session_report
+    # raises in that case, and there's nothing to evaluate anyway.
+    try:
+        report = ctx.make_session_report()
+    except RuntimeError:
+        return
 
     # Skip evaluation for very short conversations
     chat = report.chat_history.copy(exclude_function_call=True, exclude_instructions=True)
@@ -240,7 +246,7 @@ async def on_session_end(ctx: JobContext) -> None:
 async def frontdesk_agent(ctx: JobContext):
     await ctx.connect()
 
-    timezone = "utc"
+    timezone = "UTC"
 
     if cal_api_key := os.getenv("CAL_API_KEY", None):
         logger.info("CAL_API_KEY detected, using cal.com calendar")

--- a/examples/frontdesk/requirements.txt
+++ b/examples/frontdesk/requirements.txt
@@ -3,3 +3,6 @@ livekit-plugins-silero>=1.5.7
 livekit-plugins-turn-detector>=1.5.7
 python-dotenv>=1.0.0
 aiohttp>=3.9.0
+# python:3.13-slim ships no system tzdata; without this, zoneinfo.ZoneInfo
+# raises ZoneInfoNotFoundError at runtime.
+tzdata>=2024.1


### PR DESCRIPTION
## Summary

Two cascading failures on the live frontdesk deploy from the logs in slack:

1. `zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key utc'` at startup.
   - The python:3.13-slim base image ships no system tzdata, so Python's `zoneinfo` falls back to the `tzdata` PyPI package — which wasn't in `requirements.txt`.
   - Pin `tzdata>=2024.1`.
   - Also normalise the timezone constant to `"UTC"` (IANA keys are case-sensitive once the PyPI `tzdata` is the source; lowercase only ever worked on case-insensitive filesystems).

2. `RuntimeError: Cannot prepare report, no AgentSession was found` in `on_session_end`.
   - The callback runs even when the job dies before `AgentSession.start()`, so `ctx.make_session_report()` raises and adds a noisy secondary stack trace on top of the real error.
   - Wrap it in a `try/except RuntimeError` and early-return when there's nothing to evaluate.

## Test plan

- [ ] Redeploy via the Deploy Examples workflow.
- [ ] Confirm the frontdesk job boots without the ZoneInfo error.
- [ ] Confirm crashes (e.g. by forcing a startup error locally) no longer surface the `make_session_report` secondary trace.