### PR TITLE
fix(deps): relax bithuman pin to <3 for SDK 2.x compatibility

### DIFF
--- a/livekit-plugins/livekit-plugins-bithuman/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-bithuman/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 
-dependencies = ["livekit-agents>=1.5.14", "bithuman>=0.5.25,<1.12"]
+dependencies = ["livekit-agents>=1.5.14", "bithuman>=0.5.25,<3"]
 
 [project.urls]
 Documentation = "https://docs.livekit.io"


### PR DESCRIPTION
# Relax `bithuman` pin to allow 2.x

## TL;DR

`livekit-plugins-bithuman` currently pins `bithuman>=0.5.25,<1.12`. The bithuman SDK is now on the 2.x line (latest `2.2.6`) and is API-compatible with everything the plugin uses. This PR relaxes the upper bound to `<3` so users can install both packages together.

## Why

PR #5743 added the `<1.12` cap because some 1.x releases shipped incomplete wheel coverage on macOS/3.13. That problem is gone in 2.x:

- `bithuman 2.2.6` ships **14 wheels** covering py3.10/3.11/3.12/3.13/3.14 on `macosx_arm64` and `manylinux_2_28_{x86_64,aarch64}`.
- No platform regressions vs. the highest 1.x version covered by the current pin.

Holding the pin at `<1.12` now blocks every downstream that consumes both packages.

## Compatibility evidence

The plugin touches the bithuman SDK in exactly these places (`livekit/plugins/bithuman/avatar.py`):

| Symbol used by plugin | Present in `bithuman==2.2.6` |
|---|---|
| `from bithuman import AsyncBithuman` | yes |
| `AsyncBithuman.create(model_path=, api_secret=, token=, api_url=)` | yes (`runtime_async.AsyncBithuman.create`) |
| `runtime.transaction_id` (attr) | yes (set in `Bithuman.__init__`) |
| `runtime._regenerate_transaction_id()` | yes (`runtime.py`) |
| `runtime._initialize_token()` (async) | yes |
| `runtime.get_first_frame()` | yes |
| `runtime.settings.FPS` / `.INPUT_SAMPLE_RATE` | yes (`settings` populated in init) |
| `runtime.run()` (async iter of frames with `.bgr_image` / `.audio_chunk` / `.end_of_speech`) | yes |
| `runtime.push_audio(bytes, sample_rate, last_chunk=False)` | yes |
| `runtime.flush()` | yes |
| `runtime.interrupt()` | yes |
| `runtime.cleanup()` | yes |
| `runtime.stop()` | yes |

### Live install test (Python 3.13, macOS arm64)

```bash
python -m venv venv && source venv/bin/activate
pip install "bithuman==2.2.6"
pip install --upgrade "livekit-agents[openai]>=1.5.14"
pip install --no-deps "livekit-plugins-bithuman==1.5.14"

python -c "
from livekit.plugins import bithuman as lk_bh
av = lk_bh.AvatarSession(api_url='http://localhost:8088/launch',
                        api_secret='fake', avatar_id='nova', model='essence')
print('OK:', av)
"
# => OK: <livekit.plugins.bithuman.avatar.AvatarSession object at 0x...>
```

`AvatarSession` constructs successfully in both `cloud` and `local` modes against `bithuman==2.2.6`.

## The change

```diff
- dependencies = ["livekit-agents>=1.5.14", "bithuman>=0.5.25,<1.12"]
+ dependencies = ["livekit-agents>=1.5.14", "bithuman>=0.5.25,<3"]
```

(File: `livekit-plugins/livekit-plugins-bithuman/pyproject.toml`)

## Impact

- Existing `bithuman 1.x` users: unaffected — `<3` still resolves to whatever the user/pip picks within the available range.
- New users on 2.x: `pip install livekit-plugins-bithuman` now resolves cleanly alongside `bithuman==2.2.6`.
- No code change required in the plugin itself.
