### PR TITLE
ci(deploy-examples): include avatar in matrix + wire LEMONSLICE_API_KEY

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        example: [healthcare, survey, frontdesk, drive-thru, inference]
+        example: [healthcare, survey, frontdesk, drive-thru, inference, avatar]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -72,6 +72,7 @@ jobs:
         working-directory: examples/${{ matrix.example }}
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          LEMONSLICE_API_KEY: ${{ secrets.LEMONSLICE_API_KEY }}
         run: |
           : > .env.deploy
           # Register the agent under a deterministic name so the playground
@@ -80,6 +81,9 @@ jobs:
           case "${{ matrix.example }}" in
             healthcare)
               keys="OPENAI_API_KEY"
+              ;;
+            avatar)
+              keys="LEMONSLICE_API_KEY"
               ;;
             *)
               keys=""


### PR DESCRIPTION
## Summary

The avatar example shipped in #5834 was intentionally left out of the CI deploy matrix while its secret-provisioning story was pinned down — that's why the workflow runs for the avatar PR didn't actually push a new build of the agent.

This adds \`avatar\` to the matrix and plumbs \`LEMONSLICE_API_KEY\` through the same \`.env.deploy\` secrets-file mechanism healthcare uses for \`OPENAI_API_KEY\`.

## Prereq

\`LEMONSLICE_API_KEY\` needs to be set as a GitHub Actions secret on the repo (settings → Secrets and variables → Actions) before the next deploy. Today it's only set per-agent via \`lk agent update-secrets\` for local out-of-band deploys.

## Test plan

- [ ] Add the \`LEMONSLICE_API_KEY\` repo secret.
- [ ] Trigger the workflow (workflow_dispatch with ref=\`main\` after this merges).
- [ ] Confirm the \`Deploy avatar\` matrix job succeeds and \`CA_dzjZwsBsRKzZ\` picks up the new build.