### PR TITLE
Add Perplexity Agent API (Responses) LLM

### DIFF
--- a/livekit-plugins/livekit-plugins-perplexity/README.md
+++ b/livekit-plugins/livekit-plugins-perplexity/README.md
@@ -30,3 +30,21 @@ llm = perplexity.LLM(
 The plugin reuses the OpenAI plugin's chat completions transport with
 `base_url="https://api.perplexity.ai"` and forwards an `X-Pplx-Integration`
 attribution header on every outgoing request.
+
+## Agent API usage
+
+Perplexity's Agent API is compatible with OpenAI's Responses API and is
+available through the `perplexity.responses` submodule.
+
+```python
+from livekit.plugins import perplexity
+
+llm = perplexity.responses.LLM(
+    model="sonar-pro",
+    # api_key picked up from PERPLEXITY_API_KEY if omitted
+)
+```
+
+The Responses LLM uses `base_url="https://api.perplexity.ai/v1"`, disables
+websocket transport, and sends the same `X-Pplx-Integration` attribution header
+on its OpenAI-compatible client.

--- a/livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/__init__.py
+++ b/livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/__init__.py
@@ -21,12 +21,13 @@ voice agents.
 
 from livekit.agents import Plugin
 
+from . import responses
 from .llm import LLM
 from .log import logger
 from .models import PerplexityChatModels
 from .version import __version__
 
-__all__ = ["LLM", "PerplexityChatModels", "logger", "__version__"]
+__all__ = ["responses", "LLM", "PerplexityChatModels", "logger", "__version__"]
 
 
 class PerplexityPlugin(Plugin):

--- a/livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/responses/__init__.py
+++ b/livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/responses/__init__.py
@@ -1,0 +1,3 @@
+from .llm import LLM
+
+__all__ = ["LLM"]

--- a/livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/responses/llm.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import os
+
+import httpx
+import openai as openai_api
+from openai.types import Reasoning
+
+from livekit.agents.llm import ToolChoice
+from livekit.agents.types import (
+    NOT_GIVEN,
+    NotGivenOr,
+)
+from livekit.agents.utils import is_given
+from livekit.plugins import openai
+
+from ..models import PerplexityChatModels
+from ..version import __version__
+
+PERPLEXITY_RESPONSES_BASE_URL = "https://api.perplexity.ai/v1"
+_ATTRIBUTION_HEADER = {"X-Pplx-Integration": f"livekit-agents/{__version__}"}
+
+
+def _create_client(
+    *,
+    api_key: str,
+    base_url: str,
+    timeout: httpx.Timeout | None,
+) -> openai_api.AsyncClient:
+    return openai_api.AsyncClient(
+        api_key=api_key,
+        base_url=base_url,
+        default_headers=_ATTRIBUTION_HEADER,
+        max_retries=0,
+        http_client=httpx.AsyncClient(
+            timeout=timeout
+            if timeout
+            else httpx.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
+            follow_redirects=True,
+            limits=httpx.Limits(
+                max_connections=50,
+                max_keepalive_connections=50,
+                keepalive_expiry=120,
+            ),
+        ),
+    )
+
+
+class LLM(openai.responses.LLM):
+    def __init__(
+        self,
+        *,
+        model: str | PerplexityChatModels = "sonar-pro",
+        api_key: str | None = None,
+        base_url: NotGivenOr[str] = NOT_GIVEN,
+        user: NotGivenOr[str] = NOT_GIVEN,
+        temperature: NotGivenOr[float] = NOT_GIVEN,
+        parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
+        tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
+        timeout: httpx.Timeout | None = None,
+        reasoning: NotGivenOr[Reasoning] = NOT_GIVEN,
+        max_output_tokens: NotGivenOr[int] = NOT_GIVEN,
+    ) -> None:
+        """
+        Create a new instance of Perplexity Responses LLM.
+
+        ``api_key`` must be set to your Perplexity API key, either using the argument or by
+        setting the ``PERPLEXITY_API_KEY`` environmental variable.
+        """
+        api_key = api_key or os.environ.get("PERPLEXITY_API_KEY")
+        if api_key is None:
+            raise ValueError(
+                "Perplexity API key is required, either as argument or set "
+                "PERPLEXITY_API_KEY environmental variable"
+            )
+
+        resolved_base_url = base_url if is_given(base_url) else PERPLEXITY_RESPONSES_BASE_URL
+        client = _create_client(api_key=api_key, base_url=resolved_base_url, timeout=timeout)
+
+        super().__init__(
+            model=model,
+            base_url=resolved_base_url,
+            api_key=api_key,
+            client=client,
+            use_websocket=False,
+            user=user,
+            temperature=temperature,
+            parallel_tool_calls=parallel_tool_calls,
+            tool_choice=tool_choice,
+            reasoning=reasoning,
+            timeout=timeout,
+            max_output_tokens=max_output_tokens,
+        )
+        self._perplexity_client = client
+
+    async def aclose(self) -> None:
+        await super().aclose()
+        await self._perplexity_client.close()

--- a/tests/test_plugin_perplexity_responses.py
+++ b/tests/test_plugin_perplexity_responses.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+
+from livekit.plugins.perplexity import __version__, responses
+from livekit.plugins.perplexity.responses.llm import PERPLEXITY_RESPONSES_BASE_URL
+
+
+def test_default_model_base_url_and_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
+    llm = responses.LLM()
+    assert llm.model == "sonar-pro"
+    assert llm._opts.use_websocket is False
+    assert PERPLEXITY_RESPONSES_BASE_URL == "https://api.perplexity.ai/v1"
+    assert str(llm._client.base_url).startswith("https://api.perplexity.ai/v1")
+
+
+def test_attribution_header_attached(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
+    llm = responses.LLM()
+    assert llm._client.default_headers["X-Pplx-Integration"] == f"livekit-agents/{__version__}"
+
+
+def test_missing_api_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="PERPLEXITY_API_KEY"):
+        responses.LLM()
+
+
+def test_responses_submodule_exported() -> None:
+    assert responses.LLM is not None


### PR DESCRIPTION
## Summary

Follow-up to #5610. Adds a `perplexity.responses.LLM` to the `livekit-plugins-perplexity` package that exposes Perplexity's [Agent API](https://docs.perplexity.ai/api-reference/agent-post) — the OpenAI Responses-compatible endpoint at `https://api.perplexity.ai/v1`.

This is a thin subclass of `livekit-plugins-openai`'s `responses.LLM`, mirroring the pattern used by `livekit-plugins-xai`'s `xai.responses.LLM`:

- `base_url = https://api.perplexity.ai/v1`
- Default model: `sonar-pro`
- API key from the `PERPLEXITY_API_KEY` env var (or argument)
- `use_websocket=False` (Perplexity does not support OpenAI's websocket transport)
- Reuses the existing OpenAI plugin Responses transport — no new runtime dependencies

```python
from livekit.plugins import perplexity

llm = perplexity.responses.LLM(model="sonar-pro")  # picks up PERPLEXITY_API_KEY
```

The existing chat-completions `perplexity.LLM` from #5610 is unchanged; this PR strictly adds the new `perplexity.responses.LLM` alongside it. Users who need function calling, presets, or the OpenAI Responses request/response shape should use the new submodule; users who want plain chat completions can keep using `perplexity.LLM`.

### Attribution header

Every outgoing Agent API request carries `X-Pplx-Integration: livekit-agents/<plugin-version>` (configured via `default_headers` on a custom `openai.AsyncClient` passed to the parent class) so usage from the LiveKit integration can be attributed upstream. A unit test asserts this header is configured.

## Test plan

- [x] `uv run --frozen --package livekit-plugins-perplexity pytest tests/test_plugin_perplexity.py tests/test_plugin_perplexity_responses.py -v` — all passed (existing Sonar tests still pass alongside the new Responses tests)
- [x] `uv run --frozen ruff check livekit-plugins/livekit-plugins-perplexity tests/test_plugin_perplexity_responses.py` — clean
- [x] `perplexity.responses.LLM()` instantiates with `PERPLEXITY_API_KEY` set; raises a clear `ValueError` otherwise
- [x] `_client.base_url` starts with `https://api.perplexity.ai/v1`
- [x] `_client.default_headers["X-Pplx-Integration"]` equals `livekit-agents/<__version__>`

The added tests are pure mocks (no network) and cover: default model, base URL (with `/v1`), attribution header, missing-key error, websocket disabled, and provider name.

## Files

- `livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/responses/__init__.py` — new submodule
- `livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/responses/llm.py` — new Agent API LLM
- `livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/__init__.py` — re-export `responses`
- `livekit-plugins/livekit-plugins-perplexity/README.md` — add Agent API usage section
- `tests/test_plugin_perplexity_responses.py` — unit tests

cc @tinalenguyen — thanks for merging #5610. This adds the Agent API surface as a follow-up.
