### PR TITLE
fix(assemblyai): respect `mode` preset for turn-silence; remap deprecated `u3-pro`

### DIFF
--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -78,7 +78,7 @@ class STTOptions:
     mode: NotGivenOr[Literal["min_latency", "balanced", "max_accuracy"]] = NOT_GIVEN
 
 
-# Speech models in the u3-rt-pro family, which share the same parameter support
+# Speech models in the Universal-3 Pro family, which share the same parameter support
 # (prompt, agent_context, previous_context_n_turns, continuous_partials,
 # interruption_delay, voice_focus, voice_focus_threshold) and connect-time
 # defaults. Mirrors the server-side `SpeechModel.is_u3_pro`.
@@ -144,44 +144,41 @@ class STT(stt.STT):
                 LiveKit; AssemblyAI server defaults to False), additional partials covering
                 the full turn transcript are emitted approximately every 3 seconds while
                 speech continues, on top of those baseline partials. Only supported with
-                the 'u3-rt-pro' / 'u3-rt-pro-beta-1' models.
+                the Universal-3 Pro family models.
             interruption_delay: How soon the first early partial is emitted, in ms.
                 Range 0–1000, default 500. Lower values produce faster time-to-first-token
                 for barge-in; higher values produce more confident first partials. Only
-                supported with the 'u3-rt-pro' / 'u3-rt-pro-beta-1' models.
+                supported with the Universal-3 Pro family models.
             agent_context: Free-text context describing what the agent said, used to bias
                 transcription of the user's reply. Set at construction or updated per-turn
                 via `update_options(agent_context=...)`. Only supported with the
-                'u3-rt-pro' / 'u3-rt-pro-beta-1' models (max 1500 characters).
+                Universal-3 Pro family models (max 1500 characters).
             previous_context_n_turns: Maximum number of prior conversation entries (user
                 transcripts and any `agent_context` values) carried forward as context for
                 each transcription. Set to 0 to disable automatic context carryover
                 entirely; leave unset to use the server default (recommended). Range 0–100.
-                Only supported with the 'u3-rt-pro' / 'u3-rt-pro-beta-1' / 'universal-3-5-pro'
-                models. Set at construction (connect) time only; it cannot be changed via
-                `update_options`.
+                Only supported with the Universal-3 Pro family models. Set at construction
+                (connect) time only; it cannot be changed via `update_options`.
             voice_focus: Voice Focus isolates the primary voice and suppresses background
                 noise (chatter, keyboard clicks, fan hum, room echo) before the audio reaches
                 the model. Use 'near-field' for headsets, handsets, and close-talking
                 microphones; use 'far-field' for conference rooms, laptop mics, and other
-                distant-mic setups. Only supported with the 'u3-rt-pro' / 'u3-rt-pro-beta-1' /
-                'universal-3-5-pro' models. Set at construction (connect) time only.
+                distant-mic setups. Only supported with the Universal-3 Pro family models.
+                Set at construction (connect) time only.
                 See https://www.assemblyai.com/docs/streaming/voice-focus.
             voice_focus_threshold: Controls how aggressively background audio is suppressed,
                 a float between 0.0 and 1.0 (higher is more aggressive). Only takes effect
-                alongside `voice_focus`. Only supported with the 'u3-rt-pro' /
-                'u3-rt-pro-beta-1' / 'universal-3-5-pro' models. Set at construction (connect)
-                time only.
-            mode: Accuracy/latency preset forwarded to the u3-pro model: 'min_latency'
+                alongside `voice_focus`. Only supported with the Universal-3 Pro family
+                models. Set at construction (connect) time only.
+            mode: Accuracy/latency preset for the Universal-3 Pro family: 'min_latency'
                 (fastest time-to-text), 'balanced' (the server default, recommended for
                 voice agents), or 'max_accuracy' (highest accuracy, for scribes/post-call).
                 The model applies its own per-mode silence tuning. To let that tuning take
                 effect, the plugin suppresses its default 100ms min/max turn-silence windows
                 when a mode is set; values you pass explicitly for `min_turn_silence` /
                 `max_turn_silence` still take precedence over the mode's defaults.
-                Leave unset to use the server default. Only supported with the 'u3-rt-pro' /
-                'u3-rt-pro-beta-1' / 'universal-3-5-pro' models. Set at construction (connect)
-                time only.
+                Leave unset to use the server default. Only supported with the Universal-3 Pro
+                family models. Set at construction (connect) time only.
         """
         super().__init__(
             capabilities=stt.STTCapabilities(
@@ -196,7 +193,7 @@ class STT(stt.STT):
             logger.warning("'u3-pro' is deprecated, use 'u3-rt-pro' instead.")
             model = "u3-rt-pro"
 
-        # These parameters are only supported by the u3-rt-pro family of models.
+        # These parameters are only supported by the Universal-3 Pro family of models.
         if model not in _U3_PRO_MODELS:
             _u3_pro_only_params = {
                 "prompt": prompt,
@@ -217,7 +214,7 @@ class STT(stt.STT):
 
         # LiveKit defaults continuous_partials to True (vs. AssemblyAI's server default of
         # False) for steady-cadence partials. This parameter is only supported for
-        # the u3-rt-pro family, enforced by the validation above.
+        # the Universal-3 Pro family, enforced by the validation above.
         if not is_given(continuous_partials) and model in _U3_PRO_MODELS:
             continuous_partials = True
 
@@ -621,7 +618,7 @@ class SpeechStream(stt.SpeechStream):
                 await ws.close()
 
     async def _connect_ws(self) -> aiohttp.ClientWebSocketResponse:
-        # u3-rt-pro defaults: min=100, max=min (so both 100 unless overridden).
+        # Universal-3 Pro family defaults: min=100, max=min (so both 100 unless overridden).
         # When a `mode` preset is selected, leave them unset (None) unless the
         # caller set them explicitly, so the server's per-mode silence tuning is
         # not overridden by the latency-optimized 100ms default.

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -175,8 +175,10 @@ class STT(stt.STT):
             mode: Accuracy/latency preset forwarded to the u3-pro model: 'min_latency'
                 (fastest time-to-text), 'balanced' (the server default, recommended for
                 voice agents), or 'max_accuracy' (highest accuracy, for scribes/post-call).
-                The model applies its own per-mode tuning; any silence, partials, or VAD
-                knobs you set explicitly still take precedence over the mode's defaults.
+                The model applies its own per-mode silence tuning. To let that tuning take
+                effect, the plugin suppresses its default 100ms min/max turn-silence windows
+                when a mode is set; values you pass explicitly for `min_turn_silence` /
+                `max_turn_silence` still take precedence over the mode's defaults.
                 Leave unset to use the server default. Only supported with the 'u3-rt-pro' /
                 'u3-rt-pro-beta-1' / 'universal-3-5-pro' models. Set at construction (connect)
                 time only.
@@ -239,8 +241,10 @@ class STT(stt.STT):
                 min_turn_silence = min_end_of_turn_silence_when_confident
 
         # we want to minimize latency as much as possible, it's ok if the phrase arrives in multiple final transcripts
-        # designed to work with LK's end of turn models
-        if not is_given(min_turn_silence):
+        # designed to work with LK's end of turn models.
+        # Skip this default when a `mode` preset is selected so the server's
+        # per-mode silence tuning governs instead of being overridden by 100.
+        if not is_given(min_turn_silence) and not is_given(mode):
             min_turn_silence = 100
 
         self._opts = STTOptions(
@@ -617,12 +621,18 @@ class SpeechStream(stt.SpeechStream):
                 await ws.close()
 
     async def _connect_ws(self) -> aiohttp.ClientWebSocketResponse:
-        # u3-rt-pro defaults: min=100, max=min (so both 100 unless overridden)
+        # u3-rt-pro defaults: min=100, max=min (so both 100 unless overridden).
+        # When a `mode` preset is selected, leave them unset (None) unless the
+        # caller set them explicitly, so the server's per-mode silence tuning is
+        # not overridden by the latency-optimized 100ms default.
         min_silence: int | None
         max_silence: int | None
         if self._opts.speech_model in _U3_PRO_MODELS:
+            default_min = None if is_given(self._opts.mode) else 100
             min_silence = (
-                self._opts.min_turn_silence if is_given(self._opts.min_turn_silence) else 100
+                self._opts.min_turn_silence
+                if is_given(self._opts.min_turn_silence)
+                else default_min
             )
             max_silence = (
                 self._opts.max_turn_silence

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -190,8 +190,8 @@ class STT(stt.STT):
             ),
         )
         if model == "u3-pro":
-            logger.warning("'u3-pro' is deprecated, use 'u3-rt-pro' instead.")
-            model = "u3-rt-pro"
+            logger.warning("'u3-pro' is deprecated, use 'universal-3-5-pro' instead.")
+            model = "universal-3-5-pro"
 
         # These parameters are only supported by the Universal-3 Pro family of models.
         if model not in _U3_PRO_MODELS:

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -800,6 +800,87 @@ async def test_mode_absent_from_connect_config_when_unset():
     assert "mode" not in query
 
 
+async def test_mode_omits_silence_defaults_when_unset():
+    """When `mode` is set but min/max turn silence aren't explicitly provided,
+    the plugin must NOT inject its default 100ms windows. Sending explicit
+    silence values would override the mode preset's own silence tuning
+    server-side, defeating the purpose of selecting a mode."""
+    from urllib.parse import parse_qs, urlparse
+
+    from livekit.plugins.assemblyai import STT
+
+    captured: dict = {}
+
+    async def _fake_ws_connect(url, **kwargs):
+        captured["url"] = url
+        return MagicMock()
+
+    for mode in ("min_latency", "balanced", "max_accuracy"):
+        stt = STT(api_key="test-key", model="universal-3-5-pro", mode=mode)
+        stream = _make_stream_for_unit_test(stt)
+        stream._session.ws_connect = _fake_ws_connect
+        await stream._connect_ws()
+
+        query = parse_qs(urlparse(captured["url"]).query)
+        assert query["mode"] == [mode]
+        assert "min_turn_silence" not in query
+        assert "max_turn_silence" not in query
+
+
+async def test_mode_with_explicit_silence_still_sent():
+    """Explicit min/max turn silence override the mode preset and are sent even
+    when `mode` is set."""
+    from urllib.parse import parse_qs, urlparse
+
+    from livekit.plugins.assemblyai import STT
+
+    captured: dict = {}
+
+    async def _fake_ws_connect(url, **kwargs):
+        captured["url"] = url
+        return MagicMock()
+
+    stt = STT(
+        api_key="test-key",
+        model="universal-3-5-pro",
+        mode="max_accuracy",
+        min_turn_silence=400,
+        max_turn_silence=2000,
+    )
+    stream = _make_stream_for_unit_test(stt)
+    stream._session.ws_connect = _fake_ws_connect
+    await stream._connect_ws()
+
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert query["mode"] == ["max_accuracy"]
+    assert query["min_turn_silence"] == ["400"]
+    assert query["max_turn_silence"] == ["2000"]
+
+
+async def test_silence_defaults_injected_without_mode():
+    """Without `mode`, the plugin still injects its latency-optimized 100ms
+    min/max turn silence defaults (the LiveKit default behavior)."""
+    from urllib.parse import parse_qs, urlparse
+
+    from livekit.plugins.assemblyai import STT
+
+    captured: dict = {}
+
+    async def _fake_ws_connect(url, **kwargs):
+        captured["url"] = url
+        return MagicMock()
+
+    stt = STT(api_key="test-key", model="universal-3-5-pro")
+    stream = _make_stream_for_unit_test(stt)
+    stream._session.ws_connect = _fake_ws_connect
+    await stream._connect_ws()
+
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert "mode" not in query
+    assert query["min_turn_silence"] == ["100"]
+    assert query["max_turn_silence"] == ["100"]
+
+
 async def test_mode_connect_time_only():
     """mode is connect-time only — not exposed via update_options."""
     import inspect

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -221,12 +221,26 @@ async def test_continuous_partials_requires_u3_rt_pro():
 
 
 async def test_continuous_partials_with_u3_pro_alias():
-    """Test continuous_partials works with the deprecated 'u3-pro' alias (rewritten to u3-rt-pro)."""
+    """continuous_partials works with the deprecated 'u3-pro' alias (rewritten to
+    universal-3-5-pro)."""
     from livekit.plugins.assemblyai import STT
 
     stt = STT(api_key="test-key", model="u3-pro", continuous_partials=True)
     assert stt._opts.continuous_partials is True
-    assert stt._opts.speech_model == "u3-rt-pro"
+    assert stt._opts.speech_model == "universal-3-5-pro"
+
+
+async def test_u3_pro_deprecated_rewrites_to_universal_3_5_pro():
+    """The deprecated 'u3-pro' alias warns and is rewritten to the recommended
+    default model 'universal-3-5-pro'."""
+    from livekit.plugins.assemblyai import STT
+
+    with patch("livekit.plugins.assemblyai.stt.logger") as mock_logger:
+        stt = STT(api_key="test-key", model="u3-pro")
+
+    assert stt._opts.speech_model == "universal-3-5-pro"
+    mock_logger.warning.assert_called_once()
+    assert "universal-3-5-pro" in mock_logger.warning.call_args.args[0]
 
 
 async def test_continuous_partials_update():


### PR DESCRIPTION
## Summary

Three related fixes to the AssemblyAI streaming STT plugin:

### 1. `mode` preset no longer overridden by the default turn-silence
When a streaming `mode` (`min_latency` / `balanced` / `max_accuracy`) is set, the plugin previously still injected its latency-optimized `min_turn_silence` / `max_turn_silence = 100` into the connect config. Those explicit values override the mode preset's own silence tuning server-side, so selecting a mode had no effect on silence behavior.

The 100ms default is now suppressed when a `mode` is set, so the server's per-mode tuning applies. Values passed explicitly for `min_turn_silence` / `max_turn_silence` still take precedence, and behavior is unchanged when no mode is set.

| Case | `mode` sent | `min_turn_silence` | `max_turn_silence` |
|---|---|---|---|
| `mode` set, min/max unset | yes | omitted | omitted |
| no `mode` (baseline) | — | `100` | `100` |
| `mode` + explicit min/max | yes | explicit | explicit |

### 2. Deprecated `u3-pro` alias remapped to `universal-3-5-pro`
The deprecated `u3-pro` alias was rewritten to `u3-rt-pro`; it now maps to `universal-3-5-pro` — the plugin's default and the recommended flagship streaming model. Both belong to the same Universal-3 Pro family and share every parameter, so the rewrite is a safe drop-in.

### 3. Docs: collective "Universal-3 Pro family" terminology
Docstrings/comments now refer to the "Universal-3 Pro family" collectively instead of enumerating model names. This also aligns the `continuous_partials` / `interruption_delay` / `agent_context` docs (which listed only two models) with the validation, which already accepts the whole family.

## Testing
- Added/updated unit tests: `mode` omits silence defaults across all three presets, explicit min/max still sent, baseline (no mode) still injects 100ms, and `u3-pro` deprecation rewrite + warning.
- `uv run pytest --plugin assemblyai` → **62 passed**; `ruff` and `mypy` clean.