### PR TITLE
Update download-files deprecation message

### DIFF
--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -1958,7 +1958,7 @@ def _build_cli(server: AgentServer) -> typer.Typer:
         _configure_logger(c, logging.DEBUG)
 
         c.print(
-            "[yellow]Invoking the download-files command via your agent entrypoint is "
+            "[yellow]Invoking the download-files command via your agent script is "
             "deprecated as of 1.5.10. Run it directly against the livekit.agents module "
             "instead, e.g. `uv run -m livekit.agents download-files`.[/yellow]"
         )

--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -1958,13 +1958,14 @@ def _build_cli(server: AgentServer) -> typer.Typer:
         _configure_logger(c, logging.DEBUG)
 
         c.print(
-            "[yellow]`download-files` via the agent CLI is deprecated. "
-            "Use `python -m livekit.agents download-files` instead — it discovers installed "
-            "plugins without loading your agent code.[/yellow]"
+            "[yellow]Invoking the download-files command via your agent entrypoint is "
+            "deprecated as of 1.5.10. Run it directly against the livekit.agents module "
+            "instead, e.g. `uv run -m livekit.agents download-files`.[/yellow]"
         )
         warnings.warn(
-            "`download-files` via the agent CLI is deprecated. "
-            "Use `python -m livekit.agents download-files` instead.",
+            "Invoking the download-files command via your agent entrypoint is deprecated "
+            "as of 1.5.10. Run it directly against the livekit.agents module instead, "
+            "e.g. `uv run -m livekit.agents download-files`.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -1963,7 +1963,7 @@ def _build_cli(server: AgentServer) -> typer.Typer:
             "instead, e.g. `uv run -m livekit.agents download-files`.[/yellow]"
         )
         warnings.warn(
-            "Invoking the download-files command via your agent entrypoint is deprecated "
+            "Invoking the download-files command via your agent script is deprecated "
             "as of 1.5.10. Run it directly against the livekit.agents module instead, "
             "e.g. `uv run -m livekit.agents download-files`.",
             DeprecationWarning,


### PR DESCRIPTION
Updates the deprecation warning and console message for the `download-files` command when invoked via the agent CLI entrypoint.

## Changes

- Updated the deprecation message to be more specific about the version (1.5.10) when this deprecation was introduced
- Clarified the recommended approach: running the command directly against the `livekit.agents` module instead of through the agent entrypoint
- Updated example command from `python -m livekit.agents download-files` to `uv run -m livekit.agents download-files` to reflect current tooling recommendations
- Applied the same message updates to both the console output and the `DeprecationWarning`

## Rationale

The new messaging is clearer about the deprecation timeline and provides a more practical example using modern Python tooling (`uv`), making it easier for users to understand and adopt the recommended approach.

https://claude.ai/code/session_01Foiz3HektpTey3FaG841Yd