### PR TITLE
feat(core): allow non-primary sessions without job_ctx

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -613,6 +613,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         # deprecated
         room_input_options: NotGivenOr[room_io.RoomInputOptions] = NOT_GIVEN,
         room_output_options: NotGivenOr[room_io.RoomOutputOptions] = NOT_GIVEN,
+        _register_as_room_host: NotGivenOr[bool] = NOT_GIVEN,
     ) -> RunResult: ...
 
     @overload
@@ -627,6 +628,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         # deprecated
         room_input_options: NotGivenOr[room_io.RoomInputOptions] = NOT_GIVEN,
         room_output_options: NotGivenOr[room_io.RoomOutputOptions] = NOT_GIVEN,
+        _register_as_room_host: NotGivenOr[bool] = NOT_GIVEN,
     ) -> None: ...
 
     async def start(
@@ -640,6 +642,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         # deprecated
         room_input_options: NotGivenOr[room_io.RoomInputOptions] = NOT_GIVEN,
         room_output_options: NotGivenOr[room_io.RoomOutputOptions] = NOT_GIVEN,
+        _register_as_room_host: NotGivenOr[bool] = NOT_GIVEN,
     ) -> RunResult | None:
         """Start the voice agent.
 
@@ -670,13 +673,13 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             if self._text_only:
                 self._recording_options["audio"] = False
 
-            is_primary = True
             if job_ctx:
                 # set the primary session
                 if job_ctx._primary_agent_session is None or job_ctx._primary_agent_session is self:
                     job_ctx._primary_agent_session = self
                 else:
-                    is_primary = False
+                    if not is_given(_register_as_room_host):
+                        _register_as_room_host = False
                     if any(self._recording_options.values()):
                         if record_is_given:
                             raise RuntimeError(
@@ -774,7 +777,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 self._room_io = room_io.RoomIO(room=room, agent_session=self, options=room_options)
                 await self._room_io.start()
 
-                if is_primary:
+                if _register_as_room_host or not is_given(_register_as_room_host):
                     # only the primary session can have a session host
                     transport = RoomSessionTransport(room)
                     self._session_host = SessionHost(transport)

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -777,7 +777,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 self._room_io = room_io.RoomIO(room=room, agent_session=self, options=room_options)
                 await self._room_io.start()
 
-                if _register_as_room_host or not is_given(_register_as_room_host):
+                if _register_as_room_host is not False:
                     # only the primary session can have a session host
                     transport = RoomSessionTransport(room)
                     self._session_host = SessionHost(transport)

--- a/tests/test_room_host.py
+++ b/tests/test_room_host.py
@@ -1,0 +1,191 @@
+"""Tests for room-host (SessionHost over RoomSessionTransport) registration on start().
+
+Covers the `_register_as_room_host` parameter introduced to decouple room-host
+registration from the primary-session designation, so a session can opt out of
+being the room host even without a JobContext.
+
+Resolution rules (see AgentSession.start):
+- not given      -> register as host
+- explicit True  -> register as host (overrides non-primary auto-opt-out)
+- explicit False -> do not register as host
+- with a JobContext, a non-primary session auto-resolves to False when not given.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from livekit.agents import Agent, AgentSession
+
+from .fake_io import FakeAudioInput, FakeAudioOutput, FakeTextOutput
+from .fake_llm import FakeLLM
+from .fake_stt import FakeSTT
+from .fake_tts import FakeTTS
+from .fake_vad import FakeVAD
+
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
+
+_MOD = "livekit.agents.voice.agent_session"
+
+
+class SimpleAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(instructions="You are a test agent.")
+
+
+def _create_simple_session() -> AgentSession:
+    """Minimal AgentSession with audio I/O set (so RoomIO leaves them alone)."""
+    session = AgentSession[None](
+        vad=FakeVAD(fake_user_speeches=[], min_silence_duration=0.5, min_speech_duration=0.05),
+        stt=FakeSTT(fake_user_speeches=[]),
+        llm=FakeLLM(fake_responses=[]),
+        tts=FakeTTS(fake_responses=[]),
+    )
+    session.input.audio = FakeAudioInput()
+    session.output.audio = FakeAudioOutput()
+    session.output.transcription = FakeTextOutput()
+    return session
+
+
+async def _cleanup(session: AgentSession) -> None:
+    with contextlib.suppress(RuntimeError):
+        await session.drain()
+    await session.aclose()
+
+
+def _make_mock_job_ctx(primary: object | None = None) -> MagicMock:
+    """A JobContext stub exposing only the fields start() touches in this path."""
+    mock_ctx = MagicMock()
+    mock_ctx.job.enable_recording = False  # keep recording off; this suite is host-only
+    mock_ctx.job.id = "test-job-id"
+    mock_ctx.job.agent_name = "test-agent"
+    mock_ctx.room.name = "test-room"
+    mock_ctx._primary_agent_session = primary
+    mock_ctx.session_directory = Path("/tmp/test-session")
+    mock_ctx.connect = AsyncMock()
+    return mock_ctx
+
+
+@contextlib.contextmanager
+def _patch_host(job_ctx: MagicMock | None = None) -> Iterator[tuple[MagicMock, MagicMock]]:
+    """Patch RoomIO and the host primitives; yield (RoomSessionTransport, SessionHost) mocks."""
+    room_io_inst = MagicMock()
+    room_io_inst.start = AsyncMock()
+    room_io_inst.aclose = AsyncMock()
+    with (
+        patch(f"{_MOD}.get_job_context", return_value=job_ctx),
+        patch(f"{_MOD}.room_io.RoomIO", return_value=room_io_inst),
+        patch(f"{_MOD}.RoomSessionTransport") as mock_transport,
+        patch(f"{_MOD}.SessionHost") as mock_host,
+    ):
+        # start()/aclose() await these on the registered host
+        mock_host.return_value.start = AsyncMock()
+        mock_host.return_value.aclose = AsyncMock()
+        yield mock_transport, mock_host
+
+
+def _assert_registered(
+    session: AgentSession, transport: MagicMock, host: MagicMock, room: MagicMock
+) -> None:
+    transport.assert_called_once_with(room)
+    host.assert_called_once_with(transport.return_value)
+    host.return_value.register_session.assert_called_once_with(session)
+    assert session._session_host is host.return_value
+
+
+def _assert_not_registered(session: AgentSession, transport: MagicMock, host: MagicMock) -> None:
+    transport.assert_not_called()
+    host.assert_not_called()
+    assert session._session_host is None
+
+
+# ---------------------------------------------------------------------------
+# Without a JobContext
+# ---------------------------------------------------------------------------
+
+
+async def test_registers_as_host_by_default_without_job_ctx() -> None:
+    """No JobContext and the flag omitted: the session becomes the room host."""
+    session = _create_simple_session()
+    room = MagicMock()
+    with _patch_host(job_ctx=None) as (transport, host):
+        await session.start(SimpleAgent(), room=room)
+        _assert_registered(session, transport, host, room)
+        await _cleanup(session)
+
+
+async def test_opt_out_of_host_without_job_ctx() -> None:
+    """The new capability: opt out of being the room host even without a JobContext."""
+    session = _create_simple_session()
+    room = MagicMock()
+    with _patch_host(job_ctx=None) as (transport, host):
+        await session.start(SimpleAgent(), room=room, _register_as_room_host=False)
+        _assert_not_registered(session, transport, host)
+        await _cleanup(session)
+
+
+async def test_explicit_opt_in_of_host_without_job_ctx() -> None:
+    """Explicit True without a JobContext registers as host."""
+    session = _create_simple_session()
+    room = MagicMock()
+    with _patch_host(job_ctx=None) as (transport, host):
+        await session.start(SimpleAgent(), room=room, _register_as_room_host=True)
+        _assert_registered(session, transport, host, room)
+        await _cleanup(session)
+
+
+# ---------------------------------------------------------------------------
+# With a JobContext (primary-session interaction)
+# ---------------------------------------------------------------------------
+
+
+async def test_primary_session_registers_as_host() -> None:
+    """The first session under a JobContext is primary and registers as host by default."""
+    session = _create_simple_session()
+    room = MagicMock()
+    mock_ctx = _make_mock_job_ctx(primary=None)
+    with _patch_host(job_ctx=mock_ctx) as (transport, host):
+        await session.start(SimpleAgent(), room=room)
+        assert mock_ctx._primary_agent_session is session
+        _assert_registered(session, transport, host, room)
+        await _cleanup(session)
+
+
+async def test_non_primary_session_does_not_register_by_default() -> None:
+    """A second session under the same JobContext is non-primary and is not the host."""
+    session = _create_simple_session()
+    room = MagicMock()
+    mock_ctx = _make_mock_job_ctx(primary=object())  # another session already primary
+    with _patch_host(job_ctx=mock_ctx) as (transport, host):
+        await session.start(SimpleAgent(), room=room)
+        _assert_not_registered(session, transport, host)
+        await _cleanup(session)
+
+
+async def test_non_primary_session_can_force_host() -> None:
+    """Explicit True overrides the non-primary auto opt-out."""
+    session = _create_simple_session()
+    room = MagicMock()
+    mock_ctx = _make_mock_job_ctx(primary=object())
+    with _patch_host(job_ctx=mock_ctx) as (transport, host):
+        await session.start(SimpleAgent(), room=room, _register_as_room_host=True)
+        _assert_registered(session, transport, host, room)
+        await _cleanup(session)
+
+
+async def test_primary_session_can_opt_out_of_host() -> None:
+    """Explicit False keeps a primary session from becoming the room host."""
+    session = _create_simple_session()
+    room = MagicMock()
+    mock_ctx = _make_mock_job_ctx(primary=None)
+    with _patch_host(job_ctx=mock_ctx) as (transport, host):
+        await session.start(SimpleAgent(), room=room, _register_as_room_host=False)
+        # still claims primary, just not the room host
+        assert mock_ctx._primary_agent_session is session
+        _assert_not_registered(session, transport, host)
+        await _cleanup(session)

--- a/tests/test_room_host.py
+++ b/tests/test_room_host.py
@@ -1,26 +1,22 @@
-"""Tests for room-host (SessionHost over RoomSessionTransport) registration on start().
+"""Room-host (SessionHost over RoomSessionTransport) registration on start().
 
-Covers the `_register_as_room_host` parameter introduced to decouple room-host
-registration from the primary-session designation, so a session can opt out of
-being the room host even without a JobContext.
-
-Resolution rules (see AgentSession.start):
-- not given      -> register as host
-- explicit True  -> register as host (overrides non-primary auto-opt-out)
-- explicit False -> do not register as host
-- with a JobContext, a non-primary session auto-resolves to False when not given.
+`_register_as_room_host` decouples host registration from primary designation:
+omitted -> register; True -> register (overriding non-primary); False -> don't.
+With a JobContext a non-primary session auto-resolves to False.
 """
 
 from __future__ import annotations
 
 import contextlib
 from collections.abc import Iterator
+from enum import Enum
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from livekit.agents import Agent, AgentSession
+from livekit.agents.types import NOT_GIVEN, NotGiven
 
 from .fake_io import FakeAudioInput, FakeAudioOutput, FakeTextOutput
 from .fake_llm import FakeLLM
@@ -38,8 +34,7 @@ class SimpleAgent(Agent):
         super().__init__(instructions="You are a test agent.")
 
 
-def _create_simple_session() -> AgentSession:
-    """Minimal AgentSession with audio I/O set (so RoomIO leaves them alone)."""
+def _make_session() -> AgentSession:
     session = AgentSession[None](
         vad=FakeVAD(fake_user_speeches=[], min_silence_duration=0.5, min_speech_duration=0.05),
         stt=FakeSTT(fake_user_speeches=[]),
@@ -52,140 +47,89 @@ def _create_simple_session() -> AgentSession:
     return session
 
 
-async def _cleanup(session: AgentSession) -> None:
-    with contextlib.suppress(RuntimeError):
-        await session.drain()
-    await session.aclose()
+_PRIMARY, _OTHER = "self", "other"  # this session claims primary / another already holds it
 
 
-def _make_mock_job_ctx(primary: object | None = None) -> MagicMock:
-    """A JobContext stub exposing only the fields start() touches in this path."""
-    mock_ctx = MagicMock()
-    mock_ctx.job.enable_recording = False  # keep recording off; this suite is host-only
-    mock_ctx.job.id = "test-job-id"
-    mock_ctx.job.agent_name = "test-agent"
-    mock_ctx.room.name = "test-room"
-    mock_ctx._primary_agent_session = primary
-    mock_ctx.session_directory = Path("/tmp/test-session")
-    mock_ctx.connect = AsyncMock()
-    return mock_ctx
+def _job_ctx(marker: str | None) -> MagicMock | None:
+    """JobContext stub for the given primary marker; None means no job context at all.
+
+    Exposes only the fields start() touches here; recording stays off.
+    """
+    if marker is None:
+        return None
+    ctx = MagicMock()
+    ctx.job.enable_recording = False
+    ctx.job.id = "test-job-id"
+    ctx.job.agent_name = "test-agent"
+    ctx.room.name = "test-room"
+    ctx._primary_agent_session = None if marker == _PRIMARY else object()
+    ctx.session_directory = Path("/tmp/test-session")
+    ctx.connect = AsyncMock()
+    return ctx
 
 
 @contextlib.contextmanager
-def _patch_host(job_ctx: MagicMock | None = None) -> Iterator[tuple[MagicMock, MagicMock]]:
-    """Patch RoomIO and the host primitives; yield (RoomSessionTransport, SessionHost) mocks."""
-    room_io_inst = MagicMock()
-    room_io_inst.start = AsyncMock()
-    room_io_inst.aclose = AsyncMock()
+def _patched(job_ctx: MagicMock | None) -> Iterator[tuple[MagicMock, MagicMock]]:
+    room_io = MagicMock(start=AsyncMock(), aclose=AsyncMock())
     with (
         patch(f"{_MOD}.get_job_context", return_value=job_ctx),
-        patch(f"{_MOD}.room_io.RoomIO", return_value=room_io_inst),
-        patch(f"{_MOD}.RoomSessionTransport") as mock_transport,
-        patch(f"{_MOD}.SessionHost") as mock_host,
+        patch(f"{_MOD}.room_io.RoomIO", return_value=room_io),
+        patch(f"{_MOD}.RoomSessionTransport") as transport,
+        patch(f"{_MOD}.SessionHost") as host,
     ):
-        # start()/aclose() await these on the registered host
-        mock_host.return_value.start = AsyncMock()
-        mock_host.return_value.aclose = AsyncMock()
-        yield mock_transport, mock_host
+        host.return_value.start = AsyncMock()
+        host.return_value.aclose = AsyncMock()
+        yield transport, host
 
 
-def _assert_registered(
-    session: AgentSession, transport: MagicMock, host: MagicMock, room: MagicMock
+class Outcome(Enum):
+    REGISTERS = True
+    NOT_REGISTERS = False
+
+
+# fmt: off
+# @formatter:off
+_CASES = [
+    # "_register_as_room_host", "job_ctx primary marker" and  "expected outcome")
+    pytest.param(True,      None,     Outcome.REGISTERS,     id="no_ctx/opt-in"),
+    pytest.param(True,      _OTHER,   Outcome.REGISTERS,     id="non_primary/force"),
+    pytest.param(NOT_GIVEN, None,     Outcome.REGISTERS,     id="no_ctx/default"),
+    pytest.param(NOT_GIVEN, _PRIMARY, Outcome.REGISTERS,     id="primary/default"),
+    pytest.param(False,     _PRIMARY, Outcome.NOT_REGISTERS, id="primary/opt-out"),
+    pytest.param(NOT_GIVEN, _OTHER,   Outcome.NOT_REGISTERS, id="non_primary/default"),
+    pytest.param(False,     None,     Outcome.NOT_REGISTERS, id="no_ctx/opt-out"),
+]
+# @formatter:on
+# fmt: on
+
+
+@pytest.mark.parametrize("flag, ctx_marker, expected_outcome", _CASES)
+async def test_room_host_registration(
+    flag: bool | NotGiven, ctx_marker: str | None, expected_outcome: Outcome
 ) -> None:
-    transport.assert_called_once_with(room)
-    host.assert_called_once_with(transport.return_value)
-    host.return_value.register_session.assert_called_once_with(session)
-    assert session._session_host is host.return_value
-
-
-def _assert_not_registered(session: AgentSession, transport: MagicMock, host: MagicMock) -> None:
-    transport.assert_not_called()
-    host.assert_not_called()
-    assert session._session_host is None
-
-
-# ---------------------------------------------------------------------------
-# Without a JobContext
-# ---------------------------------------------------------------------------
-
-
-async def test_registers_as_host_by_default_without_job_ctx() -> None:
-    """No JobContext and the flag omitted: the session becomes the room host."""
-    session = _create_simple_session()
+    session = _make_session()
+    job_ctx = _job_ctx(ctx_marker)
     room = MagicMock()
-    with _patch_host(job_ctx=None) as (transport, host):
-        await session.start(SimpleAgent(), room=room)
-        _assert_registered(session, transport, host, room)
-        await _cleanup(session)
+    kwargs = {} if flag is NOT_GIVEN else {"_register_as_room_host": flag}
 
+    with _patched(job_ctx) as (transport, host):
+        await session.start(SimpleAgent(), room=room, **kwargs)  # type: ignore[arg-type]
 
-async def test_opt_out_of_host_without_job_ctx() -> None:
-    """The new capability: opt out of being the room host even without a JobContext."""
-    session = _create_simple_session()
-    room = MagicMock()
-    with _patch_host(job_ctx=None) as (transport, host):
-        await session.start(SimpleAgent(), room=room, _register_as_room_host=False)
-        _assert_not_registered(session, transport, host)
-        await _cleanup(session)
+        match expected_outcome:
+            case Outcome.REGISTERS:
+                transport.assert_called_once_with(room)
+                host.assert_called_once_with(transport.return_value)
+                host.return_value.register_session.assert_called_once_with(session)
+                assert session._session_host is host.return_value
+            case Outcome.NOT_REGISTERS:
+                transport.assert_not_called()
+                host.assert_not_called()
+                assert session._session_host is None
 
+        # primary designation is claimed regardless of host opt-out
+        if ctx_marker == _PRIMARY:
+            assert job_ctx._primary_agent_session is session
 
-async def test_explicit_opt_in_of_host_without_job_ctx() -> None:
-    """Explicit True without a JobContext registers as host."""
-    session = _create_simple_session()
-    room = MagicMock()
-    with _patch_host(job_ctx=None) as (transport, host):
-        await session.start(SimpleAgent(), room=room, _register_as_room_host=True)
-        _assert_registered(session, transport, host, room)
-        await _cleanup(session)
-
-
-# ---------------------------------------------------------------------------
-# With a JobContext (primary-session interaction)
-# ---------------------------------------------------------------------------
-
-
-async def test_primary_session_registers_as_host() -> None:
-    """The first session under a JobContext is primary and registers as host by default."""
-    session = _create_simple_session()
-    room = MagicMock()
-    mock_ctx = _make_mock_job_ctx(primary=None)
-    with _patch_host(job_ctx=mock_ctx) as (transport, host):
-        await session.start(SimpleAgent(), room=room)
-        assert mock_ctx._primary_agent_session is session
-        _assert_registered(session, transport, host, room)
-        await _cleanup(session)
-
-
-async def test_non_primary_session_does_not_register_by_default() -> None:
-    """A second session under the same JobContext is non-primary and is not the host."""
-    session = _create_simple_session()
-    room = MagicMock()
-    mock_ctx = _make_mock_job_ctx(primary=object())  # another session already primary
-    with _patch_host(job_ctx=mock_ctx) as (transport, host):
-        await session.start(SimpleAgent(), room=room)
-        _assert_not_registered(session, transport, host)
-        await _cleanup(session)
-
-
-async def test_non_primary_session_can_force_host() -> None:
-    """Explicit True overrides the non-primary auto opt-out."""
-    session = _create_simple_session()
-    room = MagicMock()
-    mock_ctx = _make_mock_job_ctx(primary=object())
-    with _patch_host(job_ctx=mock_ctx) as (transport, host):
-        await session.start(SimpleAgent(), room=room, _register_as_room_host=True)
-        _assert_registered(session, transport, host, room)
-        await _cleanup(session)
-
-
-async def test_primary_session_can_opt_out_of_host() -> None:
-    """Explicit False keeps a primary session from becoming the room host."""
-    session = _create_simple_session()
-    room = MagicMock()
-    mock_ctx = _make_mock_job_ctx(primary=None)
-    with _patch_host(job_ctx=mock_ctx) as (transport, host):
-        await session.start(SimpleAgent(), room=room, _register_as_room_host=False)
-        # still claims primary, just not the room host
-        assert mock_ctx._primary_agent_session is session
-        _assert_not_registered(session, transport, host)
-        await _cleanup(session)
+        with contextlib.suppress(RuntimeError):
+            await session.drain()
+        await session.aclose()

--- a/tests/test_room_host.py
+++ b/tests/test_room_host.py
@@ -95,8 +95,8 @@ _CASES = [
     pytest.param(True,      _OTHER,   Outcome.REGISTERS,     id="non_primary/force"),
     pytest.param(NOT_GIVEN, None,     Outcome.REGISTERS,     id="no_ctx/default"),
     pytest.param(NOT_GIVEN, _PRIMARY, Outcome.REGISTERS,     id="primary/default"),
-    pytest.param(False,     _PRIMARY, Outcome.NOT_REGISTERS, id="primary/opt-out"),
     pytest.param(NOT_GIVEN, _OTHER,   Outcome.NOT_REGISTERS, id="non_primary/default"),
+    pytest.param(False,     _PRIMARY, Outcome.NOT_REGISTERS, id="primary/opt-out"),
     pytest.param(False,     None,     Outcome.NOT_REGISTERS, id="no_ctx/opt-out"),
 ]
 # @formatter:on


### PR DESCRIPTION
Add private optional argument `_register_as_room_host` for `AgentSession.start()`, behavior stays the same when it's not used.

This allows using `AgentSession` as a non-primary session, which is required in simulations.

We can promote it to public interface when (if) it'll find any other use-cases.