### PR TITLE
fix(workflows): bind GetDtmfTask user-state handler to user_state_changed

### DIFF
--- a/livekit-agents/livekit/agents/beta/workflows/dtmf_inputs.py
+++ b/livekit-agents/livekit/agents/beta/workflows/dtmf_inputs.py
@@ -187,7 +187,7 @@ class GetDtmfTask(AgentTask[GetDtmfResult]):
         ctx = get_job_context()
 
         ctx.room.on("sip_dtmf_received", self._on_sip_dtmf_received)
-        self.session.on("agent_state_changed", self._on_user_state_changed)
+        self.session.on("user_state_changed", self._on_user_state_changed)
         self.session.on("agent_state_changed", self._on_agent_state_changed)
         self.session.generate_reply(tool_choice="none")
 
@@ -195,6 +195,6 @@ class GetDtmfTask(AgentTask[GetDtmfResult]):
         ctx = get_job_context()
 
         ctx.room.off("sip_dtmf_received", self._on_sip_dtmf_received)
-        self.session.off("agent_state_changed", self._on_user_state_changed)
+        self.session.off("user_state_changed", self._on_user_state_changed)
         self.session.off("agent_state_changed", self._on_agent_state_changed)
         self._generate_dtmf_reply.cancel()


### PR DESCRIPTION
## Summary
- `GetDtmfTask.on_enter` registered `_on_user_state_changed` against `agent_state_changed` (copy-paste typo introduced in d38c39da2). The handler is written against `UserStateChangedEvent` and exists specifically to cancel a pending debounced DTMF reply when the user starts speaking — that preemption never fires today.
- Side effects of the typo: every `AgentStateChangedEvent` runs through both handlers (silent double-fire — `ev.new_state` happens to overlap), and no listener is ever bound to `user_state_changed`. `on_exit` mirrors the same typo, so detaches line up with the (wrong) attachments and there's no leak symptom either.
- Fix: subscribe and detach the user-state handler against `user_state_changed`. Two string literals.

## Test plan
- [ ] Existing `tests/test_workflow.py::test_get_dtmf_sip_event_*` still pass (happy-path DTMF unaffected).
- [ ] Manual: drive a SIP DTMF mid-collection, then have the user start speaking before the debounce fires — confirm the pending `_generate_dtmf_reply` is cancelled (was not before this fix).
- [ ] Follow-up (not in this PR): add a regression test that emits `user_state_changed` → `speaking` during the debounce window and asserts the reply is cancelled.