### PR TITLE
Add Resemble Detect plugin

### DIFF
--- a/livekit-plugins/livekit-plugins-resemble/README.md
+++ b/livekit-plugins/livekit-plugins-resemble/README.md
@@ -1,6 +1,7 @@
 # Resemble plugin for LiveKit Agents
 
-Support for voice synthesis with the [Resemble AI](https://www.resemble.ai/) API, using both their REST API and WebSocket streaming interface.
+Support for [Resemble AI](https://www.resemble.ai/) voice synthesis and real-time
+deepfake detection in LiveKit Agents.
 
 See [https://docs.livekit.io/agents/integrations/tts/resemble/](https://docs.livekit.io/agents/integrations/tts/resemble/) for more information.
 
@@ -12,13 +13,14 @@ pip install livekit-plugins-resemble
 
 ## Pre-requisites
 
-You'll need an API key from Resemble AI. It can be set as an environment variable: `RESEMBLE_API_KEY`
+You'll need an API key from Resemble AI. It can be set as an environment variable:
+`RESEMBLE_API_KEY`.
 
-Additionally, you'll need the voice UUID from your Resemble AI account.
+For TTS, you'll also need the voice UUID from your Resemble AI account.
 
 ## Examples
 
-### Recommended
+### Text-to-speech
 
 ```python
 import asyncio
@@ -31,8 +33,7 @@ async def run_tts_example():
         voice_uuid="your_voice_uuid",
         # Optional parameters
         sample_rate=44100,  # Sample rate in Hz (default: 44100)
-        precision="PCM_16",  # Audio precision (PCM_32, PCM_24, PCM_16, MULAW)
-        output_format="wav",  # Output format (wav or mp3)
+        model="chatterbox-turbo",
     ) as tts:
         # One-off synthesis (uses REST API)
         audio_stream = tts.synthesize("Hello, world!")
@@ -58,6 +59,99 @@ async def run_tts_example():
 # Run the example
 asyncio.run(run_tts_example())
 ```
+
+### Deepfake detection
+
+Add Resemble Detect to a LiveKit room with a small, event-driven surface:
+
+```python
+from livekit.plugins import resemble
+
+detect = resemble.ResembleDetect(security="standard")
+detect.attach(ctx.room)  # auto-subscribes to the first remote microphone track
+
+
+def on_synthetic(result: resemble.DetectionResult) -> None:
+    # result.label is the raw Detect label ("fake"); normalized_label is app-facing.
+    if result.normalized_label == "synthetic":
+        # pause account actions, ask for step-up verification, or escalate
+        ...
+
+
+detect.on("synthetic_detected", on_synthetic)
+```
+
+Each result exposes a stable app payload:
+
+```python
+{
+    "label": "synthetic",
+    "score": 0.86,
+    "confidence": 0.9,
+    "window_ts": 41.2,
+    "scan_index": 3,
+    "is_final": False,
+}
+```
+
+Use `result.to_dict()` or `verdict.to_dict()` if you want this shape directly.
+
+### Detection options
+
+1. **Standard security** - default for most calls. Checks a 4s speech window early, samples
+   across the call, and emits `synthetic_detected` only after 2-of-3 recent checks agree.
+
+   ```python
+   detect = resemble.ResembleDetect(security="standard")
+   ```
+
+2. **Spot check** - lowest cost. Runs one check once enough speech is available.
+
+   ```python
+   detect = resemble.ResembleDetect(security="spot")
+   ```
+
+3. **High security** - continuous monitoring for sensitive workflows.
+
+   ```python
+   detect = resemble.ResembleDetect(security="high")
+   ```
+
+4. **Custom policy** - override any preset with simple keyword arguments.
+
+   ```python
+   detect = resemble.ResembleDetect(
+       security="standard",
+       window_seconds=4.0,
+       sample_interval_seconds=20.0,
+       fake_threshold=0.75,
+       agreement_window=3,
+       min_fake_results=2,
+       zero_retention_mode=True,
+       extra_form_fields={"use_ood_detector": True},
+   )
+   ```
+
+5. **Custom transport** - keep the LiveKit integration logic but swap how audio reaches
+   Detect. This is useful for a streaming Detect backend, a gateway, or tests.
+
+   ```python
+   detect = resemble.ResembleDetect(transport=my_detect_transport)
+   ```
+
+For a sensitive action such as a password reset, request a fresh check before proceeding:
+
+```python
+detect.check_now()
+```
+
+`fake_detected` is still emitted for every raw window that crosses `fake_threshold`.
+Production agents should usually act on `synthetic_detected`, which applies the configured
+agreement policy.
+
+The default REST transport uploads short WAV windows directly to Detect with `Prefer: wait`
+and `zero_retention_mode=True`. Pass `extra_form_fields` for advanced Detect options, or pass
+a custom `transport` when using a streaming Detect backend or gateway.
 
 ### Alternative: Manual Resource Management
 
@@ -117,4 +211,4 @@ This plugin uses two different approaches to generate speech:
 1. **One-off Synthesis** - Uses Resemble's REST API for simple text-to-speech conversion
 2. **Streaming Synthesis** - Uses Resemble's WebSocket API for real-time streaming synthesis
 
-The WebSocket streaming API is only available for Resemble AI Business plan users. 
+The WebSocket streaming API is only available for Resemble AI Business plan users.

--- a/livekit-plugins/livekit-plugins-resemble/README.md
+++ b/livekit-plugins/livekit-plugins-resemble/README.md
@@ -1,7 +1,7 @@
 # Resemble plugin for LiveKit Agents
 
-Support for [Resemble AI](https://www.resemble.ai/) voice synthesis and real-time
-deepfake detection in LiveKit Agents.
+Support for [Resemble AI](https://www.resemble.ai/) voice synthesis, real-time
+deepfake detection, and fraud/scam-intent scoring in LiveKit Agents.
 
 See [https://docs.livekit.io/agents/integrations/tts/resemble/](https://docs.livekit.io/agents/integrations/tts/resemble/) for more information.
 
@@ -95,6 +95,64 @@ Each result exposes a stable app payload:
 ```
 
 Use `result.to_dict()` or `verdict.to_dict()` if you want this shape directly.
+
+### Fraud and scam-intent scoring
+
+Use Resemble Signal when you want to score text, audio, video, or image content against
+fraud and scam categories. It is a companion to Detect: Detect verifies media
+authenticity, while Signal identifies suspicious intent.
+
+```python
+from livekit.plugins import resemble
+
+signal = resemble.ResembleSignal()
+
+result = await signal.score_text(
+    "Hi, it's me. Please read me the reset code you just received."
+)
+
+if result.verdict == "fraud":
+    # block the action, step up verification, or escalate to a human reviewer
+    print(result.top_category.name if result.top_category else "fraud")
+```
+
+Each Signal result exposes a stable app payload:
+
+```python
+{
+    "verdict": "fraud",
+    "score": 0.91,
+    "recommended_action": "block",
+    "input_modality": "text",
+    "top_category": {
+        "name": "CEO Impersonation / Wire Diversion",
+        "score": 0.91,
+        "icon": "wire",
+    },
+}
+```
+
+Signal can also score media files and manage custom fraud categories:
+
+```python
+await signal.score_file(
+    wav_bytes,
+    filename="call.wav",
+    media_type="audio",
+    content_type="audio/wav",
+)
+
+await signal.create_custom_category(
+    name="Tech Support Scam",
+    scenarios=[
+        "Your computer has a virus, press 1 to continue",
+        "We detected suspicious activity, verify your identity now",
+    ],
+)
+```
+
+Signal uses the same bearer authorization style as the rest of this plugin. If you need to
+override it, pass the full `Bearer ...` value as `api_key`.
 
 ### Detection options
 

--- a/livekit-plugins/livekit-plugins-resemble/README.md
+++ b/livekit-plugins/livekit-plugins-resemble/README.md
@@ -27,6 +27,7 @@ For TTS, you'll also need the voice UUID from your Resemble AI account.
 import asyncio
 from livekit.plugins.resemble import TTS
 
+
 async def run_tts_example():
     # Use TTS with async context manager for automatic resource cleanup
     async with TTS(
@@ -38,23 +39,22 @@ async def run_tts_example():
     ) as tts:
         # One-off synthesis (uses REST API)
         audio_stream = tts.synthesize("Hello, world!")
-        
+
         # Process chunks as they arrive
         async for chunk in audio_stream:
             # Audio data is in the 'frame.data' attribute of SynthesizedAudio objects
             audio_data = chunk.frame.data
             print(f"Received chunk: {len(audio_data)} bytes")
-        
+
         # Alternative: collect all audio at once into a single AudioFrame
         audio_stream = tts.synthesize("Another example sentence.")
         audio_frame = await audio_stream.collect()
         print(f"Collected complete audio: {len(audio_frame.data)} bytes")
-        
+
         # Real-time streaming synthesis (uses WebSocket API)
         # Only available for Business plan users in Resemble AI
         stream = tts.stream()
         await stream.synthesize_text("Hello, world!")
-        
 
 
 # Run the example
@@ -108,9 +108,7 @@ from livekit.plugins import resemble
 
 signal = resemble.ResembleSignal()
 
-result = await signal.score_text(
-    "Hi, it's me. Please read me the reset code you just received."
-)
+result = await signal.score_text("Hi, it's me. Please read me the reset code you just received.")
 
 if result.verdict == "fraud":
     # block the action, step up verification, or escalate to a human reviewer
@@ -272,10 +270,11 @@ If you prefer to manage resources manually, make sure to properly clean up:
 import asyncio
 from livekit.plugins.resemble import TTS
 
+
 async def run_tts_example():
     # Initialize TTS with your credentials
     tts = TTS(
-        api_key="your_api_key", 
+        api_key="your_api_key",
         voice_uuid="your_voice_uuid",
     )
 
@@ -288,6 +287,7 @@ async def run_tts_example():
     finally:
         # Always clean up resources when done
         await tts.aclose()
+
 
 # Run the example
 asyncio.run(run_tts_example())

--- a/livekit-plugins/livekit-plugins-resemble/README.md
+++ b/livekit-plugins/livekit-plugins-resemble/README.md
@@ -1,7 +1,8 @@
 # Resemble plugin for LiveKit Agents
 
 Support for [Resemble AI](https://www.resemble.ai/) voice synthesis, real-time
-deepfake detection, and fraud/scam-intent scoring in LiveKit Agents.
+deepfake detection, fraud/scam-intent scoring, and speaker verification in
+LiveKit Agents.
 
 See [https://docs.livekit.io/agents/integrations/tts/resemble/](https://docs.livekit.io/agents/integrations/tts/resemble/) for more information.
 
@@ -153,6 +154,58 @@ await signal.create_custom_category(
 
 Signal uses the same bearer authorization style as the rest of this plugin. If you need to
 override it, pass the full `Bearer ...` value as `api_key`.
+
+### Speaker verification
+
+Use Resemble Identity to verify a caller against the account's enrolled voiceprints.
+It completes the security trio: Detect answers "is this media synthetic?", Signal
+answers "does this content match a fraud/scam pattern?", and Identity answers
+"is this the enrolled speaker?".
+
+Identity's `/search` endpoint fetches audio from a URL rather than accepting an
+upload, so raw-bytes searches need an `audio_host` hook that makes the clip publicly
+reachable (an S3 presigned URL, a public bucket, or an app endpoint):
+
+```python
+from livekit.plugins import resemble
+
+
+async def host_audio(audio: bytes, filename: str) -> str:
+    key = f"identity/{filename}"
+    await s3.put_object(Bucket="clips", Key=key, Body=audio)
+    return f"https://clips.example.com/{key}"
+
+
+identity = resemble.ResembleIdentity(audio_host=host_audio, threshold=70)
+
+result = await identity.search(turn_wav_bytes, filename="turn-7.wav")
+if result.matched:
+    print(f"verified as {result.name} ({result.score:.0f})")
+```
+
+Clips that are already hosted can be searched directly — no hook required:
+
+```python
+result = await identity.search_url("https://clips.example.com/identity/turn-7.wav")
+```
+
+Each result exposes a stable app payload:
+
+```python
+{
+    "matched": True,
+    "name": "Harold",
+    "score": 91.4,
+    "threshold": 70.0,
+    "matches": [
+        {"uuid": "...", "name": "Harold", "score": 91.4},
+        {"uuid": "...", "name": "Alex", "score": 40.0},
+    ],
+}
+```
+
+Apps without hosting infrastructure can simply skip Identity — Detect and Signal
+work from raw bytes and keep running without it.
 
 ### Detection options
 

--- a/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/__init__.py
+++ b/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/__init__.py
@@ -17,11 +17,35 @@
 See https://docs.livekit.io/agents/integrations/tts/resemble/ for more information.
 """
 
+from .detect import (
+    DetectionAction,
+    DetectionMonitor,
+    DetectionResult,
+    DetectionSecurity,
+    DetectionVerdict,
+    DetectTransport,
+    ResembleDetect,
+    RestDetectTransport,
+)
 from .models import TTSModels
 from .tts import TTS, ChunkedStream, SynthesizeStream
 from .version import __version__
 
-__all__ = ["TTS", "TTSModels", "ChunkedStream", "SynthesizeStream", "__version__"]
+__all__ = [
+    "TTS",
+    "TTSModels",
+    "ChunkedStream",
+    "SynthesizeStream",
+    "ResembleDetect",
+    "DetectionMonitor",
+    "DetectionResult",
+    "DetectionVerdict",
+    "DetectionAction",
+    "DetectionSecurity",
+    "DetectTransport",
+    "RestDetectTransport",
+    "__version__",
+]
 
 from livekit.agents import Plugin
 

--- a/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/__init__.py
+++ b/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/__init__.py
@@ -28,6 +28,16 @@ from .detect import (
     RestDetectTransport,
 )
 from .models import TTSModels
+from .signal import (
+    ResembleSignal,
+    RestSignalTransport,
+    SignalAction,
+    SignalCategoryScore,
+    SignalModality,
+    SignalResult,
+    SignalTransport,
+    SignalVerdict,
+)
 from .tts import TTS, ChunkedStream, SynthesizeStream
 from .version import __version__
 
@@ -44,6 +54,14 @@ __all__ = [
     "DetectionSecurity",
     "DetectTransport",
     "RestDetectTransport",
+    "ResembleSignal",
+    "SignalResult",
+    "SignalCategoryScore",
+    "SignalVerdict",
+    "SignalModality",
+    "SignalAction",
+    "SignalTransport",
+    "RestSignalTransport",
     "__version__",
 ]
 

--- a/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/__init__.py
+++ b/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/__init__.py
@@ -27,6 +27,14 @@ from .detect import (
     ResembleDetect,
     RestDetectTransport,
 )
+from .identity import (
+    AudioHost,
+    IdentityMatch,
+    IdentityResult,
+    IdentityTransport,
+    ResembleIdentity,
+    RestIdentityTransport,
+)
 from .models import TTSModels
 from .signal import (
     ResembleSignal,
@@ -62,6 +70,12 @@ __all__ = [
     "SignalAction",
     "SignalTransport",
     "RestSignalTransport",
+    "ResembleIdentity",
+    "IdentityResult",
+    "IdentityMatch",
+    "IdentityTransport",
+    "RestIdentityTransport",
+    "AudioHost",
     "__version__",
 ]
 

--- a/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/detect.py
+++ b/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/detect.py
@@ -1,0 +1,967 @@
+# Copyright 2025 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+import io
+import math
+import os
+import struct
+import time
+import wave
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol
+
+import aiohttp
+
+from livekit import rtc
+from livekit.agents import APIConnectionError, APIStatusError, utils
+
+from .log import logger
+
+RESEMBLE_DETECT_API_URL = "https://app.resemble.ai/api/v2"
+
+DETECT_SAMPLE_RATE = 16000
+"""Sample rate (Hz) the monitor resamples participant audio to before analysis."""
+
+DetectionMode = Literal["sampled", "first_n", "continuous"]
+DetectionLabel = Literal["real", "fake", "inconclusive"]
+DetectionNormalizedLabel = Literal["real", "synthetic", "inconclusive"]
+DetectionSecurity = Literal["spot", "standard", "high"]
+DetectionAction = Literal["continue", "watch", "verify", "block"]
+DetectFormFieldValue = str | int | float | bool
+
+EventTypes = Literal["result", "fake_detected", "synthetic_detected", "verdict", "error"]
+
+
+class DetectTransport(Protocol):
+    """Transport used by :class:`DetectionMonitor` to submit one audio window.
+
+    The default implementation calls Resemble Detect's REST endpoint. Advanced users can
+    pass their own transport to use a streaming Detect backend, a gateway, or a test double
+    without changing the LiveKit-facing monitor logic.
+    """
+
+    async def submit(
+        self,
+        pcm16: bytes,
+        *,
+        frame_length: int,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        """Submit mono 16 kHz PCM16 audio and return a completed Detect ``item`` payload."""
+
+
+@dataclass(frozen=True)
+class _SecurityPreset:
+    mode: DetectionMode
+    samples: int
+    sample_interval_seconds: float
+    analysis_budget_seconds: float
+    agreement_window: int
+    min_fake_results: int
+
+
+_SECURITY_PRESETS: dict[DetectionSecurity, _SecurityPreset] = {
+    "spot": _SecurityPreset(
+        mode="sampled",
+        samples=1,
+        sample_interval_seconds=0.0,
+        analysis_budget_seconds=4.0,
+        agreement_window=1,
+        min_fake_results=1,
+    ),
+    "standard": _SecurityPreset(
+        mode="sampled",
+        samples=3,
+        sample_interval_seconds=30.0,
+        analysis_budget_seconds=16.0,
+        agreement_window=3,
+        min_fake_results=2,
+    ),
+    "high": _SecurityPreset(
+        mode="continuous",
+        samples=3,
+        sample_interval_seconds=0.0,
+        analysis_budget_seconds=0.0,
+        agreement_window=3,
+        min_fake_results=2,
+    ),
+}
+
+_DEFAULT_WINDOW_SECONDS = 4.0
+_DEFAULT_FAKE_THRESHOLD = 0.7
+_DEFAULT_LIKELY_SYNTHETIC_THRESHOLD = 0.5
+_DEFAULT_UNCLEAR_THRESHOLD = 0.3
+
+
+@dataclass
+class DetectionResult:
+    """Outcome of analyzing one audio window with Resemble Detect."""
+
+    label: DetectionLabel
+    """``"fake"`` or ``"real"`` as returned by the API."""
+    aggregated_score: float
+    """Aggregated fake-probability for the window (0.0 = real, 1.0 = fake)."""
+    scores: list[float]
+    """Per-frame fake-probabilities inside the window (one per ``frame_length`` seconds)."""
+    consistency: float | None
+    """Model consistency metric for the window, when provided by the API."""
+    window_index: int
+    """0-based index of the analyzed window within this monitor's stream."""
+    window_start: float
+    """Start of the window, in seconds since monitoring began."""
+    window_end: float
+    """End of the window, in seconds since monitoring began."""
+    participant_identity: str | None
+    """Identity of the monitored participant, when known."""
+    detection_uuid: str | None
+    """UUID of the detection job on Resemble's side (for follow-up queries)."""
+    latency: float
+    """Round-trip seconds spent on the API call for this window."""
+    forced: bool = False
+    """True if this check was triggered on demand via :meth:`DetectionMonitor.check_now`
+    rather than by the ambient schedule."""
+    raw: dict[str, Any] = field(repr=False, default_factory=dict)
+    """Raw ``item`` payload returned by the API."""
+
+    @property
+    def score(self) -> float:
+        """Alias for ``aggregated_score``; a fake/synthetic probability in ``[0, 1]``."""
+        return self.aggregated_score
+
+    @property
+    def normalized_label(self) -> DetectionNormalizedLabel:
+        """Developer-facing label: ``"synthetic"`` instead of Detect's raw ``"fake"``."""
+        return _normalize_label(self.label)
+
+    @property
+    def confidence(self) -> float:
+        """Best-effort confidence in ``[0, 1]``.
+
+        Resemble Detect can return ``consistency`` as either a percentage or a fraction. If it
+        is absent, fall back to distance from the decision boundary.
+        """
+        if self.consistency is not None:
+            return _clamp01(self.consistency / 100 if self.consistency > 1 else self.consistency)
+        return _clamp01(abs(self.aggregated_score - 0.5) * 2)
+
+    @property
+    def scan_index(self) -> int:
+        """1-based scan index for UI/event payloads."""
+        return self.window_index + 1
+
+    @property
+    def window_ts(self) -> float:
+        """End timestamp of the analyzed window, seconds since monitoring began."""
+        return self.window_end
+
+    @property
+    def is_final(self) -> bool:
+        """Per-window results are interim; finality is represented by ``DetectionVerdict``."""
+        return False
+
+    @property
+    def recommended_action(self) -> DetectionAction:
+        """Action band using the default Resemble Detect score strategy."""
+        if self.aggregated_score < _DEFAULT_UNCLEAR_THRESHOLD:
+            return "continue"
+        if self.aggregated_score < _DEFAULT_LIKELY_SYNTHETIC_THRESHOLD:
+            return "watch"
+        if self.aggregated_score < _DEFAULT_FAKE_THRESHOLD:
+            return "verify"
+        return "block"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a small, stable payload suitable for app events or dashboards."""
+        return {
+            "label": self.normalized_label,
+            "raw_label": self.label,
+            "score": self.score,
+            "confidence": self.confidence,
+            "window_ts": self.window_ts,
+            "scan_index": self.scan_index,
+            "is_final": self.is_final,
+            "recommended_action": self.recommended_action,
+            "participant_identity": self.participant_identity,
+            "detection_uuid": self.detection_uuid,
+            "latency": self.latency,
+            "forced": self.forced,
+        }
+
+
+@dataclass
+class DetectionVerdict:
+    """Aggregate verdict across all analyzed windows of a monitoring session."""
+
+    label: DetectionLabel
+    """``"fake"`` if the security policy confirmed a synthetic caller, ``"real"`` if speech
+    was analyzed and stayed below the unclear band, ``"inconclusive"`` otherwise."""
+    max_score: float | None
+    """Highest window ``aggregated_score`` observed."""
+    analyzed_seconds: float
+    """Total seconds of speech submitted for analysis."""
+    results: list[DetectionResult]
+    """All per-window results that informed the verdict."""
+
+    @property
+    def score(self) -> float:
+        """Highest fake/synthetic probability observed, or ``0.0`` if no speech was analyzed."""
+        return self.max_score or 0.0
+
+    @property
+    def normalized_label(self) -> DetectionNormalizedLabel:
+        """Developer-facing label: ``"synthetic"`` instead of Detect's raw ``"fake"``."""
+        return _normalize_label(self.label)
+
+    @property
+    def confidence(self) -> float:
+        """Confidence from the highest-scoring result, or ``0.0`` if no result exists."""
+        if not self.results:
+            return 0.0
+        result = max(self.results, key=lambda r: r.aggregated_score)
+        return result.confidence
+
+    @property
+    def scan_index(self) -> int:
+        """1-based index of the latest scan represented by this verdict."""
+        return len(self.results)
+
+    @property
+    def window_ts(self) -> float:
+        """End timestamp of the latest analyzed window."""
+        if not self.results:
+            return 0.0
+        return self.results[-1].window_end
+
+    @property
+    def is_final(self) -> bool:
+        """Verdicts are final for the completed ambient detection budget."""
+        return True
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a small, stable payload suitable for app events or dashboards."""
+        return {
+            "label": self.normalized_label,
+            "raw_label": self.label,
+            "score": self.score,
+            "confidence": self.confidence,
+            "window_ts": self.window_ts,
+            "scan_index": self.scan_index,
+            "is_final": self.is_final,
+            "analyzed_seconds": self.analyzed_seconds,
+        }
+
+
+@dataclass
+class _DetectOptions:
+    security: DetectionSecurity
+    window_seconds: float
+    mode: DetectionMode
+    analysis_budget_seconds: float
+    samples: int
+    sample_interval_seconds: float
+    fake_threshold: float
+    likely_synthetic_threshold: float
+    unclear_threshold: float
+    agreement_window: int
+    min_fake_results: int
+    force_immediate_fake: bool
+    frame_length: int
+    silence_rms_threshold: float
+    request_timeout: float
+
+
+class DetectionMonitor(rtc.EventEmitter[EventTypes]):
+    """Real-time deepfake detection for LiveKit participants, powered by Resemble Detect.
+
+    The monitor taps a participant's audio in parallel with the agent pipeline (it never
+    modifies or delays frames), buffers it into short windows, and submits each window to
+    the Resemble Detect API (https://docs.resemble.ai/detect). Results are surfaced as
+    events so an agent can warn the user, flag the session, or end the call:
+
+    - ``"result"`` (:class:`DetectionResult`): a window was analyzed
+    - ``"fake_detected"`` (:class:`DetectionResult`): a raw window crossed ``fake_threshold``
+      (kept for backwards compatibility)
+    - ``"synthetic_detected"`` (:class:`DetectionResult`): the configured security policy
+      has enough agreement to treat the caller as synthetic
+    - ``"verdict"`` (:class:`DetectionVerdict`): the analysis budget completed (``first_n``
+      mode) or the stream ended
+    - ``"error"`` (Exception): an API call failed (monitoring continues)
+
+    By default, ``security="standard"`` checks about four seconds of real speech early,
+    repeats spot-checks across the call, and only emits ``"synthetic_detected"`` after
+    two suspicious windows in the last three checks. Set ``security="spot"`` for a single
+    low-cost check or ``security="high"`` for continuous monitoring.
+    """
+
+    def __init__(
+        self,
+        *,
+        security: DetectionSecurity = "standard",
+        api_key: str | None = None,
+        base_url: str = RESEMBLE_DETECT_API_URL,
+        window_seconds: float | None = None,
+        mode: DetectionMode | None = None,
+        samples: int | None = None,
+        sample_interval_seconds: float | None = None,
+        analysis_budget_seconds: float | None = None,
+        fake_threshold: float = _DEFAULT_FAKE_THRESHOLD,
+        likely_synthetic_threshold: float = _DEFAULT_LIKELY_SYNTHETIC_THRESHOLD,
+        unclear_threshold: float = _DEFAULT_UNCLEAR_THRESHOLD,
+        agreement_window: int | None = None,
+        min_fake_results: int | None = None,
+        force_immediate_fake: bool = False,
+        frame_length: int = 2,
+        silence_rms_threshold: float = 0.0035,
+        request_timeout: float = 30.0,
+        http_session: aiohttp.ClientSession | None = None,
+        transport: DetectTransport | None = None,
+        zero_retention_mode: bool = True,
+        extra_form_fields: Mapping[str, DetectFormFieldValue] | None = None,
+    ) -> None:
+        """Create a new deepfake-detection monitor.
+
+        Args:
+            security (DetectionSecurity, optional): Preset detection strategy. ``"spot"``
+                performs one low-cost check. ``"standard"`` (default) samples early and
+                across the call with 2-of-3 agreement. ``"high"`` monitors continuously.
+            api_key (str, optional): Resemble API key. If not provided, it will be read
+                from the RESEMBLE_API_KEY environment variable. Not required if
+                ``transport`` is provided.
+            base_url (str, optional): Override the Resemble REST Detect API base URL.
+            window_seconds (float, optional): Seconds of audio per detection request.
+                Defaults to 4.0 (minimum 2.0). Overrides the selected preset.
+            mode (DetectionMode, optional): ``"sampled"`` takes ``samples``
+                spot-checks of ``window_seconds`` each, spaced ``sample_interval_seconds``
+                apart, then emits a ``"verdict"`` and stops — low, predictable cost per call.
+                ``"first_n"`` analyzes the first ``analysis_budget_seconds`` of speech back
+                to back, then stops. ``"continuous"`` analyzes for the lifetime of the track.
+                Overrides the selected preset.
+            samples (int, optional): Number of spot-checks in ``"sampled"`` mode.
+                Overrides the selected preset.
+            sample_interval_seconds (float, optional): Idle gap between spot-checks in
+                ``"sampled"`` mode (audio in the gap is not analyzed). Overrides the preset.
+            analysis_budget_seconds (float, optional): Speech budget for ``"first_n"`` mode.
+                Overrides the selected preset.
+            fake_threshold (float, optional): ``aggregated_score`` at or above which a
+                window emits ``"fake_detected"``. Defaults to 0.7.
+            likely_synthetic_threshold (float, optional): Score at or above which a final
+                verdict is inconclusive unless agreement confirms a synthetic caller.
+            unclear_threshold (float, optional): Score at or above which a final verdict is
+                inconclusive instead of real.
+            agreement_window (int, optional): Number of recent checks considered for
+                agreement. Overrides the selected preset.
+            min_fake_results (int, optional): Suspicious results needed within
+                ``agreement_window`` before emitting ``"synthetic_detected"``. Overrides
+                the selected preset.
+            force_immediate_fake (bool, optional): If true, an on-demand ``check_now()``
+                result crossing ``fake_threshold`` immediately emits ``"synthetic_detected"``.
+            frame_length (int, optional): Analysis sub-window in seconds (1-4) passed to
+                the API. Defaults to 2.
+            silence_rms_threshold (float, optional): Windows whose normalized RMS falls
+                below this are treated as silence and skipped (no API call). Set to 0 to
+                analyze everything.
+            request_timeout (float, optional): Per-request timeout in seconds.
+            http_session (aiohttp.ClientSession, optional): An existing aiohttp
+                ClientSession to use. If not provided, a new session will be created.
+            transport (DetectTransport, optional): Custom Detect transport. Use this for a
+                streaming Detect backend, gateway, or tests.
+            zero_retention_mode (bool, optional): Enable Detect's zero-retention mode for
+                the default REST transport. Defaults to True.
+            extra_form_fields (Mapping[str, str | int | float | bool], optional): Extra
+                Detect form fields sent by the default REST transport, for example
+                ``{"use_ood_detector": True}``. Ignored when ``transport`` is provided.
+        """
+        super().__init__()
+
+        if security not in _SECURITY_PRESETS:
+            raise ValueError(f"security must be one of {sorted(_SECURITY_PRESETS)}")
+
+        preset = _SECURITY_PRESETS[security]
+        resolved_window_seconds = (
+            window_seconds if window_seconds is not None else _DEFAULT_WINDOW_SECONDS
+        )
+        resolved_mode = mode if mode is not None else preset.mode
+        resolved_samples = samples if samples is not None else preset.samples
+        resolved_sample_interval_seconds = (
+            sample_interval_seconds
+            if sample_interval_seconds is not None
+            else preset.sample_interval_seconds
+        )
+        resolved_analysis_budget_seconds = (
+            analysis_budget_seconds
+            if analysis_budget_seconds is not None
+            else preset.analysis_budget_seconds
+        )
+        resolved_agreement_window = (
+            agreement_window if agreement_window is not None else preset.agreement_window
+        )
+        resolved_min_fake_results = (
+            min_fake_results if min_fake_results is not None else preset.min_fake_results
+        )
+
+        if resolved_mode not in ("sampled", "first_n", "continuous"):
+            raise ValueError("mode must be one of 'sampled', 'first_n', or 'continuous'")
+        if resolved_window_seconds < 2.0:
+            raise ValueError("window_seconds must be >= 2.0 (Detect scores 1-4s frames)")
+        if not 1 <= frame_length <= 4:
+            raise ValueError("frame_length must be between 1 and 4")
+        if resolved_samples < 1:
+            raise ValueError("samples must be >= 1")
+        if resolved_sample_interval_seconds < 0:
+            raise ValueError("sample_interval_seconds must be >= 0")
+        if resolved_mode == "first_n" and resolved_analysis_budget_seconds <= 0:
+            raise ValueError("analysis_budget_seconds must be > 0 in first_n mode")
+        _validate_threshold("fake_threshold", fake_threshold)
+        _validate_threshold("likely_synthetic_threshold", likely_synthetic_threshold)
+        _validate_threshold("unclear_threshold", unclear_threshold)
+        if not unclear_threshold <= likely_synthetic_threshold <= fake_threshold:
+            raise ValueError(
+                "thresholds must satisfy unclear_threshold <= likely_synthetic_threshold "
+                "<= fake_threshold"
+            )
+        if resolved_agreement_window < 1:
+            raise ValueError("agreement_window must be >= 1")
+        if resolved_min_fake_results < 1:
+            raise ValueError("min_fake_results must be >= 1")
+        if resolved_min_fake_results > resolved_agreement_window:
+            raise ValueError("min_fake_results must be <= agreement_window")
+
+        if transport is None:
+            api_key = api_key or os.environ.get("RESEMBLE_API_KEY")
+            if not api_key:
+                raise ValueError(
+                    "Resemble API key is required, either as argument or set RESEMBLE_API_KEY"
+                    " environment variable"
+                )
+            transport = RestDetectTransport(
+                api_key=api_key,
+                base_url=base_url,
+                http_session=http_session,
+                zero_retention_mode=zero_retention_mode,
+                extra_form_fields=extra_form_fields,
+            )
+
+        self._opts = _DetectOptions(
+            security=security,
+            window_seconds=resolved_window_seconds,
+            mode=resolved_mode,
+            analysis_budget_seconds=resolved_analysis_budget_seconds,
+            samples=resolved_samples,
+            sample_interval_seconds=resolved_sample_interval_seconds,
+            fake_threshold=fake_threshold,
+            likely_synthetic_threshold=likely_synthetic_threshold,
+            unclear_threshold=unclear_threshold,
+            agreement_window=resolved_agreement_window,
+            min_fake_results=resolved_min_fake_results,
+            force_immediate_fake=force_immediate_fake,
+            frame_length=frame_length,
+            silence_rms_threshold=silence_rms_threshold,
+            request_timeout=request_timeout,
+        )
+
+        self._transport = transport
+        self._tasks: set[asyncio.Task[Any]] = set()
+        self._analysis_tasks: set[asyncio.Task[Any]] = set()
+        self._results: list[DetectionResult] = []
+        self._analyzed_seconds = 0.0
+        self._window_index = 0
+        self._samples_taken = 0
+        self._verdict_emitted = False
+        self._synthetic_alert_emitted = False
+        self._closed = False
+        self._paused = False
+        self._force_pending = False
+
+    def check_now(self) -> None:
+        """Force an immediate spot-check of the next speech window, on demand.
+
+        Independent of the ``sampled`` schedule — useful to verify the caller right before
+        a sensitive action (a payment, a password reset), or to drive a "verify now" button.
+        The monitor keeps serving these even after its ambient sample budget is spent.
+        """
+        self._force_pending = True
+
+    def pause(self) -> None:
+        """Pause collection — incoming audio is dropped until :meth:`resume`.
+
+        Use this to analyze only the monitored party's own speech. In a voice agent,
+        pause while *your* agent is speaking so its (always-synthetic) voice is never
+        analyzed, avoiding false positives from echo or shared/mixed audio.
+        """
+        self._paused = True
+
+    def resume(self) -> None:
+        """Resume collection after :meth:`pause`."""
+        self._paused = False
+
+    @property
+    def paused(self) -> bool:
+        """Whether collection is currently paused."""
+        return self._paused
+
+    @property
+    def security(self) -> DetectionSecurity:
+        """Configured security preset."""
+        return self._opts.security
+
+    @property
+    def samples(self) -> int:
+        """Configured number of ambient samples for sampled mode."""
+        return self._opts.samples
+
+    @property
+    def window_seconds(self) -> float:
+        """Seconds of audio submitted per detection request."""
+        return self._opts.window_seconds
+
+    @property
+    def results(self) -> list[DetectionResult]:
+        """All per-window results collected so far."""
+        return list(self._results)
+
+    @property
+    def verdict(self) -> DetectionVerdict:
+        """Aggregate verdict over everything analyzed so far."""
+        max_score = max((r.aggregated_score for r in self._results), default=None)
+        if max_score is None:
+            label: DetectionLabel = "inconclusive"
+        elif self._synthetic_alert_emitted or self._has_confirmed_fake():
+            label = "fake"
+        elif max_score >= self._opts.unclear_threshold:
+            label = "inconclusive"
+        else:
+            label = "real"
+        return DetectionVerdict(
+            label=label,
+            max_score=max_score,
+            analyzed_seconds=self._analyzed_seconds,
+            results=self.results,
+        )
+
+    def start(
+        self,
+        room: rtc.Room,
+        participant: rtc.RemoteParticipant | None = None,
+        *,
+        track_source: rtc.TrackSource.ValueType = rtc.TrackSource.SOURCE_MICROPHONE,
+    ) -> None:
+        """Begin monitoring a participant's audio in the given room.
+
+        Args:
+            room (rtc.Room): The room the agent is connected to.
+            participant (rtc.RemoteParticipant, optional): The participant to monitor.
+                If not provided, the first existing or future remote participant is
+                monitored.
+            track_source (rtc.TrackSource.ValueType, optional): Which audio source to
+                monitor. Defaults to the participant's microphone.
+        """
+        if self._closed:
+            raise RuntimeError("DetectionMonitor is closed")
+
+        self._spawn(self._run(room, participant, track_source))
+
+    def attach(
+        self,
+        room: rtc.Room,
+        participant: rtc.RemoteParticipant | None = None,
+        *,
+        track_source: rtc.TrackSource.ValueType = rtc.TrackSource.SOURCE_MICROPHONE,
+    ) -> None:
+        """Alias for :meth:`start`, matching the high-level Resemble Detect examples."""
+        self.start(room, participant, track_source=track_source)
+
+    def monitor_track(self, track: rtc.Track, *, participant_identity: str | None = None) -> None:
+        """Begin monitoring a specific audio track (lower-level alternative to start())."""
+        if self._closed:
+            raise RuntimeError("DetectionMonitor is closed")
+
+        stream = rtc.AudioStream(track, sample_rate=DETECT_SAMPLE_RATE, num_channels=1)
+        self._spawn(self._consume(stream, participant_identity))
+
+    async def aclose(self) -> None:
+        """Stop monitoring and release resources."""
+        self._closed = True
+        for task in list(self._tasks):
+            task.cancel()
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+
+    def _spawn(self, coro: Any, *, analysis: bool = False) -> None:
+        task = asyncio.create_task(coro)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        if analysis:
+            self._analysis_tasks.add(task)
+            task.add_done_callback(self._analysis_tasks.discard)
+
+    async def _run(
+        self,
+        room: rtc.Room,
+        participant: rtc.RemoteParticipant | None,
+        track_source: rtc.TrackSource.ValueType,
+    ) -> None:
+        if participant is None:
+            participant = await self._wait_for_participant(room)
+
+        stream = rtc.AudioStream.from_participant(
+            participant=participant,
+            track_source=track_source,
+            sample_rate=DETECT_SAMPLE_RATE,
+            num_channels=1,
+        )
+        await self._consume(stream, participant.identity)
+
+    async def _wait_for_participant(self, room: rtc.Room) -> rtc.RemoteParticipant:
+        if room.remote_participants:
+            return next(iter(room.remote_participants.values()))
+
+        fut: asyncio.Future[rtc.RemoteParticipant] = asyncio.get_running_loop().create_future()
+
+        def _on_join(p: rtc.RemoteParticipant) -> None:
+            if not fut.done():
+                fut.set_result(p)
+
+        room.on("participant_connected", _on_join)
+        try:
+            return await fut
+        finally:
+            room.off("participant_connected", _on_join)
+
+    async def _consume(self, stream: rtc.AudioStream, participant_identity: str | None) -> None:
+        window_samples = int(self._opts.window_seconds * DETECT_SAMPLE_RATE)
+        buf = bytearray()
+        stream_pos = 0.0  # seconds of audio consumed from the stream
+        cooldown_until = 0.0  # sampled mode: ignore audio until this stream position
+
+        try:
+            async for event in stream:
+                # paused (e.g. while our own agent is speaking): drop audio and never let
+                # a window straddle the pause boundary, so the agent's voice is never scored
+                if self._paused:
+                    if buf:
+                        buf.clear()
+                    continue
+
+                frame = event.frame
+                buf.extend(frame.data)
+                if len(buf) // 2 < window_samples:
+                    continue
+
+                window = bytes(buf[: window_samples * 2])
+                del buf[: window_samples * 2]
+                window_start = stream_pos
+                stream_pos += self._opts.window_seconds
+
+                forced = self._force_pending  # check_now(): analyze the next window right away
+
+                if self._opts.mode == "sampled" and not forced:
+                    # between spot-checks, drain audio without analyzing it
+                    if stream_pos <= cooldown_until:
+                        continue
+                    # ambient budget spent: idle, but keep listening for on-demand checks
+                    if self._samples_taken >= self._opts.samples:
+                        continue
+
+                if self._budget_exhausted():
+                    if self._opts.mode == "first_n":
+                        await self._flush_and_emit_verdict()
+                        return
+                    continue
+
+                if self._is_silence(window) and not forced:
+                    logger.debug("skipping silent window", extra={"window_start": window_start})
+                    continue
+
+                self._analyzed_seconds += self._opts.window_seconds
+                index = self._window_index
+                self._window_index += 1
+                self._spawn(
+                    self._analyze_window(
+                        window,
+                        index=index,
+                        window_start=window_start,
+                        participant_identity=participant_identity,
+                        forced=forced,
+                    ),
+                    analysis=True,
+                )
+
+                if self._opts.mode == "sampled":
+                    if forced:
+                        self._force_pending = False
+                    else:
+                        self._samples_taken += 1
+                        cooldown_until = stream_pos + self._opts.sample_interval_seconds
+                        if self._samples_taken >= self._opts.samples:
+                            # settle the ambient verdict but stay alive for check_now()
+                            await self._flush_and_emit_verdict()
+        finally:
+            await stream.aclose()
+            if not self._closed:
+                await self._flush_and_emit_verdict()
+
+    async def _flush_and_emit_verdict(self) -> None:
+        # let in-flight window analyses land before settling the verdict
+        while self._analysis_tasks:
+            await asyncio.gather(*list(self._analysis_tasks), return_exceptions=True)
+        self._emit_verdict()
+
+    def _budget_exhausted(self) -> bool:
+        return (
+            self._opts.mode == "first_n"
+            and self._analyzed_seconds >= self._opts.analysis_budget_seconds
+        )
+
+    def _is_silence(self, pcm16: bytes) -> bool:
+        if self._opts.silence_rms_threshold <= 0:
+            return False
+        samples = struct.unpack(f"<{len(pcm16) // 2}h", pcm16)
+        rms = math.sqrt(sum(s * s for s in samples) / len(samples)) / 32768.0
+        return rms < self._opts.silence_rms_threshold
+
+    def _emit_verdict(self) -> None:
+        if self._verdict_emitted:
+            return
+        self._verdict_emitted = True
+        self.emit("verdict", self.verdict)
+
+    async def _analyze_window(
+        self,
+        pcm16: bytes,
+        *,
+        index: int,
+        window_start: float,
+        participant_identity: str | None,
+        forced: bool = False,
+    ) -> None:
+        try:
+            started = time.monotonic()
+            item = await self._submit(pcm16)
+            latency = time.monotonic() - started
+        except Exception as exc:
+            logger.warning("resemble detect request failed", exc_info=exc)
+            self.emit("error", exc)
+            return
+
+        metrics = item.get("metrics") or {}
+        try:
+            # the API pads the score array with None for a trailing partial frame
+            scores = [float(s) for s in metrics.get("score") or [] if s is not None]
+            aggregated = float(metrics["aggregated_score"])
+            label: DetectionLabel = "fake" if metrics["label"] == "fake" else "real"
+        except (KeyError, TypeError, ValueError):
+            self.emit("error", APIConnectionError(f"unexpected detect response shape: {item}"))
+            return
+
+        result = DetectionResult(
+            label=label,
+            aggregated_score=aggregated,
+            scores=scores,
+            consistency=_opt_float(metrics.get("consistency")),
+            window_index=index,
+            window_start=window_start,
+            window_end=window_start + self._opts.window_seconds,
+            participant_identity=participant_identity,
+            detection_uuid=item.get("uuid"),
+            latency=latency,
+            forced=forced,
+            raw=item,
+        )
+        self._results.append(result)
+        logger.debug(
+            "detect window analyzed",
+            extra={
+                "label": result.label,
+                "aggregated_score": result.aggregated_score,
+                "window_index": index,
+                "latency": round(latency, 3),
+            },
+        )
+        self.emit("result", result)
+        if aggregated >= self._opts.fake_threshold:
+            self.emit("fake_detected", result)
+        if self._should_emit_synthetic_detected(result):
+            self._synthetic_alert_emitted = True
+            self.emit("synthetic_detected", result)
+
+    async def _submit(self, pcm16: bytes) -> dict[str, Any]:
+        return await self._transport.submit(
+            pcm16,
+            frame_length=self._opts.frame_length,
+            request_timeout=self._opts.request_timeout,
+        )
+
+    def _has_confirmed_fake(self) -> bool:
+        if not self._results:
+            return False
+        recent = self._results[-self._opts.agreement_window :]
+        fake_results = [r for r in recent if r.aggregated_score >= self._opts.fake_threshold]
+        return len(fake_results) >= self._opts.min_fake_results
+
+    def _should_emit_synthetic_detected(self, result: DetectionResult) -> bool:
+        if self._synthetic_alert_emitted:
+            return False
+        if result.aggregated_score < self._opts.fake_threshold:
+            return False
+        if result.forced and self._opts.force_immediate_fake:
+            return True
+        return self._has_confirmed_fake()
+
+
+class ResembleDetect(DetectionMonitor):
+    """High-level LiveKit Detect component.
+
+    This is a semantic alias for :class:`DetectionMonitor` with the developer-facing name
+    used in integration examples:
+
+    .. code-block:: python
+
+        detect = resemble.ResembleDetect(security="standard")
+        detect.attach(ctx.room)
+        detect.on("synthetic_detected", on_synthetic)
+    """
+
+
+class RestDetectTransport:
+    """Default transport for Resemble Detect's REST API."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str = RESEMBLE_DETECT_API_URL,
+        http_session: aiohttp.ClientSession | None = None,
+        zero_retention_mode: bool = True,
+        extra_form_fields: Mapping[str, DetectFormFieldValue] | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._session = http_session
+        self._extra_form_fields = {
+            "zero_retention_mode": _form_value(zero_retention_mode),
+            **{key: _form_value(value) for key, value in (extra_form_fields or {}).items()},
+        }
+
+    async def submit(
+        self,
+        pcm16: bytes,
+        *,
+        frame_length: int,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        form = aiohttp.FormData()
+        form.add_field(
+            "file",
+            _wav_bytes(pcm16),
+            filename="window.wav",
+            content_type="audio/wav",
+        )
+        form.add_field("modality", "audio")
+        form.add_field("frame_length", str(frame_length))
+        for key, value in self._extra_form_fields.items():
+            form.add_field(key, value)
+
+        async with self._ensure_session().post(
+            f"{self._base_url}/detect",
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Prefer": "wait",
+            },
+            data=form,
+            timeout=aiohttp.ClientTimeout(total=request_timeout),
+        ) as resp:
+            if resp.status not in (200, 201):
+                body = await resp.text()
+                raise APIStatusError(
+                    message="resemble detect request failed",
+                    status_code=resp.status,
+                    request_id=None,
+                    body=body[:500],
+                )
+            payload = await resp.json()
+
+        item: dict[str, Any] = payload.get("item") or {}
+        if item.get("status") == "completed":
+            return item
+
+        # `Prefer: wait` normally completes synchronously; poll as a fallback
+        uuid = item.get("uuid")
+        if not uuid:
+            raise APIConnectionError(f"detect response missing uuid: {payload}")
+        return await self._poll(uuid, request_timeout=request_timeout)
+
+    async def _poll(self, uuid: str, *, request_timeout: float) -> dict[str, Any]:
+        deadline = time.monotonic() + request_timeout
+        while time.monotonic() < deadline:
+            await asyncio.sleep(1.0)
+            async with self._ensure_session().get(
+                f"{self._base_url}/detect/{uuid}",
+                headers={"Authorization": f"Bearer {self._api_key}"},
+                timeout=aiohttp.ClientTimeout(total=request_timeout),
+            ) as resp:
+                if resp.status != 200:
+                    continue
+                payload = await resp.json()
+            item: dict[str, Any] = payload.get("item") or {}
+            if item.get("status") == "completed":
+                return item
+        raise APIConnectionError(f"detection {uuid} did not complete in time")
+
+    def _ensure_session(self) -> aiohttp.ClientSession:
+        if not self._session:
+            self._session = utils.http_context.http_session()
+
+        return self._session
+
+
+def _wav_bytes(pcm16: bytes) -> bytes:
+    out = io.BytesIO()
+    with wave.open(out, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(DETECT_SAMPLE_RATE)
+        wf.writeframes(pcm16)
+    return out.getvalue()
+
+
+def _opt_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_label(label: DetectionLabel) -> DetectionNormalizedLabel:
+    if label == "fake":
+        return "synthetic"
+    return label
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _validate_threshold(name: str, value: float) -> None:
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(f"{name} must be between 0 and 1")
+
+
+def _form_value(value: DetectFormFieldValue) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)

--- a/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/detect.py
+++ b/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/detect.py
@@ -701,10 +701,11 @@ class DetectionMonitor(rtc.EventEmitter[EventTypes]):
                     analysis=True,
                 )
 
+                if forced:
+                    self._force_pending = False
+
                 if self._opts.mode == "sampled":
-                    if forced:
-                        self._force_pending = False
-                    else:
+                    if not forced:
                         self._samples_taken += 1
                         cooldown_until = stream_pos + self._opts.sample_interval_seconds
                         if self._samples_taken >= self._opts.samples:
@@ -783,6 +784,9 @@ class DetectionMonitor(rtc.EventEmitter[EventTypes]):
             raw=item,
         )
         self._results.append(result)
+        # Concurrent API calls can finish out of order; agreement is defined over audio
+        # windows, not request completion order.
+        self._results.sort(key=lambda detection: detection.window_index)
         logger.debug(
             "detect window analyzed",
             extra={

--- a/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/detect.py
+++ b/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/detect.py
@@ -142,6 +142,12 @@ class DetectionResult:
     forced: bool = False
     """True if this check was triggered on demand via :meth:`DetectionMonitor.check_now`
     rather than by the ambient schedule."""
+    unclear_threshold: float = _DEFAULT_UNCLEAR_THRESHOLD
+    """This monitor's configured boundary between the ``continue`` and ``watch`` bands."""
+    likely_synthetic_threshold: float = _DEFAULT_LIKELY_SYNTHETIC_THRESHOLD
+    """This monitor's configured boundary between the ``watch`` and ``verify`` bands."""
+    fake_threshold: float = _DEFAULT_FAKE_THRESHOLD
+    """This monitor's configured boundary between the ``verify`` and ``block`` bands."""
     raw: dict[str, Any] = field(repr=False, default_factory=dict)
     """Raw ``item`` payload returned by the API."""
 
@@ -183,12 +189,12 @@ class DetectionResult:
 
     @property
     def recommended_action(self) -> DetectionAction:
-        """Action band using the default Resemble Detect score strategy."""
-        if self.aggregated_score < _DEFAULT_UNCLEAR_THRESHOLD:
+        """Action band using this monitor's configured score thresholds."""
+        if self.aggregated_score < self.unclear_threshold:
             return "continue"
-        if self.aggregated_score < _DEFAULT_LIKELY_SYNTHETIC_THRESHOLD:
+        if self.aggregated_score < self.likely_synthetic_threshold:
             return "watch"
-        if self.aggregated_score < _DEFAULT_FAKE_THRESHOLD:
+        if self.aggregated_score < self.fake_threshold:
             return "verify"
         return "block"
 
@@ -365,11 +371,13 @@ class DetectionMonitor(rtc.EventEmitter[EventTypes]):
             analysis_budget_seconds (float, optional): Speech budget for ``"first_n"`` mode.
                 Overrides the selected preset.
             fake_threshold (float, optional): ``aggregated_score`` at or above which a
-                window emits ``"fake_detected"``. Defaults to 0.7.
-            likely_synthetic_threshold (float, optional): Score at or above which a final
-                verdict is inconclusive unless agreement confirms a synthetic caller.
+                window emits ``"fake_detected"`` and ``recommended_action`` becomes
+                ``"block"``. Defaults to 0.7.
+            likely_synthetic_threshold (float, optional): Score at or above which a
+                result's ``recommended_action`` escalates from ``"watch"`` to ``"verify"``.
             unclear_threshold (float, optional): Score at or above which a final verdict is
-                inconclusive instead of real.
+                inconclusive instead of real; also the boundary between the ``"continue"``
+                and ``"watch"`` action bands.
             agreement_window (int, optional): Number of recent checks considered for
                 agreement. Overrides the selected preset.
             min_fake_results (int, optional): Suspicious results needed within
@@ -652,11 +660,19 @@ class DetectionMonitor(rtc.EventEmitter[EventTypes]):
     async def _consume(self, stream: rtc.AudioStream, participant_identity: str | None) -> None:
         window_samples = int(self._opts.window_seconds * DETECT_SAMPLE_RATE)
         buf = bytearray()
-        stream_pos = 0.0  # seconds of audio consumed from the stream
-        cooldown_until = 0.0  # sampled mode: ignore audio until this stream position
+        # samples consumed from the stream, including audio dropped while paused, so window
+        # timestamps and spot-check spacing track real elapsed stream time (integer sample
+        # counting stays exact over arbitrarily long calls)
+        stream_samples = 0
+        cooldown_until = 0.0  # sampled mode: ignore audio until this stream position (seconds)
 
         try:
             async for event in stream:
+                frame = event.frame
+                data = frame.data
+                nbytes = data.nbytes if isinstance(data, memoryview) else len(data)
+                stream_samples += nbytes // 2
+
                 # paused (e.g. while our own agent is speaking): drop audio and never let
                 # a window straddle the pause boundary, so the agent's voice is never scored
                 if self._paused:
@@ -664,21 +680,20 @@ class DetectionMonitor(rtc.EventEmitter[EventTypes]):
                         buf.clear()
                     continue
 
-                frame = event.frame
-                buf.extend(frame.data)
+                buf.extend(data)
                 if len(buf) // 2 < window_samples:
                     continue
 
                 window = bytes(buf[: window_samples * 2])
                 del buf[: window_samples * 2]
-                window_start = stream_pos
-                stream_pos += self._opts.window_seconds
+                window_end = (stream_samples - len(buf) // 2) / DETECT_SAMPLE_RATE
+                window_start = window_end - self._opts.window_seconds
 
                 forced = self._force_pending  # check_now(): analyze the next window right away
 
                 if self._opts.mode == "sampled" and not forced:
                     # between spot-checks, drain audio without analyzing it
-                    if stream_pos <= cooldown_until:
+                    if window_end <= cooldown_until:
                         continue
                     # ambient budget spent: idle, but keep listening for on-demand checks
                     if self._samples_taken >= self._opts.samples:
@@ -714,7 +729,7 @@ class DetectionMonitor(rtc.EventEmitter[EventTypes]):
                 if self._opts.mode == "sampled":
                     if not forced:
                         self._samples_taken += 1
-                        cooldown_until = stream_pos + self._opts.sample_interval_seconds
+                        cooldown_until = window_end + self._opts.sample_interval_seconds
                         if self._samples_taken >= self._opts.samples:
                             # settle the ambient verdict but stay alive for check_now()
                             await self._flush_and_emit_verdict()
@@ -781,7 +796,11 @@ class DetectionMonitor(rtc.EventEmitter[EventTypes]):
             # the API pads the score array with None for a trailing partial frame
             scores = [float(s) for s in metrics.get("score") or [] if s is not None]
             aggregated = float(metrics["aggregated_score"])
-            label: DetectionLabel = "fake" if metrics["label"] == "fake" else "real"
+            raw_label = metrics["label"]
+            # never report an unclassifiable window as a verified human speaker
+            label: DetectionLabel = (
+                raw_label if raw_label in ("fake", "real", "inconclusive") else "inconclusive"
+            )
         except (KeyError, TypeError, ValueError):
             self.emit("error", APIConnectionError(f"unexpected detect response shape: {item}"))
             return
@@ -798,6 +817,9 @@ class DetectionMonitor(rtc.EventEmitter[EventTypes]):
             detection_uuid=item.get("uuid"),
             latency=latency,
             forced=forced,
+            unclear_threshold=self._opts.unclear_threshold,
+            likely_synthetic_threshold=self._opts.likely_synthetic_threshold,
+            fake_threshold=self._opts.fake_threshold,
             raw=item,
         )
         self._results.append(result)

--- a/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/detect.py
+++ b/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/detect.py
@@ -44,7 +44,14 @@ DetectionSecurity = Literal["spot", "standard", "high"]
 DetectionAction = Literal["continue", "watch", "verify", "block"]
 DetectFormFieldValue = str | int | float | bool
 
-EventTypes = Literal["result", "fake_detected", "synthetic_detected", "verdict", "error"]
+EventTypes = Literal[
+    "analysis_started",
+    "result",
+    "fake_detected",
+    "synthetic_detected",
+    "verdict",
+    "error",
+]
 
 
 class DetectTransport(Protocol):
@@ -750,6 +757,16 @@ class DetectionMonitor(rtc.EventEmitter[EventTypes]):
         participant_identity: str | None,
         forced: bool = False,
     ) -> None:
+        self.emit(
+            "analysis_started",
+            {
+                "window_index": index,
+                "window_start": window_start,
+                "window_end": window_start + self._opts.window_seconds,
+                "participant_identity": participant_identity,
+                "forced": forced,
+            },
+        )
         try:
             started = time.monotonic()
             item = await self._submit(pcm16)

--- a/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/identity.py
+++ b/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/identity.py
@@ -1,0 +1,338 @@
+# Copyright 2025 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import inspect
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Protocol, cast
+
+import aiohttp
+
+from livekit.agents import APIStatusError, utils
+
+RESEMBLE_IDENTITY_API_URL = "https://app.resemble.ai/api/v2"
+
+DEFAULT_MATCH_THRESHOLD = 70.0
+"""Similarity score (0-100) at or above which the best match counts as verified."""
+
+
+class AudioHost(Protocol):
+    """Hook that makes one audio clip publicly reachable and returns its URL.
+
+    Resemble Identity's ``/search`` endpoint fetches audio from a URL instead of
+    accepting a file upload, so callers who start from raw bytes must host the clip
+    somewhere Resemble's backend can reach — an S3 presigned URL, a public bucket,
+    or an app endpoint. Any async callable with this shape works:
+
+    .. code-block:: python
+
+        async def host_audio(audio: bytes, filename: str) -> str:
+            key = f"identity/{filename}"
+            await s3.put_object(Bucket="clips", Key=key, Body=audio)
+            return f"https://clips.example.com/{key}"
+    """
+
+    async def __call__(self, audio: bytes, filename: str) -> str:
+        """Host ``audio`` and return a publicly reachable URL for it."""
+        ...
+
+
+class IdentityTransport(Protocol):
+    """Transport used by :class:`ResembleIdentity` to call Resemble Identity."""
+
+    async def search(self, url: str, *, request_timeout: float) -> dict[str, Any]:
+        """Search enrolled identities against hosted audio; return the ``item`` payload."""
+
+
+@dataclass
+class IdentityMatch:
+    """One enrolled speaker compared against the submitted audio."""
+
+    uuid: str
+    name: str
+    score: float | None
+    """Similarity to the submitted audio (0-100, higher is closer); None if unscored."""
+    raw: dict[str, Any] = field(repr=False, default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "uuid": self.uuid,
+            "name": self.name,
+            "score": self.score,
+        }
+
+
+@dataclass
+class IdentityResult:
+    """Outcome of searching enrolled identities with Resemble Identity."""
+
+    matches: list[IdentityMatch]
+    """All scored enrollments, sorted best-first (unscored entries last)."""
+    threshold: float
+    """Similarity at or above which :attr:`matched` is True."""
+    raw: dict[str, Any] = field(repr=False, default_factory=dict)
+
+    @property
+    def best(self) -> IdentityMatch | None:
+        """The closest enrolled speaker, or None when nothing is enrolled."""
+        return self.matches[0] if self.matches else None
+
+    @property
+    def matched(self) -> bool:
+        """Whether the best match clears the configured similarity threshold."""
+        best = self.best
+        return bool(best and best.score is not None and best.score >= self.threshold)
+
+    @property
+    def name(self) -> str | None:
+        """Name of the closest enrolled speaker, or None."""
+        return self.best.name if self.best else None
+
+    @property
+    def score(self) -> float | None:
+        """Similarity of the closest enrolled speaker, or None."""
+        return self.best.score if self.best else None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable payload suitable for app events or dashboards."""
+        return {
+            "matched": self.matched,
+            "name": self.name,
+            "score": self.score,
+            "threshold": self.threshold,
+            "matches": [match.to_dict() for match in self.matches],
+        }
+
+
+class ResembleIdentity:
+    """Speaker verification against enrolled voiceprints, powered by Resemble Identity.
+
+    Identity completes the Resemble security trio: Detect answers "is this media
+    synthetic?", Signal answers "does this content match a fraud/scam pattern?", and
+    Identity answers "is this the enrolled speaker?".
+
+    Because the underlying ``/search`` endpoint fetches audio from a URL rather than
+    accepting an upload, raw-bytes searches need an :class:`AudioHost` hook that hosts
+    the clip publicly. Apps without hosting infrastructure can skip Identity entirely
+    (Detect and Signal keep working) or search pre-hosted clips with
+    :meth:`search_url`.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str = RESEMBLE_IDENTITY_API_URL,
+        threshold: float = DEFAULT_MATCH_THRESHOLD,
+        audio_host: AudioHost | None = None,
+        http_session: aiohttp.ClientSession | None = None,
+        transport: IdentityTransport | None = None,
+        request_timeout: float = 60.0,
+    ) -> None:
+        """Create an Identity client.
+
+        Args:
+            api_key (str, optional): Resemble API key. If omitted, ``RESEMBLE_API_KEY`` is
+                read from the environment. Not required when ``transport`` is provided.
+                Pass a full ``"Bearer ..."`` value to override the default bearer header.
+            base_url (str, optional): Override the Resemble REST Identity API base URL.
+            threshold (float, optional): Similarity score (0-100) at or above which the
+                best match counts as verified. Defaults to 70.
+            audio_host (AudioHost, optional): Async hook that hosts audio bytes at a
+                publicly reachable URL. Required only for :meth:`search`;
+                :meth:`search_url` works without it.
+            http_session (aiohttp.ClientSession, optional): Existing session for the
+                default REST transport.
+            transport (IdentityTransport, optional): Custom transport, useful for
+                gateways or tests.
+            request_timeout (float, optional): Per-request timeout in seconds.
+        """
+        if request_timeout <= 0:
+            raise ValueError("request_timeout must be > 0")
+        _validate_threshold(threshold)
+
+        if transport is None:
+            api_key = api_key or os.environ.get("RESEMBLE_API_KEY")
+            if not api_key:
+                raise ValueError(
+                    "Resemble API key is required, either as argument or set RESEMBLE_API_KEY"
+                    " environment variable"
+                )
+            transport = RestIdentityTransport(
+                api_key=api_key,
+                base_url=base_url,
+                http_session=http_session,
+            )
+
+        self._transport = transport
+        self._threshold = threshold
+        self._audio_host = audio_host
+        self._request_timeout = request_timeout
+
+    @property
+    def threshold(self) -> float:
+        """Configured similarity threshold."""
+        return self._threshold
+
+    async def search(
+        self,
+        audio: bytes,
+        *,
+        filename: str = "identity-search.wav",
+        threshold: float | None = None,
+        request_timeout: float | None = None,
+    ) -> IdentityResult:
+        """Verify raw audio bytes against the account's enrolled identities.
+
+        Hosts the clip through the configured ``audio_host`` hook, then searches the
+        resulting URL. Raises ValueError when no ``audio_host`` was provided.
+        """
+        if not audio:
+            raise ValueError("audio is required")
+        if self._audio_host is None:
+            raise ValueError(
+                "searching raw audio requires an audio_host hook: Resemble Identity's"
+                " /search endpoint fetches audio from a public URL instead of accepting"
+                " an upload. Provide audio_host=..., or host the clip yourself and call"
+                " search_url()."
+            )
+        url = await self._audio_host(audio, filename)
+        return await self.search_url(
+            url,
+            threshold=threshold,
+            request_timeout=request_timeout,
+        )
+
+    async def search_url(
+        self,
+        url: str,
+        *,
+        threshold: float | None = None,
+        request_timeout: float | None = None,
+    ) -> IdentityResult:
+        """Verify audio already hosted at a publicly reachable URL."""
+        url = url.strip()
+        if not url:
+            raise ValueError("url is required")
+        if threshold is not None:
+            _validate_threshold(threshold)
+        item = await self._transport.search(
+            url,
+            request_timeout=request_timeout or self._request_timeout,
+        )
+        return _parse_identity_result(
+            item,
+            threshold=threshold if threshold is not None else self._threshold,
+        )
+
+    async def aclose(self) -> None:
+        """Close transport resources when the transport exposes a close method."""
+        close = getattr(self._transport, "close", None)
+        if callable(close):
+            maybe_awaitable = close()
+            if inspect.isawaitable(maybe_awaitable):
+                await maybe_awaitable
+
+
+class RestIdentityTransport:
+    """Default transport for Resemble Identity's REST API."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str = RESEMBLE_IDENTITY_API_URL,
+        http_session: aiohttp.ClientSession | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._session = http_session
+
+    async def search(self, url: str, *, request_timeout: float) -> dict[str, Any]:
+        async with self._ensure_session().post(
+            f"{self._base_url}/identity/search",
+            headers={
+                "Authorization": _authorization_value(self._api_key),
+                "Content-Type": "application/json",
+            },
+            json={"url": url},
+            timeout=aiohttp.ClientTimeout(total=request_timeout),
+        ) as resp:
+            if resp.status < 200 or resp.status >= 300:
+                body = await resp.text()
+                raise APIStatusError(
+                    message="resemble identity request failed",
+                    status_code=resp.status,
+                    request_id=None,
+                    body=body[:500],
+                )
+            payload: object = await resp.json()
+            if not isinstance(payload, dict):
+                raise APIStatusError(
+                    message="resemble identity response was not a JSON object",
+                    status_code=resp.status,
+                    request_id=None,
+                    body=str(payload)[:500],
+                )
+
+        item = payload.get("item")
+        if item is None:
+            return {}
+        if not isinstance(item, Mapping):
+            raise ValueError(f"Resemble Identity response has malformed item: {payload}")
+        return dict(cast("Mapping[str, Any]", item))
+
+    def _ensure_session(self) -> aiohttp.ClientSession:
+        session = self._session
+        if session is None:
+            session = utils.http_context.http_session()
+            self._session = session
+
+        return session
+
+
+def _parse_identity_result(item: Mapping[str, Any], *, threshold: float) -> IdentityResult:
+    matches = []
+    for uuid, info in item.items():
+        if not isinstance(info, Mapping):
+            continue
+        matches.append(
+            IdentityMatch(
+                uuid=str(uuid),
+                name=str(info.get("name") or "Unknown"),
+                score=_opt_float(info.get("distance")),
+                raw=dict(info),
+            )
+        )
+    matches.sort(key=lambda match: (match.score is None, -(match.score or 0.0)))
+    return IdentityResult(matches=matches, threshold=threshold, raw=dict(item))
+
+
+def _validate_threshold(threshold: float) -> None:
+    if not 0.0 <= threshold <= 100.0:
+        raise ValueError("threshold must be between 0 and 100")
+
+
+def _authorization_value(api_key: str) -> str:
+    return api_key if api_key.lower().startswith("bearer ") else f"Bearer {api_key}"
+
+
+def _opt_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/identity.py
+++ b/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/identity.py
@@ -19,6 +19,7 @@ import os
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Protocol, cast
+from urllib.parse import urlparse
 
 import aiohttp
 
@@ -69,6 +70,7 @@ class IdentityMatch:
     raw: dict[str, Any] = field(repr=False, default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        """Return a stable payload for this enrolled-speaker match."""
         return {
             "uuid": self.uuid,
             "name": self.name,
@@ -228,6 +230,11 @@ class ResembleIdentity:
         url = url.strip()
         if not url:
             raise ValueError("url is required")
+        # the URL is fetched by Resemble's backend — never forward non-web schemes
+        # (file://, internal metadata endpoints, ...) from untrusted input
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            raise ValueError("url must be an absolute http(s) URL")
         if threshold is not None:
             _validate_threshold(threshold)
         item = await self._transport.search(

--- a/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/signal.py
+++ b/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/signal.py
@@ -1,0 +1,704 @@
+# Copyright 2025 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import inspect
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol, cast
+
+import aiohttp
+
+from livekit.agents import APIStatusError, utils
+
+RESEMBLE_SIGNAL_API_URL = "https://app.resemble.ai/api/v2"
+
+SignalVerdict = Literal["safe", "suspicious", "fraud"]
+SignalModality = Literal["text", "audio", "video", "image"]
+SignalAction = Literal["allow", "review", "block"]
+
+
+class SignalTransport(Protocol):
+    """Transport used by :class:`ResembleSignal` to call Resemble Signal."""
+
+    async def score_text(self, text: str, *, request_timeout: float) -> dict[str, Any]:
+        """Score text and return the Signal ``item`` payload."""
+
+    async def score_file(
+        self,
+        file: bytes,
+        *,
+        filename: str,
+        media_type: SignalModality | None,
+        content_type: str | None,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        """Score a media file and return the Signal ``item`` payload."""
+
+    async def list_submissions(
+        self,
+        *,
+        page: int,
+        per_page: int,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        """List historical Signal submissions."""
+
+    async def delete_submission(self, submission_id: str | int, *, request_timeout: float) -> None:
+        """Delete a historical Signal submission."""
+
+    async def list_custom_categories(self, *, request_timeout: float) -> dict[str, Any]:
+        """List built-in and custom Signal categories."""
+
+    async def create_custom_category(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        """Create a custom Signal category."""
+
+    async def get_custom_category(
+        self,
+        category_id: str | int,
+        *,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        """Fetch one custom Signal category."""
+
+    async def update_custom_category(
+        self,
+        category_id: str | int,
+        payload: Mapping[str, Any],
+        *,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        """Update one custom Signal category."""
+
+    async def delete_custom_category(
+        self, category_id: str | int, *, request_timeout: float
+    ) -> None:
+        """Delete one custom Signal category."""
+
+    async def update_settings(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        """Update team-level Signal settings."""
+
+
+@dataclass
+class SignalCategoryScore:
+    """A category score returned by Resemble Signal."""
+
+    name: str
+    score: float
+    icon: str | None = None
+    raw: dict[str, Any] = field(repr=False, default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "score": self.score,
+            "icon": self.icon,
+        }
+
+
+@dataclass
+class SignalResult:
+    """Outcome of scoring content with Resemble Signal."""
+
+    verdict: SignalVerdict
+    input_modality: SignalModality
+    id: str | int | None = None
+    top_category: SignalCategoryScore | None = None
+    category_scores: list[SignalCategoryScore] = field(default_factory=list)
+    benign_score: float | None = None
+    margin_over_second: float | None = None
+    examples: list[str] = field(default_factory=list)
+    top_matches: list[dict[str, Any]] = field(default_factory=list)
+    duration_seconds: float | None = None
+    created_at: str | None = None
+    raw: dict[str, Any] = field(repr=False, default_factory=dict)
+
+    @property
+    def score(self) -> float:
+        """Return the best fraud/scam category score in ``[0, 1]`` when available."""
+        if self.top_category is not None:
+            return self.top_category.score
+        if self.benign_score is not None:
+            return max(0.0, min(1.0, 1.0 - self.benign_score))
+        return 0.0
+
+    @property
+    def recommended_action(self) -> SignalAction:
+        """Return a conservative app action for the Signal verdict."""
+        if self.verdict == "fraud":
+            return "block"
+        if self.verdict == "suspicious":
+            return "review"
+        return "allow"
+
+    @property
+    def is_fraud(self) -> bool:
+        """Whether Signal classified the content as fraud."""
+        return self.verdict == "fraud"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable payload suitable for app events or dashboards."""
+        return {
+            "id": self.id,
+            "verdict": self.verdict,
+            "score": self.score,
+            "recommended_action": self.recommended_action,
+            "input_modality": self.input_modality,
+            "top_category": self.top_category.to_dict() if self.top_category else None,
+            "category_scores": [category.to_dict() for category in self.category_scores],
+            "benign_score": self.benign_score,
+            "margin_over_second": self.margin_over_second,
+            "examples": self.examples,
+            "top_matches": self.top_matches,
+            "duration_seconds": self.duration_seconds,
+            "created_at": self.created_at,
+        }
+
+
+class ResembleSignal:
+    """Fraud and scam-intent scoring powered by Resemble Signal.
+
+    Signal complements Resemble Detect: Detect answers "is this media synthetic?", while
+    Signal answers "does this content match a fraud/scam pattern?".
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str = RESEMBLE_SIGNAL_API_URL,
+        http_session: aiohttp.ClientSession | None = None,
+        transport: SignalTransport | None = None,
+        request_timeout: float = 30.0,
+    ) -> None:
+        """Create a Signal client.
+
+        Args:
+            api_key (str, optional): Resemble API key. If omitted, ``RESEMBLE_API_KEY`` is
+                read from the environment. Not required when ``transport`` is provided.
+                Pass a full ``"Bearer ..."`` value to override the default bearer header.
+            base_url (str, optional): Override the Resemble REST Signal API base URL.
+            http_session (aiohttp.ClientSession, optional): Existing session for the default
+                REST transport.
+            transport (SignalTransport, optional): Custom transport, useful for gateways or
+                tests.
+            request_timeout (float, optional): Per-request timeout in seconds.
+        """
+        if request_timeout <= 0:
+            raise ValueError("request_timeout must be > 0")
+
+        if transport is None:
+            api_key = api_key or os.environ.get("RESEMBLE_API_KEY")
+            if not api_key:
+                raise ValueError(
+                    "Resemble API key is required, either as argument or set RESEMBLE_API_KEY"
+                    " environment variable"
+                )
+            transport = RestSignalTransport(
+                api_key=api_key,
+                base_url=base_url,
+                http_session=http_session,
+            )
+
+        self._transport = transport
+        self._request_timeout = request_timeout
+
+    async def score_text(
+        self,
+        text: str,
+        *,
+        request_timeout: float | None = None,
+    ) -> SignalResult:
+        """Score text for fraud/scam intent."""
+        text = text.strip()
+        if not text:
+            raise ValueError("text is required")
+        item = await self._transport.score_text(
+            text,
+            request_timeout=request_timeout or self._request_timeout,
+        )
+        return _parse_signal_result(item)
+
+    async def score_file(
+        self,
+        file: bytes,
+        *,
+        filename: str = "signal-upload",
+        media_type: SignalModality | None = None,
+        content_type: str | None = None,
+        request_timeout: float | None = None,
+    ) -> SignalResult:
+        """Score an audio, video, or image file for fraud/scam intent."""
+        if not file:
+            raise ValueError("file is required")
+        item = await self._transport.score_file(
+            file,
+            filename=filename,
+            media_type=media_type,
+            content_type=content_type,
+            request_timeout=request_timeout or self._request_timeout,
+        )
+        return _parse_signal_result(item)
+
+    async def list_submissions(
+        self,
+        *,
+        page: int = 1,
+        per_page: int = 10,
+        request_timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """List historical Signal submissions."""
+        _validate_page(page, per_page)
+        return await self._transport.list_submissions(
+            page=page,
+            per_page=per_page,
+            request_timeout=request_timeout or self._request_timeout,
+        )
+
+    async def delete_submission(
+        self,
+        submission_id: str | int,
+        *,
+        request_timeout: float | None = None,
+    ) -> None:
+        """Delete one historical Signal submission."""
+        await self._transport.delete_submission(
+            submission_id,
+            request_timeout=request_timeout or self._request_timeout,
+        )
+
+    async def list_custom_categories(
+        self,
+        *,
+        request_timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """List built-in categories, custom categories, and team settings."""
+        return await self._transport.list_custom_categories(
+            request_timeout=request_timeout or self._request_timeout
+        )
+
+    async def create_custom_category(
+        self,
+        *,
+        name: str,
+        scenarios: Sequence[str] | str,
+        description: str | None = None,
+        icon: str | None = None,
+        enabled: bool | None = None,
+        request_timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """Create a custom category from example fraud/scam scenarios."""
+        payload = _category_payload(
+            name=name,
+            scenarios=scenarios,
+            description=description,
+            icon=icon,
+            enabled=enabled,
+        )
+        return await self._transport.create_custom_category(
+            payload,
+            request_timeout=request_timeout or self._request_timeout,
+        )
+
+    async def get_custom_category(
+        self,
+        category_id: str | int,
+        *,
+        request_timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """Fetch one custom category."""
+        return await self._transport.get_custom_category(
+            category_id,
+            request_timeout=request_timeout or self._request_timeout,
+        )
+
+    async def update_custom_category(
+        self,
+        category_id: str | int,
+        *,
+        name: str | None = None,
+        scenarios: Sequence[str] | str | None = None,
+        description: str | None = None,
+        icon: str | None = None,
+        enabled: bool | None = None,
+        request_timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """Update one custom category. Passing scenarios replaces its scenario set."""
+        payload = _category_payload(
+            name=name,
+            scenarios=scenarios,
+            description=description,
+            icon=icon,
+            enabled=enabled,
+            allow_partial=True,
+        )
+        if not payload:
+            raise ValueError("at least one custom category field is required")
+        return await self._transport.update_custom_category(
+            category_id,
+            payload,
+            request_timeout=request_timeout or self._request_timeout,
+        )
+
+    async def delete_custom_category(
+        self,
+        category_id: str | int,
+        *,
+        request_timeout: float | None = None,
+    ) -> None:
+        """Delete one custom category."""
+        await self._transport.delete_custom_category(
+            category_id,
+            request_timeout=request_timeout or self._request_timeout,
+        )
+
+    async def update_settings(
+        self,
+        *,
+        use_builtin_categories: bool,
+        request_timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """Toggle whether built-in categories are included during scoring."""
+        return await self._transport.update_settings(
+            {"use_builtin_categories": use_builtin_categories},
+            request_timeout=request_timeout or self._request_timeout,
+        )
+
+    async def aclose(self) -> None:
+        """Close transport resources when the transport exposes a close method."""
+        close = getattr(self._transport, "close", None)
+        if callable(close):
+            maybe_awaitable = close()
+            if inspect.isawaitable(maybe_awaitable):
+                await maybe_awaitable
+
+
+class RestSignalTransport:
+    """Default transport for Resemble Signal's REST API."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str = RESEMBLE_SIGNAL_API_URL,
+        http_session: aiohttp.ClientSession | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._session = http_session
+
+    async def score_text(self, text: str, *, request_timeout: float) -> dict[str, Any]:
+        payload = await self._request(
+            "POST",
+            "/signal",
+            json={"text": text},
+            request_timeout=request_timeout,
+        )
+        return _item(payload, "signal")
+
+    async def score_file(
+        self,
+        file: bytes,
+        *,
+        filename: str,
+        media_type: SignalModality | None,
+        content_type: str | None,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        form = aiohttp.FormData()
+        form.add_field(
+            "file",
+            file,
+            filename=filename,
+            content_type=content_type or "application/octet-stream",
+        )
+        if media_type is not None:
+            form.add_field("media_type", media_type)
+
+        payload = await self._request(
+            "POST",
+            "/signal",
+            data=form,
+            request_timeout=request_timeout,
+        )
+        return _item(payload, "signal")
+
+    async def list_submissions(
+        self,
+        *,
+        page: int,
+        per_page: int,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        return await self._request(
+            "GET",
+            "/signal",
+            params={"page": page, "per_page": per_page},
+            request_timeout=request_timeout,
+        )
+
+    async def delete_submission(self, submission_id: str | int, *, request_timeout: float) -> None:
+        await self._request(
+            "DELETE",
+            f"/signal/{submission_id}",
+            request_timeout=request_timeout,
+        )
+
+    async def list_custom_categories(self, *, request_timeout: float) -> dict[str, Any]:
+        return await self._request(
+            "GET",
+            "/signal/custom_categories",
+            request_timeout=request_timeout,
+        )
+
+    async def create_custom_category(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        response = await self._request(
+            "POST",
+            "/signal/custom_categories",
+            json=dict(payload),
+            request_timeout=request_timeout,
+        )
+        return _item(response, "custom category")
+
+    async def get_custom_category(
+        self,
+        category_id: str | int,
+        *,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        response = await self._request(
+            "GET",
+            f"/signal/custom_categories/{category_id}",
+            request_timeout=request_timeout,
+        )
+        return _item(response, "custom category")
+
+    async def update_custom_category(
+        self,
+        category_id: str | int,
+        payload: Mapping[str, Any],
+        *,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        response = await self._request(
+            "PATCH",
+            f"/signal/custom_categories/{category_id}",
+            json=dict(payload),
+            request_timeout=request_timeout,
+        )
+        return _item(response, "custom category")
+
+    async def delete_custom_category(
+        self, category_id: str | int, *, request_timeout: float
+    ) -> None:
+        await self._request(
+            "DELETE",
+            f"/signal/custom_categories/{category_id}",
+            request_timeout=request_timeout,
+        )
+
+    async def update_settings(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        return await self._request(
+            "PATCH",
+            "/signal/settings",
+            json=dict(payload),
+            request_timeout=request_timeout,
+        )
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        request_timeout: float,
+        json: Mapping[str, Any] | None = None,
+        data: aiohttp.FormData | None = None,
+        params: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        headers = {"Authorization": _authorization_value(self._api_key)}
+        if json is not None:
+            headers["Content-Type"] = "application/json"
+
+        async with self._ensure_session().request(
+            method,
+            f"{self._base_url}{path}",
+            headers=headers,
+            json=json,
+            data=data,
+            params=params,
+            timeout=aiohttp.ClientTimeout(total=request_timeout),
+        ) as resp:
+            if resp.status < 200 or resp.status >= 300:
+                body = await resp.text()
+                raise APIStatusError(
+                    message="resemble signal request failed",
+                    status_code=resp.status,
+                    request_id=None,
+                    body=body[:500],
+                )
+            payload: object = await resp.json()
+            if not isinstance(payload, dict):
+                raise APIStatusError(
+                    message="resemble signal response was not a JSON object",
+                    status_code=resp.status,
+                    request_id=None,
+                    body=str(payload)[:500],
+                )
+
+            return cast(dict[str, Any], payload)
+
+    def _ensure_session(self) -> aiohttp.ClientSession:
+        session = self._session
+        if session is None:
+            session = utils.http_context.http_session()
+            self._session = session
+
+        return session
+
+
+def _parse_signal_result(item: Mapping[str, Any]) -> SignalResult:
+    verdict = item.get("verdict")
+    if verdict not in ("safe", "suspicious", "fraud"):
+        raise ValueError(f"Unexpected Resemble Signal verdict: {verdict!r}")
+
+    input_modality = item.get("input_modality")
+    if input_modality not in ("text", "audio", "video", "image"):
+        raise ValueError(f"Unexpected Resemble Signal input_modality: {input_modality!r}")
+
+    top_category = _parse_category(item.get("top_category"))
+    category_scores = [
+        category
+        for category in (_parse_category(raw) for raw in item.get("category_scores") or [])
+        if category is not None
+    ]
+    examples = [str(example) for example in item.get("examples") or []]
+    top_matches = [
+        dict(match) for match in item.get("top_matches") or [] if isinstance(match, Mapping)
+    ]
+
+    return SignalResult(
+        id=item.get("id"),
+        verdict=verdict,
+        input_modality=input_modality,
+        top_category=top_category,
+        category_scores=category_scores,
+        benign_score=_opt_float(item.get("benign_score")),
+        margin_over_second=_opt_float(item.get("margin_over_second")),
+        examples=examples,
+        top_matches=top_matches,
+        duration_seconds=_opt_float(item.get("duration_seconds")),
+        created_at=item.get("created_at"),
+        raw=dict(item),
+    )
+
+
+def _parse_category(raw: Any) -> SignalCategoryScore | None:
+    if not isinstance(raw, Mapping):
+        return None
+    try:
+        name = str(raw["name"])
+        score = float(raw["score"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    return SignalCategoryScore(
+        name=name,
+        score=max(0.0, min(1.0, score)),
+        icon=str(raw["icon"]) if raw.get("icon") is not None else None,
+        raw=dict(raw),
+    )
+
+
+def _category_payload(
+    *,
+    name: str | None,
+    scenarios: Sequence[str] | str | None,
+    description: str | None,
+    icon: str | None,
+    enabled: bool | None,
+    allow_partial: bool = False,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    if name is not None:
+        name = name.strip()
+        if not name:
+            raise ValueError("name is required")
+        payload["name"] = name
+    elif not allow_partial:
+        raise ValueError("name is required")
+
+    if scenarios is not None:
+        if isinstance(scenarios, str):
+            normalized_scenarios = [line.strip() for line in scenarios.splitlines() if line.strip()]
+        else:
+            normalized_scenarios = [str(scenario).strip() for scenario in scenarios if scenario]
+        if not normalized_scenarios:
+            raise ValueError("at least one scenario is required")
+        payload["scenarios"] = normalized_scenarios
+    elif not allow_partial:
+        raise ValueError("at least one scenario is required")
+
+    if description is not None:
+        payload["description"] = description
+    if icon is not None:
+        payload["icon"] = icon
+    if enabled is not None:
+        payload["enabled"] = enabled
+    return payload
+
+
+def _validate_page(page: int, per_page: int) -> None:
+    if page < 1:
+        raise ValueError("page must be >= 1")
+    if not 1 <= per_page <= 100:
+        raise ValueError("per_page must be between 1 and 100")
+
+
+def _item(payload: Mapping[str, Any], name: str) -> dict[str, Any]:
+    item = payload.get("item")
+    if not isinstance(item, Mapping):
+        raise ValueError(f"Resemble Signal {name} response missing item: {payload}")
+    return dict(item)
+
+
+def _authorization_value(api_key: str) -> str:
+    return api_key if api_key.lower().startswith("bearer ") else f"Bearer {api_key}"
+
+
+def _opt_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/signal.py
+++ b/livekit-plugins/livekit-plugins-resemble/livekit/plugins/resemble/signal.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import inspect
+import json as _json
 import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
@@ -112,6 +113,7 @@ class SignalCategoryScore:
     raw: dict[str, Any] = field(repr=False, default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        """Return a stable payload for this category score."""
         return {
             "name": self.name,
             "score": self.score,
@@ -569,7 +571,21 @@ class RestSignalTransport:
                     request_id=None,
                     body=body[:500],
                 )
-            payload: object = await resp.json()
+            # deletes legitimately answer 204 / an empty body — that is success, not JSON
+            if resp.status == 204:
+                return {}
+            body = await resp.read()
+            if not body.strip():
+                return {}
+            try:
+                payload: object = _json.loads(body)
+            except ValueError:
+                raise APIStatusError(
+                    message="resemble signal response was not valid JSON",
+                    status_code=resp.status,
+                    request_id=None,
+                    body=body[:500].decode(errors="replace"),
+                ) from None
             if not isinstance(payload, dict):
                 raise APIStatusError(
                     message="resemble signal response was not a JSON object",

--- a/livekit-plugins/livekit-plugins-resemble/tests/test_detect.py
+++ b/livekit-plugins/livekit-plugins-resemble/tests/test_detect.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import unittest
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -36,6 +38,48 @@ class _FakeTransport:
                 "consistency": self._consistency,
             },
         }
+
+
+class _OutOfOrderTransport:
+    async def submit(
+        self,
+        pcm16: bytes,
+        *,
+        frame_length: int,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        del frame_length, request_timeout
+        index = pcm16[0]
+        await asyncio.sleep((4 - index) * 0.01)
+        score = (0.92, 0.91, 0.05, 0.04)[index]
+        return {
+            "uuid": f"detect-{index}",
+            "status": "completed",
+            "metrics": {
+                "score": [score],
+                "aggregated_score": score,
+                "label": "fake" if score >= 0.7 else "real",
+                "consistency": 92.0,
+            },
+        }
+
+
+class _FakeAudioStream:
+    def __init__(self, *chunks: bytes) -> None:
+        self._events = iter(SimpleNamespace(frame=SimpleNamespace(data=chunk)) for chunk in chunks)
+        self.closed = False
+
+    def __aiter__(self) -> _FakeAudioStream:
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            return next(self._events)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+    async def aclose(self) -> None:
+        self.closed = True
 
 
 class DetectionMonitorPolicyTests(unittest.IsolatedAsyncioTestCase):
@@ -108,6 +152,53 @@ class DetectionMonitorPolicyTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(len(confirmed_hits), 1)
         self.assertTrue(confirmed_hits[0].forced)
+
+    async def test_forced_check_only_marks_one_window_in_non_sampled_modes(self) -> None:
+        window = b"\x01\x00" * 32000
+
+        for mode in ("continuous", "first_n"):
+            with self.subTest(mode=mode):
+                transport = _FakeTransport(0.1, 0.1)
+                monitor = DetectionMonitor(
+                    transport=transport,
+                    mode=mode,
+                    window_seconds=2.0,
+                    analysis_budget_seconds=4.0,
+                    silence_rms_threshold=0,
+                )
+                stream = _FakeAudioStream(window, window)
+
+                monitor.check_now()
+                await monitor._consume(stream, "caller")  # type: ignore[arg-type]
+
+                self.assertEqual([result.forced for result in monitor.results], [True, False])
+                self.assertFalse(monitor._force_pending)
+                self.assertTrue(stream.closed)
+
+    async def test_concurrent_results_use_chronological_window_order(self) -> None:
+        monitor = DetectionMonitor(
+            transport=_OutOfOrderTransport(),
+            agreement_window=2,
+            min_fake_results=2,
+        )
+        confirmed_hits = []
+        monitor.on("synthetic_detected", confirmed_hits.append)
+
+        await asyncio.gather(
+            *(
+                monitor._analyze_window(
+                    bytes((index, 0)),
+                    index=index,
+                    window_start=index * 4.0,
+                    participant_identity="caller",
+                )
+                for index in range(4)
+            )
+        )
+
+        self.assertEqual([result.window_index for result in monitor.results], [0, 1, 2, 3])
+        self.assertEqual(confirmed_hits, [])
+        self.assertEqual(monitor.verdict.label, "inconclusive")
 
     async def test_final_verdict_preserves_confirmed_synthetic_alert(self) -> None:
         transport = _FakeTransport(0.91, 0.92, 0.02)

--- a/livekit-plugins/livekit-plugins-resemble/tests/test_detect.py
+++ b/livekit-plugins/livekit-plugins-resemble/tests/test_detect.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+import pytest
+
+from livekit.plugins.resemble import DetectionMonitor, ResembleDetect
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeTransport:
+    def __init__(self, *scores: float, consistency: float = 92.0) -> None:
+        self._scores = list(scores)
+        self._consistency = consistency
+        self.calls: list[dict[str, float | int]] = []
+
+    async def submit(
+        self,
+        _pcm16: bytes,
+        *,
+        frame_length: int,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        index = len(self.calls)
+        score = self._scores[index]
+        self.calls.append({"frame_length": frame_length, "request_timeout": request_timeout})
+        return {
+            "uuid": f"detect-{index}",
+            "status": "completed",
+            "metrics": {
+                "score": [score],
+                "aggregated_score": score,
+                "label": "fake" if score >= 0.7 else "real",
+                "consistency": self._consistency,
+            },
+        }
+
+
+class DetectionMonitorPolicyTests(unittest.IsolatedAsyncioTestCase):
+    async def test_standard_requires_agreement_before_confirming_synthetic(self) -> None:
+        transport = _FakeTransport(0.92, 0.05, 0.88)
+        monitor = DetectionMonitor(transport=transport)
+        raw_hits = []
+        confirmed_hits = []
+        monitor.on("fake_detected", raw_hits.append)
+        monitor.on("synthetic_detected", confirmed_hits.append)
+
+        await monitor._analyze_window(
+            b"\0\0",
+            index=0,
+            window_start=0.0,
+            participant_identity="caller",
+        )
+
+        self.assertEqual(len(raw_hits), 1)
+        self.assertEqual(len(confirmed_hits), 0)
+        self.assertEqual(monitor.verdict.label, "inconclusive")
+
+        await monitor._analyze_window(
+            b"\0\0",
+            index=1,
+            window_start=4.0,
+            participant_identity="caller",
+        )
+        await monitor._analyze_window(
+            b"\0\0",
+            index=2,
+            window_start=8.0,
+            participant_identity="caller",
+        )
+
+        self.assertEqual(len(raw_hits), 2)
+        self.assertEqual(len(confirmed_hits), 1)
+        self.assertEqual(monitor.verdict.label, "fake")
+        self.assertEqual(monitor.verdict.normalized_label, "synthetic")
+
+    async def test_spot_confirms_from_one_fake_result(self) -> None:
+        transport = _FakeTransport(0.91)
+        monitor = DetectionMonitor(security="spot", transport=transport)
+        confirmed_hits = []
+        monitor.on("synthetic_detected", confirmed_hits.append)
+
+        await monitor._analyze_window(
+            b"\0\0",
+            index=0,
+            window_start=0.0,
+            participant_identity="caller",
+        )
+
+        self.assertEqual(len(confirmed_hits), 1)
+        self.assertEqual(monitor.verdict.label, "fake")
+
+    async def test_forced_check_can_confirm_immediately_when_configured(self) -> None:
+        transport = _FakeTransport(0.94)
+        monitor = DetectionMonitor(transport=transport, force_immediate_fake=True)
+        confirmed_hits = []
+        monitor.on("synthetic_detected", confirmed_hits.append)
+
+        await monitor._analyze_window(
+            b"\0\0",
+            index=0,
+            window_start=0.0,
+            participant_identity="caller",
+            forced=True,
+        )
+
+        self.assertEqual(len(confirmed_hits), 1)
+        self.assertTrue(confirmed_hits[0].forced)
+
+    async def test_final_verdict_preserves_confirmed_synthetic_alert(self) -> None:
+        transport = _FakeTransport(0.91, 0.92, 0.02)
+        monitor = DetectionMonitor(security="spot", transport=transport)
+        confirmed_hits = []
+        monitor.on("synthetic_detected", confirmed_hits.append)
+
+        await monitor._analyze_window(
+            b"\0\0",
+            index=0,
+            window_start=0.0,
+            participant_identity="caller",
+        )
+        await monitor._analyze_window(
+            b"\0\0",
+            index=1,
+            window_start=4.0,
+            participant_identity="caller",
+        )
+        await monitor._analyze_window(
+            b"\0\0",
+            index=2,
+            window_start=8.0,
+            participant_identity="caller",
+        )
+
+        self.assertEqual(len(confirmed_hits), 1)
+        self.assertEqual(monitor.verdict.label, "fake")
+
+    async def test_result_payload_uses_stable_developer_shape(self) -> None:
+        transport = _FakeTransport(0.82, consistency=91.0)
+        monitor = DetectionMonitor(security="spot", transport=transport)
+
+        await monitor._analyze_window(
+            b"\0\0",
+            index=0,
+            window_start=12.0,
+            participant_identity="caller",
+        )
+
+        result = monitor.results[0]
+        self.assertEqual(result.normalized_label, "synthetic")
+        self.assertEqual(result.score, 0.82)
+        self.assertEqual(result.confidence, 0.91)
+        self.assertEqual(result.scan_index, 1)
+        self.assertEqual(result.window_ts, 16.0)
+        self.assertEqual(result.recommended_action, "block")
+        self.assertEqual(
+            result.to_dict(),
+            {
+                "label": "synthetic",
+                "raw_label": "fake",
+                "score": 0.82,
+                "confidence": 0.91,
+                "window_ts": 16.0,
+                "scan_index": 1,
+                "is_final": False,
+                "recommended_action": "block",
+                "participant_identity": "caller",
+                "detection_uuid": "detect-0",
+                "latency": result.latency,
+                "forced": False,
+            },
+        )
+
+    async def test_custom_transport_receives_runtime_options(self) -> None:
+        transport = _FakeTransport(0.1)
+        monitor = ResembleDetect(
+            security="high",
+            transport=transport,
+            frame_length=3,
+            request_timeout=12.0,
+            sample_interval_seconds=11.0,
+            agreement_window=2,
+            min_fake_results=1,
+        )
+
+        await monitor._analyze_window(
+            b"\0\0",
+            index=0,
+            window_start=0.0,
+            participant_identity="caller",
+        )
+
+        self.assertIsInstance(monitor, DetectionMonitor)
+        self.assertEqual(monitor.security, "high")
+        self.assertEqual(monitor._opts.mode, "continuous")
+        self.assertEqual(monitor._opts.sample_interval_seconds, 11.0)
+        self.assertEqual(transport.calls, [{"frame_length": 3, "request_timeout": 12.0}])
+
+    def test_invalid_explicit_overrides_are_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "samples must be >= 1"):
+            DetectionMonitor(transport=_FakeTransport(0.1), samples=0)
+
+        with self.assertRaisesRegex(ValueError, "min_fake_results must be <= agreement_window"):
+            DetectionMonitor(
+                transport=_FakeTransport(0.1),
+                agreement_window=1,
+                min_fake_results=2,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/livekit-plugins/livekit-plugins-resemble/tests/test_detect.py
+++ b/livekit-plugins/livekit-plugins-resemble/tests/test_detect.py
@@ -82,6 +82,28 @@ class _FakeAudioStream:
         self.closed = True
 
 
+class _ScriptedAudioStream:
+    """Audio stream that can run callables (pause/resume) between frames."""
+
+    def __init__(self, *items: Any) -> None:
+        self._items = iter(items)
+        self.closed = False
+
+    def __aiter__(self) -> _ScriptedAudioStream:
+        return self
+
+    async def __anext__(self) -> Any:
+        for item in self._items:
+            if callable(item):
+                item()
+                continue
+            return SimpleNamespace(frame=SimpleNamespace(data=item))
+        raise StopAsyncIteration
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
 class DetectionMonitorPolicyTests(unittest.IsolatedAsyncioTestCase):
     async def test_standard_requires_agreement_before_confirming_synthetic(self) -> None:
         transport = _FakeTransport(0.92, 0.05, 0.88)
@@ -288,6 +310,86 @@ class DetectionMonitorPolicyTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(monitor._opts.mode, "continuous")
         self.assertEqual(monitor._opts.sample_interval_seconds, 11.0)
         self.assertEqual(transport.calls, [{"frame_length": 3, "request_timeout": 12.0}])
+
+    async def test_recommended_action_honors_configured_thresholds(self) -> None:
+        transport = _FakeTransport(0.75)
+        monitor = DetectionMonitor(
+            transport=transport,
+            unclear_threshold=0.2,
+            likely_synthetic_threshold=0.6,
+            fake_threshold=0.9,
+        )
+
+        await monitor._analyze_window(
+            b"\0\0",
+            index=0,
+            window_start=0.0,
+            participant_identity="caller",
+        )
+
+        # the default cutoffs would say "block" at 0.75; the configured policy says "verify"
+        self.assertEqual(monitor.results[0].recommended_action, "verify")
+
+    async def test_unclassifiable_labels_are_reported_as_inconclusive(self) -> None:
+        class _WeirdLabelTransport:
+            def __init__(self) -> None:
+                self._labels = iter(["inconclusive", "unknown-future-label"])
+
+            async def submit(
+                self,
+                _pcm16: bytes,
+                *,
+                frame_length: int,
+                request_timeout: float,
+            ) -> dict[str, Any]:
+                del frame_length, request_timeout
+                return {
+                    "uuid": "detect-x",
+                    "status": "completed",
+                    "metrics": {
+                        "score": [0.5],
+                        "aggregated_score": 0.5,
+                        "label": next(self._labels),
+                        "consistency": 90.0,
+                    },
+                }
+
+        monitor = DetectionMonitor(transport=_WeirdLabelTransport())
+
+        await monitor._analyze_window(
+            b"\0\0",
+            index=0,
+            window_start=0.0,
+            participant_identity="caller",
+        )
+        await monitor._analyze_window(
+            b"\0\0",
+            index=1,
+            window_start=4.0,
+            participant_identity="caller",
+        )
+
+        self.assertEqual([r.label for r in monitor.results], ["inconclusive", "inconclusive"])
+        self.assertEqual(monitor.results[0].normalized_label, "inconclusive")
+
+    async def test_paused_audio_still_advances_window_timestamps(self) -> None:
+        second = b"\x00\x40" * 16000  # 1s of loud (non-silent) 16 kHz PCM16
+        transport = _FakeTransport(0.1, 0.1)
+        monitor = DetectionMonitor(transport=transport, sample_interval_seconds=0.0)
+
+        stream = _ScriptedAudioStream(
+            second * 4,  # window [0, 4) analyzed
+            monitor.pause,
+            second * 3,  # dropped while paused, but stream time still passes
+            monitor.resume,
+            second * 4,  # window [7, 11) analyzed
+        )
+        await monitor._consume(stream, "caller")
+
+        self.assertEqual(
+            [(r.window_start, r.window_end) for r in monitor.results],
+            [(0.0, 4.0), (7.0, 11.0)],
+        )
 
     def test_invalid_explicit_overrides_are_rejected(self) -> None:
         with self.assertRaisesRegex(ValueError, "samples must be >= 1"):

--- a/livekit-plugins/livekit-plugins-resemble/tests/test_identity.py
+++ b/livekit-plugins/livekit-plugins-resemble/tests/test_identity.py
@@ -128,6 +128,13 @@ class ResembleIdentityTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaisesRegex(ValueError, "url is required"):
             await identity.search_url("   ")
 
+        # never forward non-web schemes to Resemble's URL fetcher
+        with self.assertRaisesRegex(ValueError, "http"):
+            await identity.search_url("file:///etc/passwd")
+
+        with self.assertRaisesRegex(ValueError, "http"):
+            await identity.search_url("ftp://internal-host/clip.wav")
+
         with self.assertRaisesRegex(ValueError, "audio is required"):
             await identity.search(b"")
 

--- a/livekit-plugins/livekit-plugins-resemble/tests/test_identity.py
+++ b/livekit-plugins/livekit-plugins-resemble/tests/test_identity.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+import pytest
+
+from livekit.plugins.resemble import ResembleIdentity
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeTransport:
+    def __init__(self, item: dict[str, Any]) -> None:
+        self._item = item
+        self.calls: list[dict[str, Any]] = []
+
+    async def search(self, url: str, *, request_timeout: float) -> dict[str, Any]:
+        self.calls.append({"url": url, "request_timeout": request_timeout})
+        return self._item
+
+
+class _FakeHost:
+    def __init__(self, url: str = "https://clips.example.com/turn.wav") -> None:
+        self.url = url
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, audio: bytes, filename: str) -> str:
+        self.calls.append({"audio": audio, "filename": filename})
+        return self.url
+
+
+_ENROLLED = {
+    "uuid-harold": {"name": "Harold", "distance": 91.4},
+    "uuid-alex": {"name": "Alex", "distance": 40.0},
+    "uuid-unscored": {"name": "Broken", "distance": None},
+}
+
+
+class ResembleIdentityTests(unittest.IsolatedAsyncioTestCase):
+    async def test_search_url_ranks_matches_and_applies_threshold(self) -> None:
+        transport = _FakeTransport(_ENROLLED)
+        identity = ResembleIdentity(transport=transport)
+
+        result = await identity.search_url("https://clips.example.com/turn.wav")
+
+        self.assertEqual([match.name for match in result.matches], ["Harold", "Alex", "Broken"])
+        self.assertTrue(result.matched)
+        self.assertEqual(result.name, "Harold")
+        self.assertEqual(result.score, 91.4)
+        self.assertEqual(result.threshold, 70.0)
+        self.assertEqual(
+            transport.calls,
+            [{"url": "https://clips.example.com/turn.wav", "request_timeout": 60.0}],
+        )
+
+    async def test_below_threshold_is_not_matched(self) -> None:
+        transport = _FakeTransport({"uuid-alex": {"name": "Alex", "distance": 40.0}})
+        identity = ResembleIdentity(transport=transport)
+
+        result = await identity.search_url("https://clips.example.com/turn.wav")
+
+        self.assertFalse(result.matched)
+        self.assertEqual(result.name, "Alex")
+
+    async def test_per_call_threshold_overrides_configured_threshold(self) -> None:
+        transport = _FakeTransport({"uuid-alex": {"name": "Alex", "distance": 40.0}})
+        identity = ResembleIdentity(transport=transport, threshold=90.0)
+
+        result = await identity.search_url(
+            "https://clips.example.com/turn.wav",
+            threshold=30.0,
+        )
+
+        self.assertTrue(result.matched)
+        self.assertEqual(result.threshold, 30.0)
+
+    async def test_no_enrollments_yields_unmatched_empty_result(self) -> None:
+        identity = ResembleIdentity(transport=_FakeTransport({}))
+
+        result = await identity.search_url("https://clips.example.com/turn.wav")
+
+        self.assertEqual(result.matches, [])
+        self.assertFalse(result.matched)
+        self.assertIsNone(result.name)
+        self.assertIsNone(result.score)
+
+    async def test_result_payload_uses_stable_developer_shape(self) -> None:
+        identity = ResembleIdentity(transport=_FakeTransport(_ENROLLED))
+
+        result = await identity.search_url("https://clips.example.com/turn.wav")
+
+        self.assertEqual(
+            result.to_dict(),
+            {
+                "matched": True,
+                "name": "Harold",
+                "score": 91.4,
+                "threshold": 70.0,
+                "matches": [
+                    {"uuid": "uuid-harold", "name": "Harold", "score": 91.4},
+                    {"uuid": "uuid-alex", "name": "Alex", "score": 40.0},
+                    {"uuid": "uuid-unscored", "name": "Broken", "score": None},
+                ],
+            },
+        )
+
+    async def test_search_hosts_audio_then_searches_hosted_url(self) -> None:
+        transport = _FakeTransport(_ENROLLED)
+        host = _FakeHost()
+        identity = ResembleIdentity(transport=transport, audio_host=host)
+
+        result = await identity.search(b"pcm-bytes", filename="turn-7.wav")
+
+        self.assertTrue(result.matched)
+        self.assertEqual(host.calls, [{"audio": b"pcm-bytes", "filename": "turn-7.wav"}])
+        self.assertEqual(transport.calls[0]["url"], host.url)
+
+    async def test_search_without_audio_host_explains_url_requirement(self) -> None:
+        identity = ResembleIdentity(transport=_FakeTransport(_ENROLLED))
+
+        with self.assertRaisesRegex(ValueError, "audio_host"):
+            await identity.search(b"pcm-bytes")
+
+    async def test_invalid_inputs_are_rejected(self) -> None:
+        identity = ResembleIdentity(transport=_FakeTransport(_ENROLLED))
+
+        with self.assertRaisesRegex(ValueError, "url is required"):
+            await identity.search_url("   ")
+
+        with self.assertRaisesRegex(ValueError, "audio is required"):
+            await identity.search(b"")
+
+        with self.assertRaisesRegex(ValueError, "threshold"):
+            ResembleIdentity(transport=_FakeTransport(_ENROLLED), threshold=101.0)
+
+        with self.assertRaisesRegex(ValueError, "threshold"):
+            await identity.search_url("https://clips.example.com/turn.wav", threshold=-1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/livekit-plugins/livekit-plugins-resemble/tests/test_signal.py
+++ b/livekit-plugins/livekit-plugins-resemble/tests/test_signal.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+import pytest
+
+from livekit.plugins.resemble import ResembleSignal
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeSignalTransport:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def score_text(self, text: str, *, request_timeout: float) -> dict[str, Any]:
+        self.calls.append({"op": "score_text", "text": text, "request_timeout": request_timeout})
+        return _signal_item(input_modality="text")
+
+    async def score_file(
+        self,
+        file: bytes,
+        *,
+        filename: str,
+        media_type: str | None,
+        content_type: str | None,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "op": "score_file",
+                "file": file,
+                "filename": filename,
+                "media_type": media_type,
+                "content_type": content_type,
+                "request_timeout": request_timeout,
+            }
+        )
+        return _signal_item(input_modality="audio")
+
+    async def list_submissions(
+        self,
+        *,
+        page: int,
+        per_page: int,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "op": "list_submissions",
+                "page": page,
+                "per_page": per_page,
+                "request_timeout": request_timeout,
+            }
+        )
+        return {"success": True, "items": [], "page": page, "per_page": per_page}
+
+    async def delete_submission(self, submission_id: str | int, *, request_timeout: float) -> None:
+        self.calls.append(
+            {
+                "op": "delete_submission",
+                "submission_id": submission_id,
+                "request_timeout": request_timeout,
+            }
+        )
+
+    async def list_custom_categories(self, *, request_timeout: float) -> dict[str, Any]:
+        self.calls.append({"op": "list_custom_categories", "request_timeout": request_timeout})
+        return {"success": True, "custom_categories": []}
+
+    async def create_custom_category(
+        self,
+        payload: dict[str, Any],
+        *,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {"op": "create_custom_category", "payload": payload, "request_timeout": request_timeout}
+        )
+        return {"id": 99, **payload, "status": "pending"}
+
+    async def get_custom_category(
+        self,
+        category_id: str | int,
+        *,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "op": "get_custom_category",
+                "category_id": category_id,
+                "request_timeout": request_timeout,
+            }
+        )
+        return {"id": category_id, "name": "Tech Support Scam"}
+
+    async def update_custom_category(
+        self,
+        category_id: str | int,
+        payload: dict[str, Any],
+        *,
+        request_timeout: float,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "op": "update_custom_category",
+                "category_id": category_id,
+                "payload": payload,
+                "request_timeout": request_timeout,
+            }
+        )
+        return {"id": category_id, **payload}
+
+    async def delete_custom_category(
+        self, category_id: str | int, *, request_timeout: float
+    ) -> None:
+        self.calls.append(
+            {
+                "op": "delete_custom_category",
+                "category_id": category_id,
+                "request_timeout": request_timeout,
+            }
+        )
+
+    async def update_settings(
+        self, payload: dict[str, Any], *, request_timeout: float
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {"op": "update_settings", "payload": payload, "request_timeout": request_timeout}
+        )
+        return {"success": True, "settings": payload}
+
+
+def _signal_item(*, input_modality: str) -> dict[str, Any]:
+    return {
+        "id": 12345,
+        "input_modality": input_modality,
+        "verdict": "fraud",
+        "top_category": {
+            "name": "CEO Impersonation / Wire Diversion",
+            "icon": "wire",
+            "score": 0.91,
+        },
+        "category_scores": [
+            {"name": "CEO Impersonation / Wire Diversion", "icon": "wire", "score": 0.91},
+            {"name": "Vendor Invoice / Payment Redirection", "icon": "invoice", "score": 0.7},
+        ],
+        "benign_score": 0.12,
+        "margin_over_second": 0.21,
+        "examples": ["transfer the funds immediately"],
+        "top_matches": [
+            {"category": "CEO Impersonation / Wire Diversion", "text": "wire funds", "score": 0.92}
+        ],
+        "duration_seconds": None,
+        "created_at": "2026-06-14T10:30:45.123Z",
+    }
+
+
+class ResembleSignalTests(unittest.IsolatedAsyncioTestCase):
+    async def test_score_text_returns_stable_payload(self) -> None:
+        transport = _FakeSignalTransport()
+        signal = ResembleSignal(transport=transport, request_timeout=12.0)
+
+        result = await signal.score_text(" wire the funds now ")
+
+        self.assertEqual(result.verdict, "fraud")
+        self.assertEqual(result.input_modality, "text")
+        self.assertEqual(result.score, 0.91)
+        self.assertEqual(result.recommended_action, "block")
+        self.assertEqual(
+            result.top_category.name if result.top_category else None,
+            "CEO Impersonation / Wire Diversion",
+        )
+        self.assertEqual(len(result.category_scores), 2)
+        self.assertEqual(
+            transport.calls[0],
+            {"op": "score_text", "text": "wire the funds now", "request_timeout": 12.0},
+        )
+        self.assertEqual(
+            result.to_dict(),
+            {
+                "id": 12345,
+                "verdict": "fraud",
+                "score": 0.91,
+                "recommended_action": "block",
+                "input_modality": "text",
+                "top_category": {
+                    "name": "CEO Impersonation / Wire Diversion",
+                    "score": 0.91,
+                    "icon": "wire",
+                },
+                "category_scores": [
+                    {
+                        "name": "CEO Impersonation / Wire Diversion",
+                        "score": 0.91,
+                        "icon": "wire",
+                    },
+                    {
+                        "name": "Vendor Invoice / Payment Redirection",
+                        "score": 0.7,
+                        "icon": "invoice",
+                    },
+                ],
+                "benign_score": 0.12,
+                "margin_over_second": 0.21,
+                "examples": ["transfer the funds immediately"],
+                "top_matches": [
+                    {
+                        "category": "CEO Impersonation / Wire Diversion",
+                        "text": "wire funds",
+                        "score": 0.92,
+                    }
+                ],
+                "duration_seconds": None,
+                "created_at": "2026-06-14T10:30:45.123Z",
+            },
+        )
+
+    async def test_score_file_forwards_media_metadata(self) -> None:
+        transport = _FakeSignalTransport()
+        signal = ResembleSignal(transport=transport)
+
+        result = await signal.score_file(
+            b"wav",
+            filename="call.wav",
+            media_type="audio",
+            content_type="audio/wav",
+            request_timeout=3.0,
+        )
+
+        self.assertEqual(result.input_modality, "audio")
+        self.assertEqual(
+            transport.calls[0],
+            {
+                "op": "score_file",
+                "file": b"wav",
+                "filename": "call.wav",
+                "media_type": "audio",
+                "content_type": "audio/wav",
+                "request_timeout": 3.0,
+            },
+        )
+
+    async def test_management_helpers_validate_and_forward_payloads(self) -> None:
+        transport = _FakeSignalTransport()
+        signal = ResembleSignal(transport=transport)
+
+        created = await signal.create_custom_category(
+            name="Tech Support Scam",
+            scenarios="virus warning\nverify your identity now",
+            enabled=True,
+        )
+        await signal.update_custom_category(99, scenarios=["new scenario"], enabled=False)
+        await signal.update_settings(use_builtin_categories=False)
+
+        self.assertEqual(created["status"], "pending")
+        self.assertEqual(
+            transport.calls[0]["payload"],
+            {
+                "name": "Tech Support Scam",
+                "scenarios": ["virus warning", "verify your identity now"],
+                "enabled": True,
+            },
+        )
+        self.assertEqual(
+            transport.calls[1]["payload"], {"scenarios": ["new scenario"], "enabled": False}
+        )
+        self.assertEqual(transport.calls[2]["payload"], {"use_builtin_categories": False})
+
+    async def test_empty_inputs_are_rejected(self) -> None:
+        signal = ResembleSignal(transport=_FakeSignalTransport())
+
+        with self.assertRaisesRegex(ValueError, "text is required"):
+            await signal.score_text(" ")
+        with self.assertRaisesRegex(ValueError, "file is required"):
+            await signal.score_file(b"")
+        with self.assertRaisesRegex(ValueError, "per_page must be between"):
+            await signal.list_submissions(per_page=101)
+        with self.assertRaisesRegex(ValueError, "at least one custom category field"):
+            await signal.update_custom_category(99)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/livekit-plugins/livekit-plugins-resemble/tests/test_signal.py
+++ b/livekit-plugins/livekit-plugins-resemble/tests/test_signal.py
@@ -283,3 +283,61 @@ class ResembleSignalTests(unittest.IsolatedAsyncioTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class _FakeHttpResponse:
+    def __init__(self, status: int = 200, body: bytes = b"") -> None:
+        self.status = status
+        self._body = body
+
+    async def read(self) -> bytes:
+        return self._body
+
+    async def text(self) -> str:
+        return self._body.decode()
+
+    async def __aenter__(self) -> _FakeHttpResponse:
+        return self
+
+    async def __aexit__(self, *args: Any) -> bool:
+        return False
+
+
+class _FakeHttpSession:
+    def __init__(self, response: _FakeHttpResponse) -> None:
+        self._response = response
+        self.calls: list[tuple[str, str]] = []
+
+    def request(self, method: str, url: str, **_kwargs: Any) -> _FakeHttpResponse:
+        self.calls.append((method, url))
+        return self._response
+
+
+class RestSignalTransportResponseTests(unittest.IsolatedAsyncioTestCase):
+    async def test_delete_succeeds_on_204_no_content(self) -> None:
+        from livekit.plugins.resemble import RestSignalTransport
+
+        session = _FakeHttpSession(_FakeHttpResponse(status=204))
+        transport = RestSignalTransport(api_key="key", http_session=session)  # type: ignore[arg-type]
+
+        await transport.delete_submission("sub-1", request_timeout=5.0)
+
+        self.assertEqual(session.calls, [("DELETE", "https://app.resemble.ai/api/v2/signal/sub-1")])
+
+    async def test_delete_succeeds_on_empty_body(self) -> None:
+        from livekit.plugins.resemble import RestSignalTransport
+
+        session = _FakeHttpSession(_FakeHttpResponse(status=200, body=b""))
+        transport = RestSignalTransport(api_key="key", http_session=session)  # type: ignore[arg-type]
+
+        await transport.delete_custom_category(7, request_timeout=5.0)
+
+    async def test_invalid_json_raises_api_error(self) -> None:
+        from livekit.agents import APIStatusError
+        from livekit.plugins.resemble import RestSignalTransport
+
+        session = _FakeHttpSession(_FakeHttpResponse(status=200, body=b"<html>not json</html>"))
+        transport = RestSignalTransport(api_key="key", http_session=session)  # type: ignore[arg-type]
+
+        with self.assertRaises(APIStatusError):
+            await transport.list_submissions(page=1, per_page=10, request_timeout=5.0)

--- a/tests/test_plugin_resemble_detect.py
+++ b/tests/test_plugin_resemble_detect.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import pytest
+
+from livekit.plugins import resemble
+
+pytestmark = pytest.mark.plugin("resemble")
+
+
+class _FakeTransport:
+    def __init__(self, *scores: float) -> None:
+        self._scores = list(scores)
+        self.calls: list[dict[str, float | int]] = []
+
+    async def submit(
+        self,
+        _pcm16: bytes,
+        *,
+        frame_length: int,
+        request_timeout: float,
+    ) -> dict[str, object]:
+        index = len(self.calls)
+        score = self._scores[index]
+        self.calls.append({"frame_length": frame_length, "request_timeout": request_timeout})
+        return {
+            "uuid": f"detect-{index}",
+            "status": "completed",
+            "metrics": {
+                "score": [score],
+                "aggregated_score": score,
+                "label": "fake" if score >= 0.7 else "real",
+                "consistency": 0.9,
+            },
+        }
+
+
+async def test_resemble_detect_standard_preset_requires_agreement() -> None:
+    monitor = resemble.ResembleDetect(transport=_FakeTransport(0.94, 0.1, 0.93))
+    raw_hits: list[resemble.DetectionResult] = []
+    policy_hits: list[resemble.DetectionResult] = []
+    monitor.on("fake_detected", raw_hits.append)
+    monitor.on("synthetic_detected", policy_hits.append)
+
+    await monitor._analyze_window(
+        b"\0\0",
+        index=0,
+        window_start=0.0,
+        participant_identity="caller",
+    )
+
+    assert len(raw_hits) == 1
+    assert policy_hits == []
+    assert monitor.verdict.to_dict()["label"] == "inconclusive"
+
+    await monitor._analyze_window(
+        b"\0\0",
+        index=1,
+        window_start=4.0,
+        participant_identity="caller",
+    )
+    await monitor._analyze_window(
+        b"\0\0",
+        index=2,
+        window_start=8.0,
+        participant_identity="caller",
+    )
+
+    assert len(raw_hits) == 2
+    assert len(policy_hits) == 1
+    assert policy_hits[0].to_dict() == {
+        "label": "synthetic",
+        "raw_label": "fake",
+        "score": 0.93,
+        "confidence": 0.9,
+        "window_ts": 12.0,
+        "scan_index": 3,
+        "is_final": False,
+        "recommended_action": "block",
+        "participant_identity": "caller",
+        "detection_uuid": "detect-2",
+        "latency": policy_hits[0].latency,
+        "forced": False,
+    }
+    assert monitor.verdict.to_dict()["label"] == "synthetic"
+
+
+async def test_resemble_detect_custom_transport_receives_options() -> None:
+    transport = _FakeTransport(0.1)
+    monitor = resemble.ResembleDetect(
+        security="high",
+        transport=transport,
+        frame_length=3,
+        request_timeout=12.0,
+        sample_interval_seconds=11.0,
+        agreement_window=2,
+        min_fake_results=1,
+    )
+
+    await monitor._analyze_window(
+        b"\0\0",
+        index=0,
+        window_start=0.0,
+        participant_identity="caller",
+    )
+
+    assert isinstance(monitor, resemble.DetectionMonitor)
+    assert monitor.security == "high"
+    assert monitor._opts.mode == "continuous"
+    assert monitor._opts.sample_interval_seconds == 11.0
+    assert transport.calls == [{"frame_length": 3, "request_timeout": 12.0}]
+
+
+async def test_resemble_detect_verdict_preserves_confirmed_synthetic_alert() -> None:
+    monitor = resemble.ResembleDetect(
+        security="spot",
+        transport=_FakeTransport(0.94, 0.03),
+    )
+    policy_hits: list[resemble.DetectionResult] = []
+    monitor.on("synthetic_detected", policy_hits.append)
+
+    await monitor._analyze_window(
+        b"\0\0",
+        index=0,
+        window_start=0.0,
+        participant_identity="caller",
+    )
+    await monitor._analyze_window(
+        b"\0\0",
+        index=1,
+        window_start=4.0,
+        participant_identity="caller",
+    )
+
+    assert len(policy_hits) == 1
+    assert monitor.verdict.label == "fake"
+
+
+def test_resemble_detect_rest_transport_defaults_to_zero_retention() -> None:
+    transport = resemble.RestDetectTransport(api_key="test")
+    assert transport._extra_form_fields["zero_retention_mode"] == "true"
+
+
+def test_resemble_detect_rest_transport_normalizes_extra_fields() -> None:
+    transport = resemble.RestDetectTransport(
+        api_key="test",
+        zero_retention_mode=False,
+        extra_form_fields={"use_ood_detector": True, "start_region": 1.25},
+    )
+
+    assert transport._extra_form_fields == {
+        "zero_retention_mode": "false",
+        "use_ood_detector": "true",
+        "start_region": "1.25",
+    }


### PR DESCRIPTION
## Summary

- add `ResembleDetect` / `DetectionMonitor` to the existing `livekit-plugins-resemble` package
- monitor a participant or track in parallel with the agent pipeline without delaying audio
- support sampled, first-N, continuous, and on-demand detection policies
- expose typed per-window results, confirmed-synthetic events, final verdicts, and zero-retention REST options
- add focused unit and plugin-level coverage using a fake transport

## Review updates

- rebased onto current `livekit/agents` `main`
- removed the Resemble Signal client from this PR so the change stays focused on Detect
- clear on-demand state after exactly one analyzed window in every monitoring mode
- keep concurrent API results in chronological audio-window order before evaluating agreement
- add regressions for forced checks in `continuous` / `first_n` modes and out-of-order API completion

## Validation

- `ruff format --check livekit/plugins/resemble/detect.py tests/test_detect.py`
- `ruff check livekit/plugins/resemble/detect.py tests/test_detect.py`
- `mypy --strict livekit/plugins/resemble/detect.py`
- `pytest -q livekit-plugins/livekit-plugins-resemble/tests/test_detect.py tests/test_plugin_resemble_detect.py` — 14 passed, 2 subtests passed
