### PR TITLE
fix(google): merge timeout into caller-set http_options instead of replacing

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -476,9 +476,11 @@ class LLMStream(llm.LLMStream):
                     )
                 self._extra_kwargs.pop("tools", None)
                 self._extra_kwargs.pop("tool_config", None)
-            http_options = self._llm._opts.http_options or types.HttpOptions(
-                timeout=int(self._conn_options.timeout * 1000)
-            )
+            http_options = self._llm._opts.http_options or types.HttpOptions()
+            if http_options.timeout is None and self._conn_options.timeout:
+                http_options = http_options.model_copy(
+                    update={"timeout": int(self._conn_options.timeout * 1000)}
+                )
             if not http_options.headers:
                 http_options.headers = {}
             http_options.headers["x-goog-api-client"] = f"livekit-agents/{__version__}"


### PR DESCRIPTION
## Problem

In `LLMStream._run`, the request HTTP options are resolved as:

```python
http_options = self._llm._opts.http_options or types.HttpOptions(
    timeout=int(self._conn_options.timeout * 1000)
)
```

When a caller passes `http_options` to `google.LLM(...)` (e.g. to set custom headers for Vertex AI Priority PayGo), the `or` short-circuits and uses the caller's options directly — but the caller typically doesn't set `timeout`. This means `conn_options.timeout` is silently dropped, which disables timeout-based fallback for `llm.FallbackAdapter`.

Fixes #5972

## Fix

Merge the timeout field into the caller's `http_options` when they haven't set one explicitly:

```python
http_options = self._llm._opts.http_options or types.HttpOptions()
if http_options.timeout is None and self._conn_options.timeout:
    http_options = http_options.model_copy(
        update={"timeout": int(self._conn_options.timeout * 1000)}
    )
```

This preserves both custom headers and framework-enforced timeouts.