### PR TITLE
test: categorize tests and select via `pytest --unit`/`--plugin openai`/ … flags

### DIFF
--- a/.github/workflows/test-realtime.yml
+++ b/.github/workflows/test-realtime.yml
@@ -52,4 +52,4 @@ jobs:
           AZURE_OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
           # XAI_API_KEY not set — xAI rate-limits GitHub Actions IPs (429 on ws handshake)
         run: |
-          uv run pytest -v tests/test_realtime/ -s --tb=long -p no:xdist
+          uv run pytest --realtime -v -s --tb=long -p no:xdist

--- a/.github/workflows/test-stt.yml
+++ b/.github/workflows/test-stt.yml
@@ -198,7 +198,7 @@ jobs:
           # AWS_REGION: ${{ secrets.AWS_REGION }}
           SARVAM_API_KEY: ${{ secrets.SARVAM_API_KEY }}
         run: |
-          uv run pytest -n 3 -v tests/test_stt.py --tb=long --junitxml=test-results.xml 2>&1 | tee test-output.txt || true
+          uv run pytest -n 3 -v --stt --tb=long --junitxml=test-results.xml 2>&1 | tee test-output.txt || true
 
       - name: Cleanup Google credentials
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
           LIVEKIT_API_KEY: ${{ secrets.LIVEKIT_API_KEY }}
           LIVEKIT_API_SECRET: ${{ secrets.LIVEKIT_API_SECRET }}
 
-        run: uv run pytest tests/test_workflows.py tests/test_evals.py
+        run: uv run pytest --evals
 
   tests:
     # don't run tests for PRs on forks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,9 +48,9 @@ uv run pytest --list-categories         # list every module grouped by category,
 ```
 
 **Adding a test:** give the new module a category marker (`pytestmark =
-pytest.mark.unit`, etc.) — collection fails with a hint if it lacks one. During
-local development you can bypass the check with `--allow-uncategorized`; CI keeps
-enforcement on (the default), so don't rely on it.
+pytest.mark.unit`, etc.) — collection fails with a hint if it lacks one. Run
+pytest with the `--allow-uncategorized` option to temporarily disable this rule
+(CI keeps it on by default).
 
 Known-broken tests stay collected and visible via
 `@pytest.mark.xfail(strict=True, reason=...)` rather than being deleted or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,11 +52,6 @@ pytest.mark.unit`, etc.) — collection fails with a hint if it lacks one. Run
 pytest with the `--allow-uncategorized` option to temporarily disable this rule
 (CI keeps it on by default).
 
-Known-broken tests stay collected and visible via
-`@pytest.mark.xfail(strict=True, reason=...)` rather than being deleted or
-silently skipped — `strict` flips CI red the moment the underlying bug is fixed,
-forcing the marker's removal.
-
 ### Running Agents
 ```bash
 python myagent.py console   # Terminal mode with local audio I/O (no server needed)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ it.
 | `pytest.mark.tts` | `--tts` | cross-provider text-to-speech suite (`tests/test_tts.py`) |
 | `pytest.mark.realtime("name")` | `--realtime [name]` | realtime-model test |
 | `pytest.mark.evals` | `--evals` | behavioral evals against the LiveKit inference gateway |
+| `pytest.mark.docs` | `--docs` | tests for the docs-build tooling under `.github/` |
 
 ```bash
 uv run pytest --unit                    # the CI unit gate (no cloud accounts)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,11 +20,42 @@ make check            # Run all checks (format-check, lint, type-check)
 
 ### Testing
 ```bash
-uv run pytest                           # Run all tests
 uv run pytest tests/test_tools.py       # Run a single test file
 uv run pytest tests/test_tools.py -k "test_name"  # Run specific test
-cd tests && make unit-tests             # Run unit tests that doesn't require cloud accounts
+make unit-tests                         # Run unit tests that don't require cloud accounts
 ```
+
+#### Test categories
+
+Every test module declares exactly one category via a module-level marker, and
+each category has a matching `--<category>` selection flag. Selection happens
+*before* import, so a category run never imports (or fails on) modules outside
+it.
+
+| Marker | Flag | Meaning |
+|--------|------|---------|
+| `pytest.mark.unit` | `--unit` | fast, hermetic, no external providers/credentials/network |
+| `pytest.mark.plugin("name")` | `--plugin [name]` | provider integration test (needs that provider's deps/keys) |
+| `pytest.mark.stt` | `--stt` | cross-provider speech-to-text suite (`tests/test_stt.py`) |
+| `pytest.mark.tts` | `--tts` | cross-provider text-to-speech suite (`tests/test_tts.py`) |
+| `pytest.mark.realtime("name")` | `--realtime [name]` | realtime-model test |
+| `pytest.mark.evals` | `--evals` | behavioral evals against the LiveKit inference gateway |
+
+```bash
+uv run pytest --unit                    # the CI unit gate (no cloud accounts)
+uv run pytest --plugin openai           # only the openai provider tests
+uv run pytest --list-categories         # list every module grouped by category, then exit
+```
+
+**Adding a test:** give the new module a category marker (`pytestmark =
+pytest.mark.unit`, etc.) — collection fails with a hint if it lacks one. During
+local development you can bypass the check with `--allow-uncategorized`; CI keeps
+enforcement on (the default), so don't rely on it.
+
+Known-broken tests stay collected and visible via
+`@pytest.mark.xfail(strict=True, reason=...)` rather than being deleted or
+silently skipped — `strict` flips CI red the moment the underlying bug is fixed,
+forcing the marker's removal.
 
 ### Running Agents
 ```bash

--- a/makefile
+++ b/makefile
@@ -84,7 +84,7 @@ fix: format lint-fix ## Run format and lint checks and fix issues automatically 
 
 unit-tests: ## Run unit tests (modules marked with `pytestmark = pytest.mark.unit`)
 	@echo "$(BOLD)$(CYAN)Running unit tests...$(RESET)"
-	PYTHONPATH="$$PWD" uv run pytest --unit tests/ $(PYTEST_ARGS)
+	PYTHONPATH="$$PWD" uv run pytest --unit $(PYTEST_ARGS)
 
 # ============================================
 # Development Workflows

--- a/makefile
+++ b/makefile
@@ -82,44 +82,9 @@ check: format-check lint type-check ## Run all checks (format, lint, type-check)
 
 fix: format lint-fix ## Run format and lint checks and fix issues automatically (format, lint)
 
-unit-tests:
+unit-tests: ## Run unit tests (modules marked with `pytestmark = pytest.mark.unit`)
 	@echo "$(BOLD)$(CYAN)Running unit tests...$(RESET)"
-	PYTHONPATH="$$PWD" uv run pytest \
-		tests/test_agent_session.py \
-		tests/test_aio.py \
-		tests/test_audio_decoder.py \
-		tests/test_chat_ctx.py \
-		tests/test_config.py \
-		tests/test_connection_pool.py \
-		tests/test_debounce.py \
-		tests/test_google_thought_signatures.py \
-		tests/test_inference_stt_fallback.py \
-		tests/test_inference_tts_fallback.py \
-		tests/test_ipc.py \
-		tests/test_ivr_activity.py \
-		tests/test_langgraph.py \
-		tests/test_language.py \
-		tests/test_schema_gemini.py \
-		tests/test_tts_fallback.py \
-		tests/test_stt_fallback.py \
-		tests/test_recording.py \
-		tests/test_tokenizer.py \
-		tests/test_transcription_filter.py \
-		tests/test_tools.py \
-		tests/test_aio_itertools.py \
-		tests/test_room.py \
-		tests/test_room_io.py \
-		tests/test_audio_recognition_handoff.py \
-		tests/test_audio_recognition_push_audio.py \
-		tests/test_utils/test_audio_array_buffer.py \
-		tests/test_utils/test_bounded_dict.py \
-		tests/test_interruption/test_overlapping_speech_event.py \
-		tests/test_tool_search.py \
-		tests/test_tool_proxy.py \
-		tests/test_endpointing.py \
-		tests/test_amd_classifier.py \
-		tests/test_session_host.py \
-		tests/test_http_context_helper.py
+	PYTHONPATH="$$PWD" uv run pytest --unit tests/ $(PYTEST_ARGS)
 
 # ============================================
 # Development Workflows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,8 @@ dev = [
     "tiktoken>=0.9.0",
     "pytest-xdist>=3.8.0",
     "playwright>=1.58.0",
+    "beautifulsoup4",
+    "markdownify",
 ]
 docs = ["pdoc3", "setuptools", "beautifulsoup4", "markdownify"]
 
@@ -127,8 +129,14 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 addopts = ["--import-mode=importlib", "--ignore=examples"]
 pythonpath = ["."]
+testpaths = ["tests"]
 markers = [
-    "unit: marks a test module as a unit test (no cloud credentials or optional deps); select with `--unit` (see tests/conftest.py)",
+    "unit: fast tests with no external providers (select with --unit)",
+    "plugin(name): provider integration test for `name` (select with --plugin [name])",
+    "realtime(name): realtime-model test, optionally for provider `name` (--realtime [name])",
+    "stt(name): speech-to-text test, optionally for provider `name` (--stt [name])",
+    "tts(name): text-to-speech test, optionally for provider `name` (--tts [name])",
+    "evals: behavioral evals run against the LiveKit inference gateway (--evals)",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,9 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 addopts = ["--import-mode=importlib", "--ignore=examples"]
 pythonpath = ["."]
+markers = [
+    "unit: marks a test module as a unit test (no cloud credentials or optional deps); select with `--unit` (see tests/conftest.py)",
+]
 
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,8 +94,6 @@ dev = [
     "tiktoken>=0.9.0",
     "pytest-xdist>=3.8.0",
     "playwright>=1.58.0",
-    "beautifulsoup4",
-    "markdownify",
 ]
 docs = ["pdoc3", "setuptools", "beautifulsoup4", "markdownify"]
 
@@ -137,6 +135,7 @@ markers = [
     "stt(name): speech-to-text test, optionally for provider `name` (--stt [name])",
     "tts(name): text-to-speech test, optionally for provider `name` (--tts [name])",
     "evals: behavioral evals run against the LiveKit inference gateway (--evals)",
+    "docs: tests for the docs-build tooling under .github/ (select with --docs)",
 ]
 
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -30,7 +30,7 @@ test: up
 	$(MAKE) down
 
 unit-tests:
-	uv run pytest tests/ --ignore=tests/test_realtime --ignore=tests/test_stt.py --ignore=tests/test_tts.py -x -v $(PYTEST_ARGS)
+	uv run pytest --unit tests/ -x -v $(PYTEST_ARGS)
 
 realtime-tests:
 	uv run pytest tests/test_realtime/ -v $(PYTEST_ARGS)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -30,7 +30,7 @@ test: up
 	$(MAKE) down
 
 unit-tests:
-	uv run pytest --unit tests/ -x -v $(PYTEST_ARGS)
+	uv run pytest --unit -x -v $(PYTEST_ARGS)
 
 realtime-tests:
 	uv run pytest tests/test_realtime/ -v $(PYTEST_ARGS)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -26,11 +26,11 @@ test: up
 	echo 'Toxiproxy is ready'
 
 	docker compose exec app uv sync --all-extras --dev
-	docker compose exec -e PLUGIN="$(PLUGIN)" app uv run pytest -s --color=yes --tb=short --log-cli-level=DEBUG tests/test_tts.py --show-capture=all $(PYTEST_ARGS)
+	docker compose exec -e PLUGIN="$(PLUGIN)" app uv run pytest -s --color=yes --tb=short --log-cli-level=DEBUG --tts --show-capture=all $(PYTEST_ARGS)
 	$(MAKE) down
 
 unit-tests:
 	uv run pytest --unit -x -v $(PYTEST_ARGS)
 
 realtime-tests:
-	uv run pytest tests/test_realtime/ -v $(PYTEST_ARGS)
+	uv run pytest --realtime -v $(PYTEST_ARGS)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -30,7 +30,7 @@ test: up
 	$(MAKE) down
 
 unit-tests:
-	uv run pytest --unit -x -v $(PYTEST_ARGS)
+	uv run pytest --unit --plugin --evals --docs -x -v $(PYTEST_ARGS)
 
 realtime-tests:
 	uv run pytest --realtime -v $(PYTEST_ARGS)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import asyncio
 import dataclasses
 import logging
+import re
+from pathlib import Path
 
 import pytest
 
@@ -10,6 +12,41 @@ from livekit.agents.cli import log
 from .toxic_proxy import Toxiproxy
 
 TEST_CONNECT_OPTIONS = dataclasses.replace(DEFAULT_API_CONNECT_OPTIONS, retry_interval=0.0)
+
+# Matches `pytest.mark.unit` so we can detect unit-marked modules *statically*,
+# without importing them. This lets `--unit` skip modules with heavy/optional
+# imports (cloud SDKs, bs4, ...) that would otherwise crash collection.
+_UNIT_MARKER_RE = re.compile(r"pytest\.mark\.unit\b")
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--unit",
+        action="store_true",
+        default=False,
+        help="Only collect test modules marked as unit tests "
+        "(`pytestmark = pytest.mark.unit`). Non-unit modules are skipped before "
+        "import, so their optional dependencies are never required.",
+    )
+
+
+def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool | None:
+    if not config.getoption("--unit"):
+        return None
+
+    # only decide on test modules; let pytest handle directories/other files
+    if collection_path.is_dir() or not collection_path.name.startswith("test_"):
+        return None
+    if collection_path.suffix != ".py":
+        return None
+
+    try:
+        source = collection_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    # ignore (don't import) modules that aren't marked as unit tests
+    return _UNIT_MARKER_RE.search(source) is None
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,16 +25,17 @@ _CATEGORY_RE = re.compile(r"pytest\.mark\.(" + "|".join(CATEGORIES) + r")\b")
 # a module "has tests" if it declares any (non-commented) test function or Test class.
 _HAS_TESTS_RE = re.compile(r"^\s*(?:async\s+)?def test|^\s*class Test", re.MULTILINE)
 
-_CATEGORY_HINT = (
-    "Every test module must declare its category with a module-level marker, e.g.:\n\n"
-    "    pytestmark = pytest.mark.unit              # fast, no external providers\n"
-    '    pytestmark = pytest.mark.plugin("openai")  # provider integration test\n'
-    "    pytestmark = pytest.mark.stt               # speech-to-text suite\n"
-    "    pytestmark = pytest.mark.tts               # text-to-speech suite\n"
-    '    pytestmark = pytest.mark.realtime("nvidia")  # realtime-model test\n'
-    "    pytestmark = pytest.mark.evals             # inference-gateway evals\n\n"
-    "Escape hatch for local development (never on CI): pytest --allow-uncategorized"
-)
+_CATEGORY_HINT = """\
+Every test module must declare its category with a module-level marker, e.g.:
+
+    pytestmark = pytest.mark.unit              # fast, no external providers
+    pytestmark = pytest.mark.plugin("openai")  # provider integration test
+    pytestmark = pytest.mark.stt               # speech-to-text suite
+    pytestmark = pytest.mark.tts               # text-to-speech suite
+    pytestmark = pytest.mark.realtime("nvidia")  # realtime-model test
+    pytestmark = pytest.mark.evals             # inference-gateway evals
+
+Run pytest with the --allow-uncategorized option to temporarily disable this rule."""
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -59,8 +60,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--allow-uncategorized",
         action="store_true",
         default=False,
-        help="escape hatch: allow test modules without a category marker. For local "
-        "development only — CI must keep enforcement on (the default).",
+        help="allow test modules without a category marker, temporarily disabling "
+        "the categorization rule (CI keeps it on by default).",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import asyncio
 import dataclasses
 import logging
 import re
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -78,16 +79,14 @@ def _plural(n: int, noun: str) -> str:
     return f"{n} {noun}" if n == 1 else f"{n} {noun}s"
 
 
-def _iter_test_files(config: pytest.Config) -> list[Path]:
+def _iter_test_files(config: pytest.Config) -> Iterator[Path]:
     rootdir = Path(str(config.rootdir))
-    files: list[Path] = []
     for testpath in config.getini("testpaths") or ["tests"]:
         base = rootdir / testpath
         if base.is_dir():
-            files.extend(sorted(base.rglob("test_*.py")))
+            yield from sorted(base.rglob("test_*.py"))
         elif base.is_file() and base.name.startswith("test_"):
-            files.append(base)
-    return files
+            yield base
 
 
 def _uncategorized_modules(config: pytest.Config) -> list[Path]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,10 @@ def _module_categories(source: str) -> set[str]:
     return set(_CATEGORY_RE.findall(source))
 
 
+def _plural(n: int, noun: str) -> str:
+    return f"{n} {noun}" if n == 1 else f"{n} {noun}s"
+
+
 def _iter_test_files(config: pytest.Config) -> list[Path]:
     rootdir = Path(str(config.rootdir))
     files: list[Path] = []
@@ -120,10 +124,11 @@ def pytest_configure(config: pytest.Config) -> None:
     lines = ["", "Test categories (select with --<category>):", ""]
     for category in CATEGORIES:
         modules = by_category[category]
-        lines.append(f"  {category:<10} {len(modules):>3} module(s)")
+        lines.append(f"  {category:<8} {_plural(len(modules), 'module')}")
         lines.extend(f"             - {rel}" for rel in modules)
     if uncategorized:
-        lines.append(f"\n  UNCATEGORIZED {len(uncategorized)} module(s) — run is blocked:")
+        blocked = _plural(len(uncategorized), "module")
+        lines.append(f"\n  UNCATEGORIZED {blocked} — run is blocked:")
         lines.extend(f"             - {rel}" for rel in uncategorized)
     pytest.exit("\n".join(lines), returncode=0)
 
@@ -136,8 +141,8 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
             rootdir = Path(str(config.rootdir))
             listed = "\n".join(f"  - {p.relative_to(rootdir)}" for p in offenders)
             raise pytest.UsageError(
-                f"{len(offenders)} test module(s) have no category marker:\n\n"
-                f"{listed}\n\n{_CATEGORY_HINT}"
+                f"Found {_plural(len(offenders), 'test module')} without a "
+                f"category marker:\n\n{listed}\n\n{_CATEGORY_HINT}"
             )
 
     _filter_by_provider(config, items)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import asyncio
 import dataclasses
 import logging
-import re
 from pathlib import Path
 
 import pytest
@@ -13,31 +12,49 @@ from .toxic_proxy import Toxiproxy
 
 TEST_CONNECT_OPTIONS = dataclasses.replace(DEFAULT_API_CONNECT_OPTIONS, retry_interval=0.0)
 
-# Matches `pytest.mark.unit` so we can detect unit-marked modules *statically*,
-# without importing them. This lets `--unit` skip modules with heavy/optional
-# imports (cloud SDKs, bs4, ...) that would otherwise crash collection.
-_UNIT_MARKER_RE = re.compile(r"pytest\.mark\.unit\b")
+# Test categories, each exposed as a `--<category>` flag and a `pytest.mark.<category>`
+# marker. Provider-specific categories also accept an argument, e.g.
+# `pytestmark = pytest.mark.plugin("anthropic")`, selectable via `--plugin anthropic`.
+CATEGORIES = ("unit", "plugin", "realtime", "stt", "tts", "evals")
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
-    parser.addoption(
-        "--unit",
-        action="store_true",
-        default=False,
-        help="Only collect test modules marked as unit tests "
-        "(`pytestmark = pytest.mark.unit`). Non-unit modules are skipped before "
-        "import, so their optional dependencies are never required.",
-    )
+    group = parser.getgroup("categories", "test category selection")
+    for category in CATEGORIES:
+        group.addoption(
+            f"--{category}",
+            nargs="?",
+            const=True,
+            default=None,
+            metavar="PROVIDER",
+            help=f"select only `{category}` tests; optionally narrow to a single "
+            f"provider/target (e.g. --{category} <name>). Repeatable categories are unioned.",
+        )
+
+
+def _selected_categories(config: pytest.Config) -> dict[str, object]:
+    # category -> True (whole category) or a provider string (single target)
+    selected: dict[str, object] = {}
+    for category in CATEGORIES:
+        value = config.getoption(f"--{category}")
+        if value is not None:
+            selected[category] = value
+    return selected
 
 
 def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool | None:
-    if not config.getoption("--unit"):
-        return None
+    """Skip non-selected modules *before* importing them.
 
-    # only decide on test modules; let pytest handle directories/other files
-    if collection_path.is_dir() or not collection_path.name.startswith("test_"):
+    Marker selection alone can't do this: pytest must import a module to read its
+    markers, and some modules fail to import without optional/cloud deps. So we
+    detect the category marker by a plain substring scan of the source instead.
+    """
+    selected = _selected_categories(config)
+    if not selected:
         return None
-    if collection_path.suffix != ".py":
+    if collection_path.is_dir() or collection_path.suffix != ".py":
+        return None
+    if not collection_path.name.startswith("test_"):
         return None
 
     try:
@@ -45,8 +62,38 @@ def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool 
     except OSError:
         return None
 
-    # ignore (don't import) modules that aren't marked as unit tests
-    return _UNIT_MARKER_RE.search(source) is None
+    # ignore the module only if it carries none of the selected categories' markers;
+    # otherwise return None (defer) so --ignore and other plugins still apply.
+    if any(f"pytest.mark.{category}" in source for category in selected):
+        return None
+    return True
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Apply provider-argument filtering once modules are imported.
+
+    `--plugin anthropic` keeps only items whose `plugin` marker carries "anthropic"
+    in its args; a bare `--plugin` keeps the whole category.
+    """
+    selected = _selected_categories(config)
+    if not selected:
+        return
+
+    kept, deselected = [], []
+    for item in items:
+        keep = False
+        for category, target in selected.items():
+            for marker in item.iter_markers(category):
+                if target is True or target in marker.args:
+                    keep = True
+                    break
+            if keep:
+                break
+        (kept if keep else deselected).append(item)
+
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = kept
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ TEST_CONNECT_OPTIONS = dataclasses.replace(DEFAULT_API_CONNECT_OPTIONS, retry_in
 # Test categories, each exposed as a `--<category>` flag and a `pytest.mark.<category>`
 # marker. Provider-specific categories also accept an argument, e.g.
 # `pytestmark = pytest.mark.plugin("anthropic")`, selectable via `--plugin anthropic`.
-CATEGORIES = ("unit", "plugin", "realtime", "stt", "tts", "evals")
+CATEGORIES = ("unit", "plugin", "realtime", "stt", "tts", "evals", "docs")
 
 # matches `pytest.mark.<category>` anywhere in a module's source (module-level
 # `pytestmark = ...` or per-test `@pytest.mark.<category>` decorators).
@@ -34,6 +34,7 @@ Every test module must declare its category with a module-level marker, e.g.:
     pytestmark = pytest.mark.tts               # text-to-speech suite
     pytestmark = pytest.mark.realtime("nvidia")  # realtime-model test
     pytestmark = pytest.mark.evals             # inference-gateway evals
+    pytestmark = pytest.mark.docs              # docs-build tooling (.github/)
 
 Run pytest with the --allow-uncategorized option to temporarily disable this rule."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 import dataclasses
 import logging
+import re
 from pathlib import Path
 
 import pytest
@@ -17,6 +18,23 @@ TEST_CONNECT_OPTIONS = dataclasses.replace(DEFAULT_API_CONNECT_OPTIONS, retry_in
 # `pytestmark = pytest.mark.plugin("anthropic")`, selectable via `--plugin anthropic`.
 CATEGORIES = ("unit", "plugin", "realtime", "stt", "tts", "evals")
 
+# matches `pytest.mark.<category>` anywhere in a module's source (module-level
+# `pytestmark = ...` or per-test `@pytest.mark.<category>` decorators).
+_CATEGORY_RE = re.compile(r"pytest\.mark\.(" + "|".join(CATEGORIES) + r")\b")
+# a module "has tests" if it declares any (non-commented) test function or Test class.
+_HAS_TESTS_RE = re.compile(r"^\s*(?:async\s+)?def test|^\s*class Test", re.MULTILINE)
+
+_CATEGORY_HINT = (
+    "Every test module must declare its category with a module-level marker, e.g.:\n\n"
+    "    pytestmark = pytest.mark.unit              # fast, no external providers\n"
+    '    pytestmark = pytest.mark.plugin("openai")  # provider integration test\n'
+    "    pytestmark = pytest.mark.stt               # speech-to-text suite\n"
+    "    pytestmark = pytest.mark.tts               # text-to-speech suite\n"
+    '    pytestmark = pytest.mark.realtime("nvidia")  # realtime-model test\n'
+    "    pytestmark = pytest.mark.evals             # inference-gateway evals\n\n"
+    "Escape hatch for local development (never on CI): pytest --allow-uncategorized"
+)
+
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     group = parser.getgroup("categories", "test category selection")
@@ -30,6 +48,99 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             help=f"select only `{category}` tests; optionally narrow to a single "
             f"provider/target (e.g. --{category} <name>). Repeatable categories are unioned.",
         )
+    group.addoption(
+        "--list-categories",
+        action="store_true",
+        default=False,
+        help="list every test module grouped by category, then exit (no tests run).",
+    )
+    group.addoption(
+        "--allow-uncategorized",
+        action="store_true",
+        default=False,
+        help="escape hatch: allow test modules without a category marker. For local "
+        "development only — CI must keep enforcement on (the default).",
+    )
+
+
+def _read_source(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _module_categories(source: str) -> set[str]:
+    return set(_CATEGORY_RE.findall(source))
+
+
+def _iter_test_files(config: pytest.Config) -> list[Path]:
+    rootdir = Path(str(config.rootdir))
+    files: list[Path] = []
+    for testpath in config.getini("testpaths") or ["tests"]:
+        base = rootdir / testpath
+        if base.is_dir():
+            files.extend(sorted(base.rglob("test_*.py")))
+        elif base.is_file() and base.name.startswith("test_"):
+            files.append(base)
+    return files
+
+
+def _uncategorized_modules(config: pytest.Config) -> list[Path]:
+    """Test files that contain tests but declare no category marker."""
+    offenders: list[Path] = []
+    for path in _iter_test_files(config):
+        source = _read_source(path)
+        if not _HAS_TESTS_RE.search(source):
+            continue  # empty / fully-commented module: nothing to categorize
+        if not _module_categories(source):
+            offenders.append(path)
+    return offenders
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Handle `--list-categories` before any collection/import happens."""
+    if not config.getoption("--list-categories"):
+        return
+
+    rootdir = Path(str(config.rootdir))
+    by_category: dict[str, list[str]] = {c: [] for c in CATEGORIES}
+    uncategorized: list[str] = []
+    for path in _iter_test_files(config):
+        source = _read_source(path)
+        if not _HAS_TESTS_RE.search(source):
+            continue
+        rel = str(path.relative_to(rootdir))
+        cats = _module_categories(source)
+        if not cats:
+            uncategorized.append(rel)
+        for cat in cats:
+            by_category[cat].append(rel)
+
+    lines = ["", "Test categories (select with --<category>):", ""]
+    for category in CATEGORIES:
+        modules = by_category[category]
+        lines.append(f"  {category:<10} {len(modules):>3} module(s)")
+        lines.extend(f"             - {rel}" for rel in modules)
+    if uncategorized:
+        lines.append(f"\n  UNCATEGORIZED {len(uncategorized)} module(s) — run is blocked:")
+        lines.extend(f"             - {rel}" for rel in uncategorized)
+    pytest.exit("\n".join(lines), returncode=0)
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Enforce category markers, then apply provider-argument filtering."""
+    if not config.getoption("--allow-uncategorized"):
+        offenders = _uncategorized_modules(config)
+        if offenders:
+            rootdir = Path(str(config.rootdir))
+            listed = "\n".join(f"  - {p.relative_to(rootdir)}" for p in offenders)
+            raise pytest.UsageError(
+                f"{len(offenders)} test module(s) have no category marker:\n\n"
+                f"{listed}\n\n{_CATEGORY_HINT}"
+            )
+
+    _filter_by_provider(config, items)
 
 
 def _selected_categories(config: pytest.Config) -> dict[str, object]:
@@ -69,7 +180,7 @@ def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool 
     return True
 
 
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+def _filter_by_provider(config: pytest.Config, items: list[pytest.Item]) -> None:
     """Apply provider-argument filtering once modules are imported.
 
     `--plugin anthropic` keeps only items whose `plugin` marker carries "anthropic"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -230,6 +230,28 @@ def configure_test():
     log._silence_noisy_loggers()
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _logging_baseline():
+    """Pristine logging state, snapshotted once before any test runs."""
+    loggers = [logging.getLogger()]  # root
+    loggers += [
+        logging.getLogger(name)
+        for name in logging.root.manager.loggerDict
+        if name.startswith("livekit")
+    ]
+    return [(logger, logger.level, logger.handlers[:], logger.propagate) for logger in loggers]
+
+
+@pytest.fixture(autouse=True)
+def _restore_logging(_logging_baseline):
+    """Revert global logging a test mutated (e.g. via cli.log.setup_logging)."""
+    yield
+    for logger, level, handlers, propagate in _logging_baseline:
+        logger.setLevel(level)
+        logger.handlers[:] = handlers
+        logger.propagate = propagate
+
+
 @pytest.fixture
 def toxiproxy():
     toxiproxy = Toxiproxy()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,10 +14,22 @@ from .toxic_proxy import Toxiproxy
 
 TEST_CONNECT_OPTIONS = dataclasses.replace(DEFAULT_API_CONNECT_OPTIONS, retry_interval=0.0)
 
-# Test categories, each exposed as a `--<category>` flag and a `pytest.mark.<category>`
-# marker. Provider-specific categories also accept an argument, e.g.
-# `pytestmark = pytest.mark.plugin("anthropic")`, selectable via `--plugin anthropic`.
-CATEGORIES = ("unit", "plugin", "realtime", "stt", "tts", "evals", "docs")
+# Category names are the pytest markers declared in pyproject.toml — the single
+# source of truth. They're read from the file rather than via config.getini()
+# because the --<category> options are registered in pytest_addoption, which runs
+# before pytest has parsed the ini file.
+_PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def _load_categories() -> tuple[str, ...]:
+    block = re.search(r"(?ms)^markers\s*=\s*\[(.*?)^\s*\]", _PYPROJECT.read_text(encoding="utf-8"))
+    names = re.findall(r'^\s*"(\w+)', block.group(1), re.MULTILINE) if block else []
+    if not names:
+        raise RuntimeError(f"no pytest markers found in {_PYPROJECT}")
+    return tuple(dict.fromkeys(names))
+
+
+CATEGORIES = _load_categories()
 
 # matches `pytest.mark.<category>` anywhere in a module's source (module-level
 # `pytestmark = ...` or per-test `@pytest.mark.<category>` decorators).
@@ -25,18 +37,11 @@ _CATEGORY_RE = re.compile(r"pytest\.mark\.(" + "|".join(CATEGORIES) + r")\b")
 # a module "has tests" if it declares any (non-commented) test function or Test class.
 _HAS_TESTS_RE = re.compile(r"^\s*(?:async\s+)?def test|^\s*class Test", re.MULTILINE)
 
-_CATEGORY_HINT = """\
-Every test module must declare its category with a module-level marker, e.g.:
-
-    pytestmark = pytest.mark.unit              # fast, no external providers
-    pytestmark = pytest.mark.plugin("openai")  # provider integration test
-    pytestmark = pytest.mark.stt               # speech-to-text suite
-    pytestmark = pytest.mark.tts               # text-to-speech suite
-    pytestmark = pytest.mark.realtime("nvidia")  # realtime-model test
-    pytestmark = pytest.mark.evals             # inference-gateway evals
-    pytestmark = pytest.mark.docs              # docs-build tooling (.github/)
-
-Run pytest with the --allow-uncategorized option to temporarily disable this rule."""
+_CATEGORY_HINT = (
+    "Every test module must declare its category with a module-level marker, one of:\n\n"
+    + "\n".join(f"    pytestmark = pytest.mark.{c}" for c in CATEGORIES)
+    + "\n\nRun pytest with the --allow-uncategorized option to temporarily disable this rule."
+)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -34,6 +34,8 @@ from livekit.agents.voice.io import PlaybackFinishedEvent
 
 from .fake_session import FakeActions, create_session, run_session
 
+pytestmark = pytest.mark.unit
+
 
 class MyAgent(Agent):
     def __init__(

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -1,6 +1,10 @@
 import asyncio
 
+import pytest
+
 from livekit.agents.utils import aio
+
+pytestmark = pytest.mark.unit
 
 
 async def test_channel():

--- a/tests/test_aio_itertools.py
+++ b/tests/test_aio_itertools.py
@@ -4,6 +4,8 @@ import pytest
 
 from livekit.agents.utils.aio.itertools import Tee
 
+pytestmark = pytest.mark.unit
+
 
 async def _async_iter(items):
     for item in items:

--- a/tests/test_amd_classifier.py
+++ b/tests/test_amd_classifier.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import asyncio
 import time
 
+import pytest
+
 from livekit.agents.llm import FunctionToolCall
 from livekit.agents.voice.amd.classifier import (
     AMDCategory,
@@ -18,6 +20,8 @@ from livekit.agents.voice.amd.classifier import (
 )
 
 from .fake_llm import FakeLLM, FakeLLMResponse
+
+pytestmark = pytest.mark.unit
 
 
 def _make_classifier(

--- a/tests/test_audio_decoder.py
+++ b/tests/test_audio_decoder.py
@@ -15,6 +15,8 @@ from livekit.agents.utils.misc import is_cloud
 
 from .utils import wer
 
+pytestmark = pytest.mark.unit
+
 TEST_AUDIO_FILEPATH = os.path.join(os.path.dirname(__file__), "change-sophie.opus")
 
 

--- a/tests/test_audio_emitter.py
+++ b/tests/test_audio_emitter.py
@@ -11,6 +11,8 @@ import pytest
 from livekit.agents import tts, utils
 from livekit.agents.types import USERDATA_TIMED_TRANSCRIPT, TimedString
 
+pytestmark = pytest.mark.unit
+
 
 def _make_pcm(sample_rate: int, num_channels: int, duration_ms: int) -> bytes:
     num_samples = sample_rate * duration_ms // 1000 * num_channels

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -15,6 +15,8 @@ import pytest
 
 from livekit.agents.voice.audio_recognition import AudioRecognition
 
+pytestmark = pytest.mark.unit
+
 
 class TestAudioRecognitionAclose:
     """Test cases for AudioRecognition.aclose() handling cancelled tasks."""

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -15,6 +15,8 @@ import pytest
 
 from livekit.agents.voice.audio_recognition import AudioRecognition
 
+pytestmark = pytest.mark.unit
+
 
 class TestAudioRecognitionAclose:
     """Test cases for AudioRecognition.aclose() handling cancelled tasks."""
@@ -97,6 +99,12 @@ class TestAudioRecognitionAclose:
         except asyncio.CancelledError:
             pass
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="_create_audio_recognition() builds a partial instance without "
+        "_stt_pipeline; aclose() touches self._stt_pipeline -> AttributeError. "
+        "Mock setup is stale w.r.t. AudioRecognition.__init__.",
+    )
     @pytest.mark.asyncio
     async def test_aclose_handles_precancelled_tasks_gracefully(self):
         """

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -31,10 +31,13 @@ class TestAudioRecognitionAclose:
         audio_recognition._hooks = MagicMock()
         audio_recognition._closing = asyncio.Event()
         audio_recognition._tasks = set()
-        audio_recognition._stt_atask = None
+        audio_recognition._stt_pipeline = None
+        audio_recognition._stt_consumer_atask = None
         audio_recognition._vad_atask = None
+        audio_recognition._interruption_atask = None
         audio_recognition._commit_user_turn_atask = None
         audio_recognition._end_of_turn_task = None
+        audio_recognition._backchannel_boundary_timer = None
 
         return audio_recognition
 
@@ -99,11 +102,6 @@ class TestAudioRecognitionAclose:
         except asyncio.CancelledError:
             pass
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="aclose() accesses self._stt_pipeline, which _create_audio_recognition() "
-        "does not set -> AttributeError",
-    )
     @pytest.mark.asyncio
     async def test_aclose_handles_precancelled_tasks_gracefully(self):
         """

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -101,9 +101,8 @@ class TestAudioRecognitionAclose:
 
     @pytest.mark.xfail(
         strict=True,
-        reason="_create_audio_recognition() builds a partial instance without "
-        "_stt_pipeline; aclose() touches self._stt_pipeline -> AttributeError. "
-        "Mock setup is stale w.r.t. AudioRecognition.__init__.",
+        reason="aclose() accesses self._stt_pipeline, which _create_audio_recognition() "
+        "does not set -> AttributeError",
     )
     @pytest.mark.asyncio
     async def test_aclose_handles_precancelled_tasks_gracefully(self):

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -15,8 +15,6 @@ import pytest
 
 from livekit.agents.voice.audio_recognition import AudioRecognition
 
-pytestmark = pytest.mark.unit
-
 
 class TestAudioRecognitionAclose:
     """Test cases for AudioRecognition.aclose() handling cancelled tasks."""

--- a/tests/test_audio_recognition_handoff.py
+++ b/tests/test_audio_recognition_handoff.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 from collections.abc import AsyncIterable
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
+import pytest
+
 from livekit import rtc
 from livekit.agents import Agent
 from livekit.agents.voice.agent import ModelSettings
 from livekit.agents.voice.agent_activity import AgentActivity
+
+pytestmark = pytest.mark.unit
 
 
 def _make_activity(agent: Agent, stt: object) -> MagicMock:

--- a/tests/test_audio_recognition_push_audio.py
+++ b/tests/test_audio_recognition_push_audio.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from livekit import rtc
 from livekit.agents.voice.audio_recognition import AudioRecognition
+
+pytestmark = pytest.mark.unit
 
 
 def _make_frame(byte: int = 0x11, samples: int = 160, sample_rate: int = 16000) -> rtc.AudioFrame:

--- a/tests/test_chat_ctx.py
+++ b/tests/test_chat_ctx.py
@@ -14,6 +14,8 @@ from livekit.agents.types import (
 
 from .fake_llm import FakeLLM, FakeLLMResponse
 
+pytestmark = pytest.mark.unit
+
 
 def ai_function1(a: int, b: str = "default") -> None:
     """

--- a/tests/test_cli_log_level.py
+++ b/tests/test_cli_log_level.py
@@ -8,6 +8,8 @@ from typer.testing import CliRunner
 from livekit.agents.cli.cli import _build_cli
 from livekit.agents.worker import AgentServer, ServerEnvOption, ServerOptions
 
+pytestmark = pytest.mark.unit
+
 
 def _make_server(**kwargs) -> AgentServer:
     async def _fake_entrypoint(ctx):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,8 @@
+import pytest
+
 from livekit.plugins.openai.realtime.realtime_model import process_base_url
+
+pytestmark = pytest.mark.unit
 
 
 def test_process_base_url():

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -4,6 +4,8 @@ import pytest
 
 from livekit.agents.utils import ConnectionPool
 
+pytestmark = pytest.mark.unit
+
 
 class DummyConnection:
     def __init__(self, id):

--- a/tests/test_convert_html_docs.py
+++ b/tests/test_convert_html_docs.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.unit
+pytestmark = pytest.mark.docs
 
 # The module lives at .github/convert_html_docs.py which isn't a regular
 # package, so we load it by file path.

--- a/tests/test_convert_html_docs.py
+++ b/tests/test_convert_html_docs.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 # The module lives at .github/convert_html_docs.py which isn't a regular
 # package, so we load it by file path.
 _SCRIPT_PATH = Path(__file__).resolve().parent.parent / ".github" / "convert_html_docs.py"

--- a/tests/test_debounce.py
+++ b/tests/test_debounce.py
@@ -4,6 +4,8 @@ import pytest
 
 from livekit.agents.utils.aio.debounce import Debounced, debounced
 
+pytestmark = pytest.mark.unit
+
 
 class TestDebounce:
     """Test cases for the Debounce class."""

--- a/tests/test_drain_timeout.py
+++ b/tests/test_drain_timeout.py
@@ -27,6 +27,8 @@ from livekit.agents.ipc.supervised_proc import SupervisedProc
 from livekit.agents.utils import aio
 from livekit.agents.worker import AgentServer
 
+pytestmark = pytest.mark.unit
+
 _CLI_ARGS = CliArgs(log_level="ERROR", url=None, api_key=None, api_secret=None)
 
 

--- a/tests/test_endpointing.py
+++ b/tests/test_endpointing.py
@@ -3,6 +3,8 @@ import pytest
 from livekit.agents.utils.exp_filter import ExpFilter
 from livekit.agents.voice.endpointing import DynamicEndpointing, create_endpointing
 
+pytestmark = pytest.mark.unit
+
 
 class TestExponentialMovingAverage:
     """Test cases for the ExponentialMovingAverage class."""

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -5,6 +5,8 @@ import pytest
 
 from livekit.agents import Agent, AgentSession, AgentTask, RunContext, function_tool, inference, llm
 
+pytestmark = pytest.mark.evals
+
 
 def _llm_model() -> llm.LLM:
     return inference.LLM(model="openai/gpt-4.1-mini")

--- a/tests/test_google_thought_signatures.py
+++ b/tests/test_google_thought_signatures.py
@@ -6,6 +6,8 @@ from livekit.plugins.google.llm import (
     _requires_thought_signatures,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestGeminiModelDetection:
     """Tests for Gemini model detection helper functions."""

--- a/tests/test_http_context_helper.py
+++ b/tests/test_http_context_helper.py
@@ -12,6 +12,8 @@ import pytest
 from livekit.agents import inference
 from livekit.agents.utils import http_context
 
+pytestmark = pytest.mark.unit
+
 
 async def test_open_yields_working_session_and_closes_on_exit() -> None:
     with pytest.raises(RuntimeError):

--- a/tests/test_inference_stt_fallback.py
+++ b/tests/test_inference_stt_fallback.py
@@ -12,6 +12,8 @@ from livekit.agents.types import (
     APIConnectOptions,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _make_stt(**kwargs):
     """Helper to create STT with required credentials."""

--- a/tests/test_inference_tts_fallback.py
+++ b/tests/test_inference_tts_fallback.py
@@ -7,6 +7,8 @@ from livekit.agents.inference.tts import (
     _parse_model_string,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _make_tts(**kwargs):
     """Helper to create TTS with required credentials."""

--- a/tests/test_inference_utils.py
+++ b/tests/test_inference_utils.py
@@ -24,6 +24,8 @@ from livekit.agents.inference._utils import (
     get_inference_headers,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class _FakeLiveRoom:
     """Stands in for ``JobContext.room`` (the live rtc.Room with isconnected())."""

--- a/tests/test_interruption/test_interruption_failover.py
+++ b/tests/test_interruption/test_interruption_failover.py
@@ -28,6 +28,8 @@ from livekit.agents.inference.interruption import (
 )
 from livekit.agents.types import APIConnectOptions
 
+pytestmark = pytest.mark.unit
+
 MAX_RETRY = 2
 CONN_OPTIONS = APIConnectOptions(max_retry=MAX_RETRY, retry_interval=0.0, timeout=1.0)
 

--- a/tests/test_interruption/test_overlapping_speech_event.py
+++ b/tests/test_interruption/test_overlapping_speech_event.py
@@ -1,6 +1,9 @@
 import numpy as np
+import pytest
 
 from livekit.agents.inference import OverlappingSpeechEvent
+
+pytestmark = pytest.mark.unit
 
 
 def test_interruption_event_serialization() -> None:

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -21,6 +21,8 @@ from livekit.agents.ipc.log_queue import LogQueueHandler, LogQueueListener
 from livekit.agents.utils.aio import duplex_unix
 from livekit.protocol import agent
 
+pytestmark = pytest.mark.unit
+
 
 @dataclass
 class EmptyMessage:

--- a/tests/test_ivr_activity.py
+++ b/tests/test_ivr_activity.py
@@ -1,4 +1,8 @@
+import pytest
+
 from livekit.agents.voice.ivr.ivr_activity import TfidfLoopDetector
+
+pytestmark = pytest.mark.unit
 
 
 def _count_loops(transcripts: list[str], detector: TfidfLoopDetector | None = None) -> int:

--- a/tests/test_langgraph.py
+++ b/tests/test_langgraph.py
@@ -16,6 +16,8 @@ from typing_extensions import TypedDict
 from livekit.agents.llm import ChatContext
 from livekit.plugins.langchain import LLMAdapter
 
+pytestmark = pytest.mark.unit
+
 # --- State definitions ---
 
 

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -1,5 +1,9 @@
+import pytest
+
 from livekit.agents.language import LanguageCode
 from livekit.agents.stt import SpeechData
+
+pytestmark = pytest.mark.unit
 
 
 class TestSpeechDataCoercion:

--- a/tests/test_nested_agent_task.py
+++ b/tests/test_nested_agent_task.py
@@ -9,6 +9,8 @@ from livekit.agents.llm import FunctionToolCall
 
 from .fake_llm import FakeLLM, FakeLLMResponse
 
+pytestmark = pytest.mark.unit
+
 
 class InnerTask(AgentTask):
     """A task that needs a second user turn to complete (user must trigger 'finish')."""

--- a/tests/test_personaplex_realtime_model.py
+++ b/tests/test_personaplex_realtime_model.py
@@ -19,6 +19,8 @@ from livekit.plugins.nvidia.experimental.realtime.realtime_model import (
     _ResponseGeneration,
 )
 
+pytestmark = pytest.mark.unit
+
 # -- RealtimeModel init tests --
 
 

--- a/tests/test_personaplex_realtime_model.py
+++ b/tests/test_personaplex_realtime_model.py
@@ -19,7 +19,7 @@ from livekit.plugins.nvidia.experimental.realtime.realtime_model import (
     _ResponseGeneration,
 )
 
-pytestmark = pytest.mark.unit
+pytestmark = pytest.mark.realtime("nvidia")
 
 # -- RealtimeModel init tests --
 

--- a/tests/test_personaplex_realtime_model.py
+++ b/tests/test_personaplex_realtime_model.py
@@ -19,7 +19,7 @@ from livekit.plugins.nvidia.experimental.realtime.realtime_model import (
     _ResponseGeneration,
 )
 
-pytestmark = pytest.mark.realtime("nvidia")
+pytestmark = pytest.mark.plugin("nvidia")
 
 # -- RealtimeModel init tests --
 

--- a/tests/test_plugin_anthropic.py
+++ b/tests/test_plugin_anthropic.py
@@ -8,6 +8,8 @@ import pytest
 from livekit.agents import APIConnectOptions, llm
 from livekit.plugins.anthropic.llm import LLMStream
 
+pytestmark = pytest.mark.plugin("anthropic")
+
 
 def _make_llm(**kwargs):
     from livekit.plugins.anthropic import LLM

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -10,6 +10,8 @@ import pytest
 from livekit.agents.stt import SpeechEventType
 from livekit.agents.types import NOT_GIVEN
 
+pytestmark = pytest.mark.plugin("assemblyai")
+
 
 async def test_vad_threshold_default():
     """Test vad_threshold is not set by default."""

--- a/tests/test_plugin_cerebras.py
+++ b/tests/test_plugin_cerebras.py
@@ -9,6 +9,8 @@ from livekit.agents import Agent, AgentSession, RunContext, function_tool, llm
 from livekit.plugins.cerebras import LLM
 from livekit.plugins.cerebras.llm import _CerebrasClient
 
+pytestmark = pytest.mark.plugin("cerebras")
+
 # llama3.1-8b is fast and has generous rate limits but can't do tool calls reliably;
 # qwen-3-235b is needed for function calling but has tight per-minute token quotas.
 CHAT_MODEL = "llama3.1-8b"

--- a/tests/test_plugin_elevenlabs_tts.py
+++ b/tests/test_plugin_elevenlabs_tts.py
@@ -10,6 +10,8 @@ import pytest
 
 from livekit.plugins.elevenlabs import tts as elevenlabs_tts
 
+pytestmark = pytest.mark.plugin("elevenlabs")
+
 
 class _FakeWebSocket:
     def __init__(self, messages: list[object]) -> None:

--- a/tests/test_plugin_gnani_stt.py
+++ b/tests/test_plugin_gnani_stt.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytestmark = pytest.mark.plugin("gnani")
+
 
 def test_stt_requires_api_key():
     """STT constructor raises when no API key is provided."""

--- a/tests/test_plugin_gnani_tts.py
+++ b/tests/test_plugin_gnani_tts.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 
 import pytest
 
+pytestmark = pytest.mark.plugin("gnani")
+
 
 def test_tts_requires_api_key():
     """TTS constructor raises when no API key is provided."""

--- a/tests/test_plugin_google_llm.py
+++ b/tests/test_plugin_google_llm.py
@@ -10,6 +10,8 @@ from livekit.agents.llm import ChatContext, function_tool
 from livekit.plugins.google.llm import LLM, LLMStream
 from livekit.plugins.google.realtime.realtime_api import RealtimeModel, RealtimeSession
 
+pytestmark = pytest.mark.plugin("google")
+
 
 @pytest.fixture
 def llm_stream():

--- a/tests/test_plugin_google_stt.py
+++ b/tests/test_plugin_google_stt.py
@@ -1,3 +1,4 @@
+import pytest
 from google.cloud.speech_v1.types import cloud_speech as cloud_speech_v1
 from google.cloud.speech_v2.types import cloud_speech as cloud_speech_v2
 from google.protobuf.duration_pb2 import Duration
@@ -9,6 +10,8 @@ from livekit.plugins.google.stt import (
     _recognize_response_to_speech_event,  # pyright: ignore[reportPrivateUsage]
     _streaming_recognize_response_to_speech_data,  # pyright: ignore[reportPrivateUsage]
 )
+
+pytestmark = pytest.mark.plugin("google")
 
 
 async def test_streaming_recognize_response_to_speech_data_01():

--- a/tests/test_plugin_gradium_stt.py
+++ b/tests/test_plugin_gradium_stt.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytestmark = pytest.mark.plugin("gradium")
+
 
 def test_stt_default_language():
     """STT defaults to English."""

--- a/tests/test_plugin_inworld_tts.py
+++ b/tests/test_plugin_inworld_tts.py
@@ -12,6 +12,8 @@ from livekit.agents import APIConnectionError
 from livekit.agents.types import NOT_GIVEN
 from livekit.agents.utils import aio
 
+pytestmark = pytest.mark.plugin("inworld")
+
 
 async def test_delivery_mode_default_not_given():
     from livekit.plugins.inworld import TTS

--- a/tests/test_plugin_openai_realtime_reasoning.py
+++ b/tests/test_plugin_openai_realtime_reasoning.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
 from openai.types.realtime import RealtimeReasoning
 
 from livekit.agents.types import APIConnectOptions
 from livekit.plugins.openai.realtime.realtime_model import RealtimeModel
+
+pytestmark = pytest.mark.plugin("openai")
 
 _NO_RETRY = APIConnectOptions(max_retry=0, timeout=0.1)
 

--- a/tests/test_plugin_perplexity.py
+++ b/tests/test_plugin_perplexity.py
@@ -5,6 +5,8 @@ import pytest
 from livekit.plugins.perplexity import LLM, __version__
 from livekit.plugins.perplexity.llm import PERPLEXITY_BASE_URL
 
+pytestmark = pytest.mark.plugin("perplexity")
+
 
 def test_default_model_and_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")

--- a/tests/test_plugin_perplexity_responses.py
+++ b/tests/test_plugin_perplexity_responses.py
@@ -5,6 +5,8 @@ import pytest
 from livekit.plugins.perplexity import __version__, responses
 from livekit.plugins.perplexity.responses.llm import PERPLEXITY_RESPONSES_BASE_URL
 
+pytestmark = pytest.mark.plugin("perplexity")
+
 
 def test_default_model_base_url_and_transport(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")

--- a/tests/test_plugin_soniox_stt.py
+++ b/tests/test_plugin_soniox_stt.py
@@ -26,6 +26,8 @@ from livekit.agents import APIStatusError
 from livekit.agents.language import LanguageCode
 from livekit.agents.stt import SpeechData, SpeechEventType
 
+pytestmark = pytest.mark.plugin("soniox")
+
 # ---------------------------------------------------------------------------
 # SpeechData.__post_init__: target_languages coercion
 # ---------------------------------------------------------------------------

--- a/tests/test_realtime/test_realtime.py
+++ b/tests/test_realtime/test_realtime.py
@@ -15,6 +15,8 @@ from livekit import rtc
 from livekit.agents import RunContext, function_tool, llm, utils
 from livekit.plugins import openai, xai
 
+pytestmark = pytest.mark.realtime
+
 TESTS_DIR = Path(__file__).parent
 SAMPLE_RATE = 24000
 

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -27,6 +27,8 @@ from .fake_stt import FakeSTT
 from .fake_tts import FakeTTS
 from .fake_vad import FakeVAD
 
+pytestmark = pytest.mark.unit
+
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_room.py
+++ b/tests/test_room.py
@@ -32,6 +32,8 @@ from .utils.livekit_test import (
     wait_for_event,
 )
 
+pytestmark = pytest.mark.unit
+
 TIMEOUT = 5.0
 
 

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -16,6 +16,8 @@ from livekit.agents.voice.room_io._output import _ParticipantTranscriptionOutput
 from livekit.agents.voice.room_io.room_io import RoomIO
 from livekit.agents.voice.room_io.types import NoiseCancellationParams
 
+pytestmark = pytest.mark.unit
+
 # -- helpers ------------------------------------------------------------------
 
 

--- a/tests/test_schema_gemini.py
+++ b/tests/test_schema_gemini.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel, Field
 
 from livekit.plugins.google import utils
 
+pytestmark = pytest.mark.unit
+
 #  Gemini Schema Tests
 
 

--- a/tests/test_session_host.py
+++ b/tests/test_session_host.py
@@ -32,6 +32,8 @@ from livekit.agents.voice.remote_session import (
 )
 from livekit.protocol.agent_pb import agent_session as agent_pb
 
+pytestmark = pytest.mark.unit
+
 # ---------------------------------------------------------------------------
 # In-memory transport for testing
 # ---------------------------------------------------------------------------

--- a/tests/test_speaker_id_grouping.py
+++ b/tests/test_speaker_id_grouping.py
@@ -7,7 +7,11 @@ format `[SPEAKER_ID]TEXT[/SPEAKER_ID]` for testing.
 
 import re
 
+import pytest
+
 from livekit.agents import LanguageCode, stt
+
+pytestmark = pytest.mark.unit
 
 
 class TestSpeakerIdGrouping:
@@ -61,6 +65,11 @@ class TestSpeakerIdGrouping:
         result = self._process_fragments(fragments)
         assert result == "[S1]In making reservations.[/S1]"
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="trailing whitespace in fragment text is not stripped before wrapping; "
+        "expectation and code disagree (see AGT speaker-id grouping)",
+    )
     def test_two_speakers_simple_alternation(self):
         """Test simple alternation between two speakers."""
         fragments = [
@@ -92,6 +101,11 @@ class TestSpeakerIdGrouping:
             "[S3]Nine[/S3]"
         )
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="_process_fragments calls re.match() on a None speaker_id -> TypeError; "
+        "None is not guarded before the ignore-pattern check",
+    )
     def test_none_speaker_id(self):
         """Test handling fragments with None speaker_id."""
         fragments = [

--- a/tests/test_speaker_id_grouping.py
+++ b/tests/test_speaker_id_grouping.py
@@ -7,7 +7,11 @@ format `[SPEAKER_ID]TEXT[/SPEAKER_ID]` for testing.
 
 import re
 
+import pytest
+
 from livekit.agents import LanguageCode, stt
+
+pytestmark = pytest.mark.unit
 
 
 class TestSpeakerIdGrouping:

--- a/tests/test_speaker_id_grouping.py
+++ b/tests/test_speaker_id_grouping.py
@@ -18,6 +18,7 @@ class TestSpeakerIdGrouping:
     """Test cases for speaker ID grouping functionality."""
 
     def _format_text(self, text, speaker_id):
+        text = text.strip()
         if speaker_id:
             return f"[{speaker_id}]{text}[/{speaker_id}]"
         return text
@@ -27,7 +28,7 @@ class TestSpeakerIdGrouping:
         result = ""
         for text, speaker_id in fragments:
             # Skip speakers to ignore
-            if re.match(r"^__[A-Z0-9_]{2,}__$", speaker_id):
+            if speaker_id and re.match(r"^__[A-Z0-9_]{2,}__$", speaker_id):
                 continue
 
             # Create a SpeakerSpeechData object and get formatted text
@@ -65,10 +66,6 @@ class TestSpeakerIdGrouping:
         result = self._process_fragments(fragments)
         assert result == "[S1]In making reservations.[/S1]"
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="trailing whitespace in the fragment text is not stripped before wrapping",
-    )
     def test_two_speakers_simple_alternation(self):
         """Test simple alternation between two speakers."""
         fragments = [
@@ -100,10 +97,6 @@ class TestSpeakerIdGrouping:
             "[S3]Nine[/S3]"
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="_process_fragments runs re.match() on a None speaker_id -> TypeError",
-    )
     def test_none_speaker_id(self):
         """Test handling fragments with None speaker_id."""
         fragments = [

--- a/tests/test_speaker_id_grouping.py
+++ b/tests/test_speaker_id_grouping.py
@@ -7,11 +7,7 @@ format `[SPEAKER_ID]TEXT[/SPEAKER_ID]` for testing.
 
 import re
 
-import pytest
-
 from livekit.agents import LanguageCode, stt
-
-pytestmark = pytest.mark.unit
 
 
 class TestSpeakerIdGrouping:

--- a/tests/test_speaker_id_grouping.py
+++ b/tests/test_speaker_id_grouping.py
@@ -67,8 +67,7 @@ class TestSpeakerIdGrouping:
 
     @pytest.mark.xfail(
         strict=True,
-        reason="trailing whitespace in fragment text is not stripped before wrapping; "
-        "expectation and code disagree (see AGT speaker-id grouping)",
+        reason="trailing whitespace in the fragment text is not stripped before wrapping",
     )
     def test_two_speakers_simple_alternation(self):
         """Test simple alternation between two speakers."""
@@ -103,8 +102,7 @@ class TestSpeakerIdGrouping:
 
     @pytest.mark.xfail(
         strict=True,
-        reason="_process_fragments calls re.match() on a None speaker_id -> TypeError; "
-        "None is not guarded before the ignore-pattern check",
+        reason="_process_fragments runs re.match() on a None speaker_id -> TypeError",
     )
     def test_none_speaker_id(self):
         """Test handling fragments with None speaker_id."""

--- a/tests/test_speech_start_time_persistence.py
+++ b/tests/test_speech_start_time_persistence.py
@@ -29,6 +29,8 @@ import pytest
 from livekit.agents.vad import VADEvent, VADEventType
 from livekit.agents.voice.audio_recognition import AudioRecognition
 
+pytestmark = pytest.mark.unit
+
 
 class TestUserTurnStartPersistence:
     """Test cases for `AudioRecognition._user_turn_start` lifecycle."""

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -35,6 +35,8 @@ from livekit.plugins import (
 
 from .utils import make_test_speech, wer
 
+pytestmark = pytest.mark.stt
+
 SAMPLE_RATE = 24000
 WER_THRESHOLD = 0.25
 MAX_RETRIES = 2

--- a/tests/test_stt_base.py
+++ b/tests/test_stt_base.py
@@ -19,6 +19,8 @@ from livekit.agents.stt import (
 from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS
 from livekit.agents.utils.audio import AudioBuffer
 
+pytestmark = pytest.mark.unit
+
 
 class _DummyStream(RecognizeStream):
     """Minimal RecognizeStream for unit tests — does not hit the network."""

--- a/tests/test_stt_fallback.py
+++ b/tests/test_stt_fallback.py
@@ -20,6 +20,8 @@ from livekit.agents.utils.audio import AudioBuffer
 
 from .fake_stt import FakeSTT
 
+pytestmark = pytest.mark.unit
+
 
 class FallbackAdapterTester(FallbackAdapter):
     def __init__(

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -5,6 +5,8 @@ from livekit.agents.tokenize import basic, blingfire
 from livekit.agents.tokenize._basic_paragraph import split_paragraphs
 from livekit.plugins import nltk
 
+pytestmark = pytest.mark.unit
+
 # Download the punkt tokenizer, will only download if not already present
 nltk.NltkPlugin().download_files()
 

--- a/tests/test_tool_proxy.py
+++ b/tests/test_tool_proxy.py
@@ -6,6 +6,8 @@ import pytest
 from livekit.agents.beta.toolsets.tool_proxy import ToolProxyToolset
 from livekit.agents.llm import ToolContext, ToolError, Toolset, function_tool
 
+pytestmark = pytest.mark.unit
+
 
 @function_tool
 async def weather_tool(city: str) -> str:

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -10,6 +10,8 @@ from livekit.agents.beta.toolsets.tool_search import (
 )
 from livekit.agents.llm import Tool, ToolContext, Toolset, function_tool
 
+pytestmark = pytest.mark.unit
+
 
 @function_tool
 async def weather_tool(city: str) -> str:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -15,6 +15,8 @@ from livekit.agents.llm.utils import (
     prepare_function_arguments,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class MockOption(str, enum.Enum):
     A = "a"

--- a/tests/test_transcription_filter.py
+++ b/tests/test_transcription_filter.py
@@ -3,6 +3,8 @@ import pytest
 from livekit.agents.voice.transcription.filters import filter_emoji, filter_markdown
 from livekit.agents.voice.transcription.text_transforms import _apply_text_transforms, replace
 
+pytestmark = pytest.mark.unit
+
 MARKDOWN_INPUT = """# Mathematics and Markdown Guide
 
 Hi there~~ How are you?  # the ~~ shouldn't be removed.

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -42,6 +42,8 @@ from .fake_tts import FakeTTS
 from .toxic_proxy import Proxy, Toxiproxy
 from .utils import EventCollector, fake_llm_stream, wer
 
+pytestmark = pytest.mark.tts
+
 load_dotenv(override=True)
 
 

--- a/tests/test_tts_fallback.py
+++ b/tests/test_tts_fallback.py
@@ -13,6 +13,8 @@ from livekit.agents.utils.aio.channel import ChanEmpty
 
 from .fake_tts import FakeTTS
 
+pytestmark = pytest.mark.unit
+
 
 class FallbackAdapterTester(FallbackAdapter):
     def __init__(

--- a/tests/test_user_turn_exceeded.py
+++ b/tests/test_user_turn_exceeded.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
+
 from livekit.agents import Agent, UserTurnExceededEvent
 from livekit.agents.voice.transcription.synchronizer import _SyncedAudioOutput
 
 from .fake_session import FakeActions, create_session, run_session
+
+pytestmark = pytest.mark.unit
 
 SESSION_TIMEOUT = 30
 

--- a/tests/test_utils/test_audio_array_buffer.py
+++ b/tests/test_utils/test_audio_array_buffer.py
@@ -6,6 +6,8 @@ import pytest
 from livekit import rtc
 from livekit.agents.utils.audio import AudioArrayBuffer
 
+pytestmark = pytest.mark.unit
+
 
 def _frame(samples: list[int], *, sr: int = 16000, ch: int = 1) -> rtc.AudioFrame:
     data = np.array(samples, dtype=np.int16).tobytes()

--- a/tests/test_utils/test_bounded_dict.py
+++ b/tests/test_utils/test_bounded_dict.py
@@ -4,6 +4,8 @@ import pytest
 
 from livekit.agents.utils.bounded_dict import BoundedDict
 
+pytestmark = pytest.mark.unit
+
 
 @dataclass
 class _Item:

--- a/tests/test_vad.py
+++ b/tests/test_vad.py
@@ -7,7 +7,7 @@ from livekit.plugins import silero
 
 from . import utils
 
-# needs the silero ONNX model (loaded at import), so it is not a hermetic unit test
+# loads the silero ONNX model at import
 pytestmark = pytest.mark.plugin("silero")
 
 SAMPLE_RATES = [16000, 44100]  # test multiple input sample rates

--- a/tests/test_vad.py
+++ b/tests/test_vad.py
@@ -7,6 +7,8 @@ from livekit.plugins import silero
 
 from . import utils
 
+pytestmark = pytest.mark.unit
+
 SAMPLE_RATES = [16000, 44100]  # test multiple input sample rates
 
 

--- a/tests/test_vad.py
+++ b/tests/test_vad.py
@@ -7,7 +7,8 @@ from livekit.plugins import silero
 
 from . import utils
 
-pytestmark = pytest.mark.unit
+# needs the silero ONNX model (loaded at import), so it is not a hermetic unit test
+pytestmark = pytest.mark.plugin("silero")
 
 SAMPLE_RATES = [16000, 44100]  # test multiple input sample rates
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -8,6 +8,8 @@ from livekit.agents.llm.tool_context import ToolError
 from livekit.agents.voice.run_result import RunResult
 from livekit.rtc import Room
 
+pytestmark = pytest.mark.evals
+
 
 def _llm_model() -> llm.LLM:
     return inference.LLM(model="openai/gpt-4.1")


### PR DESCRIPTION
### TL;DR: Add explicit source of truth for tests categorization and unified selection

Select and run tests as
```bash
uv run pytest --unit 
uv run pytest --realtime
uv run pytest --plugin openai
```
Categorize new test modules via 
```python
import pytest
...
pytestmark = pytest.mark.unit  # or pytest.mark.plugin("provider-name")
```

### Motivation
Currently there is no clear indication of which tests to run where and how. `./makefile` has a manually maintained list of unit-tests modules to run: all new modules must be added in order to be tested in CI, but nothing keeps this in check. This leads to [stale/ignored tests](#stale-tests-section)

Plain `pytest ./tests` doesn't work on most environment, even with `-k` selection, as the collection will fail due to missing dependencies. 

This PR fixes both problems by defining single source of truth and mechanism for tests isolation.

### Changes
- Add `pytestmark = pytest.mark.<category>` to existing modules
- Add `pytest --<category>` flags that runs tests of that category (with dependencies isolation)
- Add [`pytest --list-categories`](#list-categories-output) arg that lists all modules and their categories
- Require categorizing future tests to prevent orphaned tests (can be temporarily disabled via `--allow-uncategorized`)
- [Fix](https://github.com/livekit/agents/pull/5945/changes/b59db1d78afaade6c4ea77ae3961f6b919e8b4d1) broken tests in `test_audio_recognition_aclose.py` and `test_speaker_id_grouping.py`
- [Fix](https://github.com/livekit/agents/pull/5945/commits/efeab03cbe3fd2cdf79f89203abe173e1706e983) deadlock caused by `test_cli_log_level.py`

Categories and dependencies:
| Category | Needs |
|---|---|
| `--unit` | — |
| `--plugin [name]` | that provider's dependencies/keys |
| `--stt` / `--tts` | cross-provider STT/TTS suite + keys |
| `--realtime` | live realtime model + keys |
| `--evals` | LiveKit inference gateway |
| `--docs` | the `docs` dependency group |

### Notes

<details open>
<summary id="stale-tests-section">

#### Stale tests ignored in CI before this PR

</summary>

| # | Module| Tests | Note |
|---|------------|---------:|----------------|
| 1 | `test_audio_emitter.py` | 10 | |
| 2 | `test_audio_recognition_aclose.py` | 2 | fixed 1 broken test |
| 3 | `test_cli_log_level.py` | 25 | fixed deadlock when it's enabled|
| 4 | `test_drain_timeout.py` | 6 | |
| 5 | `test_interruption/test_interruption_failover.py` | 6 | |
| 6 | `test_nested_agent_task.py` | 1 | |
| 7 | `test_speaker_id_grouping.py` | 7 | fixed 2 broken tests |
| 8 | `test_speech_start_time_persistence.py` | 3 | |
| 9 | `test_stt_base.py` | 4 | |
| 10 | `test_user_turn_exceeded.py` | 9 | |

</details>

<details>
<summary id="list-categories-output">

#### `pytest --list-categories` output

</summary>

```
Test categories (select with --<category>):

  unit     45 modules
             - tests/test_agent_session.py
             - tests/test_aio.py
             - tests/test_aio_itertools.py
             - tests/test_amd_classifier.py
             - tests/test_audio_decoder.py
             - tests/test_audio_emitter.py
             - tests/test_audio_recognition_aclose.py
             - tests/test_audio_recognition_handoff.py
             - tests/test_audio_recognition_push_audio.py
             - tests/test_chat_ctx.py
             - tests/test_cli_log_level.py
             - tests/test_config.py
             - tests/test_connection_pool.py
             - tests/test_debounce.py
             - tests/test_drain_timeout.py
             - tests/test_endpointing.py
             - tests/test_google_thought_signatures.py
             - tests/test_http_context_helper.py
             - tests/test_inference_stt_fallback.py
             - tests/test_inference_tts_fallback.py
             - tests/test_interruption/test_interruption_failover.py
             - tests/test_interruption/test_overlapping_speech_event.py
             - tests/test_ipc.py
             - tests/test_ivr_activity.py
             - tests/test_langgraph.py
             - tests/test_language.py
             - tests/test_nested_agent_task.py
             - tests/test_recording.py
             - tests/test_room.py
             - tests/test_room_io.py
             - tests/test_schema_gemini.py
             - tests/test_session_host.py
             - tests/test_speaker_id_grouping.py
             - tests/test_speech_start_time_persistence.py
             - tests/test_stt_base.py
             - tests/test_stt_fallback.py
             - tests/test_tokenizer.py
             - tests/test_tool_proxy.py
             - tests/test_tool_search.py
             - tests/test_tools.py
             - tests/test_transcription_filter.py
             - tests/test_tts_fallback.py
             - tests/test_user_turn_exceeded.py
             - tests/test_utils/test_audio_array_buffer.py
             - tests/test_utils/test_bounded_dict.py
  plugin   15 modules
             - tests/test_personaplex_realtime_model.py
             - tests/test_plugin_anthropic.py
             - tests/test_plugin_assemblyai_stt.py
             - tests/test_plugin_cerebras.py
             - tests/test_plugin_elevenlabs_tts.py
             - tests/test_plugin_gnani_stt.py
             - tests/test_plugin_gnani_tts.py
             - tests/test_plugin_google_llm.py
             - tests/test_plugin_google_stt.py
             - tests/test_plugin_gradium_stt.py
             - tests/test_plugin_inworld_tts.py
             - tests/test_plugin_perplexity.py
             - tests/test_plugin_perplexity_responses.py
             - tests/test_plugin_soniox_stt.py
             - tests/test_vad.py
  realtime 1 module
             - tests/test_realtime/test_realtime.py
  stt      1 module
             - tests/test_stt.py
  tts      1 module
             - tests/test_tts.py
  evals    2 modules
             - tests/test_evals.py
             - tests/test_workflows.py
  docs     1 module
             - tests/test_convert_html_docs.py
```
</details>

<details>
<summary>

#### New `### Testing` section in AGENTS.md (authored by Claude)

</summary>

### Testing
```bash
uv run pytest tests/test_tools.py                  # Run a single test file
uv run pytest tests/test_tools.py -k "test_name"   # Run specific test
uv run pytest --unit                               # Run unit tests that don't require cloud accounts
```

#### Test categories

Every test module declares exactly one category via a module-level marker, and
each category has a matching `--<category>` selection flag. Selection happens
*before* import, so a category run never imports (or fails on) modules outside
it.

| Marker | Flag | Meaning |
|--------|------|---------|
| `pytest.mark.unit` | `--unit` | fast, hermetic, no external providers/credentials/network |
| `pytest.mark.plugin("name")` | `--plugin [name]` | provider integration test (needs that provider's deps/keys) |
| `pytest.mark.stt` | `--stt` | cross-provider speech-to-text suite (`tests/test_stt.py`) |
| `pytest.mark.tts` | `--tts` | cross-provider text-to-speech suite (`tests/test_tts.py`) |
| `pytest.mark.realtime("name")` | `--realtime [name]` | realtime-model test |
| `pytest.mark.evals` | `--evals` | behavioral evals against the LiveKit inference gateway |
| `pytest.mark.docs` | `--docs` | tests for the docs-build tooling under `.github/` |

```bash
uv run pytest --unit                    # the CI unit gate (no cloud accounts)
uv run pytest --plugin openai           # only the openai provider tests
uv run pytest --list-categories         # list every module grouped by category, then exit
```

**Adding a test:** give the new module a category marker (`pytestmark =
pytest.mark.unit`, etc.) — collection fails with a hint if it lacks one. Run
pytest with the `--allow-uncategorized` option to temporarily disable this rule
(CI keeps it on by default).

</details>

2 STT failures seem to be unrelated to the changes.
