### PR TITLE
fix: aclose() blocks for close_timeout when child is externally killed

### DIFF
--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -289,9 +289,7 @@ class SupervisedProc(ABC):
                 await channel.asend_message(self._pch, proto.ShutdownRequest())
 
             try:
-                await asyncio.wait_for(
-                    self._shutdown_ack_fut, timeout=self._opts.close_timeout
-                )
+                await asyncio.wait_for(self._shutdown_ack_fut, timeout=self._opts.close_timeout)
             except asyncio.TimeoutError:
                 logger.error(
                     "process did not ack shutdown in time, killing process",

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -195,6 +195,7 @@ class SupervisedProc(ABC):
             mp_cch.close()
 
             self._pid = self._proc.pid
+            self._proc_sentinel = os.dup(self._proc.sentinel)
             self._join_fut = asyncio.Future[None]()
 
             def _sync_run() -> None:
@@ -266,44 +267,61 @@ class SupervisedProc(ABC):
             self._initialize_fut.set_exception(e)
             raise
 
+    def _on_exit_resolve_futures(self) -> None:
+        """Called via add_reader when the process exits."""
+        if not self._shutdown_ack_fut.done():
+            self._shutdown_ack_fut.set_result(None)
+        if not self._shutting_down_fut.done():
+            self._shutting_down_fut.set_result(None)
+
     async def aclose(self) -> None:
         """attempt to gracefully close the supervised process"""
         if not self.started:
             return
 
         self._closing = True
-        with contextlib.suppress(duplex_unix.DuplexClosed):
-            await channel.asend_message(self._pch, proto.ShutdownRequest())
+
+        loop = asyncio.get_running_loop()
+        loop.add_reader(self._proc_sentinel, self._on_exit_resolve_futures)
 
         try:
-            await asyncio.wait_for(self._shutdown_ack_fut, timeout=self._opts.close_timeout)
-        except asyncio.TimeoutError:
-            logger.error(
-                "process did not ack shutdown in time, killing process",
-                extra=self.logging_extra(),
-            )
-            await self._send_dump_signal()
-            await self._send_kill_signal()
+            with contextlib.suppress(duplex_unix.DuplexClosed):
+                await channel.asend_message(self._pch, proto.ShutdownRequest())
 
-        if not self._shutting_down_fut.done():
-            await self._shutting_down_fut
-
-        if self._supervise_atask and not self._supervise_atask.done():
             try:
                 await asyncio.wait_for(
-                    asyncio.shield(self._supervise_atask), timeout=self._opts.close_timeout
+                    self._shutdown_ack_fut, timeout=self._opts.close_timeout
                 )
             except asyncio.TimeoutError:
                 logger.error(
-                    "process did not exit in time, killing process",
+                    "process did not ack shutdown in time, killing process",
                     extra=self.logging_extra(),
                 )
                 await self._send_dump_signal()
                 await self._send_kill_signal()
 
-        async with self._lock:
-            if self._supervise_atask:
-                await asyncio.shield(self._supervise_atask)
+            if not self._shutting_down_fut.done():
+                await self._shutting_down_fut
+
+            if self._supervise_atask and not self._supervise_atask.done():
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(self._supervise_atask),
+                        timeout=self._opts.close_timeout,
+                    )
+                except asyncio.TimeoutError:
+                    logger.error(
+                        "process did not exit in time, killing process",
+                        extra=self.logging_extra(),
+                    )
+                    await self._send_dump_signal()
+                    await self._send_kill_signal()
+
+            async with self._lock:
+                if self._supervise_atask:
+                    await asyncio.shield(self._supervise_atask)
+        finally:
+            loop.remove_reader(self._proc_sentinel)
 
     async def kill(self) -> None:
         """forcefully kill the supervised process"""

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -330,7 +330,7 @@ class SupervisedProc(ABC):
             if hasattr(self, "_proc_sentinel"):
                 loop = asyncio.get_running_loop()
                 loop.remove_reader(self._proc_sentinel)
-                os.close(self._proc_sentinel)
+                self._close_sentinel()
 
     async def kill(self) -> None:
         """forcefully kill the supervised process"""
@@ -420,8 +420,7 @@ class SupervisedProc(ABC):
         await self._join_fut
         self._exitcode = self._proc.exitcode
         self._proc.close()
-        if hasattr(self, "_proc_sentinel"):
-            os.close(self._proc_sentinel)
+        self._close_sentinel()
         await aio.cancel_and_wait(ping_task, read_ipc_task, main_task)
 
         if memory_monitor_task is not None:

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -275,6 +275,12 @@ class SupervisedProc(ABC):
         if not self._shutting_down_fut.done():
             self._shutting_down_fut.set_result(None)
 
+    def _close_sentinel(self) -> None:
+        """Close the dup'd sentinel fd exactly once."""
+        if hasattr(self, "_proc_sentinel"):
+            os.close(self._proc_sentinel)
+            del self._proc_sentinel
+
     async def aclose(self) -> None:
         """attempt to gracefully close the supervised process"""
         if not self.started:

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -320,6 +320,7 @@ class SupervisedProc(ABC):
                     await asyncio.shield(self._supervise_atask)
         finally:
             loop.remove_reader(self._proc_sentinel)
+            os.close(self._proc_sentinel)
 
     async def kill(self) -> None:
         """forcefully kill the supervised process"""

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -278,6 +278,7 @@ class SupervisedProc(ABC):
     def _close_sentinel(self) -> None:
         """Close the dup'd sentinel fd exactly once."""
         if hasattr(self, "_proc_sentinel"):
+            self._loop.remove_reader(self._proc_sentinel)
             os.close(self._proc_sentinel)
             del self._proc_sentinel
 

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -195,7 +195,8 @@ class SupervisedProc(ABC):
             mp_cch.close()
 
             self._pid = self._proc.pid
-            self._proc_sentinel = os.dup(self._proc.sentinel)
+            if sys.platform != "win32":
+                self._proc_sentinel = os.dup(self._proc.sentinel)
             self._join_fut = asyncio.Future[None]()
 
             def _sync_run() -> None:
@@ -281,8 +282,9 @@ class SupervisedProc(ABC):
 
         self._closing = True
 
-        loop = asyncio.get_running_loop()
-        loop.add_reader(self._proc_sentinel, self._on_exit_resolve_futures)
+        if sys.platform != "win32" and hasattr(self, "_proc_sentinel"):
+            loop = asyncio.get_running_loop()
+            loop.add_reader(self._proc_sentinel, self._on_exit_resolve_futures)
 
         try:
             with contextlib.suppress(duplex_unix.DuplexClosed):
@@ -319,8 +321,10 @@ class SupervisedProc(ABC):
                 if self._supervise_atask:
                     await asyncio.shield(self._supervise_atask)
         finally:
-            loop.remove_reader(self._proc_sentinel)
-            os.close(self._proc_sentinel)
+            if hasattr(self, "_proc_sentinel"):
+                loop = asyncio.get_running_loop()
+                loop.remove_reader(self._proc_sentinel)
+                os.close(self._proc_sentinel)
 
     async def kill(self) -> None:
         """forcefully kill the supervised process"""
@@ -410,6 +414,8 @@ class SupervisedProc(ABC):
         await self._join_fut
         self._exitcode = self._proc.exitcode
         self._proc.close()
+        if hasattr(self, "_proc_sentinel"):
+            os.close(self._proc_sentinel)
         await aio.cancel_and_wait(ping_task, read_ipc_task, main_task)
 
         if memory_monitor_task is not None:


### PR DESCRIPTION
Fixes #5929

When the supervised process is killed by an external SIGTERM (e.g. process-group signal) before aclose() is called, the IPC channel is already closed.  aclose() sends ShutdownRequest anyway (suppressed) then waits for ShutdownRequestAck via _shutdown_ack_fut.  This future is resolved by _read_ipc_task when the channel closes, but that runs as a separate asyncio task — if the event loop hasn't processed it yet, aclose() blocks for the full close_timeout.

Fix: check is_alive() before sending ShutdownRequest.  If the process is already dead, resolve both pending futures immediately.