### PR TITLE
fix(ipc): close supervised process when start() is cancelled

### DIFF
--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -128,6 +128,7 @@ class SupervisedProc(ABC):
         self._last_memory_warn_time: float = 0.0
         self._last_memory_warn_mb: float = 0.0
 
+        self._start_atask: asyncio.Task[None] | None = None
         self._supervise_atask: asyncio.Task[None] | None = None
         self._closing = False
         self._kill_sent = False
@@ -181,7 +182,9 @@ class SupervisedProc(ABC):
         if self._closing:
             raise RuntimeError("process is closed")
 
-        await asyncio.shield(self._start())
+        # keep a handle so aclose() can await an abandoned (cancelled) start()
+        self._start_atask = asyncio.create_task(self._start())
+        await asyncio.shield(self._start_atask)
 
     async def _start(self) -> None:
         def _add_proc_ctx_log(record: logging.LogRecord) -> None:
@@ -304,7 +307,16 @@ class SupervisedProc(ABC):
 
     async def aclose(self) -> None:
         """attempt to gracefully close the supervised process"""
+        if self._start_atask is not None and not self._start_atask.done():
+            # start() may have been cancelled mid-shield; wait so the started check can't race
+            await asyncio.wait([self._start_atask])
+
         if not self.started:
+            return
+
+        if not self._initialize_fut.done():
+            # never initialized: the child can't ack a graceful shutdown yet, kill it instead
+            await self.kill()
             return
 
         self._closing = True
@@ -347,6 +359,11 @@ class SupervisedProc(ABC):
             raise RuntimeError("process not started")
 
         self._closing = True
+        if not self._initialize_fut.done():
+            # unblock the supervise task waiting on this future
+            self._initialize_fut.set_exception(
+                RuntimeError("process killed before initialization completed")
+            )
         await self._send_dump_signal()
         await self._send_kill_signal()
 

--- a/tests/fake_session.py
+++ b/tests/fake_session.py
@@ -93,7 +93,7 @@ def create_session(
     return session
 
 
-async def run_session(session: AgentSession, agent: Agent, *, drain_delay: float = 0.2) -> float:
+async def run_session(session: AgentSession, agent: Agent, *, drain_delay: float = 5) -> float:
     stt = session.stt
     audio_input = session.input.audio
     assert isinstance(stt, FakeSTT)

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -88,7 +88,7 @@ SESSION_TIMEOUT = 60.0
 
 
 async def test_events_and_metrics() -> None:
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.5, 2.5, "Hello, how are you?", stt_delay=0.2)  # EOU at 2.5+0.5=3.0s
     actions.add_llm("I'm doing well, thank you!", ttft=0.1, duration=0.3)
@@ -164,7 +164,7 @@ async def test_events_and_metrics() -> None:
 
 
 async def test_tool_call() -> None:
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.5, 2.5, "What's the weather in Tokyo?")
     actions.add_llm(
@@ -245,7 +245,7 @@ async def test_tool_call() -> None:
 async def test_interruption(
     resume_false_interruption: bool, expected_interruption_time: float
 ) -> None:
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.5, 2.5, "Tell me a story.")
     actions.add_llm("Here is a long story for you ... the end.")
@@ -296,7 +296,7 @@ async def test_interruption(
 
 
 async def test_interruption_options() -> None:
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.5, 2.5, "Tell me a story.")
     actions.add_llm("Here is a long story for you ... the end.")
@@ -337,7 +337,7 @@ async def test_interruption_options() -> None:
 
 
 async def test_interruption_by_text_input() -> None:
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.5, 2.5, "Tell me a story.")
     actions.add_llm("Here is a long story for you ... the end.")
@@ -359,7 +359,7 @@ async def test_interruption_by_text_input() -> None:
 
     asyncio.get_event_loop().call_later(5 / speed, fake_text_input)
 
-    await asyncio.wait_for(run_session(session, agent, drain_delay=0.5), timeout=SESSION_TIMEOUT)
+    await asyncio.wait_for(run_session(session, agent), timeout=SESSION_TIMEOUT)
 
     assert len(playback_finished_events) == 2
     assert playback_finished_events[0].interrupted is True
@@ -403,7 +403,7 @@ async def test_interruption_by_text_input() -> None:
 async def test_interruption_before_speaking(
     resume_false_interruption: bool, expected_interruption_time: float
 ) -> None:
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.5, 2.5, "Tell me a story.")
     actions.add_llm("Here is a long story for you ... the end.", duration=1.0)
@@ -457,7 +457,7 @@ async def test_interrupt_before_speaking_with_pausable_audio() -> None:
     User turn starting while the agent is ``thinking`` must pause the
     pausable output so the stale reply never promotes to ``speaking``.
     """
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.5, 2.5, "Tell me a story.")
     actions.add_llm("Here is a long story for you ... the end.", duration=1.0)
@@ -510,7 +510,7 @@ async def test_false_interruption_before_speaking_resumes() -> None:
     Brief VAD-only noise during ``thinking`` must pause then resume on VAD EOS,
     letting the stale reply play through normally.
     """
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.5, 2.5, "Tell me a story.")
     actions.add_llm("Here is a short reply.", ttft=0.05, duration=0.05)
@@ -547,7 +547,7 @@ async def test_generate_reply() -> None:
     """
     Test `generate_reply` in `on_enter` and tool call, `say` in `on_user_turn_completed`
     """
-    speed = 5.0
+    speed = 1
 
     actions = FakeActions()
     # llm and tts response for generate_reply() and say()
@@ -575,9 +575,7 @@ async def test_generate_reply() -> None:
     session.on("function_tools_executed", tool_executed_events.append)
     session.output.audio.on("playback_finished", playback_finished_events.append)
 
-    t_origin = await asyncio.wait_for(
-        run_session(session, agent, drain_delay=0.5), timeout=SESSION_TIMEOUT
-    )
+    t_origin = await asyncio.wait_for(run_session(session, agent), timeout=SESSION_TIMEOUT)
 
     # playback_finished
     assert len(playback_finished_events) == 3
@@ -645,7 +643,7 @@ async def test_aec_warmup() -> None:
     The interruption is delayed to 5.5s (EOU: speech end 5.0 + 0.5 endpointing delay)
     because FakeSTT is timer-based and still produces transcripts during warmup.
     """
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.5, 2.5, "Tell me a story.")
     actions.add_llm("Here is a long story for you ... the end.")
@@ -687,7 +685,7 @@ async def test_start_boundary_does_not_block_vad_interruption() -> None:
     This validates that the backchannel_boundary config is properly handled and doesn't
     regress normal interruption behavior.
     """
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.5, 2.5, "Tell me a story.")
     actions.add_llm("Here is a long story for you ... the end.")
@@ -984,7 +982,7 @@ async def test_force_flush_held_transcripts_emits_buffered_events() -> None:
     ],
 )
 async def test_preemptive_generation(preemptive_generation: dict, expected_latency: float) -> None:
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.5, 2.0, "Hello, how are you?", stt_delay=0.1)
     actions.add_llm("I'm doing great, thank you!", ttft=0.1, duration=0.3)
@@ -1042,7 +1040,7 @@ async def test_interrupt_during_on_user_turn_completed(
     """
     Test interrupt during preemptive generation and on_user_turn_completed.
     """
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.5, 2.0, "Tell me a story", stt_delay=0.2)
     actions.add_llm("Here is a story for you...", ttft=0.1, duration=0.3)
@@ -1063,7 +1061,7 @@ async def test_interrupt_during_on_user_turn_completed(
     session.on("agent_state_changed", agent_state_events.append)
     session.on("conversation_item_added", conversation_events.append)
 
-    await asyncio.wait_for(run_session(session, agent, drain_delay=1.0), timeout=SESSION_TIMEOUT)
+    await asyncio.wait_for(run_session(session, agent), timeout=SESSION_TIMEOUT)
 
     assert agent_state_events[0].old_state == "initializing"
     assert agent_state_events[0].new_state == "listening"
@@ -1095,7 +1093,7 @@ async def test_interrupt_during_on_user_turn_completed(
 
 
 async def test_unknown_function_call() -> None:
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.5, 2.5, "Check the weather")
     actions.add_llm(
@@ -1141,7 +1139,7 @@ async def test_invalid_tool_arguments_surface_as_tool_error() -> None:
     stripped from the conversation. Instead the schema error is wrapped in a
     ToolError so the model receives a descriptive message and can self-correct
     on the next turn."""
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.5, 2.5, "What's the weather?")
     # get_weather requires `location: str` — emit a call with no args so it
@@ -1204,7 +1202,7 @@ async def test_tool_internal_exception_returns_generic_error() -> None:
             """Always blows up."""
             raise RuntimeError("kaboom: secret database password leaked")
 
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.5, 2.5, "What's the weather in Tokyo?")
     actions.add_llm(
@@ -1341,7 +1339,7 @@ def check_timestamp(
 
 
 async def test_silent_tool_call_pause_state_does_not_leak_into_tool_reply() -> None:
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.1, 0.2, "What's the weather in Tokyo?", stt_delay=0.05)
 
@@ -1418,7 +1416,7 @@ class FlushMultiSegmentAgent(Agent):
 
 
 async def test_pipeline_multi_segment_flush() -> None:
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.5, 2.5, "Hello, how are you?", stt_delay=0.2)
     # the agent's llm_node injects a FlushSentinel, splitting the reply into two
@@ -1447,7 +1445,7 @@ async def test_pipeline_multi_segment_flush() -> None:
 
 
 async def test_pipeline_multi_segment_interrupted() -> None:
-    speed = 5.0
+    speed = 1
     actions = FakeActions()
     actions.add_user_speech(0.5, 2.5, "Hello, how are you?", stt_delay=0.2)
     # long first segment so the interrupt lands while it is still playing

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -488,6 +488,27 @@ def _create_proc(
     return proc, start_args
 
 
+async def test_aclose_after_cancelled_start():
+    """When start() is cancelled mid-flight, the shielded _start() keeps running;
+    aclose() must still tear down the supervise task and the child process."""
+    mp_ctx = mp.get_context("spawn")
+    proc, _ = _create_proc(close_timeout=10.0, mp_ctx=mp_ctx)
+
+    start_task = asyncio.create_task(proc.start())
+    await asyncio.sleep(0)  # let start() enter the shielded _start()
+    start_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await start_task
+
+    # mimics ProcPool._proc_spawn_task's cleanup after swallowing the cancellation
+    await proc.aclose()
+
+    assert proc._supervise_atask is not None, "start() should have completed under the shield"
+    assert proc._supervise_atask.done()
+    assert proc.pid is not None
+    assert not psutil.pid_exists(proc.pid)
+
+
 async def test_shutdown_no_job():
     mp_ctx = mp.get_context("spawn")
     proc, start_args = _create_proc(close_timeout=10.0, mp_ctx=mp_ctx)


### PR DESCRIPTION
## Summary

`test_slow_initialization` [flakes on CI](https://github.com/livekit/agents/actions/runs/27320364739/job/80709911381) with a leaked `ProcJobExecutor._supervise_task` at teardown. The root cause is a real shutdown race in `SupervisedProc`, not a test issue.

When the owning task (e.g. `ProcPool._proc_spawn_task` during pool close) is cancelled while awaiting `start()`, the shielded `_start()` keeps running and creates the supervise task afterwards. The cleanup path then calls `aclose()`, which no-ops because the proc isn't marked started yet — leaking the supervise task and the child process. The orphaned child blocks forever waiting for `InitializeRequest`, and its non-daemon join thread can hang worker shutdown indefinitely.

## Changes

- `start()` keeps a handle on the shielded `_start()` task; `aclose()` waits for it before checking `started`, so an abandoned start can't race past the check.
- `aclose()` kills a never-initialized process instead of attempting a graceful shutdown: the child reads `InitializeRequest` before servicing any other message, so a `ShutdownRequest` could never be acked.
- `kill()` resolves a pending `_initialize_fut` so the supervise task (which waits on it before supervising) can observe the process exit.
- Added `test_aclose_after_cancelled_start`, which deterministically reproduces the leak (fails the leaked-tasks check and hangs pytest exit without the fix).

nit: Also sets the agent session tests to `speed = 1` and raises the default `drain_delay` — they run under virtual time, so the speed factor no longer buys wall-clock time.