### PR TITLE
feat(clevrlabs): add Clevr Labs TTS plugin

### DIFF
--- a/livekit-plugins/livekit-plugins-clevrlabs/README.md
+++ b/livekit-plugins/livekit-plugins-clevrlabs/README.md
@@ -1,0 +1,21 @@
+# Clevr Labs plugin for LiveKit Agents
+
+Support for [Clevr Labs](https://theclevr.com/)' conversational speech model in LiveKit Agents.
+
+More information is available in the docs for the [TTS](https://docs.livekit.io/agents/integrations/tts/) integration.
+
+## Installation
+
+```bash
+pip install livekit-plugins-clevrlabs
+```
+
+## Pre-requisites
+
+You'll need an API key from Clevr Labs, available at [theclevr.com](https://theclevr.com/). Pass it to the plugin via the `api_key` argument:
+
+```python
+from livekit.plugins import clevrlabs
+
+session = AgentSession(tts=clevrlabs.TTS(api_key="clevr_..."), ...)
+```

--- a/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/__init__.py
+++ b/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/__init__.py
@@ -1,0 +1,46 @@
+# Copyright 2025 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Clevr Labs plugin for LiveKit Agents
+
+Supports streaming TTS (text-to-speech) backed by the Clevr Labs conversational
+speech model. See https://docs.livekit.io/agents/integrations/tts/ for more
+information.
+"""
+
+from .tts import TTS
+from .version import __version__
+
+__all__ = ["TTS", "__version__"]
+
+from livekit.agents import Plugin
+
+from .log import logger
+
+
+class ClevrLabsPlugin(Plugin):
+    def __init__(self) -> None:
+        super().__init__(__name__, __version__, __package__, logger)
+
+
+Plugin.register_plugin(ClevrLabsPlugin())
+
+# Cleanup docs of unexported modules
+_module = dir()
+NOT_IN_ALL = [m for m in _module if m not in __all__]
+
+__pdoc__ = {}
+
+for n in NOT_IN_ALL:
+    __pdoc__[n] = False

--- a/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/_text.py
+++ b/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/_text.py
@@ -14,8 +14,8 @@
 
 """Text normalisation before TTS synthesis.
 
-Translation table is built once at import time — import this module at
-process startup so the C table is never rebuilt per-request.
+Strips punctuation and symbol characters (minus a small allowlist) and expands
+currency amounts, so the model only ever receives speakable text.
 """
 
 import re
@@ -60,18 +60,26 @@ _REPLACE = {
     "°": " degrees ",
 }
 
-_table = str.maketrans(
-    {
-        **{
-            chr(cp): None
-            for cp in range(0x110000)
-            if unicodedata.category(chr(cp)).startswith(("P", "S"))
-            and chr(cp) not in _KEEP
-            and chr(cp) not in _REPLACE
-        },
-        **_REPLACE,
-    }
-)
+
+def _strip_punctuation_and_symbols(text: str) -> str:
+    """Drop punctuation/symbol characters, keeping the _KEEP allowlist.
+
+    Only the characters actually present in ``text`` are inspected, so there is
+    no import-time cost from scanning the whole Unicode range.
+    """
+    out: list[str] = []
+    for char in text:
+        replacement = _REPLACE.get(char)
+        if replacement is not None:
+            out.append(replacement)
+        elif char in _KEEP:
+            out.append(char)
+        elif unicodedata.category(char)[0] in ("P", "S"):
+            continue  # punctuation or symbol — drop it
+        else:
+            out.append(char)
+    return "".join(out)
+
 
 _EMAIL = re.compile(r"\b[\w.+-]+@[\w.-]+\.[a-zA-Z]{2,}\b")
 _SPACE_BEFORE_COMMA = re.compile(r" ,")
@@ -82,7 +90,7 @@ def clean_text(text: str) -> str:
     text = _CURRENCY_RE.sub(_expand_currency, text)
     text = re.sub(r"\s+", " ", text).strip()
     text = _EMAIL.sub(lambda m: m.group().replace(".", " dot ").replace("@", " at "), text)
-    text = text.translate(_table)
+    text = _strip_punctuation_and_symbols(text)
     text = re.sub(r" {2,}", " ", text)
     text = _SPACE_BEFORE_COMMA.sub(",", text)
     text = _MULTI_PUNCT.sub(lambda m: m.group()[-1], text)

--- a/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/_text.py
+++ b/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/_text.py
@@ -1,0 +1,89 @@
+# Copyright 2025 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Text normalisation before TTS synthesis.
+
+Translation table is built once at import time — import this module at
+process startup so the C table is never rebuilt per-request.
+"""
+
+import re
+import unicodedata
+from decimal import ROUND_HALF_UP, Decimal
+
+from num2words import num2words  # type: ignore[import-untyped]
+
+_CURRENCY_MAP = {
+    "$": ("dollar", "cent"),
+    "£": ("pound", "penny"),
+    "€": ("euro", "cent"),
+}
+
+
+def _expand_currency(m: re.Match) -> str:
+    symbol = m.group(1)
+    number = m.group(2).replace(",", "")
+    name, frac_name = _CURRENCY_MAP.get(symbol, ("dollar", "cent"))
+    amount = Decimal(number)
+    whole = int(amount)
+    cents = int((amount - whole).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP) * 100)
+    parts = [f"{num2words(whole)} {name}{'s' if whole != 1 else ''}"]
+    if cents:
+        parts.append(f"{num2words(cents)} {frac_name}{'s' if cents != 1 else ''}")
+    return " and ".join(parts)
+
+
+_CURRENCY_RE = re.compile(r"([$£€])([\d,]+(?:\.\d{1,2})?)")
+
+_KEEP = set(",'?.-%$!:/£⁇¿")
+
+_REPLACE = {
+    "—": ",",
+    "–": "-",
+    "’": "'",
+    "@": " at ",
+    "&": "and",
+    "×": " times ",
+    "÷": " divided by ",
+    "±": " plus or minus ",
+    "°": " degrees ",
+}
+
+_table = str.maketrans(
+    {
+        **{
+            chr(cp): None
+            for cp in range(0x110000)
+            if unicodedata.category(chr(cp)).startswith(("P", "S"))
+            and chr(cp) not in _KEEP
+            and chr(cp) not in _REPLACE
+        },
+        **_REPLACE,
+    }
+)
+
+_EMAIL = re.compile(r"\b[\w.+-]+@[\w.-]+\.[a-zA-Z]{2,}\b")
+_SPACE_BEFORE_COMMA = re.compile(r" ,")
+_MULTI_PUNCT = re.compile(r"[,'?.%$!:/£⁇¿-]{2,}")
+
+
+def clean_text(text: str) -> str:
+    text = _CURRENCY_RE.sub(_expand_currency, text)
+    text = re.sub(r"\s+", " ", text).strip()
+    text = _EMAIL.sub(lambda m: m.group().replace(".", " dot ").replace("@", " at "), text)
+    text = text.translate(_table)
+    text = re.sub(r" {2,}", " ", text)
+    text = _SPACE_BEFORE_COMMA.sub(",", text)
+    text = _MULTI_PUNCT.sub(lambda m: m.group()[-1], text)
+    return text

--- a/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/_text.py
+++ b/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/_text.py
@@ -24,23 +24,31 @@ from decimal import ROUND_HALF_UP, Decimal
 
 from num2words import num2words  # type: ignore[import-untyped]
 
+# (singular, plural) for the whole and fractional units — explicit because some
+# plurals are irregular (penny -> pence, not "pennys").
 _CURRENCY_MAP = {
-    "$": ("dollar", "cent"),
-    "£": ("pound", "penny"),
-    "€": ("euro", "cent"),
+    "$": ("dollar", "dollars", "cent", "cents"),
+    "£": ("pound", "pounds", "penny", "pence"),
+    "€": ("euro", "euros", "cent", "cents"),
 }
 
 
 def _expand_currency(m: re.Match) -> str:
     symbol = m.group(1)
     number = m.group(2).replace(",", "")
-    name, frac_name = _CURRENCY_MAP.get(symbol, ("dollar", "cent"))
+    whole_name, whole_plural, frac_name, frac_plural = _CURRENCY_MAP.get(
+        symbol, ("dollar", "dollars", "cent", "cents")
+    )
     amount = Decimal(number)
     whole = int(amount)
     cents = int((amount - whole).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP) * 100)
-    parts = [f"{num2words(whole)} {name}{'s' if whole != 1 else ''}"]
+
+    parts = []
+    # Skip the whole part for sub-unit amounts (e.g. $0.50 -> "fifty cents").
+    if whole != 0 or cents == 0:
+        parts.append(f"{num2words(whole)} {whole_name if whole == 1 else whole_plural}")
     if cents:
-        parts.append(f"{num2words(cents)} {frac_name}{'s' if cents != 1 else ''}")
+        parts.append(f"{num2words(cents)} {frac_name if cents == 1 else frac_plural}")
     return " and ".join(parts)
 
 

--- a/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/log.py
+++ b/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/log.py
@@ -1,0 +1,17 @@
+# Copyright 2025 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+logger = logging.getLogger("livekit.plugins.clevrlabs")

--- a/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/tts.py
@@ -41,6 +41,10 @@ from .log import logger
 
 _DEFAULT_SERVER_URL = "https://api.theclevr.com"
 
+# The Clevr Labs model always synthesizes at 24 kHz (and the pipeline encodes
+# user audio at 24 kHz too), so the output rate is fixed, not configurable.
+_OUTPUT_SAMPLE_RATE = 24000
+
 
 class TTS(tts.TTS):
     """Streaming text-to-speech backed by the Clevr Labs conversational speech model.
@@ -67,7 +71,6 @@ class TTS(tts.TTS):
         *,
         api_key: str,
         server_url: str = _DEFAULT_SERVER_URL,
-        sample_rate: int = 24000,
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
     ):
         """Create a Clevr Labs TTS plugin.
@@ -77,12 +80,11 @@ class TTS(tts.TTS):
                           https://theclevr.com.
             server_url:   Base URL of the Clevr Labs API. Defaults to the hosted
                           endpoint; override only to target a different deployment.
-            sample_rate:  Output sample rate, in Hz, of the synthesized audio.
             conn_options: Connection and retry options applied to synthesis requests.
         """
         super().__init__(
             capabilities=tts.TTSCapabilities(streaming=True),
-            sample_rate=sample_rate,
+            sample_rate=_OUTPUT_SAMPLE_RATE,
             num_channels=1,
         )
         self._server_url = server_url.rstrip("/")
@@ -90,9 +92,6 @@ class TTS(tts.TTS):
 
         self._session_id: str | None = None
         self._session_started: bool = False
-        self._session_starting: bool = False
-        self._session_ready = asyncio.Event()
-        self._session_error: Exception | None = None
         self._session_lock = asyncio.Lock()
         self._pending_user_turn: dict | None = None
 
@@ -139,46 +138,38 @@ class TTS(tts.TTS):
         """Eagerly start a session in the background.
 
         Call this right after construction (from an async context) so the
-        session is ready before the first synthesis request. If not called,
-        the session is started lazily on first use.
+        session is ready before the first synthesis request. This is purely an
+        optimization: if not called, the session is opened lazily on first use,
+        and a failed eager start is simply retried on first use.
         """
-        self._session_starting = True
-        asyncio.ensure_future(self._start_session_bg())
 
-    async def _open_session(self) -> None:
-        resp = await self._http_client.post("/tts/session/start")
-        resp.raise_for_status()
-        data = resp.json()
-        self._session_id = data["session_id"]
-        self._session_started = True
-        logger.info("Clevr session started: %s", self._session_id)
+        async def _eager_start() -> None:
+            try:
+                await self._ensure_session()
+            except Exception:
+                logger.warning(
+                    "Eager Clevr session start failed; will retry on first synthesis",
+                    exc_info=True,
+                )
 
-    async def _start_session_bg(self) -> None:
-        try:
-            await self._open_session()
-        except Exception as e:
-            self._session_error = e
-            logger.error("Failed to start Clevr session: %s", e)
-        finally:
-            self._session_ready.set()
+        asyncio.ensure_future(_eager_start())
 
     async def _ensure_session(self) -> None:
         if self._session_started:
             return
 
-        # start_session() kicked off a background start; wait for it to finish.
-        if self._session_starting:
-            await self._session_ready.wait()
-            if self._session_error is not None:
-                raise self._session_error
-            return
-
-        # Otherwise start lazily on first use. The lock stops concurrent segments
-        # from racing to open two sessions.
+        # The lock serializes concurrent callers so only one session is opened.
+        # A failed attempt leaves _session_started False, so the next call retries
+        # instead of permanently caching the error.
         async with self._session_lock:
             if self._session_started:
                 return
-            await self._open_session()
+            resp = await self._http_client.post("/tts/session/start")
+            resp.raise_for_status()
+            data = resp.json()
+            self._session_id = data["session_id"]
+            self._session_started = True
+            logger.info("Clevr session started: %s", self._session_id)
 
     async def _end_session(self) -> None:
         if not self._session_started or not self._session_id:
@@ -294,23 +285,27 @@ class ClevrLabsSynthesizeStream(tts.SynthesizeStream):
         if not text:
             return
 
-        await self._tts._ensure_session()
-
         t_start = time.perf_counter()
 
+        # Read but don't yet clear the pending user turn: if the request fails and
+        # the base class retries _run(), the context must still be available.
+        pending_user_turn = self._tts._pending_user_turn
         payload: dict = {
             "text": text,
             "speaker": 0,
-            "session_id": self._tts._session_id,
         }
-        if self._tts._pending_user_turn is not None:
-            payload["context"] = [self._tts._pending_user_turn]
-            self._tts._pending_user_turn = None
+        if pending_user_turn is not None:
+            payload["context"] = [pending_user_turn]
 
         audio_chunks: list = []
         byte_buffer = b""
 
         try:
+            # Opening the session is inside the try so its HTTP errors are wrapped
+            # as APIError too (e.g. a 401 from a bad key stays visible/retryable).
+            await self._tts._ensure_session()
+            payload["session_id"] = self._tts._session_id
+
             async with self._tts._http_client.stream(
                 "POST", "/tts/synthesize/stream", json=payload
             ) as resp:
@@ -337,6 +332,11 @@ class ClevrLabsSynthesizeStream(tts.SynthesizeStream):
 
             for frame in audio_bstream.flush():
                 output_emitter.push(frame.data.tobytes())
+
+            # Request succeeded — only now drop the user context so it isn't
+            # re-sent on the next segment (and is preserved for a retry on failure).
+            if pending_user_turn is not None:
+                self._tts._pending_user_turn = None
 
         except asyncio.CancelledError:
             raise

--- a/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/tts.py
@@ -1,0 +1,341 @@
+# Copyright 2025 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LiveKit TTS plugin for the Clevr Labs conversational speech model."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import re
+import time
+from math import gcd
+
+import httpx
+import numpy as np
+from scipy.signal import resample_poly
+
+from livekit.agents import APIConnectOptions, tts, utils
+from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS
+
+from ._text import clean_text
+from .log import logger
+
+_DEFAULT_SERVER_URL = "https://api.theclevr.com"
+
+
+class TTS(tts.TTS):
+    """Streaming text-to-speech backed by the Clevr Labs conversational speech model.
+
+    Audio is synthesized on the Clevr Labs servers and streamed back as PCM; no
+    model runs locally. The plugin keeps a single voice consistent across a
+    conversation as long as each user turn is fed back via ``add_user_turn``.
+
+    Example::
+
+        from livekit.plugins import clevrlabs
+
+        tts = clevrlabs.TTS(api_key="clevr_...")
+
+        # Wire into a LiveKit AgentSession:
+        session = AgentSession(tts=tts, ...)
+
+        # After each user turn, forward the audio so the voice stays consistent:
+        tts.add_user_turn(text=transcript, audio=audio_np, sample_rate=48000)
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        server_url: str = _DEFAULT_SERVER_URL,
+        sample_rate: int = 24000,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+    ):
+        """Create a Clevr Labs TTS plugin.
+
+        Args:
+            api_key:      Clevr Labs API key (``clevr_...``), available at
+                          https://theclevr.com.
+            server_url:   Base URL of the Clevr Labs API. Defaults to the hosted
+                          endpoint; override only to target a different deployment.
+            sample_rate:  Output sample rate, in Hz, of the synthesized audio.
+            conn_options: Connection and retry options applied to synthesis requests.
+        """
+        super().__init__(
+            capabilities=tts.TTSCapabilities(streaming=True),
+            sample_rate=sample_rate,
+            num_channels=1,
+        )
+        self._server_url = server_url.rstrip("/")
+        self._conn_options = conn_options
+
+        self._session_id: str | None = None
+        self._session_started: bool = False
+        self._session_ready = asyncio.Event()
+        self._session_error: Exception | None = None
+        self._pending_user_turn: dict | None = None
+
+        self._http_client = httpx.AsyncClient(
+            base_url=self._server_url,
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=httpx.Timeout(90.0, connect=10.0),
+        )
+
+    def add_user_turn(self, *, text: str, audio: np.ndarray, sample_rate: int) -> None:
+        """Buffer a user turn to send with the next synthesis request.
+
+        The server owns all conversation context in its KV cache. The client
+        only needs to forward new user audio so the server can encode it.
+
+        Args:
+            text:        Transcript of what the user said.
+            audio:       Float32 numpy array of the user's speech. Int16 arrays
+                         are accepted and converted automatically.
+            sample_rate: Sample rate of the audio array (e.g. 48000, 16000).
+        """
+        if not text.strip() or audio.size == 0:
+            logger.debug(
+                "add_user_turn: dropping empty turn (text=%r, audio_size=%d)",
+                text,
+                audio.size,
+            )
+            return
+
+        if audio.dtype != np.float32:
+            audio = audio.astype(np.float32)
+            if np.abs(audio).max() > 1.0:
+                audio /= 32768.0
+
+        if sample_rate != 24000:
+            g = gcd(sample_rate, 24000)
+            audio = resample_poly(audio, 24000 // g, sample_rate // g).astype(np.float32)
+
+        audio_b64 = base64.b64encode(audio.tobytes()).decode("ascii")
+        self._pending_user_turn = {"speaker": 1, "text": text, "audio_b64": audio_b64}
+
+    def start_session(self) -> None:
+        """Eagerly start a session in the background.
+
+        Call this right after construction (from an async context) so the
+        session is ready before the first synthesis request. If not called,
+        the session is started lazily on first use.
+        """
+        asyncio.ensure_future(self._start_session_bg())
+
+    async def _start_session_bg(self) -> None:
+        try:
+            resp = await self._http_client.post("/tts/session/start")
+            resp.raise_for_status()
+            data = resp.json()
+            self._session_id = data["session_id"]
+            self._session_started = True
+            logger.info("Clevr session started: %s", self._session_id)
+        except Exception as e:
+            self._session_error = e
+            logger.error("Failed to start Clevr session: %s", e)
+        finally:
+            self._session_ready.set()
+
+    async def _ensure_session(self) -> None:
+        if self._session_started:
+            return
+        if not self._session_ready.is_set():
+            await self._session_ready.wait()
+        if self._session_error is not None:
+            raise self._session_error
+        if not self._session_started:
+            resp = await self._http_client.post("/tts/session/start")
+            resp.raise_for_status()
+            data = resp.json()
+            self._session_id = data["session_id"]
+            self._session_started = True
+            logger.info("Clevr session started: %s", self._session_id)
+
+    async def _end_session(self) -> None:
+        if not self._session_started or not self._session_id:
+            return
+        try:
+            resp = await self._http_client.post(
+                "/tts/session/end", params={"session_id": self._session_id}
+            )
+            resp.raise_for_status()
+            logger.info("Clevr session ended: %s", self._session_id)
+        except Exception:
+            logger.warning("Failed to end Clevr session %s", self._session_id, exc_info=True)
+        finally:
+            self._session_started = False
+            self._session_id = None
+
+    async def aclose(self) -> None:
+        await self._end_session()
+        await self._http_client.aclose()
+
+    @property
+    def model(self) -> str:
+        return "csm-1"
+
+    @property
+    def provider(self) -> str:
+        return "clevr"
+
+    def synthesize(
+        self, text: str, *, conn_options: APIConnectOptions | None = None
+    ) -> tts.ChunkedStream:
+        return self._synthesize_with_stream(
+            text=text, conn_options=conn_options or self._conn_options
+        )
+
+    def stream(self, *, conn_options: APIConnectOptions | None = None) -> ClevrLabsSynthesizeStream:
+        return ClevrLabsSynthesizeStream(tts=self, conn_options=conn_options or self._conn_options)
+
+
+class _SentenceBuffer:
+    """Buffers streamed LLM tokens and emits chunks of N complete sentences."""
+
+    def __init__(self, n: int = 3) -> None:
+        self._n = n
+        self._buf = ""
+        self._pattern = re.compile(r"([.!?]+(?:\s+|\n+|\Z))")
+
+    def push(self, text: str) -> list:
+        self._buf += text
+        chunks = []
+        while True:
+            matches = list(self._pattern.finditer(self._buf))
+            if len(matches) < self._n:
+                break
+            split_idx = matches[self._n - 1].end()
+            chunk = self._buf[:split_idx].strip()
+            self._buf = self._buf[split_idx:]
+            if chunk:
+                chunks.append(chunk)
+        return chunks
+
+    def flush(self) -> str:
+        text = self._buf.strip()
+        self._buf = ""
+        return text
+
+
+class ClevrLabsSynthesizeStream(tts.SynthesizeStream):
+    def __init__(self, *, tts: TTS, conn_options: APIConnectOptions) -> None:
+        super().__init__(tts=tts, conn_options=conn_options)
+        self._tts: TTS = tts
+
+    async def _run(self, output_emitter: tts.AudioEmitter) -> None:
+        request_id = utils.shortuuid()
+        output_emitter.initialize(
+            request_id=request_id,
+            sample_rate=self._tts.sample_rate,
+            num_channels=self._tts.num_channels,
+            mime_type="audio/pcm",
+            stream=True,
+        )
+        audio_bstream = utils.audio.AudioByteStream(
+            sample_rate=self._tts.sample_rate,
+            num_channels=1,
+        )
+        segment_id = utils.shortuuid()
+        output_emitter.start_segment(segment_id=segment_id)
+
+        buf = _SentenceBuffer(n=3)
+        async for data in self._input_ch:
+            if isinstance(data, tts.SynthesizeStream._FlushSentinel):
+                text = buf.flush()
+                if text:
+                    await self._synthesize_segment(text, output_emitter, audio_bstream)
+            else:
+                for chunk in buf.push(data):
+                    await self._synthesize_segment(chunk, output_emitter, audio_bstream)
+
+        text = buf.flush()
+        if text:
+            await self._synthesize_segment(text, output_emitter, audio_bstream)
+
+        output_emitter.flush()
+        output_emitter.end_segment()
+
+    async def _synthesize_segment(
+        self,
+        text: str,
+        output_emitter: tts.AudioEmitter,
+        audio_bstream: utils.audio.AudioByteStream,
+    ) -> None:
+        text = clean_text(text.strip())
+        if not text:
+            return
+
+        await self._tts._ensure_session()
+
+        t_start = time.perf_counter()
+
+        payload: dict = {
+            "text": text,
+            "speaker": 0,
+            "session_id": self._tts._session_id,
+        }
+        if self._tts._pending_user_turn is not None:
+            payload["context"] = [self._tts._pending_user_turn]
+            self._tts._pending_user_turn = None
+
+        audio_chunks: list = []
+        byte_buffer = b""
+
+        try:
+            async with self._tts._http_client.stream(
+                "POST", "/tts/synthesize/stream", json=payload
+            ) as resp:
+                if resp.status_code >= 400:
+                    await resp.aread()
+                    raise httpx.HTTPStatusError(
+                        f"HTTP {resp.status_code}",
+                        request=resp.request,
+                        response=resp,
+                    )
+                async for raw in resp.aiter_bytes():
+                    byte_buffer += raw
+                    complete = (len(byte_buffer) // 4) * 4
+                    if complete == 0:
+                        continue
+                    chunk_np = np.frombuffer(byte_buffer[:complete], dtype=np.float32).copy()
+                    byte_buffer = byte_buffer[complete:]
+
+                    audio_chunks.append(chunk_np)
+                    chunk_np = np.clip(chunk_np, -1.0, 1.0)
+                    chunk_int16 = (chunk_np * 32767).astype(np.int16)
+                    for frame in audio_bstream.write(chunk_int16.tobytes()):
+                        output_emitter.push(frame.data.tobytes())
+
+            for frame in audio_bstream.flush():
+                output_emitter.push(frame.data.tobytes())
+
+        except asyncio.CancelledError:
+            raise
+        except httpx.ConnectError as e:
+            raise RuntimeError(
+                f"Cannot connect to Clevr TTS server at {self._tts._server_url}. "
+                "Check your server_url or visit https://theclevr.com for status."
+            ) from e
+        except httpx.HTTPStatusError as e:
+            raise RuntimeError(
+                f"Clevr TTS server returned {e.response.status_code}: {e.response.text}"
+            ) from e
+        finally:
+            total_ms = (time.perf_counter() - t_start) * 1000
+            audio_np = (
+                np.concatenate(audio_chunks) if audio_chunks else np.zeros(0, dtype=np.float32)
+            )
+            duration_s = len(audio_np) / self._tts.sample_rate
+            logger.info("[clevr] %.1fs audio in %.0fms", duration_s, total_ms)

--- a/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/tts.py
@@ -26,7 +26,14 @@ import httpx
 import numpy as np
 from scipy.signal import resample_poly
 
-from livekit.agents import APIConnectOptions, tts, utils
+from livekit.agents import (
+    APIConnectionError,
+    APIConnectOptions,
+    APIStatusError,
+    APITimeoutError,
+    tts,
+    utils,
+)
 from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS
 
 from ._text import clean_text
@@ -83,8 +90,10 @@ class TTS(tts.TTS):
 
         self._session_id: str | None = None
         self._session_started: bool = False
+        self._session_starting: bool = False
         self._session_ready = asyncio.Event()
         self._session_error: Exception | None = None
+        self._session_lock = asyncio.Lock()
         self._pending_user_turn: dict | None = None
 
         self._http_client = httpx.AsyncClient(
@@ -101,8 +110,8 @@ class TTS(tts.TTS):
 
         Args:
             text:        Transcript of what the user said.
-            audio:       Float32 numpy array of the user's speech. Int16 arrays
-                         are accepted and converted automatically.
+            audio:       Float32 numpy array of the user's speech. Integer arrays
+                         (e.g. int16) are accepted and normalised automatically.
             sample_rate: Sample rate of the audio array (e.g. 48000, 16000).
         """
         if not text.strip() or audio.size == 0:
@@ -113,10 +122,11 @@ class TTS(tts.TTS):
             )
             return
 
-        if audio.dtype != np.float32:
+        if np.issubdtype(audio.dtype, np.integer):
+            max_int = np.iinfo(audio.dtype).max
+            audio = audio.astype(np.float32) / max_int
+        elif audio.dtype != np.float32:
             audio = audio.astype(np.float32)
-            if np.abs(audio).max() > 1.0:
-                audio /= 32768.0
 
         if sample_rate != 24000:
             g = gcd(sample_rate, 24000)
@@ -132,16 +142,20 @@ class TTS(tts.TTS):
         session is ready before the first synthesis request. If not called,
         the session is started lazily on first use.
         """
+        self._session_starting = True
         asyncio.ensure_future(self._start_session_bg())
+
+    async def _open_session(self) -> None:
+        resp = await self._http_client.post("/tts/session/start")
+        resp.raise_for_status()
+        data = resp.json()
+        self._session_id = data["session_id"]
+        self._session_started = True
+        logger.info("Clevr session started: %s", self._session_id)
 
     async def _start_session_bg(self) -> None:
         try:
-            resp = await self._http_client.post("/tts/session/start")
-            resp.raise_for_status()
-            data = resp.json()
-            self._session_id = data["session_id"]
-            self._session_started = True
-            logger.info("Clevr session started: %s", self._session_id)
+            await self._open_session()
         except Exception as e:
             self._session_error = e
             logger.error("Failed to start Clevr session: %s", e)
@@ -151,17 +165,20 @@ class TTS(tts.TTS):
     async def _ensure_session(self) -> None:
         if self._session_started:
             return
-        if not self._session_ready.is_set():
+
+        # start_session() kicked off a background start; wait for it to finish.
+        if self._session_starting:
             await self._session_ready.wait()
-        if self._session_error is not None:
-            raise self._session_error
-        if not self._session_started:
-            resp = await self._http_client.post("/tts/session/start")
-            resp.raise_for_status()
-            data = resp.json()
-            self._session_id = data["session_id"]
-            self._session_started = True
-            logger.info("Clevr session started: %s", self._session_id)
+            if self._session_error is not None:
+                raise self._session_error
+            return
+
+        # Otherwise start lazily on first use. The lock stops concurrent segments
+        # from racing to open two sessions.
+        async with self._session_lock:
+            if self._session_started:
+                return
+            await self._open_session()
 
     async def _end_session(self) -> None:
         if not self._session_started or not self._session_id:
@@ -323,14 +340,19 @@ class ClevrLabsSynthesizeStream(tts.SynthesizeStream):
 
         except asyncio.CancelledError:
             raise
-        except httpx.ConnectError as e:
-            raise RuntimeError(
+        except httpx.HTTPStatusError as e:
+            raise APIStatusError(
+                message=e.response.text,
+                status_code=e.response.status_code,
+                request_id=None,
+                body=None,
+            ) from None
+        except httpx.TimeoutException as e:
+            raise APITimeoutError() from e
+        except httpx.HTTPError as e:
+            raise APIConnectionError(
                 f"Cannot connect to Clevr TTS server at {self._tts._server_url}. "
                 "Check your server_url or visit https://theclevr.com for status."
-            ) from e
-        except httpx.HTTPStatusError as e:
-            raise RuntimeError(
-                f"Clevr TTS server returned {e.response.status_code}: {e.response.text}"
             ) from e
         finally:
             total_ms = (time.perf_counter() - t_start) * 1000

--- a/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/version.py
+++ b/livekit-plugins/livekit-plugins-clevrlabs/livekit/plugins/clevrlabs/version.py
@@ -1,0 +1,15 @@
+# Copyright 2025 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.1.0"

--- a/livekit-plugins/livekit-plugins-clevrlabs/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-clevrlabs/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "livekit-plugins-clevrlabs"
+dynamic = ["version"]
+description = "LiveKit Agents Plugin for Clevr Labs"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.10.0"
+authors = [{ name = "LiveKit", email = "hello@livekit.io" }]
+keywords = ["voice", "ai", "realtime", "audio", "video", "livekit", "clevrlabs", "tts"]
+classifiers = [
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: Multimedia :: Sound/Audio",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3 :: Only",
+]
+dependencies = [
+    "livekit-agents>=1.5.18",
+    "numpy>=1.24",
+    "scipy>=1.10",
+    "num2words>=0.5",
+]
+
+[project.urls]
+Documentation = "https://docs.livekit.io"
+Website = "https://livekit.io/"
+Source = "https://github.com/livekit/agents"
+
+[tool.hatch.version]
+path = "livekit/plugins/clevrlabs/version.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["livekit"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/livekit"]
+
+[tool.uv]
+exclude-newer = "7 days"
+exclude-newer-package = { livekit-agents = "0 days" }

--- a/livekit-plugins/livekit-plugins-clevrlabs/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-clevrlabs/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "livekit-agents>=1.5.18",
+    "httpx>=0.28",
     "numpy>=1.24",
     "scipy>=1.10",
     "num2words>=0.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ livekit-plugins-bithuman = { workspace = true }
 livekit-plugins-cambai = { workspace = true }
 livekit-plugins-cartesia = { workspace = true }
 livekit-plugins-cerebras = { workspace = true }
+livekit-plugins-clevrlabs = { workspace = true }
 livekit-plugins-clova = { workspace = true }
 livekit-plugins-deepgram = { workspace = true }
 livekit-plugins-elevenlabs = { workspace = true }


### PR DESCRIPTION
## livekit-plugins-clevrlabs

  Adds a streaming TTS plugin for the Clevr Labs conversational speech    
  model,
  following the existing provider-plugin structure (modeled on cartesia). 

  - Streaming `tts.TTS` (streaming=True)
  - Per-conversation voice consistency via `add_user_turn()`
  - No generation knobs on the constructor (keeps provider-internal params
  off the public surface)

  Already published & in production use:
  https://pypi.org/project/livekit-plugins-clevrlabs/

  Passes `make check` (ruff lint + format, mypy --strict) under the root  
  config.

  ### Testing
  Talks to the hosted Clevr API; needs a key (free at theclevr.com). The  
  model is
  live right now — happy to provision a credited test account for any     
  maintainer
  who wants to run it live, or you can talk to the hosted model directly. 
  Reach me
  on the LiveKit Slack (@cyrus), or at cyrus@theclevr.com. 
  
  ### Demo link, Uploaded to youtube for ease of access. 
  Youtube: https://youtu.be/pN7K82K9SzE
  
  Cheers, Thank you for all the work you do. =)