### PR TITLE
fix(google): require compatible google-genai version

### DIFF
--- a/livekit-plugins/livekit-plugins-google/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-google/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "google-auth >= 2, < 3",
     "google-cloud-speech >= 2, < 3",
     "google-cloud-texttospeech >= 2.32, < 3",
-    "google-genai >= 1.55; python_version >= '3.10'",
+    "google-genai >= 1.67; python_version >= '3.10'",
     "livekit-agents>=1.5.18",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2094,7 +2094,7 @@ requires-dist = [
     { name = "livekit-plugins-ultravox", marker = "extra == 'ultravox'", editable = "livekit-plugins/livekit-plugins-ultravox" },
     { name = "livekit-plugins-upliftai", marker = "extra == 'upliftai'", editable = "livekit-plugins/livekit-plugins-upliftai" },
     { name = "livekit-plugins-xai", marker = "extra == 'xai'", editable = "livekit-plugins/livekit-plugins-xai" },
-    { name = "livekit-protocol", specifier = ">=1.1.11,<2" },
+    { name = "livekit-protocol", specifier = ">=1.1.13,<2" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.24.0,<2" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "numpy", specifier = ">=1.26.0" },
@@ -2517,7 +2517,7 @@ requires-dist = [
     { name = "google-auth", specifier = ">=2,<3" },
     { name = "google-cloud-speech", specifier = ">=2,<3" },
     { name = "google-cloud-texttospeech", specifier = ">=2.32,<3" },
-    { name = "google-genai", marker = "python_full_version >= '3.10'", specifier = ">=1.55" },
+    { name = "google-genai", marker = "python_full_version >= '3.10'", specifier = ">=1.67" },
     { name = "livekit-agents", editable = "livekit-agents" },
 ]
 
@@ -2781,7 +2781,7 @@ vertex = [
 requires-dist = [
     { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0.0" },
     { name = "livekit-agents", extras = ["codecs", "images"], editable = "livekit-agents" },
-    { name = "openai", extras = ["realtime"], specifier = ">=2" },
+    { name = "openai", extras = ["realtime"], specifier = ">=2.36" },
 ]
 provides-extras = ["vertex"]
 
@@ -3095,15 +3095,15 @@ requires-dist = [{ name = "livekit-agents", extras = ["openai"], editable = "liv
 
 [[package]]
 name = "livekit-protocol"
-version = "1.1.11"
+version = "1.1.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
     { name = "types-protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/fa/1faf45f0e771226121569020ed050f74fd9c96feb0937c9c94595590680f/livekit_protocol-1.1.11.tar.gz", hash = "sha256:2ac65845b99e1f8e43e4f71e9d67ef0c5243ecdf4f30faa2e24e320d5e5f3b93", size = 100874, upload-time = "2026-05-29T17:51:58.151Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ed/09cf0419967e1f46b5b84447d29dff58473b13308fafa44456d431d53883/livekit_protocol-1.1.13.tar.gz", hash = "sha256:38eff0dc23ff9d6b7d9d10220b74735a0ec784a4a5196ef02c10c6052f8f7f6c", size = 101474, upload-time = "2026-06-02T22:06:40.34Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/9f/950516146a51ceff9e2dabcec00426f9fc1312b980167c59b9d2be08a13e/livekit_protocol-1.1.11-py3-none-any.whl", hash = "sha256:3c779489819eba15aee3860327fb6cac2f4a58a32ab23067c411fe4852f6b795", size = 123360, upload-time = "2026-05-29T17:51:56.944Z" },
+    { url = "https://files.pythonhosted.org/packages/52/66/d16928af7f7641a4edda734c69cdf1af07b6c5f378d72691580ecf4fe6bd/livekit_protocol-1.1.13-py3-none-any.whl", hash = "sha256:8827860835ae576cd66948f5721c5949a285fe72856ebf67af8e42e368a994e7", size = 125127, upload-time = "2026-06-02T22:06:39.081Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #5987

## Summary
- raises the `livekit-plugins-google` minimum `google-genai` dependency to `>=1.67`
- updates the lockfile metadata to match

## Testing
- `uv run python - <<'PY' ...` dependency metadata assertion
- `uv run pytest tests/test_plugin_google_llm.py tests/test_google_thought_signatures.py` (48 passed)

Note: I also tried `uv run pytest tests/test_plugin_google_llm.py tests/test_plugin_google_stt.py tests/test_google_thought_signatures.py`; the Google STT subset fails locally because Application Default Credentials are not configured, while the LLM/thought-signature tests pass.

No PR template was present in the repository.