### PR TITLE
fix(cerebras): require openai>=2.16.0 for FinalRequestOptions.content

### DIFF
--- a/livekit-plugins/livekit-plugins-cerebras/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-cerebras/pyproject.toml
@@ -23,6 +23,9 @@ classifiers = [
 ]
 dependencies = [
     "livekit-agents[codecs, openai]>=1.5.10",
+    # _CerebrasClient._build_request sets options.content on FinalRequestOptions,
+    # a field added in openai 2.16.0 (binary request streaming support).
+    "openai>=2.16.0",
     "msgpack>=1.0",
     "msgpack-types>=0.7.0",
 ]


### PR DESCRIPTION
## Summary

- `livekit-plugins-cerebras` 1.5.10 added a custom OpenAI client whose `_CerebrasClient._build_request` assigns `options.content = body` on `FinalRequestOptions` to bypass `openapi_dumps()` for msgpack/gzip payloads.
- `FinalRequestOptions` is a strict Pydantic v2 model. The `content` field was added in openai-python **v2.16.0** (binary request streaming, openai/openai-python@a532f6e). On earlier 2.x releases the assignment raises:

  ```
  ValueError: "FinalRequestOptions" object has no field "content"
  ```

  which `livekit/agents/inference/llm.py` then wraps as `APIConnectionError`, so end users see repeating `failed to generate LLM completion: Connection error.` retries from `livekit.plugins.cerebras.llm.LLM`.
- The plugin's existing deps only pull `openai` transitively via `livekit-agents[codecs, openai]` → `livekit-plugins-openai` → `openai[realtime]>=2`, so resolvers can legitimately pick 2.0.0–2.15.x and break at runtime. Reproduced locally by forcing `openai==2.15.0` into an otherwise-locked venv and running the agent.
- This PR adds an explicit `openai>=2.16.0` to the cerebras plugin's dependencies so resolvers can't land on a version missing the field.

## Test plan

- [x] Reproduced the crash against `openai==2.15.0` (matching `FinalRequestOptions.model_fields` lacks `content`); same warning/retry pattern as the originally reported trace.
- [x] Verified `openai==2.37.0` (current lock) and `openai>=2.16.0` have the field and the plugin succeeds.
- [ ] CI green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)