### PR TITLE
fix(plugins-google): thought_signature dropped for version-less Gemini model aliases

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -55,11 +55,20 @@ def _requires_thought_signatures(model: str) -> bool:
 
     Gemini 2.5+ models require thought signatures to be stored from responses and
     passed back in subsequent requests for proper multi-turn function calling.
+
+    Note: signature handling at runtime is response-driven (a signature is stored
+    whenever the API returns one and resent whenever present), so it no longer
+    depends on this name match. This helper is retained for backwards
+    compatibility and also recognizes the version-less aliases
+    ``gemini-flash-latest`` / ``gemini-flash-lite-latest``, which resolve to
+    Gemini 3 server-side and therefore require thought signatures too.
     """
     if _is_gemini_3_model(model):
         return True
     model_lower = model.lower()
-    return "gemini-2.5" in model_lower or model_lower.startswith("gemini-2.5")
+    if "gemini-2.5" in model_lower or model_lower.startswith("gemini-2.5"):
+        return True
+    return model_lower in ("gemini-flash-latest", "gemini-flash-lite-latest")
 
 
 @dataclass
@@ -440,10 +449,14 @@ class LLMStream(llm.LLMStream):
         request_id = utils.shortuuid()
 
         try:
-            # Pass thought_signatures for Gemini 2.5+ multi-turn function calling
-            thought_sigs = (
-                self._llm._thought_signatures if _requires_thought_signatures(self._model) else None
-            )
+            # Resend any stored thought_signatures: Gemini requires them echoed
+            # back on subsequent turns of multi-turn function calling. They are
+            # stored only when the API returns one (see _parse_part), so passing
+            # them whenever present is correct for every model that needs them --
+            # including version-less aliases like "gemini-flash-latest" /
+            # "gemini-flash-lite-latest" that resolve to Gemini 3 server-side.
+            # Empty -> None (no-op for models that never emit signatures).
+            thought_sigs = self._llm._thought_signatures or None
             turns_dict, extra_data = self._chat_ctx.to_provider_format(
                 format="google", thought_signatures=thought_sigs
             )
@@ -607,12 +620,11 @@ class LLMStream(llm.LLMStream):
                 call_id=part.function_call.id or utils.shortuuid("function_call_"),
             )
 
-            # Store thought_signature for Gemini 2.5+ multi-turn function calling
-            if (
-                _requires_thought_signatures(self._model)
-                and hasattr(part, "thought_signature")
-                and part.thought_signature
-            ):
+            # Store the thought_signature whenever the API returns one so it can
+            # be echoed back on the next turn (required by Gemini for multi-turn
+            # function calling). Driven by the response rather than a model-name
+            # guess, so it works for every signature-emitting model and alias.
+            if getattr(part, "thought_signature", None):
                 self._llm._thought_signatures[tool_call.call_id] = part.thought_signature
 
             chat_chunk = llm.ChatChunk(

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -624,7 +624,7 @@ class LLMStream(llm.LLMStream):
             # be echoed back on the next turn (required by Gemini for multi-turn
             # function calling). Driven by the response rather than a model-name
             # guess, so it works for every signature-emitting model and alias.
-            if getattr(part, "thought_signature", None):
+            if hasattr(part, "thought_signature") and part.thought_signature:
                 self._llm._thought_signatures[tool_call.call_id] = part.thought_signature
 
             chat_chunk = llm.ChatChunk(

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -39,36 +39,32 @@ from .models import ChatModels
 from .utils import create_tools_config, to_response_format
 from .version import __version__
 
+# Version-less aliases that resolve to the latest (Gemini 3.x) flash models
+# server-side. They can't be introspected client-side, so treat them as Gemini 3
+# flash for thinking-config and thought-signature handling.
+_GEMINI_3_FLASH_ALIASES = ("gemini-flash-latest", "gemini-flash-lite-latest")
+
 
 def _is_gemini_3_model(model: str) -> bool:
-    """Check if model is Gemini 3 series"""
-    return "gemini-3" in model.lower() or model.lower().startswith("gemini-3")
+    """Check if model is Gemini 3 series (including version-less aliases)."""
+    m = model.lower()
+    return "gemini-3" in m or m in _GEMINI_3_FLASH_ALIASES
 
 
 def _is_gemini_3_flash_model(model: str) -> bool:
-    """Check if model is Gemini 3 Flash"""
-    return "gemini-3-flash" in model.lower() or model.lower().startswith("gemini-3-flash")
+    """Check if model is a Gemini 3 Flash model (any 3.x flash + version-less aliases)."""
+    m = model.lower()
+    return (_is_gemini_3_model(m) and "flash" in m) or m in _GEMINI_3_FLASH_ALIASES
 
 
 def _requires_thought_signatures(model: str) -> bool:
-    """Check if model requires thought_signature handling for multi-turn function calling.
+    """Whether the model needs thought_signature handling for multi-turn function calling.
 
-    Gemini 2.5+ models require thought signatures to be stored from responses and
-    passed back in subsequent requests for proper multi-turn function calling.
-
-    Note: signature handling at runtime is response-driven (a signature is stored
-    whenever the API returns one and resent whenever present), so it no longer
-    depends on this name match. This helper is retained for backwards
-    compatibility and also recognizes the version-less aliases
-    ``gemini-flash-latest`` / ``gemini-flash-lite-latest``, which resolve to
-    Gemini 3 server-side and therefore require thought signatures too.
+    Gemini 2.5+/3.x (incl. version-less aliases) require it. NOTE: the runtime path
+    is now response-driven (see _parse_part / _run); this is retained for tests.
     """
-    if _is_gemini_3_model(model):
-        return True
-    model_lower = model.lower()
-    if "gemini-2.5" in model_lower or model_lower.startswith("gemini-2.5"):
-        return True
-    return model_lower in ("gemini-flash-latest", "gemini-flash-lite-latest")
+    m = model.lower()
+    return _is_gemini_3_model(m) or "gemini-2.5" in m
 
 
 @dataclass

--- a/tests/test_google_thought_signatures.py
+++ b/tests/test_google_thought_signatures.py
@@ -63,6 +63,12 @@ class TestGeminiModelDetection:
             ("gemini-3-flash", True),
             ("gemini-3-pro", True),
             ("GEMINI-3-FLASH", True),  # case insensitive
+            # Latest Gemini 3 point releases - should return True (matched by gemini-3)
+            ("gemini-3.5-flash", True),
+            ("gemini-3.1-flash-lite", True),
+            # Version-less Gemini aliases - should return True (resolve to Gemini 3 server-side)
+            ("gemini-flash-latest", True),
+            ("gemini-flash-lite-latest", True),
             # Gemini 2.5 models - should return True (requires thought signatures)
             ("gemini-2.5-flash", True),
             ("gemini-2.5-pro-preview-05-06", True),

--- a/tests/test_google_thought_signatures.py
+++ b/tests/test_google_thought_signatures.py
@@ -21,10 +21,17 @@ class TestGeminiModelDetection:
             ("gemini-3-flash", True),
             ("gemini-3-pro", True),
             ("GEMINI-3-FLASH", True),  # case insensitive
+            # Latest Gemini 3 point releases - should return True (matched by gemini-3)
+            ("gemini-3.5-flash", True),
+            ("gemini-3.1-flash-lite", True),
+            # Version-less Gemini aliases - should return True (resolve to Gemini 3 server-side)
+            ("gemini-flash-latest", True),
+            ("gemini-flash-lite-latest", True),
             # Gemini 2.5 models - should return False
             ("gemini-2.5-flash", False),
             ("gemini-2.5-pro-preview-05-06", False),
             # Gemini 2.0 models - should return False
+            ("gemini-2.0-flash", False),
             ("gemini-2.0-flash-001", False),
             # Gemini 1.5 models - should return False
             ("gemini-1.5-pro", False),
@@ -43,6 +50,12 @@ class TestGeminiModelDetection:
             ("gemini-3-flash-preview", True),
             ("gemini-3-flash", True),
             ("GEMINI-3-FLASH", True),  # case insensitive
+            # Latest Gemini 3 flash point releases - should return True
+            ("gemini-3.5-flash", True),
+            ("gemini-3.1-flash-lite", True),
+            # Version-less Gemini aliases - should return True (resolve to Gemini 3 flash server-side)
+            ("gemini-flash-latest", True),
+            ("gemini-flash-lite-latest", True),
             # Gemini 3 Pro models - should return False
             ("gemini-3-pro-preview", False),
             ("gemini-3-pro", False),
@@ -76,10 +89,12 @@ class TestGeminiModelDetection:
             ("gemini-2.5-flash-preview-05-20", True),
             ("GEMINI-2.5-FLASH", True),  # case insensitive
             # Gemini 2.0 models - should return False (does not require thought signatures)
+            ("gemini-2.0-flash", False),
             ("gemini-2.0-flash-001", False),
             ("gemini-2.0-flash-lite-preview-02-05", False),
             ("gemini-2.0-pro-exp-02-05", False),
             # Gemini 1.5 models - should return False
+            ("gemini-1.5-flash", False),
             ("gemini-1.5-pro", False),
             # Other models - should return False
             ("gpt-4", False),


### PR DESCRIPTION
## Problem
Multi-turn function calling fails with `400 INVALID_ARGUMENT: "Function call is missing a thought_signature in functionCall parts"` when the LLM model is a **version-less Gemini alias** such as `gemini-flash-latest` or `gemini-flash-lite-latest` (these resolve to Gemini 3 server-side). It works on the first turn and breaks on the first follow-up that echoes a function call back.

## Root cause
`_requires_thought_signatures(model)` gates BOTH storing (`_parse_part`) and resending (`_run`) of `thought_signature`, but only matches literal `gemini-2.5*` / `gemini-3*` strings. Version-less aliases return `False`, so the signature is never stored or resent — and Gemini 3 requires it echoed back.

## Fix
Make signature handling response-driven instead of model-name-driven:
- store a `thought_signature` whenever the API returns one (`_parse_part`);
- resend whatever was stored, whenever present (`_run`).

Correct for every signature-emitting model + alias; a no-op for models that never emit them (nothing stored → nothing resent). Signature handling at runtime no longer depends on the `_requires_thought_signatures` model-name heuristic. The helper itself is retained (its alias handling corrected so `gemini-flash-latest` / `gemini-flash-lite-latest` also return `True`) because the existing unit tests in `tests/test_google_thought_signatures.py` import and assert on it.

## Model coverage note
The current latest flash models are `gemini-3.5-flash` and `gemini-3.1-flash-lite`. Both already match the `gemini-3` detection, so — unlike the version-less `-latest` aliases — they were already storing and resending signatures before this change; the response-driven fix keeps them correct. The fix also covers the `-latest` aliases automatically (they no longer depend on the name heuristic at runtime), while the retained helper additionally recognizes them so the unit tests stay accurate. The dropped-signature 400 was specific to the version-less `-latest` aliases.

## Test
Verified live against the real Gemini API, driving the plugin's `llm.LLM` through a 2-turn function-calling exchange with a single `save_answer(answer: str)` tool (turn 1 forces the tool call; turn 2 echoes the `FunctionCall` + `FunctionCallOutput` back, reusing the harvested `call_id`).

### `gemini-flash-lite-latest` (the version-less alias bug)
**Before (unpatched):** turn 1 stores nothing (`LLM._thought_signatures` is empty), turn 2 raises:
```
APIStatusError status_code=400 INVALID_ARGUMENT
"Function call is missing a thought_signature in functionCall parts. This is required
for tools to work correctly... function call `default_api:save_answer`, position 2."
```
**After (patched):** turn 1 stores the signature (`LLM._thought_signatures` keys = `['<call_id>']`), turn 2 succeeds with a normal assistant response — no 400. Same script, same model, only the plugin changed.

### `gemini-3.5-flash` (latest flash)
Also verified live for `gemini-3.5-flash`. Because this model matches the `gemini-3` detection in both the original and patched code, the runtime gate is `True` either way, so it never hit the dropped-signature 400. With the patched plugin, multi-turn function calling succeeds: turn 1 stores the signature (`LLM._thought_signatures` keys = `['<call_id>']`), turn 2 returns a normal assistant response — no 400. The response-driven fix keeps `gemini-3.5-flash` (and `gemini-3.1-flash-lite`) correct.

### Unit tests
The existing unit cases in `tests/test_google_thought_signatures.py` still pass unchanged. Added `_requires_thought_signatures` → `True` cases for the current latest models `gemini-3.5-flash` and `gemini-3.1-flash-lite`, plus the version-less aliases `gemini-flash-latest` and `gemini-flash-lite-latest` (38 passed).



---

## Follow-up fix — model-detection gaps in `thinking_config` and flash defaults

The same fragile string matching affected two sibling helpers in `llm.py`, surfaced during review:

- `_is_gemini_3_model` / `_is_gemini_3_flash_model` only matched literal `gemini-3*` / `gemini-3-flash*`. They returned `False` for the version-less aliases `gemini-flash-latest` / `gemini-flash-lite-latest` (which resolve to Gemini 3.x flash server-side) and mis-handled `gemini-3.5-flash`.
- Consequence 1: the `thinking_config` block called `_is_gemini_3_model(model)`; for the aliases it took the "Gemini 2.5 and earlier" branch and raised `ValueError("does not support thinking_level")`, even though those aliases support `thinking_level`.
- Consequence 2: `_is_gemini_3_flash_model("gemini-3.5-flash")` returned `False`, so 3.5-flash missed the `"minimal"` flash thinking default and fell back to `"low"`.

### Fix
A shared `_GEMINI_3_FLASH_ALIASES` constant plus alias/`3.x`-aware helpers:
- `_is_gemini_3_model` now matches any `gemini-3` substring (covers `gemini-3.5-flash`, `gemini-3.1-flash-lite`) and the version-less aliases.
- `_is_gemini_3_flash_model` is `True` for any 3.x flash model and both aliases.
- The `thinking_config` block is unchanged — correcting the helpers makes the aliases take the Gemini-3 branch (no `ValueError`) and gives `gemini-3.5-flash` the `"minimal"` flash default.

### Tests
Expanded the parametrized cases in `tests/test_google_thought_signatures.py` for all three helpers to cover the aliases, `gemini-3.5-flash`, and `gemini-3.1-flash-lite` (e.g. `_is_gemini_3_model("gemini-flash-latest") → True`, `_is_gemini_3_flash_model("gemini-3.5-flash") → True`, plus `gemini-3-pro-preview → False` to keep pro models out of the flash path).
