### PR TITLE
feat(smallestai): add word_timestamps support to TTS

### DIFF
--- a/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/tts.py
+++ b/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/tts.py
@@ -55,6 +55,7 @@ class _TTSOptions:
     output_format: TTSEncoding | str
     base_url: str
     ws_url: str
+    word_timestamps: bool
 
 
 class TTS(tts.TTS):
@@ -70,6 +71,7 @@ class TTS(tts.TTS):
         output_format: TTSEncoding | str = "pcm",
         base_url: str = SMALLEST_BASE_URL,
         ws_url: str = SMALLEST_WS_URL,
+        word_timestamps: bool = False,
         http_session: aiohttp.ClientSession | None = None,
     ) -> None:
         """
@@ -92,6 +94,12 @@ class TTS(tts.TTS):
                 "ulaw", "alaw"). WebSocket streaming always returns PCM.
             base_url: Base URL for the Smallest AI HTTP API.
             ws_url: WebSocket URL for low-latency streaming synthesis.
+            word_timestamps: When True, the server interleaves word_timestamp events
+                with audio chunks on WebSocket streaming; each carries {id, word,
+                start, end} where start/end are seconds relative to the audio stream
+                start. Supported on base-queue English + Hindi voices (meher, devansh,
+                kartik, maithili, liam, avery). Other voice families silently emit no
+                word events. Defaults to False.
             http_session: An existing aiohttp ClientSession to use.
         """
         super().__init__(
@@ -120,6 +128,7 @@ class TTS(tts.TTS):
             output_format=output_format,
             base_url=base_url,
             ws_url=ws_url,
+            word_timestamps=word_timestamps,
         )
         self._session = http_session
         self._pool = utils.ConnectionPool[aiohttp.ClientWebSocketResponse](
@@ -167,6 +176,7 @@ class TTS(tts.TTS):
         sample_rate: NotGivenOr[int] = NOT_GIVEN,
         language: NotGivenOr[str] = NOT_GIVEN,
         output_format: NotGivenOr[TTSEncoding | str] = NOT_GIVEN,
+        word_timestamps: NotGivenOr[bool] = NOT_GIVEN,
     ) -> None:
         """Update TTS options."""
         if is_given(model):
@@ -181,6 +191,8 @@ class TTS(tts.TTS):
             self._opts.language = LanguageCode(language)
         if is_given(output_format):
             self._opts.output_format = output_format
+        if is_given(word_timestamps):
+            self._opts.word_timestamps = word_timestamps
 
     def synthesize(
         self,
@@ -307,6 +319,9 @@ class SynthesizeStream(tts.SynthesizeStream):
             else self._opts.language,
         }
 
+        if self._opts.word_timestamps:
+            payload["word_timestamps"] = True
+
         async with self._tts._pool.connection(timeout=self._conn_options.timeout) as ws:
             self._acquire_time = self._tts._pool.last_acquire_time
             self._connection_reused = self._tts._pool.last_connection_reused
@@ -337,6 +352,8 @@ class SynthesizeStream(tts.SynthesizeStream):
                     audio_b64 = event.get("data", {}).get("audio")
                     if audio_b64:
                         output_emitter.push(base64.b64decode(audio_b64))
+                elif status == "word_timestamp":
+                    pass  # per-word timing events; no dedicated frame type in livekit-agents
                 elif status == "complete":
                     output_emitter.end_segment()
                     break


### PR DESCRIPTION
## Summary

Adds `word_timestamps` opt-in flag to the Smallest AI TTS plugin, matching the feature shipped in Lightning v3.1 and v3.1 Pro on 2026-06-01.

## Changes

- Added `word_timestamps: bool` to `_TTSOptions` dataclass
- Added `word_timestamps: bool = False` parameter to `TTS.__init__`
- Added `word_timestamps` to `update_options`
- In `SynthesizeStream._run_ws`: includes `word_timestamps: true` in the WebSocket payload when enabled, and handles the new `word_timestamp` status frame

## Usage

```python
tts = smallestai.TTS(
    model="lightning_v3.1_pro",
    voice_id="meher",
    word_timestamps=True,
)
```

When enabled, the server interleaves `status: "word_timestamp"` frames with audio chunks. Each frame carries `data: { id, word, start, end }` where `start`/`end` are floats in seconds relative to the start of the audio stream.

Supported voices: base-queue English + Hindi voices (`meher`, `devansh`, `kartik`, `maithili`, `liam`, `avery`). Other voice families silently emit no word events — audio works normally.

Defaults to `False` — purely opt-in, no behavior change for existing integrations.