### PR TITLE
docs(readme): fix syntax errors in StoryAgent and test snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ class StoryAgent(Agent):
     def __init__(self, name: str, location: str) -> None:
         super().__init__(
             instructions=f"You are a storyteller. Use the user's information in order to make the story personalized."
-            f"The user's name is {name}, from {location}"
+            f"The user's name is {name}, from {location}",
             # override the default model, switching to Realtime API from standard LLMs
             llm=openai.realtime.RealtimeModel(voice="echo"),
             chat_ctx=chat_ctx,
@@ -222,7 +222,7 @@ Automated tests are essential for building reliable agents, especially with the 
 @pytest.mark.asyncio
 async def test_no_availability() -> None:
     llm = google.LLM()
-    async AgentSession(llm=llm) as sess:
+    async with AgentSession(llm=llm) as sess:
         await sess.start(MyAgent())
         result = await sess.run(
             user_input="Hello, I need to place an order."


### PR DESCRIPTION
## Summary
- Add missing comma after the `instructions=` f-string in the `StoryAgent.__init__` `super().__init__(...)` call — without it, Python raises `SyntaxError` at the next keyword argument (`llm=`).
- Change `async AgentSession(llm=llm) as sess:` to `async with AgentSession(llm=llm) as sess:` in the testing snippet — the previous form is not valid Python.

Both snippets are copy-paste hazards: README fenced ```python blocks aren't executed in CI, so the errors went unnoticed.

## Test plan
- [ ] Copy the updated `StoryAgent` snippet into a file and verify it parses with `python -c "import ast; ast.parse(open('f.py').read())"`.
- [ ] Copy the updated test snippet and verify it parses.
- [ ] (Optional follow-up) Add a CI step that runs `py_compile` over fenced ```python blocks in README.md to prevent regressions.