### PR TITLE
fix(anthropic): use non-whitespace trailing dummy to satisfy provider validation

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/anthropic.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/anthropic.py
@@ -98,7 +98,7 @@ def to_chat_ctx(
     # Claude 4.6+ does not support prefilling (trailing assistant messages).
     # Append a dummy user message so the request ends with a user turn.
     if inject_trailing_user_message and messages and messages[-1]["role"] == "assistant":
-        messages.append({"role": "user", "content": [{"text": " ", "type": "text"}]})
+        messages.append({"role": "user", "content": [{"text": ".", "type": "text"}]})
 
     return messages, AnthropicFormatData(system_messages=system_messages)
 


### PR DESCRIPTION
## Summary

One-line fix in `livekit-agents/livekit/agents/llm/_provider_format/anthropic.py`: the trailing dummy user message injected when the last message is from the assistant now uses `"."` instead of `" "` (a single non-whitespace character instead of whitespace).

## Why

Anthropic's API rejects messages whose text content is empty or whitespace-only. When `inject_trailing_user_message=True` appends a placeholder user turn to satisfy Claude 4.6+'s no-prefilling requirement, the current `" "` (single space) trips Anthropic's server-side validation and the request fails before the model is ever reached. Replacing it with `"."` keeps the placeholder semantically inert while clearing the validation gate.

## Relationship to existing issues

This addresses [#5254](https://github.com/livekit/agents/issues/5254), which was closed as stale. The bug still reproduces verbatim on current `main` (1.6.3) — any conversation that ends with an assistant turn and is then re-submitted to the Anthropic provider hits the same validation error described in the original report.

Requesting reopen of #5254 and merge of this fix.

## Change

```diff
-        messages.append({"role": "user", "content": [{"text": " ", "type": "text"}]})
+        messages.append({"role": "user", "content": [{"text": ".", "type": "text"}]})
```

That is the entire diff.