### PR TITLE
fix(bargein): error when no interruption threshold is known

### DIFF
--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -772,9 +772,7 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
     def _resolve_effective_threshold(self, default_threshold: float | None) -> float | None:
         """Return the effective threshold for observability only.
 
-        Precedence: user override, then server default. Returns None when neither is known, so
-        the log reports an honest "unknown" rather than a hardcoded value that may disagree with
-        the server.
+        Precedence: user override, then server default; None when neither is known.
         """
         if is_given(self._opts.threshold):
             return self._opts.threshold
@@ -849,6 +847,16 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
 
                 match msg:
                     case InterruptionWSSessionCreatedMessage():
+                        if not is_given(self._opts.threshold) and msg.default_threshold is None:
+                            raise APIStatusError(
+                                message=(
+                                    "adaptive interruption session created without a threshold: "
+                                    "no user override and the server did not report a "
+                                    "default_threshold"
+                                ),
+                                status_code=500,
+                                retryable=False,
+                            )
                         # Observability only — the server makes the actual decision;
                         logger.debug(
                             "adaptive interruption session created",
@@ -860,11 +868,6 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                                 "user_override": is_given(self._opts.threshold),
                             },
                         )
-                        if not is_given(self._opts.threshold) and msg.default_threshold is None:
-                            logger.warning(
-                                "adaptive interruption session created without a threshold from "
-                                "the server; the effective threshold is unknown"
-                            )
                     case InterruptionWSSessionClosedMessage():
                         pass
                     case InterruptionWSDetectedMessage():

--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -50,8 +50,6 @@ from ._utils import (
 )
 
 SAMPLE_RATE = 16000
-# local fallback when server/model side threshold is not available
-THRESHOLD = 0.656
 MIN_INTERRUPTION_DURATION = 0.025 * 2  # 25ms per frame, 2 consecutive frames
 MAX_AUDIO_DURATION = 3  # 3 seconds
 DETECTION_INTERVAL = 0.1  # 0.1 second
@@ -281,7 +279,7 @@ class AdaptiveInterruptionDetector(
         Initialize a AdaptiveInterruptionDetector instance.
 
         Args:
-            threshold (float, optional): The threshold for the interruption detection. When not set, the server-recommended default (returned in session.created) is used, falling back to THRESHOLD if the server does not provide one.
+            threshold (float, optional): The threshold for the interruption detection. When not set, the server-recommended default (returned in session.created) is used.
             min_interruption_duration (float, optional): The minimum duration, in seconds, of the interruption event, defaults to 50ms.
             max_audio_duration (float, optional): The maximum audio duration, including the audio prefix, in seconds, for the interruption detection, defaults to 3s.
             audio_prefix_duration (float, optional): The audio prefix duration, in seconds, for the interruption detection, defaults to 0.5s.
@@ -771,13 +769,18 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
         # opts are shared with the detector (self._opts is model._opts), no need to update them here
         self._reconnect_event.set()
 
-    def _resolve_effective_threshold(self, default_threshold: float | None) -> float:
-        """Return the effective threshold."""
+    def _resolve_effective_threshold(self, default_threshold: float | None) -> float | None:
+        """Return the effective threshold for observability only.
+
+        Precedence: user override, then server default. Returns None when neither is known, so
+        the log reports an honest "unknown" rather than a hardcoded value that may disagree with
+        the server.
+        """
         if is_given(self._opts.threshold):
             return self._opts.threshold
         if default_threshold is not None:
             return default_threshold
-        return THRESHOLD
+        return None
 
     async def _run(self) -> None:
         closing_ws = False
@@ -857,6 +860,11 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                                 "user_override": is_given(self._opts.threshold),
                             },
                         )
+                        if not is_given(self._opts.threshold) and msg.default_threshold is None:
+                            logger.warning(
+                                "adaptive interruption session created without a threshold from "
+                                "the server; the effective threshold is unknown"
+                            )
                     case InterruptionWSSessionClosedMessage():
                         pass
                     case InterruptionWSDetectedMessage():

--- a/tests/test_interruption/test_interruption_failover.py
+++ b/tests/test_interruption/test_interruption_failover.py
@@ -7,6 +7,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from unittest.mock import AsyncMock, MagicMock
 
@@ -15,7 +16,7 @@ import numpy as np
 import pytest
 
 from livekit import rtc
-from livekit.agents._exceptions import APIError
+from livekit.agents._exceptions import APIError, APIStatusError
 from livekit.agents.inference.interruption import (
     AdaptiveInterruptionDetector,
     InterruptionDetectionError,
@@ -197,6 +198,55 @@ class TestWsCacheTimeout:
         assert exc is not None
         assert isinstance(exc, APIError)
 
+        recoverable_errors = [e for e in errors if e.recoverable]
+        unrecoverable_errors = [e for e in errors if not e.recoverable]
+        assert len(recoverable_errors) == 0
+        assert len(unrecoverable_errors) == 1
+
+
+class TestWsSessionCreatedMissingThreshold:
+    @pytest.mark.asyncio
+    async def test_immediate_unrecoverable_when_server_omits_threshold(self) -> None:
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+
+        def _make_mock_ws() -> MagicMock:
+            mock_ws = MagicMock(spec=aiohttp.ClientWebSocketResponse)
+            mock_ws.send_str = AsyncMock()
+            mock_ws.send_bytes = AsyncMock()
+            mock_ws.closed = False
+            mock_ws.close_code = None
+
+            sent_created = False
+
+            async def _receive() -> aiohttp.WSMessage:
+                nonlocal sent_created
+                if not sent_created:
+                    sent_created = True
+                    return aiohttp.WSMessage(
+                        type=aiohttp.WSMsgType.TEXT,
+                        data=json.dumps({"type": "session.created"}),
+                        extra=None,
+                    )
+                await asyncio.sleep(3600)
+                return aiohttp.WSMessage(type=aiohttp.WSMsgType.CLOSED, data=None, extra=None)
+
+            mock_ws.receive = _receive
+            mock_ws.close = AsyncMock(return_value=True)
+            return mock_ws
+
+        mock_session.ws_connect = AsyncMock(side_effect=lambda *a, **kw: _make_mock_ws())
+
+        detector = _create_detector(mock_session)
+        errors = _collect_errors(detector)
+        stream = detector.stream(conn_options=CONN_OPTIONS)
+
+        exc = await _wait_for_stream_failure(stream)
+
+        assert isinstance(exc, APIStatusError)
+        assert exc.status_code == 500
+        assert exc.retryable is False
+
+        # retryable=False -> no retries, immediate unrecoverable
         recoverable_errors = [e for e in errors if e.recoverable]
         unrecoverable_errors = [e for e in errors if not e.recoverable]
         assert len(recoverable_errors) == 0

--- a/tests/test_interruption/test_interruption_session_create.py
+++ b/tests/test_interruption/test_interruption_session_create.py
@@ -16,7 +16,6 @@ import aiohttp
 import pytest
 
 from livekit.agents.inference.interruption import (
-    THRESHOLD,
     AdaptiveInterruptionDetector,
     InterruptionWebSocketStream,
     InterruptionWSSessionCreatedMessage,
@@ -113,7 +112,7 @@ class TestSessionCreatedDefaultThreshold:
 
 
 class TestResolveEffectiveThreshold:
-    """Observability-only resolution: user override > server default > THRESHOLD backup."""
+    """Observability-only resolution: user override > server default > None."""
 
     @pytest.mark.asyncio
     async def test_user_override_wins(self) -> None:
@@ -132,9 +131,9 @@ class TestResolveEffectiveThreshold:
             await stream.aclose()
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_constant_when_server_silent(self) -> None:
+    async def test_returns_none_when_server_silent(self) -> None:
         stream = await _make_idle_stream(_make_detector())
         try:
-            assert stream._resolve_effective_threshold(None) == THRESHOLD
+            assert stream._resolve_effective_threshold(None) is None
         finally:
             await stream.aclose()


### PR DESCRIPTION
## What

Drops the local `THRESHOLD = 0.656` constant from the adaptive interruption detector and **errors the stream** when no threshold is known.

## Why

The server makes the actual interruption decision. The client only ever used `THRESHOLD` as the last fallback in `_resolve_effective_threshold()`, which feeds the **observability-only** `effective_threshold` debug log. A hardcoded client-side fallback can silently disagree with the server's real default — misleading in exactly the situation you'd be debugging.

When the user doesn't override `threshold`, the client sends nothing and the server applies its own default; the server-reported `default_threshold` on `session.created` is optional. The only genuinely broken case is when **both** are absent — no user override *and* no server default — which we now treat as a hard contract violation and fail fast.

## Changes

- Remove the `THRESHOLD` constant.
- `_resolve_effective_threshold()` now returns `float | None` (user override → server default → `None`).
- On `session.created` with no user override **and** no server `default_threshold`, raise a non-retryable `APIStatusError` (status 500) so the stream fails fast instead of silently running with an unknown threshold.
- Validate **before** the observability log, so we don't emit a "session created" line with a null threshold immediately before failing.
- Update docstring and tests; add `TestWsSessionCreatedMissingThreshold` covering the fail-fast path.

This is a follow-up cleanup to #5946.

## Test plan

- [x] `pytest tests/test_interruption/` — 14 passed
- [x] `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)