### PR TITLE
fix(llm): sort function tools to make order an invariant

### DIFF
--- a/livekit-agents/livekit/agents/llm/tool_context.py
+++ b/livekit-agents/livekit/agents/llm/tool_context.py
@@ -501,6 +501,7 @@ class ToolContext:
         # https://developers.openai.com/cookbook/examples/prompt_caching101#example-1-caching-tools-and-multi-turn-conversations
         # "When caching tools, it is important that the tool definitions and their order remain identical for them to be included in the prompt prefix."
         self._fnc_tools_map = dict(sorted(self._fnc_tools_map.items()))
+        self._provider_tools.sort(key=lambda t: t.id)
 
     def copy(self) -> ToolContext:
         return ToolContext(self._tools.copy())

--- a/livekit-agents/livekit/agents/llm/tool_context.py
+++ b/livekit-agents/livekit/agents/llm/tool_context.py
@@ -498,6 +498,10 @@ class ToolContext:
         for tool in itertools.chain(tools, find_function_tools(self)):
             add_tool(tool)
 
+        # https://developers.openai.com/cookbook/examples/prompt_caching101#example-1-caching-tools-and-multi-turn-conversations
+        # "When caching tools, it is important that the tool definitions and their order remain identical for them to be included in the prompt prefix."
+        self._fnc_tools_map = dict(sorted(self._fnc_tools_map.items()))
+
     def copy(self) -> ToolContext:
         return ToolContext(self._tools.copy())
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -288,11 +288,20 @@ class TestToolContext:
             return schema["name"]
 
         ctx = ToolContext([mock_tool_3, mock_tool_1, mock_tool_2])
-        for fmt in ("openai", "anthropic", "aws"):
+        for fmt in ("openai", "openai.responses", "anthropic", "aws", "google"):
             names = [tool_name(fmt, s) for s in ctx.parse_function_tools(fmt)]
             assert names == ["mock_tool_1", "mock_tool_2", "mock_tool_3"], (
                 f"{fmt} tool order not sorted: {names}"
             )
+
+        # provider tools are part of the same cached prefix (e.g. openai responses
+        # api flattens function + provider tools together), so they must also be
+        # order-invariant
+        provider_a = DummyProviderTool("provider_a")
+        provider_b = DummyProviderTool("provider_b")
+        provider_c = DummyProviderTool("provider_c")
+        ctx = ToolContext([provider_c, provider_a, provider_b])
+        assert [t.id for t in ctx.provider_tools] == ["provider_a", "provider_b", "provider_c"]
 
 
 class TestToolExecution:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -277,6 +277,23 @@ class TestToolContext:
         ctx6 = ToolContext([mock_tool_1, mock_tool_2])
         assert ctx5 != ctx6
 
+    def test_serialized_tool_order_is_sorted(self):
+        # provider tool definitions are part of the cached prompt prefix, so the
+        # serialized order must be deterministic regardless of input order
+        def tool_name(fmt: str, schema: dict[str, Any]) -> str:
+            if fmt == "openai":
+                return schema["function"]["name"]
+            if fmt == "aws":
+                return schema["toolSpec"]["name"]
+            return schema["name"]
+
+        ctx = ToolContext([mock_tool_3, mock_tool_1, mock_tool_2])
+        for fmt in ("openai", "anthropic", "aws"):
+            names = [tool_name(fmt, s) for s in ctx.parse_function_tools(fmt)]
+            assert names == ["mock_tool_1", "mock_tool_2", "mock_tool_3"], (
+                f"{fmt} tool order not sorted: {names}"
+            )
+
 
 class TestToolExecution:
     def test_function_arguments_to_pydantic_model(self):


### PR DESCRIPTION
## Summary

`ToolContext` currently preserves whatever insertion order it receives, so the serialized tool block is a function of how the caller assembled the list rather than a function of the tool set itself. For prompt caching to work, providers like Anthropic and OpenAI require the tool definitions and their order to be identical across requests.

This establishes the invariant: **the serialized tool order is determined by the tool set, not by insertion order.** Sort `_fnc_tools_map` by name once in `ToolContext.update_tools` so every downstream consumer (provider serializers, realtime models, `tool_proxy`) sees the same order regardless of how the input list was built.

> "When caching tools, it is important that the tool definitions and their order remain identical for them to be included in the prompt prefix."
> — https://developers.openai.com/cookbook/examples/prompt_caching101#example-1-caching-tools-and-multi-turn-conversations

## Test plan

- [x] `tests/test_tools.py::TestToolContext::test_serialized_tool_order_is_sorted` — feeds tools in non-alphabetical order and asserts the openai / anthropic / aws serialized payloads come out sorted by name.
- [x] Verified the test fails without the fix (provider output preserves input order, e.g. `['mock_tool_3', 'mock_tool_1', 'mock_tool_2']`).