### PR TITLE
fix(voice): avoid redundant work in speech paths

### DIFF
--- a/livekit-agents/livekit/agents/tts/stream_pacer.py
+++ b/livekit-agents/livekit/agents/tts/stream_pacer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections import deque
 from dataclasses import dataclass
 
 from .. import utils
@@ -53,7 +54,7 @@ class StreamPacerWrapper(SentenceStream):
 
         self._closing = False
         self._input_ended = False
-        self._sentences: list[str] = []
+        self._sentences: deque[str] = deque()
         self._wakeup_event = asyncio.Event()
         self._wakeup_timer: asyncio.TimerHandle | None = None
 
@@ -135,11 +136,14 @@ class StreamPacerWrapper(SentenceStream):
                 generation_stopped and remaining_audio <= self._options.min_remaining_audio
             ):
                 batch: list[str] = []
+                batch_text_len = 0
                 while self._sentences:
-                    batch.append(self._sentences.pop(0))
+                    sentence = self._sentences.popleft()
+                    batch.append(sentence)
+                    batch_text_len += len(sentence)
                     if (
                         first_sentence  # send first sentence immediately
-                        or sum(len(s) for s in batch) >= self._options.max_text_length
+                        or batch_text_len >= self._options.max_text_length
                     ):
                         break
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -805,8 +805,7 @@ class AudioRecognition:
 
             transcript = self._audio_transcript
             self._audio_interim_transcript = ""
-            chat_ctx = self._hooks.retrieve_chat_ctx().copy()
-            self._run_eou_detection(chat_ctx, skip_reply=skip_reply)
+            self._run_eou_detection(self._hooks.retrieve_chat_ctx(), skip_reply=skip_reply)
             self._user_turn_committed = True
             if not fut.done():
                 fut.set_result(transcript)
@@ -949,8 +948,7 @@ class AudioRecognition:
                     )
 
                 if not self._speaking:
-                    chat_ctx = self._hooks.retrieve_chat_ctx().copy()
-                    self._run_eou_detection(chat_ctx)
+                    self._run_eou_detection(self._hooks.retrieve_chat_ctx())
 
         elif ev.type == stt.SpeechEventType.PREFLIGHT_TRANSCRIPT:
             self._hooks.on_interim_transcript(
@@ -1036,8 +1034,7 @@ class AudioRecognition:
                 # vad disabled or missed a speech, use stt timestamp
                 self._last_speaking_time = stt_last_speaking_time
 
-            chat_ctx = self._hooks.retrieve_chat_ctx().copy()
-            self._run_eou_detection(chat_ctx)
+            self._run_eou_detection(self._hooks.retrieve_chat_ctx())
 
         elif ev.type == stt.SpeechEventType.START_OF_SPEECH and self._turn_detection_mode == "stt":
             # If the plugin provided a server onset timestamp, use it;
@@ -1093,8 +1090,7 @@ class AudioRecognition:
             if self._vad_base_turn_detection or (
                 self._turn_detection_mode == "stt" and self._user_turn_committed
             ):
-                chat_ctx = self._hooks.retrieve_chat_ctx().copy()
-                self._run_eou_detection(chat_ctx)
+                self._run_eou_detection(self._hooks.retrieve_chat_ctx())
 
             if self._session.amd is not None:
                 self._session.amd._on_user_speech_ended(ev.silence_duration)


### PR DESCRIPTION
 -  `_run_eou_detection()` already copies the chat context before appending the user message, so callers do not need to copy it first.
 - `StreamPacerWrapper` treats `_sentences` as a FIFO queue, so `deque.popleft()` is a better fit than `list.pop(0)`. The batch length is also tracked as sentences are added instead of recalculating it each loop.