### PR TITLE
fix(voice): don't re-issue in-flight tool calls on a new turn

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -68,6 +68,8 @@ from .generation import (
     ToolExecutionOutput,
     _AudioOutput,
     _ForwardOutput,
+    _inject_running_tool_calls,
+    _strip_running_tool_calls,
     _TextOutput,
     _TTSGenerationData,
     apply_instructions_modality,
@@ -81,7 +83,7 @@ from .generation import (
     update_instructions,
 )
 from .speech_handle import DEFAULT_INPUT_DETAILS, InputDetails, SpeechHandle
-from .tool_executor import _resolve_async_tool_options, _ToolExecutor
+from .tool_executor import _resolve_async_tool_options, _RunningTasks, _ToolExecutor
 from .turn import (
     EndpointingOptions,
     PreemptiveGenerationOptions,
@@ -2699,6 +2701,15 @@ class AgentActivity(RecognitionHooks):
         # TODO(theomonnom): since pause is closing STT/LLM/TTS, we have issues for SpeechHandle still in queue  # noqa: E501
         # I should implement a retry mechanism?
 
+        # a tool still running from a previous turn isn't in this turn's ctx, so the model
+        # re-issues it and duplicates side effects. inject an in-progress placeholder so it
+        # leaves the call alone. mutating chat_ctx directly (not a copy) keeps a custom
+        # llm_node's edits; the placeholder is stripped again before chat_ctx is forwarded.
+        _inject_running_tool_calls(
+            chat_ctx,
+            [task.ctx.function_call for task in _RunningTasks.get(self._session, {}).values()],
+        )
+
         tasks: list[asyncio.Task[Any]] = []
         llm_task, llm_gen_data = perform_llm_inference(
             node=self._agent.llm_node,
@@ -3117,7 +3128,11 @@ class AgentActivity(RecognitionHooks):
                 draining = True
 
             tool_messages = new_calls + new_fnc_outputs
-            if fnc_executed_ev._reply_required:
+            if fnc_executed_ev._reply_required and not speech_handle.interrupted:
+                # forwarding chat_ctx to the tool reply: drop the in-progress placeholders
+                # (the next turn re-injects from the live running set)
+                _strip_running_tool_calls(chat_ctx)
+
                 # refresh conversation items added during tool execution: a tool that
                 # awaits an inline AgentTask runs a whole sub-conversation, merged into
                 # the agent's chat_ctx at handoff-return - this turn's snapshot predates

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -4,7 +4,7 @@ import asyncio
 import functools
 import json
 import time
-from collections.abc import AsyncIterable, Callable, Sequence
+from collections.abc import AsyncIterable, Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
@@ -53,6 +53,66 @@ class _LLMGenerationData:
     id: str = field(default_factory=lambda: utils.shortuuid("item_"))
     started_fut: asyncio.Future[None] = field(default_factory=asyncio.Future)
     ttft: float | None = None
+
+
+# output for an injected in-progress tool call, phrased so the model waits instead of
+# re-issuing the call.
+_RUNNING_TOOL_PLACEHOLDER = "The tool call is still in progress."
+# extra flag marking an injected pair so it can be stripped before the ctx is forwarded.
+_RUNNING_PLACEHOLDER_KEY = "__lk_running_placeholder__"
+
+
+def _inject_running_tool_calls(
+    chat_ctx: ChatContext,
+    running_calls: Iterable[llm.FunctionCall],
+    *,
+    placeholder: str = _RUNNING_TOOL_PLACEHOLDER,
+) -> None:
+    """Add a flagged in-progress pair for each running tool call missing from ``chat_ctx``
+    so the model won't re-issue an in-flight call. Mutates in place; strip the pairs with
+    :func:`_strip_running_tool_calls` before the ctx is persisted or forwarded."""
+    existing = {
+        item.call_id
+        for item in chat_ctx.items
+        if item.type in ("function_call", "function_call_output")
+    }
+    for fnc_call in running_calls:
+        if fnc_call.call_id in existing:
+            continue
+        existing.add(fnc_call.call_id)
+        # copy so the executor's live FunctionCall stays unflagged
+        call = fnc_call.model_copy(
+            update={"extra": {**fnc_call.extra, _RUNNING_PLACEHOLDER_KEY: True}}
+        )
+        chat_ctx.insert(
+            [
+                call,
+                llm.FunctionCallOutput(
+                    call_id=fnc_call.call_id,
+                    name=fnc_call.name,
+                    output=placeholder,
+                    is_error=False,
+                    created_at=fnc_call.created_at,
+                ),
+            ]
+        )
+
+
+def _strip_running_tool_calls(chat_ctx: ChatContext) -> None:
+    """Remove the pairs added by :func:`_inject_running_tool_calls`, keeping everything
+    else (e.g. items a custom ``llm_node`` added)."""
+    flagged = {
+        item.call_id
+        for item in chat_ctx.items
+        if item.type == "function_call" and item.extra.get(_RUNNING_PLACEHOLDER_KEY)
+    }
+    if not flagged:
+        return
+    chat_ctx.items[:] = [
+        item
+        for item in chat_ctx.items
+        if not (item.type in ("function_call", "function_call_output") and item.call_id in flagged)
+    ]
 
 
 def perform_llm_inference(

--- a/tests/test_running_tool_placeholders.py
+++ b/tests/test_running_tool_placeholders.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents.llm.chat_context import ChatContext, FunctionCall, FunctionCallOutput
+from livekit.agents.voice.generation import (
+    _RUNNING_PLACEHOLDER_KEY,
+    _inject_running_tool_calls,
+    _strip_running_tool_calls,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_inject_adds_flagged_pair_for_inflight_call() -> None:
+    chat_ctx = ChatContext.empty()
+    chat_ctx.add_message(role="user", content="book me a flight")
+
+    running = FunctionCall(call_id="call_1", name="book_flight", arguments="{}", created_at=1.0)
+    _inject_running_tool_calls(chat_ctx, [running])
+
+    calls = [i for i in chat_ctx.items if i.type == "function_call" and i.call_id == "call_1"]
+    outs = [i for i in chat_ctx.items if i.type == "function_call_output" and i.call_id == "call_1"]
+    assert len(calls) == 1 and len(outs) == 1
+    assert calls[0].extra.get(_RUNNING_PLACEHOLDER_KEY) is True
+    assert outs[0].output and outs[0].is_error is False
+    # the call must precede its output so the pair is valid for the LLM
+    assert chat_ctx.items.index(calls[0]) < chat_ctx.items.index(outs[0])
+
+
+def test_inject_does_not_flag_the_live_running_call() -> None:
+    # the flag goes on a copy; the FunctionCall held by _RunningTasks stays clean
+    running = FunctionCall(call_id="call_1", name="book_flight", arguments="{}")
+    _inject_running_tool_calls(ChatContext.empty(), [running])
+    assert _RUNNING_PLACEHOLDER_KEY not in running.extra
+
+
+def test_inject_skips_call_already_present() -> None:
+    chat_ctx = ChatContext.empty()
+    chat_ctx.insert(FunctionCall(call_id="call_1", name="book_flight", arguments="{}"))
+    chat_ctx.insert(
+        FunctionCallOutput(call_id="call_1", name="book_flight", output="booked", is_error=False)
+    )
+
+    _inject_running_tool_calls(
+        chat_ctx, [FunctionCall(call_id="call_1", name="book_flight", arguments="{}")]
+    )
+
+    outs = [i for i in chat_ctx.items if i.type == "function_call_output" and i.call_id == "call_1"]
+    assert len(outs) == 1 and outs[0].output == "booked"
+
+
+def test_strip_removes_injected_pairs_only() -> None:
+    chat_ctx = ChatContext.empty()
+    chat_ctx.add_message(role="user", content="hi")
+    # a real, completed call/output pair (unflagged) must survive
+    chat_ctx.insert(FunctionCall(call_id="real", name="t", arguments="{}"))
+    chat_ctx.insert(FunctionCallOutput(call_id="real", name="t", output="done", is_error=False))
+
+    _inject_running_tool_calls(chat_ctx, [FunctionCall(call_id="run", name="t2", arguments="{}")])
+    _strip_running_tool_calls(chat_ctx)
+
+    assert not any(
+        i.type in ("function_call", "function_call_output") and i.call_id == "run"
+        for i in chat_ctx.items
+    )
+    assert any(i.type == "function_call" and i.call_id == "real" for i in chat_ctx.items)
+    assert any(i.type == "function_call_output" and i.call_id == "real" for i in chat_ctx.items)
+    assert any(i.type == "message" for i in chat_ctx.items)
+
+
+def test_inject_then_strip_preserves_user_added_items() -> None:
+    # mirrors llm_node mutating the ctx: the LLM sees the placeholder, the user appends an
+    # item, then we strip before forwarding -> the user's item survives, placeholder gone
+    chat_ctx = ChatContext.empty()
+    chat_ctx.add_message(role="user", content="hi")
+
+    _inject_running_tool_calls(chat_ctx, [FunctionCall(call_id="run", name="t", arguments="{}")])
+    chat_ctx.add_message(role="system", content="extra context from llm_node")
+    _strip_running_tool_calls(chat_ctx)
+
+    assert not any(getattr(i, "call_id", None) == "run" for i in chat_ctx.items)
+    assert "extra context from llm_node" in [
+        i.text_content for i in chat_ctx.items if i.type == "message"
+    ]
+
+
+def test_strip_is_noop_without_placeholders() -> None:
+    chat_ctx = ChatContext.empty()
+    chat_ctx.add_message(role="user", content="hi")
+    before = list(chat_ctx.items)
+    _strip_running_tool_calls(chat_ctx)
+    assert chat_ctx.items == before


### PR DESCRIPTION
When a new generation fires while a tool from a previous turn is still running, the in-flight call has no entry in the turn's chat context, so the model re-issues it and duplicates side effects (e.g. booking a flight twice).

This injects an ephemeral in-progress `function_call`/`function_call_output` pair for the running tool calls (from the session-wide `_RunningTasks` registry, covering both activity- and session-scoped executors) into the copy of the chat context fed to the LLM only. It is recomputed every turn and never persisted or forwarded, so it is superseded as soon as the real output lands and a placeholder can never go stale.

It also stops spawning a tool-response generation for an interrupted turn: that reply would be dropped by the interrupted check anyway and waste an LLM call. The completed tool outputs are committed to the chat context directly instead, so an interrupted tool's result is preserved rather than lost.

