### PR TITLE
fix(aws): nest endpointingSensitivity under turnDetectionConfiguration for Nova Sonic 2

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/events.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/events.py
@@ -95,9 +95,16 @@ class ToolConfiguration(BaseModel):
     tools: list[Tool]
 
 
+class TurnDetectionConfiguration(BaseModel):
+    endpointingSensitivity: TURN_DETECTION
+
+
 class SessionStart(BaseModel):
     inferenceConfiguration: InferenceConfiguration
-    endpointingSensitivity: TURN_DETECTION | None = "MEDIUM"
+    # Nova Sonic 1 used a flat field; Nova Sonic 2 requires it nested under
+    # turnDetectionConfiguration. Exactly one is populated per model.
+    endpointingSensitivity: TURN_DETECTION | None = None
+    turnDetectionConfiguration: TurnDetectionConfiguration | None = None
 
 
 class InputTextContentStart(BaseModel):
@@ -227,9 +234,12 @@ class Event(BaseModel):
 
 
 class SonicEventBuilder:
-    def __init__(self, prompt_name: str, audio_content_name: str):
+    def __init__(
+        self, prompt_name: str, audio_content_name: str, model: str = "amazon.nova-2-sonic-v1:0"
+    ):
         self.prompt_name = prompt_name
         self.audio_content_name = audio_content_name
+        self._nova_sonic_2 = "nova-2-sonic" in model
 
     @classmethod
     def get_event_type(cls, json_data: dict) -> str:
@@ -366,19 +376,23 @@ class SonicEventBuilder:
         temperature: float = 0.7,
         endpointing_sensitivity: TURN_DETECTION | None = "MEDIUM",
     ) -> str:
-        event = Event(
-            event=SessionStartEvent(
-                sessionStart=SessionStart(
-                    inferenceConfiguration=InferenceConfiguration(
-                        maxTokens=max_tokens,
-                        topP=top_p,
-                        temperature=temperature,
-                    ),
-                    endpointingSensitivity=endpointing_sensitivity,
-                )
-            )
+        inference = InferenceConfiguration(
+            maxTokens=max_tokens, topP=top_p, temperature=temperature
         )
-        return event.model_dump_json(exclude_none=False)
+        if self._nova_sonic_2 and endpointing_sensitivity is not None:
+            session_start = SessionStart(
+                inferenceConfiguration=inference,
+                turnDetectionConfiguration=TurnDetectionConfiguration(
+                    endpointingSensitivity=endpointing_sensitivity
+                ),
+            )
+        else:
+            session_start = SessionStart(
+                inferenceConfiguration=inference,
+                endpointingSensitivity=endpointing_sensitivity,
+            )
+        event = Event(event=SessionStartEvent(sessionStart=session_start))
+        return event.model_dump_json(exclude_none=True)  # was exclude_none=False
 
     def create_audio_content_start_event(
         self,

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/events.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/events.py
@@ -314,7 +314,7 @@ class SonicEventBuilder:
         max_tokens: int = 1024,
         top_p: float = 0.9,
         temperature: float = 0.7,
-        endpointing_sensitivity: TURN_DETECTION | None = "MEDIUM",
+        endpointing_sensitivity: TURN_DETECTION = "MEDIUM",
     ) -> tuple[list[str], list[str]]:
         """Build session init events and history events separately.
 
@@ -374,12 +374,12 @@ class SonicEventBuilder:
         max_tokens: int = 1024,
         top_p: float = 0.9,
         temperature: float = 0.7,
-        endpointing_sensitivity: TURN_DETECTION | None = "MEDIUM",
+        endpointing_sensitivity: TURN_DETECTION = "MEDIUM",
     ) -> str:
         inference = InferenceConfiguration(
             maxTokens=max_tokens, topP=top_p, temperature=temperature
         )
-        if self._nova_sonic_2 and endpointing_sensitivity is not None:
+        if self._nova_sonic_2:
             session_start = SessionStart(
                 inferenceConfiguration=inference,
                 turnDetectionConfiguration=TurnDetectionConfiguration(

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -511,6 +511,7 @@ class RealtimeSession(  # noqa: F811
         self._event_builder = seb(
             prompt_name=str(uuid.uuid4()),
             audio_content_name=str(uuid.uuid4()),
+            model=self._realtime_model._model,
         )
         self._input_resampler: rtc.AudioResampler | None = None
         self._bstream = utils.audio.AudioByteStream(
@@ -752,6 +753,7 @@ class RealtimeSession(  # noqa: F811
         self._event_builder = seb(
             prompt_name=str(uuid.uuid4()),
             audio_content_name=str(uuid.uuid4()),
+            model=self._realtime_model._model,
         )
         self._tool_results_ch = utils.aio.Chan[dict[str, str]]()
         self._audio_input_chan = utils.aio.Chan[bytes]()

--- a/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_turn_detection.py
+++ b/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_turn_detection.py
@@ -16,6 +16,10 @@ import sys
 from typing import Literal
 from unittest.mock import MagicMock
 
+import pytest
+
+pytestmark = pytest.mark.unit
+
 # ---------------------------------------------------------------------------
 # Stub out the optional AWS Smithy/Bedrock SDK not installed in the base venv.
 # Importing the realtime package pulls in realtime_model, which imports the SDK.

--- a/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_turn_detection.py
+++ b/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_turn_detection.py
@@ -1,0 +1,73 @@
+"""
+Regression tests for Nova Sonic turn-detection serialization in sessionStart.
+
+Nova Sonic 2 (amazon.nova-2-sonic-v1:0) rejects the sessionStart event with a
+ValidationException unless the turn-detection setting is nested under
+turnDetectionConfiguration.  Nova Sonic 1 (amazon.nova-sonic-v1:0) predates
+controllable endpointing and uses the legacy flat endpointingSensitivity field.
+
+SonicEventBuilder serializes model-aware: Nova 2 (including cross-region
+inference-profile ids such as us.amazon.nova-2-sonic-v1:0) → nested form;
+Nova 1 → flat form.
+"""
+
+import json
+import sys
+from typing import Literal
+from unittest.mock import MagicMock
+
+# ---------------------------------------------------------------------------
+# Stub out the optional AWS Smithy/Bedrock SDK not installed in the base venv.
+# Importing the realtime package pulls in realtime_model, which imports the SDK.
+# ---------------------------------------------------------------------------
+_AWS_STUBS = [
+    "aws_sdk_bedrock_runtime",
+    "aws_sdk_bedrock_runtime.client",
+    "aws_sdk_bedrock_runtime.models",
+    "aws_sdk_bedrock_runtime.config",
+    "smithy_aws_core",
+    "smithy_aws_core.identity",
+    "smithy_aws_event_stream",
+    "smithy_aws_event_stream.exceptions",
+    "smithy_core",
+    "smithy_core.aio",
+    "smithy_core.aio.interfaces",
+    "smithy_core.aio.interfaces.identity",
+]
+for _mod in _AWS_STUBS:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+
+def _session_start(model: str, sensitivity: Literal["HIGH", "MEDIUM", "LOW"] = "HIGH") -> dict:
+    from livekit.plugins.aws.experimental.realtime.events import SonicEventBuilder
+
+    builder = SonicEventBuilder("prompt-name", "audio-content-name", model=model)
+    payload = builder.create_session_start_event(endpointing_sensitivity=sensitivity)
+    return json.loads(payload)["event"]["sessionStart"]
+
+
+class TestSessionStartTurnDetection:
+    """Model-aware serialization of the turn-detection setting."""
+
+    def test_nova_sonic_2_nests_under_turn_detection_configuration(self):
+        ss = _session_start("amazon.nova-2-sonic-v1:0")
+
+        assert ss["turnDetectionConfiguration"]["endpointingSensitivity"] == "HIGH"
+        # the legacy flat field must not be emitted for Nova 2
+        assert "endpointingSensitivity" not in ss
+
+    def test_nova_sonic_1_keeps_flat_field(self):
+        ss = _session_start("amazon.nova-sonic-v1:0")
+
+        assert ss["endpointingSensitivity"] == "HIGH"
+        # the nested field must not be emitted for Nova 1
+        assert "turnDetectionConfiguration" not in ss
+
+    def test_cross_region_inference_profile_uses_nested_form(self):
+        # Bedrock cross-region inference profiles prefix the model id with a
+        # region group (us./eu./apac.); these are still Nova 2 and must nest.
+        ss = _session_start("us.amazon.nova-2-sonic-v1:0")
+
+        assert ss["turnDetectionConfiguration"]["endpointingSensitivity"] == "HIGH"
+        assert "endpointingSensitivity" not in ss


### PR DESCRIPTION
## Summary

Nova Sonic 2 (`amazon.nova-2-sonic-v1:0`) rejects the `sessionStart` event with
`ValidationException: Invalid input request` because the plugin emits the
turn-detection setting as a flat `endpointingSensitivity` field — the legacy
Nova Sonic 1 shape. Nova 2 requires it nested under `turnDetectionConfiguration`
([AWS docs](https://docs.aws.amazon.com/nova/latest/nova2-userguide/sonic-turn-taking.html)).
This breaks every Nova Sonic 2 session at startup and cascades into
`speech not done in time after interruption` and session shutdown.

## Changes

- Add a `TurnDetectionConfiguration` model and a `turnDetectionConfiguration`
  field on `SessionStart`.
- Make `SonicEventBuilder` serialization model-aware: Nova Sonic 2 → nested
  `turnDetectionConfiguration`; Nova Sonic 1 (`amazon.nova-sonic-v1:0`) → legacy
  flat `endpointingSensitivity` (no regression). Detection uses a substring
  match (`"nova-2-sonic" in model`) so cross-region inference-profile ids such
  as `us.amazon.nova-2-sonic-v1:0` are handled correctly.
- Thread the model id into **both** `SonicEventBuilder` construction sites,
  including the session reconnect/restart path — otherwise a reconnected
  Nova Sonic 1 session would fall back to the default model id and wrongly emit
  the nested form.
- Serialize the `sessionStart` event with `exclude_none=True` so only the
  relevant field is emitted.

## Behavior notes

- The plugin's serialization was unchanged across recent releases (verified back
  through 1.3.x), so this is an AWS-side validation tightening, not a recent
  plugin regression. On Nova Sonic 2 the flat field was previously *silently
  ignored*, so `turn_detection=...` was effectively a no-op there — it now
  actually applies.

## Testing

- New unit tests in `livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_turn_detection.py`:
  - Nova Sonic 2 builder → `turnDetectionConfiguration.endpointingSensitivity`,
    no flat field.
  - Nova Sonic 1 builder → flat `endpointingSensitivity`, no nested field.
  - Cross-region inference profile (`us.amazon.nova-2-sonic-v1:0`) → nested form.
- `make check` passes (ruff format, ruff lint, mypy).
closes #6200 