### PR TITLE
fix(aws): add dummy user message for Claude 4.5+/Opus 4.6+ trailing assistant turns

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/aws.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/aws.py
@@ -16,7 +16,10 @@ class BedrockFormatData:
 
 
 def to_chat_ctx(
-    chat_ctx: llm.ChatContext, *, inject_dummy_user_message: bool = True
+    chat_ctx: llm.ChatContext,
+    *,
+    inject_dummy_user_message: bool = True,
+    inject_trailing_user_message: bool = False,
 ) -> tuple[list[dict], BedrockFormatData]:
     chat_ctx = convert_mid_conversation_instructions(chat_ctx)
 
@@ -82,6 +85,13 @@ def to_chat_ctx(
     # Ensure the message list starts with a "user" message
     if inject_dummy_user_message and (not messages or messages[0]["role"] != "user"):
         messages.insert(0, {"role": "user", "content": [{"text": "(empty)"}]})
+
+    # Claude 4.5+/Opus 4.6+ no longer support prefilling (trailing assistant
+    # messages). Append a dummy user message so the request ends with a user
+    # turn. See https://github.com/livekit/agents/pull/4973 for the Anthropic
+    # plugin's equivalent fix.
+    if inject_trailing_user_message and messages and messages[-1]["role"] == "assistant":
+        messages.append({"role": "user", "content": [{"text": " "}]})
 
     return messages, BedrockFormatData(system_messages=system_messages)
 

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -35,6 +35,30 @@ from .log import logger
 
 DEFAULT_TEXT_MODEL = "amazon.nova-2-lite-v1:0"
 
+# Claude 4.5+/Opus 4.6+ no longer support prefilling (trailing assistant
+# messages). Bedrock surfaces this as a ValidationException at the Converse
+# API layer. Substring matching is used because Bedrock model IDs vary in
+# shape — plain IDs (``claude-sonnet-4-6``), date-stamped snapshots
+# (``anthropic.claude-sonnet-4-5-20250929-v1:0``), and cross-region inference
+# profiles (``global.anthropic.claude-sonnet-4-6``,
+# ``us.anthropic.claude-opus-4-7-v1:0``). See
+# https://platform.claude.com/docs/en/about-claude/models/migration-guide
+_NO_PREFILL_PATTERNS = (
+    "claude-sonnet-4-5",
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-7",
+    "claude-opus-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+)
+
+
+def _model_disables_prefill(model: str | None) -> bool:
+    """Return True if the model does not support assistant message prefilling."""
+    if not model:
+        return False
+    return any(p in model for p in _NO_PREFILL_PATTERNS)
+
 
 @dataclass
 class _LLMOptions:
@@ -177,7 +201,12 @@ class LLM(llm.LLM):
             opts["toolConfig"] = tool_config
         else:
             chat_ctx = chat_ctx.copy(exclude_function_call=True)
-        messages, extra_data = chat_ctx.to_provider_format(format="aws")
+        # Claude 4.5+/Opus 4.6+ do not support prefilling — see
+        # _NO_PREFILL_PATTERNS above and PR #4973 for the Anthropic precedent.
+        inject_trailing = _model_disables_prefill(self._opts.model)
+        messages, extra_data = chat_ctx.to_provider_format(
+            format="aws", inject_trailing_user_message=inject_trailing
+        )
         opts["messages"] = messages
         if extra_data.system_messages:
             system_messages: list[dict[str, str | dict]] = [

--- a/tests/test_chat_ctx.py
+++ b/tests/test_chat_ctx.py
@@ -696,3 +696,69 @@ def test_responses_assistant_phase_absent_when_not_set():
     assistant_items = [item for item in items if item.get("role") == "assistant"]
     assert assistant_items
     assert all("phase" not in item for item in assistant_items)
+
+
+def test_aws_inject_trailing_user_message_appends_when_last_is_assistant():
+    """A trailing assistant message gets a dummy user appended when the flag is on."""
+    from livekit.agents.llm import ChatContext
+
+    ctx = ChatContext.empty()
+    ctx.add_message(role="user", content="hello")
+    ctx.add_message(role="assistant", content="hi there")
+
+    messages, _ = ctx.to_provider_format(format="aws", inject_trailing_user_message=True)
+    assert messages[-1]["role"] == "user"
+    # Original last assistant turn is preserved; a new user turn is appended.
+    assert len(messages) == 3
+    assert messages[1]["role"] == "assistant"
+    assert messages[2]["content"] == [{"text": " "}]
+
+
+def test_aws_inject_trailing_user_message_default_off_keeps_assistant_last():
+    """By default, a trailing assistant message is left in place (backward compatible)."""
+    from livekit.agents.llm import ChatContext
+
+    ctx = ChatContext.empty()
+    ctx.add_message(role="user", content="hello")
+    ctx.add_message(role="assistant", content="hi there")
+
+    messages, _ = ctx.to_provider_format(format="aws")
+    assert messages[-1]["role"] == "assistant"
+    assert len(messages) == 2
+
+
+def test_aws_inject_trailing_user_message_idempotent_when_last_is_user():
+    """When the message list already ends with a user turn, no extra user is appended."""
+    from livekit.agents.llm import ChatContext
+
+    ctx = ChatContext.empty()
+    ctx.add_message(role="user", content="hello")
+    ctx.add_message(role="assistant", content="hi")
+    ctx.add_message(role="user", content="follow-up")
+
+    messages, _ = ctx.to_provider_format(format="aws", inject_trailing_user_message=True)
+    assert messages[-1]["role"] == "user"
+    # No extra dummy turn — the existing user turn satisfies the requirement.
+    assert len(messages) == 3
+    assert messages[-1]["content"] == [{"text": "follow-up"}]
+
+
+def test_aws_model_disables_prefill_matches_inference_profiles():
+    """The Bedrock model-ID gate matches plain IDs, snapshots, and inference profiles."""
+    from livekit.plugins.aws.llm import _model_disables_prefill
+
+    # Affected models (Claude 4.5+/Opus 4.6+) — every shape Bedrock emits.
+    assert _model_disables_prefill("claude-sonnet-4-6")
+    assert _model_disables_prefill("anthropic.claude-sonnet-4-5-20250929-v1:0")
+    assert _model_disables_prefill("global.anthropic.claude-sonnet-4-6")
+    assert _model_disables_prefill("us.anthropic.claude-opus-4-7-v1:0")
+    assert _model_disables_prefill("eu.anthropic.claude-opus-4-6-v1:0")
+
+    # Unaffected models — older Claude, Nova, Llama, Mistral, and empties.
+    assert not _model_disables_prefill("anthropic.claude-3-5-sonnet-20241022-v2:0")
+    assert not _model_disables_prefill("anthropic.claude-sonnet-4-20250514-v1:0")
+    assert not _model_disables_prefill("amazon.nova-2-lite-v1:0")
+    assert not _model_disables_prefill("meta.llama3-70b-instruct-v1:0")
+    assert not _model_disables_prefill("mistral.mistral-large-2407-v1:0")
+    assert not _model_disables_prefill("")
+    assert not _model_disables_prefill(None)


### PR DESCRIPTION
## Summary

Mirror [#4973](https://github.com/livekit/agents/pull/4973)'s Anthropic-plugin fix on the AWS Bedrock plugin. When the active model is in the Claude 4.5+/Opus 4.6+ family (which no longer supports assistant-message prefill), append a minimal dummy user message if the conversation would otherwise end on `assistant`. This prevents `botocore.errorfactory.ValidationException: This model does not support assistant message prefill. The conversation must end with a user message.` at the Bedrock `ConverseStream` validation layer.

Closes #6007. Anthropic-plugin precedent: #4973 (merged 2026-03-03), #4907.

## Motivation

Anthropic [removed assistant-message prefill](https://platform.claude.com/docs/en/about-claude/models/migration-guide) starting in Claude Sonnet 4.5 and Opus 4.6 (carried forward to Sonnet 4.6/4.7, Opus 4.7/4.8). The same removal applies on Bedrock, where it surfaces as a `ConverseStream` `ValidationException`. PR #4973 added end-side dummy-user injection to the Anthropic plugin gated on model ID, but the equivalent fix was never applied to the AWS Bedrock plugin — so anyone routing affected Claude models (e.g., `global.anthropic.claude-sonnet-4-6`, `us.anthropic.claude-opus-4-7-v1:0`, `anthropic.claude-sonnet-4-5-20250929-v1:0`) through `livekit.plugins.aws.llm.LLM` hits the same wall.

The AWS provider format already has start-side `inject_dummy_user_message=True` (prepends a dummy when `messages[0]["role"] != "user"`); this PR adds the symmetric end-side handling.

## Changes

- **`livekit-agents/livekit/agents/llm/_provider_format/aws.py`** — add `inject_trailing_user_message: bool = False` parameter to `to_chat_ctx()`. When True and `messages[-1]["role"] == "assistant"`, append `{"role": "user", "content": [{"text": " "}]}`. Defaults to False, so existing callers see no behavior change.
- **`livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py`** — add `_NO_PREFILL_PATTERNS` and `_model_disables_prefill(model)`, and pass `inject_trailing_user_message=_model_disables_prefill(self._opts.model)` to `chat_ctx.to_provider_format`. Models in the affected Claude family get the injection; everything else (Nova, Llama, Mistral, older Claude) is unaffected.
- **`tests/test_chat_ctx.py`** — four new test cases:
  - `test_aws_inject_trailing_user_message_appends_when_last_is_assistant` — happy path.
  - `test_aws_inject_trailing_user_message_default_off_keeps_assistant_last` — backward compat for callers not opting in.
  - `test_aws_inject_trailing_user_message_idempotent_when_last_is_user` — no extra dummy when already user-terminated.
  - `test_aws_model_disables_prefill_matches_inference_profiles` — gate matches plain IDs, date-stamped snapshots, and cross-region inference profile prefixes; excludes Nova, Llama, Mistral, older Claude, and empty/None.

## Why substring matching instead of `startswith`

PR #4973 used `_NO_PREFILL_PATTERNS = ("claude-sonnet-4-6", "claude-opus-4-6")` with `model.startswith(p)`. That works for the Anthropic plugin because its model IDs are short and unprefixed (`claude-sonnet-4-6`).

Bedrock model IDs vary in shape:

- Plain: `claude-sonnet-4-6`
- Date-stamped snapshot: `anthropic.claude-sonnet-4-5-20250929-v1:0`
- Cross-region inference profile: `global.anthropic.claude-sonnet-4-6`, `us.anthropic.claude-opus-4-7-v1:0`, `eu.anthropic.claude-opus-4-6-v1:0`

`startswith("claude-sonnet-4-6")` would miss the prefixed forms, so this PR uses substring matching (`any(p in model for p in _NO_PREFILL_PATTERNS)`). If a future change unifies the two plugins' detection logic, that's a reasonable follow-up — keeping them separate for now mirrors #4973's local-to-the-plugin shape.

## Pattern list scope

Includes Sonnet 4.5/4.6/4.7 and Opus 4.6/4.7/4.8. Sonnet 4.5 is included (it's the actual cut-line per Anthropic's migration guide); #4973's list omitted it. Future versions will need additions to this tuple; the doc comment above it points at the Anthropic migration guide as the source of truth.

## Verification

- `make format`: clean (848 files unchanged).
- `make lint`: clean.
- `make type-check`: clean.
- Full `tests/test_chat_ctx.py`: 23 passed, 1 skipped (pre-existing), 0 failures.
- The 4 new tests pass and exercise both branches of the new flag plus the model gate across all the Bedrock ID shapes I could enumerate.
