### PR TITLE
fix(anthropic): replace whitespace-only trailing user message with non-whitespace character

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/anthropic.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/anthropic.py
@@ -98,7 +98,7 @@ def to_chat_ctx(
     # Claude 4.6+ does not support prefilling (trailing assistant messages).
     # Append a dummy user message so the request ends with a user turn.
     if inject_trailing_user_message and messages and messages[-1]["role"] == "assistant":
-        messages.append({"role": "user", "content": [{"text": " ", "type": "text"}]})
+        messages.append({"role": "user", "content": [{"text": ".", "type": "text"}]})
 
     return messages, AnthropicFormatData(system_messages=system_messages)
 


### PR DESCRIPTION
Fixes #5254
Fixes #6213

`to_chat_ctx` in `_provider_format/anthropic.py` appends a trailing user turn when `inject_trailing_user_message=True` and the chat context ends on an assistant message. This path is taken for models matched by `_NO_PREFILL_PATTERNS` (currently `claude-sonnet-4-6` and `claude-opus-4-6`) to satisfy their no-prefill constraint.

The placeholder text was a single ASCII space (`" "`), which Anthropic's Messages API rejects:

```
HTTP 400: messages: text content blocks must contain non-whitespace text
```

This fails every LLM call that goes through the no-prefill branch when the context ends on an assistant turn — common in sequential `generate_reply()` calls, agent handoffs, and silence re-engagement flows.

The fix replaces the single space with a period. The structural intent (forcing a user turn) is preserved; the one-character change is the minimal-blast-radius fix that satisfies the API constraint.