### PR TITLE
fix(azure): emit STT recognition usage metrics

### DIFF
--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+import time
 import weakref
 from copy import deepcopy
 from dataclasses import dataclass
@@ -232,6 +233,8 @@ class SpeechStream(stt.SpeechStream):
 
         self._loop = asyncio.get_running_loop()
         self._reconnect_event = asyncio.Event()
+        self._audio_duration = 0.0
+        self._last_audio_duration_report_time = time.monotonic()
 
     def update_options(
         self,
@@ -280,7 +283,12 @@ class SpeechStream(stt.SpeechStream):
                 async def process_input() -> None:
                     async for input in self._input_ch:
                         if isinstance(input, rtc.AudioFrame):
+                            self._audio_duration += input.duration
+                            self._maybe_emit_recognition_usage()
                             self._stream.write(input.data.tobytes())
+                        elif isinstance(input, self._FlushSentinel):
+                            self._emit_recognition_usage()
+                    self._emit_recognition_usage()
 
                 process_input_task = asyncio.create_task(process_input())
                 wait_reconnect_task = asyncio.create_task(self._reconnect_event.wait())
@@ -348,6 +356,25 @@ class SpeechStream(stt.SpeechStream):
                 stt.SpeechEvent(
                     type=stt.SpeechEventType.FINAL_TRANSCRIPT, alternatives=[final_data]
                 ),
+            )
+
+    def _maybe_emit_recognition_usage(self) -> None:
+        if time.monotonic() - self._last_audio_duration_report_time >= 5.0:
+            self._emit_recognition_usage()
+
+    def _emit_recognition_usage(self) -> None:
+        if self._audio_duration <= 0.0:
+            return
+
+        audio_duration = self._audio_duration
+        self._audio_duration = 0.0
+        self._last_audio_duration_report_time = time.monotonic()
+        with contextlib.suppress(RuntimeError):
+            self._event_ch.send_nowait(
+                stt.SpeechEvent(
+                    type=stt.SpeechEventType.RECOGNITION_USAGE,
+                    recognition_usage=stt.RecognitionUsage(audio_duration=audio_duration),
+                )
             )
 
     def _on_recognizing(self, evt: speechsdk.SpeechRecognitionEventArgs) -> None:

--- a/tests/test_plugin_azure_stt.py
+++ b/tests/test_plugin_azure_stt.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+
+import pytest
+
+from livekit.agents import stt
+from livekit.plugins.azure import stt as azure_stt
+
+pytestmark = pytest.mark.plugin("azure")
+
+
+def test_azure_recognized_emits_final_transcript(monkeypatch):
+    events = []
+    monkeypatch.setattr(
+        azure_stt.speechsdk,
+        "AutoDetectSourceLanguageResult",
+        lambda result: SimpleNamespace(language="en-US"),
+    )
+
+    stream = azure_stt.SpeechStream.__new__(azure_stt.SpeechStream)
+    stream._opts = SimpleNamespace(language=["en-US"])
+    stream._loop = SimpleNamespace(call_soon_threadsafe=lambda callback, *args: callback(*args))
+    stream._event_ch = SimpleNamespace(send_nowait=events.append)
+    stream._start_time_offset = 0.0
+
+    stream._on_recognized(
+        SimpleNamespace(
+            result=SimpleNamespace(
+                text="hello",
+                offset=10_000_000,
+                duration=20_000_000,
+                result_id="azure-result-id",
+            )
+        )
+    )
+
+    assert [event.type for event in events] == [stt.SpeechEventType.FINAL_TRANSCRIPT]
+
+
+def test_azure_stream_emits_usage_for_processed_audio():
+    events = []
+    stream = azure_stt.SpeechStream.__new__(azure_stt.SpeechStream)
+    stream._event_ch = SimpleNamespace(send_nowait=events.append)
+    stream._audio_duration = 3.5
+    stream._last_audio_duration_report_time = 0.0
+
+    stream._emit_recognition_usage()
+
+    assert [event.type for event in events] == [stt.SpeechEventType.RECOGNITION_USAGE]
+    assert events[0].recognition_usage is not None
+    assert events[0].recognition_usage.audio_duration == 3.5
+    assert stream._audio_duration == 0.0


### PR DESCRIPTION
Fixes #6151

Replaces #6154 after refreshing the branch onto the current upstream main.

This tracks processed Azure streaming audio duration and emits recognition usage metrics periodically/on flush, so silence is included instead of using only recognized speech segment duration.

Tests:
- uv run pytest tests/test_plugin_azure_stt.py
- uv run ruff check livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py tests/test_plugin_azure_stt.py