### PR TITLE
fix(voice): skip commit_user_turn on close when no turn is pending

### DIFF
--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -260,6 +260,11 @@ STTEncoding = Literal["pcm_s16le"]
 DEFAULT_ENCODING: STTEncoding = "pcm_s16le"
 DEFAULT_SAMPLE_RATE: int = 16000
 
+# inference STT error codes that should not be retried — reconnecting after
+# these just produces another instance of the same error.
+# 2007: server closed an idle session; a fresh socket would idle out the same way.
+_NON_RETRYABLE_ERROR_CODES: frozenset[int] = frozenset({2007})
+
 
 @dataclass
 class STTOptions:
@@ -775,10 +780,14 @@ class SpeechStream(stt.SpeechStream):
                 elif msg_type == "session.closed":
                     pass
                 elif msg_type == "error":
+                    code = data.get("code", -1)
+                    # `None` lets APIStatusError apply its default (4xx → non-retryable).
+                    retryable = False if code in _NON_RETRYABLE_ERROR_CODES else None
                     raise APIStatusError(
                         f"LiveKit Inference STT returned error: {data.get('message')}",
-                        status_code=data.get("code", -1),
+                        status_code=code,
                         body=data,
+                        retryable=retryable,
                     )
 
         ws: aiohttp.ClientWebSocketResponse | None = None

--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -382,7 +382,7 @@ class RecognizeStream(ABC):
                 last_start_time = time.time()
                 return await self._run()
             except APIError as e:
-                if max_retries == 0:
+                if max_retries == 0 or not e.retryable:
                     self._emit_error(e, recoverable=False)
                     raise
                 elif self._num_retries == max_retries:

--- a/livekit-agents/livekit/agents/tts/tts.py
+++ b/livekit-agents/livekit/agents/tts/tts.py
@@ -309,7 +309,11 @@ class ChunkedStream(ABC):
                     return
 
                 retry_interval = self._conn_options._interval_for_retry(i)
-                if self._conn_options.max_retry == 0 or self._conn_options.max_retry == i:
+                if (
+                    self._conn_options.max_retry == 0
+                    or self._conn_options.max_retry == i
+                    or not e.retryable
+                ):
                     self._emit_error(e, recoverable=False)
                     raise
                 else:

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import copy
 import time
-from collections.abc import AsyncIterable, Callable, Sequence
+from collections.abc import AsyncIterable, Awaitable, Callable, Sequence
 from contextlib import AbstractContextManager, nullcontext
 from contextvars import Token
 from dataclasses import dataclass
@@ -196,6 +197,49 @@ class VoiceActivityVideoSampler:
 
 
 DEFAULT_TTS_TEXT_TRANSFORMS: list[TextTransforms] = ["filter_markdown", "filter_emoji"]
+
+# emit a warning if session drain hasn't completed after this many seconds.
+# drain is not cancelled — this is purely an observability signal so a stalled
+# close path leaves a breadcrumb of what tasks are still running.
+_DRAIN_WARN_AFTER: float = 300.0
+
+
+_T = TypeVar("_T")
+
+
+# cap how many running tasks we dump in the slow-drain warning so structured
+# log sinks aren't flooded when the process has hundreds of live tasks.
+_SLOW_WARNING_TASK_LIMIT: int = 50
+
+
+async def _run_with_slow_warning(coro: Awaitable[_T], *, after: float, label: str) -> _T:
+    """Run *coro* and log a warning with a snapshot of running tasks if it
+    takes longer than *after* seconds. Never cancels *coro*."""
+
+    async def _watchdog() -> None:
+        await asyncio.sleep(after)
+        self_task = asyncio.current_task()
+        running = [t for t in asyncio.all_tasks() if not t.done() and t is not self_task]
+        truncated = running[:_SLOW_WARNING_TASK_LIMIT]
+        logger.warning(
+            "%s still running after %.1fs",
+            label,
+            after,
+            extra={
+                "running_tasks": [
+                    {"name": t.get_name(), "coro": repr(t.get_coro())} for t in truncated
+                ],
+                "running_tasks_total": len(running),
+            },
+        )
+
+    watchdog = asyncio.create_task(_watchdog(), name=f"{label}_watchdog")
+    try:
+        return await coro
+    finally:
+        watchdog.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await watchdog
 
 
 class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
@@ -944,7 +988,12 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                     except RuntimeError:
                         # uninterruptible speech
                         pass
-                await activity.drain()
+
+                await _run_with_slow_warning(
+                    activity.drain(),
+                    after=_DRAIN_WARN_AFTER,
+                    label="agent_session_drain",
+                )
 
                 # wait any uninterruptible speech to finish
                 if activity.current_speech:
@@ -959,12 +1008,19 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 if (
                     reason != CloseReason.ERROR
                     and (audio_recognition := activity._audio_recognition) is not None
+                    and audio_recognition.has_pending_user_turn
                 ):
-                    # wait for the user transcript to be committed
-                    audio_recognition.commit_user_turn(
-                        audio_detached=True,
-                        transcript_timeout=self._opts.session_close_transcript_timeout,
-                    )
+                    # best-effort: wait for the in-flight user transcript to be committed
+                    # before tearing down. Bounded by `session_close_transcript_timeout`
+                    # inside the task. Any failure here must not block close — STT/EOU
+                    # errors and timeouts can still leave a clean shutdown.
+                    try:
+                        await audio_recognition.commit_user_turn(
+                            audio_detached=True,
+                            transcript_timeout=self._opts.session_close_transcript_timeout,
+                        )
+                    except (asyncio.TimeoutError, APIError, RuntimeError) as e:
+                        logger.warning("commit_user_turn during close failed", exc_info=e)
 
                 await activity.aclose()
             self._activity = None

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -711,6 +711,24 @@ class AudioRecognition:
         self.update_stt(None)
         self.update_stt(stt)
 
+    @property
+    def has_pending_user_turn(self) -> bool:
+        """True if there is in-flight user input that has not been committed yet.
+
+        A user turn is considered pending when any of these are true:
+        - VAD or STT currently report the user as speaking
+        - We have transcript text (interim or final) buffered
+        - A user_turn span is open — covers the post-EOS / pre-transcript window
+          where audio may still be sitting in the STT pipeline buffer
+        """
+        return (
+            self._vad_speech_started
+            or self._speaking
+            or bool(self._audio_interim_transcript)
+            or bool(self._audio_transcript)
+            or (self._user_turn_span is not None and self._user_turn_span.is_recording())
+        )
+
     def commit_user_turn(
         self,
         *,


### PR DESCRIPTION
- Add `AudioRecognition.has_pending_user_turn` and gate the session-close commit on it, avoiding spurious empty-turn commits and the resulting timeout warnings during teardown.
- Make the close-path commit best-effort: catch timeout / API / runtime errors so STT or EOU failures don't block a clean shutdown.
- Wrap `activity.drain()` in a non-cancelling watchdog that logs a snapshot of running tasks if drain stalls past 300s, for shutdown observability.
- Mark inference STT error 2007 (idle session closed by server) as non-retryable; reconnecting just produces the same error.
- Honor `APIError.retryable` in STT (`stt/stt.py`) and TTS (`tts/tts.py` chunked stream) retry loops, matching the existing pattern in `llm/llm.py` and `inference/interruption.py`.