### PR TITLE
feat(vad): bundle optimized silero vad and deprecate the plugin

### DIFF
--- a/examples/avatar_agents/audio_wave/agent_worker.py
+++ b/examples/avatar_agents/audio_wave/agent_worker.py
@@ -18,7 +18,6 @@ from livekit.agents import (
 from livekit.agents.voice.avatar import DataStreamAudioOutput
 from livekit.agents.voice.io import PlaybackFinishedEvent, PlaybackStartedEvent
 from livekit.agents.voice.room_io import ATTRIBUTE_PUBLISH_ON_BEHALF
-from livekit.plugins import silero
 
 load_dotenv()
 
@@ -75,7 +74,7 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("google/gemini-2.5-flash"),
         tts=inference.TTS("cartesia/sonic-3"),
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         resume_false_interruption=False,
     )
 

--- a/examples/avatar_agents/audio_wave/agent_worker.py
+++ b/examples/avatar_agents/audio_wave/agent_worker.py
@@ -74,7 +74,6 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("google/gemini-2.5-flash"),
         tts=inference.TTS("cartesia/sonic-3"),
-        vad=inference.VAD(model="silero"),
         resume_false_interruption=False,
     )
 

--- a/examples/avatar_agents/keyframe/agent_worker.py
+++ b/examples/avatar_agents/keyframe/agent_worker.py
@@ -51,7 +51,6 @@ async def entrypoint(ctx: JobContext):
         llm=inference.LLM("google/gemini-2.5-flash"),
         tts=inference.TTS("cartesia/sonic-3"),
         resume_false_interruption=False,
-        vad=inference.VAD(model="silero"),
         turn_detection=AudioTurnDetector(),
     )
 

--- a/examples/avatar_agents/keyframe/agent_worker.py
+++ b/examples/avatar_agents/keyframe/agent_worker.py
@@ -15,7 +15,7 @@ from livekit.agents import (
     inference,
 )
 from livekit.agents.inference import AudioTurnDetector
-from livekit.plugins import keyframe, silero
+from livekit.plugins import keyframe
 from livekit.plugins.keyframe import Emotion
 
 load_dotenv()
@@ -51,7 +51,7 @@ async def entrypoint(ctx: JobContext):
         llm=inference.LLM("google/gemini-2.5-flash"),
         tts=inference.TTS("cartesia/sonic-3"),
         resume_false_interruption=False,
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         turn_detection=AudioTurnDetector(),
     )
 

--- a/examples/drive-thru/agent.py
+++ b/examples/drive-thru/agent.py
@@ -487,7 +487,6 @@ async def drive_thru_agent(ctx: JobContext) -> None:
         llm=inference.LLM("openai/gpt-5-mini"),
         tts=inference.TTS("cartesia/sonic-3", voice="f786b574-daa5-4673-aa0c-cbe3e8534c02"),
         turn_detection=AudioTurnDetector(),
-        vad=inference.VAD(model="silero"),
         max_tool_steps=10,
     )
 

--- a/examples/drive-thru/agent.py
+++ b/examples/drive-thru/agent.py
@@ -35,7 +35,6 @@ from livekit.agents import (
     inference,
 )
 from livekit.agents.inference import AudioTurnDetector
-from livekit.plugins import silero
 
 load_dotenv()
 
@@ -488,7 +487,7 @@ async def drive_thru_agent(ctx: JobContext) -> None:
         llm=inference.LLM("openai/gpt-5-mini"),
         tts=inference.TTS("cartesia/sonic-3", voice="f786b574-daa5-4673-aa0c-cbe3e8534c02"),
         turn_detection=AudioTurnDetector(),
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         max_tool_steps=10,
     )
 

--- a/examples/frontdesk/agent.py
+++ b/examples/frontdesk/agent.py
@@ -266,7 +266,6 @@ async def frontdesk_agent(ctx: JobContext):
         llm=inference.LLM("google/gemini-2.5-flash"),
         tts=inference.TTS("cartesia/sonic-3", voice="39b376fc-488e-4d0c-8b37-e00b72059fdd"),
         turn_detection=AudioTurnDetector(),
-        vad=inference.VAD(model="silero"),
         max_tool_steps=1,
     )
 

--- a/examples/frontdesk/agent.py
+++ b/examples/frontdesk/agent.py
@@ -39,7 +39,6 @@ from livekit.agents.evals import (
     tool_use_judge,
 )
 from livekit.agents.inference import AudioTurnDetector
-from livekit.plugins import silero
 
 load_dotenv()
 
@@ -267,7 +266,7 @@ async def frontdesk_agent(ctx: JobContext):
         llm=inference.LLM("google/gemini-2.5-flash"),
         tts=inference.TTS("cartesia/sonic-3", voice="39b376fc-488e-4d0c-8b37-e00b72059fdd"),
         turn_detection=AudioTurnDetector(),
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         max_tool_steps=1,
     )
 

--- a/examples/healthcare/agent.py
+++ b/examples/healthcare/agent.py
@@ -32,7 +32,6 @@ from livekit.agents.beta.workflows import (
     WarmTransferTask,
 )
 from livekit.agents.llm import ToolError, function_tool
-from livekit.plugins import silero
 
 logger = logging.getLogger("HealthcareAgent")
 
@@ -754,7 +753,7 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3", language="multi"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("inworld/inworld-tts-1"),
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         preemptive_generation=True,
     )
 

--- a/examples/healthcare/agent.py
+++ b/examples/healthcare/agent.py
@@ -753,7 +753,6 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3", language="multi"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("inworld/inworld-tts-1"),
-        vad=inference.VAD(model="silero"),
         preemptive_generation=True,
     )
 

--- a/examples/inference/agent.py
+++ b/examples/inference/agent.py
@@ -58,7 +58,6 @@ async def entrypoint(ctx: JobContext) -> None:
         stt=inference.STT(model=DEFAULT_STT),
         llm=inference.LLM(model=DEFAULT_LLM),
         tts=inference.TTS(model=DEFAULT_TTS),
-        vad=inference.VAD(model="silero"),
     )
 
     def parse_value(payload: str, fallback: str) -> str:

--- a/examples/inference/agent.py
+++ b/examples/inference/agent.py
@@ -12,7 +12,6 @@ from livekit.agents import (
     cli,
     inference,
 )
-from livekit.plugins import silero
 from livekit.rtc import RpcInvocationData
 
 logger = logging.getLogger("inference")
@@ -59,7 +58,7 @@ async def entrypoint(ctx: JobContext) -> None:
         stt=inference.STT(model=DEFAULT_STT),
         llm=inference.LLM(model=DEFAULT_LLM),
         tts=inference.TTS(model=DEFAULT_TTS),
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
     )
 
     def parse_value(payload: str, fallback: str) -> str:

--- a/examples/other/elevenlab_scribe_v2.py
+++ b/examples/other/elevenlab_scribe_v2.py
@@ -2,8 +2,8 @@ import logging
 
 from dotenv import load_dotenv
 
-from livekit.agents import Agent, AgentServer, AgentSession, JobContext, JobProcess, cli, inference
-from livekit.plugins import elevenlabs, silero
+from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli, inference
+from livekit.plugins import elevenlabs
 
 logger = logging.getLogger("realtime-scribe-v2")
 logger.setLevel(logging.INFO)
@@ -12,13 +12,6 @@ load_dotenv()
 
 
 server = AgentServer()
-
-
-def prewarm(proc: JobProcess) -> None:
-    proc.userdata["vad"] = silero.VAD.load()
-
-
-server.setup_fnc = prewarm
 
 
 @server.rtc_session()
@@ -37,7 +30,7 @@ async def entrypoint(ctx: JobContext) -> None:
 
     session: AgentSession = AgentSession(
         allow_interruptions=True,
-        vad=ctx.proc.userdata["vad"],
+        vad=inference.VAD(model="silero"),
         stt=stt,
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/other/elevenlab_scribe_v2.py
+++ b/examples/other/elevenlab_scribe_v2.py
@@ -30,7 +30,6 @@ async def entrypoint(ctx: JobContext) -> None:
 
     session: AgentSession = AgentSession(
         allow_interruptions=True,
-        vad=inference.VAD(model="silero"),
         stt=stt,
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/other/kokoro_tts.py
+++ b/examples/other/kokoro_tts.py
@@ -2,9 +2,17 @@ import logging
 
 from dotenv import load_dotenv
 
-from livekit.agents import Agent, AgentServer, AgentSession, JobContext, JobProcess, cli, metrics
+from livekit.agents import (
+    Agent,
+    AgentServer,
+    AgentSession,
+    JobContext,
+    cli,
+    inference,
+    metrics,
+)
 from livekit.agents.voice import MetricsCollectedEvent
-from livekit.plugins import deepgram, openai, silero
+from livekit.plugins import deepgram, openai
 
 logger = logging.getLogger("kokoro-tts-agent")
 
@@ -27,13 +35,6 @@ class MyAgent(Agent):
 server = AgentServer()
 
 
-def prewarm(proc: JobProcess):
-    proc.userdata["vad"] = silero.VAD.load()
-
-
-server.setup_fnc = prewarm
-
-
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     # each log entry will include these fields
@@ -42,7 +43,7 @@ async def entrypoint(ctx: JobContext):
         "user_id": "your user_id",
     }
     session = AgentSession(
-        vad=ctx.proc.userdata["vad"],
+        vad=inference.VAD(model="silero"),
         # any combination of STT, LLM, TTS, or realtime API can be used
         llm=openai.LLM(model="gpt-4.1-mini"),
         stt=deepgram.STT(model="nova-3", language="multi"),

--- a/examples/other/kokoro_tts.py
+++ b/examples/other/kokoro_tts.py
@@ -8,7 +8,6 @@ from livekit.agents import (
     AgentSession,
     JobContext,
     cli,
-    inference,
     metrics,
 )
 from livekit.agents.voice import MetricsCollectedEvent
@@ -43,7 +42,6 @@ async def entrypoint(ctx: JobContext):
         "user_id": "your user_id",
     }
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         # any combination of STT, LLM, TTS, or realtime API can be used
         llm=openai.LLM(model="gpt-4.1-mini"),
         stt=deepgram.STT(model="nova-3", language="multi"),

--- a/examples/other/transcription/multi-user-transcriber.py
+++ b/examples/other/transcription/multi-user-transcriber.py
@@ -89,9 +89,7 @@ class MultiUserTranscriber:
         if participant.identity in self._sessions:
             return self._sessions[participant.identity]
 
-        session = AgentSession(
-            vad=inference.VAD(model="silero"),
-        )
+        session = AgentSession()
         await session.start(
             agent=Transcriber(
                 participant_identity=participant.identity,

--- a/examples/other/transcription/multi-user-transcriber.py
+++ b/examples/other/transcription/multi-user-transcriber.py
@@ -10,7 +10,6 @@ from livekit.agents import (
     AgentSession,
     AutoSubscribe,
     JobContext,
-    JobProcess,
     StopResponse,
     cli,
     inference,
@@ -18,7 +17,6 @@ from livekit.agents import (
     room_io,
     utils,
 )
-from livekit.plugins import silero
 
 load_dotenv()
 
@@ -92,7 +90,7 @@ class MultiUserTranscriber:
             return self._sessions[participant.identity]
 
         session = AgentSession(
-            vad=self.ctx.proc.userdata["vad"],
+            vad=inference.VAD(model="silero"),
         )
         await session.start(
             agent=Transcriber(
@@ -135,12 +133,6 @@ async def entrypoint(ctx: JobContext):
 
     ctx.add_shutdown_callback(cleanup)
 
-
-def prewarm(proc: JobProcess):
-    proc.userdata["vad"] = silero.VAD.load()
-
-
-server.setup_fnc = prewarm
 
 if __name__ == "__main__":
     cli.run_app(server)

--- a/examples/other/transcription/transcriber.py
+++ b/examples/other/transcription/transcriber.py
@@ -11,11 +11,12 @@ from livekit.agents import (
     MetricsCollectedEvent,
     StopResponse,
     cli,
+    inference,
     llm,
     metrics,
     room_io,
 )
-from livekit.plugins import openai, silero
+from livekit.plugins import openai
 
 load_dotenv()
 
@@ -50,7 +51,7 @@ async def entrypoint(ctx: JobContext):
 
     session = AgentSession(
         # vad is needed for non-streaming STT implementations
-        vad=silero.VAD.load(min_silence_duration=0.3),
+        vad=inference.VAD(model="silero", min_silence_duration=0.3),
     )
 
     @session.on("metrics_collected")

--- a/examples/other/transcription/translator.py
+++ b/examples/other/transcription/translator.py
@@ -12,12 +12,13 @@ from livekit.agents import (
     MetricsCollectedEvent,
     StopResponse,
     cli,
+    inference,
     llm,
     metrics,
     room_io,
     utils,
 )
-from livekit.plugins import openai, silero
+from livekit.plugins import openai
 
 load_dotenv()
 
@@ -76,7 +77,7 @@ async def entrypoint(ctx: JobContext):
 
     session = AgentSession(
         # vad is only needed for non-streaming STT implementations
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
     )
 
     @session.on("metrics_collected")

--- a/examples/other/transcription/translator.py
+++ b/examples/other/transcription/translator.py
@@ -12,7 +12,6 @@ from livekit.agents import (
     MetricsCollectedEvent,
     StopResponse,
     cli,
-    inference,
     llm,
     metrics,
     room_io,
@@ -77,7 +76,6 @@ async def entrypoint(ctx: JobContext):
 
     session = AgentSession(
         # vad is only needed for non-streaming STT implementations
-        vad=inference.VAD(model="silero"),
     )
 
     @session.on("metrics_collected")

--- a/examples/primitives/echo-agent.py
+++ b/examples/primitives/echo-agent.py
@@ -9,9 +9,9 @@ from livekit.agents import (
     AutoSubscribe,
     JobContext,
     cli,
+    inference,
 )
 from livekit.agents.vad import VADEventType
-from livekit.plugins import silero
 
 load_dotenv()
 logger = logging.getLogger("echo-agent")
@@ -35,7 +35,8 @@ async def entrypoint(ctx: JobContext):
         participant=participant,
         track_source=rtc.TrackSource.SOURCE_MICROPHONE,
     )
-    vad = silero.VAD.load(
+    vad = inference.VAD(
+        model="silero",
         min_speech_duration=0.2,
         min_silence_duration=0.6,
     )

--- a/examples/survey/agent.py
+++ b/examples/survey/agent.py
@@ -353,7 +353,6 @@ async def entrypoint(ctx: JobContext):
         llm=inference.LLM("google/gemini-2.5-flash"),
         stt=inference.STT("deepgram/nova-3", language="multi"),
         tts=inference.TTS("inworld/inworld-tts-1"),
-        vad=inference.VAD(model="silero"),
         turn_detection=AudioTurnDetector(),
         preemptive_generation=True,
     )

--- a/examples/survey/agent.py
+++ b/examples/survey/agent.py
@@ -22,7 +22,6 @@ from livekit.agents import (
 from livekit.agents.beta.workflows import GetEmailTask, TaskGroup
 from livekit.agents.inference import AudioTurnDetector
 from livekit.agents.llm import function_tool
-from livekit.plugins import silero
 
 logger = logging.getLogger("SurveyAgent")
 
@@ -354,7 +353,7 @@ async def entrypoint(ctx: JobContext):
         llm=inference.LLM("google/gemini-2.5-flash"),
         stt=inference.STT("deepgram/nova-3", language="multi"),
         tts=inference.TTS("inworld/inworld-tts-1"),
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         turn_detection=AudioTurnDetector(),
         preemptive_generation=True,
     )

--- a/examples/telephony/amd.py
+++ b/examples/telephony/amd.py
@@ -46,7 +46,6 @@ async def entrypoint(ctx: JobContext):
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3", voice="9626c31c-bec5-4cca-baa8-f8ba9e84c8bc"),
         turn_detection=AudioTurnDetector(),
-        vad=inference.VAD(model="silero"),
         preemptive_generation=True,
     )
 

--- a/examples/telephony/amd.py
+++ b/examples/telephony/amd.py
@@ -11,12 +11,10 @@ from livekit.agents import (
     AgentServer,
     AgentSession,
     JobContext,
-    JobProcess,
     cli,
     inference,
 )
 from livekit.agents.inference import AudioTurnDetector
-from livekit.plugins import silero
 
 logger = logging.getLogger("basic-agent")
 
@@ -38,13 +36,6 @@ class MyAgent(Agent):
 server = AgentServer()
 
 
-def prewarm(proc: JobProcess):
-    proc.userdata["vad"] = silero.VAD.load()
-
-
-server.setup_fnc = prewarm
-
-
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     ctx.log_context_fields = {
@@ -55,7 +46,7 @@ async def entrypoint(ctx: JobContext):
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3", voice="9626c31c-bec5-4cca-baa8-f8ba9e84c8bc"),
         turn_detection=AudioTurnDetector(),
-        vad=ctx.proc.userdata["vad"],
+        vad=inference.VAD(model="silero"),
         preemptive_generation=True,
     )
 

--- a/examples/telephony/bank-ivr/ivr_navigator_agent.py
+++ b/examples/telephony/bank-ivr/ivr_navigator_agent.py
@@ -82,7 +82,6 @@ async def dtmf_session(ctx: JobContext) -> None:
     }
 
     session: AgentSession = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("rime/arcana"),

--- a/examples/telephony/bank-ivr/ivr_navigator_agent.py
+++ b/examples/telephony/bank-ivr/ivr_navigator_agent.py
@@ -9,7 +9,6 @@ from livekit.agents import (
     AgentServer,
     AgentSession,
     JobContext,
-    JobProcess,
     MetricsCollectedEvent,
     RunContext,
     cli,
@@ -17,7 +16,6 @@ from livekit.agents import (
     metrics,
 )
 from livekit.agents.llm.tool_context import function_tool
-from livekit.plugins import silero
 
 logger = logging.getLogger("phone-tree-agent")
 
@@ -76,13 +74,6 @@ class DtmfAgent(Agent):
         context.session.shutdown(drain=True)
 
 
-def prewarm(proc: JobProcess) -> None:
-    proc.userdata["vad"] = silero.VAD.load()
-
-
-server.setup_fnc = prewarm
-
-
 @server.rtc_session(agent_name=PHONE_TREE_AGENT_DISPATCH_NAME)
 async def dtmf_session(ctx: JobContext) -> None:
     await ctx.connect()
@@ -91,7 +82,7 @@ async def dtmf_session(ctx: JobContext) -> None:
     }
 
     session: AgentSession = AgentSession(
-        vad=ctx.proc.userdata["vad"],
+        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("rime/arcana"),

--- a/examples/telephony/bank-ivr/ivr_system_agent.py
+++ b/examples/telephony/bank-ivr/ivr_system_agent.py
@@ -22,7 +22,6 @@ from livekit.agents import (
     AgentSession,
     AgentTask,
     JobContext,
-    JobProcess,
     MetricsCollectedEvent,
     cli,
     inference,
@@ -31,7 +30,6 @@ from livekit.agents import (
 from livekit.agents.beta.workflows.dtmf_inputs import GetDtmfTask
 from livekit.agents.inference import AudioTurnDetector
 from livekit.agents.llm.tool_context import ToolError
-from livekit.plugins import silero
 
 load_dotenv()
 
@@ -624,13 +622,6 @@ class RewardsTask(BaseBankTask):
 SubmenuTaskType = DepositAccountsTask | CreditCardsTask | LoansTask | RewardsTask
 
 
-def prewarm(proc: JobProcess) -> None:
-    proc.userdata["vad"] = silero.VAD.load()
-
-
-server.setup_fnc = prewarm
-
-
 @server.rtc_session(agent_name=BANK_IVR_DISPATCH_NAME)
 async def bank_ivr_session(ctx: JobContext) -> None:
     ctx.log_context_fields = {"room": ctx.room.name}
@@ -639,7 +630,7 @@ async def bank_ivr_session(ctx: JobContext) -> None:
     state = SessionState()
 
     session: AgentSession[SessionState] = AgentSession(
-        vad=ctx.proc.userdata["vad"],
+        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/telephony/bank-ivr/ivr_system_agent.py
+++ b/examples/telephony/bank-ivr/ivr_system_agent.py
@@ -630,7 +630,6 @@ async def bank_ivr_session(ctx: JobContext) -> None:
     state = SessionState()
 
     session: AgentSession[SessionState] = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/telephony/basic_dtmf_agent.py
+++ b/examples/telephony/basic_dtmf_agent.py
@@ -19,7 +19,6 @@ from livekit.agents.inference import AudioTurnDetector
 from livekit.agents.llm.tool_context import ToolError, function_tool
 from livekit.agents.voice.events import RunContext
 from livekit.agents.worker import AgentServer
-from livekit.plugins import silero
 
 logger = logging.getLogger("dtmf-agent")
 
@@ -136,7 +135,7 @@ async def entrypoint(ctx: JobContext) -> None:
     }
 
     session: AgentSession = AgentSession(
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("inworld/inworld-tts-1"),

--- a/examples/telephony/basic_dtmf_agent.py
+++ b/examples/telephony/basic_dtmf_agent.py
@@ -135,7 +135,6 @@ async def entrypoint(ctx: JobContext) -> None:
     }
 
     session: AgentSession = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("inworld/inworld-tts-1"),

--- a/examples/voice_agents/annotated_tool_args.py
+++ b/examples/voice_agents/annotated_tool_args.py
@@ -8,7 +8,6 @@ from pydantic import Field  # noqa: F401
 
 from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli, inference
 from livekit.agents.llm import function_tool
-from livekit.plugins import silero
 
 logger = logging.getLogger("annotated-tool-args")
 logger.setLevel(logging.INFO)
@@ -92,7 +91,7 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     agent = AgentSession(
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("google/gemini-2.5-flash"),
         tts=inference.TTS("rime/arcana"),

--- a/examples/voice_agents/annotated_tool_args.py
+++ b/examples/voice_agents/annotated_tool_args.py
@@ -91,7 +91,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     agent = AgentSession(
-        vad=inference.VAD(model="silero"),
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("google/gemini-2.5-flash"),
         tts=inference.TTS("rime/arcana"),

--- a/examples/voice_agents/async_tool_agent.py
+++ b/examples/voice_agents/async_tool_agent.py
@@ -193,7 +193,6 @@ async def entrypoint(ctx: JobContext):
         llm=inference.LLM("openai/gpt-5.3-chat-latest"),
         tts=inference.TTS("cartesia/sonic-3", voice="e07c00bc-4134-4eae-9ea4-1a55fb45746b"),
         # llm=google.realtime.RealtimeModel(),
-        vad=inference.VAD(model="silero"),
         turn_handling={"interruption": {"mode": "vad"}},
     )
 

--- a/examples/voice_agents/async_tool_agent.py
+++ b/examples/voice_agents/async_tool_agent.py
@@ -14,7 +14,6 @@ except ImportError as e:
 
 from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli, inference, llm
 from livekit.agents.llm.async_toolset import AsyncRunContext, AsyncToolset
-from livekit.plugins import silero
 
 logger = logging.getLogger("async-travel-helper")
 
@@ -194,7 +193,7 @@ async def entrypoint(ctx: JobContext):
         llm=inference.LLM("openai/gpt-5.3-chat-latest"),
         tts=inference.TTS("cartesia/sonic-3", voice="e07c00bc-4134-4eae-9ea4-1a55fb45746b"),
         # llm=google.realtime.RealtimeModel(),
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         turn_handling={"interruption": {"mode": "vad"}},
     )
 

--- a/examples/voice_agents/basic_agent.py
+++ b/examples/voice_agents/basic_agent.py
@@ -85,7 +85,6 @@ async def entrypoint(ctx: JobContext) -> None:
         # Text-to-speech (TTS) is your agent's voice, turning the LLM's text into speech that the user can hear
         # See all available models as well as voice selections at https://docs.livekit.io/agents/models/tts/
         tts=inference.TTS("cartesia/sonic-3", voice="9626c31c-bec5-4cca-baa8-f8ba9e84c8bc"),
-        vad=inference.VAD(model="silero"),
         turn_handling=TurnHandlingOptions(
             # VAD and turn detection are used to determine when the user is speaking and when the agent should respond
             # See more at https://docs.livekit.io/agents/build/turns

--- a/examples/voice_agents/basic_agent.py
+++ b/examples/voice_agents/basic_agent.py
@@ -7,7 +7,6 @@ from livekit.agents import (
     AgentServer,
     AgentSession,
     JobContext,
-    JobProcess,
     MetricsCollectedEvent,
     RunContext,
     TurnHandlingOptions,
@@ -20,7 +19,6 @@ from livekit.agents import (
 from livekit.agents.beta import EndCallTool
 from livekit.agents.inference import AudioTurnDetector
 from livekit.agents.llm import function_tool
-from livekit.plugins import silero
 
 # uncomment to enable Krisp background voice/noise cancellation
 # from livekit.plugins import noise_cancellation
@@ -71,13 +69,6 @@ class MyAgent(Agent):
 server = AgentServer()
 
 
-def prewarm(proc: JobProcess) -> None:
-    proc.userdata["vad"] = silero.VAD.load()
-
-
-server.setup_fnc = prewarm
-
-
 @server.rtc_session()
 async def entrypoint(ctx: JobContext) -> None:
     # each log entry will include these fields
@@ -94,7 +85,7 @@ async def entrypoint(ctx: JobContext) -> None:
         # Text-to-speech (TTS) is your agent's voice, turning the LLM's text into speech that the user can hear
         # See all available models as well as voice selections at https://docs.livekit.io/agents/models/tts/
         tts=inference.TTS("cartesia/sonic-3", voice="9626c31c-bec5-4cca-baa8-f8ba9e84c8bc"),
-        vad=ctx.proc.userdata["vad"],
+        vad=inference.VAD(model="silero"),
         turn_handling=TurnHandlingOptions(
             # VAD and turn detection are used to determine when the user is speaking and when the agent should respond
             # See more at https://docs.livekit.io/agents/build/turns

--- a/examples/voice_agents/dynamic_tool_creation.py
+++ b/examples/voice_agents/dynamic_tool_creation.py
@@ -18,7 +18,6 @@ from livekit.agents import (
     function_tool,
     inference,
 )
-from livekit.plugins import silero
 
 logger = logging.getLogger("grok-agent")
 logger.setLevel(logging.INFO)
@@ -115,7 +114,7 @@ async def entrypoint(ctx: JobContext):
     )
 
     session = AgentSession(
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/dynamic_tool_creation.py
+++ b/examples/voice_agents/dynamic_tool_creation.py
@@ -114,7 +114,6 @@ async def entrypoint(ctx: JobContext):
     )
 
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/email_example.py
+++ b/examples/voice_agents/email_example.py
@@ -13,7 +13,6 @@ from livekit.agents import (
     inference,
 )
 from livekit.agents.llm import function_tool
-from livekit.plugins import silero
 
 logger = logging.getLogger("get-email-agent")
 
@@ -61,7 +60,7 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/email_example.py
+++ b/examples/voice_agents/email_example.py
@@ -60,7 +60,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/error_callback.py
+++ b/examples/voice_agents/error_callback.py
@@ -9,7 +9,6 @@ from livekit.agents import AgentServer, JobContext, cli, inference
 from livekit.agents.utils.audio import audio_frames_from_file
 from livekit.agents.voice import Agent, AgentSession
 from livekit.agents.voice.events import CloseEvent, ErrorEvent
-from livekit.plugins import silero
 from livekit.rtc import ParticipantKind
 
 logger = logging.getLogger("my-worker")
@@ -30,7 +29,7 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
     )
 
     custom_error_audio = os.path.join(pathlib.Path(__file__).parent.absolute(), "error_message.ogg")

--- a/examples/voice_agents/error_callback.py
+++ b/examples/voice_agents/error_callback.py
@@ -29,7 +29,6 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),
-        vad=inference.VAD(model="silero"),
     )
 
     custom_error_audio = os.path.join(pathlib.Path(__file__).parent.absolute(), "error_message.ogg")

--- a/examples/voice_agents/fast-preresponse.py
+++ b/examples/voice_agents/fast-preresponse.py
@@ -10,7 +10,6 @@ from livekit.agents import (
     AgentSession,
     JobContext,
     cli,
-    inference,
     llm,
 )
 from livekit.agents.llm.chat_context import ChatContext, ChatMessage
@@ -83,7 +82,6 @@ async def entrypoint(ctx: JobContext):
     session = AgentSession(
         stt=deepgram.STT(),
         tts=openai.TTS(),
-        vad=inference.VAD(model="silero"),
     )
     await session.start(PreResponseAgent(), room=ctx.room)
 

--- a/examples/voice_agents/fast-preresponse.py
+++ b/examples/voice_agents/fast-preresponse.py
@@ -10,10 +10,11 @@ from livekit.agents import (
     AgentSession,
     JobContext,
     cli,
+    inference,
     llm,
 )
 from livekit.agents.llm.chat_context import ChatContext, ChatMessage
-from livekit.plugins import deepgram, groq, openai, silero
+from livekit.plugins import deepgram, groq, openai
 
 logger = logging.getLogger("pre-reseponse-agent")
 
@@ -82,7 +83,7 @@ async def entrypoint(ctx: JobContext):
     session = AgentSession(
         stt=deepgram.STT(),
         tts=openai.TTS(),
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
     )
     await session.start(PreResponseAgent(), room=ctx.room)
 

--- a/examples/voice_agents/flush_llm_node.py
+++ b/examples/voice_agents/flush_llm_node.py
@@ -15,10 +15,10 @@ from livekit.agents import (
     ModelSettings,
     cli,
     function_tool,
+    inference,
     llm,
     metrics,
 )
-from livekit.plugins import silero
 
 logger = logging.getLogger("flush-llm-node")
 
@@ -111,7 +111,7 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         llm="openai/gpt-4.1-mini",
         stt="deepgram/nova-3:en",
         tts="cartesia/sonic-3:9626c31c-bec5-4cca-baa8-f8ba9e84c8bc",

--- a/examples/voice_agents/flush_llm_node.py
+++ b/examples/voice_agents/flush_llm_node.py
@@ -15,7 +15,6 @@ from livekit.agents import (
     ModelSettings,
     cli,
     function_tool,
-    inference,
     llm,
     metrics,
 )
@@ -111,7 +110,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm="openai/gpt-4.1-mini",
         stt="deepgram/nova-3:en",
         tts="cartesia/sonic-3:9626c31c-bec5-4cca-baa8-f8ba9e84c8bc",

--- a/examples/voice_agents/grok/grok_voice_agent_api.py
+++ b/examples/voice_agents/grok/grok_voice_agent_api.py
@@ -8,7 +8,6 @@ from livekit.agents import (
     AgentSession,
     JobContext,
     cli,
-    inference,
     room_io,
 )
 from livekit.agents.inference import AudioTurnDetector
@@ -45,7 +44,6 @@ async def my_agent(ctx: JobContext):
         llm=xai.realtime.RealtimeModel(voice="ara"),
         turn_detection=AudioTurnDetector(),
         tools=[xai.realtime.XSearch(), xai.realtime.WebSearch()],
-        vad=inference.VAD(model="silero"),
         preemptive_generation=True,
     )
 

--- a/examples/voice_agents/grok/grok_voice_agent_api.py
+++ b/examples/voice_agents/grok/grok_voice_agent_api.py
@@ -7,12 +7,12 @@ from livekit.agents import (
     AgentServer,
     AgentSession,
     JobContext,
-    JobProcess,
     cli,
+    inference,
     room_io,
 )
 from livekit.agents.inference import AudioTurnDetector
-from livekit.plugins import silero, xai
+from livekit.plugins import xai
 
 # uncomment lines 18 and 66-68 to enable Krisp background voice/noise cancellation
 # from livekit.plugins import noise_cancellation
@@ -35,13 +35,6 @@ class Assistant(Agent):
 server = AgentServer()
 
 
-def prewarm(proc: JobProcess):
-    proc.userdata["vad"] = silero.VAD.load()
-
-
-server.setup_fnc = prewarm
-
-
 @server.rtc_session()
 async def my_agent(ctx: JobContext):
     ctx.log_context_fields = {
@@ -52,7 +45,7 @@ async def my_agent(ctx: JobContext):
         llm=xai.realtime.RealtimeModel(voice="ara"),
         turn_detection=AudioTurnDetector(),
         tools=[xai.realtime.XSearch(), xai.realtime.WebSearch()],
-        vad=ctx.proc.userdata["vad"],
+        vad=inference.VAD(model="silero"),
         preemptive_generation=True,
     )
 

--- a/examples/voice_agents/inactive_user.py
+++ b/examples/voice_agents/inactive_user.py
@@ -12,7 +12,6 @@ from livekit.agents import (
     cli,
     inference,
 )
-from livekit.plugins import silero
 
 logger = logging.getLogger("get-email-agent")
 
@@ -24,7 +23,7 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/inactive_user.py
+++ b/examples/voice_agents/inactive_user.py
@@ -23,7 +23,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/instructions_per_modality.py
+++ b/examples/voice_agents/instructions_per_modality.py
@@ -8,13 +8,11 @@ from livekit.agents import (
     AgentServer,
     AgentSession,
     JobContext,
-    JobProcess,
     cli,
     function_tool,
     inference,
 )
 from livekit.agents.beta import Instructions
-from livekit.plugins import silero
 
 logger = logging.getLogger("instructions-per-modality")
 
@@ -82,20 +80,13 @@ class SchedulingAgent(Agent):
 server = AgentServer()
 
 
-def prewarm(proc: JobProcess) -> None:
-    proc.userdata["vad"] = silero.VAD.load()
-
-
-server.setup_fnc = prewarm
-
-
 @server.rtc_session()
 async def entrypoint(ctx: JobContext) -> None:
     session = AgentSession(
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),
-        vad=ctx.proc.userdata["vad"],
+        vad=inference.VAD(model="silero"),
     )
 
     await session.start(agent=SchedulingAgent(), room=ctx.room)

--- a/examples/voice_agents/instructions_per_modality.py
+++ b/examples/voice_agents/instructions_per_modality.py
@@ -86,7 +86,6 @@ async def entrypoint(ctx: JobContext) -> None:
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),
-        vad=inference.VAD(model="silero"),
     )
 
     await session.start(agent=SchedulingAgent(), room=ctx.room)

--- a/examples/voice_agents/langfuse_trace.py
+++ b/examples/voice_agents/langfuse_trace.py
@@ -22,7 +22,7 @@ from livekit.agents.stt import FallbackAdapter as FallbackSTTAdapter
 from livekit.agents.telemetry import set_tracer_provider
 from livekit.agents.tts import FallbackAdapter as FallbackTTSAdapter
 from livekit.agents.voice import MetricsCollectedEvent
-from livekit.plugins import openai, silero
+from livekit.plugins import openai
 
 logger = logging.getLogger("langfuse-trace-example")
 
@@ -149,7 +149,7 @@ async def entrypoint(ctx: JobContext):
 
     ctx.add_shutdown_callback(flush_trace)
 
-    session = AgentSession(vad=silero.VAD.load())
+    session = AgentSession(vad=inference.VAD(model="silero"))
 
     @session.on("metrics_collected")
     def _on_metrics_collected(ev: MetricsCollectedEvent):

--- a/examples/voice_agents/langfuse_trace.py
+++ b/examples/voice_agents/langfuse_trace.py
@@ -149,7 +149,7 @@ async def entrypoint(ctx: JobContext):
 
     ctx.add_shutdown_callback(flush_trace)
 
-    session = AgentSession(vad=inference.VAD(model="silero"))
+    session = AgentSession()
 
     @session.on("metrics_collected")
     def _on_metrics_collected(ev: MetricsCollectedEvent):

--- a/examples/voice_agents/langgraph_agent.py
+++ b/examples/voice_agents/langgraph_agent.py
@@ -12,12 +12,11 @@ from livekit.agents import (
     AgentServer,
     AgentSession,
     JobContext,
-    JobProcess,
     cli,
     inference,
 )
 from livekit.agents.inference import AudioTurnDetector
-from livekit.plugins import langchain, silero
+from livekit.plugins import langchain
 
 logger = logging.getLogger("basic-agent")
 
@@ -33,13 +32,6 @@ load_dotenv()
 # - livekit-agents[openai,silero,langchain,deepgram,turn_detector]
 
 server = AgentServer()
-
-
-def prewarm(proc: JobProcess):
-    proc.userdata["vad"] = silero.VAD.load()
-
-
-server.setup_fnc = prewarm
 
 
 class State(TypedDict):
@@ -71,7 +63,7 @@ async def entrypoint(ctx: JobContext):
     )
 
     session = AgentSession(
-        vad=ctx.proc.userdata["vad"],
+        vad=inference.VAD(model="silero"),
         # any combination of STT, LLM, TTS, or realtime API can be used
         stt=inference.STT("deepgram/nova-3", language="multi"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/langgraph_agent.py
+++ b/examples/voice_agents/langgraph_agent.py
@@ -63,7 +63,6 @@ async def entrypoint(ctx: JobContext):
     )
 
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         # any combination of STT, LLM, TTS, or realtime API can be used
         stt=inference.STT("deepgram/nova-3", language="multi"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/llamaindex-rag/chat_engine.py
+++ b/examples/voice_agents/llamaindex-rag/chat_engine.py
@@ -22,7 +22,6 @@ from livekit.agents import (
     llm,
 )
 from livekit.agents.voice.agent import ModelSettings
-from livekit.plugins import silero
 
 load_dotenv()
 
@@ -54,7 +53,7 @@ class ChatEngineAgent(Agent):
                 "with users will be voice. You should use short and concise "
                 "responses, and avoiding usage of unpronouncable punctuation."
             ),
-            vad=silero.VAD.load(),
+            vad=inference.VAD(model="silero"),
             stt=inference.STT("deepgram/nova-3"),
             llm=DummyLLM(),  # use a dummy LLM to enable the pipeline reply
             tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/llamaindex-rag/chat_engine.py
+++ b/examples/voice_agents/llamaindex-rag/chat_engine.py
@@ -53,7 +53,6 @@ class ChatEngineAgent(Agent):
                 "with users will be voice. You should use short and concise "
                 "responses, and avoiding usage of unpronouncable punctuation."
             ),
-            vad=inference.VAD(model="silero"),
             stt=inference.STT("deepgram/nova-3"),
             llm=DummyLLM(),  # use a dummy LLM to enable the pipeline reply
             tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/llamaindex-rag/query_engine.py
+++ b/examples/voice_agents/llamaindex-rag/query_engine.py
@@ -18,7 +18,6 @@ from livekit.agents import (
     inference,
     llm,
 )
-from livekit.plugins import silero
 
 load_dotenv()
 
@@ -59,7 +58,7 @@ async def entrypoint(ctx: JobContext):
             "with users will be voice. You should use short and concise "
             "responses, and avoiding usage of unpronouncable punctuation."
         ),
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/llamaindex-rag/query_engine.py
+++ b/examples/voice_agents/llamaindex-rag/query_engine.py
@@ -58,7 +58,6 @@ async def entrypoint(ctx: JobContext):
             "with users will be voice. You should use short and concise "
             "responses, and avoiding usage of unpronouncable punctuation."
         ),
-        vad=inference.VAD(model="silero"),
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/llamaindex-rag/retrieval.py
+++ b/examples/voice_agents/llamaindex-rag/retrieval.py
@@ -16,7 +16,6 @@ from livekit.agents import (
     AutoSubscribe,
     JobContext,
     cli,
-    inference,
     llm,
 )
 from livekit.agents.voice.agent import ModelSettings
@@ -47,7 +46,6 @@ class RetrievalAgent(Agent):
                 "with users will be voice. You should use short and concise "
                 "responses, and avoiding usage of unpronouncable punctuation."
             ),
-            vad=inference.VAD(model="silero"),
             stt=deepgram.STT(),
             llm=openai.LLM(),
             tts=openai.TTS(),

--- a/examples/voice_agents/llamaindex-rag/retrieval.py
+++ b/examples/voice_agents/llamaindex-rag/retrieval.py
@@ -16,10 +16,11 @@ from livekit.agents import (
     AutoSubscribe,
     JobContext,
     cli,
+    inference,
     llm,
 )
 from livekit.agents.voice.agent import ModelSettings
-from livekit.plugins import deepgram, openai, silero
+from livekit.plugins import deepgram, openai
 
 load_dotenv()
 
@@ -46,7 +47,7 @@ class RetrievalAgent(Agent):
                 "with users will be voice. You should use short and concise "
                 "responses, and avoiding usage of unpronouncable punctuation."
             ),
-            vad=silero.VAD.load(),
+            vad=inference.VAD(model="silero"),
             stt=deepgram.STT(),
             llm=openai.LLM(),
             tts=openai.TTS(),

--- a/examples/voice_agents/long_running_function.py
+++ b/examples/voice_agents/long_running_function.py
@@ -68,7 +68,6 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),
-        vad=inference.VAD(model="silero"),
     )
 
     await session.start(agent=MyAgent(), room=ctx.room)

--- a/examples/voice_agents/long_running_function.py
+++ b/examples/voice_agents/long_running_function.py
@@ -13,7 +13,6 @@ from livekit.agents import (
     inference,
 )
 from livekit.agents.llm import function_tool
-from livekit.plugins import silero
 
 logger = logging.getLogger("long-running-function")
 logger.setLevel(logging.INFO)
@@ -69,7 +68,7 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
     )
 
     await session.start(agent=MyAgent(), room=ctx.room)

--- a/examples/voice_agents/mcp/mcp-agent.py
+++ b/examples/voice_agents/mcp/mcp-agent.py
@@ -31,7 +31,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         stt=inference.STT("deepgram/nova-3", language="multi"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/mcp/mcp-agent.py
+++ b/examples/voice_agents/mcp/mcp-agent.py
@@ -4,7 +4,6 @@ from dotenv import load_dotenv
 
 from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli, inference, mcp
 from livekit.agents.inference import AudioTurnDetector
-from livekit.plugins import silero
 
 logger = logging.getLogger("mcp-agent")
 
@@ -32,7 +31,7 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         stt=inference.STT("deepgram/nova-3", language="multi"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/multi_agent.py
+++ b/examples/voice_agents/multi_agent.py
@@ -10,15 +10,15 @@ from livekit.agents import (
     AgentSession,
     ChatContext,
     JobContext,
-    JobProcess,
     RunContext,
     cli,
+    inference,
     metrics,
 )
 from livekit.agents.job import get_job_context
 from livekit.agents.llm import function_tool
 from livekit.agents.voice import MetricsCollectedEvent
-from livekit.plugins import deepgram, openai, silero
+from livekit.plugins import deepgram, openai
 
 # uncomment to enable Krisp BVC noise cancellation, currently supported on Linux and MacOS
 # from livekit.plugins import noise_cancellation
@@ -132,17 +132,10 @@ class StoryAgent(Agent):
 server = AgentServer()
 
 
-def prewarm(proc: JobProcess):
-    proc.userdata["vad"] = silero.VAD.load()
-
-
-server.setup_fnc = prewarm
-
-
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession[StoryData](
-        vad=ctx.proc.userdata["vad"],
+        vad=inference.VAD(model="silero"),
         # any combination of STT, LLM, TTS, or realtime API can be used
         llm=openai.LLM(model="gpt-4.1-mini"),
         stt=deepgram.STT(model="nova-3"),

--- a/examples/voice_agents/multi_agent.py
+++ b/examples/voice_agents/multi_agent.py
@@ -12,7 +12,6 @@ from livekit.agents import (
     JobContext,
     RunContext,
     cli,
-    inference,
     metrics,
 )
 from livekit.agents.job import get_job_context
@@ -135,7 +134,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession[StoryData](
-        vad=inference.VAD(model="silero"),
         # any combination of STT, LLM, TTS, or realtime API can be used
         llm=openai.LLM(model="gpt-4.1-mini"),
         stt=deepgram.STT(model="nova-3"),

--- a/examples/voice_agents/nvidia_test.py
+++ b/examples/voice_agents/nvidia_test.py
@@ -8,7 +8,6 @@ from livekit.agents import (
     JobContext,
     WorkerOptions,
     cli,
-    inference,
 )
 from livekit.agents.inference import AudioTurnDetector
 from livekit.plugins import nvidia, openai
@@ -20,7 +19,6 @@ load_dotenv()
 
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=openai.LLM(model="gpt-4.1-mini"),
         stt=nvidia.STT(),
         tts=nvidia.TTS(),

--- a/examples/voice_agents/nvidia_test.py
+++ b/examples/voice_agents/nvidia_test.py
@@ -6,25 +6,21 @@ from livekit.agents import (
     Agent,
     AgentSession,
     JobContext,
-    JobProcess,
     WorkerOptions,
     cli,
+    inference,
 )
 from livekit.agents.inference import AudioTurnDetector
-from livekit.plugins import nvidia, openai, silero
+from livekit.plugins import nvidia, openai
 
 logger = logging.getLogger("basic-agent")
 
 load_dotenv()
 
 
-def prewarm(proc: JobProcess):
-    proc.userdata["vad"] = silero.VAD.load()
-
-
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=ctx.proc.userdata["vad"],
+        vad=inference.VAD(model="silero"),
         llm=openai.LLM(model="gpt-4.1-mini"),
         stt=nvidia.STT(),
         tts=nvidia.TTS(),
@@ -42,4 +38,4 @@ async def entrypoint(ctx: JobContext):
 
 
 if __name__ == "__main__":
-    cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint, prewarm_fnc=prewarm))
+    cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))

--- a/examples/voice_agents/raw_function_description.py
+++ b/examples/voice_agents/raw_function_description.py
@@ -11,7 +11,7 @@ from livekit.agents import (
     cli,
     function_tool,
 )
-from livekit.plugins import openai, silero  # noqa: F401
+from livekit.plugins import openai  # noqa: F401
 
 # This demo defines an agent using a raw function tool to open predefined gates via enum input.
 # When using raw function tools, compatibility across LLM providers is not guaranteed,
@@ -72,7 +72,7 @@ async def entrypoint(ctx: JobContext):
         # stt=openai.STT(),
         # llm=openai.LLM(),
         # tts=openai.TTS(),
-        # vad=silero.VAD.load(),
+        # vad=inference.VAD(model="silero"),
         llm=openai.realtime.RealtimeModel()
     )
     await session.start(RawFunctionAgent(), room=ctx.room)

--- a/examples/voice_agents/realtime_joke_teller.py
+++ b/examples/voice_agents/realtime_joke_teller.py
@@ -53,10 +53,11 @@ from livekit.agents import (
     AgentSession,
     AutoSubscribe,
     ToolError,
+    inference,
     room_io,
 )
 from livekit.agents.llm import function_tool
-from livekit.plugins import aws, silero
+from livekit.plugins import aws
 
 load_dotenv()
 
@@ -221,7 +222,7 @@ async def entrypoint(ctx: agents.JobContext):
                     stt=aws.STT(),
                     llm=aws.LLM(),
                     tts=aws.TTS(),
-                    vad=silero.VAD.load(),
+                    vad=inference.VAD(model="silero"),
                 )
             else:
                 print("⚡ Using REALTIME mode: Nova Sonic 2.0")

--- a/examples/voice_agents/realtime_joke_teller.py
+++ b/examples/voice_agents/realtime_joke_teller.py
@@ -53,7 +53,6 @@ from livekit.agents import (
     AgentSession,
     AutoSubscribe,
     ToolError,
-    inference,
     room_io,
 )
 from livekit.agents.llm import function_tool
@@ -222,7 +221,6 @@ async def entrypoint(ctx: agents.JobContext):
                     stt=aws.STT(),
                     llm=aws.LLM(),
                     tts=aws.TTS(),
-                    vad=inference.VAD(model="silero"),
                 )
             else:
                 print("⚡ Using REALTIME mode: Nova Sonic 2.0")

--- a/examples/voice_agents/realtime_turn_detector.py
+++ b/examples/voice_agents/realtime_turn_detector.py
@@ -3,7 +3,7 @@ import logging
 from dotenv import load_dotenv
 from google.genai import types  # noqa: F401
 
-from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli, inference
+from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli
 from livekit.agents.inference import AudioTurnDetector
 from livekit.plugins import deepgram, google, openai  # noqa: F401
 
@@ -25,7 +25,6 @@ async def entrypoint(ctx: JobContext):
     session = AgentSession(
         allow_interruptions=True,
         turn_detection=AudioTurnDetector(),
-        vad=inference.VAD(model="silero"),
         stt=deepgram.STT(),
         # To use OpenAI Realtime API
         llm=openai.realtime.RealtimeModel(

--- a/examples/voice_agents/realtime_turn_detector.py
+++ b/examples/voice_agents/realtime_turn_detector.py
@@ -3,9 +3,9 @@ import logging
 from dotenv import load_dotenv
 from google.genai import types  # noqa: F401
 
-from livekit.agents import Agent, AgentServer, AgentSession, JobContext, JobProcess, cli
+from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli, inference
 from livekit.agents.inference import AudioTurnDetector
-from livekit.plugins import deepgram, google, openai, silero  # noqa: F401
+from livekit.plugins import deepgram, google, openai  # noqa: F401
 
 logger = logging.getLogger("realtime-turn-detector")
 logger.setLevel(logging.INFO)
@@ -25,7 +25,7 @@ async def entrypoint(ctx: JobContext):
     session = AgentSession(
         allow_interruptions=True,
         turn_detection=AudioTurnDetector(),
-        vad=ctx.proc.userdata["vad"],
+        vad=inference.VAD(model="silero"),
         stt=deepgram.STT(),
         # To use OpenAI Realtime API
         llm=openai.realtime.RealtimeModel(
@@ -47,12 +47,6 @@ async def entrypoint(ctx: JobContext):
     )
     await session.start(agent=Agent(instructions="You are a helpful assistant."), room=ctx.room)
 
-
-def prewarm(proc: JobProcess):
-    proc.userdata["vad"] = silero.VAD.load()
-
-
-server.setup_fnc = prewarm
 
 if __name__ == "__main__":
     cli.run_app(server)

--- a/examples/voice_agents/realtime_video_agent.py
+++ b/examples/voice_agents/realtime_video_agent.py
@@ -8,10 +8,11 @@ from livekit.agents import (
     AgentSession,
     JobContext,
     cli,
+    inference,
     room_io,
     voice,  # noqa: F401
 )
-from livekit.plugins import google, silero
+from livekit.plugins import google
 
 logger = logging.getLogger("realtime-video-agent")
 
@@ -23,7 +24,7 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         # both Gemini and OpenAI Realtime API support streaming video input
         llm=google.realtime.RealtimeModel(),
         # customize how video frames are sampled

--- a/examples/voice_agents/realtime_video_agent.py
+++ b/examples/voice_agents/realtime_video_agent.py
@@ -8,7 +8,6 @@ from livekit.agents import (
     AgentSession,
     JobContext,
     cli,
-    inference,
     room_io,
     voice,  # noqa: F401
 )
@@ -24,7 +23,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         # both Gemini and OpenAI Realtime API support streaming video input
         llm=google.realtime.RealtimeModel(),
         # customize how video frames are sampled

--- a/examples/voice_agents/restaurant_agent.py
+++ b/examples/voice_agents/restaurant_agent.py
@@ -327,7 +327,6 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT(model="deepgram/nova-3"),
         llm=inference.LLM(model="openai/gpt-4.1-mini"),
         tts=inference.TTS(model="cartesia/sonic-3"),
-        vad=inference.VAD(model="silero"),
         max_tool_steps=5,
         # to use realtime model, replace the stt, llm, tts and vad with the following
         # llm=openai.realtime.RealtimeModel(voice="alloy"),

--- a/examples/voice_agents/restaurant_agent.py
+++ b/examples/voice_agents/restaurant_agent.py
@@ -8,9 +8,6 @@ from pydantic import Field
 
 from livekit.agents import Agent, AgentServer, AgentSession, JobContext, RunContext, cli, inference
 from livekit.agents.llm import function_tool
-from livekit.plugins import silero
-
-# from livekit.plugins import noise_cancellation
 
 # This example demonstrates a multi-agent system where tasks are delegated to sub-agents
 # based on the user's request.
@@ -330,7 +327,7 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT(model="deepgram/nova-3"),
         llm=inference.LLM(model="openai/gpt-4.1-mini"),
         tts=inference.TTS(model="cartesia/sonic-3"),
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         max_tool_steps=5,
         # to use realtime model, replace the stt, llm, tts and vad with the following
         # llm=openai.realtime.RealtimeModel(voice="alloy"),

--- a/examples/voice_agents/resume_interrupted_agent.py
+++ b/examples/voice_agents/resume_interrupted_agent.py
@@ -3,7 +3,6 @@ import logging
 from dotenv import load_dotenv
 
 from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli, inference
-from livekit.plugins import silero
 
 logger = logging.getLogger("resume-agent")
 
@@ -21,7 +20,7 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/resume_interrupted_agent.py
+++ b/examples/voice_agents/resume_interrupted_agent.py
@@ -20,7 +20,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/session_close_callback.py
+++ b/examples/voice_agents/session_close_callback.py
@@ -2,7 +2,7 @@ import logging
 
 from dotenv import load_dotenv
 
-from livekit.agents import Agent, AgentServer, AgentSession, CloseEvent, JobContext, cli, inference
+from livekit.agents import Agent, AgentServer, AgentSession, CloseEvent, JobContext, cli
 from livekit.agents.beta.tools import EndCallTool
 from livekit.plugins import google  # noqa: F401
 
@@ -42,9 +42,7 @@ server = AgentServer()
 
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
-    session = AgentSession(
-        vad=inference.VAD(model="silero"),
-    )
+    session = AgentSession()
 
     await session.start(agent=MyAgent(), room=ctx.room)
 

--- a/examples/voice_agents/session_close_callback.py
+++ b/examples/voice_agents/session_close_callback.py
@@ -2,9 +2,9 @@ import logging
 
 from dotenv import load_dotenv
 
-from livekit.agents import Agent, AgentServer, AgentSession, CloseEvent, JobContext, cli
+from livekit.agents import Agent, AgentServer, AgentSession, CloseEvent, JobContext, cli, inference
 from livekit.agents.beta.tools import EndCallTool
-from livekit.plugins import google, silero  # noqa: F401
+from livekit.plugins import google  # noqa: F401
 
 logger = logging.getLogger("my-worker")
 logger.setLevel(logging.INFO)
@@ -43,7 +43,7 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
     )
 
     await session.start(agent=MyAgent(), room=ctx.room)

--- a/examples/voice_agents/silent_function_call.py
+++ b/examples/voice_agents/silent_function_call.py
@@ -59,7 +59,6 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),
-        vad=inference.VAD(model="silero"),
     )
 
     @session.on("function_tools_executed")

--- a/examples/voice_agents/silent_function_call.py
+++ b/examples/voice_agents/silent_function_call.py
@@ -12,7 +12,6 @@ from livekit.agents import (
     inference,
 )
 from livekit.agents.llm import function_tool
-from livekit.plugins import silero
 
 logger = logging.getLogger("silent-function-call")
 logger.setLevel(logging.INFO)
@@ -60,7 +59,7 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
     )
 
     @session.on("function_tools_executed")

--- a/examples/voice_agents/speaker_id_multi_speaker.py
+++ b/examples/voice_agents/speaker_id_multi_speaker.py
@@ -6,9 +6,9 @@ import datetime
 
 from dotenv import load_dotenv
 
-from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli
+from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli, inference
 from livekit.agents.stt import MultiSpeakerAdapter
-from livekit.plugins import deepgram, openai, silero, speechmatics  # noqa: F401
+from livekit.plugins import deepgram, openai, speechmatics  # noqa: F401
 
 # Load environment variables from .env file
 # Required: SPEECHMATICS_API_KEY, OPENAI_API_KEY
@@ -54,7 +54,7 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext) -> None:
     session = AgentSession(
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         llm=openai.LLM(),
         tts=openai.TTS(),
         stt=MultiSpeakerAdapter(

--- a/examples/voice_agents/speaker_id_multi_speaker.py
+++ b/examples/voice_agents/speaker_id_multi_speaker.py
@@ -6,7 +6,7 @@ import datetime
 
 from dotenv import load_dotenv
 
-from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli, inference
+from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli
 from livekit.agents.stt import MultiSpeakerAdapter
 from livekit.plugins import deepgram, openai, speechmatics  # noqa: F401
 
@@ -54,7 +54,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext) -> None:
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=openai.LLM(),
         tts=openai.TTS(),
         stt=MultiSpeakerAdapter(

--- a/examples/voice_agents/speedup_output_audio.py
+++ b/examples/voice_agents/speedup_output_audio.py
@@ -106,7 +106,6 @@ async def entrypoint(ctx: JobContext):
         "user_id": "your user_id",
     }
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/speedup_output_audio.py
+++ b/examples/voice_agents/speedup_output_audio.py
@@ -16,7 +16,6 @@ from livekit.agents import (
     inference,
     utils,
 )
-from livekit.plugins import silero
 
 try:
     import librosa
@@ -92,8 +91,6 @@ server = AgentServer()
 
 
 def prewarm(proc: JobProcess):
-    proc.userdata["vad"] = silero.VAD.load()
-
     # warmup the librosa JIT
     librosa.effects.time_stretch(np.random.randn(16000).astype(np.float32), rate=1.2)
 
@@ -109,7 +106,7 @@ async def entrypoint(ctx: JobContext):
         "user_id": "your user_id",
     }
     session = AgentSession(
-        vad=ctx.proc.userdata["vad"],
+        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/structured_output.py
+++ b/examples/voice_agents/structured_output.py
@@ -17,9 +17,10 @@ from livekit.agents import (
     JobContext,
     ModelSettings,
     cli,
+    inference,
 )
 from livekit.agents.inference import AudioTurnDetector
-from livekit.plugins import openai, silero
+from livekit.plugins import openai
 
 logger = logging.getLogger("structured-output")
 load_dotenv()
@@ -129,7 +130,7 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         turn_detection=AudioTurnDetector(),
     )
     await session.start(agent=MyAgent(), room=ctx.room)

--- a/examples/voice_agents/structured_output.py
+++ b/examples/voice_agents/structured_output.py
@@ -17,7 +17,6 @@ from livekit.agents import (
     JobContext,
     ModelSettings,
     cli,
-    inference,
 )
 from livekit.agents.inference import AudioTurnDetector
 from livekit.plugins import openai
@@ -130,7 +129,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         turn_detection=AudioTurnDetector(),
     )
     await session.start(agent=MyAgent(), room=ctx.room)

--- a/examples/voice_agents/timed_agent_transcript.py
+++ b/examples/voice_agents/timed_agent_transcript.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli, inference, room_io
 from livekit.agents.types import TimedString
 from livekit.agents.voice.agent import ModelSettings
-from livekit.plugins import cartesia, silero
+from livekit.plugins import cartesia
 
 logger = logging.getLogger("my-worker")
 logger.setLevel(logging.INFO)
@@ -44,7 +44,7 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("google/gemini-2.5-flash"),
         tts=cartesia.TTS(),
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         # enable TTS-aligned transcript, can be configured at the Agent level as well
         use_tts_aligned_transcript=True,
     )

--- a/examples/voice_agents/timed_agent_transcript.py
+++ b/examples/voice_agents/timed_agent_transcript.py
@@ -44,7 +44,6 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("google/gemini-2.5-flash"),
         tts=cartesia.TTS(),
-        vad=inference.VAD(model="silero"),
         # enable TTS-aligned transcript, can be configured at the Agent level as well
         use_tts_aligned_transcript=True,
     )

--- a/examples/voice_agents/tool_search_agent.py
+++ b/examples/voice_agents/tool_search_agent.py
@@ -171,7 +171,6 @@ async def entrypoint(ctx: JobContext):
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),
         stt=inference.STT("deepgram/nova-3"),
-        vad=inference.VAD(model="silero"),
     )
 
     # Track token usage to observe prompt caching behavior.

--- a/examples/voice_agents/tool_search_agent.py
+++ b/examples/voice_agents/tool_search_agent.py
@@ -31,7 +31,6 @@ from livekit.agents import (
 )
 from livekit.agents.beta.toolsets import ToolProxyToolset, ToolSearchToolset
 from livekit.agents.metrics.base import LLMMetrics
-from livekit.plugins import silero
 
 logger = logging.getLogger("tool-search-example")
 logger.setLevel(logging.INFO)
@@ -172,7 +171,7 @@ async def entrypoint(ctx: JobContext):
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),
         stt=inference.STT("deepgram/nova-3"),
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
     )
 
     # Track token usage to observe prompt caching behavior.

--- a/examples/voice_agents/ultravox_realtime_api.py
+++ b/examples/voice_agents/ultravox_realtime_api.py
@@ -9,9 +9,9 @@ from livekit.agents import (
     JobContext,
     cli,
     function_tool,
+    inference,
     room_io,
 )
-from livekit.plugins import silero
 from livekit.plugins.ultravox.realtime import RealtimeModel
 
 logger = logging.getLogger("ultravox-agent")
@@ -28,7 +28,7 @@ class MyAgent(Agent):
                 voice="Jessica",
                 language_hint="en",
             ),
-            vad=silero.VAD.load(),
+            vad=inference.VAD(model="silero"),
         )
 
     async def on_enter(self):

--- a/examples/voice_agents/ultravox_realtime_api.py
+++ b/examples/voice_agents/ultravox_realtime_api.py
@@ -9,7 +9,6 @@ from livekit.agents import (
     JobContext,
     cli,
     function_tool,
-    inference,
     room_io,
 )
 from livekit.plugins.ultravox.realtime import RealtimeModel
@@ -28,7 +27,6 @@ class MyAgent(Agent):
                 voice="Jessica",
                 language_hint="en",
             ),
-            vad=inference.VAD(model="silero"),
         )
 
     async def on_enter(self):

--- a/examples/voice_agents/zapier_mcp_integration.py
+++ b/examples/voice_agents/zapier_mcp_integration.py
@@ -9,14 +9,12 @@ from livekit.agents import (
     AgentSession,
     AutoSubscribe,
     JobContext,
-    JobProcess,
     cli,
     inference,
     mcp,
     metrics,
 )
 from livekit.agents.inference import AudioTurnDetector
-from livekit.plugins import silero
 
 load_dotenv(dotenv_path=".env.local")
 logger = logging.getLogger("voice-agent")
@@ -45,13 +43,6 @@ class Assistant(Agent):
 server = AgentServer()
 
 
-def prewarm(proc: JobProcess):
-    proc.userdata["vad"] = silero.VAD.load()
-
-
-server.setup_fnc = prewarm
-
-
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     logger.info(f"connecting to room {ctx.room.name}")
@@ -75,7 +66,7 @@ async def entrypoint(ctx: JobContext):
         logger.warning("ZAPIER_MCP_SERVER environment variable not set. MCP integration disabled.")
 
     session = AgentSession(
-        vad=ctx.proc.userdata["vad"],
+        vad=inference.VAD(model="silero"),
         # minimum delay for endpointing, used when turn detector believes the user is done with their turn  # noqa: E501
         min_endpointing_delay=0.5,
         # maximum delay for endpointing, used when turn detector does not believe the user is done with their turn  # noqa: E501

--- a/examples/voice_agents/zapier_mcp_integration.py
+++ b/examples/voice_agents/zapier_mcp_integration.py
@@ -66,7 +66,6 @@ async def entrypoint(ctx: JobContext):
         logger.warning("ZAPIER_MCP_SERVER environment variable not set. MCP integration disabled.")
 
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         # minimum delay for endpointing, used when turn detector believes the user is done with their turn  # noqa: E501
         min_endpointing_delay=0.5,
         # maximum delay for endpointing, used when turn detector does not believe the user is done with their turn  # noqa: E501

--- a/examples/warm-transfer/warm_transfer.py
+++ b/examples/warm-transfer/warm_transfer.py
@@ -9,12 +9,13 @@ from livekit.agents import (
     AgentSession,
     JobContext,
     cli,
+    inference,
     room_io,
 )
 from livekit.agents.beta.workflows import WarmTransferTask
 from livekit.agents.inference import AudioTurnDetector
 from livekit.agents.llm import ToolError, function_tool
-from livekit.plugins import noise_cancellation, silero
+from livekit.plugins import noise_cancellation
 
 logger = logging.getLogger("warm-transfer")
 
@@ -96,7 +97,7 @@ server = AgentServer()
 @server.rtc_session(agent_name="sip-inbound")
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=silero.VAD.load(),
+        vad=inference.VAD(model="silero"),
         llm="openai/gpt-4.1-mini",
         stt="deepgram/nova-3:en",
         tts="cartesia/sonic-3:9626c31c-bec5-4cca-baa8-f8ba9e84c8bc",

--- a/examples/warm-transfer/warm_transfer.py
+++ b/examples/warm-transfer/warm_transfer.py
@@ -9,7 +9,6 @@ from livekit.agents import (
     AgentSession,
     JobContext,
     cli,
-    inference,
     room_io,
 )
 from livekit.agents.beta.workflows import WarmTransferTask
@@ -97,7 +96,6 @@ server = AgentServer()
 @server.rtc_session(agent_name="sip-inbound")
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm="openai/gpt-4.1-mini",
         stt="deepgram/nova-3:en",
         tts="cartesia/sonic-3:9626c31c-bec5-4cca-baa8-f8ba9e84c8bc",

--- a/livekit-agents/livekit/agents/inference/__init__.py
+++ b/livekit-agents/livekit/agents/inference/__init__.py
@@ -8,15 +8,18 @@ from .interruption import (
 from .llm import LLM, LLMModels, LLMStream
 from .stt import STT, STTModels
 from .tts import TTS, TTSModels
+from .vad import VAD, VADModels
 
 __all__ = [
     "STT",
     "TTS",
     "LLM",
+    "VAD",
     "LLMStream",
     "STTModels",
     "TTSModels",
     "LLMModels",
+    "VADModels",
     "AdaptiveInterruptionDetector",
     "InterruptionDetectionError",
     "OverlappingSpeechEvent",

--- a/livekit-agents/livekit/agents/inference/_warmup.py
+++ b/livekit-agents/livekit/agents/inference/_warmup.py
@@ -1,0 +1,14 @@
+"""Side-effect module: imported in the forkserver preload list so the
+native ``livekit-local-inference`` model singletons are loaded inside the
+forkserver process. Child job processes then inherit the resident weight
+pages via COW.
+
+This must NOT be imported eagerly in the worker process itself — the worker
+is not the parent of forked jobs (the forkserver is), so paging weights in
+here would not benefit jobs and would cost the worker ~hundreds of MB.
+"""
+
+import livekit.local_inference as _li
+
+_li.init_vad()
+_li.init_eot()

--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -218,14 +218,9 @@ def _resolve_vad_for_model(
         )
         return None
     if is_speechmatics and vad_instance is None:
-        try:
-            from livekit.plugins.silero import VAD as SileroVAD
-        except ImportError as e:
-            raise ImportError(
-                "livekit-plugins-silero is required: model "
-                f"{model!r} does not handle endpointing server-side."
-            ) from e
-        vad_instance = SileroVAD.load()
+        from .vad import VAD
+
+        vad_instance = VAD(model="silero")
     return vad_instance
 
 

--- a/livekit-agents/livekit/agents/inference/vad.py
+++ b/livekit-agents/livekit/agents/inference/vad.py
@@ -1,4 +1,4 @@
-# Copyright 2023 LiveKit, Inc.
+# Copyright 2026 LiveKit, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,25 +17,23 @@ from __future__ import annotations
 import asyncio
 import time
 import weakref
-from dataclasses import dataclass
-from pathlib import Path
+from dataclasses import dataclass, replace
 from typing import Literal
 
 import numpy as np
-import onnxruntime  # type: ignore
 
-from livekit import agents, rtc
-from livekit.agents import utils
-from livekit.agents.types import (
-    NOT_GIVEN,
-    NotGivenOr,
-)
-from livekit.agents.utils import is_given
+from livekit import rtc
+from livekit.local_inference import VAD as _NativeVAD, VAD_WINDOW_SAMPLES
 
-from . import onnx_model
-from .log import logger
+from .. import utils, vad
+from ..log import logger
+from ..types import NOT_GIVEN, NotGivenOr
+from ..utils import is_given
 
 SLOW_INFERENCE_THRESHOLD = 0.2  # late by 200ms
+_MODEL_SAMPLE_RATE = 16000
+
+VADModels = Literal["silero"]
 
 
 @dataclass
@@ -46,159 +44,60 @@ class _VADOptions:
     max_buffered_speech: float
     activation_threshold: float
     deactivation_threshold: float
-    sample_rate: int
 
 
-class VAD(agents.vad.VAD):
+class VAD(vad.VAD):
+    """Voice Activity Detection backed by ``livekit-local-inference``.
+
+    The native model singleton is loaded once at module import (via the
+    pybind11 ``.so`` constructor); each stream allocates its own per-instance
+    LSTM/context state.
     """
-    Silero Voice Activity Detection (VAD) class.
 
-    This class provides functionality to detect speech segments within audio data using the Silero VAD model.
-    """  # noqa: E501
-
-    @classmethod
-    def load(
-        cls,
+    def __init__(
+        self,
         *,
+        model: VADModels = "silero",
         min_speech_duration: float = 0.05,
-        min_silence_duration: float = 0.55,
+        min_silence_duration: float = 0.1,
         prefix_padding_duration: float = 0.5,
         max_buffered_speech: float = 60.0,
         activation_threshold: float = 0.5,
-        sample_rate: Literal[8000, 16000] = 16000,
-        force_cpu: bool = True,
-        onnx_file_path: NotGivenOr[Path | str] = NOT_GIVEN,
         deactivation_threshold: NotGivenOr[float] = NOT_GIVEN,
-        # deprecated
-        padding_duration: NotGivenOr[float] = NOT_GIVEN,
-    ) -> agents.vad.VAD:
-        """
-        Load and initialize the Silero VAD model.
-
-        This method loads the ONNX model and prepares it for inference. When options are not provided,
-        sane defaults are used.
-
-        **Note:**
-            This method is blocking and may take time to load the model into memory.
-            It is recommended to call this method inside your prewarm mechanism.
-
-        **Example:**
-
-            ```python
-            def prewarm(proc: JobProcess):
-                proc.userdata["vad"] = silero.VAD.load()
-
-
-            async def entrypoint(ctx: JobContext):
-                vad = (ctx.proc.userdata["vad"],)
-                # your agent logic...
-
-
-            if __name__ == "__main__":
-                cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint, prewarm_fnc=prewarm))
-            ```
-
-        Args:
-            min_speech_duration (float): Minimum duration of speech to start a new speech chunk.
-            min_silence_duration (float): At the end of each speech, wait this duration before ending the speech.
-            prefix_padding_duration (float): Duration of padding to add to the beginning of each speech chunk.
-            max_buffered_speech (float): Maximum duration of speech to keep in the buffer (in seconds).
-            activation_threshold (float): Threshold to consider a frame as speech.
-            sample_rate (Literal[8000, 16000]): Sample rate for the inference (only 8KHz and 16KHz are supported).
-            onnx_file_path (Path | str | None): Path to the ONNX model file. If not provided, the default model will be loaded. This can be helpful if you want to use a previous version of the silero model.
-            force_cpu (bool): Force the use of CPU for inference.
-            deactivation_threshold (float): Negative threshold (noise or exit threshold). If model's current state is SPEECH, values BELOW this value are considered as NON-SPEECH. Default is max(activation_threshold - 0.15, 0.01).
-            padding_duration (float | None): **Deprecated**. Use `prefix_padding_duration` instead.
-
-        Returns:
-            VAD: An instance of the VAD class ready for streaming.
-
-        Raises:
-            ValueError: If an unsupported sample rate is provided.
-        """  # noqa: E501
-        if sample_rate not in onnx_model.SUPPORTED_SAMPLE_RATES:
-            raise ValueError("Silero VAD only supports 8KHz and 16KHz sample rates")
-
-        if is_given(padding_duration):
-            logger.warning(
-                "padding_duration is deprecated and will be removed in 1.5.0, use prefix_padding_duration instead",  # noqa: E501
-            )
-            prefix_padding_duration = padding_duration
-
+    ) -> None:
+        super().__init__(capabilities=vad.VADCapabilities(update_interval=0.032))
+        if model != "silero":
+            raise ValueError(f"Unknown VAD model: {model!r}. Supported: 'silero'.")
         if is_given(deactivation_threshold) and deactivation_threshold <= 0:
             raise ValueError("deactivation_threshold must be greater than 0")
-
-        # When the requested settings are compatible with the native
-        # implementation in `livekit-local-inference`, delegate to the new
-        # `livekit.agents.inference.VAD(model="silero")` so users get the
-        # COW-shared / faster path without changing their call sites. The
-        # native lib only supports 16 kHz with the bundled model file, so
-        # custom sample rate or `onnx_file_path` falls back to the legacy
-        # onnxruntime path.
-        if sample_rate == 16000 and not is_given(onnx_file_path):
-            if not force_cpu:
-                logger.warning(
-                    "force_cpu=False is ignored when using the bundled native "
-                    "VAD; the model runs CPU-only. Pass `onnx_file_path=...` "
-                    "to keep the legacy onnxruntime path that honors force_cpu."
-                )
-            from livekit.agents import inference
-
-            return inference.VAD(
-                model="silero",
-                min_speech_duration=min_speech_duration,
-                min_silence_duration=min_silence_duration,
-                prefix_padding_duration=prefix_padding_duration,
-                max_buffered_speech=max_buffered_speech,
-                activation_threshold=activation_threshold,
-                deactivation_threshold=deactivation_threshold,
-            )
-
-        session = onnx_model.new_inference_session(force_cpu, onnx_file_path=onnx_file_path or None)
-        opts = _VADOptions(
+        self._model = model
+        self._opts = _VADOptions(
             min_speech_duration=min_speech_duration,
             min_silence_duration=min_silence_duration,
             prefix_padding_duration=prefix_padding_duration,
             max_buffered_speech=max_buffered_speech,
             activation_threshold=activation_threshold,
-            deactivation_threshold=deactivation_threshold or max(activation_threshold - 0.15, 0.01),
-            sample_rate=sample_rate,
+            deactivation_threshold=deactivation_threshold
+            if is_given(deactivation_threshold)
+            else max(activation_threshold - 0.15, 0.01),
         )
-        return cls(session=session, opts=opts)
-
-    def __init__(
-        self,
-        *,
-        session: onnxruntime.InferenceSession,
-        opts: _VADOptions,
-    ) -> None:
-        super().__init__(capabilities=agents.vad.VADCapabilities(update_interval=0.032))
-        self._onnx_session = session
-        self._opts = opts
-        self._streams = weakref.WeakSet[VADStream]()
+        self._streams: weakref.WeakSet[_VADStream] = weakref.WeakSet()
 
     @property
     def model(self) -> str:
-        return "silero"
+        return self._model
 
     @property
     def provider(self) -> str:
-        return "ONNX"
+        return "livekit-local-inference"
 
-    def stream(self) -> VADStream:
-        """
-        Create a new VADStream for processing audio data.
-
-        Returns:
-            VADStream: A stream object for processing audio input and detecting speech.
-        """
-        stream = VADStream(
-            self,
-            self._opts,
-            onnx_model.OnnxModel(
-                onnx_session=self._onnx_session, sample_rate=self._opts.sample_rate
-            ),
-        )
+    def stream(self) -> vad.VADStream:
+        # Each stream owns its own _VADOptions snapshot so that
+        # _VADStream.update_options() can read the prior value of
+        # max_buffered_speech before mutating it. Sharing the dataclass would
+        # let VAD.update_options() mutate the stream's view first, and the
+        # stream would never observe an increase.
+        stream = _VADStream(self, replace(self._opts))
         self._streams.add(stream)
         return stream
 
@@ -212,18 +111,6 @@ class VAD(agents.vad.VAD):
         activation_threshold: NotGivenOr[float] = NOT_GIVEN,
         deactivation_threshold: NotGivenOr[float] = NOT_GIVEN,
     ) -> None:
-        """
-        Update the VAD options.
-
-        This method allows you to update the VAD options after the VAD object has been created.
-
-        Args:
-            min_speech_duration (float): Minimum duration of speech to start a new speech chunk.
-            min_silence_duration (float): At the end of each speech, wait this duration before ending the speech.
-            prefix_padding_duration (float): Duration of padding to add to the beginning of each speech chunk.
-            max_buffered_speech (float): Maximum duration of speech to keep in the buffer (in seconds).
-            activation_threshold (float): Threshold to consider a frame as speech.
-        """  # noqa: E501
         if is_given(min_speech_duration):
             self._opts.min_speech_duration = min_speech_duration
         if is_given(min_silence_duration):
@@ -248,12 +135,11 @@ class VAD(agents.vad.VAD):
             )
 
 
-class VADStream(agents.vad.VADStream):
-    def __init__(self, vad: VAD, opts: _VADOptions, model: onnx_model.OnnxModel) -> None:
-        super().__init__(vad)
-        self._opts, self._model = opts, model
-        self._loop = asyncio.get_event_loop()
-        self._exp_filter = utils.ExpFilter(alpha=0.35)
+class _VADStream(vad.VADStream):
+    def __init__(self, parent: VAD, opts: _VADOptions) -> None:
+        super().__init__(parent)
+        self._opts = opts
+        self._native_vad = _NativeVAD()
 
         self._input_sample_rate = 0
         self._speech_buffer: np.ndarray | None = None
@@ -270,19 +156,6 @@ class VADStream(agents.vad.VADStream):
         activation_threshold: NotGivenOr[float] = NOT_GIVEN,
         deactivation_threshold: NotGivenOr[float] = NOT_GIVEN,
     ) -> None:
-        """
-        Update the VAD options.
-
-        This method allows you to update the VAD options after the VAD object has been created.
-
-        Args:
-            min_speech_duration (float): Minimum duration of speech to start a new speech chunk.
-            min_silence_duration (float): At the end of each speech, wait this duration before ending the speech.
-            prefix_padding_duration (float): Duration of padding to add to the beginning of each speech chunk.
-            max_buffered_speech (float): Maximum duration of speech to keep in the buffer (in seconds).
-            activation_threshold (float): Threshold to consider a frame as speech.
-            deactivation_threshold (float): Negative threshold (noise or exit threshold). If model's current state is SPEECH, values BELOW this value are considered as NON-SPEECH.
-        """  # noqa: E501
         old_max_buffered_speech = self._opts.max_buffered_speech
 
         if is_given(min_speech_duration):
@@ -313,9 +186,8 @@ class VADStream(agents.vad.VADStream):
             if self._opts.max_buffered_speech > old_max_buffered_speech:
                 self._speech_buffer_max_reached = False
 
-    @agents.utils.log_exceptions(logger=logger)
+    @utils.log_exceptions(logger=logger)
     async def _main_task(self) -> None:
-        inference_f32_data = np.empty(self._model.window_size_samples, dtype=np.float32)
         speech_buffer_index: int = 0
 
         # "pub_" means public, these values are exposed to the users through events
@@ -355,12 +227,12 @@ class VADStream(agents.vad.VADStream):
                     dtype=np.int16,
                 )
 
-                if self._input_sample_rate != self._opts.sample_rate:
+                if self._input_sample_rate != _MODEL_SAMPLE_RATE:
                     # resampling needed: the input sample rate isn't the same as the model's
                     # sample rate used for inference
                     resampler = rtc.AudioResampler(
                         input_rate=self._input_sample_rate,
-                        output_rate=self._opts.sample_rate,
+                        output_rate=_MODEL_SAMPLE_RATE,
                         quality=rtc.AudioResamplerQuality.QUICK,  # VAD doesn't need high quality
                     )
 
@@ -384,33 +256,27 @@ class VADStream(agents.vad.VADStream):
                 available_inference_samples = sum(
                     [frame.samples_per_channel for frame in inference_frames]
                 )
-                if available_inference_samples < self._model.window_size_samples:
+                if available_inference_samples < VAD_WINDOW_SAMPLES:
                     break  # not enough samples to run inference
 
                 input_frame = utils.combine_frames(input_frames)
                 inference_frame = utils.combine_frames(inference_frames)
 
-                # convert data to f32
-                np.divide(
-                    inference_frame.data[: self._model.window_size_samples],
-                    np.iinfo(np.int16).max,
-                    out=inference_f32_data,
-                    dtype=np.float32,
+                # native lib takes int16 directly — no float32 conversion
+                inference_window = np.asarray(
+                    inference_frame.data[:VAD_WINDOW_SAMPLES], dtype=np.int16
                 )
 
                 # run the inference
-                p = await self._loop.run_in_executor(None, self._model, inference_f32_data)
-                p = self._exp_filter.apply(exp=1.0, sample=p)
+                p = await asyncio.to_thread(self._native_vad.predict, inference_window)
 
-                window_duration = self._model.window_size_samples / self._opts.sample_rate
+                window_duration = VAD_WINDOW_SAMPLES / _MODEL_SAMPLE_RATE
 
-                pub_current_sample += self._model.window_size_samples
+                pub_current_sample += VAD_WINDOW_SAMPLES
                 pub_timestamp += window_duration
 
-                resampling_ratio = self._input_sample_rate / self._model.sample_rate
-                to_copy = (
-                    self._model.window_size_samples * resampling_ratio + input_copy_remaining_fract
-                )
+                resampling_ratio = self._input_sample_rate / _MODEL_SAMPLE_RATE
+                to_copy = VAD_WINDOW_SAMPLES * resampling_ratio + input_copy_remaining_fract
                 to_copy_int = int(to_copy)
                 input_copy_remaining_fract = to_copy - to_copy_int
 
@@ -473,8 +339,8 @@ class VADStream(agents.vad.VADStream):
                     pub_silence_duration += window_duration
 
                 self._event_ch.send_nowait(
-                    agents.vad.VADEvent(
-                        type=agents.vad.VADEventType.INFERENCE_DONE,
+                    vad.VADEvent(
+                        type=vad.VADEventType.INFERENCE_DONE,
                         samples_index=pub_current_sample,
                         timestamp=pub_timestamp,
                         silence_duration=pub_silence_duration,
@@ -508,8 +374,8 @@ class VADStream(agents.vad.VADStream):
                             pub_speech_duration = speech_threshold_duration
 
                             self._event_ch.send_nowait(
-                                agents.vad.VADEvent(
-                                    type=agents.vad.VADEventType.START_OF_SPEECH,
+                                vad.VADEvent(
+                                    type=vad.VADEventType.START_OF_SPEECH,
                                     samples_index=pub_current_sample,
                                     timestamp=pub_timestamp,
                                     silence_duration=pub_silence_duration,
@@ -534,8 +400,8 @@ class VADStream(agents.vad.VADStream):
                         pub_silence_duration = silence_threshold_duration
 
                         self._event_ch.send_nowait(
-                            agents.vad.VADEvent(
-                                type=agents.vad.VADEventType.END_OF_SPEECH,
+                            vad.VADEvent(
+                                type=vad.VADEventType.END_OF_SPEECH,
                                 samples_index=pub_current_sample,
                                 timestamp=pub_timestamp,
                                 silence_duration=pub_silence_duration,
@@ -567,12 +433,12 @@ class VADStream(agents.vad.VADStream):
                         )
                     )
 
-                if len(inference_frame.data) - self._model.window_size_samples > 0:
-                    data = inference_frame.data[self._model.window_size_samples :].tobytes()
+                if len(inference_frame.data) - VAD_WINDOW_SAMPLES > 0:
+                    data = inference_frame.data[VAD_WINDOW_SAMPLES:].tobytes()
                     inference_frames.append(
                         rtc.AudioFrame(
                             data=data,
-                            sample_rate=self._opts.sample_rate,
+                            sample_rate=_MODEL_SAMPLE_RATE,
                             num_channels=1,
                             samples_per_channel=len(data) // 2,
                         )

--- a/livekit-agents/livekit/agents/vad.py
+++ b/livekit-agents/livekit/agents/vad.py
@@ -78,6 +78,7 @@ class VAD(ABC, rtc.EventEmitter[Literal["metrics_collected"]]):
         super().__init__()
         self._capabilities = capabilities
         self._label = f"{type(self).__module__}.{type(self).__name__}"
+        self._is_default = False
 
     @property
     def model(self) -> str:
@@ -90,6 +91,18 @@ class VAD(ABC, rtc.EventEmitter[Literal["metrics_collected"]]):
     @property
     def capabilities(self) -> VADCapabilities:
         return self._capabilities
+
+    @property
+    def is_default(self) -> bool:
+        """True iff this VAD instance was auto-provisioned by ``AgentSession``.
+
+        Set by the framework when constructing the default VAD; never set by
+        user code. Call sites that activate behaviour just because a VAD is
+        present (e.g. realtime turn-detection fallback, adaptive interruption,
+        STT-hook ``speaking=`` payload) should treat a default-VAD instance as
+        if no VAD were configured.
+        """
+        return self._is_default
 
     @abstractmethod
     def stream(self) -> VADStream: ...

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -284,7 +284,14 @@ class AgentActivity(RecognitionHooks):
                 mode = None
 
             # fallback to VAD if server side turn detection is disabled and VAD is available
-            if not llm_model.capabilities.turn_detection and vad_model and mode is None:
+            # (only when the user explicitly supplied a VAD — don't auto-flip turn detection
+            # just because the framework's default silero VAD is present).
+            if (
+                not llm_model.capabilities.turn_detection
+                and vad_model is not None
+                and not vad_model.is_default
+                and mode is None
+            ):
                 mode = "vad"
 
         elif mode == "realtime_llm":
@@ -794,11 +801,24 @@ class AgentActivity(RecognitionHooks):
             self._session._chat_ctx.insert(initial_config)
 
         await self._resume_scheduling_task()
+        # When the realtime LLM provides server-side VAD, the framework-supplied
+        # default VAD is dead weight: server events drive turn detection, and
+        # wiring it would only burn per-stream silero CPU. Skip it. A
+        # user-configured VAD still gets wired so explicit AudioTurnDetector /
+        # turn_detection="vad" opt-ins keep working.
+        wired_vad = self.vad
+        if (
+            wired_vad is not None
+            and wired_vad.is_default
+            and isinstance(self.llm, llm.RealtimeModel)
+            and self.llm.capabilities.turn_detection
+        ):
+            wired_vad = None
         self._audio_recognition = AudioRecognition(
             self._session,
             hooks=self,
             stt=self._agent.stt_node if self.stt else None,
-            vad=self.vad,
+            vad=wired_vad,
             interruption_detection=self._interruption_detector,
             endpointing=create_endpointing(self.endpointing_opts),
             turn_detection=self._turn_detection,
@@ -1532,7 +1552,10 @@ class AgentActivity(RecognitionHooks):
         self._session.emit("overlapping_speech", ev)
 
     def _on_input_speech_started(self, _: llm.InputSpeechStartedEvent) -> None:
-        if self.vad is None:
+        # When only the framework default VAD is present, server-side VAD events
+        # are the canonical state source (the default VAD isn't even wired in
+        # this realtime+server-VAD path). Treat default-VAD as no-VAD here.
+        if self.vad is None or self.vad.is_default:
             self._session._update_user_state("speaking")
             if self._audio_recognition:
                 self._audio_recognition.on_start_of_speech(
@@ -1550,7 +1573,7 @@ class AgentActivity(RecognitionHooks):
             )
 
     def _on_input_speech_stopped(self, ev: llm.InputSpeechStoppedEvent) -> None:
-        if self.vad is None:
+        if self.vad is None or self.vad.is_default:
             if self._audio_recognition:
                 self._audio_recognition.on_end_of_speech(
                     ended_at=time.time(),
@@ -3794,11 +3817,15 @@ class AgentActivity(RecognitionHooks):
         return self._agent.vad if is_given(self._agent.vad) else self._session.vad
 
     def _resolve_interruption_detection(self) -> inference.AdaptiveInterruptionDetector | None:
+        # Adaptive interruption is opt-in (or opt-in-by-environment); we don't
+        # want a framework-default VAD to silently flip eligibility on for
+        # users who never configured a VAD themselves.
+        user_vad = self.vad is not None and not self.vad.is_default
         if not (
             self.stt is not None
             and self.stt.capabilities.aligned_transcript
             and self.stt.capabilities.streaming
-            and self.vad is not None
+            and user_vad
             and self._turn_detection not in ("manual", "realtime_llm")
             and not isinstance(self.llm, llm.RealtimeModel)
         ):

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -198,6 +198,12 @@ class VoiceActivityVideoSampler:
 DEFAULT_TTS_TEXT_TRANSFORMS: list[TextTransforms] = ["filter_markdown", "filter_emoji"]
 
 
+def _build_default_vad() -> vad.VAD:
+    instance = inference.VAD(model="silero")
+    instance._is_default = True
+    return instance
+
+
 class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
     @deprecate_params(
         {
@@ -266,7 +272,10 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         Args:
             stt (stt.STT | str, optional): Speech-to-text backend.
-            vad (vad.VAD, optional): Voice-activity detector
+            vad (vad.VAD, optional): Voice-activity detector. Defaults to the
+                bundled silero VAD (``inference.VAD(model="silero")``) when
+                omitted. Pass ``vad=None`` to opt out, or pass an explicit
+                instance to customise options.
             llm (llm.LLM | llm.RealtimeModel | str, optional): LLM or RealtimeModel
             tts (tts.TTS | str, optional): Text-to-speech engine.
             tools (list[llm.FunctionTool | llm.RawFunctionTool], optional): List of
@@ -395,6 +404,8 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             tts = inference.TTS.from_model_string(tts)
 
         self._stt = stt or None
+        if not is_given(vad):
+            vad = _build_default_vad()
         self._vad = vad or None
         self._llm = llm or None
         self._tts = tts or None

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -219,7 +219,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         self,
         *,
         stt: NotGivenOr[stt.STT | STTModels | str] = NOT_GIVEN,
-        vad: NotGivenOr[vad.VAD] = NOT_GIVEN,
+        vad: NotGivenOr[vad.VAD | None] = NOT_GIVEN,
         llm: NotGivenOr[llm.LLM | llm.RealtimeModel | LLMModels | str] = NOT_GIVEN,
         tts: NotGivenOr[tts.TTS | TTSModels | str] = NOT_GIVEN,
         turn_handling: NotGivenOr[TurnHandlingOptions] = NOT_GIVEN,

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -304,6 +304,16 @@ class AudioRecognition:
             and not self._interruption_ch.closed
         )
 
+    @property
+    def _has_user_vad(self) -> bool:
+        """True only when a user-configured VAD is wired. Framework-default
+        VAD instances return False here so the STT-hook ``speaking=`` payload
+        type and ``_last_speaking_time`` source stay on their pre-default-VAD
+        codepaths (preserving observable behaviour for sessions that didn't
+        configure a VAD).
+        """
+        return self._vad is not None and not self._vad.is_default
+
     # region: boundary for adaptive interruption detection
 
     @property
@@ -981,7 +991,7 @@ class AudioRecognition:
             self._hooks.on_final_transcript(
                 ev,
                 speaking=self._speaking
-                if self._vad or self._turn_detection_mode == "stt"
+                if self._has_user_vad or self._turn_detection_mode == "stt"
                 else None,
             )
             if self._session.amd is not None:
@@ -1000,8 +1010,8 @@ class AudioRecognition:
             self._audio_interim_transcript = ""
             self._audio_preflight_transcript = ""
 
-            if not self._vad or self._last_speaking_time is None:
-                # vad disabled, use stt timestamp
+            if not self._has_user_vad or self._last_speaking_time is None:
+                # no user-configured vad, use stt timestamp
                 # TODO: this would screw up transcription latency metrics
                 # but we'll live with it for now.
                 # the correct way is to ensure STT fires SpeechEventType.END_OF_SPEECH
@@ -1038,7 +1048,7 @@ class AudioRecognition:
             self._hooks.on_interim_transcript(
                 ev,
                 speaking=self._speaking
-                if self._vad or self._turn_detection_mode == "stt"
+                if self._has_user_vad or self._turn_detection_mode == "stt"
                 else None,
             )
             transcript = ev.alternatives[0].text
@@ -1064,8 +1074,8 @@ class AudioRecognition:
             self._audio_preflight_transcript = (self._audio_transcript + " " + transcript).lstrip()
             self._audio_interim_transcript = transcript
 
-            if not self._vad or self._last_speaking_time is None:
-                # vad disabled, use stt timestamp
+            if not self._has_user_vad or self._last_speaking_time is None:
+                # no user-configured vad, use stt timestamp
                 self._last_speaking_time = time.time()
 
             if self._turn_detection_mode != "manual" or self._user_turn_committed:
@@ -1082,7 +1092,7 @@ class AudioRecognition:
             self._hooks.on_interim_transcript(
                 ev,
                 speaking=self._speaking
-                if self._vad or self._turn_detection_mode == "stt"
+                if self._has_user_vad or self._turn_detection_mode == "stt"
                 else None,
             )
             self._audio_interim_transcript = ev.alternatives[0].text
@@ -1105,7 +1115,7 @@ class AudioRecognition:
 
             self._speaking = False
             self._user_turn_committed = True
-            if not self._vad or self._last_speaking_time is None:
+            if not self._has_user_vad or self._last_speaking_time is None:
                 self._last_speaking_time = time.time()
 
             chat_ctx = self._hooks.retrieve_chat_ctx().copy()

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -714,12 +714,13 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                 )
 
             if self._mp_ctx_str == "forkserver":
-                # Preloading ``livekit.local_inference`` in the forkserver
-                # triggers the pybind11 constructor that pages in EOT model
-                # weights; each forked job inherits those pages via COW.
+                # `livekit.agents.inference._warmup` is a side-effect module:
+                # importing it from the forkserver process calls `init_vad()` and
+                # `init_eot()`, paging the native model weights into the
+                # forkserver. Forked job processes inherit those pages via COW.
                 plugin_packages = [p.package for p in Plugin.registered_plugins] + [
                     "av",
-                    "livekit.local_inference",
+                    "livekit.agents.inference._warmup",
                 ]
                 logger.info("preloading plugins", extra={"packages": plugin_packages})
                 self._mp_ctx.set_forkserver_preload(plugin_packages)

--- a/livekit-agents/pyproject.toml
+++ b/livekit-agents/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "livekit-local-inference>=0.2.5",
     "livekit-protocol>=1.1.9,<2",
     "livekit-blingfire~=1.1,<2",
+    "livekit-local-inference>=0.2.5",
     "protobuf>=3",
     "pyjwt>=2.0",
     "types-protobuf>=4",

--- a/livekit-agents/pyproject.toml
+++ b/livekit-agents/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "livekit-local-inference>=0.2.5",
     "livekit-protocol>=1.1.9,<2",
     "livekit-blingfire~=1.1,<2",
-    "livekit-local-inference>=0.2.5",
     "protobuf>=3",
     "pyjwt>=2.0",
     "types-protobuf>=4",

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/__init__.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/__init__.py
@@ -30,7 +30,10 @@ from .log import logger
 
 warnings.warn(
     "livekit-plugins-silero is deprecated and will be removed in v2.0. "
-    'Use `from livekit.agents import inference; inference.VAD(model="silero")` instead.',
+    "AgentSession now defaults to the bundled silero VAD, so you can drop the "
+    "explicit `vad=` argument entirely; pass `vad=None` to opt out, or use "
+    '`from livekit.agents import inference; inference.VAD(model="silero", ...)`'
+    " to customise options.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/__init__.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/__init__.py
@@ -17,6 +17,8 @@
 See https://docs.livekit.io/agents/build/turns/vad/ for more information.
 """
 
+import warnings
+
 from .vad import VAD, VADStream
 from .version import __version__
 
@@ -25,6 +27,13 @@ __all__ = ["VAD", "VADStream", "__version__"]
 from livekit.agents import Plugin
 
 from .log import logger
+
+warnings.warn(
+    "livekit-plugins-silero is deprecated and will be removed in v2.0. "
+    'Use `from livekit.agents import inference; inference.VAD(model="silero")` instead.',
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 class SileroPlugin(Plugin):

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -1248,3 +1248,40 @@ async def test_silent_tool_call_pause_state_does_not_leak_into_tool_reply() -> N
     assert transitions[silent_step_finished + 1] == ("listening", "speaking")
     assert false_interruption_events
     assert false_interruption_events[-1].resumed is True
+
+
+async def test_default_vad_is_auto_provisioned() -> None:
+    from livekit.agents.voice.agent_session import AgentSession
+
+    session = AgentSession()
+    try:
+        assert session.vad is not None
+        assert session.vad.is_default is True
+    finally:
+        await session.aclose()
+
+
+async def test_explicit_vad_none_opts_out() -> None:
+    from livekit.agents.voice.agent_session import AgentSession
+
+    session = AgentSession(vad=None)
+    try:
+        assert session.vad is None
+    finally:
+        await session.aclose()
+
+
+async def test_user_supplied_vad_keeps_is_default_false() -> None:
+    from livekit.agents.voice.agent_session import AgentSession
+
+    from .fake_vad import FakeVAD
+
+    user_vad = FakeVAD(fake_user_speeches=[])
+    assert user_vad.is_default is False
+
+    session = AgentSession(vad=user_vad)
+    try:
+        assert session.vad is user_vad
+        assert session.vad.is_default is False
+    finally:
+        await session.aclose()

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -30,7 +30,12 @@ class TestAudioRecognitionAclose:
         audio_recognition._closing = asyncio.Event()
         audio_recognition._tasks = set()
         audio_recognition._stt_atask = None
+        audio_recognition._stt_consumer_atask = None
+        audio_recognition._stt_pipeline = None
         audio_recognition._vad_atask = None
+        audio_recognition._interruption_atask = None
+        audio_recognition._turn_detection_atask = None
+        audio_recognition._backchannel_boundary_timer = None
         audio_recognition._commit_user_turn_atask = None
         audio_recognition._end_of_turn_task = None
 

--- a/tests/test_audio_recognition_turn_detection.py
+++ b/tests/test_audio_recognition_turn_detection.py
@@ -568,9 +568,9 @@ class TestVadMinSilenceOverride:
 
         ar._maybe_apply_vad_silence_override()
 
-        assert ar._vad._opts.min_silence_duration == pytest.approx(0.2)
+        assert ar._vad._opts.min_silence_duration == pytest.approx(0.25)
         assert ar._vad_min_silence_orig == pytest.approx(0.1)
-        assert ar._vad.update_options_calls == [pytest.approx(0.2)]
+        assert ar._vad.update_options_calls == [pytest.approx(0.25)]
 
     def test_audio_detector_leaves_high_min_silence_alone(self) -> None:
         ar = _make_recognition_for_override()
@@ -588,7 +588,7 @@ class TestVadMinSilenceOverride:
         ar._vad = _FakeVad(min_silence_duration=0.1)
         ar._turn_detector = MagicMock(spec=_AudioTurnDetector)
         ar._maybe_apply_vad_silence_override()
-        assert ar._vad._opts.min_silence_duration == pytest.approx(0.2)
+        assert ar._vad._opts.min_silence_duration == pytest.approx(0.25)
 
         ar._revert_vad_silence_override()
 
@@ -603,7 +603,7 @@ class TestVadMinSilenceOverride:
         ar._maybe_apply_vad_silence_override()
         ar._maybe_apply_vad_silence_override()
 
-        assert ar._vad.update_options_calls == [pytest.approx(0.2)]
+        assert ar._vad.update_options_calls == [pytest.approx(0.25)]
         assert ar._vad_min_silence_orig == pytest.approx(0.1)
 
     def test_non_audio_detector_skips(self) -> None:
@@ -675,7 +675,7 @@ class TestVadMinSilenceOverride:
             ar._vad = _FakeVad(min_silence_duration=0.05)
             ar._maybe_apply_vad_silence_override()
 
-        bumped = [r for r in caplog.records if "bumped VAD min_silence_duration" in r.message]
+        bumped = [r for r in caplog.records if "bumping vad min_silence_duration" in r.message]
         assert len(bumped) == 1
 
     async def test_update_turn_detector_drives_apply_and_revert(self) -> None:
@@ -695,7 +695,7 @@ class TestVadMinSilenceOverride:
 
         try:
             ar.update_turn_detector(detector)
-            assert ar._vad._opts.min_silence_duration == pytest.approx(0.2)
+            assert ar._vad._opts.min_silence_duration == pytest.approx(0.25)
             assert ar._vad_min_silence_orig == pytest.approx(0.1)
 
             ar.update_turn_detector(None)

--- a/tests/test_vad.py
+++ b/tests/test_vad.py
@@ -1,14 +1,15 @@
 import pytest
 
 from livekit.agents import vad
-from livekit.plugins import silero
+from livekit.agents.inference import VAD as InferenceVAD
 
 from . import utils
 
 SAMPLE_RATES = [16000, 44100]  # test multiple input sample rates
 
 
-VAD = silero.VAD.load(
+VAD = InferenceVAD(
+    model="silero",
     min_speech_duration=0.5,
     min_silence_duration=0.75,
 )

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import os
 import pathlib
+import wave
 from collections.abc import AsyncGenerator
 
 import jiwer as tr
@@ -64,6 +66,19 @@ async def read_audio_file(path) -> rtc.AudioFrame:
         frames.append(f)
 
     return rtc.combine_audio_frames(frames)
+
+
+def make_wav_file(frames: list[rtc.AudioFrame]) -> bytes:
+    if not frames:
+        return b""
+    combined = rtc.combine_audio_frames(frames)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(combined.num_channels)
+        wf.setsampwidth(2)  # int16
+        wf.setframerate(combined.sample_rate)
+        wf.writeframes(combined.data.tobytes())
+    return buf.getvalue()
 
 
 async def make_test_speech(


### PR DESCRIPTION
### Why

Silero VAD is the default endpointing implementation for voice agents, but lived behind a separate `livekit-plugins-silero` install step. That extra hop made the standard quickstart longer than it needed to be, and the plugin's `onnxruntime`-based loader paid the full model load cost in every job process (no fork-time sharing).

This PR moves Silero VAD into `livekit-agents` core, backed by `livekit-local-inference`. The plugin stays installable as a deprecated shim until v2.0, and existing call sites continue to work — they transparently route to the new implementation when settings are compatible.

This PR also introduces changes to follow the official silero settings, similar to https://github.com/livekit/agents/pull/5788:
- removed exp filter
- changed the default `min_silence_duration` from 0.55s to 0.1s.

### Code example

**Before**

```python
from livekit.agents import Agent, AgentSession, JobContext, JobProcess, WorkerOptions, cli
from livekit.plugins import deepgram, openai, silero


def prewarm(proc: JobProcess) -> None:
    # Heavy ONNX session construction — must live behind prewarm so each
    # job process doesn't pay the load on every conversation start.
    proc.userdata["vad"] = silero.VAD.load()


async def entrypoint(ctx: JobContext) -> None:
    session = AgentSession(
        vad=ctx.proc.userdata["vad"],
        stt=deepgram.STT(),
        llm=openai.LLM(),
        tts=openai.TTS(),
    )
    await session.start(agent=Agent(instructions="..."), room=ctx.room)


if __name__ == "__main__":
    cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint, prewarm_fnc=prewarm))
```

**After**

```python
from livekit.agents import Agent, AgentSession, JobContext, WorkerOptions, cli, inference
from livekit.plugins import deepgram, openai


async def entrypoint(ctx: JobContext) -> None:
    session = AgentSession(
        vad=inference.VAD(model="silero"),
        stt=deepgram.STT(),
        llm=openai.LLM(),
        tts=openai.TTS(),
    )
    await session.start(agent=Agent(instructions="..."), room=ctx.room)


if __name__ == "__main__":
    cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))
```

No `prewarm_fnc`, no `silero` plugin import, no `proc.userdata` shuttle. Weights are loaded once in the forkserver and inherited by every job process via COW.

### API change

| Before | After |
|---|---|
| `pip install livekit-agents livekit-plugins-silero` | `pip install livekit-agents` — Silero is bundled |
| `from livekit.plugins.silero import VAD` <br>`vad = VAD.load(min_silence_duration=0.4)` | `from livekit.agents import inference` <br>`vad = inference.VAD(model="silero", min_silence_duration=0.4)` |
| `silero.VAD.load()` did a heavy onnxruntime session construction → expected to live behind a `prewarm` hook | `inference.VAD(model="silero")` is a cheap wrapper; weights are loaded once at forkserver-preload time, inherited via COW |
| Per-job: ~6 MB Silero ONNX loaded into every job process | Per-fork: weights resident in the forkserver, COW-shared with each job (Linux); spawn platforms unchanged |
| Plugin owned its own `VAD`/`VADStream`/`OnnxModel` (~650 LOC) | Core owns the wrapper; plugin keeps a frozen copy as a deprecation shim |
| `silero.VAD.load(force_cpu=False, sample_rate=16000)` ran onnxruntime; with custom `onnx_file_path`, used a user-supplied model | `silero.VAD.load(...)` transparently delegates to `inference.VAD(model="silero", ...)` when settings are compatible; 8 kHz + `onnx_file_path` still routes to the legacy onnxruntime path |
| `vad: NotGivenOr[vad.VAD] = NOT_GIVEN` in `AgentSession.__init__` — `vad=None` was illegal per type, even though the code accepted it | `vad: NotGivenOr[vad.VAD \| None] = NOT_GIVEN` — `vad=None` now type-legal as an explicit "no VAD" signal |
| No way to invoke Silero VAD without importing the plugin | `from livekit.agents.inference import VAD` |

### Behaviour change

| Before | After |
|---|---|
| Worker startup: each forked job pays the full Silero ONNX load (~tens of ms) | Forkserver preload runs `livekit.agents.inference._warmup` once → `init_vad()` + `init_eot()` page native weights into the forkserver. Jobs fork with weights already resident. |
| `import livekit.plugins.silero` — silent | Emits a single `DeprecationWarning` pointing to `inference.VAD(model="silero")`; v2.0 removal target |
| `silero.VAD.load(force_cpu=False)` honored the user's GPU request via onnxruntime | When delegating to native, `force_cpu=False` is ignored (native lib is CPU-only) → now emits a `WARNING` explaining the kwarg is ignored and pointing at `onnx_file_path` as the legacy escape hatch |
| AgentSession with default args → `session.vad is None` | **No change** on this branch — default stays `None`.  |


### Migration

| If you currently use… | Do nothing? | Recommended update |
|---|---|---|
| `silero.VAD.load()` with default settings | Works (delegates) — deprecation warning prints once at plugin import | `from livekit.agents import inference; inference.VAD(model="silero")` |
| `silero.VAD.load(sample_rate=8000)` | Works — still routes to legacy onnxruntime | No native equivalent; stay on plugin until v2.0 then migrate if 16 kHz is acceptable |
| `silero.VAD.load(onnx_file_path=...)` | Works — still routes to legacy onnxruntime | Stay on plugin until v2.0; the bundled native model is fixed |
| `silero.VAD.load(force_cpu=False)` | Works but a warning now fires noting `force_cpu` is ignored on the delegated native path | Use `inference.VAD(model="silero")` (and accept CPU) or keep the plugin form with `onnx_file_path=...` to keep the legacy path |


