### PR TITLE
fix(agents): keep STT input anchor on the pipeline across handoff

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -154,6 +154,11 @@ class _STTPipeline:
         self._event_ch = aio.Chan[stt.SpeechEvent]()
         self._pump_task = asyncio.create_task(self._stt_pump())
         self._pump_task.add_done_callback(lambda _: self._event_ch.close())
+        # wall-clock anchor for this stream's `end_time=0`; lives on the pipeline so it
+        # survives agent handoff together with the stream it describes. Resetting it on a
+        # reused pipeline would desync STT `end_time` (relative to the original stream
+        # start) from wall clock, pushing the derived speaking time far into the future.
+        self.input_started_at: float | None = None
 
     @property
     def audio_ch(self) -> aio.Chan[rtc.AudioFrame]:
@@ -253,7 +258,6 @@ class AudioRecognition:
         self._interruption_atask: asyncio.Task[None] | None = None
         self._interruption_detection = interruption_detection
         self._interruption_ch: aio.Chan[inference.InterruptionDataFrameType] | None = None
-        self._input_started_at: float | None = None
         self._ignore_user_transcript_until: NotGivenOr[float] = NOT_GIVEN
         self._transcript_buffer: deque[SpeechEvent] = deque()
         self._interruption_enabled: bool = interruption_detection is not None and vad is not None
@@ -326,6 +330,16 @@ class AudioRecognition:
                     if self._turn_detector_stream is not None:
                         self._turn_detector_stream.cancel_inference()
                     self._turn_detector_prediction_fut = None
+
+    @property
+    def _input_started_at(self) -> float | None:
+        # anchored on the STT pipeline so it survives handoff alongside its stream
+        return self._stt_pipeline.input_started_at if self._stt_pipeline is not None else None
+
+    @_input_started_at.setter
+    def _input_started_at(self, value: float | None) -> None:
+        if self._stt_pipeline is not None:
+            self._stt_pipeline.input_started_at = value
 
     def start(
         self,
@@ -713,10 +727,11 @@ class AudioRecognition:
                 )
             )
             self._stt_pipeline = pipeline
-            # reset interruption handling related state
+            # reset interruption handling related state. the input anchor lives on the
+            # pipeline (None on a fresh one, carried over on a reused one), so it is not
+            # reset here.
             self._transcript_buffer.clear()
             self._ignore_user_transcript_until = NOT_GIVEN
-            self._input_started_at = None
         else:
             if self._stt_consumer_atask is not None:
                 task = asyncio.create_task(aio.cancel_and_wait(self._stt_consumer_atask))
@@ -798,7 +813,6 @@ class AudioRecognition:
             )
             self._transcript_buffer.clear()
             self._ignore_user_transcript_until = NOT_GIVEN
-            self._input_started_at = None
         elif self._interruption_atask is not None:
             task = asyncio.create_task(aio.cancel_and_wait(self._interruption_atask))
             task.add_done_callback(lambda _: self._tasks.discard(task))

--- a/tests/test_audio_recognition_handoff.py
+++ b/tests/test_audio_recognition_handoff.py
@@ -7,8 +7,11 @@ import pytest
 
 from livekit import rtc
 from livekit.agents import Agent
+from livekit.agents.types import NOT_GIVEN
+from livekit.agents.utils import aio
 from livekit.agents.voice.agent import ModelSettings
 from livekit.agents.voice.agent_activity import AgentActivity
+from livekit.agents.voice.audio_recognition import AudioRecognition, _STTPipeline
 from livekit.agents.voice.turn import _StreamingTurnDetector
 
 pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
@@ -200,3 +203,52 @@ async def test_turn_detector_not_reusable_when_new_opts_out() -> None:
     result = await _detach_turn_detector_if_reusable(old, new)
     assert result is None
     old._audio_recognition.detach_turn_detector.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Input-time anchor (end_time=0 wall clock) survives pipeline reuse
+# ---------------------------------------------------------------------------
+
+
+def _stub_recognition() -> AudioRecognition:
+    ar = object.__new__(AudioRecognition)
+    ar._stt_consumer_atask = None  # type: ignore[attr-defined]
+    ar._stt_pipeline = None  # type: ignore[attr-defined]
+    ar._transcript_buffer = MagicMock()  # type: ignore[attr-defined]
+    ar._ignore_user_transcript_until = NOT_GIVEN  # type: ignore[attr-defined]
+    return ar
+
+
+async def test_input_anchor_preserved_when_pipeline_reused() -> None:
+    """update_stt must not reset a reused pipeline's input anchor.
+
+    The STT ``end_time`` clock is relative to the original stream start. Re-anchoring
+    ``input_started_at`` to the handoff time would desync the two and push the derived
+    speaking time minutes into the future (see the 68s end-of-turn stall).
+    """
+    reused = object.__new__(_STTPipeline)
+    reused.input_started_at = 1000.0  # anchored during the previous activity
+    ch = aio.Chan()  # type: ignore[var-annotated]
+    ch.close()  # closed channel → the swapped-in consumer exits immediately
+    reused._event_ch = ch  # type: ignore[attr-defined]
+
+    ar = _stub_recognition()
+    ar.update_stt(MagicMock(), pipeline=reused)
+
+    assert ar._input_started_at == 1000.0  # carried over, not reset to None
+    if ar._stt_consumer_atask is not None:
+        await ar._stt_consumer_atask
+
+
+def test_input_anchor_delegates_to_pipeline() -> None:
+    """The anchor lives on the pipeline so it travels with the stream across handoff."""
+    ar = _stub_recognition()
+    assert ar._input_started_at is None  # no pipeline attached yet
+
+    pipeline = object.__new__(_STTPipeline)
+    pipeline.input_started_at = None
+    ar._stt_pipeline = pipeline  # type: ignore[attr-defined]
+
+    ar._input_started_at = 1234.5
+    assert pipeline.input_started_at == 1234.5
+    assert ar._input_started_at == 1234.5

--- a/tests/test_audio_recognition_push_audio.py
+++ b/tests/test_audio_recognition_push_audio.py
@@ -23,9 +23,10 @@ def _make_frame(byte: int = 0x11, samples: int = 160, sample_rate: int = 16000) 
 def _make_recognition() -> AudioRecognition:
     """Build an AudioRecognition stub with just the attributes ``push_audio`` reads."""
     ar = object.__new__(AudioRecognition)
-    ar._input_started_at = None  # type: ignore[attr-defined]
     ar._sample_rate = None  # type: ignore[attr-defined]
     ar._stt_pipeline = MagicMock()  # type: ignore[attr-defined]
+    # the input anchor lives on the pipeline (see _STTPipeline.input_started_at)
+    ar._stt_pipeline.input_started_at = None  # type: ignore[attr-defined]
     ar._vad_ch = MagicMock()  # type: ignore[attr-defined]
     ar._interruption_ch = MagicMock()  # type: ignore[attr-defined]
     ar._session = MagicMock()  # type: ignore[attr-defined]


### PR DESCRIPTION
## Problem

After an agent/AgentTask handoff that **reuses the STT pipeline**, a user turn could stall for a long time between the end-of-turn prediction and the actual commit. Observed in the async-tool example: a ~68s gap between `eot prediction` and `user turn committed`, with the (preemptively generated) agent turn span staying open the whole time while its LLM finished in 0.5s.

```
13:35:07  eot prediction  prob=0.82  endpointing_delay=0.3
13:36:15  user turn committed  last_speaking_time=<68s in the future>
```

## Root cause

The reused `_STTPipeline` keeps its STT stream open, so `end_time` keeps measuring from the **original** stream start. But `_input_started_at` (the wall-clock anchor for `end_time = 0`) was reset to `None` on the new `AudioRecognition` and re-anchored to the **handoff** time on the next frame.

`stt_last_speaking_time = end_time + _input_started_at` then double-counts the pre-handoff interval, yielding a `_last_speaking_time` minutes in the future. `_bounce_eou_task` waits `endpointing_delay + (last_speaking_time - now)`, so it sleeps for that entire drift before committing.

This surfaces whenever the STT timestamp is used for the speaking anchor — including the common default-VAD case (`using_default_vad=True`), where the VAD-derived time is intentionally discarded. That's why VAD never reported the user as speaking yet the turn still hung.

## Fix

Move the `input_started_at` anchor onto `_STTPipeline`, so it travels with the stream it describes, and stop resetting it in `update_stt` / `update_interruption_detection` when a pipeline is reused. `AudioRecognition._input_started_at` becomes a thin property delegating to the current pipeline, leaving all existing call sites unchanged.

## Tests

- `test_input_anchor_preserved_when_pipeline_reused` — `update_stt` with a reused pipeline keeps its anchor.
- `test_input_anchor_delegates_to_pipeline` — anchor lives on the pipeline.
- Updated `test_audio_recognition_push_audio.py` stub for the pipeline-owned anchor.

`make check` (format/lint/type) and the recognition/turn-detection unit suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)