### PR TITLE
test(openai realtime): fix process_base_url assertion that was always passing

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,12 +9,12 @@ def test_process_base_url():
     assert (
         process_base_url("http://example.com", "gpt-4") == "ws://example.com/realtime?model=gpt-4"
     )
-    assert (  # noqa: F631
+    assert (
         process_base_url(
             "wss://livekit.ai/voice/v1/chat/voice?client=oai&enable_noise_suppression=true",
             "gpt-4",
         )
-        == "wss://livekit.ai/voice/v1/chat/voice?client=oai&enable_noise_suppression=true",
+        == "wss://livekit.ai/voice/v1/chat/voice?client=oai&enable_noise_suppression=true&model=gpt-4"
     )
     assert (
         process_base_url(


### PR DESCRIPTION
## Summary
One assertion in `test_process_base_url` had a trailing comma on the RHS, turning the asserted expression into a 1-tuple (always truthy). The `# noqa: F631` silenced ruff's warning about it. The assertion has been silently inert and would have masked any regression in `process_base_url`'s handling of already-formed `wss://` URLs.

## History
- [b156eaa6a](https://github.com/livekit/agents/commit/b156eaa6a) (2025-03-17) — introduced the test, originally asserting that `&model=gpt-4` IS appended:
  ```
  == "wss://livekit.ai/voice/v1/chat/voice?client=oai&enable_noise_suppression=true&model=gpt-4"
  ```
- [f0df13cf0](https://github.com/livekit/agents/commit/f0df13cf0) (2025-03-17, 3 min later, commit msg "fix test") — in one move dropped `&model=gpt-4` from the expected string AND added the trailing comma that makes the assert always pass. No PR discussion exists.

## This change
Restores the originally-asserted expected value (with `&model=gpt-4`) and removes the trailing comma + `# noqa: F631`. The assertion now actually verifies the function's current behavior. OpenAI and Azure Realtime docs do not specify a "proxy URLs should skip `?model=`" contract, so there's no documented reason to expect passthrough behavior — preserving append-model is the conservative choice.

No implementation changes; no behavior change in production.

## Test plan
- [x] `uv run pytest tests/test_config.py -k test_process_base_url`
- [x] `uv run ruff check tests/test_config.py`