### PR TITLE
fix(voice): skip end-of-turn metrics on stale/out-of-order speaking anchor

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2222,8 +2222,8 @@ class AgentActivity(RecognitionHooks):
 
         eou_metrics = EOUMetrics(
             timestamp=time.time(),
-            end_of_utterance_delay=info.end_of_turn_delay or 0.0,
-            transcription_delay=info.transcription_delay or 0.0,
+            end_of_utterance_delay=info.metrics.end_of_turn_delay or 0.0,
+            transcription_delay=info.metrics.transcription_delay or 0.0,
             on_user_turn_completed_delay=on_user_turn_completed_delay,
             speech_id=speech_handle.id,
             metadata=metadata,
@@ -3890,17 +3890,17 @@ class AgentActivity(RecognitionHooks):
                 "model_name": self.stt.model,
                 "model_provider": self.stt.provider,
             }
-        if info.started_speaking_at is not None:
-            metrics_report["started_speaking_at"] = info.started_speaking_at
+        if info.metrics.started_speaking_at is not None:
+            metrics_report["started_speaking_at"] = info.metrics.started_speaking_at
 
-        if info.stopped_speaking_at is not None:
-            metrics_report["stopped_speaking_at"] = info.stopped_speaking_at
+        if info.metrics.stopped_speaking_at is not None:
+            metrics_report["stopped_speaking_at"] = info.metrics.stopped_speaking_at
 
-        if info.transcription_delay is not None:
-            metrics_report["transcription_delay"] = info.transcription_delay
+        if info.metrics.transcription_delay is not None:
+            metrics_report["transcription_delay"] = info.metrics.transcription_delay
 
-        if info.end_of_turn_delay is not None:
-            metrics_report["end_of_turn_delay"] = info.end_of_turn_delay
+        if info.metrics.end_of_turn_delay is not None:
+            metrics_report["end_of_turn_delay"] = info.metrics.end_of_turn_delay
 
         return metrics_report
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -49,12 +49,7 @@ class _EndOfTurnInfo:
     """If True, a reply was already triggered and should be skipped after end of turn detection."""
     new_transcript: str
     transcript_confidence: float
-
-    # metrics report
-    started_speaking_at: float | None
-    stopped_speaking_at: float | None
-    transcription_delay: float | None
-    end_of_turn_delay: float | None
+    metrics: _EndOfTurnMetrics
 
 
 @dataclass
@@ -1255,20 +1250,12 @@ class AudioRecognition:
                 last_final_transcript_time=last_final_transcript_time,
                 now=time.time(),
             )
-            started_speaking_at = metrics.started_speaking_at
-            stopped_speaking_at = metrics.stopped_speaking_at
-            transcription_delay = metrics.transcription_delay
-            end_of_turn_delay = metrics.end_of_turn_delay
-
             committed = self._hooks.on_end_of_turn(
                 _EndOfTurnInfo(
                     skip_reply=skip_reply,
                     new_transcript=self._audio_transcript,
                     transcript_confidence=confidence_avg,
-                    transcription_delay=transcription_delay or 0,
-                    end_of_turn_delay=end_of_turn_delay,
-                    started_speaking_at=started_speaking_at,
-                    stopped_speaking_at=stopped_speaking_at,
+                    metrics=metrics,
                 )
             )
             if committed:
@@ -1276,8 +1263,8 @@ class AudioRecognition:
                     {
                         trace_types.ATTR_USER_TRANSCRIPT: self._audio_transcript,
                         trace_types.ATTR_TRANSCRIPT_CONFIDENCE: confidence_avg,
-                        trace_types.ATTR_TRANSCRIPTION_DELAY: transcription_delay or 0,
-                        trace_types.ATTR_END_OF_TURN_DELAY: end_of_turn_delay or 0,
+                        trace_types.ATTR_TRANSCRIPTION_DELAY: metrics.transcription_delay or 0,
+                        trace_types.ATTR_END_OF_TURN_DELAY: metrics.end_of_turn_delay or 0,
                     }
                 )
                 if self._stt_request_ids:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -58,6 +58,55 @@ class _EndOfTurnInfo:
 
 
 @dataclass
+class _EndOfTurnMetrics:
+    started_speaking_at: float | None
+    stopped_speaking_at: float | None
+    transcription_delay: float | None
+    end_of_turn_delay: float | None
+
+
+def _compute_end_of_turn_metrics(
+    *,
+    speech_start_time: float | None,
+    last_speaking_time: float | None,
+    last_final_transcript_time: float | None,
+    now: float,
+) -> _EndOfTurnMetrics:
+    """Compute the end-of-turn timing metrics from the captured turn anchors.
+
+    ``last_speaking_time`` is the internal ``_last_speaking_time`` anchor (reported
+    as ``stopped_speaking_at``). When the turn detector commits a turn whose anchor
+    was never refreshed for this segment, that value can be stale and predate the
+    start of the current turn, producing wildly inflated delays (see issue #6093).
+
+    We treat such an inconsistent anchor the same way we treat unreliable VAD: skip
+    the calculation and return ``None`` rather than emit a likely wrong value. A
+    valid anchor must satisfy ``last_speaking_time >= speech_start_time`` (you cannot
+    stop speaking before the turn started).
+    """
+    if (
+        speech_start_time is None
+        or last_speaking_time is None
+        or last_final_transcript_time is None
+        # stale/out-of-order anchor: stopping to speak cannot predate the turn start
+        or last_speaking_time < speech_start_time
+    ):
+        return _EndOfTurnMetrics(
+            started_speaking_at=None,
+            stopped_speaking_at=None,
+            transcription_delay=None,
+            end_of_turn_delay=None,
+        )
+
+    return _EndOfTurnMetrics(
+        started_speaking_at=speech_start_time,
+        stopped_speaking_at=last_speaking_time,
+        transcription_delay=max(last_final_transcript_time - last_speaking_time, 0),
+        end_of_turn_delay=max(now - last_speaking_time, 0),
+    )
+
+
+@dataclass
 class _PreemptiveGenerationInfo:
     new_transcript: str
     transcript_confidence: float
@@ -1197,22 +1246,19 @@ class AudioRecognition:
                 else 0
             )
 
-            started_speaking_at = None
-            stopped_speaking_at = None
-            transcription_delay = None
-            end_of_turn_delay = None
-
-            # sometimes, we can't calculate the metrics because VAD was unreliable.
-            # in this case, we just ignore the calculation, it's better than providing likely wrong values
-            if (
-                last_final_transcript_time is not None
-                and last_speaking_time is not None
-                and speech_start_time is not None
-            ):
-                started_speaking_at = speech_start_time
-                stopped_speaking_at = last_speaking_time
-                transcription_delay = max(last_final_transcript_time - last_speaking_time, 0)
-                end_of_turn_delay = time.time() - last_speaking_time
+            # sometimes, we can't calculate the metrics because VAD was unreliable or
+            # the speaking anchor is stale/out-of-order (see issue #6093). in this case,
+            # we just ignore the calculation, it's better than providing likely wrong values
+            metrics = _compute_end_of_turn_metrics(
+                speech_start_time=speech_start_time,
+                last_speaking_time=last_speaking_time,
+                last_final_transcript_time=last_final_transcript_time,
+                now=time.time(),
+            )
+            started_speaking_at = metrics.started_speaking_at
+            stopped_speaking_at = metrics.stopped_speaking_at
+            transcription_delay = metrics.transcription_delay
+            end_of_turn_delay = metrics.end_of_turn_delay
 
             committed = self._hooks.on_end_of_turn(
                 _EndOfTurnInfo(

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -44,20 +44,20 @@ _EOU_MAX_HISTORY_TURNS = 6
 
 
 @dataclass
+class _EndOfTurnMetrics:
+    started_speaking_at: float | None
+    stopped_speaking_at: float | None
+    transcription_delay: float | None
+    end_of_turn_delay: float | None
+
+
+@dataclass
 class _EndOfTurnInfo:
     skip_reply: bool
     """If True, a reply was already triggered and should be skipped after end of turn detection."""
     new_transcript: str
     transcript_confidence: float
     metrics: _EndOfTurnMetrics
-
-
-@dataclass
-class _EndOfTurnMetrics:
-    started_speaking_at: float | None
-    stopped_speaking_at: float | None
-    transcription_delay: float | None
-    end_of_turn_delay: float | None
 
 
 def _compute_end_of_turn_metrics(

--- a/tests/test_end_of_turn_metrics.py
+++ b/tests/test_end_of_turn_metrics.py
@@ -1,0 +1,109 @@
+"""Unit tests for the end-of-turn timing metric computation.
+
+These exercise ``_compute_end_of_turn_metrics`` in isolation, with crafted
+timestamps (no audio, no STT/VAD). They pin down the behaviour described in
+issue #6093: when the internal ``_last_speaking_time`` anchor (reported as
+``stopped_speaking_at``) is stale and predates the start of the current turn,
+the previous code emitted wildly inflated ``transcription_delay`` /
+``end_of_turn_delay`` values (often >200s) instead of skipping the calculation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents.voice.audio_recognition import _compute_end_of_turn_metrics
+
+pytestmark = pytest.mark.unit
+
+
+def test_normal_turn_produces_small_bounded_delays() -> None:
+    """A well-ordered turn yields the expected sub-second delays."""
+    started = 1000.0
+    stopped = 1005.0  # finished speaking 5s after starting
+    last_final = 1005.2  # final transcript landed 0.2s later
+    now = 1005.4  # turn committed 0.4s after the user stopped
+
+    metrics = _compute_end_of_turn_metrics(
+        speech_start_time=started,
+        last_speaking_time=stopped,
+        last_final_transcript_time=last_final,
+        now=now,
+    )
+
+    assert metrics.started_speaking_at == started
+    assert metrics.stopped_speaking_at == stopped
+    assert metrics.transcription_delay == pytest.approx(0.2)
+    assert metrics.end_of_turn_delay == pytest.approx(0.4)
+
+
+def test_stale_anchor_predating_turn_start_is_skipped() -> None:
+    """Regression for issue #6093.
+
+    When the turn detector commits a turn whose ``_last_speaking_time`` anchor was
+    never refreshed for this segment, the anchor can be from a much earlier point
+    in the session and predate ``speech_start_time``. The old code passed the
+    not-None guard and computed ``end_of_turn_delay = now - last_speaking_time``,
+    yielding ~220s. The metric must instead be skipped (left as ``None``) rather
+    than reported as a bogus huge value.
+    """
+    # numbers mirror the issue payload: stopped_speaking_at ~220s before the start
+    started = 1781342804.815377
+    stopped = 1781342584.6181495  # ~220s BEFORE `started` — stale anchor
+    last_final = 1781342804.9027314
+    now = 1781342804.9027314
+
+    metrics = _compute_end_of_turn_metrics(
+        speech_start_time=started,
+        last_speaking_time=stopped,
+        last_final_transcript_time=last_final,
+        now=now,
+    )
+
+    assert metrics.started_speaking_at is None
+    assert metrics.stopped_speaking_at is None
+    assert metrics.transcription_delay is None
+    assert metrics.end_of_turn_delay is None
+
+
+def test_anchor_equal_to_start_is_accepted() -> None:
+    """An anchor exactly at the turn start is valid (boundary, delay == 0)."""
+    started = 2000.0
+    metrics = _compute_end_of_turn_metrics(
+        speech_start_time=started,
+        last_speaking_time=started,
+        last_final_transcript_time=started,
+        now=started + 0.3,
+    )
+
+    assert metrics.started_speaking_at == started
+    assert metrics.stopped_speaking_at == started
+    assert metrics.transcription_delay == 0.0
+    assert metrics.end_of_turn_delay == pytest.approx(0.3)
+
+
+@pytest.mark.parametrize(
+    ("speech_start_time", "last_speaking_time", "last_final_transcript_time"),
+    [
+        (None, 1005.0, 1005.2),
+        (1000.0, None, 1005.2),
+        (1000.0, 1005.0, None),
+    ],
+)
+def test_missing_anchor_is_skipped(
+    speech_start_time: float | None,
+    last_speaking_time: float | None,
+    last_final_transcript_time: float | None,
+) -> None:
+    """Any missing anchor skips the calculation (unreliable VAD/STT timing)."""
+    metrics = _compute_end_of_turn_metrics(
+        speech_start_time=speech_start_time,
+        last_speaking_time=last_speaking_time,
+        last_final_transcript_time=last_final_transcript_time,
+        now=1006.0,
+    )
+
+    assert metrics.started_speaking_at is None
+    assert metrics.stopped_speaking_at is None
+    assert metrics.transcription_delay is None
+    assert metrics.end_of_turn_delay is None


### PR DESCRIPTION
## Summary

Fixes #6093.

For some user turns, the reported `transcription_delay` / `end_of_turn_delay` metrics on `ChatMessage` are extremely large (often >200s) even though the session recordings show no real delay, and `stopped_speaking_at` can precede `started_speaking_at`. In other turns the fields are missing entirely.

### Root cause

The metrics are computed in `_bounce_eou_task` (`audio_recognition.py`) from three captured anchors:

```python
started_speaking_at  = speech_start_time
stopped_speaking_at  = last_speaking_time           # the internal _last_speaking_time anchor
transcription_delay  = max(last_final_transcript_time - last_speaking_time, 0)
end_of_turn_delay    = time.time() - last_speaking_time
```

The guard around this block only checked that the three values are **not `None`**. When the turn detector commits a user turn whose `_last_speaking_time` was never refreshed for that segment — e.g. consecutive same-role turns split from one continuous utterance, with no VAD speech-stop/start cycle between them — the anchor is left over from an earlier point in the session and can predate the start of the current turn.

In that case the not-`None` guard still passes, so `end_of_turn_delay = now - last_speaking_time` becomes ~200s and `stopped_speaking_at` ends up *before* `started_speaking_at`, exactly the payload reported in the issue.

This is the same class of bug noted in #2361 / #5669 / #4388 (stale/`0` anchor), now manifesting as an *out-of-order* anchor on adjacent turns within one long utterance.

### Fix

An anchor that predates the start of the turn (`last_speaking_time < speech_start_time`) is logically impossible — you cannot stop speaking before the turn started. The existing code already has a policy for unreliable timing (see the in-code comment): *skip the calculation and report the metrics as `None`, because that is better than emitting a likely-wrong value.* This change extends that same policy to the out-of-order case.

The computation is extracted into a small pure helper, `_compute_end_of_turn_metrics`, which:

- returns `None` for all four metrics when any anchor is missing **or** when `last_speaking_time < speech_start_time` (stale/out-of-order), and
- otherwise returns the same values as before (with `end_of_turn_delay` now clamped to `>= 0`, consistent with the existing `transcription_delay` clamp).

This makes the behaviour directly unit-testable without audio/STT/VAD.

## Testing

New unit test module `tests/test_end_of_turn_metrics.py` exercises the pure helper with crafted timestamps (no audio):

- `test_normal_turn_produces_small_bounded_delays` — well-ordered turn yields the expected sub-second delays.
- `test_stale_anchor_predating_turn_start_is_skipped` — regression for this issue, using the exact `~220s` numbers from the reported payload; all four metrics must be `None`.
- `test_anchor_equal_to_start_is_accepted` — boundary (`last_speaking_time == speech_start_time`) stays valid.
- `test_missing_anchor_is_skipped` — any missing anchor skips the calculation.

```
$ uv run pytest tests/test_end_of_turn_metrics.py --unit -q
......                                                                   [100%]
6 passed in 0.02s
```

Confirmed RED before the fix (reverting the ordering guard): `test_stale_anchor_predating_turn_start_is_skipped` failed with `started_speaking_at=1781342804.815377`, `end_of_turn_delay=220.28458189964294` — i.e. the bogus >200s value. The existing `tests/test_speech_start_time_persistence.py` still passes.

`ruff check`, `ruff format --check`, and `mypy` are clean on the changed files.

## AI disclosure

This change was AI-assisted; all logic, tests, and verification were reviewed by the author.
