### PR TITLE
fix(ipc): hint about missing Git LFS on prewarm init failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,8 @@ This project uses [uv](https://docs.astral.sh/uv/) for package management. To in
 uv sync --all-extras --dev
 ```
 
+This repo stores some large file assets with [Git LFS](https://git-lfs.com). Make sure `git-lfs` is installed *before* cloning, otherwise those files are left as small pointer placeholders which fail to load at runtime. If you already cloned without it, install `git-lfs` then run `git lfs install && git lfs pull` (or clone again) to fetch the actual files.
+
 ### Examples
 
 This project includes many examples in the [`examples`](examples/) directory. To run them, create the file `examples/.env` with credentials for LiveKit Server and any necessary model providers (see `examples/.env.example`), then run:

--- a/livekit-agents/livekit/agents/ipc/proc_client.py
+++ b/livekit-agents/livekit/agents/ipc/proc_client.py
@@ -47,7 +47,12 @@ class _ProcClient:
                 send_message(cch, InitializeResponse())
             except Exception as e:
                 send_message(cch, InitializeResponse(error=str(e)))
-                raise
+                raise RuntimeError(
+                    "failed to initialize proc_client. Hint: If resource file "
+                    "failed to load (e.g. INVALID_PROTOBUF), your dev repo may have "
+                    "been cloned without Git LFS. Install git-lfs then run "
+                    "`git lfs install && git lfs pull`, or clone again."
+                ) from e
 
             self._initialized = True
             cch.detach()


### PR DESCRIPTION
If the repo is cloned without Git LFS, the LFS-tracked assets (e.g. the Silero VAD model) are left as pointer placeholder files.  This breaks even the basic examples, which crash with a cryptic error, e.g.

onnxruntime.capi.onnxruntime_pybind11_state.InvalidProtobuf: [ONNXRuntimeError] : 7 : INVALID_PROTOBUF : Load model from .../livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/resources/silero_vad.onnx failed:Protobuf parsing failed.

Wrap the prewarm/init failure in _ProcClient.initialize() to append a hint suggesting the repo may have been cloned without Git LFS and instructions to resolve.  Also document the Git LFS requirement in the README dev setup section.

Fixes #6043