### PR TITLE
deploy-examples: fix manifest publishing (\u escapes + --force push)

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -125,11 +125,18 @@ jobs:
           python <<'PY' > examples-manifest.json
           # The playground links out to GitHub for source / README; we only
           # need the yaml metadata in the manifest now.
+          #
+          # ensure_ascii=True keeps any non-ASCII codepoint (e.g. the
+          # FontAwesome private-use glyphs `` in view titles) as
+          # literal `\uXXXX` escapes in the JSON. Without it they get
+          # written as raw UTF-8 bytes that look like invisible blanks
+          # in any editor without the FA font, making the manifest
+          # diffs unreadable.
           import json, yaml
           from pathlib import Path
           root = Path("agents/examples")
           m = yaml.safe_load((root / "playground.yaml").read_text())
-          print(json.dumps(m, indent=2, ensure_ascii=False))
+          print(json.dumps(m, indent=2, ensure_ascii=True))
           PY
 
       - name: Checkout agents-jukebox

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -164,7 +164,12 @@ jobs:
           # `main` is protected — push to a bot branch and open a PR.
           git checkout -B "$branch"
           git commit -m "chore: refresh examples manifest"
-          git push --force-with-lease origin "$branch"
+          # Plain `--force`: the bot branch is fully bot-managed and
+          # rewritten on every deploy. `--force-with-lease` aborts with
+          # "stale info" here because actions/checkout does a shallow
+          # clone of `main` only, so there's no remote-tracking ref for
+          # the bot branch for the lease check to compare against.
+          git push --force origin "$branch"
 
           # Open the PR if one doesn't already exist for this head; `gh pr view`
           # finds open *or* closed PRs, so filter by state.


### PR DESCRIPTION
## Summary

Two follow-ups to PR #5760 surfaced after the first live run:

1. **`ensure_ascii=False` mangled FA glyphs in the published manifest.** `json.dumps` was writing `\uf07a` (and similar FontAwesome private-use codepoints) as raw UTF-8 bytes. They render as invisible blanks in any editor without the FA font installed, so the manifest at `agents-jukebox/next/public/examples-manifest.json` reads `"title": " Current order"` and the diff is unreadable. Flip back to `ensure_ascii=True`; JSON.parse on the playground side resolves either form to the same string at runtime.
2. **`git push --force-with-lease` rejected the bot-branch push with "stale info".** `actions/checkout` shallow-clones `main` only, so there's no remote-tracking ref for `bot/refresh-examples-manifest` for the lease check to compare against. The bot branch is fully bot-managed and rewritten on every run, so plain `--force` is the right tool here.

## Test plan

- [ ] Trigger the deploy-examples workflow.
- [ ] Confirm the resulting PR on agents-jukebox shows `"\uf07a"` (literal escape) rather than a blank in the title.
- [ ] Confirm the bot-branch push succeeds even when `bot/refresh-examples-manifest` already exists on the remote.