### PR TITLE
fix: bound fallback LLM time to first chunk

### DIFF
--- a/livekit-agents/livekit/agents/llm/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/fallback_adapter.py
@@ -177,7 +177,21 @@ class FallbackLLMStream(LLMStream):
                 ),
             ) as stream:
                 should_set_current = not check_recovery
-                async for chunk in stream:
+                stream_iter = stream.__aiter__()
+                try:
+                    first_chunk = await asyncio.wait_for(
+                        stream_iter.__anext__(),
+                        timeout=self._fallback_adapter._attempt_timeout,
+                    )
+                except StopAsyncIteration:
+                    return
+
+                if should_set_current:
+                    should_set_current = False
+                    self._current_stream = stream
+                yield first_chunk
+
+                async for chunk in stream_iter:
                     if should_set_current:
                         should_set_current = False
                         self._current_stream = stream

--- a/tests/test_llm_fallback.py
+++ b/tests/test_llm_fallback.py
@@ -1,0 +1,33 @@
+import asyncio
+import contextlib
+
+import pytest
+
+from livekit.agents.llm import ChatContext
+from livekit.agents.llm.fallback_adapter import FallbackAdapter
+
+from .fake_llm import FakeLLM, FakeLLMResponse
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_fallback_adapter_attempt_timeout_bounds_time_to_first_chunk() -> None:
+    slow = FakeLLM(
+        fake_responses=[FakeLLMResponse(input="hello", content="slow", ttft=1, duration=1)]
+    )
+    fast = FakeLLM(
+        fake_responses=[FakeLLMResponse(input="hello", content="fast", ttft=0, duration=0)]
+    )
+    fallback = FallbackAdapter([slow, fast], attempt_timeout=0.01)
+    chat_ctx = ChatContext()
+    chat_ctx.add_message(role="user", content="hello")
+
+    response = await fallback.chat(chat_ctx=chat_ctx).collect()
+
+    assert response.text == "fast"
+    if recovery_task := fallback._status[0].recovering_task:
+        recovery_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await recovery_task
+    await fallback.aclose()


### PR DESCRIPTION
Fixes #6171

## Summary
- enforce `attempt_timeout` while waiting for the first yielded chat chunk in `FallbackAdapter`
- fall through to the next LLM when the current provider stalls before producing a chunk
- add a regression test covering slow time-to-first-chunk fallback

## Tests
- `uv run ruff format --check livekit-agents/livekit/agents/llm/fallback_adapter.py tests/test_llm_fallback.py`
- `uv run ruff check livekit-agents/livekit/agents/llm/fallback_adapter.py tests/test_llm_fallback.py`
- `uv run pytest tests/test_llm_fallback.py -q`