### PR TITLE
feat(assemblyai): add language_code streaming param for language steering

### DIFF
--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -59,6 +59,7 @@ class STTOptions:
         "universal-3-5-pro",
     ] = "universal-3-5-pro"
     language_detection: NotGivenOr[bool] = NOT_GIVEN
+    language_code: NotGivenOr[str] = NOT_GIVEN
     end_of_turn_confidence_threshold: NotGivenOr[float] = NOT_GIVEN
     min_turn_silence: NotGivenOr[int] = NOT_GIVEN
     max_turn_silence: NotGivenOr[int] = NOT_GIVEN
@@ -101,6 +102,7 @@ class STT(stt.STT):
             "universal-3-5-pro",
         ] = "universal-3-5-pro",
         language_detection: NotGivenOr[bool] = NOT_GIVEN,
+        language_code: NotGivenOr[str] = NOT_GIVEN,
         end_of_turn_confidence_threshold: NotGivenOr[float] = NOT_GIVEN,
         min_turn_silence: NotGivenOr[int] = NOT_GIVEN,
         max_turn_silence: NotGivenOr[int] = NOT_GIVEN,
@@ -134,6 +136,12 @@ class STT(stt.STT):
                 0 and 1 that determines how sensitive the VAD is. Lower values make the VAD
                 more sensitive (detects quieter speech). Higher values make it less sensitive.
                 Defaults to 0.4.
+            language_code: Steer transcription toward a specific language (e.g. 'en', 'es',
+                'fr'). When set, the model is biased toward this language instead of
+                automatically detecting/code-switching across the supported languages.
+                Leave unset to use the model's default multilingual behavior. Only
+                supported with the 'u3-rt-pro' / 'u3-rt-pro-beta-1' / 'universal-3-5-pro'
+                models. Set at construction (connect) time only.
             min_turn_silence: Minimum silence in ms before a confident end-of-turn is finalized.
             min_end_of_turn_silence_when_confident: Deprecated. Use min_turn_silence instead.
             continuous_partials: Whether to emit additional partial transcripts during long
@@ -204,6 +212,7 @@ class STT(stt.STT):
                 "voice_focus": voice_focus,
                 "voice_focus_threshold": voice_focus_threshold,
                 "mode": mode,
+                "language_code": language_code,
             }
             for _param_name, _param_value in _u3_pro_only_params.items():
                 if is_given(_param_value):
@@ -250,6 +259,7 @@ class STT(stt.STT):
             encoding=encoding,
             speech_model=model,
             language_detection=language_detection,
+            language_code=language_code,
             end_of_turn_confidence_threshold=end_of_turn_confidence_threshold,
             min_turn_silence=min_turn_silence,
             max_turn_silence=max_turn_silence,
@@ -669,6 +679,9 @@ class SpeechStream(stt.SpeechStream):
             if "multilingual" in self._opts.speech_model
             or self._opts.speech_model in _U3_PRO_MODELS
             else False,
+            "language_code": self._opts.language_code
+            if is_given(self._opts.language_code)
+            else None,
             "prompt": self._opts.prompt if is_given(self._opts.prompt) else None,
             "agent_context": self._opts.agent_context
             if is_given(self._opts.agent_context)

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -59,7 +59,7 @@ class STTOptions:
         "universal-3-5-pro",
     ] = "universal-3-5-pro"
     language_detection: NotGivenOr[bool] = NOT_GIVEN
-    language_code: NotGivenOr[str] = NOT_GIVEN
+    language_code: NotGivenOr[LanguageCode] = NOT_GIVEN
     end_of_turn_confidence_threshold: NotGivenOr[float] = NOT_GIVEN
     min_turn_silence: NotGivenOr[int] = NOT_GIVEN
     max_turn_silence: NotGivenOr[int] = NOT_GIVEN
@@ -102,7 +102,7 @@ class STT(stt.STT):
             "universal-3-5-pro",
         ] = "universal-3-5-pro",
         language_detection: NotGivenOr[bool] = NOT_GIVEN,
-        language_code: NotGivenOr[str] = NOT_GIVEN,
+        language_code: NotGivenOr[LanguageCode | str] = NOT_GIVEN,
         end_of_turn_confidence_threshold: NotGivenOr[float] = NOT_GIVEN,
         min_turn_silence: NotGivenOr[int] = NOT_GIVEN,
         max_turn_silence: NotGivenOr[int] = NOT_GIVEN,
@@ -137,11 +137,12 @@ class STT(stt.STT):
                 more sensitive (detects quieter speech). Higher values make it less sensitive.
                 Defaults to 0.4.
             language_code: Steer transcription toward a specific language (e.g. 'en', 'es',
-                'fr'). When set, the model is biased toward this language instead of
-                automatically detecting/code-switching across the supported languages.
-                Leave unset to use the model's default multilingual behavior. Only
-                supported with the 'u3-rt-pro' / 'u3-rt-pro-beta-1' / 'universal-3-5-pro'
-                models. Set at construction (connect) time only.
+                'fr'). Accepts any common format ('en', 'en-US', 'english'); it is normalized
+                to a bare ISO 639-1 code before being sent. When set, the model is biased
+                toward this language instead of automatically detecting/code-switching across
+                the supported languages. Leave unset to use the model's default multilingual
+                behavior. Only supported with the Universal-3 Pro family models. Set at
+                construction (connect) time only.
             min_turn_silence: Minimum silence in ms before a confident end-of-turn is finalized.
             min_end_of_turn_silence_when_confident: Deprecated. Use min_turn_silence instead.
             continuous_partials: Whether to emit additional partial transcripts during long
@@ -253,13 +254,19 @@ class STT(stt.STT):
         if not is_given(min_turn_silence) and not is_given(mode):
             min_turn_silence = 100
 
+        # Normalize to a bare ISO 639-1 code (e.g. "es-ES" / "Spanish" -> "es"),
+        # the form AssemblyAI's language steering expects.
+        normalized_language_code: NotGivenOr[LanguageCode] = NOT_GIVEN
+        if is_given(language_code):
+            normalized_language_code = LanguageCode(LanguageCode(language_code).language)
+
         self._opts = STTOptions(
             sample_rate=sample_rate,
             buffer_size_seconds=buffer_size_seconds,
             encoding=encoding,
             speech_model=model,
             language_detection=language_detection,
-            language_code=language_code,
+            language_code=normalized_language_code,
             end_of_turn_confidence_threshold=end_of_turn_confidence_threshold,
             min_turn_silence=min_turn_silence,
             max_turn_silence=max_turn_silence,

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -59,7 +59,7 @@ class STTOptions:
         "universal-3-5-pro",
     ] = "universal-3-5-pro"
     language_detection: NotGivenOr[bool] = NOT_GIVEN
-    language_code: NotGivenOr[LanguageCode] = NOT_GIVEN
+    language_code: NotGivenOr[str] = NOT_GIVEN
     end_of_turn_confidence_threshold: NotGivenOr[float] = NOT_GIVEN
     min_turn_silence: NotGivenOr[int] = NOT_GIVEN
     max_turn_silence: NotGivenOr[int] = NOT_GIVEN
@@ -102,7 +102,7 @@ class STT(stt.STT):
             "universal-3-5-pro",
         ] = "universal-3-5-pro",
         language_detection: NotGivenOr[bool] = NOT_GIVEN,
-        language_code: NotGivenOr[LanguageCode | str] = NOT_GIVEN,
+        language_code: NotGivenOr[str] = NOT_GIVEN,
         end_of_turn_confidence_threshold: NotGivenOr[float] = NOT_GIVEN,
         min_turn_silence: NotGivenOr[int] = NOT_GIVEN,
         max_turn_silence: NotGivenOr[int] = NOT_GIVEN,
@@ -256,9 +256,9 @@ class STT(stt.STT):
 
         # Normalize to a bare ISO 639-1 code (e.g. "es-ES" / "Spanish" -> "es"),
         # the form AssemblyAI's language steering expects.
-        normalized_language_code: NotGivenOr[LanguageCode] = NOT_GIVEN
+        normalized_language_code: NotGivenOr[str] = NOT_GIVEN
         if is_given(language_code):
-            normalized_language_code = LanguageCode(LanguageCode(language_code).language)
+            normalized_language_code = LanguageCode(language_code).language
 
         self._opts = STTOptions(
             sample_rate=sample_rate,

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -904,3 +904,101 @@ async def test_mode_connect_time_only():
 
     assert "mode" not in inspect.signature(STT.update_options).parameters
     assert "mode" not in inspect.signature(SpeechStream.update_options).parameters
+
+
+# ---------------------------------------------------------------------------
+# language_code (language steering)
+#
+# `language_code` biases transcription toward a single language (e.g. "en",
+# "es") instead of automatic detection/code-switching. Steering is only applied
+# by the u3-pro ASR, so — like `mode` and the context/voice-focus params — it is
+# u3-rt-pro-family-only and connect-time only (not exposed via update_options,
+# matching the AssemblyAI streaming API, where `language_code` is a connect-time
+# parameter and not part of UpdateConfiguration).
+# ---------------------------------------------------------------------------
+
+
+async def test_language_code_default():
+    """language_code is unset by default (automatic detection applies)."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key")
+    assert stt._opts.language_code is NOT_GIVEN
+
+
+async def test_language_code_set():
+    """language_code can be set in the constructor."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key", model="u3-rt-pro", language_code="es")
+    assert stt._opts.language_code == "es"
+
+
+async def test_language_code_requires_u3_pro_family():
+    """language_code raises ValueError when used with a non-u3-rt-pro-family model."""
+    from livekit.plugins.assemblyai import STT
+
+    with pytest.raises(ValueError, match="language_code"):
+        STT(api_key="test-key", model="universal-streaming-multilingual", language_code="es")
+
+
+async def test_language_code_allowed_for_all_u3_pro_family_models():
+    """language_code is accepted for every u3-rt-pro-family model, not just the default."""
+    from livekit.plugins.assemblyai import STT
+
+    for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro"):
+        stt = STT(api_key="test-key", model=model, language_code="en")
+        assert stt._opts.language_code == "en"
+
+
+async def test_language_code_in_connect_config():
+    """language_code is sent in the connect config query."""
+    from urllib.parse import parse_qs, urlparse
+
+    from livekit.plugins.assemblyai import STT
+
+    captured: dict = {}
+
+    async def _fake_ws_connect(url, **kwargs):
+        captured["url"] = url
+        return MagicMock()
+
+    stt = STT(api_key="test-key", model="universal-3-5-pro", language_code="es")
+    stream = _make_stream_for_unit_test(stt)
+    stream._session.ws_connect = _fake_ws_connect
+    await stream._connect_ws()
+
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert query["language_code"] == ["es"]
+
+
+async def test_language_code_absent_from_connect_config_when_unset():
+    """language_code key is omitted from the connect config when not set."""
+    from urllib.parse import parse_qs, urlparse
+
+    from livekit.plugins.assemblyai import STT
+
+    captured: dict = {}
+
+    async def _fake_ws_connect(url, **kwargs):
+        captured["url"] = url
+        return MagicMock()
+
+    stt = STT(api_key="test-key", model="universal-3-5-pro")
+    stream = _make_stream_for_unit_test(stt)
+    stream._session.ws_connect = _fake_ws_connect
+    await stream._connect_ws()
+
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert "language_code" not in query
+
+
+async def test_language_code_connect_time_only():
+    """language_code is connect-time only — not exposed via update_options."""
+    import inspect
+
+    from livekit.plugins.assemblyai import STT
+    from livekit.plugins.assemblyai.stt import SpeechStream
+
+    assert "language_code" not in inspect.signature(STT.update_options).parameters
+    assert "language_code" not in inspect.signature(SpeechStream.update_options).parameters

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -934,6 +934,22 @@ async def test_language_code_set():
     assert stt._opts.language_code == "es"
 
 
+async def test_language_code_normalized_to_iso_639_1():
+    """language_code is normalized to a bare ISO 639-1 code regardless of input format."""
+    from livekit.plugins.assemblyai import STT
+
+    for raw, expected in (
+        ("es", "es"),
+        ("es-ES", "es"),
+        ("Spanish", "es"),
+        ("en-US", "en"),
+        ("english", "en"),
+        ("pt-BR", "pt"),
+    ):
+        stt = STT(api_key="test-key", model="u3-rt-pro", language_code=raw)
+        assert stt._opts.language_code == expected
+
+
 async def test_language_code_requires_u3_pro_family():
     """language_code raises ValueError when used with a non-u3-rt-pro-family model."""
     from livekit.plugins.assemblyai import STT


### PR DESCRIPTION
## Summary

Adds a `language_code` connect-time parameter to the AssemblyAI STT plugin so users can **steer transcription toward a specific language** (e.g. `"en"`, `"es"`, `"fr"`) instead of relying on automatic detection / code-switching.

Today the plugin only exposes `language_detection`, which is an output toggle (whether `language_code`/`language_confidence` are returned on turn messages) — there is no way to *steer* the model toward a language. The AssemblyAI streaming API already accepts `language_code` as a connect-time parameter, so this just plumbs it through.

This is useful for known-monolingual sessions, where steering improves accuracy on short/ambiguous utterances (e.g. disambiguating "see" vs. "si").

## Details

- Added `language_code: NotGivenOr[str]` to `STTOptions` and the `STT.__init__` signature, forwarded into the connect-time `live_config` querystring (omitted when unset).
- **Gated to the u3-rt-pro family** (`u3-rt-pro`, `u3-rt-pro-beta-1`, `universal-3-5-pro`) via the existing `_U3_PRO_MODELS` validation — passing it with another model raises `ValueError`. Language *steering* is applied by the u3-pro ASR; on the universal-streaming models `language_code` does not steer, so this matches the parameter's documented behavior and how `mode`/`voice_focus` are handled.
- **Connect-time only**, matching the AssemblyAI streaming API — `language_code` is not part of `UpdateConfiguration`, so it is not added to `update_options`.
- Follows the structure of the recent `mode` param PR (#6156).

## Test plan

Added unit tests in `tests/test_plugin_assemblyai_stt.py`:

- default is `NOT_GIVEN`
- value is stored from the constructor
- raises `ValueError` on a non-u3-rt-pro-family model
- accepted across every u3-rt-pro-family model
- present in the connect config querystring when set
- absent from the querystring when unset
- not exposed via `update_options` (connect-time only)

```
65 passed   # full tests/test_plugin_assemblyai_stt.py
```

`ruff check` and `ruff format` pass on both changed files.