### PR TITLE
fix(interruption): incorrect guard skips true interruptions

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -1059,8 +1059,10 @@ class AudioRecognition:
                 self._session.amd._on_user_speech_ended(ev.silence_duration)
 
     async def _on_overlap_speech_event(self, ev: inference.OverlappingSpeechEvent) -> None:
-        if self.backchannel_boundary_active:
-            logger.trace("ignoring overlap speech event during backchannel boundary cooldown")
+        if self.backchannel_boundary_active and not ev.is_interruption:
+            logger.trace(
+                "ignoring backchannel event during backchannel boundary cooldown, falling back to vad"
+            )
             return
 
         if ev.is_interruption:

--- a/livekit-agents/livekit/agents/voice/turn.py
+++ b/livekit-agents/livekit/agents/voice/turn.py
@@ -106,11 +106,12 @@ class InterruptionOptions(TypedDict, total=False):
     """Seconds of silence after an interruption before it is
     classified as false. ``None`` disables. Defaults to ``2.0``."""
     backchannel_boundary: float | tuple[float, float] | None
-    """Seconds to suppress adaptive interruption handling when the agent
-    starts or stops speaking each turn to allow for easier turn correction.
-    Use tuple to apply different values for start and end separately.
-    ``None`` disables. Defaults to ``(1.0, 3.5)``. End value should be higher
-    to account for STT transcript timestamp inaccuracy."""
+    """Seconds near the start/end of each agent turn during which overlapping
+    speech classified as a backchannel by the adaptive detector is suppressed
+    (events flagged as interruptions still pass through). Use a tuple to apply
+    different values for start and end separately. ``None`` disables. Defaults
+    to ``(1.0, 3.5)``. End value should be higher to account for STT transcript
+    timestamp inaccuracy."""
 
 
 _INTERRUPTION_DEFAULTS: InterruptionOptions = {

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -719,7 +719,7 @@ async def test_start_boundary_does_not_block_vad_interruption() -> None:
     check_timestamp(speaking_to_listening.created_at - t_origin, 4.5, speed_factor=speed)
 
 
-async def test_backchannel_boundary_suppresses_start_boundary_interruption() -> None:
+async def test_backchannel_boundary_suppresses_start_boundary_backchannel() -> None:
     actions = FakeActions()
     session = create_session(
         actions,
@@ -738,14 +738,20 @@ async def test_backchannel_boundary_suppresses_start_boundary_interruption() -> 
 
     try:
         recognition.on_start_of_agent_speech(started_at=time.time())
-        await recognition._on_overlap_speech_event(_interruption_event())
-
+        # backchannels during the cooldown are dropped (they are a no-op anyway,
+        # but this guards against the gate firing on `on_interruption`)
+        await recognition._on_overlap_speech_event(_backchannel_event())
         assert hooks.interruptions == []
 
-        await asyncio.sleep(0.06)
+        # a real interruption during the cooldown must still fire
         await recognition._on_overlap_speech_event(_interruption_event())
-
         assert len(hooks.interruptions) == 1
+
+        # after cooldown, both event types behave normally
+        await asyncio.sleep(0.06)
+        await recognition._on_overlap_speech_event(_backchannel_event())
+        await recognition._on_overlap_speech_event(_interruption_event())
+        assert len(hooks.interruptions) == 2
     finally:
         await _close_test_session(session)
 
@@ -1116,6 +1122,15 @@ def _interruption_event() -> inference.OverlappingSpeechEvent:
     return inference.OverlappingSpeechEvent(
         type="overlapping_speech",
         is_interruption=True,
+        overlap_started_at=time.time(),
+        detected_at=time.time(),
+    )
+
+
+def _backchannel_event() -> inference.OverlappingSpeechEvent:
+    return inference.OverlappingSpeechEvent(
+        type="overlapping_speech",
+        is_interruption=False,
         overlap_started_at=time.time(),
         detected_at=time.time(),
     )

--- a/uv.lock
+++ b/uv.lock
@@ -2362,6 +2362,7 @@ dependencies = [
     { name = "livekit-agents", extra = ["codecs", "openai"] },
     { name = "msgpack" },
     { name = "msgpack-types" },
+    { name = "openai" },
 ]
 
 [package.metadata]
@@ -2369,6 +2370,7 @@ requires-dist = [
     { name = "livekit-agents", extras = ["codecs", "openai"], editable = "livekit-agents" },
     { name = "msgpack", specifier = ">=1.0" },
     { name = "msgpack-types", specifier = ">=0.7.0" },
+    { name = "openai", specifier = ">=2.16.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Interruptions should always come through, previously vad might not have enough time to trigger an interruption while interruption from barge-in model is ignored. 


This closes AGT-2912.