### PR TITLE
fix(ipc): rate-limit and contextualize high-memory warnings

### DIFF
--- a/livekit-agents/livekit/agents/ipc/inference_proc_executor.py
+++ b/livekit-agents/livekit/agents/ipc/inference_proc_executor.py
@@ -12,7 +12,7 @@ from ..log import logger
 from ..utils import aio, log_exceptions, shortuuid
 from . import channel, proto
 from .inference_proc_lazy_main import ProcStartArgs, proc_main
-from .supervised_proc import SupervisedProc
+from .supervised_proc import SupervisedProc, SupervisedProcKind
 
 
 class InferenceProcExecutor(SupervisedProc):
@@ -48,8 +48,8 @@ class InferenceProcExecutor(SupervisedProc):
         self._active_requests: dict[str, asyncio.Future[proto.InferenceResponse]] = {}
 
     @property
-    def process_kind(self) -> str:
-        return "inference process"
+    def process_kind(self) -> SupervisedProcKind:
+        return SupervisedProcKind.inference
 
     def _create_process(self, cch: socket.socket, log_cch: socket.socket) -> mp.Process:
         proc_args = ProcStartArgs(

--- a/livekit-agents/livekit/agents/ipc/inference_proc_executor.py
+++ b/livekit-agents/livekit/agents/ipc/inference_proc_executor.py
@@ -49,7 +49,7 @@ class InferenceProcExecutor(SupervisedProc):
 
     @property
     def process_kind(self) -> SupervisedProcKind:
-        return SupervisedProcKind.inference
+        return SupervisedProcKind.INFERENCE
 
     def _create_process(self, cch: socket.socket, log_cch: socket.socket) -> mp.Process:
         proc_args = ProcStartArgs(

--- a/livekit-agents/livekit/agents/ipc/inference_proc_executor.py
+++ b/livekit-agents/livekit/agents/ipc/inference_proc_executor.py
@@ -47,6 +47,10 @@ class InferenceProcExecutor(SupervisedProc):
         self._runners = runners
         self._active_requests: dict[str, asyncio.Future[proto.InferenceResponse]] = {}
 
+    @property
+    def process_kind(self) -> str:
+        return "inference process"
+
     def _create_process(self, cch: socket.socket, log_cch: socket.socket) -> mp.Process:
         proc_args = ProcStartArgs(
             log_cch=log_cch,

--- a/livekit-agents/livekit/agents/ipc/job_proc_executor.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_executor.py
@@ -69,7 +69,7 @@ class ProcJobExecutor(SupervisedProc):
 
     @property
     def process_kind(self) -> SupervisedProcKind:
-        return SupervisedProcKind.job
+        return SupervisedProcKind.JOB
 
     @property
     def status(self) -> JobStatus:

--- a/livekit-agents/livekit/agents/ipc/job_proc_executor.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_executor.py
@@ -16,7 +16,7 @@ from . import channel, proto
 from .inference_executor import InferenceExecutor
 from .job_executor import JobStatus
 from .job_proc_lazy_main import ProcStartArgs, proc_main
-from .supervised_proc import SupervisedProc
+from .supervised_proc import SupervisedProc, SupervisedProcKind
 
 
 class ProcJobExecutor(SupervisedProc):
@@ -68,8 +68,8 @@ class ProcJobExecutor(SupervisedProc):
         return self._id
 
     @property
-    def process_kind(self) -> str:
-        return "job process"
+    def process_kind(self) -> SupervisedProcKind:
+        return SupervisedProcKind.job
 
     @property
     def status(self) -> JobStatus:

--- a/livekit-agents/livekit/agents/ipc/job_proc_executor.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_executor.py
@@ -68,6 +68,10 @@ class ProcJobExecutor(SupervisedProc):
         return self._id
 
     @property
+    def process_kind(self) -> str:
+        return "job process"
+
+    @property
     def status(self) -> JobStatus:
         if self._job_status is None:
             raise RuntimeError("job status not available")

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -13,6 +13,7 @@ import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator
 from dataclasses import dataclass
+from enum import Enum
 from multiprocessing.context import BaseContext
 from types import FrameType
 from typing import Any
@@ -37,6 +38,14 @@ _MEMORY_WARN_COOLDOWN = 120.0
 # re-emit the warning before the cooldown elapses if usage grew by at least this much
 # since the last warning (so a genuine leak still surfaces promptly)
 _MEMORY_WARN_RESET_DELTA_MB = 50.0
+
+
+class SupervisedProcKind(str, Enum):
+    job = "job"
+    inference = "inference"
+
+    def __str__(self) -> str:
+        return self.value
 
 
 @contextlib.contextmanager
@@ -154,9 +163,8 @@ class SupervisedProc(ABC):
         return self._supervise_atask is not None
 
     @property
-    def process_kind(self) -> str:
-        """log label for this kind of process; subclasses override it."""
-        return "process"
+    @abstractmethod
+    def process_kind(self) -> SupervisedProcKind: ...
 
     @property
     def uptime(self) -> float:
@@ -554,7 +562,7 @@ class SupervisedProc(ABC):
 
                 if self._opts.memory_limit_mb > 0 and memory_mb > self._opts.memory_limit_mb:
                     logger.error(
-                        f"{self.process_kind} exceeded memory limit, killing it",
+                        f"{self.process_kind} process exceeded memory limit, killing it",
                         extra=self._memory_logging_extra(memory_mb),
                     )
                     await self._send_dump_signal()
@@ -568,7 +576,8 @@ class SupervisedProc(ABC):
                         # nothing is terminated, so say so to avoid alarming operators.
                         advisory = self._opts.memory_limit_mb <= 0
                         logger.warning(
-                            f"{self.process_kind} memory usage is above the warning threshold"
+                            f"{self.process_kind} process memory usage is above the"
+                            " warning threshold"
                             + (
                                 " (advisory only, the process will not be terminated)"
                                 if advisory

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -155,16 +155,12 @@ class SupervisedProc(ABC):
 
     @property
     def process_kind(self) -> str:
-        """human-readable label for this kind of process, used in log messages.
-
-        Subclasses override this (e.g. "job process", "inference process") so log
-        lines name the process accurately instead of guessing.
-        """
+        """log label for this kind of process; subclasses override it."""
         return "process"
 
     @property
     def uptime(self) -> float:
-        """seconds since the process was spawned, or 0.0 if it hasn't started yet"""
+        """seconds since spawn, 0.0 if not started yet."""
         if self._spawn_time is None:
             return 0.0
         return time.monotonic() - self._spawn_time
@@ -510,13 +506,8 @@ class SupervisedProc(ABC):
             await aio.cancel_and_wait(*tasks)
 
     def _should_emit_memory_warning(self, memory_mb: float, *, now: float) -> bool:
-        """Decide whether to emit a high-memory warning, applying the cooldown.
-
-        Returns True (and records this emission) when either the cooldown has elapsed
-        since the last warning, or usage grew by at least _MEMORY_WARN_RESET_DELTA_MB
-        since then. This keeps a process that lingers above the threshold from spamming
-        a warning on every sample while still surfacing real growth promptly.
-        """
+        """True (and records the emission) if the cooldown elapsed or usage grew
+        by _MEMORY_WARN_RESET_DELTA_MB since the last warning."""
         cooled_down = now - self._last_memory_warn_time >= _MEMORY_WARN_COOLDOWN
         grew = memory_mb - self._last_memory_warn_mb >= _MEMORY_WARN_RESET_DELTA_MB
         if cooled_down or grew:
@@ -526,15 +517,8 @@ class SupervisedProc(ABC):
         return False
 
     def _memory_logging_extra(self, memory_mb: float) -> dict[str, Any]:
-        """Build the diagnostic context shared by the memory warning/limit logs.
-
-        The extra fields are meant to answer "is this a process that started heavy,
-        or one whose usage grew over time?" without needing follow-up requests:
-          - uptime / has_running_job: distinguishes a freshly warmed process from one
-            that has been handling a job for a while
-          - baseline_memory_mb: RSS right after initialization (prewarm), before any job
-          - growth_memory_mb: how much the process has grown since that baseline
-        """
+        """Diagnostic context for the memory logs: tells a process that started
+        heavy from one that grew over time (uptime, baseline RSS, growth)."""
         extra: dict[str, Any] = {
             "memory_usage_mb": round(memory_mb, 1),
             "memory_warn_mb": self._opts.memory_warn_mb,

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -154,11 +154,20 @@ class SupervisedProc(ABC):
         return self._supervise_atask is not None
 
     @property
+    def process_kind(self) -> str:
+        """human-readable label for this kind of process, used in log messages.
+
+        Subclasses override this (e.g. "job process", "inference process") so log
+        lines name the process accurately instead of guessing.
+        """
+        return "process"
+
+    @property
     def uptime(self) -> float:
         """seconds since the process was spawned, or 0.0 if it hasn't started yet"""
         if self._spawn_time is None:
             return 0.0
-        return time.time() - self._spawn_time
+        return time.monotonic() - self._spawn_time
 
     async def start(self) -> None:
         """start the supervised process"""
@@ -217,7 +226,7 @@ class SupervisedProc(ABC):
             mp_cch.close()
 
             self._pid = self._proc.pid
-            self._spawn_time = time.time()
+            self._spawn_time = time.monotonic()
             self._join_fut = asyncio.Future[None]()
 
             def _sync_run() -> None:
@@ -561,7 +570,7 @@ class SupervisedProc(ABC):
 
                 if self._opts.memory_limit_mb > 0 and memory_mb > self._opts.memory_limit_mb:
                     logger.error(
-                        "process exceeded memory limit, killing process",
+                        f"{self.process_kind} exceeded memory limit, killing it",
                         extra=self._memory_logging_extra(memory_mb),
                     )
                     await self._send_dump_signal()
@@ -570,12 +579,12 @@ class SupervisedProc(ABC):
                     # rate-limit the warning: a process that lingers above the threshold
                     # would otherwise emit a warning on every sample (every few seconds).
                     # still re-emit early if usage jumped noticeably since the last warning.
-                    if self._should_emit_memory_warning(memory_mb, now=time.time()):
+                    if self._should_emit_memory_warning(memory_mb, now=time.monotonic()):
                         # when no hard limit is configured the warning is purely advisory:
                         # nothing is terminated, so say so to avoid alarming operators.
                         advisory = self._opts.memory_limit_mb <= 0
                         logger.warning(
-                            "job process memory usage is above the warning threshold"
+                            f"{self.process_kind} memory usage is above the warning threshold"
                             + (
                                 " (advisory only, the process will not be terminated)"
                                 if advisory

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -41,8 +41,8 @@ _MEMORY_WARN_RESET_DELTA_MB = 50.0
 
 
 class SupervisedProcKind(str, Enum):
-    job = "job"
-    inference = "inference"
+    JOB = "job"
+    INFERENCE = "inference"
 
     def __str__(self) -> str:
         return self.value

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -29,6 +29,15 @@ from .log_queue import LogQueueListener
 _mask_ctrl_c_refcount = 0
 _mask_ctrl_c_original: Callable[[int, FrameType | None], Any] | int | None = signal.SIG_DFL
 
+# how often the memory monitor samples the process RSS (seconds)
+_MEMORY_MONITOR_INTERVAL = 5.0
+# minimum delay between two "high memory usage" warnings for the same process, so a
+# process that sits above the threshold doesn't emit a warning on every sample
+_MEMORY_WARN_COOLDOWN = 120.0
+# re-emit the warning before the cooldown elapses if usage grew by at least this much
+# since the last warning (so a genuine leak still surfaces promptly)
+_MEMORY_WARN_RESET_DELTA_MB = 50.0
+
 
 @contextlib.contextmanager
 def _mask_ctrl_c() -> Generator[None, None, None]:
@@ -103,6 +112,12 @@ class SupervisedProc(ABC):
 
         self._exitcode: int | None = None
         self._pid: int | None = None
+        self._spawn_time: float | None = None
+
+        # memory monitoring state (see _memory_monitor_task)
+        self._memory_baseline_mb: float | None = None
+        self._last_memory_warn_time: float = 0.0
+        self._last_memory_warn_mb: float = 0.0
 
         self._supervise_atask: asyncio.Task[None] | None = None
         self._closing = False
@@ -137,6 +152,13 @@ class SupervisedProc(ABC):
     @property
     def started(self) -> bool:
         return self._supervise_atask is not None
+
+    @property
+    def uptime(self) -> float:
+        """seconds since the process was spawned, or 0.0 if it hasn't started yet"""
+        if self._spawn_time is None:
+            return 0.0
+        return time.time() - self._spawn_time
 
     async def start(self) -> None:
         """start the supervised process"""
@@ -195,6 +217,7 @@ class SupervisedProc(ABC):
             mp_cch.close()
 
             self._pid = self._proc.pid
+            self._spawn_time = time.time()
             self._join_fut = asyncio.Future[None]()
 
             def _sync_run() -> None:
@@ -477,13 +500,53 @@ class SupervisedProc(ABC):
         finally:
             await aio.cancel_and_wait(*tasks)
 
+    def _should_emit_memory_warning(self, memory_mb: float, *, now: float) -> bool:
+        """Decide whether to emit a high-memory warning, applying the cooldown.
+
+        Returns True (and records this emission) when either the cooldown has elapsed
+        since the last warning, or usage grew by at least _MEMORY_WARN_RESET_DELTA_MB
+        since then. This keeps a process that lingers above the threshold from spamming
+        a warning on every sample while still surfacing real growth promptly.
+        """
+        cooled_down = now - self._last_memory_warn_time >= _MEMORY_WARN_COOLDOWN
+        grew = memory_mb - self._last_memory_warn_mb >= _MEMORY_WARN_RESET_DELTA_MB
+        if cooled_down or grew:
+            self._last_memory_warn_time = now
+            self._last_memory_warn_mb = memory_mb
+            return True
+        return False
+
+    def _memory_logging_extra(self, memory_mb: float) -> dict[str, Any]:
+        """Build the diagnostic context shared by the memory warning/limit logs.
+
+        The extra fields are meant to answer "is this a process that started heavy,
+        or one whose usage grew over time?" without needing follow-up requests:
+          - uptime / has_running_job: distinguishes a freshly warmed process from one
+            that has been handling a job for a while
+          - baseline_memory_mb: RSS right after initialization (prewarm), before any job
+          - growth_memory_mb: how much the process has grown since that baseline
+        """
+        extra: dict[str, Any] = {
+            "memory_usage_mb": round(memory_mb, 1),
+            "memory_warn_mb": self._opts.memory_warn_mb,
+            "memory_limit_mb": self._opts.memory_limit_mb,
+            "uptime": round(self.uptime, 1),
+            # _running_job only exists on the job executor subclass, not the inference one
+            "has_running_job": getattr(self, "_running_job", None) is not None,
+        }
+        if self._memory_baseline_mb is not None:
+            extra["baseline_memory_mb"] = round(self._memory_baseline_mb, 1)
+            extra["growth_memory_mb"] = round(memory_mb - self._memory_baseline_mb, 1)
+        extra.update(self.logging_extra())
+        return extra
+
     @log_exceptions(logger=logger)
     async def _memory_monitor_task(self) -> None:
         """Monitor memory usage and kill the process if it exceeds the limit."""
         while not self._closing and not self._kill_sent:
             try:
                 if not self._pid:
-                    await asyncio.sleep(5)
+                    await asyncio.sleep(_MEMORY_MONITOR_INTERVAL)
                     continue
 
                 # get process memory info
@@ -491,27 +554,35 @@ class SupervisedProc(ABC):
                 memory_info = process.memory_info()
                 memory_mb = memory_info.rss / (1024 * 1024)  # Convert to MB
 
+                # the first sample (taken shortly after initialization) is treated as the
+                # post-prewarm baseline, so later samples can report growth since startup
+                if self._memory_baseline_mb is None:
+                    self._memory_baseline_mb = memory_mb
+
                 if self._opts.memory_limit_mb > 0 and memory_mb > self._opts.memory_limit_mb:
                     logger.error(
                         "process exceeded memory limit, killing process",
-                        extra={
-                            "memory_usage_mb": memory_mb,
-                            "memory_limit_mb": self._opts.memory_limit_mb,
-                            **self.logging_extra(),
-                        },
+                        extra=self._memory_logging_extra(memory_mb),
                     )
                     await self._send_dump_signal()
                     await self._send_kill_signal()
                 elif self._opts.memory_warn_mb > 0 and memory_mb > self._opts.memory_warn_mb:
-                    logger.warning(
-                        "process memory usage is high",
-                        extra={
-                            "memory_usage_mb": memory_mb,
-                            "memory_warn_mb": self._opts.memory_warn_mb,
-                            "memory_limit_mb": self._opts.memory_limit_mb,
-                            **self.logging_extra(),
-                        },
-                    )
+                    # rate-limit the warning: a process that lingers above the threshold
+                    # would otherwise emit a warning on every sample (every few seconds).
+                    # still re-emit early if usage jumped noticeably since the last warning.
+                    if self._should_emit_memory_warning(memory_mb, now=time.time()):
+                        # when no hard limit is configured the warning is purely advisory:
+                        # nothing is terminated, so say so to avoid alarming operators.
+                        advisory = self._opts.memory_limit_mb <= 0
+                        logger.warning(
+                            "job process memory usage is above the warning threshold"
+                            + (
+                                " (advisory only, the process will not be terminated)"
+                                if advisory
+                                else ""
+                            ),
+                            extra=self._memory_logging_extra(memory_mb),
+                        )
 
             except (psutil.NoSuchProcess, psutil.AccessDenied) as e:
                 if self._closing or self._kill_sent:
@@ -533,7 +604,7 @@ class SupervisedProc(ABC):
                     extra=self.logging_extra(),
                 )
 
-            await asyncio.sleep(5)  # check every 5 seconds
+            await asyncio.sleep(_MEMORY_MONITOR_INTERVAL)
 
     def logging_extra(self) -> dict[str, Any]:
         extra: dict[str, Any] = {

--- a/tests/test_drain_timeout.py
+++ b/tests/test_drain_timeout.py
@@ -40,7 +40,7 @@ def _make_server(drain_timeout: int = 1) -> AgentServer:
 class _DummySupervisedProc(SupervisedProc):
     @property
     def process_kind(self) -> SupervisedProcKind:
-        return SupervisedProcKind.job
+        return SupervisedProcKind.JOB
 
     def _create_process(self, cch: socket.socket, log_cch: socket.socket) -> mp.Process:
         raise NotImplementedError

--- a/tests/test_drain_timeout.py
+++ b/tests/test_drain_timeout.py
@@ -23,7 +23,7 @@ import pytest
 
 from livekit.agents.cli.cli import _ExitCli, _run_worker
 from livekit.agents.cli.proto import CliArgs
-from livekit.agents.ipc.supervised_proc import SupervisedProc
+from livekit.agents.ipc.supervised_proc import SupervisedProc, SupervisedProcKind
 from livekit.agents.utils import aio
 from livekit.agents.worker import AgentServer
 
@@ -38,6 +38,10 @@ def _make_server(drain_timeout: int = 1) -> AgentServer:
 
 
 class _DummySupervisedProc(SupervisedProc):
+    @property
+    def process_kind(self) -> SupervisedProcKind:
+        return SupervisedProcKind.job
+
     def _create_process(self, cch: socket.socket, log_cch: socket.socket) -> mp.Process:
         raise NotImplementedError
 

--- a/tests/test_supervised_proc_memory.py
+++ b/tests/test_supervised_proc_memory.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import asyncio
+import multiprocessing as mp
+import socket
+
+from livekit.agents.ipc.supervised_proc import (
+    _MEMORY_WARN_COOLDOWN,
+    _MEMORY_WARN_RESET_DELTA_MB,
+    SupervisedProc,
+)
+
+
+class _FakeProc(SupervisedProc):
+    """Minimal concrete SupervisedProc for testing the memory-warning bookkeeping.
+
+    The process is never actually started; we only exercise the pure helpers that
+    decide whether/what to log.
+    """
+
+    def _create_process(self, cch: socket.socket, log_cch: socket.socket):  # pragma: no cover
+        raise NotImplementedError
+
+    async def _main_task(self, ipc_ch):  # pragma: no cover
+        raise NotImplementedError
+
+
+def _make_proc(*, memory_warn_mb: float = 500, memory_limit_mb: float = 0) -> _FakeProc:
+    return _FakeProc(
+        initialize_timeout=10.0,
+        close_timeout=10.0,
+        memory_warn_mb=memory_warn_mb,
+        memory_limit_mb=memory_limit_mb,
+        ping_interval=2.5,
+        ping_timeout=60.0,
+        high_ping_threshold=0.5,
+        http_proxy=None,
+        mp_ctx=mp.get_context("spawn"),
+        loop=asyncio.get_event_loop(),
+    )
+
+
+async def test_memory_warning_is_rate_limited() -> None:
+    proc = _make_proc()
+
+    # first time over the threshold fires immediately
+    assert proc._should_emit_memory_warning(520.0, now=1000.0) is True
+    # a sample right after, still above the threshold, is suppressed
+    assert proc._should_emit_memory_warning(521.0, now=1005.0) is False
+    assert proc._should_emit_memory_warning(522.0, now=1010.0) is False
+    # once the cooldown elapses it fires again
+    assert proc._should_emit_memory_warning(522.0, now=1000.0 + _MEMORY_WARN_COOLDOWN + 1) is True
+
+
+async def test_memory_warning_reemits_on_significant_growth() -> None:
+    proc = _make_proc()
+
+    assert proc._should_emit_memory_warning(520.0, now=1000.0) is True
+    # well within the cooldown, but usage jumped: re-emit so a real leak surfaces
+    grown = 520.0 + _MEMORY_WARN_RESET_DELTA_MB + 1
+    assert proc._should_emit_memory_warning(grown, now=1005.0) is True
+
+
+async def test_memory_logging_extra_reports_baseline_and_growth() -> None:
+    proc = _make_proc()
+
+    # before a baseline is captured, only the basic fields are present
+    extra = proc._memory_logging_extra(520.0)
+    assert extra["memory_usage_mb"] == 520.0
+    assert extra["memory_warn_mb"] == 500
+    assert extra["has_running_job"] is False
+    assert "uptime" in extra
+    assert "baseline_memory_mb" not in extra
+
+    # once a baseline is set, growth-since-startup is reported
+    proc._memory_baseline_mb = 300.0
+    extra = proc._memory_logging_extra(520.0)
+    assert extra["baseline_memory_mb"] == 300.0
+    assert extra["growth_memory_mb"] == 220.0
+
+
+async def test_uptime_is_zero_before_start() -> None:
+    proc = _make_proc()
+    assert proc.uptime == 0.0

--- a/tests/test_supervised_proc_memory.py
+++ b/tests/test_supervised_proc_memory.py
@@ -10,6 +10,7 @@ from livekit.agents.ipc.supervised_proc import (
     _MEMORY_WARN_COOLDOWN,
     _MEMORY_WARN_RESET_DELTA_MB,
     SupervisedProc,
+    SupervisedProcKind,
 )
 
 pytestmark = pytest.mark.unit
@@ -21,6 +22,10 @@ class _FakeProc(SupervisedProc):
     The process is never actually started; we only exercise the pure helpers that
     decide whether/what to log.
     """
+
+    @property
+    def process_kind(self) -> SupervisedProcKind:
+        return SupervisedProcKind.job
 
     def _create_process(self, cch: socket.socket, log_cch: socket.socket):  # pragma: no cover
         raise NotImplementedError
@@ -88,7 +93,31 @@ async def test_uptime_is_zero_before_start() -> None:
     assert proc.uptime == 0.0
 
 
-async def test_base_process_kind_is_generic() -> None:
-    # subclasses override this (e.g. "job process" / "inference process")
-    proc = _make_proc()
-    assert proc.process_kind == "process"
+def test_process_kind_renders_as_plain_string() -> None:
+    # the log message interpolates `f"{self.process_kind} process …"`, so the enum
+    # must stringify to its value (not "SupervisedProcKind.job")
+    assert f"{SupervisedProcKind.job} process" == "job process"
+    assert f"{SupervisedProcKind.inference} process" == "inference process"
+
+
+def test_subclassing_without_process_kind_is_rejected() -> None:
+    class _MissingKind(SupervisedProc):
+        def _create_process(self, cch, log_cch):  # pragma: no cover
+            raise NotImplementedError
+
+        async def _main_task(self, ipc_ch):  # pragma: no cover
+            raise NotImplementedError
+
+    with pytest.raises(TypeError, match="process_kind"):
+        _MissingKind(
+            initialize_timeout=1.0,
+            close_timeout=1.0,
+            memory_warn_mb=0.0,
+            memory_limit_mb=0.0,
+            ping_interval=1.0,
+            ping_timeout=1.0,
+            high_ping_threshold=1.0,
+            http_proxy=None,
+            mp_ctx=mp.get_context("spawn"),
+            loop=asyncio.get_event_loop(),
+        )

--- a/tests/test_supervised_proc_memory.py
+++ b/tests/test_supervised_proc_memory.py
@@ -25,7 +25,7 @@ class _FakeProc(SupervisedProc):
 
     @property
     def process_kind(self) -> SupervisedProcKind:
-        return SupervisedProcKind.job
+        return SupervisedProcKind.JOB
 
     def _create_process(self, cch: socket.socket, log_cch: socket.socket):  # pragma: no cover
         raise NotImplementedError
@@ -95,9 +95,9 @@ async def test_uptime_is_zero_before_start() -> None:
 
 def test_process_kind_renders_as_plain_string() -> None:
     # the log message interpolates `f"{self.process_kind} process …"`, so the enum
-    # must stringify to its value (not "SupervisedProcKind.job")
-    assert f"{SupervisedProcKind.job} process" == "job process"
-    assert f"{SupervisedProcKind.inference} process" == "inference process"
+    # must stringify to its value (not "SupervisedProcKind.JOB")
+    assert f"{SupervisedProcKind.JOB} process" == "job process"
+    assert f"{SupervisedProcKind.INFERENCE} process" == "inference process"
 
 
 def test_subclassing_without_process_kind_is_rejected() -> None:

--- a/tests/test_supervised_proc_memory.py
+++ b/tests/test_supervised_proc_memory.py
@@ -4,11 +4,15 @@ import asyncio
 import multiprocessing as mp
 import socket
 
+import pytest
+
 from livekit.agents.ipc.supervised_proc import (
     _MEMORY_WARN_COOLDOWN,
     _MEMORY_WARN_RESET_DELTA_MB,
     SupervisedProc,
 )
+
+pytestmark = pytest.mark.unit
 
 
 class _FakeProc(SupervisedProc):

--- a/tests/test_supervised_proc_memory.py
+++ b/tests/test_supervised_proc_memory.py
@@ -82,3 +82,9 @@ async def test_memory_logging_extra_reports_baseline_and_growth() -> None:
 async def test_uptime_is_zero_before_start() -> None:
     proc = _make_proc()
     assert proc.uptime == 0.0
+
+
+async def test_base_process_kind_is_generic() -> None:
+    # subclasses override this (e.g. "job process" / "inference process")
+    proc = _make_proc()
+    assert proc.process_kind == "process"


### PR DESCRIPTION
## Changes
- **Rate-limit** the warning: at most once per `_MEMORY_WARN_COOLDOWN` (120s) per process, but re-emits early if usage grew by ≥`_MEMORY_WARN_RESET_DELTA_MB` (50MB) since the last warning, so real leaks still surface promptly.
- **Reword** the message and mark it advisory when no hard limit is configured.
- Add extra: `uptime`, `has_running_job`, `baseline_memory_mb`, `growth_memory_mb` (current − baseline).
- **`process_kind` property**: base = `"process"`, overridden to `"job process"` / `"inference process"`.

## Behavior
- No change to *when* a process is killed — the `memory_limit_mb` path is untouched except for richer log context. Warning thresholds and defaults unchanged.
- Log message string and `extra` keys change

## Testing
- New unit tests (`tests/test_supervised_proc_memory.py`): cooldown suppression, growth-based re-emit, baseline/growth reporting, default `process_kind`.