### PR TITLE
fix(cli): restore terminal settings on console exit

### DIFF
--- a/livekit-agents/livekit/agents/cli/_legacy.py
+++ b/livekit-agents/livekit/agents/cli/_legacy.py
@@ -1543,6 +1543,17 @@ def _run_console(
 
         c._validate_device_or_raise(input_device=input_device, output_device=output_device)
 
+        # Snapshot and restore tty settings, so we don't leave the terminal with echo disabled.
+        tty_fd: int | None = None
+        tty_settings: Any = None
+        try:
+            import termios
+
+            tty_fd = sys.stdin.fileno()
+            tty_settings = termios.tcgetattr(tty_fd)
+        except Exception:
+            tty_fd = None
+
         exit_triggered = False
 
         def _on_worker_shutdown() -> None:
@@ -1587,6 +1598,13 @@ def _run_console(
         finally:
             console_worker.shutdown()
             console_worker.join()
+            if tty_fd is not None:
+                try:
+                    import termios
+
+                    termios.tcsetattr(tty_fd, termios.TCSADRAIN, tty_settings)
+                except Exception:
+                    pass
 
     except (CLIError, ValueError) as e:
         c.print(" ")


### PR DESCRIPTION
In console mode the key-listener runs in a daemon thread that puts the tty into no-echo mode. Ctrl-C tears down the process -- commonly while the key-listener is in mid-read so its per-read restore never gets to run.

The terminal is then left with echo disabled upon process exit.

Fix: Snapshot the tty settings at the start of _run_console and restore them in its finally, which always runs in the main thread on exit, regardless of what state the listener thread might leave the terminal in.

Fixes #6045