### PR TITLE
fix(openai realtime): pass through already-formed wss:// base URLs

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -734,7 +734,8 @@ def process_base_url(
     azure_deployment: str | None = None,
     api_version: str | None = None,
 ) -> str:
-    if url.startswith("http"):
+    scheme_rewritten = url.startswith("http")
+    if scheme_rewritten:
         url = url.replace("http", "ws", 1)
 
     parsed_url = urlparse(url)
@@ -749,11 +750,15 @@ def process_base_url(
             path = "/openai/v1/realtime"
         else:
             path = parsed_url.path
+        passthrough = False
     else:
         if not parsed_url.path or path_stripped in ["", "/v1", "/openai", "/openai/v1"]:
             path = path_stripped + "/realtime"
+            passthrough = False
         else:
             path = parsed_url.path
+            # already-formed wss/ws URLs with a custom path are passed through unchanged
+            passthrough = not scheme_rewritten
 
     if is_azure:
         query_params.pop("api-version", None)  # remove from endpoint URL if present
@@ -768,7 +773,7 @@ def process_base_url(
                 query_params["model"] = [azure_deployment]
 
     else:
-        if "model" not in query_params:
+        if not passthrough and "model" not in query_params:
             query_params["model"] = [model]
 
     new_query = urlencode(query_params, doseq=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,13 +9,14 @@ def test_process_base_url():
     assert (
         process_base_url("http://example.com", "gpt-4") == "ws://example.com/realtime?model=gpt-4"
     )
-    assert (  # noqa: F631
+    assert (
         process_base_url(
             "wss://livekit.ai/voice/v1/chat/voice?client=oai&enable_noise_suppression=true",
             "gpt-4",
         )
-        == "wss://livekit.ai/voice/v1/chat/voice?client=oai&enable_noise_suppression=true",
+        == "wss://livekit.ai/voice/v1/chat/voice?client=oai&enable_noise_suppression=true"
     )
+    assert process_base_url("wss://example.com/foo", "gpt-4") == "wss://example.com/foo"
     assert (
         process_base_url(
             "https://test.azure.com/openai",


### PR DESCRIPTION
## Summary
- The `test_process_base_url` case for already-wss passthrough was silently a no-op: a trailing comma made the asserted RHS a 1-tuple (always truthy), and `# noqa: F631` suppressed ruff's warning about it.
- Removing the comma surfaced a real bug — `process_base_url` was appending `?model=<model>` to fully-formed `wss://` URLs with custom paths (e.g. LiveKit's voice gateway `wss://livekit.ai/voice/v1/chat/voice?client=oai&...`), corrupting them.
- Fix: only inject the `model` query param when the input had its scheme rewritten from `http(s)` or matched a known openai path. Already-`wss://` URLs with a custom path now pass through unchanged.
- Added a second passthrough regression test for a bare `wss://example.com/foo` input.

## Test plan
- [x] `uv run pytest tests/test_config.py -k test_process_base_url`
- [x] `uv run ruff check` on touched files