### PR TITLE
fix(ipc): report actual consumed memory instead of RSS

### DIFF
--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -127,6 +127,7 @@ class SupervisedProc(ABC):
         self._memory_baseline_mb: float | None = None
         self._last_memory_warn_time: float = 0.0
         self._last_memory_warn_mb: float = 0.0
+        self._psutil_process: psutil.Process | None = None
 
         self._start_atask: asyncio.Task[None] | None = None
         self._supervise_atask: asyncio.Task[None] | None = None
@@ -547,11 +548,13 @@ class SupervisedProc(ABC):
             return True
         return False
 
-    def _memory_logging_extra(self, memory_mb: float) -> dict[str, Any]:
+    def _memory_logging_extra(self, memory_mb: float, memory_metric: str) -> dict[str, Any]:
         """Diagnostic context for the memory logs: tells a process that started
-        heavy from one that grew over time (uptime, baseline RSS, growth)."""
+        heavy from one that grew over time (uptime, baseline, growth). memory_metric
+        records which footprint metric the number reflects (pss/uss/rss)."""
         extra: dict[str, Any] = {
             "memory_usage_mb": round(memory_mb, 1),
+            "memory_metric": memory_metric,
             "memory_warn_mb": self._opts.memory_warn_mb,
             "memory_limit_mb": self._opts.memory_limit_mb,
             "uptime": round(self.uptime, 1),
@@ -564,6 +567,36 @@ class SupervisedProc(ABC):
         extra.update(self.logging_extra())
         return extra
 
+    def _sample_memory_mb(self) -> tuple[float, str]:
+        """Real footprint of the process, preferring metrics that don't
+        double-count shared pages. RSS counts copy-on-write pages inherited
+        from the forkserver and file-backed library pages at memory_info weight, so it
+        overstates what the process actually consumes and oversums across
+        processes. PSS (proportional, Linux only) divides shared pages among
+        their sharers and sums correctly to physical use; USS (private only) is
+        the cross-platform fallback since psutil exposes no PSS on macOS/Windows.
+        RSS is a last resort if the extended metrics are unavailable.
+
+        Synchronous and blocking: the PSS/USS path walks the target process's
+        page tables in the kernel, which scales with its mapping count and is
+        ~ms for a large child. Run via run_in_executor so that walk overlaps
+        with the event loop rather than stalling it (the read syscall releases
+        the GIL, so the offload pays off even on a single core)."""
+        process = self._psutil_process
+        if process is None:
+            process = self._psutil_process = psutil.Process(self._pid)
+
+        try:
+            memory_info: Any = process.memory_full_info()
+        except (psutil.AccessDenied, NotImplementedError):
+            memory_info = process.memory_info()
+
+        for metric in "pss", "uss", "rss":
+            if memory_bytes := getattr(memory_info, metric, 0):
+                return memory_bytes / (1024 * 1024), metric
+
+        return 0, "unknown"
+
     @log_exceptions(logger=logger)
     async def _memory_monitor_task(self) -> None:
         """Monitor memory usage and kill the process if it exceeds the limit."""
@@ -573,10 +606,9 @@ class SupervisedProc(ABC):
                     await asyncio.sleep(_MEMORY_MONITOR_INTERVAL)
                     continue
 
-                # get process memory info
-                process = psutil.Process(self._pid)
-                memory_info = process.memory_info()
-                memory_mb = memory_info.rss / (1024 * 1024)  # Convert to MB
+                memory_mb, memory_metric = await self._loop.run_in_executor(
+                    None, self._sample_memory_mb
+                )
 
                 # the first sample (taken shortly after initialization) is treated as the
                 # post-prewarm baseline, so later samples can report growth since startup
@@ -586,7 +618,7 @@ class SupervisedProc(ABC):
                 if self._opts.memory_limit_mb > 0 and memory_mb > self._opts.memory_limit_mb:
                     logger.error(
                         f"{self.process_kind} process exceeded memory limit, killing it",
-                        extra=self._memory_logging_extra(memory_mb),
+                        extra=self._memory_logging_extra(memory_mb, memory_metric),
                     )
                     await self._send_dump_signal()
                     await self._send_kill_signal()
@@ -606,7 +638,7 @@ class SupervisedProc(ABC):
                                 if advisory
                                 else ""
                             ),
-                            extra=self._memory_logging_extra(memory_mb),
+                            extra=self._memory_logging_extra(memory_mb, memory_metric),
                         )
 
             except (psutil.NoSuchProcess, psutil.AccessDenied) as e:

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -587,7 +587,7 @@ class SupervisedProc(ABC):
             process = self._psutil_process = psutil.Process(self._pid)
 
         try:
-            memory_info = process.memory_full_info()
+            memory_info: Any = process.memory_full_info()
         except (psutil.AccessDenied, NotImplementedError):
             memory_info = process.memory_info()
 

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -127,6 +127,7 @@ class SupervisedProc(ABC):
         self._memory_baseline_mb: float | None = None
         self._last_memory_warn_time: float = 0.0
         self._last_memory_warn_mb: float = 0.0
+        self._psutil_process: psutil.Process | None = None
 
         self._start_atask: asyncio.Task[None] | None = None
         self._supervise_atask: asyncio.Task[None] | None = None
@@ -547,11 +548,13 @@ class SupervisedProc(ABC):
             return True
         return False
 
-    def _memory_logging_extra(self, memory_mb: float) -> dict[str, Any]:
+    def _memory_logging_extra(self, memory_mb: float, memory_metric: str) -> dict[str, Any]:
         """Diagnostic context for the memory logs: tells a process that started
-        heavy from one that grew over time (uptime, baseline RSS, growth)."""
+        heavy from one that grew over time (uptime, baseline, growth). memory_metric
+        records which footprint metric the number reflects (pss/uss/rss)."""
         extra: dict[str, Any] = {
             "memory_usage_mb": round(memory_mb, 1),
+            "memory_metric": memory_metric,
             "memory_warn_mb": self._opts.memory_warn_mb,
             "memory_limit_mb": self._opts.memory_limit_mb,
             "uptime": round(self.uptime, 1),
@@ -564,6 +567,36 @@ class SupervisedProc(ABC):
         extra.update(self.logging_extra())
         return extra
 
+    def _sample_memory_mb(self) -> tuple[float, str]:
+        """Real footprint of the process, preferring metrics that don't
+        double-count shared pages. RSS counts copy-on-write pages inherited
+        from the forkserver and file-backed library pages at memory_info weight, so it
+        overstates what the process actually consumes and oversums across
+        processes. PSS (proportional, Linux only) divides shared pages among
+        their sharers and sums correctly to physical use; USS (private only) is
+        the cross-platform fallback since psutil exposes no PSS on macOS/Windows.
+        RSS is a last resort if the extended metrics are unavailable.
+
+        Synchronous and blocking: the PSS/USS path walks the target process's
+        page tables in the kernel, which scales with its mapping count and is
+        ~ms for a large child. Run via run_in_executor so that walk overlaps
+        with the event loop rather than stalling it (the read syscall releases
+        the GIL, so the offload pays off even on a single core)."""
+        process = self._psutil_process
+        if process is None:
+            process = self._psutil_process = psutil.Process(self._pid)
+
+        try:
+            memory_info = process.memory_full_info()
+        except (psutil.AccessDenied, NotImplementedError):
+            memory_info = process.memory_info()
+
+        for metric in "pss", "uss", "rss":
+            if memory_bytes := getattr(memory_info, metric, 0):
+                return memory_bytes / (1024 * 1024), metric
+
+        return 0, "unknown"
+
     @log_exceptions(logger=logger)
     async def _memory_monitor_task(self) -> None:
         """Monitor memory usage and kill the process if it exceeds the limit."""
@@ -573,10 +606,9 @@ class SupervisedProc(ABC):
                     await asyncio.sleep(_MEMORY_MONITOR_INTERVAL)
                     continue
 
-                # get process memory info
-                process = psutil.Process(self._pid)
-                memory_info = process.memory_info()
-                memory_mb = memory_info.rss / (1024 * 1024)  # Convert to MB
+                memory_mb, memory_metric = await self._loop.run_in_executor(
+                    None, self._sample_memory_mb
+                )
 
                 # the first sample (taken shortly after initialization) is treated as the
                 # post-prewarm baseline, so later samples can report growth since startup
@@ -586,7 +618,7 @@ class SupervisedProc(ABC):
                 if self._opts.memory_limit_mb > 0 and memory_mb > self._opts.memory_limit_mb:
                     logger.error(
                         f"{self.process_kind} process exceeded memory limit, killing it",
-                        extra=self._memory_logging_extra(memory_mb),
+                        extra=self._memory_logging_extra(memory_mb, memory_metric),
                     )
                     await self._send_dump_signal()
                     await self._send_kill_signal()
@@ -606,7 +638,7 @@ class SupervisedProc(ABC):
                                 if advisory
                                 else ""
                             ),
-                            extra=self._memory_logging_extra(memory_mb),
+                            extra=self._memory_logging_extra(memory_mb, memory_metric),
                         )
 
             except (psutil.NoSuchProcess, psutil.AccessDenied) as e:

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -194,7 +194,7 @@ class ServerOptions:
     Defaults to 0.7 on "production" mode, and is disabled in "development" mode.
     """
 
-    job_memory_warn_mb: float = 1000
+    job_memory_warn_mb: float = 500
     """Memory warning threshold in MB. If the job process exceeds this limit, a warning will be logged."""  # noqa: E501
     job_memory_limit_mb: float = 0
     """Maximum memory usage for a job in MB, the job process will be killed if it exceeds this limit.
@@ -304,7 +304,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
         *,
         job_executor_type: JobExecutorType = _default_job_executor_type,
         load_threshold: float | ServerEnvOption[float] = _default_load_threshold,
-        job_memory_warn_mb: float = 1000,
+        job_memory_warn_mb: float = 500,
         job_memory_limit_mb: float = 0,
         drain_timeout: int = 1800,
         num_idle_processes: int | ServerEnvOption[int] = _default_num_idle_processes,

--- a/tests/test_supervised_proc_memory.py
+++ b/tests/test_supervised_proc_memory.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import multiprocessing as mp
+import os
 import socket
+import sys
 
+import psutil
 import pytest
 
 from livekit.agents.ipc.supervised_proc import (
@@ -74,7 +77,7 @@ async def test_memory_logging_extra_reports_baseline_and_growth() -> None:
     proc = _make_proc()
 
     # before a baseline is captured, only the basic fields are present
-    extra = proc._memory_logging_extra(520.0)
+    extra = proc._memory_logging_extra(520.0, "pss")
     assert extra["memory_usage_mb"] == 520.0
     assert extra["memory_warn_mb"] == 500
     assert extra["has_running_job"] is False
@@ -83,7 +86,7 @@ async def test_memory_logging_extra_reports_baseline_and_growth() -> None:
 
     # once a baseline is set, growth-since-startup is reported
     proc._memory_baseline_mb = 300.0
-    extra = proc._memory_logging_extra(520.0)
+    extra = proc._memory_logging_extra(520.0, "pss")
     assert extra["baseline_memory_mb"] == 300.0
     assert extra["growth_memory_mb"] == 220.0
 
@@ -169,3 +172,63 @@ def test_subclassing_without_process_kind_is_rejected() -> None:
             mp_ctx=mp.get_context("spawn"),
             loop=asyncio.get_event_loop(),
         )
+
+
+def test_sample_memory_picks_metric_psutil_actually_exposes() -> None:
+    proc = _make_proc()
+    proc._pid = os.getpid()
+
+    value_mb, metric = proc._sample_memory_mb()
+
+    assert metric in ("pss", "uss", "rss")
+    assert value_mb > 0
+
+    # must select the highest-priority field psutil reports nonzero on this host
+    info = psutil.Process(os.getpid()).memory_full_info()
+    expected_metric = next(m for m in ("pss", "uss", "rss") if getattr(info, m, 0))
+    assert metric == expected_metric
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="PSS is only exposed on Linux")
+def test_sample_memory_reports_pss_on_linux() -> None:
+    proc = _make_proc()
+    proc._pid = os.getpid()
+
+    value_mb, metric = proc._sample_memory_mb()
+
+    assert metric == "pss"
+    assert value_mb > 0
+
+
+@pytest.mark.skipif(
+    sys.platform not in ("darwin", "win32"),
+    reason="USS-without-PSS path applies to macOS and Windows",
+)
+def test_sample_memory_reports_uss_on_macos_and_windows() -> None:
+    proc = _make_proc()
+    proc._pid = os.getpid()
+
+    value_mb, metric = proc._sample_memory_mb()
+
+    assert metric == "uss"
+    assert value_mb > 0
+
+
+def test_sample_memory_falls_back_to_rss_when_full_info_unavailable() -> None:
+    # AccessDenied/NotImplementedError can't be provoked on one's own process, so
+    # only the trigger is faked: memory_full_info is shadowed on a real Process
+    # instance (instance attribute, so no global/class state leaks across the
+    # concurrent suite) while memory_info().rss stays a genuine psutil read.
+    proc = _make_proc()
+    real = psutil.Process(os.getpid())
+
+    def _unavailable():
+        raise NotImplementedError
+
+    real.memory_full_info = _unavailable  # type: ignore[method-assign]
+    proc._psutil_process = real
+
+    value_mb, metric = proc._sample_memory_mb()
+
+    assert metric == "rss"
+    assert value_mb > 0


### PR DESCRIPTION

### Changes
- Report PSS (if not available, fall back to USS, then back to RSS)

RSS includes memory shared with the parent process, which doesn't show what process actually costs the system.

### Caveat
`psutil` won't allow to get anything but RSS for supervised process on macOS, unless parent is running as root.

maOS allows to read real memory footprint via `libproc.dylib`, but I haven't found a good way to support it, other than reaching for `ctypes`.

Implementation would look something like (leaving it out of this PR):
<details>

```py
if sys.platform == "darwin":
    import ctypes

    # proc_pid_rusage reads the per-process memory ledger through the proc_info path,
    # which is permitted for a same-uid target (or root) — unlike task_for_pid, which
    # backs psutil's USS and is restricted to root/debugger-entitled callers. Apple's
    # own guidance is to use proc_pid_rusage for cross-process stats. phys_footprint is
    # present from rusage_info_v0, so V0 is all we need.
    _RUSAGE_INFO_V0 = 0

    class _DarwinRUsageInfoV0(ctypes.Structure):
        _fields_ = [
            ("ri_uuid", ctypes.c_uint8 * 16),
            ("ri_user_time", ctypes.c_uint64),
            ("ri_system_time", ctypes.c_uint64),
            ("ri_pkg_idle_wkups", ctypes.c_uint64),
            ("ri_interrupt_wkups", ctypes.c_uint64),
            ("ri_pageins", ctypes.c_uint64),
            ("ri_wired_size", ctypes.c_uint64),
            ("ri_resident_size", ctypes.c_uint64),
            ("ri_phys_footprint", ctypes.c_uint64),
            ("ri_proc_start_abstime", ctypes.c_uint64),
            ("ri_proc_exit_abstime", ctypes.c_uint64),
        ]

    try:
        _libproc = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
        _libproc.proc_pid_rusage.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_void_p]
        _libproc.proc_pid_rusage.restype = ctypes.c_int
    except OSError:
        _libproc = None

    def _darwin_phys_footprint_mb(pid: int) -> float | None:
        if _libproc is None:
            return None
        info = _DarwinRUsageInfoV0()
        # nonzero return: EPERM (cross-uid), ESRCH (gone) — let the caller fall back
        if _libproc.proc_pid_rusage(pid, _RUSAGE_INFO_V0, ctypes.byref(info)) != 0:
            return None
        return info.ri_phys_footprint / (1024 * 1024)
```

</details>

