### PR TITLE
fix(workflows): normalize two-digit years in GetDOBTask

### DIFF
--- a/livekit-agents/livekit/agents/beta/workflows/dob.py
+++ b/livekit-agents/livekit/agents/beta/workflows/dob.py
@@ -151,6 +151,14 @@ class GetDOBTask(AgentTask[GetDOBResult]):
     async def _update_dob_impl(
         self, year: int, month: int, day: int, ctx: RunContext
     ) -> str | None:
+        # Normalize two-digit years to the intended century, matching what the
+        # prompt already asks the model to do ("90" -> 1990, "05" -> 2005). A
+        # literal two-digit year is otherwise a valid date (e.g. 90 -> year 90 AD)
+        # that passes the future-date check and silently corrupts the result.
+        if 0 <= year < 100:
+            current_yy = date.today().year % 100
+            year += 2000 if year <= current_yy else 1900
+
         try:
             dob = date(year, month, day)
         except ValueError as e:

--- a/tests/test_dob.py
+++ b/tests/test_dob.py
@@ -1,0 +1,32 @@
+from datetime import date
+
+import pytest
+
+from livekit.agents import beta
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_dob_two_digit_year_normalized() -> None:
+    # The prompt asks the model to normalize two-digit years, but smaller/faster
+    # models often pass the spoken value through literally. The tool layer must not
+    # accept "90" as year 90 AD. https://github.com/livekit/agents/issues/6067
+    task = beta.workflows.GetDOBTask(require_confirmation=True)
+
+    await task._update_dob_impl(90, 5, 15, ctx=None)  # type: ignore[arg-type]
+    assert task._current_dob == date(1990, 5, 15)
+
+    await task._update_dob_impl(5, 3, 1, ctx=None)  # type: ignore[arg-type]
+    assert task._current_dob == date(2005, 3, 1)
+
+
+@pytest.mark.asyncio
+async def test_dob_four_digit_year_unchanged() -> None:
+    task = beta.workflows.GetDOBTask(require_confirmation=True)
+
+    await task._update_dob_impl(1962, 7, 4, ctx=None)  # type: ignore[arg-type]
+    assert task._current_dob == date(1962, 7, 4)
+
+    await task._update_dob_impl(2001, 12, 31, ctx=None)  # type: ignore[arg-type]
+    assert task._current_dob == date(2001, 12, 31)


### PR DESCRIPTION
Closes #6067

`GetDOBTask`'s prompt tells the model to normalize two-digit years ("90" likely means 1990), but `_update_dob_impl` takes `year` as a raw int with no lower bound. Smaller/faster models often pass the spoken value through literally, and `date(90, 5, 15)` is a valid Python date (year 90 AD): the future-date check passes, no `ToolError` is raised, and the task completes with a corrupted birthdate. Because this workflow tends to feed identity/healthcare/fintech intake, it's silent data corruption rather than a visible error.

Fix: normalize `year < 100` at the top of `_update_dob_impl` with a pivot window keyed on the current year, which is exactly what the prompt already promises. 90 -> 1990, 05 -> 2005, 26 -> 2026, 27 -> 1927. Four-digit years are left untouched, so there's no regression. The issue floated a hard floor (raise on `year < 1900`) as an alternative; I went with normalization since it matches the documented prompt contract and the smaller behavioral change.

Verified:
- Added `tests/test_dob.py` (unit, no LLM). It fails on `main` (`date(90, 5, 15) != date(1990, 5, 15)`) and passes with the fix.
- `pytest tests/test_dob.py --unit` -> 2 passed.
- `ruff check` and `ruff format --check` clean on both files.
