### PR TITLE
fix(openai): skip empty messages in realtime chat updates

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1249,7 +1249,6 @@ class RealtimeSession(
     async def update_chat_ctx(self, chat_ctx: llm.ChatContext) -> None:
         async with self._update_chat_ctx_lock:
             chat_ctx = chat_ctx.copy(
-                exclude_empty_message=True,
                 exclude_handoff=True,
                 exclude_config_update=True,
             )
@@ -1280,6 +1279,20 @@ class RealtimeSession(
     ) -> list[ConversationItemCreateEvent | ConversationItemDeleteEvent]:
         events: list[ConversationItemCreateEvent | ConversationItemDeleteEvent] = []
         remote_ctx = self._remote_chat_ctx.to_chat_ctx()
+
+        # Empty message content can mean either:
+        # - a local placeholder that should not be created remotely, or
+        # - an existing remote item with non-text content (audio/images) that is not
+        #   synced into the agent-side ChatContext.
+        # Keep empty messages that already exist remotely so we do not delete them.
+        remote_ids = {item.id for item in remote_ctx.items}
+        chat_ctx = llm.ChatContext(
+            [
+                item
+                for item in chat_ctx.items
+                if item.type != "message" or item.content or item.id in remote_ids
+            ]
+        )
         diff_ops = llm.utils.compute_chat_ctx_diff(remote_ctx, chat_ctx)
 
         def _delete_item(msg_id: str) -> None:

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1249,6 +1249,7 @@ class RealtimeSession(
     async def update_chat_ctx(self, chat_ctx: llm.ChatContext) -> None:
         async with self._update_chat_ctx_lock:
             chat_ctx = chat_ctx.copy(
+                exclude_empty_message=True,
                 exclude_handoff=True,
                 exclude_config_update=True,
             )

--- a/tests/test_openai_realtime_chat_ctx.py
+++ b/tests/test_openai_realtime_chat_ctx.py
@@ -1,9 +1,13 @@
 import asyncio
 import types
 
+import pytest
+
 from livekit.agents import llm
 from livekit.agents.llm import remote_chat_context
 from livekit.plugins.openai.realtime.realtime_model import RealtimeSession
+
+pytestmark = pytest.mark.unit
 
 
 def _create_session() -> RealtimeSession:

--- a/tests/test_openai_realtime_chat_ctx.py
+++ b/tests/test_openai_realtime_chat_ctx.py
@@ -6,25 +6,43 @@ from livekit.agents.llm import remote_chat_context
 from livekit.plugins.openai.realtime.realtime_model import RealtimeSession
 
 
-async def test_update_chat_ctx_filters_empty_messages() -> None:
+def _create_session() -> RealtimeSession:
     session = RealtimeSession.__new__(RealtimeSession)
     session._update_chat_ctx_lock = asyncio.Lock()
     session._remote_chat_ctx = remote_chat_context.RemoteChatContext()
     session._item_delete_future = {}
     session._item_create_future = {}
-    sent_events = []
+    session._sent_events = []
 
     def send_event(self: RealtimeSession, event: object) -> None:
-        sent_events.append(event)
+        self._sent_events.append(event)
         item = getattr(event, "item", None)
         if item is not None and item.id in self._item_create_future:
             self._item_create_future[item.id].set_result(None)
 
     session.send_event = types.MethodType(send_event, session)
+    return session
+
+
+async def test_update_chat_ctx_filters_new_empty_messages() -> None:
+    session = _create_session()
 
     chat_ctx = llm.ChatContext.empty()
     chat_ctx.add_message(role="user", content=[], id="empty-message")
 
     await session.update_chat_ctx(chat_ctx)
 
-    assert sent_events == []
+    assert session._sent_events == []
+
+
+async def test_update_chat_ctx_keeps_existing_remote_empty_messages() -> None:
+    session = _create_session()
+    remote_message = llm.ChatMessage(role="user", content=[], id="remote-empty-message")
+    session._remote_chat_ctx.insert(None, remote_message)
+
+    chat_ctx = llm.ChatContext.empty()
+    chat_ctx.items.append(remote_message)
+
+    await session.update_chat_ctx(chat_ctx)
+
+    assert session._sent_events == []

--- a/tests/test_openai_realtime_chat_ctx.py
+++ b/tests/test_openai_realtime_chat_ctx.py
@@ -1,0 +1,30 @@
+import asyncio
+import types
+
+from livekit.agents import llm
+from livekit.agents.llm import remote_chat_context
+from livekit.plugins.openai.realtime.realtime_model import RealtimeSession
+
+
+async def test_update_chat_ctx_filters_empty_messages() -> None:
+    session = RealtimeSession.__new__(RealtimeSession)
+    session._update_chat_ctx_lock = asyncio.Lock()
+    session._remote_chat_ctx = remote_chat_context.RemoteChatContext()
+    session._item_delete_future = {}
+    session._item_create_future = {}
+    sent_events = []
+
+    def send_event(self: RealtimeSession, event: object) -> None:
+        sent_events.append(event)
+        item = getattr(event, "item", None)
+        if item is not None and item.id in self._item_create_future:
+            self._item_create_future[item.id].set_result(None)
+
+    session.send_event = types.MethodType(send_event, session)
+
+    chat_ctx = llm.ChatContext.empty()
+    chat_ctx.add_message(role="user", content=[], id="empty-message")
+
+    await session.update_chat_ctx(chat_ctx)
+
+    assert sent_events == []


### PR DESCRIPTION
Fixes #5951

## Summary
- filter empty chat messages before generating OpenAI Realtime chat context update events
- add a regression test covering update_chat_ctx with an empty message

## Tests
- uv run --group dev pytest tests/test_openai_realtime_chat_ctx.py -q
- uv run --group dev ruff check livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py tests/test_openai_realtime_chat_ctx.py