### PR TITLE
fix(plugins/bithuman): make Pillow optional + close AvatarRunner in aclose()

### DIFF
--- a/livekit-plugins/livekit-plugins-bithuman/livekit/plugins/bithuman/avatar.py
+++ b/livekit-plugins/livekit-plugins-bithuman/livekit/plugins/bithuman/avatar.py
@@ -13,7 +13,10 @@ import aiohttp
 import cv2
 import numpy as np
 from loguru import logger as _logger
-from PIL import Image
+try:
+    from PIL import Image
+except ModuleNotFoundError:  # Pillow only needed for cloud-mode avatar_image
+    Image = None
 
 from livekit import api, rtc
 from livekit.agents import (
@@ -196,7 +199,7 @@ class AvatarSession(BaseAvatarSession):
                 raise BitHumanException("BITHUMAN_API_URL are required for cloud mode")
 
         self._avatar_image: Image.Image | str | None = None
-        if isinstance(avatar_image, Image.Image):
+        if Image is not None and isinstance(avatar_image, Image.Image):
             self._avatar_image = avatar_image
         elif isinstance(avatar_image, str):
             if os.path.exists(avatar_image):
@@ -423,7 +426,7 @@ class AvatarSession(BaseAvatarSession):
         }
 
         # Handle avatar image - convert to base64 for JSON serialization
-        if isinstance(self._avatar_image, Image.Image):
+        if Image is not None and isinstance(self._avatar_image, Image.Image):
             img_byte_arr = io.BytesIO()
             self._avatar_image.save(img_byte_arr, format="JPEG", quality=95)
             img_byte_arr.seek(0)
@@ -502,7 +505,7 @@ class AvatarSession(BaseAvatarSession):
             form_data.add_field("async_mode", "true" if async_mode else "false")
 
         # Handle avatar image - send as file upload or URL
-        if isinstance(self._avatar_image, Image.Image):
+        if Image is not None and isinstance(self._avatar_image, Image.Image):
             # Convert PIL Image to bytes and upload as file
             img_byte_arr = io.BytesIO()
             self._avatar_image.save(img_byte_arr, format="JPEG", quality=95)
@@ -624,6 +627,13 @@ class AvatarSession(BaseAvatarSession):
 
     async def aclose(self) -> None:
         await super().aclose()
+        # Tear down the AvatarRunner too: the base aclose() only removes the
+        # room participant, leaving the runner's read/forward tasks, the AV
+        # synchronizer, and the rust audio/video sources open — a native leak
+        # that accumulates per session/reconnect.
+        if self._avatar_runner is not None:
+            await self._avatar_runner.aclose()
+            self._avatar_runner = None
         if self._mode == "local" and utils.is_given(self._runtime) and self._runtime is not None:
             self._runtime.cleanup()
 

--- a/livekit-plugins/livekit-plugins-bithuman/livekit/plugins/bithuman/avatar.py
+++ b/livekit-plugins/livekit-plugins-bithuman/livekit/plugins/bithuman/avatar.py
@@ -203,6 +203,11 @@ class AvatarSession(BaseAvatarSession):
             self._avatar_image = avatar_image
         elif isinstance(avatar_image, str):
             if os.path.exists(avatar_image):
+                if Image is None:
+                    raise BitHumanException(
+                        "Pillow is required to load an avatar image from a file path. "
+                        "Install it with: pip install Pillow"
+                    )
                 self._avatar_image = Image.open(avatar_image)
             elif avatar_image.startswith(("http://", "https://")):
                 self._avatar_image = avatar_image


### PR DESCRIPTION
Two small fixes for the `livekit-plugins-bithuman` avatar plugin, found while validating a self-hosted bitHuman essence integration.

### 1. Pillow is an undeclared dependency
`avatar.py` does `from PIL import Image` at module top, but Pillow is **not** in the package's dependencies — so a clean `pip install livekit-plugins-bithuman` fails to import the plugin:
```
ModuleNotFoundError: No module named 'PIL'
```
PIL is used **only** for cloud-mode `avatar_image` handling; **local mode** (`model_path`) never touches it. This makes the import optional (`try/except ModuleNotFoundError` → `Image = None`) and guards the three `isinstance(..., Image.Image)` call sites, so local-mode users don't need Pillow. (`from __future__ import annotations` already makes the `Image.Image` type hints lazy.)

Verified: with Pillow uninstalled, `from livekit.plugins.bithuman import AvatarSession` imports and a local `AvatarSession(model_path=..., api_secret=...)` constructs successfully.

### 2. `AvatarSession.aclose()` leaks the `AvatarRunner`
`aclose()` calls `super().aclose()` (which only removes the room participant) + `runtime.cleanup()`, but never closes `self._avatar_runner`. That leaves the runner's `_read_audio`/`_forward_video` tasks, the `AVSynchronizer`, and the rust `AudioSource`/`VideoSource` open — a native resource leak that accumulates per session/reconnect. Now `aclose()` awaits `self._avatar_runner.aclose()` first.

Both changes are confined to `avatar.py`. No behavior change for cloud mode (Pillow present) or for the happy-path local stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)