### PR TITLE
fix(sarvam): emit speech timing for STT metrics

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -992,32 +992,7 @@ class SpeechStream(stt.SpeechStream):
             return None
         return float(value)
 
-    def _ensure_utterance_timing_state(self) -> None:
-        if not hasattr(self, "_audio_position"):
-            self._audio_position = 0.0
-        if not hasattr(self, "_utterance_start_audio_pos"):
-            self._utterance_start_audio_pos = 0.0
-        if not hasattr(self, "_utterance_speech_end_audio_pos"):
-            self._utterance_speech_end_audio_pos = None
-        if not hasattr(self, "_utterance_speech_start_wall"):
-            self._utterance_speech_start_wall = None
-        if not hasattr(self, "_utterance_speech_end_wall"):
-            self._utterance_speech_end_wall = None
-        if not hasattr(self, "_pending_final_data"):
-            self._pending_final_data = None
-        if not hasattr(self, "_pending_eos"):
-            self._pending_eos = False
-        if not hasattr(self, "_eos_fallback_task"):
-            self._eos_fallback_task = None
-        if not hasattr(self, "_eos_fallback_timeout"):
-            self._eos_fallback_timeout = EOS_FALLBACK_TIMEOUT
-        if not hasattr(self, "_final_received_for_utterance"):
-            self._final_received_for_utterance = False
-        if not hasattr(self, "_eos_emitted_for_utterance"):
-            self._eos_emitted_for_utterance = False
-
     def _reset_utterance_state(self) -> None:
-        self._ensure_utterance_timing_state()
         self._cancel_eos_fallback()
         self._pending_final_data = None
         self._pending_eos = False
@@ -1040,7 +1015,6 @@ class SpeechStream(stt.SpeechStream):
     def _send_final_transcript(
         self, transcript_data: dict[str, Any], *, require_end_time: bool = False
     ) -> bool:
-        self._ensure_utterance_timing_state()
         transcript_text = transcript_data.get("transcript", "")
         if not transcript_text:
             return False
@@ -1077,7 +1051,6 @@ class SpeechStream(stt.SpeechStream):
         return True
 
     def _try_commit_utterance(self) -> None:
-        self._ensure_utterance_timing_state()
         if (
             self._pending_final_data is None
             or self._utterance_speech_end_audio_pos is None
@@ -1099,7 +1072,6 @@ class SpeechStream(stt.SpeechStream):
             self._pending_final_data = None
 
     def _emit_end_of_speech(self) -> None:
-        self._ensure_utterance_timing_state()
         if self._eos_emitted_for_utterance:
             return
 
@@ -1650,7 +1622,6 @@ class SpeechStream(stt.SpeechStream):
 
     async def _handle_transcript_data(self, data: dict) -> None:
         """Handle transcription result messages."""
-        self._ensure_utterance_timing_state()
         transcript_data = data.get("data", {})
         transcript_text = transcript_data.get("transcript", "")
         self._maybe_set_server_request_id(transcript_data)
@@ -1713,7 +1684,6 @@ class SpeechStream(stt.SpeechStream):
 
     async def _handle_events(self, data: dict) -> None:
         """Handle VAD (Voice Activity Detection) events."""
-        self._ensure_utterance_timing_state()
         event_data = data.get("data", {})
         signal_type = event_data.get("signal_type")
         self._maybe_set_server_request_id(event_data)

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -53,6 +53,7 @@ from livekit.agents.utils.misc import is_given
 from .log import logger
 
 USER_AGENT = f"Livekit/{livekit_version} Python/{platform.python_version()}"
+EOS_FALLBACK_TIMEOUT = 1.0
 
 # Sarvam API details
 SARVAM_STT_BASE_URL = "https://api.sarvam.ai/speech-to-text"
@@ -926,6 +927,7 @@ class SpeechStream(stt.SpeechStream):
         self._pending_final_data: dict[str, Any] | None = None
         self._pending_eos = False
         self._eos_fallback_task: asyncio.Task[None] | None = None
+        self._eos_fallback_timeout = EOS_FALLBACK_TIMEOUT
         self._final_received_for_utterance = False
         self._eos_emitted_for_utterance = False
 
@@ -1007,6 +1009,8 @@ class SpeechStream(stt.SpeechStream):
             self._pending_eos = False
         if not hasattr(self, "_eos_fallback_task"):
             self._eos_fallback_task = None
+        if not hasattr(self, "_eos_fallback_timeout"):
+            self._eos_fallback_timeout = EOS_FALLBACK_TIMEOUT
         if not hasattr(self, "_final_received_for_utterance"):
             self._final_received_for_utterance = False
         if not hasattr(self, "_eos_emitted_for_utterance"):
@@ -1024,12 +1028,14 @@ class SpeechStream(stt.SpeechStream):
         self._final_received_for_utterance = False
         self._eos_emitted_for_utterance = False
 
-    def _cancel_eos_fallback(self) -> None:
+    def _cancel_eos_fallback(self) -> asyncio.Task[None] | None:
         current_task = asyncio.current_task()
         fallback_task = self._eos_fallback_task
         self._eos_fallback_task = None
         if fallback_task and fallback_task is not current_task and not fallback_task.done():
             fallback_task.cancel()
+            return fallback_task
+        return None
 
     def _send_final_transcript(
         self, transcript_data: dict[str, Any], *, require_end_time: bool = False
@@ -1123,8 +1129,9 @@ class SpeechStream(stt.SpeechStream):
         self._eos_emitted_for_utterance = True
         self._pending_eos = False
 
-    async def _emit_pending_eos_after_timeout(self, timeout: float = 0.1) -> None:
+    async def _emit_pending_eos_after_timeout(self) -> None:
         try:
+            timeout = self._eos_fallback_timeout
             if timeout > 0:
                 await asyncio.sleep(timeout)
             if self._pending_eos and not self._eos_emitted_for_utterance:
@@ -1145,6 +1152,9 @@ class SpeechStream(stt.SpeechStream):
             tasks_to_cancel.append(self._audio_task)
         if self._message_task and not self._message_task.done():
             tasks_to_cancel.append(self._message_task)
+        fallback_task = self._cancel_eos_fallback()
+        if fallback_task is not None:
+            tasks_to_cancel.append(fallback_task)
 
         if tasks_to_cancel:
             try:
@@ -1368,6 +1378,9 @@ class SpeechStream(stt.SpeechStream):
         finally:
             # Clean up tasks
             all_tasks = tasks + [reconnect_task]
+            fallback_task = self._cancel_eos_fallback()
+            if fallback_task is not None:
+                all_tasks.append(fallback_task)
             await utils.aio.cancel_and_wait(*all_tasks)
 
             # Close WebSocket
@@ -1737,6 +1750,8 @@ class SpeechStream(stt.SpeechStream):
                         if self._final_received_for_utterance:
                             self._emit_end_of_speech()
                         elif self._eos_fallback_task is None or self._eos_fallback_task.done():
+                            # Give Sarvam a short grace period to deliver the
+                            # final transcript so LiveKit sees FINAL before EOS.
                             self._eos_fallback_task = asyncio.create_task(
                                 self._emit_pending_eos_after_timeout()
                             )

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -925,6 +925,7 @@ class SpeechStream(stt.SpeechStream):
         self._utterance_speech_end_wall: float | None = None
         self._pending_final_data: dict[str, Any] | None = None
         self._pending_eos = False
+        self._eos_fallback_task: asyncio.Task[None] | None = None
         self._final_received_for_utterance = False
         self._eos_emitted_for_utterance = False
 
@@ -1004,6 +1005,8 @@ class SpeechStream(stt.SpeechStream):
             self._pending_final_data = None
         if not hasattr(self, "_pending_eos"):
             self._pending_eos = False
+        if not hasattr(self, "_eos_fallback_task"):
+            self._eos_fallback_task = None
         if not hasattr(self, "_final_received_for_utterance"):
             self._final_received_for_utterance = False
         if not hasattr(self, "_eos_emitted_for_utterance"):
@@ -1011,6 +1014,7 @@ class SpeechStream(stt.SpeechStream):
 
     def _reset_utterance_state(self) -> None:
         self._ensure_utterance_timing_state()
+        self._cancel_eos_fallback()
         self._pending_final_data = None
         self._pending_eos = False
         self._utterance_start_audio_pos = self._audio_position
@@ -1020,7 +1024,16 @@ class SpeechStream(stt.SpeechStream):
         self._final_received_for_utterance = False
         self._eos_emitted_for_utterance = False
 
-    def _send_final_transcript(self, transcript_data: dict[str, Any]) -> bool:
+    def _cancel_eos_fallback(self) -> None:
+        current_task = asyncio.current_task()
+        fallback_task = self._eos_fallback_task
+        self._eos_fallback_task = None
+        if fallback_task and fallback_task is not current_task and not fallback_task.done():
+            fallback_task.cancel()
+
+    def _send_final_transcript(
+        self, transcript_data: dict[str, Any], *, require_end_time: bool = False
+    ) -> bool:
         self._ensure_utterance_timing_state()
         transcript_text = transcript_data.get("transcript", "")
         if not transcript_text:
@@ -1037,7 +1050,9 @@ class SpeechStream(stt.SpeechStream):
             or self._utterance_speech_end_audio_pos
         )
         if end_time is None:
-            return False
+            if require_end_time:
+                return False
+            end_time = 0.0
 
         speech_data = stt.SpeechData(
             language=language,
@@ -1065,7 +1080,7 @@ class SpeechStream(stt.SpeechStream):
             return
 
         committed_data = self._pending_final_data
-        if self._send_final_transcript(committed_data):
+        if self._send_final_transcript(committed_data, require_end_time=True):
             self._logger.debug(
                 "Sarvam STT utterance committed",
                 extra={
@@ -1081,6 +1096,8 @@ class SpeechStream(stt.SpeechStream):
         self._ensure_utterance_timing_state()
         if self._eos_emitted_for_utterance:
             return
+
+        self._cancel_eos_fallback()
 
         alternatives: list[stt.SpeechData] = []
         if self._utterance_speech_end_audio_pos is not None:
@@ -1105,6 +1122,15 @@ class SpeechStream(stt.SpeechStream):
         )
         self._eos_emitted_for_utterance = True
         self._pending_eos = False
+
+    async def _emit_pending_eos_after_timeout(self, timeout: float = 0.1) -> None:
+        try:
+            if timeout > 0:
+                await asyncio.sleep(timeout)
+            if self._pending_eos and not self._eos_emitted_for_utterance:
+                self._emit_end_of_speech()
+        except asyncio.CancelledError:
+            raise
 
     async def aclose(self) -> None:
         """Close the stream and clean up resources."""
@@ -1635,15 +1661,18 @@ class SpeechStream(stt.SpeechStream):
             )
             self._event_ch.send_nowait(usage_event)
 
-            self._pending_final_data = transcript_data
-            self._final_received_for_utterance = True
-
             transcript_end_time = self._positive_time(transcript_data.get("speech_end"))
             if transcript_end_time is not None and self._utterance_speech_end_audio_pos is None:
                 self._utterance_speech_end_audio_pos = transcript_end_time
                 self._utterance_speech_end_wall = time.time()
 
-            self._try_commit_utterance()
+            if self._pending_eos:
+                self._pending_final_data = transcript_data
+                self._final_received_for_utterance = True
+                self._try_commit_utterance()
+            else:
+                if self._send_final_transcript(transcript_data):
+                    self._final_received_for_utterance = True
 
             self._logger.debug(
                 "Transcript processed successfully",
@@ -1704,6 +1733,13 @@ class SpeechStream(stt.SpeechStream):
                     self._utterance_speech_end_wall = time.time()
                     self._pending_eos = True
                     self._try_commit_utterance()
+                    if not self._eos_emitted_for_utterance and self._pending_final_data is None:
+                        if self._final_received_for_utterance:
+                            self._emit_end_of_speech()
+                        elif self._eos_fallback_task is None or self._eos_fallback_task.done():
+                            self._eos_fallback_task = asyncio.create_task(
+                                self._emit_pending_eos_after_timeout()
+                            )
 
                     # Set flag to trigger flush when Sarvam detects end of speech
                     self._should_flush = True

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -1107,6 +1107,10 @@ class SpeechStream(stt.SpeechStream):
 
         alternatives: list[stt.SpeechData] = []
         if self._utterance_speech_end_audio_pos is not None:
+        # The empty SpeechData alternative is metadata-only. Sarvam's internal VAD
+        # provides the authoritative speech-end time separately from the transcript, and
+        # AudioRecognition uses this end_time to compute EOU latency metrics when using
+        # STT-based turn detection without an external VAD.
             metadata: dict[str, Any] = {}
             if self._utterance_speech_end_wall is not None:
                 metadata["speech_end_wall_time"] = self._utterance_speech_end_wall

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -25,10 +25,11 @@ import json
 import logging
 import os
 import platform
+import time
 import weakref
 from dataclasses import dataclass
 from enum import Enum
-from typing import Literal
+from typing import Any, Literal
 from urllib.parse import urlencode
 
 import aiohttp
@@ -917,6 +918,16 @@ class SpeechStream(stt.SpeechStream):
         )
         self._should_flush = False  # Flag to trigger flush
 
+        self._audio_position = 0.0
+        self._utterance_start_audio_pos = 0.0
+        self._utterance_speech_end_audio_pos: float | None = None
+        self._utterance_speech_start_wall: float | None = None
+        self._utterance_speech_end_wall: float | None = None
+        self._pending_final_data: dict[str, Any] | None = None
+        self._pending_eos = False
+        self._final_received_for_utterance = False
+        self._eos_emitted_for_utterance = False
+
         # Task management for cleanup
         self._audio_task: asyncio.Task | None = None
         self._message_task: asyncio.Task | None = None
@@ -969,6 +980,131 @@ class SpeechStream(stt.SpeechStream):
 
         if request_id:
             self._server_request_id = str(request_id)
+
+    @staticmethod
+    def _positive_time(value: object) -> float | None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        if value <= 0:
+            return None
+        return float(value)
+
+    def _ensure_utterance_timing_state(self) -> None:
+        if not hasattr(self, "_audio_position"):
+            self._audio_position = 0.0
+        if not hasattr(self, "_utterance_start_audio_pos"):
+            self._utterance_start_audio_pos = 0.0
+        if not hasattr(self, "_utterance_speech_end_audio_pos"):
+            self._utterance_speech_end_audio_pos = None
+        if not hasattr(self, "_utterance_speech_start_wall"):
+            self._utterance_speech_start_wall = None
+        if not hasattr(self, "_utterance_speech_end_wall"):
+            self._utterance_speech_end_wall = None
+        if not hasattr(self, "_pending_final_data"):
+            self._pending_final_data = None
+        if not hasattr(self, "_pending_eos"):
+            self._pending_eos = False
+        if not hasattr(self, "_final_received_for_utterance"):
+            self._final_received_for_utterance = False
+        if not hasattr(self, "_eos_emitted_for_utterance"):
+            self._eos_emitted_for_utterance = False
+
+    def _reset_utterance_state(self) -> None:
+        self._ensure_utterance_timing_state()
+        self._pending_final_data = None
+        self._pending_eos = False
+        self._utterance_start_audio_pos = self._audio_position
+        self._utterance_speech_end_audio_pos = None
+        self._utterance_speech_start_wall = time.time()
+        self._utterance_speech_end_wall = None
+        self._final_received_for_utterance = False
+        self._eos_emitted_for_utterance = False
+
+    def _send_final_transcript(self, transcript_data: dict[str, Any]) -> bool:
+        self._ensure_utterance_timing_state()
+        transcript_text = transcript_data.get("transcript", "")
+        if not transcript_text:
+            return False
+
+        language = LanguageCode(transcript_data.get("language_code", ""))
+        request_id = transcript_data.get("request_id") or self._server_request_id or ""
+        start_time = (
+            self._positive_time(transcript_data.get("speech_start"))
+            or self._utterance_start_audio_pos
+        )
+        end_time = (
+            self._positive_time(transcript_data.get("speech_end"))
+            or self._utterance_speech_end_audio_pos
+        )
+        if end_time is None:
+            return False
+
+        speech_data = stt.SpeechData(
+            language=language,
+            text=transcript_text,
+            start_time=start_time,
+            end_time=end_time,
+            confidence=_extract_confidence(transcript_data, self._logger),
+        )
+        self._event_ch.send_nowait(
+            stt.SpeechEvent(
+                type=stt.SpeechEventType.FINAL_TRANSCRIPT,
+                request_id=request_id,
+                alternatives=[speech_data],
+            )
+        )
+        return True
+
+    def _try_commit_utterance(self) -> None:
+        self._ensure_utterance_timing_state()
+        if (
+            self._pending_final_data is None
+            or self._utterance_speech_end_audio_pos is None
+            or self._eos_emitted_for_utterance
+        ):
+            return
+
+        committed_data = self._pending_final_data
+        if self._send_final_transcript(committed_data):
+            self._logger.debug(
+                "Sarvam STT utterance committed",
+                extra={
+                    **self._build_log_context(),
+                    "end_time": self._utterance_speech_end_audio_pos,
+                    "speech_end_wall_time": self._utterance_speech_end_wall,
+                },
+            )
+            self._emit_end_of_speech()
+            self._pending_final_data = None
+
+    def _emit_end_of_speech(self) -> None:
+        self._ensure_utterance_timing_state()
+        if self._eos_emitted_for_utterance:
+            return
+
+        alternatives: list[stt.SpeechData] = []
+        if self._utterance_speech_end_audio_pos is not None:
+            metadata: dict[str, Any] = {}
+            if self._utterance_speech_end_wall is not None:
+                metadata["speech_end_wall_time"] = self._utterance_speech_end_wall
+            alternatives.append(
+                stt.SpeechData(
+                    language=LanguageCode(self._opts.language),
+                    text="",
+                    end_time=self._utterance_speech_end_audio_pos,
+                    metadata=metadata or None,
+                )
+            )
+
+        self._event_ch.send_nowait(
+            stt.SpeechEvent(
+                type=stt.SpeechEventType.END_OF_SPEECH,
+                request_id=self._server_request_id or "",
+                alternatives=alternatives,
+            )
+        )
+        self._eos_emitted_for_utterance = True
+        self._pending_eos = False
 
     async def aclose(self) -> None:
         """Close the stream and clean up resources."""
@@ -1263,6 +1399,7 @@ class SpeechStream(stt.SpeechStream):
 
                             await ws.send_str(json.dumps(audio_message))
                             chunks_sent += 1
+                            self._audio_position += chunk_size / self._opts.sample_rate
 
                             # Remove sent data from buffer
                             audio_buffer = audio_buffer[chunk_size:]
@@ -1470,9 +1607,9 @@ class SpeechStream(stt.SpeechStream):
 
     async def _handle_transcript_data(self, data: dict) -> None:
         """Handle transcription result messages."""
+        self._ensure_utterance_timing_state()
         transcript_data = data.get("data", {})
         transcript_text = transcript_data.get("transcript", "")
-        language = LanguageCode(transcript_data.get("language_code", ""))
         self._maybe_set_server_request_id(transcript_data)
         # Prefer the per-message request_id from the server; fall back to the
         # session-wide server request_id captured from an earlier message.
@@ -1498,22 +1635,15 @@ class SpeechStream(stt.SpeechStream):
             )
             self._event_ch.send_nowait(usage_event)
 
-            # Create speech data
-            speech_data = stt.SpeechData(
-                language=language,
-                text=transcript_text,
-                start_time=transcript_data.get("speech_start", 0.0),
-                end_time=transcript_data.get("speech_end", 0.0),
-                confidence=_extract_confidence(transcript_data, self._logger),
-            )
+            self._pending_final_data = transcript_data
+            self._final_received_for_utterance = True
 
-            # Create final transcript event with request_id
-            speech_event = stt.SpeechEvent(
-                type=stt.SpeechEventType.FINAL_TRANSCRIPT,
-                request_id=request_id,
-                alternatives=[speech_data],
-            )
-            self._event_ch.send_nowait(speech_event)
+            transcript_end_time = self._positive_time(transcript_data.get("speech_end"))
+            if transcript_end_time is not None and self._utterance_speech_end_audio_pos is None:
+                self._utterance_speech_end_audio_pos = transcript_end_time
+                self._utterance_speech_end_wall = time.time()
+
+            self._try_commit_utterance()
 
             self._logger.debug(
                 "Transcript processed successfully",
@@ -1521,7 +1651,6 @@ class SpeechStream(stt.SpeechStream):
                     **self._build_log_context(),
                     "text_length": len(transcript_text),
                     "language": self._opts.language,
-                    "confidence": speech_data.confidence,
                 },
             )
 
@@ -1538,6 +1667,7 @@ class SpeechStream(stt.SpeechStream):
 
     async def _handle_events(self, data: dict) -> None:
         """Handle VAD (Voice Activity Detection) events."""
+        self._ensure_utterance_timing_state()
         event_data = data.get("data", {})
         signal_type = event_data.get("signal_type")
         self._maybe_set_server_request_id(event_data)
@@ -1557,16 +1687,23 @@ class SpeechStream(stt.SpeechStream):
         try:
             if signal_type == "START_SPEECH":
                 if not self._speaking:
+                    self._reset_utterance_state()
                     self._speaking = True
-                    start_event = stt.SpeechEvent(type=stt.SpeechEventType.START_OF_SPEECH)
+                    start_event = stt.SpeechEvent(
+                        type=stt.SpeechEventType.START_OF_SPEECH,
+                        request_id=self._server_request_id or "",
+                        speech_start_time=self._utterance_speech_start_wall,
+                    )
                     self._event_ch.send_nowait(start_event)
                     self._logger.debug("Speech started", extra=self._build_log_context())
 
             elif signal_type == "END_SPEECH":
                 if self._speaking:
                     self._speaking = False
-                    end_event = stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH)
-                    self._event_ch.send_nowait(end_event)
+                    self._utterance_speech_end_audio_pos = self._audio_position
+                    self._utterance_speech_end_wall = time.time()
+                    self._pending_eos = True
+                    self._try_commit_utterance()
 
                     # Set flag to trigger flush when Sarvam detects end of speech
                     self._should_flush = True

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -1107,10 +1107,10 @@ class SpeechStream(stt.SpeechStream):
 
         alternatives: list[stt.SpeechData] = []
         if self._utterance_speech_end_audio_pos is not None:
-        # The empty SpeechData alternative is metadata-only. Sarvam's internal VAD
-        # provides the authoritative speech-end time separately from the transcript, and
-        # AudioRecognition uses this end_time to compute EOU latency metrics when using
-        # STT-based turn detection without an external VAD.
+            # The empty SpeechData alternative is metadata-only. Sarvam's internal VAD
+            # provides the authoritative speech-end time separately from the transcript, and
+            # AudioRecognition uses this end_time to compute EOU latency metrics when using
+            # STT-based turn detection without an external VAD.
             metadata: dict[str, Any] = {}
             if self._utterance_speech_end_wall is not None:
                 metadata["speech_end_wall_time"] = self._utterance_speech_end_wall

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py
@@ -13,7 +13,9 @@ from livekit.plugins.sarvam.stt import SpeechStream
 pytestmark = pytest.mark.unit
 
 
-def _make_stream_under_test(*, audio_position: float = 1.25) -> tuple[SpeechStream, list[Any]]:
+def _make_stream_under_test(
+    *, audio_position: float = 1.25, eos_fallback_timeout: float = 0.01
+) -> tuple[SpeechStream, list[Any]]:
     instance = SpeechStream.__new__(SpeechStream)
     captured: list[Any] = []
     event_ch = MagicMock()
@@ -34,6 +36,7 @@ def _make_stream_under_test(*, audio_position: float = 1.25) -> tuple[SpeechStre
     instance._pending_final_data = None  # type: ignore[attr-defined]
     instance._pending_eos = False  # type: ignore[attr-defined]
     instance._eos_fallback_task = None  # type: ignore[attr-defined]
+    instance._eos_fallback_timeout = eos_fallback_timeout  # type: ignore[attr-defined]
     instance._final_received_for_utterance = False  # type: ignore[attr-defined]
     instance._eos_emitted_for_utterance = False  # type: ignore[attr-defined]
     return instance, captured
@@ -76,7 +79,7 @@ async def test_end_speech_emits_end_time_alternative() -> None:
 
     await instance._handle_events(_event("START_SPEECH"))
     await instance._handle_events(_event("END_SPEECH"))
-    await asyncio.sleep(0.15)
+    await asyncio.sleep(0.05)
 
     end_events = _events_of_type(captured, stt.SpeechEventType.END_OF_SPEECH)
     assert len(end_events) == 1
@@ -143,6 +146,30 @@ async def test_commit_order_final_before_eos_when_speech_end_arrives_first() -> 
     ]
 
 
+async def test_late_transcript_after_eos_fallback_is_emitted_after_eos() -> None:
+    instance, captured = _make_stream_under_test(audio_position=1.25)
+
+    await instance._handle_events(_event("START_SPEECH"))
+    instance._audio_position = 1.4  # type: ignore[attr-defined]
+    await instance._handle_events(_event("END_SPEECH"))
+    await asyncio.sleep(0.05)
+    await instance._handle_transcript_data(_ws_message())
+
+    event_order = [
+        ev.type
+        for ev in captured
+        if ev.type
+        in {
+            stt.SpeechEventType.FINAL_TRANSCRIPT,
+            stt.SpeechEventType.END_OF_SPEECH,
+        }
+    ]
+    assert event_order == [
+        stt.SpeechEventType.END_OF_SPEECH,
+        stt.SpeechEventType.FINAL_TRANSCRIPT,
+    ]
+
+
 async def test_final_emits_immediately_without_speech_end() -> None:
     instance, captured = _make_stream_under_test()
 
@@ -163,3 +190,28 @@ async def test_multiple_transcripts_emit_multiple_finals() -> None:
 
     final_events = _events_of_type(captured, stt.SpeechEventType.FINAL_TRANSCRIPT)
     assert [ev.alternatives[0].text for ev in final_events] == ["first", "second"]
+
+
+async def test_aclose_cancels_pending_eos_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _noop_parent_aclose(self: object) -> None:
+        return None
+
+    monkeypatch.setattr(stt.SpeechStream, "aclose", _noop_parent_aclose)
+    instance, captured = _make_stream_under_test(eos_fallback_timeout=0.05)
+    instance._connection_lock = asyncio.Lock()  # type: ignore[attr-defined]
+    instance._audio_task = None  # type: ignore[attr-defined]
+    instance._message_task = None  # type: ignore[attr-defined]
+    instance._ws = None  # type: ignore[attr-defined]
+    instance._session = SimpleNamespace(closed=True)  # type: ignore[attr-defined]
+    instance._client_request_id = "client"  # type: ignore[attr-defined]
+
+    await instance._handle_events(_event("START_SPEECH"))
+    await instance._handle_events(_event("END_SPEECH"))
+    fallback_task = instance._eos_fallback_task  # type: ignore[attr-defined]
+
+    assert fallback_task is not None
+    await instance.aclose()
+    await asyncio.sleep(0.1)
+
+    assert fallback_task.cancelled()
+    assert not _events_of_type(captured, stt.SpeechEventType.END_OF_SPEECH)

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from livekit.agents import stt
+from livekit.plugins.sarvam.stt import SpeechStream
+
+pytestmark = pytest.mark.unit
+
+
+def _make_stream_under_test(*, audio_position: float = 1.25) -> tuple[SpeechStream, list[Any]]:
+    instance = SpeechStream.__new__(SpeechStream)
+    captured: list[Any] = []
+    event_ch = MagicMock()
+    event_ch.send_nowait = captured.append
+
+    instance._event_ch = event_ch  # type: ignore[attr-defined]
+    instance._logger = MagicMock()  # type: ignore[attr-defined]
+    instance._build_log_context = lambda: {}  # type: ignore[attr-defined]
+    instance._server_request_id = "req-session"  # type: ignore[attr-defined]
+    instance._opts = SimpleNamespace(language="en-IN", sample_rate=16000)  # type: ignore[attr-defined]
+    instance._speaking = False  # type: ignore[attr-defined]
+    instance._should_flush = False  # type: ignore[attr-defined]
+    instance._audio_position = audio_position  # type: ignore[attr-defined]
+    instance._utterance_start_audio_pos = 0.0  # type: ignore[attr-defined]
+    instance._utterance_speech_end_audio_pos = None  # type: ignore[attr-defined]
+    instance._utterance_speech_start_wall = None  # type: ignore[attr-defined]
+    instance._utterance_speech_end_wall = None  # type: ignore[attr-defined]
+    instance._pending_final_data = None  # type: ignore[attr-defined]
+    instance._pending_eos = False  # type: ignore[attr-defined]
+    instance._final_received_for_utterance = False  # type: ignore[attr-defined]
+    instance._eos_emitted_for_utterance = False  # type: ignore[attr-defined]
+    return instance, captured
+
+
+def _event(signal_type: str) -> dict[str, Any]:
+    return {"type": "events", "data": {"signal_type": signal_type, "request_id": "req-test"}}
+
+
+def _ws_message(**transcript_overrides: Any) -> dict[str, Any]:
+    transcript_data: dict[str, Any] = {
+        "transcript": "नमस्ते",
+        "language_code": "hi-IN",
+        "speech_start": 0.0,
+        "speech_end": 0.0,
+        "metrics": {"audio_duration": 1.2},
+        "request_id": "req-test",
+    }
+    transcript_data.update(transcript_overrides)
+    return {"type": "data", "data": transcript_data}
+
+
+def _events_of_type(captured: list[Any], event_type: stt.SpeechEventType) -> list[stt.SpeechEvent]:
+    return [ev for ev in captured if ev.type == event_type]
+
+
+async def test_start_speech_sets_speech_start_time() -> None:
+    instance, captured = _make_stream_under_test()
+
+    await instance._handle_events(_event("START_SPEECH"))
+
+    start_events = _events_of_type(captured, stt.SpeechEventType.START_OF_SPEECH)
+    assert len(start_events) == 1
+    assert start_events[0].speech_start_time is not None
+    assert start_events[0].request_id == "req-session"
+
+
+async def test_end_speech_emits_end_time_alternative() -> None:
+    instance, captured = _make_stream_under_test(audio_position=1.4)
+
+    await instance._handle_events(_event("START_SPEECH"))
+    await instance._handle_events(_event("END_SPEECH"))
+    await instance._handle_transcript_data(_ws_message())
+
+    end_events = _events_of_type(captured, stt.SpeechEventType.END_OF_SPEECH)
+    assert len(end_events) == 1
+    assert end_events[0].alternatives[0].end_time == pytest.approx(1.4)
+    assert end_events[0].request_id == "req-session"
+
+
+async def test_final_uses_fallback_when_api_timing_zero() -> None:
+    instance, captured = _make_stream_under_test(audio_position=1.25)
+
+    await instance._handle_events(_event("START_SPEECH"))
+    instance._audio_position = 1.4  # type: ignore[attr-defined]
+    await instance._handle_transcript_data(_ws_message(speech_start=0.0, speech_end=0.0))
+    await instance._handle_events(_event("END_SPEECH"))
+
+    final = _events_of_type(captured, stt.SpeechEventType.FINAL_TRANSCRIPT)[0]
+    assert final.alternatives[0].start_time == pytest.approx(1.25)
+    assert final.alternatives[0].end_time == pytest.approx(1.4)
+
+
+async def test_commit_order_final_before_eos() -> None:
+    instance, captured = _make_stream_under_test(audio_position=1.4)
+
+    await instance._handle_events(_event("START_SPEECH"))
+    instance._audio_position = 1.4  # type: ignore[attr-defined]
+    await instance._handle_transcript_data(_ws_message())
+    await instance._handle_events(_event("END_SPEECH"))
+
+    event_order = [
+        ev.type
+        for ev in captured
+        if ev.type
+        in {
+            stt.SpeechEventType.FINAL_TRANSCRIPT,
+            stt.SpeechEventType.END_OF_SPEECH,
+        }
+    ]
+    assert event_order == [
+        stt.SpeechEventType.FINAL_TRANSCRIPT,
+        stt.SpeechEventType.END_OF_SPEECH,
+    ]
+
+
+async def test_commit_order_final_before_eos_when_speech_end_arrives_first() -> None:
+    instance, captured = _make_stream_under_test(audio_position=1.25)
+
+    await instance._handle_events(_event("START_SPEECH"))
+    instance._audio_position = 1.4  # type: ignore[attr-defined]
+    await instance._handle_events(_event("END_SPEECH"))
+    await instance._handle_transcript_data(_ws_message())
+
+    event_order = [
+        ev.type
+        for ev in captured
+        if ev.type
+        in {
+            stt.SpeechEventType.FINAL_TRANSCRIPT,
+            stt.SpeechEventType.END_OF_SPEECH,
+        }
+    ]
+    assert event_order == [
+        stt.SpeechEventType.FINAL_TRANSCRIPT,
+        stt.SpeechEventType.END_OF_SPEECH,
+    ]
+
+
+async def test_no_final_until_speech_end() -> None:
+    instance, captured = _make_stream_under_test()
+
+    await instance._handle_events(_event("START_SPEECH"))
+    await instance._handle_transcript_data(_ws_message())
+
+    assert not _events_of_type(captured, stt.SpeechEventType.FINAL_TRANSCRIPT)

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
@@ -32,6 +33,7 @@ def _make_stream_under_test(*, audio_position: float = 1.25) -> tuple[SpeechStre
     instance._utterance_speech_end_wall = None  # type: ignore[attr-defined]
     instance._pending_final_data = None  # type: ignore[attr-defined]
     instance._pending_eos = False  # type: ignore[attr-defined]
+    instance._eos_fallback_task = None  # type: ignore[attr-defined]
     instance._final_received_for_utterance = False  # type: ignore[attr-defined]
     instance._eos_emitted_for_utterance = False  # type: ignore[attr-defined]
     return instance, captured
@@ -74,7 +76,7 @@ async def test_end_speech_emits_end_time_alternative() -> None:
 
     await instance._handle_events(_event("START_SPEECH"))
     await instance._handle_events(_event("END_SPEECH"))
-    await instance._handle_transcript_data(_ws_message())
+    await asyncio.sleep(0.15)
 
     end_events = _events_of_type(captured, stt.SpeechEventType.END_OF_SPEECH)
     assert len(end_events) == 1
@@ -87,8 +89,8 @@ async def test_final_uses_fallback_when_api_timing_zero() -> None:
 
     await instance._handle_events(_event("START_SPEECH"))
     instance._audio_position = 1.4  # type: ignore[attr-defined]
-    await instance._handle_transcript_data(_ws_message(speech_start=0.0, speech_end=0.0))
     await instance._handle_events(_event("END_SPEECH"))
+    await instance._handle_transcript_data(_ws_message(speech_start=0.0, speech_end=0.0))
 
     final = _events_of_type(captured, stt.SpeechEventType.FINAL_TRANSCRIPT)[0]
     assert final.alternatives[0].start_time == pytest.approx(1.25)
@@ -141,10 +143,23 @@ async def test_commit_order_final_before_eos_when_speech_end_arrives_first() -> 
     ]
 
 
-async def test_no_final_until_speech_end() -> None:
+async def test_final_emits_immediately_without_speech_end() -> None:
     instance, captured = _make_stream_under_test()
 
     await instance._handle_events(_event("START_SPEECH"))
     await instance._handle_transcript_data(_ws_message())
 
-    assert not _events_of_type(captured, stt.SpeechEventType.FINAL_TRANSCRIPT)
+    final_events = _events_of_type(captured, stt.SpeechEventType.FINAL_TRANSCRIPT)
+    assert len(final_events) == 1
+    assert final_events[0].alternatives[0].end_time == 0.0
+
+
+async def test_multiple_transcripts_emit_multiple_finals() -> None:
+    instance, captured = _make_stream_under_test()
+
+    await instance._handle_events(_event("START_SPEECH"))
+    await instance._handle_transcript_data(_ws_message(transcript="first"))
+    await instance._handle_transcript_data(_ws_message(transcript="second"))
+
+    final_events = _events_of_type(captured, stt.SpeechEventType.FINAL_TRANSCRIPT)
+    assert [ev.alternatives[0].text for ev in final_events] == ["first", "second"]


### PR DESCRIPTION
## Summary
- Tracks Sarvam `STT` stream audio position and speech boundaries so `START_OF_SPEECH`, `FINAL_TRANSCRIPT`, and `END_OF_SPEECH` carry timing data that LiveKit can use for EOU metrics.
- Defers final transcript emission until a speech-end timestamp is known, while preserving `FINAL_TRANSCRIPT` before `END_OF_SPEECH` ordering for both transcript-before-EOS and EOS-before-transcript provider ordering.
- Adds focused Sarvam plugin tests for timestamp fallback behavior and event ordering without modifying `audio_recognition.py` or other STT providers.

## Test plan
- `uv run pytest livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py livekit-plugins/livekit-plugins-sarvam/tests/test_language_probability.py -v`
- `uv run ruff check livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py`
- `python -m py_compile livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py`
- Local console smoke test with `sarvam.STT(model="saaras:v3")`, `vad=None`, and `turn_handling={"turn_detection": "stt"}` produced non-zero EOU metrics, including `transcription_delay=0.146s` and `end_of_utterance_delay=0.501s`.

## Notes
- This is scoped to `livekit-plugins-sarvam`'s `sarvam.STT` path in `stt.py`; it does not change `STTStreaming` or framework turn detection behavior.
- The console smoke test emitted a non-interactive terminal key-listener traceback from console mode, but the agent continued and emitted the expected EOU metrics.