### PR TITLE
(phonic) Add and match audio output options: frame size and sample rate

### DIFF
--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -30,6 +30,7 @@ class _ParticipantAudioOutput(io.AudioOutput):
         *,
         sample_rate: int,
         num_channels: int,
+        frame_size_ms: int = 50,
         track_publish_options: rtc.TrackPublishOptions,
         track_name: str = "roomio_audio",
     ) -> None:
@@ -49,7 +50,7 @@ class _ParticipantAudioOutput(io.AudioOutput):
 
         self._audio_buf = utils.aio.Chan[rtc.AudioFrame]()
         self._audio_bstream = utils.audio.AudioByteStream(
-            sample_rate, num_channels, samples_per_channel=sample_rate // 20, progressive=True
+            sample_rate, num_channels, samples_per_channel=sample_rate * frame_size_ms // 1000, progressive=True
         )
 
         self._flush_task: asyncio.Task[None] | None = None

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -133,6 +133,7 @@ class RoomIO:
                 self._room,
                 sample_rate=output_audio_options.sample_rate,
                 num_channels=output_audio_options.num_channels,
+                frame_size_ms=output_audio_options.frame_size_ms,
                 track_publish_options=output_audio_options.track_publish_options,
                 track_name=(
                     output_audio_options.track_name

--- a/livekit-agents/livekit/agents/voice/room_io/types.py
+++ b/livekit-agents/livekit/agents/voice/room_io/types.py
@@ -83,6 +83,8 @@ class VideoInputOptions:
 class AudioOutputOptions:
     sample_rate: int = 24000
     num_channels: int = 1
+    frame_size_ms: int = 50
+    """The frame size in milliseconds for audio output frames."""
     track_publish_options: rtc.TrackPublishOptions = field(
         default_factory=lambda: rtc.TrackPublishOptions(source=rtc.TrackSource.SOURCE_MICROPHONE)
     )

--- a/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
@@ -13,6 +13,7 @@ from typing import Literal
 
 from livekit import rtc
 from livekit.agents import llm, utils
+from livekit.agents.voice.room_io import AudioOutputOptions
 from livekit.agents.types import (
     DEFAULT_API_CONNECT_OPTIONS,
     NOT_GIVEN,
@@ -43,6 +44,7 @@ PHONIC_INPUT_SAMPLE_RATE = 44100
 PHONIC_OUTPUT_SAMPLE_RATE = 44100
 PHONIC_NUM_CHANNELS = 1
 PHONIC_INPUT_FRAME_MS = 20
+PHONIC_OUTPUT_FRAME_MS = 20
 WS_CLOSE_NORMAL = 1000
 TOOL_CALL_OUTPUT_TIMEOUT_MS = 60000
 
@@ -220,6 +222,26 @@ class RealtimeModel(llm.RealtimeModel):
         sess = RealtimeSession(self)
         self._sessions.add(sess)
         return sess
+
+    @staticmethod
+    def audio_output_options(**kwargs: typing.Any) -> AudioOutputOptions:
+        """Return ``AudioOutputOptions`` tuned for Phonic: 44100 Hz sample rate and 20 ms frames.
+
+        Using these options with ``RoomIO`` avoids resampling (Phonic natively outputs 44100 Hz)
+        and matches the frame size to Phonic's 20 ms audio chunks, minimising buffer starvation.
+
+        Example::
+
+            model = phonic.realtime.RealtimeModel(...)
+            room_io = RoomIO(session, room=ctx.room, options=RoomOptions(
+                audio_output=model.audio_output_options()
+            ))
+        """
+        return AudioOutputOptions(
+            sample_rate=PHONIC_OUTPUT_SAMPLE_RATE,
+            frame_size_ms=PHONIC_OUTPUT_FRAME_MS,
+            **kwargs,
+        )
 
     def update_options(
         self,


### PR DESCRIPTION
## Summary
We have a hypothesis that the audio output options, specifically the audio frame size (which currently is hardcoded to 50ms, but Phonic's audio output frames are 20ms) and the sample rate contribute to the phenomenon that users can hear short but noticeable gaps in audio.

## Test Plan
If given a green light, will test again with this code to make sure it's working properly. Earlier, we have conducted an experiment which indicates that this would help.