### PR TITLE
feat(anam): forward output video dimensions via SessionOptions

### DIFF
--- a/examples/avatar_agents/anam/agent_worker.py
+++ b/examples/avatar_agents/anam/agent_worker.py
@@ -35,6 +35,10 @@ async def entrypoint(ctx: JobContext):
             avatarId=anam_avatar_id,
         ),
         api_key=anam_api_key,
+        # Optionally request explicit output dimensions (pixels). Omit to use the
+        # avatar model's default. Supported pairs are model-dependent, e.g. Cara 4
+        # landscape 1152x768.
+        # session_options=anam.SessionOptions(video_width=1152, video_height=768),
     )
     await anam_avatar.start(session, room=ctx.room)
 

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/__init__.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/__init__.py
@@ -14,13 +14,14 @@
 
 from .avatar import AvatarSession
 from .errors import AnamException
-from .types import PersonaConfig
+from .types import PersonaConfig, SessionOptions
 from .version import __version__
 
 __all__ = [
     "AnamException",
     "AvatarSession",
     "PersonaConfig",
+    "SessionOptions",
     "__version__",
 ]
 

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/api.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/api.py
@@ -97,17 +97,22 @@ class AnamAPI:
             "livekitToken": livekit_token,
         }
 
-        if session_options is not None:
-            # Anam's public API speaks camelCase pixel dimensions. Send both or
-            # neither; Anam rejects a half pair and any unsupported pair with an
-            # HTTP 400 (surfaced below as APIStatusError) rather than downgrading.
-            video_options: dict[str, int] = {}
-            if session_options.video_width is not None:
-                video_options["videoWidth"] = session_options.video_width
-            if session_options.video_height is not None:
-                video_options["videoHeight"] = session_options.video_height
-            if video_options:
-                payload["sessionOptions"] = video_options
+        if session_options is not None and (
+            session_options.video_width is not None or session_options.video_height is not None
+        ):
+            # Anam's public API speaks camelCase pixel dimensions and wants them
+            # as a matched pair: it rejects a lone width/height (and any
+            # unsupported pair) with an HTTP 400, surfaced below as
+            # APIStatusError, rather than downgrading. Fail fast on a half pair
+            # rather than round-tripping a 400.
+            if session_options.video_width is None or session_options.video_height is None:
+                raise ValueError(
+                    "video_width and video_height must be set together (both or neither)"
+                )
+            payload["sessionOptions"] = {
+                "videoWidth": session_options.video_width,
+                "videoHeight": session_options.video_height,
+            }
 
         headers = {
             "Authorization": f"Bearer {self._api_key}",  # Use API Key here

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/api.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/api.py
@@ -14,7 +14,7 @@ from livekit.agents import (
 
 from .errors import AnamException
 from .log import logger
-from .types import PersonaConfig
+from .types import PersonaConfig, SessionOptions
 
 DEFAULT_API_URL = "https://api.anam.ai"
 
@@ -62,10 +62,19 @@ class AnamAPI:
             await self._session.close()
 
     async def create_session_token(
-        self, persona_config: PersonaConfig, livekit_url: str, livekit_token: str
+        self,
+        persona_config: PersonaConfig,
+        livekit_url: str,
+        livekit_token: str,
+        session_options: SessionOptions | None = None,
     ) -> str:
         """
         Creates a session token to authorize starting an engine session.
+
+        Args:
+            session_options: Optional per-session output options (e.g. explicit
+                video dimensions) forwarded to Anam as ``sessionOptions``. When
+                ``None``, Anam uses the avatar model's default output.
 
         Returns:
             The created session token (a JWT string).
@@ -80,13 +89,26 @@ class AnamAPI:
         if persona_config.avatarModel:
             persona_config_payload["avatarModel"] = persona_config.avatarModel
 
-        payload = {
+        payload: dict[str, Any] = {
             "personaConfig": persona_config_payload,
         }
         payload["environment"] = {
             "livekitUrl": livekit_url,
             "livekitToken": livekit_token,
         }
+
+        if session_options is not None:
+            # Anam's public API speaks camelCase pixel dimensions. Send both or
+            # neither; Anam rejects a half pair and any unsupported pair with an
+            # HTTP 400 (surfaced below as APIStatusError) rather than downgrading.
+            video_options: dict[str, int] = {}
+            if session_options.video_width is not None:
+                video_options["videoWidth"] = session_options.video_width
+            if session_options.video_height is not None:
+                video_options["videoHeight"] = session_options.video_height
+            if video_options:
+                payload["sessionOptions"] = video_options
+
         headers = {
             "Authorization": f"Bearer {self._api_key}",  # Use API Key here
             "Content-Type": "application/json",

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/avatar.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/avatar.py
@@ -20,7 +20,7 @@ from livekit.agents.voice.room_io import ATTRIBUTE_PUBLISH_ON_BEHALF
 from .api import DEFAULT_API_URL, AnamAPI
 from .errors import AnamException
 from .log import logger
-from .types import PersonaConfig
+from .types import PersonaConfig, SessionOptions
 
 SAMPLE_RATE = 24000
 _AVATAR_AGENT_IDENTITY = "anam-avatar-agent"
@@ -34,6 +34,7 @@ class AvatarSession(BaseAvatarSession):
         self,
         *,
         persona_config: PersonaConfig,
+        session_options: NotGivenOr[SessionOptions] = NOT_GIVEN,
         api_url: NotGivenOr[str] = NOT_GIVEN,
         api_key: NotGivenOr[str] = NOT_GIVEN,
         avatar_participant_identity: NotGivenOr[str] = NOT_GIVEN,
@@ -47,6 +48,7 @@ class AvatarSession(BaseAvatarSession):
         self._avatar_participant_identity = avatar_participant_identity or _AVATAR_AGENT_IDENTITY
         self._avatar_participant_name = avatar_participant_name or _AVATAR_AGENT_NAME
         self._persona_config: PersonaConfig = persona_config
+        self._session_options = session_options if utils.is_given(session_options) else None
 
         api_url_val = (
             api_url if utils.is_given(api_url) else os.getenv("ANAM_API_URL", DEFAULT_API_URL)
@@ -115,6 +117,7 @@ class AvatarSession(BaseAvatarSession):
                 persona_config=self._persona_config,
                 livekit_url=livekit_url,
                 livekit_token=livekit_token,
+                session_options=self._session_options,
             )
             logger.debug("Anam session token created successfully.")
 

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
@@ -8,3 +8,22 @@ class PersonaConfig:
     name: str
     avatarId: str
     avatarModel: str | None = None
+
+
+@dataclass
+class SessionOptions:
+    """Per-session output options forwarded to Anam's session-token API.
+
+    Mirrors the ``sessionOptions`` field of the Anam session-token request.
+
+    Attributes:
+        video_width: Output video frame width in pixels. Provide together with
+            ``video_height`` (both or neither). Omit to use the avatar model's
+            default output size. Supported pairs are model-dependent and are
+            validated by Anam; an unsupported pair is rejected with an HTTP 400
+            rather than silently downgraded.
+        video_height: Output video frame height in pixels. See ``video_width``.
+    """
+
+    video_width: int | None = None
+    video_height: int | None = None


### PR DESCRIPTION
Closes #5954

## What

Adds an optional `anam.SessionOptions(video_width, video_height)` that the Anam avatar plugin forwards into Anam's session-token request as `sessionOptions.videoWidth` / `videoHeight`. The avatar video then publishes at the Anam-resolved output size.

```python
session = anam.AvatarSession(
    persona_config=anam.PersonaConfig(name="avatar", avatarId=ANAM_AVATAR_ID),
    session_options=anam.SessionOptions(video_width=1152, video_height=768),
)
```

## Why

Anam's public session-token API now accepts explicit pixel output dimensions. This lets Agents users choose the avatar's output size without any provider-specific dimensions API.

## Design

- **Pixels only**, both-or-neither — no portrait/landscape strings.
- **Validation lives in Anam, not the plugin.** The plugin is a thin pass-through and doesn't know the per-model allow-list; Anam validates the requested pair against the avatar model and returns HTTP 400 for an unsupported (or half) pair, which the plugin already surfaces as `APIStatusError` with Anam's descriptive message. No silent downgrade.
- **Mirrors `livekit-plugins-avatario`** (`VideoInfo(video_width, video_height)`). I named it `SessionOptions` to match Anam's own `sessionOptions` API field and leave room for future session-level options — happy to switch to a nested `AvatarSession.VideoInfo` if you'd prefer consistency with Avatario.
- **Backward compatible:** `session_options` is optional (`NOT_GIVEN`); when omitted the request body is identical to today and Anam applies the avatar model's default. No behaviour change for existing users.

## Scope

5 files — `types.py` (new `SessionOptions` dataclass), `avatar.py` + `api.py` (thread through + emit camelCase), `__init__.py` (export), and the anam example. No new dependencies; no change to the LiveKit token / `start_engine_session` / `wait_remote_track` flow. `ruff format` + `ruff check` clean. Left `version.py`/changelog to the release bot per CONTRIBUTING.

Happy to add unit tests for the payload construction in whatever harness you prefer.
