### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,3 +98,23 @@ STT, TTS, LLM, Realtime models have provider-agnostic interfaces with:
 - Google-style docstrings
 - Strict mypy type checking enabled
 - Use `make check` and `make fix` before committing
+
+## Cursor Cloud specific instructions
+
+This workspace at `/agent/repos/` contains multiple LiveKit repositories. The update script handles dependency installation; these notes cover non-obvious runtime caveats.
+
+### PATH requirement
+
+Commands in Python repos need uv on PATH, Go repos need go 1.24+ and mage:
+```bash
+export PATH="$HOME/.local/bin:$HOME/go/bin:/usr/local/go/bin:$PATH"
+```
+
+### Key gotchas
+
+- **Docker unavailable**: `tests/test_room.py` requires Docker. Use `make unit-tests` (defined in the root Makefile) which runs the full offline test suite excluding Docker-dependent tests.
+- **python-sdks FFI**: After syncing deps, download the native FFI binary: `cd /agent/repos/python-sdks && uv run python livekit-rtc/rust-sdks/download_ffi.py --platform linux --arch x86_64 --output livekit-rtc/livekit/rtc/resources`
+- **web submodules**: `backend-common` is a private repo. Init only the accessible ones: `git submodule update --init submodules/cloud-protocol submodules/opentelemetry-proto submodules/protocol submodules/psrpc`
+- **web turbo**: Use `pnpm exec turbo` (not bare `turbo`) — it's a devDependency.
+- **agents-js**: Must `pnpm build` after install before running tests (TypeScript must compile).
+- **Go toolchain**: Protocol repos declare `go 1.26`; set `GOTOOLCHAIN=auto` to let it download automatically.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to AGENTS.md with non-obvious caveats discovered during environment setup in Cursor Cloud VMs:

- PATH requirements for uv, Go, and mage
- Docker unavailability workaround (use `make unit-tests`)
- python-sdks FFI download command
- Web repo private submodule workaround
- turbo usage note (`pnpm exec turbo`)
- agents-js build-before-test requirement
- Go toolchain auto-download note

These instructions help future Cloud Agents set up and verify the development environment without hitting known gotchas.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2c37a1a-d22a-415a-903b-da160a9fcfec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2c37a1a-d22a-415a-903b-da160a9fcfec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

