### PR TITLE
fix(recorder): prevent close hang and fix corrupt frame splits

### DIFF
--- a/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
+++ b/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import ctypes
 import queue
 import threading
 import time
@@ -16,6 +15,7 @@ import numpy as np
 
 from livekit import rtc
 
+from ... import utils
 from ...log import logger
 from ...utils.audio import silence_frame as _create_silence_frame
 from .. import io
@@ -50,6 +50,7 @@ class RecorderIO:
         self._lock = asyncio.Lock()
         self._close_fut: asyncio.Future[None] = self._loop.create_future()
         self._output_path: Path | None = None
+        self._forward_atask: asyncio.Task[None] | None = None
 
         self._skip_padding_warning = False
 
@@ -79,6 +80,10 @@ class RecorderIO:
         async with self._lock:
             if not self._started:
                 return
+
+            if self._forward_atask is not None:
+                await utils.aio.cancel_and_wait(self._forward_atask)
+                self._forward_atask = None
 
             self._in_q.put_nowait(None)
             self._out_q.put_nowait(None)
@@ -197,85 +202,101 @@ class RecorderIO:
 
             return pos
 
-        with container:
-            while True:
-                input_buf = self._in_q.get()
-                output_buf = self._out_q.get()
+        try:
+            with container:
+                while True:
+                    input_buf = self._in_q.get()
+                    output_buf = self._out_q.get()
 
-                if input_buf is None or output_buf is None:
-                    break
+                    if input_buf is None or output_buf is None:
+                        break
 
-                # lazy creation of the resamplers
-                if in_resampler is None and len(input_buf):
-                    input_rate, num_channels = input_buf[0].sample_rate, input_buf[0].num_channels
-                    in_resampler = rtc.AudioResampler(
-                        input_rate=input_rate,
-                        output_rate=self._sample_rate,
-                        num_channels=num_channels,
+                    # lazy creation of the resamplers
+                    if in_resampler is None and len(input_buf):
+                        input_rate, num_channels = (
+                            input_buf[0].sample_rate,
+                            input_buf[0].num_channels,
+                        )
+                        in_resampler = rtc.AudioResampler(
+                            input_rate=input_rate,
+                            output_rate=self._sample_rate,
+                            num_channels=num_channels,
+                        )
+
+                    if out_resampler is None and len(output_buf):
+                        input_rate, num_channels = (
+                            output_buf[0].sample_rate,
+                            output_buf[0].num_channels,
+                        )
+                        out_resampler = rtc.AudioResampler(
+                            input_rate=input_rate,
+                            output_rate=self._sample_rate,
+                            num_channels=num_channels,
+                        )
+
+                    input_resampled = []
+                    for frame in input_buf:
+                        assert in_resampler is not None
+                        input_resampled.extend(in_resampler.push(frame))
+
+                    output_resampled = []
+                    for frame in output_buf:
+                        assert out_resampler is not None
+                        output_resampled.extend(out_resampler.push(frame))
+
+                    if output_buf:
+                        assert out_resampler is not None
+                        # the output is sent per-segment. Always flush when the playback is done
+                        output_resampled.extend(out_resampler.flush())
+
+                    len_left = remix_and_resample(input_resampled, 0)
+                    len_right = remix_and_resample(output_resampled, 1)
+
+                    if len_left != len_right:
+                        diff = abs(len_right - len_left)
+                        if len_left < len_right:
+                            if not self._skip_padding_warning:
+                                logger.warning(
+                                    f"Input is shorter by {diff} samples; silence has been prepended "
+                                    "to align the input channel. The resulting recording may not "
+                                    "accurately reflect the original audio. This is expected if the "
+                                    "input device or audio input is disabled. This warning will only "
+                                    "be shown once."
+                                )
+                                self._skip_padding_warning = True
+
+                            stereo_buf[0, diff : diff + len_left] = stereo_buf[0, :len_left]
+                            stereo_buf[0, :diff] = 0.0
+                            len_left = len_right
+                        else:
+                            stereo_buf[1, diff : diff + len_right] = stereo_buf[1, :len_right]
+                            stereo_buf[1, :diff] = 0.0
+                            len_right = len_left
+
+                    max_len = max(len_left, len_right)
+                    if max_len <= 0:
+                        continue
+
+                    stereo_slice = stereo_buf[:, :max_len]
+                    av_frame = av.AudioFrame.from_ndarray(
+                        stereo_slice, format="fltp", layout="stereo"
                     )
+                    av_frame.sample_rate = self._sample_rate
 
-                if out_resampler is None and len(output_buf):
-                    input_rate, num_channels = output_buf[0].sample_rate, output_buf[0].num_channels
-                    out_resampler = rtc.AudioResampler(
-                        input_rate=input_rate,
-                        output_rate=self._sample_rate,
-                        num_channels=num_channels,
-                    )
+                    for packet in stream.encode(av_frame):
+                        container.mux(packet)
 
-                input_resampled = []
-                for frame in input_buf:
-                    assert in_resampler is not None
-                    input_resampled.extend(in_resampler.push(frame))
-
-                output_resampled = []
-                for frame in output_buf:
-                    assert out_resampler is not None
-                    output_resampled.extend(out_resampler.push(frame))
-
-                if output_buf:
-                    assert out_resampler is not None
-                    # the output is sent per-segment. Always flush when the playback is done
-                    output_resampled.extend(out_resampler.flush())
-
-                len_left = remix_and_resample(input_resampled, 0)
-                len_right = remix_and_resample(output_resampled, 1)
-
-                if len_left != len_right:
-                    diff = abs(len_right - len_left)
-                    if len_left < len_right:
-                        if not self._skip_padding_warning:
-                            logger.warning(
-                                f"Input is shorter by {diff} samples; silence has been prepended to "
-                                "align the input channel. The resulting recording may not accurately "
-                                "reflect the original audio. This is expected if the input device "
-                                "or audio input is disabled. This warning will only be shown once."
-                            )
-                            self._skip_padding_warning = True
-
-                        stereo_buf[0, diff : diff + len_left] = stereo_buf[0, :len_left]
-                        stereo_buf[0, :diff] = 0.0
-                        len_left = len_right
-                    else:
-                        stereo_buf[1, diff : diff + len_right] = stereo_buf[1, :len_right]
-                        stereo_buf[1, :diff] = 0.0
-                        len_right = len_left
-
-                max_len = max(len_left, len_right)
-                if max_len <= 0:
-                    continue
-
-                stereo_slice = stereo_buf[:, :max_len]
-                av_frame = av.AudioFrame.from_ndarray(stereo_slice, format="fltp", layout="stereo")
-                av_frame.sample_rate = self._sample_rate
-
-                for packet in stream.encode(av_frame):
+                for packet in stream.encode(None):
                     container.mux(packet)
+        except Exception:
+            logger.exception("recorder encode thread failed; recording may be incomplete")
+        finally:
+            def resolve_close_fut() -> None:
+                if not self._close_fut.done():
+                    self._close_fut.set_result(None)
 
-            for packet in stream.encode(None):
-                container.mux(packet)
-
-        with contextlib.suppress(RuntimeError):
-            self._loop.call_soon_threadsafe(self._close_fut.set_result, None)
+            with contextlib.suppress(RuntimeError):
+                self._loop.call_soon_threadsafe(resolve_close_fut)
 
 
 class RecorderAudioInput(io.AudioInput):
@@ -551,25 +572,25 @@ def _split_frame(frame: rtc.AudioFrame, position: float) -> tuple[rtc.AudioFrame
             sample_rate=frame.sample_rate,
         )
 
-    samples_needed = int(position * frame.sample_rate)
-    bytes_per_sample = frame.num_channels * ctypes.sizeof(ctypes.c_int16)
+    samples_needed = min(int(position * frame.sample_rate), frame.samples_per_channel)
 
-    data_x, data_y = (
-        frame.data[: samples_needed * bytes_per_sample],
-        frame.data[samples_needed * bytes_per_sample :],
-    )
+    # `frame.data` is a memoryview of int16 samples (format "h"), so it is indexed in
+    # samples, not bytes. The split point in that buffer is `samples_per_channel` worth
+    # of interleaved samples across all channels.
+    split = samples_needed * frame.num_channels
+    data = frame.data
 
     return (
         rtc.AudioFrame(
-            data=data_x,
+            data=bytes(data[:split]),
             num_channels=frame.num_channels,
-            samples_per_channel=len(data_x) // bytes_per_sample,
+            samples_per_channel=samples_needed,
             sample_rate=frame.sample_rate,
         ),
         rtc.AudioFrame(
-            data=data_y,
+            data=bytes(data[split:]),
             num_channels=frame.num_channels,
-            samples_per_channel=len(data_y) // bytes_per_sample,
+            samples_per_channel=frame.samples_per_channel - samples_needed,
             sample_rate=frame.sample_rate,
         ),
     )

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -8,8 +8,10 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
+import numpy as np
 import pytest
 
+from livekit import rtc
 from livekit.agents import Agent, AgentSession
 from livekit.agents.telemetry.traces import _upload_session_report
 from livekit.agents.voice.agent_session import (
@@ -17,6 +19,7 @@ from livekit.agents.voice.agent_session import (
     _RECORDING_ALL_ON,
     RecordingOptions,
 )
+from livekit.agents.voice.recorder_io.recorder_io import _split_frame
 
 from .fake_io import FakeAudioInput, FakeAudioOutput, FakeTextOutput
 from .fake_llm import FakeLLM
@@ -415,3 +418,60 @@ async def test_recorder_io_not_created_when_audio_false() -> None:
 
     assert session._recorder_io is None
     await _cleanup(session)
+
+
+# ---------------------------------------------------------------------------
+# Group 5: _split_frame (encode-path helper)
+# ---------------------------------------------------------------------------
+
+
+def _ramp_frame(num_samples: int, num_channels: int, sample_rate: int = 24000) -> rtc.AudioFrame:
+    """A frame whose samples are a monotonic ramp, so splits can be checked for alignment."""
+    arr = np.arange(num_samples * num_channels, dtype=np.int16)
+    return rtc.AudioFrame(
+        data=arr.tobytes(),
+        num_channels=num_channels,
+        samples_per_channel=num_samples,
+        sample_rate=sample_rate,
+    )
+
+
+@pytest.mark.parametrize("num_channels", [1, 2])
+@pytest.mark.parametrize("fraction", [0.25, 0.5, 0.75])
+def test_split_frame_is_consistent_and_lossless(num_channels: int, fraction: float) -> None:
+    """`rtc.AudioFrame.data` is a memoryview of int16 *samples*, not bytes.
+
+    A split must keep each half's data length in sync with its samples_per_channel and
+    must neither drop nor duplicate samples. This guards the regression where the helper
+    indexed the buffer in bytes and produced corrupt frames on interrupted/paused playback.
+    """
+    n = 240
+    frame = _ramp_frame(n, num_channels)
+    left, right = _split_frame(frame, frame.duration * fraction)
+
+    # each half is internally consistent
+    assert len(left.data) == left.samples_per_channel * left.num_channels
+    assert len(right.data) == right.samples_per_channel * right.num_channels
+
+    # no samples lost or duplicated across the split
+    assert left.samples_per_channel + right.samples_per_channel == n
+    recon = np.concatenate(
+        [
+            np.frombuffer(bytes(left.data), dtype=np.int16),
+            np.frombuffer(bytes(right.data), dtype=np.int16),
+        ]
+    )
+    assert np.array_equal(recon, np.arange(n * num_channels, dtype=np.int16))
+
+
+def test_split_frame_boundaries() -> None:
+    """Splitting at or beyond the edges returns an empty half and the original."""
+    frame = _ramp_frame(100, 1)
+
+    empty, whole = _split_frame(frame, 0.0)
+    assert empty.samples_per_channel == 0 and len(empty.data) == 0
+    assert whole.samples_per_channel == 100
+
+    whole2, empty2 = _split_frame(frame, frame.duration * 2)
+    assert whole2.samples_per_channel == 100
+    assert empty2.samples_per_channel == 0 and len(empty2.data) == 0


### PR DESCRIPTION
## Summary

Two distinct bugs in `RecorderIO`, both surfaced by a real session where a SIP caller hung up mid-goodbye while the "caller silence check-in" pause/resume feature was active. Symptom: session shutdown stalled ~60s and the recording was incomplete/garbled.

### Bug 1 — `aclose()` hangs forever if the encode thread dies
`_encode_thread` only resolved `_close_fut` at the end of its normal loop. If the thread raised anywhere in the loop, the future stayed unresolved and `RecorderIO.aclose()` blocked on `await asyncio.shield(self._close_fut)`, stalling session shutdown until the caller's aclose watchdog fired (~60s). Because the encoder runs on a `daemon` thread, the exception went to `threading.excepthook` (stderr) instead of the structured logger, so it was invisible in observability exports.

- Wrap the encode loop in `try/except/finally` so `_close_fut` is **always** resolved (idempotent `_resolve_close_fut`), even when encoding raises.
- Log encoder exceptions via `logger.exception` instead of losing them.
- Cancel the previously-leaked `_forward_atask` in `aclose()`.

### Bug 2 — `_split_frame` corrupts audio on interrupted/paused playback
`rtc.AudioFrame.data` is a memoryview of int16 **samples** (`format="h"`) — indexed in samples, not bytes. `_split_frame` computed `bytes_per_sample = num_channels * 2` and over-sliced by 2×, producing frames whose `data` length disagreed with `samples_per_channel`. This path runs only on interrupted playback and pause/silence insertion, corrupting the recording around those points.

- Index the buffer in samples (`split = samples_needed * num_channels`), clamp `samples_needed`, and set each half's sample count correctly.

## Tests
- Adds `_split_frame` regression tests (consistency + lossless round-trip for mono/stereo, plus boundaries). The encode path previously had no coverage.
- All 23 tests in `tests/test_recording.py` pass; lint clean.

## Note
The structural fix (Bug 1) makes the hang impossible regardless of which exception killed the thread, and the new `logger.exception` will surface the precise traceback if it recurs. Bug 2 is a proven correctness bug on the interrupted/paused code path exercised by this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)