### PR TITLE
feat(deepgram): use Configure control message for mid-stream keyterm updates

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -296,6 +296,7 @@ class SpeechStreamv2(stt.SpeechStream):
 
         self._request_id = ""
         self._reconnect_event = asyncio.Event()
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
 
     def update_options(
         self,
@@ -313,6 +314,16 @@ class SpeechStreamv2(stt.SpeechStream):
         # deprecated
         keyterms: NotGivenOr[list[str]] = NOT_GIVEN,
     ) -> None:
+        if is_given(keyterms):
+            logger.warning(
+                "`keyterms` is deprecated, use `keyterm` instead for consistency with Deepgram API."
+            )
+            keyterm = keyterms
+
+        requires_reconnect = (
+            is_given(model) or is_given(sample_rate) or is_given(mip_opt_out) or is_given(endpoint_url) or is_given(tags)
+        )
+
         if is_given(model):
             self._opts.model = model
         if is_given(sample_rate):
@@ -321,11 +332,6 @@ class SpeechStreamv2(stt.SpeechStream):
             self._opts.eot_threshold = eot_threshold
         if is_given(eot_timeout_ms):
             self._opts.eot_timeout_ms = eot_timeout_ms
-        if is_given(keyterms):
-            logger.warning(
-                "`keyterms` is deprecated, use `keyterm` instead for consistency with Deepgram API."
-            )
-            keyterm = keyterms
         if is_given(keyterm):
             self._opts.keyterm = keyterm
         if is_given(mip_opt_out):
@@ -339,7 +345,53 @@ class SpeechStreamv2(stt.SpeechStream):
         if is_given(eager_eot_threshold):
             self._opts.eager_eot_threshold = eager_eot_threshold
 
-        self._reconnect_event.set()
+        if requires_reconnect:
+            self._reconnect_event.set()
+        elif self._ws is not None and not self._ws.closed:
+            self._send_configure(
+                keyterm=keyterm,
+                eot_threshold=eot_threshold,
+                eot_timeout_ms=eot_timeout_ms,
+                eager_eot_threshold=eager_eot_threshold,
+                language_hint=language_hint,
+            )
+        else:
+            self._reconnect_event.set()
+
+    def _send_configure(
+        self,
+        *,
+        keyterm: NotGivenOr[str | list[str]] = NOT_GIVEN,
+        eot_threshold: NotGivenOr[float] = NOT_GIVEN,
+        eot_timeout_ms: NotGivenOr[int] = NOT_GIVEN,
+        eager_eot_threshold: NotGivenOr[float] = NOT_GIVEN,
+        language_hint: NotGivenOr[list[str]] = NOT_GIVEN,
+    ) -> None:
+        """Send a Configure control message to update settings mid-stream without reconnecting."""
+        configure_msg: dict[str, Any] = {"type": "Configure"}
+
+        if is_given(keyterm):
+            terms = [keyterm] if isinstance(keyterm, str) else list(keyterm)
+            configure_msg["keyterms"] = terms
+
+        thresholds: dict[str, Any] = {}
+        if is_given(eot_threshold):
+            thresholds["eot_threshold"] = eot_threshold
+        if is_given(eot_timeout_ms):
+            thresholds["eot_timeout_ms"] = eot_timeout_ms
+        if is_given(eager_eot_threshold):
+            thresholds["eager_eot_threshold"] = eager_eot_threshold
+        if thresholds:
+            configure_msg["thresholds"] = thresholds
+
+        if is_given(language_hint):
+            configure_msg["language_hints"] = language_hint
+
+        if len(configure_msg) <= 1:
+            return
+
+        assert self._ws is not None
+        asyncio.ensure_future(self._ws.send_str(json.dumps(configure_msg)))
 
     async def _run(self) -> None:
         closing_ws = False
@@ -424,6 +476,7 @@ class SpeechStreamv2(stt.SpeechStream):
         while True:
             try:
                 ws = await self._connect_ws()
+                self._ws = ws
                 tasks = [
                     asyncio.create_task(send_task(ws)),
                     asyncio.create_task(recv_task(ws)),
@@ -451,6 +504,7 @@ class SpeechStreamv2(stt.SpeechStream):
                     tasks_group.cancel()
                     tasks_group.exception()  # retrieve the exception
             finally:
+                self._ws = None
                 if ws is not None:
                     await ws.close()
 

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -390,8 +390,14 @@ class SpeechStreamv2(stt.SpeechStream):
         if len(configure_msg) <= 1:
             return
 
-        assert self._ws is not None
-        asyncio.ensure_future(self._ws.send_str(json.dumps(configure_msg)))
+        asyncio.ensure_future(self._do_send_configure(json.dumps(configure_msg)))
+
+    async def _do_send_configure(self, msg_str: str) -> None:
+        try:
+            if self._ws is not None and not self._ws.closed:
+                await self._ws.send_str(msg_str)
+        except Exception:
+            logger.debug("failed to send Configure message, ws may be closing")
 
     async def _run(self) -> None:
         closing_ws = False

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -321,7 +321,11 @@ class SpeechStreamv2(stt.SpeechStream):
             keyterm = keyterms
 
         requires_reconnect = (
-            is_given(model) or is_given(sample_rate) or is_given(mip_opt_out) or is_given(endpoint_url) or is_given(tags)
+            is_given(model)
+            or is_given(sample_rate)
+            or is_given(mip_opt_out)
+            or is_given(endpoint_url)
+            or is_given(tags)
         )
 
         if is_given(model):

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -297,6 +297,7 @@ class SpeechStreamv2(stt.SpeechStream):
         self._request_id = ""
         self._reconnect_event = asyncio.Event()
         self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._configure_task: asyncio.Task[None] | None = None
 
     def update_options(
         self,
@@ -371,7 +372,6 @@ class SpeechStreamv2(stt.SpeechStream):
         eager_eot_threshold: NotGivenOr[float] = NOT_GIVEN,
         language_hint: NotGivenOr[list[str]] = NOT_GIVEN,
     ) -> None:
-        """Send a Configure control message to update settings mid-stream without reconnecting."""
         configure_msg: dict[str, Any] = {"type": "Configure"}
 
         if is_given(keyterm):
@@ -394,14 +394,18 @@ class SpeechStreamv2(stt.SpeechStream):
         if len(configure_msg) <= 1:
             return
 
-        asyncio.ensure_future(self._do_send_configure(json.dumps(configure_msg)))
+        self._configure_task = asyncio.create_task(
+            self._do_send_configure(json.dumps(configure_msg))
+        )
 
     async def _do_send_configure(self, msg_str: str) -> None:
         try:
             if self._ws is not None and not self._ws.closed:
                 await self._ws.send_str(msg_str)
+                return
         except Exception:
-            logger.debug("failed to send Configure message, ws may be closing")
+            logger.debug("failed to send Configure message, falling back to reconnect")
+        self._reconnect_event.set()
 
     async def _run(self) -> None:
         closing_ws = False
@@ -515,6 +519,9 @@ class SpeechStreamv2(stt.SpeechStream):
                     tasks_group.exception()  # retrieve the exception
             finally:
                 self._ws = None
+                if self._configure_task is not None and not self._configure_task.done():
+                    self._configure_task.cancel()
+                    self._configure_task = None
                 if ws is not None:
                     await ws.close()
 
@@ -631,6 +638,13 @@ class SpeechStreamv2(stt.SpeechStream):
 
                 end_event = stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH)
                 self._event_ch.send_nowait(end_event)
+
+        elif data["type"] == "ConfigureSuccess":
+            logger.debug("Configure message applied", extra={"data": data})
+
+        elif data["type"] == "ConfigureFailure":
+            logger.warning("Configure message rejected by Deepgram", extra={"data": data})
+            self._reconnect_event.set()
 
         elif data["type"] == "Error":
             logger.warning("deepgram sent an error", extra={"data": data})

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -372,6 +372,7 @@ class SpeechStreamv2(stt.SpeechStream):
         eager_eot_threshold: NotGivenOr[float] = NOT_GIVEN,
         language_hint: NotGivenOr[list[str]] = NOT_GIVEN,
     ) -> None:
+        """Send a Configure control message to update settings mid-stream without reconnecting."""
         configure_msg: dict[str, Any] = {"type": "Configure"}
 
         if is_given(keyterm):


### PR DESCRIPTION
## Summary

- When only `keyterm`, EOT thresholds, or `language_hint` are updated via `update_options()`, send a Deepgram [Configure control message](https://developers.deepgram.com/docs/flux/configure#configure-message) instead of reconnecting the WebSocket
- This avoids dropping in-progress speech recognition when options change mid-stream (e.g. updating keyterms while the user is speaking)
- Options that cannot be updated mid-stream (`model`, `sample_rate`, `mip_opt_out`, `endpoint_url`, `tags`) still trigger a full reconnect as before

## Motivation

Currently, any call to `SpeechStreamv2.update_options()` triggers `_reconnect_event.set()`, which tears down the active WebSocket and reconnects. If this happens while the user is speaking, any in-progress INTERIM_TRANSCRIPT is lost and the final transcript may be incomplete.

Deepgram's Flux models support a `Configure` control message that allows updating keyterms, EOT thresholds, and language hints mid-stream without reconnecting:

```json
{
  "type": "Configure",
  "keyterms": ["term1", "term2"],
  "thresholds": {
    "eot_threshold": 0.8,
    "eot_timeout_ms": 5000
  }
}
```

Ref: https://developers.deepgram.com/docs/flux/configure#configure-message

## Changes

- Added `self._ws` instance variable to `SpeechStreamv2` to hold the current WebSocket reference
- Added `_send_configure()` method that constructs and sends the Configure control message
- Modified `update_options()` to check whether the update requires a reconnect or can be applied mid-stream via Configure message
- Handle `ConfigureSuccess` / `ConfigureFailure` responses from Deepgram — on failure, fall back to reconnect so options still take effect
- Use `asyncio.create_task` with tracked reference instead of fire-and-forget `ensure_future`; cancel pending task on WebSocket cleanup
- Fall back to reconnect if Configure message send fails (e.g. WebSocket closing concurrently)

## Test plan

- [ ] Verify keyterm updates via Configure message don't interrupt ongoing speech recognition
- [ ] Verify EOT threshold updates via Configure message work correctly
- [ ] Verify model/sample_rate/endpoint changes still trigger reconnect
- [ ] Verify behavior when WebSocket is not yet connected (falls back to reconnect)
- [ ] Verify ConfigureFailure triggers reconnect and logs warning
- [ ] Verify send failure (e.g. ws closed mid-send) falls back to reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)