### PR TITLE
fix: 4xx errors should not be retryable

### DIFF
--- a/livekit-agents/livekit/agents/_exceptions.py
+++ b/livekit-agents/livekit/agents/_exceptions.py
@@ -65,9 +65,12 @@ class APIStatusError(APIError):
     ) -> None:
         if retryable is None:
             retryable = True
-            # 4xx errors are not retryable
-            if status_code >= 400 and status_code < 500:
-                retryable = False
+
+        # 4xx client errors are not retryable, except 429 (rate limit).
+        # This overrides any caller-provided retryable=True, since a client
+        # error (bad URL, auth, bad request) will keep failing on retry.
+        if 400 <= status_code < 500 and status_code != 429:
+            retryable = False
 
         super().__init__(message, body=body, retryable=retryable)
 

--- a/livekit-agents/livekit/agents/_exceptions.py
+++ b/livekit-agents/livekit/agents/_exceptions.py
@@ -66,10 +66,11 @@ class APIStatusError(APIError):
         if retryable is None:
             retryable = True
 
-        # 4xx client errors are not retryable, except 429 (rate limit).
+        # 4xx client errors are not retryable, except for transient codes:
+        # 408 (Request Timeout), 429 (Too Many Requests), 499 (Client Closed Request / gRPC CANCELLED).
         # This overrides any caller-provided retryable=True, since a client
         # error (bad URL, auth, bad request) will keep failing on retry.
-        if 400 <= status_code < 500 and status_code != 429:
+        if 400 <= status_code < 500 and status_code not in (408, 429, 499):
             retryable = False
 
         super().__init__(message, body=body, retryable=retryable)

--- a/livekit-agents/livekit/agents/voice/events.py
+++ b/livekit-agents/livekit/agents/voice/events.py
@@ -4,7 +4,7 @@ import time
 from enum import Enum, unique
 from typing import TYPE_CHECKING, Annotated, Any, Generic, Literal, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_serializer, model_validator
 from typing_extensions import Self
 
 from ..inference.interruption import (
@@ -250,6 +250,20 @@ class ErrorEvent(BaseModel):
     error: LLMError | STTError | TTSError | RealtimeModelError | InterruptionDetectionError | Any
     source: LLM | STT | TTS | RealtimeModel | AdaptiveInterruptionDetector | Any
     created_at: float = Field(default_factory=time.time)
+
+    @field_serializer("source")
+    def _serialize_source(self, source: Any) -> Any:
+        if isinstance(source, (LLM, STT, TTS, RealtimeModel, AdaptiveInterruptionDetector)):
+            return {"model": source.model, "provider": source.provider}
+        if isinstance(source, BaseModel):
+            return source.model_dump()
+        return repr(source)
+
+    @field_serializer("error")
+    def _serialize_error(self, error: Any) -> Any:
+        if isinstance(error, BaseModel):
+            return error.model_dump()
+        return repr(error)
 
 
 @unique


### PR DESCRIPTION
there are two knobs to control if a request is retryable:
1. has it produced a response already (if so, retrying it produces unpredictable output)
2. what type of error is it? 4xx means client made a mistake, which generally cannot be retried

currently we are assuming a single `retryable` flag is setting both, where it actually only reflects 1. this fix addresses 2 in a central manner, so the retryable flag is only used for 1.