### PR TITLE
fix: preserve Google LLM fallback timeouts

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -476,9 +476,12 @@ class LLMStream(llm.LLMStream):
                     )
                 self._extra_kwargs.pop("tools", None)
                 self._extra_kwargs.pop("tool_config", None)
-            http_options = self._llm._opts.http_options or types.HttpOptions(
-                timeout=int(self._conn_options.timeout * 1000)
-            )
+            if is_given(self._llm._opts.http_options):
+                http_options = self._llm._opts.http_options.model_copy(deep=True)
+            else:
+                http_options = types.HttpOptions()
+            if http_options.timeout is None:
+                http_options.timeout = int(self._conn_options.timeout * 1000)
             if not http_options.headers:
                 http_options.headers = {}
             http_options.headers["x-goog-api-client"] = f"livekit-agents/{__version__}"

--- a/tests/test_plugin_google_llm.py
+++ b/tests/test_plugin_google_llm.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from google.genai import types
 
-from livekit.agents import llm
+from livekit.agents import APIConnectOptions, llm
 from livekit.agents.llm import ChatContext, function_tool
 from livekit.plugins.google.llm import LLM, LLMStream
 from livekit.plugins.google.realtime.realtime_api import RealtimeModel, RealtimeSession
@@ -242,6 +242,29 @@ class TestCachedContentRequestSuppression:
         config = captured["config"]
         assert config.system_instruction is not None
         assert config.tools is not None and len(config.tools) >= 1
+
+    @pytest.mark.asyncio
+    async def test_request_merges_conn_timeout_into_caller_http_options(self) -> None:
+        http_options = types.HttpOptions(headers={"X-Vertex-AI-LLM-Request-Type": "shared"})
+        llm = LLM(model="gemini-2.5-flash", api_key="test", http_options=http_options)
+
+        fake, captured = self._patched_stream_capture()
+        with patch.object(llm._client.aio.models, "generate_content_stream", fake):
+            stream = llm.chat(
+                chat_ctx=ChatContext.empty(),
+                conn_options=APIConnectOptions(timeout=7.5),
+            )
+            try:
+                async for _ in stream:
+                    pass
+            finally:
+                await stream.aclose()
+
+        config = captured["config"]
+        assert config.http_options.timeout == 7500
+        assert config.http_options.headers["X-Vertex-AI-LLM-Request-Type"] == "shared"
+        assert config.http_options.headers["x-goog-api-client"].startswith("livekit-agents/")
+        assert http_options.timeout is None
 
 
 class TestMediaResolution:


### PR DESCRIPTION
Fixes #5972.

## Summary
- preserve caller-provided Google `HttpOptions` while injecting LiveKit connection timeouts when no timeout is set
- copy the caller options before adding LiveKit headers/timeouts so the original options object is not mutated
- add a regression test that captures the outgoing `GenerateContentConfig`

## To verify
- `PYTHONPATH=livekit-agents;livekit-plugins/livekit-plugins-google python -m pytest tests/test_plugin_google_llm.py -q`
- `python -m ruff check livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py tests/test_plugin_google_llm.py`
- `python -m ruff format --check livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py tests/test_plugin_google_llm.py`
- `git diff --check`
