### PR TITLE
inference(stt): remove cartesia/ink-2-latest from Cartesia STT type hints

### DIFF
--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -48,7 +48,6 @@ DeepgramFluxModels = Literal[
 CartesiaModels = Literal[
     "cartesia/ink-whisper",
     "cartesia/ink-2",
-    "cartesia/ink-2-latest",
 ]
 AssemblyAIModels = Literal[
     "assemblyai/universal-streaming",


### PR DESCRIPTION
## What

Removes `cartesia/ink-2-latest` from the `CartesiaModels` STT type hints in `livekit-agents/livekit/agents/inference/stt.py`. `cartesia/ink-whisper` and `cartesia/ink-2` remain.

(`cartesia/ink-2-2026-04-15` was never present in the Python type hints, so there is nothing to remove for it here.)

## Why

The Cartesia team wants to move away from dated / `-latest` STT snapshot aliases. The alias still works at runtime — we just stop surfacing it in the SDK type hints.

## Related

- livekit/cloud-config — removes the aliases from the inference catalog (docs/pricing source of truth): https://github.com/livekit/cloud-config/pull/13726
- livekit/agents-js — same change for the Node.js types: https://github.com/livekit/agents-js/pull/1792

🤖 Generated with [Claude Code](https://claude.com/claude-code)
