### PR TITLE
fix(deepgram): use stored language when validating model in update_options 

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -313,7 +313,9 @@ class STT(stt.STT):
         if is_given(language):
             self._opts.language = LanguageCode(language)
         if is_given(model):
-            self._opts.model = _validate_model(model, language)
+            self._opts.model = _validate_model(
+                model, language if is_given(language) else (self._opts.language or NOT_GIVEN)
+            )
         if is_given(interim_results):
             self._opts.interim_results = interim_results
         if is_given(punctuate):
@@ -456,7 +458,9 @@ class SpeechStream(stt.SpeechStream):
         if is_given(language):
             self._opts.language = LanguageCode(language)
         if is_given(model):
-            self._opts.model = _validate_model(model, language)
+            self._opts.model = _validate_model(
+                model, language if is_given(language) else (self._opts.language or NOT_GIVEN)
+            )
         if is_given(interim_results):
             self._opts.interim_results = interim_results
         if is_given(punctuate):

--- a/tests/test_plugin_deepgram_stt.py
+++ b/tests/test_plugin_deepgram_stt.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.plugin("deepgram")
+
+
+async def test_update_options_uses_stored_language_for_model_validation():
+    from livekit.plugins.deepgram import STT
+
+    stt = STT(api_key="test-key", language="fr")
+    stt.update_options(model="nova-2-meeting")
+    assert stt._opts.model == "nova-2-general"
+
+
+async def test_update_options_explicit_language_overrides_stored():
+    from livekit.plugins.deepgram import STT
+
+    stt = STT(api_key="test-key", language="fr")
+    stt.update_options(model="nova-2-meeting", language="en-US")
+    assert stt._opts.model == "nova-2-meeting"
+
+
+async def test_update_options_no_language_set_keeps_en_only_model():
+    from livekit.plugins.deepgram import STT
+
+    stt = STT(api_key="test-key")
+    stt.update_options(model="nova-2-meeting")
+    assert stt._opts.model == "nova-2-meeting"


### PR DESCRIPTION
\`STT.update_options\` and \`SpeechStream.update_options\` both call \`_validate_model(model, language)\` using the caller's \`language\` parameter. When only the model is changed, \`language\` is \`NOT_GIVEN\`, so \`_validate_model\` skips its English-only model check entirely — allowing an incompatible model/language pair to be stored silently.

For example, after \`STT(language="fr")\`, calling \`update_options(model="nova-2-meeting")\` would accept \`nova-2-meeting\` (English-only) with no warning, instead of falling back to \`nova-2-general\`.

Fix: pass \`self._opts.language or NOT_GIVEN\` when the caller omits \`language\`, so the stored language is used for validation.

Fixes #6047

## Test plan

\`\`\`
uv run pytest tests/test_plugin_deepgram_stt.py --plugin deepgram -v
\`\`\`