### PR TITLE
feat(voice): add first_transcript_after_eos_delay metric

### DIFF
--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -244,6 +244,14 @@ class MetricsReport(TypedDict, total=False):
     User `ChatMessage` only
     """
 
+    first_transcript_after_eos_delay: float
+    """Time between the end of speech (VAD or STT EOS) and the first transcript event
+    (interim or final) received after it. Unlike `transcription_delay` (time to the
+    *final* transcript), this measures the latency to the provider's *first* result.
+
+    User `ChatMessage` only
+    """
+
     on_user_turn_completed_delay: float
     """Time taken to invoke the developer's `Agent.on_user_turn_completed` callback.
 

--- a/livekit-agents/livekit/agents/metrics/base.py
+++ b/livekit-agents/livekit/agents/metrics/base.py
@@ -104,6 +104,16 @@ class EOUMetrics(_BaseMetrics):
     Set to 0.0 if the end of speech was not detected.
     """
 
+    first_transcript_after_eos_delay: float = 0.0
+    """Time between the end of speech (VAD or STT EOS) and the first transcript event
+    (interim or final) received after it.
+
+    Unlike ``transcription_delay`` (which measures the time to the *final* transcript),
+    this captures how quickly the provider returns its *first* result after the user
+    stops speaking, which is useful for comparing provider latency.
+    Set to 0.0 if the end of speech was not detected.
+    """
+
     on_user_turn_completed_delay: float
     """Time taken to invoke the user's `Agent.on_user_turn_completed` callback."""
 

--- a/livekit-agents/livekit/agents/metrics/utils.py
+++ b/livekit-agents/livekit/agents/metrics/utils.py
@@ -82,6 +82,9 @@ def log_metrics(metrics: AgentMetrics, *, logger: logging.Logger | None = None) 
             | {
                 "end_of_utterance_delay": round(metrics.end_of_utterance_delay, 2),
                 "transcription_delay": round(metrics.transcription_delay, 2),
+                "first_transcript_after_eos_delay": round(
+                    metrics.first_transcript_after_eos_delay, 2
+                ),
             },
         )
     elif isinstance(metrics, STTMetrics):

--- a/livekit-agents/livekit/agents/telemetry/trace_types.py
+++ b/livekit-agents/livekit/agents/telemetry/trace_types.py
@@ -62,6 +62,7 @@ ATTR_END_OF_TURN_DELAY = "lk.end_of_turn_delay"
 ATTR_EOU_SOURCE = "lk.eou.source"
 ATTR_EOU_DETECTION_DELAY = "lk.eou.detection_delay"
 ATTR_EOU_FROM_CACHE = "lk.eou.from_cache"
+ATTR_FIRST_TRANSCRIPT_AFTER_EOS_DELAY = "lk.first_transcript_after_eos_delay"
 
 # metrics
 ATTR_LLM_METRICS = "lk.llm_metrics"

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2443,6 +2443,7 @@ class AgentActivity(RecognitionHooks):
             timestamp=time.time(),
             end_of_utterance_delay=info.metrics.end_of_turn_delay or 0.0,
             transcription_delay=info.metrics.transcription_delay or 0.0,
+            first_transcript_after_eos_delay=info.metrics.first_transcript_after_eos_delay or 0.0,
             on_user_turn_completed_delay=on_user_turn_completed_delay,
             speech_id=speech_handle.id,
             metadata=metadata,
@@ -4312,6 +4313,11 @@ class AgentActivity(RecognitionHooks):
 
         if info.metrics.end_of_turn_delay is not None:
             metrics_report["end_of_turn_delay"] = info.metrics.end_of_turn_delay
+
+        if info.metrics.first_transcript_after_eos_delay is not None:
+            metrics_report["first_transcript_after_eos_delay"] = (
+                info.metrics.first_transcript_after_eos_delay
+            )
 
         return metrics_report
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -63,6 +63,7 @@ class _EndOfTurnMetrics:
     stopped_speaking_at: float | None
     transcription_delay: float | None
     end_of_turn_delay: float | None
+    first_transcript_after_eos_delay: float | None = None
 
 
 @dataclass
@@ -82,6 +83,8 @@ def _compute_end_of_turn_metrics(
     last_speaking_time: float | None,
     last_final_transcript_time: float | None,
     now: float,
+    end_of_speech_time: float | None = None,
+    first_transcript_after_eos_time: float | None = None,
 ) -> _EndOfTurnMetrics:
     """Compute the end-of-turn timing metrics from the captured turn anchors.
 
@@ -94,7 +97,17 @@ def _compute_end_of_turn_metrics(
     the calculation and return ``None`` rather than emit a likely wrong value. A
     valid anchor must satisfy ``last_speaking_time >= speech_start_time`` (you cannot
     stop speaking before the turn started).
+
+    ``first_transcript_after_eos_delay`` is independent of the VAD speaking anchors
+    above: it only needs the end-of-speech time and the first transcript event that
+    arrived after it, so it is still reported when the speaking anchors are unusable.
     """
+    first_transcript_after_eos_delay: float | None = None
+    if end_of_speech_time is not None and first_transcript_after_eos_time is not None:
+        first_transcript_after_eos_delay = max(
+            first_transcript_after_eos_time - end_of_speech_time, 0
+        )
+
     if (
         speech_start_time is None
         or last_speaking_time is None
@@ -107,6 +120,7 @@ def _compute_end_of_turn_metrics(
             stopped_speaking_at=None,
             transcription_delay=None,
             end_of_turn_delay=None,
+            first_transcript_after_eos_delay=first_transcript_after_eos_delay,
         )
 
     return _EndOfTurnMetrics(
@@ -114,6 +128,7 @@ def _compute_end_of_turn_metrics(
         stopped_speaking_at=last_speaking_time,
         transcription_delay=max(last_final_transcript_time - last_speaking_time, 0),
         end_of_turn_delay=max(now - last_speaking_time, 0),
+        first_transcript_after_eos_delay=first_transcript_after_eos_delay,
     )
 
 
@@ -271,6 +286,12 @@ class AudioRecognition:
         self._last_final_transcript_time: float | None = None
         self._last_speaking_time: float | None = None
         self._speech_start_time: float | None = None
+
+        # anchors for the first_transcript_after_eos_delay metric: the time the user's
+        # speech ended (VAD or STT EOS) and the time of the first transcript event that
+        # arrives after that EOS. Both are reset when a new turn starts (START_OF_SPEECH).
+        self._end_of_speech_time: float | None = None
+        self._first_transcript_after_eos_time: float | None = None
 
         # used for manual commit_user_turn
         self._final_transcript_received = asyncio.Event()
@@ -980,6 +1001,8 @@ class AudioRecognition:
         self._last_final_transcript_time = None
         self._speech_start_time = None
         self._last_speaking_time = None
+        self._end_of_speech_time = None
+        self._first_transcript_after_eos_time = None
         self._vad_speech_started = False
         self._user_turn_committed = False
         self._last_emitted_prediction = None
@@ -1102,6 +1125,23 @@ class AudioRecognition:
             return self._audio_transcript + " " + self._audio_interim_transcript
         return self._audio_transcript
 
+    def _mark_end_of_speech(self) -> None:
+        """Record an end-of-speech (VAD or STT EOS) for the ``first_transcript_after_eos``
+        metric and arm a fresh first-transcript measurement from this point.
+        """
+        self._end_of_speech_time = time.time()
+        self._first_transcript_after_eos_time = None
+
+    def _mark_first_transcript_after_eos(self) -> None:
+        """Record the arrival time of the first transcript event after end of speech.
+
+        Used to compute ``first_transcript_after_eos_delay``. The anchor is only set once
+        per turn — after an end-of-speech has been observed and before the next
+        START_OF_SPEECH clears it — so subsequent transcripts do not move it.
+        """
+        if self._end_of_speech_time is not None and self._first_transcript_after_eos_time is None:
+            self._first_transcript_after_eos_time = time.time()
+
     async def _on_stt_event(self, ev: stt.SpeechEvent) -> None:
         # Collect provider-known STT ids for this user turn. The actual attribute
         # is written once when the user_turn span ends (see _on_end_of_turn), to
@@ -1171,6 +1211,8 @@ class AudioRecognition:
             self._final_transcript_received.set()
             if not transcript:
                 return
+
+            self._mark_first_transcript_after_eos()
 
             self._hooks.on_final_transcript(
                 ev,
@@ -1244,6 +1286,8 @@ class AudioRecognition:
             if not transcript:
                 return
 
+            self._mark_first_transcript_after_eos()
+
             logger.debug(
                 "received user preflight transcript",
                 extra={"user_transcript": transcript, "language": self._last_language},
@@ -1277,6 +1321,8 @@ class AudioRecognition:
                 or self._turn_detection_mode == "stt"
                 else None,
             )
+            if ev.alternatives and ev.alternatives[0].text:
+                self._mark_first_transcript_after_eos()
             self._audio_interim_transcript = ev.alternatives[0].text
 
         elif ev.type == stt.SpeechEventType.END_OF_SPEECH and self._turn_detection_mode == "stt":
@@ -1305,6 +1351,7 @@ class AudioRecognition:
                     )
 
             self._speaking = False
+            self._mark_end_of_speech()
             self._user_turn_committed = True
             if self._vad is None or self._using_default_vad or self._last_speaking_time is None:
                 # vad disabled or missed a speech, use stt timestamp
@@ -1383,6 +1430,7 @@ class AudioRecognition:
             self._vad_speech_started = False
             self._speaking = False
             self._last_speaking_time = time.time() - ev.silence_duration - ev.inference_duration
+            self._mark_end_of_speech()
 
             if self._vad_base_turn_detection or (
                 self._turn_detection_mode == "stt" and self._user_turn_committed
@@ -1456,6 +1504,8 @@ class AudioRecognition:
             last_speaking_time: float | None = None,
             last_final_transcript_time: float | None = None,
             speech_start_time: float | None = None,
+            end_of_speech_time: float | None = None,
+            first_transcript_after_eos_time: float | None = None,
         ) -> None:
             endpointing_delay = self._endpointing.min_delay
             user_turn_span = self._ensure_user_turn_span()
@@ -1648,6 +1698,8 @@ class AudioRecognition:
                 speech_start_time=speech_start_time,
                 last_speaking_time=last_speaking_time,
                 last_final_transcript_time=last_final_transcript_time,
+                end_of_speech_time=end_of_speech_time,
+                first_transcript_after_eos_time=first_transcript_after_eos_time,
                 now=time.time(),
             )
             committed = self._hooks.on_end_of_turn(
@@ -1678,6 +1730,9 @@ class AudioRecognition:
                         trace_types.ATTR_TRANSCRIPT_CONFIDENCE: confidence_avg,
                         trace_types.ATTR_TRANSCRIPTION_DELAY: metrics.transcription_delay or 0,
                         trace_types.ATTR_END_OF_TURN_DELAY: metrics.end_of_turn_delay or 0,
+                        trace_types.ATTR_FIRST_TRANSCRIPT_AFTER_EOS_DELAY: (
+                            metrics.first_transcript_after_eos_delay or 0
+                        ),
                     }
                 )
                 if self._stt_request_ids:
@@ -1700,6 +1755,12 @@ class AudioRecognition:
                     self._vad_speech_started = False
                     self._last_speaking_time = None
 
+                # only reset the EOS anchors if no newer end-of-speech happened in
+                # the meantime (mirrors the last_speaking_time guard above)
+                if self._end_of_speech_time == end_of_speech_time:
+                    self._end_of_speech_time = None
+                    self._first_transcript_after_eos_time = None
+
                 if self._turn_detector_stream is not None:
                     self._turn_detector_stream.flush(reason="turn committed")
                     self._turn_detector_prediction_fut = None
@@ -1719,6 +1780,8 @@ class AudioRecognition:
                 self._last_speaking_time,
                 self._last_final_transcript_time,
                 self._user_turn_start,
+                self._end_of_speech_time,
+                self._first_transcript_after_eos_time,
             )
         )
 

--- a/tests/test_first_transcript_after_eos.py
+++ b/tests/test_first_transcript_after_eos.py
@@ -1,0 +1,224 @@
+"""Tests for the ``first_transcript_after_eos_delay`` latency metric.
+
+The existing ``transcription_delay`` measures ``last_final_transcript_time -
+last_speaking_time`` (last speaking anchor -> *final* transcript). The new
+``first_transcript_after_eos_delay`` measures ``first_transcript_time -
+end_of_speech_time`` (end-of-speech -> *first* transcript event), which is the
+metric requested in https://github.com/livekit/agents/issues/4795 for
+provider-latency comparison.
+
+These tests drive ``AudioRecognition`` directly with crafted VAD/STT events
+(no audio, no network) and assert on the anchors captured by the event
+handlers and on the value reported through the ``on_end_of_turn`` hook.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from livekit.agents import stt
+from livekit.agents.language import LanguageCode
+from livekit.agents.vad import VADEvent, VADEventType
+from livekit.agents.voice.audio_recognition import (
+    AudioRecognition,
+    _compute_end_of_turn_metrics,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
+
+
+def _create_audio_recognition() -> AudioRecognition:
+    """Create an ``AudioRecognition`` with just the state the handlers touch."""
+    with patch.object(AudioRecognition, "__init__", lambda self, *args, **kwargs: None):
+        ar = AudioRecognition.__new__(AudioRecognition)
+
+    ar._speech_start_time = None
+    ar._vad_speech_started = False
+    ar._user_silence_ev = asyncio.Event()
+    ar._speaking = False
+    ar._end_of_turn_task = None
+    ar._user_turn_span = None
+    ar._user_turn_start = None
+    ar._user_turn_committed = False
+    ar._vad_base_turn_detection = False
+    ar._turn_detection_mode = None
+    ar._stt = None
+    ar._vad = None
+    ar._stt_model = None
+    ar._stt_provider = None
+    ar._stt_request_ids = []
+    ar._stt_pipeline = None
+    ar._agent_speaking = False
+    ar._turn_detector_stream = None
+    ar._turn_detector_prediction_fut = None
+    ar._turn_detector_flushed = False
+    ar._turn_backchannel_over_agent = False
+    ar._overlap_in_current_turn = False
+    ar._using_default_vad = False
+    ar._audio_transcript = ""
+    ar._audio_interim_transcript = ""
+    ar._audio_preflight_transcript = ""
+    ar._last_speaking_time = None
+    ar._last_final_transcript_time = None
+    ar._last_language = None
+    ar._final_transcript_received = asyncio.Event()
+    ar._final_transcript_confidence = []
+    ar._interruption_enabled = False
+    ar._end_of_speech_time = None
+    ar._first_transcript_after_eos_time = None
+
+    ar._hooks = MagicMock()
+    ar._session = MagicMock()
+    ar._session.amd = None
+    ar._session._room_io = None
+    ar._session.options.turn_handling = {"user_turn_limit": {}}
+
+    return ar
+
+
+def _vad_eos() -> VADEvent:
+    return VADEvent(
+        type=VADEventType.END_OF_SPEECH,
+        samples_index=0,
+        timestamp=time.time(),
+        speech_duration=1.0,
+        silence_duration=0.6,
+        inference_duration=0.0,
+    )
+
+
+def _final_transcript(text: str = "hello world") -> stt.SpeechEvent:
+    return stt.SpeechEvent(
+        type=stt.SpeechEventType.FINAL_TRANSCRIPT,
+        alternatives=[stt.SpeechData(language=LanguageCode("en"), text=text, confidence=0.9)],
+    )
+
+
+@pytest.mark.asyncio
+async def test_vad_end_of_speech_sets_end_of_speech_time():
+    """A VAD END_OF_SPEECH event anchors ``_end_of_speech_time``."""
+    ar = _create_audio_recognition()
+    ar._speaking = True
+
+    before = time.time()
+    await ar._on_vad_event(_vad_eos())
+    after = time.time()
+
+    assert ar._end_of_speech_time is not None
+    assert before <= ar._end_of_speech_time <= after
+
+
+@pytest.mark.asyncio
+async def test_first_transcript_after_eos_time_recorded_once():
+    """The first transcript event after EOS anchors the time; later ones don't move it."""
+    ar = _create_audio_recognition()
+    ar._speaking = True
+
+    await ar._on_vad_event(_vad_eos())
+    assert ar._first_transcript_after_eos_time is None  # nothing yet
+
+    await ar._on_stt_event(_final_transcript("hello"))
+    first = ar._first_transcript_after_eos_time
+    assert first is not None
+    assert first >= ar._end_of_speech_time
+
+    await asyncio.sleep(0.05)
+    await ar._on_stt_event(_final_transcript("world"))
+    assert ar._first_transcript_after_eos_time == pytest.approx(first, abs=1e-9), (
+        "the anchor must capture the FIRST transcript after EOS, not be overwritten"
+    )
+
+
+@pytest.mark.asyncio
+async def test_transcript_before_eos_does_not_set_anchor():
+    """A transcript arriving while the user is still speaking is not 'after EOS'."""
+    ar = _create_audio_recognition()
+    ar._speaking = True
+
+    # transcript before any end-of-speech -> no EOS anchor, no first-transcript anchor
+    await ar._on_stt_event(_final_transcript("partial"))
+    assert ar._end_of_speech_time is None
+    assert ar._first_transcript_after_eos_time is None
+
+
+@pytest.mark.asyncio
+async def test_end_of_turn_info_reports_first_transcript_after_eos_delay():
+    """The computed delay equals first_transcript_time - end_of_speech_time and is
+    surfaced on ``_EndOfTurnInfo`` passed to ``on_end_of_turn``."""
+    ar = _create_audio_recognition()
+
+    captured: dict[str, object] = {}
+
+    def _on_end_of_turn(info):
+        captured["info"] = info
+        return True
+
+    ar._hooks.on_end_of_turn.side_effect = _on_end_of_turn
+    ar._hooks.retrieve_chat_ctx.return_value = MagicMock(copy=lambda: MagicMock(items=[]))
+
+    eos_t = 1000.0
+    first_t = 1000.4
+    ar._end_of_speech_time = eos_t
+    ar._first_transcript_after_eos_time = first_t
+    ar._last_speaking_time = eos_t
+    ar._last_final_transcript_time = first_t
+    ar._speech_start_time = 999.0
+    ar._user_turn_start = 999.0
+    ar._audio_transcript = "hello world"
+
+    # call the metrics computation path directly via _run_eou_detection's inner task
+    chat_ctx = MagicMock()
+    chat_ctx.copy.return_value = chat_ctx
+    chat_ctx.items = []
+    ar._turn_detector = None
+    ar._endpointing = MagicMock()
+    ar._endpointing.min_delay = 0.0
+    ar._endpointing.max_delay = 0.0
+    ar._closing = asyncio.Event()
+
+    with patch.object(ar, "_ensure_user_turn_span", return_value=MagicMock()):
+        ar._run_eou_detection(chat_ctx, trigger="vad")
+        await ar._end_of_turn_task
+
+    info = captured["info"]
+    assert info.metrics.first_transcript_after_eos_delay == pytest.approx(0.4, abs=1e-6)
+
+
+def test_reported_even_when_speaking_anchors_are_unusable():
+    """The metric only depends on the EOS anchors, not on the VAD speaking anchors.
+
+    ``_compute_end_of_turn_metrics`` drops the speaking-anchor metrics when the
+    ``_last_speaking_time`` anchor is stale/out-of-order (issue #6093). The
+    end-of-speech based metric is computed independently and must survive that.
+    """
+    metrics = _compute_end_of_turn_metrics(
+        speech_start_time=1000.0,
+        # stale anchor: predates the turn start -> speaking metrics are dropped
+        last_speaking_time=900.0,
+        last_final_transcript_time=1005.0,
+        now=1005.5,
+        end_of_speech_time=1000.0,
+        first_transcript_after_eos_time=1000.4,
+    )
+
+    assert metrics.started_speaking_at is None
+    assert metrics.stopped_speaking_at is None
+    assert metrics.transcription_delay is None
+    assert metrics.end_of_turn_delay is None
+    assert metrics.first_transcript_after_eos_delay == pytest.approx(0.4, abs=1e-6)
+
+
+def test_absent_when_no_end_of_speech_was_observed():
+    """No EOS anchor -> the metric is None (surfaced as 0.0 by the metrics layer)."""
+    metrics = _compute_end_of_turn_metrics(
+        speech_start_time=1000.0,
+        last_speaking_time=1005.0,
+        last_final_transcript_time=1005.2,
+        now=1005.4,
+    )
+
+    assert metrics.first_transcript_after_eos_delay is None


### PR DESCRIPTION
## Summary

Closes #4795.

Adds a new end-of-turn latency metric, **`first_transcript_after_eos_delay`**, computed as:

```
first_transcript_after_eos_delay = first_transcript_time - end_of_speech_time
```

where `end_of_speech_time` is captured on VAD or STT end-of-speech, and `first_transcript_time` is the first interim/final transcript event received **after** that EOS.

### Why

The existing `transcription_delay` is computed from the last speaking anchor to the **final** transcript, so it reflects end-to-end turn latency rather than "speech end → first result". As noted in the issue, a "speech end → first transcript" metric is needed for comparing provider latency and aligning with backend SLA definitions. This new metric is distinct from and complementary to `transcription_delay`.

### What changed

`AudioRecognition` now tracks two new per-turn anchors:

- `_end_of_speech_time` — set on VAD `END_OF_SPEECH` and STT `END_OF_SPEECH` (`stt` turn-detection mode).
- `_first_transcript_after_eos_time` — set to the arrival time of the **first** transcript event (interim / preflight / final) that occurs after an end-of-speech, and only set once per turn so later transcripts don't move it.

The computed delay is plumbed through additively:

- `_EndOfTurnInfo.first_transcript_after_eos_delay`
- `EOUMetrics.first_transcript_after_eos_delay` (defaults to `0.0`)
- the user `MetricsReport`
- `log_metrics` output for `EOUMetrics`
- the `user_turn` telemetry span (`lk.first_transcript_after_eos_delay`)

The metric is computed independently of the VAD speaking anchors used by `transcription_delay` / `end_of_turn_delay`, and falls back to `0.0` (VAD EOS) when STT EOS is unavailable, per the issue's note. When no transcript arrives strictly after EOS the value is left unset (`None` internally, `0.0` on the public model), which is honest rather than reporting a misleading value. The change is additive and backward-compatible — no existing field or default changes.

## Testing

New unit test `tests/test_first_transcript_after_eos.py` drives `AudioRecognition` directly with crafted VAD/STT events (no audio, no network) and asserts:

- a VAD `END_OF_SPEECH` event anchors `_end_of_speech_time`;
- the **first** transcript after EOS anchors the time and later transcripts don't overwrite it;
- a transcript arriving before any EOS does **not** set the anchor;
- the value reported on `_EndOfTurnInfo` equals `first_transcript_time - end_of_speech_time`.

```
$ uv run pytest tests/test_first_transcript_after_eos.py --unit
4 passed
```

Also verified no regressions in the existing audio-recognition / session suites:

```
$ uv run pytest tests/test_speech_start_time_persistence.py \
    tests/test_audio_recognition_push_audio.py \
    tests/test_audio_recognition_aclose.py \
    tests/test_agent_session.py tests/test_session_host.py --unit
```

Lint / format / types on the changed files:

```
$ uv run ruff check <changed files>          # All checks passed!
$ uv run ruff format --check <changed files>  # already formatted
$ mypy --strict (pydantic plugin) -p livekit.agents  # no errors in changed modules
```

---

_AI-assisted: this change was prepared with AI assistance and reviewed/verified by me._
