### PR TITLE
feat(examples/avatar): added animation triggers and trimmed personas

### DIFF
--- a/examples/avatar/README.md
+++ b/examples/avatar/README.md
@@ -1,19 +1,22 @@
 # LemonSlice Avatar
 
 A voice agent with a talking-head avatar you can swap mid-conversation.
-Pick a persona from the dropdown — an influencer, a cat, a fox, a music
-teacher, Marilyn Monroe — and the agent's face, voice, and personality
+Pick a persona from the dropdown — Leila, Jess, a software engineer, a
+cat, a fox — and the agent's face, voice, and personality
 all change without dropping the call.
 
 Try it in the [LiveKit Playground](https://agents.livekit.io/?example=avatar).
 
 ## What's in here
 
-- **15 personas** to choose from — each has its own face, voice, system
+- **9 personas** to choose from — each has its own face, voice, system
   prompt, and idle/speaking body-language hints.
 - **Live persona switching** — the dropdown fires a `set_avatar` RPC; a
   short hold tone plays while the avatar reconnects with the new face
   and voice.
+- **Hero motions** — for **Leila**, **Jess**, and **Mr Fox**, the LLM can
+  trigger wave, dance, or turn via tool calls (one motion at a time,
+  ~6 seconds each). They wave automatically when the session starts.
 - **LiveKit Inference** for STT + LLM (Deepgram Nova-3 + Gemini 3.5
   Flash), Cartesia for TTS, [LemonSlice](https://lemonslice.com) for
   the avatar video.
@@ -36,8 +39,7 @@ python agent.py dev
 ```
 
 Connect from any LiveKit client. The agent reads the starting persona
-from the job metadata; if no metadata is sent it defaults to the
-California influencer.
+from the job metadata; if no metadata is sent it defaults to Leila.
 
 ## Adding or editing personas
 
@@ -72,7 +74,8 @@ No reconnect, no page refresh — the same call, with a different face.
 
 ```
 agent.py        entry point + the set_avatar RPC
-personas.py     the 15 personas and the shared prompt rules
+actions.py      pose controller (opening wave + LLM tool motions)
+personas.py     the 9 personas and the shared prompt rules
 hold_music.py   the soft three-note "please wait" tone
 Dockerfile      for cloud deploys
 ```

--- a/examples/avatar/actions.py
+++ b/examples/avatar/actions.py
@@ -1,0 +1,140 @@
+"""Avatar pose triggers via LLM tools (wave, dance, turn)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass
+
+import aiohttp
+
+logger = logging.getLogger("avatar.actions")
+
+NONE = "none"
+
+ACTION_PERSONAS = frozenset({"leila", "jess", "mr_fox"})
+
+POSE_NAMES: dict[str, dict[str, str]] = {
+    "leila": {
+        "wave": "wave-2-leila",
+        "turn": "turn-leila",
+        "dance": "dance-leila",
+    },
+    "jess": {
+        "wave": "jess_wave",
+        "turn": "jess_turn",
+        "dance": "jess_dance",
+    },
+    "mr_fox": {
+        "wave": "fox2_wave",
+        "turn": "fox2_turn",
+        "dance": "fox2_dance",
+    },
+}
+
+DEFAULT_POSE_DURATION_S = 6.0
+OPENING_WAVE_DELAY_S = 0.5
+
+
+def supports_actions(persona_id: str) -> bool:
+    return persona_id in ACTION_PERSONAS
+
+
+def _control_url(session_id: str) -> str:
+    base = os.getenv("LEMONSLICE_API_BASE", "https://lemonslice.com/api").rstrip("/")
+    return f"{base}/liveai/sessions/{session_id}/control"
+
+
+async def trigger_pose(session_id: str, name: str) -> bool:
+    url = _control_url(session_id)
+    payload = {"event": "pose-trigger", "pose_trigger": {"name": name}}
+    timeout = aiohttp.ClientTimeout(total=30.0)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.post(
+            url,
+            headers={
+                "Content-Type": "application/json",
+                "X-API-Key": os.environ["LEMONSLICE_API_KEY"],
+            },
+            json=payload,
+        ) as response:
+            return response.ok
+
+
+@dataclass
+class _PlayingSlot:
+    ends_at: float
+
+
+class ActionController:
+    """Plays one LemonSlice pose at a time; each blocks others for ``DEFAULT_POSE_DURATION_S``."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._session_id: str | None = None
+        self._persona_id: str | None = None
+        self._slot: _PlayingSlot | None = None
+
+    def set_session(self, session_id: str, persona_id: str) -> None:
+        self._session_id = session_id
+        self._persona_id = persona_id
+
+    def clear_session(self) -> None:
+        self._session_id = None
+        self._persona_id = None
+
+    def _current_slot(self) -> _PlayingSlot | None:
+        if self._slot is None:
+            return None
+        if time.monotonic() >= self._slot.ends_at:
+            self._slot = None
+            return None
+        return self._slot
+
+    async def cancel(self) -> None:
+        async with self._lock:
+            self._slot = None
+        sid = self._session_id
+        self.clear_session()
+        if sid is not None:
+            await trigger_pose(sid, NONE)
+
+    async def shutdown(self, _: str = "") -> None:
+        await self.cancel()
+
+    async def play(self, action_id: str) -> str:
+        session_id = self._session_id
+        persona_id = self._persona_id
+        if session_id is None or persona_id is None:
+            return "Motion unavailable — avatar session not ready."
+
+        key = action_id.strip().lower()
+        pose_name = POSE_NAMES.get(persona_id, {}).get(key)
+        if pose_name is None:
+            return f"Unknown motion {action_id!r}."
+
+        async with self._lock:
+            if self._current_slot() is not None:
+                return "That motion is already playing; try again in a moment."
+
+            ok = await trigger_pose(session_id, pose_name)
+            if not ok:
+                return "Could not trigger the motion on the avatar."
+
+            self._slot = _PlayingSlot(
+                ends_at=time.monotonic() + DEFAULT_POSE_DURATION_S,
+            )
+            logger.info(
+                "pose playing: persona_id=%r action_id=%r pose_name=%r",
+                persona_id,
+                key,
+                pose_name,
+            )
+            return f"Playing motion {key}."
+
+    async def opening_wave(self) -> None:
+        if OPENING_WAVE_DELAY_S > 0:
+            await asyncio.sleep(OPENING_WAVE_DELAY_S)
+        await self.play("wave")

--- a/examples/avatar/agent.py
+++ b/examples/avatar/agent.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
+from actions import ActionController, supports_actions
 from dotenv import find_dotenv, load_dotenv
 from hold_music import hold_beats
 from personas import Persona, compose_instructions, resolve_persona
@@ -21,6 +22,7 @@ from livekit.agents import (
     inference,
     llm as agents_llm,
 )
+from livekit.agents.llm import function_tool
 from livekit.plugins import lemonslice
 from livekit.rtc import RpcError, RpcInvocationData
 
@@ -33,6 +35,32 @@ server = AgentServer()
 class State:
     persona: Persona
     avatar: lemonslice.AvatarSession
+    session_id: str
+
+
+class MotionAgent(Agent):
+    def __init__(self, persona: Persona, actions: ActionController) -> None:
+        super().__init__(
+            instructions=compose_instructions(persona),
+            tts=inference.TTS("cartesia/sonic-3.5", voice=persona.voice_id),
+            chat_ctx=agents_llm.ChatContext.empty(),
+        )
+        self._actions = actions
+
+    @function_tool
+    async def wave(self) -> str:
+        """Wave to the user. Only call when they explicitly ask you to wave."""
+        return await self._actions.play("wave")
+
+    @function_tool
+    async def dance(self) -> str:
+        """Dance for the user. Only call when they explicitly ask you to dance."""
+        return await self._actions.play("dance")
+
+    @function_tool
+    async def turn(self) -> str:
+        """Turn side to side. Only call when they explicitly ask you to turn."""
+        return await self._actions.play("turn")
 
 
 @server.rtc_session()
@@ -55,20 +83,41 @@ async def entrypoint(ctx: JobContext) -> None:
             agent_prompt=p.speaking_prompt,
             agent_idle_prompt=p.idle_prompt,
             idle_timeout=120,
+            response_done_timeout=2,
         )
 
+    actions = ActionController()
+    ctx.add_shutdown_callback(actions.shutdown)
+
     def make_agent(p: Persona) -> Agent:
+        if supports_actions(p.id):
+            return MotionAgent(p, actions)
         return Agent(
             instructions=compose_instructions(p),
             tts=inference.TTS("cartesia/sonic-3.5", voice=p.voice_id),
             chat_ctx=agents_llm.ChatContext.empty(),
         )
 
-    state = State(persona=initial, avatar=make_avatar(initial))
-    await state.avatar.start(session, room=ctx.room)
+    avatar = make_avatar(initial)
+    session_id = await avatar.start(session, room=ctx.room)
+    state = State(persona=initial, avatar=avatar, session_id=session_id)
     await state.avatar.wait_for_join()
 
+    if supports_actions(initial.id):
+        actions.set_session(state.session_id, initial.id)
+
     await session.start(agent=make_agent(initial), room=ctx.room)
+
+    if supports_actions(initial.id):
+        await actions.opening_wave()
+
+    session.generate_reply(
+        instructions=(
+            f"It's your turn to speak first. Open with a single short greeting in "
+            f"character as {initial.name} and then stop."
+            + (" Do not call wave — you already waved." if supports_actions(initial.id) else "")
+        )
+    )
 
     bg_audio = BackgroundAudioPlayer()
     await bg_audio.start(room=ctx.room, agent_session=session)
@@ -101,9 +150,10 @@ async def entrypoint(ctx: JobContext) -> None:
             session.interrupt()
 
             async with hold_music():
+                await actions.cancel()
                 await state.avatar.aclose()
                 state.avatar = make_avatar(new_persona)
-                await state.avatar.start(session, room=ctx.room)
+                state.session_id = await state.avatar.start(session, room=ctx.room)
                 await state.avatar.wait_for_join()
                 session.update_agent(make_agent(new_persona))
                 state.persona = new_persona
@@ -111,21 +161,24 @@ async def entrypoint(ctx: JobContext) -> None:
                 # before it actually consumes audio + emits frames.
                 await asyncio.sleep(1.2)
 
+            if supports_actions(new_persona.id):
+                actions.set_session(state.session_id, new_persona.id)
+                await actions.opening_wave()
+
             session.generate_reply(
                 instructions=(
                     f"It's your turn to speak first. Open with a single short line in "
                     f"character as {state.persona.name} (acknowledge that you're who they "
                     "just picked) and then stop."
+                    + (
+                        " Do not call wave — you already waved."
+                        if supports_actions(new_persona.id)
+                        else ""
+                    )
                 )
             )
-            return json.dumps({"id": state.persona.id})
 
-    session.generate_reply(
-        instructions=(
-            f"It's your turn to speak first. Open with a single short greeting in "
-            f"character as {state.persona.name} and then stop."
-        )
-    )
+            return json.dumps({"id": state.persona.id})
 
 
 if __name__ == "__main__":

--- a/examples/avatar/personas.py
+++ b/examples/avatar/personas.py
@@ -15,23 +15,6 @@ class Persona:
 
 
 PERSONAS: dict[str, Persona] = {
-    "influencer": Persona(
-        id="influencer",
-        name="Influencer",
-        image_url="https://6ammc3n5zzf5ljnz.public.blob.vercel-storage.com/inf2-image-uploads/image-iQBIIMr0hyHGhv1eXFpkzSaF0upUQt.jpg",
-        voice_id="a33f7a4c-100f-41cf-a1fd-5822e8fc253f",
-        system_prompt=(
-            "You're a California girl lifestyle influencer. Sunny, laid-back, "
-            "warm. You talk like you're catching up with a friend on FaceTime, "
-            "between iced coffees. SoCal vibes: drop natural fillers like "
-            "'like', 'totally', 'oh my god', 'for sure', 'literally', but "
-            "never overdo it. Stay breezy, never preachy. "
-            "You appear as a young woman with curly blonde hair and a soft "
-            "blue and white striped sweater, framed like a casual selfie."
-        ),
-        speaking_prompt="Be lively and use animated, camera-friendly gestures while talking.",
-        idle_prompt="Hold a relaxed selfie pose, gentle smiles, small shifts of weight, occasionally tucking a strand of hair.",
-    ),
     "software_engineer": Persona(
         id="software_engineer",
         name="Software Engineer",
@@ -49,23 +32,6 @@ PERSONAS: dict[str, Persona] = {
         ),
         speaking_prompt="Move calmly and thoughtfully while talking, like you're explaining a diagram.",
         idle_prompt="Sit still with a thoughtful expression, occasional small nods, eyes tracking the listener.",
-    ),
-    "music_teacher": Persona(
-        id="music_teacher",
-        name="Music Teacher",
-        image_url="https://6ammc3n5zzf5ljnz.public.blob.vercel-storage.com/inf2-image-uploads/image-FBPolEELkPB5bT2gF8ixYfMrwIurJv.png",
-        voice_id="9fb269e7-70fe-4cbe-aa3f-28bdb67e3e84",
-        system_prompt=(
-            "You're a patient music teacher who can guide students through "
-            "theory, technique, and practice routines. Encourage the "
-            "student, use vivid metaphors for sound and rhythm, and break "
-            "ideas into bite-sized exercises. Stay warm and supportive. "
-            "You appear as a young Black man with a warm smile and close-"
-            "cropped hair, photographed in a black and white music studio "
-            "setting."
-        ),
-        speaking_prompt="Gesture as if tapping out rhythm or shaping musical phrases in the air while talking.",
-        idle_prompt="Warm relaxed smile, gentle head sway as if hearing music, attentive listening posture.",
     ),
     "social_worker": Persona(
         id="social_worker",
@@ -85,39 +51,41 @@ PERSONAS: dict[str, Persona] = {
         speaking_prompt="Speak calmly, with soft attentive gestures and reassuring eye contact.",
         idle_prompt="Quiet attentive listening, slow nods, hands resting calmly, soft eye contact.",
     ),
-    "joyce": Persona(
-        id="joyce",
-        name="Joyce",
-        image_url="https://6ammc3n5zzf5ljnz.public.blob.vercel-storage.com/inf2-image-uploads/resized-image-Jh6FLLa1wjwuYXZxlB8BO3xO6ArUrT.jpg",
-        voice_id="32b3f3c5-7171-46aa-abe7-b598964aa793",
+    "leila": Persona(
+        id="leila",
+        name="Leila",
+        image_url="https://6ammc3n5zzf5ljnz.public.blob.vercel-storage.com/public/hero_agents/leila/base2.png",
+        voice_id="a33f7a4c-100f-41cf-a1fd-5822e8fc253f",
         system_prompt=(
-            "You're Joyce, a sharp and witty conversationalist with a "
-            "knack for storytelling. Be playful, curious, and a little "
-            "irreverent. Ask follow-up questions, riff on the user's "
-            "answers, and keep the rhythm of the conversation lively. "
-            "You appear as an anime-style young woman with bright orange "
-            "hair, expressive wide eyes, and a slightly surprised look, "
-            "cradling a softly glowing bowl in a cosy storybook scene."
+            "You're Leila, warm and easy to talk to. Keep replies short "
+            "and conversational — like a video call with a friend. "
+            "You can wave, dance, or turn on camera, but only when the "
+            "user explicitly asks — never on greetings or casual hellos. "
+            "Every so often, casually mention they can ask you to wave, "
+            "dance, or turn — one quick line, not every reply. "
+            "You appear as a woman with shoulder-length brown hair, "
+            "wearing a simple black top in a clean, minimal setting."
         ),
-        speaking_prompt="Use expressive, varied gestures while talking, animated but not chaotic.",
-        idle_prompt="Bright curious gaze, slight smile, small head tilts as if waiting for the next story beat.",
+        speaking_prompt="Natural, relaxed gestures while talking.",
+        idle_prompt="Soft idle sway, gentle head tilts, calm attentive presence.",
     ),
-    "iris": Persona(
-        id="iris",
-        name="Iris",
-        image_url="https://6ammc3n5zzf5ljnz.public.blob.vercel-storage.com/inf2-image-uploads/resized-image-CXBO9t9xHhy9AClJXjsONVsg1r2u0U.jpg",
-        voice_id="00a77add-48d5-4ef6-8157-71e5437b282d",
+    "jess": Persona(
+        id="jess",
+        name="Jess",
+        image_url="https://6ammc3n5zzf5ljnz.public.blob.vercel-storage.com/public/hero_agents/jess2/base.png",
+        voice_id="a33f7a4c-100f-41cf-a1fd-5822e8fc253f",
         system_prompt=(
-            "You're Iris, a thoughtful guide with a calm, grounded "
-            "presence. Speak slowly and deliberately, draw the user out "
-            "with reflective questions, and offer perspective rather "
-            "than answers. Keep responses concise and resonant. "
-            "You appear as an anime-style woman with long, sleek platinum "
-            "hair, dark sunglasses, and an effortlessly cool look, "
-            "behind the wheel of a vintage red convertible."
+            "You're Jess, upbeat and easy to talk to. Keep replies short "
+            "and conversational — like a video call with a friend. "
+            "You can wave, dance, or turn on camera, but only when the "
+            "user explicitly asks — never on greetings or casual hellos. "
+            "Sprinkle in playful reminders that they can tell you to "
+            "wave, dance, or spin around — keep it fun, not every turn. "
+            "You appear as a cartoon-style woman with a friendly, "
+            "expressive face in a bright, playful setting."
         ),
-        speaking_prompt="Subtle, deliberate movements while talking; present without being busy.",
-        idle_prompt="Cool composed stillness, gaze ahead through the sunglasses, occasional slow breath.",
+        speaking_prompt="Natural, relaxed gestures while talking.",
+        idle_prompt="Soft idle sway, gentle head tilts, calm attentive presence.",
     ),
     "ai_therapist": Persona(
         id="ai_therapist",
@@ -139,7 +107,7 @@ PERSONAS: dict[str, Persona] = {
     "management_consultant": Persona(
         id="management_consultant",
         name="Management Consultant",
-        image_url="https://6ammc3n5zzf5ljnz.public.blob.vercel-storage.com/inf2-image-uploads/resized-image-6heCUmOs00YJL3vNgM5vHmtrFMHKez.jpg",
+        image_url="https://6ammc3n5zzf5ljnz.public.blob.vercel-storage.com/inf2-image-uploads/resized-image-mk1lRjZO7bC4xG8shOuHqqdkF7oR5N.jpg",
         voice_id="c1c65fc2-528a-4dde-a2c4-f822785c2704",
         system_prompt=(
             "You're a sharp management consultant. Frame problems "
@@ -156,7 +124,7 @@ PERSONAS: dict[str, Persona] = {
     "shopping_assistant": Persona(
         id="shopping_assistant",
         name="Shopping Assistant",
-        image_url="https://6ammc3n5zzf5ljnz.public.blob.vercel-storage.com/inf2-image-uploads/image_15119-v1Ye6tCMWBwmxkW1TRm2i1Nnyn5cu6.png",
+        image_url="https://6ammc3n5zzf5ljnz.public.blob.vercel-storage.com/inf2-image-uploads/resized-image-9YHqae6fl4vH5Qn5ZZSZ5crRoDhhFn.jpg",
         voice_id="98c87826-dba2-44f4-b123-4c7e3c8a2647",
         system_prompt=(
             "You're a friendly shopping assistant. Ask what the user "
@@ -188,24 +156,6 @@ PERSONAS: dict[str, Persona] = {
         speaking_prompt="Playful, slightly aloof speech; quick movements with a feline flick.",
         idle_prompt="Feline alertness, occasional ear twitches, mischievous side glances, slow blinks.",
     ),
-    "mock_interviewer_legal": Persona(
-        id="mock_interviewer_legal",
-        name="Mock Interviewer (Legal)",
-        image_url="https://6ammc3n5zzf5ljnz.public.blob.vercel-storage.com/inf2-image-uploads/image-7BDeKC26MFdcGVTrNyGvas9f3XePs5.jpg",
-        voice_id="8918ddfe-2ad4-4cc8-a573-e020ca13f3f5",
-        system_prompt=(
-            "You're conducting a mock legal interview. Ask probing "
-            "questions about the candidate's reasoning, push back "
-            "respectfully on weak arguments, and keep the tone "
-            "professional. Stay structured: one question at a time, "
-            "follow-ups based on answers. "
-            "You appear as a woman with long straight brown hair, "
-            "subtle makeup, and a simple black top, sitting in a "
-            "modern high-rise office with city skyline behind you."
-        ),
-        speaking_prompt="Composed, attentive delivery; subtle nods and brief gestures while talking.",
-        idle_prompt="Poised professional listening, occasional small note-taking motion, neutral attentive expression.",
-    ),
     "mr_fox": Persona(
         id="mr_fox",
         name="Mr Fox",
@@ -216,6 +166,10 @@ PERSONAS: dict[str, Persona] = {
             "streak. Speak with warmth and a touch of theatre, weave "
             "in vivid imagery, and keep responses charming but never "
             "long-winded. "
+            "You can wave, dance, or turn on camera, but only when the "
+            "user explicitly asks — never on greetings or casual hellos. "
+            "Now and then, with a wink, let them know you take requests "
+            "— a wave, a dance, a little turn — when the moment fits. "
             "You appear as a Pixar-style anthropomorphic fox with "
             "bright orange fur, large amber eyes, and a tidy green "
             "knit vest over a white shirt and bow tie, standing in a "
@@ -224,68 +178,9 @@ PERSONAS: dict[str, Persona] = {
         speaking_prompt="Charismatic, expressive delivery; sly tilts of the head while speaking.",
         idle_prompt="Alert fox poise, ears perked, occasional tail flick, sly little grin, bright watchful eyes.",
     ),
-    "monroe": Persona(
-        id="monroe",
-        name="Monroe",
-        image_url="https://6ammc3n5zzf5ljnz.public.blob.vercel-storage.com/inf2-image-uploads/image-uFBMfKKsU31EcH4afYhMbhqlpifexx.jpg",
-        voice_id="98c87826-dba2-44f4-b123-4c7e3c8a2647",
-        system_prompt=(
-            "You're Monroe, a poised, mid-century character. Speak the way "
-            "you'd write a letter: composed, observant, gently witty. You "
-            "draw people out by asking specific, curious questions rather "
-            "than flattering or fussing over them. Keep replies short, "
-            "warm, and direct; address the user as 'you', not with pet "
-            "names. "
-            "You appear as a 1950s-style woman with shoulder-length "
-            "dark brunette curls, pale freckled skin, striking red "
-            "lipstick, and a string of pearls over a soft pink jacket, "
-            "framed on a midcentury city street."
-        ),
-        speaking_prompt="Poised, expressive speech; warm smiles and deliberate gestures while talking.",
-        idle_prompt="Vintage glamour stillness, slight knowing smile, calm gaze, occasional slow blink.",
-    ),
-    "fortnite_guide": Persona(
-        id="fortnite_guide",
-        name="Fortnite Guide",
-        image_url="https://6ammc3n5zzf5ljnz.public.blob.vercel-storage.com/inf2-image-uploads/resized-image-17UG786lUwcsK1GW9qeFSKgbOXabmH.jpg",
-        voice_id="32b3f3c5-7171-46aa-abe7-b598964aa793",
-        system_prompt=(
-            "You're an upbeat Fortnite coach. Talk through builds, "
-            "weapon picks, rotations, and meta loadouts with energy. "
-            "Use natural gamer slang (Storm, POI, mats, no-build) "
-            "without going overboard. Keep replies short and "
-            "actionable, like coaching mid-match. "
-            "You appear as a cute Pixar-style girl with vivid sky-"
-            "blue hair swept to one side, huge sparkling blue eyes, "
-            "and a purple tank top, set against a bright cloudy sky."
-        ),
-        speaking_prompt="Energetic, lively gestures while talking; gamer-coach enthusiasm.",
-        idle_prompt="Bright excited waiting, hair gently moving, big smile, eyes darting like watching the lobby.",
-    ),
-    "kitten_tutor": Persona(
-        id="kitten_tutor",
-        name="Kitten Tutor",
-        image_url="https://6ammc3n5zzf5ljnz.public.blob.vercel-storage.com/inf2-image-uploads/resized-image-uzKDXwmzmhy6622JWFAgXgWNRMAn0D.jpg",
-        voice_id="e3827ec5-697a-4b7c-9704-1a23041bbc51",
-        system_prompt=(
-            "You're a chatty young kitten who happens to know a lot about "
-            "being a cat. Speak in first person as the kitten, sharing "
-            "cat wisdom from your own point of view: feeding, litter "
-            "habits, scratching, naps, vet visits. Warm, playful, a "
-            "little cheeky. Use phrases like 'we cats' or 'when I was a "
-            "few weeks old', and never ask the user about THEIR cat, "
-            "because YOU are the cat. If they want practical advice for "
-            "raising a kitten, give it as your own lived experience. "
-            "You appear as an illustrated orange tabby kitten standing "
-            "upright on its hind legs, with huge round brown eyes, "
-            "pink paw pads held out, and a soft cream background."
-        ),
-        speaking_prompt="Calm, warm presence while talking; soft attentive movements.",
-        idle_prompt="Tiny kitten stillness, paws held out, ear twitches, slow blinks, occasional tiny head tilt.",
-    ),
 }
 
-DEFAULT_PERSONA_ID = "influencer"
+DEFAULT_PERSONA_ID = "leila"
 
 
 COMMON_INSTRUCTIONS = (

--- a/examples/playground.yaml
+++ b/examples/playground.yaml
@@ -295,7 +295,7 @@ examples:
 
   avatar:
     title: Avatar
-    description: Talk to a LemonSlice avatar. Pick anyone from the dropdown to swap who you're chatting with, from a music teacher to a Pixar fox.
+    description: Talk to a LemonSlice avatar. Pick anyone from the dropdown to swap who you're chatting with, from Leila to a Pixar fox.
     # LemonSlice brand \u2014 yellow-500 from the LK palette.
     accent: "#F9E71F"
     agent_id: CA_dzjZwsBsRKzZ
@@ -332,20 +332,14 @@ examples:
     controls:
       - rpc: set_avatar
         label: Persona
-        default: influencer
+        default: leila
         options:
-          - { value: influencer, label: Influencer }
+          - { value: leila, label: Leila }
+          - { value: jess, label: Jess }
           - { value: software_engineer, label: Software Engineer }
-          - { value: music_teacher, label: Music Teacher }
           - { value: social_worker, label: Social Worker }
-          - { value: joyce, label: Joyce }
-          - { value: iris, label: Iris }
           - { value: ai_therapist, label: AI Therapist }
           - { value: management_consultant, label: Management Consultant }
           - { value: shopping_assistant, label: Shopping Assistant }
           - { value: cat_girl, label: Cat Girl }
-          - { value: mock_interviewer_legal, label: "Mock Interviewer (Legal)" }
           - { value: mr_fox, label: Mr Fox }
-          - { value: monroe, label: Monroe }
-          - { value: fortnite_guide, label: Fortnite Guide }
-          - { value: kitten_tutor, label: Kitten Tutor }


### PR DESCRIPTION
## Summary
- Add wave/dance/turn tools for Leila, Jess, and Mr Fox via LemonSlice pose triggers (`actions.py`)
- Auto-wave on session start and after switching to a motion-capable persona
- Trim persona list from 15 to 9; add Leila and Jess, remove underperforming personas; default to Leila
- Update playground dropdown and README