### PR TITLE
fix(inference): enable STT websocket heartbeat

### DIFF
--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -259,6 +259,7 @@ STTEncoding = Literal["pcm_s16le"]
 
 DEFAULT_ENCODING: STTEncoding = "pcm_s16le"
 DEFAULT_SAMPLE_RATE: int = 16000
+WS_HEARTBEAT: float = 30.0
 
 
 @dataclass
@@ -843,7 +844,9 @@ class SpeechStream(stt.SpeechStream):
         try:
             ws = await asyncio.wait_for(
                 http_session.ws_connect(
-                    f"{base_url}/stt?model={self._opts.model}", headers=headers
+                    f"{base_url}/stt?model={self._opts.model}",
+                    headers=headers,
+                    heartbeat=WS_HEARTBEAT,
                 ),
                 self._conn_options.timeout,
             )

--- a/tests/test_inference_stt_fallback.py
+++ b/tests/test_inference_stt_fallback.py
@@ -1,8 +1,12 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 from livekit.agents.inference.stt import (
     STT,
+    WS_HEARTBEAT,
     FallbackModel,
+    SpeechStream,
     _normalize_fallback,
     _parse_model_string,
 )
@@ -23,6 +27,23 @@ def _make_stt(**kwargs):
     }
     defaults.update(kwargs)
     return STT(**defaults)
+
+
+class _FakeWebSocket:
+    def __init__(self):
+        self.sent = []
+
+    async def send_str(self, data: str) -> None:
+        self.sent.append(data)
+
+
+def _make_stream_without_tasks(stt: STT) -> SpeechStream:
+    def _fake_create_task(coro, *args, **kwargs):
+        coro.close()
+        return MagicMock()
+
+    with patch("livekit.agents.stt.stt.asyncio.create_task", side_effect=_fake_create_task):
+        return stt.stream()
 
 
 class TestParseModelString:
@@ -257,6 +278,19 @@ class TestSTTConstructorFallbackAndConnectOptions:
         assert stt._opts.conn_options.timeout == 60.0
         assert stt._opts.conn_options.max_retry == 10
         assert stt._opts.conn_options.retry_interval == 2.0
+
+
+async def test_connect_ws_enables_websocket_heartbeat():
+    stt = _make_stt(model="deepgram/nova-3")
+    stream = _make_stream_without_tasks(stt)
+    fake_ws = _FakeWebSocket()
+    session = MagicMock()
+    session.ws_connect = AsyncMock(return_value=fake_ws)
+
+    assert await stream._connect_ws(session) is fake_ws
+
+    _, kwargs = session.ws_connect.call_args
+    assert kwargs["heartbeat"] == WS_HEARTBEAT
 
 
 class TestSTTDiarizationCapabilities:


### PR DESCRIPTION
﻿## Summary
- enable aiohttp WebSocket heartbeat for LiveKit Inference STT streams
- keep normal quiet-user sessions untouched because heartbeat uses WS PING/PONG, not application message timeouts
- cover the connection path with a fake-session unit test

Fixes #5717.

## To verify
- `python -m py_compile livekit-agents\livekit\agents\inference\stt.py tests\test_inference_stt_fallback.py`
- `uv run ruff check livekit-agents\livekit\agents\inference\stt.py tests\test_inference_stt_fallback.py`
- `uv run ruff format --check livekit-agents\livekit\agents\inference\stt.py tests\test_inference_stt_fallback.py`
- `uv run pytest tests\test_inference_stt_fallback.py -q`
