### PR TITLE
fix(workflows): normalize placeholder strings in GetNameTask arguments

### DIFF
--- a/livekit-agents/livekit/agents/beta/workflows/name.py
+++ b/livekit-agents/livekit/agents/beta/workflows/name.py
@@ -50,6 +50,19 @@ If the name contains special characters or hyphens (e.g., 'Mary-Jane' or 'O'Brie
 """
 
 
+def _clean_name_arg(value: str | None) -> str | None:
+    # Some models (e.g. gemma) fill optional args with placeholder strings like
+    # "null"/"NULL" instead of omitting them, or wrap values in literal quotes.
+    # Normalize those to None/clean values so they hit the required-field
+    # validation below instead of being recorded as the user's name.
+    if value is None:
+        return None
+    value = value.strip().strip("'\"")
+    if not value or value.casefold() in ("null", "none", "nil", "n/a", "unknown", "unspecified"):
+        return None
+    return value
+
+
 @dataclass
 class GetNameResult:
     first_name: str | None = None
@@ -197,6 +210,9 @@ class GetNameTask(AgentTask[GetNameResult]):
         middle_name: str | None = None,
         last_name: str | None = None,
     ) -> str | None:
+        first_name, middle_name, last_name = (
+            _clean_name_arg(v) for v in (first_name, middle_name, last_name)
+        )
         errors: list[str] = []
         if self._collect_first_name and not (first_name and first_name.strip()):
             errors.append("first name is required but was not provided")


### PR DESCRIPTION
Some models (e.g. gemma) fill optional tool arguments with placeholder strings like `"null"`/`"NULL"`/`"unknown"` instead of omitting them, or wrap values in literal quotes. `GetNameTask` would record these as the user's actual name.

Strip surrounding quotes and map placeholder values to `None` so they hit the existing required-field validation and the task re-prompts instead.