### PR TITLE
(sarvam stt): fix end of speech timing

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -921,6 +921,12 @@ class SpeechStream(stt.SpeechStream):
 
         self._audio_position = 0.0
         self._utterance_start_audio_pos = 0.0
+        # Authoritative speech-end (audio-stream seconds) as measured by Sarvam:
+        # the END_SPEECH `occured_at` or the transcript `speech_end`. Preferred
+        # for all timing.
+        self._utterance_server_speech_end: float | None = None
+        # Fallback only: the send clock at END_SPEECH. Biased high (it counts audio
+        # uploaded, not processed), so used only when Sarvam gives no usable time.
         self._utterance_speech_end_audio_pos: float | None = None
         self._utterance_speech_start_wall: float | None = None
         self._utterance_speech_end_wall: float | None = None
@@ -992,11 +998,53 @@ class SpeechStream(stt.SpeechStream):
             return None
         return float(value)
 
+    def _interpret_signal_time(self, value: object) -> float | None:
+        """Interpret an END_SPEECH ``occured_at`` as audio-stream seconds.
+
+        Sarvam stamps each VAD signal with ``occured_at`` but does not document
+        its unit, so we accept it only when it lands within a sane window around
+        the audio we have actually streamed for this utterance. Anything outside
+        that range (a wall-clock epoch, milliseconds, a stale value, ...) is
+        rejected so the caller falls back to the local send clock instead of
+        emitting a nonsensical timestamp.
+        """
+        t = self._positive_time(value)
+        if t is None:
+            return None
+        lower = self._utterance_start_audio_pos - 1.0
+        upper = self._audio_position + 1.0  # margin for send/flush granularity
+        if lower <= t <= upper:
+            return t
+        self._logger.debug(
+            "Ignoring out-of-range END_SPEECH occured_at; using send-clock fallback",
+            extra={
+                **self._build_log_context(),
+                "occured_at": t,
+                "utterance_start_audio_pos": self._utterance_start_audio_pos,
+                "audio_position": self._audio_position,
+            },
+        )
+        return None
+
+    def _resolved_speech_end(self) -> float | None:
+        """Best speech-end time, in the audio-stream timeline.
+
+        Prefers Sarvam's authoritative value (END_SPEECH ``occured_at`` or the
+        transcript ``speech_end``); falls back to the local send clock only when
+        the server gave us nothing usable. The fallback counts audio *uploaded*
+        rather than *processed*, so it runs ahead of the true acoustic end and
+        must never override a real server value.
+        """
+        if self._utterance_server_speech_end is not None:
+            return self._utterance_server_speech_end
+        return self._utterance_speech_end_audio_pos
+
     def _reset_utterance_state(self) -> None:
         self._cancel_eos_fallback()
         self._pending_final_data = None
         self._pending_eos = False
         self._utterance_start_audio_pos = self._audio_position
+        self._utterance_server_speech_end = None
         self._utterance_speech_end_audio_pos = None
         self._utterance_speech_start_wall = time.time()
         self._utterance_speech_end_wall = None
@@ -1026,8 +1074,7 @@ class SpeechStream(stt.SpeechStream):
             or self._utterance_start_audio_pos
         )
         end_time = (
-            self._positive_time(transcript_data.get("speech_end"))
-            or self._utterance_speech_end_audio_pos
+            self._positive_time(transcript_data.get("speech_end")) or self._resolved_speech_end()
         )
         if end_time is None:
             if require_end_time:
@@ -1053,7 +1100,7 @@ class SpeechStream(stt.SpeechStream):
     def _try_commit_utterance(self) -> None:
         if (
             self._pending_final_data is None
-            or self._utterance_speech_end_audio_pos is None
+            or self._resolved_speech_end() is None
             or self._eos_emitted_for_utterance
         ):
             return
@@ -1064,7 +1111,7 @@ class SpeechStream(stt.SpeechStream):
                 "Sarvam STT utterance committed",
                 extra={
                     **self._build_log_context(),
-                    "end_time": self._utterance_speech_end_audio_pos,
+                    "end_time": self._resolved_speech_end(),
                     "speech_end_wall_time": self._utterance_speech_end_wall,
                 },
             )
@@ -1078,11 +1125,13 @@ class SpeechStream(stt.SpeechStream):
         self._cancel_eos_fallback()
 
         alternatives: list[stt.SpeechData] = []
-        if self._utterance_speech_end_audio_pos is not None:
+        resolved_end = self._resolved_speech_end()
+        if resolved_end is not None:
             # The empty SpeechData alternative is metadata-only. Sarvam's internal VAD
-            # provides the authoritative speech-end time separately from the transcript, and
-            # AudioRecognition uses this end_time to compute EOU latency metrics when using
-            # STT-based turn detection without an external VAD.
+            # provides the authoritative speech-end time (END_SPEECH `occured_at` or
+            # transcript `speech_end`); AudioRecognition uses this end_time to compute
+            # EOU latency metrics when using STT-based turn detection without an
+            # external VAD.
             metadata: dict[str, Any] = {}
             if self._utterance_speech_end_wall is not None:
                 metadata["speech_end_wall_time"] = self._utterance_speech_end_wall
@@ -1090,7 +1139,7 @@ class SpeechStream(stt.SpeechStream):
                 stt.SpeechData(
                     language=LanguageCode(self._opts.language),
                     text="",
-                    end_time=self._utterance_speech_end_audio_pos,
+                    end_time=resolved_end,
                     metadata=metadata or None,
                 )
             )
@@ -1649,10 +1698,13 @@ class SpeechStream(stt.SpeechStream):
             )
             self._event_ch.send_nowait(usage_event)
 
+            # Capture the server's authoritative speech-end. First positive value
+            # wins; the local send clock must never overwrite it.
             transcript_end_time = self._positive_time(transcript_data.get("speech_end"))
-            if transcript_end_time is not None and self._utterance_speech_end_audio_pos is None:
-                self._utterance_speech_end_audio_pos = transcript_end_time
-                self._utterance_speech_end_wall = time.time()
+            if transcript_end_time is not None and self._utterance_server_speech_end is None:
+                self._utterance_server_speech_end = transcript_end_time
+                if self._utterance_speech_end_wall is None:
+                    self._utterance_speech_end_wall = time.time()
 
             if self._pending_eos:
                 self._pending_final_data = transcript_data
@@ -1716,8 +1768,15 @@ class SpeechStream(stt.SpeechStream):
             elif signal_type == "END_SPEECH":
                 if self._speaking:
                     self._speaking = False
+                    # Sarvam stamps the VAD signal with `occured_at`; when it is a
+                    # usable audio-relative time, treat it as authoritative. The send
+                    # clock is only a fallback (it runs ahead of processed audio).
+                    server_end = self._interpret_signal_time(event_data.get("occured_at"))
+                    if server_end is not None and self._utterance_server_speech_end is None:
+                        self._utterance_server_speech_end = server_end
                     self._utterance_speech_end_audio_pos = self._audio_position
-                    self._utterance_speech_end_wall = time.time()
+                    if self._utterance_speech_end_wall is None:
+                        self._utterance_speech_end_wall = time.time()
                     self._pending_eos = True
                     self._try_commit_utterance()
                     if not self._eos_emitted_for_utterance and self._pending_final_data is None:

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -919,17 +919,7 @@ class SpeechStream(stt.SpeechStream):
         )
         self._should_flush = False  # Flag to trigger flush
 
-        self._audio_position = 0.0
-        self._utterance_start_audio_pos = 0.0
-        # Authoritative speech-end (audio-stream seconds) as measured by Sarvam:
-        # the END_SPEECH `occured_at` or the transcript `speech_end`. Preferred
-        # for all timing.
-        self._utterance_server_speech_end: float | None = None
-        # Fallback only: the send clock at END_SPEECH. Biased high (it counts audio
-        # uploaded, not processed), so used only when Sarvam gives no usable time.
-        self._utterance_speech_end_audio_pos: float | None = None
         self._utterance_speech_start_wall: float | None = None
-        self._utterance_speech_end_wall: float | None = None
         self._pending_final_data: dict[str, Any] | None = None
         self._pending_eos = False
         self._eos_fallback_task: asyncio.Task[None] | None = None
@@ -998,56 +988,11 @@ class SpeechStream(stt.SpeechStream):
             return None
         return float(value)
 
-    def _interpret_signal_time(self, value: object) -> float | None:
-        """Interpret an END_SPEECH ``occured_at`` as audio-stream seconds.
-
-        Sarvam stamps each VAD signal with ``occured_at`` but does not document
-        its unit, so we accept it only when it lands within a sane window around
-        the audio we have actually streamed for this utterance. Anything outside
-        that range (a wall-clock epoch, milliseconds, a stale value, ...) is
-        rejected so the caller falls back to the local send clock instead of
-        emitting a nonsensical timestamp.
-        """
-        t = self._positive_time(value)
-        if t is None:
-            return None
-        lower = self._utterance_start_audio_pos - 1.0
-        upper = self._audio_position + 1.0  # margin for send/flush granularity
-        if lower <= t <= upper:
-            return t
-        self._logger.debug(
-            "Ignoring out-of-range END_SPEECH occured_at; using send-clock fallback",
-            extra={
-                **self._build_log_context(),
-                "occured_at": t,
-                "utterance_start_audio_pos": self._utterance_start_audio_pos,
-                "audio_position": self._audio_position,
-            },
-        )
-        return None
-
-    def _resolved_speech_end(self) -> float | None:
-        """Best speech-end time, in the audio-stream timeline.
-
-        Prefers Sarvam's authoritative value (END_SPEECH ``occured_at`` or the
-        transcript ``speech_end``); falls back to the local send clock only when
-        the server gave us nothing usable. The fallback counts audio *uploaded*
-        rather than *processed*, so it runs ahead of the true acoustic end and
-        must never override a real server value.
-        """
-        if self._utterance_server_speech_end is not None:
-            return self._utterance_server_speech_end
-        return self._utterance_speech_end_audio_pos
-
     def _reset_utterance_state(self) -> None:
         self._cancel_eos_fallback()
         self._pending_final_data = None
         self._pending_eos = False
-        self._utterance_start_audio_pos = self._audio_position
-        self._utterance_server_speech_end = None
-        self._utterance_speech_end_audio_pos = None
         self._utterance_speech_start_wall = time.time()
-        self._utterance_speech_end_wall = None
         self._final_received_for_utterance = False
         self._eos_emitted_for_utterance = False
 
@@ -1060,32 +1005,21 @@ class SpeechStream(stt.SpeechStream):
             return fallback_task
         return None
 
-    def _send_final_transcript(
-        self, transcript_data: dict[str, Any], *, require_end_time: bool = False
-    ) -> bool:
+    def _send_final_transcript(self, transcript_data: dict[str, Any]) -> bool:
         transcript_text = transcript_data.get("transcript", "")
         if not transcript_text:
             return False
 
         language = LanguageCode(transcript_data.get("language_code", ""))
         request_id = transcript_data.get("request_id") or self._server_request_id or ""
-        start_time = (
-            self._positive_time(transcript_data.get("speech_start"))
-            or self._utterance_start_audio_pos
-        )
-        end_time = (
-            self._positive_time(transcript_data.get("speech_end")) or self._resolved_speech_end()
-        )
-        if end_time is None:
-            if require_end_time:
-                return False
-            end_time = 0.0
-
+        # Streaming reports timing via speech_start/speech_end (the batch
+        # `timestamps` array is not sent over the socket). When absent, end_time
+        # is 0.0 and the pipeline falls back to wall-clock for EOU timing.
         speech_data = stt.SpeechData(
             language=language,
             text=transcript_text,
-            start_time=start_time,
-            end_time=end_time,
+            start_time=self._positive_time(transcript_data.get("speech_start")) or 0.0,
+            end_time=self._positive_time(transcript_data.get("speech_end")) or 0.0,
             confidence=_extract_confidence(transcript_data, self._logger),
         )
         self._event_ch.send_nowait(
@@ -1098,23 +1032,13 @@ class SpeechStream(stt.SpeechStream):
         return True
 
     def _try_commit_utterance(self) -> None:
-        if (
-            self._pending_final_data is None
-            or self._resolved_speech_end() is None
-            or self._eos_emitted_for_utterance
-        ):
+        # Flush in order: FINAL_TRANSCRIPT first, then END_OF_SPEECH.
+        if self._pending_final_data is None or self._eos_emitted_for_utterance:
             return
 
         committed_data = self._pending_final_data
-        if self._send_final_transcript(committed_data, require_end_time=True):
-            self._logger.debug(
-                "Sarvam STT utterance committed",
-                extra={
-                    **self._build_log_context(),
-                    "end_time": self._resolved_speech_end(),
-                    "speech_end_wall_time": self._utterance_speech_end_wall,
-                },
-            )
+        if self._send_final_transcript(committed_data):
+            self._logger.debug("Sarvam STT utterance committed", extra=self._build_log_context())
             self._emit_end_of_speech()
             self._pending_final_data = None
 
@@ -1124,31 +1048,12 @@ class SpeechStream(stt.SpeechStream):
 
         self._cancel_eos_fallback()
 
-        alternatives: list[stt.SpeechData] = []
-        resolved_end = self._resolved_speech_end()
-        if resolved_end is not None:
-            # The empty SpeechData alternative is metadata-only. Sarvam's internal VAD
-            # provides the authoritative speech-end time (END_SPEECH `occured_at` or
-            # transcript `speech_end`); AudioRecognition uses this end_time to compute
-            # EOU latency metrics when using STT-based turn detection without an
-            # external VAD.
-            metadata: dict[str, Any] = {}
-            if self._utterance_speech_end_wall is not None:
-                metadata["speech_end_wall_time"] = self._utterance_speech_end_wall
-            alternatives.append(
-                stt.SpeechData(
-                    language=LanguageCode(self._opts.language),
-                    text="",
-                    end_time=resolved_end,
-                    metadata=metadata or None,
-                )
-            )
-
+        # Bare END_OF_SPEECH (no alternatives), like other plugins' EOS events. The
+        # speech-end timing lives on the FINAL_TRANSCRIPT's end_time, not here.
         self._event_ch.send_nowait(
             stt.SpeechEvent(
                 type=stt.SpeechEventType.END_OF_SPEECH,
                 request_id=self._server_request_id or "",
-                alternatives=alternatives,
             )
         )
         self._eos_emitted_for_utterance = True
@@ -1463,7 +1368,6 @@ class SpeechStream(stt.SpeechStream):
 
                             await ws.send_str(json.dumps(audio_message))
                             chunks_sent += 1
-                            self._audio_position += chunk_size / self._opts.sample_rate
 
                             # Remove sent data from buffer
                             audio_buffer = audio_buffer[chunk_size:]
@@ -1698,14 +1602,6 @@ class SpeechStream(stt.SpeechStream):
             )
             self._event_ch.send_nowait(usage_event)
 
-            # Capture the server's authoritative speech-end. First positive value
-            # wins; the local send clock must never overwrite it.
-            transcript_end_time = self._positive_time(transcript_data.get("speech_end"))
-            if transcript_end_time is not None and self._utterance_server_speech_end is None:
-                self._utterance_server_speech_end = transcript_end_time
-                if self._utterance_speech_end_wall is None:
-                    self._utterance_speech_end_wall = time.time()
-
             if self._pending_eos:
                 self._pending_final_data = transcript_data
                 self._final_received_for_utterance = True
@@ -1768,15 +1664,6 @@ class SpeechStream(stt.SpeechStream):
             elif signal_type == "END_SPEECH":
                 if self._speaking:
                     self._speaking = False
-                    # Sarvam stamps the VAD signal with `occured_at`; when it is a
-                    # usable audio-relative time, treat it as authoritative. The send
-                    # clock is only a fallback (it runs ahead of processed audio).
-                    server_end = self._interpret_signal_time(event_data.get("occured_at"))
-                    if server_end is not None and self._utterance_server_speech_end is None:
-                        self._utterance_server_speech_end = server_end
-                    self._utterance_speech_end_audio_pos = self._audio_position
-                    if self._utterance_speech_end_wall is None:
-                        self._utterance_speech_end_wall = time.time()
                     self._pending_eos = True
                     self._try_commit_utterance()
                     if not self._eos_emitted_for_utterance and self._pending_final_data is None:

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -980,13 +980,14 @@ class SpeechStream(stt.SpeechStream):
         if request_id:
             self._server_request_id = str(request_id)
 
-    @staticmethod
-    def _positive_time(value: object) -> float | None:
+    def _positive_time(self, value: object) -> float | None:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             return None
         if value <= 0:
             return None
-        return float(value)
+        # Shift into the stream timeline so the value survives reconnects: the base
+        # class advances start_time_offset by the session start -> audio start delay.
+        return float(value) + self.start_time_offset
 
     def _reset_utterance_state(self) -> None:
         self._cancel_eos_fallback()

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py
@@ -30,6 +30,7 @@ def _make_stream_under_test(
     instance._should_flush = False  # type: ignore[attr-defined]
     instance._audio_position = audio_position  # type: ignore[attr-defined]
     instance._utterance_start_audio_pos = 0.0  # type: ignore[attr-defined]
+    instance._utterance_server_speech_end = None  # type: ignore[attr-defined]
     instance._utterance_speech_end_audio_pos = None  # type: ignore[attr-defined]
     instance._utterance_speech_start_wall = None  # type: ignore[attr-defined]
     instance._utterance_speech_end_wall = None  # type: ignore[attr-defined]
@@ -42,8 +43,11 @@ def _make_stream_under_test(
     return instance, captured
 
 
-def _event(signal_type: str) -> dict[str, Any]:
-    return {"type": "events", "data": {"signal_type": signal_type, "request_id": "req-test"}}
+def _event(signal_type: str, *, occured_at: float | None = None) -> dict[str, Any]:
+    data: dict[str, Any] = {"signal_type": signal_type, "request_id": "req-test"}
+    if occured_at is not None:
+        data["occured_at"] = occured_at
+    return {"type": "events", "data": data}
 
 
 def _ws_message(**transcript_overrides: Any) -> dict[str, Any]:
@@ -215,3 +219,47 @@ async def test_aclose_cancels_pending_eos_fallback(monkeypatch: pytest.MonkeyPat
 
     assert fallback_task.cancelled()
     assert not _events_of_type(captured, stt.SpeechEventType.END_OF_SPEECH)
+
+
+async def test_end_speech_prefers_occured_at_over_send_clock() -> None:
+    # Sarvam stamps END_SPEECH with the audio-relative time speech actually ended.
+    # That must win over the send clock, which runs ahead of processed audio.
+    instance, captured = _make_stream_under_test(audio_position=1.4)
+
+    await instance._handle_events(_event("START_SPEECH"))
+    await instance._handle_events(_event("END_SPEECH", occured_at=1.1))
+    await asyncio.sleep(0.05)
+
+    end_events = _events_of_type(captured, stt.SpeechEventType.END_OF_SPEECH)
+    assert len(end_events) == 1
+    assert end_events[0].alternatives[0].end_time == pytest.approx(1.1)
+
+
+async def test_end_speech_ignores_out_of_range_occured_at() -> None:
+    # A wall-clock epoch (or any value outside the streamed-audio window) is not a
+    # usable audio-relative offset, so we fall back to the send clock.
+    instance, captured = _make_stream_under_test(audio_position=1.4)
+
+    await instance._handle_events(_event("START_SPEECH"))
+    await instance._handle_events(_event("END_SPEECH", occured_at=1_700_000_000.0))
+    await asyncio.sleep(0.05)
+
+    end_events = _events_of_type(captured, stt.SpeechEventType.END_OF_SPEECH)
+    assert len(end_events) == 1
+    assert end_events[0].alternatives[0].end_time == pytest.approx(1.4)
+
+
+async def test_occured_at_authoritative_even_when_end_speech_first() -> None:
+    # END_SPEECH (with occured_at) arrives before the final transcript; the server
+    # time must drive both FINAL and EOS, never the send-clock fallback.
+    instance, captured = _make_stream_under_test(audio_position=1.25)
+
+    await instance._handle_events(_event("START_SPEECH"))
+    instance._audio_position = 1.4  # type: ignore[attr-defined]
+    await instance._handle_events(_event("END_SPEECH", occured_at=1.1))
+    await instance._handle_transcript_data(_ws_message(speech_start=0.0, speech_end=0.0))
+
+    final = _events_of_type(captured, stt.SpeechEventType.FINAL_TRANSCRIPT)[0]
+    end = _events_of_type(captured, stt.SpeechEventType.END_OF_SPEECH)[0]
+    assert final.alternatives[0].end_time == pytest.approx(1.1)
+    assert end.alternatives[0].end_time == pytest.approx(1.1)

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py
@@ -28,6 +28,7 @@ def _make_stream_under_test(
     instance._opts = SimpleNamespace(language="en-IN", sample_rate=16000)  # type: ignore[attr-defined]
     instance._speaking = False  # type: ignore[attr-defined]
     instance._should_flush = False  # type: ignore[attr-defined]
+    instance._start_time_offset = 0.0  # type: ignore[attr-defined]
     instance._utterance_speech_start_wall = None  # type: ignore[attr-defined]
     instance._pending_final_data = None  # type: ignore[attr-defined]
     instance._pending_eos = False  # type: ignore[attr-defined]
@@ -113,6 +114,20 @@ async def test_final_end_time_uses_speech_end_when_present() -> None:
     final = _events_of_type(captured, stt.SpeechEventType.FINAL_TRANSCRIPT)[0]
     assert final.alternatives[0].start_time == pytest.approx(0.5)
     assert final.alternatives[0].end_time == pytest.approx(1.7)
+
+
+async def test_final_timing_includes_start_time_offset() -> None:
+    # Provider times are stream-relative; the base class accrues start_time_offset
+    # across reconnects, so present speech_start/speech_end must be shifted by it.
+    instance, captured = _make_stream_under_test()
+    instance._start_time_offset = 2.0  # type: ignore[attr-defined]
+
+    await instance._handle_events(_event("START_SPEECH"))
+    await instance._handle_transcript_data(_ws_message(speech_start=0.5, speech_end=1.7))
+
+    final = _events_of_type(captured, stt.SpeechEventType.FINAL_TRANSCRIPT)[0]
+    assert final.alternatives[0].start_time == pytest.approx(2.5)
+    assert final.alternatives[0].end_time == pytest.approx(3.7)
 
 
 async def test_commit_order_final_before_eos() -> None:

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.unit
 
 
 def _make_stream_under_test(
-    *, audio_position: float = 1.25, eos_fallback_timeout: float = 0.01
+    *, eos_fallback_timeout: float = 0.01
 ) -> tuple[SpeechStream, list[Any]]:
     instance = SpeechStream.__new__(SpeechStream)
     captured: list[Any] = []
@@ -28,12 +28,7 @@ def _make_stream_under_test(
     instance._opts = SimpleNamespace(language="en-IN", sample_rate=16000)  # type: ignore[attr-defined]
     instance._speaking = False  # type: ignore[attr-defined]
     instance._should_flush = False  # type: ignore[attr-defined]
-    instance._audio_position = audio_position  # type: ignore[attr-defined]
-    instance._utterance_start_audio_pos = 0.0  # type: ignore[attr-defined]
-    instance._utterance_server_speech_end = None  # type: ignore[attr-defined]
-    instance._utterance_speech_end_audio_pos = None  # type: ignore[attr-defined]
     instance._utterance_speech_start_wall = None  # type: ignore[attr-defined]
-    instance._utterance_speech_end_wall = None  # type: ignore[attr-defined]
     instance._pending_final_data = None  # type: ignore[attr-defined]
     instance._pending_eos = False  # type: ignore[attr-defined]
     instance._eos_fallback_task = None  # type: ignore[attr-defined]
@@ -78,8 +73,9 @@ async def test_start_speech_sets_speech_start_time() -> None:
     assert start_events[0].request_id == "req-session"
 
 
-async def test_end_speech_emits_end_time_alternative() -> None:
-    instance, captured = _make_stream_under_test(audio_position=1.4)
+async def test_end_speech_emits_bare_end_of_speech() -> None:
+    # Like every other STT plugin, END_OF_SPEECH carries no alternatives/timing.
+    instance, captured = _make_stream_under_test()
 
     await instance._handle_events(_event("START_SPEECH"))
     await instance._handle_events(_event("END_SPEECH"))
@@ -87,28 +83,42 @@ async def test_end_speech_emits_end_time_alternative() -> None:
 
     end_events = _events_of_type(captured, stt.SpeechEventType.END_OF_SPEECH)
     assert len(end_events) == 1
-    assert end_events[0].alternatives[0].end_time == pytest.approx(1.4)
+    assert end_events[0].alternatives == []
     assert end_events[0].request_id == "req-session"
 
 
-async def test_final_uses_fallback_when_api_timing_zero() -> None:
-    instance, captured = _make_stream_under_test(audio_position=1.25)
+async def test_final_end_time_is_zero_when_provider_omits_timing() -> None:
+    # Sarvam streaming exposes no word timestamps and a null speech_end, so the
+    # canonical fallback is 0.0 (the voice pipeline then uses wall-clock), never a
+    # fabricated send-clock value.
+    instance, captured = _make_stream_under_test()
 
     await instance._handle_events(_event("START_SPEECH"))
-    instance._audio_position = 1.4  # type: ignore[attr-defined]
     await instance._handle_events(_event("END_SPEECH"))
     await instance._handle_transcript_data(_ws_message(speech_start=0.0, speech_end=0.0))
 
     final = _events_of_type(captured, stt.SpeechEventType.FINAL_TRANSCRIPT)[0]
-    assert final.alternatives[0].start_time == pytest.approx(1.25)
-    assert final.alternatives[0].end_time == pytest.approx(1.4)
+    assert final.alternatives[0].start_time == 0.0
+    assert final.alternatives[0].end_time == 0.0
+
+
+async def test_final_end_time_uses_speech_end_when_present() -> None:
+    # If Sarvam ever populates the documented speech_start/speech_end fields over
+    # the socket, they flow through to the final transcript's timing.
+    instance, captured = _make_stream_under_test()
+
+    await instance._handle_events(_event("START_SPEECH"))
+    await instance._handle_transcript_data(_ws_message(speech_start=0.5, speech_end=1.7))
+
+    final = _events_of_type(captured, stt.SpeechEventType.FINAL_TRANSCRIPT)[0]
+    assert final.alternatives[0].start_time == pytest.approx(0.5)
+    assert final.alternatives[0].end_time == pytest.approx(1.7)
 
 
 async def test_commit_order_final_before_eos() -> None:
-    instance, captured = _make_stream_under_test(audio_position=1.4)
+    instance, captured = _make_stream_under_test()
 
     await instance._handle_events(_event("START_SPEECH"))
-    instance._audio_position = 1.4  # type: ignore[attr-defined]
     await instance._handle_transcript_data(_ws_message())
     await instance._handle_events(_event("END_SPEECH"))
 
@@ -128,10 +138,9 @@ async def test_commit_order_final_before_eos() -> None:
 
 
 async def test_commit_order_final_before_eos_when_speech_end_arrives_first() -> None:
-    instance, captured = _make_stream_under_test(audio_position=1.25)
+    instance, captured = _make_stream_under_test()
 
     await instance._handle_events(_event("START_SPEECH"))
-    instance._audio_position = 1.4  # type: ignore[attr-defined]
     await instance._handle_events(_event("END_SPEECH"))
     await instance._handle_transcript_data(_ws_message())
 
@@ -151,10 +160,9 @@ async def test_commit_order_final_before_eos_when_speech_end_arrives_first() -> 
 
 
 async def test_late_transcript_after_eos_fallback_is_emitted_after_eos() -> None:
-    instance, captured = _make_stream_under_test(audio_position=1.25)
+    instance, captured = _make_stream_under_test()
 
     await instance._handle_events(_event("START_SPEECH"))
-    instance._audio_position = 1.4  # type: ignore[attr-defined]
     await instance._handle_events(_event("END_SPEECH"))
     await asyncio.sleep(0.05)
     await instance._handle_transcript_data(_ws_message())
@@ -221,45 +229,17 @@ async def test_aclose_cancels_pending_eos_fallback(monkeypatch: pytest.MonkeyPat
     assert not _events_of_type(captured, stt.SpeechEventType.END_OF_SPEECH)
 
 
-async def test_end_speech_prefers_occured_at_over_send_clock() -> None:
-    # Sarvam stamps END_SPEECH with the audio-relative time speech actually ended.
-    # That must win over the send clock, which runs ahead of processed audio.
-    instance, captured = _make_stream_under_test(audio_position=1.4)
-
-    await instance._handle_events(_event("START_SPEECH"))
-    await instance._handle_events(_event("END_SPEECH", occured_at=1.1))
-    await asyncio.sleep(0.05)
-
-    end_events = _events_of_type(captured, stt.SpeechEventType.END_OF_SPEECH)
-    assert len(end_events) == 1
-    assert end_events[0].alternatives[0].end_time == pytest.approx(1.1)
-
-
-async def test_end_speech_ignores_out_of_range_occured_at() -> None:
-    # A wall-clock epoch (or any value outside the streamed-audio window) is not a
-    # usable audio-relative offset, so we fall back to the send clock.
-    instance, captured = _make_stream_under_test(audio_position=1.4)
+async def test_occured_at_is_ignored() -> None:
+    # `occured_at` is a wall-clock epoch, not an audio-relative offset, so it is
+    # never used: EOS stays bare and the final's end_time falls back to 0.0, even
+    # when END_SPEECH arrives before the final transcript.
+    instance, captured = _make_stream_under_test()
 
     await instance._handle_events(_event("START_SPEECH"))
     await instance._handle_events(_event("END_SPEECH", occured_at=1_700_000_000.0))
-    await asyncio.sleep(0.05)
-
-    end_events = _events_of_type(captured, stt.SpeechEventType.END_OF_SPEECH)
-    assert len(end_events) == 1
-    assert end_events[0].alternatives[0].end_time == pytest.approx(1.4)
-
-
-async def test_occured_at_authoritative_even_when_end_speech_first() -> None:
-    # END_SPEECH (with occured_at) arrives before the final transcript; the server
-    # time must drive both FINAL and EOS, never the send-clock fallback.
-    instance, captured = _make_stream_under_test(audio_position=1.25)
-
-    await instance._handle_events(_event("START_SPEECH"))
-    instance._audio_position = 1.4  # type: ignore[attr-defined]
-    await instance._handle_events(_event("END_SPEECH", occured_at=1.1))
     await instance._handle_transcript_data(_ws_message(speech_start=0.0, speech_end=0.0))
 
     final = _events_of_type(captured, stt.SpeechEventType.FINAL_TRANSCRIPT)[0]
     end = _events_of_type(captured, stt.SpeechEventType.END_OF_SPEECH)[0]
-    assert final.alternatives[0].end_time == pytest.approx(1.1)
-    assert end.alternatives[0].end_time == pytest.approx(1.1)
+    assert final.alternatives[0].end_time == 0.0
+    assert end.alternatives == []


### PR DESCRIPTION
###   **Problem**

  The Sarvam streaming STT plugin tried to manufacture an audio-relative speech-end time from two sources that don't actually provide one:
  - The VAD END_SPEECH event's occured_at field — which logging proved is a wall-clock Unix epoch, not an audio-stream offset, so it was rejected 100% of the time by a range-check heuristic.
  - A local send-clock counter (_audio_position) that counts audio uploaded, not processed — biased and fabricated.

  Sarvam's streaming socket genuinely sends no usable word timing (no timestamps array; speech_start/speech_end come back null), so all this machinery produced misleading timestamps.

###   **Change**

  Aligned Sarvam with how every other STT plugin (Deepgram, AssemblyAI, Google, Azure…) handles this:

  1. END_OF_SPEECH is now emitted bare — no alternatives/end_time. Previously it carried an empty-text SpeechData with a fabricated end_time + unused speech_end_wall_time metadata.
  2. FINAL_TRANSCRIPT timing comes only from the provider — start_time/end_time read from speech_start/speech_end, falling back to 0.0. The voice pipeline then uses wall-clock for EOU timing (standard behavior for providers without streaming word timing).
  3. Deleted the dead machinery: _interpret_signal_time, _resolved_speech_end, the _audio_position send-clock (+ its hot-loop increment), _utterance_server_speech_end, _utterance_speech_end_audio_pos, _utterance_speech_end_wall, and the require_end_time param.

