### PR TITLE
feat(openai): add LLM.with_cloudflare() for Cloudflare AI Gateway

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
@@ -28,7 +28,6 @@ from . import realtime, responses, tools
 from .embeddings import EmbeddingData, create_embeddings
 from .llm import LLM, LLMStream
 from .models import (
-    CloudflareCustomCost,
     CloudflareGatewayOptions,
     OpenRouterProviderPreferences,
     OpenRouterWebPlugin,
@@ -45,7 +44,6 @@ __all__ = [
     "TTS",
     "LLM",
     "LLMStream",
-    "CloudflareCustomCost",
     "CloudflareGatewayOptions",
     "OpenRouterProviderPreferences",
     "OpenRouterWebPlugin",

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
@@ -17,7 +17,8 @@
 Support for OpenAI Realtime API, LLM, TTS, and STT APIs.
 
 Also includes support for a large number of OpenAI-compatible APIs including Azure OpenAI, Cerebras,
-Fireworks, Perplexity, Telnyx, xAI, Ollama, DeepSeek, OpenRouter, and OVHcloud AI Endpoints.
+Fireworks, Perplexity, Telnyx, xAI, Ollama, DeepSeek, OpenRouter, Cloudflare AI Gateway, and
+OVHcloud AI Endpoints.
 
 See https://docs.livekit.io/agents/integrations/openai/ and
 https://docs.livekit.io/agents/integrations/llm/ for more information.
@@ -27,6 +28,8 @@ from . import realtime, responses, tools
 from .embeddings import EmbeddingData, create_embeddings
 from .llm import LLM, LLMStream
 from .models import (
+    CloudflareCustomCost,
+    CloudflareGatewayOptions,
     OpenRouterProviderPreferences,
     OpenRouterWebPlugin,
     STTModels,
@@ -42,6 +45,8 @@ __all__ = [
     "TTS",
     "LLM",
     "LLMStream",
+    "CloudflareCustomCost",
+    "CloudflareGatewayOptions",
     "OpenRouterProviderPreferences",
     "OpenRouterWebPlugin",
     "STTModels",

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from dataclasses import asdict, dataclass
 from typing import Any, Literal
@@ -42,6 +43,7 @@ from openai.types.chat import ChatCompletionToolChoiceOptionParam, completion_cr
 from .models import (
     CerebrasChatModels,
     ChatModels,
+    CloudflareGatewayOptions,
     CometAPIChatModels,
     DeepSeekChatModels,
     NebiusChatModels,
@@ -936,6 +938,125 @@ class LLM(llm.LLM):
             temperature=NOT_GIVEN,
             parallel_tool_calls=NOT_GIVEN,
             tool_choice=NOT_GIVEN,
+        )
+
+    @staticmethod
+    def with_cloudflare(
+        *,
+        model: str,
+        account_id: str | None = None,
+        gateway_id: str = "default",
+        base_url: str | None = None,
+        api_key: str | None = None,
+        cf_aig_token: str | None = None,
+        gateway_options: CloudflareGatewayOptions | None = None,
+        client: openai.AsyncClient | None = None,
+        user: NotGivenOr[str] = NOT_GIVEN,
+        temperature: NotGivenOr[float] = NOT_GIVEN,
+        parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
+        tool_choice: ToolChoice = "auto",
+        reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
+        safety_identifier: NotGivenOr[str] = NOT_GIVEN,
+        prompt_cache_key: NotGivenOr[str] = NOT_GIVEN,
+        top_p: NotGivenOr[float] = NOT_GIVEN,
+        timeout: httpx.Timeout | None = None,
+    ) -> LLM:
+        """
+        Create a new instance of an LLM backed by the Cloudflare AI Gateway.
+
+        The gateway exposes a unified OpenAI-compatible endpoint. The endpoint URL is built
+        from ``account_id`` and ``gateway_id`` unless an explicit ``base_url`` is given, and the
+        model is a ``provider/model`` string.
+
+        Args:
+            model (str): Model in ``provider/model`` form, e.g.
+                ``"workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast"`` or ``"openai/gpt-4o"``.
+            account_id (str | None, optional): Cloudflare account ID used to build the gateway
+                URL. Falls back to ``CLOUDFLARE_ACCOUNT_ID``. Required unless ``base_url`` is set.
+            gateway_id (str): Gateway name used to build the URL. Defaults to ``"default"``, which
+                Cloudflare creates automatically on first request.
+            base_url (str | None, optional): Full gateway endpoint, e.g.
+                ``"https://gateway.ai.cloudflare.com/v1/<account_id>/<gateway_id>/compat"``.
+                Overrides ``account_id`` / ``gateway_id`` when provided.
+            api_key (str | None, optional): Downstream provider key for "bring your own key"
+                mode, sent as the ``Authorization`` header. Falls back to ``CLOUDFLARE_API_KEY``.
+            cf_aig_token (str | None, optional): Gateway token sent as the
+                ``cf-aig-authorization`` header, required for authenticated gateways. Falls
+                back to ``CLOUDFLARE_AI_GATEWAY_TOKEN``.
+            gateway_options (CloudflareGatewayOptions | None, optional): Per-request gateway
+                options (caching, retries, timeout, metadata, custom cost), translated into
+                ``cf-aig-*`` request headers.
+
+        Returns:
+            LLM: A configured LLM instance routed through the Cloudflare AI Gateway.
+        """
+
+        if base_url is None:
+            account_id = account_id or os.environ.get("CLOUDFLARE_ACCOUNT_ID")
+            if account_id is None:
+                raise ValueError(
+                    "Cloudflare account_id is required, either as argument or set "
+                    "CLOUDFLARE_ACCOUNT_ID environment variable (or pass base_url directly)"
+                )
+            base_url = f"https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat"
+
+        parsed = urlparse(base_url)
+        if parsed.scheme not in {"http", "https"}:
+            raise ValueError(f"Invalid URL scheme: '{parsed.scheme}'. Must be 'http' or 'https'.")
+        if not parsed.netloc:
+            raise ValueError(f"URL '{base_url}' is missing a network location (e.g., domain name).")
+
+        cf_aig_token = cf_aig_token or os.environ.get("CLOUDFLARE_AI_GATEWAY_TOKEN")
+        api_key = api_key or os.environ.get("CLOUDFLARE_API_KEY")
+        if cf_aig_token is None and api_key is None:
+            raise ValueError(
+                "Cloudflare authentication is required: set api_key/CLOUDFLARE_API_KEY "
+                "(bring your own provider key) and/or cf_aig_token/CLOUDFLARE_AI_GATEWAY_TOKEN "
+                "(gateway token)"
+            )
+
+        default_headers: dict[str, str] = {}
+        if cf_aig_token:
+            default_headers["cf-aig-authorization"] = f"Bearer {cf_aig_token}"
+
+        if gateway_options:
+            if "cache_ttl" in gateway_options:
+                default_headers["cf-aig-cache-ttl"] = str(gateway_options["cache_ttl"])
+            if gateway_options.get("skip_cache"):
+                default_headers["cf-aig-skip-cache"] = "true"
+            if "cache_key" in gateway_options:
+                default_headers["cf-aig-cache-key"] = gateway_options["cache_key"]
+            if "request_timeout" in gateway_options:
+                default_headers["cf-aig-request-timeout"] = str(gateway_options["request_timeout"])
+            if "max_attempts" in gateway_options:
+                default_headers["cf-aig-max-attempts"] = str(gateway_options["max_attempts"])
+            if "retry_delay" in gateway_options:
+                default_headers["cf-aig-retry-delay"] = str(gateway_options["retry_delay"])
+            if "backoff" in gateway_options:
+                default_headers["cf-aig-backoff"] = gateway_options["backoff"]
+            if "metadata" in gateway_options:
+                default_headers["cf-aig-metadata"] = json.dumps(gateway_options["metadata"])
+            if "custom_cost" in gateway_options:
+                default_headers["cf-aig-custom-cost"] = json.dumps(gateway_options["custom_cost"])
+
+        return LLM(
+            model=model,
+            # The OpenAI SDK requires a non-empty api_key for the Authorization header; in
+            # gateway-stored-keys mode the real auth rides on cf-aig-authorization, so a
+            # placeholder is used (matches the with_ollama precedent).
+            api_key=api_key or "cloudflare",
+            base_url=base_url,
+            client=client,
+            user=user,
+            temperature=temperature,
+            parallel_tool_calls=parallel_tool_calls,
+            tool_choice=tool_choice,
+            reasoning_effort=reasoning_effort,
+            safety_identifier=safety_identifier,
+            prompt_cache_key=prompt_cache_key,
+            top_p=top_p,
+            extra_headers=default_headers,
+            timeout=timeout,
         )
 
     def chat(

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -1030,6 +1030,10 @@ class LLM(llm.LLM):
                 default_headers["cf-aig-retry-delay"] = str(gateway_options["retry_delay"])
             if "backoff" in gateway_options:
                 default_headers["cf-aig-backoff"] = gateway_options["backoff"]
+            if "collect_log" in gateway_options:
+                default_headers["cf-aig-collect-log"] = (
+                    "true" if gateway_options["collect_log"] else "false"
+                )
             if "metadata" in gateway_options:
                 metadata = gateway_options["metadata"]
                 default_headers["cf-aig-metadata"] = (

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -945,10 +945,9 @@ class LLM(llm.LLM):
         *,
         model: str,
         account_id: str | None = None,
-        gateway_id: str = "default",
-        base_url: str | None = None,
         api_key: str | None = None,
-        cf_aig_token: str | None = None,
+        gateway_id: str | None = None,
+        base_url: str | None = None,
         gateway_options: CloudflareGatewayOptions | None = None,
         client: openai.AsyncClient | None = None,
         user: NotGivenOr[str] = NOT_GIVEN,
@@ -964,32 +963,38 @@ class LLM(llm.LLM):
         """
         Create a new instance of an LLM backed by the Cloudflare AI Gateway.
 
-        The gateway exposes a unified OpenAI-compatible endpoint. The endpoint URL is built
-        from ``account_id`` and ``gateway_id`` unless an explicit ``base_url`` is given, and the
-        model is a ``provider/model`` string.
+        Uses the gateway's OpenAI-compatible REST API
+        (``https://api.cloudflare.com/client/v4/accounts/<account_id>/ai/v1``). The endpoint URL
+        is built from ``account_id`` unless an explicit ``base_url`` is given, and the model is a
+        ``provider/model`` string.
 
         Args:
             model (str): Model in ``provider/model`` form, e.g.
                 ``"workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast"`` or ``"openai/gpt-4o"``.
-            account_id (str | None, optional): Cloudflare account ID used to build the gateway
+            account_id (str | None, optional): Cloudflare account ID used to build the endpoint
                 URL. Falls back to ``CLOUDFLARE_ACCOUNT_ID``. Required unless ``base_url`` is set.
-            gateway_id (str): Gateway name used to build the URL. Defaults to ``"default"``, which
-                Cloudflare creates automatically on first request.
-            base_url (str | None, optional): Full gateway endpoint, e.g.
-                ``"https://gateway.ai.cloudflare.com/v1/<account_id>/<gateway_id>/compat"``.
-                Overrides ``account_id`` / ``gateway_id`` when provided.
-            api_key (str | None, optional): Downstream provider key for "bring your own key"
-                mode, sent as the ``Authorization`` header. Falls back to ``CLOUDFLARE_API_KEY``.
-            cf_aig_token (str | None, optional): Gateway token sent as the
-                ``cf-aig-authorization`` header, required for authenticated gateways. Falls
-                back to ``CLOUDFLARE_AI_GATEWAY_TOKEN``.
+            api_key (str | None, optional): Cloudflare API token with the ``AI Gateway``
+                permission, sent as the ``Authorization: Bearer`` header. Falls back to
+                ``CLOUDFLARE_API_KEY``.
+            gateway_id (str | None, optional): Route through a specific gateway via the
+                ``cf-aig-gateway-id`` header. Defaults to the account's default gateway.
+            base_url (str | None, optional): Full endpoint URL, e.g.
+                ``"https://api.cloudflare.com/client/v4/accounts/<account_id>/ai/v1"``.
+                Overrides ``account_id`` when provided.
             gateway_options (CloudflareGatewayOptions | None, optional): Per-request gateway
-                options (caching, retries, timeout, metadata, custom cost), translated into
-                ``cf-aig-*`` request headers.
+                options (caching, retries, timeout, metadata), translated into ``cf-aig-*``
+                request headers.
 
         Returns:
             LLM: A configured LLM instance routed through the Cloudflare AI Gateway.
         """
+
+        api_key = api_key or os.environ.get("CLOUDFLARE_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "Cloudflare API token is required, either as argument or set "
+                "CLOUDFLARE_API_KEY environment variable"
+            )
 
         if base_url is None:
             account_id = account_id or os.environ.get("CLOUDFLARE_ACCOUNT_ID")
@@ -998,7 +1003,7 @@ class LLM(llm.LLM):
                     "Cloudflare account_id is required, either as argument or set "
                     "CLOUDFLARE_ACCOUNT_ID environment variable (or pass base_url directly)"
                 )
-            base_url = f"https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat"
+            base_url = f"https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1"
 
         parsed = urlparse(base_url)
         if parsed.scheme not in {"http", "https"}:
@@ -1006,18 +1011,9 @@ class LLM(llm.LLM):
         if not parsed.netloc:
             raise ValueError(f"URL '{base_url}' is missing a network location (e.g., domain name).")
 
-        cf_aig_token = cf_aig_token or os.environ.get("CLOUDFLARE_AI_GATEWAY_TOKEN")
-        api_key = api_key or os.environ.get("CLOUDFLARE_API_KEY")
-        if cf_aig_token is None and api_key is None:
-            raise ValueError(
-                "Cloudflare authentication is required: set api_key/CLOUDFLARE_API_KEY "
-                "(bring your own provider key) and/or cf_aig_token/CLOUDFLARE_AI_GATEWAY_TOKEN "
-                "(gateway token)"
-            )
-
         default_headers: dict[str, str] = {}
-        if cf_aig_token:
-            default_headers["cf-aig-authorization"] = f"Bearer {cf_aig_token}"
+        if gateway_id:
+            default_headers["cf-aig-gateway-id"] = gateway_id
 
         if gateway_options:
             if "cache_ttl" in gateway_options:
@@ -1035,16 +1031,14 @@ class LLM(llm.LLM):
             if "backoff" in gateway_options:
                 default_headers["cf-aig-backoff"] = gateway_options["backoff"]
             if "metadata" in gateway_options:
-                default_headers["cf-aig-metadata"] = json.dumps(gateway_options["metadata"])
-            if "custom_cost" in gateway_options:
-                default_headers["cf-aig-custom-cost"] = json.dumps(gateway_options["custom_cost"])
+                metadata = gateway_options["metadata"]
+                default_headers["cf-aig-metadata"] = (
+                    metadata if isinstance(metadata, str) else json.dumps(metadata)
+                )
 
         return LLM(
             model=model,
-            # The OpenAI SDK requires a non-empty api_key for the Authorization header; in
-            # gateway-stored-keys mode the real auth rides on cf-aig-authorization, so a
-            # placeholder is used (matches the with_ollama precedent).
-            api_key=api_key or "cloudflare",
+            api_key=api_key,
             base_url=base_url,
             client=client,
             user=user,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -975,7 +975,7 @@ class LLM(llm.LLM):
                 URL. Falls back to ``CLOUDFLARE_ACCOUNT_ID``. Required unless ``base_url`` is set.
             api_key (str | None, optional): Cloudflare API token with the ``AI Gateway``
                 permission, sent as the ``Authorization: Bearer`` header. Falls back to
-                ``CLOUDFLARE_API_KEY``.
+                ``CLOUDFLARE_API_TOKEN``.
             gateway_id (str | None, optional): Route through a specific gateway via the
                 ``cf-aig-gateway-id`` header. Defaults to the account's default gateway.
             base_url (str | None, optional): Full endpoint URL, e.g.
@@ -989,11 +989,11 @@ class LLM(llm.LLM):
             LLM: A configured LLM instance routed through the Cloudflare AI Gateway.
         """
 
-        api_key = api_key or os.environ.get("CLOUDFLARE_API_KEY")
+        api_key = api_key or os.environ.get("CLOUDFLARE_API_TOKEN")
         if not api_key:
             raise ValueError(
                 "Cloudflare API token is required, either as argument or set "
-                "CLOUDFLARE_API_KEY environment variable"
+                "CLOUDFLARE_API_TOKEN environment variable"
             )
 
         if base_url is None:

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -969,15 +969,17 @@ class LLM(llm.LLM):
         ``provider/model`` string.
 
         Args:
-            model (str): Model in ``provider/model`` form, e.g.
-                ``"workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast"`` or ``"openai/gpt-4o"``.
+            model (str): Model in ``provider/model`` form for third-party providers, e.g.
+                ``"openai/gpt-4o"``. Workers AI models instead use the ``@cf/author/model`` form,
+                e.g. ``"@cf/meta/llama-3.3-70b-instruct-fp8-fast"``, and require ``gateway_id``.
             account_id (str | None, optional): Cloudflare account ID used to build the endpoint
                 URL. Falls back to ``CLOUDFLARE_ACCOUNT_ID``. Required unless ``base_url`` is set.
-            api_key (str | None, optional): Cloudflare API token with the ``AI Gateway``
-                permission, sent as the ``Authorization: Bearer`` header. Falls back to
-                ``CLOUDFLARE_API_TOKEN``.
+            api_key (str | None, optional): Cloudflare API token with the
+                ``Account > Workers AI > Read`` permission, sent as the ``Authorization: Bearer``
+                header. Falls back to ``CLOUDFLARE_API_TOKEN``.
             gateway_id (str | None, optional): Route through a specific gateway via the
-                ``cf-aig-gateway-id`` header. Defaults to the account's default gateway.
+                ``cf-aig-gateway-id`` header. Defaults to the account's default gateway for
+                third-party providers; required for Workers AI (``@cf/...``) models.
             base_url (str | None, optional): Full endpoint URL, e.g.
                 ``"https://api.cloudflare.com/client/v4/accounts/<account_id>/ai/v1"``.
                 Overrides ``account_id`` when provided.

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -998,7 +998,7 @@ class LLM(llm.LLM):
 
         if base_url is None:
             account_id = account_id or os.environ.get("CLOUDFLARE_ACCOUNT_ID")
-            if account_id is None:
+            if not account_id:
                 raise ValueError(
                     "Cloudflare account_id is required, either as argument or set "
                     "CLOUDFLARE_ACCOUNT_ID environment variable (or pass base_url directly)"

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -326,3 +326,36 @@ class OpenRouterProviderPreferences(TypedDict, total=False):
     quantizations: list[str]
     sort: Literal["price", "throughput", "latency"]
     max_price: dict[str, float]
+
+
+class CloudflareCustomCost(TypedDict):
+    """Custom per-token cost reported to the Cloudflare AI Gateway dashboard."""
+
+    per_token_in: float
+    per_token_out: float
+
+
+class CloudflareGatewayOptions(TypedDict, total=False):
+    """Per-request Cloudflare AI Gateway options, mapped to ``cf-aig-*`` request headers.
+
+    See https://developers.cloudflare.com/ai-gateway/configuration/ for details.
+    """
+
+    cache_ttl: int
+    """Cache duration in seconds (``cf-aig-cache-ttl``)."""
+    skip_cache: bool
+    """Bypass the cache for this request (``cf-aig-skip-cache``)."""
+    cache_key: str
+    """Override the default cache key (``cf-aig-cache-key``)."""
+    request_timeout: int
+    """Per-request timeout in milliseconds (``cf-aig-request-timeout``)."""
+    max_attempts: int
+    """Maximum number of request attempts (``cf-aig-max-attempts``)."""
+    retry_delay: int
+    """Delay between retries in milliseconds (``cf-aig-retry-delay``)."""
+    backoff: Literal["constant", "linear", "exponential"]
+    """Retry backoff strategy (``cf-aig-backoff``)."""
+    metadata: dict[str, str | int | bool]
+    """Custom metadata attached to the request (``cf-aig-metadata``)."""
+    custom_cost: CloudflareCustomCost
+    """Custom per-token cost for this request (``cf-aig-custom-cost``)."""

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -348,5 +348,7 @@ class CloudflareGatewayOptions(TypedDict, total=False):
     """Delay between retries in milliseconds (``cf-aig-retry-delay``)."""
     backoff: Literal["constant", "linear", "exponential"]
     """Retry backoff strategy (``cf-aig-backoff``)."""
+    collect_log: bool
+    """Enable or disable logging for this request (``cf-aig-collect-log``)."""
     metadata: dict[str, str | int | bool] | str
     """Custom metadata attached to the request (``cf-aig-metadata``); a dict or a JSON string."""

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -328,13 +328,6 @@ class OpenRouterProviderPreferences(TypedDict, total=False):
     max_price: dict[str, float]
 
 
-class CloudflareCustomCost(TypedDict):
-    """Custom per-token cost reported to the Cloudflare AI Gateway dashboard."""
-
-    per_token_in: float
-    per_token_out: float
-
-
 class CloudflareGatewayOptions(TypedDict, total=False):
     """Per-request Cloudflare AI Gateway options, mapped to ``cf-aig-*`` request headers.
 
@@ -355,7 +348,5 @@ class CloudflareGatewayOptions(TypedDict, total=False):
     """Delay between retries in milliseconds (``cf-aig-retry-delay``)."""
     backoff: Literal["constant", "linear", "exponential"]
     """Retry backoff strategy (``cf-aig-backoff``)."""
-    metadata: dict[str, str | int | bool]
-    """Custom metadata attached to the request (``cf-aig-metadata``)."""
-    custom_cost: CloudflareCustomCost
-    """Custom per-token cost for this request (``cf-aig-custom-cost``)."""
+    metadata: dict[str, str | int | bool] | str
+    """Custom metadata attached to the request (``cf-aig-metadata``); a dict or a JSON string."""

--- a/tests/test_openai_with_cloudflare.py
+++ b/tests/test_openai_with_cloudflare.py
@@ -8,74 +8,65 @@ from livekit.plugins import openai
 
 pytestmark = pytest.mark.unit
 
-_BASE_URL = "https://gateway.ai.cloudflare.com/v1/acct/default/compat"
+_BASE_URL = "https://api.cloudflare.com/client/v4/accounts/acct/ai/v1"
 
 
 @pytest.fixture(autouse=True)
 def _clear_cloudflare_env(monkeypatch: pytest.MonkeyPatch) -> None:
     # keep construction deterministic regardless of the host environment
     monkeypatch.delenv("CLOUDFLARE_API_KEY", raising=False)
-    monkeypatch.delenv("CLOUDFLARE_AI_GATEWAY_TOKEN", raising=False)
     monkeypatch.delenv("CLOUDFLARE_ACCOUNT_ID", raising=False)
 
 
-def test_builds_url_from_account_and_default_gateway() -> None:
-    llm = openai.LLM.with_cloudflare(model="openai/gpt-4o", account_id="acct", cf_aig_token="t")
-    assert (
-        str(llm._client.base_url).rstrip("/")
-        == "https://gateway.ai.cloudflare.com/v1/acct/default/compat"
-    )
-
-
-def test_builds_url_with_custom_gateway_id() -> None:
-    llm = openai.LLM.with_cloudflare(
-        model="openai/gpt-4o", account_id="acct", gateway_id="prod", cf_aig_token="t"
-    )
-    assert "/v1/acct/prod/compat" in str(llm._client.base_url)
+def test_builds_rest_api_url_from_account() -> None:
+    llm = openai.LLM.with_cloudflare(model="openai/gpt-4o", account_id="acct", api_key="cf-tok")
+    assert str(llm._client.base_url).rstrip("/") == _BASE_URL
 
 
 def test_account_id_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "env-acct")
-    llm = openai.LLM.with_cloudflare(model="openai/gpt-4o", cf_aig_token="t")
-    assert "/v1/env-acct/default/compat" in str(llm._client.base_url)
+    llm = openai.LLM.with_cloudflare(model="openai/gpt-4o", api_key="cf-tok")
+    assert "/accounts/env-acct/ai/v1" in str(llm._client.base_url)
+
+
+def test_api_key_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CLOUDFLARE_API_KEY", "env-tok")
+    llm = openai.LLM.with_cloudflare(model="openai/gpt-4o", account_id="acct")
+    assert llm._client.api_key == "env-tok"
+
+
+def test_token_sent_as_bearer_authorization() -> None:
+    # the Cloudflare API token is the OpenAI client's api_key -> Authorization: Bearer <token>
+    llm = openai.LLM.with_cloudflare(model="openai/gpt-4o", account_id="acct", api_key="cf-tok")
+    assert llm._client.api_key == "cf-tok"
+    # the deprecated cf-aig-authorization header is no longer used
+    assert "cf-aig-authorization" not in (llm._opts.extra_headers or {})
 
 
 def test_base_url_overrides_account_id() -> None:
     llm = openai.LLM.with_cloudflare(
-        model="openai/gpt-4o", account_id="ignored", base_url=_BASE_URL, cf_aig_token="t"
+        model="openai/gpt-4o", account_id="ignored", base_url=_BASE_URL, api_key="cf-tok"
     )
     assert str(llm._client.base_url).rstrip("/") == _BASE_URL
 
 
-def test_missing_account_id_raises() -> None:
-    with pytest.raises(ValueError):
-        openai.LLM.with_cloudflare(model="openai/gpt-4o", cf_aig_token="t")
-
-
-def test_byok_forwards_provider_key_and_base_url() -> None:
+def test_gateway_id_sets_header() -> None:
     llm = openai.LLM.with_cloudflare(
-        model="openai/gpt-4o", base_url=_BASE_URL, api_key="sk-provider"
+        model="openai/gpt-4o", account_id="acct", api_key="cf-tok", gateway_id="prod"
     )
-    assert str(llm._client.base_url).rstrip("/") == _BASE_URL
-    assert llm._client.api_key == "sk-provider"
-    # no gateway token -> no cf-aig-authorization header
-    assert "cf-aig-authorization" not in (llm._opts.extra_headers or {})
+    assert llm._opts.extra_headers["cf-aig-gateway-id"] == "prod"
 
 
-def test_gateway_token_sets_header_and_placeholder_key() -> None:
-    llm = openai.LLM.with_cloudflare(
-        model="openai/gpt-4o", base_url=_BASE_URL, cf_aig_token="cf-tok"
-    )
-    # no provider key -> SDK still needs a non-empty Authorization, so a placeholder is used
-    assert llm._client.api_key == "cloudflare"
-    assert llm._opts.extra_headers["cf-aig-authorization"] == "Bearer cf-tok"
+def test_no_gateway_id_omits_header() -> None:
+    llm = openai.LLM.with_cloudflare(model="openai/gpt-4o", account_id="acct", api_key="cf-tok")
+    assert "cf-aig-gateway-id" not in (llm._opts.extra_headers or {})
 
 
 def test_gateway_options_map_to_headers() -> None:
     llm = openai.LLM.with_cloudflare(
         model="openai/gpt-4o",
-        base_url=_BASE_URL,
-        cf_aig_token="cf-tok",
+        account_id="acct",
+        api_key="cf-tok",
         gateway_options={
             "cache_ttl": 3600,
             "cache_key": "k1",
@@ -84,7 +75,6 @@ def test_gateway_options_map_to_headers() -> None:
             "retry_delay": 500,
             "backoff": "exponential",
             "metadata": {"room": "r1", "turn": 4, "live": True},
-            "custom_cost": {"per_token_in": 0.000001, "per_token_out": 0.000002},
         },
     )
     headers = llm._opts.extra_headers
@@ -94,27 +84,33 @@ def test_gateway_options_map_to_headers() -> None:
     assert headers["cf-aig-max-attempts"] == "3"
     assert headers["cf-aig-retry-delay"] == "500"
     assert headers["cf-aig-backoff"] == "exponential"
-    # metadata and custom_cost are JSON-encoded
     assert json.loads(headers["cf-aig-metadata"]) == {"room": "r1", "turn": 4, "live": True}
-    assert json.loads(headers["cf-aig-custom-cost"]) == {
-        "per_token_in": 0.000001,
-        "per_token_out": 0.000002,
-    }
+
+
+def test_metadata_accepts_json_string() -> None:
+    llm = openai.LLM.with_cloudflare(
+        model="openai/gpt-4o",
+        account_id="acct",
+        api_key="cf-tok",
+        gateway_options={"metadata": '{"room":"r1"}'},
+    )
+    # a pre-serialized JSON string is passed through unchanged
+    assert llm._opts.extra_headers["cf-aig-metadata"] == '{"room":"r1"}'
 
 
 def test_skip_cache_header_only_emitted_when_true() -> None:
     enabled = openai.LLM.with_cloudflare(
         model="openai/gpt-4o",
-        base_url=_BASE_URL,
-        cf_aig_token="t",
+        account_id="acct",
+        api_key="cf-tok",
         gateway_options={"skip_cache": True},
     )
     assert enabled._opts.extra_headers["cf-aig-skip-cache"] == "true"
 
     disabled = openai.LLM.with_cloudflare(
         model="openai/gpt-4o",
-        base_url=_BASE_URL,
-        cf_aig_token="t",
+        account_id="acct",
+        api_key="cf-tok",
         gateway_options={"skip_cache": False},
     )
     assert "cf-aig-skip-cache" not in disabled._opts.extra_headers
@@ -122,9 +118,14 @@ def test_skip_cache_header_only_emitted_when_true() -> None:
 
 def test_invalid_base_url_raises() -> None:
     with pytest.raises(ValueError):
-        openai.LLM.with_cloudflare(model="openai/gpt-4o", base_url="not-a-url", cf_aig_token="t")
+        openai.LLM.with_cloudflare(model="openai/gpt-4o", base_url="not-a-url", api_key="cf-tok")
 
 
-def test_missing_auth_raises() -> None:
-    with pytest.raises(ValueError):
-        openai.LLM.with_cloudflare(model="openai/gpt-4o", base_url=_BASE_URL)
+def test_missing_api_key_raises() -> None:
+    with pytest.raises(ValueError, match=r"API token"):
+        openai.LLM.with_cloudflare(model="openai/gpt-4o", account_id="acct")
+
+
+def test_missing_account_id_raises() -> None:
+    with pytest.raises(ValueError, match=r"account_id"):
+        openai.LLM.with_cloudflare(model="openai/gpt-4o", api_key="cf-tok")

--- a/tests/test_openai_with_cloudflare.py
+++ b/tests/test_openai_with_cloudflare.py
@@ -98,6 +98,24 @@ def test_metadata_accepts_json_string() -> None:
     assert llm._opts.extra_headers["cf-aig-metadata"] == '{"room":"r1"}'
 
 
+def test_collect_log_emitted_true_or_false() -> None:
+    on = openai.LLM.with_cloudflare(
+        model="openai/gpt-4o",
+        account_id="acct",
+        api_key="cf-tok",
+        gateway_options={"collect_log": True},
+    )
+    assert on._opts.extra_headers["cf-aig-collect-log"] == "true"
+
+    off = openai.LLM.with_cloudflare(
+        model="openai/gpt-4o",
+        account_id="acct",
+        api_key="cf-tok",
+        gateway_options={"collect_log": False},
+    )
+    assert off._opts.extra_headers["cf-aig-collect-log"] == "false"
+
+
 def test_skip_cache_header_only_emitted_when_true() -> None:
     enabled = openai.LLM.with_cloudflare(
         model="openai/gpt-4o",

--- a/tests/test_openai_with_cloudflare.py
+++ b/tests/test_openai_with_cloudflare.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from livekit.plugins import openai
+
+pytestmark = pytest.mark.unit
+
+_BASE_URL = "https://gateway.ai.cloudflare.com/v1/acct/default/compat"
+
+
+@pytest.fixture(autouse=True)
+def _clear_cloudflare_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # keep construction deterministic regardless of the host environment
+    monkeypatch.delenv("CLOUDFLARE_API_KEY", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_AI_GATEWAY_TOKEN", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_ACCOUNT_ID", raising=False)
+
+
+def test_builds_url_from_account_and_default_gateway() -> None:
+    llm = openai.LLM.with_cloudflare(model="openai/gpt-4o", account_id="acct", cf_aig_token="t")
+    assert (
+        str(llm._client.base_url).rstrip("/")
+        == "https://gateway.ai.cloudflare.com/v1/acct/default/compat"
+    )
+
+
+def test_builds_url_with_custom_gateway_id() -> None:
+    llm = openai.LLM.with_cloudflare(
+        model="openai/gpt-4o", account_id="acct", gateway_id="prod", cf_aig_token="t"
+    )
+    assert "/v1/acct/prod/compat" in str(llm._client.base_url)
+
+
+def test_account_id_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "env-acct")
+    llm = openai.LLM.with_cloudflare(model="openai/gpt-4o", cf_aig_token="t")
+    assert "/v1/env-acct/default/compat" in str(llm._client.base_url)
+
+
+def test_base_url_overrides_account_id() -> None:
+    llm = openai.LLM.with_cloudflare(
+        model="openai/gpt-4o", account_id="ignored", base_url=_BASE_URL, cf_aig_token="t"
+    )
+    assert str(llm._client.base_url).rstrip("/") == _BASE_URL
+
+
+def test_missing_account_id_raises() -> None:
+    with pytest.raises(ValueError):
+        openai.LLM.with_cloudflare(model="openai/gpt-4o", cf_aig_token="t")
+
+
+def test_byok_forwards_provider_key_and_base_url() -> None:
+    llm = openai.LLM.with_cloudflare(
+        model="openai/gpt-4o", base_url=_BASE_URL, api_key="sk-provider"
+    )
+    assert str(llm._client.base_url).rstrip("/") == _BASE_URL
+    assert llm._client.api_key == "sk-provider"
+    # no gateway token -> no cf-aig-authorization header
+    assert "cf-aig-authorization" not in (llm._opts.extra_headers or {})
+
+
+def test_gateway_token_sets_header_and_placeholder_key() -> None:
+    llm = openai.LLM.with_cloudflare(
+        model="openai/gpt-4o", base_url=_BASE_URL, cf_aig_token="cf-tok"
+    )
+    # no provider key -> SDK still needs a non-empty Authorization, so a placeholder is used
+    assert llm._client.api_key == "cloudflare"
+    assert llm._opts.extra_headers["cf-aig-authorization"] == "Bearer cf-tok"
+
+
+def test_gateway_options_map_to_headers() -> None:
+    llm = openai.LLM.with_cloudflare(
+        model="openai/gpt-4o",
+        base_url=_BASE_URL,
+        cf_aig_token="cf-tok",
+        gateway_options={
+            "cache_ttl": 3600,
+            "cache_key": "k1",
+            "request_timeout": 2000,
+            "max_attempts": 3,
+            "retry_delay": 500,
+            "backoff": "exponential",
+            "metadata": {"room": "r1", "turn": 4, "live": True},
+            "custom_cost": {"per_token_in": 0.000001, "per_token_out": 0.000002},
+        },
+    )
+    headers = llm._opts.extra_headers
+    assert headers["cf-aig-cache-ttl"] == "3600"
+    assert headers["cf-aig-cache-key"] == "k1"
+    assert headers["cf-aig-request-timeout"] == "2000"
+    assert headers["cf-aig-max-attempts"] == "3"
+    assert headers["cf-aig-retry-delay"] == "500"
+    assert headers["cf-aig-backoff"] == "exponential"
+    # metadata and custom_cost are JSON-encoded
+    assert json.loads(headers["cf-aig-metadata"]) == {"room": "r1", "turn": 4, "live": True}
+    assert json.loads(headers["cf-aig-custom-cost"]) == {
+        "per_token_in": 0.000001,
+        "per_token_out": 0.000002,
+    }
+
+
+def test_skip_cache_header_only_emitted_when_true() -> None:
+    enabled = openai.LLM.with_cloudflare(
+        model="openai/gpt-4o",
+        base_url=_BASE_URL,
+        cf_aig_token="t",
+        gateway_options={"skip_cache": True},
+    )
+    assert enabled._opts.extra_headers["cf-aig-skip-cache"] == "true"
+
+    disabled = openai.LLM.with_cloudflare(
+        model="openai/gpt-4o",
+        base_url=_BASE_URL,
+        cf_aig_token="t",
+        gateway_options={"skip_cache": False},
+    )
+    assert "cf-aig-skip-cache" not in disabled._opts.extra_headers
+
+
+def test_invalid_base_url_raises() -> None:
+    with pytest.raises(ValueError):
+        openai.LLM.with_cloudflare(model="openai/gpt-4o", base_url="not-a-url", cf_aig_token="t")
+
+
+def test_missing_auth_raises() -> None:
+    with pytest.raises(ValueError):
+        openai.LLM.with_cloudflare(model="openai/gpt-4o", base_url=_BASE_URL)

--- a/tests/test_openai_with_cloudflare.py
+++ b/tests/test_openai_with_cloudflare.py
@@ -14,7 +14,7 @@ _BASE_URL = "https://api.cloudflare.com/client/v4/accounts/acct/ai/v1"
 @pytest.fixture(autouse=True)
 def _clear_cloudflare_env(monkeypatch: pytest.MonkeyPatch) -> None:
     # keep construction deterministic regardless of the host environment
-    monkeypatch.delenv("CLOUDFLARE_API_KEY", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_API_TOKEN", raising=False)
     monkeypatch.delenv("CLOUDFLARE_ACCOUNT_ID", raising=False)
 
 
@@ -30,7 +30,7 @@ def test_account_id_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_api_key_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("CLOUDFLARE_API_KEY", "env-tok")
+    monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "env-tok")
     llm = openai.LLM.with_cloudflare(model="openai/gpt-4o", account_id="acct")
     assert llm._client.api_key == "env-tok"
 

--- a/tests/test_openai_with_cloudflare.py
+++ b/tests/test_openai_with_cloudflare.py
@@ -147,3 +147,10 @@ def test_missing_api_key_raises() -> None:
 def test_missing_account_id_raises() -> None:
     with pytest.raises(ValueError, match=r"account_id"):
         openai.LLM.with_cloudflare(model="openai/gpt-4o", api_key="cf-tok")
+
+
+def test_empty_account_id_env_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    # an empty CLOUDFLARE_ACCOUNT_ID must not build ".../accounts//ai/v1"
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "")
+    with pytest.raises(ValueError, match=r"account_id"):
+        openai.LLM.with_cloudflare(model="openai/gpt-4o", api_key="cf-tok")


### PR DESCRIPTION
## Summary

Closes #6101. Adds `openai.LLM.with_cloudflare(...)`, a convenience constructor that routes
LLM traffic through the [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/)
OpenAI-compatible [REST API](https://developers.cloudflare.com/ai-gateway/usage/rest-api/)
endpoint — mirroring the existing `with_openrouter` / `with_azure` helpers.

```python
from livekit.plugins import openai

# Minimal: account_id from CLOUDFLARE_ACCOUNT_ID, API token from CLOUDFLARE_API_TOKEN
llm = openai.LLM.with_cloudflare(model="openai/gpt-4o")

# Explicit, with a specific gateway and per-request gateway options
llm = openai.LLM.with_cloudflare(
    model="@cf/meta/llama-3.3-70b-instruct-fp8-fast",
    account_id="<account_id>",
    gateway_id="my-gateway",
    api_key="<cloudflare_api_token>",
    gateway_options={"cache_ttl": 3600, "max_attempts": 3, "backoff": "exponential"},
)
```

## Design notes

- **REST API endpoint.** Uses
  `https://api.cloudflare.com/client/v4/accounts/<account_id>/ai/v1` per review feedback — the
  legacy `gateway.ai.cloudflare.com/.../compat` unified endpoint is deprecated for single-model
  calls. The URL is built from `account_id` (env `CLOUDFLARE_ACCOUNT_ID`), with a `base_url`
  override.
- **Auth.** A Cloudflare API token (**Account > Workers AI > Read** permission) is sent as the
  standard `Authorization: Bearer` header via the OpenAI client's `api_key`; env fallback
  `CLOUDFLARE_API_TOKEN`. The legacy endpoint's `cf-aig-authorization` dual-auth scheme is not
  used.
- **Gateway selection.** Via the `cf-aig-gateway-id` header (`gateway_id` param). When omitted,
  third-party requests route through the account's default gateway; Workers AI (`@cf/...`)
  models require it.
- **Models.** Third-party providers use `provider/model` form (e.g. `openai/gpt-4o`); Workers AI
  models use `@cf/author/model` form.
- **Per-request options are headers, not body.** Unlike OpenRouter (JSON body fields),
  Cloudflare's controls are `cf-aig-*` HTTP headers. `gateway_options` is a
  `CloudflareGatewayOptions` TypedDict covering caching, retries, timeout, logging, and metadata;
  set fields map to the corresponding headers (`metadata` accepts a dict, JSON-encoded, or a
  pre-serialized JSON string passed through verbatim). A grouped TypedDict (over loose kwargs)
  keeps the signature to one extra param while typing the structured values. Validation is
  type-level only; numeric ranges pass through to Cloudflare.

## Testing

`tests/test_openai_with_cloudflare.py` (hermetic, `--unit`): URL building from account_id,
`CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN` env fallbacks (incl. rejecting an empty
`CLOUDFLARE_ACCOUNT_ID`), `base_url` override, token-as-Bearer auth (and that the deprecated
`cf-aig-authorization` header is not emitted), the `gateway_id` header, the full
`gateway_options → cf-aig-*` header mapping (incl. JSON encoding and the
`skip_cache`-only-when-true rule), and all `ValueError` paths. `make check` passes (ruff format
+ lint, strict mypy).

## Out of scope

STT/TTS via Cloudflare Workers AI (#3163), tracked separately.
