### PR TITLE
fix(cli): handle rich logging with piped output

### DIFF
--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -302,7 +302,7 @@ class AgentsConsole:
             "logging.level.critical": Style(color="red", bold=True, reverse=True),
         }
         self.tag_width = 11
-        self.console = Console(theme=Theme(theme))
+        self.console = Console(theme=Theme(theme), force_terminal=True)
 
         self._apm = rtc.AudioProcessingModule(
             echo_cancellation=True,
@@ -838,8 +838,12 @@ class RichLoggingHandler(logging.Handler):
 
         # used to avoid rendering two same time
         self._last_time: Text | None = None
+        self._broken_pipe = False
 
     def emit(self, record: logging.LogRecord) -> None:
+        if self._broken_pipe:
+            return
+
         def middle_truncate(s: str, max_width: int) -> str:
             if len(s) <= max_width:
                 return s
@@ -953,6 +957,8 @@ class RichLoggingHandler(logging.Handler):
             if has_exc:
                 self._print_plain_traceback(record)
 
+        except (BrokenPipeError, SystemExit):
+            self._broken_pipe = True
         except Exception:
             self.handleError(record)
 

--- a/tests/test_cli_log_level.py
+++ b/tests/test_cli_log_level.py
@@ -198,3 +198,37 @@ class TestLogLevelValidation:
         result = runner.invoke(app, ["start"])
         assert result.exit_code == 0
         assert mock_run_worker.call_args.kwargs["args"].log_level == "ERROR"
+
+
+def test_agents_console_forces_terminal_colors():
+    from livekit.agents.cli.cli import AgentsConsole
+
+    console = AgentsConsole()
+    assert console.console.is_terminal is True
+
+
+def test_rich_logging_handler_suppresses_broken_pipe():
+    import logging
+
+    from livekit.agents.cli.cli import RichLoggingHandler
+
+    class BrokenConsole:
+        width = 80
+
+        def print(self, *args, **kwargs):
+            raise SystemExit(1)
+
+    class DummyAgentsConsole:
+        console = BrokenConsole()
+
+        def _render_tag(self, output, *, tag_width):
+            return output
+
+    handler = RichLoggingHandler(DummyAgentsConsole())
+    record = logging.LogRecord("test", logging.INFO, __file__, 1, "hello", (), None)
+
+    handler.emit(record)
+    assert handler._broken_pipe is True
+
+    # A follow-up log should be ignored instead of trying to write again.
+    handler.emit(record)


### PR DESCRIPTION
Fixes #4552

## Summary
- keep the CLI console in forced-terminal mode so colored logs are preserved when output is piped through tools like tee
- suppress Rich broken-pipe/SystemExit failures after the pipe closes so shutdown can continue cleanly
- add coverage for forced terminal colors and broken-pipe handling

## Testing
- uv run --group dev ruff check livekit-agents/livekit/agents/cli/cli.py tests/test_cli_log_level.py
- uv run --group dev pytest tests/test_cli_log_level.py -q