### PR TITLE
feat(gradium STT): add language option to gradium.STT

### DIFF
--- a/livekit-plugins/livekit-plugins-gradium/livekit/plugins/gradium/stt.py
+++ b/livekit-plugins/livekit-plugins-gradium/livekit/plugins/gradium/stt.py
@@ -81,6 +81,7 @@ class STT(stt.STT):
         vad_bucket: int | None = 2,
         vad_flush: bool = True,
         temperature: float | None = None,
+        language: str = "en",
     ):
         super().__init__(
             capabilities=stt.STTCapabilities(
@@ -122,6 +123,7 @@ class STT(stt.STT):
             vad_bucket=vad_bucket,
             vad_flush=vad_flush,
             temperature=temperature,
+            language=LanguageCode(language),
         )
 
         if is_given(encoding):
@@ -160,6 +162,8 @@ class STT(stt.STT):
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
     ) -> SpeechStream:
         config = dataclasses.replace(self._opts)
+        if is_given(language):
+            config.language = LanguageCode(language)
         stream = SpeechStream(
             stt=self,
             conn_options=conn_options,
@@ -419,8 +423,10 @@ class SpeechStream(stt.SpeechStream):
             "model_name": self._model_name,
             "input_format": "pcm",
         }
+        json_config: dict[str, Any] = {"language": self._opts.language.language}
         if self._opts.temperature is not None:
-            setup_msg["json_config"] = {"temp": self._opts.temperature}
+            json_config["temp"] = self._opts.temperature
+        setup_msg["json_config"] = json_config
 
         await ws.send_str(json.dumps(setup_msg))
         return ws

--- a/tests/test_plugin_gradium_stt.py
+++ b/tests/test_plugin_gradium_stt.py
@@ -1,0 +1,86 @@
+"""Tests for Gradium STT plugin configuration and behavior."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_stt_default_language():
+    """STT defaults to English."""
+    from livekit.plugins.gradium import STT
+
+    stt = STT(api_key="test-key")
+
+    assert stt._opts.language == "en"
+
+
+def test_stt_custom_language():
+    """STT accepts custom language."""
+    from livekit.plugins.gradium import STT
+
+    stt = STT(api_key="test-key", language="fr")
+
+    assert stt._opts.language == "fr"
+
+
+def test_stream_language_overrides_stream_options():
+    """stream language overrides the copied stream config."""
+    from livekit.plugins.gradium import STT
+
+    stt = STT(api_key="test-key", language="fr", http_session=MagicMock())
+
+    def _fake_create_task(coro, *args, **kwargs):
+        coro.close()
+        task = MagicMock()
+        return task
+
+    with patch("livekit.agents.stt.stt.asyncio.create_task", side_effect=_fake_create_task):
+        stream = stt.stream(language="de")
+
+    assert stream._opts.language == "de"
+    assert stt._opts.language == "fr"
+
+
+@pytest.mark.asyncio
+async def test_speech_stream_sends_language_in_json_config():
+    """SpeechStream sends language in setup json_config."""
+    from livekit.agents import DEFAULT_API_CONNECT_OPTIONS, LanguageCode
+    from livekit.plugins.gradium import STT
+    from livekit.plugins.gradium.stt import SpeechStream, STTOptions
+
+    sent_messages: list[str] = []
+
+    class FakeWebSocket:
+        async def send_str(self, message: str) -> None:
+            sent_messages.append(message)
+
+    class FakeSession:
+        async def ws_connect(self, url, headers):
+            return FakeWebSocket()
+
+    stt = STT(api_key="test-key")
+    opts = STTOptions(language=LanguageCode("pt"), temperature=0.3)
+
+    def _fake_create_task(coro, *args, **kwargs):
+        coro.close()
+        task = MagicMock()
+        return task
+
+    with patch("livekit.agents.stt.stt.asyncio.create_task", side_effect=_fake_create_task):
+        stream = SpeechStream(
+            stt=stt,
+            opts=opts,
+            conn_options=DEFAULT_API_CONNECT_OPTIONS,
+            api_key="test-key",
+            model_endpoint="wss://api.gradium.ai/api/speech/asr",
+            model_name="default",
+            http_session=FakeSession(),
+        )
+
+    await stream._connect_ws()
+
+    setup_msg = json.loads(sent_messages[0])
+    assert setup_msg["json_config"] == {"language": "pt", "temp": 0.3}


### PR DESCRIPTION
## Summary
- add language option to Gradium STT
- send language in Gradium setup json_config
- support per-stream language override
- add focused Gradium STT tests

## Tests
- uv run pytest tests/test_plugin_gradium_stt.py
- make check