### PR TITLE
fix(openai): handle string realtime status details

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -2068,8 +2068,12 @@ class RealtimeSession(
             )
         elif event.response.status in {"cancelled", "incomplete"}:
             status_details = event.response.status_details
-            status_type = status_details.type if status_details else None
-            status_reason = status_details.reason if status_details else None
+            if isinstance(status_details, str):
+                status_type = status_details
+                status_reason = None
+            else:
+                status_type = status_details.type if status_details else None
+                status_reason = status_details.reason if status_details else None
             logger.debug(
                 "%s response done but not complete with status: %s (type=%s, reason=%s)",
                 provider_label,

--- a/tests/test_openai_realtime_chat_ctx.py
+++ b/tests/test_openai_realtime_chat_ctx.py
@@ -1,10 +1,12 @@
 import asyncio
 import types
+from unittest.mock import Mock
 
 import pytest
 
 from livekit.agents import llm
 from livekit.agents.llm import remote_chat_context
+from livekit.plugins.openai.realtime import realtime_model
 from livekit.plugins.openai.realtime.realtime_model import RealtimeSession
 
 pytestmark = pytest.mark.unit
@@ -50,3 +52,23 @@ async def test_update_chat_ctx_keeps_existing_remote_empty_messages() -> None:
     await session.update_chat_ctx(chat_ctx)
 
     assert session._sent_events == []
+
+
+def test_response_done_handles_string_status_details(monkeypatch) -> None:
+    session = _create_session()
+    session._realtime_model = types.SimpleNamespace(_provider_label="xAI")
+    event = types.SimpleNamespace(
+        response=types.SimpleNamespace(
+            id="resp_1",
+            status="incomplete",
+            status_details="incomplete",
+        )
+    )
+    debug = Mock()
+    monkeypatch.setattr(realtime_model.logger, "debug", debug)
+
+    session._handle_response_done_but_not_complete(event)
+
+    debug.assert_called_once()
+    assert debug.call_args.args[3] == "incomplete"
+    assert debug.call_args.args[4] is None


### PR DESCRIPTION
Fixes #5993.

## Summary
- handle OpenAI-compatible Realtime `status_details` values that arrive as a plain string
- preserve the existing typed-object path for OpenAI responses
- add a regression test for an incomplete response with `status_details="incomplete"`

## To verify
- `$env:PYTHONPATH=((Resolve-Path .\livekit-agents).Path + ';' + (Resolve-Path .\livekit-plugins\livekit-plugins-openai).Path); python -m pytest tests\test_openai_realtime_chat_ctx.py -q`
- `python -m py_compile livekit-plugins\livekit-plugins-openai\livekit\plugins\openai\realtime\realtime_model.py tests\test_openai_realtime_chat_ctx.py`
- `python -m ruff check livekit-plugins\livekit-plugins-openai\livekit\plugins\openai\realtime\realtime_model.py tests\test_openai_realtime_chat_ctx.py`
- `git diff --check`
