### PR TITLE
feat(cerebras): expose reasoning_format for parity with reasoning_effort

### DIFF
--- a/livekit-plugins/livekit-plugins-cerebras/livekit/plugins/cerebras/llm.py
+++ b/livekit-plugins/livekit-plugins-cerebras/livekit/plugins/cerebras/llm.py
@@ -33,6 +33,7 @@ from livekit.agents.types import (
 )
 from livekit.agents.utils import is_given
 from livekit.plugins.openai import LLM as OpenAILLM
+from livekit.plugins.openai.llm import ReasoningFormat
 
 from .models import CerebrasChatModels
 
@@ -112,6 +113,7 @@ class LLM(OpenAILLM):
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
         reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
+        reasoning_format: NotGivenOr[ReasoningFormat] = NOT_GIVEN,
         safety_identifier: NotGivenOr[str] = NOT_GIVEN,
         prompt_cache_key: NotGivenOr[str] = NOT_GIVEN,
         top_p: NotGivenOr[float] = NOT_GIVEN,
@@ -125,6 +127,10 @@ class LLM(OpenAILLM):
 
         ``api_key`` must be set to your Cerebras API key, either using the argument or by setting
         the ``CEREBRAS_API_KEY`` environmental variable.
+
+        ``reasoning_format`` controls how reasoning models (e.g. ``gpt-oss-120b``) return their
+        thinking tokens. Set it to ``"hidden"`` or ``"parsed"`` to keep the model's internal
+        monologue out of the spoken message content.
 
         When ``gzip_compression`` is True (default), request payloads are gzip-compressed,
         which can reduce TTFT for requests with large prompts.
@@ -167,6 +173,7 @@ class LLM(OpenAILLM):
             parallel_tool_calls=parallel_tool_calls,
             tool_choice=tool_choice,
             reasoning_effort=reasoning_effort,
+            reasoning_format=reasoning_format,
             safety_identifier=safety_identifier,
             prompt_cache_key=prompt_cache_key,
             top_p=top_p,

--- a/livekit-plugins/livekit-plugins-cerebras/livekit/plugins/cerebras/llm.py
+++ b/livekit-plugins/livekit-plugins-cerebras/livekit/plugins/cerebras/llm.py
@@ -130,7 +130,8 @@ class LLM(OpenAILLM):
 
         ``reasoning_format`` controls how reasoning models (e.g. ``gpt-oss-120b``) return their
         thinking tokens. Set it to ``"hidden"`` or ``"parsed"`` to keep the model's internal
-        monologue out of the spoken message content.
+        monologue out of the spoken message content; ``"none"`` keeps the model's default
+        behavior.
 
         When ``gzip_compression`` is True (default), request payloads are gzip-compressed,
         which can reduce TTFT for requests with large prompts.

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -61,6 +61,7 @@ lk_oai_debug = int(os.getenv("LK_OPENAI_DEBUG", 0))
 
 Verbosity = Literal["low", "medium", "high"]
 PromptCacheRetention = Literal["in_memory", "24h"]
+ReasoningFormat = Literal["parsed", "raw", "hidden"]
 
 
 @dataclass
@@ -78,6 +79,7 @@ class _LLMOptions:
     max_completion_tokens: NotGivenOr[int]
     service_tier: NotGivenOr[str]
     reasoning_effort: NotGivenOr[ReasoningEffort]
+    reasoning_format: NotGivenOr[ReasoningFormat]
     verbosity: NotGivenOr[Verbosity]
     prompt_cache_retention: NotGivenOr[PromptCacheRetention]
     extra_body: NotGivenOr[dict[str, Any]]
@@ -107,6 +109,7 @@ class LLM(llm.LLM):
         max_retries: NotGivenOr[int] = NOT_GIVEN,
         service_tier: NotGivenOr[str] = NOT_GIVEN,
         reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
+        reasoning_format: NotGivenOr[ReasoningFormat] = NOT_GIVEN,
         verbosity: NotGivenOr[Verbosity] = NOT_GIVEN,
         prompt_cache_retention: NotGivenOr[PromptCacheRetention] = NOT_GIVEN,
         extra_body: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
@@ -120,6 +123,12 @@ class LLM(llm.LLM):
 
         ``api_key`` must be set to your OpenAI API key, either using the argument or by setting the
         ``OPENAI_API_KEY`` environmental variable.
+
+        ``reasoning_format`` controls how reasoning models (e.g. ``gpt-oss-120b`` served by
+        Cerebras or xAI) return their thinking tokens. Set it to ``"hidden"`` or ``"parsed"`` to
+        keep the model's internal monologue out of the message content so it isn't spoken by the
+        TTS pipeline. This is forwarded as a request body field and is only honored by providers
+        that support it.
         """
         super().__init__()
 
@@ -140,6 +149,7 @@ class LLM(llm.LLM):
             max_completion_tokens=max_completion_tokens,
             service_tier=service_tier,
             reasoning_effort=reasoning_effort,
+            reasoning_format=reasoning_format,
             safety_identifier=safety_identifier,
             prompt_cache_key=prompt_cache_key,
             top_p=top_p,
@@ -401,6 +411,7 @@ class LLM(llm.LLM):
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: ToolChoice = "auto",
         reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
+        reasoning_format: NotGivenOr[ReasoningFormat] = NOT_GIVEN,
         safety_identifier: NotGivenOr[str] = NOT_GIVEN,
         prompt_cache_key: NotGivenOr[str] = NOT_GIVEN,
         top_p: NotGivenOr[float] = NOT_GIVEN,
@@ -410,6 +421,9 @@ class LLM(llm.LLM):
 
         ``api_key`` must be set to your XAI API key, either using the argument or by setting
         the ``XAI_API_KEY`` environmental variable.
+
+        ``reasoning_format`` controls how Grok reasoning models return their thinking tokens; set
+        it to ``"hidden"`` or ``"parsed"`` to keep reasoning out of the spoken message content.
         """
         api_key = api_key or os.environ.get("XAI_API_KEY")
         if api_key is None:
@@ -428,6 +442,7 @@ class LLM(llm.LLM):
             tool_choice=tool_choice,
             # TODO(long): add provider fmt for grok
             reasoning_effort=reasoning_effort,
+            reasoning_format=reasoning_format,
             safety_identifier=safety_identifier,
             prompt_cache_key=prompt_cache_key,
             top_p=top_p,
@@ -981,6 +996,13 @@ class LLM(llm.LLM):
 
         if is_given(self._opts.reasoning_effort):
             extra["reasoning_effort"] = self._opts.reasoning_effort
+
+        if is_given(self._opts.reasoning_format):
+            # reasoning_format is a provider-specific body field (Cerebras/xAI), so it has to be
+            # forwarded via extra_body rather than as a top-level OpenAI SDK argument.
+            extra_body = dict(extra.get("extra_body") or {})
+            extra_body["reasoning_format"] = self._opts.reasoning_format
+            extra["extra_body"] = extra_body
 
         if is_given(self._opts.safety_identifier):
             extra["safety_identifier"] = self._opts.safety_identifier

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -124,8 +124,8 @@ class LLM(llm.LLM):
         ``api_key`` must be set to your OpenAI API key, either using the argument or by setting the
         ``OPENAI_API_KEY`` environmental variable.
 
-        ``reasoning_format`` controls how reasoning models (e.g. ``gpt-oss-120b`` served by
-        Cerebras or xAI) return their thinking tokens. Set it to ``"hidden"`` or ``"parsed"`` to
+        ``reasoning_format`` controls how reasoning models (e.g. ``gpt-oss-120b`` on Cerebras,
+        or Grok on xAI) return their thinking tokens. Set it to ``"hidden"`` or ``"parsed"`` to
         keep the model's internal monologue out of the message content so it isn't spoken by the
         TTS pipeline. This is forwarded as a request body field and is only honored by providers
         that support it.

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -277,6 +277,7 @@ class LLM(llm.LLM):
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
         reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
+        reasoning_format: NotGivenOr[ReasoningFormat] = NOT_GIVEN,
         safety_identifier: NotGivenOr[str] = NOT_GIVEN,
         prompt_cache_key: NotGivenOr[str] = NOT_GIVEN,
         top_p: NotGivenOr[float] = NOT_GIVEN,
@@ -286,6 +287,10 @@ class LLM(llm.LLM):
 
         ``api_key`` must be set to your Cerebras API key, either using the argument or by setting
         the ``CEREBRAS_API_KEY`` environment variable.
+
+        ``reasoning_format`` controls how Cerebras reasoning models (e.g. ``gpt-oss-120b``) return
+        their thinking tokens; set it to ``"hidden"`` or ``"parsed"`` to keep reasoning out of the
+        spoken message content.
         """
 
         api_key = api_key or os.environ.get("CEREBRAS_API_KEY")
@@ -304,6 +309,7 @@ class LLM(llm.LLM):
             parallel_tool_calls=parallel_tool_calls,
             tool_choice=tool_choice,
             reasoning_effort=reasoning_effort,
+            reasoning_format=reasoning_format,
             safety_identifier=safety_identifier,
             prompt_cache_key=prompt_cache_key,
             top_p=top_p,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -61,7 +61,7 @@ lk_oai_debug = int(os.getenv("LK_OPENAI_DEBUG", 0))
 
 Verbosity = Literal["low", "medium", "high"]
 PromptCacheRetention = Literal["in_memory", "24h"]
-ReasoningFormat = Literal["parsed", "raw", "hidden"]
+ReasoningFormat = Literal["parsed", "raw", "hidden", "none"]
 
 
 @dataclass
@@ -124,11 +124,11 @@ class LLM(llm.LLM):
         ``api_key`` must be set to your OpenAI API key, either using the argument or by setting the
         ``OPENAI_API_KEY`` environmental variable.
 
-        ``reasoning_format`` controls how reasoning models (e.g. ``gpt-oss-120b`` on Cerebras,
-        or Grok on xAI) return their thinking tokens. Set it to ``"hidden"`` or ``"parsed"`` to
+        ``reasoning_format`` controls how reasoning models (e.g. ``gpt-oss-120b`` served by
+        Cerebras) return their thinking tokens. Set it to ``"hidden"`` or ``"parsed"`` to
         keep the model's internal monologue out of the message content so it isn't spoken by the
-        TTS pipeline. This is forwarded as a request body field and is only honored by providers
-        that support it.
+        TTS pipeline; ``"none"`` keeps the provider's default behavior. This is forwarded as a
+        request body field and is only honored by providers that support it.
         """
         super().__init__()
 
@@ -417,7 +417,6 @@ class LLM(llm.LLM):
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: ToolChoice = "auto",
         reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
-        reasoning_format: NotGivenOr[ReasoningFormat] = NOT_GIVEN,
         safety_identifier: NotGivenOr[str] = NOT_GIVEN,
         prompt_cache_key: NotGivenOr[str] = NOT_GIVEN,
         top_p: NotGivenOr[float] = NOT_GIVEN,
@@ -427,9 +426,6 @@ class LLM(llm.LLM):
 
         ``api_key`` must be set to your XAI API key, either using the argument or by setting
         the ``XAI_API_KEY`` environmental variable.
-
-        ``reasoning_format`` controls how Grok reasoning models return their thinking tokens; set
-        it to ``"hidden"`` or ``"parsed"`` to keep reasoning out of the spoken message content.
         """
         api_key = api_key or os.environ.get("XAI_API_KEY")
         if api_key is None:
@@ -448,7 +444,6 @@ class LLM(llm.LLM):
             tool_choice=tool_choice,
             # TODO(long): add provider fmt for grok
             reasoning_effort=reasoning_effort,
-            reasoning_format=reasoning_format,
             safety_identifier=safety_identifier,
             prompt_cache_key=prompt_cache_key,
             top_p=top_p,
@@ -1004,7 +999,7 @@ class LLM(llm.LLM):
             extra["reasoning_effort"] = self._opts.reasoning_effort
 
         if is_given(self._opts.reasoning_format):
-            # reasoning_format is a provider-specific body field (Cerebras/xAI), so it has to be
+            # reasoning_format is a provider-specific body field (Cerebras), so it has to be
             # forwarded via extra_body rather than as a top-level OpenAI SDK argument.
             extra_body = dict(extra.get("extra_body") or {})
             extra_body["reasoning_format"] = self._opts.reasoning_format

--- a/tests/test_plugin_reasoning_format.py
+++ b/tests/test_plugin_reasoning_format.py
@@ -51,6 +51,22 @@ async def test_cerebras_reasoning_format_omitted_by_default() -> None:
 
 
 @pytest.mark.asyncio
+async def test_openai_with_cerebras_reasoning_format_in_request() -> None:
+    """``LLM.with_cerebras`` forwards ``reasoning_format`` to the request body."""
+    llm = OpenAILLM.with_cerebras(
+        model="gpt-oss-120b",
+        api_key="test-key",
+        reasoning_format="hidden",
+    )
+    stream = llm.chat(chat_ctx=_chat_ctx())
+    try:
+        extra_body = stream._extra_kwargs.get("extra_body", {})
+        assert extra_body.get("reasoning_format") == "hidden"
+    finally:
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
 async def test_xai_reasoning_format_in_request() -> None:
     """``LLM.with_x_ai`` forwards ``reasoning_format`` to the request body."""
     llm = OpenAILLM.with_x_ai(

--- a/tests/test_plugin_reasoning_format.py
+++ b/tests/test_plugin_reasoning_format.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents.llm import ChatContext
+from livekit.plugins.cerebras import LLM as CerebrasLLM
+from livekit.plugins.openai import LLM as OpenAILLM
+
+pytestmark = pytest.mark.unit
+
+
+def _chat_ctx() -> ChatContext:
+    chat_ctx = ChatContext()
+    chat_ctx.add_message(role="user", content="hi")
+    return chat_ctx
+
+
+@pytest.mark.asyncio
+async def test_cerebras_reasoning_format_in_request() -> None:
+    """``reasoning_format`` is forwarded to the request body via ``extra_body``."""
+    llm = CerebrasLLM(
+        model="gpt-oss-120b",
+        api_key="test-key",
+        reasoning_format="hidden",
+        gzip_compression=False,
+        msgpack_encoding=False,
+    )
+    stream = llm.chat(chat_ctx=_chat_ctx())
+    try:
+        extra_body = stream._extra_kwargs.get("extra_body", {})
+        assert extra_body.get("reasoning_format") == "hidden"
+    finally:
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cerebras_reasoning_format_omitted_by_default() -> None:
+    """No ``reasoning_format`` is sent when the option is not set."""
+    llm = CerebrasLLM(
+        model="gpt-oss-120b",
+        api_key="test-key",
+        gzip_compression=False,
+        msgpack_encoding=False,
+    )
+    stream = llm.chat(chat_ctx=_chat_ctx())
+    try:
+        extra_body = stream._extra_kwargs.get("extra_body", {})
+        assert "reasoning_format" not in extra_body
+    finally:
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_xai_reasoning_format_in_request() -> None:
+    """``LLM.with_x_ai`` forwards ``reasoning_format`` to the request body."""
+    llm = OpenAILLM.with_x_ai(
+        model="grok-4-1-fast-reasoning",
+        api_key="test-key",
+        reasoning_format="parsed",
+    )
+    stream = llm.chat(chat_ctx=_chat_ctx())
+    try:
+        extra_body = stream._extra_kwargs.get("extra_body", {})
+        assert extra_body.get("reasoning_format") == "parsed"
+    finally:
+        await stream.aclose()

--- a/tests/test_plugin_reasoning_format.py
+++ b/tests/test_plugin_reasoning_format.py
@@ -67,16 +67,18 @@ async def test_openai_with_cerebras_reasoning_format_in_request() -> None:
 
 
 @pytest.mark.asyncio
-async def test_xai_reasoning_format_in_request() -> None:
-    """``LLM.with_x_ai`` forwards ``reasoning_format`` to the request body."""
-    llm = OpenAILLM.with_x_ai(
-        model="grok-4-1-fast-reasoning",
+async def test_cerebras_reasoning_format_none_forwarded() -> None:
+    """``"none"`` (provider default) is a valid value and is forwarded verbatim."""
+    llm = CerebrasLLM(
+        model="gpt-oss-120b",
         api_key="test-key",
-        reasoning_format="parsed",
+        reasoning_format="none",
+        gzip_compression=False,
+        msgpack_encoding=False,
     )
     stream = llm.chat(chat_ctx=_chat_ctx())
     try:
         extra_body = stream._extra_kwargs.get("extra_body", {})
-        assert extra_body.get("reasoning_format") == "parsed"
+        assert extra_body.get("reasoning_format") == "none"
     finally:
         await stream.aclose()


### PR DESCRIPTION
## Summary

Closes #5989.

Reasoning models such as `gpt-oss-120b` served by **Cerebras** stream their *thinking* tokens as part of the chat-completions response. Today there is no way to tell the provider to keep that internal monologue out of the message `content`, so the TTS pipeline ends up reading the model's raw reasoning aloud.

Cerebras supports a `reasoning_format` request field (`"parsed"`, `"raw"`, `"hidden"`, `"none"`) that controls where reasoning ends up. This PR exposes it on the relevant LLM constructors, mirroring exactly how `reasoning_effort` is already plumbed.

> **Scope note:** the first revision also exposed `reasoning_format` on `LLM.with_x_ai(...)`. That was removed after review feedback ([comment](https://github.com/livekit/agents/pull/6106#issuecomment-4867523296)) — xAI's API does not document a `reasoning_format` field (its reasoning control is `reasoning_effort`), so shipping it there would have been a silent no-op. The feature is now scoped to Cerebras only.

## Changes

- **`livekit-plugins-openai`** (`llm.py`)
  - Add a `ReasoningFormat = Literal["parsed", "raw", "hidden", "none"]` type (values per the Cerebras reasoning docs).
  - Add `reasoning_format` to `_LLMOptions`, the `LLM.__init__` signature, and the `LLM.with_cerebras(...)` factory.
  - In `chat()`, forward it to the request. Because `reasoning_format` is a provider-specific body field and **not** an OpenAI SDK keyword argument (passing it top-level raises `TypeError: unexpected keyword argument`), it is merged into `extra_body` — the same mechanism already used for OpenRouter-specific body fields. The user-supplied `extra_body` dict is never mutated in place.
- **`livekit-plugins-cerebras`** (`llm.py`)
  - Add `reasoning_format` to the Cerebras `LLM.__init__` and forward it to the base class.

The change is additive and backward-compatible: when `reasoning_format` is not set, nothing is added to the request.

## How `reasoning_format` reaches the API

`reasoning_effort` is a named param in the OpenAI Python SDK (`AsyncCompletions.create`), so it is passed top-level. `reasoning_format` is not, so it must travel through `extra_body`. Verified empirically against `openai==2.40.0`:

```
top-level reasoning_format: TypeError -> AsyncCompletions.create() got an unexpected keyword argument 'reasoning_format'
extra_body call body has reasoning_format: True
```

## Testing

Added `tests/test_plugin_reasoning_format.py` (unit, no live keys — constructs the LLM and inspects the request kwargs the stream would send):

- `reasoning_format` set on Cerebras `LLM` lands in `extra_body` of the outgoing request.
- `reasoning_format` set via `LLM.with_cerebras(...)` lands in `extra_body`.
- `"none"` is accepted and forwarded verbatim.
- When unset, no `reasoning_format` is added.

```
$ uv run pytest tests/test_plugin_reasoning_format.py --unit
4 passed
```

Quality gates on the changed files:

- `uv run ruff check` — All checks passed
- `uv run ruff format --check` — already formatted
- `uv run mypy -p livekit.plugins.openai -p livekit.plugins.cerebras` (strict) — Success: no issues found

---

*AI-assisted: this change was prepared with AI assistance and reviewed by the author.*
