### PR TITLE
fix(speechmatics): avoid fake confidence for segments

### DIFF
--- a/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
+++ b/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
@@ -904,6 +904,7 @@ class SpeechStream(stt.RecognizeStream):
                 start_time=segment.get("metadata", {}).get("start_time", 0)
                 + self.start_time_offset,
                 end_time=segment.get("metadata", {}).get("end_time", 0) + self.start_time_offset,
+                confidence=_extract_confidence(segment),
             )
 
             # Create speech event
@@ -941,6 +942,27 @@ class SpeechStream(stt.RecognizeStream):
         # Remove from active streams
         if self in self._stt._streams:
             self._stt._streams.remove(self)
+
+
+def _extract_confidence(segment: dict[str, Any]) -> float:
+    value = segment.get("confidence")
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+
+    confidences: list[float] = []
+    for fragment in segment.get("fragments") or []:
+        if not isinstance(fragment, dict):
+            continue
+        fragment_confidence = fragment.get("confidence")
+        if isinstance(fragment_confidence, (int, float)) and not isinstance(
+            fragment_confidence, bool
+        ):
+            confidences.append(float(fragment_confidence))
+
+    if confidences:
+        return sum(confidences) / len(confidences)
+
+    return 0.0
 
 
 def _check_deprecated_args(kwargs: dict[str, Any], opts: STTOptions) -> None:

--- a/livekit-plugins/livekit-plugins-speechmatics/tests/test_stt_confidence.py
+++ b/livekit-plugins/livekit-plugins-speechmatics/tests/test_stt_confidence.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from livekit.agents import LanguageCode, stt
+from livekit.plugins.speechmatics.stt import SpeechStream, STTOptions, _extract_confidence
+
+
+def _stream() -> tuple[SpeechStream, list[stt.SpeechEvent]]:
+    stream = SpeechStream.__new__(SpeechStream)
+    events: list[stt.SpeechEvent] = []
+    stream._event_ch = SimpleNamespace(send_nowait=events.append)  # type: ignore[attr-defined]
+    stream._stt = SimpleNamespace(  # type: ignore[attr-defined]
+        _stt_options=STTOptions(language=LanguageCode("en")),
+    )
+    stream.start_time_offset = 0.25  # type: ignore[attr-defined]
+    return stream, events
+
+
+def _segment(**overrides: Any) -> dict[str, Any]:
+    segment: dict[str, Any] = {
+        "text": "hello",
+        "language": "en",
+        "speaker_id": "S1",
+        "metadata": {"start_time": 1.0, "end_time": 2.0},
+    }
+    segment.update(overrides)
+    return segment
+
+
+def test_send_frames_uses_reported_confidence() -> None:
+    stream, events = _stream()
+
+    stream._send_frames([_segment(confidence=0.42)], is_final=True)
+
+    assert events[0].type == stt.SpeechEventType.FINAL_TRANSCRIPT
+    data = events[0].alternatives[0]
+    assert data.confidence == pytest.approx(0.42)
+    assert data.start_time == pytest.approx(1.25)
+    assert data.end_time == pytest.approx(2.25)
+
+
+def test_send_frames_defaults_unknown_confidence_to_zero() -> None:
+    stream, events = _stream()
+
+    stream._send_frames([_segment()], is_final=False)
+
+    assert events[0].type == stt.SpeechEventType.INTERIM_TRANSCRIPT
+    assert events[0].alternatives[0].confidence == 0.0
+
+
+def test_extract_confidence_averages_fragment_confidence() -> None:
+    assert _extract_confidence(
+        {
+            "fragments": [
+                {"confidence": 0.2},
+                {"confidence": 0.8},
+                {"confidence": True},
+                {"confidence": "0.5"},
+            ]
+        }
+    ) == pytest.approx(0.5)


### PR DESCRIPTION
﻿## Summary
- stop reporting Speechmatics segment confidence as `1.0` when the segment does not include a confidence value
- propagate numeric segment confidence when present, with a fragment-confidence fallback for richer segment payloads
- add a small regression test around the emitted `SpeechData.confidence`

Fixes #5880

## To verify
- `python -m py_compile livekit-plugins\livekit-plugins-speechmatics\livekit\plugins\speechmatics\stt.py livekit-plugins\livekit-plugins-speechmatics\tests\test_stt_confidence.py`
- `python -m ruff check livekit-plugins\livekit-plugins-speechmatics\livekit\plugins\speechmatics\stt.py livekit-plugins\livekit-plugins-speechmatics\tests\test_stt_confidence.py`
- `python -m ruff format --check livekit-plugins\livekit-plugins-speechmatics\livekit\plugins\speechmatics\stt.py livekit-plugins\livekit-plugins-speechmatics\tests\test_stt_confidence.py`
- `python -m pytest livekit-plugins\livekit-plugins-speechmatics\tests -q`
