### PR TITLE
feat(vad): set default vad in agent session

### DIFF
--- a/examples/avatar_agents/audio_wave/agent_worker.py
+++ b/examples/avatar_agents/audio_wave/agent_worker.py
@@ -74,7 +74,6 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("google/gemini-2.5-flash"),
         tts=inference.TTS("cartesia/sonic-3"),
-        vad=inference.VAD(model="silero"),
         resume_false_interruption=False,
     )
 

--- a/examples/avatar_agents/keyframe/agent_worker.py
+++ b/examples/avatar_agents/keyframe/agent_worker.py
@@ -51,7 +51,6 @@ async def entrypoint(ctx: JobContext):
         llm=inference.LLM("google/gemini-2.5-flash"),
         tts=inference.TTS("cartesia/sonic-3"),
         resume_false_interruption=False,
-        vad=inference.VAD(model="silero"),
         turn_detection=AudioTurnDetector(),
     )
 

--- a/examples/drive-thru/agent.py
+++ b/examples/drive-thru/agent.py
@@ -487,7 +487,6 @@ async def drive_thru_agent(ctx: JobContext) -> None:
         llm=inference.LLM("openai/gpt-5-mini"),
         tts=inference.TTS("cartesia/sonic-3", voice="f786b574-daa5-4673-aa0c-cbe3e8534c02"),
         turn_detection=AudioTurnDetector(),
-        vad=inference.VAD(model="silero"),
         max_tool_steps=10,
     )
 

--- a/examples/frontdesk/agent.py
+++ b/examples/frontdesk/agent.py
@@ -266,7 +266,6 @@ async def frontdesk_agent(ctx: JobContext):
         llm=inference.LLM("google/gemini-2.5-flash"),
         tts=inference.TTS("cartesia/sonic-3", voice="39b376fc-488e-4d0c-8b37-e00b72059fdd"),
         turn_detection=AudioTurnDetector(),
-        vad=inference.VAD(model="silero"),
         max_tool_steps=1,
     )
 

--- a/examples/healthcare/agent.py
+++ b/examples/healthcare/agent.py
@@ -753,7 +753,6 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3", language="multi"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("inworld/inworld-tts-1"),
-        vad=inference.VAD(model="silero"),
         preemptive_generation=True,
     )
 

--- a/examples/inference/agent.py
+++ b/examples/inference/agent.py
@@ -58,7 +58,6 @@ async def entrypoint(ctx: JobContext) -> None:
         stt=inference.STT(model=DEFAULT_STT),
         llm=inference.LLM(model=DEFAULT_LLM),
         tts=inference.TTS(model=DEFAULT_TTS),
-        vad=inference.VAD(model="silero"),
     )
 
     def parse_value(payload: str, fallback: str) -> str:

--- a/examples/other/elevenlab_scribe_v2.py
+++ b/examples/other/elevenlab_scribe_v2.py
@@ -30,7 +30,6 @@ async def entrypoint(ctx: JobContext) -> None:
 
     session: AgentSession = AgentSession(
         allow_interruptions=True,
-        vad=inference.VAD(model="silero"),
         stt=stt,
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/other/kokoro_tts.py
+++ b/examples/other/kokoro_tts.py
@@ -8,7 +8,6 @@ from livekit.agents import (
     AgentSession,
     JobContext,
     cli,
-    inference,
     metrics,
 )
 from livekit.agents.voice import MetricsCollectedEvent
@@ -43,7 +42,6 @@ async def entrypoint(ctx: JobContext):
         "user_id": "your user_id",
     }
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         # any combination of STT, LLM, TTS, or realtime API can be used
         llm=openai.LLM(model="gpt-4.1-mini"),
         stt=deepgram.STT(model="nova-3", language="multi"),

--- a/examples/other/transcription/multi-user-transcriber.py
+++ b/examples/other/transcription/multi-user-transcriber.py
@@ -89,9 +89,7 @@ class MultiUserTranscriber:
         if participant.identity in self._sessions:
             return self._sessions[participant.identity]
 
-        session = AgentSession(
-            vad=inference.VAD(model="silero"),
-        )
+        session = AgentSession()
         await session.start(
             agent=Transcriber(
                 participant_identity=participant.identity,

--- a/examples/other/transcription/translator.py
+++ b/examples/other/transcription/translator.py
@@ -12,7 +12,6 @@ from livekit.agents import (
     MetricsCollectedEvent,
     StopResponse,
     cli,
-    inference,
     llm,
     metrics,
     room_io,
@@ -77,7 +76,6 @@ async def entrypoint(ctx: JobContext):
 
     session = AgentSession(
         # vad is only needed for non-streaming STT implementations
-        vad=inference.VAD(model="silero"),
     )
 
     @session.on("metrics_collected")

--- a/examples/survey/agent.py
+++ b/examples/survey/agent.py
@@ -353,7 +353,6 @@ async def entrypoint(ctx: JobContext):
         llm=inference.LLM("google/gemini-2.5-flash"),
         stt=inference.STT("deepgram/nova-3", language="multi"),
         tts=inference.TTS("inworld/inworld-tts-1"),
-        vad=inference.VAD(model="silero"),
         turn_detection=AudioTurnDetector(),
         preemptive_generation=True,
     )

--- a/examples/telephony/amd.py
+++ b/examples/telephony/amd.py
@@ -46,7 +46,6 @@ async def entrypoint(ctx: JobContext):
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3", voice="9626c31c-bec5-4cca-baa8-f8ba9e84c8bc"),
         turn_detection=AudioTurnDetector(),
-        vad=inference.VAD(model="silero"),
         preemptive_generation=True,
     )
 

--- a/examples/telephony/bank-ivr/ivr_navigator_agent.py
+++ b/examples/telephony/bank-ivr/ivr_navigator_agent.py
@@ -82,7 +82,6 @@ async def dtmf_session(ctx: JobContext) -> None:
     }
 
     session: AgentSession = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("rime/arcana"),

--- a/examples/telephony/bank-ivr/ivr_system_agent.py
+++ b/examples/telephony/bank-ivr/ivr_system_agent.py
@@ -630,7 +630,6 @@ async def bank_ivr_session(ctx: JobContext) -> None:
     state = SessionState()
 
     session: AgentSession[SessionState] = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/telephony/basic_dtmf_agent.py
+++ b/examples/telephony/basic_dtmf_agent.py
@@ -135,7 +135,6 @@ async def entrypoint(ctx: JobContext) -> None:
     }
 
     session: AgentSession = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("inworld/inworld-tts-1"),

--- a/examples/voice_agents/annotated_tool_args.py
+++ b/examples/voice_agents/annotated_tool_args.py
@@ -91,7 +91,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     agent = AgentSession(
-        vad=inference.VAD(model="silero"),
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("google/gemini-2.5-flash"),
         tts=inference.TTS("rime/arcana"),

--- a/examples/voice_agents/async_tool_agent.py
+++ b/examples/voice_agents/async_tool_agent.py
@@ -193,7 +193,6 @@ async def entrypoint(ctx: JobContext):
         llm=inference.LLM("openai/gpt-5.3-chat-latest"),
         tts=inference.TTS("cartesia/sonic-3", voice="e07c00bc-4134-4eae-9ea4-1a55fb45746b"),
         # llm=google.realtime.RealtimeModel(),
-        vad=inference.VAD(model="silero"),
         turn_handling={"interruption": {"mode": "vad"}},
     )
 

--- a/examples/voice_agents/basic_agent.py
+++ b/examples/voice_agents/basic_agent.py
@@ -85,7 +85,6 @@ async def entrypoint(ctx: JobContext) -> None:
         # Text-to-speech (TTS) is your agent's voice, turning the LLM's text into speech that the user can hear
         # See all available models as well as voice selections at https://docs.livekit.io/agents/models/tts/
         tts=inference.TTS("cartesia/sonic-3", voice="9626c31c-bec5-4cca-baa8-f8ba9e84c8bc"),
-        vad=inference.VAD(model="silero"),
         turn_handling=TurnHandlingOptions(
             # VAD and turn detection are used to determine when the user is speaking and when the agent should respond
             # See more at https://docs.livekit.io/agents/build/turns

--- a/examples/voice_agents/dynamic_tool_creation.py
+++ b/examples/voice_agents/dynamic_tool_creation.py
@@ -114,7 +114,6 @@ async def entrypoint(ctx: JobContext):
     )
 
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/email_example.py
+++ b/examples/voice_agents/email_example.py
@@ -60,7 +60,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/error_callback.py
+++ b/examples/voice_agents/error_callback.py
@@ -29,7 +29,6 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),
-        vad=inference.VAD(model="silero"),
     )
 
     custom_error_audio = os.path.join(pathlib.Path(__file__).parent.absolute(), "error_message.ogg")

--- a/examples/voice_agents/fast-preresponse.py
+++ b/examples/voice_agents/fast-preresponse.py
@@ -10,7 +10,6 @@ from livekit.agents import (
     AgentSession,
     JobContext,
     cli,
-    inference,
     llm,
 )
 from livekit.agents.llm.chat_context import ChatContext, ChatMessage
@@ -83,7 +82,6 @@ async def entrypoint(ctx: JobContext):
     session = AgentSession(
         stt=deepgram.STT(),
         tts=openai.TTS(),
-        vad=inference.VAD(model="silero"),
     )
     await session.start(PreResponseAgent(), room=ctx.room)
 

--- a/examples/voice_agents/flush_llm_node.py
+++ b/examples/voice_agents/flush_llm_node.py
@@ -15,7 +15,6 @@ from livekit.agents import (
     ModelSettings,
     cli,
     function_tool,
-    inference,
     llm,
     metrics,
 )
@@ -111,7 +110,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm="openai/gpt-4.1-mini",
         stt="deepgram/nova-3:en",
         tts="cartesia/sonic-3:9626c31c-bec5-4cca-baa8-f8ba9e84c8bc",

--- a/examples/voice_agents/grok/grok_voice_agent_api.py
+++ b/examples/voice_agents/grok/grok_voice_agent_api.py
@@ -8,7 +8,6 @@ from livekit.agents import (
     AgentSession,
     JobContext,
     cli,
-    inference,
     room_io,
 )
 from livekit.agents.inference import AudioTurnDetector
@@ -45,7 +44,6 @@ async def my_agent(ctx: JobContext):
         llm=xai.realtime.RealtimeModel(voice="ara"),
         turn_detection=AudioTurnDetector(),
         tools=[xai.realtime.XSearch(), xai.realtime.WebSearch()],
-        vad=inference.VAD(model="silero"),
         preemptive_generation=True,
     )
 

--- a/examples/voice_agents/inactive_user.py
+++ b/examples/voice_agents/inactive_user.py
@@ -23,7 +23,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/instructions_per_modality.py
+++ b/examples/voice_agents/instructions_per_modality.py
@@ -86,7 +86,6 @@ async def entrypoint(ctx: JobContext) -> None:
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),
-        vad=inference.VAD(model="silero"),
     )
 
     await session.start(agent=SchedulingAgent(), room=ctx.room)

--- a/examples/voice_agents/langfuse_trace.py
+++ b/examples/voice_agents/langfuse_trace.py
@@ -149,7 +149,7 @@ async def entrypoint(ctx: JobContext):
 
     ctx.add_shutdown_callback(flush_trace)
 
-    session = AgentSession(vad=inference.VAD(model="silero"))
+    session = AgentSession()
 
     @session.on("metrics_collected")
     def _on_metrics_collected(ev: MetricsCollectedEvent):

--- a/examples/voice_agents/langgraph_agent.py
+++ b/examples/voice_agents/langgraph_agent.py
@@ -63,7 +63,6 @@ async def entrypoint(ctx: JobContext):
     )
 
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         # any combination of STT, LLM, TTS, or realtime API can be used
         stt=inference.STT("deepgram/nova-3", language="multi"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/llamaindex-rag/chat_engine.py
+++ b/examples/voice_agents/llamaindex-rag/chat_engine.py
@@ -53,7 +53,6 @@ class ChatEngineAgent(Agent):
                 "with users will be voice. You should use short and concise "
                 "responses, and avoiding usage of unpronouncable punctuation."
             ),
-            vad=inference.VAD(model="silero"),
             stt=inference.STT("deepgram/nova-3"),
             llm=DummyLLM(),  # use a dummy LLM to enable the pipeline reply
             tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/llamaindex-rag/query_engine.py
+++ b/examples/voice_agents/llamaindex-rag/query_engine.py
@@ -58,7 +58,6 @@ async def entrypoint(ctx: JobContext):
             "with users will be voice. You should use short and concise "
             "responses, and avoiding usage of unpronouncable punctuation."
         ),
-        vad=inference.VAD(model="silero"),
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/llamaindex-rag/retrieval.py
+++ b/examples/voice_agents/llamaindex-rag/retrieval.py
@@ -16,7 +16,6 @@ from livekit.agents import (
     AutoSubscribe,
     JobContext,
     cli,
-    inference,
     llm,
 )
 from livekit.agents.voice.agent import ModelSettings
@@ -47,7 +46,6 @@ class RetrievalAgent(Agent):
                 "with users will be voice. You should use short and concise "
                 "responses, and avoiding usage of unpronouncable punctuation."
             ),
-            vad=inference.VAD(model="silero"),
             stt=deepgram.STT(),
             llm=openai.LLM(),
             tts=openai.TTS(),

--- a/examples/voice_agents/long_running_function.py
+++ b/examples/voice_agents/long_running_function.py
@@ -68,7 +68,6 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),
-        vad=inference.VAD(model="silero"),
     )
 
     await session.start(agent=MyAgent(), room=ctx.room)

--- a/examples/voice_agents/mcp/mcp-agent.py
+++ b/examples/voice_agents/mcp/mcp-agent.py
@@ -31,7 +31,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         stt=inference.STT("deepgram/nova-3", language="multi"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/multi_agent.py
+++ b/examples/voice_agents/multi_agent.py
@@ -12,7 +12,6 @@ from livekit.agents import (
     JobContext,
     RunContext,
     cli,
-    inference,
     metrics,
 )
 from livekit.agents.job import get_job_context
@@ -135,7 +134,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession[StoryData](
-        vad=inference.VAD(model="silero"),
         # any combination of STT, LLM, TTS, or realtime API can be used
         llm=openai.LLM(model="gpt-4.1-mini"),
         stt=deepgram.STT(model="nova-3"),

--- a/examples/voice_agents/nvidia_test.py
+++ b/examples/voice_agents/nvidia_test.py
@@ -8,7 +8,6 @@ from livekit.agents import (
     JobContext,
     WorkerOptions,
     cli,
-    inference,
 )
 from livekit.agents.inference import AudioTurnDetector
 from livekit.plugins import nvidia, openai
@@ -20,7 +19,6 @@ load_dotenv()
 
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=openai.LLM(model="gpt-4.1-mini"),
         stt=nvidia.STT(),
         tts=nvidia.TTS(),

--- a/examples/voice_agents/realtime_joke_teller.py
+++ b/examples/voice_agents/realtime_joke_teller.py
@@ -53,7 +53,6 @@ from livekit.agents import (
     AgentSession,
     AutoSubscribe,
     ToolError,
-    inference,
     room_io,
 )
 from livekit.agents.llm import function_tool
@@ -222,7 +221,6 @@ async def entrypoint(ctx: agents.JobContext):
                     stt=aws.STT(),
                     llm=aws.LLM(),
                     tts=aws.TTS(),
-                    vad=inference.VAD(model="silero"),
                 )
             else:
                 print("⚡ Using REALTIME mode: Nova Sonic 2.0")

--- a/examples/voice_agents/realtime_turn_detector.py
+++ b/examples/voice_agents/realtime_turn_detector.py
@@ -3,7 +3,7 @@ import logging
 from dotenv import load_dotenv
 from google.genai import types  # noqa: F401
 
-from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli, inference
+from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli
 from livekit.agents.inference import AudioTurnDetector
 from livekit.plugins import deepgram, google, openai  # noqa: F401
 
@@ -25,7 +25,6 @@ async def entrypoint(ctx: JobContext):
     session = AgentSession(
         allow_interruptions=True,
         turn_detection=AudioTurnDetector(),
-        vad=inference.VAD(model="silero"),
         stt=deepgram.STT(),
         # To use OpenAI Realtime API
         llm=openai.realtime.RealtimeModel(

--- a/examples/voice_agents/realtime_video_agent.py
+++ b/examples/voice_agents/realtime_video_agent.py
@@ -8,7 +8,6 @@ from livekit.agents import (
     AgentSession,
     JobContext,
     cli,
-    inference,
     room_io,
     voice,  # noqa: F401
 )
@@ -24,7 +23,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         # both Gemini and OpenAI Realtime API support streaming video input
         llm=google.realtime.RealtimeModel(),
         # customize how video frames are sampled

--- a/examples/voice_agents/restaurant_agent.py
+++ b/examples/voice_agents/restaurant_agent.py
@@ -327,7 +327,6 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT(model="deepgram/nova-3"),
         llm=inference.LLM(model="openai/gpt-4.1-mini"),
         tts=inference.TTS(model="cartesia/sonic-3"),
-        vad=inference.VAD(model="silero"),
         max_tool_steps=5,
         # to use realtime model, replace the stt, llm, tts and vad with the following
         # llm=openai.realtime.RealtimeModel(voice="alloy"),

--- a/examples/voice_agents/resume_interrupted_agent.py
+++ b/examples/voice_agents/resume_interrupted_agent.py
@@ -20,7 +20,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/session_close_callback.py
+++ b/examples/voice_agents/session_close_callback.py
@@ -2,7 +2,7 @@ import logging
 
 from dotenv import load_dotenv
 
-from livekit.agents import Agent, AgentServer, AgentSession, CloseEvent, JobContext, cli, inference
+from livekit.agents import Agent, AgentServer, AgentSession, CloseEvent, JobContext, cli
 from livekit.agents.beta.tools import EndCallTool
 from livekit.plugins import google  # noqa: F401
 
@@ -42,9 +42,7 @@ server = AgentServer()
 
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
-    session = AgentSession(
-        vad=inference.VAD(model="silero"),
-    )
+    session = AgentSession()
 
     await session.start(agent=MyAgent(), room=ctx.room)
 

--- a/examples/voice_agents/silent_function_call.py
+++ b/examples/voice_agents/silent_function_call.py
@@ -59,7 +59,6 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),
-        vad=inference.VAD(model="silero"),
     )
 
     @session.on("function_tools_executed")

--- a/examples/voice_agents/speaker_id_multi_speaker.py
+++ b/examples/voice_agents/speaker_id_multi_speaker.py
@@ -6,7 +6,7 @@ import datetime
 
 from dotenv import load_dotenv
 
-from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli, inference
+from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli
 from livekit.agents.stt import MultiSpeakerAdapter
 from livekit.plugins import deepgram, openai, speechmatics  # noqa: F401
 
@@ -54,7 +54,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext) -> None:
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=openai.LLM(),
         tts=openai.TTS(),
         stt=MultiSpeakerAdapter(

--- a/examples/voice_agents/speedup_output_audio.py
+++ b/examples/voice_agents/speedup_output_audio.py
@@ -106,7 +106,6 @@ async def entrypoint(ctx: JobContext):
         "user_id": "your user_id",
     }
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         stt=inference.STT("deepgram/nova-3"),
         tts=inference.TTS("cartesia/sonic-3"),

--- a/examples/voice_agents/structured_output.py
+++ b/examples/voice_agents/structured_output.py
@@ -17,7 +17,6 @@ from livekit.agents import (
     JobContext,
     ModelSettings,
     cli,
-    inference,
 )
 from livekit.agents.inference import AudioTurnDetector
 from livekit.plugins import openai
@@ -130,7 +129,6 @@ server = AgentServer()
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         turn_detection=AudioTurnDetector(),
     )
     await session.start(agent=MyAgent(), room=ctx.room)

--- a/examples/voice_agents/timed_agent_transcript.py
+++ b/examples/voice_agents/timed_agent_transcript.py
@@ -44,7 +44,6 @@ async def entrypoint(ctx: JobContext):
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("google/gemini-2.5-flash"),
         tts=cartesia.TTS(),
-        vad=inference.VAD(model="silero"),
         # enable TTS-aligned transcript, can be configured at the Agent level as well
         use_tts_aligned_transcript=True,
     )

--- a/examples/voice_agents/tool_search_agent.py
+++ b/examples/voice_agents/tool_search_agent.py
@@ -171,7 +171,6 @@ async def entrypoint(ctx: JobContext):
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),
         stt=inference.STT("deepgram/nova-3"),
-        vad=inference.VAD(model="silero"),
     )
 
     # Track token usage to observe prompt caching behavior.

--- a/examples/voice_agents/ultravox_realtime_api.py
+++ b/examples/voice_agents/ultravox_realtime_api.py
@@ -9,7 +9,6 @@ from livekit.agents import (
     JobContext,
     cli,
     function_tool,
-    inference,
     room_io,
 )
 from livekit.plugins.ultravox.realtime import RealtimeModel
@@ -28,7 +27,6 @@ class MyAgent(Agent):
                 voice="Jessica",
                 language_hint="en",
             ),
-            vad=inference.VAD(model="silero"),
         )
 
     async def on_enter(self):

--- a/examples/voice_agents/zapier_mcp_integration.py
+++ b/examples/voice_agents/zapier_mcp_integration.py
@@ -66,7 +66,6 @@ async def entrypoint(ctx: JobContext):
         logger.warning("ZAPIER_MCP_SERVER environment variable not set. MCP integration disabled.")
 
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         # minimum delay for endpointing, used when turn detector believes the user is done with their turn  # noqa: E501
         min_endpointing_delay=0.5,
         # maximum delay for endpointing, used when turn detector does not believe the user is done with their turn  # noqa: E501

--- a/examples/warm-transfer/warm_transfer.py
+++ b/examples/warm-transfer/warm_transfer.py
@@ -9,7 +9,6 @@ from livekit.agents import (
     AgentSession,
     JobContext,
     cli,
-    inference,
     room_io,
 )
 from livekit.agents.beta.workflows import WarmTransferTask
@@ -97,7 +96,6 @@ server = AgentServer()
 @server.rtc_session(agent_name="sip-inbound")
 async def entrypoint(ctx: JobContext):
     session = AgentSession(
-        vad=inference.VAD(model="silero"),
         llm="openai/gpt-4.1-mini",
         stt="deepgram/nova-3:en",
         tts="cartesia/sonic-3:9626c31c-bec5-4cca-baa8-f8ba9e84c8bc",

--- a/livekit-agents/livekit/agents/vad.py
+++ b/livekit-agents/livekit/agents/vad.py
@@ -78,6 +78,7 @@ class VAD(ABC, rtc.EventEmitter[Literal["metrics_collected"]]):
         super().__init__()
         self._capabilities = capabilities
         self._label = f"{type(self).__module__}.{type(self).__name__}"
+        self._is_default = False
 
     @property
     def model(self) -> str:
@@ -90,6 +91,18 @@ class VAD(ABC, rtc.EventEmitter[Literal["metrics_collected"]]):
     @property
     def capabilities(self) -> VADCapabilities:
         return self._capabilities
+
+    @property
+    def is_default(self) -> bool:
+        """True iff this VAD instance was auto-provisioned by ``AgentSession``.
+
+        Set by the framework when constructing the default VAD; never set by
+        user code. Call sites that activate behaviour just because a VAD is
+        present (e.g. realtime turn-detection fallback, adaptive interruption,
+        STT-hook ``speaking=`` payload) should treat a default-VAD instance as
+        if no VAD were configured.
+        """
+        return self._is_default
 
     @abstractmethod
     def stream(self) -> VADStream: ...

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -284,7 +284,14 @@ class AgentActivity(RecognitionHooks):
                 mode = None
 
             # fallback to VAD if server side turn detection is disabled and VAD is available
-            if not llm_model.capabilities.turn_detection and vad_model and mode is None:
+            # (only when the user explicitly supplied a VAD — don't auto-flip turn detection
+            # just because the framework's default silero VAD is present).
+            if (
+                not llm_model.capabilities.turn_detection
+                and vad_model is not None
+                and not vad_model.is_default
+                and mode is None
+            ):
                 mode = "vad"
 
         elif mode == "realtime_llm":
@@ -794,11 +801,24 @@ class AgentActivity(RecognitionHooks):
             self._session._chat_ctx.insert(initial_config)
 
         await self._resume_scheduling_task()
+        # When the realtime LLM provides server-side VAD, the framework-supplied
+        # default VAD is dead weight: server events drive turn detection, and
+        # wiring it would only burn per-stream silero CPU. Skip it. A
+        # user-configured VAD still gets wired so explicit AudioTurnDetector /
+        # turn_detection="vad" opt-ins keep working.
+        wired_vad = self.vad
+        if (
+            wired_vad is not None
+            and wired_vad.is_default
+            and isinstance(self.llm, llm.RealtimeModel)
+            and self.llm.capabilities.turn_detection
+        ):
+            wired_vad = None
         self._audio_recognition = AudioRecognition(
             self._session,
             hooks=self,
             stt=self._agent.stt_node if self.stt else None,
-            vad=self.vad,
+            vad=wired_vad,
             interruption_detection=self._interruption_detector,
             endpointing=create_endpointing(self.endpointing_opts),
             turn_detection=self._turn_detection,
@@ -1532,7 +1552,10 @@ class AgentActivity(RecognitionHooks):
         self._session.emit("overlapping_speech", ev)
 
     def _on_input_speech_started(self, _: llm.InputSpeechStartedEvent) -> None:
-        if self.vad is None:
+        # When only the framework default VAD is present, server-side VAD events
+        # are the canonical state source (the default VAD isn't even wired in
+        # this realtime+server-VAD path). Treat default-VAD as no-VAD here.
+        if self.vad is None or self.vad.is_default:
             self._session._update_user_state("speaking")
             if self._audio_recognition:
                 self._audio_recognition.on_start_of_speech(
@@ -1550,7 +1573,7 @@ class AgentActivity(RecognitionHooks):
             )
 
     def _on_input_speech_stopped(self, ev: llm.InputSpeechStoppedEvent) -> None:
-        if self.vad is None:
+        if self.vad is None or self.vad.is_default:
             if self._audio_recognition:
                 self._audio_recognition.on_end_of_speech(
                     ended_at=time.time(),
@@ -3794,11 +3817,15 @@ class AgentActivity(RecognitionHooks):
         return self._agent.vad if is_given(self._agent.vad) else self._session.vad
 
     def _resolve_interruption_detection(self) -> inference.AdaptiveInterruptionDetector | None:
+        # Adaptive interruption is opt-in (or opt-in-by-environment); we don't
+        # want a framework-default VAD to silently flip eligibility on for
+        # users who never configured a VAD themselves.
+        user_vad = self.vad is not None and not self.vad.is_default
         if not (
             self.stt is not None
             and self.stt.capabilities.aligned_transcript
             and self.stt.capabilities.streaming
-            and self.vad is not None
+            and user_vad
             and self._turn_detection not in ("manual", "realtime_llm")
             and not isinstance(self.llm, llm.RealtimeModel)
         ):

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -198,6 +198,12 @@ class VoiceActivityVideoSampler:
 DEFAULT_TTS_TEXT_TRANSFORMS: list[TextTransforms] = ["filter_markdown", "filter_emoji"]
 
 
+def _build_default_vad() -> vad.VAD:
+    instance = inference.VAD(model="silero")
+    instance._is_default = True
+    return instance
+
+
 class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
     @deprecate_params(
         {
@@ -266,7 +272,10 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         Args:
             stt (stt.STT | str, optional): Speech-to-text backend.
-            vad (vad.VAD, optional): Voice-activity detector
+            vad (vad.VAD, optional): Voice-activity detector. Defaults to the
+                bundled silero VAD (``inference.VAD(model="silero")``) when
+                omitted. Pass ``vad=None`` to opt out, or pass an explicit
+                instance to customise options.
             llm (llm.LLM | llm.RealtimeModel | str, optional): LLM or RealtimeModel
             tts (tts.TTS | str, optional): Text-to-speech engine.
             tools (list[llm.FunctionTool | llm.RawFunctionTool], optional): List of
@@ -395,6 +404,8 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             tts = inference.TTS.from_model_string(tts)
 
         self._stt = stt or None
+        if not is_given(vad):
+            vad = _build_default_vad()
         self._vad = vad or None
         self._llm = llm or None
         self._tts = tts or None

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -304,6 +304,16 @@ class AudioRecognition:
             and not self._interruption_ch.closed
         )
 
+    @property
+    def _has_user_vad(self) -> bool:
+        """True only when a user-configured VAD is wired. Framework-default
+        VAD instances return False here so the STT-hook ``speaking=`` payload
+        type and ``_last_speaking_time`` source stay on their pre-default-VAD
+        codepaths (preserving observable behaviour for sessions that didn't
+        configure a VAD).
+        """
+        return self._vad is not None and not self._vad.is_default
+
     # region: boundary for adaptive interruption detection
 
     @property
@@ -981,7 +991,7 @@ class AudioRecognition:
             self._hooks.on_final_transcript(
                 ev,
                 speaking=self._speaking
-                if self._vad or self._turn_detection_mode == "stt"
+                if self._has_user_vad or self._turn_detection_mode == "stt"
                 else None,
             )
             if self._session.amd is not None:
@@ -1000,8 +1010,8 @@ class AudioRecognition:
             self._audio_interim_transcript = ""
             self._audio_preflight_transcript = ""
 
-            if not self._vad or self._last_speaking_time is None:
-                # vad disabled, use stt timestamp
+            if not self._has_user_vad or self._last_speaking_time is None:
+                # no user-configured vad, use stt timestamp
                 # TODO: this would screw up transcription latency metrics
                 # but we'll live with it for now.
                 # the correct way is to ensure STT fires SpeechEventType.END_OF_SPEECH
@@ -1038,7 +1048,7 @@ class AudioRecognition:
             self._hooks.on_interim_transcript(
                 ev,
                 speaking=self._speaking
-                if self._vad or self._turn_detection_mode == "stt"
+                if self._has_user_vad or self._turn_detection_mode == "stt"
                 else None,
             )
             transcript = ev.alternatives[0].text
@@ -1064,8 +1074,8 @@ class AudioRecognition:
             self._audio_preflight_transcript = (self._audio_transcript + " " + transcript).lstrip()
             self._audio_interim_transcript = transcript
 
-            if not self._vad or self._last_speaking_time is None:
-                # vad disabled, use stt timestamp
+            if not self._has_user_vad or self._last_speaking_time is None:
+                # no user-configured vad, use stt timestamp
                 self._last_speaking_time = time.time()
 
             if self._turn_detection_mode != "manual" or self._user_turn_committed:
@@ -1082,7 +1092,7 @@ class AudioRecognition:
             self._hooks.on_interim_transcript(
                 ev,
                 speaking=self._speaking
-                if self._vad or self._turn_detection_mode == "stt"
+                if self._has_user_vad or self._turn_detection_mode == "stt"
                 else None,
             )
             self._audio_interim_transcript = ev.alternatives[0].text
@@ -1105,7 +1115,7 @@ class AudioRecognition:
 
             self._speaking = False
             self._user_turn_committed = True
-            if not self._vad or self._last_speaking_time is None:
+            if not self._has_user_vad or self._last_speaking_time is None:
                 self._last_speaking_time = time.time()
 
             chat_ctx = self._hooks.retrieve_chat_ctx().copy()

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/__init__.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/__init__.py
@@ -30,7 +30,10 @@ from .log import logger
 
 warnings.warn(
     "livekit-plugins-silero is deprecated and will be removed in v2.0. "
-    'Use `from livekit.agents import inference; inference.VAD(model="silero")` instead.',
+    "AgentSession now defaults to the bundled silero VAD, so you can drop the "
+    "explicit `vad=` argument entirely; pass `vad=None` to opt out, or use "
+    '`from livekit.agents import inference; inference.VAD(model="silero", ...)`'
+    " to customise options.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -1248,3 +1248,40 @@ async def test_silent_tool_call_pause_state_does_not_leak_into_tool_reply() -> N
     assert transitions[silent_step_finished + 1] == ("listening", "speaking")
     assert false_interruption_events
     assert false_interruption_events[-1].resumed is True
+
+
+async def test_default_vad_is_auto_provisioned() -> None:
+    from livekit.agents.voice.agent_session import AgentSession
+
+    session = AgentSession()
+    try:
+        assert session.vad is not None
+        assert session.vad.is_default is True
+    finally:
+        await session.aclose()
+
+
+async def test_explicit_vad_none_opts_out() -> None:
+    from livekit.agents.voice.agent_session import AgentSession
+
+    session = AgentSession(vad=None)
+    try:
+        assert session.vad is None
+    finally:
+        await session.aclose()
+
+
+async def test_user_supplied_vad_keeps_is_default_false() -> None:
+    from livekit.agents.voice.agent_session import AgentSession
+
+    from .fake_vad import FakeVAD
+
+    user_vad = FakeVAD(fake_user_speeches=[])
+    assert user_vad.is_default is False
+
+    session = AgentSession(vad=user_vad)
+    try:
+        assert session.vad is user_vad
+        assert session.vad.is_default is False
+    finally:
+        await session.aclose()


### PR DESCRIPTION
`AgentSession` now provisions a bundled silero VAD automatically. Existing call-site behaviour is preserved via an `is_default` marker on the VAD instance — the framework-supplied default is transparent to every code path that previously cared about "user configured a VAD."

## Before

```python
from livekit.agents import AgentSession, inference

session = AgentSession(
    stt=inference.STT("deepgram/nova-3"),
    llm=inference.LLM("openai/gpt-4.1-mini"),
    tts=inference.TTS("cartesia/sonic-3"),
    vad=inference.VAD(model="silero"),  # required boilerplate
)
``` 

…or, in examples using the prewarm pattern:

```python
def prewarm(proc: JobProcess) -> None:
    proc.userdata["vad"] = inference.VAD(model="silero")

server.setup_fnc = prewarm

@server.rtc_session()
async def entrypoint(ctx: JobContext) -> None:
    session = AgentSession(
        # ...
        vad=ctx.proc.userdata["vad"],
    )
```

## After

```python
from livekit.agents import AgentSession, inference

session = AgentSession(
    stt=inference.STT("deepgram/nova-3"),
    llm=inference.LLM("openai/gpt-4.1-mini"),
    tts=inference.TTS("cartesia/sonic-3"),
    # vad= omitted — bundled silero is provided automatically
)

# Opt out explicitly if needed:
# AgentSession(..., vad=None)

# Customise by passing your own:
# AgentSession(..., vad=inference.VAD(model="silero", min_silence_duration=0.3))
```

## What changes (and what doesn't)

| Concern | Behaviour |
|---|---|
| `AgentSession()` with no `vad=` | Now gets `inference.VAD(model="silero")` with `is_default=True` |
| `AgentSession(vad=None)` | Unchanged — no VAD |
| `AgentSession(vad=my_vad)` | Unchanged — user-supplied VAD, `is_default=False` |
| `RealtimeModel` with server-side turn detection | Default VAD is constructed but **not** wired into the audio pipeline (saves CPU); server-side VAD remains canonical |
| `turn_detection="vad"` / `AudioTurnDetector` opt-ins | Now satisfied by the default — no more "VAD model not provided" warnings |
| Realtime fallback `mode = "vad"` when server-side turn detection is off | **No change** — only flips when the user explicitly supplied a VAD |
| Adaptive interruption detection eligibility | **No change** — opt-in stays opt-in; default VAD doesn't auto-enable it |
| STT hook `speaking=` payload type and `_last_speaking_time` source | **No change** for sessions that didn't configure a VAD — default VAD is treated as absent at these sites |

The marker is exposed as a read-only `vad.VAD.is_default` property on the base class, so plugin-supplied VADs inherit `False` automatically.
