### PR TITLE
fix(slng): expose speed in update_options

### DIFF
--- a/livekit-plugins/livekit-plugins-slng/livekit/plugins/slng/tts.py
+++ b/livekit-plugins/livekit-plugins-slng/livekit/plugins/slng/tts.py
@@ -301,11 +301,13 @@ class TTS(tts.TTS):
         *,
         voice: NotGivenOr[str] = NOT_GIVEN,
         language: NotGivenOr[str] = NOT_GIVEN,
+        speed: NotGivenOr[float] = NOT_GIVEN,
     ) -> None:
         """
         Args:
             voice (str): Voice to use.
             language (str): Language code.
+            speed (float): Playback speed multiplier.
         """
         invalidate_pool = False
         if is_given(voice):
@@ -315,6 +317,9 @@ class TTS(tts.TTS):
         if is_given(language):
             invalidate_pool = invalidate_pool or self._opts.language != language
             self._opts.language = language
+        if is_given(speed):
+            invalidate_pool = invalidate_pool or self._opts.speed != speed
+            self._opts.speed = speed
 
         if invalidate_pool:
             self._pool.invalidate()


### PR DESCRIPTION
`TTS.update_options` accepted `voice` and `language` but silently dropped `speed`, even though speed is a first-class `_TTSOptions` field sent in the WebSocket init payload via `build_tts_init_payload`. Users who set speed at construction time had no way to change it afterward.

Fix: add `speed` to `update_options` and invalidate the connection pool when the value changes, consistent with how `voice` and `language` are handled.

Fixes #6174