### PR TITLE
fix: resolve shutdown futures when IPC reader stops

### DIFF
--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -420,7 +420,19 @@ class SupervisedProc(ABC):
         main_task = asyncio.create_task(self._main_task(ipc_ch))
         read_ipc_task = asyncio.create_task(self._read_ipc_task(ipc_ch, pong_timeout))
         ping_task = asyncio.create_task(self._ping_pong_task(pong_timeout))
-        read_ipc_task.add_done_callback(lambda _: ipc_ch.close())
+
+        def _on_read_ipc_done(_: asyncio.Task[None]) -> None:
+            ipc_ch.close()
+            # the read task is the sole reader of the IPC channel; once it ends, the
+            # process is gone (channel closed) or being torn down (cancelled). resolve
+            # the shutdown futures here so aclose() never waits the full close_timeout
+            # for an ack that can't arrive.
+            if not self._shutdown_ack_fut.done():
+                self._shutdown_ack_fut.set_result(None)
+            if not self._shutting_down_fut.done():
+                self._shutting_down_fut.set_result(None)
+
+        read_ipc_task.add_done_callback(_on_read_ipc_done)
 
         memory_monitor_task: asyncio.Task[None] | None = None
         if self._opts.memory_limit_mb > 0 or self._opts.memory_warn_mb > 0:
@@ -479,12 +491,6 @@ class SupervisedProc(ABC):
                 )
 
             ipc_ch.send_nowait(msg)
-
-        # resolve pending futures when the channel closes (process exited)
-        if not self._shutdown_ack_fut.done():
-            self._shutdown_ack_fut.set_result(None)
-        if not self._shutting_down_fut.done():
-            self._shutting_down_fut.set_result(None)
 
     @log_exceptions(logger=logger)
     async def _ping_pong_task(self, pong_timeout: aio.Sleep) -> None:

--- a/tests/test_supervised_proc_memory.py
+++ b/tests/test_supervised_proc_memory.py
@@ -93,6 +93,54 @@ async def test_uptime_is_zero_before_start() -> None:
     assert proc.uptime == 0.0
 
 
+async def test_supervise_resolves_shutdown_futures_when_read_task_cancelled_first() -> None:
+    """Regression for #5929.
+
+    When the child is killed externally, the join thread resolves _join_fut and
+    _supervise_task cancels _read_ipc_task. If that cancellation wins the race
+    against the read task observing the closed channel, the shutdown futures must
+    still be resolved (by the read task's done callback) — otherwise aclose()
+    blocks waiting for an ack that can never arrive.
+    """
+    from livekit.agents.ipc.supervised_proc import channel  # noqa: F401
+    from livekit.agents.utils.aio import duplex_unix
+
+    proc = _make_proc()
+
+    # a live socket pair whose peer stays open: _read_ipc_task blocks in
+    # arecv_message and never observes EOF, guaranteeing it is suspended there when
+    # cancel_and_wait() cancels it — exactly the lost-race ordering from the bug.
+    a, b = socket.socketpair()
+    proc._pch = await duplex_unix._AsyncDuplex.open(a)
+
+    async def _idle_main(ipc_ch) -> None:
+        async for _ in ipc_ch:
+            pass
+
+    proc._main_task = _idle_main  # type: ignore[method-assign]
+
+    class _FakeMpProc:
+        exitcode = 0
+
+        def close(self) -> None: ...
+
+    proc._proc = _FakeMpProc()  # type: ignore[assignment]
+    proc._join_fut = asyncio.Future()
+    proc._initialize_fut.set_result(None)
+
+    supervise = asyncio.create_task(proc._supervise_task())
+    await asyncio.sleep(0)  # let _supervise_task reach `await self._join_fut`
+
+    assert not proc._shutdown_ack_fut.done()
+    proc._join_fut.set_result(None)  # join thread signals the child has exited
+    await asyncio.wait_for(supervise, timeout=5)
+
+    assert proc._shutdown_ack_fut.done()
+    assert proc._shutting_down_fut.done()
+
+    b.close()
+
+
 def test_process_kind_renders_as_plain_string() -> None:
     # the log message interpolates `f"{self.process_kind} process …"`, so the enum
     # must stringify to its value (not "SupervisedProcKind.JOB")


### PR DESCRIPTION
Fixes #5929.

## Root cause

`aclose()` waits on `_shutdown_ack_fut` (bounded by `close_timeout`) and then on `_shutting_down_fut` (no timeout). Both are resolved by `_read_ipc_task`: on the matching `ShutdownRequestAck` / `ShuttingDown` message while its read loop runs, or on channel close once the loop breaks on EOF.

The close-path resolution sat after the read loop, so it only ran when the loop broke normally. `_supervise_task` cancels the reader via `cancel_and_wait()` as soon as `_join_fut` resolves, which races the reader observing the closed channel. When the child is killed externally the cancel wins, `CancelledError` is raised inside `arecv_message`, and the resolution is skipped. Both futures are then abandoned, so `aclose()` waits the full `close_timeout` for an ack that never arrives and then hangs on the untimed `_shutting_down_fut` await.

## Fix

Move the close-path resolution into the reader's done callback so it fires on every termination path — normal EOF, cancellation, and exception.

## Why it's safe

The reader is the sole consumer of the IPC channel, so its end is exactly the point past which no message can arrive. While it is still running the futures stay pending, preserving the unresponsive-but-alive force-kill path. The final `wait_for(self._supervise_atask, timeout=close_timeout)` still gates on the actual process exit and force-kills on timeout, so a live process is never left behind.