### PR TITLE
Strip leading and trailing whitespaces within Deepgram keyterm param

### DIFF
--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -177,15 +177,6 @@ _DIARIZATION_EXTRA_KEYS: tuple[str, ...] = (
 )
 
 
-def _strip_extra_keyterm(extra_kwargs: dict[str, Any]) -> None:
-    """Strip whitespace from keyterm entries; Deepgram returns 400 for leading/trailing spaces."""
-    keyterm = extra_kwargs.get("keyterm")
-    if isinstance(keyterm, str):
-        extra_kwargs["keyterm"] = keyterm.strip()
-    elif isinstance(keyterm, list):
-        extra_kwargs["keyterm"] = [k.strip() for k in keyterm]
-
-
 def _diarization_enabled(extra_kwargs: dict[str, Any] | None) -> bool:
     """Return True if any known provider diarization flag is truthy."""
     if not extra_kwargs:
@@ -263,9 +254,6 @@ def _normalize_fallback(
         if isinstance(model, str):
             name, _ = _parse_model_string(model)
             return FallbackModel(model=name)
-        extra = model.get("extra_kwargs")
-        if isinstance(extra, dict):
-            _strip_extra_keyterm(extra)
         return model
 
     if isinstance(fallback, list):
@@ -557,9 +545,6 @@ class STT(stt.STT):
         if is_given(fallback):
             fallback_models = _normalize_fallback(fallback)
 
-        final_extra_kwargs: dict[str, Any] = dict(extra_kwargs) if is_given(extra_kwargs) else {}
-        _strip_extra_keyterm(final_extra_kwargs)
-
         self._opts = STTOptions(
             model=model,
             language=LanguageCode(language) if isinstance(language, str) else language,
@@ -568,7 +553,7 @@ class STT(stt.STT):
             base_url=lk_base_url,
             api_key=lk_api_key,
             api_secret=lk_api_secret,
-            extra_kwargs=final_extra_kwargs,
+            extra_kwargs=dict(extra_kwargs) if is_given(extra_kwargs) else {},
             fallback=fallback_models,
             conn_options=conn_options if is_given(conn_options) else DEFAULT_API_CONNECT_OPTIONS,
         )
@@ -652,8 +637,6 @@ class STT(stt.STT):
         if is_given(language):
             self._opts.language = LanguageCode(language)
         if is_given(extra):
-            extra = dict(extra)
-            _strip_extra_keyterm(extra)
             self._opts.extra_kwargs.update(extra)
             self._capabilities = replace(
                 self._capabilities,
@@ -713,8 +696,6 @@ class SpeechStream(stt.SpeechStream):
         if is_given(language):
             self._opts.language = LanguageCode(language)
         if is_given(extra):
-            extra = dict(extra)
-            _strip_extra_keyterm(extra)
             self._opts.extra_kwargs.update(extra)
 
         has_update = is_given(model) or is_given(language) or is_given(extra)

--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -177,6 +177,15 @@ _DIARIZATION_EXTRA_KEYS: tuple[str, ...] = (
 )
 
 
+def _strip_extra_keyterm(extra_kwargs: dict[str, Any]) -> None:
+    """Strip whitespace from keyterm entries; Deepgram returns 400 for leading/trailing spaces."""
+    keyterm = extra_kwargs.get("keyterm")
+    if isinstance(keyterm, str):
+        extra_kwargs["keyterm"] = keyterm.strip()
+    elif isinstance(keyterm, list):
+        extra_kwargs["keyterm"] = [k.strip() for k in keyterm]
+
+
 def _diarization_enabled(extra_kwargs: dict[str, Any] | None) -> bool:
     """Return True if any known provider diarization flag is truthy."""
     if not extra_kwargs:
@@ -254,6 +263,9 @@ def _normalize_fallback(
         if isinstance(model, str):
             name, _ = _parse_model_string(model)
             return FallbackModel(model=name)
+        extra = model.get("extra_kwargs")
+        if isinstance(extra, dict):
+            _strip_extra_keyterm(extra)
         return model
 
     if isinstance(fallback, list):
@@ -545,6 +557,9 @@ class STT(stt.STT):
         if is_given(fallback):
             fallback_models = _normalize_fallback(fallback)
 
+        final_extra_kwargs: dict[str, Any] = dict(extra_kwargs) if is_given(extra_kwargs) else {}
+        _strip_extra_keyterm(final_extra_kwargs)
+
         self._opts = STTOptions(
             model=model,
             language=LanguageCode(language) if isinstance(language, str) else language,
@@ -553,7 +568,7 @@ class STT(stt.STT):
             base_url=lk_base_url,
             api_key=lk_api_key,
             api_secret=lk_api_secret,
-            extra_kwargs=dict(extra_kwargs) if is_given(extra_kwargs) else {},
+            extra_kwargs=final_extra_kwargs,
             fallback=fallback_models,
             conn_options=conn_options if is_given(conn_options) else DEFAULT_API_CONNECT_OPTIONS,
         )
@@ -637,6 +652,8 @@ class STT(stt.STT):
         if is_given(language):
             self._opts.language = LanguageCode(language)
         if is_given(extra):
+            extra = dict(extra)
+            _strip_extra_keyterm(extra)
             self._opts.extra_kwargs.update(extra)
             self._capabilities = replace(
                 self._capabilities,
@@ -696,6 +713,8 @@ class SpeechStream(stt.SpeechStream):
         if is_given(language):
             self._opts.language = LanguageCode(language)
         if is_given(extra):
+            extra = dict(extra)
+            _strip_extra_keyterm(extra)
             self._opts.extra_kwargs.update(extra)
 
         has_update = is_given(model) or is_given(language) or is_given(extra)

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/_utils.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/_utils.py
@@ -1,5 +1,5 @@
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Generic, TypeVar
 from urllib.parse import urlencode
 
@@ -36,6 +36,13 @@ class PeriodicCollector(Generic[T]):
             self._callback(self._total)
             self._total = None
         self._last_flush_time = time.monotonic()
+
+
+def _strip_keyterm(keyterm: str | Sequence[str]) -> str | list[str]:
+    """Strip whitespace from keyterm entries; Deepgram returns 400 for leading/trailing spaces."""
+    if isinstance(keyterm, str):
+        return keyterm.strip()
+    return [k.strip() for k in keyterm]
 
 
 def _to_deepgram_url(opts: dict, base_url: str, *, websocket: bool) -> str:

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -167,6 +167,8 @@ class STT(stt.STT):
                 "`keyterms` is deprecated, use `keyterm` instead for consistency with Deepgram API."
             )
             keyterm = keyterms
+        if is_given(keyterm):
+            keyterm = _strip_keyterm(keyterm)
         _validate_keyterm(model, language, keyterm, keywords)
 
         self._opts = STTOptions(
@@ -338,7 +340,7 @@ class STT(stt.STT):
             )
             keyterm = keyterms
         if is_given(keyterm):
-            self._opts.keyterm = keyterm
+            self._opts.keyterm = _strip_keyterm(keyterm)
         if is_given(profanity_filter):
             self._opts.profanity_filter = profanity_filter
         if is_given(redact):
@@ -481,7 +483,7 @@ class SpeechStream(stt.SpeechStream):
             )
             keyterm = keyterms
         if is_given(keyterm):
-            self._opts.keyterm = keyterm
+            self._opts.keyterm = _strip_keyterm(keyterm)
         if is_given(profanity_filter):
             self._opts.profanity_filter = profanity_filter
         if is_given(redact):
@@ -862,6 +864,13 @@ def _validate_tags(tags: list[str]) -> list[str]:
         if len(tag) > 128:
             raise ValueError("tag must be no more than 128 characters")
     return tags
+
+
+def _strip_keyterm(keyterm: str | Sequence[str]) -> str | list[str]:
+    """Strip whitespace from keyterm entries; Deepgram returns 400 for leading/trailing spaces."""
+    if isinstance(keyterm, str):
+        return keyterm.strip()
+    return [k.strip() for k in keyterm]
 
 
 def _validate_keyterm(

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -45,7 +45,7 @@ from livekit.agents.types import (
 from livekit.agents.utils import AudioBuffer, is_given
 from livekit.agents.voice.io import TimedString
 
-from ._utils import PeriodicCollector, _to_deepgram_url
+from ._utils import PeriodicCollector, _strip_keyterm, _to_deepgram_url
 from .log import logger
 from .models import DeepgramLanguages, DeepgramModels
 
@@ -864,13 +864,6 @@ def _validate_tags(tags: list[str]) -> list[str]:
         if len(tag) > 128:
             raise ValueError("tag must be no more than 128 characters")
     return tags
-
-
-def _strip_keyterm(keyterm: str | Sequence[str]) -> str | list[str]:
-    """Strip whitespace from keyterm entries; Deepgram returns 400 for leading/trailing spaces."""
-    if isinstance(keyterm, str):
-        return keyterm.strip()
-    return [k.strip() for k in keyterm]
 
 
 def _validate_keyterm(

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -617,5 +617,3 @@ def _validate_tags(tags: list[str]) -> list[str]:
         if len(tag) > 128:
             raise ValueError("tag must be no more than 128 characters")
     return tags
-
-

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -41,7 +41,7 @@ from livekit.agents.types import (
 from livekit.agents.utils import AudioBuffer, is_given
 from livekit.agents.voice.io import TimedString
 
-from ._utils import PeriodicCollector, _to_deepgram_url
+from ._utils import PeriodicCollector, _strip_keyterm, _to_deepgram_url
 from .log import logger
 from .models import V2Models
 
@@ -619,8 +619,3 @@ def _validate_tags(tags: list[str]) -> list[str]:
     return tags
 
 
-def _strip_keyterm(keyterm: str | Sequence[str]) -> str | list[str]:
-    """Strip whitespace from keyterm entries; Deepgram returns 400 for leading/trailing spaces."""
-    if isinstance(keyterm, str):
-        return keyterm.strip()
-    return [k.strip() for k in keyterm]

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -123,6 +123,8 @@ class STTv2(stt.STT):
                 "`keyterms` is deprecated, use `keyterm` instead for consistency with Deepgram API."
             )
             keyterm = keyterms
+        if is_given(keyterm):
+            keyterm = _strip_keyterm(keyterm)
 
         if is_given(eager_eot_threshold):
             effective_eot = eot_threshold if is_given(eot_threshold) else 0.7
@@ -236,7 +238,7 @@ class STTv2(stt.STT):
             )
             keyterm = keyterms
         if is_given(keyterm):
-            self._opts.keyterm = keyterm
+            self._opts.keyterm = _strip_keyterm(keyterm)
         if is_given(mip_opt_out):
             self._opts.mip_opt_out = mip_opt_out
         if is_given(tags):
@@ -327,7 +329,7 @@ class SpeechStreamv2(stt.SpeechStream):
             )
             keyterm = keyterms
         if is_given(keyterm):
-            self._opts.keyterm = keyterm
+            self._opts.keyterm = _strip_keyterm(keyterm)
         if is_given(mip_opt_out):
             self._opts.mip_opt_out = mip_opt_out
         if is_given(tags):
@@ -615,3 +617,10 @@ def _validate_tags(tags: list[str]) -> list[str]:
         if len(tag) > 128:
             raise ValueError("tag must be no more than 128 characters")
     return tags
+
+
+def _strip_keyterm(keyterm: str | Sequence[str]) -> str | list[str]:
+    """Strip whitespace from keyterm entries; Deepgram returns 400 for leading/trailing spaces."""
+    if isinstance(keyterm, str):
+        return keyterm.strip()
+    return [k.strip() for k in keyterm]


### PR DESCRIPTION
Deepgram throws 400 error if keyterm has a leading or trailing whitespace