### PR TITLE
fix(openai realtime): honor OPENAI_BASE_URL env var fallback

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -450,7 +450,7 @@ class RealtimeModel(llm.RealtimeModel):
                     )
                 base_url_val = f"{azure_endpoint.rstrip('/')}/openai"
             else:
-                base_url_val = OPENAI_BASE_URL
+                base_url_val = os.getenv("OPENAI_BASE_URL", OPENAI_BASE_URL)
 
         self._opts = _RealtimeOptions(
             model=model,


### PR DESCRIPTION
## Summary

The OpenAI realtime model ignored the `OPENAI_BASE_URL` environment variable. When no `base_url` was passed (and not using Azure), it fell back to a **hardcoded** `OPENAI_BASE_URL = "https://api.openai.com/v1"` constant rather than reading the env var.

This was inconsistent with:
- **The LLM path** (`llm.py`), which forwards `base_url=None` to `openai.AsyncClient`, letting the OpenAI SDK read `OPENAI_BASE_URL`.
- **The STT/TTS path** (`utils.get_base_url`), which falls back to `os.getenv("OPENAI_BASE_URL", ...)`.
- **The realtime constructor's own docstring**, which states: *"If not provided, uses OPENAI_BASE_URL for OpenAI."*

## Change

```python
-                base_url_val = OPENAI_BASE_URL
+                base_url_val = os.getenv("OPENAI_BASE_URL", OPENAI_BASE_URL)
```

The passed `base_url` still takes precedence when given (`is_given(base_url)`); the env var is only used as the fallback, matching the other code paths. The hardcoded constant remains the final default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)