### PR TITLE
feat(voice): surface FlushSentinel boundaries in transcription_node

### DIFF
--- a/livekit-agents/livekit/agents/__init__.py
+++ b/livekit-agents/livekit/agents/__init__.py
@@ -63,6 +63,7 @@ from .types import (
     NOT_GIVEN,
     APIConnectOptions,
     FlushSentinel,
+    FlushSentinelText,
     NotGiven,
     NotGivenOr,
 )
@@ -207,6 +208,7 @@ __all__ = [
     "AudioConfig",
     "PlayHandle",
     "FlushSentinel",
+    "FlushSentinelText",
     "LanguageCode",
     "io",
     "avatar",

--- a/livekit-agents/livekit/agents/types.py
+++ b/livekit-agents/livekit/agents/types.py
@@ -47,8 +47,21 @@ The key for the timed transcripts in the audio frame userdata.
 _T = TypeVar("_T")
 
 
+@dataclass
 class FlushSentinel:
-    pass
+    id: str | None = None
+    """Optional tag, echoed on the FlushSentinelText seen in the transcription node."""
+
+
+class FlushSentinelText(str):
+    """Empty-string marker for a FlushSentinel boundary, readable in the transcription node."""
+
+    id: str | None
+
+    def __new__(cls, *, id: str | None = None) -> "FlushSentinelText":
+        self = super().__new__(cls, "")
+        self.id = id
+        return self
 
 
 class NotGiven:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -34,7 +34,7 @@ from ..metrics import (
 )
 from ..telemetry import otel_metrics, trace_types, tracer, utils as trace_utils
 from ..tokenize.basic import split_words
-from ..types import NOT_GIVEN, FlushSentinel, NotGivenOr
+from ..types import NOT_GIVEN, FlushSentinel, FlushSentinelText, NotGivenOr
 from ..utils.misc import is_given
 from ._utils import _set_participant_attributes
 from .agent import (
@@ -2633,6 +2633,8 @@ class AgentActivity(RecognitionHooks):
         ) -> AsyncIterable[str]:
             async for chunk in llm_output:
                 if isinstance(chunk, FlushSentinel):
+                    # surface the boundary marker into the transcription node
+                    yield FlushSentinelText(id=chunk.id)
                     continue
                 yield chunk
 

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -25,7 +25,7 @@ from ..llm import (
 from ..llm.chat_context import Instructions
 from ..log import logger
 from ..telemetry import trace_types, tracer
-from ..types import USERDATA_TIMED_TRANSCRIPT, FlushSentinel, NotGivenOr
+from ..types import USERDATA_TIMED_TRANSCRIPT, FlushSentinel, FlushSentinelText, NotGivenOr
 from ..utils import aio, is_given
 from ..utils.aio import itertools
 from . import io
@@ -356,6 +356,10 @@ async def _text_forwarding_task(
 ) -> None:
     try:
         async for delta in source:
+            # don't forward FlushSentinelText as transcription text
+            if isinstance(delta, FlushSentinelText):
+                continue
+
             out.text += delta
             if text_output is not None:
                 await text_output.capture_text(delta)


### PR DESCRIPTION
## Summary

A `FlushSentinel` yielded from `llm_node` was stripped before the transcription node, so a single reply was always one transcript segment with no way to detect the internal boundaries.

`FlushSentinel` now takes an optional `id` and is surfaced into `transcription_node` as an empty-string `FlushSentinelText` carrying that `id`. A custom `transcription_node` can detect the boundary and read the tag; it is dropped before reaching the `TextOutput`, so default consumers are unaffected. The published `TranscriptionSegment.id` is unchanged.

```python
async def llm_node(self, chat_ctx, tools, model_settings):
    yield "Yes, let me look that up. "
    yield FlushSentinel(id="ack")        # flush to TTS, mark a boundary
    ...
    yield "It is 18 degrees and sunny."

async def transcription_node(self, text, model_settings):
    async for chunk in text:
        if isinstance(chunk, FlushSentinelText):
            # boundary reached; chunk.id == the id from the FlushSentinel
            ...
        yield chunk
```

## Notes

This flows through the non-aligned transcription path. With `use_tts_aligned_transcript`, the transcription input is TTS-derived timed text and carries no `FlushSentinel`, so the marker does not appear there.
