### PR TITLE
Handle STT error tolerance in AgentSession

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -424,6 +424,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         # unrecoverable error counts, reset after agent speaking
         self._llm_error_counts = 0
+        self._stt_error_counts = 0
         self._tts_error_counts = 0
 
         # aec warmup: disable interruptions while AEC warms up
@@ -1032,6 +1033,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             self._user_state = "listening"
             self._agent_state = "initializing"
             self._llm_error_counts = 0
+            self._stt_error_counts = 0
             self._tts_error_counts = 0
             self._root_span_context = None
 
@@ -1498,6 +1500,10 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             self._tts_error_counts += 1
             if self._tts_error_counts <= self.conn_options.max_unrecoverable_errors:
                 return
+        elif error.type == "stt_error":
+            self._stt_error_counts += 1
+            if self._stt_error_counts <= self.conn_options.max_unrecoverable_errors:
+                return
 
         if isinstance(error.error, APIError):
             logger.error(f"AgentSession is closing due to unrecoverable error: {error.error}")
@@ -1583,6 +1589,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         if state == "speaking":
             self._llm_error_counts = 0
+            self._stt_error_counts = 0
             self._tts_error_counts = 0
 
             if self._agent_speaking_span is None:

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -27,9 +27,10 @@ from livekit.agents.llm import (
     FunctionToolCall,
 )
 from livekit.agents.llm.chat_context import ChatContext, ChatMessage
-from livekit.agents.stt import SpeechData, SpeechEvent, SpeechEventType
+from livekit.agents.stt import SpeechData, SpeechEvent, SpeechEventType, STTError
 from livekit.agents.utils import aio
 from livekit.agents.voice.agent_activity import AgentActivity
+from livekit.agents.voice.agent_session import SessionConnectOptions
 from livekit.agents.voice.audio_recognition import AudioRecognition, _EndOfTurnInfo
 from livekit.agents.voice.endpointing import BaseEndpointing
 from livekit.agents.voice.events import FunctionToolsExecutedEvent
@@ -879,6 +880,38 @@ async def test_interruption_detection_error_is_not_session_error() -> None:
 
         assert error_events == []
         fallback.assert_called_once_with(unrecoverable)
+    finally:
+        await _close_test_session(session)
+
+
+async def test_stt_errors_use_session_tolerance_before_closing() -> None:
+    session = create_session(
+        FakeActions(),
+        extra_kwargs={"conn_options": SessionConnectOptions(max_unrecoverable_errors=1)},
+    )
+
+    try:
+        session._on_error(
+            STTError(
+                timestamp=time.time(),
+                label="test-stt",
+                error=RuntimeError("first"),
+                recoverable=False,
+            )
+        )
+
+        assert session._closing_task is None
+
+        session._on_error(
+            STTError(
+                timestamp=time.time(),
+                label="test-stt",
+                error=RuntimeError("second"),
+                recoverable=False,
+            )
+        )
+
+        assert session._closing_task is not None
     finally:
         await _close_test_session(session)
 


### PR DESCRIPTION
## Summary

- add an STT unrecoverable-error counter to `AgentSession`
- apply `max_unrecoverable_errors` to `stt_error` the same way it already applies to LLM and TTS errors
- reset the STT counter alongside the existing LLM/TTS counters when the session closes or the agent starts speaking
- add a focused regression test for the STT tolerance behavior

Fixes livekit/agents#5665.

## Tests

- `uv run pytest tests/test_agent_session.py::test_stt_errors_use_session_tolerance_before_closing`
- `uv run pytest tests/test_agent_session.py::test_interruption_detection_error_is_not_session_error tests/test_agent_session.py::test_stt_errors_use_session_tolerance_before_closing tests/test_agent_session.py::test_vad_fallback_uses_next_vad_inference_event`
- `uv run ruff format --check livekit-agents/livekit/agents/voice/agent_session.py tests/test_agent_session.py`
- `uv run ruff check livekit-agents/livekit/agents/voice/agent_session.py tests/test_agent_session.py`
