### PR TITLE
fix(google): broaden _is_gemini_3_flash_model to cover all Gemini 3 Flash variants

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -47,7 +47,8 @@ def _is_gemini_3_model(model: str) -> bool:
 
 def _is_gemini_3_flash_model(model: str) -> bool:
     """Check if model is Gemini 3 Flash"""
-    return "gemini-3-flash" in model.lower() or model.lower().startswith("gemini-3-flash")
+    m = model.lower()
+    return m.startswith("gemini-3") and "flash" in m
 
 
 def _requires_thought_signatures(model: str) -> bool:


### PR DESCRIPTION
## Summary

- `_is_gemini_3_flash_model` previously checked for the substring `"gemini-3-flash"`, which missed `gemini-3.5-flash` (dot notation)
- New logic: `m.startswith("gemini-3") and "flash" in m` — covers both `gemini-3-flash-preview` and `gemini-3.5-flash`, while correctly excluding `gemini-3-pro-preview`
- Also removes the redundant `startswith` branch that was a subset of the `in` check

## Test plan

- [ ] Confirm `gemini-3.5-flash` returns `True`
- [ ] Confirm `gemini-3-flash-preview` returns `True`
- [ ] Confirm `gemini-3-pro-preview` returns `False`
- [ ] Confirm `gemini-2.5-flash` returns `False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)