### PR TITLE
fix(openai): expose azure_deployment on LLM and fix model property fallback

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -65,7 +65,8 @@ PromptCacheRetention = Literal["in_memory", "24h"]
 
 @dataclass
 class _LLMOptions:
-    model: str | ChatModels
+    model: str | ChatModels | None
+    azure_deployment: str | None
     user: NotGivenOr[str]
     safety_identifier: NotGivenOr[str]
     prompt_cache_key: NotGivenOr[str]
@@ -89,7 +90,7 @@ class LLM(llm.LLM):
     def __init__(
         self,
         *,
-        model: str | ChatModels = "gpt-4.1",
+        model: str | ChatModels | None = "gpt-4.1",
         api_key: NotGivenOr[str] = NOT_GIVEN,
         base_url: NotGivenOr[str] = NOT_GIVEN,
         client: openai.AsyncClient | None = None,
@@ -131,6 +132,7 @@ class LLM(llm.LLM):
 
         self._opts = _LLMOptions(
             model=model,
+            azure_deployment=None,
             user=user,
             temperature=temperature,
             parallel_tool_calls=parallel_tool_calls,
@@ -181,7 +183,11 @@ class LLM(llm.LLM):
 
     @property
     def model(self) -> str:
-        return self._opts.model
+        return self._opts.model or self._opts.azure_deployment or "unknown"
+
+    @property
+    def azure_deployment(self) -> str | None:
+        return self._opts.azure_deployment
 
     @property
     def provider(self) -> str:
@@ -190,7 +196,7 @@ class LLM(llm.LLM):
     @staticmethod
     def with_azure(
         *,
-        model: str | ChatModels = "gpt-4o",
+        model: str | ChatModels | None = None,
         azure_endpoint: str | None = None,
         azure_deployment: str | None = None,
         api_version: str | None = None,
@@ -252,6 +258,7 @@ class LLM(llm.LLM):
             verbosity=verbosity,
             max_completion_tokens=max_completion_tokens,
         )
+        llm._opts.azure_deployment = azure_deployment
         llm._owns_client = True
         return llm
 


### PR DESCRIPTION
Closes #6209

When calling `LLM.with_azure()` without an explicit `model` argument, the `model` property on the returned instance returned `"unknown"` even when `azure_deployment` was set. This happened because the model fallback in `with_azure()` previously hard-coded a default and the `model` property had no awareness of `azure_deployment`.

This change adds `azure_deployment` to `_LLMOptions` so it is tracked independently of `model`. The `with_azure()` factory now stores the `azure_deployment` value in opts rather than using it to silently fill in `model`. The `model` property is updated to fall back to `azure_deployment` when `model` is `None`, and a new `azure_deployment` property is exposed so callers can inspect the value directly.

The `LLM.__init__` signature is updated to accept `None` for `model` to support the Azure path cleanly without overloading the default.