### PR TITLE
(examples deploy): fix lfs

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -27,6 +27,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref || github.ref }}
+          # Fetch Git-LFS assets (e.g. examples/drive-thru/bg_noise.mp3) so the
+          # real binaries — not pointer files — get uploaded as the build context
+          # and copied into the image via `COPY . .`. This checkout authenticates
+          # with GITHUB_TOKEN, so its LFS fetch is allowed (unlike pip's anonymous
+          # git clone). Without this the agent crashes at runtime decoding a
+          # 131-byte pointer as audio.
+          lfs: true
 
       - name: Install LiveKit CLI
         run: |


### PR DESCRIPTION
Problem

  Deployed examples crash at runtime when they use a Git-LFS-tracked asset that lives in the example directory. The drive-thru agent fails with:

  av.error.InvalidDataError: [Errno 1094995529] Invalid data found when processing input: '<none>'
    ... in livekit-agents/.../utils/codecs/decoder.py, _decode_loop -> av.open(...)

  Root cause

  examples/drive-thru/agent.py loads bg_noise.mp3 via BackgroundAudioPlayer, and *.mp3 is Git-LFS tracked. The deploy path is:

  1. actions/checkout runs without lfs: true → the workspace holds a 131-byte LFS pointer instead of the real MP3.
  2. lk agent deploy . uploads that example dir as the build context.
  3. The Dockerfile's COPY . . copies the pointer into the image.
  4. At runtime BackgroundAudioPlayer hands the 131-byte pointer text to the decoder, which calls av.open(..., format="mp3") → FFmpeg rejects it → InvalidDataError.

  This is distinct from the silero VAD onnx issue: that asset arrives via pip's git clone of the SDK (which can't fetch LFS anonymously, so it's kept on PyPI). bg_noise.mp3 instead
  arrives via the checkout workspace → COPY . ., so it has to be fixed at the checkout step.

  Fix

  Add lfs: true to the actions/checkout step. The checkout authenticates with GITHUB_TOKEN, so its LFS fetch is allowed (unlike pip's anonymous clone) and the real binaries are
  materialized before lk agent deploy uploads the build context.

  - uses: actions/checkout@...v6
    with:
      ref: ${{ inputs.ref || github.ref }}
      lfs: true

  Scope / notes

  - Fixes any example-local LFS asset, not just drive-thru.
  - Built-in livekit-agents/.../resources/*.ogg background clips are not covered here — they ship inside the git-installed SDK and would need a separate fix (e.g. publishing them in the
  wheel) if a deployed example uses a built-in clip.

  Testing

  - [ ] Manually dispatch Deploy Examples from this branch and confirm the drive-thru agent starts and plays background audio without the InvalidDataError.
