### PR TITLE
tests: speed up unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,9 +86,10 @@ dev = [
     "python-dotenv>=1.0.1",
     "mypy",
     "scikit-learn",
-    "pytest",
+    "pytest>=9.0.3,<9.1",
     "ruff",
     "pytest-asyncio>=0.25.3",
+    "pytest-asyncio-concurrent==0.5.2",
     "jiwer>=3.1.0",
     "scipy>=1.13.1",
     "tiktoken>=0.9.0",
@@ -125,7 +126,7 @@ convention = "google"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-addopts = ["--import-mode=importlib", "--ignore=examples"]
+addopts = ["--import-mode=importlib", "--ignore=examples", "-p", "tests.concurrency"]
 pythonpath = ["."]
 testpaths = ["tests"]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,12 @@ convention = "google"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+filterwarnings = [
+    # virtual-time tests override the event_loop_policy fixture (tests/virtual_time.py) to run on
+    # an autojumping virtual-time loop; pytest-asyncio deprecates the override but offers no per-test
+    # alternative that returns a default loop for unmarked tests without erroring.
+    "ignore:Overriding the \"event_loop_policy\" fixture is deprecated:Warning",
+]
 addopts = ["--import-mode=importlib", "--ignore=examples", "-p", "tests.concurrency"]
 pythonpath = ["."]
 testpaths = ["tests"]

--- a/tests/concurrency.py
+++ b/tests/concurrency.py
@@ -1,0 +1,1018 @@
+"""Run a module's async tests concurrently on one event loop, with correct per-test isolation.
+
+A thin layer over the `pytest-asyncio-concurrent` plugin, which supplies the hard part:
+collecting a *group*'s async tests and running them together via `asyncio.gather` (so a slow,
+I/O-bound module like `test_agent_session.py` finishes in a fraction of the wall time). What the
+plugin does *not* give us, and this module adds:
+
+1. Per-task output capture. pytest's stdout/stderr/log/caplog capture is process-global, so under
+   concurrency output leaks or is misattributed to whichever test finishes first. We key capture
+   on a `contextvars.ContextVar` instead: each gathered test runs in its own task/context, so the
+   stream proxies, root-log handler, and `caplog` records route to the right test's buffer and
+   surface only when that test fails -- as normal.
+
+2. Per-test reporting + a live progress line. The plugin reports nothing until the whole group is
+   done (and double-prints names under `-v`); we report each test the moment it finishes, and on
+   a non-verbose color TTY draw a transient one-cell-per-test line with a blue head orbiting the
+   still-running cells, each cell freezing to its status letter on completion.
+
+3. Per-test leaked-task attribution. On a shared loop, diffing `asyncio.all_tasks()` can't tell
+   whose task is whose. A task factory tags each task with its creating test's nodeid (via a
+   contextvar, inherited by spawned tasks); `fail_on_leaked_tasks` then inspects only its own
+   still-pending tasks. See :func:`owned_pending_tasks`.
+
+4. Concurrency control, via two markers and a switch:
+
+   - `@pytest.mark.concurrent`    -- always run this async test concurrently (unless off).
+   - `@pytest.mark.no_concurrent` -- never (process-global state, signal handlers, capsys, ...);
+     honored even under `--concurrent`.
+   - `--concurrent` (or `LK_TEST_CONCURRENCY=all`) runs *every* async test concurrently except
+     `no_concurrent` ones; the default runs only `concurrent` ones; `--no-concurrent` (or
+     `LK_TEST_CONCURRENCY=0`) forces everything sequential.
+
+   Markers apply at test, class, or module level (`pytestmark = ...`); `capsys`/`capfd` users
+   are auto-excluded (process-global fixtures).
+
+5. The fixes that make pytest-asyncio's `auto` mode cooperate:
+
+   - :func:`repromote_collected` restores the concurrent members after auto mode claims (and would
+     sequentialize) every async test.
+   - One concurrent group per *module*, so module-level tests and every class in the file share a
+     loop (the plugin otherwise pins a group to its first member's parent).
+   - The gather's loop is captured *after* per-member setup: in auto mode pytest-asyncio builds its
+     own loop during fixture setup, and capturing before it crashes with "future belongs to a
+     different loop".
+
+Loaded as a *global* plugin via `-p tests.concurrency` (see pyproject.toml), not conftest.py: the
+plugin drives `pytest_runtest_protocol_async_group` through the rootdir-scoped `session.ihook`,
+which would not see hooks defined in a subdirectory conftest.
+
+Limitations:
+- Module-scoped groups break *class*-scoped fixtures on concurrent members (the finalizer needs a
+  Class node that module grouping drops); function/module/session scopes are fine.
+- The shared loop couples timing: a test that hogs it can perturb another's. If a concurrent run
+  gets flaky, force it sequential with `--no-concurrent`.
+- pytest-xdist distributes by item and would split a group across workers, so `-n` disables
+  concurrency entirely: :func:`pytest_configure` unregisters the underlying plugin (whose
+  runtestloop wrapper and collection regrouping otherwise desync xdist's per-worker item indexing,
+  crashing the worker with an IndexError), and the default mode falls back to sequential with a
+  one-line notice at session start (see :func:`pytest_report_header`); an explicit `--concurrent`
+  under `-n` is rejected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import contextvars
+import inspect
+import io
+import logging
+import math
+import os
+import sys
+import threading
+import warnings
+import weakref
+from typing import TYPE_CHECKING, Any, Literal
+
+import pytest
+
+try:
+    from pytest_asyncio_concurrent.grouping import (
+        AsyncioConcurrentGroup,
+        AsyncioConcurrentGroupMember,
+        PytestAsyncioConcurrentGroupingWarning,
+    )
+    from pytest_asyncio_concurrent.plugin import (
+        _call_and_report,
+        _call_runtest_async,
+        _check_interactive_exception,
+        _setup_child,
+        _teardown_child,
+    )
+
+    PYTEST_ASYNCIO_CONCURRENT_INSTALLED = True
+except ImportError:
+    PYTEST_ASYNCIO_CONCURRENT_INSTALLED = False
+
+if TYPE_CHECKING:
+    from _pytest.config.argparsing import Parser
+    from pluggy import Result
+
+# `caplog` reads its handler/records out of these item-stash keys. We populate them per
+# test ourselves (pytest's logging plugin never runs for concurrent members). Guarded so a
+# pytest internals change degrades gracefully to "no caplog support" instead of a hard error.
+try:
+    from _pytest.logging import (
+        LogCaptureHandler,
+        caplog_handler_key,
+        caplog_records_key,
+    )
+
+    _CAPLOG_SUPPORTED = True
+except Exception:  # pragma: no cover - defensive
+    LogCaptureHandler = None  # type: ignore[assignment,misc]
+    _CAPLOG_SUPPORTED = False
+
+_ENV_TOGGLE = "LK_TEST_CONCURRENCY"
+_DEFAULT_LOG_FORMAT = "%(levelname)-8s %(name)s:%(filename)s:%(lineno)s %(message)s"
+_CAPTURE_FIXTURES = frozenset({"capsys", "capfd", "capsysbinary", "capfdbinary", "capteesys"})
+
+
+def register_markers(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers", "concurrent: run this async test concurrently with its peers."
+    )
+    config.addinivalue_line(
+        "markers",
+        "no_concurrent: never run this async test concurrently (it relies on process-global "
+        "state, signal handlers, capsys, etc.).",
+    )
+
+
+def add_toggle_option(parser: Parser) -> None:
+    group = parser.getgroup("concurrency", "concurrent async test execution")
+    group.addoption(
+        "--concurrent",
+        action="store_true",
+        default=False,
+        help="Run every async test concurrently, except @pytest.mark.no_concurrent ones.",
+    )
+    group.addoption(
+        "--no-concurrent",
+        action="store_true",
+        default=False,
+        help="Run all tests sequentially, even @pytest.mark.concurrent ones.",
+    )
+
+
+def _xdist_active(config: pytest.Config) -> bool:
+    """True when pytest-xdist is in play -- on the controller *and* inside each worker.
+
+    xdist splits a run by *item*, which would scatter a concurrent group (one shared event loop)
+    across workers. The controller carries `-n` / `--dist`; a worker process carries neither
+    (xdist clears them so the worker doesn't itself re-distribute) but does carry `workerinput`.
+    The concurrent plugin must be disabled on the worker too -- that's where its runtestloop
+    wrapper fights xdist's remote loop (`items[nextitem_index]` -> IndexError). `-n0` / no
+    xdist leaves this False everywhere.
+    """
+    if hasattr(config, "workerinput"):
+        return True
+    if getattr(config.option, "dist", "no") not in ("no", None):
+        return True
+    return bool(getattr(config.option, "numprocesses", None))
+
+
+def _requested_mode(config: pytest.Config) -> Literal["default", "all", "off"]:
+    """Run mode the user asked for via flags/env, before the xdist override: off/default/all."""
+    env = os.environ.get(_ENV_TOGGLE, "").strip().lower()
+    if config.getoption("--no-concurrent", default=False) or env in ("0", "off", "false", "no"):
+        return "off"
+    if config.getoption("--concurrent", default=False) or env in ("all", "1", "on", "yes"):
+        return "all"
+    return "default"
+
+
+def concurrency_mode(config: pytest.Config) -> Literal["default", "all", "off"]:
+    """Resolve the effective run mode.
+
+    Under pytest-xdist (`-n`) concurrency can't work -- a group shares one event loop and xdist
+    would split it across workers -- so any non-off request is forced to `"off"` here. The
+    incompatible `--concurrent` + `-n` case is rejected outright in :func:`pytest_configure`;
+    the default mode is downgraded quietly (notice in :func:`pytest_report_header`).
+    """
+    requested = _requested_mode(config)
+    if requested != "off" and _xdist_active(config):
+        return "off"
+    return requested
+
+
+def concurrency_enabled(config: pytest.Config) -> bool:
+    """Whether any concurrent execution happens at all."""
+    return concurrency_mode(config) != "off"
+
+
+def should_run_concurrently(item: pytest.Function, mode: Literal["default", "all", "off"]) -> bool:
+    """Whether this async test should run as a concurrent group member (see marker table above)."""
+    if mode == "off":
+        return False
+    if item.get_closest_marker("no_concurrent") is not None:
+        return False
+    if _CAPTURE_FIXTURES.intersection(getattr(item._fixtureinfo, "names_closure", ())):
+        return False
+    if mode == "all":
+        return True
+    return item.get_closest_marker("concurrent") is not None
+
+
+def is_concurrent_member(node: object) -> bool:
+    """True if `node` is a test running as part of a concurrent group.
+
+    Used by fixtures that can't behave correctly when tests share one event loop
+    (e.g. per-test leaked-task detection). When concurrency is toggled off the tests
+    are ordinary items and this returns False, so such fixtures run normally.
+    """
+    return PYTEST_ASYNCIO_CONCURRENT_INSTALLED and isinstance(node, AsyncioConcurrentGroupMember)
+
+
+# --------------------------------------------------------------------------- #
+# Per-task capture machinery
+# --------------------------------------------------------------------------- #
+_active: contextvars.ContextVar[_TestCapture | None] = contextvars.ContextVar(
+    "lk_concurrent_capture", default=None
+)
+
+
+class _TestCapture:
+    """Output sink for a single concurrently-running test."""
+
+    def __init__(self) -> None:
+        self.stdout = io.StringIO()
+        self.stderr = io.StringIO()
+        # pytest's own handler type so `caplog.text` / `caplog.records` keep working.
+        self.log_handler = LogCaptureHandler() if _CAPLOG_SUPPORTED else None
+        if self.log_handler is not None:
+            self.log_handler.setLevel(0)
+
+
+class _DispatchStream:
+    """A `sys.stdout`/`sys.stderr` stand-in that routes writes to the active test.
+
+    With no active test (e.g. pytest's own machinery between tests) it falls through to the
+    real stream, so nothing is silently swallowed.
+    """
+
+    def __init__(self, wrapped: Any, attr: str) -> None:
+        self._wrapped = wrapped
+        self._attr = attr
+
+    def write(self, data: str) -> int:
+        cap = _active.get()
+        if cap is None:
+            return self._wrapped.write(data)
+        return getattr(cap, self._attr).write(data)
+
+    def flush(self) -> None:
+        if _active.get() is None:
+            self._wrapped.flush()
+
+    def isatty(self) -> bool:
+        return False
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._wrapped, name)
+
+
+class _RoutingLogHandler(logging.Handler):
+    """Root-logger handler that routes each record to the active test's capture."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        cap = _active.get()
+        if cap is None or cap.log_handler is None:
+            return
+        # Replicate the level gating Logger.callHandlers would normally do, so
+        # `caplog.set_level(...)` keeps working.
+        if record.levelno >= cap.log_handler.level:
+            cap.log_handler.handle(record)
+
+
+class _CaptureController:
+    """Installs the dispatch streams + routing handler once, around a concurrent gather.
+
+    The group's members all run on one event loop in one thread. Each member installs on
+    entry and uninstalls on exit; a refcount keeps the proxies in place for the whole gather
+    window (every member starts -- and so increments -- before any of them awaits to
+    completion, so the count only returns to zero once the last member is done).
+    """
+
+    def __init__(self) -> None:
+        self._depth = 0
+        self._saved: tuple[Any, Any] | None = None
+        self._handler: logging.Handler | None = None
+
+    def __enter__(self) -> _CaptureController:
+        if self._depth == 0:
+            self._saved = (sys.stdout, sys.stderr)
+            sys.stdout = _DispatchStream(sys.stdout, "stdout")  # type: ignore[assignment]
+            sys.stderr = _DispatchStream(sys.stderr, "stderr")  # type: ignore[assignment]
+            self._handler = _RoutingLogHandler()
+            self._handler.setLevel(0)
+            logging.getLogger().addHandler(self._handler)
+        self._depth += 1
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._depth -= 1
+        if self._depth == 0:
+            assert self._saved is not None
+            sys.stdout, sys.stderr = self._saved
+            if self._handler is not None:
+                logging.getLogger().removeHandler(self._handler)
+            self._saved = None
+            self._handler = None
+
+
+_controller = _CaptureController()
+
+
+@contextlib.contextmanager
+def _capture_subprocess_fds(terminalreporter: Any) -> Any:
+    """Capture file-descriptor-level output for the duration of a concurrent gather.
+
+    The per-task :class:`_CaptureController` only swaps `sys.stdout`/`sys.stderr`, so it sees
+    in-process `print`s but not writes a *subprocess* (or C extension) makes straight to the
+    inherited stdout/stderr file descriptors -- e.g. a spawned child's `print()`. With pytest's
+    own fd capture suspended while tests run, those writes hit the real terminal and corrupt the
+    live progress line (and leak into CI logs).
+
+    So for the gather window we point fds 1/2 at a pipe and drain it on a background thread, while
+    rerouting the *parent's* terminal writer to the preserved fds -- so dots, the live line and
+    reports still render; only out-of-process writes are diverted. The buffer is shared by every
+    member (they share the fds) and so can't be attributed to one test; it's yielded back for the
+    caller to surface only if the group failed, matching pytest's "show captured output on failure
+    only" behaviour. A no-op (`b""`) is yielded when there are no real fds to capture.
+    """
+    tw = terminalreporter._tw
+    original_file = tw._file
+    try:
+        original_file.flush()
+        sys.stdout.flush()
+        sys.stderr.flush()
+    except Exception:  # pragma: no cover - best effort flush
+        pass
+
+    try:
+        saved_out, saved_err = os.dup(1), os.dup(2)
+    except OSError:  # pragma: no cover - no real fds (e.g. fully in-memory streams)
+        yield lambda: b""
+        return
+
+    pipe_r, pipe_w = os.pipe()
+    os.dup2(pipe_w, 1)
+    os.dup2(pipe_w, 2)
+    os.close(pipe_w)
+
+    # Parent-side terminal output bypasses the captured fds via the preserved stdout.
+    preserved = os.fdopen(saved_out, "w", buffering=1, closefd=True)
+    tw._file = preserved
+
+    buffer = bytearray()
+
+    def _pump() -> None:
+        while True:
+            try:
+                chunk = os.read(pipe_r, 65536)
+            except OSError:
+                break
+            if not chunk:  # EOF: every write end (fds 1/2) has been restored/closed
+                break
+            buffer.extend(chunk)
+
+    pump = threading.Thread(target=_pump, name="lk-concurrent-fd-capture", daemon=True)
+    pump.start()
+
+    try:
+        yield lambda: bytes(buffer)
+    finally:
+        try:
+            preserved.flush()
+        except Exception:  # pragma: no cover
+            pass
+        # Restore the real fds; this drops the last refs to the pipe's write end, so the pump
+        # sees EOF and exits.
+        os.dup2(saved_out, 1)
+        os.dup2(saved_err, 2)
+        os.close(saved_err)
+        pump.join(timeout=2.0)
+        if not pump.is_alive():
+            os.close(pipe_r)
+        tw._file = original_file
+        preserved.close()  # closes saved_out
+
+
+def _emit_captured_subprocess_output(
+    terminalreporter: Any,
+    results: list[tuple[Any, pytest.CallInfo, pytest.TestReport]],
+    data: bytes,
+) -> None:
+    """Surface a concurrent group's captured fd output -- but only if a member failed.
+
+    The output can't be attributed to a single member (they shared the fds), so it's shown as a
+    group-level section rather than per test, mirroring pytest's failure-only capture display.
+    """
+    if not data or not any(report.failed for _, _, report in results):
+        return
+    text = data.decode("utf-8", "replace")
+    terminalreporter.write_sep("-", "Captured subprocess stdout/stderr (concurrent group)")
+    terminalreporter._tw.write(text if text.endswith("\n") else text + "\n")
+
+
+def _format_log(records: list[logging.LogRecord], config: pytest.Config) -> str:
+    fmt = config.getini("log_format") or _DEFAULT_LOG_FORMAT
+    formatter = logging.Formatter(fmt)
+    return "\n".join(formatter.format(record) for record in records)
+
+
+# --------------------------------------------------------------------------- #
+# Hook bodies (called from conftest.py)
+# --------------------------------------------------------------------------- #
+def repromote_collected(outcome: Result, config: pytest.Config) -> None:
+    """Turn the async tests that should run concurrently into concurrent group members.
+
+    In auto mode pytest-asyncio claims every async test (and would run it sequentially); after it
+    has had its say we promote the ones :func:`should_run_concurrently` selects, grouping each by
+    its parent (module or class) so a group's members share a parent as the plugin requires. The
+    user-facing markers are `concurrent` / `no_concurrent`; `asyncio_concurrent` (which the
+    underlying plugin keys on) is an internal detail we attach here.
+
+    Meant to be called from a `pytest_pycollect_makeitem` *hookwrapper* registered
+    `tryfirst` (outermost), so it runs after pytest-asyncio has had its say.
+    """
+    mode = concurrency_mode(config)
+    if mode == "off":
+        return
+    result = outcome.get_result()
+    if not result:
+        return
+    items = result if isinstance(result, list) else [result]
+    changed = False
+    for index, item in enumerate(items):
+        if (
+            isinstance(item, pytest.Function)
+            and not isinstance(item, AsyncioConcurrentGroupMember)
+            and inspect.iscoroutinefunction(item.obj)
+            and should_run_concurrently(item, mode)
+        ):
+            member = AsyncioConcurrentGroupMember.promote_from_function(item)
+            # Group by module (possible thanks to _enable_cross_parent_grouping)
+            group_name = item.getparent(pytest.Module).nodeid
+            member.add_marker(pytest.mark.asyncio_concurrent(group=group_name))
+            items[index] = member
+            changed = True
+    if changed:
+        outcome.force_result(items)
+
+
+# --------------------------------------------------------------------------- #
+# Task ownership (per-test leaked-task attribution)
+# --------------------------------------------------------------------------- #
+# Concurrent group members share one event loop, so the usual "diff asyncio.all_tasks() around
+# each test" can't tell whose task is whose -- a still-running task from test B looks like a
+# leak from test A. Instead we tag every task with the test that created it: a contextvar
+# carries the owning test's nodeid, and a task factory on the group's loop records it. The
+# factory runs synchronously in the creating task's context, and asyncio tasks inherit their
+# parent's context, so background tasks a test spawns (and their descendants) are attributed to
+# that test too. fail_on_leaked_tasks then asks only about *its own* still-pending tasks.
+_task_owner: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "lk_task_owner", default=None
+)
+_owner_by_task: weakref.WeakKeyDictionary[asyncio.Task[Any], str] = weakref.WeakKeyDictionary()
+_group_loop: asyncio.AbstractEventLoop | None = None
+
+
+def _tagging_task_factory(
+    loop: asyncio.AbstractEventLoop, coro: Any, **kwargs: Any
+) -> asyncio.Task[Any]:
+    task: asyncio.Task[Any] = asyncio.Task(coro, loop=loop, **kwargs)
+    owner = _task_owner.get()
+    if owner is not None:
+        _owner_by_task[task] = owner
+    return task
+
+
+@contextlib.contextmanager
+def _task_ownership(loop: asyncio.AbstractEventLoop) -> Any:
+    """Install the tagging task factory + expose the loop for the duration of a group."""
+    global _group_loop
+    previous_factory = loop.get_task_factory()
+    previous_loop = _group_loop
+    loop.set_task_factory(_tagging_task_factory)
+    _group_loop = loop
+    try:
+        yield
+    finally:
+        loop.set_task_factory(previous_factory)
+        _group_loop = previous_loop
+
+
+def owned_pending_tasks(owner: str) -> list[asyncio.Task[Any]]:
+    """Still-pending tasks created by test `owner` (see module note on task ownership).
+
+    Lets fail_on_leaked_tasks attribute leaks per test even though the whole group shares one
+    event loop. Returns `[]` when no group is running (e.g. sequential mode), so callers fall
+    back to their normal whole-loop check.
+    """
+    loop = _group_loop
+    if loop is None:
+        return []
+    # asyncio.all_tasks() already excludes finished tasks.
+    return [task for task in asyncio.all_tasks(loop) if _owner_by_task.get(task) == owner]
+
+
+# --------------------------------------------------------------------------- #
+# Live progress line
+# --------------------------------------------------------------------------- #
+_ORBIT_INTERVAL = 0.01  # seconds between frames; the only thing that wakes the shared loop
+_ORBIT_TRAIL = 10  # base comet length (lit dots behind the head); widened to cover fast steps
+_ORBIT_SPEED = 1.0  # default dots advanced per frame (speed); 2.0 == twice as fast, same frame rate
+_RUNNING_MARKUP = {"blue": True}
+
+
+# Cell sentinel: this test is in flight -- render the orbiting head for it (blank braille otherwise).
+_RUNNING = object()
+
+
+def _emit(child: pytest.Function, callinfo: pytest.CallInfo, report: pytest.TestReport) -> None:
+    # logstart + logreport back-to-back => one clean line per test (no -v double-print).
+    child.ihook.pytest_runtest_logstart(nodeid=child.nodeid, location=child.location)
+    if _check_interactive_exception(call=callinfo, report=report):
+        child.ihook.pytest_exception_interact(node=child, call=callinfo, report=report)
+    child.ihook.pytest_runtest_logreport(report=report)
+
+
+def _orbit_path(cells: list[int]) -> list[tuple[int, int]]:
+    """Braille-dot positions tracing the rectangle around `cells` clockwise from the top-left.
+
+    `cells` are the running columns, left to right; finished columns are simply absent, so the
+    head jumps over them and the walls sit on the first/last running column. Per cell the dots are
+    1,4 across the top, 7,8 across the bottom, 1,2,3,7 down the left and 4,5,6,8 down the right.
+    Top dots run left->right, down the right wall of the last cell, bottom dots right->left, then
+    up the left wall of the first cell. Shared corners are not repeated.
+    """
+    if not cells:
+        return []
+    first, last = cells[0], cells[-1]
+    top = [(cell, bit) for cell in cells for bit in (0x01, 0x08)]
+    right = [(last, bit) for bit in (0x10, 0x20, 0x80)]
+    bottom = [(cell, bit) for cell in reversed(cells) for bit in (0x80, 0x40)][1:]
+    left = [(first, 0x04), (first, 0x02)]
+    return top + right + bottom + left
+
+
+class _GroupProgress:
+    """Owns how one concurrent group reports -- both strategies behind one interface.
+
+    The mode is decided once in `__init__` and never leaks to the caller:
+
+    * live (non-verbose colour TTY, capture on): a transient in-place line, one cell per test.
+      While a test runs its cell is blank braille; collectively the running cells show a colored
+      head orbiting just the running cells -- finished columns are dropped from the loop, so the
+      head jumps over them (see :func:`_orbit_path`). Test starts and completions only mutate
+      cell state; the line is redrawn on the animation timer (see :meth:`ticking`), so a cell
+      freezes to its final status letter/colour on the next frame and a burst of completions
+      costs one redraw rather than one per test. Per-test reports are withheld until the line is
+      frozen, then replayed through a silenced terminal writer so stats/failures/other plugins
+      still see them via the hooks without a second dot row; the cumulative `[ XX%]` is stamped
+      on afterwards (see :meth:`_finish_line`).
+    * streaming (everything else): no line; each report is emitted the moment its test finishes,
+      so pytest prints dots/names live as usual.
+
+    `run_group` drives this purely through `begin` / `on_start` / `on_finish` /
+    `ticking` / `finalize` and never branches on the mode.
+    """
+
+    def __init__(self, terminalreporter: Any, config: pytest.Config) -> None:
+        self._terminalreporter = terminalreporter
+        self._tw = terminalreporter._tw
+        self._config = config
+        verbose = config.get_verbosity() > 0
+        capture_off = config.option.capture == "no"
+        self._live: bool = self._tw.hasmarkup and not verbose and not capture_off
+        self._cell: dict[Any, Any] = {}
+        self._done: set[Any] = set()
+        self._order: list[Any] = []
+        self._lit: dict[int, int] = {}
+        self._label = ""
+        self._width = 0
+        self._last_plain = ""
+        self._phase = 0.0
+        self._step = _ORBIT_SPEED
+        self._trail = max(_ORBIT_TRAIL, math.ceil(self._step))
+        self._marked: dict[Any, str] = {}
+        self._glyph_cache: dict[str, str] = {}
+        self._count_width = 0
+        self._fullwidth = 0
+
+    # -- driven by run_group ------------------------------------------------- #
+    def begin(self, children: list[Any]) -> None:
+        self._order = list(children)
+        self._cell = dict.fromkeys(children, _RUNNING)
+        self._marked = {}
+        self._count_width = len(str(len(self._order)))
+        self._fullwidth = self._tw.fullwidth
+        if self._order:
+            self._label = self._order[0].nodeid.split("::", 1)[0] + " "
+        self._render()
+
+    def on_start(self, child: Any) -> None:
+        self._cell[child] = _RUNNING
+
+    def on_finish(
+        self, child: pytest.Function, callinfo: pytest.CallInfo, report: pytest.TestReport
+    ) -> None:
+        letter, markup = self._letter_and_markup(report)
+        if self._live:
+            self._marked[child] = self._tw.markup(letter, **markup)
+        self._cell[child] = (letter, markup)
+        self._done.add(child)
+        if not self._live:
+            _emit(child, callinfo, report)
+
+    @contextlib.asynccontextmanager
+    async def ticking(self) -> Any:
+        """Step the orbiting head on a timer while the group's gather runs (live only).
+
+        Also the only place the live line is redrawn while the gather runs: on_start/on_finish
+        merely mutate cell state, and the final redraw here (after the head is cancelled) freezes
+        the end state that _finish_line then stamps the percentage onto.
+        """
+        if not self._live:
+            yield
+            return
+        # No owner tag (created in the gather's own task context), so it can't look like a
+        # leaked test task; cancelled and awaited here.
+        orbit = asyncio.ensure_future(self._drive_orbit())
+        try:
+            yield
+        finally:
+            orbit.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await orbit
+            self._render()
+
+    @contextlib.contextmanager
+    def finalize(
+        self,
+        results: list[tuple[AsyncioConcurrentGroupMember, pytest.CallInfo, pytest.TestReport]],
+        *,
+        is_last_group: bool,
+    ) -> Any:
+        """Wrap teardown: replay withheld reports silently, then stamp the line's progress (live only).
+
+        Streaming mode already emitted each report in :meth:`on_finish`, so it just runs the body.
+        The reports replay through a throwaway writer so stats/failures/other plugins still see
+        them via the hooks without a second dot row -- but that throwaway writer is also where
+        pytest's own `[ XX%]` would land, so the cumulative percentage is stamped onto the real
+        writer afterwards (see :meth:`_finish_line`).
+        """
+        if not self._live:
+            yield
+            return
+        from _pytest.config import create_terminal_writer
+
+        original_tw = self._terminalreporter._tw
+        self._terminalreporter._tw = create_terminal_writer(
+            self._terminalreporter.config, io.StringIO()
+        )
+        try:
+            for child, callinfo, report in results:
+                _emit(child, callinfo, report)
+            yield
+        finally:
+            self._terminalreporter._tw = original_tw
+            self._finish_line(is_last_group=is_last_group)
+
+    # -- rendering ----------------------------------------------------------- #
+    async def _drive_orbit(self) -> None:
+        while True:
+            await asyncio.sleep(_ORBIT_INTERVAL)
+            self._advance_orbit()
+            self._render()
+
+    def _advance_orbit(self) -> None:
+        """Advance the head by `self._step` dots along the loop of still-running cells.
+
+        Distance per frame is the speed knob: raising it moves the head faster without touching
+        the frame rate (`_ORBIT_INTERVAL`), so no extra event-loop wakeups and no added load on
+        the gathered tests. The head is a phase in [0, 1) so that when a finished cell drops out
+        and the loop shortens it stays at the same fraction of the way round rather than
+        teleporting (which flickered when a burst of completions landed between two frames). The
+        trail widens to `self._trail` >= step so a fast head stays a continuous comet instead of
+        a dot hopping with gaps.
+        """
+        running = [
+            index for index, child in enumerate(self._order) if self._cell[child] is _RUNNING
+        ]
+        path = _orbit_path(running)
+        if not path:
+            self._lit = {}
+            return
+        period = len(path)
+        self._phase = (self._phase + self._step / period) % 1.0
+        head = int(self._phase * period)
+        lit: dict[int, int] = {}
+        for offset in range(self._trail):
+            cell, dot = path[(head - offset) % period]
+            lit[cell] = lit.get(cell, 0) | dot
+        self._lit = lit
+
+    def _letter_and_markup(self, report: pytest.TestReport) -> tuple[str, dict[str, bool]]:
+        """The exact status letter + colour pytest would use for this report."""
+        _, letter, word = self._config.hook.pytest_report_teststatus(
+            report=report, config=self._config
+        )
+        if isinstance(word, tuple):  # a plugin already chose the markup
+            return letter, word[1]
+        was_xfail = hasattr(report, "wasxfail")
+        if report.passed:
+            markup = {"yellow": True} if was_xfail else {"green": True}  # xpass vs pass
+        elif report.failed:
+            markup = {"red": True}
+        elif report.skipped:
+            markup = {"yellow": True}  # skipped / xfailed
+        else:
+            markup = {}
+        return letter, markup
+
+    def _finish_line(self, is_last_group: bool) -> None:
+        """Stamp the cumulative `[ XX%]` onto the finished colour line and keep it as the record.
+
+        The colour line carries embedded markup, so its raw width is wrong -- reset
+        `_current_line` to the plain text first, then let pytest fill the same right-aligned
+        progress message it writes after an ordinary dot row, so concurrent groups read exactly
+        like the sequential lines. The final group is left untouched: pytest's own end-of-loop
+        `[100%]` lands on it, and writing it here too would double.
+        """
+        if not (self._live and self._width):
+            return
+        self._tw._current_line = self._last_plain
+        if is_last_group:
+            return
+        self._terminalreporter._write_progress_information_filling_space()
+        self._tw.line()
+
+    def _render(self) -> None:
+        if not self._live:
+            return
+        counter = f" [{len(self._done):>{self._count_width}}/{len(self._order)}]"
+        glyphs: list[str] = []
+        marked: list[str] = []
+        for index, child in enumerate(self._order):
+            cell = self._cell[child]
+            if cell is _RUNNING:
+                glyph = chr(0x2800 + self._lit.get(index, 0))
+                glyphs.append(glyph)
+                marked.append(self._render_glyph(glyph))
+            else:
+                glyphs.append(cell[0])
+                marked.append(self._marked[child])
+        plain = self._label + "".join(glyphs) + counter
+        if len(plain) >= self._fullwidth:  # too wide for one cell per test
+            body = plain = f"{self._label}running {len(self._done)}/{len(self._order)}"
+        else:
+            body = self._label + "".join(marked) + counter
+        pad = " " * max(0, self._width - len(plain))  # erase a previously longer line
+        self._tw.write("\r" + body + pad, flush=True)
+        self._width = len(plain)
+        self._last_plain = plain
+
+    def _render_glyph(self, glyph: str) -> str:
+        cached = self._glyph_cache.get(glyph)
+        if cached is None:
+            cached = self._tw.markup(glyph, **_RUNNING_MARKUP)
+            self._glyph_cache[glyph] = cached
+        return cached
+
+
+def run_group(group: AsyncioConcurrentGroup, nextgroup: AsyncioConcurrentGroup | None) -> object:
+    """Run one concurrent group, fixing the plugin's event-loop handling and reporting.
+
+    This mirrors `pytest_asyncio_concurrent.plugin.pytest_runtest_protocol_async_group` but
+    differs in two ways:
+
+    * It captures the event loop **after** per-member setup instead of before. In auto mode,
+      pytest-asyncio sets up its own loop while the members' fixtures are created, so the
+      plugin's pre-setup capture no longer matches the loop `asyncio.gather` actually binds
+      to -- which crashes with "future belongs to a different loop". Capturing after setup keeps
+      the gather, `run_until_complete` and the test coroutines all on the same loop.
+
+    * It reports each test **as it finishes** instead of all at once after the gather, via the
+      :class:`_GroupProgress` reporter -- which also drives a colour-coded live line for a
+      non-verbose TTY. The plugin instead emits `logstart` for every test up front and
+      `logreport` for every test at the end, which shows no progress until everything is done
+      and prints every name twice under `-v`.
+
+    Registered `tryfirst` for the plugin's `firstresult` hook, so this wins and the plugin's
+    own implementation does not run. We reuse the plugin's (private) helpers for the individual
+    setup/call/teardown steps so behaviour otherwise stays identical.
+    """
+    if not group.children_have_same_parent:
+        for child in group.children:
+            child.add_marker("skip")
+        warnings.warn(
+            PytestAsyncioConcurrentGroupingWarning(
+                f"Asyncio Concurrent Group [{group.name}] has children from different parents, "
+                "skipping all of its children."
+            ),
+            stacklevel=2,
+        )
+
+    terminalreporter = group.config.pluginmanager.get_plugin("terminalreporter")
+    progress = _GroupProgress(terminalreporter, group.config)
+
+    item_passed_setup: list[AsyncioConcurrentGroupMember] = []
+    for child in group.children:
+        report = _call_and_report(_setup_child(child), child, "setup")
+        if report.passed:
+            item_passed_setup.append(child)
+
+    progress.begin(item_passed_setup)
+
+    async def run_one(
+        child: AsyncioConcurrentGroupMember,
+    ) -> tuple[AsyncioConcurrentGroupMember, pytest.CallInfo, pytest.TestReport]:
+        progress.on_start(child)
+        callinfo = await _call_runtest_async(child)
+        report = child.ihook.pytest_runtest_makereport(item=child, call=callinfo)
+        progress.on_finish(child, callinfo, report)
+        return child, callinfo, report
+
+    async def _run_all() -> list[
+        tuple[AsyncioConcurrentGroupMember, pytest.CallInfo, pytest.TestReport]
+    ]:
+        async with progress.ticking():
+            return await asyncio.gather(*[run_one(c) for c in item_passed_setup])
+
+    loop = _current_event_loop()
+    # Under `-s` the user asked to see output live, so don't divert the subprocess fds.
+    capture_subprocess = group.config.option.capture != "no"
+    # Tag tasks with their owning test (for leaked-task attribution) for the whole group,
+    # including teardown -- that's when fail_on_leaked_tasks inspects the loop.
+    with _task_ownership(loop):
+        if capture_subprocess:
+            with _capture_subprocess_fds(terminalreporter) as captured:
+                results = loop.run_until_complete(_run_all())
+            captured_subprocess_output = captured()
+        else:
+            results = loop.run_until_complete(_run_all())
+            captured_subprocess_output = b""
+        with progress.finalize(results, is_last_group=nextgroup is None):
+            for child in group.children:
+                _call_and_report(_teardown_child(child, nextgroup=nextgroup), child, "teardown")
+                child.ihook.pytest_runtest_logfinish(nodeid=child.nodeid, location=child.location)
+        _emit_captured_subprocess_output(terminalreporter, results, captured_subprocess_output)
+
+    return True
+
+
+def _current_event_loop() -> asyncio.AbstractEventLoop:
+    try:
+        return asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop
+
+
+async def run_member_capturing(item: pytest.Function) -> object:
+    """Run one concurrent test with per-task output capture.
+
+    Replaces the plugin's `pytest_runtest_call_async` (registered `tryfirst` so this wins
+    the `firstresult` race). We deliberately skip the plugin's `hook_wrapper_entered` --
+    that is what re-enters pytest's broken-under-concurrency global capture -- and capture here.
+    """
+    if not inspect.iscoroutinefunction(item.obj):
+        pytest.skip("Marking a sync function with @asyncio_concurrent is invalid.")
+
+    testfunction = item.obj
+    testargs = {arg: item.funcargs[arg] for arg in item._fixtureinfo.argnames}
+
+    # Tag tasks this test spawns with its nodeid so fail_on_leaked_tasks can attribute leaks
+    # to it even though the whole group shares one event loop.
+    owner_token = _task_owner.set(item.nodeid)
+    try:
+        # `-s` / `--capture=no`: the user asked to see output live -- don't buffer it.
+        if item.config.option.capture == "no":
+            return await testfunction(**testargs)
+
+        cap = _TestCapture()
+        # Wire caplog to *this* test's records so caplog-using tests stay correct (and isolated).
+        if _CAPLOG_SUPPORTED and cap.log_handler is not None:
+            item.stash[caplog_handler_key] = cap.log_handler
+            item.stash[caplog_records_key] = {
+                "setup": [],
+                "call": cap.log_handler.records,
+                "teardown": [],
+            }
+
+        with _controller:
+            token = _active.set(cap)
+            try:
+                return await testfunction(**testargs)
+            finally:
+                _active.reset(token)
+                if cap.stdout.getvalue():
+                    item.add_report_section("call", "stdout", cap.stdout.getvalue())
+                if cap.stderr.getvalue():
+                    item.add_report_section("call", "stderr", cap.stderr.getvalue())
+                if cap.log_handler is not None and cap.log_handler.records:
+                    item.add_report_section(
+                        "call", "log", _format_log(cap.log_handler.records, item.config)
+                    )
+    finally:
+        _task_owner.reset(owner_token)
+
+
+# HACK: some callers invoke pytest without installing dev dependencies,
+# so we might end up here without the underlying plugin installed.
+# Keeping the previous behavior intact here.
+if PYTEST_ASYNCIO_CONCURRENT_INSTALLED:
+    # --------------------------------------------------------------------------- #
+    # pytest hooks
+    #
+    # This module is loaded as a *global* plugin (`-p tests.concurrency` in pyproject), not via
+    # conftest.py. That matters: the underlying plugin invokes `pytest_runtest_protocol_async_group`
+    # through `session.ihook`, which is scoped to the rootdir and would NOT see hooks defined in a
+    # subdirectory conftest like tests/conftest.py.
+    # --------------------------------------------------------------------------- #
+    def pytest_addoption(parser: Parser) -> None:
+        add_toggle_option(parser)
+
+    def _disable_concurrent_plugin(config: pytest.Config) -> None:
+        """Unregister pytest-asyncio-concurrent so it doesn't fight xdist.
+
+        Its runtestloop wrapper and collection regrouping assume a single in-process run; under xdist
+        they desync the worker's positional item indexing -- `items[nextitem_index]` runs off the
+        end and the worker dies with an IndexError (surfaced as an INTERNALERROR on the controller).
+        With the plugin gone, plain pytest-asyncio (auto mode) handles the async tests and xdist
+        distributes them by item as usual. Matching on the module name covers both the package and its
+        `.plugin` submodule, and does not match regular `pytest_asyncio`.
+        """
+        pm = config.pluginmanager
+        for plugin in list(pm.get_plugins()):
+            module = getattr(plugin, "__name__", "") or getattr(type(plugin), "__module__", "")
+            if isinstance(module, str) and module.startswith("pytest_asyncio_concurrent"):
+                pm.unregister(plugin)
+
+    def pytest_configure(config: pytest.Config) -> None:
+        if not PYTEST_ASYNCIO_CONCURRENT_INSTALLED:
+            return
+
+        register_markers(config)
+        if _xdist_active(config):
+            # xdist distributes by item; a concurrent group can't span workers. Reject an explicit
+            # request, otherwise disable concurrency (the underlying plugin included) and go sequential.
+            if _requested_mode(config) == "all":
+                raise pytest.UsageError(
+                    "--concurrent (or LK_TEST_CONCURRENCY=all) is incompatible with pytest-xdist "
+                    "(-n): a concurrent group shares a single event loop, which xdist would split "
+                    "across worker processes. Drop -n to run concurrently, or drop --concurrent."
+                )
+            _disable_concurrent_plugin(config)
+            return
+        _enable_cross_parent_grouping()
+
+    def pytest_report_header(config: pytest.Config) -> str | None:
+        # Once per session, on the controller, at the top of the run: announce that -n forced the
+        # default concurrent mode to sequential. (--concurrent under -n already errored in configure.)
+        if hasattr(config, "workerinput"):
+            return None
+        if _xdist_active(config) and _requested_mode(config) != "off":
+            return "concurrency: disabled under pytest-xdist (-n); async tests run sequentially."
+        return None
+
+    @pytest.hookimpl(hookwrapper=True, tryfirst=True)
+    def pytest_pycollect_makeitem(collector: pytest.Collector, name: str, obj: object) -> Any:
+        # Outermost wrapper: runs after pytest-asyncio's auto-mode conversion, so we can restore
+        # the concurrent group members it converted back to ordinary sequential items.
+        outcome = yield
+        repromote_collected(outcome, collector.config)
+
+    @pytest.hookimpl(specname="pytest_runtest_protocol_async_group", tryfirst=True)
+    def pytest_runtest_protocol_async_group(
+        group: AsyncioConcurrentGroup, nextgroup: AsyncioConcurrentGroup | None
+    ) -> object:
+        # Wins the plugin's firstresult hook; fixes its event-loop handling (see run_group).
+        return run_group(group, nextgroup)
+
+    @pytest.hookimpl(specname="pytest_runtest_call_async", tryfirst=True)
+    async def pytest_runtest_call_async(item: pytest.Function) -> object:
+        # Wins the plugin's firstresult hook; adds per-task output capture.
+        return await run_member_capturing(item)
+
+    def _enable_cross_parent_grouping() -> None:
+        """One concurrent group per module: module-level tests plus every class in the file.
+
+        The plugin pins a group to the parent of its first member and skips any group whose
+        members don't all share it. Here the group sits at the Module and mixed parents are
+        allowed. A class-scoped fixture on a concurrent member fails at setup as a result --
+        its finalizer needs the Class node on SetupState, which module grouping removes.
+        Function-, module-, and session-scoped fixtures are unaffected.
+        """
+        if getattr(AsyncioConcurrentGroup, "_lk_cross_parent_grouping", False):
+            return
+
+        original_init = AsyncioConcurrentGroup.__init__
+
+        def init_at_module(self, parent, originalname):
+            original_init(self, parent.getparent(pytest.Module) or parent, originalname)
+
+        def add_child_keep_group(self, item):
+            item.group = self
+            self.children.append(item)
+            self.children_finalizer[item] = []
+
+        AsyncioConcurrentGroup.__init__ = init_at_module
+        AsyncioConcurrentGroup.add_child = add_child_keep_group
+        AsyncioConcurrentGroup._lk_cross_parent_grouping = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,12 @@ from livekit.agents.cli import log
 
 from . import concurrency
 from .toxic_proxy import Toxiproxy
+from .virtual_time import (  # noqa: F401  (re-exported so pytest discovers the fixtures)
+    _virtual_wall_clock,
+    add_realtime_option as _add_realtime_option,
+    event_loop_policy,
+    register_marker as _register_virtual_time_marker,
+)
 
 TEST_CONNECT_OPTIONS = dataclasses.replace(DEFAULT_API_CONNECT_OPTIONS, retry_interval=0.0)
 
@@ -48,6 +54,7 @@ _CATEGORY_HINT = (
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
+    _add_realtime_option(parser)
     group = parser.getgroup("categories", "test category selection")
     for category in CATEGORIES:
         group.addoption(
@@ -124,6 +131,7 @@ def _uncategorized_modules(config: pytest.Config) -> list[Path]:
 def pytest_configure(config: pytest.Config) -> None:
     """Handle `--list-categories` before any collection/import happens."""
     _module_facts.cache_clear()
+    _register_virtual_time_marker(config)
 
     if not config.getoption("--list-categories"):
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,16 @@ import dataclasses
 import logging
 import re
 from collections.abc import Iterator
+from functools import cache
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 
 from livekit.agents import DEFAULT_API_CONNECT_OPTIONS, utils
 from livekit.agents.cli import log
 
+from . import concurrency
 from .toxic_proxy import Toxiproxy
 
 TEST_CONNECT_OPTIONS = dataclasses.replace(DEFAULT_API_CONNECT_OPTIONS, retry_interval=0.0)
@@ -71,15 +74,25 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-def _read_source(path: Path) -> str:
+class _ModuleFacts(NamedTuple):
+    categories: frozenset[str]
+    has_tests: bool
+
+
+@cache
+def _module_facts(path: Path) -> _ModuleFacts:
+    """
+    Retrieve information about the module without importing it.
+    Cache to avoid redundant filesystem reads.
+    """
     try:
-        return path.read_text(encoding="utf-8")
+        source = path.read_text(encoding="utf-8")
     except OSError:
-        return ""
-
-
-def _module_categories(source: str) -> set[str]:
-    return set(_CATEGORY_RE.findall(source))
+        return _ModuleFacts(frozenset(), False)
+    return _ModuleFacts(
+        frozenset(_CATEGORY_RE.findall(source)),
+        _HAS_TESTS_RE.search(source) is not None,
+    )
 
 
 def _plural(n: int, noun: str) -> str:
@@ -100,16 +113,18 @@ def _uncategorized_modules(config: pytest.Config) -> list[Path]:
     """Test files that contain tests but declare no category marker."""
     offenders: list[Path] = []
     for path in _iter_test_files(config):
-        source = _read_source(path)
-        if not _HAS_TESTS_RE.search(source):
+        facts = _module_facts(path)
+        if not facts.has_tests:
             continue  # empty / fully-commented module: nothing to categorize
-        if not _module_categories(source):
+        if not facts.categories:
             offenders.append(path)
     return offenders
 
 
 def pytest_configure(config: pytest.Config) -> None:
     """Handle `--list-categories` before any collection/import happens."""
+    _module_facts.cache_clear()
+
     if not config.getoption("--list-categories"):
         return
 
@@ -117,14 +132,13 @@ def pytest_configure(config: pytest.Config) -> None:
     by_category: dict[str, list[str]] = {c: [] for c in CATEGORIES}
     uncategorized: list[str] = []
     for path in _iter_test_files(config):
-        source = _read_source(path)
-        if not _HAS_TESTS_RE.search(source):
+        facts = _module_facts(path)
+        if not facts.has_tests:
             continue
         rel = str(path.relative_to(rootdir))
-        cats = _module_categories(source)
-        if not cats:
+        if not facts.categories:
             uncategorized.append(rel)
-        for cat in cats:
+        for cat in facts.categories:
             by_category[cat].append(rel)
 
     lines = ["", "Test categories (select with --<category>):", ""]
@@ -178,16 +192,9 @@ def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool 
         return None
     if not collection_path.name.startswith("test_"):
         return None
-
-    try:
-        source = collection_path.read_text(encoding="utf-8")
-    except OSError:
+    if _module_facts(collection_path).categories.intersection(selected):
         return None
 
-    # ignore the module only if it carries none of the selected categories' markers;
-    # otherwise return None (defer) so --ignore and other plugins still apply.
-    if any(f"pytest.mark.{category}" in source for category in selected):
-        return None
     return True
 
 
@@ -242,7 +249,7 @@ def _logging_baseline():
     return [(logger, logger.level, logger.handlers[:], logger.propagate) for logger in loggers]
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def _restore_logging(_logging_baseline):
     """Revert global logging a test mutated (e.g. via cli.log.setup_logging)."""
     yield
@@ -307,7 +314,22 @@ def format_task(task) -> str:
 
 
 @pytest.fixture(autouse=True)
-async def fail_on_leaked_tasks():
+async def fail_on_leaked_tasks(request):
+    if concurrency.is_concurrent_member(request.node):
+        # Concurrent group members share one event loop, so we can't diff asyncio.all_tasks()
+        # (it would flag other still-running tests). Instead ask which still-pending tasks were
+        # created by *this* test -- tagged via contextvars, see tests/concurrency.py.
+        yield
+        leaked_tasks = [
+            task
+            for task in concurrency.owned_pending_tasks(request.node.nodeid)
+            if not _is_ignorable_task(task)
+        ]
+        if leaked_tasks:
+            tasks_msg = "\n\n".join(format_task(task) for task in leaked_tasks)
+            pytest.fail("Test leaked tasks:\n\n" + tasks_msg)
+        return
+
     tasks_before = set(asyncio.all_tasks())
 
     yield

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -37,7 +37,7 @@ from livekit.agents.voice.io import PlaybackFinishedEvent
 
 from .fake_session import FakeActions, create_session, run_session
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 
 class MyAgent(Agent):

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -4,7 +4,7 @@ import pytest
 
 from livekit.agents.utils import aio
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 
 async def test_channel():

--- a/tests/test_aio_itertools.py
+++ b/tests/test_aio_itertools.py
@@ -4,7 +4,7 @@ import pytest
 
 from livekit.agents.utils.aio.itertools import Tee
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 
 async def _async_iter(items):

--- a/tests/test_amd_classifier.py
+++ b/tests/test_amd_classifier.py
@@ -21,7 +21,7 @@ from livekit.agents.voice.amd.classifier import (
 
 from .fake_llm import FakeLLM, FakeLLMResponse
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 
 def _make_classifier(

--- a/tests/test_audio_decoder.py
+++ b/tests/test_audio_decoder.py
@@ -130,7 +130,7 @@ def test_stream_buffer_large_chunks():
     def reader():
         nonlocal received_size
         # allow writer to start first
-        time.sleep(1)
+        time.sleep(0.1)
         while True:
             chunk = buffer.read(8192)  # Read in 8KB chunks
             if not chunk:

--- a/tests/test_audio_decoder.py
+++ b/tests/test_audio_decoder.py
@@ -15,7 +15,9 @@ from livekit.agents.utils.misc import is_cloud
 
 from .utils import wer
 
-pytestmark = pytest.mark.unit
+# Decodes audio on background threads / executors with blocking waits; it deadlocks when forced
+# to share one event loop with other tests.
+pytestmark = [pytest.mark.unit, pytest.mark.no_concurrent]
 
 TEST_AUDIO_FILEPATH = os.path.join(os.path.dirname(__file__), "change-sophie.opus")
 

--- a/tests/test_audio_emitter.py
+++ b/tests/test_audio_emitter.py
@@ -11,7 +11,7 @@ import pytest
 from livekit.agents import tts, utils
 from livekit.agents.types import USERDATA_TIMED_TRANSCRIPT, TimedString
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 
 def _make_pcm(sample_rate: int, num_channels: int, duration_ms: int) -> bytes:

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -15,7 +15,7 @@ import pytest
 
 from livekit.agents.voice.audio_recognition import AudioRecognition
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 
 class TestAudioRecognitionAclose:

--- a/tests/test_audio_recognition_handoff.py
+++ b/tests/test_audio_recognition_handoff.py
@@ -10,7 +10,7 @@ from livekit.agents import Agent
 from livekit.agents.voice.agent import ModelSettings
 from livekit.agents.voice.agent_activity import AgentActivity
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 
 def _make_activity(agent: Agent, stt: object) -> MagicMock:

--- a/tests/test_chat_ctx.py
+++ b/tests/test_chat_ctx.py
@@ -14,7 +14,7 @@ from livekit.agents.types import (
 
 from .fake_llm import FakeLLM, FakeLLMResponse
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 
 def ai_function1(a: int, b: str = "default") -> None:

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -4,7 +4,7 @@ import pytest
 
 from livekit.agents.utils import ConnectionPool
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 
 class DummyConnection:

--- a/tests/test_debounce.py
+++ b/tests/test_debounce.py
@@ -4,7 +4,7 @@ import pytest
 
 from livekit.agents.utils.aio.debounce import Debounced, debounced
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 
 class TestDebounce:

--- a/tests/test_drain_timeout.py
+++ b/tests/test_drain_timeout.py
@@ -27,7 +27,7 @@ from livekit.agents.ipc.supervised_proc import SupervisedProc, SupervisedProcKin
 from livekit.agents.utils import aio
 from livekit.agents.worker import AgentServer
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 _CLI_ARGS = CliArgs(log_level="ERROR", url=None, api_key=None, api_secret=None)
 

--- a/tests/test_filler.py
+++ b/tests/test_filler.py
@@ -9,7 +9,7 @@ import pytest
 from livekit.agents.voice.events import AgentStateChangedEvent, UserStateChangedEvent
 from livekit.agents.voice.filler_scheduler import _FillerScheduler
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 
 class _FakeSpeechHandle:

--- a/tests/test_http_context_helper.py
+++ b/tests/test_http_context_helper.py
@@ -12,7 +12,7 @@ import pytest
 from livekit.agents import inference
 from livekit.agents.utils import http_context
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 
 async def test_open_yields_working_session_and_closes_on_exit() -> None:

--- a/tests/test_interruption/test_interruption_failover.py
+++ b/tests/test_interruption/test_interruption_failover.py
@@ -28,7 +28,7 @@ from livekit.agents.inference.interruption import (
 )
 from livekit.agents.types import APIConnectOptions
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 MAX_RETRY = 2
 CONN_OPTIONS = APIConnectOptions(max_retry=MAX_RETRY, retry_interval=0.0, timeout=1.0)

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -21,7 +21,7 @@ from livekit.agents.ipc.log_queue import LogQueueHandler, LogQueueListener
 from livekit.agents.utils.aio import duplex_unix
 from livekit.protocol import agent
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 
 @dataclass

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -88,7 +88,7 @@ async def test_async_channel():
     )
 
     await pch.aclose()
-    await asyncio.sleep(0.5)
+    await asyncio.sleep(0.1)
     proc.terminate()
     proc.join()
 
@@ -194,7 +194,7 @@ async def _job_entrypoint_session_aclose_hangs(job_ctx: JobContext) -> None:
     from livekit.agents.ipc import job_proc_lazy_main
 
     # Shrink the hardcoded guardrail so the test doesn't wait the full 60s.
-    job_proc_lazy_main._SESSION_ACLOSE_TIMEOUT = 2.0
+    job_proc_lazy_main._SESSION_ACLOSE_TIMEOUT = 0.5
 
     start_args: _StartArgs = job_ctx.proc.user_arguments
 
@@ -507,7 +507,7 @@ async def test_shutdown_no_job():
 
 async def test_job_slow_shutdown():
     mp_ctx = mp.get_context("spawn")
-    proc, start_args = _create_proc(close_timeout=1.0, mp_ctx=mp_ctx)
+    proc, start_args = _create_proc(close_timeout=0.3, mp_ctx=mp_ctx)
     start_args.shutdown_simulate_work_time = 10.0
 
     await proc.start()
@@ -527,7 +527,7 @@ async def test_shutdown_callback_runs_when_session_aclose_hangs():
     """Regression test: when AgentSession.aclose() blocks indefinitely during
     job shutdown, the _SESSION_ACLOSE_TIMEOUT guardrail must fire and
     user-registered shutdown callbacks must still run. The entrypoint shrinks
-    the hardcoded constant to 2s so the test stays fast."""
+    the hardcoded constant to 0.5s so the test stays fast."""
     mp_ctx = mp.get_context("spawn")
     proc, start_args = _create_proc(
         close_timeout=20.0,
@@ -577,7 +577,7 @@ async def test_shutdown_callback_runs_when_entrypoint_raises():
 async def test_job_graceful_shutdown():
     mp_ctx = mp.get_context("spawn")
     proc, start_args = _create_proc(close_timeout=10.0, mp_ctx=mp_ctx)
-    start_args.shutdown_simulate_work_time = 1.0
+    start_args.shutdown_simulate_work_time = 0.3
     await proc.start()
     await proc.initialize()
 

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -90,7 +90,7 @@ async def test_async_channel():
     await pch.aclose()
     await asyncio.sleep(0.1)
     proc.terminate()
-    proc.join()
+    await asyncio.get_running_loop().run_in_executor(None, proc.join)
 
 
 def test_sync_channel():
@@ -159,6 +159,12 @@ def _initialize_proc(proc: JobProcess) -> None:
 
     with start_args.update_ev:
         start_args.update_ev.notify()
+
+
+def _failing_initialize_proc(proc: JobProcess) -> None:
+    # Runs in the spawned child; raising here makes every spawn's initialize() fail. Used instead
+    # of monkeypatching ProcJobExecutor process-wide, so the test is safe to run concurrently.
+    raise RuntimeError("simulated init failure")
 
 
 async def _job_entrypoint(job_ctx: JobContext) -> None:
@@ -409,39 +415,24 @@ async def test_slow_initialization():
         assert exitcode != 0, "process should have been killed"
 
 
-async def test_proc_pool_launch_job_raises_when_all_spawns_fail(monkeypatch):
+async def test_proc_pool_launch_job_raises_when_all_spawns_fail():
     """When every spawn task fails to initialize, launch_job should raise
-    instead of hanging on an empty warmed-process queue. Reproduces #5868."""
+    instead of hanging on an empty warmed-process queue. Reproduces #5868.
 
-    class FailingProc:
-        running_job = None
-
-        def __init__(self, **kwargs):
-            pass
-
-        async def start(self) -> None:
-            pass
-
-        async def initialize(self) -> None:
-            raise TimeoutError("init timed out")
-
-        async def aclose(self) -> None:
-            pass
-
-        def logging_extra(self) -> dict:
-            return {}
-
-    monkeypatch.setattr(ipc.proc_pool.job_proc_executor, "ProcJobExecutor", FailingProc)
-
+    The failure is injected via a real executor whose init fn raises (not by
+    monkeypatching ProcJobExecutor process-wide), so this is safe to run
+    concurrently with its peers.
+    """
     mp_ctx = mp.get_context("spawn")
     loop = asyncio.get_running_loop()
     pool = ipc.proc_pool.ProcPool(
         job_executor_type=job.JobExecutorType.PROCESS,
-        initialize_process_fnc=_initialize_proc,
+        initialize_process_fnc=_failing_initialize_proc,
         job_entrypoint_fnc=_job_entrypoint,
         session_end_fnc=None,
         num_idle_processes=0,
-        initialize_timeout=0.1,
+        # generous so initialize() fails via the init fn raising, not a spawn-racing timeout
+        initialize_timeout=10.0,
         close_timeout=20.0,
         session_end_timeout=300.0,
         inference_executor=None,

--- a/tests/test_langgraph.py
+++ b/tests/test_langgraph.py
@@ -16,7 +16,7 @@ from typing_extensions import TypedDict
 from livekit.agents.llm import ChatContext
 from livekit.plugins.langchain import LLMAdapter
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 # --- State definitions ---
 

--- a/tests/test_nested_agent_task.py
+++ b/tests/test_nested_agent_task.py
@@ -9,7 +9,7 @@ from livekit.agents.llm import FunctionToolCall
 
 from .fake_llm import FakeLLM, FakeLLMResponse
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 
 class InnerTask(AgentTask):

--- a/tests/test_openai_realtime_chat_ctx.py
+++ b/tests/test_openai_realtime_chat_ctx.py
@@ -9,7 +9,7 @@ from livekit.agents.llm import remote_chat_context
 from livekit.plugins.openai.realtime import realtime_model
 from livekit.plugins.openai.realtime.realtime_model import RealtimeSession
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 
 def _create_session() -> RealtimeSession:

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -27,7 +27,7 @@ from .fake_stt import FakeSTT
 from .fake_tts import FakeTTS
 from .fake_vad import FakeVAD
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 # ---------------------------------------------------------------------------
 # Shared helpers

--- a/tests/test_room.py
+++ b/tests/test_room.py
@@ -354,7 +354,7 @@ class TestReconnect:
                 )
 
                 # Audio continues to flow uninterrupted.
-                await mon.assert_audio_continuous(min_rms=_AUDIO_RMS_THRESHOLD, duration=1.5)
+                await mon.assert_audio_continuous(min_rms=_AUDIO_RMS_THRESHOLD, duration=1.0)
 
     async def test_full_reconnect_republishes_once_and_audio_recovers(self):
         """Full reconnect must fire `reconnected` exactly once, end with
@@ -413,5 +413,5 @@ class TestReconnect:
                 async with AudioEnergyMonitor.watch(new_track) as new_mon:
                     await new_mon.wait_for_audio(min_rms=_AUDIO_RMS_THRESHOLD, timeout=10.0)
                     await new_mon.assert_audio_continuous(
-                        min_rms=_AUDIO_RMS_THRESHOLD, duration=1.5
+                        min_rms=_AUDIO_RMS_THRESHOLD, duration=1.0
                     )

--- a/tests/test_room.py
+++ b/tests/test_room.py
@@ -32,7 +32,7 @@ from .utils.livekit_test import (
     wait_for_event,
 )
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 TIMEOUT = 5.0
 

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -16,7 +16,7 @@ from livekit.agents.voice.room_io._output import _ParticipantTranscriptionOutput
 from livekit.agents.voice.room_io.room_io import RoomIO
 from livekit.agents.voice.room_io.types import NoiseCancellationParams
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 # -- helpers ------------------------------------------------------------------
 

--- a/tests/test_schema_gemini.py
+++ b/tests/test_schema_gemini.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 
 from livekit.plugins.google import utils
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 #  Gemini Schema Tests
 

--- a/tests/test_session_host.py
+++ b/tests/test_session_host.py
@@ -32,7 +32,7 @@ from livekit.agents.voice.remote_session import (
 )
 from livekit.protocol.agent_pb import agent_session as agent_pb
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 # ---------------------------------------------------------------------------
 # In-memory transport for testing

--- a/tests/test_speech_start_time_persistence.py
+++ b/tests/test_speech_start_time_persistence.py
@@ -29,7 +29,7 @@ import pytest
 from livekit.agents.vad import VADEvent, VADEventType
 from livekit.agents.voice.audio_recognition import AudioRecognition
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 
 class TestUserTurnStartPersistence:

--- a/tests/test_stt_base.py
+++ b/tests/test_stt_base.py
@@ -19,7 +19,7 @@ from livekit.agents.stt import (
 from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS
 from livekit.agents.utils.audio import AudioBuffer
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 
 class _DummyStream(RecognizeStream):

--- a/tests/test_stt_fallback.py
+++ b/tests/test_stt_fallback.py
@@ -20,7 +20,7 @@ from livekit.agents.utils.audio import AudioBuffer
 
 from .fake_stt import FakeSTT
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 
 class FallbackAdapterTester(FallbackAdapter):

--- a/tests/test_supervised_proc_memory.py
+++ b/tests/test_supervised_proc_memory.py
@@ -13,7 +13,7 @@ from livekit.agents.ipc.supervised_proc import (
     SupervisedProcKind,
 )
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 
 class _FakeProc(SupervisedProc):

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -5,7 +5,7 @@ from livekit.agents.tokenize import basic, blingfire
 from livekit.agents.tokenize._basic_paragraph import split_paragraphs
 from livekit.plugins import nltk
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 # Download the punkt tokenizer, will only download if not already present
 nltk.NltkPlugin().download_files()

--- a/tests/test_tool_proxy.py
+++ b/tests/test_tool_proxy.py
@@ -6,7 +6,7 @@ import pytest
 from livekit.agents.beta.toolsets.tool_proxy import ToolProxyToolset
 from livekit.agents.llm import ToolContext, ToolError, Toolset, function_tool
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 
 @function_tool

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -10,7 +10,7 @@ from livekit.agents.beta.toolsets.tool_search import (
 )
 from livekit.agents.llm import Tool, ToolContext, Toolset, function_tool
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 
 @function_tool

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -23,7 +23,7 @@ from livekit.agents.llm.utils import (
     prepare_function_arguments,
 )
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 
 class MockOption(str, enum.Enum):

--- a/tests/test_transcription_filter.py
+++ b/tests/test_transcription_filter.py
@@ -3,7 +3,7 @@ import pytest
 from livekit.agents.voice.transcription.filters import filter_emoji, filter_markdown
 from livekit.agents.voice.transcription.text_transforms import _apply_text_transforms, replace
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 MARKDOWN_INPUT = """# Mathematics and Markdown Guide
 

--- a/tests/test_tts_fallback.py
+++ b/tests/test_tts_fallback.py
@@ -13,7 +13,7 @@ from livekit.agents.utils.aio.channel import ChanEmpty
 
 from .fake_tts import FakeTTS
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 
 class FallbackAdapterTester(FallbackAdapter):

--- a/tests/test_user_turn_exceeded.py
+++ b/tests/test_user_turn_exceeded.py
@@ -9,7 +9,7 @@ from livekit.agents.voice.transcription.synchronizer import _SyncedAudioOutput
 
 from .fake_session import FakeActions, create_session, run_session
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 SESSION_TIMEOUT = 30
 

--- a/tests/virtual_time.py
+++ b/tests/virtual_time.py
@@ -1,0 +1,381 @@
+"""Deterministic virtual-time execution for timing-coupled async tests.
+
+Voice tests drive the agent through fake STT/TTS/VAD/audio components in *real* wall-clock
+time: the agent's endpointing, interruption timeouts and audio play-out clock all schedule
+against the event loop and measure durations with `time.time()` / `time.perf_counter()`.
+That makes the suite sensitive to scheduler jitter -- a shared event loop, or a slow/contended
+CI runner, perturbs the relative timing and the count assertions race.
+
+A test marked `@pytest.mark.virtual_time` runs instead on a :class:`_VirtualTimeLoop`, whose
+clock only advances when the loop goes idle (it jumps straight to the next scheduled timer). No
+real time passes, so a 30-second scripted conversation completes in microseconds and, crucially,
+*deterministically* -- the order of timer firings is fixed by their scheduled times, not by who
+won a CPU slice.
+
+The loop only virtualizes `loop.time()` (what `asyncio.sleep`/`call_later` read). The
+agent and fakes also read wall time directly, so :func:`_virtual_wall_clock` additionally points
+`time.time()` / `time.perf_counter()` at the running loop's virtual clock *for the duration of
+the marked test only* -- a scoped patch, so no global state leaks between tests.
+
+Wiring (conftest.py re-exports these so pytest discovers them):
+- :func:`event_loop_policy` is pytest-asyncio's override point for the loop a test runs on; it
+  returns the virtual-time policy for marked tests and the default policy otherwise (so non-marked
+  tests behave exactly as before).
+- :func:`_virtual_wall_clock` is autouse; a no-op unless the test carries the marker. It patches
+  the `time` module for inline reads and, for `Field(default_factory=time.time)` references
+  captured at import (which a module patch cannot reach), rewrites the validators in place via
+  :func:`_patch_model_factories` so `created_at` timestamps also run on virtual time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import selectors
+import time
+from collections.abc import Callable, Iterator, Mapping
+from typing import Any
+from unittest import mock
+
+import pytest
+
+# A fixed, realistic wall-clock base so patched `time.time()` still looks like a real epoch.
+# Only differences are ever asserted under virtual time, so the exact value is irrelevant.
+_WALL_CLOCK_EPOCH = 1_700_000_000.0
+
+# The real clocks, captured at import (before any patch is installed) so the fallbacks below can
+# hand real wall time to callers that aren't on the virtual loop, and as the signature for
+# discovering which captured `default_factory` references to redirect.
+_REAL_TIME = time.time
+_REAL_PERF = time.perf_counter
+
+# Smallest separation between two wall-clock reads at the same loop instant. The clock does not
+# move between reads within one tick, but synchronously-created items still need distinct, ordered
+# `created_at` values (ChatContext reconciliation orders by it), so reads are nudged to stay
+# strictly increasing (see _VirtualClock.read). Tiny enough that accumulation across a test stays
+# far below any timing assertion's tolerance.
+_TICK_EPSILON = 1e-6
+
+
+def _virtual_loop() -> _VirtualTimeLoop | None:
+    """The virtual-time loop driving the current call, or None.
+
+    Returns None when there is no running loop (e.g. a background thread such as the OpenTelemetry
+    metrics exporter) or the running loop is an ordinary real one. The clock patch lives on the
+    `time` module process-wide for the duration of a virtual-time test, so it is reachable from
+    any thread; only callers actually on the virtual loop should see virtual time -- everyone else
+    must get the real wall clock, otherwise a stray read freezes at the epoch (which, for the
+    metrics exporter, stamps batches with a 2023 timestamp the gateway then rejects).
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return None
+    return loop if isinstance(loop, _VirtualTimeLoop) else None
+
+
+def _now() -> float:
+    # Off the virtual loop (no running loop, or a real one) fall back to the real clock, so stray
+    # reads from other threads see true wall time.
+    loop = _virtual_loop()
+    return _WALL_CLOCK_EPOCH + loop.monotonic_read() if loop is not None else _REAL_TIME()
+
+
+def _perf() -> float:
+    loop = _virtual_loop()
+    return loop.monotonic_read() if loop is not None else _REAL_PERF()
+
+
+# Maps a captured real clock to its virtual replacement. A model field built with
+# `Field(default_factory=time.time)` captures the bare `time.time` at import; patching the
+# `time` module later cannot reach that captured reference, so :func:`_patch_model_factories`
+# rewrites it in the validator instead.
+_VIRTUAL_FOR = {_REAL_TIME: _now, _REAL_PERF: _perf}
+
+
+def is_virtual_time(node: pytest.Item) -> bool:
+    # `--real-time` disables virtual time globally; the `real_time` marker opts out a single test.
+    if node.config.getoption("--real-time", default=False):
+        return False
+    return (
+        node.get_closest_marker("virtual_time") is not None
+        and node.get_closest_marker("real_time") is None
+    )
+
+
+def _to_plain(obj: Any) -> Any:
+    """Materialize a (possibly lazy `MockCoreSchema`) core schema into a fresh plain dict tree.
+
+    pydantic exposes `__pydantic_core_schema__` as a `Mapping` proxy whose `deepcopy` stays
+    a proxy, but `SchemaValidator` needs real dicts. Rebuilding every mapping/list also gives an
+    independent copy we can edit without touching the class's schema.
+    """
+    if isinstance(obj, Mapping):
+        return {k: _to_plain(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_to_plain(v) for v in obj]
+    return obj
+
+
+def _model_node(schema: dict[str, Any]) -> dict[str, Any]:
+    """Descend `definitions` / validator wrappers to the `model` node holding the fields."""
+    node = schema
+    while node.get("type") != "model":
+        node = node["schema"]
+    return node
+
+
+# Built once, lazily: `model -> (patched_validator, original_validator)`. The patched validator
+# is invariant across tests (its `default_factory` is `_now`, which resolves the running loop
+# at call time), so we pay the schema-edit + validator construction a single time and then only
+# swap references per test.
+_PATCHED: dict[type, tuple[Any, Any]] = {}
+
+
+def _build_patch_cache() -> None:
+    """Construct, once, a virtual-clock validator for every model with a captured real clock."""
+    if _PATCHED:
+        return
+    from pydantic_core import SchemaValidator
+
+    for model, fields in _discover_factory_patches().items():
+        schema = _to_plain(model.__pydantic_core_schema__)
+        node = _model_node(schema)
+        field_schemas = node["schema"]["fields"]
+        for name, factory in fields.items():
+            field_schemas[name]["schema"]["default_factory"] = factory
+        # _use_prebuilt=False forces a build from our edited schema instead of reusing the
+        # validator cached on the class.
+        patched = SchemaValidator(schema, node.get("config"), _use_prebuilt=False)
+        _PATCHED[model] = (patched, model.__pydantic_validator__)
+
+
+@contextlib.contextmanager
+def _patched_model_clocks() -> Iterator[None]:
+    """Swap every captured-clock model onto its virtual-clock validator, then restore.
+
+    All such models move together so `created_at`-ordered structures (e.g. `ChatContext`,
+    which inserts by `created_at`) stay consistent -- a partial swap would interleave virtual
+    and real timestamps and scramble item order. The per-test cost is just the reference swaps.
+    """
+    _build_patch_cache()
+    try:
+        for model, (patched, _original) in _PATCHED.items():
+            model.__pydantic_validator__ = patched  # type: ignore[attr-defined]
+        yield
+    finally:
+        for model, (_patched, original) in _PATCHED.items():
+            model.__pydantic_validator__ = original  # type: ignore[attr-defined]
+
+
+def _discover_factory_patches() -> dict[type, dict[str, Callable[[], Any]]]:
+    """Find every pydantic model field whose `default_factory` is a real clock, grouped by model.
+
+    Self-maintaining: any new event/chat-context model with a `default_factory=time.time` field
+    is picked up automatically, no registry to update. Imported lazily so importing this module
+    stays cheap and free of livekit import-order constraints.
+    """
+    from pydantic import BaseModel
+
+    from livekit.agents.inference import interruption
+    from livekit.agents.llm import chat_context
+    from livekit.agents.voice import events
+
+    patches: dict[type, dict[str, Callable[[], Any]]] = {}
+    for module in (events, chat_context, interruption):
+        for obj in vars(module).values():
+            if not (isinstance(obj, type) and issubclass(obj, BaseModel)):
+                continue
+            fields = {
+                name: _VIRTUAL_FOR[info.default_factory]  # type: ignore[index]
+                for name, info in obj.model_fields.items()
+                if info.default_factory in _VIRTUAL_FOR
+            }
+            if fields:
+                patches[obj] = fields
+    return patches
+
+
+# Sub-tick ordering granularity. The autojumping clock jumps straight onto the next scheduled
+# time, so two timers due at the same virtual instant fire in asyncio's heap order (which reflects
+# heap structure, not scheduling order) -- and that can invert the order real time would produce
+# for causally-ordered-but-simultaneous events. We give each timer a strictly increasing
+# sub-microsecond nudge so same-instant timers fire in *scheduling* (FIFO) order, matching the
+# causal order real wall-clock produces. The nudge needs a finer clock resolution than the default
+# 1e-6 to be representable; accumulation across a test stays far below any timing tolerance.
+_TIE_BREAK = 1e-9
+_FINE_RESOLUTION = 1e-12
+
+
+class _VirtualClock:
+    """The loop's virtual clock.
+
+    `time()` only moves when `advance()` is called (by the selector), and is what asyncio reads for
+    scheduling -- it must stay raw so the sub-nanosecond timer tie-break (see _VirtualTimeLoop) is
+    not swamped. `read()` is the wall-clock view: the same virtual time, but nudged to stay
+    strictly increasing within a tick so synchronously-created items get distinct, ordered
+    `created_at`. The high-water mark lives here (per loop), so it resets naturally with each test's
+    fresh loop -- no global state.
+    """
+
+    __slots__ = ("_time", "_read")
+
+    def __init__(self) -> None:
+        self._time = 0.0
+        self._read = 0.0
+
+    def time(self) -> float:
+        return self._time
+
+    def advance(self, seconds: float) -> None:
+        if seconds > 0:
+            self._time += seconds
+
+    def read(self) -> float:
+        self._read = self._time if self._time > self._read else self._read + _TICK_EPSILON
+        return self._read
+
+
+class _AutojumpSelector(selectors.BaseSelector):
+    """A selector that never really blocks: instead of waiting `timeout` seconds for the next
+    timer, it jumps the virtual clock there and returns immediately.
+
+    It delegates fd registration to a real selector and still polls it non-blockingly, so the
+    loop's own self-pipe (and thus `call_soon_threadsafe` wakeups from executor threads) keep
+    working. A `None` timeout means the loop has nothing scheduled and is genuinely waiting on
+    such a wakeup, so we block on the real selector -- matching stock asyncio.
+    """
+
+    def __init__(self, clock: _VirtualClock) -> None:
+        self._clock = clock
+        self._real = selectors.DefaultSelector()
+
+    def register(self, fileobj: Any, events: int, data: Any = None) -> selectors.SelectorKey:
+        return self._real.register(fileobj, events, data)
+
+    def unregister(self, fileobj: Any) -> selectors.SelectorKey:
+        return self._real.unregister(fileobj)
+
+    def modify(self, fileobj: Any, events: int, data: Any = None) -> selectors.SelectorKey:
+        return self._real.modify(fileobj, events, data)
+
+    def select(self, timeout: float | None = None) -> list[tuple[selectors.SelectorKey, int]]:
+        # Hot path: only the loop's self-pipe is registered (no real I/O). A real poll could only
+        # ever report that self-pipe, and a `call_soon_threadsafe` wakeup's callback is already
+        # queued in the loop's `_ready` (so the next iteration runs it regardless) -- skipping the
+        # poll therefore can't drop work. It just avoids an epoll syscall on every loop iteration,
+        # which is what keeps virtual time as fast as a fully virtual selector.
+        if len(self._real.get_map()) <= 1:
+            if timeout is None:
+                return self._real.select(None)  # genuinely idle: block for an off-loop wakeup
+            if timeout > 0:
+                self._clock.advance(timeout)
+            return []
+        # Real I/O is registered: poll without blocking and jump only if nothing is ready.
+        ready = self._real.select(0)
+        if ready or timeout == 0:
+            return ready
+        if timeout is None:
+            return self._real.select(None)
+        self._clock.advance(timeout)
+        return []
+
+    def get_map(self) -> Any:
+        return self._real.get_map()
+
+    def close(self) -> None:
+        self._real.close()
+
+
+class _VirtualTimeLoop(asyncio.SelectorEventLoop):
+    """A `SelectorEventLoop` whose clock only advances when the loop would otherwise sleep.
+
+    The selector jumps the virtual clock straight to the next scheduled callback (see
+    :class:`_AutojumpSelector`), so timing-coupled tests run in ~0 wall time and deterministically.
+    Same-instant timers are nudged into scheduling (FIFO) order so they fire in the causal order
+    real wall time would produce.
+    """
+
+    def __init__(self) -> None:
+        self._virtual_clock = _VirtualClock()
+        super().__init__(selector=_AutojumpSelector(self._virtual_clock))
+        # Resolve finely enough that the sub-nanosecond tie-break is representable and only the
+        # exact-same-instant timer fires per jump.
+        self._clock_resolution = _FINE_RESOLUTION
+        self._tie_seq = 0
+
+    def time(self) -> float:
+        return self._virtual_clock.time()
+
+    def monotonic_read(self) -> float:
+        """Strictly-increasing wall-clock read off this loop's clock (see _VirtualClock.read)."""
+        return self._virtual_clock.read()
+
+    def call_at(self, when: float, callback: Any, *args: Any, **kwargs: Any) -> Any:
+        self._tie_seq += 1
+        return super().call_at(when + self._tie_seq * _TIE_BREAK, callback, *args, **kwargs)
+
+
+class _VirtualTimePolicy(asyncio.DefaultEventLoopPolicy):
+    def new_event_loop(self) -> asyncio.AbstractEventLoop:
+        return _VirtualTimeLoop()
+
+
+@pytest.fixture
+def event_loop_policy(request: pytest.FixtureRequest) -> asyncio.AbstractEventLoopPolicy:
+    """Loop policy pytest-asyncio builds the test loop from.
+
+    Virtual-time tests get a :class:`_VirtualTimeLoop` (autojumping virtual clock); everything else
+    gets the default policy, i.e. exactly what pytest-asyncio would use without this override, so
+    non-marked tests are unaffected. `real_time` opts a test out even under a module-level mark.
+    """
+    if is_virtual_time(request.node):
+        return _VirtualTimePolicy()
+    return asyncio.DefaultEventLoopPolicy()
+
+
+@pytest.fixture(autouse=True)
+def _virtual_wall_clock(request: pytest.FixtureRequest) -> Iterator[None]:
+    """Point wall-clock reads at the running loop's virtual clock for a `virtual_time` test.
+
+    No-op unless the test is marked `virtual_time`. Two kinds of reads are covered:
+
+    - inline `time.time()` / `time.perf_counter()` -- redirected by patching the `time`
+      module (these re-read the attribute at call time, so a scoped patch reaches them);
+    - `default_factory=time.time` captured on event/chat-context models at import -- redirected
+      by :func:`_patched_model_clocks`, since a module patch cannot reach a captured reference.
+
+    Both resolve the loop at call time, so reads inside the loop see virtual time while any stray
+    read from outside it (no running loop) falls back to a stable constant. Scoped to the test.
+    """
+    if not is_virtual_time(request.node):
+        yield
+        return
+
+    with (
+        mock.patch.object(time, "time", _now),
+        mock.patch.object(time, "perf_counter", _perf),
+        _patched_model_clocks(),
+    ):
+        yield
+
+
+def add_realtime_option(parser: pytest.Parser) -> None:
+    group = parser.getgroup("virtual time")
+    group.addoption(
+        "--real-time",
+        action="store_true",
+        default=False,
+        help="Disable virtual-time patching entirely; virtual_time tests run on the real clock.",
+    )
+
+
+def register_marker(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "virtual_time: run the test on a deterministic autojumping virtual-time event loop.",
+    )
+    config.addinivalue_line(
+        "markers",
+        "real_time: opt a test out of a module-level virtual_time mark (runs on the real loop).",
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -87,8 +87,9 @@ dev = [
     { name = "jiwer", specifier = ">=3.1.0" },
     { name = "mypy" },
     { name = "playwright", specifier = ">=1.58.0" },
-    { name = "pytest" },
+    { name = "pytest", specifier = ">=9.0.3,<9.1" },
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
+    { name = "pytest-asyncio-concurrent", specifier = "==0.5.2" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "ruff" },
@@ -4387,6 +4388,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-asyncio-concurrent"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/e5/a79e3ffb4bbb13da16038695edff8ab9cbc2cc6b708916a94c10c28cd50e/pytest_asyncio_concurrent-0.5.2.tar.gz", hash = "sha256:35d5aab732746deb0f3d806a9261b47f0567410f5fa4ad8785e992d0df09f424", size = 18539, upload-time = "2026-04-09T22:08:44.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/5f/36bacece56a2b9a62371a49728537f0d9330aa640797761628589362efe4/pytest_asyncio_concurrent-0.5.2-py3-none-any.whl", hash = "sha256:a32826103e2626dccb9d82e677fc2a031a506d3a677319d7478c74f173838b94", size = 14407, upload-time = "2026-04-09T22:08:43.228Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Running `pytest --unit` with these changes goes from 3 minutes 44 seconds to just **30 seconds**.  

### How does it work
#### Virtual time
Takes advantage of the fact that many of the tests rely on `asyncio.sleep()` to synchronize events in the loop. It unties it from the real time so that `await asyncio.sleep(60)` returns instantly with `loop.time()` reporting 60 seconds passed. `time.time()` is then patched to report loop time. This brings down `test_agent_session.py` test time form 90 seconds to just 1 second without any modifications to the test itself.

- To disable globally `--real-time` option can be used.
- To enable/disable per-module or per-test `pytest.mark.virtual_time`/`.real_time` can be used.

#### Concurrent tests
Tests with real I/O are groupped by their module and executed in a shared event loop. This shrinks wall time of the whole module to wall time of the slowest test + raw compute. `contextvars` are used to preserve input capture and track leaked tasks.

- To disable concurrent execution, `--no-concurrent` option can be used.
- To enable/disable per-module or per-test, `pytest.mark.no_concurrent`/`.no_concurrent` can be used.

### Changes
- Add `pytest-asyncio-concurrent` — gives the speedup for I/O bound tests
- Add `tests/concurrent.py` that extends on `pytest-asyncio-concurrent` and adds crucial features:
    - Captures stdout/stderr and reports on failure (same as `pytest`)
    - Allows leaked tasks detection in concurrent mode (so that `fail_on_leaked_tasks` continues to work)
    - adds `--concurrent`/`--no-concurrent` options
    - Adds live progress
- Add `tests/virtual_time.py` that provides instant and deterministic `asyncio` clock for time-bound execution

#### Changes to the tests sources
- https://github.com/livekit/agents/pull/5980/commits/04fe6cbb55c32d1058a01a4c0ddda790b5834770: Add `concurrent`/`virtual_time` markers to tests modules
- https://github.com/livekit/agents/pull/5980/changes/a8f5be0be8b76efefaa55743d8ad0a5d77b15b1b: Tighten timings in `test_audio_decoder.py`, `test_ipc.pt` and `test_room.py` 
- https://github.com/livekit/agents/pull/5980/changes/396bce8cbf4618a292ab28a257ea13f58bd3c5a6: Make `test_async_channel` and `test_proc_pool_launch_job_raises_when_all_spawns_fail` in `test_ipc.py` safe to run concurrently

