### PR TITLE
fix(voice): restrict stt pipeline reuse to default stt_node

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -610,11 +610,13 @@ class AgentActivity(RecognitionHooks):
         resources = _ReusableResources()
 
         try:
-            # stt pipeline
+            # stt pipeline; only reuse with the default stt_node, a custom override may
+            # access the old self.session/activity inside the yield loop after detach
             if (
                 self._audio_recognition
                 and self.stt is not None
-                and type(self.agent).stt_node is type(new_activity.agent).stt_node
+                and type(self.agent).stt_node is Agent.stt_node
+                and type(new_activity.agent).stt_node is Agent.stt_node
                 and self.stt is new_activity.stt
             ):
                 resources.stt_pipeline = await self._audio_recognition.detach_stt()

--- a/tests/test_audio_recognition_handoff.py
+++ b/tests/test_audio_recognition_handoff.py
@@ -86,10 +86,12 @@ async def test_not_reusable_different_stt_node_override() -> None:
     assert result is None
 
 
-async def test_reusable_subclass_inherits_stt_node() -> None:
-    """Old agent overrides stt_node; new agent is a subclass that inherits it → reusable.
+async def test_not_reusable_subclass_inherits_custom_stt_node() -> None:
+    """Both agents share a custom stt_node via inheritance → not reusable.
 
-    B(A) does not override stt_node, so B.stt_node is A.stt_node (same object via MRO).
+    The pipeline is bound to the old agent's `self`; a custom stt_node may access
+    self.session/activity inside the yield loop, which raises after detach.
+    Only the default Agent.stt_node is known to be safe to reuse.
     """
     shared_stt = MagicMock()
 
@@ -108,8 +110,7 @@ async def test_reusable_subclass_inherits_stt_node() -> None:
     new = _make_activity(AgentB(instructions="b"), shared_stt)
 
     result = await _detach_stt_if_reusable(old, new)
-    assert result is not None
-    old._audio_recognition.detach_stt.assert_awaited_once()
+    assert result is None
 
 
 async def test_not_reusable_subclass_overrides_stt_node() -> None:


### PR DESCRIPTION
## Summary

On agent handoff, `_detach_reusable_resources` reuses the STT pipeline when `type(self.agent).stt_node is type(new_activity.agent).stt_node`. That check passes whenever two agents share the same `stt_node` method object — including via a common base class — but the detached pipeline is a running generator bound to the **old** agent's `self`. The default `Agent.stt_node` is safe because it only reads `self`/`activity` at startup, before the yield loop. Any custom override that touches `self.session` or `self.activity` inside the loop will crash after handoff:

```
File "/code/ai_receptionist/logic/livekit_agents/base.py", line 1079, in stt_node
    self.session,
File ".../voice/agent.py", line 684, in session
    return self._get_activity_or_raise().session
File ".../voice/agent.py", line 382, in _get_activity_or_raise
    raise RuntimeError("no activity context found, the agent is not running")
```

Tighten the precondition to "both agents use `Agent.stt_node` directly." Custom overrides — even ones shared via inheritance — no longer trigger reuse, since we can't verify they're safe to keep iterating after their bound `self` loses its activity.