### PR TITLE
fix(google): clean up STT input frame task

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -786,7 +786,12 @@ class SpeechStream(stt.SpeechStream):
                 tasks: list[asyncio.Task[object]] = [stop_task]
                 if frame_task is not None:
                     tasks.append(frame_task)
-                await utils.aio.gracefully_cancel(*tasks)
+                cleanup_task = asyncio.create_task(utils.aio.gracefully_cancel(*tasks))
+                try:
+                    await asyncio.shield(cleanup_task)
+                except asyncio.CancelledError:
+                    await cleanup_task
+                    raise
 
         async def process_stream(
             client: SpeechAsyncClientV2 | SpeechAsyncClientV1,

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -753,6 +753,7 @@ class SpeechStream(stt.SpeechStream):
         ]:
             nonlocal audio_pushed
             stop_task = asyncio.create_task(should_stop.wait())
+            frame_task: asyncio.Task[object] | None = None
             try:
                 yield self._build_init_request(client)
 
@@ -766,12 +767,13 @@ class SpeechStream(stt.SpeechStream):
                         [frame_task, stop_task], return_when=asyncio.FIRST_COMPLETED
                     )
                     if stop_task in done:
-                        frame_task.cancel()
                         return
                     try:
                         frame = frame_task.result()
                     except ChanClosed:
                         return
+                    finally:
+                        frame_task = None
 
                     if isinstance(frame, rtc.AudioFrame):
                         yield self._build_audio_request(frame)
@@ -781,7 +783,10 @@ class SpeechStream(stt.SpeechStream):
             except Exception:
                 logger.exception("an error occurred while streaming input to google STT")
             finally:
-                stop_task.cancel()
+                tasks: list[asyncio.Task[object]] = [stop_task]
+                if frame_task is not None:
+                    tasks.append(frame_task)
+                await utils.aio.gracefully_cancel(*tasks)
 
         async def process_stream(
             client: SpeechAsyncClientV2 | SpeechAsyncClientV1,

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -783,15 +783,9 @@ class SpeechStream(stt.SpeechStream):
             except Exception:
                 logger.exception("an error occurred while streaming input to google STT")
             finally:
-                tasks: list[asyncio.Task[object]] = [stop_task]
-                if frame_task is not None:
-                    tasks.append(frame_task)
-                cleanup_task = asyncio.create_task(utils.aio.gracefully_cancel(*tasks))
-                try:
-                    await asyncio.shield(cleanup_task)
-                except asyncio.CancelledError:
-                    await cleanup_task
-                    raise
+                await utils.aio.gracefully_cancel(
+                    stop_task, *([frame_task] if frame_task is not None else [])
+                )
 
         async def process_stream(
             client: SpeechAsyncClientV2 | SpeechAsyncClientV1,

--- a/tests/test_plugin_google_stt.py
+++ b/tests/test_plugin_google_stt.py
@@ -145,6 +145,56 @@ async def test_google_stt_stream_cancel_does_not_leak_chanclosed_task():
     assert unhandled_chanclosed == []
 
 
+async def test_google_stt_stream_cancel_waits_for_cleanup_if_cancelled_twice(monkeypatch):
+    from livekit.plugins.google import stt as google_stt
+
+    client = _FakeSpeechClient()
+    stream = SpeechStream(
+        stt=_FakeSTT(),
+        conn_options=APIConnectOptions(max_retry=0, timeout=0.1),
+        pool=_FakeConnectionPool(client),
+        recognizer_cb=lambda _client: "",
+        config=_default_stt_options(),
+    )
+    cleanup_started = asyncio.Event()
+    cleanup_release = asyncio.Event()
+    cleanup_done = asyncio.Event()
+    original_gracefully_cancel = google_stt.utils.aio.gracefully_cancel
+
+    async def delayed_input_cleanup(*tasks):
+        if any(
+            isinstance(task, asyncio.Task) and task.get_coro().__qualname__ == "Chan.recv"
+            for task in tasks
+        ):
+            cleanup_started.set()
+            try:
+                await cleanup_release.wait()
+                await original_gracefully_cancel(*tasks)
+            finally:
+                cleanup_done.set()
+            return
+
+        await original_gracefully_cancel(*tasks)
+
+    monkeypatch.setattr(google_stt.utils.aio, "gracefully_cancel", delayed_input_cleanup)
+
+    try:
+        await asyncio.wait_for(client.call_ready.wait(), timeout=1)
+        assert client.call is not None
+        await asyncio.wait_for(client.call.awaiting_audio.wait(), timeout=1)
+        await asyncio.wait_for(cleanup_started.wait(), timeout=1)
+
+        client.call.cancel()
+        await asyncio.sleep(0)
+
+        cleanup_release.set()
+        await asyncio.wait_for(cleanup_done.wait(), timeout=1)
+        await asyncio.wait_for(client.call.consumer_done.wait(), timeout=1)
+    finally:
+        cleanup_release.set()
+        await stream.aclose()
+
+
 async def test_streaming_recognize_response_to_speech_data_01():
     srr = cloud_speech_v2.StreamingRecognizeResponse(
         results=[cloud_speech_v2.StreamingRecognitionResult()]

--- a/tests/test_plugin_google_stt.py
+++ b/tests/test_plugin_google_stt.py
@@ -1,17 +1,148 @@
+import asyncio
+import contextlib
+import gc
+
 import pytest
 from google.cloud.speech_v1.types import cloud_speech as cloud_speech_v1
 from google.cloud.speech_v2.types import cloud_speech as cloud_speech_v2
 from google.protobuf.duration_pb2 import Duration
 
-from livekit.agents import LanguageCode
+from livekit.agents import APIConnectOptions, LanguageCode
 from livekit.agents.stt import SpeechData, SpeechEvent, SpeechEventType
 from livekit.agents.types import TimedString
+from livekit.agents.utils.aio import ChanClosed
 from livekit.plugins.google.stt import (
+    SpeechStream,
+    STTOptions,
     _recognize_response_to_speech_event,  # pyright: ignore[reportPrivateUsage]
     _streaming_recognize_response_to_speech_data,  # pyright: ignore[reportPrivateUsage]
 )
 
 pytestmark = pytest.mark.plugin("google")
+
+
+@pytest.fixture
+def mock_google_adc(monkeypatch):
+    from livekit.plugins.google import stt as google_stt
+
+    monkeypatch.setattr(google_stt, "gauth_default", lambda: (None, "test-project"))
+
+
+class _FakeSTT:
+    _label = "google.STT"
+    model = "default"
+    provider = "Google Cloud Platform"
+
+    def emit(self, *_args, **_kwargs):
+        pass
+
+
+class _FakeStreamingCall:
+    def __init__(self, requests):
+        self._requests = requests
+        self._consumer_task = asyncio.create_task(self._consume_requests())
+        self.awaiting_audio = asyncio.Event()
+        self.consumer_done = asyncio.Event()
+
+    async def _consume_requests(self):
+        try:
+            await self._requests.__anext__()
+            self.awaiting_audio.set()
+            await self._requests.__anext__()
+        finally:
+            self.consumer_done.set()
+
+    def cancel(self):
+        self._consumer_task.cancel()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        await self.awaiting_audio.wait()
+        raise StopAsyncIteration
+
+
+class _FakeSpeechClient:
+    def __init__(self):
+        self.call: _FakeStreamingCall | None = None
+        self.call_ready = asyncio.Event()
+
+    async def streaming_recognize(self, *, requests):
+        self.call = _FakeStreamingCall(requests)
+        self.call_ready.set()
+        return self.call
+
+
+class _FakeConnectionPool:
+    last_acquire_time = 0.0
+    last_connection_reused = False
+
+    def __init__(self, client):
+        self._client = client
+
+    @contextlib.asynccontextmanager
+    async def connection(self, *, timeout):
+        yield self._client
+
+    def remove(self, _client):
+        pass
+
+
+def _default_stt_options() -> STTOptions:
+    return STTOptions(
+        languages=[LanguageCode("en-US")],
+        detect_language=True,
+        interim_results=True,
+        punctuate=True,
+        spoken_punctuation=False,
+        enable_word_time_offsets=True,
+        enable_word_confidence=False,
+        enable_voice_activity_events=False,
+        model="default",
+        sample_rate=16000,
+        min_confidence_threshold=0.65,
+        profanity_filter=False,
+    )
+
+
+async def test_google_stt_stream_cancel_does_not_leak_chanclosed_task():
+    client = _FakeSpeechClient()
+    stream = SpeechStream(
+        stt=_FakeSTT(),
+        conn_options=APIConnectOptions(max_retry=0, timeout=0.1),
+        pool=_FakeConnectionPool(client),
+        recognizer_cb=lambda _client: "",
+        config=_default_stt_options(),
+    )
+
+    loop = asyncio.get_running_loop()
+    original_exception_handler = loop.get_exception_handler()
+    contexts = []
+    loop.set_exception_handler(lambda _loop, context: contexts.append(context))
+
+    try:
+        await asyncio.wait_for(client.call_ready.wait(), timeout=1)
+        assert client.call is not None
+        await asyncio.wait_for(client.call.awaiting_audio.wait(), timeout=1)
+
+        await asyncio.wait_for(stream._task, timeout=1)
+        await asyncio.wait_for(client.call.consumer_done.wait(), timeout=1)
+
+        await stream.aclose()
+        for _ in range(3):
+            gc.collect()
+            await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(original_exception_handler)
+
+    unhandled_chanclosed = [
+        context
+        for context in contexts
+        if context.get("message") == "Task exception was never retrieved"
+        and isinstance(context.get("exception"), ChanClosed)
+    ]
+    assert unhandled_chanclosed == []
 
 
 async def test_streaming_recognize_response_to_speech_data_01():
@@ -328,7 +459,7 @@ async def test_recognize_response_to_speech_event_words():
     ]
 
 
-async def test_voice_activity_timeout_defaults():
+async def test_voice_activity_timeout_defaults(mock_google_adc):
     """Test voice activity timeouts are not set by default."""
     from livekit.agents.types import NOT_GIVEN
     from livekit.plugins.google import STT
@@ -338,7 +469,7 @@ async def test_voice_activity_timeout_defaults():
     assert stt._config.speech_end_timeout is NOT_GIVEN
 
 
-async def test_voice_activity_timeout_set():
+async def test_voice_activity_timeout_set(mock_google_adc):
     """Test voice activity timeouts can be set."""
     from livekit.plugins.google import STT
 
@@ -350,7 +481,7 @@ async def test_voice_activity_timeout_set():
     assert stt._config.speech_end_timeout == 2.5
 
 
-async def test_voice_activity_timeout_fractional_seconds():
+async def test_voice_activity_timeout_fractional_seconds(mock_google_adc):
     """Test voice activity timeouts handle fractional seconds."""
     from livekit.plugins.google import STT
 
@@ -362,7 +493,7 @@ async def test_voice_activity_timeout_fractional_seconds():
     assert stt._config.speech_end_timeout == 1.25
 
 
-async def test_voice_activity_timeout_speech_start_only():
+async def test_voice_activity_timeout_speech_start_only(mock_google_adc):
     """Test setting only speech_start_timeout."""
     from livekit.agents.types import NOT_GIVEN
     from livekit.plugins.google import STT
@@ -372,7 +503,7 @@ async def test_voice_activity_timeout_speech_start_only():
     assert stt._config.speech_end_timeout is NOT_GIVEN
 
 
-async def test_voice_activity_timeout_speech_end_only():
+async def test_voice_activity_timeout_speech_end_only(mock_google_adc):
     """Test setting only speech_end_timeout."""
     from livekit.agents.types import NOT_GIVEN
     from livekit.plugins.google import STT
@@ -382,7 +513,7 @@ async def test_voice_activity_timeout_speech_end_only():
     assert stt._config.speech_start_timeout is NOT_GIVEN
 
 
-async def test_voice_activity_timeout_v2_model():
+async def test_voice_activity_timeout_v2_model(mock_google_adc):
     """Test that V2 model detection works correctly."""
     from livekit.plugins.google import STT
 
@@ -393,7 +524,7 @@ async def test_voice_activity_timeout_v2_model():
     assert stt_v1._config.version == 1
 
 
-async def test_voice_activity_timeout_update():
+async def test_voice_activity_timeout_update(mock_google_adc):
     """Test that timeout options can be updated dynamically."""
     from livekit.plugins.google import STT
 
@@ -409,7 +540,7 @@ async def test_voice_activity_timeout_update():
     assert stt._config.speech_end_timeout == 3.0
 
 
-async def test_voice_activity_timeout_partial_update():
+async def test_voice_activity_timeout_partial_update(mock_google_adc):
     """Test updating only one timeout at a time."""
     from livekit.plugins.google import STT
 


### PR DESCRIPTION
## Summary

Fixes #6181.

This cleans up the Google STT streaming request generator when the surrounding gRPC stream is cancelled while it is waiting for the next audio frame. The user-visible streaming behavior is unchanged, but the pending `self._input_ch.recv()` task is now cancelled and awaited before the generator exits.

## Background

PR #5591 added a race between `self._input_ch.recv()` and a stop event so Google STT can reconnect without leaving an idle request generator parked on the input channel. That fixed the idle-stream leak, but left a smaller cleanup gap: if the request generator itself is cancelled while `frame_task` is still waiting on `Chan.recv()`, the generator's `finally` block only cancelled `stop_task`.

When the input channel later closes, that orphaned task can finish with `ChanClosed`, causing:

`Task exception was never retrieved`
`future: <Task finished ... coro=<Chan.recv()> exception=ChanClosed()>`

## Changes

- Track the active Google STT input `frame_task`.
- Cancel and await both `stop_task` and any pending `frame_task` via `utils.aio.gracefully_cancel`.
- Add a regression test covering stream cancellation while waiting for audio.
- Mock Google ADC only for config-only tests so `test_plugin_google_stt.py` can run locally without real credentials.

## Validation

- `python -m pytest tests/test_plugin_google_stt.py -q`
  - `16 passed`
- `python -m ruff format --check livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py tests/test_plugin_google_stt.py`
- `python -m ruff check livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py tests/test_plugin_google_stt.py`
- `python -m py_compile livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py tests/test_plugin_google_stt.py`
- `git diff --check`