### PR TITLE
Drop unused agent_id kwarg from AgentConfigUpdate

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -420,7 +420,6 @@ class AgentActivity(RecognitionHooks):
         # Record the configuration change
         config_update = llm.AgentConfigUpdate(
             instructions=instructions,
-            agent_id=self._agent.id,
         )
         self._agent._chat_ctx.insert(config_update)
         self._session._chat_ctx.insert(config_update)
@@ -447,7 +446,6 @@ class AgentActivity(RecognitionHooks):
             config_update = llm.AgentConfigUpdate(
                 tools_added=tools_added,
                 tools_removed=tools_removed,
-                agent_id=self._agent.id,
             )
             config_update._tools = llm.ToolContext(tools).flatten()
             self._agent._chat_ctx.insert(config_update)
@@ -829,7 +827,6 @@ class AgentActivity(RecognitionHooks):
             initial_config = llm.AgentConfigUpdate(
                 instructions=self._agent.instructions,
                 tools_added=initial_tools,
-                agent_id=self._agent.id,
             )
             initial_config._tools = llm.ToolContext(self.tools).flatten()
             self._agent._chat_ctx.insert(initial_config)


### PR DESCRIPTION
`AgentConfigUpdate` has no `agent_id` field, so passing `agent_id=self._agent.id` was silently dropped by pydantic (default `extra="ignore"`) and never reached the model, the proto serializer in `remote_session.py`, or the wire protocol. Nothing reads `.agent_id` off a config-update item anywhere in the codebase, so the kwarg was pure dead code. This removes it from the three call sites in `agent_activity.py`.