### PR TITLE
fix: explicitly select CUDAExecutionProvider to avoid silent CPU fallback when TensorRT is absent (closes #5860)

### DIFF
--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/onnx_model.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/onnx_model.py
@@ -40,13 +40,15 @@ def new_inference_session(
     opts.intra_op_num_threads = 1
     opts.execution_mode = onnxruntime.ExecutionMode.ORT_SEQUENTIAL
 
-    if force_cpu and "CPUExecutionProvider" in onnxruntime.get_available_providers():
-        session = onnxruntime.InferenceSession(
-            path, providers=["CPUExecutionProvider"], sess_options=opts
-        )
+    available = onnxruntime.get_available_providers()
+    if force_cpu and "CPUExecutionProvider" in available:
+        providers = ["CPUExecutionProvider"]
+    elif not force_cpu and "CUDAExecutionProvider" in available:
+        providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
     else:
-        session = onnxruntime.InferenceSession(path, sess_options=opts)
+        providers = ["CPUExecutionProvider"]
 
+    session = onnxruntime.InferenceSession(path, providers=providers, sess_options=opts)
     return session
 
 


### PR DESCRIPTION
## What

When `force_cpu=False` and a CUDA GPU is available but TensorRT is not installed, ONNX Runtime silently falls back to `CPUExecutionProvider` instead of using `CUDAExecutionProvider`. This happens because ORT's default provider priority list places `TensorrtExecutionProvider` before `CUDAExecutionProvider`, and when TRT fails to load it skips CUDA entirely.

## Fix

Explicitly build the providers list in `new_inference_session()` by checking `onnxruntime.get_available_providers()` and preferring `CUDAExecutionProvider` when it is available and `force_cpu=False`. This ensures CUDA is used whenever possible, regardless of whether TensorRT is installed.

Closes #5860