### PR TITLE
feat(plugins): add livekit-plugins-rumik for Rumik AI TTS support

### DIFF
--- a/livekit-plugins/livekit-plugins-rumik/README.md
+++ b/livekit-plugins/livekit-plugins-rumik/README.md
@@ -1,0 +1,31 @@
+# Rumik AI plugin for LiveKit Agents
+
+Support for speech synthesis (TTS) with the [Rumik AI](https://rumik.ai/) API.
+
+## Installation
+
+```bash
+pip install livekit-plugins-rumik
+```
+
+## Pre-requisites
+
+You'll need an API key from Rumik AI. It can be set as an environment variable: `RUMIK_API_KEY`
+
+## Usage
+
+### Text-to-Speech
+
+```python
+from livekit.plugins import rumik
+
+# Standard tone-steered TTS (muga)
+tts = rumik.TTS(model="muga")
+
+# Rich instruct-based TTS (mulberry)
+tts = rumik.TTS(
+    model="mulberry",
+    description="warm, upbeat narrator",
+    speaker="speaker_2",
+)
+```

--- a/livekit-plugins/livekit-plugins-rumik/livekit/plugins/rumik/__init__.py
+++ b/livekit-plugins/livekit-plugins-rumik/livekit/plugins/rumik/__init__.py
@@ -1,0 +1,42 @@
+# Copyright 2026 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rumik AI plugin for LiveKit Agents
+
+See https://docs.livekit.io/agents/integrations/rumik/ for more information.
+"""
+
+from .tts import TTS as TTS, ChunkedStream as ChunkedStream
+from .version import __version__ as __version__
+
+__all__ = ["TTS", "ChunkedStream", "__version__"]
+
+from livekit.agents import Plugin
+
+
+class RumikPlugin(Plugin):
+    def __init__(self) -> None:
+        super().__init__(__name__, __version__, __package__)
+
+
+Plugin.register_plugin(RumikPlugin())
+
+# Cleanup docs of unexported modules
+_module = dir()
+NOT_IN_ALL = [m for m in _module if m not in __all__]
+
+__pdoc__ = {}
+
+for n in NOT_IN_ALL:
+    __pdoc__[n] = False

--- a/livekit-plugins/livekit-plugins-rumik/livekit/plugins/rumik/log.py
+++ b/livekit-plugins/livekit-plugins-rumik/livekit/plugins/rumik/log.py
@@ -1,0 +1,4 @@
+# Simple logger for the plugin
+import logging
+
+logger = logging.getLogger("livekit.plugins.rumik")

--- a/livekit-plugins/livekit-plugins-rumik/livekit/plugins/rumik/models.py
+++ b/livekit-plugins/livekit-plugins-rumik/livekit/plugins/rumik/models.py
@@ -1,0 +1,6 @@
+from typing import Literal
+
+TTSModels = Literal[
+    "muga",
+    "mulberry",
+]

--- a/livekit-plugins/livekit-plugins-rumik/livekit/plugins/rumik/py.typed
+++ b/livekit-plugins/livekit-plugins-rumik/livekit/plugins/rumik/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.

--- a/livekit-plugins/livekit-plugins-rumik/livekit/plugins/rumik/tts.py
+++ b/livekit-plugins/livekit-plugins-rumik/livekit/plugins/rumik/tts.py
@@ -1,0 +1,376 @@
+# Copyright 2026 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from dataclasses import dataclass, replace
+from typing import Any
+
+import aiohttp
+
+from livekit.agents import (
+    APIConnectionError,
+    APIConnectOptions,
+    APIStatusError,
+    APITimeoutError,
+    create_api_error_from_http,
+    tts,
+    utils,
+)
+from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, NotGivenOr
+from livekit.agents.utils import is_given
+
+from .models import TTSModels
+
+NUM_CHANNELS = 1
+SAMPLE_RATE = 24000
+RUMIK_BASE_URL = "https://silk-api.rumik.ai"
+
+
+@dataclass
+class _TTSOptions:
+    model: TTSModels | str
+    api_key: str
+    description: str | None
+    speaker: str | None
+    f0_up_key: int | None
+    temperature: float | None
+    top_p: float | None
+    top_k: int | None
+    repetition_penalty: float | None
+    max_new_tokens: int | None
+    base_url: str
+
+
+class TTS(tts.TTS):
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: TTSModels | str = "muga",
+        description: str | None = None,
+        speaker: str | None = None,
+        f0_up_key: int | None = None,
+        temperature: float | None = None,
+        top_p: float | None = None,
+        top_k: int | None = None,
+        repetition_penalty: float | None = None,
+        max_new_tokens: int | None = None,
+        base_url: str = RUMIK_BASE_URL,
+        http_session: aiohttp.ClientSession | None = None,
+    ) -> None:
+        """Create a new instance of Rumik AI Silk TTS.
+
+        Args:
+            api_key: Your Rumik AI API key.
+            model: The TTS model to use ("muga" or "mulberry").
+            description: Mulberry only. Natural-language description to steer the voice.
+            speaker: Mulberry only. Preset voice ("speaker_1"..."speaker_4").
+            f0_up_key: Mulberry only. Pitch shift in semitones (-12...12).
+            temperature: Sampling temperature.
+            top_p: Nucleus sampling.
+            top_k: Top-k sampling.
+            repetition_penalty: Repetition penalty.
+            max_new_tokens: Output length cap.
+            base_url: Base URL for Rumik AI API.
+            http_session: An existing ClientSession to use.
+        """
+        super().__init__(
+            capabilities=tts.TTSCapabilities(streaming=True),
+            sample_rate=SAMPLE_RATE,
+            num_channels=NUM_CHANNELS,
+        )
+
+        api_key = api_key or os.environ.get("RUMIK_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "Rumik AI API key is required, either as argument or set "
+                "via the RUMIK_API_KEY environment variable"
+            )
+
+        self._opts = _TTSOptions(
+            model=model,
+            api_key=api_key,
+            description=description,
+            speaker=speaker,
+            f0_up_key=f0_up_key,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            repetition_penalty=repetition_penalty,
+            max_new_tokens=max_new_tokens,
+            base_url=base_url,
+        )
+        self._session = http_session
+
+    @property
+    def model(self) -> str:
+        return self._opts.model
+
+    @property
+    def provider(self) -> str:
+        return "RumikAI"
+
+    def _ensure_session(self) -> aiohttp.ClientSession:
+        if not self._session:
+            self._session = utils.http_context.http_session()
+        return self._session
+
+    def update_options(
+        self,
+        *,
+        model: NotGivenOr[TTSModels | str] = NOT_GIVEN,
+        description: NotGivenOr[str | None] = NOT_GIVEN,
+        speaker: NotGivenOr[str | None] = NOT_GIVEN,
+        f0_up_key: NotGivenOr[int | None] = NOT_GIVEN,
+        temperature: NotGivenOr[float | None] = NOT_GIVEN,
+        top_p: NotGivenOr[float | None] = NOT_GIVEN,
+        top_k: NotGivenOr[int | None] = NOT_GIVEN,
+        repetition_penalty: NotGivenOr[float | None] = NOT_GIVEN,
+        max_new_tokens: NotGivenOr[int | None] = NOT_GIVEN,
+    ) -> None:
+        """Update TTS options."""
+        if is_given(model):
+            self._opts.model = model
+        if is_given(description):
+            self._opts.description = description
+        if is_given(speaker):
+            self._opts.speaker = speaker
+        if is_given(f0_up_key):
+            self._opts.f0_up_key = f0_up_key
+        if is_given(temperature):
+            self._opts.temperature = temperature
+        if is_given(top_p):
+            self._opts.top_p = top_p
+        if is_given(top_k):
+            self._opts.top_k = top_k
+        if is_given(repetition_penalty):
+            self._opts.repetition_penalty = repetition_penalty
+        if is_given(max_new_tokens):
+            self._opts.max_new_tokens = max_new_tokens
+
+    def synthesize(
+        self,
+        text: str,
+        *,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+    ) -> ChunkedStream:
+        return ChunkedStream(tts=self, input_text=text, conn_options=conn_options)
+
+    def stream(
+        self,
+        *,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+    ) -> SynthesizeStream:
+        return SynthesizeStream(tts=self, conn_options=conn_options)
+
+
+class ChunkedStream(tts.ChunkedStream):
+    """HTTP-based synthesis — used when synthesize() is called directly."""
+
+    def __init__(self, *, tts: TTS, input_text: str, conn_options: APIConnectOptions) -> None:
+        super().__init__(tts=tts, input_text=input_text, conn_options=conn_options)
+        self._tts: TTS = tts
+        self._opts = replace(tts._opts)
+
+    async def _run(self, output_emitter: tts.AudioEmitter) -> None:
+        try:
+            headers = {
+                "Authorization": f"Bearer {self._opts.api_key}",
+                "Content-Type": "application/json",
+            }
+            data: dict[str, Any] = {
+                "model": self._opts.model,
+                "text": self._input_text,
+            }
+            if self._opts.description is not None:
+                data["description"] = self._opts.description
+            if self._opts.speaker is not None:
+                data["speaker"] = self._opts.speaker
+            if self._opts.f0_up_key is not None:
+                data["f0_up_key"] = self._opts.f0_up_key
+            if self._opts.temperature is not None:
+                data["temperature"] = self._opts.temperature
+            if self._opts.top_p is not None:
+                data["top_p"] = self._opts.top_p
+            if self._opts.top_k is not None:
+                data["top_k"] = self._opts.top_k
+            if self._opts.repetition_penalty is not None:
+                data["repetition_penalty"] = self._opts.repetition_penalty
+            if self._opts.max_new_tokens is not None:
+                data["max_new_tokens"] = self._opts.max_new_tokens
+
+            async with self._tts._ensure_session().post(
+                f"{self._opts.base_url}/v1/tts",
+                headers=headers,
+                json=data,
+                timeout=aiohttp.ClientTimeout(total=self._conn_options.timeout),
+            ) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    raise create_api_error_from_http(body, status=resp.status)
+
+                output_emitter.initialize(
+                    request_id=utils.shortuuid(),
+                    sample_rate=SAMPLE_RATE,
+                    num_channels=NUM_CHANNELS,
+                    mime_type="audio/wav",
+                )
+
+                async for chunk, _ in resp.content.iter_chunks():
+                    output_emitter.push(chunk)
+
+                output_emitter.flush()
+
+        except asyncio.TimeoutError:
+            raise APITimeoutError() from None
+        except aiohttp.ClientResponseError as e:
+            raise create_api_error_from_http(e.message, status=e.status) from None
+        except APIStatusError:
+            raise
+        except Exception as e:
+            raise APIConnectionError() from e
+
+
+class SynthesizeStream(tts.SynthesizeStream):
+    """WebSocket-based streaming synthesis — primary path used by the agent pipeline."""
+
+    def __init__(self, *, tts: TTS, conn_options: APIConnectOptions) -> None:
+        super().__init__(tts=tts, conn_options=conn_options)
+        self._tts: TTS = tts
+        self._opts = replace(tts._opts)
+
+    async def _run(self, output_emitter: tts.AudioEmitter) -> None:
+        output_emitter.initialize(
+            request_id=utils.shortuuid(),
+            sample_rate=SAMPLE_RATE,
+            num_channels=NUM_CHANNELS,
+            mime_type="audio/pcm",
+            stream=True,
+        )
+
+        try:
+            text_buffer = ""
+            async for data in self._input_ch:
+                if isinstance(data, str):
+                    text_buffer += data
+                elif isinstance(data, self._FlushSentinel):
+                    if text_buffer.strip():
+                        await self._run_ws(text_buffer.strip(), output_emitter)
+                    text_buffer = ""
+        except asyncio.TimeoutError:
+            raise APITimeoutError() from None
+        except aiohttp.ClientResponseError as e:
+            raise APIStatusError(
+                message=e.message, status_code=e.status, request_id=None, body=None
+            ) from None
+        except APIStatusError:
+            raise
+        except Exception as e:
+            raise APIConnectionError() from e
+
+    async def _run_ws(self, text: str, output_emitter: tts.AudioEmitter) -> None:
+        segment_id = utils.shortuuid()
+        output_emitter.start_segment(segment_id=segment_id)
+
+        # 1. Mint WebSocket Session Url
+        headers = {"Authorization": f"Bearer {self._opts.api_key}"}
+        req_body = {
+            "model": self._opts.model,
+            "text": text,
+        }
+        async with self._tts._ensure_session().post(
+            f"{self._opts.base_url}/v1/tts/ws-connect",
+            headers=headers,
+            json=req_body,
+            timeout=aiohttp.ClientTimeout(total=self._conn_options.timeout),
+        ) as resp:
+            if resp.status >= 400:
+                body = await resp.text()
+                raise create_api_error_from_http(body, status=resp.status)
+            res_data = await resp.json()
+            ws_url = res_data["ws_url"]
+            token = res_data["token"]
+
+        # 2. Connect and synthesize
+        ws_endpoint = f"{ws_url}?token={token}"
+        try:
+            ws = await asyncio.wait_for(
+                self._tts._ensure_session().ws_connect(
+                    ws_endpoint,
+                    timeout=aiohttp.ClientWSTimeout(
+                        ws_receive=self._conn_options.timeout, ws_close=self._conn_options.timeout
+                    ),
+                ),
+                timeout=self._conn_options.timeout,
+            )
+        except (aiohttp.ClientConnectorError, asyncio.TimeoutError) as e:
+            raise APIConnectionError("failed to connect to Rumik AI WebSocket") from e
+
+        try:
+            self._mark_started()
+
+            frame: dict[str, Any] = {
+                "text": text,
+            }
+            if self._opts.description is not None:
+                frame["description"] = self._opts.description
+            if self._opts.speaker is not None:
+                frame["speaker"] = self._opts.speaker
+            if self._opts.f0_up_key is not None:
+                frame["f0_up_key"] = self._opts.f0_up_key
+            if self._opts.temperature is not None:
+                frame["temperature"] = self._opts.temperature
+            if self._opts.top_p is not None:
+                frame["top_p"] = self._opts.top_p
+            if self._opts.top_k is not None:
+                frame["top_k"] = self._opts.top_k
+            if self._opts.repetition_penalty is not None:
+                frame["repetition_penalty"] = self._opts.repetition_penalty
+            if self._opts.max_new_tokens is not None:
+                frame["max_new_tokens"] = self._opts.max_new_tokens
+
+            await ws.send_str(json.dumps(frame))
+
+            # 3. Read Binary PCM frames
+            while True:
+                msg = await ws.receive(timeout=self._conn_options.timeout)
+
+                if msg.type in (
+                    aiohttp.WSMsgType.CLOSE,
+                    aiohttp.WSMsgType.CLOSED,
+                    aiohttp.WSMsgType.CLOSING,
+                ):
+                    raise APIStatusError(
+                        "Rumik AI WebSocket closed unexpectedly",
+                        status_code=ws.close_code or -1,
+                        body=str(msg.data),
+                    )
+
+                if msg.type == aiohttp.WSMsgType.BINARY:
+                    output_emitter.push(msg.data)
+                elif msg.type == aiohttp.WSMsgType.TEXT:
+                    event = json.loads(msg.data)
+                    if event.get("type") == "done":
+                        output_emitter.end_segment()
+                        break
+                    elif "error" in event:
+                        raise APIConnectionError(
+                            f"Rumik AI TTS error: {event.get('error', 'unknown error')}"
+                        )
+        finally:
+            await ws.close()

--- a/livekit-plugins/livekit-plugins-rumik/livekit/plugins/rumik/version.py
+++ b/livekit-plugins/livekit-plugins-rumik/livekit/plugins/rumik/version.py
@@ -1,0 +1,15 @@
+# Copyright 2026 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "1.6.0"

--- a/livekit-plugins/livekit-plugins-rumik/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-rumik/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "livekit-plugins-rumik"
+dynamic = ["version"]
+description = "Agent Framework plugin for speech synthesis with Rumik AI."
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.10.0"
+authors = [{ name = "LiveKit", email = "hello@livekit.io" }]
+keywords = ["webrtc", "realtime", "audio", "video", "livekit", "rumik", "tts"]
+classifiers = [
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: Multimedia :: Sound/Audio",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3 :: Only",
+]
+dependencies = ["livekit-agents[codecs]>=1.6.0", "numpy>=1.26"]
+
+[project.urls]
+Documentation = "https://docs.livekit.io"
+Website = "https://livekit.io/"
+Source = "https://github.com/livekit/agents"
+
+[tool.hatch.version]
+path = "livekit/plugins/rumik/version.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["livekit"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/livekit"]
+
+[tool.uv]
+exclude-newer = "7 days"
+exclude-newer-package = { livekit-agents = "0 days" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ livekit-plugins-perplexity = { workspace = true }
 livekit-plugins-resemble = { workspace = true }
 livekit-plugins-respeecher = { workspace = true }
 livekit-plugins-rime = { workspace = true }
+livekit-plugins-rumik = { workspace = true }
 livekit-plugins-runway = { workspace = true }
 livekit-plugins-rtzr = { workspace = true }
 livekit-plugins-sarvam = { workspace = true }

--- a/tests/test_plugin_rumik_tts.py
+++ b/tests/test_plugin_rumik_tts.py
@@ -1,0 +1,86 @@
+"""Tests for Rumik AI TTS plugin configuration and behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.plugin("rumik")
+
+
+def test_tts_requires_api_key():
+    """TTS constructor raises when no API key is provided."""
+    from livekit.plugins.rumik import TTS
+
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ValueError, match="API key is required"):
+            TTS(api_key=None)
+
+
+def test_tts_accepts_api_key_directly():
+    """TTS constructor accepts api_key argument."""
+    from livekit.plugins.rumik import TTS
+
+    tts = TTS(api_key="test-key")
+    assert tts._opts.api_key == "test-key"
+
+
+def test_tts_accepts_api_key_from_env():
+    """TTS constructor reads RUMIK_API_KEY from environment."""
+    from livekit.plugins.rumik import TTS
+
+    with patch.dict("os.environ", {"RUMIK_API_KEY": "env-key"}):
+        tts = TTS()
+        assert tts._opts.api_key == "env-key"
+
+
+def test_tts_default_model():
+    """TTS defaults to 'muga' model."""
+    from livekit.plugins.rumik import TTS
+
+    tts = TTS(api_key="test-key")
+    assert tts._opts.model == "muga"
+    assert tts.model == "muga"
+
+
+def test_tts_custom_model():
+    """TTS accepts custom model."""
+    from livekit.plugins.rumik import TTS
+
+    tts = TTS(api_key="test-key", model="mulberry")
+    assert tts._opts.model == "mulberry"
+    assert tts.model == "mulberry"
+
+
+def test_tts_provider_property():
+    """TTS provider property returns 'RumikAI'."""
+    from livekit.plugins.rumik import TTS
+
+    tts = TTS(api_key="test-key")
+    assert tts.provider == "RumikAI"
+
+
+def test_tts_capabilities():
+    """TTS reports streaming=True."""
+    from livekit.plugins.rumik import TTS
+
+    tts = TTS(api_key="test-key")
+    assert tts.capabilities.streaming is True
+
+
+def test_tts_update_options():
+    """update_options can change parameters."""
+    from livekit.plugins.rumik import TTS
+
+    tts = TTS(api_key="test-key")
+    tts.update_options(
+        model="mulberry",
+        description="warm, friendly voice",
+        speaker="speaker_3",
+        f0_up_key=2,
+    )
+    assert tts._opts.model == "mulberry"
+    assert tts._opts.description == "warm, friendly voice"
+    assert tts._opts.speaker == "speaker_3"
+    assert tts._opts.f0_up_key == 2

--- a/uv.lock
+++ b/uv.lock
@@ -61,6 +61,7 @@ members = [
     "livekit-plugins-respeecher",
     "livekit-plugins-rime",
     "livekit-plugins-rtzr",
+    "livekit-plugins-rumik",
     "livekit-plugins-runway",
     "livekit-plugins-sarvam",
     "livekit-plugins-silero",
@@ -2916,6 +2917,20 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "httpx", specifier = ">=0.24.0" },
     { name = "livekit-agents", editable = "livekit-agents" },
+]
+
+[[package]]
+name = "livekit-plugins-rumik"
+source = { editable = "livekit-plugins/livekit-plugins-rumik" }
+dependencies = [
+    { name = "livekit-agents", extra = ["codecs"] },
+    { name = "numpy" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "livekit-agents", extras = ["codecs"], editable = "livekit-agents" },
+    { name = "numpy", specifier = ">=1.26" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This pull request introduces the new **Rumik AI Text-to-Speech** plugin (`livekit-plugins-rumik`) to support Rumik AI's `muga` and `mulberry` models.

### Key Features
* **REST & WebSocket Support**: Supports standard chunked HTTP synthesize (returning mono `audio/wav`) and low-latency real-time WebSockets (streaming mono `audio/pcm` @ 24 kHz).
* **Rich Configuration**: Supports model steering via natural language description, preset speakers, pitch semitone shifts (`f0_up_key`), temperature, repetition penalty, etc.
* **Compliance**: Includes comprehensive unit tests in [test_plugin_rumik_tts.py](file:///home/lothnic/Desktop/OpenSource/agents/tests/test_plugin_rumik_tts.py) and is fully compliant with strict `ruff` and `mypy` check rules.
