### PR TITLE
feat(openai stt): support gpt-realtime-whisper

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -33,11 +33,13 @@ from livekit.agents import (
     DEFAULT_API_CONNECT_OPTIONS,
     APIConnectionError,
     APIConnectOptions,
+    APIError,
     APIStatusError,
     APITimeoutError,
     LanguageCode,
     stt,
     utils,
+    vad,
 )
 from livekit.agents.types import (
     NOT_GIVEN,
@@ -60,6 +62,12 @@ _max_session_duration = 10 * 60
 _delta_transcript_interval = 0.5
 SAMPLE_RATE = 24000
 NUM_CHANNELS = 1
+
+
+def _is_whisper_realtime(model: str) -> bool:
+    # gpt-realtime-whisper rejects any turn_detection config; the client must
+    # commit the audio buffer manually (e.g. driven by an external VAD).
+    return model.startswith("gpt-realtime-whisper")
 
 
 @dataclass
@@ -86,6 +94,7 @@ class STT(stt.STT):
         api_key: NotGivenOr[str] = NOT_GIVEN,
         client: openai.AsyncClient | None = None,
         use_realtime: bool = False,
+        vad: NotGivenOr[vad.VAD | None] = NOT_GIVEN,
     ):
         """
         Create a new instance of OpenAI STT.
@@ -97,13 +106,37 @@ class STT(stt.STT):
             prompt: Optional text prompt to guide the transcription. Only supported for whisper-1.
             turn_detection: When using realtime transcription, this controls how model detects the user is done speaking.
                 Final transcripts are generated only after the turn is over. See: https://platform.openai.com/docs/guides/realtime-vad
+                Ignored for `gpt-realtime-whisper`, which does not support server-side turn detection.
             noise_reduction_type: Type of noise reduction to apply. "near_field" or "far_field"
                 This isn't needed when using LiveKit's noise cancellation.
             base_url: Custom base URL for OpenAI API.
             api_key: Your OpenAI API key. If not provided, will use the OPENAI_API_KEY environment variable.
             client: Optional pre-configured OpenAI AsyncClient instance.
             use_realtime: Whether to use the realtime transcription API. (default: False)
+            vad: Optional Voice Activity Detector used to commit the audio buffer when the model
+                does not support server-side turn detection (e.g. `gpt-realtime-whisper`).
+                When not provided and the model requires it, Silero VAD is auto-loaded with default
+                settings. Pass `vad=None` to opt out of the auto-load and drive
+                `input_audio_buffer.commit` yourself.
         """  # noqa: E501
+
+        whisper_realtime = use_realtime and _is_whisper_realtime(model)
+        if whisper_realtime:
+            if is_given(turn_detection):
+                logger.warning(
+                    "turn_detection is not supported for %s; ignoring the provided value", model
+                )
+                turn_detection = NOT_GIVEN
+            if not is_given(vad):
+                try:
+                    from livekit.plugins.silero import VAD as SileroVAD
+                except ImportError as e:
+                    raise ImportError(
+                        "livekit-plugins-silero is required for the gpt-realtime-whisper model "
+                        "(no server-side endpointing). Pass `vad=None` to opt out and drive "
+                        "`input_audio_buffer.commit` manually."
+                    ) from e
+                vad = SileroVAD.load()
 
         super().__init__(
             capabilities=stt.STTCapabilities(
@@ -130,6 +163,8 @@ class STT(stt.STT):
         )
         if is_given(noise_reduction_type):
             self._opts.noise_reduction_type = noise_reduction_type
+
+        self._vad = vad if is_given(vad) else None
 
         if is_given(api_key) and not api_key:
             raise ValueError(
@@ -188,6 +223,7 @@ class STT(stt.STT):
         base_url: str | None = None,
         use_realtime: bool = False,
         timeout: httpx.Timeout | None = None,
+        vad: NotGivenOr[vad.VAD | None] = NOT_GIVEN,
     ) -> STT:
         """
         Create a new instance of Azure OpenAI STT.
@@ -226,6 +262,7 @@ class STT(stt.STT):
             noise_reduction_type=noise_reduction_type,
             client=azure_client,
             use_realtime=use_realtime,
+            vad=vad,
         )
 
     @staticmethod
@@ -272,6 +309,7 @@ class STT(stt.STT):
             stt=self,
             pool=self._pool,
             conn_options=conn_options,
+            vad_instance=self._vad,
         )
         self._streams.add(stream)
         return stream
@@ -332,8 +370,11 @@ class STT(stt.STT):
                 "rate": SAMPLE_RATE,
             },
             "transcription": transcription_config,
-            "turn_detection": self._opts.turn_detection,
         }
+        # gpt-realtime-whisper rejects any turn_detection config — omit the key entirely.
+        # For other models, send the configured turn_detection (server-side VAD).
+        if not _is_whisper_realtime(self._opts.model):
+            input_config["turn_detection"] = self._opts.turn_detection
 
         if self._opts.noise_reduction_type:
             input_config["noise_reduction"] = {"type": self._opts.noise_reduction_type}
@@ -430,6 +471,7 @@ class SpeechStream(stt.SpeechStream):
         stt: STT,
         conn_options: APIConnectOptions,
         pool: utils.ConnectionPool[aiohttp.ClientWebSocketResponse],
+        vad_instance: vad.VAD | None = None,
     ) -> None:
         super().__init__(stt=stt, conn_options=conn_options, sample_rate=SAMPLE_RATE)
 
@@ -437,6 +479,7 @@ class SpeechStream(stt.SpeechStream):
         self._language = stt._opts.language
         self._request_id = ""
         self._reconnect_event = asyncio.Event()
+        self._vad = vad_instance
 
     def update_options(
         self,
@@ -452,7 +495,9 @@ class SpeechStream(stt.SpeechStream):
         closing_ws = False
 
         @utils.log_exceptions(logger=logger)
-        async def send_task(ws: aiohttp.ClientWebSocketResponse) -> None:
+        async def send_task(
+            ws: aiohttp.ClientWebSocketResponse, vad_stream: vad.VADStream | None
+        ) -> None:
             nonlocal closing_ws
 
             # forward audio to OAI in chunks of 50ms
@@ -465,6 +510,8 @@ class SpeechStream(stt.SpeechStream):
             async for data in self._input_ch:
                 frames: list[rtc.AudioFrame] = []
                 if isinstance(data, rtc.AudioFrame):
+                    if vad_stream is not None:
+                        vad_stream.push_frame(data)
                     frames.extend(audio_bstream.write(data.data.tobytes()))
                 elif isinstance(data, self._FlushSentinel):
                     frames.extend(audio_bstream.flush())
@@ -476,7 +523,15 @@ class SpeechStream(stt.SpeechStream):
                     }
                     await ws.send_json(encoded_frame)
 
+            if vad_stream is not None:
+                vad_stream.end_input()
             closing_ws = True
+
+        @utils.log_exceptions(logger=logger)
+        async def vad_task(ws: aiohttp.ClientWebSocketResponse, vad_stream: vad.VADStream) -> None:
+            async for ev in vad_stream:
+                if ev.type == vad.VADEventType.END_OF_SPEECH:
+                    await ws.send_json({"type": "input_audio_buffer.commit"})
 
         @utils.log_exceptions(logger=logger)
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
@@ -595,6 +650,13 @@ class SpeechStream(stt.SpeechStream):
                             self._pool.remove(ws)
                             self._reconnect_event.set()
                             return
+                    elif msg_type == "error":
+                        error_body = data.get("error", {})
+                        raise APIError(
+                            message=f"OpenAI Realtime STT error: {error_body.get('message', 'Unknown error')}",
+                            body=error_body,
+                            retryable=False,
+                        )
 
                 except Exception:
                     logger.exception("failed to process OpenAI message")
@@ -605,10 +667,13 @@ class SpeechStream(stt.SpeechStream):
                 self._report_connection_acquired(
                     self._pool.last_acquire_time, self._pool.last_connection_reused
                 )
+                vad_stream = self._vad.stream() if self._vad is not None else None
                 tasks = [
-                    asyncio.create_task(send_task(ws)),
+                    asyncio.create_task(send_task(ws, vad_stream)),
                     asyncio.create_task(recv_task(ws)),
                 ]
+                if vad_stream is not None:
+                    tasks.append(asyncio.create_task(vad_task(ws, vad_stream)))
                 tasks_group = asyncio.gather(*tasks)
                 wait_reconnect_task = asyncio.create_task(self._reconnect_event.wait())
                 try:
@@ -630,3 +695,5 @@ class SpeechStream(stt.SpeechStream):
                     await utils.aio.gracefully_cancel(*tasks, wait_reconnect_task)
                     tasks_group.cancel()
                     tasks_group.exception()  # retrieve the exception
+                    if vad_stream is not None:
+                        await vad_stream.aclose()

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -658,6 +658,8 @@ class SpeechStream(stt.SpeechStream):
                             retryable=False,
                         )
 
+                except APIError:
+                    raise
                 except Exception:
                     logger.exception("failed to process OpenAI message")
 


### PR DESCRIPTION
## Summary

OpenAI's new [`gpt-realtime-whisper`](https://developers.openai.com/api/docs/models/gpt-realtime-whisper) model does not support server-side turn detection — the API returns *"Turn detection is not supported for this transcription model"* if `turn_detection` is included in the session config. The client must drive `input_audio_buffer.commit` itself.

This PR makes `openai.STT(use_realtime=True, model="gpt-realtime-whisper")` work with a local VAD:

- New `vad: NotGivenOr[vad.VAD | None]` parameter on `STT` (and `STT.with_azure`). When the model needs it and `vad` is not provided, Silero VAD is auto-loaded; pass `vad=None` to opt out and drive commits yourself.
- `SpeechStream` pushes each audio frame into the VAD stream and sends `{"type": "input_audio_buffer.commit"}` on `VADEventType.END_OF_SPEECH`. VAD stream is opened/closed per realtime ws connection so it survives reconnects.

Same pattern already used by `livekit-plugins-mistralai` and `livekit-plugins-speechmatics` for models without server-side endpointing.

## Usage

```python
# auto-loads Silero VAD internally
stt = openai.STT(use_realtime=True, model="gpt-realtime-whisper")

# or share the session-level VAD to avoid loading Silero twice
stt = openai.STT(
    use_realtime=True,
    model="gpt-realtime-whisper",
    vad=ctx.proc.userdata["vad"],
)
```
