### PR TITLE
fix(voice): expose item_id on UserInputTranscribedEvent

### DIFF
--- a/livekit-agents/livekit/agents/voice/events.py
+++ b/livekit-agents/livekit/agents/voice/events.py
@@ -331,7 +331,11 @@ class UserInputTranscribedEvent(BaseModel):
     transcript: str
     is_final: bool
     item_id: str | None = None
-    """Provider-specific ID for the transcribed input item, when available."""
+    """Stable id correlating all interim transcripts belonging to the same utterance.
+
+    Mirrors ``llm.InputTranscriptionCompleted.item_id``. Useful for deduplicating
+    repeated interim events from realtime models (e.g. only reacting once per
+    utterance instead of once per streamed delta chunk)."""
     speaker_id: str | None = None
     language: LanguageCode | None = None
     created_at: float = Field(default_factory=time.time)

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -114,6 +114,7 @@ def test_user_input_transcribed_event_item_id():
     ev_no_id = UserInputTranscribedEvent(transcript="hello", is_final=True)
     assert ev_no_id.item_id is None
 
+
 async def test_events_and_metrics() -> None:
     speed = 1
     actions = FakeActions()

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -31,7 +31,6 @@ from livekit.agents import (
 from livekit.agents.llm import (
     FunctionTool,
     FunctionToolCall,
-    InputTranscriptionCompleted,
     RawFunctionTool,
     ToolContext,
     ToolFlag,

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -100,30 +100,19 @@ class MyAgent(Agent):
 SESSION_TIMEOUT = 60.0
 
 
-def test_realtime_user_input_transcription_preserves_item_id() -> None:
-    captured_events: list[UserInputTranscribedEvent] = []
+def test_user_input_transcribed_event_item_id():
+    """UserInputTranscribedEvent should accept and expose item_id (#6110).
 
-    class DummySession:
-        def _user_input_transcribed(self, ev: UserInputTranscribedEvent) -> None:
-            captured_events.append(ev)
+    item_id is the stable correlation key from llm.InputTranscriptionCompleted,
+    forwarded by AgentActivity._on_input_audio_transcription_completed so realtime
+    consumers can dedup repeated interim transcripts belonging to the same utterance.
+    """
+    ev = UserInputTranscribedEvent(transcript="hello", is_final=False, item_id="item_abc123")
+    assert ev.item_id == "item_abc123"
 
-    activity = object.__new__(AgentActivity)
-    activity._session = DummySession()
-
-    AgentActivity._on_input_audio_transcription_completed(
-        activity,
-        InputTranscriptionCompleted(
-            item_id="item_123",
-            transcript="hello",
-            is_final=False,
-        ),
-    )
-
-    assert len(captured_events) == 1
-    assert captured_events[0].transcript == "hello"
-    assert captured_events[0].is_final is False
-    assert captured_events[0].item_id == "item_123"
-
+    # item_id remains optional for non-realtime (STT-pipeline) transcripts
+    ev_no_id = UserInputTranscribedEvent(transcript="hello", is_final=True)
+    assert ev_no_id.item_id is None
 
 async def test_events_and_metrics() -> None:
     speed = 1


### PR DESCRIPTION
Closes livekit/agents#6110

## What

Adds `item_id: str | None = None` to `UserInputTranscribedEvent` and forwards<br>`ev.item_id` from `llm.InputTranscriptionCompleted` in<br>`AgentActivity._on_input_audio_transcription_completed`.

## Why

Realtime models (OpenAI/xAI/Gemini) emit multiple interim<br>`user_input_transcribed` events per utterance. `InputTranscriptionCompleted`<br>already carries a stable `item_id` to correlate these, but it was being<br>dropped when re-emitted as `UserInputTranscribedEvent`, forcing consumers to<br>either track state manually (impossible — the field wasn't exposed) or<br>subscribe to provider-specific raw events.

## Testing

* Added `test_user_input_transcribed_event_item_id` covering both the<br>populated and default-None cases
* `ruff check` / `ruff format`: clean
* `mypy` (full project, 601 source files): 0 issues
* Existing test suite: no regressions