### PR TITLE
feat(simulation): drive audio-disable via update_io, drop room attribute logic

### DIFF
--- a/livekit-agents/livekit/agents/voice/io.py
+++ b/livekit-agents/livekit/agents/voice/io.py
@@ -355,14 +355,9 @@ class AgentInput:
 
         # enabled by default
         self._audio_enabled = True
-        self._audio_locked = False
         self._video_enabled = True
 
     def set_audio_enabled(self, enable: bool) -> None:
-        if self._audio_locked:
-            logger.warning("audio input is locked, ignoring set_audio_enabled(%s)", enable)
-            return
-
         if enable and not self._audio_stream:
             logger.warning("Cannot enable audio input when it's not set")
 
@@ -465,7 +460,6 @@ class AgentOutput:
         self._transcription_changed = transcription_changed
 
         self._audio_enabled = True
-        self._audio_locked = False
         self._video_enabled = True
         self._transcription_enabled = True
 
@@ -487,10 +481,6 @@ class AgentOutput:
             self._video_sink.on_detached()
 
     def set_audio_enabled(self, enabled: bool) -> None:
-        if self._audio_locked:
-            logger.warning("audio output is locked, ignoring set_audio_enabled(%s)", enabled)
-            return
-
         if enabled and not self._audio_sink:
             logger.warning("Cannot enable audio output when it's not set")
 

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -1042,6 +1042,41 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
         resp = await self._send_request(req, timeout=timeout)
         return resp.run_input
 
+    async def update_io(
+        self,
+        *,
+        input_audio_enabled: bool | None = None,
+        input_video_enabled: bool | None = None,
+        output_audio_enabled: bool | None = None,
+        output_video_enabled: bool | None = None,
+        output_transcription_enabled: bool | None = None,
+        timeout: float = 60.0,
+    ) -> agent_pb.SessionResponse.UpdateIOResponse:
+        """Toggle the agent's I/O channels remotely.
+
+        Only the channels passed (non-None) are applied; the rest are left
+        untouched. Simulators use this to disable the agent's audio I/O instead
+        of relying on a room attribute.
+        """
+        update = agent_pb.SessionRequest.UpdateIO()
+        if input_audio_enabled is not None:
+            update.input.audio_enabled = input_audio_enabled
+        if input_video_enabled is not None:
+            update.input.video_enabled = input_video_enabled
+        if output_audio_enabled is not None:
+            update.output.audio_enabled = output_audio_enabled
+        if output_video_enabled is not None:
+            update.output.video_enabled = output_video_enabled
+        if output_transcription_enabled is not None:
+            update.output.transcription_enabled = output_transcription_enabled
+
+        req = agent_pb.SessionRequest(
+            request_id=utils.shortuuid("req_"),
+            update_io=update,
+        )
+        resp = await self._send_request(req, timeout=timeout)
+        return resp.update_io
+
     async def finalize_simulation(
         self,
         *,

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -11,7 +11,6 @@ from ...log import logger
 from ...types import (
     ATTRIBUTE_AGENT_STATE,
     ATTRIBUTE_PUBLISH_ON_BEHALF,
-    ATTRIBUTE_SIMULATOR,
     DEFAULT_API_CONNECT_OPTIONS,
     NOT_GIVEN,
     TOPIC_CHAT,
@@ -76,7 +75,6 @@ class RoomIO:
         self._participant_available_fut = asyncio.Future[rtc.RemoteParticipant]()
         self._room_connected_fut = asyncio.Future[None]()
 
-        self._simulator_mode = False
         self._ready_fut: asyncio.Future[None] = asyncio.Future()
         self._init_atask: asyncio.Task[None] | None = None
         self._user_transcript_ch: utils.aio.Chan[UserInputTranscribedEvent] | None = None
@@ -175,7 +173,6 @@ class RoomIO:
         self._room.on("participant_connected", self._on_participant_connected)
         self._room.on("connection_state_changed", self._on_connection_state_changed)
         self._room.on("participant_disconnected", self._on_participant_disconnected)
-        self._room.on("participant_attributes_changed", self._on_participant_attributes_changed)
         if self._room.isconnected():
             self._on_connection_state_changed(rtc.ConnectionState.CONN_CONNECTED)
 
@@ -347,14 +344,6 @@ class RoomIO:
         participant = await self._participant_available_fut
         self.set_participant(participant.identity)
 
-        if ATTRIBUTE_SIMULATOR in participant.attributes:
-            self._simulator_mode = True
-            logger.info(
-                "simulator participant detected, audio I/O disabled",
-                extra={"participant": participant.identity},
-            )
-            await self._force_disable_audio()
-
         # init outputs
         if self._agent_tr_output:
             self._agent_tr_output.set_participant(self._room.local_participant.identity)
@@ -369,24 +358,6 @@ class RoomIO:
         """Wait until participant detection and audio setup are complete."""
         await self._ready_fut
 
-    def _lock_audio(self) -> None:
-        self._agent_session.input.set_audio_enabled(False)
-        self._agent_session.input._audio_locked = True
-        self._agent_session.output.set_audio_enabled(False)
-        self._agent_session.output._audio_locked = True
-
-    async def _force_disable_audio(self) -> None:
-        self._lock_audio()
-        if self._audio_input:
-            await self._audio_input.aclose()
-            self._audio_input = None
-        self._agent_session.input.audio = None
-
-        if self._audio_output:
-            await self._audio_output.aclose()
-            self._audio_output = None
-        self._agent_session.output.audio = None
-
     @utils.log_exceptions(logger=logger)
     async def _forward_user_transcript(
         self, event_ch: utils.aio.Chan[UserInputTranscribedEvent]
@@ -398,19 +369,6 @@ class RoomIO:
             await self._user_tr_output.capture_text(ev.transcript)
             if ev.is_final:
                 self._user_tr_output.flush()
-
-    def _on_participant_attributes_changed(
-        self,
-        changed_attributes: dict[str, str],
-        participant: rtc.Participant,
-    ) -> None:
-        if ATTRIBUTE_SIMULATOR in changed_attributes and not self._simulator_mode:
-            self._simulator_mode = True
-            logger.info(
-                "simulator participant detected (late attribute), audio I/O disabled",
-                extra={"participant": participant.identity},
-            )
-            self._lock_audio()
 
     def _on_connection_state_changed(self, state: rtc.ConnectionState.ValueType) -> None:
         if self._room.isconnected() and not self._room_connected_fut.done():


### PR DESCRIPTION
Simulators now disable the agent's audio I/O by sending `update_io` over the SessionHost channel instead of relying on the `lk.simulator` room attribute.

- add `RemoteSession.update_io()` client method to toggle input/output channels
- remove the `ATTRIBUTE_SIMULATOR` auto-disable + audio lock from `RoomIO` (join and late-attribute paths)
- remove the now-unused `_audio_locked` primitive in `voice/io.py`

Pairs with the agents-private simulator change (update_io on start) — that should land first/together so sim audio stays muted.