### PR TITLE
feat(llm): list available tools in unknown-function error output

### DIFF
--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -749,16 +749,21 @@ async def execute_function_call(
     function_tool = tool_ctx.function_tools.get(tool_call.name)
     if function_tool is None:
         logger.warning(f"unknown AI function `{tool_call.name}`")
+        # Name the available tools so the model can self-correct
+        msg = (
+            f"Unknown function: {tool_call.name} - available tools: "
+            f"{', '.join(tool_ctx.function_tools.keys())}"
+        )
         return FunctionCallResult(
             fnc_call=fnc_call,
             fnc_call_out=FunctionCallOutput(
                 name=tool_call.name,
                 call_id=tool_call.call_id,
-                output=f"Unknown function: {tool_call.name}",
+                output=msg,
                 is_error=True,
             ),
             raw_output=None,
-            raw_exception=ValueError(f"Unknown function: {tool_call.name}"),
+            raw_exception=ValueError(msg),
         )
 
     try:

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -618,7 +618,11 @@ async def _execute_tools_task(
                     make_tool_output(
                         fnc_call=fnc_call,
                         output=None,
-                        exception=ToolError(f"Unknown function: {fnc_call.name}"),
+                        # Name the available tools so the model can self-correct
+                        exception=ToolError(
+                            f"Unknown function: {fnc_call.name} - available tools: "
+                            f"{', '.join(tool_ctx.function_tools.keys())}"
+                        ),
                     )
                 )
                 continue


### PR DESCRIPTION
When a model hallucinates a tool name, the error fed back to it is just `Unknown function: <name>`, which gives it nothing to self-correct with — smaller models in particular tend to retry the same invalid name.

Include the available tool names in the error output (both in `execute_function_call` and the voice generation path) so the model can pick a valid tool on the next attempt.