### PR TITLE
fix(openai): avoid duplicate responses function calls

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -313,7 +313,16 @@ class LLM(llm.LLM):
                 self._prev_chat_ctx
             ) and self._pending_tool_calls_completed(chat_ctx.items[n:]):
                 # send only the new items appended since the last response
-                input_chat_ctx = ChatContext(items=chat_ctx.items[n:])
+                input_chat_ctx = ChatContext(
+                    items=[
+                        item
+                        for item in chat_ctx.items[n:]
+                        if not (
+                            item.type == "function_call"
+                            and item.call_id in self._pending_tool_calls
+                        )
+                    ]
+                )
                 extra["previous_response_id"] = self._prev_resp_id
             # if the context was modified otherwise, resend the whole context and omit previous response id
         return LLMStream(

--- a/tests/test_openai_responses_llm.py
+++ b/tests/test_openai_responses_llm.py
@@ -1,0 +1,28 @@
+import pytest
+
+from livekit.agents import llm
+from livekit.plugins.openai import responses
+
+
+@pytest.mark.asyncio
+async def test_previous_response_id_filters_only_pending_function_calls() -> None:
+    openai_llm = responses.LLM(api_key="test", use_websocket=False)
+    prev_message = llm.ChatMessage(role="user", content=["check the weather"])
+    openai_llm._prev_chat_ctx = llm.ChatContext(items=[prev_message])
+    openai_llm._prev_resp_id = "resp_123"
+    openai_llm._pending_tool_calls = {"call_pending"}
+
+    duplicate_call = llm.FunctionCall(call_id="call_pending", name="get_weather", arguments="{}")
+    tool_output = llm.FunctionCallOutput(
+        call_id="call_pending", name="get_weather", output="sunny", is_error=False
+    )
+    new_call = llm.FunctionCall(call_id="call_new", name="get_time", arguments="{}")
+    current_ctx = llm.ChatContext(items=[prev_message, duplicate_call, tool_output, new_call])
+
+    stream = openai_llm.chat(chat_ctx=current_ctx)
+    try:
+        assert stream._extra_kwargs["previous_response_id"] == "resp_123"
+        assert stream._chat_ctx.items == [tool_output, new_call]
+    finally:
+        await stream.aclose()
+        await openai_llm.aclose()


### PR DESCRIPTION
Fixes #5136

## Summary
- when using `previous_response_id`, filter pending `function_call` items from the delta context while preserving their `function_call_output` items
- add a regression test for Responses API context reuse

## Tests
- `uv run ruff check livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py tests/test_openai_responses_llm.py`
- `uv run ruff format --check livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py tests/test_openai_responses_llm.py`
- `uv run pytest tests/test_openai_responses_llm.py`