### PR TITLE
fix: honor per-agent preemptive_generation options

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -80,7 +80,7 @@ from .generation import (
 )
 from .speech_handle import DEFAULT_INPUT_DETAILS, InputDetails, SpeechHandle
 from .tool_executor import _resolve_async_tool_options, _ToolExecutor
-from .turn import EndpointingOptions, TurnDetectionMode
+from .turn import EndpointingOptions, PreemptiveGenerationOptions, TurnDetectionMode
 
 if TYPE_CHECKING:
     from ..llm import mcp
@@ -363,6 +363,13 @@ class AgentActivity(RecognitionHooks):
             max_delay=agent_endpointing.get("max_delay", session_endpointing["max_delay"]),
             alpha=agent_endpointing.get("alpha", session_endpointing["alpha"]),
         )
+
+    @property
+    def preemptive_generation_opts(self) -> PreemptiveGenerationOptions:
+        # session is always fully resolved; agent-level keys override it
+        agent_preemptive = self._agent._turn_handling.get("preemptive_generation", {})
+        session_preemptive = self._session.options.preemptive_generation
+        return PreemptiveGenerationOptions(**{**session_preemptive, **agent_preemptive})
 
     @property
     def min_endpointing_delay(self) -> float:
@@ -1953,7 +1960,7 @@ class AgentActivity(RecognitionHooks):
         )
 
     def on_preemptive_generation(self, info: _PreemptiveGenerationInfo) -> None:
-        preemptive_opts = self._session.options.preemptive_generation
+        preemptive_opts = self.preemptive_generation_opts
         if (
             not preemptive_opts["enabled"]
             or self._scheduling_paused
@@ -2710,7 +2717,7 @@ class AgentActivity(RecognitionHooks):
 
         # start synthesis preemptively (before the speech is scheduled) when enabled;
         # otherwise it starts right after scheduling below
-        preemptive_opts = self._session.options.preemptive_generation
+        preemptive_opts = self.preemptive_generation_opts
         synthesize_task: asyncio.Task[None] | None = None
         if (
             audio_output is not None

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from livekit.agents import (
+    NOT_GIVEN,
     Agent,
     AgentFalseInterruptionEvent,
     AgentStateChangedEvent,
@@ -17,6 +18,8 @@ from livekit.agents import (
     LanguageCode,
     MetricsCollectedEvent,
     ModelSettings,
+    NotGivenOr,
+    TurnHandlingOptions,
     UserInputTranscribedEvent,
     UserStateChangedEvent,
     function_tool,
@@ -47,9 +50,11 @@ class MyAgent(Agent):
         generate_reply_on_enter: bool = False,
         say_on_user_turn_completed: bool = False,
         on_user_turn_completed_delay: float = 0.0,
+        turn_handling: NotGivenOr[TurnHandlingOptions] = NOT_GIVEN,
     ) -> None:
         super().__init__(
             instructions=("You are a helpful assistant."),
+            turn_handling=turn_handling,
         )
         self.generate_reply_on_enter = generate_reply_on_enter
         self.say_on_user_turn_completed = say_on_user_turn_completed
@@ -1023,6 +1028,50 @@ async def test_preemptive_generation(preemptive_generation: dict, expected_laten
         max_abs_diff=0.2,
     )
     assert agent_state_events[3].new_state == "listening"
+
+
+@pytest.mark.parametrize(
+    "session_preemptive, agent_preemptive, expected_latency",
+    [
+        # agent disables what the session enabled -> no preemptive generation (1.1s)
+        ({"preemptive_tts": True}, {"enabled": False}, 1.1),
+        # agent enables (with TTS) what the session disabled -> fully preemptive (0.7s)
+        ({"enabled": False}, {"enabled": True, "preemptive_tts": True}, 0.7),
+    ],
+)
+async def test_preemptive_generation_on_agent(
+    session_preemptive: dict, agent_preemptive: dict, expected_latency: float
+) -> None:
+    # preemptive generation set on the agent must override the session value
+    speed = 1
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.0, "Hello, how are you?", stt_delay=0.1)
+    actions.add_llm("I'm doing great, thank you!", ttft=0.1, duration=0.3)
+    actions.add_tts(3.0, ttfb=0.3)
+    # preemptive_generation with TTS enabled: e2e latency is 0.1+0.3+0.3=0.7s
+    # preemptive_generation disabled: e2e latency is 0.5+0.3+0.3=1.1s
+
+    session = create_session(
+        actions,
+        speed_factor=speed,
+        turn_handling={"preemptive_generation": session_preemptive},
+    )
+    agent = MyAgent(turn_handling={"preemptive_generation": agent_preemptive})
+
+    agent_state_events: list[AgentStateChangedEvent] = []
+    user_state_events: list[UserStateChangedEvent] = []
+    session.on("agent_state_changed", agent_state_events.append)
+    session.on("user_state_changed", user_state_events.append)
+
+    await asyncio.wait_for(run_session(session, agent), timeout=SESSION_TIMEOUT)
+    t_user_stop_speaking = user_state_events[1].created_at
+    t_agent_start_speaking = agent_state_events[2].created_at
+    check_timestamp(
+        t_agent_start_speaking - t_user_stop_speaking,
+        t_target=expected_latency,
+        speed_factor=speed,
+        max_abs_diff=0.2,
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #6112.

`preemptive_generation` was read directly from `session.options`, so an agent's `turn_handling={"preemptive_generation": {...}}` had no effect — the session value (default `enabled: True`) always won. This is inconsistent with `endpointing`, which already resolves agent-over-session via `endpointing_opts`.

This adds a `preemptive_generation_opts` property on `AgentActivity` that merges the agent's keys over the fully-resolved session value, and routes both call sites (`on_preemptive_generation` and the preemptive-TTS branch in `pipeline_reply`) through it.

Note this only fixes the effective behavior. The session report (`make_session_report`) still reflects session-level options only, so it won't show per-agent overrides; that reporting gap is tracked separately.