### PR TITLE
feat(soniox): support stt-rt-v5 with endpoint_sensitivity option

### DIFF
--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
@@ -124,12 +124,20 @@ class STTOptions:
     Range: 500–3000.
     See: https://soniox.com/docs/stt/rt/endpoint-detection"""
 
+    endpoint_sensitivity: float | None = None
+    """How readily the model emits speech endpoints. Range: -1.0 to 1.0.
+    Higher values make endpoints more likely (finalize sooner); lower values make them
+    less likely. Leave as None to use the server-side default.
+    Introduced in the Soniox v5 model; earlier models reject it."""
+
     client_reference_id: str | None = None
     translation: TranslationConfig | None = None
 
     def __post_init__(self) -> None:
         if not (500 <= self.max_endpoint_delay_ms <= 3000):
             raise ValueError("max_endpoint_delay_ms must be between 500 and 3000")
+        if self.endpoint_sensitivity is not None and not (-1.0 <= self.endpoint_sensitivity <= 1.0):
+            raise ValueError("endpoint_sensitivity must be between -1.0 and 1.0")
 
 
 class STT(stt.STT):
@@ -261,6 +269,8 @@ class SpeechStream(stt.SpeechStream):
             "client_reference_id": self._stt._params.client_reference_id,
         }
         config["max_endpoint_delay_ms"] = self._stt._params.max_endpoint_delay_ms
+        if self._stt._params.endpoint_sensitivity is not None:
+            config["endpoint_sensitivity"] = self._stt._params.endpoint_sensitivity
         if self._stt._params.translation is not None:
             tr = self._stt._params.translation
             translation_dict: dict[str, Any] = {"type": tr.type}

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
@@ -107,7 +107,7 @@ class TranslationConfig:
 class STTOptions:
     """Configuration options for Soniox Speech-to-Text service."""
 
-    model: str = "stt-rt-v4"
+    model: str = "stt-rt-v5"
 
     language_hints: list[str] | None = None
     language_hints_strict: bool = False

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
@@ -119,7 +119,7 @@ class STTOptions:
     enable_speaker_diarization: bool = False
     enable_language_identification: bool = True
 
-    max_endpoint_delay_ms: int = 500
+    max_endpoint_delay_ms: int = 2000
     """Maximum delay in milliseconds between speech cessation and endpoint detection.
     Range: 500–3000.
     See: https://soniox.com/docs/stt/rt/endpoint-detection"""


### PR DESCRIPTION
Updates the LiveKit Soniox plugin for the v5 model.

- Add `endpoint_sensitivity` to `STTOptions` (`float | None`, range `-1.0` to `1.0`). Controls how quickly the model commits endpoints. Higher values finalize sooner. Only supported by v5; earlier models reject the field. Skipped on the wire when `None` so the server uses its default.
- Default STT model is now `stt-rt-v5`.
- Default `max_endpoint_delay_ms` raised from `500` (the API minimum) to `2000`. The old default was too aggressive on phone-call audio: short pauses between word or digit groups would cause Soniox to finalize a segment too early, before the model had enough context. `2000` matches the Soniox API's own default.
