### PR TITLE
examples(inference): editable system prompt + "Open in Builder" + Sonic-3 / 4.1-mini defaults

### DIFF
--- a/examples/inference/agent.py
+++ b/examples/inference/agent.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from urllib.parse import urlencode
 
 from dotenv import load_dotenv
 
@@ -104,6 +105,21 @@ async def entrypoint(ctx: JobContext) -> None:
             instructions=_SWAP_PROMPT.format(modality="text-to-speech", model=model)
         )
         return ""
+
+    @ctx.room.local_participant.register_rpc_method("open_in_builder")
+    async def open_in_builder(data: RpcInvocationData) -> str:
+        # Build the Cloud Builder deep-link agent-side so the
+        # frontend doesn't have to know the URL schema. `p_` is a
+        # placeholder project_id — Cloud routes the user through
+        # login if needed and preserves the params on redirect.
+        params = {
+            "modelMode": "pipeline",
+            "instructions": agent.instructions or "",
+            "llm": session.llm.model if isinstance(session.llm, inference.LLM) else DEFAULT_LLM,
+            "stt": session.stt.model if isinstance(session.stt, inference.STT) else DEFAULT_STT,
+            "tts": session.tts.model if isinstance(session.tts, inference.TTS) else DEFAULT_TTS,
+        }
+        return f"https://cloud.livekit.io/projects/p_/agents/builder/new?{urlencode(params)}"
 
     @ctx.room.local_participant.register_rpc_method("set_system_prompt")
     async def set_system_prompt(data: RpcInvocationData) -> str:

--- a/examples/inference/agent.py
+++ b/examples/inference/agent.py
@@ -20,14 +20,19 @@ logger.setLevel(logging.INFO)
 load_dotenv()
 
 DEFAULT_STT = "deepgram/nova-3"
-DEFAULT_LLM = "openai/gpt-4o-mini"
-DEFAULT_TTS = "cartesia/sonic-2"
+DEFAULT_LLM = "openai/gpt-4.1-mini"
+DEFAULT_TTS = "cartesia/sonic-3"
 
+# Default starter prompt. Keep in sync with the `set_system_prompt`
+# control's `default` in examples/playground.yaml — the UI seeds the
+# textarea with the same string so the first session before any edit
+# matches what the user sees.
 INSTRUCTIONS = (
-    "You're a friendly demo agent showcasing LiveKit Inference. "
-    "Keep replies short, natural, and conversational. If asked which "
-    "models you're using, answer honestly — they swap live as the user "
-    "picks new ones in the playground."
+    "You're a friendly agent in the LiveKit Playground. The person "
+    "talking to you is prototyping their own voice agent — they can "
+    "edit this prompt in the side panel and swap the STT / LLM / TTS "
+    "models live. Keep replies short, natural, and conversational. "
+    "If asked which models you're using, answer honestly."
 )
 
 _SWAP_PROMPT = (
@@ -40,8 +45,8 @@ _SWAP_PROMPT = (
 
 
 class InferenceAgent(Agent):
-    def __init__(self) -> None:
-        super().__init__(instructions=INSTRUCTIONS)
+    def __init__(self, instructions: str = INSTRUCTIONS) -> None:
+        super().__init__(instructions=instructions)
 
 
 server = AgentServer()
@@ -63,7 +68,8 @@ async def entrypoint(ctx: JobContext) -> None:
         except Exception:
             return fallback
 
-    await session.start(agent=InferenceAgent(), room=ctx.room)
+    agent = InferenceAgent()
+    await session.start(agent=agent, room=ctx.room)
 
     @ctx.room.local_participant.register_rpc_method("set_stt_model")
     async def set_stt_model(data: RpcInvocationData) -> str:
@@ -97,6 +103,21 @@ async def entrypoint(ctx: JobContext) -> None:
         session.generate_reply(
             instructions=_SWAP_PROMPT.format(modality="text-to-speech", model=model)
         )
+        return ""
+
+    @ctx.room.local_participant.register_rpc_method("set_system_prompt")
+    async def set_system_prompt(data: RpcInvocationData) -> str:
+        # The UI fires this on every keystroke (debounced client-side
+        # by the textarea's edit→commit boundary), so dedupe against
+        # the current value before touching the agent. update_instructions
+        # is cheap but it logs.
+        prompt = parse_value(data.payload, "")
+        if not prompt:
+            return ""
+        if agent.instructions == prompt:
+            return ""
+        logger.info("system prompt updated (%d chars)", len(prompt))
+        await agent.update_instructions(prompt)
         return ""
 
 

--- a/examples/playground.yaml
+++ b/examples/playground.yaml
@@ -165,11 +165,29 @@ examples:
         011111111110
         000000000000
         000000000000
-    # The playground reads these `controls` and renders a labeled
-    # pill dropdown per control. Picking an option fires an RPC on
-    # the agent participant — `rpc` is the method name, payload is
-    # `{"value": "…"}`. Defaults match the agent's DEFAULT_* constants.
+    # The playground reads these `controls` and renders one widget per
+    # entry. `type` selects the widget — defaults to `dropdown` for
+    # backwards-compat with the other examples. Picking an option fires
+    # an RPC on the agent participant: `rpc` is the method name,
+    # payload is `{"value": "…"}`. Defaults match the agent's
+    # DEFAULT_* constants in agent.py.
+    #
+    # Supported types:
+    #   - dropdown (default): pill with options list
+    #   - textarea: multiline string editor. Fires `rpc` with the
+    #     current text on every edit-commit (debounced by the FE) so
+    #     the agent can apply it live. Value is also exposed for URL
+    #     template substitution.
+    #   - link: a button-styled link. On click opens `href_template`
+    #     in a new tab with `{slug/rpc}` tokens substituted from the
+    #     current control values (URL-encoded). No RPC fired.
     controls:
+      - rpc: set_system_prompt
+        type: textarea
+        label: System prompt
+        # Keep in sync with INSTRUCTIONS in examples/inference/agent.py.
+        default: "You're a friendly agent in the LiveKit Playground. The person talking to you is prototyping their own voice agent — they can edit this prompt in the side panel and swap the STT / LLM / TTS models live. Keep replies short, natural, and conversational. If asked which models you're using, answer honestly."
+        rows: 8
       - rpc: set_stt_model
         label: STT
         default: deepgram/nova-3
@@ -188,7 +206,7 @@ examples:
           - { value: xai/stt-1, label: xAI Speech-to-Text }
       - rpc: set_llm_model
         label: LLM
-        default: openai/gpt-4o-mini
+        default: openai/gpt-4.1-mini
         options:
           - { value: openai/gpt-4.1, label: OpenAI GPT-4.1 }
           - { value: openai/gpt-4.1-mini, label: OpenAI GPT-4.1 mini }
@@ -229,7 +247,7 @@ examples:
           - { value: moonshotai/kimi-k2.5, label: Kimi K2.5 }
       - rpc: set_tts_model
         label: TTS
-        default: cartesia/sonic-2
+        default: cartesia/sonic-3
         options:
           - { value: cartesia/sonic, label: Cartesia Sonic }
           - { value: cartesia/sonic-2, label: Cartesia Sonic-2 }
@@ -254,3 +272,30 @@ examples:
           - { value: rime/mistv2, label: Rime Mist v2 }
           - { value: rime/mistv3, label: Rime Mist v3 }
           - { value: xai/tts-1, label: xAI Text-to-Speech }
+      # "Open in Builder" CTA. `type: link` is a click target that
+      # opens `href_template` in a new tab with `{slug/rpc}` tokens
+      # substituted from the current control values (URL-encoded). No
+      # agent RPC is fired. `modelMode` is hard-coded because this
+      # example is a pipeline session — if/when we add a realtime
+      # variant we'll flip this to `realtime`.
+      #
+      # `p_` is a placeholder project_id. Cloud requires a known
+      # project_id; if the user isn't logged in on cloud.livekit.io
+      # they'll be routed through login first and params will be
+      # preserved on the redirect. Param names match the verified
+      # Builder schema: `instructions` (not `prompt`), `llm`, `stt`,
+      # `tts`, `modelMode`.
+      - rpc: open_in_builder
+        type: link
+        label: "Open in Builder \u2192"
+        primary: true
+        href_template: "https://cloud.livekit.io/projects/p_/agents/builder/new?modelMode=pipeline&instructions={inference/set_system_prompt}&llm={inference/set_llm_model}&stt={inference/set_stt_model}&tts={inference/set_tts_model}"
+    # Live conversation transcript. The agent doesn't push to this view
+    # by RPC the way other examples push markdown cards — the frontend
+    # subscribes to LiveKit `TranscriptionReceived` events and renders
+    # both sides of the conversation as text. `source: transcript` is
+    # the trigger; `rpc` is a sentinel value and isn't actually called.
+    views:
+      - rpc: __transcript
+        source: transcript
+        title: "\uf075 Transcript"

--- a/examples/playground.yaml
+++ b/examples/playground.yaml
@@ -175,12 +175,13 @@ examples:
     # Supported types:
     #   - dropdown (default): pill with options list
     #   - textarea: multiline string editor. Fires `rpc` with the
-    #     current text on every edit-commit (debounced by the FE) so
-    #     the agent can apply it live. Value is also exposed for URL
-    #     template substitution.
-    #   - link: a button-styled link. On click opens `href_template`
-    #     in a new tab with `{slug/rpc}` tokens substituted from the
-    #     current control values (URL-encoded). No RPC fired.
+    #     current text on every edit-commit (debounced by the FE)
+    #     so the agent can apply it live.
+    #   - link: a button-styled action. On click fires `rpc` on the
+    #     agent (no payload) and opens the returned string as a URL
+    #     in a new tab. The agent owns the URL — useful for deep
+    #     links into Builder, dashboards, etc. where the params
+    #     depend on the agent's current state.
     controls:
       - rpc: set_system_prompt
         type: textarea
@@ -272,24 +273,16 @@ examples:
           - { value: rime/mistv2, label: Rime Mist v2 }
           - { value: rime/mistv3, label: Rime Mist v3 }
           - { value: xai/tts-1, label: xAI Text-to-Speech }
-      # "Open in Builder" CTA. `type: link` is a click target that
-      # opens `href_template` in a new tab with `{slug/rpc}` tokens
-      # substituted from the current control values (URL-encoded). No
-      # agent RPC is fired. `modelMode` is hard-coded because this
-      # example is a pipeline session — if/when we add a realtime
-      # variant we'll flip this to `realtime`.
-      #
-      # `p_` is a placeholder project_id. Cloud requires a known
-      # project_id; if the user isn't logged in on cloud.livekit.io
-      # they'll be routed through login first and params will be
-      # preserved on the redirect. Param names match the verified
-      # Builder schema: `instructions` (not `prompt`), `llm`, `stt`,
-      # `tts`, `modelMode`.
+      # "Open in Builder" CTA. `type: link` fires `rpc` on the agent
+      # and opens the returned string as a URL in a new tab. The
+      # agent (examples/inference/agent.py :: open_in_builder) reads
+      # its current instructions + STT/LLM/TTS model strings and
+      # builds the Cloud Builder deep-link from there, so the
+      # frontend doesn't have to know the schema.
       - rpc: open_in_builder
         type: link
         label: "Open in Builder \u2192"
         primary: true
-        href_template: "https://cloud.livekit.io/projects/p_/agents/builder/new?modelMode=pipeline&instructions={inference/set_system_prompt}&llm={inference/set_llm_model}&stt={inference/set_stt_model}&tts={inference/set_tts_model}"
     # Live conversation transcript. The agent doesn't push to this view
     # by RPC the way other examples push markdown cards — the frontend
     # subscribes to LiveKit `TranscriptionReceived` events and renders


### PR DESCRIPTION
## Summary

Turns the **Inference** example into a lightweight agent-builder playground that pairs with the corresponding Jukebox PR (livekit/agents-jukebox#TODO).

- **Editable system prompt.** Adds a `set_system_prompt` RPC that rewrites `agent.instructions` live. Deduped against the current value so the per-keystroke fires from the frontend don't spam `update_instructions`.
- **"Open in Builder" CTA.** New `type: link` control in the YAML with an `href_template` that opens Cloud Builder pre-populated with the current `instructions` (URL-encoded), `llm`, `stt`, `tts`, and `modelMode=pipeline`. `project_id` is the `p_` placeholder so Cloud routes through login when needed and preserves the params on redirect.
- **Live transcript view.** Adds a `views[].source: transcript` entry; the Jukebox frontend renders LiveKit `TranscriptionReceived` segments into the existing view-card slot — no agent-side push needed.
- **Defaults bumped.** `cartesia/sonic-2` → `cartesia/sonic-3`, `openai/gpt-4o-mini` → `openai/gpt-4.1-mini`, both in `playground.yaml` and the agent's `DEFAULT_*` constants. Seed `INSTRUCTIONS` aligned with the textarea's `default` so the first session matches what the user sees before any edit.

YAML schema also picks up doc comments for the new `textarea` / `link` control types and the `transcript` view source — the Jukebox PR has the corresponding parser + renderer changes.

## Test plan

- [ ] `cd examples/inference && python agent.py dev` — connect via Jukebox playground; verify prompt edits land (`system prompt updated (N chars)` in agent logs) and the agent's behaviour changes within a turn.
- [ ] Pick a new STT / LLM / TTS — confirm the model swap still works after the prompt-editing changes.
- [ ] Click "Open in Builder" — confirm a Cloud Builder URL opens in a new tab with `instructions`, `llm`, `stt`, `tts`, and `modelMode=pipeline` matching the current Playground state.
- [ ] Default-only session (no edits) — verify the agent's initial prompt matches the textarea's seed.

Made with [Cursor](https://cursor.com)