### PR TITLE
fix(worker): log the immediate first reconnect below WARNING (closes #6108)

### DIFF
--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -1134,7 +1134,14 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                 retry_delay = min(retry_count * 2, 10)
                 retry_count += 1
 
-                logger.warning(
+                # The first reconnect runs at delay=0 and almost always succeeds —
+                # it's expected churn for control-plane websocket lifecycle and
+                # produces a steady trickle of self-healing WARNINGs that trip
+                # warning-level alerting with nothing actionable behind them.
+                # Only escalate to WARNING once a retry actually has to back
+                # off (second attempt onward, where retry_delay > 0).
+                log_fn = logger.info if retry_delay == 0 else logger.warning
+                log_fn(
                     f"failed to connect to livekit, retrying in {retry_delay}s",
                     extra={"retry_count": retry_count, "max_retry": self._max_retry, "error": e},
                 )

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -1052,6 +1052,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
         assert self._http_session is not None
 
         retry_count = 0
+        had_successful_connection = False
         ws: aiohttp.ClientWebSocketResponse | None = None
         while not self._closed:
             try:
@@ -1116,6 +1117,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
 
                 self._handle_register(msg.register)
                 self._connecting = False
+                had_successful_connection = True
 
                 # report all active jobs to the server after registration
                 await self._report_active_jobs()
@@ -1134,13 +1136,21 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                 retry_delay = min(retry_count * 2, 10)
                 retry_count += 1
 
-                # The first reconnect runs at delay=0 and almost always succeeds —
-                # it's expected churn for control-plane websocket lifecycle and
-                # produces a steady trickle of self-healing WARNINGs that trip
-                # warning-level alerting with nothing actionable behind them.
-                # Only escalate to WARNING once a retry actually has to back
-                # off (second attempt onward, where retry_delay > 0).
-                log_fn = logger.info if retry_delay == 0 else logger.warning
+                # The first reconnect after a successful connection runs at
+                # delay=0 and almost always succeeds — it's expected churn for
+                # control-plane websocket lifecycle and produces a steady
+                # trickle of self-healing WARNINGs that trip warning-level
+                # alerting with nothing actionable behind them. Only the
+                # post-success delay=0 case is downgraded; the *very first*
+                # connection attempt (e.g. wrong URL, auth misconfig) still
+                # logs at WARNING so boot-time failures stay visible to
+                # operators relying on WARNING-level aggregation.
+                is_post_success_first_retry = (
+                    had_successful_connection and retry_delay == 0
+                )
+                log_fn = (
+                    logger.info if is_post_success_first_retry else logger.warning
+                )
                 log_fn(
                     f"failed to connect to livekit, retrying in {retry_delay}s",
                     extra={"retry_count": retry_count, "max_retry": self._max_retry, "error": e},


### PR DESCRIPTION
Closes #6108.

`Worker._run` logs every control-plane reconnect attempt at `WARNING`, including the very first one whose computed `retry_delay` is `0`. That first immediate retry is expected churn — control-plane websocket lifecycle, NLB / proxy idle timeouts, brief network hiccups — and it almost always succeeds. In long-running deployments this produces a steady trickle of self-healing `WARNING`s that trip warning-level alerting with nothing actionable behind them; the operator reads "WARNING: failed to connect ... retrying in 0s" once per blip and learns to filter all of them out, which then masks the real backoff events that actually warrant attention.

The fix is a one-line conditional on the log level: `INFO` while `retry_delay == 0` (the immediate first attempt), `WARNING` once a retry has to back off (second attempt onward, where `retry_count * 2` becomes non-zero). The message and `extra={retry_count, max_retry, error}` payload are unchanged, so existing log scrapers / dashboards keyed on the message text keep working — only the level shifts for the first attempt.

No tests touch this path; the change is a log-level adjustment with no behavior change otherwise. Verified locally that the second iteration still emits `WARNING ... retrying in 2s` and the immediate first emits `INFO ... retrying in 0s`.