### PR TITLE
fix quick reconnect participant keyerror

### DIFF
--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -743,7 +743,9 @@ class JobContext:
             self._participant_tasks[(p.identity, coro)] = task
 
             def _on_done(task: asyncio.Task[Any], *, coro: Any = coro) -> None:
-                self._participant_tasks.pop((p.identity, coro))
+                # pop with default: a fast same-identity reconnect overwrites the entry, so both
+                # done-callbacks target the same key and the second would KeyError
+                self._participant_tasks.pop((p.identity, coro), None)
                 if not task.cancelled() and (exc := task.exception()) is not None:
                     logger.error(
                         f"error in participant entrypoint {coro.__name__} for '{p.identity}'",

--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -743,9 +743,9 @@ class JobContext:
             self._participant_tasks[(p.identity, coro)] = task
 
             def _on_done(task: asyncio.Task[Any], *, coro: Any = coro) -> None:
-                # pop with default: a fast same-identity reconnect overwrites the entry, so both
-                # done-callbacks target the same key and the second would KeyError
-                self._participant_tasks.pop((p.identity, coro), None)
+                key = (p.identity, coro)
+                if self._participant_tasks.get(key) is task:
+                    self._participant_tasks.pop(key, None)
                 if not task.cancelled() and (exc := task.exception()) is not None:
                     logger.error(
                         f"error in participant entrypoint {coro.__name__} for '{p.identity}'",


### PR DESCRIPTION
`JobContext._participant_available()` stores participant-entrypoint tasks keyed by (identity, coro) and the done-callback does `self._participant_tasks.pop((p.identity, coro))` with no default. When the same identity connects twice in quick succession (normal client reconnect on flaky mobile networks; Cloud later evicts the duplicate with `DUPLICATE_IDENTITY`), the second connect overwrites the dict entry at `job.py:727`. Both done-callbacks then pop the same key: the first wins, the second raises an unhandled `KeyError` into asyncio's default exception handler.
```
Exception in callback JobContext._participant_available.<locals>.<lambda>(<Task finishe...> result=None>)
  at .../site-packages/livekit/agents/job.py:729
KeyError: ('<identity>', <function participant_entrypoint ...>)
```
The code already anticipates the overlap but cleanup is not idempotent.