### PR TITLE
fix(cli): propagate exit signal callbacks

### DIFF
--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -68,7 +68,7 @@ class _ToggleMode(Exception):
     pass
 
 
-class _ExitCli(BaseException):
+class _ExitCli(KeyboardInterrupt):
     pass
 
 
@@ -1178,6 +1178,8 @@ def _text_mode(c: AgentsConsole) -> None:
                 key_read_cb=_key_read,
                 placeholder="Type to talk to your agent",
             )
+        except _ExitCli:
+            raise
         except KeyboardInterrupt:
             break
 

--- a/tests/test_drain_timeout.py
+++ b/tests/test_drain_timeout.py
@@ -178,9 +178,9 @@ class TestDrainTimeout:
         """SIGTERM/SIGINT should not be eaten by broad Exception handlers.
 
         Issue #4664 showed _ExitCli being raised from a signal handler while
-        _memory_monitor_task() was inside psutil. Because _ExitCli inherited
-        from Exception, the blanket ``except Exception`` here swallowed the
-        shutdown signal and left the worker running instead of draining.
+        _memory_monitor_task() was inside psutil. _ExitCli must stay outside
+        Exception so blanket ``except Exception`` blocks do not swallow the
+        shutdown signal and leave the worker running instead of draining.
         """
         proc = _make_supervised_proc()
         proc._pid = 123
@@ -200,3 +200,23 @@ class TestDrainTimeout:
                 asyncio.get_event_loop().run_until_complete(proc._memory_monitor_task())
 
         mock_exception.assert_not_called()
+
+    def test_exitcli_propagates_from_asyncio_callback_frame(self) -> None:
+        """asyncio.Handle._run re-raises KeyboardInterrupt subclasses.
+
+        This covers the race where a signal handler raises _ExitCli while the
+        loop is running an arbitrary callback frame.
+        """
+        loop = asyncio.new_event_loop()
+        done: asyncio.Future[None] = loop.create_future()
+
+        def _raise_exit() -> None:
+            raise _ExitCli()
+
+        try:
+            loop.call_soon(_raise_exit)
+            loop.call_later(0.01, done.set_result, None)
+            with pytest.raises(_ExitCli):
+                loop.run_until_complete(done)
+        finally:
+            loop.close()


### PR DESCRIPTION
## Summary
- make `_ExitCli` inherit from `KeyboardInterrupt` so asyncio callback frames re-raise it instead of routing it to the loop exception handler
- keep `_ExitCli` outside `Exception`, preserving the previous fix for broad `except Exception` handlers
- add a regression test for the callback-frame race described in #5856

Fixes #5856.

## To verify
- `uv run pytest tests/test_drain_timeout.py -q`
- `uv run ruff check livekit-agents\livekit\agents\cli\cli.py tests\test_drain_timeout.py`
- `uv run ruff format --check livekit-agents\livekit\agents\cli\cli.py tests\test_drain_timeout.py`
- `uv run python -m py_compile livekit-agents\livekit\agents\cli\cli.py tests\test_drain_timeout.py`
- `git diff --check`
