### PR TITLE
fix(voice): no audio recording under text simulation, warn once on missing input speech

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -667,6 +667,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 record = job_ctx.job.enable_recording if job_ctx else False
 
             self._recording_options = _resolve_recording_options(record)  # type: ignore[arg-type]
+            if self._text_only:
+                # text simulations have no audio I/O, so there is nothing to record
+                self._recording_options["audio"] = False
 
             is_primary = True
             if job_ctx:

--- a/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
+++ b/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
@@ -308,6 +308,7 @@ class RecorderAudioInput(io.AudioInput):
         self.__acc_frames: list[rtc.AudioFrame] = []
         self.__started_time: None | float = None
         self.__padded: bool = False
+        self.__warned_no_speech: bool = False
 
     @property
     def started_wall_time(self) -> float | None:
@@ -338,10 +339,12 @@ class RecorderAudioInput(io.AudioInput):
         # we could pad with silence here with some fixed SR and channels,
         # but it's better for the user to know that this is happening
         elif pad_since and self.__started_time is None and not self.__padded and not frames:
-            logger.warning(
-                "input speech hasn't started yet, skipping silence padding, "
-                "recording may be inaccurate until the speech starts"
-            )
+            if not self.__warned_no_speech:
+                self.__warned_no_speech = True
+                logger.warning(
+                    "input speech hasn't started yet, skipping silence padding, "
+                    "recording may be inaccurate until the speech starts"
+                )
 
         return frames
 


### PR DESCRIPTION
Text simulations with `enable_recording: true` wire the audio recorder and then disable all audio I/O, so the recorder flush loop logs `input speech hasn't started yet, skipping silence padding` every few seconds for the whole job.

- `AgentSession.start`: drop `audio` from the recording options under a text simulation; there is no audio to record. Transcript/logs/traces recording is unchanged.
- `RecorderAudioInput.take_buf`: the missing-input-speech warning now fires once per input instead of on every flush, for the non-simulation cases where input speech is legitimately late.

🤖 Generated with [Claude Code](https://claude.com/claude-code)