### PR TITLE
fix(lemonslice): bind avatar audio output before the upstream session HTTP call

### DIFF
--- a/livekit-plugins/livekit-plugins-lemonslice/livekit/plugins/lemonslice/avatar.py
+++ b/livekit-plugins/livekit-plugins-lemonslice/livekit/plugins/lemonslice/avatar.py
@@ -98,6 +98,20 @@ class AvatarSession(BaseAvatarSession):
             .to_jwt()
         )
 
+        # Rebind audio output BEFORE the slow upstream HTTP call so
+        # subsequent generations are routed to the (about-to-arrive)
+        # avatar identity immediately. wait_remote_track buffers
+        # frames until the video track shows up, so nothing is lost
+        # in the gap.
+        agent_session.output.audio = DataStreamAudioOutput(
+            room=room,
+            destination_identity=self._avatar_participant_identity,
+            sample_rate=SAMPLE_RATE,
+            wait_remote_track=rtc.TrackKind.KIND_VIDEO,
+            clear_buffer_timeout=None,
+            wait_playback_start=True,
+        )
+
         async with LemonSliceAPI(
             api_url=self._api_url,
             api_key=self._api_key,
@@ -114,14 +128,5 @@ class AvatarSession(BaseAvatarSession):
                 livekit_token=livekit_token,
                 extra_payload=self._extra_payload,
             )
-
-        agent_session.output.audio = DataStreamAudioOutput(
-            room=room,
-            destination_identity=self._avatar_participant_identity,
-            sample_rate=SAMPLE_RATE,
-            wait_remote_track=rtc.TrackKind.KIND_VIDEO,
-            clear_buffer_timeout=None,
-            wait_playback_start=True,
-        )
 
         return session_id


### PR DESCRIPTION
## Summary

Rebind `agent_session.output.audio` to the avatar-bound `DataStreamAudioOutput` **before** the LemonSlice session-creation HTTP call instead of after. The call is on the order of a second, and during a mid-session avatar swap any `generate_reply` triggered in that gap stays routed to the previous audio destination. `wait_remote_track=KIND_VIDEO` buffers frames until the new video track actually shows up, so binding early doesn't drop audio.

## Test plan

- [ ] Confirm mid-session persona swaps in the LemonSlice avatar example route their first post-swap utterance to the new avatar's audio path.
- [ ] First-time avatar bring-up still works (no regression: wait_remote_track keeps frames buffered until the video track arrives).