### PR TITLE
fix(azure): flush buffered audio on end_input to avoid truncated STT

### DIFF
--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
@@ -286,6 +286,7 @@ class SpeechStream(stt.SpeechStream):
                 wait_reconnect_task = asyncio.create_task(self._reconnect_event.wait())
                 wait_stopped_task = asyncio.create_task(self._session_stopped_event.wait())
 
+                input_ended = False
                 try:
                     done, _ = await asyncio.wait(
                         [process_input_task, wait_reconnect_task, wait_stopped_task],
@@ -298,14 +299,22 @@ class SpeechStream(stt.SpeechStream):
                     if wait_stopped_task in done:
                         raise APIConnectionError("SpeechRecognition session stopped")
 
-                    if wait_reconnect_task not in done:
-                        break
-                    self._reconnect_event.clear()
+                    # session-stopped is handled above, so the wait unblocked
+                    # either because input ended (process_input drained) or a
+                    # reconnect was requested; reset the event in the latter case
+                    input_ended = wait_reconnect_task not in done
+                    if not input_ended:
+                        self._reconnect_event.clear()
                 finally:
                     await utils.aio.gracefully_cancel(process_input_task, wait_reconnect_task)
 
+                # close the push stream to flush finals for buffered audio before
+                # teardown, otherwise ending input truncates the transcript
                 self._stream.close()
                 await self._session_stopped_event.wait()
+
+                if input_ended:
+                    break
             finally:
 
                 def _cleanup() -> None:


### PR DESCRIPTION
## Problem

When the input channel drained (`end_input`/`aclose`), `SpeechStream._run` broke out of the loop and tore the recognizer down via `stop_continuous_recognition` **without first closing the SDK push stream**. Azure was stopped mid-stream, so trailing phrase finals for already-buffered audio were never emitted and the transcript was truncated to the first phrase.

## Fix

Route the input-ended case through the same flush already used for reconnect:
- Close the push stream (signals end-of-stream so Azure emits the remaining finals)
- Await session-stopped
- Then exit the loop

## Verification

Verified against the real Azure service: a multi-phrase utterance pushed in full + `end_input` now returns the complete transcript instead of just the first phrase.