### PR TITLE
fix(voice): include conversation items added during tool execution in reply context

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3045,7 +3045,15 @@ class AgentActivity(RecognitionHooks):
 
             tool_messages = new_calls + new_fnc_outputs
             if fnc_executed_ev._reply_required:
+                # refresh conversation items added during tool execution: a tool that
+                # awaits an inline AgentTask runs a whole sub-conversation, merged into
+                # the agent's chat_ctx at handoff-return - this turn's snapshot predates
+                # it. Without the refresh, the tool response is generated blind to what
+                # was actually said inside the tool call (and re-asks captured fields).
+                # Conversational analog of the update_instructions() refresh below.
+                # tool_messages must be added first so merge() dedups them by id.
                 chat_ctx.items.extend(tool_messages)
+                chat_ctx.merge(self._agent._chat_ctx, exclude_instructions=True)
 
                 # refresh instructions in chat_ctx so that any update_instructions()
                 # calls made inside tool functions are reflected in the tool response


### PR DESCRIPTION
When a function tool awaits an inline `AgentTask`, the sub-conversation it runs is merged into the agent's `chat_ctx` at handoff-return. But the reply generated after tool execution uses a `chat_ctx` snapshot taken before the tool ran, so it's blind to everything said inside the task — in practice the agent re-asks for fields the task already collected.

This refreshes the snapshot with any chat items added during tool execution before generating the tool reply, mirroring the existing `update_instructions()` refresh just below it.

Found while benchmarking the hotel receptionist example, where the card-collection `AgentTask` would complete and the agent would immediately ask for the card number again.