### PR TITLE
fix(llm): convert per-turn instructions on the very first turn too

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/utils.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/utils.py
@@ -31,8 +31,12 @@ def convert_mid_conversation_instructions(
     items: list[llm.ChatItem] = []
 
     for item in chat_ctx.items:
-        is_system = item.type == "message" and item.role in ("system", "developer")
-        if is_system and first_system_seen and (text := item.text_content):
+        if (
+            item.type == "message"
+            and item.role in ("system", "developer")
+            and first_system_seen
+            and (text := item.text_content)
+        ):
             items.append(
                 llm.ChatMessage(
                     id=item.id,
@@ -42,7 +46,7 @@ def convert_mid_conversation_instructions(
                 )
             )
         else:
-            if is_system:
+            if item.type == "message" and item.role in ("system", "developer"):
                 first_system_seen = True
             items.append(item)
 

--- a/livekit-agents/livekit/agents/llm/_provider_format/utils.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/utils.py
@@ -17,19 +17,22 @@ def convert_mid_conversation_instructions(
 ) -> llm.ChatContext:
     """Convert mid-conversation system messages to the given role to preserve their position.
 
-    Preamble system messages (before any user/assistant turn) are kept as-is.
-    Later ones are converted using the given role and template.
+    The first system/developer message is kept as the base preamble.
+    Every later system/developer message is rewritten with the given
+    role, wrapped in ``template``. This covers both mid-conversation
+    instructions and per-turn instructions appended by ``generate_reply``
+    on the very first turn (when there's no user/assistant content yet
+    to anchor "mid-conversation"). Without this, providers like Gemini,
+    Anthropic, and AWS fall back to ``inject_dummy_user_message``
+    (a literal ``"."`` user turn the model frequently responds to with
+    "you didn't say anything").
     """
-    seen_non_system = False
+    first_system_seen = False
     items: list[llm.ChatItem] = []
 
     for item in chat_ctx.items:
-        if (
-            item.type == "message"
-            and item.role in ("system", "developer")
-            and seen_non_system
-            and (text := item.text_content)
-        ):
+        is_system = item.type == "message" and item.role in ("system", "developer")
+        if is_system and first_system_seen and (text := item.text_content):
             items.append(
                 llm.ChatMessage(
                     id=item.id,
@@ -39,12 +42,8 @@ def convert_mid_conversation_instructions(
                 )
             )
         else:
-            if not seen_non_system and (
-                item.type in ("function_call", "function_call_output")
-                or (item.type == "message" and item.role in ("assistant", "user"))
-            ):
-                seen_non_system = True
-
+            if is_system:
+                first_system_seen = True
             items.append(item)
 
     return llm.ChatContext(items)


### PR DESCRIPTION
## Summary

`convert_mid_conversation_instructions` only rewrote system messages to a user-role `<instructions>` turn after the conversation had already seen a user/assistant turn (the `seen_non_system` flag).

On the very first `generate_reply(instructions=...)` of a session, the chat context contains:

- `system`: agent's base prompt
- `system`: per-turn instructions just appended by `generate_reply`

…and no user/assistant turn yet. The condition fails, both stay `system`, and the providers that require the conversation to end on a `user`/`tool` turn (Gemini, Anthropic, AWS) fall back to `inject_dummy_user_message`, which appends a literal `{"role": "user", "parts": [{"text": "."}]}`. The model — Gemini especially — sees the lone `.` and responds with things like *"You haven't said anything yet, did you mean to ask something?"*

## Fix

Drop the `seen_non_system` tracking and apply a single rule: the **first** system/developer message is the preamble, every **subsequent** system/developer message is per-turn instructions and gets converted using the existing role + template.

This keeps:

- the "only one base system prompt, nothing else" path unchanged (still falls back to the dummy `"."`, which is the intentional behaviour when there is genuinely nothing for the model to respond to);
- the existing mid-conversation path unchanged (per-turn instructions added after the user has spoken are still rewritten);

…and adds the new case: base + per-turn before any user turn now also gets converted, so providers never have to inject the dummy.

## Smoke test

```
A: only base system
  google: [{'role': 'user', 'parts': [{'text': '.'}]}]   # unchanged

B: base + per-turn, no user yet
  google: [{'role': 'user', 'parts': [{'text': '<instructions>\nSpeak first.\n</instructions>'}]}]   # was '.'

C: mid-conv per-turn (system after user/assistant)
  google: [...user, model, user(<instructions>)]   # unchanged

D: base + user
  google: [{'role': 'user', 'parts': [{'text': 'hi'}]}]   # unchanged
```

Benefits Anthropic, AWS, and Google providers (all three call `convert_mid_conversation_instructions`). OpenAI handles mid-conversation system messages natively and isn't affected.

## Test plan

- [ ] Existing tests still pass.
- [ ] Manual: a voice agent that calls `session.generate_reply(instructions=...)` as its first action no longer responds with *"you didn't say anything"* under Gemini.