### PR TITLE
fix(inference): don't leak mock participant sid into request headers

### DIFF
--- a/livekit-agents/livekit/agents/inference/_utils.py
+++ b/livekit-agents/livekit/agents/inference/_utils.py
@@ -52,11 +52,11 @@ def get_inference_headers() -> dict[str, str]:
         from ..job import get_job_context
 
         ctx = get_job_context()
-        if ctx.job.room.sid:
-            headers[HEADER_ROOM_ID] = ctx.job.room.sid
-        if ctx.job.id:
-            headers[HEADER_JOB_ID] = ctx.job.id
-        if agent_sid := ctx.agent.sid:
+        if isinstance(room_sid := ctx.job.room.sid, str) and room_sid:
+            headers[HEADER_ROOM_ID] = room_sid
+        if isinstance(job_id := ctx.job.id, str) and job_id:
+            headers[HEADER_JOB_ID] = job_id
+        if isinstance(agent_sid := ctx.agent.sid, str) and agent_sid:
             headers[HEADER_AGENT_ID] = agent_sid
     except RuntimeError:
         pass

--- a/livekit-agents/livekit/agents/ipc/mock_room.py
+++ b/livekit-agents/livekit/agents/ipc/mock_room.py
@@ -9,6 +9,10 @@ from livekit import rtc
 def create_mock_room() -> Any:
     MockRoom = create_autospec(rtc.Room, instance=True)
     MockRoom.local_participant = create_autospec(rtc.LocalParticipant, instance=True)
+    # autospec leaves attributes as truthy mocks; pin sid/identity to real strings
+    # so they don't leak into places like inference request headers (see _utils.py).
+    MockRoom.local_participant.sid = ""
+    MockRoom.local_participant.identity = "agent"
     MockRoom._info = create_autospec(rtc.room.proto_room.RoomInfo, instance=True)  # type: ignore
     MockRoom.isconnected.return_value = True
     MockRoom.name = "console"


### PR DESCRIPTION
## Problem

Running an agent in `console` mode crashes on startup as soon as STT connects:

```
TypeError: Cannot serialize non-str key <MagicMock name='mock.local_participant.sid'>
ERROR  AgentSession is closing due to unrecoverable error
```

This is a regression from #5937 (agent ID header). That change made `get_inference_headers()` read `ctx.agent.sid` — which is `room.local_participant.sid`. In console mode the room comes from `create_mock_room()`, where `local_participant` is an `autospec` mock and `.sid` was never assigned, so it stayed a **truthy `MagicMock`**. The mock passed the truthy check, got added as the `X-LiveKit-Agent-ID` header value, and aiohttp then failed to serialize it during the WebSocket handshake — taking down STT and the whole session.

## Fix

- **`ipc/mock_room.py`**: pin `local_participant.sid = ""` and `identity = "agent"` to real strings, matching how the remote participant already sets `.sid`.
- **`inference/_utils.py`**: harden `get_inference_headers()` to only emit non-empty `str` values for room/job/agent IDs, so no mock or test context can inject a non-serializable header again.

## Testing

Verified `console` mode starts and STT connects. Confirmed the mock room now returns a string sid (`""`, falsy → header omitted, matching the docstring's "omitted in console mode or tests").

🤖 Generated with [Claude Code](https://claude.com/claude-code)