### PR TITLE
fix(plugins/sarvam): thread language_probability into SpeechData.confidence

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -692,13 +692,32 @@ class STT(stt.STT):
                 if start_time == 0.0 and end_time == 0.0:
                     end_time = _calculate_audio_duration(buffer)
 
+                # Sarvam Saaras returns ``language_probability``
+                # on every response — thread it into SpeechData.confidence
+                # so downstream consumers
+                # see real confidence values instead of a hardcoded 1.0.
+                # Defensive: defaults to 1.0 if the field is absent or has
+                # an unexpected type (API contract drift detection).
+                _lang_prob = response_json.get("language_probability")
+                if isinstance(_lang_prob, (int, float)):
+                    _confidence = float(_lang_prob)
+                else:
+                    if _lang_prob is not None:
+                        logger.debug(
+                            "Unexpected language_probability type: %s (value=%r); "
+                            "falling back to confidence=1.0",
+                            type(_lang_prob).__name__,
+                            _lang_prob,
+                        )
+                    _confidence = 1.0
+
                 alternatives = [
                     stt.SpeechData(
                         language=detected_language,
                         text=transcript_text,
                         start_time=start_time,
                         end_time=end_time,
-                        confidence=1.0,  # Sarvam doesn't provide confidence score in this response
+                        confidence=_confidence,
                     )
                 ]
 
@@ -1471,12 +1490,33 @@ class SpeechStream(stt.SpeechStream):
             )
             self._event_ch.send_nowait(usage_event)
 
+            # Sarvam Saaras streaming WS sends ``language_probability``
+            # in the transcript_data payload — thread it into SpeechData.confidence
+            # so downstream consumers see
+            # real confidence values instead of the SpeechData default (1.0).
+            # Defensive: defaults to 1.0 if the field is absent or has an
+            # unexpected type (the field is documented for REST but not
+            # explicitly for streaming — API contract drift detection).
+            _lang_prob = transcript_data.get("language_probability")
+            if isinstance(_lang_prob, (int, float)):
+                _confidence = float(_lang_prob)
+            else:
+                if _lang_prob is not None:
+                    self._logger.debug(
+                        "Unexpected language_probability type: %s (value=%r); "
+                        "falling back to confidence=1.0",
+                        type(_lang_prob).__name__,
+                        _lang_prob,
+                    )
+                _confidence = 1.0
+
             # Create speech data
             speech_data = stt.SpeechData(
                 language=language,
                 text=transcript_text,
                 start_time=transcript_data.get("speech_start", 0.0),
                 end_time=transcript_data.get("speech_end", 0.0),
+                confidence=_confidence,
             )
 
             # Create final transcript event with request_id

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -703,7 +703,7 @@ class STT(stt.STT):
                     _confidence = float(_lang_prob)
                 else:
                     if _lang_prob is not None:
-                        logger.debug(
+                        self._logger.debug(
                             "Unexpected language_probability type: %s (value=%r); "
                             "falling back to confidence=1.0",
                             type(_lang_prob).__name__,

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -356,7 +356,10 @@ def _extract_confidence(
     explicitly for streaming, so contract drift is logged for visibility).
     """
     value = payload.get("language_probability")
-    if isinstance(value, (int, float)):
+    # bool is a subclass of int — exclude explicitly so that an accidental
+    # JSON `false` doesn't silently become ``confidence=0.0``. Same pattern
+    # as livekit-plugins-slng/.../stt.py.
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
         return float(value)
     if value is not None:
         instance_logger.debug(

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import enum
 import json
+import logging
 import os
 import platform
 import weakref
@@ -341,6 +342,29 @@ def _get_urls_for_model(model: str) -> tuple[str, str]:
     if model_config and model_config.use_translate_endpoint:
         return SARVAM_STT_TRANSLATE_BASE_URL, SARVAM_STT_TRANSLATE_STREAMING_URL
     return SARVAM_STT_BASE_URL, SARVAM_STT_STREAMING_URL
+
+
+def _extract_confidence(
+    payload: dict,
+    instance_logger: logging.Logger,
+) -> float:
+    """Read Sarvam's ``language_probability`` from a response payload.
+
+    Returns the value as a float when present and numeric. Falls back to
+    ``1.0`` when the field is absent, ``None``, or has an unexpected type
+    (defensive — the field is documented for the REST endpoint but not
+    explicitly for streaming, so contract drift is logged for visibility).
+    """
+    value = payload.get("language_probability")
+    if isinstance(value, (int, float)):
+        return float(value)
+    if value is not None:
+        instance_logger.debug(
+            "Unexpected language_probability type: %s (value=%r); falling back to confidence=1.0",
+            type(value).__name__,
+            value,
+        )
+    return 1.0
 
 
 def _calculate_audio_duration(
@@ -692,32 +716,13 @@ class STT(stt.STT):
                 if start_time == 0.0 and end_time == 0.0:
                     end_time = _calculate_audio_duration(buffer)
 
-                # Sarvam Saaras returns ``language_probability``
-                # on every response — thread it into SpeechData.confidence
-                # so downstream consumers
-                # see real confidence values instead of a hardcoded 1.0.
-                # Defensive: defaults to 1.0 if the field is absent or has
-                # an unexpected type (API contract drift detection).
-                _lang_prob = response_json.get("language_probability")
-                if isinstance(_lang_prob, (int, float)):
-                    _confidence = float(_lang_prob)
-                else:
-                    if _lang_prob is not None:
-                        self._logger.debug(
-                            "Unexpected language_probability type: %s (value=%r); "
-                            "falling back to confidence=1.0",
-                            type(_lang_prob).__name__,
-                            _lang_prob,
-                        )
-                    _confidence = 1.0
-
                 alternatives = [
                     stt.SpeechData(
                         language=detected_language,
                         text=transcript_text,
                         start_time=start_time,
                         end_time=end_time,
-                        confidence=_confidence,
+                        confidence=_extract_confidence(response_json, self._logger),
                     )
                 ]
 
@@ -1490,33 +1495,13 @@ class SpeechStream(stt.SpeechStream):
             )
             self._event_ch.send_nowait(usage_event)
 
-            # Sarvam Saaras streaming WS sends ``language_probability``
-            # in the transcript_data payload — thread it into SpeechData.confidence
-            # so downstream consumers see
-            # real confidence values instead of the SpeechData default (1.0).
-            # Defensive: defaults to 1.0 if the field is absent or has an
-            # unexpected type (the field is documented for REST but not
-            # explicitly for streaming — API contract drift detection).
-            _lang_prob = transcript_data.get("language_probability")
-            if isinstance(_lang_prob, (int, float)):
-                _confidence = float(_lang_prob)
-            else:
-                if _lang_prob is not None:
-                    self._logger.debug(
-                        "Unexpected language_probability type: %s (value=%r); "
-                        "falling back to confidence=1.0",
-                        type(_lang_prob).__name__,
-                        _lang_prob,
-                    )
-                _confidence = 1.0
-
             # Create speech data
             speech_data = stt.SpeechData(
                 language=language,
                 text=transcript_text,
                 start_time=transcript_data.get("speech_start", 0.0),
                 end_time=transcript_data.get("speech_end", 0.0),
-                confidence=_confidence,
+                confidence=_extract_confidence(transcript_data, self._logger),
             )
 
             # Create final transcript event with request_id

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_language_probability.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_language_probability.py
@@ -1,27 +1,73 @@
 """Tests for SpeechData.confidence threading from Sarvam's language_probability.
 
-Place at: livekit-plugins/livekit-plugins-sarvam/tests/test_language_probability.py
+Verifies that both the REST and WS paths thread ``language_probability`` from
+Sarvam's response into ``SpeechData.confidence`` (instead of the previous
+hardcoded ``1.0``), with a defensive fallback when the field is absent or has
+an unexpected type.
 """
 
-from unittest.mock import MagicMock, patch
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
 from livekit.agents import stt
-from livekit.plugins.sarvam.stt import STT
+from livekit.plugins.sarvam.stt import SpeechStream
+
+# ---------------------------------------------------------------------------
+# Helpers — build a minimal STT instance + fake the channel/logger/state that
+# `_handle_transcript_data` touches. We bypass __init__ so the test doesn't
+# need an API key, an HTTP session, or a real WebSocket.
+# ---------------------------------------------------------------------------
 
 
-# Helper: build a minimal transcript_data dict matching Saaras v3 WS payload shape
-def _ws_payload(**overrides):
-    base = {
-        "text": "hello world",
-        "language": "en-IN",
+def _make_stream_under_test() -> tuple[SpeechStream, list[Any]]:
+    """Construct a minimal SpeechStream and collect its emitted events.
+
+    Returns ``(stream_instance, captured_events)`` where each event sent via
+    ``send_nowait`` is appended to ``captured_events``. We bypass ``__init__``
+    so the test doesn't need an API key, an HTTP session, or a real WebSocket.
+    """
+    instance = SpeechStream.__new__(SpeechStream)
+    captured: list[Any] = []
+    event_ch = MagicMock()
+    event_ch.send_nowait = captured.append
+    instance._event_ch = event_ch  # type: ignore[attr-defined]
+    instance._logger = MagicMock()  # type: ignore[attr-defined]
+    instance._build_log_context = lambda: {}  # type: ignore[attr-defined]
+    instance._server_request_id = None  # type: ignore[attr-defined]
+    instance._opts = MagicMock(language="en-IN")  # type: ignore[attr-defined]
+    return instance, captured
+
+
+def _ws_message(**transcript_overrides: Any) -> dict:
+    """Build the outer WS message dict expected by ``_handle_transcript_data``.
+
+    Default shape mirrors a Saaras v3 streaming final-transcript chunk.
+    """
+    transcript_data: dict[str, Any] = {
+        "transcript": "नमस्ते",
+        "language_code": "hi-IN",
         "speech_start": 0.0,
         "speech_end": 1.2,
         "metrics": {"audio_duration": 1.2},
+        "request_id": "req-test",
     }
-    base.update(overrides)
-    return base
+    transcript_data.update(transcript_overrides)
+    return {"type": "data", "data": transcript_data}
+
+
+def _final_event(captured: list[Any]) -> stt.SpeechEvent:
+    finals = [ev for ev in captured if ev.type == stt.SpeechEventType.FINAL_TRANSCRIPT]
+    assert finals, "no FINAL_TRANSCRIPT event emitted"
+    return finals[0]
+
+
+# ---------------------------------------------------------------------------
+# WS path — happy cases
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -31,67 +77,62 @@ def _ws_payload(**overrides):
         (1.0, 1.0),
         (0.0, 0.0),
         (0.5, 0.5),
+        (0.123, 0.123),
     ],
 )
-def test_ws_threads_language_probability_into_confidence(language_probability, expected_confidence):
+async def test_ws_threads_language_probability_into_confidence(
+    language_probability: float, expected_confidence: float
+) -> None:
     """WS path must thread Sarvam's language_probability into SpeechData.confidence."""
-    payload = _ws_payload(language_probability=language_probability)
-    captured = []
-
-    # Patch the event channel so we can capture what gets emitted
-    with patch.object(STT, "__init__", return_value=None):
-        instance = STT.__new__(STT)
-        instance._event_ch = MagicMock()
-        instance._event_ch.send_nowait = lambda ev: captured.append(ev)
-        instance._logger = MagicMock()
-        instance._opts = MagicMock(language="en-IN")
-        instance._build_log_context = lambda: {}
-        instance._handle_transcript_data(payload, request_id="test")
-
-    final_events = [ev for ev in captured if ev.type == stt.SpeechEventType.FINAL_TRANSCRIPT]
-    assert final_events, "no FINAL_TRANSCRIPT event emitted"
-    assert final_events[0].alternatives[0].confidence == pytest.approx(expected_confidence)
+    instance, captured = _make_stream_under_test()
+    await instance._handle_transcript_data(_ws_message(language_probability=language_probability))
+    final = _final_event(captured)
+    assert final.alternatives[0].confidence == pytest.approx(expected_confidence)
 
 
-@pytest.mark.parametrize(
-    "bad_value",
-    [None, "0.95", True, [], {}, float("nan")],  # noqa: F632 — nan handled below
-)
-def test_ws_falls_back_to_1_0_on_missing_or_bad_type(bad_value):
-    """Missing field or unexpected type → confidence falls back to 1.0 (no crash)."""
-    if bad_value is None:
-        payload = _ws_payload()  # field absent
-    else:
-        payload = _ws_payload(language_probability=bad_value)
-
-    captured = []
-    with patch.object(STT, "__init__", return_value=None):
-        instance = STT.__new__(STT)
-        instance._event_ch = MagicMock()
-        instance._event_ch.send_nowait = lambda ev: captured.append(ev)
-        instance._logger = MagicMock()
-        instance._opts = MagicMock(language="en-IN")
-        instance._build_log_context = lambda: {}
-        instance._handle_transcript_data(payload, request_id="test")
-
-    final = [ev for ev in captured if ev.type == stt.SpeechEventType.FINAL_TRANSCRIPT]
-    # bool is a subclass of int in Python; isinstance(True, int) is True.
-    # If you want bool rejected, tighten the parser's guard accordingly.
-    if isinstance(bad_value, bool):
-        # bool currently coerces: True → 1.0, False → 0.0
-        assert final[0].alternatives[0].confidence == pytest.approx(float(bad_value))
-    else:
-        assert final[0].alternatives[0].confidence == 1.0
+# ---------------------------------------------------------------------------
+# WS path — defensive fallback cases (absent / null / wrong type)
+# ---------------------------------------------------------------------------
 
 
-def test_rest_threads_language_probability_into_confidence():
-    """REST path must thread Sarvam's language_probability into SpeechData.confidence.
+async def test_ws_missing_language_probability_falls_back_to_1_0() -> None:
+    """When the field is absent, confidence falls back to 1.0 (no crash)."""
+    instance, captured = _make_stream_under_test()
+    # _ws_message() helper omits language_probability by default
+    await instance._handle_transcript_data(_ws_message())
+    final = _final_event(captured)
+    assert final.alternatives[0].confidence == 1.0
 
-    Mocks the HTTP response with a payload containing language_probability=0.91.
-    Asserts the returned SpeechEvent's confidence == 0.91.
-    """
-    # NOTE: REST path test requires more setup (mocking aiohttp session). The minimal
-    # shape: construct a response dict with language_probability=0.91, feed it through
-    # the parser branch, assert SpeechData.confidence == 0.91. See WS test pattern;
-    # the REST parser logic is identical (isinstance guard + fallback).
-    pytest.skip("REST integration test stub — implement against real session mock")
+
+async def test_ws_null_language_probability_falls_back_to_1_0() -> None:
+    """Explicit null also falls back to 1.0."""
+    instance, captured = _make_stream_under_test()
+    await instance._handle_transcript_data(_ws_message(language_probability=None))
+    final = _final_event(captured)
+    assert final.alternatives[0].confidence == 1.0
+
+
+@pytest.mark.parametrize("bad_value", ["0.95", [], {}, object()])
+async def test_ws_unexpected_type_falls_back_to_1_0(bad_value: Any) -> None:
+    """String / list / dict / object → confidence falls back to 1.0 with a debug log."""
+    instance, captured = _make_stream_under_test()
+    await instance._handle_transcript_data(_ws_message(language_probability=bad_value))
+    final = _final_event(captured)
+    assert final.alternatives[0].confidence == 1.0
+    # The defensive branch logs a debug warning so contract drift is visible.
+    assert instance._logger.debug.called  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# WS path — out-of-range values pass through verbatim (clamping is not this
+# layer's job; downstream consumers can clamp if they need to).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [-0.5, 1.5, 2.0])
+async def test_ws_out_of_range_values_passed_through(value: float) -> None:
+    """Out-of-[0,1] values are passed through verbatim (no clamping)."""
+    instance, captured = _make_stream_under_test()
+    await instance._handle_transcript_data(_ws_message(language_probability=value))
+    final = _final_event(captured)
+    assert final.alternatives[0].confidence == pytest.approx(value)

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_language_probability.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_language_probability.py
@@ -1,0 +1,97 @@
+"""Tests for SpeechData.confidence threading from Sarvam's language_probability.
+
+Place at: livekit-plugins/livekit-plugins-sarvam/tests/test_language_probability.py
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from livekit.agents import stt
+from livekit.plugins.sarvam.stt import STT
+
+
+# Helper: build a minimal transcript_data dict matching Saaras v3 WS payload shape
+def _ws_payload(**overrides):
+    base = {
+        "text": "hello world",
+        "language": "en-IN",
+        "speech_start": 0.0,
+        "speech_end": 1.2,
+        "metrics": {"audio_duration": 1.2},
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.parametrize(
+    "language_probability, expected_confidence",
+    [
+        (0.87, 0.87),
+        (1.0, 1.0),
+        (0.0, 0.0),
+        (0.5, 0.5),
+    ],
+)
+def test_ws_threads_language_probability_into_confidence(language_probability, expected_confidence):
+    """WS path must thread Sarvam's language_probability into SpeechData.confidence."""
+    payload = _ws_payload(language_probability=language_probability)
+    captured = []
+
+    # Patch the event channel so we can capture what gets emitted
+    with patch.object(STT, "__init__", return_value=None):
+        instance = STT.__new__(STT)
+        instance._event_ch = MagicMock()
+        instance._event_ch.send_nowait = lambda ev: captured.append(ev)
+        instance._logger = MagicMock()
+        instance._opts = MagicMock(language="en-IN")
+        instance._build_log_context = lambda: {}
+        instance._handle_transcript_data(payload, request_id="test")
+
+    final_events = [ev for ev in captured if ev.type == stt.SpeechEventType.FINAL_TRANSCRIPT]
+    assert final_events, "no FINAL_TRANSCRIPT event emitted"
+    assert final_events[0].alternatives[0].confidence == pytest.approx(expected_confidence)
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [None, "0.95", True, [], {}, float("nan")],  # noqa: F632 — nan handled below
+)
+def test_ws_falls_back_to_1_0_on_missing_or_bad_type(bad_value):
+    """Missing field or unexpected type → confidence falls back to 1.0 (no crash)."""
+    if bad_value is None:
+        payload = _ws_payload()  # field absent
+    else:
+        payload = _ws_payload(language_probability=bad_value)
+
+    captured = []
+    with patch.object(STT, "__init__", return_value=None):
+        instance = STT.__new__(STT)
+        instance._event_ch = MagicMock()
+        instance._event_ch.send_nowait = lambda ev: captured.append(ev)
+        instance._logger = MagicMock()
+        instance._opts = MagicMock(language="en-IN")
+        instance._build_log_context = lambda: {}
+        instance._handle_transcript_data(payload, request_id="test")
+
+    final = [ev for ev in captured if ev.type == stt.SpeechEventType.FINAL_TRANSCRIPT]
+    # bool is a subclass of int in Python; isinstance(True, int) is True.
+    # If you want bool rejected, tighten the parser's guard accordingly.
+    if isinstance(bad_value, bool):
+        # bool currently coerces: True → 1.0, False → 0.0
+        assert final[0].alternatives[0].confidence == pytest.approx(float(bad_value))
+    else:
+        assert final[0].alternatives[0].confidence == 1.0
+
+
+def test_rest_threads_language_probability_into_confidence():
+    """REST path must thread Sarvam's language_probability into SpeechData.confidence.
+
+    Mocks the HTTP response with a payload containing language_probability=0.91.
+    Asserts the returned SpeechEvent's confidence == 0.91.
+    """
+    # NOTE: REST path test requires more setup (mocking aiohttp session). The minimal
+    # shape: construct a response dict with language_probability=0.91, feed it through
+    # the parser branch, assert SpeechData.confidence == 0.91. See WS test pattern;
+    # the REST parser logic is identical (isinstance guard + fallback).
+    pytest.skip("REST integration test stub — implement against real session mock")

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_language_probability.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_language_probability.py
@@ -112,9 +112,15 @@ async def test_ws_null_language_probability_falls_back_to_1_0() -> None:
     assert final.alternatives[0].confidence == 1.0
 
 
-@pytest.mark.parametrize("bad_value", ["0.95", [], {}, object()])
+@pytest.mark.parametrize("bad_value", ["0.95", [], {}, object(), True, False])
 async def test_ws_unexpected_type_falls_back_to_1_0(bad_value: Any) -> None:
-    """String / list / dict / object → confidence falls back to 1.0 with a debug log."""
+    """String / list / dict / object / bool → confidence falls back to 1.0 with a debug log.
+
+    bool is included because Python's ``bool`` is a subclass of ``int``;
+    without an explicit guard a JSON ``false`` from Sarvam would silently
+    become ``confidence=0.0`` and wrongly flag a valid transcript as low
+    confidence. Same defensive pattern as ``livekit-plugins-slng``.
+    """
     instance, captured = _make_stream_under_test()
     await instance._handle_transcript_data(_ws_message(language_probability=bad_value))
     final = _final_event(captured)


### PR DESCRIPTION
## Summary

Fixes #5829. The `livekit-plugins-sarvam` STT silently dropped Sarvam's `language_probability` and reported `confidence=1.0` everywhere. This wires the real value through both the REST and WS paths.

## Changes

- `livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py`:
  - REST `recognize()`: parse `language_probability` from response JSON; thread into `SpeechData(confidence=...)`.
  - WS `_handle_transcript_data()`: parse `language_probability` from `transcript_data`; thread into `SpeechData(confidence=...)`.
  - Both sites: `isinstance(_, (int, float))` guard with 1.0 fallback so callers don't crash on null/missing/string values. `logger.debug` on unexpected types so contract drift is visible.

- `livekit-plugins/livekit-plugins-sarvam/tests/test_language_probability.py` (new):
  - Asserts `SpeechData.confidence == 0.87` for a mocked WS payload containing `language_probability: 0.87`.
  - Asserts fallback to 1.0 when the field is absent, null, or has a wrong type.
  - REST test stubbed (mocks aiohttp session — same isinstance-guard logic as WS).

## Validation

Tested in a downstream voice assistant via a vendored fork carrying these exact patches: worker logs show `confidence` varying across utterances rather than the previous flat 1.0. The defensive fallback handles missing/null cases without crashing.

## Notes / Open question for review

- `language_probability` is documented for Sarvam's REST batch endpoint. **Open question (see #5829)**: is it guaranteed present on Saaras v3 WS chunks, or best-effort? The defensive `isinstance + 1.0 fallback` makes the PR safe under either answer, but if it's guaranteed, the fallback path becomes dead code we could tighten later.
- `@dhruvladia-sarvam` — would appreciate confirmation on field stability so we know whether to keep or remove the fallback in a follow-up.
- Defensive fallback to 1.0 preserves backward behaviour for callers that read `confidence` defensively.
- No public API changes.
- CLA: will be signed before merge (first-time contributor).
