### PR TITLE
add new bulbul:v3 speaker voices

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -210,6 +210,12 @@ SarvamTTSSpeakers = Literal[
     # bulbul:v3-beta International
     "amelia",
     "sophia",
+    # bulbul:v3
+    "suhani",
+    "rupali",
+    "tanya",
+    "shruti",
+    "kavitha",
 ]
 
 # Model-Speaker compatibility mapping
@@ -290,6 +296,11 @@ MODEL_SPEAKER_COMPATIBILITY = {
             "roopa",
             "amelia",
             "sophia",
+            "suhani",
+            "rupali",
+            "tanya",
+            "shruti",
+            "kavitha",
         ],
         "male": [
             "shubh",
@@ -333,6 +344,11 @@ MODEL_SPEAKER_COMPATIBILITY = {
             "advait",
             "amelia",
             "sophia",
+            "suhani",
+            "rupali",
+            "tanya",
+            "shruti",
+            "kavitha",
         ],
     },
 }


### PR DESCRIPTION
Add five new female speaker voices exclusive to the `bulbul:v3` model:
`suhani`, `rupali`, `tanya`, `shruti`, and `kavitha`.

- Added to `SarvamTTSSpeakers` Literal type for type-safe usage
- Added to `MODEL_SPEAKER_COMPATIBILITY["bulbul:v3"]` female and all lists
Ref docs:-https://docs.sarvam.ai/api-reference-docs/api-guides-tutorials/text-to-speech/rest-api