### PR TITLE
fix(clova): stop _recognize_impl from mutating instance language as a side effect

### DIFF
--- a/livekit-plugins/livekit-plugins-clova/livekit/plugins/clova/stt.py
+++ b/livekit-plugins/livekit-plugins-clova/livekit/plugins/clova/stt.py
@@ -111,10 +111,11 @@ class STT(stt.STT):
     ) -> stt.SpeechEvent:
         try:
             url = self.url_builder()
+            lang = self._language
             if is_given(language):
                 normalized = LanguageCode(language).iso
-                self._language = clova_languages_mapping.get(normalized, normalized)
-            payload = json.dumps({"language": self._language, "completion": "sync"})
+                lang = clova_languages_mapping.get(normalized, normalized)
+            payload = json.dumps({"language": lang, "completion": "sync"})
 
             buffer = merge_frames(buffer)
             buffer_bytes = resample_audio(
@@ -155,7 +156,7 @@ class STT(stt.STT):
                         f"Confidence: {confidence} is bellow threshold {self.threshold}. Skipping."
                     )
                 logger.info(f"final event: {response_data}")
-                return self._transcription_to_speech_event(text=text)
+                return self._transcription_to_speech_event(text=text, language=lang)
 
         except asyncio.TimeoutError as e:
             raise APITimeoutError() from e
@@ -171,8 +172,11 @@ class STT(stt.STT):
         self,
         text: str,
         event_type: SpeechEventType = stt.SpeechEventType.INTERIM_TRANSCRIPT,
+        language: str | None = None,
     ) -> stt.SpeechEvent:
         return stt.SpeechEvent(
             type=event_type,
-            alternatives=[stt.SpeechData(text=text, language=LanguageCode(self._language))],
+            alternatives=[
+                stt.SpeechData(text=text, language=LanguageCode(language or self._language))
+            ],
         )


### PR DESCRIPTION
`_recognize_impl` accepted a per-call `language` override but wrote it back to `self._language`, permanently changing the instance's language for all subsequent calls that don't specify one.

Fix: compute a local `lang` variable from the per-call override (falling back to `self._language`), use it in the request payload, and pass it through to `_transcription_to_speech_event` so the response language also reflects the correct per-call value. `self._language` is now only ever mutated by `__init__` and `update_options`.

Fixes #6096