### PR TITLE
fix(voice): race between flush and clear_buffer on interrupt leaks unplayed transcript

### DIFF
--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -407,6 +407,7 @@ async def _audio_forwarding_task(
 ) -> None:
     resampler: rtc.AudioResampler | None = None
 
+    cancelled = False
     try:
         audio_output.resume()
 
@@ -437,6 +438,9 @@ async def _audio_forwarding_task(
             for frame in resampler.flush():
                 await audio_output.capture_frame(frame)
 
+    except asyncio.CancelledError:
+        cancelled = True
+        raise
     finally:
         if isinstance(tts_output, _ACloseable):
             try:
@@ -445,6 +449,8 @@ async def _audio_forwarding_task(
                 logger.error("error while closing tts output", exc_info=e)
 
         audio_output.flush()
+        if cancelled:
+            audio_output.clear_buffer()
 
 
 @dataclass

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -153,7 +153,7 @@ class _ParticipantAudioOutput(io.AudioOutput):
             return_when=asyncio.FIRST_COMPLETED,
         )
 
-        interrupted = wait_for_interruption.done()
+        interrupted = self._interrupted_event.is_set()
         pushed_duration = self._pushed_duration
 
         if interrupted:


### PR DESCRIPTION
## Summary

- When a speech was interrupted right around playout, the full reply text could leak into the chat context. The cancelled `_audio_forwarding_task` called `flush()` in its finally block, which let the tiny in-flight audio drain naturally and report `interrupted=False` before `agent_activity`'s `clear_buffer()` could mark it interrupted. The synchronizer then treated playback as completed and returned the full pushed text as the synchronized transcript.
- Call `clear_buffer()` from the cancelled task's finally so the interrupt signal lands before any natural completion event fires.
