### PR TITLE
fix(openai): delete trimmed empty audio items

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1364,11 +1364,6 @@ class RealtimeSession(
             return False
 
         for msg_id in diff_ops.to_remove:
-            # we don't have content synced down for some types of content (audio/images)
-            # these won't be present in the Agent's view of the context
-            # so in those cases, we do not want to remove them from the server context
-            if _is_content_empty(msg_id):
-                continue
             _delete_item(msg_id)
 
         for previous_msg_id, msg_id in diff_ops.to_create:
@@ -1376,7 +1371,7 @@ class RealtimeSession(
 
         # update the items with the same id but different content
         for previous_msg_id, msg_id in diff_ops.to_update:
-            # likewise, empty content almost always means the content is not synced down
+            # empty content almost always means the content is not synced down
             # we don't want to recreate these items there
             if _is_content_empty(msg_id):
                 continue

--- a/tests/test_realtime/test_openai_realtime_model.py
+++ b/tests/test_realtime/test_openai_realtime_model.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+from livekit.agents import llm
+from livekit.agents.llm.remote_chat_context import RemoteChatContext
+from livekit.plugins.openai.realtime.realtime_model import RealtimeSession
+
+
+def test_update_chat_ctx_deletes_empty_remote_items() -> None:
+    remote_ctx = RemoteChatContext()
+    audio_item = llm.ChatMessage(id="audio_item", role="user", content=[])
+    kept_item = llm.ChatMessage(id="assistant_item", role="assistant", content=["kept"])
+    remote_ctx.insert(None, audio_item)
+    remote_ctx.insert(audio_item.id, kept_item)
+
+    session = cast(RealtimeSession, SimpleNamespace(_remote_chat_ctx=remote_ctx))
+    events = RealtimeSession._create_update_chat_ctx_events(
+        session,
+        llm.ChatContext(items=[kept_item]),
+    )
+
+    delete_ids = [
+        getattr(event, "item_id", None)
+        for event in events
+        if getattr(event, "type", None) == "conversation.item.delete"
+    ]
+    assert delete_ids == ["audio_item"]


### PR DESCRIPTION
## Summary
- delete items explicitly trimmed out by `update_chat_ctx()`, even if the local copy has empty content
- keep the empty-content guard for updates so unsynced audio/image items are not recreated
- add a unit test for empty audio-like remote items being deleted from the OpenAI realtime context diff

Fixes #5886.

## To verify
- `uv run pytest tests/test_realtime/test_openai_realtime_model.py -q`
- `uv run ruff check livekit-plugins\livekit-plugins-openai\livekit\plugins\openai\realtime\realtime_model.py tests\test_realtime\test_openai_realtime_model.py`
- `uv run ruff format --check livekit-plugins\livekit-plugins-openai\livekit\plugins\openai\realtime\realtime_model.py tests\test_realtime\test_openai_realtime_model.py`
- `uv run python -m py_compile livekit-plugins\livekit-plugins-openai\livekit\plugins\openai\realtime\realtime_model.py tests\test_realtime\test_openai_realtime_model.py`
- `git diff --check`

## Notes
- `uv run python scripts\check_types.py` currently fails on Windows in `livekit-agents\livekit\agents\cli\readchar.py` because mypy sees POSIX `termios`/`tty` attributes as missing. The errors are outside this diff.
