### PR TITLE
feat(inference): Add agent ID header to inference requests

### DIFF
--- a/livekit-agents/livekit/agents/inference/_utils.py
+++ b/livekit-agents/livekit/agents/inference/_utils.py
@@ -14,6 +14,7 @@ STAGING_INFERENCE_URL = "https://agent-gateway.staging.livekit.cloud/v1"
 HEADER_USER_AGENT = "User-Agent"
 HEADER_ROOM_ID = "X-LiveKit-Room-ID"
 HEADER_JOB_ID = "X-LiveKit-Job-ID"
+HEADER_AGENT_ID = "X-LiveKit-Agent-ID"
 HEADER_INFERENCE_PROVIDER = "X-LiveKit-Inference-Provider"
 HEADER_INFERENCE_PRIORITY = "X-LiveKit-Inference-Priority"
 
@@ -41,8 +42,8 @@ def get_inference_headers() -> dict[str, str]:
     """Build identification headers for inference requests.
 
     Always includes User-Agent with SDK version and Python version.
-    Includes X-LiveKit-Room-ID and X-LiveKit-Job-ID when running
-    inside a job context (omitted in console mode or tests).
+    Includes X-LiveKit-Room-ID, X-LiveKit-Job-ID, and X-LiveKit-Agent-ID
+    when running inside a job context (omitted in console mode or tests).
     """
     headers: dict[str, str] = {
         HEADER_USER_AGENT: (f"LiveKit Agents/{__version__} (python {platform.python_version()})"),
@@ -55,6 +56,8 @@ def get_inference_headers() -> dict[str, str]:
             headers[HEADER_ROOM_ID] = ctx.job.room.sid
         if ctx.job.id:
             headers[HEADER_JOB_ID] = ctx.job.id
+        if agent_sid := ctx.agent.sid:
+            headers[HEADER_AGENT_ID] = agent_sid
     except RuntimeError:
         pass
     return headers

--- a/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
+++ b/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
@@ -291,6 +291,7 @@ class RecorderIO:
         except Exception:
             logger.exception("recorder encode thread failed; recording may be incomplete")
         finally:
+
             def resolve_close_fut() -> None:
                 if not self._close_fut.done():
                     self._close_fut.set_result(None)


### PR DESCRIPTION
## Summary

Adds the agent's participant SID as a new `X-LiveKit-Agent-ID` header in `get_inference_headers`, alongside the existing `X-LiveKit-Room-ID` and `X-LiveKit-Job-ID` headers. The header is only emitted when running inside a job context (and when the SID is set), so console mode and tests are unaffected.

This lets the inference gateway attribute requests to the specific running agent instance, not just the room and job.

### Changes
- `livekit-agents/livekit/agents/inference/_utils.py`
  - New `HEADER_AGENT_ID = "X-LiveKit-Agent-ID"` constant
  - Emit the header from `ctx.agent.sid` when present

### Drive-by fix
- `livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py` — adds the blank line after `finally:` that `ruff` 0.15.12 requires. This was already failing the repo-wide `ruff format --check` on `main` and blocking CI; included here to get this PR green.

## Testing

`make check` passes (ruff lint + format + type-check) repo-wide.