### PR TITLE
fix(voice): propagate ChatMessage.interrupted through proto serializer

### DIFF
--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -292,6 +292,7 @@ def _chat_item_to_proto(item: llm.ChatItem) -> agent_pb.ChatContext.ChatItem:
             id=item.id,
             role=pb_role,
             content=content,
+            interrupted=item.interrupted,
             metrics=_metrics_to_proto(item.metrics),
         )
         return agent_pb.ChatContext.ChatItem(message=pb_msg)


### PR DESCRIPTION
## Summary

`_chat_item_to_proto` in [`livekit-agents/livekit/agents/voice/remote_session.py`](livekit-agents/livekit/agents/voice/remote_session.py) omits the `interrupted` field when converting `llm.ChatMessage` to its proto form. The model has the field (`interrupted: bool = False` in [`livekit-agents/livekit/agents/llm/chat_context.py:320`](livekit-agents/livekit/agents/llm/chat_context.py)) and the proto schema has it (`ChatMessage.interrupted` at field 4 in [`livekit_agent_session.proto`](https://github.com/livekit/protocol/blob/main/protobufs/agent/livekit_agent_session.proto)), but the serializer drops it on the floor. Result: every `conversation_item_added` event on the wire reports `interrupted=false`, even for messages whose model copy was committed with `interrupted=True`.

## Repro

Drive the agent into a partial-speech-then-interrupt scenario — e.g. ask for a long story, then send a new `runInput` after ~2 s of speaking. Subscribe to `AgentSessionMessage.event` over the `lk.agent.session` byte-stream topic. The framework's `AgentActivity` commits the partial assistant message with `interrupted=True` (model-side), but the emitted proto event has `item.message.interrupted=false` on the wire.

After this PR:

```jsonc
// conversation_item_added event for the interrupted partial speech
{
  "item": {
    "message": {
      "role": "ASSISTANT",
      "content": [{ "text": "Alright, picture this: three" }],
      "interrupted": true, // <-- now correctly propagated
    },
  },
}
```

## Fix

```diff
         pb_msg = agent_pb.ChatMessage(
             id=item.id,
             role=pb_role,
             content=content,
+            interrupted=item.interrupted,
             metrics=_metrics_to_proto(item.metrics),
         )
```

Single field added to the `ChatMessage` constructor. No API change, no behaviour change for the model — only the wire serialization is affected.

## Test plan

- [x] Verified locally against `examples/voice_agents/basic_agent.py` with an external proto consumer. Before the fix, all messages had `interrupted=false`. After the fix, the partial assistant message that was interrupted mid-speech shows `interrupted=true`, matching the JS framework's behaviour.
- [x] CI: `make check` (ruff lint + mypy) passes.
