### PR TITLE
Add Hopper LLM provider

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -44,6 +44,7 @@ from .models import (
     ChatModels,
     CometAPIChatModels,
     DeepSeekChatModels,
+    HopperChatModels,
     NebiusChatModels,
     OctoChatModels,
     OpenRouterProviderPreferences,
@@ -805,6 +806,54 @@ class LLM(llm.LLM):
             safety_identifier=safety_identifier,
             prompt_cache_key=prompt_cache_key,
             top_p=top_p,
+        )
+
+    @staticmethod
+    def with_hopper(
+        *,
+        model: str | HopperChatModels = "Qwen/Qwen3.6-35B-A3B",
+        api_key: str | None = None,
+        base_url: str = "https://api.withhopper.com/v1",
+        client: openai.AsyncClient | None = None,
+        user: NotGivenOr[str] = NOT_GIVEN,
+        temperature: NotGivenOr[float] = NOT_GIVEN,
+        parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
+        tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
+        reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
+        safety_identifier: NotGivenOr[str] = NOT_GIVEN,
+        prompt_cache_key: NotGivenOr[str] = NOT_GIVEN,
+        top_p: NotGivenOr[float] = NOT_GIVEN,
+    ) -> LLM:
+        """
+        Create a new instance of Hopper LLM (OpenAI-compatible).
+
+        Hopper serves open-source models optimized for low time-to-first-token, aimed at
+        voice agents. See https://withhopper.com.
+
+        ``api_key`` must be set to your Hopper API key, either using the argument or by setting
+        the ``HOPPER_API_KEY`` environment variable.
+        """
+
+        api_key = api_key or os.environ.get("HOPPER_API_KEY")
+        if api_key is None:
+            raise ValueError(
+                "Hopper API key is required, either as argument or set HOPPER_API_KEY environment variable"  # noqa: E501
+            )
+
+        return LLM(
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            client=client,
+            user=user,
+            temperature=temperature,
+            parallel_tool_calls=parallel_tool_calls,
+            tool_choice=tool_choice,
+            reasoning_effort=reasoning_effort,
+            safety_identifier=safety_identifier,
+            prompt_cache_key=prompt_cache_key,
+            top_p=top_p,
+            _strict_tool_schema=False,
         )
 
     @staticmethod

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -107,6 +107,8 @@ NebiusChatModels = Literal[
     "google/gemma-2-2b-it",
 ]
 
+HopperChatModels = Literal["Qwen/Qwen3.6-35B-A3B"]
+
 CerebrasChatModels = Literal[
     "llama3.1-8b",
     "llama-3.3-70b",


### PR DESCRIPTION
## Summary

Adds a `LLM.with_hopper()` factory to the OpenAI plugin, alongside the other
OpenAI-compatible providers (Cerebras, Together, Nebius, Telnyx, …).

[Hopper](https://withhopper.com) serves open-source models optimized for low
time-to-first-token, aimed at voice agents. The API is OpenAI-compatible, so
this follows the existing `with_*` provider pattern — no new plugin, just a
factory method plus a `HopperChatModels` type.

## Usage

```python
from livekit.plugins import openai

llm = openai.LLM.with_hopper(
    # api_key defaults to HOPPER_API_KEY env var
    model="Qwen/Qwen3.6-35B-A3B",
)
```

Get an API key at https://withhopper.com.

## Changes

- `with_hopper()` classmethod on `openai.LLM` (defaults: `base_url=https://api.withhopper.com/v1`, `HOPPER_API_KEY`).
- `HopperChatModels` literal in `models.py`.
- `_strict_tool_schema=False`, matching the other open-model providers served on vLLM-style backends (same as Cerebras, #3134).

## Latency

TTFT (time to first token) over a warm connection, voice-agent-shaped context
(~2k-token system prompt + short user turn), 10-run p50:

- From **us-west-2** (same region as the model server): **p50 62ms** (min 56, max 77)
- From a residential laptop in SF: ~170ms — the difference is network round-trip

First-token latency is dominated by where your agent runs relative to the model,
not the serving itself; colocated, it's ~60ms.

## Testing

Verified against the live endpoint through the plugin:

- factory builds with the correct base URL and model
- streaming `chat()` returns a valid completion
- function calling emits a correct tool call (validates `_strict_tool_schema=False`)
- `ruff check` passes on the changed files
