### PR TITLE
fix: bound ProcPool process wait

### DIFF
--- a/livekit-agents/livekit/agents/ipc/proc_pool.py
+++ b/livekit-agents/livekit/agents/ipc/proc_pool.py
@@ -23,6 +23,7 @@ EventTypes = Literal[
 ]
 
 MAX_CONCURRENT_INITIALIZATIONS = min(math.ceil(get_cpu_monitor().cpu_count()), 4)
+WARMED_PROCESS_WAIT_TIMEOUT_BUFFER = 2.0
 
 
 class ProcPool(utils.EventEmitter[EventTypes]):
@@ -129,7 +130,25 @@ class ProcPool(utils.EventEmitter[EventTypes]):
                         extra={"job_id": info.job.id},
                     )
 
-                proc = await self._warmed_proc_queue.get()
+                try:
+                    proc = await asyncio.wait_for(
+                        self._warmed_proc_queue.get(),
+                        timeout=self._initialize_timeout + WARMED_PROCESS_WAIT_TIMEOUT_BUFFER,
+                    )
+                except asyncio.TimeoutError as exc:
+                    if attempt == MAX_ATTEMPTS - 1:
+                        logger.error(
+                            "failed to launch job because no process became available after %d attempts",
+                            MAX_ATTEMPTS,
+                            extra={"job_id": info.job.id},
+                        )
+                        raise RuntimeError("no process became available for the job") from exc
+
+                    logger.warning(
+                        "timed out waiting for warmed process, retrying with a new process",
+                        extra={"job_id": info.job.id, "attempt": attempt + 1},
+                    )
+                    continue
             finally:
                 self._jobs_waiting_for_process -= 1
 

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -14,6 +14,7 @@ from multiprocessing.context import BaseContext
 from typing import ClassVar
 
 import psutil
+import pytest
 
 from livekit.agents import JobContext, JobProcess, ipc, job, utils
 from livekit.agents.ipc.log_queue import LogQueueHandler, LogQueueListener
@@ -404,6 +405,43 @@ async def test_slow_initialization():
 
     for exitcode in exitcodes:
         assert exitcode != 0, "process should have been killed"
+
+
+async def test_proc_pool_launch_job_times_out_when_spawn_never_warms_process(monkeypatch):
+    mp_ctx = mp.get_context("spawn")
+    loop = asyncio.get_running_loop()
+    pool = ipc.proc_pool.ProcPool(
+        initialize_process_fnc=_initialize_proc,
+        job_entrypoint_fnc=_job_entrypoint,
+        session_end_fnc=None,
+        num_idle_processes=0,
+        job_executor_type=job.JobExecutorType.THREAD,
+        initialize_timeout=0.01,
+        close_timeout=20.0,
+        session_end_timeout=300.0,
+        inference_executor=None,
+        memory_warn_mb=0,
+        memory_limit_mb=0,
+        http_proxy=None,
+        mp_ctx=mp_ctx,
+        loop=loop,
+    )
+
+    spawn_attempts = 0
+
+    async def _spawn_fails_without_queue_item() -> None:
+        nonlocal spawn_attempts
+        spawn_attempts += 1
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(pool, "_proc_spawn_task", _spawn_fails_without_queue_item)
+    monkeypatch.setattr(ipc.proc_pool, "WARMED_PROCESS_WAIT_TIMEOUT_BUFFER", 0.0)
+
+    with pytest.raises(RuntimeError, match="no process became available"):
+        await pool.launch_job(_generate_fake_job())
+
+    assert spawn_attempts == 3
+    assert pool._jobs_waiting_for_process == 0
 
 
 def _create_proc(


### PR DESCRIPTION
﻿## Summary
- add a bounded wait when `ProcPool.launch_job()` is waiting for a warmed process
- retry the existing launch loop when a spawn task exits without putting a process on the queue
- add a regression test for the empty-queue failure path so the coroutine fails instead of hanging forever

## To verify
- `uv run pytest tests/test_ipc.py::test_proc_pool_launch_job_times_out_when_spawn_never_warms_process -q`
- `uv run ruff check livekit-agents\livekit\agents\ipc\proc_pool.py tests\test_ipc.py`
- `uv run ruff format --check livekit-agents\livekit\agents\ipc\proc_pool.py tests\test_ipc.py`
- `uv run python -m py_compile livekit-agents\livekit\agents\ipc\proc_pool.py tests\test_ipc.py`
- `git diff --check`

`tests/test_ipc.py::test_slow_initialization` timed out after 120s on my Windows machine without producing test output; I did not treat that as part of this patch because the new regression test isolates the empty warmed-process queue path without spawning worker processes.

Closes #5868
