### PR TITLE
fix(voice): scope audio forwarding playback_started listener to its own segment

### DIFF
--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -346,9 +346,18 @@ class _AudioOutput:
     """Future that will be set with the timestamp of the first frame's capture"""
 
     started_forwarding_at: float | None = None
+    has_captured_own_frame: bool = False
+    """Set once this forwarder has captured its own first frame onto the output."""
 
     def _resolve_first_frame_fut(self, ev: io.PlaybackStartedEvent) -> None:
-        if not self.first_frame_fut.done():
+        # The audio output is shared across overlapping segments. When a speech is
+        # interrupted, the scheduler immediately authorizes the next speech, so this
+        # forwarder can register its listener while the interrupted segment's teardown
+        # is still emitting playback_started on the same output. Only honor the event
+        # once this forwarder has captured its own first frame, so a stray event from
+        # another segment can't resolve our first_frame_fut prematurely (which would
+        # skip resampler creation and push an unresampled frame to the AudioSource).
+        if self.has_captured_own_frame and not self.first_frame_fut.done():
             self.first_frame_fut.set_result(ev.created_at)
 
 
@@ -395,6 +404,10 @@ async def _audio_forwarding_task(
                     output_rate=audio_output.sample_rate,
                     num_channels=frame.num_channels,
                 )
+
+            # Mark before capturing so the playback_started emitted synchronously
+            # inside the first capture_frame is attributed to this segment.
+            out.has_captured_own_frame = True
 
             if resampler:
                 for f in resampler.push(frame):


### PR DESCRIPTION
## Summary

Fixes an interruption-time crash where the interrupted speech and the new response speech got cross-wired through the shared audio output, raising `sample_rate and num_channels don't match` from `AudioSource.capture_frame` (accompanied by `playback finished before speech started` and `playback_finished called more times than playback segments were captured`).

### Root cause

When a speech is interrupted, the scheduler returns immediately and authorizes the **next** speech while the interrupted segment's reply is still tearing down (clear buffer / wait for playout) on the **shared** `audio_output`.

The new segment's audio forwarder registers its `playback_started` listener on that shared output before reading its first frame. A stray `playback_started` emitted by the interrupted segment's teardown then resolves the **new** segment's `first_frame_fut` prematurely. Because resampler creation is gated on `not first_frame_fut.done()`, the resampler is skipped and an unresampled frame (e.g. 16 kHz TTS) is pushed to a differently-configured `AudioSource`.

### Fix

Scope the listener to the segment: `_resolve_first_frame_fut` only resolves `first_frame_fut` after the forwarder has captured its **own** first frame (`has_captured_own_frame`). Stray events from an interrupted overlapping segment are ignored, so segments no longer cross-wire their first-frame / playback bookkeeping.

> Ported from the Node.js fix in `livekit/agents-js#1760`.

## Test plan

- [ ] Reproduce the interrupt scenario (interrupt the agent mid-reply, then send a new turn) and confirm no `sample_rate and num_channels don't match` error
- [ ] Existing voice/generation tests pass

Made with [Cursor](https://cursor.com)