### PR TITLE
feat(voice): surface unrecoverable error message with a spoken fallback

### DIFF
--- a/examples/voice_agents/error_callback.py
+++ b/examples/voice_agents/error_callback.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import os
 import pathlib
 
 from dotenv import load_dotenv
@@ -24,8 +23,6 @@ server = AgentServer()
 
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
-    custom_error_audio = os.path.join(pathlib.Path(__file__).parent.absolute(), "error_message.ogg")
-
     session = AgentSession(
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
@@ -33,7 +30,7 @@ async def entrypoint(ctx: JobContext):
         # play a pre-recorded file (or any AudioSource) before the session closes on an
         # unrecoverable error; bypasses TTS, so it's still heard when TTS is the failed
         # resource. A non-file str is synthesized through TTS instead.
-        unrecoverable_error_message=custom_error_audio,
+        unrecoverable_error_message=str(pathlib.Path(__file__).parent / "error_message.ogg"),
     )
 
     # Advanced path: for full control (e.g. continuing the conversation on recoverable

--- a/examples/voice_agents/error_callback.py
+++ b/examples/voice_agents/error_callback.py
@@ -6,7 +6,6 @@ import pathlib
 from dotenv import load_dotenv
 
 from livekit.agents import AgentServer, JobContext, cli, inference
-from livekit.agents.utils.audio import audio_frames_from_file
 from livekit.agents.voice import Agent, AgentSession
 from livekit.agents.voice.events import CloseEvent, ErrorEvent
 from livekit.rtc import ParticipantKind
@@ -25,27 +24,27 @@ server = AgentServer()
 
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
+    custom_error_audio = os.path.join(pathlib.Path(__file__).parent.absolute(), "error_message.ogg")
+
     session = AgentSession(
         stt=inference.STT("deepgram/nova-3"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),
+        # play a pre-recorded file (or any AudioSource) before the session closes on an
+        # unrecoverable error; bypasses TTS, so it's still heard when TTS is the failed
+        # resource. A non-file str is synthesized through TTS instead.
+        unrecoverable_error_message=custom_error_audio,
     )
 
-    custom_error_audio = os.path.join(pathlib.Path(__file__).parent.absolute(), "error_message.ogg")
-
+    # Advanced path: for full control (e.g. continuing the conversation on recoverable
+    # errors, or triggering a SIP transfer) handle the "error" event yourself. This runs
+    # in addition to the built-in unrecoverable_error_message above.
     @session.on("error")
     def on_error(ev: ErrorEvent):
         if ev.error.recoverable:
             return
 
         logger.info(f"session is closing due to unrecoverable error {ev.error}")
-
-        # To bypass the TTS service in case it's unavailable, we use a custom audio file instead
-        session.say(
-            "I'm having trouble connecting right now. Let me transfer your call.",
-            audio=audio_frames_from_file(custom_error_audio),
-            allow_interruptions=False,
-        )
 
         # If want to continue the conversation, we can set the recoverable to True
 

--- a/livekit-agents/livekit/agents/__init__.py
+++ b/livekit-agents/livekit/agents/__init__.py
@@ -107,7 +107,8 @@ from .voice.amd import (
     AMDCategory,
     AMDPredictionEvent,
 )
-from .voice.background_audio import AudioConfig, BackgroundAudioPlayer, BuiltinAudioClip, PlayHandle
+from .voice.audio_source import AudioSource, BuiltinAudioClip
+from .voice.background_audio import AudioConfig, BackgroundAudioPlayer, PlayHandle
 from .voice.room_io import RoomInputOptions, RoomIO, RoomOutputOptions
 from .voice.run_result import (
     AgentHandoffEvent,
@@ -220,6 +221,7 @@ __all__ = [
     "DEFAULT_API_CONNECT_OPTIONS",
     "BackgroundAudioPlayer",
     "BuiltinAudioClip",
+    "AudioSource",
     "AudioConfig",
     "PlayHandle",
     "FlushSentinel",

--- a/livekit-agents/livekit/agents/_exceptions.py
+++ b/livekit-agents/livekit/agents/_exceptions.py
@@ -48,14 +48,14 @@ class APIError(Exception):
 
         self.message = message
         self.body = body
-        self.retryable = retryable
+        self.retryable = retryable and not terminal
         self.terminal = terminal
 
     def __str__(self) -> str:
         return self.message
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.message!r}, body={self.body!r}, retryable={self.retryable!r})"
+        return f"{self.__class__.__name__}({self.message!r}, body={self.body!r}, retryable={self.retryable!r}, terminal={self.terminal!r})"
 
 
 class APIStatusError(APIError):
@@ -97,6 +97,7 @@ class APIStatusError(APIError):
             f"message={self.message!r}",
             f"status_code={self.status_code}",
             f"retryable={self.retryable}",
+            f"terminal={self.terminal}",
         ]
         if self.request_id:
             parts.append(f"request_id={self.request_id}")
@@ -110,7 +111,8 @@ class APIStatusError(APIError):
             f"status_code={self.status_code!r}, "
             f"request_id={self.request_id!r}, "
             f"body={self.body!r}, "
-            f"retryable={self.retryable!r})"
+            f"retryable={self.retryable!r}, "
+            f"terminal={self.terminal!r})"
         )
 
 

--- a/livekit-agents/livekit/agents/_exceptions.py
+++ b/livekit-agents/livekit/agents/_exceptions.py
@@ -29,14 +29,27 @@ class APIError(Exception):
     """
 
     retryable: bool = False
-    """Whether the error can be retried."""
+    """Whether the error can be retried (within the request's retry loop)."""
 
-    def __init__(self, message: str, *, body: object | None = None, retryable: bool = True) -> None:
+    terminal: bool = False
+    """Whether the error is terminal — it will fail identically on every turn, so
+    callers should surface it immediately rather than absorbing it under a
+    transient-error tolerance (e.g. ``AgentSession``'s ``max_unrecoverable_errors``)."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        body: object | None = None,
+        retryable: bool = True,
+        terminal: bool = False,
+    ) -> None:
         super().__init__(message)
 
         self.message = message
         self.body = body
         self.retryable = retryable
+        self.terminal = terminal
 
     def __str__(self) -> str:
         return self.message
@@ -62,6 +75,7 @@ class APIStatusError(APIError):
         request_id: str | None = None,
         body: object | None = None,
         retryable: bool | None = None,
+        terminal: bool = False,
     ) -> None:
         if retryable is None:
             retryable = True
@@ -73,7 +87,7 @@ class APIStatusError(APIError):
         if 400 <= status_code < 500 and status_code not in (408, 429, 499):
             retryable = False
 
-        super().__init__(message, body=body, retryable=retryable)
+        super().__init__(message, body=body, retryable=retryable, terminal=terminal)
 
         self.status_code = status_code
         self.request_id = request_id

--- a/livekit-agents/livekit/agents/beta/workflows/warm_transfer.py
+++ b/livekit-agents/livekit/agents/beta/workflows/warm_transfer.py
@@ -18,11 +18,10 @@ from ...utils import is_given
 from ...voice import room_io
 from ...voice.agent import Agent, AgentTask
 from ...voice.agent_session import AgentSession
+from ...voice.audio_source import AudioSource, BuiltinAudioClip
 from ...voice.background_audio import (
     AudioConfig,
-    AudioSource,
     BackgroundAudioPlayer,
-    BuiltinAudioClip,
     PlayHandle,
 )
 from .utils import InstructionParts

--- a/livekit-agents/livekit/agents/inference/__init__.py
+++ b/livekit-agents/livekit/agents/inference/__init__.py
@@ -1,3 +1,4 @@
+from ._exceptions import InferenceQuotaExceededError
 from .eot import TurnDetector, TurnDetectorModels, TurnDetectorVersions
 from .interruption import (
     AdaptiveInterruptionDetector,
@@ -22,6 +23,7 @@ __all__ = [
     "VADModels",
     "AdaptiveInterruptionDetector",
     "InterruptionDetectionError",
+    "InferenceQuotaExceededError",
     "OverlappingSpeechEvent",
     "InterruptionDataFrameType",
     "TurnDetector",

--- a/livekit-agents/livekit/agents/inference/_exceptions.py
+++ b/livekit-agents/livekit/agents/inference/_exceptions.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from .._exceptions import APIStatusError
+
+_INFERENCE_QUOTA_EXCEEDED_TYPE = "inference_quota_exceeded"
+"""Value of the ``type`` field in a LiveKit Inference 429 quota response body."""
+
+_TERMINAL_QUOTA_CATEGORIES = frozenset(
+    {"MaxGatewayCredits", "MaxBargeInRequests", "MaxEotRequests"}
+)
+
+
+def _str_or_none(value: object) -> str | None:
+    """Coerce an untrusted JSON field to ``str``; non-str values become ``None``."""
+    return value if isinstance(value, str) else None
+
+
+class InferenceQuotaExceededError(APIStatusError):
+    """Raised when the LiveKit Inference gateway rejects a request because a usage quota
+    or rate limit has been exhausted.
+
+    The gateway answers an exhausted project with ``HTTP 429`` and a structured JSON
+    body (``type == "inference_quota_exceeded"``). This error surfaces the fields of that
+    body directly so callers can log the quota state or forward it to their frontend
+    instead of leaving the agent silent.
+
+    The gateway uses this single ``type`` for two different conditions, told apart by
+    ``category``:
+
+    * **Credit/quota exhaustion** (``MaxGatewayCredits``, ``MaxBargeInRequests``,
+      ``MaxEotRequests``) — recovers only at the next billing cycle, so it is
+      :attr:`terminal` and ``retryable=False``.
+    * **Rate / concurrency limits** (e.g. ``MaxConcurrentGatewayLLMRpm`` / ``…Tpm``) —
+      recover within ~a minute via backoff, so they stay ``retryable=True`` and
+      non-terminal (they fall through the usual transient-error handling).
+
+    ``retryable`` / ``terminal`` are derived from ``category`` automatically; pass them
+    explicitly to override.
+
+    On a terminal quota error, ``AgentSession`` by default speaks a generic,
+    provider-agnostic message and closes on the first occurrence (see
+    ``AgentSession(unrecoverable_error_message=...)``); transient variants go through the
+    normal retry/tolerance path. The gateway ``hint`` is never spoken — quota details
+    aren't surfaced to end users. Subscribe to ``error`` when you need the structured
+    fields, e.g. to log the quota state or forward an "out of credits" state to your
+    frontend. ``ErrorEvent.error`` is the ``LLMError``/``STTError``/… wrapper, so the
+    underlying exception is at ``ev.error.error``:
+
+    Example:
+        ```python
+        from livekit.agents import ErrorEvent
+        from livekit.agents.inference import InferenceQuotaExceededError
+
+
+        @session.on("error")
+        def _on_error(ev: ErrorEvent) -> None:
+            err = ev.error.error
+            if isinstance(err, InferenceQuotaExceededError):
+                logger.warning("inference quota exceeded: %s (%s)", err.hint, err.quota_type)
+        ```
+    """
+
+    quota_type: str | None
+    """Quota resource: ``"llm"``, ``"stt"``, ``"tts"``, ``"bargein"`` or ``"eot"``."""
+
+    category: str | None
+    """Quota error category. Credit-exhaustion categories (``"MaxGatewayCredits"``,
+    ``"MaxBargeInRequests"``, ``"MaxEotRequests"``) are terminal; rate-limit variants
+    such as ``"MaxConcurrentGatewayLLMRpm"`` are transient."""
+
+    hint: str | None
+    """Human-readable explanation from the error."""
+
+    remaining_limit: str | None
+    """Remaining quota for ``quota_type`` as reported by the gateway; ``"0"`` when
+    fully exhausted. An opaque diagnostic string (not guaranteed numeric)."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int = 429,
+        request_id: str | None = None,
+        body: object | None = None,
+        retryable: bool | None = None,
+        terminal: bool | None = None,
+        quota_type: str | None = None,
+        category: str | None = None,
+        hint: str | None = None,
+        remaining_limit: str | None = None,
+    ) -> None:
+        if isinstance(body, dict):
+            if quota_type is None:
+                quota_type = _str_or_none(body.get("quota_type"))
+            if category is None:
+                category = _str_or_none(body.get("category"))
+            if hint is None:
+                hint = _str_or_none(body.get("hint"))
+            if remaining_limit is None:
+                remaining_limit = _str_or_none(body.get("remaining_limit"))
+
+        is_credit_exhaustion = category in _TERMINAL_QUOTA_CATEGORIES
+        if terminal is None:
+            terminal = is_credit_exhaustion
+        if retryable is None:
+            retryable = not is_credit_exhaustion
+
+        super().__init__(
+            message,
+            status_code=status_code,
+            request_id=request_id,
+            body=body,
+            retryable=retryable,
+            terminal=terminal,
+        )
+
+        self.quota_type = quota_type
+        self.category = category
+        self.hint = hint
+        self.remaining_limit = remaining_limit
+
+    @classmethod
+    def from_response(
+        cls,
+        message: str,
+        *,
+        status_code: int = 429,
+        request_id: str | None = None,
+        body: object | None = None,
+    ) -> InferenceQuotaExceededError | None:
+        """Build an :class:`InferenceQuotaExceededError` from a response body, or return
+        ``None`` if the body isn't a LiveKit Inference quota-exceeded payload.
+
+        Lets plugins centralize quota detection: pass the decoded JSON body and
+        raise the result when it isn't ``None``.
+        """
+        if not (isinstance(body, dict) and body.get("type") == _INFERENCE_QUOTA_EXCEEDED_TYPE):
+            return None
+
+        return cls(message, status_code=status_code, request_id=request_id, body=body)

--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 from dataclasses import dataclass
 from typing import Any, Literal, cast
@@ -459,24 +460,20 @@ class LLMStream(llm.LLMStream):
         except openai.APITimeoutError:
             raise APITimeoutError(retryable=retryable) from None
         except openai.APIStatusError as e:
-            # a depleted project answers 429 with a structured `inference_quota_exceeded`
-            # JSON body. The openai SDK narrows a mapping body to its `error` value
-            # before raising — a bare string for gateway payloads — so re-parse the
-            # response to recover the full body.
+            # OpenAI's SDK stores only body["error"] on the exception; for gateway quota
+            # payloads that's a bare string, dropping the `type`/`category` fields we need,
+            # so re-parse the raw response to recover the full JSON body.
             body: object = e.body
             if not isinstance(body, dict):
-                try:
+                with contextlib.suppress(Exception):
                     body = e.response.json()
-                except Exception:
-                    body = e.body
 
-            quota_error = InferenceQuotaExceededError.from_response(
+            if quota_error := InferenceQuotaExceededError.from_response(
                 e.message,
                 status_code=e.status_code,
                 request_id=e.request_id,
                 body=body,
-            )
-            if quota_error is not None:
+            ):
                 raise quota_error from None
 
             raise APIStatusError(

--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -21,13 +21,18 @@ from openai.types.shared_params import Metadata
 from typing_extensions import TypedDict
 
 from .. import llm
-from .._exceptions import APIConnectionError, APIStatusError, APITimeoutError
+from .._exceptions import (
+    APIConnectionError,
+    APIStatusError,
+    APITimeoutError,
+)
 from ..llm import ToolChoice, utils as llm_utils
 from ..llm.chat_context import ChatContext
 from ..llm.tool_context import Tool
 from ..log import logger
 from ..types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, APIConnectOptions, NotGivenOr
 from ..utils import is_given
+from ._exceptions import InferenceQuotaExceededError
 from ._utils import (
     HEADER_INFERENCE_PRIORITY,
     HEADER_INFERENCE_PROVIDER,
@@ -454,6 +459,26 @@ class LLMStream(llm.LLMStream):
         except openai.APITimeoutError:
             raise APITimeoutError(retryable=retryable) from None
         except openai.APIStatusError as e:
+            # a depleted project answers 429 with a structured `inference_quota_exceeded`
+            # JSON body. The openai SDK narrows a mapping body to its `error` value
+            # before raising — a bare string for gateway payloads — so re-parse the
+            # response to recover the full body.
+            body: object = e.body
+            if not isinstance(body, dict):
+                try:
+                    body = e.response.json()
+                except Exception:
+                    body = e.body
+
+            quota_error = InferenceQuotaExceededError.from_response(
+                e.message,
+                status_code=e.status_code,
+                request_id=e.request_id,
+                body=body,
+            )
+            if quota_error is not None:
+                raise quota_error from None
+
             raise APIStatusError(
                 e.message,
                 status_code=e.status_code,

--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -881,6 +881,9 @@ class SpeechStream(stt.SpeechStream):
             params["type"] = "session.create"
             await ws.send_str(json.dumps(params))
         except aiohttp.ClientResponseError as e:
+            # aiohttp discards the failed-handshake body, so we can't pass the quota
+            # JSON to body=; a quota 429 stays a plain APIStatusError here. Without the
+            # body's `category` it can't be classified anyway. Typing it is future work.
             raise create_api_error_from_http(e.message, status=e.status) from e
         except asyncio.TimeoutError as e:
             raise APITimeoutError("LiveKit Inference STT connection timed out.") from e

--- a/livekit-agents/livekit/agents/inference/tts.py
+++ b/livekit-agents/livekit/agents/inference/tts.py
@@ -737,6 +737,9 @@ class SynthesizeStream(tts.SynthesizeStream):
             raise APITimeoutError() from None
 
         except aiohttp.ClientResponseError as e:
+            # No body= for the same reason as the connect path above (see :496): aiohttp
+            # discards the failed-response body, so a quota 429 stays a plain
+            # APIStatusError. Typing it is future work.
             raise create_api_error_from_http(e.message, status=e.status) from None
 
         except APIError:

--- a/livekit-agents/livekit/agents/inference/tts.py
+++ b/livekit-agents/livekit/agents/inference/tts.py
@@ -493,6 +493,9 @@ class TTS(tts.TTS):
                 timeout,
             )
         except aiohttp.ClientResponseError as e:
+            # aiohttp discards the failed-handshake body, so we can't pass the quota
+            # JSON to body=; a quota 429 stays a plain APIStatusError here. Without the
+            # body's `category` it can't be classified anyway. Typing it is future work.
             raise create_api_error_from_http(e.message, status=e.status) from e
         except asyncio.TimeoutError as e:
             raise APITimeoutError("LiveKit Inference TTS connection timed out.") from e

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1667,7 +1667,7 @@ class AgentActivity(RecognitionHooks):
         | llm.RealtimeModelError
         | inference.InterruptionDetectionError,
     ) -> None:
-        source: llm.LLM | llm.RealtimeModel | stt.STT | tts.TTS | None
+        source: llm.LLM | llm.RealtimeModel | stt.STT | tts.TTS | None = None
         if isinstance(error, (llm.LLMError, llm.RealtimeModelError)):
             source = self.llm
         elif isinstance(error, stt.STTError):
@@ -1680,7 +1680,8 @@ class AgentActivity(RecognitionHooks):
             return
 
         ev = ErrorEvent(error=error, source=source)
-        # emit before deciding: a user "error" handler may set ev.error.recoverable
+        # emit first before calling _on_error so user hooks take priority
+        # for in-place recoverable field update
         self._session.emit("error", ev)
         self._session._on_error(ev)
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1668,23 +1668,17 @@ class AgentActivity(RecognitionHooks):
         | inference.InterruptionDetectionError,
     ) -> None:
         if isinstance(error, llm.LLMError):
-            error_event = ErrorEvent(error=error, source=self.llm)
-            self._session.emit("error", error_event)
+            self._session.emit("error", ErrorEvent(error=error, source=self.llm))
         elif isinstance(error, llm.RealtimeModelError):
-            error_event = ErrorEvent(error=error, source=self.llm)
-            self._session.emit("error", error_event)
+            self._session.emit("error", ErrorEvent(error=error, source=self.llm))
         elif isinstance(error, stt.STTError):
-            error_event = ErrorEvent(error=error, source=self.stt)
-            self._session.emit("error", error_event)
+            self._session.emit("error", ErrorEvent(error=error, source=self.stt))
         elif isinstance(error, tts.TTSError):
-            error_event = ErrorEvent(error=error, source=self.tts)
-            self._session.emit("error", error_event)
+            self._session.emit("error", ErrorEvent(error=error, source=self.tts))
         elif isinstance(error, inference.InterruptionDetectionError):
             if not error.recoverable:
                 self._fallback_to_vad_interruption(error)
             return
-
-        self._session._on_error(error)
 
     def _on_overlap_speech_ended(self, ev: inference.OverlappingSpeechEvent) -> None:
         if ev.is_interruption:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1667,18 +1667,22 @@ class AgentActivity(RecognitionHooks):
         | llm.RealtimeModelError
         | inference.InterruptionDetectionError,
     ) -> None:
-        if isinstance(error, llm.LLMError):
-            self._session.emit("error", ErrorEvent(error=error, source=self.llm))
-        elif isinstance(error, llm.RealtimeModelError):
-            self._session.emit("error", ErrorEvent(error=error, source=self.llm))
+        source: llm.LLM | llm.RealtimeModel | stt.STT | tts.TTS | None
+        if isinstance(error, (llm.LLMError, llm.RealtimeModelError)):
+            source = self.llm
         elif isinstance(error, stt.STTError):
-            self._session.emit("error", ErrorEvent(error=error, source=self.stt))
+            source = self.stt
         elif isinstance(error, tts.TTSError):
-            self._session.emit("error", ErrorEvent(error=error, source=self.tts))
+            source = self.tts
         elif isinstance(error, inference.InterruptionDetectionError):
             if not error.recoverable:
                 self._fallback_to_vad_interruption(error)
             return
+
+        ev = ErrorEvent(error=error, source=source)
+        # emit before deciding: a user "error" handler may set ev.error.recoverable
+        self._session.emit("error", ev)
+        self._session._on_error(ev)
 
     def _on_overlap_speech_ended(self, ev: inference.OverlappingSpeechEvent) -> None:
         if ev.is_interruption:

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -337,8 +337,8 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             unrecoverable_error_message (str | AudioSource | None, optional): Spoken just
                 before the session closes on an unrecoverable error, so the agent isn't
                 silent. A ``str`` is synthesized via TTS (or played as-is if it's a file
-                path); an :data:`~livekit.agents.AudioSource` is played directly (use this
-                when TTS is the failed resource). ``None`` disables spoken errors. The
+                path); any other :data:`~livekit.agents.AudioSource` is played directly
+                (use this when TTS is the failed resource). ``None`` disables spoken errors. The
                 default speaks :data:`DEFAULT_UNRECOVERABLE_ERROR_MESSAGE` (English) only on
                 terminal errors; set your own for non-English agents. ``error``/``close``
                 events fire regardless.

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -355,7 +355,6 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             agent_false_interruption_timeout (NotGivenOr[float | None]): Deprecated, use turn_handling=TurnHandlingOptions(...) instead.
         """
         super().__init__()
-        self.on("error", self._on_error)
         self._loop = loop or asyncio.get_event_loop()
         self._video_sampler = (
             video_sampler
@@ -1613,7 +1612,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 audio = message
 
             handle = self.say(text, audio=audio, allow_interruptions=False, add_to_chat_ctx=False)
-            await asyncio.wait_for(handle.wait_for_playout(), timeout=_ERROR_MESSAGE_PLAYOUT_TIMEOUT)
+            await asyncio.wait_for(
+                handle.wait_for_playout(), timeout=_ERROR_MESSAGE_PLAYOUT_TIMEOUT
+            )
         except Exception:
             logger.warning("failed to play the unrecoverable-error message", exc_info=True)
         finally:

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import os
 import time
 from collections.abc import AsyncIterable, AsyncIterator, Callable, Sequence
 from contextlib import AbstractContextManager, asynccontextmanager, nullcontext
@@ -41,6 +42,7 @@ from ..types import (
     APIConnectOptions,
     NotGivenOr,
 )
+from ..utils.audio import audio_frames_from_file
 from ..utils.deprecation import deprecate_params
 from ..utils.misc import is_given
 from . import io, room_io
@@ -48,6 +50,7 @@ from ._utils import _set_participant_attributes
 from .agent import Agent, AgentTask
 from .agent_activity import AgentActivity, _ReusableResources
 from .amd import AMD
+from .audio_source import AudioSource, BuiltinAudioClip
 from .events import (
     AgentEvent,
     AgentState,
@@ -55,6 +58,7 @@ from .events import (
     CloseEvent,
     CloseReason,
     ConversationItemAddedEvent,
+    ErrorEvent,
     EventTypes,
     UserInputTranscribedEvent,
     UserState,
@@ -205,6 +209,11 @@ class VoiceActivityVideoSampler:
 
 DEFAULT_TTS_TEXT_TRANSFORMS: list[TextTransforms] = ["filter_markdown", "filter_emoji"]
 
+DEFAULT_UNRECOVERABLE_ERROR_MESSAGE = (
+    "I'm sorry, the assistant is temporarily unavailable. Please try again later."
+)
+_ERROR_MESSAGE_PLAYOUT_TIMEOUT = 16.0
+
 
 class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
     @deprecate_params(
@@ -246,6 +255,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         ivr_detection: bool = False,
         user_away_timeout: float | None = 15.0,
         session_close_transcript_timeout: float = 2.0,
+        unrecoverable_error_message: NotGivenOr[AudioSource | None] = NOT_GIVEN,
         # Runtime settings
         conn_options: NotGivenOr[SessionConnectOptions] = NOT_GIVEN,
         loop: asyncio.AbstractEventLoop | None = None,
@@ -324,6 +334,14 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             session_close_transcript_timeout (float, optional): Seconds to wait for the
                 final STT transcript when closing the session (after audio is detached).
                 Default ``2.0`` s (independent of ``commit_user_turn``'s ``transcript_timeout``).
+            unrecoverable_error_message (str | AudioSource | None, optional): Spoken just
+                before the session closes on an unrecoverable error, so the agent isn't
+                silent. A ``str`` is synthesized via TTS (or played as-is if it's a file
+                path); an :data:`~livekit.agents.AudioSource` is played directly (use this
+                when TTS is the failed resource). ``None`` disables spoken errors. The
+                default speaks :data:`DEFAULT_UNRECOVERABLE_ERROR_MESSAGE` (English) only on
+                terminal errors; set your own for non-English agents. ``error``/``close``
+                events fire regardless.
             preemptive_generation (NotGivenOr[bool | PreemptiveGenerationOptions]): Deprecated, use turn_handling=TurnHandlingOptions(...) instead.
             min_endpointing_delay (NotGivenOr[float]): Deprecated, use turn_handling=TurnHandlingOptions(...) instead.
             max_endpointing_delay (NotGivenOr[float]): Deprecated, use turn_handling=TurnHandlingOptions(...) instead.
@@ -337,6 +355,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             agent_false_interruption_timeout (NotGivenOr[float | None]): Deprecated, use turn_handling=TurnHandlingOptions(...) instead.
         """
         super().__init__()
+        self.on("error", self._on_error)
         self._loop = loop or asyncio.get_event_loop()
         self._video_sampler = (
             video_sampler
@@ -398,6 +417,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             session_close_transcript_timeout=session_close_transcript_timeout,
         )
         self._conn_options = conn_options or SessionConnectOptions()
+        self._unrecoverable_error_message = unrecoverable_error_message
         self._started = False
 
         if isinstance(stt, str):
@@ -1521,20 +1541,27 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         # debug messages ride the proto, not the Pydantic event union.
         super().emit("debug_message", agent_pb.DebugMessage(payload=st))
 
-    def _on_error(
-        self, error: llm.LLMError | stt.STTError | tts.TTSError | llm.RealtimeModelError
-    ) -> None:
+    def _on_error(self, ev: ErrorEvent) -> None:
+        error = ev.error
+        if not isinstance(
+            error, (llm.LLMError, stt.STTError, tts.TTSError, llm.RealtimeModelError)
+        ):
+            return
+
         if self._closing_task or error.recoverable:
             return
 
-        if error.type == "llm_error":
-            self._llm_error_counts += 1
-            if self._llm_error_counts <= self.conn_options.max_unrecoverable_errors:
-                return
-        elif error.type == "tts_error":
-            self._tts_error_counts += 1
-            if self._tts_error_counts <= self.conn_options.max_unrecoverable_errors:
-                return
+        terminal = isinstance(error.error, APIError) and error.error.terminal
+
+        if not terminal:
+            if error.type == "llm_error":
+                self._llm_error_counts += 1
+                if self._llm_error_counts <= self.conn_options.max_unrecoverable_errors:
+                    return
+            elif error.type == "tts_error":
+                self._tts_error_counts += 1
+                if self._tts_error_counts <= self.conn_options.max_unrecoverable_errors:
+                    return
 
         if isinstance(error.error, APIError):
             logger.error(f"AgentSession is closing due to unrecoverable error: {error.error}")
@@ -1547,10 +1574,50 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         def on_close_done(_: asyncio.Task[None]) -> None:
             self._closing_task = None
 
-        self._closing_task = asyncio.create_task(
-            self._aclose_impl(error=error, reason=CloseReason.ERROR)
-        )
+        self._closing_task = asyncio.create_task(self._close_on_error(error))
         self._closing_task.add_done_callback(on_close_done)
+
+    def _resolve_error_message(self, error: Exception) -> AudioSource | None:
+        """Resolve the message to speak before closing on an unrecoverable error."""
+        if is_given(message := self._unrecoverable_error_message):
+            return message
+        # Terminal errors (e.g. depleted LiveKit Inference credits) get a generic spoken
+        # message — we deliberately don't surface provider quota details to end users.
+        if isinstance(error, APIError) and error.terminal:
+            return DEFAULT_UNRECOVERABLE_ERROR_MESSAGE
+        return None
+
+    async def _close_on_error(
+        self, error: llm.LLMError | stt.STTError | tts.TTSError | llm.RealtimeModelError
+    ) -> None:
+        # best-effort: speak a fallback message before teardown so the agent isn't silent.
+        # A failing or unavailable source just falls through to close — the error/close
+        # events fire either way.
+        try:
+            message = self._resolve_error_message(error.error)
+            if message is None or self._activity is None or self.output.audio is None:
+                return
+
+            # pre-recorded audio is played as-is, so it survives a dead/exhausted TTS; a
+            # non-file str falls back to TTS synthesis.
+            text = ""
+            audio: NotGivenOr[AsyncIterable[rtc.AudioFrame]] = NOT_GIVEN
+            if isinstance(message, BuiltinAudioClip):
+                audio = audio_frames_from_file(message.path())
+            elif isinstance(message, str):
+                if os.path.isfile(message):
+                    audio = audio_frames_from_file(message)
+                else:
+                    text = message
+            else:
+                audio = message
+
+            handle = self.say(text, audio=audio, allow_interruptions=False, add_to_chat_ctx=False)
+            await asyncio.wait_for(handle.wait_for_playout(), timeout=_ERROR_MESSAGE_PLAYOUT_TIMEOUT)
+        except Exception:
+            logger.warning("failed to play the unrecoverable-error message", exc_info=True)
+        finally:
+            await self._aclose_impl(error=error, reason=CloseReason.ERROR)
 
     @utils.log_exceptions(logger=logger)
     async def _forward_audio_task(self) -> None:

--- a/livekit-agents/livekit/agents/voice/audio_source.py
+++ b/livekit-agents/livekit/agents/voice/audio_source.py
@@ -26,4 +26,8 @@ class BuiltinAudioClip(enum.Enum):
         return str(_resource_stack.enter_context(as_file(file_path)))
 
 
+# Note: consumers interpret the `str` arm differently. AgentSession (error-message
+# playout) treats a str as a file path only when os.path.isfile() is true, otherwise
+# as text to synthesize via TTS; BackgroundAudioPlayer always treats a str as a file
+# path (no TTS fallback). The contracts genuinely differ, so there is no shared resolver.
 AudioSource = AsyncIterator[rtc.AudioFrame] | str | BuiltinAudioClip

--- a/livekit-agents/livekit/agents/voice/audio_source.py
+++ b/livekit-agents/livekit/agents/voice/audio_source.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import atexit
+import contextlib
+import enum
+from collections.abc import AsyncIterator
+from importlib.resources import as_file, files
+
+from livekit import rtc
+
+_resource_stack = contextlib.ExitStack()
+atexit.register(_resource_stack.close)
+
+
+class BuiltinAudioClip(enum.Enum):
+    CITY_AMBIENCE = "city-ambience.ogg"
+    FOREST_AMBIENCE = "forest-ambience.ogg"
+    OFFICE_AMBIENCE = "office-ambience.ogg"
+    CROWDED_ROOM = "crowded-room.ogg"
+    KEYBOARD_TYPING = "keyboard-typing.ogg"
+    KEYBOARD_TYPING2 = "keyboard-typing2.ogg"
+    HOLD_MUSIC = "hold_music.ogg"
+
+    def path(self) -> str:
+        file_path = files("livekit.agents.resources") / self.value
+        return str(_resource_stack.enter_context(as_file(file_path)))
+
+
+AudioSource = AsyncIterator[rtc.AudioFrame] | str | BuiltinAudioClip

--- a/livekit-agents/livekit/agents/voice/background_audio.py
+++ b/livekit-agents/livekit/agents/voice/background_audio.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-import atexit
 import contextlib
-import enum
 import random
 from collections.abc import AsyncGenerator, AsyncIterator, Generator
-from importlib.resources import as_file, files
 from typing import Any, NamedTuple
 
 import numpy as np
@@ -20,27 +17,8 @@ from ..utils import is_given, log_exceptions
 from ..utils.aio import cancel_and_wait
 from ..utils.audio import audio_frames_from_file
 from .agent_session import AgentSession
+from .audio_source import AudioSource, BuiltinAudioClip
 from .events import AgentStateChangedEvent
-
-_resource_stack = contextlib.ExitStack()
-atexit.register(_resource_stack.close)
-
-
-class BuiltinAudioClip(enum.Enum):
-    CITY_AMBIENCE = "city-ambience.ogg"
-    FOREST_AMBIENCE = "forest-ambience.ogg"
-    OFFICE_AMBIENCE = "office-ambience.ogg"
-    CROWDED_ROOM = "crowded-room.ogg"
-    KEYBOARD_TYPING = "keyboard-typing.ogg"
-    KEYBOARD_TYPING2 = "keyboard-typing2.ogg"
-    HOLD_MUSIC = "hold_music.ogg"
-
-    def path(self) -> str:
-        file_path = files("livekit.agents.resources") / self.value
-        return str(_resource_stack.enter_context(as_file(file_path)))
-
-
-AudioSource = AsyncIterator[rtc.AudioFrame] | str | BuiltinAudioClip
 
 
 def _frame_gain(

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,249 @@
+"""Tests for typed API errors, in particular the inference quota-exceeded error.
+
+Covers:
+- InferenceQuotaExceededError field extraction / retryable semantics
+- InferenceQuotaExceededError.from_response detection
+- create_api_error_from_http staying provider-agnostic (no quota special-casing)
+- the inference LLM plugin raising InferenceQuotaExceededError on a 429 quota body
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import openai
+import pytest
+
+from livekit.agents import (
+    APIConnectionError,
+    APIStatusError,
+    create_api_error_from_http,
+    inference,
+)
+from livekit.agents.inference import InferenceQuotaExceededError
+from livekit.agents.inference._exceptions import _INFERENCE_QUOTA_EXCEEDED_TYPE
+from livekit.agents.llm import ChatContext
+from livekit.agents.types import APIConnectOptions
+
+pytestmark = pytest.mark.unit
+
+
+def _quota_body(hint: str | None = "Wait for the next billing cycle or upgrade your plan.") -> dict:
+    """A credit-exhaustion (terminal) quota body."""
+    return {
+        "type": _INFERENCE_QUOTA_EXCEEDED_TYPE,
+        "error": "LLM token credit quota exceeded, category: MaxGatewayCredits, remaining_limit: 0",
+        "hint": hint,
+        "quota_type": "llm",
+        "category": "MaxGatewayCredits",
+        "remaining_limit": "0",
+        "free_tier": "false",
+        "documentation_url": "https://livekit.com/pricing",
+    }
+
+
+def _rate_limit_body() -> dict:
+    """A per-minute rate-limit (transient) quota body — same `type`, different category."""
+    return {
+        "type": _INFERENCE_QUOTA_EXCEEDED_TYPE,
+        "error": "LLM request/min rate limit exceeded",
+        "hint": "LLM request rate limit reached. Reduce request rate or upgrade your plan.",
+        "quota_type": "llm",
+        "category": "MaxConcurrentGatewayLLMRpm",
+        "remaining_limit": "0",
+    }
+
+
+def test_quota_error_extracts_fields_from_body() -> None:
+    err = InferenceQuotaExceededError("quota exceeded", status_code=429, body=_quota_body())
+
+    assert isinstance(err, APIStatusError)
+    assert err.status_code == 429
+    assert err.quota_type == "llm"
+    assert err.category == "MaxGatewayCredits"
+    assert err.hint == "Wait for the next billing cycle or upgrade your plan."
+    assert err.remaining_limit == "0"
+
+
+def test_credit_quota_error_is_terminal_and_not_retryable() -> None:
+    # credit exhaustion will fail identically on an immediate retry and every turn
+    err = InferenceQuotaExceededError("quota exceeded", status_code=429, body=_quota_body())
+    assert err.retryable is False
+    assert err.terminal is True
+
+
+def test_rate_limit_quota_error_is_retryable_and_not_terminal() -> None:
+    # a per-minute rate limit recovers via backoff: keep it retryable + non-terminal so
+    # it isn't misclassified as "out of credits" and doesn't kill the session on turn 1
+    err = InferenceQuotaExceededError("rate limited", status_code=429, body=_rate_limit_body())
+    assert err.category == "MaxConcurrentGatewayLLMRpm"
+    assert err.retryable is True
+    assert err.terminal is False
+
+
+def test_unknown_quota_category_defaults_to_transient() -> None:
+    # an unknown/missing category is treated as transient (no regression: it falls
+    # through the existing tolerance instead of killing the session immediately)
+    body = {**_quota_body(), "category": "SomeFutureCategory"}
+    err = InferenceQuotaExceededError("quota exceeded", status_code=429, body=body)
+    assert err.terminal is False
+    assert err.retryable is True
+
+
+def test_quota_error_explicit_terminal_and_retryable_override() -> None:
+    err = InferenceQuotaExceededError(
+        "rate limited", status_code=429, body=_rate_limit_body(), terminal=True, retryable=False
+    )
+    assert err.terminal is True
+    assert err.retryable is False
+
+
+def test_quota_error_explicit_fields_take_precedence_over_body() -> None:
+    err = InferenceQuotaExceededError(
+        "quota exceeded",
+        status_code=429,
+        body=_quota_body(),
+        quota_type="tts",
+        hint="custom hint",
+    )
+    assert err.quota_type == "tts"
+    assert err.hint == "custom hint"
+    # untouched fields still come from the body
+    assert err.category == "MaxGatewayCredits"
+
+
+def test_quota_error_missing_body_fields_are_none() -> None:
+    err = InferenceQuotaExceededError("quota exceeded", status_code=429, body={"type": "x"})
+    assert err.quota_type is None
+    assert err.category is None
+    assert err.hint is None
+    assert err.remaining_limit is None
+
+
+def test_quota_error_non_str_body_fields_are_dropped() -> None:
+    # wire data from a user-pointable endpoint: non-str values must not crash the
+    # category check (unhashable types) or leak into the `str | None` fields
+    body = {
+        "type": _INFERENCE_QUOTA_EXCEEDED_TYPE,
+        "quota_type": 3,
+        "category": ["MaxGatewayCredits"],  # unhashable without coercion
+        "hint": {"text": "x"},
+        "remaining_limit": 0,
+    }
+    err = InferenceQuotaExceededError("quota exceeded", status_code=429, body=body)
+    assert err.quota_type is None
+    assert err.category is None
+    assert err.hint is None
+    assert err.remaining_limit is None
+    # an invalid category cannot be credit exhaustion -> stays transient
+    assert err.terminal is False
+    assert err.retryable is True
+
+
+def test_from_response_detects_quota_body() -> None:
+    err = InferenceQuotaExceededError.from_response(
+        "quota exceeded", status_code=429, body=_quota_body()
+    )
+    assert isinstance(err, InferenceQuotaExceededError)
+    assert err.quota_type == "llm"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        None,
+        "rate limited",  # non-dict body (e.g. plain text)
+        {"type": "something_else"},
+        {"error": "no type field"},
+    ],
+)
+def test_from_response_returns_none_for_non_quota_body(body: object) -> None:
+    assert InferenceQuotaExceededError.from_response("msg", status_code=429, body=body) is None
+
+
+def test_create_api_error_from_http_stays_provider_agnostic() -> None:
+    # the generic helper never special-cases the inference quota schema, even for a
+    # quota-shaped body — typing that body is the inference plugin's job.
+    err = create_api_error_from_http("quota exceeded", status=429, body=_quota_body())
+    assert type(err) is APIStatusError
+
+
+def _inference_llm_raising(body: dict) -> tuple[inference.LLM, MagicMock, openai.AsyncClient]:
+    """Build an inference LLM whose client raises a 429 with ``body``.
+
+    The exception is constructed through the openai SDK's own response handling
+    (``_make_status_error_from_response``) so tests exercise the body shape real
+    gateway traffic produces: the SDK narrows a mapping body to its ``error`` value,
+    a bare string for gateway payloads, so the plugin must re-parse the response.
+
+    Returns (llm, mock_client, real_client). Swap the client *before* chat() so the
+    background stream task uses the mock. Caller must close the real client.
+    """
+    inference_llm = inference.LLM("gpt-4o", api_key="devkey", api_secret="s" * 32)
+    real_client = inference_llm._client
+
+    response = httpx.Response(
+        429, json=body, request=httpx.Request("POST", "http://x/v1/chat/completions")
+    )
+    status_error = real_client._make_status_error_from_response(response)
+    # the SDK unwrapped body["error"] — keep this pinned so the fixture stays honest
+    assert not isinstance(status_error.body, dict)
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(side_effect=status_error)
+    inference_llm._client = mock_client
+    return inference_llm, mock_client, real_client
+
+
+async def test_inference_llm_raises_quota_error_on_429() -> None:
+    """The inference LLM plugin surfaces a 429 credit-quota body as a typed,
+    terminal, non-retryable InferenceQuotaExceededError carrying the gateway hint."""
+    inference_llm, mock_client, real_client = _inference_llm_raising(_quota_body())
+
+    chat_ctx = ChatContext.empty()
+    chat_ctx.add_message(role="user", content="hello")
+
+    stream = inference_llm.chat(chat_ctx=chat_ctx)
+
+    with pytest.raises(InferenceQuotaExceededError) as exc_info:
+        async for _ in stream:
+            pass
+
+    err = exc_info.value
+    assert err.status_code == 429
+    assert err.quota_type == "llm"
+    assert err.hint == "Wait for the next billing cycle or upgrade your plan."
+    assert err.retryable is False
+    assert err.terminal is True
+
+    # credit exhaustion is terminal: no retries, the endpoint is hit exactly once
+    assert mock_client.chat.completions.create.await_count == 1
+
+    await stream.aclose()
+    await real_client.close()
+
+
+async def test_inference_llm_retries_rate_limit_429() -> None:
+    """A 429 rate-limit body is retryable, so the stream retries it with backoff
+    instead of giving up on the first attempt (contrast with credit exhaustion)."""
+    inference_llm, mock_client, real_client = _inference_llm_raising(_rate_limit_body())
+
+    chat_ctx = ChatContext.empty()
+    chat_ctx.add_message(role="user", content="hello")
+
+    max_retry = 2
+    stream = inference_llm.chat(
+        chat_ctx=chat_ctx,
+        conn_options=APIConnectOptions(max_retry=max_retry, retry_interval=0.0),
+    )
+
+    # after exhausting retries the stream raises APIConnectionError, not the 429
+    with pytest.raises(APIConnectionError):
+        async for _ in stream:
+            pass
+
+    assert mock_client.chat.completions.create.await_count == max_retry + 1
+
+    await stream.aclose()
+    await real_client.close()

--- a/tests/test_unrecoverable_error.py
+++ b/tests/test_unrecoverable_error.py
@@ -135,6 +135,23 @@ async def test_quota_error_closes_on_first_occurrence() -> None:
     await session.aclose()
 
 
+async def test_user_error_handler_runs_before_close_decision() -> None:
+    session = _make_session()
+    await session.start(_Agent())
+
+    @session.on("error")
+    def _keep_alive(ev: ErrorEvent) -> None:
+        ev.error.recoverable = True
+
+    activity = session._activity
+    assert activity is not None
+    activity._on_error(_llm_error(_quota_error()))  # terminal: would close without the flip
+
+    assert session._closing_task is None
+
+    await session.aclose()
+
+
 async def test_generic_unrecoverable_error_is_tolerated() -> None:
     # a non-terminal unrecoverable error is still absorbed up to max_unrecoverable_errors,
     # so a single blip does not close the session
@@ -468,23 +485,16 @@ async def test_error_message_non_path_string_falls_back_to_tts(
     await session.aclose()
 
 
-async def test_emit_error_event_drives_unrecoverable_close() -> None:
-    # the close teardown is driven by the "error" event itself: a single emit() with an
-    # unrecoverable error must spawn the close, independent of the activity's _on_error
+async def test_bare_emit_error_does_not_close() -> None:
+    # teardown is owned by the activity's _on_error, not by the "error" event itself, so
+    # a bare emit() (e.g. from user code) must not close the session.
     session = _make_session(unrecoverable_error_message=None)
     await session.start(_Agent())
-
-    close_events: list = []
-    session.on("close", close_events.append)
 
     activity = session._activity
     assert activity is not None
     session.emit("error", ErrorEvent(error=_llm_error(_quota_error()), source=activity.llm))
 
-    closing_task = session._closing_task
-    assert closing_task is not None, "emitting an unrecoverable error must drive the close"
-    await closing_task
-
-    assert close_events[0].reason == CloseReason.ERROR
+    assert session._closing_task is None
 
     await session.aclose()

--- a/tests/test_unrecoverable_error.py
+++ b/tests/test_unrecoverable_error.py
@@ -1,0 +1,490 @@
+"""Tests for how AgentSession surfaces unrecoverable errors to the end user.
+
+A terminal quota error (out of LiveKit Inference credits) must:
+- close the session on the FIRST occurrence rather than after
+  ``max_unrecoverable_errors`` silent dead turns, and
+- speak a generic, provider-agnostic fallback message before closing, so the
+  agent never goes silently unresponsive (the gateway ``hint`` is never spoken —
+  quota details aren't surfaced to end users).
+
+See https://github.com/livekit/agents/issues/6009
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+
+from livekit import rtc
+from livekit.agents import (
+    NOT_GIVEN,
+    Agent,
+    APIConnectOptions,
+    APIError,
+    BuiltinAudioClip,
+)
+from livekit.agents.inference import InferenceQuotaExceededError
+from livekit.agents.llm import LLMError, RealtimeModelError
+from livekit.agents.tts import TTS
+from livekit.agents.voice.agent_session import (
+    DEFAULT_UNRECOVERABLE_ERROR_MESSAGE,
+    AgentSession,
+    SessionConnectOptions,
+)
+from livekit.agents.voice.events import CloseReason, ErrorEvent
+
+from .fake_io import FakeAudioInput, FakeAudioOutput, FakeTextOutput
+from .fake_llm import FakeLLM
+from .fake_stt import FakeSTT
+from .fake_tts import FakeTTS
+from .fake_vad import FakeVAD
+
+pytestmark = pytest.mark.unit
+
+INFERENCE_QUOTA_BODY = {
+    "type": "inference_quota_exceeded",
+    "hint": "You're out of credits. Upgrade your plan or wait for the next cycle.",
+    "quota_type": "llm",
+    "category": "MaxGatewayCredits",
+    "remaining_limit": "0",
+}
+
+
+class _Agent(Agent):
+    def __init__(self) -> None:
+        super().__init__(instructions="You are a helpful assistant.")
+
+
+def _make_session(*, tts: TTS | None = None, **kwargs: Any) -> AgentSession:
+    session = AgentSession(
+        stt=FakeSTT(),
+        vad=FakeVAD(),
+        llm=FakeLLM(),
+        tts=tts or FakeTTS(fake_audio_duration=0.05),
+        aec_warmup_duration=None,
+        **kwargs,
+    )
+    session.input.audio = FakeAudioInput()
+    session.output.audio = FakeAudioOutput()
+    session.output.transcription = FakeTextOutput()
+    return session
+
+
+def _llm_error(exc: Exception) -> LLMError:
+    return LLMError(timestamp=time.time(), label="test-llm", error=exc, recoverable=False)
+
+
+def _realtime_error(exc: Exception) -> RealtimeModelError:
+    return RealtimeModelError(timestamp=time.time(), label="test-rt", error=exc, recoverable=False)
+
+
+def _quota_error(*, hint: str | None = INFERENCE_QUOTA_BODY["hint"]) -> InferenceQuotaExceededError:
+    body = {**INFERENCE_QUOTA_BODY, "hint": hint}
+    return InferenceQuotaExceededError(
+        "LLM token credit quota exceeded", status_code=429, body=body
+    )
+
+
+def _rate_limit_error() -> InferenceQuotaExceededError:
+    # same `type`, but a transient rate-limit category -> non-terminal, recoverable
+    body = {
+        "type": "inference_quota_exceeded",
+        "hint": "LLM request rate limit reached. Reduce request rate or upgrade your plan.",
+        "quota_type": "llm",
+        "category": "MaxConcurrentGatewayLLMRpm",
+        "remaining_limit": "0",
+    }
+    return InferenceQuotaExceededError("rate limited", status_code=429, body=body)
+
+
+def _spy_say(session: AgentSession) -> list[str]:
+    """Record the text passed to ``session.say`` while still calling through."""
+    spoken: list[str] = []
+    original_say = session.say
+
+    def spy(text: Any, **kwargs: Any) -> Any:
+        spoken.append(text)
+        return original_say(text, **kwargs)
+
+    session.say = spy  # type: ignore[method-assign]
+    return spoken
+
+
+async def test_quota_error_closes_on_first_occurrence() -> None:
+    # unrecoverable_error_message=None isolates the close behavior from the spoken-message path
+    session = _make_session(unrecoverable_error_message=None)
+    await session.start(_Agent())
+
+    close_events: list = []
+    session.on("close", close_events.append)
+
+    activity = session._activity
+    assert activity is not None
+    activity._on_error(_llm_error(_quota_error()))
+
+    closing_task = session._closing_task
+    assert closing_task is not None, "a terminal quota error must close on the first occurrence"
+    await closing_task
+
+    assert len(close_events) == 1
+    assert close_events[0].reason == CloseReason.ERROR
+    assert isinstance(close_events[0].error.error, InferenceQuotaExceededError)
+
+    await session.aclose()
+
+
+async def test_generic_unrecoverable_error_is_tolerated() -> None:
+    # a non-terminal unrecoverable error is still absorbed up to max_unrecoverable_errors,
+    # so a single blip does not close the session
+    session = _make_session()
+    await session.start(_Agent())
+
+    activity = session._activity
+    assert activity is not None
+    activity._on_error(_llm_error(APIError("transient blip")))
+
+    assert session._closing_task is None
+    assert session._llm_error_counts == 1
+
+    await session.aclose()
+
+
+@pytest.mark.parametrize("hint", ["You are out of credits.", None])
+async def test_quota_error_speaks_generic_message_by_default(hint: str | None) -> None:
+    # the gateway hint is never spoken — a terminal quota error always falls back to the
+    # generic, provider-agnostic message regardless of what the gateway sent.
+    session = _make_session()  # unrecoverable_error_message defaults to NOT_GIVEN
+    await session.start(_Agent())
+
+    spoken = _spy_say(session)
+
+    activity = session._activity
+    assert activity is not None
+    activity._on_error(_llm_error(_quota_error(hint=hint)))
+
+    closing_task = session._closing_task
+    assert closing_task is not None
+    await closing_task
+
+    assert spoken == [DEFAULT_UNRECOVERABLE_ERROR_MESSAGE]
+
+    await session.aclose()
+
+
+async def test_error_message_none_disables_spoken_fallback() -> None:
+    session = _make_session(unrecoverable_error_message=None)
+    await session.start(_Agent())
+
+    spoken = _spy_say(session)
+
+    activity = session._activity
+    assert activity is not None
+    activity._on_error(_llm_error(_quota_error()))
+
+    closing_task = session._closing_task
+    assert closing_task is not None
+    await closing_task
+
+    assert spoken == []
+
+    await session.aclose()
+
+
+async def test_custom_error_message_spoken_on_unrecoverable_error() -> None:
+    # a configured unrecoverable_error_message is spoken for any unrecoverable error, not
+    # just quota;
+    # max_unrecoverable_errors=0 forces the close on the first occurrence
+    session = _make_session(
+        unrecoverable_error_message="Goodbye for now.",
+        conn_options=SessionConnectOptions(max_unrecoverable_errors=0),
+    )
+    await session.start(_Agent())
+
+    spoken = _spy_say(session)
+
+    activity = session._activity
+    assert activity is not None
+    activity._on_error(_llm_error(APIError("boom")))
+
+    closing_task = session._closing_task
+    assert closing_task is not None
+    await closing_task
+
+    assert spoken == ["Goodbye for now."]
+
+    await session.aclose()
+
+
+async def test_custom_error_message_overrides_default_for_quota() -> None:
+    # an explicit unrecoverable_error_message wins over the default generic message for
+    # quota errors
+    session = _make_session(unrecoverable_error_message="Custom branded message.")
+    await session.start(_Agent())
+
+    spoken = _spy_say(session)
+
+    activity = session._activity
+    assert activity is not None
+    activity._on_error(_llm_error(_quota_error(hint="Gateway hint.")))
+
+    closing_task = session._closing_task
+    assert closing_task is not None
+    await closing_task
+
+    assert spoken == ["Custom branded message."]
+
+    await session.aclose()
+
+
+async def test_rate_limit_quota_error_is_tolerated_not_terminal() -> None:
+    # a transient rate-limit quota error must NOT close on the first occurrence and
+    # must NOT speak "out of credits" — it falls through the normal tolerance
+    session = _make_session()
+    await session.start(_Agent())
+
+    spoken = _spy_say(session)
+
+    activity = session._activity
+    assert activity is not None
+    activity._on_error(_llm_error(_rate_limit_error()))
+
+    assert session._closing_task is None
+    assert session._llm_error_counts == 1
+    assert spoken == []
+
+    await session.aclose()
+
+
+async def test_realtime_quota_error_speaks_and_closes_on_first_occurrence() -> None:
+    # the realtime path routes through the same _on_error mechanism
+    session = _make_session()
+    await session.start(_Agent())
+
+    spoken = _spy_say(session)
+    close_events: list = []
+    session.on("close", close_events.append)
+
+    activity = session._activity
+    assert activity is not None
+    activity._on_error(_realtime_error(_quota_error(hint="Out of credits.")))
+
+    closing_task = session._closing_task
+    assert closing_task is not None
+    await closing_task
+
+    assert spoken == [DEFAULT_UNRECOVERABLE_ERROR_MESSAGE]
+    assert close_events[0].reason == CloseReason.ERROR
+
+    await session.aclose()
+
+
+async def test_speaking_error_message_survives_tts_failure() -> None:
+    # best-effort: if the TTS fails while speaking the fallback, the session must still
+    # close cleanly and emit the close event (never strand the session open)
+    session = _make_session(
+        tts=FakeTTS(fake_audio_duration=0.05, fake_exception=APIError("tts down")),
+        # fail fast so the deliberate TTS error isn't retried with backoff
+        conn_options=SessionConnectOptions(
+            tts_conn_options=APIConnectOptions(max_retry=0, retry_interval=0.0)
+        ),
+    )
+    await session.start(_Agent())
+
+    close_events: list = []
+    session.on("close", close_events.append)
+
+    activity = session._activity
+    assert activity is not None
+    activity._on_error(_llm_error(_quota_error()))
+
+    closing_task = session._closing_task
+    assert closing_task is not None
+    await closing_task
+
+    assert len(close_events) == 1
+    assert close_events[0].reason == CloseReason.ERROR
+
+    await session.aclose()
+
+
+async def test_no_spoken_fallback_without_audio_output() -> None:
+    # with no audio output sink, speaking is skipped but the session still closes
+    session = _make_session()
+    session.output.audio = None
+    await session.start(_Agent())
+
+    spoken = _spy_say(session)
+    close_events: list = []
+    session.on("close", close_events.append)
+
+    activity = session._activity
+    assert activity is not None
+    activity._on_error(_llm_error(_quota_error()))
+
+    closing_task = session._closing_task
+    assert closing_task is not None
+    await closing_task
+
+    assert spoken == []
+    assert close_events[0].reason == CloseReason.ERROR
+
+    await session.aclose()
+
+
+# --- str | AudioSource error messages -------------------------------------------------
+
+
+async def _silent_frames() -> Any:
+    yield rtc.AudioFrame(
+        data=b"\x00\x00" * 240, sample_rate=24000, num_channels=1, samples_per_channel=240
+    )
+
+
+def _spy_say_calls(session: AgentSession) -> list[dict[str, Any]]:
+    """Record both the text and the ``audio`` kwarg passed to ``session.say``."""
+    calls: list[dict[str, Any]] = []
+    original_say = session.say
+
+    def spy(text: Any, **kwargs: Any) -> Any:
+        calls.append({"text": text, "audio": kwargs.get("audio", NOT_GIVEN)})
+        return original_say(text, **kwargs)
+
+    session.say = spy  # type: ignore[method-assign]
+    return calls
+
+
+def _patch_audio_frames(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Capture paths passed to audio_frames_from_file; avoid real audio decoding."""
+    paths: list[str] = []
+
+    def fake(path: str, *args: Any, **kwargs: Any) -> Any:
+        paths.append(path)
+        return _silent_frames()
+
+    monkeypatch.setattr("livekit.agents.voice.agent_session.audio_frames_from_file", fake)
+    return paths
+
+
+async def test_error_message_file_path_plays_audio(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # a str that points at an existing file is played as audio, not synthesized via TTS
+    audio_file = tmp_path / "bye.ogg"
+    audio_file.write_bytes(b"fake-ogg")
+    decoded_paths = _patch_audio_frames(monkeypatch)
+
+    session = _make_session(unrecoverable_error_message=str(audio_file))
+    await session.start(_Agent())
+    calls = _spy_say_calls(session)
+
+    activity = session._activity
+    assert activity is not None
+    activity._on_error(_llm_error(_quota_error()))
+
+    closing_task = session._closing_task
+    assert closing_task is not None
+    await closing_task
+
+    assert decoded_paths == [str(audio_file)]
+    assert len(calls) == 1
+    assert calls[0]["text"] == ""  # no TTS text — audio is played as-is
+    assert calls[0]["audio"] is not NOT_GIVEN
+
+    await session.aclose()
+
+
+async def test_error_message_builtin_clip_plays_audio(monkeypatch: pytest.MonkeyPatch) -> None:
+    decoded_paths = _patch_audio_frames(monkeypatch)
+
+    session = _make_session(unrecoverable_error_message=BuiltinAudioClip.HOLD_MUSIC)
+    await session.start(_Agent())
+    calls = _spy_say_calls(session)
+
+    activity = session._activity
+    assert activity is not None
+    activity._on_error(_llm_error(_quota_error()))
+
+    closing_task = session._closing_task
+    assert closing_task is not None
+    await closing_task
+
+    assert decoded_paths == [BuiltinAudioClip.HOLD_MUSIC.path()]
+    assert calls[0]["text"] == ""
+    assert calls[0]["audio"] is not NOT_GIVEN
+
+    await session.aclose()
+
+
+async def test_error_message_audio_iterator_played_directly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # a pre-built AudioSource iterator is forwarded as-is (no file decoding)
+    decoded_paths = _patch_audio_frames(monkeypatch)
+    frames = _silent_frames()
+
+    session = _make_session(unrecoverable_error_message=frames)
+    await session.start(_Agent())
+    calls = _spy_say_calls(session)
+
+    activity = session._activity
+    assert activity is not None
+    activity._on_error(_llm_error(_quota_error()))
+
+    closing_task = session._closing_task
+    assert closing_task is not None
+    await closing_task
+
+    assert decoded_paths == []  # not a path/clip — never decoded from file
+    assert calls[0]["text"] == ""
+    assert calls[0]["audio"] is frames
+
+    await session.aclose()
+
+
+async def test_error_message_non_path_string_falls_back_to_tts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # a str that is NOT an existing file is synthesized through TTS (legacy behavior)
+    decoded_paths = _patch_audio_frames(monkeypatch)
+
+    session = _make_session(unrecoverable_error_message="The assistant is unavailable.")
+    await session.start(_Agent())
+    calls = _spy_say_calls(session)
+
+    activity = session._activity
+    assert activity is not None
+    activity._on_error(_llm_error(_quota_error()))
+
+    closing_task = session._closing_task
+    assert closing_task is not None
+    await closing_task
+
+    assert decoded_paths == []
+    assert calls[0]["text"] == "The assistant is unavailable."
+    assert calls[0]["audio"] is NOT_GIVEN
+
+    await session.aclose()
+
+
+async def test_emit_error_event_drives_unrecoverable_close() -> None:
+    # the close teardown is driven by the "error" event itself: a single emit() with an
+    # unrecoverable error must spawn the close, independent of the activity's _on_error
+    session = _make_session(unrecoverable_error_message=None)
+    await session.start(_Agent())
+
+    close_events: list = []
+    session.on("close", close_events.append)
+
+    activity = session._activity
+    assert activity is not None
+    session.emit("error", ErrorEvent(error=_llm_error(_quota_error()), source=activity.llm))
+
+    closing_task = session._closing_task
+    assert closing_task is not None, "emitting an unrecoverable error must drive the close"
+    await closing_task
+
+    assert close_events[0].reason == CloseReason.ERROR
+
+    await session.aclose()


### PR DESCRIPTION
An unrecoverable error (e.g. out of LiveKit Inference credits) used to leave the agent silently connected but mute. Now `AgentSession`:

- **Closes on the first terminal error** instead of waiting out `max_unrecoverable_errors` identical failures.
- **Speaks `unrecoverable_error_message` before closing**, so the agent isn't silent — a `str` (synthesized via TTS, or played as-is if it's a file path), an `AudioSource` / `BuiltinAudioClip` (played directly, so it survives a dead TTS), or `None` to disable. Defaults to a generic message on terminal errors.

Inference `429` quota errors are now a typed **`InferenceQuotaExceededError`** (`livekit.agents.inference`) you can catch from the `error` event, carrying the gateway's `quota_type` / `category` / `hint`. Quota details are never spoken to end users.

---

Supersedes #6012 (consolidated; original author credited as co-author). Closes #6009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
