### PR TITLE
fix: apply session error tolerance to STT

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -135,7 +135,7 @@ class SessionConnectOptions:
     llm_conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
     tts_conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
     max_unrecoverable_errors: int = 3
-    """Maximum number of consecutive unrecoverable errors from llm or tts."""
+    """Maximum number of consecutive unrecoverable errors from llm, stt, or tts."""
 
 
 @dataclass
@@ -424,6 +424,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         # unrecoverable error counts, reset after agent speaking
         self._llm_error_counts = 0
+        self._stt_error_counts = 0
         self._tts_error_counts = 0
 
         # aec warmup: disable interruptions while AEC warms up
@@ -1032,6 +1033,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             self._user_state = "listening"
             self._agent_state = "initializing"
             self._llm_error_counts = 0
+            self._stt_error_counts = 0
             self._tts_error_counts = 0
             self._root_span_context = None
 
@@ -1494,6 +1496,10 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             self._llm_error_counts += 1
             if self._llm_error_counts <= self.conn_options.max_unrecoverable_errors:
                 return
+        elif error.type == "stt_error":
+            self._stt_error_counts += 1
+            if self._stt_error_counts <= self.conn_options.max_unrecoverable_errors:
+                return
         elif error.type == "tts_error":
             self._tts_error_counts += 1
             if self._tts_error_counts <= self.conn_options.max_unrecoverable_errors:
@@ -1583,6 +1589,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         if state == "speaking":
             self._llm_error_counts = 0
+            self._stt_error_counts = 0
             self._tts_error_counts = 0
 
             if self._agent_speaking_span is None:

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -21,6 +21,7 @@ from livekit.agents import (
     UserStateChangedEvent,
     function_tool,
     inference,
+    stt,
     vad,
 )
 from livekit.agents.llm import (
@@ -30,6 +31,7 @@ from livekit.agents.llm.chat_context import ChatContext, ChatMessage
 from livekit.agents.stt import SpeechData, SpeechEvent, SpeechEventType
 from livekit.agents.utils import aio
 from livekit.agents.voice.agent_activity import AgentActivity
+from livekit.agents.voice.agent_session import SessionConnectOptions
 from livekit.agents.voice.audio_recognition import AudioRecognition, _EndOfTurnInfo
 from livekit.agents.voice.endpointing import BaseEndpointing
 from livekit.agents.voice.events import FunctionToolsExecutedEvent
@@ -881,6 +883,40 @@ async def test_interruption_detection_error_is_not_session_error() -> None:
         fallback.assert_called_once_with(unrecoverable)
     finally:
         await _close_test_session(session)
+
+
+async def test_stt_errors_use_unrecoverable_error_tolerance() -> None:
+    actions = FakeActions()
+    session = create_session(
+        actions,
+        extra_kwargs={
+            "conn_options": SessionConnectOptions(max_unrecoverable_errors=1),
+        },
+    )
+
+    first_error = stt.STTError(
+        timestamp=time.time(),
+        label="test",
+        error=RuntimeError("stt unavailable"),
+        recoverable=False,
+    )
+    session._on_error(first_error)
+
+    assert session._closing_task is None
+    assert session._stt_error_counts == 1
+
+    second_error = stt.STTError(
+        timestamp=time.time(),
+        label="test",
+        error=RuntimeError("stt unavailable"),
+        recoverable=False,
+    )
+    session._on_error(second_error)
+
+    assert session._closing_task is not None
+    await session._closing_task
+
+    await _close_test_session(session)
 
 
 async def test_vad_fallback_uses_next_vad_inference_event(


### PR DESCRIPTION
## Summary
- apply the existing `max_unrecoverable_errors` tolerance to unrecoverable STT errors
- reset the STT error counter alongside the existing LLM/TTS counters
- update the connection option docstring and add a focused regression test

Fixes #5665.

## To verify
- `python -m py_compile livekit-agents\livekit\agents\voice\agent_session.py tests\test_agent_session.py`
- `python -m ruff check livekit-agents\livekit\agents\voice\agent_session.py tests\test_agent_session.py`
- `python -m ruff format --check livekit-agents\livekit\agents\voice\agent_session.py tests\test_agent_session.py`
- `PYTHONPATH=livekit-agents python -m pytest tests\test_agent_session.py::test_stt_errors_use_unrecoverable_error_tolerance -q`

Note: `ruff check` completed successfully locally but could not write one `.ruff_cache` entry due a Windows cache permission warning.
