### PR TITLE
fix(voice): deadlock when session closes while awaiting an AgentTask

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -869,6 +869,10 @@ class AgentTask(Agent, Generic[TaskResult_T]):
         ):
             blocked_tasks.append(old_activity._on_enter_task)
 
+        # register before any await so a concurrent drain (e.g. session close)
+        # won't wait for tasks blocked on this handoff
+        old_activity._add_drain_blocked_tasks(blocked_tasks)
+
         if (
             task_info.function_call
             and isinstance(old_activity.llm, RealtimeModel)
@@ -948,7 +952,11 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                 except BaseException:
                     logger.exception("error in on_enter task of agent %s", self.id)
 
-            if session.current_agent != self:
+            if session._closing and self._activity is None:
+                # the activity never started (session closing), skip the handoff;
+                # the close path owns the previous activity
+                pass
+            elif session.current_agent != self:
                 logger.warning(
                     f"{self.__class__.__name__} completed, but the agent has changed in the meantime. "
                     "Ignoring handoff to the previous agent, likely due to `AgentSession.update_agent` being invoked."

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -184,7 +184,7 @@ class AgentActivity(RecognitionHooks):
         self._authorization_allowed = asyncio.Event()
         self._authorization_allowed.set()
 
-        self._drain_blocked_tasks: list[asyncio.Task[Any]] = []
+        self._drain_blocked_tasks: set[asyncio.Task[Any]] = set()
         self._mcp_tools: list[mcp.MCPToolset] = []
 
         # activity-scoped executor: cancels cancellable tools / awaits the rest on drain,
@@ -904,7 +904,8 @@ class AgentActivity(RecognitionHooks):
             return
 
         self._scheduling_paused = True
-        self._drain_blocked_tasks = blocked_tasks or []
+        if blocked_tasks:
+            self._add_drain_blocked_tasks(blocked_tasks)
         self._wake_up_scheduling_task()
 
         if self._scheduling_atask is not None:
@@ -912,6 +913,12 @@ class AgentActivity(RecognitionHooks):
             # This means that even if the SpeechHandle themselves have finished,
             # we still wait for the entire execution (e.g function_tools)
             await asyncio.shield(self._scheduling_atask)
+
+    def _add_drain_blocked_tasks(self, tasks: list[asyncio.Task[Any]]) -> None:
+        # tasks blocked on an agent handoff are excluded from the drain wait,
+        # otherwise drain would wait for them while the handoff waits for drain's lock
+        self._drain_blocked_tasks.update(tasks)
+        self._wake_up_scheduling_task()
 
     async def _resume_scheduling_task(self) -> None:
         assert self._lock.locked(), "_finalize_main_task should only be used when locked."
@@ -921,6 +928,7 @@ class AgentActivity(RecognitionHooks):
 
         self._scheduling_paused = False
         self._new_turns_blocked = False
+        self._drain_blocked_tasks.clear()
         self._scheduling_atask = asyncio.create_task(
             self._scheduling_task(), name="_scheduling_task"
         )
@@ -955,6 +963,10 @@ class AgentActivity(RecognitionHooks):
 
         # When resuming, the AgentSession.update_agent must use the same AgentActivity instance!
         async with self._lock:
+            if self._closed:
+                # already closed by the session close
+                return None
+
             span = tracer.start_span(
                 "pause_agent_activity",
                 attributes={trace_types.ATTR_AGENT_LABEL: self._agent.label},

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1410,6 +1410,13 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         wait_on_enter: bool = True,
     ) -> None:
         async with self._activity_lock:
+            if self._closing and new_activity == "start":
+                # checked again after the drain below: closing may start while it's in flight
+                logger.warning(
+                    f"session is closing, skipping start activity of agent {agent.id}",
+                )
+                return
+
             # _update_activity is called directly sometimes, update for redundancy
             self._agent = agent
 

--- a/tests/test_agent_task_close_race.py
+++ b/tests/test_agent_task_close_race.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from livekit.agents import Agent, AgentSession, AgentTask
+from livekit.agents.llm import ToolError
+
+from .fake_llm import FakeLLM
+
+pytestmark = [pytest.mark.unit, pytest.mark.no_concurrent]
+
+
+class _SimpleTask(AgentTask):
+    def __init__(self) -> None:
+        super().__init__(instructions="simple task")
+
+
+class _ParentAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(instructions="parent agent")
+        self.entered = asyncio.Event()
+        self.exit_started = asyncio.Event()
+        self.task_error: BaseException | None = None
+
+    async def on_enter(self) -> None:
+        self.entered.set()
+        # hold on_enter until the session close has started draining this activity
+        # (on_exit runs inside drain() while it holds the activity lock), reproducing
+        # a participant disconnect racing `await AgentTask()`
+        await self.exit_started.wait()
+        try:
+            await _SimpleTask()
+        except ToolError as e:
+            self.task_error = e
+
+    async def on_exit(self) -> None:
+        self.exit_started.set()
+
+
+@pytest.mark.asyncio
+async def test_aclose_while_on_enter_awaits_agent_task() -> None:
+    """Closing the session while on_enter awaits an AgentTask must not deadlock:
+    drain() waits for the on_enter task, which waits for the activity handoff,
+    which waits for the activity lock held by drain()."""
+    session = AgentSession(llm=FakeLLM())
+    agent = _ParentAgent()
+    await session.start(agent)
+    await asyncio.wait_for(agent.entered.wait(), timeout=5.0)
+
+    await asyncio.wait_for(session.aclose(), timeout=10.0)
+
+    assert isinstance(agent.task_error, ToolError)


### PR DESCRIPTION
Fixes a deadlock where the session never closes when a participant disconnects while `on_enter` (or a function tool) is about to `await AgentTask()` — `AgentSession.aclose()` then times out after 60s. Reported in https://community.livekit.io/t/solved-session-never-closes-when-participant-disconnects-before-agenttask/1411.

**Root cause**

`aclose()` drains the current activity while holding the activity lock and waits for all speech tasks, including the `on_enter` task. Meanwhile the `AgentTask` handoff calls `pause()` on the same activity, which blocks on that lock — a circular wait: drain → scheduling task → on_enter → drain's lock. The existing `blocked_tasks` mechanism was designed to break exactly this edge, but it was only threaded as an argument through `pause()`, so a drain initiated by the session close never knew about the blocked tasks.

**Fix**

- `AgentTask.__await_impl` now registers the handoff-blocked tasks on the old activity (`_add_drain_blocked_tasks`, before any await), so any drain — including one initiated by the session close — excludes them from its wait. `_drain_blocked_tasks` is now a set; `_pause_scheduling_task` merges into it instead of overwriting, and it's cleared on resume.
- `_update_activity` bails out early when the session is closing instead of pausing the previous activity for a handoff that will be skipped anyway.
- `AgentTask.__await_impl` skips the parent handoff in its `finally` when the activity never started due to the close, instead of resuming the parent activity mid-close.
- `pause()` returns early on an already-closed activity.

The `AgentTask` now completes with the existing `ToolError("activity doesn't start ...")` and the session closes promptly. Added a regression test that deterministically reproduces the race (it deadlocks without the fix).