### PR TITLE
feat(assemblyai): add universal-3-5-pro (now default) and Voice Focus streaming params

### DIFF
--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -56,7 +56,8 @@ class STTOptions:
         "u3-rt-pro",
         "u3-rt-pro-beta-1",
         "u3-pro",
-    ] = "universal-streaming-english"
+        "universal-3-5-pro",
+    ] = "universal-3-5-pro"
     language_detection: NotGivenOr[bool] = NOT_GIVEN
     end_of_turn_confidence_threshold: NotGivenOr[float] = NOT_GIVEN
     min_turn_silence: NotGivenOr[int] = NOT_GIVEN
@@ -72,12 +73,15 @@ class STTOptions:
     speaker_labels: NotGivenOr[bool] = NOT_GIVEN
     max_speakers: NotGivenOr[int] = NOT_GIVEN
     domain: NotGivenOr[str] = NOT_GIVEN
+    voice_focus: NotGivenOr[Literal["near-field", "far-field"]] = NOT_GIVEN
+    voice_focus_threshold: NotGivenOr[float] = NOT_GIVEN
 
 
 # Speech models in the u3-rt-pro family, which share the same parameter support
 # (prompt, agent_context, previous_context_n_turns, continuous_partials,
-# interruption_delay). Mirrors the server-side `SpeechModel.is_u3_pro`.
-_U3_PRO_MODELS = ("u3-rt-pro", "u3-rt-pro-beta-1")
+# interruption_delay, voice_focus, voice_focus_threshold) and connect-time
+# defaults. Mirrors the server-side `SpeechModel.is_u3_pro`.
+_U3_PRO_MODELS = ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro")
 
 
 class STT(stt.STT):
@@ -93,7 +97,8 @@ class STT(stt.STT):
             "u3-rt-pro",
             "u3-rt-pro-beta-1",
             "u3-pro",
-        ] = "universal-streaming-english",
+            "universal-3-5-pro",
+        ] = "universal-3-5-pro",
         language_detection: NotGivenOr[bool] = NOT_GIVEN,
         end_of_turn_confidence_threshold: NotGivenOr[float] = NOT_GIVEN,
         min_turn_silence: NotGivenOr[int] = NOT_GIVEN,
@@ -109,6 +114,8 @@ class STT(stt.STT):
         speaker_labels: NotGivenOr[bool] = NOT_GIVEN,
         max_speakers: NotGivenOr[int] = NOT_GIVEN,
         domain: NotGivenOr[str] = NOT_GIVEN,
+        voice_focus: NotGivenOr[Literal["near-field", "far-field"]] = NOT_GIVEN,
+        voice_focus_threshold: NotGivenOr[float] = NOT_GIVEN,
         http_session: aiohttp.ClientSession | None = None,
         buffer_size_seconds: float = 0.05,
         base_url: str = "wss://streaming.assemblyai.com",
@@ -148,8 +155,21 @@ class STT(stt.STT):
                 transcripts and any `agent_context` values) carried forward as context for
                 each transcription. Set to 0 to disable automatic context carryover
                 entirely; leave unset to use the server default (recommended). Range 0–100.
-                Only supported with the 'u3-rt-pro' / 'u3-rt-pro-beta-1' models. Set at
-                construction (connect) time only; it cannot be changed via `update_options`.
+                Only supported with the 'u3-rt-pro' / 'u3-rt-pro-beta-1' / 'universal-3-5-pro'
+                models. Set at construction (connect) time only; it cannot be changed via
+                `update_options`.
+            voice_focus: Voice Focus isolates the primary voice and suppresses background
+                noise (chatter, keyboard clicks, fan hum, room echo) before the audio reaches
+                the model. Use 'near-field' for headsets, handsets, and close-talking
+                microphones; use 'far-field' for conference rooms, laptop mics, and other
+                distant-mic setups. Only supported with the 'u3-rt-pro' / 'u3-rt-pro-beta-1' /
+                'universal-3-5-pro' models. Set at construction (connect) time only.
+                See https://www.assemblyai.com/docs/streaming/voice-focus.
+            voice_focus_threshold: Controls how aggressively background audio is suppressed,
+                a float between 0.0 and 1.0 (higher is more aggressive). Only takes effect
+                alongside `voice_focus`. Only supported with the 'u3-rt-pro' /
+                'u3-rt-pro-beta-1' / 'universal-3-5-pro' models. Set at construction (connect)
+                time only.
         """
         super().__init__(
             capabilities=stt.STTCapabilities(
@@ -164,31 +184,23 @@ class STT(stt.STT):
             logger.warning("'u3-pro' is deprecated, use 'u3-rt-pro' instead.")
             model = "u3-rt-pro"
 
-        if is_given(prompt) and model not in _U3_PRO_MODELS:
-            raise ValueError(
-                "The 'prompt' parameter is only supported with the 'u3-rt-pro' models."
-            )
-
-        if is_given(agent_context) and model not in _U3_PRO_MODELS:
-            raise ValueError(
-                "The 'agent_context' parameter is only supported with the 'u3-rt-pro' models."
-            )
-
-        if is_given(previous_context_n_turns) and model not in _U3_PRO_MODELS:
-            raise ValueError(
-                "The 'previous_context_n_turns' parameter is only supported with the "
-                "'u3-rt-pro' models."
-            )
-
-        if is_given(continuous_partials) and model not in _U3_PRO_MODELS:
-            raise ValueError(
-                "The 'continuous_partials' parameter is only supported with the 'u3-rt-pro' models."
-            )
-
-        if is_given(interruption_delay) and model not in _U3_PRO_MODELS:
-            raise ValueError(
-                "The 'interruption_delay' parameter is only supported with the 'u3-rt-pro' models."
-            )
+        # These parameters are only supported by the u3-rt-pro family of models.
+        if model not in _U3_PRO_MODELS:
+            _u3_pro_only_params = {
+                "prompt": prompt,
+                "agent_context": agent_context,
+                "previous_context_n_turns": previous_context_n_turns,
+                "continuous_partials": continuous_partials,
+                "interruption_delay": interruption_delay,
+                "voice_focus": voice_focus,
+                "voice_focus_threshold": voice_focus_threshold,
+            }
+            for _param_name, _param_value in _u3_pro_only_params.items():
+                if is_given(_param_value):
+                    raise ValueError(
+                        f"The {_param_name!r} parameter is only supported with the "
+                        f"{', '.join(_U3_PRO_MODELS)} models."
+                    )
 
         # LiveKit defaults continuous_partials to True (vs. AssemblyAI's server default of
         # False) for steady-cadence partials. This parameter is only supported for
@@ -240,6 +252,8 @@ class STT(stt.STT):
             speaker_labels=speaker_labels,
             max_speakers=max_speakers,
             domain=domain,
+            voice_focus=voice_focus,
+            voice_focus_threshold=voice_focus_threshold,
         )
         self._session = http_session
         self._streams = weakref.WeakSet[SpeechStream]()
@@ -651,6 +665,10 @@ class SpeechStream(stt.SpeechStream):
             else None,
             "max_speakers": self._opts.max_speakers if is_given(self._opts.max_speakers) else None,
             "domain": self._opts.domain if is_given(self._opts.domain) else None,
+            "voice_focus": self._opts.voice_focus if is_given(self._opts.voice_focus) else None,
+            "voice_focus_threshold": self._opts.voice_focus_threshold
+            if is_given(self._opts.voice_focus_threshold)
+            else None,
         }
 
         headers = {

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -192,10 +192,15 @@ async def test_start_time_has_default_before_plugin_override():
 
 
 async def test_continuous_partials_default():
-    """Test continuous_partials is not set by default."""
+    """Test continuous_partials is not set by default for a non-u3-rt-pro-family model.
+
+    (The plugin default model is universal-3-5-pro, a u3-rt-pro-family model that
+    defaults continuous_partials to True — covered by
+    test_universal_3_5_pro_defaults_continuous_partials_true.)
+    """
     from livekit.plugins.assemblyai import STT
 
-    stt = STT(api_key="test-key")
+    stt = STT(api_key="test-key", model="universal-streaming-english")
     assert stt._opts.continuous_partials is NOT_GIVEN
 
 
@@ -212,7 +217,7 @@ async def test_continuous_partials_requires_u3_rt_pro():
     from livekit.plugins.assemblyai import STT
 
     with pytest.raises(ValueError, match="continuous_partials"):
-        STT(api_key="test-key", continuous_partials=True)
+        STT(api_key="test-key", model="universal-streaming-english", continuous_partials=True)
 
 
 async def test_continuous_partials_with_u3_pro_alias():
@@ -303,7 +308,7 @@ async def test_interruption_delay_requires_u3_rt_pro():
     from livekit.plugins.assemblyai import STT
 
     with pytest.raises(ValueError, match="interruption_delay"):
-        STT(api_key="test-key", interruption_delay=200)
+        STT(api_key="test-key", model="universal-streaming-english", interruption_delay=200)
 
 
 # ---------------------------------------------------------------------------
@@ -435,7 +440,7 @@ async def test_agent_context_requires_u3_rt_pro():
     from livekit.plugins.assemblyai import STT
 
     with pytest.raises(ValueError, match="agent_context"):
-        STT(api_key="test-key", agent_context="hello")
+        STT(api_key="test-key", model="universal-streaming-english", agent_context="hello")
 
 
 async def test_agent_context_allowed_for_u3_rt_pro_models():
@@ -473,7 +478,7 @@ async def test_previous_context_n_turns_requires_u3_rt_pro():
     from livekit.plugins.assemblyai import STT
 
     with pytest.raises(ValueError, match="previous_context_n_turns"):
-        STT(api_key="test-key", previous_context_n_turns=5)
+        STT(api_key="test-key", model="universal-streaming-english", previous_context_n_turns=5)
 
 
 async def test_previous_context_n_turns_zero_is_forwarded():
@@ -498,3 +503,210 @@ async def test_previous_context_n_turns_zero_is_forwarded():
 
     query = parse_qs(urlparse(captured["url"]).query)
     assert query["previous_context_n_turns"] == ["0"]
+
+
+# ---------------------------------------------------------------------------
+# universal-3-5-pro: default model + u3-rt-pro parameter family
+#
+# universal-3-5-pro is the plugin's default model and belongs to the u3-rt-pro
+# parameter family, so it accepts the u3-pro-gated params (prompt,
+# agent_context, previous_context_n_turns, continuous_partials,
+# interruption_delay) and inherits the family's connect-time defaults.
+# ---------------------------------------------------------------------------
+
+
+async def test_default_model_is_universal_3_5_pro():
+    """The plugin defaults to universal-3-5-pro."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key")
+    assert stt.model == "universal-3-5-pro"
+    assert stt._opts.speech_model == "universal-3-5-pro"
+
+
+async def test_universal_3_5_pro_accepts_u3_pro_params():
+    """universal-3-5-pro shares the u3-rt-pro parameter family."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(
+        api_key="test-key",
+        model="universal-3-5-pro",
+        prompt="medical dictation",
+        agent_context="The agent asked for the patient's name.",
+        previous_context_n_turns=10,
+        interruption_delay=300,
+    )
+    assert stt._opts.speech_model == "universal-3-5-pro"
+    assert stt._opts.prompt == "medical dictation"
+    assert stt._opts.agent_context == "The agent asked for the patient's name."
+    assert stt._opts.previous_context_n_turns == 10
+    assert stt._opts.interruption_delay == 300
+
+
+async def test_universal_3_5_pro_defaults_continuous_partials_true():
+    """continuous_partials defaults to True for universal-3-5-pro (u3-rt-pro family)."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key", model="universal-3-5-pro")
+    assert stt._opts.continuous_partials is True
+
+
+# ---------------------------------------------------------------------------
+# voice_focus / voice_focus_threshold
+#
+# Voice Focus isolates the primary voice and suppresses background noise.
+# voice_focus is a string enum ("near-field" / "far-field"); voice_focus_threshold
+# is a float in [0, 1]. Both are u3-rt-pro-family-only and connect-time only
+# (not exposed via update_options).
+# ---------------------------------------------------------------------------
+
+
+async def test_voice_focus_default():
+    """voice_focus and voice_focus_threshold are unset by default."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key")
+    assert stt._opts.voice_focus is NOT_GIVEN
+    assert stt._opts.voice_focus_threshold is NOT_GIVEN
+
+
+async def test_voice_focus_set():
+    """voice_focus accepts the documented near-field / far-field values."""
+    from livekit.plugins.assemblyai import STT
+
+    near = STT(api_key="test-key", voice_focus="near-field")
+    assert near._opts.voice_focus == "near-field"
+
+    far = STT(api_key="test-key", voice_focus="far-field")
+    assert far._opts.voice_focus == "far-field"
+
+
+async def test_voice_focus_threshold_set():
+    """voice_focus_threshold is stored on the options."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key", voice_focus="near-field", voice_focus_threshold=0.7)
+    assert stt._opts.voice_focus_threshold == 0.7
+
+
+async def test_voice_focus_requires_u3_pro_family():
+    """voice_focus raises ValueError when used with a non-u3-rt-pro-family model."""
+    from livekit.plugins.assemblyai import STT
+
+    with pytest.raises(ValueError, match="voice_focus"):
+        STT(api_key="test-key", model="universal-streaming-english", voice_focus="near-field")
+
+
+async def test_voice_focus_threshold_requires_u3_pro_family():
+    """voice_focus_threshold raises ValueError when used with a non-u3-rt-pro-family model."""
+    from livekit.plugins.assemblyai import STT
+
+    with pytest.raises(ValueError, match="voice_focus_threshold"):
+        STT(
+            api_key="test-key",
+            model="universal-streaming-english",
+            voice_focus_threshold=0.5,
+        )
+
+
+async def test_voice_focus_in_connect_config():
+    """voice_focus and voice_focus_threshold are sent in the connect config query."""
+    from urllib.parse import parse_qs, urlparse
+
+    from livekit.plugins.assemblyai import STT
+
+    captured: dict = {}
+
+    async def _fake_ws_connect(url, **kwargs):
+        captured["url"] = url
+        return MagicMock()
+
+    stt = STT(
+        api_key="test-key",
+        model="universal-3-5-pro",
+        voice_focus="far-field",
+        voice_focus_threshold=0.8,
+    )
+    stream = _make_stream_for_unit_test(stt)
+    stream._session.ws_connect = _fake_ws_connect
+    await stream._connect_ws()
+
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert query["voice_focus"] == ["far-field"]
+    assert query["voice_focus_threshold"] == ["0.8"]
+
+
+async def test_voice_focus_absent_from_connect_config_when_unset():
+    """voice_focus keys are omitted from the connect config when not set."""
+    from urllib.parse import parse_qs, urlparse
+
+    from livekit.plugins.assemblyai import STT
+
+    captured: dict = {}
+
+    async def _fake_ws_connect(url, **kwargs):
+        captured["url"] = url
+        return MagicMock()
+
+    stt = STT(api_key="test-key", model="universal-3-5-pro")
+    stream = _make_stream_for_unit_test(stt)
+    stream._session.ws_connect = _fake_ws_connect
+    await stream._connect_ws()
+
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert "voice_focus" not in query
+    assert "voice_focus_threshold" not in query
+
+
+async def test_voice_focus_connect_time_only():
+    """voice_focus is connect-time only — not exposed via update_options."""
+    import inspect
+
+    from livekit.plugins.assemblyai import STT
+    from livekit.plugins.assemblyai.stt import SpeechStream
+
+    assert "voice_focus" not in inspect.signature(STT.update_options).parameters
+    assert "voice_focus_threshold" not in inspect.signature(STT.update_options).parameters
+    assert "voice_focus" not in inspect.signature(SpeechStream.update_options).parameters
+
+
+async def test_voice_focus_threshold_zero_is_forwarded():
+    """0.0 is a meaningful threshold (minimum suppression), distinct from unset, and must
+    be sent in the connect config rather than dropped by a truthiness filter."""
+    from urllib.parse import parse_qs, urlparse
+
+    from livekit.plugins.assemblyai import STT
+
+    captured: dict = {}
+
+    async def _fake_ws_connect(url, **kwargs):
+        captured["url"] = url
+        return MagicMock()
+
+    stt = STT(api_key="test-key", voice_focus="near-field", voice_focus_threshold=0.0)
+    assert stt._opts.voice_focus_threshold == 0.0
+
+    stream = _make_stream_for_unit_test(stt)
+    stream._session.ws_connect = _fake_ws_connect
+    await stream._connect_ws()
+
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert query["voice_focus_threshold"] == ["0.0"]
+
+
+async def test_voice_focus_allowed_for_all_u3_pro_family_models():
+    """voice_focus is accepted for every u3-rt-pro-family model, not just the default."""
+    from livekit.plugins.assemblyai import STT
+
+    for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro"):
+        stt = STT(api_key="test-key", model=model, voice_focus="far-field")
+        assert stt._opts.voice_focus == "far-field"
+
+
+async def test_default_model_defaults_continuous_partials_true():
+    """A bare STT() (relying on the default model) defaults continuous_partials to True,
+    tying the default-model choice to its u3-rt-pro-family behavior."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key")
+    assert stt._opts.continuous_partials is True


### PR DESCRIPTION
## Summary
- **universal-3-5-pro**: new streaming model, now the **plugin default** (was `universal-streaming-english`). It joins the u3-rt-pro parameter family, so it accepts the full u3-pro parameter set (`prompt`, `agent_context`, `previous_context_n_turns`, `continuous_partials`, `interruption_delay`) and inherits the family's connect-time defaults (`continuous_partials=True`, `language_detection=True`, punctuation-based turn detection).
- **voice_focus**: new connect-time parameter (u3-rt-pro family only) — `"near-field"` for headsets/handsets/close-talking mics, `"far-field"` for conference rooms/laptop mics. Isolates the primary voice and suppresses background noise before audio reaches the model. See https://www.assemblyai.com/docs/streaming/voice-focus.
- **voice_focus_threshold**: new connect-time parameter (u3-rt-pro family only) — float in `[0.0, 1.0]` controlling how aggressively background audio is suppressed.
- Consolidated the per-parameter u3-rt-pro-family validation into a single loop so the `ValueError` lists the actual supported models (it previously named only `u3-rt-pro`, now misleading since `universal-3-5-pro` is the default).

> **Behavior change:** because the default model is now a u3-rt-pro-family model, a bare `STT()` now defaults to `continuous_partials=True`, `language_detection=True`, and punctuation-based turn detection (`min_turn_silence=100`, `max_turn_silence=min`). Callers who relied on the previous `universal-streaming-english` default should set `model="universal-streaming-english"` explicitly.

## Test Plan
- `uv run pytest --plugin assemblyai` — 51 tests (default-model assertions, u3-rt-pro-family gating + acceptance across all family models, `voice_focus`/`voice_focus_threshold` plumbing, connect-config forwarding incl. `voice_focus_threshold=0.0`, `update_options` exclusion). 5 existing gating tests were updated to pin `model="universal-streaming-english"` since the default now joins the family.
- ruff format + lint + mypy clean on touched files.
