### PR TITLE
fix: skip shutdown IPC for dead supervised processes

### DIFF
--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -308,8 +308,14 @@ class SupervisedProc(ABC):
             return
 
         self._closing = True
-        with contextlib.suppress(duplex_unix.DuplexClosed):
-            await channel.asend_message(self._pch, proto.ShutdownRequest())
+        if not self._process_is_alive():
+            self._mark_shutdown_complete()
+        else:
+            with contextlib.suppress(duplex_unix.DuplexClosed):
+                await channel.asend_message(self._pch, proto.ShutdownRequest())
+
+            if not self._process_is_alive():
+                self._mark_shutdown_complete()
 
         try:
             await asyncio.wait_for(self._shutdown_ack_fut, timeout=self._opts.close_timeout)
@@ -340,6 +346,18 @@ class SupervisedProc(ABC):
         async with self._lock:
             if self._supervise_atask:
                 await asyncio.shield(self._supervise_atask)
+
+    def _process_is_alive(self) -> bool:
+        try:
+            return self._proc.is_alive()
+        except ValueError:
+            return False
+
+    def _mark_shutdown_complete(self) -> None:
+        if not self._shutdown_ack_fut.done():
+            self._shutdown_ack_fut.set_result(None)
+        if not self._shutting_down_fut.done():
+            self._shutting_down_fut.set_result(None)
 
     async def kill(self) -> None:
         """forcefully kill the supervised process"""

--- a/tests/test_supervised_proc_memory.py
+++ b/tests/test_supervised_proc_memory.py
@@ -93,6 +93,31 @@ async def test_uptime_is_zero_before_start() -> None:
     assert proc.uptime == 0.0
 
 
+async def test_aclose_skips_shutdown_request_when_process_is_already_dead(monkeypatch) -> None:
+    proc = _make_proc()
+
+    class _DeadProcess:
+        def is_alive(self) -> bool:
+            return False
+
+    async def _unexpected_shutdown_request(*args, **kwargs):
+        raise AssertionError("aclose should not send ShutdownRequest to a dead child")
+
+    proc._proc = _DeadProcess()
+    proc._supervise_atask = asyncio.create_task(asyncio.sleep(0))
+    await proc._supervise_atask
+
+    monkeypatch.setattr(
+        "livekit.agents.ipc.supervised_proc.channel.asend_message",
+        _unexpected_shutdown_request,
+    )
+
+    await proc.aclose()
+
+    assert proc._shutdown_ack_fut.done()
+    assert proc._shutting_down_fut.done()
+
+
 def test_process_kind_renders_as_plain_string() -> None:
     # the log message interpolates `f"{self.process_kind} process …"`, so the enum
     # must stringify to its value (not "SupervisedProcKind.JOB")


### PR DESCRIPTION
## Summary
- avoid sending a shutdown IPC request when a supervised child process is already dead
- mark shutdown futures complete in that path so `aclose()` does not wait for an ack that cannot arrive
- add a focused regression test for the dead-child close path

Fixes #5929.

## To verify
- `python -m py_compile livekit-agents\livekit\agents\ipc\supervised_proc.py tests\test_supervised_proc_memory.py`
- `python -m ruff check livekit-agents\livekit\agents\ipc\supervised_proc.py tests\test_supervised_proc_memory.py`
- `python -m ruff format --check livekit-agents\livekit\agents\ipc\supervised_proc.py tests\test_supervised_proc_memory.py`
- `PYTHONPATH=livekit-agents python -m pytest tests\test_supervised_proc_memory.py -q`
- `PYTHONPATH=livekit-agents python -m pytest tests\test_ipc.py::test_shutdown_no_job -q`
