### PR TITLE
fix(elevenlabs): end server vad turns

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
@@ -350,6 +350,9 @@ class SpeechStream(stt.SpeechStream):
         )
         self._event_ch.send_nowait(usage_event)
 
+    def _uses_server_vad(self) -> bool:
+        return is_given(self._opts.server_vad) and self._opts.server_vad is not None
+
     async def _run(self) -> None:
         """Run the streaming transcription session"""
         closing_ws = False
@@ -481,7 +484,7 @@ class SpeechStream(stt.SpeechStream):
 
     async def _connect_ws(self) -> aiohttp.ClientWebSocketResponse:
         """Establish WebSocket connection to ElevenLabs Scribe v2 API"""
-        commit_strategy = "manual" if self._opts.server_vad is None else "vad"
+        commit_strategy = "vad" if self._uses_server_vad() else "manual"
         params = [
             f"model_id={self._opts.model_id}",
             f"audio_format=pcm_{self._opts.sample_rate}",
@@ -491,7 +494,9 @@ class SpeechStream(stt.SpeechStream):
         if not self._language:
             params.append("include_language_detection=true")
 
-        if server_vad := self._opts.server_vad:
+        if self._uses_server_vad():
+            server_vad = self._opts.server_vad
+            assert is_given(server_vad) and server_vad is not None
             if (
                 vad_silence_threshold_secs := server_vad.get("vad_silence_threshold_secs")
             ) is not None:
@@ -596,6 +601,9 @@ class SpeechStream(stt.SpeechStream):
                     alternatives=[speech_data],
                 )
                 self._event_ch.send_nowait(final_event)
+                if self._uses_server_vad():
+                    self._event_ch.send_nowait(stt.SpeechEvent(type=SpeechEventType.END_OF_SPEECH))
+                    self._speaking = False
             else:
                 # Empty commit signals end of speech segment (similar to Cartesia's is_final flag)
                 # This groups multiple committed transcripts into one speech segment

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
@@ -350,8 +350,9 @@ class SpeechStream(stt.SpeechStream):
         )
         self._event_ch.send_nowait(usage_event)
 
-    def _uses_server_vad(self) -> bool:
-        return is_given(self._opts.server_vad) and self._opts.server_vad is not None
+    @property
+    def _server_vad(self) -> VADOptions | None:
+        return self._opts.server_vad if is_given(self._opts.server_vad) else None
 
     async def _run(self) -> None:
         """Run the streaming transcription session"""
@@ -484,7 +485,7 @@ class SpeechStream(stt.SpeechStream):
 
     async def _connect_ws(self) -> aiohttp.ClientWebSocketResponse:
         """Establish WebSocket connection to ElevenLabs Scribe v2 API"""
-        commit_strategy = "vad" if self._uses_server_vad() else "manual"
+        commit_strategy = "vad" if self._server_vad is not None else "manual"
         params = [
             f"model_id={self._opts.model_id}",
             f"audio_format=pcm_{self._opts.sample_rate}",
@@ -494,9 +495,7 @@ class SpeechStream(stt.SpeechStream):
         if not self._language:
             params.append("include_language_detection=true")
 
-        if self._uses_server_vad():
-            server_vad = self._opts.server_vad
-            assert is_given(server_vad) and server_vad is not None
+        if (server_vad := self._server_vad) is not None:
             if (
                 vad_silence_threshold_secs := server_vad.get("vad_silence_threshold_secs")
             ) is not None:
@@ -601,7 +600,7 @@ class SpeechStream(stt.SpeechStream):
                     alternatives=[speech_data],
                 )
                 self._event_ch.send_nowait(final_event)
-                if self._uses_server_vad():
+                if self._server_vad is not None:
                     self._event_ch.send_nowait(stt.SpeechEvent(type=SpeechEventType.END_OF_SPEECH))
                     self._speaking = False
             else:

--- a/tests/test_plugin_elevenlabs_stt.py
+++ b/tests/test_plugin_elevenlabs_stt.py
@@ -6,7 +6,7 @@ from livekit.agents import stt
 from livekit.agents.types import NOT_GIVEN
 from livekit.plugins.elevenlabs import stt as elevenlabs_stt
 
-pytestmark = pytest.mark.plugin
+pytestmark = pytest.mark.plugin("elevenlabs")
 
 
 class _EventSink:

--- a/tests/test_plugin_elevenlabs_stt.py
+++ b/tests/test_plugin_elevenlabs_stt.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents import stt
+from livekit.agents.types import NOT_GIVEN
+from livekit.plugins.elevenlabs import stt as elevenlabs_stt
+
+pytestmark = pytest.mark.plugin
+
+
+class _EventSink:
+    def __init__(self) -> None:
+        self.events: list[stt.SpeechEvent] = []
+
+    def send_nowait(self, event: stt.SpeechEvent) -> None:
+        self.events.append(event)
+
+
+def _new_stream(*, server_vad=NOT_GIVEN) -> elevenlabs_stt.SpeechStream:
+    stream = object.__new__(elevenlabs_stt.SpeechStream)
+    stream._opts = elevenlabs_stt.STTOptions(
+        model_id="scribe_v2_realtime",
+        api_key="test-key",
+        base_url=elevenlabs_stt.API_BASE_URL_V1,
+        language_code=None,
+        tag_audio_events=True,
+        include_timestamps=False,
+        sample_rate=16000,
+        server_vad=server_vad,
+        keyterms=NOT_GIVEN,
+    )
+    stream._language = None
+    stream._event_ch = _EventSink()
+    stream._speaking = False
+    stream._start_time_offset = 0.0
+    return stream
+
+
+def _committed_transcript(text: str) -> dict:
+    return {
+        "message_type": "committed_transcript",
+        "text": text,
+        "words": [
+            {"text": text, "start": 0.1, "end": 0.4},
+        ]
+        if text
+        else [],
+    }
+
+
+def test_server_vad_commit_emits_end_of_speech() -> None:
+    stream = _new_stream(server_vad={"vad_silence_threshold_secs": 0.5})
+
+    stream._process_stream_event(_committed_transcript("hello"))
+
+    assert [event.type for event in stream._event_ch.events] == [
+        stt.SpeechEventType.START_OF_SPEECH,
+        stt.SpeechEventType.FINAL_TRANSCRIPT,
+        stt.SpeechEventType.END_OF_SPEECH,
+    ]
+    assert stream._event_ch.events[1].alternatives[0].text == "hello"
+    assert stream._speaking is False
+
+
+def test_manual_commit_still_waits_for_empty_commit() -> None:
+    stream = _new_stream(server_vad=None)
+
+    stream._process_stream_event(_committed_transcript("hello"))
+
+    assert [event.type for event in stream._event_ch.events] == [
+        stt.SpeechEventType.START_OF_SPEECH,
+        stt.SpeechEventType.FINAL_TRANSCRIPT,
+    ]
+    assert stream._speaking is True
+
+    stream._process_stream_event(_committed_transcript(""))
+
+    assert stream._event_ch.events[-1].type == stt.SpeechEventType.END_OF_SPEECH
+    assert stream._speaking is False


### PR DESCRIPTION
﻿## Summary
- map ElevenLabs server-VAD committed transcripts to LiveKit `END_OF_SPEECH`
- leave manual commit behavior unchanged: manual streams still wait for an empty commit before EOS
- avoid treating an omitted `server_vad` option as server VAD when building the realtime websocket URL

## To verify
- `python -m py_compile livekit-plugins\livekit-plugins-elevenlabs\livekit\plugins\elevenlabs\stt.py tests\test_plugin_elevenlabs_stt.py`
- `uv run ruff check livekit-plugins\livekit-plugins-elevenlabs\livekit\plugins\elevenlabs\stt.py tests\test_plugin_elevenlabs_stt.py`
- `uv run pytest tests/test_plugin_elevenlabs_stt.py -q --basetemp .tmp\pytest-5849 -p no:cacheprovider`

Related: #5849
