### PR TITLE
feat(smallestai): word_timestamps for TTS, v4 STT endpoints, eou_timeout fix

### DIFF
--- a/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/stt.py
+++ b/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/stt.py
@@ -96,7 +96,7 @@ class _STTOptions:
     encoding: STTEncoding | str
     word_timestamps: bool
     diarize: bool
-    eou_timeout_ms: int  # end-of-utterance silence timeout (100–10 000 ms)
+    eou_timeout_ms: int  # end-of-utterance silence timeout in ms; valid range 100–10000ms
     base_url: str
 
 
@@ -110,7 +110,7 @@ class STT(stt.STT):
         encoding: STTEncoding | str = "linear16",
         word_timestamps: bool = True,
         diarize: bool = False,
-        eou_timeout_ms: int = 0,
+        eou_timeout_ms: int = 100,
         api_key: str | None = None,
         http_session: aiohttp.ClientSession | None = None,
         base_url: str = SMALLEST_STT_BASE_URL,
@@ -137,11 +137,12 @@ class STT(stt.STT):
                 speaker ID (integer during streaming, string label in batch).
                 Defaults to False.
             eou_timeout_ms: Milliseconds of silence before the server considers an
-                utterance complete and emits a final transcript. Defaults to 0 (disabled).
-                The server's native default when this parameter is omitted is 800ms —
-                the plugin sends 0 explicitly to disable it, since LiveKit's VAD handles
-                turn detection. Set to a value between 100 and 10000 to enable
-                server-side end-of-utterance detection alongside LiveKit's own logic.
+                utterance complete and emits a final transcript. Must be between 100 and
+                10000ms. Defaults to 100ms (the minimum) so that server-side EOU adds
+                minimal latency alongside LiveKit's own end-of-turn detection. If omitted,
+                the server applies an 800ms default. Note: the Smallest AI API will soon
+                support disabling server-side EOU entirely, which will allow LiveKit's
+                end-of-turn detection to be used exclusively.
             api_key: Smallest AI API key. Falls back to the SMALLEST_API_KEY
                 environment variable if not provided.
             http_session: An existing aiohttp ClientSession to reuse.
@@ -452,9 +453,6 @@ class SpeechStream(stt.SpeechStream):
             "word_timestamps": str(self._opts.word_timestamps).lower(),
             "diarize": str(self._opts.diarize).lower(),
         }
-        # Always send eou_timeout_ms. Default is 0 (disabled) so LiveKit's own
-        # VAD controls turn detection. The server's native default when this
-        # parameter is omitted is 800ms, which would conflict with LiveKit VAD.
         params["eou_timeout_ms"] = self._opts.eou_timeout_ms
         ws_url = (
             self._opts.base_url.replace("https://", "wss://", 1).replace("http://", "ws://", 1)

--- a/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/stt.py
+++ b/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/stt.py
@@ -51,6 +51,10 @@ NUM_CHANNELS = 1
 # Batch:     https://api.smallest.ai/waves/v1/stt/?model={model}
 SMALLEST_STT_BASE_URL = "https://api.smallest.ai/waves/v1"
 
+# Models that support real-time streaming. All others are batch-only and will be
+# wrapped with a StreamAdapter by the agent framework automatically.
+_STREAMING_MODELS: frozenset[str] = frozenset({"pulse"})
+
 # ---------------------------------------------------------------------------
 # Minimal PeriodicCollector — same logic as livekit-plugins-deepgram/_utils.py
 # ---------------------------------------------------------------------------
@@ -145,7 +149,7 @@ class STT(stt.STT):
         """
         super().__init__(
             capabilities=stt.STTCapabilities(
-                streaming=True,
+                streaming=model in _STREAMING_MODELS,
                 interim_results=True,
                 diarization=diarize,
                 aligned_transcript="word" if word_timestamps else False,
@@ -242,9 +246,9 @@ class STT(stt.STT):
         language: NotGivenOr[str] = NOT_GIVEN,
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
     ) -> SpeechStream:
-        if self._opts.model == "pulse-pro":
+        if not self.capabilities.streaming:
             raise ValueError(
-                "pulse-pro does not support streaming; use recognize() for batch transcription"
+                f"{self._opts.model} does not support streaming; use recognize() for batch transcription"
             )
         config = self._sanitize_options(language=language)
         stream = SpeechStream(

--- a/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/stt.py
+++ b/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/stt.py
@@ -272,6 +272,7 @@ class STT(stt.STT):
         """Update STT options; propagates to all active streams (triggers reconnect)."""
         if is_given(model):
             self._opts.model = model
+            self._capabilities.streaming = model in _STREAMING_MODELS
         if is_given(language):
             self._opts.language = language
         if is_given(sample_rate):

--- a/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/stt.py
+++ b/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/stt.py
@@ -47,8 +47,8 @@ from .version import __version__
 
 NUM_CHANNELS = 1
 # Base URL for the Smallest AI API.
-# Streaming: wss://api.smallest.ai/waves/v1/{model}/get_text
-# Batch:     https://api.smallest.ai/waves/v1/{model}/get_text
+# Streaming: wss://api.smallest.ai/waves/v1/stt/live?model={model}
+# Batch:     https://api.smallest.ai/waves/v1/stt/?model={model}
 SMALLEST_STT_BASE_URL = "https://api.smallest.ai/waves/v1"
 
 # ---------------------------------------------------------------------------
@@ -111,20 +111,27 @@ class STT(stt.STT):
         http_session: aiohttp.ClientSession | None = None,
         base_url: str = SMALLEST_STT_BASE_URL,
     ) -> None:
-        """Create a new instance of Smallest AI Pulse STT.
+        """Create a new instance of Smallest AI STT.
 
         Args:
-            model: STT model to use. Currently only "pulse" is available.
+            model: STT model to use. ``"pulse"`` supports streaming and batch
+                transcription across 38 languages. ``"pulse-pro"`` is a
+                higher-accuracy English-only model available for batch
+                (pre-recorded) transcription only — calling ``stream()`` with
+                ``pulse-pro`` raises ``ValueError``.
             language: BCP-47 language code (e.g. "en", "hi", "fr"). Use "multi"
                 for automatic language detection across 39 supported languages.
+                ``pulse-pro`` only supports ``"en"``.
             sample_rate: Audio sample rate in Hz. Supported: 8000, 16000, 22050,
                 24000, 44100, 48000. Defaults to 16000.
             encoding: PCM encoding of the audio stream. Use "linear16" for raw
                 16-bit PCM (the default and most compatible choice for streaming).
             word_timestamps: Include per-word start/end timestamps and confidence
-                scores in transcripts. Defaults to True.
+                scores in transcripts. Supported by both ``pulse`` and
+                ``pulse-pro``. Defaults to True.
             diarize: Enable speaker diarization. When True, each word includes a
-                speaker ID (integer during streaming). Defaults to False.
+                speaker ID (integer during streaming, string label in batch).
+                Defaults to False.
             eou_timeout_ms: Milliseconds of silence before the server considers an
                 utterance complete and emits a final transcript. Set to 0 to disable
                 server-side end-of-utterance detection, which is recommended when using
@@ -186,6 +193,7 @@ class STT(stt.STT):
     ) -> stt.SpeechEvent:
         config = self._sanitize_options(language=language)
         params: dict[str, Any] = {
+            "model": config.model,
             "language": config.language,
             "encoding": config.encoding,
             "sample_rate": config.sample_rate,
@@ -195,7 +203,7 @@ class STT(stt.STT):
 
         try:
             async with self._ensure_session().post(
-                url=f"{config.base_url}/{config.model}/get_text",
+                url=f"{config.base_url}/stt/",
                 headers={
                     "Authorization": f"Bearer {config.api_key}",
                     "Content-Type": "application/octet-stream",
@@ -232,6 +240,10 @@ class STT(stt.STT):
         language: NotGivenOr[str] = NOT_GIVEN,
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
     ) -> SpeechStream:
+        if self._opts.model == "pulse-pro":
+            raise ValueError(
+                "pulse-pro does not support streaming; use recognize() for batch transcription"
+            )
         config = self._sanitize_options(language=language)
         stream = SpeechStream(
             stt=self,
@@ -426,6 +438,7 @@ class SpeechStream(stt.SpeechStream):
 
     async def _connect_ws(self) -> aiohttp.ClientWebSocketResponse:
         params: dict[str, Any] = {
+            "model": self._opts.model,
             "language": self._opts.language,
             "encoding": self._opts.encoding,
             "sample_rate": self._opts.sample_rate,
@@ -440,7 +453,7 @@ class SpeechStream(stt.SpeechStream):
             params["eou_timeout_ms"] = self._opts.eou_timeout_ms
         ws_url = (
             self._opts.base_url.replace("https://", "wss://", 1).replace("http://", "ws://", 1)
-            + f"/{self._opts.model}/get_text"
+            + "/stt/live"
             + f"?{urlencode(params)}"
         )
 

--- a/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/stt.py
+++ b/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/stt.py
@@ -133,9 +133,11 @@ class STT(stt.STT):
                 speaker ID (integer during streaming, string label in batch).
                 Defaults to False.
             eou_timeout_ms: Milliseconds of silence before the server considers an
-                utterance complete and emits a final transcript. Set to 0 to disable
-                server-side end-of-utterance detection, which is recommended when using
-                LiveKit's built-in turn detection to minimise latency. Defaults to 0.
+                utterance complete and emits a final transcript. Defaults to 0 (disabled).
+                The server's native default when this parameter is omitted is 800ms —
+                the plugin sends 0 explicitly to disable it, since LiveKit's VAD handles
+                turn detection. Set to a value between 100 and 10000 to enable
+                server-side end-of-utterance detection alongside LiveKit's own logic.
             api_key: Smallest AI API key. Falls back to the SMALLEST_API_KEY
                 environment variable if not provided.
             http_session: An existing aiohttp ClientSession to reuse.
@@ -445,12 +447,10 @@ class SpeechStream(stt.SpeechStream):
             "word_timestamps": str(self._opts.word_timestamps).lower(),
             "diarize": str(self._opts.diarize).lower(),
         }
-        # Only send eou_timeout_ms when explicitly set (non-zero).
-        # When 0, omit the parameter and let the server use its default,
-        # which avoids adding server-side silence latency on top of LiveKit's
-        # own end-of-turn detection.
-        if self._opts.eou_timeout_ms > 0:
-            params["eou_timeout_ms"] = self._opts.eou_timeout_ms
+        # Always send eou_timeout_ms. Default is 0 (disabled) so LiveKit's own
+        # VAD controls turn detection. The server's native default when this
+        # parameter is omitted is 800ms, which would conflict with LiveKit VAD.
+        params["eou_timeout_ms"] = self._opts.eou_timeout_ms
         ws_url = (
             self._opts.base_url.replace("https://", "wss://", 1).replace("http://", "ws://", 1)
             + "/stt/live"

--- a/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/tts.py
+++ b/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/tts.py
@@ -196,6 +196,7 @@ class TTS(tts.TTS):
             self._opts.output_format = output_format
         if is_given(word_timestamps):
             self._opts.word_timestamps = word_timestamps
+            self._capabilities.aligned_transcript = word_timestamps
 
     def synthesize(
         self,

--- a/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/tts.py
+++ b/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/tts.py
@@ -94,9 +94,10 @@ class TTS(tts.TTS):
             output_format: Output format for HTTP synthesize() calls ("pcm", "mp3", "wav",
                 "ulaw", "alaw"). WebSocket streaming always returns PCM.
             word_timestamps: Request per-word timing events from the server and emit them
-                as timed transcript entries alongside audio. Disabled by default. Supported
-                on base-queue English + Hindi voices (meher, devansh, kartik, maithili,
-                liam, avery); other voices silently emit no word events.
+                as timed transcript entries alongside audio. Applies to WebSocket streaming
+                only; HTTP synthesize() returns raw audio without word events. Disabled by
+                default. Supported on base-queue English + Hindi voices (meher, devansh,
+                kartik, maithili, liam, avery); other voices silently emit no word events.
             base_url: Base URL for the Smallest AI HTTP API.
             ws_url: WebSocket URL for low-latency streaming synthesis.
             http_session: An existing aiohttp ClientSession to use.

--- a/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/tts.py
+++ b/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/tts.py
@@ -35,6 +35,7 @@ from livekit.agents import (
 )
 from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, NotGivenOr
 from livekit.agents.utils import is_given
+from livekit.agents.voice.io import TimedString
 
 from .models import TTSEncoding, TTSModels
 from .version import __version__
@@ -53,6 +54,7 @@ class _TTSOptions:
     speed: float
     language: LanguageCode
     output_format: TTSEncoding | str
+    word_timestamps: bool
     base_url: str
     ws_url: str
 
@@ -68,6 +70,7 @@ class TTS(tts.TTS):
         speed: float = 1.0,
         language: str = "en",
         output_format: TTSEncoding | str = "pcm",
+        word_timestamps: bool = True,
         base_url: str = SMALLEST_BASE_URL,
         ws_url: str = SMALLEST_WS_URL,
         http_session: aiohttp.ClientSession | None = None,
@@ -90,12 +93,20 @@ class TTS(tts.TTS):
                 detection and code-switching. Pro supports "en", "hi", and "auto" only.
             output_format: Output format for HTTP synthesize() calls ("pcm", "mp3", "wav",
                 "ulaw", "alaw"). WebSocket streaming always returns PCM.
+            word_timestamps: Request per-word timing events from the server and emit them
+                as timed transcript entries alongside audio. Enabled by default. Supported
+                on base-queue English + Hindi voices (meher, devansh, kartik, maithili,
+                liam, avery); other voices silently emit no word events so leaving this on
+                is safe regardless of voice.
             base_url: Base URL for the Smallest AI HTTP API.
             ws_url: WebSocket URL for low-latency streaming synthesis.
             http_session: An existing aiohttp ClientSession to use.
         """
         super().__init__(
-            capabilities=tts.TTSCapabilities(streaming=True),
+            capabilities=tts.TTSCapabilities(
+                streaming=True,
+                aligned_transcript=word_timestamps,
+            ),
             sample_rate=sample_rate,
             num_channels=NUM_CHANNELS,
         )
@@ -118,6 +129,7 @@ class TTS(tts.TTS):
             speed=speed,
             language=LanguageCode(language),
             output_format=output_format,
+            word_timestamps=word_timestamps,
             base_url=base_url,
             ws_url=ws_url,
         )
@@ -167,6 +179,7 @@ class TTS(tts.TTS):
         sample_rate: NotGivenOr[int] = NOT_GIVEN,
         language: NotGivenOr[str] = NOT_GIVEN,
         output_format: NotGivenOr[TTSEncoding | str] = NOT_GIVEN,
+        word_timestamps: NotGivenOr[bool] = NOT_GIVEN,
     ) -> None:
         """Update TTS options."""
         if is_given(model):
@@ -181,6 +194,8 @@ class TTS(tts.TTS):
             self._opts.language = LanguageCode(language)
         if is_given(output_format):
             self._opts.output_format = output_format
+        if is_given(word_timestamps):
+            self._opts.word_timestamps = word_timestamps
 
     def synthesize(
         self,
@@ -307,6 +322,9 @@ class SynthesizeStream(tts.SynthesizeStream):
             else self._opts.language,
         }
 
+        if self._opts.word_timestamps:
+            payload["word_timestamps"] = True
+
         async with self._tts._pool.connection(timeout=self._conn_options.timeout) as ws:
             self._acquire_time = self._tts._pool.last_acquire_time
             self._connection_reused = self._tts._pool.last_connection_reused
@@ -337,6 +355,15 @@ class SynthesizeStream(tts.SynthesizeStream):
                     audio_b64 = event.get("data", {}).get("audio")
                     if audio_b64:
                         output_emitter.push(base64.b64decode(audio_b64))
+                elif status == "word_timestamp":
+                    data = event.get("data", {})
+                    word = data.get("word")
+                    start = data.get("start")
+                    end = data.get("end")
+                    if word is not None and start is not None and end is not None:
+                        output_emitter.push_timed_transcript(
+                            TimedString(text=word, start_time=start, end_time=end)
+                        )
                 elif status == "complete":
                     output_emitter.end_segment()
                     break

--- a/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/tts.py
+++ b/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/tts.py
@@ -70,7 +70,7 @@ class TTS(tts.TTS):
         speed: float = 1.0,
         language: str = "en",
         output_format: TTSEncoding | str = "pcm",
-        word_timestamps: bool = True,
+        word_timestamps: bool = False,
         base_url: str = SMALLEST_BASE_URL,
         ws_url: str = SMALLEST_WS_URL,
         http_session: aiohttp.ClientSession | None = None,
@@ -94,10 +94,9 @@ class TTS(tts.TTS):
             output_format: Output format for HTTP synthesize() calls ("pcm", "mp3", "wav",
                 "ulaw", "alaw"). WebSocket streaming always returns PCM.
             word_timestamps: Request per-word timing events from the server and emit them
-                as timed transcript entries alongside audio. Enabled by default. Supported
+                as timed transcript entries alongside audio. Disabled by default. Supported
                 on base-queue English + Hindi voices (meher, devansh, kartik, maithili,
-                liam, avery); other voices silently emit no word events so leaving this on
-                is safe regardless of voice.
+                liam, avery); other voices silently emit no word events.
             base_url: Base URL for the Smallest AI HTTP API.
             ws_url: WebSocket URL for low-latency streaming synthesis.
             http_session: An existing aiohttp ClientSession to use.


### PR DESCRIPTION
## Summary

Three improvements to the `livekit-plugins-smallestai` plugin:

### 1. Word-level timestamps for TTS (`smallestai.TTS`)

Adds opt-in `word_timestamps` parameter to the Smallest AI WebSocket TTS integration, matching the feature shipped in Lightning v3.1 and v3.1 Pro.

- New `word_timestamps: bool = False` constructor parameter
- Sets `aligned_transcript=word_timestamps` on `TTSCapabilities`
- Sends `word_timestamps: true` in the WebSocket payload when enabled
- Handles `word_timestamp` status events by calling `output_emitter.push_timed_transcript(TimedString(...))`
- Supported on base-queue English + Hindi voices (`meher`, `devansh`, `kartik`, `maithili`, `liam`, `avery`); other voices silently emit no word events

```python
tts = smallestai.TTS(
    word_timestamps=True,  # opt in to per-word timed transcript entries
)
```

### 2. STT endpoints updated to v4 API format (`smallestai.STT`)

The Smallest AI API moved from `/{model}/get_text` (path-based model) to model as a query parameter:

- Streaming: `wss://api.smallest.ai/waves/v1/stt/live?model=pulse`
- Batch: `https://api.smallest.ai/waves/v1/stt/?model=pulse`

### 3. Fix `eou_timeout_ms` bug (`smallestai.STT`)

The old `> 0` guard silently omitted `eou_timeout_ms` when set to `0`, causing the server to apply its **800ms default** EOU detection — which conflicts with LiveKit's own VAD-based turn detection.

The fix always sends `eou_timeout_ms`, so the default of `0` explicitly disables server-side EOU and lets LiveKit's VAD control turn detection entirely. Users who want server-side EOU can pass `100–10000`.

## Test plan

- [ ] Verify TTS word timestamps fire `push_timed_transcript` events for supported voices (`meher`, `devansh`, etc.)
- [ ] Verify unsupported voices work normally with `word_timestamps=True` (no errors, just no transcript events)
- [ ] Verify STT streaming connects successfully to new endpoint
- [ ] Verify STT batch transcription works with new endpoint
- [ ] Verify `eou_timeout_ms=0` disables server EOU (no server-triggered finals without LiveKit VAD triggering first)
- [ ] Verify `eou_timeout_ms=500` enables server EOU at 500ms