### PR TITLE
feat(fishaudio): add speed/volume prosody params and default to s2.1-pro

### DIFF
--- a/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/models.py
+++ b/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/models.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-TTSModels = Literal["s1", "s2-pro"]
+TTSModels = Literal["s1", "s2-pro", "s2.1-pro"]
 
 OutputFormat = Literal["wav", "pcm", "mp3", "opus"]
 

--- a/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/tts.py
+++ b/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/tts.py
@@ -25,7 +25,7 @@ from .log import logger
 from .models import LatencyMode, OutputFormat, TTSModels
 from .version import __version__
 
-DEFAULT_MODEL: TTSModels = "s2-pro"
+DEFAULT_MODEL: TTSModels = "s2.1-pro"
 DEFAULT_VOICE_ID = "933563129e564b19a115bedd57b7406a"
 DEFAULT_BASE_URL = "https://api.fish.audio"
 NUM_CHANNELS = 1
@@ -51,6 +51,8 @@ class _TTSOptions:
     api_key: str
     latency_mode: LatencyMode
     chunk_length: int
+    speed: NotGivenOr[float]
+    volume: NotGivenOr[float]
 
     def get_http_url(self, path: str) -> str:
         return f"{self.base_url}{path}"
@@ -71,6 +73,8 @@ class TTS(tts.TTS):
         base_url: NotGivenOr[str] = NOT_GIVEN,
         latency_mode: LatencyMode = "balanced",
         chunk_length: int = 100,
+        speed: NotGivenOr[float] = NOT_GIVEN,
+        volume: NotGivenOr[float] = NOT_GIVEN,
         tokenizer: NotGivenOr[tokenize.SentenceTokenizer] = NOT_GIVEN,
         http_session: aiohttp.ClientSession | None = None,
     ) -> None:
@@ -82,7 +86,7 @@ class TTS(tts.TTS):
 
         Args:
             api_key (NotGivenOr[str]): Fish Audio API key. Reads ``FISH_API_KEY`` if unset.
-            model (TTSModels | str): TTS model to use. Defaults to ``"s2-pro"``.
+            model (TTSModels | str): TTS model to use. Defaults to ``"s2.1-pro"``.
             voice_id (NotGivenOr[str]): Voice model ID. Fish Audio's API refers to this
                 as ``reference_id``; it's the same value either way.
             output_format (OutputFormat): Audio output format. Defaults to ``"wav"``.
@@ -94,6 +98,12 @@ class TTS(tts.TTS):
                 (100–300). With sentence-level flushing this is only hit by sentences longer
                 than ``chunk_length``; otherwise audio is produced when each sentence is
                 flushed. Defaults to 100.
+            speed (NotGivenOr[float]): Speaking rate multiplier (Fish ``prosody.speed``).
+                ``1.0`` is normal; below 1.0 is slower, above is faster. Unset uses the
+                voice's natural pace.
+            volume (NotGivenOr[float]): Loudness adjustment in decibels (Fish
+                ``prosody.volume``). ``0`` is the voice's natural level. Unset leaves it
+                unchanged.
             tokenizer (tokenize.SentenceTokenizer): Sentence tokenizer used to detect
                 sentence boundaries. Defaults to ``tokenize.blingfire.SentenceTokenizer()``.
             http_session (aiohttp.ClientSession | None): Optional aiohttp session.
@@ -133,6 +143,8 @@ class TTS(tts.TTS):
             api_key=fish_api_key,
             latency_mode=latency_mode,
             chunk_length=chunk_length,
+            speed=speed,
+            volume=volume,
         )
 
         self._session = http_session
@@ -178,6 +190,8 @@ class TTS(tts.TTS):
         voice_id: NotGivenOr[str] = NOT_GIVEN,
         latency_mode: NotGivenOr[LatencyMode] = NOT_GIVEN,
         chunk_length: NotGivenOr[int] = NOT_GIVEN,
+        speed: NotGivenOr[float] = NOT_GIVEN,
+        volume: NotGivenOr[float] = NOT_GIVEN,
     ) -> None:
         if is_given(model):
             self._opts.model = model
@@ -189,6 +203,10 @@ class TTS(tts.TTS):
             if not 100 <= chunk_length <= 300:
                 raise ValueError("chunk_length must be between 100 and 300")
             self._opts.chunk_length = chunk_length
+        if is_given(speed):
+            self._opts.speed = speed
+        if is_given(volume):
+            self._opts.volume = volume
 
     def synthesize(
         self,
@@ -218,6 +236,15 @@ def _build_tts_request(opts: _TTSOptions, *, text: str = "") -> dict[str, Any]:
     # server doesn't fall back to its own (larger) defaults — in particular the
     # docs default of `chunk_length=300` produces large bursts that leave audible
     # gaps between Fish's chunk boundaries.
+    # `prosody` stays None unless the caller set speed/volume, so the default
+    # request is byte-for-byte unchanged.
+    prosody: dict[str, float] | None = None
+    if is_given(opts.speed) or is_given(opts.volume):
+        prosody = {}
+        if is_given(opts.speed):
+            prosody["speed"] = opts.speed
+        if is_given(opts.volume):
+            prosody["volume"] = opts.volume
     return {
         "text": text,
         "chunk_length": opts.chunk_length,
@@ -231,7 +258,7 @@ def _build_tts_request(opts: _TTSOptions, *, text: str = "") -> dict[str, Any]:
         "reference_id": opts.voice_id if is_given(opts.voice_id) else None,
         "normalize": True,
         "latency": opts.latency_mode,
-        "prosody": None,
+        "prosody": prosody,
         "top_p": 0.7,
         "temperature": 0.7,
     }

--- a/tests/test_plugin_fishaudio_tts.py
+++ b/tests/test_plugin_fishaudio_tts.py
@@ -1,0 +1,89 @@
+"""Tests for Fish Audio TTS plugin configuration and request building."""
+
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents.types import NOT_GIVEN
+
+pytestmark = pytest.mark.plugin("fishaudio")
+
+
+def test_default_model_is_s2_1_pro():
+    """A bare TTS() defaults to the s2.1-pro model."""
+    from livekit.plugins.fishaudio import TTS
+
+    tts = TTS(api_key="test-key")
+    assert tts.model == "s2.1-pro"
+
+
+def test_model_variants_accepted():
+    """s1, s2-pro, and s2.1-pro are all accepted."""
+    from livekit.plugins.fishaudio import TTS
+
+    for model in ("s1", "s2-pro", "s2.1-pro"):
+        assert TTS(api_key="test-key", model=model).model == model
+
+
+def test_prosody_omitted_by_default():
+    """Without speed/volume the request sends prosody=None (unchanged default)."""
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    tts = TTS_opts()
+    assert tts.speed is NOT_GIVEN
+    assert tts.volume is NOT_GIVEN
+    assert _build_tts_request(tts, text="hi")["prosody"] is None
+
+
+def test_speed_sets_prosody():
+    """speed populates only prosody.speed."""
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    assert _build_tts_request(TTS_opts(speed=0.8), text="hi")["prosody"] == {"speed": 0.8}
+
+
+def test_volume_sets_prosody():
+    """volume populates only prosody.volume."""
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    assert _build_tts_request(TTS_opts(volume=-3.0), text="hi")["prosody"] == {"volume": -3.0}
+
+
+def test_speed_and_volume_set_prosody():
+    """speed and volume together populate both prosody fields."""
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    prosody = _build_tts_request(TTS_opts(speed=1.2, volume=-3.0), text="hi")["prosody"]
+    assert prosody == {"speed": 1.2, "volume": -3.0}
+
+
+def test_update_options_sets_speed_and_volume():
+    """update_options forwards speed/volume onto the request."""
+    from livekit.plugins.fishaudio import TTS
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    tts = TTS(api_key="test-key")
+    assert _build_tts_request(tts._opts, text="hi")["prosody"] is None
+
+    tts.update_options(speed=0.9, volume=2.0)
+    assert _build_tts_request(tts._opts, text="hi")["prosody"] == {"speed": 0.9, "volume": 2.0}
+
+
+def TTS_opts(**overrides):
+    """Build a _TTSOptions with sensible test defaults, overriding as needed."""
+    from livekit.plugins.fishaudio.tts import DEFAULT_BASE_URL, DEFAULT_MODEL, _TTSOptions
+
+    opts = {
+        "model": DEFAULT_MODEL,
+        "output_format": "wav",
+        "sample_rate": 24000,
+        "voice_id": NOT_GIVEN,
+        "base_url": DEFAULT_BASE_URL,
+        "api_key": "test-key",
+        "latency_mode": "balanced",
+        "chunk_length": 100,
+        "speed": NOT_GIVEN,
+        "volume": NOT_GIVEN,
+    }
+    opts.update(overrides)
+    return _TTSOptions(**opts)


### PR DESCRIPTION
## Summary
- **speed / volume**: new `fishaudio.TTS` params (and on `update_options`) wired to Fish Audio's `prosody` request field. `speed` is a rate multiplier (1.0 = normal), `volume` is a dB offset (0 = natural). Both default to `NOT_GIVEN` → `prosody` stays `null`, so existing requests are byte-for-byte unchanged.
- **s2.1-pro**: added to `TTSModels` and now the plugin default (was `s2-pro`). Markup/expressive tag injection is unaffected — the `s2` provider-key check still matches `s2.1-pro`.

## Test Plan
- `uv run pytest --plugin fishaudio` — 7 tests (default model, model variants, prosody omitted by default, speed/volume/both, `update_options` plumbing).
- ruff format + lint + mypy clean on touched files.