### PR TITLE
A gemini_tts.py plugin patch for populating the input/output tokens.

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/gemini_tts.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/beta/gemini_tts.py
@@ -206,6 +206,13 @@ class ChunkedStream(tts.ChunkedStream):
                 config=config,
             )
 
+            # Capture Gemini text input token count and audio output token count for telemetry/cost tracking.
+            if response.usage_metadata:
+                self._set_token_usage(
+                    input_tokens=response.usage_metadata.prompt_token_count or 0,
+                    output_tokens=response.usage_metadata.candidates_token_count or 0,
+                )
+
             output_emitter.initialize(
                 request_id=utils.shortuuid(),
                 sample_rate=self._tts.sample_rate,


### PR DESCRIPTION
The current version of the GeminiTTS plugin is not populating the input and output tokens from the usage_metadata of the response, for tts models which use token based calculation. This fix solves the issue by getting the token count from response.usage_metadata.prompt_token_count and candidates_token_count where Gemini API surfaces them.