### PR TITLE
fix(examples): check anam_avatar_id in ANAM_AVATAR_ID guard

### DIFF
--- a/examples/avatar_agents/anam/agent_worker.py
+++ b/examples/avatar_agents/anam/agent_worker.py
@@ -26,7 +26,7 @@ async def entrypoint(ctx: JobContext):
         raise ValueError("ANAM_API_KEY is not set")
 
     anam_avatar_id = os.getenv("ANAM_AVATAR_ID")
-    if not anam_api_key:
+    if not anam_avatar_id:
         raise ValueError("ANAM_AVATAR_ID is not set")
 
     anam_avatar = anam.AvatarSession(


### PR DESCRIPTION
## Summary
- In `examples/avatar_agents/anam/agent_worker.py`, the guard intended to validate `ANAM_AVATAR_ID` was checking `anam_api_key` instead (copy-paste from the block above).
- With `ANAM_API_KEY` set but `ANAM_AVATAR_ID` unset, the check silently passed and `avatarId=None` was forwarded to `PersonaConfig`, producing a confusing downstream failure instead of the intended early `ValueError`.

## Test plan
- [ ] Run `examples/avatar_agents/anam/agent_worker.py` with `ANAM_API_KEY` set and `ANAM_AVATAR_ID` unset; confirm `ValueError("ANAM_AVATAR_ID is not set")` is raised at startup.