### PR TITLE
fix(tests): replace TCP port check with HTTP readiness probe in livekit_server fixture

### DIFF
--- a/tests/lk_server.py
+++ b/tests/lk_server.py
@@ -30,12 +30,13 @@ def _port_in_use(port: int) -> bool:
 
 
 def _wait_for_ready(port: int, timeout: float = 15.0) -> None:
-    """Wait until the LiveKit server is fully ready to accept WebSocket connections.
+    """Wait until the LiveKit server is ready to accept connections.
 
-    Polls the HTTP endpoint on the same port rather than just checking TCP
-    reachability. The TCP port binding precedes full WebSocket handler
-    initialisation, so a raw port check can allow tests to connect before the
-    server is truly ready, causing transient ConnectError failures.
+    Polls the HTTP endpoint on the same port as a readiness proxy. Any HTTP
+    response (including 4xx/5xx) confirms that the server's handler stack is
+    fully initialised — a stronger signal than TCP reachability alone, which
+    can return true before the WebSocket acceptor is ready, causing transient
+    ConnectError failures in tests that open multiple rapid connections.
     """
     deadline = time.monotonic() + timeout
     last_exc: Exception | None = None

--- a/tests/lk_server.py
+++ b/tests/lk_server.py
@@ -46,7 +46,7 @@ def _wait_for_ready(port: int, timeout: float = 15.0) -> None:
                 return  # any HTTP response means the server is up
         except urllib.error.HTTPError:
             return  # a 4xx/5xx reply still means the server is ready
-        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        except (urllib.error.URLError, OSError) as exc:
             last_exc = exc
             time.sleep(0.3)
     raise TimeoutError(

--- a/tests/lk_server.py
+++ b/tests/lk_server.py
@@ -40,11 +40,13 @@ def _wait_for_ready(port: int, timeout: float = 15.0) -> None:
     """
     deadline = time.monotonic() + timeout
     last_exc: Exception | None = None
+    req = urllib.request.Request(f"http://127.0.0.1:{port}", method="HEAD")
     while time.monotonic() < deadline:
         try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{port}", timeout=0.5):
+            with urllib.request.urlopen(req, timeout=0.5):
                 return  # any HTTP response means the server is up
-        except urllib.error.HTTPError:
+        except urllib.error.HTTPError as exc:
+            exc.close()  # HTTPError is a response object; close to avoid FD leak
             return  # a 4xx/5xx reply still means the server is ready
         except (urllib.error.URLError, OSError) as exc:
             last_exc = exc

--- a/tests/lk_server.py
+++ b/tests/lk_server.py
@@ -38,15 +38,20 @@ def _wait_for_ready(port: int, timeout: float = 15.0) -> None:
     server is truly ready, causing transient ConnectError failures.
     """
     deadline = time.monotonic() + timeout
+    last_exc: Exception | None = None
     while time.monotonic() < deadline:
         try:
-            urllib.request.urlopen(f"http://localhost:{port}", timeout=0.5)
-            return  # any HTTP response means the server is up
+            with urllib.request.urlopen(f"http://127.0.0.1:{port}", timeout=0.5):
+                return  # any HTTP response means the server is up
         except urllib.error.HTTPError:
             return  # a 4xx/5xx reply still means the server is ready
-        except Exception:
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            last_exc = exc
             time.sleep(0.3)
-    raise TimeoutError(f"LiveKit server did not become ready within {timeout}s (port {port})")
+    raise TimeoutError(
+        f"LiveKit server did not become ready within {timeout}s (port {port})"
+        + (f": last error: {last_exc!r}" if last_exc else "")
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/lk_server.py
+++ b/tests/lk_server.py
@@ -11,6 +11,8 @@ import platform
 import socket
 import subprocess
 import time
+import urllib.error
+import urllib.request
 
 import pytest
 
@@ -27,13 +29,24 @@ def _port_in_use(port: int) -> bool:
         return s.connect_ex(("127.0.0.1", port)) == 0
 
 
-def _wait_for_port(port: int, timeout: float = 15.0) -> None:
+def _wait_for_ready(port: int, timeout: float = 15.0) -> None:
+    """Wait until the LiveKit server is fully ready to accept WebSocket connections.
+
+    Polls the HTTP endpoint on the same port rather than just checking TCP
+    reachability. The TCP port binding precedes full WebSocket handler
+    initialisation, so a raw port check can allow tests to connect before the
+    server is truly ready, causing transient ConnectError failures.
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        if _port_in_use(port):
-            return
-        time.sleep(0.3)
-    raise TimeoutError(f"LiveKit server did not start within {timeout}s (port {port})")
+        try:
+            urllib.request.urlopen(f"http://localhost:{port}", timeout=0.5)
+            return  # any HTTP response means the server is up
+        except urllib.error.HTTPError:
+            return  # a 4xx/5xx reply still means the server is ready
+        except Exception:
+            time.sleep(0.3)
+    raise TimeoutError(f"LiveKit server did not become ready within {timeout}s (port {port})")
 
 
 @pytest.fixture(scope="session")
@@ -65,7 +78,7 @@ def livekit_server():
         )
 
     try:
-        _wait_for_port(_PORT)
+        _wait_for_ready(_PORT)
         yield
     finally:
         proc.terminate()


### PR DESCRIPTION
## Problem
`tests/test_room.py::TestWaitForParticipant::test_with_identity` was
intermittently failing on Linux with:

    ConnectError: engine: signal failure: ws failure: IO error: Invalid argument (os error 22)

The `livekit_server` fixture starts a docker container and considered it
"ready" as soon as the TCP port accepted a connection. But, the TCP port
binding precedes full WebSocket handler initialisation which creates a small
window where tests could attempt to connect before the server was truly ready.

`test_with_identity` opens up 3 sequential connections in rapid succession,
making it very likely to hit this window.

## Fix
Replace the TCP-only `_wait_for_port()` check with `_wait_for_ready()`,
which polls the HTTP endpoint on port 7880. Any HTTP response (including
4xx/5xx) confirms the server's WebSocket handler is fully initialised and
ready to accept connections. I only used the stdlib modules which are `urllib.request` and
`urllib.error`.

## Verification
Full unit suite: 850 passed, 4 skipped (was 849 passed, 1 failed).
