### PR TITLE
fix: unblock jobs after process init failure

### DIFF
--- a/livekit-agents/livekit/agents/ipc/proc_pool.py
+++ b/livekit-agents/livekit/agents/ipc/proc_pool.py
@@ -62,7 +62,7 @@ class ProcPool(utils.EventEmitter[EventTypes]):
         self._target_idle_processes = num_idle_processes
 
         self._init_sem = asyncio.Semaphore(MAX_CONCURRENT_INITIALIZATIONS)
-        self._warmed_proc_queue = asyncio.Queue[JobExecutor]()
+        self._warmed_proc_queue = asyncio.Queue[JobExecutor | None]()
         self._executors: list[JobExecutor] = []
         self._spawn_tasks: set[asyncio.Task[None]] = set()
         self._close_tasks: set[asyncio.Task[None]] = set()
@@ -82,6 +82,11 @@ class ProcPool(utils.EventEmitter[EventTypes]):
             (x for x in self._executors if x.running_job and x.running_job.job.id == job_id),
             None,
         )
+
+    def _discard_finished_spawn_tasks(self) -> None:
+        for task in tuple(self._spawn_tasks):
+            if task.done():
+                self._spawn_tasks.discard(task)
 
     async def start(self) -> None:
         if self._started:
@@ -114,6 +119,7 @@ class ProcPool(utils.EventEmitter[EventTypes]):
         for attempt in range(MAX_ATTEMPTS):
             self._jobs_waiting_for_process += 1
             try:
+                self._discard_finished_spawn_tasks()
                 if (
                     self._warmed_proc_queue.empty()
                     and len(self._spawn_tasks) < self._jobs_waiting_for_process
@@ -130,6 +136,22 @@ class ProcPool(utils.EventEmitter[EventTypes]):
                     )
 
                 proc = await self._warmed_proc_queue.get()
+                if proc is None:
+                    if attempt == MAX_ATTEMPTS - 1:
+                        logger.error(
+                            "failed to acquire process for job after %d attempts",
+                            MAX_ATTEMPTS,
+                            extra={"job_id": info.job.id},
+                        )
+                        raise RuntimeError(
+                            f"no process became available after {MAX_ATTEMPTS} attempts"
+                        )
+
+                    logger.warning(
+                        "process failed to initialize, retrying with a new process",
+                        extra={"job_id": info.job.id, "attempt": attempt + 1},
+                    )
+                    continue
             finally:
                 self._jobs_waiting_for_process -= 1
 
@@ -222,6 +244,8 @@ class ProcPool(utils.EventEmitter[EventTypes]):
             self._executors.remove(proc)
             await proc.aclose()
             self.emit("process_closed", proc)
+            if self._jobs_waiting_for_process > 0:
+                self._warmed_proc_queue.put_nowait(None)
             return
 
         monitor_task = asyncio.create_task(self._monitor_process_task(proc))
@@ -240,6 +264,7 @@ class ProcPool(utils.EventEmitter[EventTypes]):
     async def _main_task(self) -> None:
         try:
             while not self._closed:
+                self._discard_finished_spawn_tasks()
                 current_pending = self._warmed_proc_queue.qsize() + len(self._spawn_tasks)
                 target = max(
                     min(self._target_idle_processes, self._default_num_idle_processes),

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -14,6 +14,7 @@ from multiprocessing.context import BaseContext
 from typing import ClassVar
 
 import psutil
+import pytest
 
 from livekit.agents import JobContext, JobProcess, ipc, job, utils
 from livekit.agents.ipc.log_queue import LogQueueHandler, LogQueueListener
@@ -368,6 +369,53 @@ async def test_slow_initialization():
 
     for exitcode in exitcodes:
         assert exitcode != 0, "process should have been killed"
+
+
+async def test_proc_pool_launch_job_returns_when_initialization_fails(monkeypatch):
+    class FailingProc:
+        running_job = None
+
+        def __init__(self, **kwargs):
+            pass
+
+        async def start(self) -> None:
+            pass
+
+        async def initialize(self) -> None:
+            raise TimeoutError("init timed out")
+
+        async def aclose(self) -> None:
+            pass
+
+        def logging_extra(self) -> dict:
+            return {}
+
+    monkeypatch.setattr(ipc.proc_pool.job_proc_executor, "ProcJobExecutor", FailingProc)
+
+    mp_ctx = mp.get_context("spawn")
+    loop = asyncio.get_running_loop()
+    pool = ipc.proc_pool.ProcPool(
+        job_executor_type=job.JobExecutorType.PROCESS,
+        initialize_process_fnc=_initialize_proc,
+        job_entrypoint_fnc=_job_entrypoint,
+        session_end_fnc=None,
+        num_idle_processes=0,
+        initialize_timeout=0.1,
+        close_timeout=20.0,
+        session_end_timeout=300.0,
+        inference_executor=None,
+        memory_warn_mb=0,
+        memory_limit_mb=0,
+        http_proxy=None,
+        mp_ctx=mp_ctx,
+        loop=loop,
+    )
+
+    with pytest.raises(RuntimeError, match="no process became available"):
+        await pool.launch_job(_generate_fake_job())
+
+    assert pool._jobs_waiting_for_process == 0
+    assert len(pool.processes) == 0
 
 
 def _create_proc(


### PR DESCRIPTION
﻿## Summary
- wake jobs waiting on `ProcPool` when a process fails initialization
- retry the existing 3-attempt launch path instead of waiting forever on an empty warmed-process queue
- cover the failure path with a fake executor test that does not depend on OS process spawning

## To verify
- `python -m py_compile livekit-agents\livekit\agents\ipc\proc_pool.py tests\test_ipc.py`
- `uv run ruff check livekit-agents\livekit\agents\ipc\proc_pool.py tests\test_ipc.py`
- `uv run pytest tests/test_ipc.py::test_proc_pool_launch_job_returns_when_initialization_fails -q --basetemp .tmp\pytest-5868-fast -p no:cacheprovider`

Related: #5868
