### PR TITLE
fix(llm): make to_responses_fnc_ctx.provider_tool_type optional

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/openai.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/openai.py
@@ -222,7 +222,7 @@ def to_responses_fnc_ctx(
     tool_ctx: llm.ToolContext,
     *,
     strict: bool = True,
-    provider_tool_type: type[llm.ProviderTool],
+    provider_tool_type: type[llm.ProviderTool] | None = None,
 ) -> list[dict[str, Any]]:
     schemas: list[dict[str, Any]] = []
     for tool in tool_ctx.flatten():
@@ -233,7 +233,11 @@ def to_responses_fnc_ctx(
         elif isinstance(tool, llm.FunctionTool):
             schema = llm.utils.build_legacy_openai_schema(tool, internally_tagged=True)
             schemas.append(schema)
-        elif isinstance(tool, provider_tool_type) and hasattr(tool, "to_dict"):
+        elif (
+            provider_tool_type is not None
+            and isinstance(tool, provider_tool_type)
+            and hasattr(tool, "to_dict")
+        ):
             schemas.append(tool.to_dict())
 
     return schemas

--- a/livekit-agents/livekit/agents/llm/tool_context.py
+++ b/livekit-agents/livekit/agents/llm/tool_context.py
@@ -517,7 +517,7 @@ class ToolContext:
         format: Literal["openai.responses"],
         *,
         strict: bool = True,
-        provider_tool_type: type[ProviderTool],
+        provider_tool_type: type[ProviderTool] | None = None,
     ) -> list[dict[str, Any]]: ...
 
     @overload


### PR DESCRIPTION
## Summary

Fixes a regression that's been red on \`main\` CI since #5865 + #5884 landed back-to-back.

#5865 added a **required** keyword-only \`provider_tool_type\` to \`to_responses_fnc_ctx\`, but \`ToolContext.parse_function_tools\` forwards \`**kwargs\` blindly:

```python
elif format == "openai.responses":
    return _provider_format.openai.to_responses_fnc_ctx(self, **kwargs)
```

So any caller that goes through \`parse_function_tools("openai.responses")\` without explicitly threading \`provider_tool_type\` hits a \`TypeError\`. #5884 landed exactly such a caller (the new \`test_serialized_tool_order_is_sorted\`):

```python
for fmt in ("openai", "openai.responses", "anthropic", "aws", "google"):
    names = [tool_name(fmt, s) for s in ctx.parse_function_tools(fmt)]
```

Result: \`tests/test_tools.py::TestToolContext::test_serialized_tool_order_is_sorted\` fails on every CI run (e.g. [run on \`6d50c5da\`](https://github.com/livekit/agents/actions/runs/26535514098)).

## Fix

Make \`provider_tool_type\` optional (\`type[ProviderTool] | None = None\`) and gate the provider-tool \`isinstance\` branch on its presence. Behavior is unchanged for legitimate callers — the openai.responses plugin always passes \`provider_tool_type=self._llm._provider_tool_type\`; the \`None\` path just emits function-tool schemas, which is the right thing for generic serialization where no provider-tool subtype is in scope.

Also widens the matching \`@overload\` signature in \`tool_context.py\` so static callers see the same default.

## Test plan

- [x] \`uv run pytest tests/test_tools.py\` → 49 passed (was 1 failed on main)
- [x] \`uv run ruff check\` / \`ruff format --check\` → clean
- [x] \`uv run mypy -p livekit.agents.llm\` → clean

Made with [Cursor](https://cursor.com)