### PR TITLE
feat(assemblyai): add streaming mode (latency/accuracy preset) param

### DIFF
--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -75,6 +75,7 @@ class STTOptions:
     domain: NotGivenOr[str] = NOT_GIVEN
     voice_focus: NotGivenOr[Literal["near-field", "far-field"]] = NOT_GIVEN
     voice_focus_threshold: NotGivenOr[float] = NOT_GIVEN
+    mode: NotGivenOr[Literal["min_latency", "balanced", "max_accuracy"]] = NOT_GIVEN
 
 
 # Speech models in the u3-rt-pro family, which share the same parameter support
@@ -116,6 +117,7 @@ class STT(stt.STT):
         domain: NotGivenOr[str] = NOT_GIVEN,
         voice_focus: NotGivenOr[Literal["near-field", "far-field"]] = NOT_GIVEN,
         voice_focus_threshold: NotGivenOr[float] = NOT_GIVEN,
+        mode: NotGivenOr[Literal["min_latency", "balanced", "max_accuracy"]] = NOT_GIVEN,
         http_session: aiohttp.ClientSession | None = None,
         buffer_size_seconds: float = 0.05,
         base_url: str = "wss://streaming.assemblyai.com",
@@ -170,6 +172,14 @@ class STT(stt.STT):
                 alongside `voice_focus`. Only supported with the 'u3-rt-pro' /
                 'u3-rt-pro-beta-1' / 'universal-3-5-pro' models. Set at construction (connect)
                 time only.
+            mode: Accuracy/latency preset forwarded to the u3-pro model: 'min_latency'
+                (fastest time-to-text), 'balanced' (the server default, recommended for
+                voice agents), or 'max_accuracy' (highest accuracy, for scribes/post-call).
+                The model applies its own per-mode tuning; any silence, partials, or VAD
+                knobs you set explicitly still take precedence over the mode's defaults.
+                Leave unset to use the server default. Only supported with the 'u3-rt-pro' /
+                'u3-rt-pro-beta-1' / 'universal-3-5-pro' models. Set at construction (connect)
+                time only.
         """
         super().__init__(
             capabilities=stt.STTCapabilities(
@@ -194,6 +204,7 @@ class STT(stt.STT):
                 "interruption_delay": interruption_delay,
                 "voice_focus": voice_focus,
                 "voice_focus_threshold": voice_focus_threshold,
+                "mode": mode,
             }
             for _param_name, _param_value in _u3_pro_only_params.items():
                 if is_given(_param_value):
@@ -254,6 +265,7 @@ class STT(stt.STT):
             domain=domain,
             voice_focus=voice_focus,
             voice_focus_threshold=voice_focus_threshold,
+            mode=mode,
         )
         self._session = http_session
         self._streams = weakref.WeakSet[SpeechStream]()
@@ -669,6 +681,7 @@ class SpeechStream(stt.SpeechStream):
             "voice_focus_threshold": self._opts.voice_focus_threshold
             if is_given(self._opts.voice_focus_threshold)
             else None,
+            "mode": self._opts.mode if is_given(self._opts.mode) else None,
         }
 
         headers = {

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -710,3 +710,102 @@ async def test_default_model_defaults_continuous_partials_true():
 
     stt = STT(api_key="test-key")
     assert stt._opts.continuous_partials is True
+
+
+# ---------------------------------------------------------------------------
+# mode (latency/accuracy preset)
+#
+# `mode` selects the u3-pro accuracy/latency tradeoff: "min_latency",
+# "balanced" (server default), or "max_accuracy". It is forwarded to the
+# u3-pro ASR server, which applies its own per-mode tuning, so it is
+# u3-rt-pro-family-only and connect-time only (not exposed via update_options,
+# matching the official AssemblyAI SDK, where `mode` lives on the connect-time
+# parameters and not on UpdateConfiguration).
+# ---------------------------------------------------------------------------
+
+
+async def test_mode_default():
+    """mode is unset by default (server default of 'balanced' applies)."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key")
+    assert stt._opts.mode is NOT_GIVEN
+
+
+async def test_mode_set():
+    """mode accepts each documented value."""
+    from livekit.plugins.assemblyai import STT
+
+    for value in ("min_latency", "balanced", "max_accuracy"):
+        stt = STT(api_key="test-key", model="u3-rt-pro", mode=value)
+        assert stt._opts.mode == value
+
+
+async def test_mode_requires_u3_pro_family():
+    """mode raises ValueError when used with a non-u3-rt-pro-family model."""
+    from livekit.plugins.assemblyai import STT
+
+    with pytest.raises(ValueError, match="mode"):
+        STT(api_key="test-key", model="universal-streaming-english", mode="max_accuracy")
+
+
+async def test_mode_allowed_for_all_u3_pro_family_models():
+    """mode is accepted for every u3-rt-pro-family model, not just the default."""
+    from livekit.plugins.assemblyai import STT
+
+    for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro"):
+        stt = STT(api_key="test-key", model=model, mode="min_latency")
+        assert stt._opts.mode == "min_latency"
+
+
+async def test_mode_in_connect_config():
+    """mode is sent in the connect config query."""
+    from urllib.parse import parse_qs, urlparse
+
+    from livekit.plugins.assemblyai import STT
+
+    captured: dict = {}
+
+    async def _fake_ws_connect(url, **kwargs):
+        captured["url"] = url
+        return MagicMock()
+
+    stt = STT(api_key="test-key", model="universal-3-5-pro", mode="max_accuracy")
+    stream = _make_stream_for_unit_test(stt)
+    stream._session.ws_connect = _fake_ws_connect
+    await stream._connect_ws()
+
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert query["mode"] == ["max_accuracy"]
+
+
+async def test_mode_absent_from_connect_config_when_unset():
+    """mode key is omitted from the connect config when not set."""
+    from urllib.parse import parse_qs, urlparse
+
+    from livekit.plugins.assemblyai import STT
+
+    captured: dict = {}
+
+    async def _fake_ws_connect(url, **kwargs):
+        captured["url"] = url
+        return MagicMock()
+
+    stt = STT(api_key="test-key", model="universal-3-5-pro")
+    stream = _make_stream_for_unit_test(stt)
+    stream._session.ws_connect = _fake_ws_connect
+    await stream._connect_ws()
+
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert "mode" not in query
+
+
+async def test_mode_connect_time_only():
+    """mode is connect-time only — not exposed via update_options."""
+    import inspect
+
+    from livekit.plugins.assemblyai import STT
+    from livekit.plugins.assemblyai.stt import SpeechStream
+
+    assert "mode" not in inspect.signature(STT.update_options).parameters
+    assert "mode" not in inspect.signature(SpeechStream.update_options).parameters


### PR DESCRIPTION
## Summary

Adds a `mode` streaming parameter to the AssemblyAI STT plugin, exposing the u3-pro accuracy/latency preset:

- `min_latency` — fastest time-to-text
- `balanced` — the server default, recommended for voice agents
- `max_accuracy` — highest accuracy, for scribes/post-call

`mode` is forwarded to the u3-pro ASR server, which applies its own per-mode tuning. Any silence / partials / VAD knobs set explicitly still take precedence over the mode's defaults.

## Details

- **u3-rt-pro-family only** (`u3-rt-pro`, `u3-rt-pro-beta-1`, `universal-3-5-pro`) — passing `mode` with any other model raises `ValueError`, consistent with the other u3-pro-gated params (`prompt`, `voice_focus`, etc.).
- **Connect-time only**, not exposed via `update_options`. This mirrors the official AssemblyAI Python SDK, where `mode` lives on the connect-time `StreamingParameters` and is not part of `UpdateConfiguration`.
- Sent as a connection query parameter; omitted entirely when unset so the server default applies.

Implementation follows the existing `voice_focus` param precedent (#6119).

## Test plan

New tests in `tests/test_plugin_assemblyai_stt.py`:
- default (unset)
- accepts each of the three values
- raises for non-u3-pro-family models
- accepted for every u3-pro-family model
- present in the connect config query when set / absent when unset
- not exposed via `update_options` (connect-time only)

All 58 plugin tests pass; `ruff format`, `ruff check`, and `mypy` clean.