### PR TITLE
fix(worker): exit when connection fails after max retries

### DIFF
--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -827,6 +827,16 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                 )
                 tasks.append(self._conn_task)
 
+                # surface a terminal connection failure (e.g. exhausting
+                # max_retry) so run() stops awaiting and re-raises it
+                def _on_conn_task_done(task: asyncio.Task[None]) -> None:
+                    if task.cancelled() or self._close_future is None or self._close_future.done():
+                        return
+                    if (exc := task.exception()) is not None:
+                        self._close_future.set_exception(exc)
+
+                self._conn_task.add_done_callback(_on_conn_task_done)
+
             self.emit("worker_started")
 
         await self._close_future

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -827,8 +827,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                 )
                 tasks.append(self._conn_task)
 
-                # surface a terminal connection failure (e.g. exhausting
-                # max_retry) so run() stops awaiting and re-raises it
+                # propagate a terminal connection failure out of run()
                 def _on_conn_task_done(task: asyncio.Task[None]) -> None:
                     if task.cancelled() or self._close_future is None or self._close_future.done():
                         return
@@ -1001,7 +1000,9 @@ class AgentServer(utils.EventEmitter[EventTypes]):
         async with self._lock:
             if self._closed:
                 if self._close_future is not None:
-                    await self._close_future
+                    # _close_future may hold run()'s error; keep aclose() a no-op
+                    with contextlib.suppress(Exception):
+                        await self._close_future
                 return
 
             self._closed = True

--- a/tests/test_worker_connection.py
+++ b/tests/test_worker_connection.py
@@ -49,3 +49,4 @@ async def test_run_raises_when_connection_exhausts_retries() -> None:
                 await asyncio.wait_for(server.run(devmode=True), timeout=10)
         finally:
             await server.aclose()
+            await server.aclose()  # repeated aclose() stays a no-op

--- a/tests/test_worker_connection.py
+++ b/tests/test_worker_connection.py
@@ -1,0 +1,51 @@
+"""Connection-failure propagation tests.
+
+When the worker's connection task exhausts ``max_retry`` it raises, and that
+failure must surface out of ``AgentServer.run()`` instead of leaving the worker
+hanging forever (https://github.com/livekit/agents/issues/6083).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from livekit.agents.job import JobContext
+from livekit.agents.worker import AgentServer
+
+pytestmark = pytest.mark.unit
+
+
+def _make_server() -> AgentServer:
+    server = AgentServer(
+        ws_url="ws://127.0.0.1:1",  # unreachable: connection refused
+        api_key="devkey",
+        api_secret="devsecret",
+        max_retry=0,
+        num_idle_processes=0,
+    )
+
+    @server.rtc_session()
+    async def _entry(ctx: JobContext) -> None:
+        pass
+
+    server._simulation = True  # skip binding the health HTTP server
+    return server
+
+
+async def test_run_raises_when_connection_exhausts_retries() -> None:
+    server = _make_server()
+
+    fake_pool = MagicMock()
+    fake_pool.start = AsyncMock()
+    fake_pool.aclose = AsyncMock()
+    fake_pool.processes = []
+
+    with patch("livekit.agents.ipc.proc_pool.ProcPool", return_value=fake_pool):
+        try:
+            with pytest.raises(RuntimeError, match="failed to connect"):
+                await asyncio.wait_for(server.run(devmode=True), timeout=10)
+        finally:
+            await server.aclose()


### PR DESCRIPTION
Fixes #6083.

When the worker connects to a wrong or unreachable URL, it never exits after exhausting `max_retry` — it hangs as a zombie, and a user `try/except` around `server.run()` never catches the error.

`AgentServer.run()` completes only when `_close_future` resolves, which happens exclusively in `aclose()`. The connection task is fire-and-forget: it's created and appended to a local `tasks` list that is never awaited or watched. When `_connection_task` exhausts `max_retry` it raises `RuntimeError`, but that exception dies on the orphaned task. Nothing resolves `_close_future`, so `run()` blocks forever, the CLI's `except Exception` never fires (no drain/exit), and callers' `try/except` catches nothing.

This adds a done callback on the connection task that propagates its terminal exception to `_close_future`, so `run()` re-raises it. The CLI then logs `worker failed` and runs its normal drain/aclose teardown so the process exits, and a user `try/except` around `server.run()` finally catches the failure.

Scoped to the connection task only — not the load task, whose failures are logged-and-continue today and should not start crashing the worker.