### PR TITLE
feat(job): expose single_peer_connection in JobContext.connect

### DIFF
--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -508,6 +508,7 @@ class JobContext:
         encryption: rtc.E2EEOptions | None = None,
         auto_subscribe: AutoSubscribe = AutoSubscribe.SUBSCRIBE_ALL,
         rtc_config: rtc.RtcConfiguration | None = None,
+        single_peer_connection: bool | None = None,
         # deprecated
         e2ee: rtc.E2EEOptions | None = None,
     ) -> None:
@@ -517,6 +518,7 @@ class JobContext:
             encryption: End-to-end encryption options. If provided, the Agent will utilize end-to-end encryption. Note: clients will also need to handle E2EE.
             auto_subscribe: Whether to automatically subscribe to tracks. Default is AutoSubscribe.SUBSCRIBE_ALL.
             rtc_config: Custom RTC configuration to use when connecting to the room.
+            single_peer_connection: Use a single peer connection for both publish and subscribe. When None, uses the default (False).
         """  # noqa: E501
         async with self._lock:
             if self._connected:
@@ -527,6 +529,7 @@ class JobContext:
                 encryption=encryption,
                 auto_subscribe=auto_subscribe == AutoSubscribe.SUBSCRIBE_ALL,
                 rtc_config=rtc_config,
+                single_peer_connection=single_peer_connection,
             )
 
             await self._room.connect(self._info.url, self._info.token, options=room_options)


### PR DESCRIPTION
## Summary

`rtc.RoomOptions` supports `single_peer_connection` (added to `livekit-rtc` in [python-sdks#576](https://github.com/livekit/python-sdks/pull/576), shipped in `rtc-v1.1.0`), but `JobContext.connect` builds its `RoomOptions` internally and only forwards `encryption`, `auto_subscribe`, and `rtc_config`. As a result there's no way to enable single peer connection mode from an agent short of bypassing `ctx.connect()` and calling `room.connect()` directly (and re-implementing `connect()`'s side effects).

This forwards `single_peer_connection` through `JobContext.connect` like the other connection options. Defaults to `None`, preserving current behavior (server default = dual peer connection, with graceful fallback).

```python
await ctx.connect(single_peer_connection=True)
```

## Notes

- `livekit-agents` already pins `livekit==1.1.8`, so the field is available.
- The sibling option `connect_timeout` (added in the same rtc PR) is also not exposed by `JobContext.connect`; happy to include it here too if preferred, but kept this PR focused on `single_peer_connection`.

## Test plan

- [ ] `make check` (ruff + typecheck) passes
- [ ] `await ctx.connect(single_peer_connection=True)` results in a single `RTCPeerConnection`

_Written by Claude Opus 4.8, using Cursor._

Made with [Cursor](https://cursor.com)