### PR TITLE
feat(phonic): handle user text input for Phonic plugin

### DIFF
--- a/examples/voice_agents/phonic_realtime_agent.py
+++ b/examples/voice_agents/phonic_realtime_agent.py
@@ -46,7 +46,7 @@ class MyAgent(Agent):
 server = AgentServer()
 
 
-@server.rtc_session()
+@server.rtc_session(agent_name="my-agent-june-18")
 async def entrypoint(ctx: JobContext):
     session = AgentSession()
     await session.start(agent=MyAgent(), room=ctx.room)

--- a/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
@@ -435,6 +435,11 @@ class RealtimeSession(llm.RealtimeSession):
             self._generate_reply_task.cancel()
         self._generate_reply_task = asyncio.create_task(self._send_say(text), name="phonic-say")
 
+        # say() drives speech directly and supersedes any buffered user text turn. Drop it
+        # here since _send_say won't consume it, otherwise it would leak into a later
+        # generate_reply.
+        self._pending_user_text = None
+
         self._close_current_generation(interrupted=False)
 
         if self._pending_generate_reply_fut and not self._pending_generate_reply_fut.done():

--- a/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
@@ -328,7 +328,8 @@ class RealtimeSession(llm.RealtimeSession):
         diff_ops = llm.utils.compute_chat_ctx_diff(self._chat_ctx, chat_ctx)
         sent_tool_call_output = False
         sent_system_message = False
-        sent_user_message = False
+        buffered_user_text = False
+        last_item_id = chat_ctx.items[-1].id if chat_ctx.items else None
 
         for _, item_id in diff_ops.to_create:
             item = chat_ctx.get_by_id(item_id)
@@ -360,16 +361,21 @@ class RealtimeSession(llm.RealtimeSession):
                         )
                         sent_system_message = True
 
-            if isinstance(item, llm.ChatMessage) and item.role == "user":
+            # Only treat a user message as text input when it's appended at the tail of the context.
+            if (
+                isinstance(item, llm.ChatMessage)
+                and item.role == "user"
+                and item_id == last_item_id
+            ):
                 text = item.text_content
                 if text:
                     logger.info(f"Received user text input: {text}")
                     self._pending_user_text = text
-                    sent_user_message = True
+                    buffered_user_text = True
 
         self._chat_ctx = chat_ctx.copy()
 
-        if not sent_tool_call_output and not sent_system_message and not sent_user_message:
+        if not sent_tool_call_output and not sent_system_message and not buffered_user_text:
             logger.warning(
                 "update_chat_ctx called but no new tool call outputs to send. "
                 "Phonic does not support general chat context updates."
@@ -514,6 +520,7 @@ class RealtimeSession(llm.RealtimeSession):
                 # external cancel: drop the queued send if it hasn't gone out yet
                 if not send_task.done():
                     send_task.cancel()
+                self._pending_user_text = None
 
         fut.add_done_callback(_on_fut_done)
         return fut

--- a/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
@@ -270,6 +270,7 @@ class RealtimeSession(llm.RealtimeSession):
         self._pending_tool_call_ids: set[str] = set()
         self._tool_definitions: list[dict] = []
         self._system_prompt_postfix: str = ""
+        self._pending_user_text: str | None = None
 
     async def _close_active_session(self) -> None:
         async with self._session_lock:
@@ -327,6 +328,7 @@ class RealtimeSession(llm.RealtimeSession):
         diff_ops = llm.utils.compute_chat_ctx_diff(self._chat_ctx, chat_ctx)
         sent_tool_call_output = False
         sent_system_message = False
+        sent_user_message = False
 
         for _, item_id in diff_ops.to_create:
             item = chat_ctx.get_by_id(item_id)
@@ -358,9 +360,16 @@ class RealtimeSession(llm.RealtimeSession):
                         )
                         sent_system_message = True
 
+            if isinstance(item, llm.ChatMessage) and item.role == "user":
+                text = item.text_content
+                if text:
+                    logger.info(f"Received user text input: {text}")
+                    self._pending_user_text = text
+                    sent_user_message = True
+
         self._chat_ctx = chat_ctx.copy()
 
-        if not sent_tool_call_output and not sent_system_message:
+        if not sent_tool_call_output and not sent_system_message and not sent_user_message:
             logger.warning(
                 "update_chat_ctx called but no new tool call outputs to send. "
                 "Phonic does not support general chat context updates."
@@ -513,8 +522,24 @@ class RealtimeSession(llm.RealtimeSession):
         await self._ready_to_start.wait()
         if self._session_should_close.is_set():
             return
+
+        system_message = payload.system_message
+        if self._pending_user_text:
+            user_text_instruction = (
+                f'The user sent the following text message: "{self._pending_user_text}". '
+                "Please respond to their message."
+            )
+            system_message = (
+                f"{system_message}\n\n{user_text_instruction}"
+                if system_message
+                else user_text_instruction
+            )
+            self._pending_user_text = None
+
         if self._socket:
-            await self._socket.send_generate_reply(payload)
+            await self._socket.send_generate_reply(
+                GenerateReplyPayload(system_message=system_message)
+            )
 
     def commit_audio(self) -> None:
         logger.warning("commit_audio is not supported by the Phonic realtime model.")


### PR DESCRIPTION
When a user sends text (e.g. typing in a chat), the framework calls update_chat_ctx with the user message followed by generate_reply. Previously the Phonic plugin ignored user messages in update_chat_ctx, so text input was silently dropped.

This change:
- Detects new user messages in update_chat_ctx and stores the text
- Includes the user text in the generate_reply system_message sent to the Phonic downstream service, so the LLM can see and respond to typed user input

Tested in same manner as Typescript version: https://screen.studio/share/TViyimYO (didn't record again using python)

