### PR TITLE
fix: preserve transcription item id

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1728,7 +1728,11 @@ class AgentActivity(RecognitionHooks):
 
     def _on_input_audio_transcription_completed(self, ev: llm.InputTranscriptionCompleted) -> None:
         self._session._user_input_transcribed(
-            UserInputTranscribedEvent(transcript=ev.transcript, is_final=ev.is_final)
+            UserInputTranscribedEvent(
+                transcript=ev.transcript,
+                is_final=ev.is_final,
+                item_id=ev.item_id,
+            )
         )
 
         if ev.is_final:

--- a/livekit-agents/livekit/agents/voice/events.py
+++ b/livekit-agents/livekit/agents/voice/events.py
@@ -315,6 +315,8 @@ class UserInputTranscribedEvent(BaseModel):
     type: Literal["user_input_transcribed"] = "user_input_transcribed"
     transcript: str
     is_final: bool
+    item_id: str | None = None
+    """Provider-specific ID for the transcribed input item, when available."""
     speaker_id: str | None = None
     language: LanguageCode | None = None
     created_at: float = Field(default_factory=time.time)

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -26,9 +26,7 @@ from livekit.agents import (
     inference,
     vad,
 )
-from livekit.agents.llm import (
-    FunctionToolCall,
-)
+from livekit.agents.llm import FunctionToolCall, InputTranscriptionCompleted
 from livekit.agents.llm.chat_context import ChatContext, ChatMessage
 from livekit.agents.stt import SpeechData, SpeechEvent, SpeechEventType
 from livekit.agents.utils import aio
@@ -90,6 +88,31 @@ class MyAgent(Agent):
 
 
 SESSION_TIMEOUT = 60.0
+
+
+def test_realtime_user_input_transcription_preserves_item_id() -> None:
+    captured_events: list[UserInputTranscribedEvent] = []
+
+    class DummySession:
+        def _user_input_transcribed(self, ev: UserInputTranscribedEvent) -> None:
+            captured_events.append(ev)
+
+    activity = object.__new__(AgentActivity)
+    activity._session = DummySession()
+
+    AgentActivity._on_input_audio_transcription_completed(
+        activity,
+        InputTranscriptionCompleted(
+            item_id="item_123",
+            transcript="hello",
+            is_final=False,
+        ),
+    )
+
+    assert len(captured_events) == 1
+    assert captured_events[0].transcript == "hello"
+    assert captured_events[0].is_final is False
+    assert captured_events[0].item_id == "item_123"
 
 
 async def test_events_and_metrics() -> None:


### PR DESCRIPTION
Fixes #6109

## Summary
- expose `item_id` on `UserInputTranscribedEvent`
- pass through realtime input transcription item IDs when re-emitting user transcription events
- add a regression test for item ID propagation

## Testing
- `uv run pytest tests/test_agent_session.py -q`
- `uv run pytest tests/test_agent_session.py::test_realtime_user_input_transcription_preserves_item_id -q`
- `uv run ruff check livekit-agents/livekit/agents/voice/events.py livekit-agents/livekit/agents/voice/agent_activity.py tests/test_agent_session.py`