### PR TITLE
feat(sarvam): add realtime STT plugin for Saaras v3

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/__init__.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/__init__.py
@@ -12,21 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Sarvam.ai plugin for LiveKit Agents
+"""Sarvam.ai plugin for LiveKit Agents.
 
-Support for speech-to-text, text-to-speech, and LLM with [Sarvam.ai](https://sarvam.ai/).
+Support for speech-to-text, text-to-speech, and LLM with Sarvam.ai.
 
-Sarvam.ai provides high-quality STT and TTS for Indian languages and OpenAI-compatible LLMs.
+Sarvam.ai provides high-quality STT and TTS for Indian languages and
+OpenAI-compatible LLMs.
 
 For API access, visit https://sarvam.ai/
 """
 
 from .llm import LLM, SarvamLLMModels
 from .stt import STT
+from .stt_streaming import StreamingSpeechStream, STTStreaming
 from .tts import TTS
 from .version import __version__
 
-__all__ = ["STT", "TTS", "LLM", "SarvamLLMModels", "__version__"]
+__all__ = [
+    "STT",
+    "STTStreaming",
+    "StreamingSpeechStream",
+    "TTS",
+    "LLM",
+    "SarvamLLMModels",
+    "__version__",
+]
 
 
 from livekit.agents import Plugin

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/_utils.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/_utils.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class PeriodicCollector(Generic[T]):
+    def __init__(
+        self,
+        callback: Callable[[T], None],
+        *,
+        duration: float,
+    ) -> None:
+        self._duration = duration
+        self._callback = callback
+        self._last_flush_time = time.monotonic()
+        self._total: T | None = None
+
+    def push(self, value: T) -> None:
+        if self._total is None:
+            self._total = value
+        else:
+            self._total += value  # type: ignore[operator]
+
+        if time.monotonic() - self._last_flush_time >= self._duration:
+            self.flush()
+
+    def flush(self) -> None:
+        if self._total is not None:
+            self._callback(self._total)
+            self._total = None
+        self._last_flush_time = time.monotonic()

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -438,6 +438,7 @@ class StreamingSpeechStream(stt.SpeechStream):
                     if reconnect_task not in done:
                         break
                     self._reconnect_event.clear()
+                    self._reset_connection_state()
                 finally:
                     await utils.aio.gracefully_cancel(*tasks, reconnect_task)
                     tasks_group.cancel()
@@ -462,6 +463,23 @@ class StreamingSpeechStream(stt.SpeechStream):
         if self._eos_fallback_task and not self._eos_fallback_task.done():
             self._eos_fallback_task.cancel()
         self._eos_fallback_task = None
+
+    def _reset_connection_state(self) -> None:
+        self._cancel_eos_fallback()
+        self._request_id = ""
+        self._session_id = ""
+        self._session_ended = False
+        self._manual_speech_started = False
+        self._pending_eos = False
+        self._pending_eos_time = None
+        self._pending_final_data = None
+        self._utterance_start_audio_pos = 0.0
+        self._utterance_speech_end_audio_pos = None
+        self._utterance_speech_end_wall = None
+        self._final_received_for_utterance = False
+        self._eos_emitted_for_utterance = False
+        self._audio_duration_collector.flush()
+        self._total_reported_audio_duration = 0.0
 
     def _reset_utterance_state(self) -> None:
         self._cancel_eos_fallback()

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -1,0 +1,870 @@
+# Copyright 2025 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import platform
+import time
+import weakref
+from dataclasses import dataclass
+from typing import Any, Literal
+from urllib.parse import urlencode
+
+import aiohttp
+
+from livekit import rtc
+from livekit.agents import (
+    DEFAULT_API_CONNECT_OPTIONS,
+    APIConnectionError,
+    APIConnectOptions,
+    APIStatusError,
+    APITimeoutError,
+    LanguageCode,
+    __version__ as livekit_version,
+    stt,
+    utils,
+)
+from livekit.agents.types import NOT_GIVEN, NotGivenOr
+from livekit.agents.utils import AudioBuffer
+from livekit.agents.utils.misc import is_given
+
+from ._utils import PeriodicCollector
+from .log import logger
+from .stt import _looks_like_error_text
+
+USER_AGENT = f"Livekit/{livekit_version} Python/{platform.python_version()}"
+
+SARVAM_STT_REALTIME_URL = "wss://api.sarvam.ai/speech-to-text-realtime/ws"
+REALTIME_MODEL = "saaras:v3-realtime"
+
+RealtimeStreamType = Literal["fast", "balanced", "simulated"]
+RealtimeEndpointing = Literal["vad", "manual"]
+RealtimeEncoding = Literal["linear16"]
+RealtimeMode = Literal["transcribe", "translate", "indic-en", "verbatim", "translit", "codemix"]
+
+SUPPORTED_SAMPLE_RATES = {8000, 16000}
+SUPPORTED_STREAM_TYPES = {"fast", "balanced", "simulated"}
+SUPPORTED_ENDPOINTING = {"vad", "manual"}
+SUPPORTED_ENCODINGS = {"linear16"}
+SUPPORTED_MODES = {"transcribe", "translate", "indic-en", "verbatim", "translit", "codemix"}
+STREAM_TYPE_CHUNK_MS = {"fast": 500, "balanced": 1000, "simulated": 1000}
+EOS_FALLBACK_TIMEOUT = 2.0
+
+SUPPORTED_LANGUAGES = {
+    "en-IN",
+    "hi-IN",
+    "bn-IN",
+    "kn-IN",
+    "ml-IN",
+    "mr-IN",
+    "or-IN",
+    "pa-IN",
+    "ta-IN",
+    "te-IN",
+    "gu-IN",
+    "as-IN",
+    "ur-IN",
+    "ne-IN",
+    "kok-IN",
+    "ks-IN",
+    "sd-IN",
+    "sa-IN",
+    "sat-IN",
+    "mni-IN",
+    "brx-IN",
+    "mai-IN",
+    "doi-IN",
+    "auto",
+}
+
+
+@dataclass
+class StreamingSTTOptions:
+    language: str
+    api_key: str
+    stream_type: RealtimeStreamType | str = "balanced"
+    mode: RealtimeMode | str = "transcribe"
+    endpointing: RealtimeEndpointing | str = "vad"
+    encoding: RealtimeEncoding | str = "linear16"
+    sample_rate: int = 16000
+    model: str = REALTIME_MODEL
+    base_url: str = SARVAM_STT_REALTIME_URL
+    vad_sot_threshold: float | None = None
+    vad_min_speech_ms: int | None = None
+    vad_min_silence_ms: int | None = None
+    vad_smoothing_alpha: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.model != REALTIME_MODEL:
+            raise ValueError(f"model must be {REALTIME_MODEL}")
+        if self.language not in SUPPORTED_LANGUAGES:
+            raise ValueError(f"language {self.language} is not supported")
+        if self.stream_type not in SUPPORTED_STREAM_TYPES:
+            raise ValueError(
+                f"stream_type must be one of {', '.join(sorted(SUPPORTED_STREAM_TYPES))}"
+            )
+        if self.language == "auto" and self.stream_type != "simulated":
+            raise ValueError("language auto is only supported when stream_type is simulated")
+        if self.mode not in SUPPORTED_MODES:
+            raise ValueError(f"mode must be one of {', '.join(sorted(SUPPORTED_MODES))}")
+        if self.endpointing not in SUPPORTED_ENDPOINTING:
+            raise ValueError(
+                f"endpointing must be one of {', '.join(sorted(SUPPORTED_ENDPOINTING))}"
+            )
+        if self.encoding not in SUPPORTED_ENCODINGS:
+            raise ValueError(f"encoding must be one of {', '.join(sorted(SUPPORTED_ENCODINGS))}")
+        if self.sample_rate not in SUPPORTED_SAMPLE_RATES:
+            raise ValueError(
+                f"sample_rate must be one of {', '.join(str(r) for r in SUPPORTED_SAMPLE_RATES)}"
+            )
+        if self.vad_sot_threshold is not None and not 0.0 <= self.vad_sot_threshold <= 1.0:
+            raise ValueError("vad_sot_threshold must be between 0.0 and 1.0")
+        if self.vad_smoothing_alpha is not None and not 0.0 < self.vad_smoothing_alpha <= 1.0:
+            raise ValueError("vad_smoothing_alpha must be greater than 0.0 and at most 1.0")
+        if self.vad_min_speech_ms is not None and self.vad_min_speech_ms < 0:
+            raise ValueError("vad_min_speech_ms must be greater than or equal to 0")
+        if self.vad_min_silence_ms is not None and self.vad_min_silence_ms < 0:
+            raise ValueError("vad_min_silence_ms must be greater than or equal to 0")
+
+
+def _build_realtime_ws_url(base_url: str, opts: StreamingSTTOptions) -> str:
+    params: dict[str, str] = {
+        "language-code": opts.language,
+        "stream-type": opts.stream_type,
+        "endpointing": opts.endpointing,
+        "encoding": opts.encoding,
+        "sample_rate": str(opts.sample_rate),
+        "model": opts.model,
+    }
+
+    if opts.stream_type == "simulated":
+        params["mode"] = opts.mode
+
+    if opts.endpointing == "vad":
+        if opts.vad_sot_threshold is not None:
+            params["vad_sot_threshold"] = str(opts.vad_sot_threshold)
+        if opts.vad_min_speech_ms is not None:
+            params["vad_min_speech_ms"] = str(opts.vad_min_speech_ms)
+        if opts.vad_min_silence_ms is not None:
+            params["vad_min_silence_ms"] = str(opts.vad_min_silence_ms)
+        if opts.vad_smoothing_alpha is not None:
+            params["vad_smoothing_alpha"] = str(opts.vad_smoothing_alpha)
+
+    return f"{base_url}?{urlencode(params)}"
+
+
+class STTStreaming(stt.STT):
+    def __init__(
+        self,
+        *,
+        language: str = "en-IN",
+        stream_type: RealtimeStreamType | str = "balanced",
+        mode: RealtimeMode | str = "transcribe",
+        endpointing: RealtimeEndpointing | str = "vad",
+        encoding: RealtimeEncoding | str = "linear16",
+        sample_rate: int = 16000,
+        api_key: str | None = None,
+        base_url: str = SARVAM_STT_REALTIME_URL,
+        http_session: aiohttp.ClientSession | None = None,
+        vad_sot_threshold: float | None = None,
+        vad_min_speech_ms: int | None = None,
+        vad_min_silence_ms: int | None = None,
+        vad_smoothing_alpha: float | None = None,
+    ) -> None:
+        super().__init__(
+            capabilities=stt.STTCapabilities(
+                streaming=True,
+                interim_results=True,
+                aligned_transcript=False,
+                offline_recognize=False,
+            )
+        )
+
+        api_key = api_key or os.environ.get("SARVAM_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "Sarvam API key is required. "
+                "Provide it directly or set SARVAM_API_KEY environment variable."
+            )
+
+        self._opts = StreamingSTTOptions(
+            language=language,
+            api_key=api_key,
+            stream_type=stream_type,
+            mode=mode,
+            endpointing=endpointing,
+            encoding=encoding,
+            sample_rate=sample_rate,
+            base_url=base_url,
+            vad_sot_threshold=vad_sot_threshold,
+            vad_min_speech_ms=vad_min_speech_ms,
+            vad_min_silence_ms=vad_min_silence_ms,
+            vad_smoothing_alpha=vad_smoothing_alpha,
+        )
+        self._session = http_session
+        self._owns_session = http_session is None
+        self._streams = weakref.WeakSet[StreamingSpeechStream]()
+
+    @property
+    def model(self) -> str:
+        return REALTIME_MODEL
+
+    @property
+    def provider(self) -> str:
+        return "Sarvam"
+
+    def _ensure_session(self) -> aiohttp.ClientSession:
+        if not self._session:
+            try:
+                self._session = utils.http_context.http_session()
+                self._owns_session = False
+            except RuntimeError:
+                self._session = aiohttp.ClientSession()
+                self._owns_session = True
+        return self._session
+
+    async def _recognize_impl(
+        self,
+        buffer: AudioBuffer,
+        *,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        conn_options: APIConnectOptions,
+    ) -> stt.SpeechEvent:
+        del buffer, language, conn_options
+        raise NotImplementedError("Sarvam realtime STT only supports streaming")
+
+    def update_options(
+        self,
+        *,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        stream_type: NotGivenOr[RealtimeStreamType | str] = NOT_GIVEN,
+        mode: NotGivenOr[RealtimeMode | str] = NOT_GIVEN,
+        endpointing: NotGivenOr[RealtimeEndpointing | str] = NOT_GIVEN,
+        sample_rate: NotGivenOr[int] = NOT_GIVEN,
+        vad_sot_threshold: NotGivenOr[float | None] = NOT_GIVEN,
+        vad_min_speech_ms: NotGivenOr[int | None] = NOT_GIVEN,
+        vad_min_silence_ms: NotGivenOr[int | None] = NOT_GIVEN,
+        vad_smoothing_alpha: NotGivenOr[float | None] = NOT_GIVEN,
+    ) -> None:
+        opts = StreamingSTTOptions(
+            language=language if is_given(language) else self._opts.language,
+            api_key=self._opts.api_key,
+            stream_type=stream_type if is_given(stream_type) else self._opts.stream_type,
+            mode=mode if is_given(mode) else self._opts.mode,
+            endpointing=endpointing if is_given(endpointing) else self._opts.endpointing,
+            encoding=self._opts.encoding,
+            sample_rate=sample_rate if is_given(sample_rate) else self._opts.sample_rate,
+            base_url=self._opts.base_url,
+            vad_sot_threshold=vad_sot_threshold
+            if is_given(vad_sot_threshold)
+            else self._opts.vad_sot_threshold,
+            vad_min_speech_ms=vad_min_speech_ms
+            if is_given(vad_min_speech_ms)
+            else self._opts.vad_min_speech_ms,
+            vad_min_silence_ms=vad_min_silence_ms
+            if is_given(vad_min_silence_ms)
+            else self._opts.vad_min_silence_ms,
+            vad_smoothing_alpha=vad_smoothing_alpha
+            if is_given(vad_smoothing_alpha)
+            else self._opts.vad_smoothing_alpha,
+        )
+        self._opts = opts
+        for stream in self._streams:
+            stream.update_options(opts)
+
+    def stream(
+        self,
+        *,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+    ) -> StreamingSpeechStream:
+        opts = StreamingSTTOptions(
+            language=language if is_given(language) else self._opts.language,
+            api_key=self._opts.api_key,
+            stream_type=self._opts.stream_type,
+            mode=self._opts.mode,
+            endpointing=self._opts.endpointing,
+            encoding=self._opts.encoding,
+            sample_rate=self._opts.sample_rate,
+            base_url=self._opts.base_url,
+            vad_sot_threshold=self._opts.vad_sot_threshold,
+            vad_min_speech_ms=self._opts.vad_min_speech_ms,
+            vad_min_silence_ms=self._opts.vad_min_silence_ms,
+            vad_smoothing_alpha=self._opts.vad_smoothing_alpha,
+        )
+        stream = StreamingSpeechStream(
+            stt=self,
+            opts=opts,
+            conn_options=conn_options,
+            http_session=self._ensure_session(),
+        )
+        self._streams.add(stream)
+        return stream
+
+    async def aclose(self) -> None:
+        for stream in list(self._streams):
+            await stream.aclose()
+        self._streams.clear()
+        if self._owns_session and self._session and not self._session.closed:
+            await self._session.close()
+
+
+class StreamingSpeechStream(stt.SpeechStream):
+    def __init__(
+        self,
+        *,
+        stt: STTStreaming,
+        opts: StreamingSTTOptions,
+        conn_options: APIConnectOptions,
+        http_session: aiohttp.ClientSession,
+    ) -> None:
+        super().__init__(stt=stt, conn_options=conn_options, sample_rate=opts.sample_rate)
+        self._opts = opts
+        self._session = http_session
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._request_id = ""
+        self._session_id = ""
+        self._session_ended = False
+        self._reconnect_event = asyncio.Event()
+        self._manual_speech_started = False
+        self._pending_eos = False
+        self._pending_eos_time: float | None = None
+        self._pending_final_data: dict[str, Any] | None = None
+        self._utterance_start_audio_pos = 0.0
+        self._utterance_speech_end_audio_pos: float | None = None
+        self._utterance_speech_end_wall: float | None = None
+        self._final_received_for_utterance = False
+        self._eos_emitted_for_utterance = False
+        self._eos_fallback_task: asyncio.Task[None] | None = None
+        self._stream_started_at = time.time()
+        self._audio_position = 0.0
+        self._total_reported_audio_duration = 0.0
+        self._audio_duration_collector = PeriodicCollector(
+            callback=self._on_audio_duration_report,
+            duration=5.0,
+        )
+        self._logger = logger
+
+    def update_options(self, opts: StreamingSTTOptions) -> None:
+        self._opts = opts
+        self._reconnect_event.set()
+
+    def _build_log_context(self) -> dict[str, Any]:
+        return {
+            "request_id": self._request_id,
+            "session_id": self._session_id,
+            "model": self._opts.model,
+            "language": self._opts.language,
+            "stream_type": self._opts.stream_type,
+            "endpointing": self._opts.endpointing,
+        }
+
+    @staticmethod
+    def _extract_request_id(data: dict[str, Any]) -> str | None:
+        request_id = data.get("request_id")
+        if request_id is None:
+            nested = data.get("data")
+            if isinstance(nested, dict):
+                request_id = nested.get("request_id")
+            metadata = data.get("metadata")
+            if request_id is None and isinstance(metadata, dict):
+                request_id = metadata.get("request_id")
+        if isinstance(request_id, str) and request_id:
+            return request_id
+        return None
+
+    @staticmethod
+    def _extract_session_id(data: dict[str, Any]) -> str | None:
+        session_id = data.get("session_id")
+        if isinstance(session_id, str) and session_id:
+            return session_id
+        return None
+
+    def _capture_server_ids(self, data: dict[str, Any]) -> None:
+        session_id = self._extract_session_id(data)
+        if session_id is not None:
+            self._session_id = session_id
+
+        if not self._request_id:
+            request_id = self._extract_request_id(data)
+            if request_id is not None:
+                self._request_id = request_id
+
+    async def aclose(self) -> None:
+        try:
+            self._cancel_eos_fallback()
+            if self._ws and not self._ws.closed:
+                await self._ws.close()
+        finally:
+            self._ws = None
+            await super().aclose()
+
+    async def _run(self) -> None:
+        ws: aiohttp.ClientWebSocketResponse | None = None
+        while True:
+            try:
+                ws = await self._connect_ws()
+                self._ws = ws
+                tasks = [
+                    asyncio.create_task(self._process_audio(ws)),
+                    asyncio.create_task(self._process_messages(ws)),
+                ]
+                reconnect_task = asyncio.create_task(self._reconnect_event.wait())
+                tasks_group = asyncio.gather(*tasks)
+
+                try:
+                    done, _ = await asyncio.wait(
+                        (tasks_group, reconnect_task),
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    for task in done:
+                        if task is not reconnect_task:
+                            task.result()
+
+                    if reconnect_task not in done:
+                        break
+                    self._reconnect_event.clear()
+                finally:
+                    await utils.aio.gracefully_cancel(*tasks, reconnect_task)
+                    tasks_group.cancel()
+                    tasks_group.exception()
+            except asyncio.TimeoutError as e:
+                raise APITimeoutError("Timed out connecting to Sarvam realtime STT") from e
+            except aiohttp.ClientResponseError as e:
+                raise APIStatusError(
+                    message=e.message,
+                    status_code=e.status,
+                    request_id=self._request_id or None,
+                    body=e.message,
+                ) from e
+            except aiohttp.ClientConnectorError as e:
+                raise APIConnectionError("failed to connect to Sarvam realtime STT") from e
+            finally:
+                if ws is not None:
+                    await ws.close()
+                self._ws = None
+
+    def _cancel_eos_fallback(self) -> None:
+        if self._eos_fallback_task and not self._eos_fallback_task.done():
+            self._eos_fallback_task.cancel()
+        self._eos_fallback_task = None
+
+    def _reset_utterance_state(self) -> None:
+        self._cancel_eos_fallback()
+        self._pending_eos = False
+        self._pending_eos_time = None
+        self._pending_final_data = None
+        self._utterance_start_audio_pos = self._audio_position
+        self._utterance_speech_end_audio_pos = None
+        self._utterance_speech_end_wall = None
+        self._final_received_for_utterance = False
+        self._eos_emitted_for_utterance = False
+
+    async def _safe_send_str(
+        self,
+        ws: Any,
+        payload: dict[str, Any],
+    ) -> None:
+        if ws.closed:
+            return
+
+        try:
+            await ws.send_str(json.dumps(payload))
+        except (aiohttp.ClientConnectionResetError, ConnectionError):
+            self._logger.debug(
+                "Sarvam realtime STT WebSocket closed before send completed",
+                extra={**self._build_log_context(), "payload": payload},
+            )
+
+    async def _connect_ws(self) -> aiohttp.ClientWebSocketResponse:
+        ws_url = _build_realtime_ws_url(self._opts.base_url, self._opts)
+        headers = {
+            "API-SUBSCRIPTION-KEY": self._opts.api_key,
+            "User-Agent": USER_AGENT,
+        }
+        self._logger.info(
+            "Connecting to Sarvam realtime STT WebSocket", extra=self._build_log_context()
+        )
+        try:
+            ws = await asyncio.wait_for(
+                self._session.ws_connect(ws_url, headers=headers, heartbeat=30.0),
+                self._conn_options.timeout,
+            )
+        except (aiohttp.ClientConnectorError, asyncio.TimeoutError):
+            raise
+        except aiohttp.ClientResponseError:
+            raise
+        except Exception as e:
+            raise APIConnectionError("failed to connect to Sarvam realtime STT") from e
+        self._logger.info(
+            "Sarvam realtime STT WebSocket connected", extra=self._build_log_context()
+        )
+        return ws
+
+    @utils.log_exceptions(logger=logger)
+    async def _process_audio(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        cap_ms = STREAM_TYPE_CHUNK_MS[self._opts.stream_type]
+        samples_per_channel = max(int(self._opts.sample_rate * cap_ms / 1000), 1)
+        audio_bstream = utils.audio.AudioByteStream(
+            sample_rate=self._opts.sample_rate,
+            num_channels=1,
+            samples_per_channel=samples_per_channel,
+        )
+
+        async for data in self._input_ch:
+            frames: list[rtc.AudioFrame] = []
+            if isinstance(data, rtc.AudioFrame):
+                frames.extend(audio_bstream.write(data.data.tobytes()))
+            elif isinstance(data, self._FlushSentinel):
+                frames.extend(audio_bstream.flush())
+
+            for frame in frames:
+                if self._opts.endpointing == "manual" and not self._manual_speech_started:
+                    await self._safe_send_str(ws, {"event": "speech_start"})
+                    self._manual_speech_started = True
+
+                self._audio_duration_collector.push(frame.duration)
+                self._audio_position += frame.duration
+                await ws.send_bytes(frame.data.tobytes())
+
+            if isinstance(data, self._FlushSentinel):
+                self._audio_duration_collector.flush()
+                if self._opts.endpointing == "manual" and self._manual_speech_started:
+                    await self._safe_send_str(ws, {"event": "speech_end"})
+                    self._manual_speech_started = False
+
+        self._audio_duration_collector.flush()
+        await self._safe_send_str(ws, {"event": "end"})
+
+    @utils.log_exceptions(logger=logger)
+    async def _process_messages(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        while True:
+            msg = await ws.receive()
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                try:
+                    await self._handle_message(json.loads(msg.data))
+                except json.JSONDecodeError as e:
+                    if _looks_like_error_text(msg.data):
+                        raise APIStatusError(
+                            message=f"Sarvam realtime STT non-JSON error message: {msg.data}",
+                            request_id=self._request_id or None,
+                            body={"raw_message": msg.data},
+                        ) from e
+                    self._logger.warning(
+                        "Invalid JSON received from Sarvam realtime STT",
+                        extra={**self._build_log_context(), "raw_data": msg.data},
+                    )
+                    continue
+            elif msg.type == aiohttp.WSMsgType.ERROR:
+                raise APIConnectionError(f"Sarvam realtime STT WebSocket error: {msg.data}")
+            elif msg.type in (
+                aiohttp.WSMsgType.CLOSED,
+                aiohttp.WSMsgType.CLOSE,
+                aiohttp.WSMsgType.CLOSING,
+            ):
+                close_code = ws.close_code if ws.close_code is not None else msg.data
+                close_reason = msg.extra
+                if self._session_ended and close_code in (1000, 1001, None):
+                    break
+                if close_code in (1000, 1001, None) and not _looks_like_error_text(close_reason):
+                    break
+                raise self._status_error_from_close(close_code, close_reason)
+            else:
+                self._logger.debug(
+                    "Unknown Sarvam realtime STT WebSocket message type",
+                    extra={**self._build_log_context(), "message_type": str(msg.type)},
+                )
+
+    def _status_error_from_close(self, close_code: object, close_reason: object) -> APIStatusError:
+        status_code = int(close_code) if isinstance(close_code, int) else -1
+        retryable = close_code == 1013
+        message = f"Sarvam realtime STT WebSocket closed unexpectedly: {close_reason}"
+        if close_code == 1003:
+            message = "Sarvam realtime STT authentication, quota, or rate limit error"
+        elif close_code == 1008:
+            message = "Sarvam realtime STT session timed out or exceeded the maximum duration"
+        elif close_code == 1013:
+            message = "Sarvam realtime STT backend temporarily unavailable"
+        elif close_code == 4000:
+            message = f"Sarvam realtime STT rejected the session: {close_reason}"
+
+        return APIStatusError(
+            message=message,
+            status_code=status_code,
+            request_id=self._request_id or None,
+            body={
+                "close_code": close_code,
+                "close_reason": close_reason,
+            },
+            retryable=retryable,
+        )
+
+    async def _handle_message(self, data: dict[str, Any]) -> None:
+        event = data.get("event")
+        self._capture_server_ids(data)
+        self._log_stt_event(event, data)
+        if event == "session.begin":
+            return
+        elif event == "vad.speech_start":
+            self._reset_utterance_state()
+            self._event_ch.send_nowait(
+                stt.SpeechEvent(
+                    type=stt.SpeechEventType.START_OF_SPEECH,
+                    request_id=self._request_id,
+                )
+            )
+        elif event == "vad.speech_end":
+            self._handle_speech_end()
+        elif event == "transcript.partial":
+            self._send_transcript_event(stt.SpeechEventType.INTERIM_TRANSCRIPT, data)
+        elif event == "transcript.final":
+            if self._opts.endpointing == "vad":
+                if self._is_valid_transcript(data):
+                    self._pending_final_data = data
+                    self._final_received_for_utterance = True
+                    self._try_commit_utterance()
+            elif self._send_transcript_event(stt.SpeechEventType.FINAL_TRANSCRIPT, data):
+                self._final_received_for_utterance = True
+        elif event == "session.end":
+            self._handle_session_end(data)
+        elif event == "error":
+            self._handle_error_event(data)
+        elif event == "pong":
+            return
+        else:
+            self._logger.debug(
+                "Unknown Sarvam realtime STT event",
+                extra={**self._build_log_context(), "event": event, "data": data},
+            )
+
+    def _log_stt_event(self, event: object, data: dict[str, Any]) -> None:
+        if event == "pong":
+            return
+
+        extra: dict[str, Any] = {
+            **self._build_log_context(),
+            "event": event,
+            "utterance_idx": data.get("utterance_idx"),
+            "raw_data": data,
+        }
+        if event in {"transcript.partial", "transcript.final"}:
+            text = data.get("text")
+            if isinstance(text, str):
+                extra["text"] = text[:200]
+                extra["text_length"] = len(text)
+            extra["language"] = data.get("language") or self._opts.language
+            extra["confidence"] = data.get("language_confidence", data.get("confidence"))
+        elif event == "vad.speech_start":
+            extra["audio_position"] = self._audio_position
+        elif event == "vad.speech_end":
+            extra["audio_position"] = self._audio_position
+        elif event == "session.begin":
+            pass
+        elif event == "session.end":
+            extra["audio_duration_s"] = data.get("audio_duration_s")
+        else:
+            return
+
+        self._logger.info(f"Sarvam realtime STT {event}", extra=extra)
+
+    def _is_valid_transcript(self, data: dict[str, Any]) -> bool:
+        text = data.get("text")
+        return isinstance(text, str) and bool(text)
+
+    def _handle_speech_end(self) -> None:
+        self._utterance_speech_end_audio_pos = self._audio_position
+        self._utterance_speech_end_wall = time.time()
+
+        if self._opts.endpointing != "vad":
+            self._emit_end_of_speech()
+            return
+
+        if self._eos_emitted_for_utterance:
+            return
+
+        if self._final_received_for_utterance:
+            self._try_commit_utterance()
+            return
+
+        self._pending_eos = True
+        self._pending_eos_time = self._utterance_speech_end_wall
+        if self._eos_fallback_task is None or self._eos_fallback_task.done():
+            self._eos_fallback_task = asyncio.create_task(self._emit_pending_eos_after_timeout())
+
+    async def _emit_pending_eos_after_timeout(
+        self,
+        timeout: float = EOS_FALLBACK_TIMEOUT,
+    ) -> None:
+        try:
+            if timeout > 0:
+                await asyncio.sleep(timeout)
+            if self._pending_eos and not self._eos_emitted_for_utterance:
+                self._emit_end_of_speech()
+        except asyncio.CancelledError:
+            raise
+
+    def _try_commit_utterance(self) -> None:
+        if (
+            self._pending_final_data is None
+            or self._utterance_speech_end_audio_pos is None
+            or self._eos_emitted_for_utterance
+        ):
+            return
+
+        committed_data = self._pending_final_data
+        if self._send_transcript_event(
+            stt.SpeechEventType.FINAL_TRANSCRIPT,
+            committed_data,
+        ):
+            self._logger.info(
+                "Sarvam realtime STT utterance committed",
+                extra={
+                    **self._build_log_context(),
+                    "end_time": self._utterance_speech_end_audio_pos,
+                    "speech_end_wall_time": self._utterance_speech_end_wall,
+                },
+            )
+            self._emit_end_of_speech()
+            self._pending_final_data = None
+
+    def _emit_end_of_speech(self) -> None:
+        current_task = asyncio.current_task()
+        fallback_task = self._eos_fallback_task
+        self._eos_fallback_task = None
+        if fallback_task and fallback_task is not current_task and not fallback_task.done():
+            fallback_task.cancel()
+
+        if self._eos_emitted_for_utterance:
+            return
+
+        alternatives: list[stt.SpeechData] = []
+        if self._utterance_speech_end_audio_pos is not None:
+            metadata: dict[str, Any] = {}
+            if self._utterance_speech_end_wall is not None:
+                metadata["speech_end_wall_time"] = self._utterance_speech_end_wall
+            if self._pending_final_data is not None:
+                utterance_idx = self._pending_final_data.get("utterance_idx")
+                if utterance_idx is not None:
+                    metadata["utterance_idx"] = utterance_idx
+            alternatives.append(
+                stt.SpeechData(
+                    language=LanguageCode(self._opts.language),
+                    text="",
+                    end_time=self._utterance_speech_end_audio_pos,
+                    metadata=metadata or None,
+                )
+            )
+
+        self._event_ch.send_nowait(
+            stt.SpeechEvent(
+                type=stt.SpeechEventType.END_OF_SPEECH,
+                request_id=self._request_id,
+                alternatives=alternatives,
+            )
+        )
+        self._pending_eos = False
+        self._pending_eos_time = None
+        self._eos_emitted_for_utterance = True
+
+    def _send_transcript_event(self, event_type: stt.SpeechEventType, data: dict[str, Any]) -> bool:
+        text = data.get("text")
+        if not isinstance(text, str) or not text:
+            return False
+
+        language = data.get("language") or self._opts.language
+        confidence = data.get("language_confidence")
+        if confidence is None:
+            confidence = data.get("confidence", 0.0)
+        if not isinstance(confidence, (int, float)) or isinstance(confidence, bool):
+            confidence = 0.0
+
+        metadata = {
+            key: data[key]
+            for key in ("utterance_idx", "language_confidence")
+            if key in data and data[key] is not None
+        }
+        if (
+            event_type == stt.SpeechEventType.FINAL_TRANSCRIPT
+            and self._utterance_speech_end_wall is not None
+        ):
+            metadata["speech_end_wall_time"] = self._utterance_speech_end_wall
+        end_time = 0.0
+        if (
+            event_type == stt.SpeechEventType.FINAL_TRANSCRIPT
+            and self._utterance_speech_end_audio_pos is not None
+        ):
+            end_time = self._utterance_speech_end_audio_pos
+        elif event_type == stt.SpeechEventType.FINAL_TRANSCRIPT and self._audio_position > 0:
+            end_time = self._audio_position
+
+        speech_data = stt.SpeechData(
+            language=LanguageCode(language),
+            text=text,
+            end_time=end_time,
+            confidence=float(confidence),
+            metadata=metadata or None,
+        )
+        self._event_ch.send_nowait(
+            stt.SpeechEvent(
+                type=event_type,
+                request_id=self._request_id,
+                alternatives=[speech_data],
+            )
+        )
+        return True
+
+    def _handle_session_end(self, data: dict[str, Any]) -> None:
+        self._capture_server_ids(data)
+        audio_duration = data.get("audio_duration_s")
+        if isinstance(audio_duration, (int, float)) and not isinstance(audio_duration, bool):
+            delta = max(float(audio_duration) - self._total_reported_audio_duration, 0.0)
+            if delta:
+                self._emit_usage(delta)
+        self._session_ended = True
+
+    def _handle_error_event(self, data: dict[str, Any]) -> None:
+        if not data.get("is_fatal", False):
+            self._logger.warning(
+                "Non-fatal Sarvam realtime STT error",
+                extra={**self._build_log_context(), "error": data},
+            )
+            return
+
+        code = data.get("code", "unknown")
+        status_code = data.get("status_code", -1)
+        if not isinstance(status_code, int):
+            status_code = -1
+        raise APIStatusError(
+            message=f"Sarvam realtime STT error: {data.get('message', code)}",
+            status_code=status_code,
+            request_id=self._request_id or None,
+            body=data,
+            retryable=code == "model_unavailable",
+        )
+
+    def _on_audio_duration_report(self, duration: float) -> None:
+        self._emit_usage(duration)
+
+    def _emit_usage(self, duration: float) -> None:
+        self._total_reported_audio_duration += duration
+        self._event_ch.send_nowait(
+            stt.SpeechEvent(
+                type=stt.SpeechEventType.RECOGNITION_USAGE,
+                request_id=self._request_id,
+                recognition_usage=stt.RecognitionUsage(audio_duration=duration),
+            )
+        )

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -638,6 +638,7 @@ class StreamingSpeechStream(stt.SpeechStream):
         if event == "session.begin":
             return
         elif event == "vad.speech_start":
+            self._emit_pending_eos_before_new_speech()
             self._reset_utterance_state()
             self._event_ch.send_nowait(
                 stt.SpeechEvent(
@@ -702,6 +703,10 @@ class StreamingSpeechStream(stt.SpeechStream):
     def _is_valid_transcript(self, data: dict[str, Any]) -> bool:
         text = data.get("text")
         return isinstance(text, str) and bool(text)
+
+    def _emit_pending_eos_before_new_speech(self) -> None:
+        if self._pending_eos and not self._eos_emitted_for_utterance:
+            self._emit_end_of_speech()
 
     def _handle_speech_end(self) -> None:
         self._utterance_speech_end_audio_pos = self._audio_position

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -49,8 +49,15 @@ def _make_stream(
     stream._final_received_for_utterance = False
     stream._eos_emitted_for_utterance = False
     stream._eos_fallback_task = None
+    stream._manual_speech_started = False
     stream._stream_started_at = stt_streaming.time.time()
     stream._audio_position = 0.0
+    stream._audio_duration_collector = stt_streaming.PeriodicCollector(
+        callback=stt_streaming.StreamingSpeechStream._on_audio_duration_report.__get__(
+            stream, stt_streaming.StreamingSpeechStream
+        ),
+        duration=5.0,
+    )
     return stream
 
 
@@ -514,6 +521,115 @@ async def test_streaming_error_handling_distinguishes_fatal_and_non_fatal() -> N
     assert excinfo.value.status_code == 503
     assert excinfo.value.body["code"] == "model_unavailable"
     assert excinfo.value.retryable is True
+
+
+def test_reset_connection_state_clears_session_and_utterance_fields() -> None:
+    class _FakeFallbackTask:
+        def __init__(self) -> None:
+            self.cancelled = False
+
+        def done(self) -> bool:
+            return False
+
+        def cancel(self) -> None:
+            self.cancelled = True
+
+    stream = _make_stream()
+    stream._request_id = "req_old"
+    stream._session_id = "sess_old"
+    stream._session_ended = True
+    stream._manual_speech_started = True
+    stream._pending_eos = True
+    stream._pending_eos_time = 1.0
+    stream._pending_final_data = {"text": "hello"}
+    stream._utterance_start_audio_pos = 3.0
+    stream._utterance_speech_end_audio_pos = 4.0
+    stream._utterance_speech_end_wall = 5.0
+    stream._final_received_for_utterance = True
+    stream._eos_emitted_for_utterance = True
+    stream._total_reported_audio_duration = 50.0
+    fallback_task = _FakeFallbackTask()
+    stream._eos_fallback_task = fallback_task
+
+    stream._reset_connection_state()
+
+    assert fallback_task.cancelled is True
+
+    assert stream._request_id == ""
+    assert stream._session_id == ""
+    assert stream._session_ended is False
+    assert stream._manual_speech_started is False
+    assert stream._pending_eos is False
+    assert stream._pending_eos_time is None
+    assert stream._pending_final_data is None
+    assert stream._utterance_start_audio_pos == 0.0
+    assert stream._utterance_speech_end_audio_pos is None
+    assert stream._utterance_speech_end_wall is None
+    assert stream._final_received_for_utterance is False
+    assert stream._eos_emitted_for_utterance is False
+    assert stream._total_reported_audio_duration == 0.0
+    assert stream._eos_fallback_task is None
+
+
+@pytest.mark.asyncio
+async def test_session_end_delta_after_connection_reset() -> None:
+    stream = _make_stream()
+    stream._total_reported_audio_duration = 50.0
+
+    stream._reset_connection_state()
+
+    await stream._handle_message(
+        {
+            "event": "session.end",
+            "session_id": "sess_new",
+            "audio_duration_s": 12.0,
+        }
+    )
+
+    usage_events = [
+        event
+        for event in stream._event_ch.events
+        if event.type == stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE
+    ]
+    assert len(usage_events) == 1
+    assert usage_events[0].recognition_usage.audio_duration == 12.0
+
+
+@pytest.mark.asyncio
+async def test_collector_flush_before_reset_emits_pending_usage() -> None:
+    stream = _make_stream()
+    stream._audio_duration_collector.push(2.5)
+
+    stream._reset_connection_state()
+
+    usage_events = [
+        event
+        for event in stream._event_ch.events
+        if event.type == stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE
+    ]
+    assert len(usage_events) == 1
+    assert usage_events[0].recognition_usage.audio_duration == 2.5
+    assert stream._total_reported_audio_duration == 0.0
+
+
+@pytest.mark.asyncio
+async def test_reset_connection_state_allows_new_request_id_capture() -> None:
+    stream = _make_stream()
+    stream._request_id = "req_old"
+    stream._session_id = "sess_old"
+
+    stream._reset_connection_state()
+
+    await stream._handle_message(
+        {
+            "event": "session.begin",
+            "session_id": "sess_new",
+            "request_id": "req_new",
+        }
+    )
+
+    assert stream._request_id == "req_new"
+    assert stream._session_id == "sess_new"
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -1,0 +1,539 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from livekit.agents import APIStatusError
+from livekit.plugins.sarvam import stt_streaming
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeEventChannel:
+    def __init__(self) -> None:
+        self.events = []
+
+    def send_nowait(self, event: object) -> None:
+        self.events.append(event)
+
+
+def _make_stream(
+    *,
+    endpointing: str = "vad",
+) -> stt_streaming.StreamingSpeechStream:
+    stream = object.__new__(stt_streaming.StreamingSpeechStream)
+    stream._event_ch = _FakeEventChannel()
+    stream._request_id = ""
+    stream._session_id = ""
+    stream._session_ended = False
+    stream._total_reported_audio_duration = 0.0
+    stream._opts = stt_streaming.StreamingSTTOptions(
+        language="hi-IN",
+        api_key="sk_test",
+        endpointing=endpointing,
+    )
+    stream._logger = stt_streaming.logger.getChild("StreamingSpeechStream")
+    stream._build_log_context = stt_streaming.StreamingSpeechStream._build_log_context.__get__(
+        stream, stt_streaming.StreamingSpeechStream
+    )
+    stream._pending_eos = False
+    stream._pending_eos_time = None
+    stream._pending_final_data = None
+    stream._utterance_start_audio_pos = 0.0
+    stream._utterance_speech_end_audio_pos = None
+    stream._utterance_speech_end_wall = None
+    stream._final_received_for_utterance = False
+    stream._eos_emitted_for_utterance = False
+    stream._eos_fallback_task = None
+    stream._stream_started_at = stt_streaming.time.time()
+    stream._audio_position = 0.0
+    return stream
+
+
+def _parse_ws_url(url: str) -> dict[str, str]:
+    parsed = urlparse(url)
+    qs = parse_qs(parsed.query)
+    return {key: value[0] for key, value in qs.items()}
+
+
+def test_realtime_ws_url_includes_core_and_vad_params() -> None:
+    opts = stt_streaming.StreamingSTTOptions(
+        language="hi-IN",
+        api_key="sk_test",
+        stream_type="fast",
+        endpointing="vad",
+        sample_rate=16000,
+        vad_sot_threshold=0.4,
+        vad_min_speech_ms=300,
+        vad_min_silence_ms=800,
+        vad_smoothing_alpha=0.5,
+    )
+
+    url = stt_streaming._build_realtime_ws_url(stt_streaming.SARVAM_STT_REALTIME_URL, opts)
+
+    assert url.startswith(stt_streaming.SARVAM_STT_REALTIME_URL)
+    assert _parse_ws_url(url) == {
+        "language-code": "hi-IN",
+        "stream-type": "fast",
+        "endpointing": "vad",
+        "encoding": "linear16",
+        "sample_rate": "16000",
+        "model": "saaras:v3-realtime",
+        "vad_sot_threshold": "0.4",
+        "vad_min_speech_ms": "300",
+        "vad_min_silence_ms": "800",
+        "vad_smoothing_alpha": "0.5",
+    }
+
+
+def test_realtime_ws_url_omits_vad_params_for_manual_endpointing() -> None:
+    opts = stt_streaming.StreamingSTTOptions(
+        language="en-IN",
+        api_key="sk_test",
+        endpointing="manual",
+        vad_sot_threshold=0.4,
+        vad_min_speech_ms=300,
+    )
+
+    url = stt_streaming._build_realtime_ws_url(stt_streaming.SARVAM_STT_REALTIME_URL, opts)
+
+    params = _parse_ws_url(url)
+    assert params["endpointing"] == "manual"
+    assert "vad_sot_threshold" not in params
+    assert "vad_min_speech_ms" not in params
+
+
+def test_streaming_options_validate_realtime_contract() -> None:
+    with pytest.raises(ValueError, match="language auto is only supported"):
+        stt_streaming.StreamingSTTOptions(language="auto", api_key="sk_test", stream_type="fast")
+
+    with pytest.raises(ValueError, match="sample_rate must be one of"):
+        stt_streaming.StreamingSTTOptions(language="hi-IN", api_key="sk_test", sample_rate=44100)
+
+    with pytest.raises(ValueError, match="language od-IN is not supported"):
+        stt_streaming.StreamingSTTOptions(language="od-IN", api_key="sk_test")
+
+
+def test_simulated_streaming_allows_auto_language_and_mode() -> None:
+    opts = stt_streaming.StreamingSTTOptions(
+        language="auto",
+        api_key="sk_test",
+        stream_type="simulated",
+        mode="translate",
+    )
+
+    params = _parse_ws_url(
+        stt_streaming._build_realtime_ws_url(stt_streaming.SARVAM_STT_REALTIME_URL, opts)
+    )
+
+    assert params["language-code"] == "auto"
+    assert params["stream-type"] == "simulated"
+    assert params["mode"] == "translate"
+
+
+@pytest.mark.asyncio
+async def test_streaming_event_mapping_emits_speech_and_transcript_events() -> None:
+    stream = _make_stream()
+    stream._audio_position = 1.25
+
+    await stream._handle_message(
+        {
+            "event": "session.begin",
+            "session_id": "sess_123",
+            "request_id": "20260608_31c9dc1d-3435-4e76-ae51-05de31025a68",
+        }
+    )
+    await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
+    await stream._handle_message(
+        {
+            "event": "transcript.partial",
+            "utterance_idx": 0,
+            "text": "नमस्ते",
+            "confidence": 0.91,
+        }
+    )
+    await stream._handle_message(
+        {
+            "event": "transcript.final",
+            "utterance_idx": 0,
+            "text": "नमस्ते आप कैसे हैं",
+            "language": "hi-IN",
+            "language_confidence": 0.99,
+        }
+    )
+
+    assert [event.type for event in stream._event_ch.events] == [
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.INTERIM_TRANSCRIPT,
+    ]
+
+    stream._audio_position = 1.75
+    await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
+
+    event_types = [event.type for event in stream._event_ch.events]
+    assert event_types == [
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.INTERIM_TRANSCRIPT,
+        stt_streaming.stt.SpeechEventType.FINAL_TRANSCRIPT,
+        stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
+    ]
+    final_event = stream._event_ch.events[2]
+    assert stream._session_id == "sess_123"
+    assert stream._request_id == "20260608_31c9dc1d-3435-4e76-ae51-05de31025a68"
+    assert final_event.request_id == "20260608_31c9dc1d-3435-4e76-ae51-05de31025a68"
+    assert final_event.alternatives[0].text == "नमस्ते आप कैसे हैं"
+    assert final_event.alternatives[0].language == "hi-IN"
+    assert final_event.alternatives[0].confidence == 0.99
+    assert final_event.alternatives[0].end_time == 1.75
+
+    eos_event = stream._event_ch.events[3]
+    assert eos_event.alternatives[0].end_time == 1.75
+    assert eos_event.alternatives[0].metadata["utterance_idx"] == 0
+
+
+@pytest.mark.asyncio
+async def test_streaming_session_begin_captures_server_request_id() -> None:
+    stream = _make_stream()
+
+    await stream._handle_message(
+        {
+            "event": "session.begin",
+            "session_id": "sess_4594d4503cd4",
+            "request_id": "20260608_31c9dc1d-3435-4e76-ae51-05de31025a68",
+        }
+    )
+
+    assert stream._session_id == "sess_4594d4503cd4"
+    assert stream._request_id == "20260608_31c9dc1d-3435-4e76-ae51-05de31025a68"
+
+
+@pytest.mark.asyncio
+async def test_streaming_request_id_stores_raw_value_without_format_assumptions() -> None:
+    stream = _make_stream()
+
+    await stream._handle_message(
+        {
+            "event": "session.begin",
+            "session_id": "sess_xyz",
+            "request_id": "srv_custom-id_v9",
+        }
+    )
+
+    assert stream._session_id == "sess_xyz"
+    assert stream._request_id == "srv_custom-id_v9"
+
+
+@pytest.mark.asyncio
+async def test_streaming_session_begin_without_request_id_leaves_request_id_empty() -> None:
+    stream = _make_stream()
+
+    await stream._handle_message({"event": "session.begin", "session_id": "sess_only"})
+
+    assert stream._session_id == "sess_only"
+    assert stream._request_id == ""
+
+
+@pytest.mark.asyncio
+async def test_streaming_defers_end_of_speech_until_final_transcript() -> None:
+    stream = _make_stream()
+
+    await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
+    await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
+
+    assert [event.type for event in stream._event_ch.events] == [
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+    ]
+
+    await stream._handle_message(
+        {
+            "event": "transcript.final",
+            "utterance_idx": 0,
+            "text": "नमस्ते आप कैसे हैं",
+            "language": "hi-IN",
+            "language_confidence": 0.99,
+        }
+    )
+
+    assert [event.type for event in stream._event_ch.events] == [
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.FINAL_TRANSCRIPT,
+        stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_streaming_final_after_speech_end_includes_audio_end_time() -> None:
+    stream = _make_stream()
+    stream._audio_position = 1.25
+
+    await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
+    stream._audio_position = 1.75
+    await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
+    await stream._handle_message(
+        {
+            "event": "transcript.final",
+            "utterance_idx": 0,
+            "text": "नमस्ते आप कैसे हैं",
+            "language": "hi-IN",
+            "language_confidence": 0.99,
+        }
+    )
+
+    final_event = stream._event_ch.events[1]
+    eos_event = stream._event_ch.events[2]
+    assert final_event.alternatives[0].end_time == 1.75
+    assert eos_event.alternatives[0].end_time == 1.75
+    assert final_event.alternatives[0].metadata["speech_end_wall_time"] > 0
+
+
+@pytest.mark.asyncio
+async def test_streaming_final_transcript_waits_for_speech_end_for_end_time() -> None:
+    stream = _make_stream()
+    stream._audio_position = 1.25
+
+    await stream._handle_message(
+        {
+            "event": "transcript.final",
+            "utterance_idx": 0,
+            "text": "नमस्ते आप कैसे हैं",
+            "language": "hi-IN",
+            "language_confidence": 0.99,
+        }
+    )
+
+    assert stream._event_ch.events == []
+
+    stream._audio_position = 2.0
+    await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
+
+    final_event = stream._event_ch.events[0]
+    eos_event = stream._event_ch.events[1]
+    assert final_event.alternatives[0].end_time == 2.0
+    assert eos_event.alternatives[0].end_time == 2.0
+
+
+@pytest.mark.asyncio
+async def test_streaming_final_transcript_uses_current_audio_position_without_vad() -> None:
+    stream = _make_stream(endpointing="manual")
+    stream._audio_position = 1.25
+
+    await stream._handle_message(
+        {
+            "event": "transcript.final",
+            "utterance_idx": 0,
+            "text": "नमस्ते आप कैसे हैं",
+            "language": "hi-IN",
+            "language_confidence": 0.99,
+        }
+    )
+
+    final_event = stream._event_ch.events[0]
+    assert final_event.alternatives[0].end_time == 1.25
+
+
+@pytest.mark.asyncio
+async def test_streaming_logs_include_server_request_id_after_session_begin(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    stream = _make_stream()
+
+    with caplog.at_level(logging.INFO, logger=stt_streaming.logger.name):
+        await stream._handle_message(
+            {
+                "event": "session.begin",
+                "session_id": "sess_4594d4503cd4",
+                "request_id": "srv_custom-id_v9",
+            }
+        )
+        await stream._handle_message(
+            {
+                "event": "transcript.partial",
+                "utterance_idx": 0,
+                "text": "नमस्ते",
+                "confidence": 0.91,
+            }
+        )
+
+    partial_records = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "Sarvam realtime STT transcript.partial"
+    ]
+    assert len(partial_records) == 1
+    assert partial_records[0].request_id == "srv_custom-id_v9"
+    assert partial_records[0].session_id == "sess_4594d4503cd4"
+
+
+@pytest.mark.asyncio
+async def test_streaming_logs_partial_and_final_transcripts(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    stream = _make_stream()
+    stream._audio_position = 1.0
+
+    with caplog.at_level(logging.INFO, logger=stt_streaming.logger.name):
+        await stream._handle_message(
+            {
+                "event": "transcript.partial",
+                "utterance_idx": 0,
+                "text": "नमस्ते",
+                "confidence": 0.91,
+            }
+        )
+        await stream._handle_message(
+            {
+                "event": "transcript.final",
+                "utterance_idx": 0,
+                "text": "नमस्ते आप कैसे हैं",
+                "language": "hi-IN",
+                "language_confidence": 0.99,
+            }
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert "Sarvam realtime STT transcript.partial" in messages
+    assert "Sarvam realtime STT transcript.final" in messages
+
+
+@pytest.mark.asyncio
+async def test_streaming_emits_pending_end_of_speech_when_final_never_arrives() -> None:
+    stream = _make_stream()
+
+    await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
+    await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
+    await stream._emit_pending_eos_after_timeout(0)
+
+    assert [event.type for event in stream._event_ch.events] == [
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_streaming_safe_send_str_ignores_closed_transport() -> None:
+    stream = _make_stream()
+    calls = []
+
+    closed_ws = SimpleNamespace(closed=True, send_str=lambda payload: calls.append(payload))
+    await stream._safe_send_str(closed_ws, {"event": "end"})
+
+    assert calls == []
+
+    async def _raise_reset(payload: str) -> None:
+        raise stt_streaming.aiohttp.ClientConnectionResetError("Cannot write to closing transport")
+
+    closing_ws = SimpleNamespace(closed=False, send_str=_raise_reset)
+    await stream._safe_send_str(closing_ws, {"event": "end"})
+
+
+@pytest.mark.asyncio
+async def test_streaming_usage_metrics_emit_periodic_and_session_end_deltas() -> None:
+    stream = _make_stream()
+    stream._request_id = "sess_123"
+
+    stream._on_audio_duration_report(1.5)
+    await stream._handle_message(
+        {
+            "event": "session.end",
+            "session_id": "sess_123",
+            "audio_duration_s": 2.25,
+        }
+    )
+
+    usage_events = [
+        event
+        for event in stream._event_ch.events
+        if event.type == stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE
+    ]
+    assert [event.recognition_usage.audio_duration for event in usage_events] == [1.5, 0.75]
+    assert all(event.request_id == "sess_123" for event in usage_events)
+    assert stream._session_ended is True
+
+
+@pytest.mark.asyncio
+async def test_streaming_usage_event_is_converted_to_livekit_stt_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _idle_run(self: object) -> None:
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(stt_streaming.StreamingSpeechStream, "_run", _idle_run)
+    stt_impl = stt_streaming.STTStreaming(api_key="sk_test")
+    metrics = []
+    stt_impl.on("metrics_collected", metrics.append)
+    stream = stt_impl.stream()
+
+    stream._event_ch.send_nowait(
+        stt_streaming.stt.SpeechEvent(
+            type=stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE,
+            request_id="sess_123",
+            recognition_usage=stt_streaming.stt.RecognitionUsage(audio_duration=3.0),
+        )
+    )
+    await asyncio.sleep(0)
+    await stream.aclose()
+    await stt_impl.aclose()
+
+    assert len(metrics) == 1
+    assert metrics[0].request_id == "sess_123"
+    assert metrics[0].audio_duration == 3.0
+    assert metrics[0].streamed is True
+    assert metrics[0].metadata.model_name == "saaras:v3-realtime"
+    assert metrics[0].metadata.model_provider == "Sarvam"
+
+
+@pytest.mark.asyncio
+async def test_streaming_error_handling_distinguishes_fatal_and_non_fatal() -> None:
+    stream = _make_stream()
+    stream._request_id = "sess_123"
+
+    await stream._handle_message(
+        {
+            "event": "error",
+            "code": "chunk_too_large",
+            "message": "chunk too large",
+            "is_fatal": False,
+        }
+    )
+
+    with pytest.raises(APIStatusError) as excinfo:
+        await stream._handle_message(
+            {
+                "event": "error",
+                "code": "model_unavailable",
+                "message": "backend saturated",
+                "is_fatal": True,
+                "status_code": 503,
+            }
+        )
+
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.body["code"] == "model_unavailable"
+    assert excinfo.value.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_streaming_process_messages_raises_on_realtime_rejection_close() -> None:
+    stream = _make_stream()
+
+    ws = SimpleNamespace(
+        receive=lambda: asyncio.sleep(
+            0,
+            result=SimpleNamespace(
+                type=stt_streaming.aiohttp.WSMsgType.CLOSE,
+                data=4000,
+                extra="beta access denied",
+            ),
+        ),
+        close_code=4000,
+    )
+
+    with pytest.raises(APIStatusError) as excinfo:
+        await stream._process_messages(ws)
+
+    assert excinfo.value.status_code == 4000
+    assert "beta access denied" in excinfo.value.message

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -421,6 +421,30 @@ async def test_streaming_emits_pending_end_of_speech_when_final_never_arrives() 
 
 
 @pytest.mark.asyncio
+async def test_new_speech_start_emits_pending_end_of_speech_for_previous_utterance() -> None:
+    stream = _make_stream()
+    stream._audio_position = 1.0
+
+    await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
+    stream._audio_position = 1.5
+    await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
+    stream._audio_position = 2.0
+    await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 1})
+
+    assert [event.type for event in stream._event_ch.events] == [
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+    ]
+    eos_event = stream._event_ch.events[1]
+    assert eos_event.alternatives[0].end_time == 1.5
+    assert eos_event.alternatives[0].metadata["speech_end_wall_time"] > 0
+    assert stream._pending_eos is False
+    assert stream._eos_emitted_for_utterance is False
+    assert stream._utterance_start_audio_pos == 2.0
+
+
+@pytest.mark.asyncio
 async def test_streaming_safe_send_str_ignores_closed_transport() -> None:
     stream = _make_stream()
     calls = []


### PR DESCRIPTION
Introducing STTStreaming, a LiveKit Agents STT implementation for Sarvam's
saaras:v3-realtime WebSocket API.

- WebSocket streaming with fast/balanced/simulated stream types
- VAD and manual endpointing, with configurable VAD query params
- Maps Sarvam events to LiveKit speech events (interim/final transcripts,
  start/end of speech) with symmetric utterance commit ordering
- Sets SpeechData.end_time from utterance speech-end position so EOU
  transcription_delay is computed correctly
- Captures server request_id and session_id as raw tracing values
- Usage metrics, reconnect on option changes, structured INFO logging
- Shared PeriodicCollector helper in _utils.py
- Export STTStreaming from the Sarvam plugin package
- Add unit tests for URL construction, event mapping, timing, logging,
  usage metrics, and error handling