### PR TITLE
fix(google): preserve request timeout with http options

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -476,12 +476,16 @@ class LLMStream(llm.LLMStream):
                     )
                 self._extra_kwargs.pop("tools", None)
                 self._extra_kwargs.pop("tool_config", None)
-            http_options = self._llm._opts.http_options or types.HttpOptions(
-                timeout=int(self._conn_options.timeout * 1000)
-            )
-            if not http_options.headers:
-                http_options.headers = {}
-            http_options.headers["x-goog-api-client"] = f"livekit-agents/{__version__}"
+            if is_given(self._llm._opts.http_options):
+                http_options = self._llm._opts.http_options.model_copy()
+                if http_options.timeout is None:
+                    http_options.timeout = int(self._conn_options.timeout * 1000)
+            else:
+                http_options = types.HttpOptions(timeout=int(self._conn_options.timeout * 1000))
+
+            headers = dict(http_options.headers or {})
+            headers["x-goog-api-client"] = f"livekit-agents/{__version__}"
+            http_options.headers = headers
             config = types.GenerateContentConfig(
                 system_instruction=(
                     None

--- a/tests/test_plugin_google_llm.py
+++ b/tests/test_plugin_google_llm.py
@@ -7,6 +7,7 @@ from google.genai import types
 
 from livekit.agents import llm
 from livekit.agents.llm import ChatContext, function_tool
+from livekit.agents.types import APIConnectOptions
 from livekit.plugins.google.llm import LLM, LLMStream
 from livekit.plugins.google.realtime.realtime_api import RealtimeModel, RealtimeSession
 
@@ -242,6 +243,34 @@ class TestCachedContentRequestSuppression:
         config = captured["config"]
         assert config.system_instruction is not None
         assert config.tools is not None and len(config.tools) >= 1
+
+    @pytest.mark.asyncio
+    async def test_request_merges_timeout_into_caller_http_options(self) -> None:
+        caller_http_options = types.HttpOptions(headers={"X-Vertex-Test": "1"})
+        llm = LLM(
+            model="gemini-2.5-flash",
+            api_key="test",
+            http_options=caller_http_options,
+        )
+
+        fake, captured = self._patched_stream_capture()
+        with patch.object(llm._client.aio.models, "generate_content_stream", fake):
+            stream = llm.chat(
+                chat_ctx=ChatContext.empty(),
+                conn_options=APIConnectOptions(timeout=7.5),
+            )
+            try:
+                async for _ in stream:
+                    pass
+            finally:
+                await stream.aclose()
+
+        config = captured["config"]
+        assert config.http_options.timeout == 7500
+        assert config.http_options.headers["X-Vertex-Test"] == "1"
+        assert "livekit-agents/" in config.http_options.headers["x-goog-api-client"]
+        assert caller_http_options.timeout is None
+        assert caller_http_options.headers == {"X-Vertex-Test": "1"}
 
 
 class TestMediaResolution:


### PR DESCRIPTION
## Summary
- preserve `conn_options.timeout` when callers pass custom Google `http_options`
- copy request-local HTTP options before adding LiveKit headers, avoiding mutation of the caller's object
- add a Google LLM regression test for custom headers plus fallback timeout propagation

Fixes #5972

## To verify
- `PYTHONPATH=livekit-agents;livekit-plugins\livekit-plugins-google python -m pytest tests\test_plugin_google_llm.py::TestCachedContentRequestSuppression::test_request_merges_timeout_into_caller_http_options tests\test_plugin_google_llm.py::TestCachedContentRequestSuppression::test_request_includes_system_instruction_and_tools_when_no_cache -q`
- `python -m py_compile livekit-plugins\livekit-plugins-google\livekit\plugins\google\llm.py tests\test_plugin_google_llm.py`
- `python -m ruff check livekit-plugins\livekit-plugins-google\livekit\plugins\google\llm.py tests\test_plugin_google_llm.py`
- `python -m ruff format --check livekit-plugins\livekit-plugins-google\livekit\plugins\google\llm.py tests\test_plugin_google_llm.py`
- `git diff --check`

Local test environment note: upgraded `livekit-protocol` to the project-declared `>=1.1.13` and installed the Google plugin's declared speech/texttospeech dependencies so the existing Google plugin tests could import cleanly.