### PR TITLE
fix(examples): raise ToolError instead of returning it in realtime_joke_teller

### DIFF
--- a/examples/voice_agents/realtime_joke_teller.py
+++ b/examples/voice_agents/realtime_joke_teller.py
@@ -64,7 +64,7 @@ g = DDGS()
 
 
 @function_tool
-async def get_weather(city: str, units: str = "fahrenheit") -> dict[str, int | str] | ToolError:
+async def get_weather(city: str, units: str = "fahrenheit") -> dict[str, int | str]:
     """
     Retrieve the current weather for a city.
 
@@ -90,7 +90,7 @@ async def get_weather(city: str, units: str = "fahrenheit") -> dict[str, int | s
                 "humidity": weather.humidity,
             }
     except Exception as e:
-        return ToolError(f"Error getting weather for {city}: {e}")
+        raise ToolError(f"Error getting weather for {city}: {e}") from e
 
 
 @function_tool
@@ -112,7 +112,7 @@ async def search_web(query: str, max_results: int = 1) -> dict[str, Any]:
     try:
         results = g.text(query, max_results=max_results)
     except Exception as e:
-        return ToolError(f"Error searching the web: {e}")
+        raise ToolError(f"Error searching the web: {e}") from e
     d = {str(i): res for i, res in enumerate(results)}
     for v in d.values():
         v["url"] = v.pop("href")
@@ -120,7 +120,7 @@ async def search_web(query: str, max_results: int = 1) -> dict[str, Any]:
 
 
 @function_tool
-async def tell_joke(category: str = "Any") -> dict[str, Any] | ToolError:
+async def tell_joke(category: str = "Any") -> dict[str, Any]:
     """
     Tell a joke that pertains to the category of the user's request. Just choose a Pun category if they don't specify
 
@@ -152,7 +152,7 @@ async def tell_joke(category: str = "Any") -> dict[str, Any] | ToolError:
         else:
             return {"setup": joke["setup"], "delivery": joke["delivery"]}
     except Exception as e:
-        return ToolError(f"Error getting joke: {e}")
+        raise ToolError(f"Error getting joke: {e}") from e
 
 
 class Assistant(Agent):


### PR DESCRIPTION
## Summary
- `get_weather`, `search_web`, and `tell_joke` in `examples/voice_agents/realtime_joke_teller.py` constructed `ToolError(...)` and returned it on exception. `ToolError` is an `Exception` subclass and the framework's contract is to **raise** it so the message is surfaced to the LLM — returning serializes it as an opaque success value, and the LLM never learns the call failed.
- Switched all three sites to `raise ToolError(...) from e` and dropped the bogus `| ToolError` return annotations on `get_weather` and `tell_joke`.

Every other example in `examples/` already uses `raise ToolError(...)` (drive-thru, frontdesk, healthcare, warm-transfer, web_search, telephony) — this file was the only outlier.

## Test plan
- [ ] Run `python examples/voice_agents/realtime_joke_teller.py console` and trigger an error path (e.g. unreachable joke API / invalid city) — confirm the LLM responds to the failure instead of speaking a serialized object.