### PR TITLE
fix(speechmatics): propagate segment confidence

### DIFF
--- a/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
+++ b/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
@@ -50,6 +50,24 @@ from .log import logger
 from .version import __version__ as lk_version
 
 
+def _extract_segment_confidence(segment: dict[str, Any]) -> float:
+    confidence = segment.get("confidence")
+    if isinstance(confidence, int | float):
+        return float(confidence)
+
+    fragments = segment.get("fragments") or []
+    fragment_confidences = [
+        float(fragment["confidence"])
+        for fragment in fragments
+        if isinstance(fragment, dict) and isinstance(fragment.get("confidence"), int | float)
+    ]
+
+    if fragment_confidences:
+        return sum(fragment_confidences) / len(fragment_confidences)
+
+    return 0.0
+
+
 class TurnDetectionMode(str, Enum):
     """Endpoint and turn detection handling mode.
 
@@ -828,7 +846,7 @@ class SpeechStream(stt.RecognizeStream):
                 start_time=segment.get("metadata", {}).get("start_time", 0)
                 + self.start_time_offset,
                 end_time=segment.get("metadata", {}).get("end_time", 0) + self.start_time_offset,
-                confidence=1.0,
+                confidence=_extract_segment_confidence(segment),
             )
 
             # Create speech event

--- a/tests/test_speechmatics.py
+++ b/tests/test_speechmatics.py
@@ -1,0 +1,15 @@
+from livekit.plugins.speechmatics.stt import _extract_segment_confidence
+
+
+def test_extract_segment_confidence_uses_segment_confidence() -> None:
+    assert _extract_segment_confidence({"confidence": 0.42}) == 0.42
+
+
+def test_extract_segment_confidence_averages_fragment_confidences() -> None:
+    assert _extract_segment_confidence(
+        {"fragments": [{"confidence": 0.2}, {"confidence": 0.8}, {"content": "."}]}
+    ) == 0.5
+
+
+def test_extract_segment_confidence_defaults_to_zero() -> None:
+    assert _extract_segment_confidence({"text": "hello"}) == 0.0


### PR DESCRIPTION
Fixes #5880

## Summary
- use Speechmatics segment confidence when provided
- average fragment confidence when available
- default missing confidence to 0.0 instead of reporting 1.0

## Testing
- uv run --package livekit-plugins-speechmatics pytest tests/test_speechmatics.py
- uv run ruff check livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py tests/test_speechmatics.py