### PR TITLE
fix(voice): route and drain AsyncToolset executors correctly on handoff

### DIFF
--- a/livekit-agents/livekit/agents/llm/async_toolset.py
+++ b/livekit-agents/livekit/agents/llm/async_toolset.py
@@ -90,4 +90,5 @@ class AsyncToolset(Toolset):
 
     async def aclose(self) -> None:
         await super().aclose()
+        await self._executor.drain()
         await self._executor.aclose()

--- a/livekit-agents/livekit/agents/llm/tool_context.py
+++ b/livekit-agents/livekit/agents/llm/tool_context.py
@@ -605,10 +605,14 @@ class ToolContext:
         lifecycle remain the toolset's) — it just stops being callable.
         """
         current = self.flatten()
-        added = [t for t in tools if not any(t is c for c in current)]
-        removed = [c for c in current if not any(c is t for t in tools)]
-        if not added and not removed:
+        current_ids = {id(t) for t in current}
+        tool_ids = {id(t) for t in tools}
+        if current_ids == tool_ids:
             return
+
+        added = [t for t in tools if id(t) not in current_ids]
+        removed_ids = current_ids - tool_ids
+        removed = [c for c in current if id(c) in removed_ids]
 
         structured = [t for t in self._tools if not any(t is r for r in removed)]
         self._update_tools([*structured, *added], exclude=removed)

--- a/livekit-agents/livekit/agents/llm/tool_context.py
+++ b/livekit-agents/livekit/agents/llm/tool_context.py
@@ -552,12 +552,20 @@ class ToolContext:
         return True
 
     def update_tools(self, tools: Sequence[Tool | Toolset]) -> None:
+        self._update_tools(tools)
+
+    def _update_tools(
+        self, tools: Sequence[Tool | Toolset], *, exclude: Sequence[Tool] = ()
+    ) -> None:
         self._tools = list(tools)
         self._fnc_tools_map: dict[str, FunctionTool | RawFunctionTool] = {}
         self._provider_tools: list[ProviderTool] = []
         self._tool_sets: list[Toolset] = []
 
         def add_tool(tool: Tool | Toolset) -> None:
+            if any(tool is e for e in exclude):
+                return
+
             if isinstance(tool, ProviderTool):
                 self._provider_tools.append(tool)
 
@@ -588,6 +596,22 @@ class ToolContext:
 
         for tool in itertools.chain(tools, find_function_tools(self)):
             add_tool(tool)
+
+    def _sync_flattened(self, tools: Sequence[Tool]) -> None:
+        """Apply in-place edits of a ``flatten()`` list, preserving Toolset grouping.
+
+        Added tools become top-level entries; removed tools are dropped from the
+        flat lookup. A removed Toolset member stays in its toolset (membership and
+        lifecycle remain the toolset's) — it just stops being callable.
+        """
+        current = self.flatten()
+        added = [t for t in tools if not any(t is c for c in current)]
+        removed = [c for c in current if not any(c is t for t in tools)]
+        if not added and not removed:
+            return
+
+        structured = [t for t in self._tools if not any(t is r for r in removed)]
+        self._update_tools([*structured, *added], exclude=removed)
 
     def copy(self) -> ToolContext:
         return ToolContext(self._tools.copy())

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1044,19 +1044,6 @@ class AgentActivity(RecognitionHooks):
             # cancel cancellable tools and await the rest before teardown
             await self._tool_executor.drain()
 
-            # agent-scoped AsyncToolsets have their own executors; drain them too
-            # so a non-cancellable one is awaited rather than cancelled by the
-            # aclose() sweep below (session-scoped toolsets aren't drained here).
-            from ..llm.async_toolset import AsyncToolset
-
-            agent_async_executors = [
-                tool._executor for tool in self._agent.tools if isinstance(tool, AsyncToolset)
-            ]
-            if agent_async_executors:
-                await asyncio.gather(
-                    *(ex.drain() for ex in agent_async_executors), return_exceptions=True
-                )
-
             await self._close_session()
             await asyncio.gather(*self._interrupt_background_speeches(force=False))
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1044,6 +1044,19 @@ class AgentActivity(RecognitionHooks):
             # cancel cancellable tools and await the rest before teardown
             await self._tool_executor.drain()
 
+            # agent-scoped AsyncToolsets have their own executors; drain them too
+            # so a non-cancellable one is awaited rather than cancelled by the
+            # aclose() sweep below (session-scoped toolsets aren't drained here).
+            from ..llm.async_toolset import AsyncToolset
+
+            agent_async_executors = [
+                tool._executor for tool in self._agent.tools if isinstance(tool, AsyncToolset)
+            ]
+            if agent_async_executors:
+                await asyncio.gather(
+                    *(ex.drain() for ex in agent_async_executors), return_exceptions=True
+                )
+
             await self._close_session()
             await asyncio.gather(*self._interrupt_background_speeches(force=False))
 

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -583,26 +583,13 @@ async def _execute_tools_task(
         )
         return
 
-    # We need to decide which executor runs each tool. A tool that belongs to an
-    # AsyncToolset must run on that toolset's own executor; every other tool runs
-    # on the activity's executor.
-    #
-    # Why we don't use ``tool_ctx.toolsets`` here: the LLM inference step shares
-    # this same ``tool_ctx`` object and runs first. To hand the model a plain
-    # list of functions it flattens the toolsets and writes the flat list back
-    # into ``tool_ctx`` in place (see ``_llm_inference_task``: ``tools =
-    # tool_ctx.flatten()`` then ``tool_ctx.update_tools(tools)``). After that,
-    # ``tool_ctx.toolsets`` is empty -- the "which tool came from which toolset"
-    # grouping is gone. If we routed off that, a session-scoped tool would look
-    # like a normal activity tool. That matters on handoff: when we switch
-    # agents the old activity shuts down and cancels its tools, but a
-    # session-scoped tool is supposed to keep running and report back to the new
-    # agent. Routed wrong, it gets cancelled and its result is lost.
-    #
-    # So we rebuild the list of toolsets directly from where they actually live
-    # (the session, the current agent, and MCP), which still knows which tools
-    # belong to which toolset, and use that to map each tool to the right
-    # executor.
+    # Route AsyncToolset members to their own executor; everything else falls
+    # back to the activity executor. We rebuild the toolset list from the
+    # registered sources (session + agent + MCP) instead of `tool_ctx.toolsets`:
+    # `_llm_inference_task` flattens `tool_ctx` in place, so by now its toolset
+    # grouping is gone. Without it a session-scoped tool would route to the
+    # activity executor and be cancelled on handoff instead of surviving to
+    # deliver under the next agent.
     routing_toolsets: list[llm.Toolset] = [
         t for t in session.tools if isinstance(t, llm.Toolset)
     ]

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -590,9 +590,7 @@ async def _execute_tools_task(
     # grouping is gone. Without it a session-scoped tool would route to the
     # activity executor and be cancelled on handoff instead of surviving to
     # deliver under the next agent.
-    routing_toolsets: list[llm.Toolset] = [
-        t for t in session.tools if isinstance(t, llm.Toolset)
-    ]
+    routing_toolsets: list[llm.Toolset] = [t for t in session.tools if isinstance(t, llm.Toolset)]
     routing_toolsets += [t for t in activity._agent.tools if isinstance(t, llm.Toolset)]
     routing_toolsets += list(activity._mcp_tools)
     executor_by_name = _build_executor_map(

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -583,10 +583,33 @@ async def _execute_tools_task(
         )
         return
 
-    # AsyncToolset members route to their own executor for per-toolset
-    # update/reply coalescing; the rest fall back to the activity executor
+    # We need to decide which executor runs each tool. A tool that belongs to an
+    # AsyncToolset must run on that toolset's own executor; every other tool runs
+    # on the activity's executor.
+    #
+    # Why we don't use ``tool_ctx.toolsets`` here: the LLM inference step shares
+    # this same ``tool_ctx`` object and runs first. To hand the model a plain
+    # list of functions it flattens the toolsets and writes the flat list back
+    # into ``tool_ctx`` in place (see ``_llm_inference_task``: ``tools =
+    # tool_ctx.flatten()`` then ``tool_ctx.update_tools(tools)``). After that,
+    # ``tool_ctx.toolsets`` is empty -- the "which tool came from which toolset"
+    # grouping is gone. If we routed off that, a session-scoped tool would look
+    # like a normal activity tool. That matters on handoff: when we switch
+    # agents the old activity shuts down and cancels its tools, but a
+    # session-scoped tool is supposed to keep running and report back to the new
+    # agent. Routed wrong, it gets cancelled and its result is lost.
+    #
+    # So we rebuild the list of toolsets directly from where they actually live
+    # (the session, the current agent, and MCP), which still knows which tools
+    # belong to which toolset, and use that to map each tool to the right
+    # executor.
+    routing_toolsets: list[llm.Toolset] = [
+        t for t in session.tools if isinstance(t, llm.Toolset)
+    ]
+    routing_toolsets += [t for t in activity._agent.tools if isinstance(t, llm.Toolset)]
+    routing_toolsets += list(activity._mcp_tools)
     executor_by_name = _build_executor_map(
-        toolsets=tool_ctx.toolsets, default=activity._tool_executor
+        toolsets=routing_toolsets, default=activity._tool_executor
     )
 
     tasks: list[asyncio.Task[Any]] = []

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -125,8 +125,10 @@ async def _llm_inference_task(
 
     # store any updated tools, to ensure subsequent tool calls in the same turn (nested calls)
     # are using the newer tools.
-    # tool_ctx here is ephemeral for this turn, and we allow manipulations
-    tool_ctx.update_tools(tools)
+    # tool_ctx here is ephemeral for this turn, and we allow manipulations.
+    # _sync_flattened writes back flat edits while preserving Toolset grouping
+    # (e.g. tool_ctx.toolsets stays intact for executor routing on handoff).
+    tool_ctx._sync_flattened(tools)
     tools_snapshot = tools.copy()
 
     if isinstance(llm_node, str):
@@ -163,7 +165,7 @@ async def _llm_inference_task(
                             tool_ctx.get_function_tool(tool.name) is None
                             and tools != tools_snapshot
                         ):
-                            tool_ctx.update_tools(tools)
+                            tool_ctx._sync_flattened(tools)
                             tools_snapshot = tools.copy()
 
                         fnc_call = llm.FunctionCall(
@@ -583,18 +585,10 @@ async def _execute_tools_task(
         )
         return
 
-    # Route AsyncToolset members to their own executor; everything else falls
-    # back to the activity executor. We rebuild the toolset list from the
-    # registered sources (session + agent + MCP) instead of `tool_ctx.toolsets`:
-    # `_llm_inference_task` flattens `tool_ctx` in place, so by now its toolset
-    # grouping is gone. Without it a session-scoped tool would route to the
-    # activity executor and be cancelled on handoff instead of surviving to
-    # deliver under the next agent.
-    routing_toolsets: list[llm.Toolset] = [t for t in session.tools if isinstance(t, llm.Toolset)]
-    routing_toolsets += [t for t in activity._agent.tools if isinstance(t, llm.Toolset)]
-    routing_toolsets += list(activity._mcp_tools)
+    # Route AsyncToolset members to their own executor so session-scoped async
+    # tools survive handoff; everything else falls back to the activity executor.
     executor_by_name = _build_executor_map(
-        toolsets=routing_toolsets, default=activity._tool_executor
+        toolsets=tool_ctx.toolsets, default=activity._tool_executor
     )
 
     tasks: list[asyncio.Task[Any]] = []


### PR DESCRIPTION
Two related fixes for async toolset (`AsyncToolset`) routing/teardown around agent handoff.

## 1. Session-scoped AsyncToolset cancelled at handoff (primary)

A session-scoped `AsyncToolset` (`AgentSession(tools=[...])`) should survive an agent handoff: a long-running `ctx.update()` tool started under agent A keeps running and delivers under agent B. In the pipeline path it didn't — the in-flight tool was cancelled at handoff and its deferred result lost.

**Root cause:** the tool->executor routing map was built from `tool_ctx.toolsets`. But the LLM inference step shares the same `tool_ctx` and runs first; to hand the model a flat function list it flattens the toolsets and writes the flat list back into `tool_ctx` in place (`_llm_inference_task`: `tools = tool_ctx.flatten()` then `tool_ctx.update_tools(tools)`). After that `tool_ctx.toolsets` is empty, so a session-scoped tool was routed to the activity executor and cancelled when the activity drained on handoff.

**Fix:** build the routing map from the registered toolsets directly (`session.tools` + the current agent's tools + MCP), which still carry the `AsyncToolset` grouping, instead of the post-inference `tool_ctx`.

## 2. Agent-scoped AsyncToolset hard-cancelled at handoff

Exposed by fix #(1) (and flagged in review). Agent-scoped `AsyncToolset`s (`Agent(tools=[...])`) run on their own executors, but `aclose()` only `drain()`ed the activity executor; the agent toolset executors were `aclose()`d (cancel-all). So a **non-cancellable** agent-scoped async tool that had returned from its first `ctx.update()` was hard-cancelled at handoff instead of being awaited, losing its result.

**Fix:** drain the agent-scoped `AsyncToolset` executors alongside the activity executor (cancel cancellable, await non-cancellable) before the aclose() sweep. Session-scoped toolsets are owned by the session and intentionally not drained here.

## Verification

Reproduced and verified end-to-end with `agents-cli` against real inference (text + voice):
- Session-scoped async tool started under A survives a mid-flight handoff and delivers under B; an activity-scoped tool correctly drains at handoff.
- Agent-scoped non-cancellable async tool: before fix #(2) it logged `CANCELLED` at handoff; after, it logs `COMPLETED` (awaited to completion).

This matches the JS implementation, which keeps `toolCtx.toolsets` intact and routes off it. A deeper follow-up could stop the inference step from destructively flattening the shared `tool_ctx` in place; these fixes address routing/teardown at the consumer with minimal blast radius.