### PR TITLE
fix(job): close RecorderIO at session end if session close was interrupted

### DIFF
--- a/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
@@ -398,7 +398,10 @@ class _JobProc:
             except Exception:
                 logger.exception("error while executing the on_session_end callback")
 
-        await self._job_ctx._on_session_end()
+        try:
+            await self._job_ctx._on_session_end()
+        except Exception:
+            logger.exception("error in job_ctx._on_session_end")
 
         await self._client.send(ShuttingDown())
 

--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -261,6 +261,12 @@ class JobContext:
         otel_metrics.flush_turn_metrics(session.history)
 
         c = AgentsConsole.get_instance()
+
+        # in case AgentSession.aclose() was cancelled due to timeout
+        if (recorder_io := session._recorder_io) and recorder_io.recording:
+            logger.warning("recorder_io is still recording at session end, closing it")
+            await recorder_io.aclose()
+
         report = self.make_session_report(session)
 
         # console recording, dump data to a local file


### PR DESCRIPTION
Complements #5926.

When `session.aclose()` is cancelled during job shutdown (e.g. by the aclose timeout), it can return before `RecorderIO.aclose()` is reached, leaving the recorder still recording. `make_session_report()` then raises and the error propagates out of `_on_session_end`, preventing the registered shutdown callbacks from running.

This closes `RecorderIO` at session end if it is still recording, and wraps `_on_session_end()` so a failure there no longer blocks the shutdown callbacks.