### PR TITLE
feat(elevenlabs): add no_verbatim option to STT

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
@@ -303,7 +303,7 @@ class STT(stt.STT):
             self._opts.no_verbatim = no_verbatim
 
         for stream in self._streams:
-            stream.update_options(server_vad=server_vad)
+            stream.update_options(server_vad=server_vad, no_verbatim=no_verbatim)
 
     def stream(
         self,
@@ -349,9 +349,13 @@ class SpeechStream(stt.SpeechStream):
         self,
         *,
         server_vad: NotGivenOr[VADOptions] = NOT_GIVEN,
+        no_verbatim: NotGivenOr[bool] = NOT_GIVEN,
     ) -> None:
         if is_given(server_vad):
             self._opts.server_vad = server_vad
+            self._reconnect_event.set()
+        if is_given(no_verbatim):
+            self._opts.no_verbatim = no_verbatim
             self._reconnect_event.set()
 
     def _on_audio_duration_report(self, duration: float) -> None:

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
@@ -74,6 +74,7 @@ class STTOptions:
     sample_rate: STTRealtimeSampleRates
     server_vad: NotGivenOr[VADOptions | None]
     keyterms: NotGivenOr[list[str]]
+    no_verbatim: bool
 
 
 class STT(stt.STT):
@@ -91,6 +92,7 @@ class STT(stt.STT):
         http_session: aiohttp.ClientSession | None = None,
         model_id: NotGivenOr[ElevenLabsSTTModels | str] = NOT_GIVEN,
         keyterms: NotGivenOr[list[str]] = NOT_GIVEN,
+        no_verbatim: NotGivenOr[bool] = NOT_GIVEN,
     ) -> None:
         """
         Create a new instance of ElevenLabs STT.
@@ -112,6 +114,9 @@ class STT(stt.STT):
                 Each keyterm can contain at most 5 words and must be less than 50 characters.
                 Maximum of 100 keyterms. Only supported for Scribe v2 batch recognition
                 (not realtime streaming). Usage incurs additional costs.
+            no_verbatim (NotGivenOr[bool]): When True, the model removes filler words, false starts
+                and disfluencies from the transcript, producing cleaner output. Supported for both
+                Scribe v2 (batch) and Scribe v2 realtime. Default is False.
         """
 
         if is_given(use_realtime):
@@ -157,6 +162,7 @@ class STT(stt.STT):
             include_timestamps=include_timestamps,
             model_id=model_id,
             keyterms=keyterms,
+            no_verbatim=no_verbatim if is_given(no_verbatim) else False,
         )
         self._session = http_session
         self._streams = weakref.WeakSet[SpeechStream]()
@@ -195,6 +201,8 @@ class STT(stt.STT):
         if is_given(self._opts.keyterms):
             for keyterm in self._opts.keyterms:
                 form.add_field("keyterms", keyterm)
+        if self._opts.no_verbatim:
+            form.add_field("no_verbatim", "true")
 
         try:
             async with self._ensure_session().post(
@@ -280,6 +288,7 @@ class STT(stt.STT):
         tag_audio_events: NotGivenOr[bool] = NOT_GIVEN,
         server_vad: NotGivenOr[VADOptions] = NOT_GIVEN,
         keyterms: NotGivenOr[list[str]] = NOT_GIVEN,
+        no_verbatim: NotGivenOr[bool] = NOT_GIVEN,
     ) -> None:
         if is_given(tag_audio_events):
             self._opts.tag_audio_events = tag_audio_events
@@ -289,6 +298,9 @@ class STT(stt.STT):
 
         if is_given(keyterms):
             self._opts.keyterms = keyterms
+
+        if is_given(no_verbatim):
+            self._opts.no_verbatim = no_verbatim
 
         for stream in self._streams:
             stream.update_options(server_vad=server_vad)
@@ -512,6 +524,9 @@ class SpeechStream(stt.SpeechStream):
 
         if self._opts.include_timestamps:
             params.append("include_timestamps=true")
+
+        if self._opts.no_verbatim:
+            params.append("no_verbatim=true")
 
         query_string = "&".join(params)
 

--- a/tests/test_plugin_elevenlabs_stt.py
+++ b/tests/test_plugin_elevenlabs_stt.py
@@ -106,3 +106,20 @@ def test_update_options_leaves_no_verbatim_untouched_when_not_given() -> None:
     instance = _stt(no_verbatim=True)
     instance.update_options(tag_audio_events=False)
     assert instance._opts.no_verbatim is True
+
+
+def test_update_options_forwards_no_verbatim_to_active_streams() -> None:
+    # no_verbatim is a WebSocket query param applied at connect time, so a live
+    # realtime stream must be told to reconnect. Verify STT.update_options
+    # forwards it to active streams (which trigger a reconnect).
+    instance = _stt()
+    captured: dict[str, object] = {}
+
+    class _FakeStream:
+        def update_options(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+    fake = _FakeStream()
+    instance._streams.add(fake)
+    instance.update_options(no_verbatim=True)
+    assert captured.get("no_verbatim") is True

--- a/tests/test_plugin_elevenlabs_stt.py
+++ b/tests/test_plugin_elevenlabs_stt.py
@@ -1,3 +1,5 @@
+"""Unit tests for ElevenLabs STT plugin configuration."""
+
 from __future__ import annotations
 
 import pytest
@@ -29,6 +31,7 @@ def _new_stream(*, server_vad=NOT_GIVEN) -> elevenlabs_stt.SpeechStream:
         sample_rate=16000,
         server_vad=server_vad,
         keyterms=NOT_GIVEN,
+        no_verbatim=False,
     )
     stream._language = None
     stream._event_ch = _EventSink()
@@ -78,3 +81,28 @@ def test_manual_commit_still_waits_for_empty_commit() -> None:
 
     assert stream._event_ch.events[-1].type == stt.SpeechEventType.END_OF_SPEECH
     assert stream._speaking is False
+
+
+def _stt(**kwargs: object) -> elevenlabs_stt.STT:
+    return elevenlabs_stt.STT(api_key="test-key", model_id="scribe_v2_realtime", **kwargs)
+
+
+def test_no_verbatim_defaults_to_false() -> None:
+    assert _stt()._opts.no_verbatim is False
+
+
+def test_no_verbatim_can_be_enabled() -> None:
+    assert _stt(no_verbatim=True)._opts.no_verbatim is True
+
+
+def test_update_options_sets_no_verbatim() -> None:
+    instance = _stt()
+    assert instance._opts.no_verbatim is False
+    instance.update_options(no_verbatim=True)
+    assert instance._opts.no_verbatim is True
+
+
+def test_update_options_leaves_no_verbatim_untouched_when_not_given() -> None:
+    instance = _stt(no_verbatim=True)
+    instance.update_options(tag_audio_events=False)
+    assert instance._opts.no_verbatim is True


### PR DESCRIPTION
## Summary

Exposes ElevenLabs' **`no_verbatim`** speech-to-text option in the plugin. When enabled, the model removes filler words, false starts and disfluencies from the transcript, producing cleaner output.

Both **Scribe v2 (batch)** and **Scribe v2 realtime** support this flag (it's a documented STT parameter — a form field for batch and a websocket query parameter for realtime), but the plugin previously had no way to set it.

## Changes

- Add `no_verbatim: bool = False` to `STT.__init__` and `STTOptions` (documented).
- Batch recognition (`_recognize_impl`): add the `no_verbatim` form field when enabled.
- Realtime (`_connect_ws`): append `no_verbatim=true` to the websocket query params when enabled.
- `update_options`: allow toggling `no_verbatim` at runtime.
- Add unit tests (`tests/test_plugin_elevenlabs_stt.py`) covering default, enabling, and `update_options`.

## Why

Spontaneous speech transcripts carry heavy disfluency ("eh", "mmm", false starts) that degrades downstream LLM consumers (e.g. classification/scoring over the transcript). `no_verbatim` lets the STT clean this at the source. Default remains `False`, so behavior is unchanged unless opted in.

## Notes

- `ruff check` and `ruff format` pass (per CONTRIBUTING).
- Default `False` → no behavior change for existing users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)