### PR TITLE
fix(openai): default reasoning_effort to none for gpt-5.4-mini

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -124,7 +124,10 @@ class LLM(llm.LLM):
         super().__init__()
 
         if not is_given(reasoning_effort) and _supports_reasoning_effort(model):
-            if model in ["gpt-5.1", "gpt-5.2", "gpt-5.4"]:
+            # gpt-5.1+ dropped "minimal" as a valid reasoning_effort; sending it
+            # back to the API returns a 400. mini/nano variants of those models
+            # inherit the same rejection.
+            if model in ["gpt-5.1", "gpt-5.2", "gpt-5.4", "gpt-5.4-mini"]:
                 reasoning_effort = "none"
             else:
                 reasoning_effort = "minimal"

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -186,7 +186,10 @@ class LLM(llm.LLM):
         super().__init__()
 
         if not is_given(reasoning) and _supports_reasoning_effort(model):
-            if model in ["gpt-5.1", "gpt-5.2", "gpt-5.4"]:
+            # gpt-5.1+ dropped "minimal" as a valid reasoning_effort; sending it
+            # back to the API returns a 400. mini/nano variants of those models
+            # inherit the same rejection.
+            if model in ["gpt-5.1", "gpt-5.2", "gpt-5.4", "gpt-5.4-mini"]:
                 reasoning = Reasoning(effort="none")
             else:
                 reasoning = Reasoning(effort="minimal")

--- a/tests/test_plugin_openai_llm_reasoning_effort.py
+++ b/tests/test_plugin_openai_llm_reasoning_effort.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from livekit.plugins.openai import LLM
+from livekit.plugins.openai.responses import LLM as ResponsesLLM
+
+pytestmark = pytest.mark.plugin("openai")
+
+
+# Models whose API rejects ``reasoning_effort="minimal"`` and only accepts the
+# new ``none/low/medium/high/xhigh`` set, so the plugin must default to
+# ``"none"`` when the user didn't pass an explicit value.
+_NO_MINIMAL_MODELS = ["gpt-5.1", "gpt-5.2", "gpt-5.4", "gpt-5.4-mini"]
+
+
+@pytest.mark.parametrize("model", _NO_MINIMAL_MODELS)
+def test_chat_completions_llm_defaults_reasoning_effort_to_none(model: str) -> None:
+    """Regression for #6147: gpt-5.4-mini and other gpt-5.1+ variants reject
+    ``reasoning_effort="minimal"``."""
+    llm = LLM(model=model, api_key="sk-test")
+    assert llm._opts.reasoning_effort == "none"
+
+
+@pytest.mark.parametrize("model", _NO_MINIMAL_MODELS)
+def test_responses_llm_defaults_reasoning_effort_to_none(model: str) -> None:
+    """Same gap on the Responses-API wrapper (mirrors `LLM.__init__`)."""
+    llm = ResponsesLLM(model=model, api_key="sk-test")
+    assert llm._opts.reasoning is not None
+    assert llm._opts.reasoning.effort == "none"
+
+
+def test_chat_completions_llm_keeps_minimal_default_for_gpt_5() -> None:
+    """The pre-existing default for plain gpt-5 (which still accepts
+    ``"minimal"``) must keep working."""
+    llm = LLM(model="gpt-5", api_key="sk-test")
+    assert llm._opts.reasoning_effort == "minimal"


### PR DESCRIPTION
Closes #6147.

`openai.LLM(model="gpt-5.4-mini")` and the Responses-API wrapper used to default `reasoning_effort` to `"minimal"` whenever the model wasn't one of `gpt-5.1` / `gpt-5.2` / `gpt-5.4`. gpt-5.4-mini *does* support `reasoning_effort` (it's in `_supports_reasoning_effort`), but the OpenAI API rejects `"minimal"` for it and the other gpt-5.1+ mini variants:

```
APIStatusError: 400 - Unsupported value: 'reasoning_effort' does not support 'minimal' with this model.
Supported values are: 'none', 'low', 'medium', 'high', and 'xhigh'.
```

Added `gpt-5.4-mini` to the `"none"`-default list in both `llm.py` and `responses/llm.py` (these two constructors share the same default-resolution shape, so the patch lands in both).

### Tests

New `tests/test_plugin_openai_llm_reasoning_effort.py` parameterises over `gpt-5.1`, `gpt-5.2`, `gpt-5.4`, and `gpt-5.4-mini` on both the chat-completions and Responses-API constructors, and pins the existing `gpt-5` → `"minimal"` default so the surrounding behaviour can't silently drift. `make format`, `make lint`, `make type-check`, and `uv run pytest --plugin openai tests/test_plugin_openai_llm_reasoning_effort.py` are all green locally.