### PR TITLE
feat(agent_session): allow update_options(stt=, tts=)

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -575,7 +575,22 @@ class AgentActivity(RecognitionHooks):
             # session swap changes the effective STT and a rewire ensures the next
             # utterance picks up the new instance.
             agent_owns_stt = self._agent is not None and is_given(self._agent.stt)
-            if not agent_owns_stt and self._audio_recognition is not None:
+            if agent_owns_stt and resolved_stt is not None:
+                # Silent-failure case: caller is providing a non-None STT but the
+                # agent-bound contract shadows it. Note that the resolution path
+                # treats both `agent.stt = None` and `agent.stt = SomeSTT` the same
+                # way (`is_given()` returns True for both), so this warning covers
+                # both "agent has its own STT" and "agent has STT disabled" cases
+                # where the caller tries to enable via session-level swap.
+                logger.warning(
+                    "AgentSession.update_options(stt=...) is a no-op because the "
+                    "current agent was constructed with its own stt (%r); "
+                    "activity.stt will continue to resolve to the agent's value. "
+                    "Use session.update_agent(...) or construct the agent "
+                    "without an explicit stt to redirect the session swap.",
+                    self._agent.stt,
+                )
+            elif self._audio_recognition is not None:
                 self._audio_recognition.update_stt(
                     self._agent.stt_node if resolved_stt is not None else None
                 )

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -635,10 +635,10 @@ class AgentActivity(RecognitionHooks):
 
                 # module reference; the `stt` parameter on update_options shadows
                 # the module-level name inside this function body.
-                if isinstance(old_stt, _stt_module.STT):
+                new_stt = self.stt  # reads through the updated session._stt
+                if isinstance(old_stt, _stt_module.STT) and new_stt is not old_stt:
                     old_stt.off("metrics_collected", self._on_metrics_collected)
                     old_stt.off("error", self._on_error)
-                new_stt = self.stt  # reads through the updated session._stt
                 if isinstance(new_stt, _stt_module.STT) and new_stt is not old_stt:
                     new_stt.on("metrics_collected", self._on_metrics_collected)
                     new_stt.on("error", self._on_error)
@@ -699,10 +699,10 @@ class AgentActivity(RecognitionHooks):
 
                 # module reference; the `tts` parameter on update_options shadows
                 # the module-level name inside this function body.
-                if isinstance(old_tts, _tts_module.TTS):
+                new_tts = self.tts  # reads through the updated session._tts
+                if isinstance(old_tts, _tts_module.TTS) and new_tts is not old_tts:
                     old_tts.off("metrics_collected", self._on_metrics_collected)
                     old_tts.off("error", self._on_error)
-                new_tts = self.tts  # reads through the updated session._tts
                 if isinstance(new_tts, _tts_module.TTS) and new_tts is not old_tts:
                     new_tts.on("metrics_collected", self._on_metrics_collected)
                     new_tts.on("error", self._on_error)

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -575,43 +575,70 @@ class AgentActivity(RecognitionHooks):
             # session swap changes the effective STT and a rewire ensures the next
             # utterance picks up the new instance.
             agent_owns_stt = self._agent is not None and is_given(self._agent.stt)
-            if agent_owns_stt:
-                if resolved_stt is not None:
-                    # Silent-failure case: caller is providing a non-None STT but the
-                    # agent-bound contract shadows it. Note that the resolution path
-                    # treats both `agent.stt = None` and `agent.stt = SomeSTT` the same
-                    # way (`is_given()` returns True for both), so this warning covers
-                    # both "agent has its own STT" and "agent has STT disabled" cases
-                    # where the caller tries to enable via session-level swap.
-                    logger.warning(
-                        "AgentSession.update_options(stt=...) is a no-op because the "
-                        "current agent was constructed with its own stt (%r); "
-                        "activity.stt will continue to resolve to the agent's value. "
-                        "Use session.update_agent(...) or construct the agent "
-                        "without an explicit stt to redirect the session swap.",
-                        self._agent.stt,
-                    )
+            if agent_owns_stt and resolved_stt is not None:
+                # Silent-failure case: caller is providing a non-None STT but the
+                # agent-bound contract shadows it. Note that the resolution path
+                # treats both `agent.stt = None` and `agent.stt = SomeSTT` the same
+                # way (`is_given()` returns True for both), so this warning covers
+                # both "agent has its own STT" and "agent has STT disabled" cases
+                # where the caller tries to enable via session-level swap. We also
+                # skip prewarm() here so providers that eagerly open connections
+                # (e.g. Sarvam STT overriding prewarm) don't open WebSockets that
+                # will never be used (since activity.stt will keep resolving to
+                # agent._stt).
+                logger.warning(
+                    "AgentSession.update_options(stt=...) is a no-op because the "
+                    "current agent was constructed with its own stt (%r); "
+                    "activity.stt will continue to resolve to the agent's value. "
+                    "Use session.update_agent(...) or construct the agent "
+                    "without an explicit stt to redirect the session swap.",
+                    self._agent.stt,
+                )
             elif self._audio_recognition is not None:
                 self._audio_recognition.update_stt(
                     self._agent.stt_node if resolved_stt is not None else None
                 )
-            # Prewarm the new STT instance so providers that eagerly open connections
-            # don't pay first-call latency after a swap. Base-class prewarm() is a no-op,
-            # so this is a free call for the common case.
-            if resolved_stt is not None:
-                resolved_stt.prewarm()
+                # Prewarm the new STT instance so providers that eagerly open
+                # connections don't pay first-call latency after a swap. Only
+                # called on the safe branch above; the agent-bound case skipped
+                # prewarm to avoid opening connections that will never be used.
+                # Base-class prewarm() is a no-op, so this is a free call for
+                # the common case.
+                if resolved_stt is not None:
+                    resolved_stt.prewarm()
 
         if is_given(tts):
-            # No pipeline to restart: tts_node reads activity.tts fresh on every synthesis
-            # call. Mirror the swap onto session._tts so activity.tts resolves to the new
-            # instance on the next read — see the stt branch above for the rationale.
+            # No TTS pipeline to restart: tts_node reads activity.tts fresh on every
+            # synthesis call, so the session swap takes effect on the next synthesis
+            # without rewiring. The session mirror (line below) keeps the resolution
+            # order consistent when callers bypass the session entry point and call
+            # update_options on the activity directly. As with STT, we deliberately
+            # do NOT touch agent._tts; agent-bound TTS keeps precedence.
             resolved_tts = tts if tts is not None else None
             self._session._tts = resolved_tts
-            # Prewarm the new TTS instance. For providers like Sarvam TTS that open a
-            # WebSocket from a connection pool, this opens one connection during the
-            # swap so the first synthesis doesn't pay connection-setup latency.
-            if resolved_tts is not None:
-                resolved_tts.prewarm()
+            # Mirror the STT branch: when the agent owns its own TTS, session-level
+            # swaps are silently shadowed by the agent-bound value on the next read.
+            # Warn so callers know they need update_agent(...) or to omit the tts
+            # kwarg on the agent, and skip prewarm() so providers like Sarvam TTS
+            # that eagerly open WebSockets don't waste resources on an instance that
+            # will never be used.
+            agent_owns_tts = self._agent is not None and is_given(self._agent.tts)
+            if agent_owns_tts and resolved_tts is not None:
+                logger.warning(
+                    "AgentSession.update_options(tts=...) is a no-op because the "
+                    "current agent was constructed with its own tts (%r); "
+                    "activity.tts will continue to resolve to the agent's value. "
+                    "Use session.update_agent(...) or construct the agent "
+                    "without an explicit tts to redirect the session swap.",
+                    self._agent.tts,
+                )
+            else:
+                # Prewarm the new TTS instance so providers that eagerly open
+                # connections don't pay first-call latency after a swap. Only
+                # called on the safe branch above; the agent-bound case skipped
+                # prewarm to avoid opening WebSockets that will never be used.
+                if resolved_tts is not None:
+                    resolved_tts.prewarm()
 
         if self._audio_recognition:
             self._audio_recognition.update_options(

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -565,6 +565,12 @@ class AgentActivity(RecognitionHooks):
             # We deliberately do NOT touch agent._stt; that is user-owned agent config
             # and the existing activity.stt resolution order prefers it when present.
             resolved_stt = stt if stt is not None else None
+            # Capture the *prior* session-level STT before mutating it. We read the raw
+            # session attribute (NOT self.stt) because self.stt resolves through the
+            # agent-bound chain too — on the agent-bound path self.stt returns agent._stt,
+            # but we only reach this point on the common path. Reading the raw attribute
+            # makes the captured reference the exact instance being replaced.
+            old_stt = self._session._stt
             self._session._stt = resolved_stt
             # Rewire the live STT pipeline only if the agent does NOT own its STT.
             # When the agent was constructed with its own STT, activity.stt resolves
@@ -610,6 +616,29 @@ class AgentActivity(RecognitionHooks):
                 # the common case.
                 if resolved_stt is not None:
                     resolved_stt.prewarm()
+                # Migrate metrics/error event listeners from old to new STT.
+                # _start_session (lines ~906-908) attaches metrics_collected/error
+                # listeners to whichever STT instance is current at start time,
+                # and _stop_session (lines ~1188-1190) detaches from whichever
+                # instance is current at teardown time. After a runtime swap,
+                # the new instance never had listeners attached (silently dropping
+                # metrics and error events), while the old instance retained
+                # orphaned listeners (preventing GC and routing stale events).
+                # We close that gap here on the common-path branch — the only
+                # branch where the effective STT actually changes. Listener
+                # migration is a no-op when the old and new instances are the
+                # same object.
+                from .. import stt as _stt_module  # local re-import to get the
+
+                # module reference; the `stt` parameter on update_options shadows
+                # the module-level name inside this function body.
+                if isinstance(old_stt, _stt_module.STT):
+                    old_stt.off("metrics_collected", self._on_metrics_collected)
+                    old_stt.off("error", self._on_error)
+                new_stt = self.stt  # reads through the updated session._stt
+                if isinstance(new_stt, _stt_module.STT) and new_stt is not old_stt:
+                    new_stt.on("metrics_collected", self._on_metrics_collected)
+                    new_stt.on("error", self._on_error)
 
         if is_given(tts):
             # No TTS pipeline to restart: tts_node reads activity.tts fresh on every
@@ -619,6 +648,10 @@ class AgentActivity(RecognitionHooks):
             # update_options on the activity directly. As with STT, we deliberately
             # do NOT touch agent._tts; agent-bound TTS keeps precedence.
             resolved_tts = tts if tts is not None else None
+            # Capture the *prior* session-level TTS before mutating session._tts.
+            # See the STT branch above for the rationale (raw session attribute
+            # instead of self.tts to avoid the agent-bound resolution).
+            old_tts = self._session._tts
             self._session._tts = resolved_tts
             # Mirror the STT branch: when the agent owns its own TTS, session-level
             # swaps are silently shadowed by the agent-bound value on the next read.
@@ -637,12 +670,26 @@ class AgentActivity(RecognitionHooks):
                     self._agent.tts,
                 )
             else:
-                # Prewarm the new TTS instance so providers that eagerly open
-                # connections don't pay first-call latency after a swap. Only
-                # called on the safe branch above; the agent-bound case skipped
-                # prewarm to avoid opening WebSockets that will never be used.
+                # Common path: prewarm and migrate listeners. Listener migration
+                # is what _start_session does for the initial TTS — _stop_session
+                # symmetrically detaches from the current instance at teardown.
+                # Without this, swapping TTS at runtime would silently drop
+                # metrics_collected/error events from the new instance and leave
+                # orphaned listeners on the old one. Mirrors the STT listener
+                # migration above.
                 if resolved_tts is not None:
                     resolved_tts.prewarm()
+                from .. import tts as _tts_module  # local re-import to get the
+
+                # module reference; the `tts` parameter on update_options shadows
+                # the module-level name inside this function body.
+                if isinstance(old_tts, _tts_module.TTS):
+                    old_tts.off("metrics_collected", self._on_metrics_collected)
+                    old_tts.off("error", self._on_error)
+                new_tts = self.tts  # reads through the updated session._tts
+                if isinstance(new_tts, _tts_module.TTS) and new_tts is not old_tts:
+                    new_tts.on("metrics_collected", self._on_metrics_collected)
+                    new_tts.on("error", self._on_error)
 
         if self._audio_recognition:
             self._audio_recognition.update_options(

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -561,31 +561,36 @@ class AgentActivity(RecognitionHooks):
             # Rewire the live STT pipeline. We pass the agent's stt_node (the bound method),
             # which the agent_activity wired in during __init__ — passing it here mirrors that
             # initial wiring, but the STT instance it pulls from inside the node now reads
-            # activity.stt per call (which has been updated on the session and agent).
-            # Passing None disables STT.
+            # activity.stt per call. Passing None disables STT.
             if self._audio_recognition is not None:
                 self._audio_recognition.update_stt(
                     self._agent.stt_node if stt is not None else None
                 )
-            # Also mirror the swap onto session._stt / agent._stt so activity.stt
-            # resolves to the new instance on the next read. AgentSession.update_options
-            # already does this before calling here, so this branch is normally a no-op
-            # — but it makes the contract symmetric for callers that invoke
-            # update_options on the activity directly (e.g. custom plugins or tests).
+            # Mirror the swap onto session._stt so activity.stt resolves to the new
+            # instance on the next read. AgentSession.update_options already does this
+            # before calling here, so this is normally a no-op — but it keeps the contract
+            # symmetric for callers that invoke update_options on the activity directly.
+            # We deliberately do NOT touch agent._stt; that is user-owned agent config
+            # and the existing activity.stt resolution order prefers it when present.
             resolved_stt = stt if stt is not None else None
             self._session._stt = resolved_stt
-            if is_given(self._agent.stt):
-                self._agent._stt = resolved_stt
+            # Prewarm the new STT instance so providers that eagerly open connections
+            # don't pay first-call latency after a swap. Base-class prewarm() is a no-op,
+            # so this is a free call for the common case.
+            if resolved_stt is not None:
+                resolved_stt.prewarm()
 
         if is_given(tts):
             # No pipeline to restart: tts_node reads activity.tts fresh on every synthesis
-            # call. Mirror the swap onto session._tts / agent._tts so activity.tts
-            # resolves to the new instance on the next read — see the stt branch above
-            # for the rationale.
+            # call. Mirror the swap onto session._tts so activity.tts resolves to the new
+            # instance on the next read — see the stt branch above for the rationale.
             resolved_tts = tts if tts is not None else None
             self._session._tts = resolved_tts
-            if is_given(self._agent.tts):
-                self._agent._tts = resolved_tts
+            # Prewarm the new TTS instance. For providers like Sarvam TTS that open a
+            # WebSocket from a connection pool, this opens one connection during the
+            # swap so the first synthesis doesn't pay connection-setup latency.
+            if resolved_tts is not None:
+                resolved_tts.prewarm()
 
         if self._audio_recognition:
             self._audio_recognition.update_options(

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -575,21 +575,22 @@ class AgentActivity(RecognitionHooks):
             # session swap changes the effective STT and a rewire ensures the next
             # utterance picks up the new instance.
             agent_owns_stt = self._agent is not None and is_given(self._agent.stt)
-            if agent_owns_stt and resolved_stt is not None:
-                # Silent-failure case: caller is providing a non-None STT but the
-                # agent-bound contract shadows it. Note that the resolution path
-                # treats both `agent.stt = None` and `agent.stt = SomeSTT` the same
-                # way (`is_given()` returns True for both), so this warning covers
-                # both "agent has its own STT" and "agent has STT disabled" cases
-                # where the caller tries to enable via session-level swap.
-                logger.warning(
-                    "AgentSession.update_options(stt=...) is a no-op because the "
-                    "current agent was constructed with its own stt (%r); "
-                    "activity.stt will continue to resolve to the agent's value. "
-                    "Use session.update_agent(...) or construct the agent "
-                    "without an explicit stt to redirect the session swap.",
-                    self._agent.stt,
-                )
+            if agent_owns_stt:
+                if resolved_stt is not None:
+                    # Silent-failure case: caller is providing a non-None STT but the
+                    # agent-bound contract shadows it. Note that the resolution path
+                    # treats both `agent.stt = None` and `agent.stt = SomeSTT` the same
+                    # way (`is_given()` returns True for both), so this warning covers
+                    # both "agent has its own STT" and "agent has STT disabled" cases
+                    # where the caller tries to enable via session-level swap.
+                    logger.warning(
+                        "AgentSession.update_options(stt=...) is a no-op because the "
+                        "current agent was constructed with its own stt (%r); "
+                        "activity.stt will continue to resolve to the agent's value. "
+                        "Use session.update_agent(...) or construct the agent "
+                        "without an explicit stt to redirect the session swap.",
+                        self._agent.stt,
+                    )
             elif self._audio_recognition is not None:
                 self._audio_recognition.update_stt(
                     self._agent.stt_node if resolved_stt is not None else None

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -514,7 +514,7 @@ class AgentActivity(RecognitionHooks):
         *,
         tool_choice: NotGivenOr[llm.ToolChoice | None] = NOT_GIVEN,
         stt: NotGivenOr[stt.STT | None] = NOT_GIVEN,
-        tts: NotGivenOr[object] = NOT_GIVEN,
+        tts: NotGivenOr[tts.TTS | None] = NOT_GIVEN,
         endpointing_opts: NotGivenOr[EndpointingOptions] = NOT_GIVEN,
         turn_detection: NotGivenOr[TurnDetectionMode | None] = NOT_GIVEN,
         # deprecated
@@ -567,12 +567,25 @@ class AgentActivity(RecognitionHooks):
                 self._audio_recognition.update_stt(
                     self._agent.stt_node if stt is not None else None
                 )
+            # Also mirror the swap onto session._stt / agent._stt so activity.stt
+            # resolves to the new instance on the next read. AgentSession.update_options
+            # already does this before calling here, so this branch is normally a no-op
+            # — but it makes the contract symmetric for callers that invoke
+            # update_options on the activity directly (e.g. custom plugins or tests).
+            resolved_stt = stt if stt is not None else None
+            self._session._stt = resolved_stt
+            if is_given(self._agent.stt):
+                self._agent._stt = resolved_stt
 
         if is_given(tts):
             # No pipeline to restart: tts_node reads activity.tts fresh on every synthesis
-            # call, and activity.tts already resolves to the new TTS because session._tts
-            # and (if applicable) agent._tts were updated upstream in AgentSession.update_options.
-            pass
+            # call. Mirror the swap onto session._tts / agent._tts so activity.tts
+            # resolves to the new instance on the next read — see the stt branch above
+            # for the rationale.
+            resolved_tts = tts if tts is not None else None
+            self._session._tts = resolved_tts
+            if is_given(self._agent.tts):
+                self._agent._tts = resolved_tts
 
         if self._audio_recognition:
             self._audio_recognition.update_options(

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -575,25 +575,29 @@ class AgentActivity(RecognitionHooks):
             # session swap changes the effective STT and a rewire ensures the next
             # utterance picks up the new instance.
             agent_owns_stt = self._agent is not None and is_given(self._agent.stt)
-            if agent_owns_stt and resolved_stt is not None:
-                # Silent-failure case: caller is providing a non-None STT but the
-                # agent-bound contract shadows it. Note that the resolution path
-                # treats both `agent.stt = None` and `agent.stt = SomeSTT` the same
-                # way (`is_given()` returns True for both), so this warning covers
-                # both "agent has its own STT" and "agent has STT disabled" cases
-                # where the caller tries to enable via session-level swap. We also
-                # skip prewarm() here so providers that eagerly open connections
-                # (e.g. Sarvam STT overriding prewarm) don't open WebSockets that
-                # will never be used (since activity.stt will keep resolving to
-                # agent._stt).
-                logger.warning(
-                    "AgentSession.update_options(stt=...) is a no-op because the "
-                    "current agent was constructed with its own stt (%r); "
-                    "activity.stt will continue to resolve to the agent's value. "
-                    "Use session.update_agent(...) or construct the agent "
-                    "without an explicit stt to redirect the session swap.",
-                    self._agent.stt,
-                )
+            if agent_owns_stt:
+                # Agent owns its STT — session-level swap is silently shadowed by
+                # the activity.stt resolution order regardless of whether the caller
+                # passes a non-None STT or None. Skip the pipeline rewire entirely:
+                # - For non-None resolved_stt: the rewire would either no-op (if the
+                #   caller passed the same STT instance the agent already has) or
+                #   restart the pipeline with no functional change since
+                #   activity.stt still resolves to agent._stt — losing buffered
+                #   transcription and tearing down the in-progress stream.
+                # - For resolved_stt=None: the rewire would call update_stt(None)
+                #   which cancels the consumer task and tears down the pipeline
+                #   even though the agent's STT is still configured and should
+                #   keep the pipeline running. Speech recognition would silently
+                #   stop for the rest of the session.
+                if resolved_stt is not None:
+                    logger.warning(
+                        "AgentSession.update_options(stt=...) is a no-op because the "
+                        "current agent was constructed with its own stt (%r); "
+                        "activity.stt will continue to resolve to the agent's value. "
+                        "Use session.update_agent(...) or construct the agent "
+                        "without an explicit stt to redirect the session swap.",
+                        self._agent.stt,
+                    )
             elif self._audio_recognition is not None:
                 self._audio_recognition.update_stt(
                     self._agent.stt_node if resolved_stt is not None else None

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -513,6 +513,8 @@ class AgentActivity(RecognitionHooks):
         self,
         *,
         tool_choice: NotGivenOr[llm.ToolChoice | None] = NOT_GIVEN,
+        stt: NotGivenOr[stt.STT | None] = NOT_GIVEN,
+        tts: NotGivenOr[object] = NOT_GIVEN,
         endpointing_opts: NotGivenOr[EndpointingOptions] = NOT_GIVEN,
         turn_detection: NotGivenOr[TurnDetectionMode | None] = NOT_GIVEN,
         # deprecated
@@ -554,6 +556,23 @@ class AgentActivity(RecognitionHooks):
                 "manual",
                 "realtime_llm",
             )
+
+        if is_given(stt):
+            # Rewire the live STT pipeline. We pass the agent's stt_node (the bound method),
+            # which the agent_activity wired in during __init__ — passing it here mirrors that
+            # initial wiring, but the STT instance it pulls from inside the node now reads
+            # activity.stt per call (which has been updated on the session and agent).
+            # Passing None disables STT.
+            if self._audio_recognition is not None:
+                self._audio_recognition.update_stt(
+                    self._agent.stt_node if stt is not None else None
+                )
+
+        if is_given(tts):
+            # No pipeline to restart: tts_node reads activity.tts fresh on every synthesis
+            # call, and activity.tts already resolves to the new TTS because session._tts
+            # and (if applicable) agent._tts were updated upstream in AgentSession.update_options.
+            pass
 
         if self._audio_recognition:
             self._audio_recognition.update_options(

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -660,15 +660,16 @@ class AgentActivity(RecognitionHooks):
             # that eagerly open WebSockets don't waste resources on an instance that
             # will never be used.
             agent_owns_tts = self._agent is not None and is_given(self._agent.tts)
-            if agent_owns_tts and resolved_tts is not None:
-                logger.warning(
-                    "AgentSession.update_options(tts=...) is a no-op because the "
-                    "current agent was constructed with its own tts (%r); "
-                    "activity.tts will continue to resolve to the agent's value. "
-                    "Use session.update_agent(...) or construct the agent "
-                    "without an explicit tts to redirect the session swap.",
-                    self._agent.tts,
-                )
+            if agent_owns_tts:
+                if resolved_tts is not None:
+                    logger.warning(
+                        "AgentSession.update_options(tts=...) is a no-op because the "
+                        "current agent was constructed with its own tts (%r); "
+                        "activity.tts will continue to resolve to the agent's value. "
+                        "Use session.update_agent(...) or construct the agent "
+                        "without an explicit tts to redirect the session swap.",
+                        self._agent.tts,
+                    )
             else:
                 # Common path: prewarm and migrate listeners. Listener migration
                 # is what _start_session does for the initial TTS — _stop_session

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -570,9 +570,12 @@ class AgentActivity(RecognitionHooks):
             # agent-bound chain too — on the agent-bound path self.stt returns agent._stt,
             # but we only reach this point on the common path. Reading the raw attribute
             # makes the captured reference the exact instance being replaced.
+            # AgentSession.update_options writes self._session._stt AFTER calling us
+            # when _activity is None, so this capture correctly sees the prior value
+            # in both cases (when _activity is set, AgentSession doesn't pre-write
+            # — letting us do the write + migration atomically).
             old_stt = self._session._stt
             self._session._stt = resolved_stt
-            # Rewire the live STT pipeline only if the agent does NOT own its STT.
             # When the agent was constructed with its own STT, activity.stt resolves
             # to agent._stt (unchanged by this swap, per the agent-bound contract),
             # so the pipeline would just restart with the exact same STT instance —
@@ -661,6 +664,18 @@ class AgentActivity(RecognitionHooks):
             # will never be used.
             agent_owns_tts = self._agent is not None and is_given(self._agent.tts)
             if agent_owns_tts:
+                # Mirror the STT branch: when the agent owns its own TTS,
+                # session-level swap is silently shadowed by the agent-bound value
+                # on the next read regardless of whether the caller passes a
+                # non-None TTS or None. Skip prewarm, listener migration, and
+                # everything else — the agent-bound contract means there's no
+                # actual swap. The warning only fires on the "you tried to set"
+                # case (caller passed a non-None TTS).
+                # Devin Review on PR #6235: this also closes the
+                # double-attach bug — _start_session attaches listeners on the
+                # agent-bound TTS, and previously update_options would call
+                # .on() again when agent_owns_tts=True and resolved_tts=None,
+                # leaking listeners that never get cleaned up.
                 if resolved_tts is not None:
                     logger.warning(
                         "AgentSession.update_options(tts=...) is a no-op because the "

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -558,14 +558,6 @@ class AgentActivity(RecognitionHooks):
             )
 
         if is_given(stt):
-            # Rewire the live STT pipeline. We pass the agent's stt_node (the bound method),
-            # which the agent_activity wired in during __init__ — passing it here mirrors that
-            # initial wiring, but the STT instance it pulls from inside the node now reads
-            # activity.stt per call. Passing None disables STT.
-            if self._audio_recognition is not None:
-                self._audio_recognition.update_stt(
-                    self._agent.stt_node if stt is not None else None
-                )
             # Mirror the swap onto session._stt so activity.stt resolves to the new
             # instance on the next read. AgentSession.update_options already does this
             # before calling here, so this is normally a no-op — but it keeps the contract
@@ -574,6 +566,19 @@ class AgentActivity(RecognitionHooks):
             # and the existing activity.stt resolution order prefers it when present.
             resolved_stt = stt if stt is not None else None
             self._session._stt = resolved_stt
+            # Rewire the live STT pipeline only if the agent does NOT own its STT.
+            # When the agent was constructed with its own STT, activity.stt resolves
+            # to agent._stt (unchanged by this swap, per the agent-bound contract),
+            # so the pipeline would just restart with the exact same STT instance —
+            # tearing down the in-progress stream and losing buffered transcription
+            # for no functional change. When the agent does not own its STT, the
+            # session swap changes the effective STT and a rewire ensures the next
+            # utterance picks up the new instance.
+            agent_owns_stt = self._agent is not None and is_given(self._agent.stt)
+            if not agent_owns_stt and self._audio_recognition is not None:
+                self._audio_recognition.update_stt(
+                    self._agent.stt_node if resolved_stt is not None else None
+                )
             # Prewarm the new STT instance so providers that eagerly open connections
             # don't pay first-call latency after a swap. Base-class prewarm() is a no-op,
             # so this is a free call for the common case.

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1100,9 +1100,13 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         Args:
             stt (NotGivenOr[stt.STT | None], optional): Replace the speech-to-text component.
                 The live recognition pipeline is rewired immediately; the new language/model
-                takes effect from the next speech segment.
+                takes effect from the next speech segment. If the current agent was
+                constructed with its own STT, it continues to take precedence via the
+                existing ``activity.stt`` resolution order — use ``session.update_agent``
+                or construct the agent without its own STT to redirect fully.
             tts (NotGivenOr[tts.TTS | None], optional): Replace the text-to-speech component.
                 Takes effect from the next synthesis call — no pipeline restart required.
+                Agent-bound TTS behaves the same way as agent-bound STT.
             endpointing_opts (NotGivenOr[EndpointingOptions], optional): Endpointing options.
             turn_detection (NotGivenOr[TurnDetectionMode | None], optional): Strategy for deciding
                 when the user has finished speaking. ``None`` reverts to automatic selection.
@@ -1144,18 +1148,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         if is_given(stt):
             self._stt = stt
-            # activity.stt prefers agent._stt when the agent was initialized with its own
-            # STT instance, so mirror the swap there too. Otherwise the activity would keep
-            # reading the old agent-bound STT and ignore the new session-level one.
-            if self._agent is not None and is_given(self._agent.stt):
-                self._agent._stt = stt
 
         if is_given(tts):
             self._tts = tts
-            # Same rationale as stt above: if the current agent was given its own TTS at
-            # construction, the activity resolves tts via agent._tts first.
-            if self._agent is not None and is_given(self._agent.tts):
-                self._agent._tts = tts
 
         if self._activity is not None:
             self._activity.update_options(

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1117,6 +1117,14 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             ``stt`` and ``tts`` are also module names imported at the top of this file. Inside
             this method they are rebound to the parameter values; the module references are
             not used in the method body, so no aliasing is required.
+
+        Note:
+            The framework does not take ownership of STT/TTS instances passed in. The previous
+            instances are *not* closed automatically — the caller is responsible for managing
+            their lifecycle (consistent with how ``AgentSession``'s constructor treats the
+            initial ``stt`` and ``tts`` arguments). If you want the old instances closed
+            after a swap, call ``await old_stt.aclose()`` (and likewise for TTS) yourself
+            once the swap is complete.
         """
         if is_given(min_endpointing_delay) or is_given(max_endpointing_delay):
             logger.warning(

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1154,11 +1154,12 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         if is_given(turn_detection):
             self._turn_detection = turn_detection
 
-        if is_given(stt):
-            self._stt = stt
-
-        if is_given(tts):
-            self._tts = tts
+        # Note: self._stt / self._tts are NOT written here. AgentActivity.update_options
+        # performs the actual swap (writes self._session._stt, self._session._tts, and
+        # migrates metrics/error event listeners) so the capture-old / apply-new sequence
+        # runs in one method. This ordering is required for listener migration to work —
+        # the activity reads the prior session._stt before mutating it, and that prior
+        # value must still be the old instance.
 
         if self._activity is not None:
             self._activity.update_options(

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1154,12 +1154,14 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         if is_given(turn_detection):
             self._turn_detection = turn_detection
 
-        # Note: self._stt / self._tts are NOT written here. AgentActivity.update_options
-        # performs the actual swap (writes self._session._stt, self._session._tts, and
-        # migrates metrics/error event listeners) so the capture-old / apply-new sequence
-        # runs in one method. This ordering is required for listener migration to work —
-        # the activity reads the prior session._stt before mutating it, and that prior
-        # value must still be the old instance.
+        # self._stt and self._tts are mutated by Activity.update_options when
+        # _activity is set. When _activity is None (pre-start or between agent
+        # handoffs), we still need to keep public state consistent so callers
+        # can read it back via session._stt / session._tts. We do this AFTER the
+        # activity call to preserve listener migration — the activity needs to
+        # read the prior value of self._stt before we mutate it. When _activity
+        # is None, no listener migration is needed (no listeners exist yet),
+        # so the post-write is harmless.
 
         if self._activity is not None:
             self._activity.update_options(
@@ -1170,6 +1172,13 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 ),
                 turn_detection=turn_detection,
             )
+        else:
+            # No activity yet — just update public state so the next time an
+            # activity starts (session.start(agent)), it sees the swapped values.
+            if is_given(stt):
+                self._stt = stt
+            if is_given(tts):
+                self._tts = tts
 
     async def _start_ivr_detection(self, transcript: str | None = None) -> None:
         """Start IVR detection on this session.

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1086,6 +1086,8 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
     def update_options(
         self,
         *,
+        stt: NotGivenOr[stt.STT | None] = NOT_GIVEN,
+        tts: NotGivenOr[tts.TTS | None] = NOT_GIVEN,
         endpointing_opts: NotGivenOr[EndpointingOptions] = NOT_GIVEN,
         turn_detection: NotGivenOr[TurnDetectionMode | None] = NOT_GIVEN,
         # deprecated
@@ -1096,11 +1098,21 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         Update the options for the agent session.
 
         Args:
+            stt (NotGivenOr[stt.STT | None], optional): Replace the speech-to-text component.
+                The live recognition pipeline is rewired immediately; the new language/model
+                takes effect from the next speech segment.
+            tts (NotGivenOr[tts.TTS | None], optional): Replace the text-to-speech component.
+                Takes effect from the next synthesis call — no pipeline restart required.
             endpointing_opts (NotGivenOr[EndpointingOptions], optional): Endpointing options.
             turn_detection (NotGivenOr[TurnDetectionMode | None], optional): Strategy for deciding
                 when the user has finished speaking. ``None`` reverts to automatic selection.
             min_endpointing_delay: Deprecated, use ``endpointing_opts`` instead.
             max_endpointing_delay: Deprecated, use ``endpointing_opts`` instead.
+
+        Note:
+            ``stt`` and ``tts`` are also module names imported at the top of this file. Inside
+            this method they are rebound to the parameter values; the module references are
+            not used in the method body, so no aliasing is required.
         """
         if is_given(min_endpointing_delay) or is_given(max_endpointing_delay):
             logger.warning(
@@ -1130,8 +1142,25 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         if is_given(turn_detection):
             self._turn_detection = turn_detection
 
+        if is_given(stt):
+            self._stt = stt
+            # activity.stt prefers agent._stt when the agent was initialized with its own
+            # STT instance, so mirror the swap there too. Otherwise the activity would keep
+            # reading the old agent-bound STT and ignore the new session-level one.
+            if self._agent is not None and is_given(self._agent.stt):
+                self._agent._stt = stt
+
+        if is_given(tts):
+            self._tts = tts
+            # Same rationale as stt above: if the current agent was given its own TTS at
+            # construction, the activity resolves tts via agent._tts first.
+            if self._agent is not None and is_given(self._agent.tts):
+                self._agent._tts = tts
+
         if self._activity is not None:
             self._activity.update_options(
+                stt=stt,
+                tts=tts,
                 endpointing_opts=(
                     self._opts.endpointing if is_given(endpointing_opts) else NOT_GIVEN
                 ),

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1154,15 +1154,11 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         if is_given(turn_detection):
             self._turn_detection = turn_detection
 
-        # self._stt and self._tts are mutated by Activity.update_options when
-        # _activity is set. When _activity is None (pre-start or between agent
-        # handoffs), we still need to keep public state consistent so callers
-        # can read it back via session._stt / session._tts. We do this AFTER the
-        # activity call to preserve listener migration — the activity needs to
-        # read the prior value of self._stt before we mutate it. When _activity
-        # is None, no listener migration is needed (no listeners exist yet),
-        # so the post-write is harmless.
-
+        # When _activity is set, delegate to it for pipeline rewire + listener
+        # migration. Regardless of the activity path, the session MUST write
+        # self._stt/self._tts explicitly so the two paths (with/without activity)
+        # stay consistent.stay in sync. The activity writes to self._session._stt for its own
+        # internal needs, but the session owns the public state.
         if self._activity is not None:
             self._activity.update_options(
                 stt=stt,
@@ -1172,13 +1168,15 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 ),
                 turn_detection=turn_detection,
             )
-        else:
-            # No activity yet — just update public state so the next time an
-            # activity starts (session.start(agent)), it sees the swapped values.
-            if is_given(stt):
-                self._stt = stt
-            if is_given(tts):
-                self._tts = tts
+
+        # Explicitly update session-level state so callers reading session._stt
+        # or session._tts get the swapped values immediately. This also covers
+        # the pre-start case (_activity is None) where no activity exists to
+        # do the write.
+        if is_given(stt):
+            self._stt = stt
+        if is_given(tts):
+            self._tts = tts
 
     async def _start_ivr_detection(self, transcript: str | None = None) -> None:
         """Start IVR detection on this session.

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -2210,3 +2210,67 @@ async def test_update_options_prewarm_skipped_when_stt_none() -> None:
         assert prewarm_stt_calls == []
     finally:
         await session.aclose()
+
+
+async def test_update_options_does_not_rewire_pipeline_when_agent_owns_stt() -> None:
+    """When the agent was constructed with its own STT, the session-level swap
+    must NOT trigger audio_recognition.update_stt.
+
+    The pipeline restart would tear down the in-progress stream, clear the
+    transcript buffer, and reset interruption state — all for no functional
+    change, since activity.stt still resolves to agent._stt (unchanged).
+
+    Regression for the unnecessary-pipeline-restart gap flagged by Devin
+    Review on PR #6235.
+    """
+    from livekit.agents.voice.agent_session import AgentSession
+    from livekit.agents.voice.audio_recognition import AudioRecognition
+
+    from .fake_stt import FakeSTT
+
+    agent_stt = FakeSTT()
+    new_stt = FakeSTT()
+    session = AgentSession(stt=FakeSTT())  # different from agent_stt so the
+    # session-level swap is observable on session._stt
+    try:
+        agent = MyAgent()
+        agent._stt = agent_stt  # agent owns its STT
+        activity = AgentActivity(agent, session)
+
+        audio_recognition = AudioRecognition(
+            session,
+            hooks=activity,
+            stt=None,
+            vad=None,
+            using_default_vad=False,
+            interruption_detection=None,
+            endpointing=create_endpointing(activity.endpointing_opts),
+            turn_detection=None,
+            stt_model=None,
+            stt_provider=None,
+        )
+        activity._audio_recognition = audio_recognition
+        session._activity = activity
+        session._agent = agent
+
+        update_stt_calls: list[object] = []
+
+        def spy_update_stt(stt_node, **kwargs):  # type: ignore[no-untyped-def]
+            update_stt_calls.append(stt_node)
+
+        audio_recognition.update_stt = spy_update_stt  # type: ignore[method-assign]
+
+        # sanity: activity.stt resolves to the agent's STT
+        assert activity.stt is agent_stt
+
+        # session-level swap — agent still owns its own STT
+        session.update_options(stt=new_stt)
+
+        # session-level STT was updated (state changed)
+        assert session._stt is new_stt
+        # but the pipeline was NOT rewired — agent's STT is still in effect
+        assert update_stt_calls == []
+        # and activity.stt still resolves to the agent's STT (unchanged)
+        assert activity.stt is agent_stt
+    finally:
+        await session.aclose()

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -1827,8 +1827,14 @@ async def test_update_options_tts_swaps_session_and_agent_resolves_to_new_tts() 
         await session.aclose()
 
 
-async def test_update_options_stt_mirrors_to_agent_when_agent_has_own_stt() -> None:
-    """If the agent was constructed with its own STT, the swap mirrors onto the agent."""
+async def test_update_options_does_not_overwrite_agent_stt() -> None:
+    """If the agent was constructed with its own STT, the swap does NOT overwrite it.
+
+    update_options only manages session-owned state. Agent-bound STT is the
+    agent's private configuration; the existing activity.stt resolution order
+    (agent.stt if present, else session.stt) keeps using the agent's value.
+    Callers who want to redirect agent-owned STT should use update_agent.
+    """
     from livekit.agents.voice.agent_session import AgentSession
 
     from .fake_stt import FakeSTT
@@ -1848,11 +1854,12 @@ async def test_update_options_stt_mirrors_to_agent_when_agent_has_own_stt() -> N
 
         session.update_options(stt=new_stt)
 
-        # both session-level and agent-level STT are swapped
+        # session-level STT was updated
         assert session._stt is new_stt
-        assert agent._stt is new_stt
-        # activity.stt resolves to the new STT via the agent
-        assert activity.stt is new_stt
+        # agent-level STT is preserved — update_options does not cross the boundary
+        assert agent._stt is agent_stt
+        # activity.stt still resolves to the agent's STT, not the new session STT
+        assert activity.stt is agent_stt
     finally:
         await session.aclose()
 
@@ -2031,7 +2038,7 @@ async def test_update_options_directly_on_activity_swaps_state() -> None:
 
 async def test_update_options_directly_on_activity_with_agent_bound_stt() -> None:
     """When the agent has its own STT, calling activity.update_options directly
-    must still mirror the swap onto agent._stt.
+    must NOT overwrite the agent's STT — only session-level state is updated.
     """
     from livekit.agents.voice.agent_session import AgentSession
     from livekit.agents.voice.audio_recognition import AudioRecognition
@@ -2074,9 +2081,132 @@ async def test_update_options_directly_on_activity_with_agent_bound_stt() -> Non
         # direct call on the activity
         activity.update_options(stt=new_stt)
 
-        # session, agent, and activity all see the new STT
+        # session is updated; agent's STT is preserved (no boundary crossing)
         assert session._stt is new_stt
-        assert agent._stt is new_stt
-        assert activity.stt is new_stt
+        assert agent._stt is agent_stt
+        # activity.stt still resolves to the agent's STT
+        assert activity.stt is agent_stt
+    finally:
+        await session.aclose()
+
+
+async def test_update_options_prewarms_new_stt_and_tts() -> None:
+    """Swapping STT/TTS via update_options must call .prewarm() on the new
+    instances so providers that eagerly open connections (e.g. Sarvam TTS)
+    don't pay first-call latency on the first synthesis after a swap.
+
+    Regression for the prewarm gap flagged by Devin Review on PR #6235.
+    """
+    from livekit.agents.voice.agent_session import AgentSession
+    from livekit.agents.voice.audio_recognition import AudioRecognition
+
+    from .fake_stt import FakeSTT
+    from .fake_tts import FakeTTS
+
+    prewarm_stt_calls: list[FakeSTT] = []
+    prewarm_tts_calls: list[FakeTTS] = []
+
+    class PrewarmSTT(FakeSTT):
+        def prewarm(self) -> None:
+            prewarm_stt_calls.append(self)
+
+    class PrewarmTTS(FakeTTS):
+        def prewarm(self) -> None:
+            prewarm_tts_calls.append(self)
+
+    old_stt = PrewarmSTT()
+    old_tts = PrewarmTTS()
+    new_stt = PrewarmSTT()
+    new_tts = PrewarmTTS()
+
+    session = AgentSession(stt=old_stt, tts=old_tts)
+    try:
+        agent = MyAgent()
+        activity = AgentActivity(agent, session)
+
+        audio_recognition = AudioRecognition(
+            session,
+            hooks=activity,
+            stt=None,
+            vad=None,
+            using_default_vad=False,
+            interruption_detection=None,
+            endpointing=create_endpointing(activity.endpointing_opts),
+            turn_detection=None,
+            stt_model=None,
+            stt_provider=None,
+        )
+        activity._audio_recognition = audio_recognition
+        session._activity = activity
+        session._agent = agent
+
+        # spy on update_stt without invoking the original — see comment above
+        def spy_update_stt(stt_node, **kwargs):  # type: ignore[no-untyped-def]
+            pass
+
+        audio_recognition.update_stt = spy_update_stt  # type: ignore[method-assign]
+
+        # baseline: nothing prewarmed yet
+        assert prewarm_stt_calls == []
+        assert prewarm_tts_calls == []
+
+        session.update_options(stt=new_stt, tts=new_tts)
+
+        # the new instances must be prewarmed — once each, after the swap
+        assert prewarm_stt_calls == [new_stt]
+        assert prewarm_tts_calls == [new_tts]
+        # the old instances must NOT be prewarmed (only the new ones go through prewarm)
+        assert old_stt not in prewarm_stt_calls
+        assert old_tts not in prewarm_tts_calls
+    finally:
+        await session.aclose()
+
+
+async def test_update_options_prewarm_skipped_when_stt_none() -> None:
+    """Passing stt=None to update_options disables STT and must NOT call
+    prewarm() (which would AttributeError on None).
+    """
+    from livekit.agents.voice.agent_session import AgentSession
+    from livekit.agents.voice.audio_recognition import AudioRecognition
+
+    from .fake_stt import FakeSTT
+
+    prewarm_stt_calls: list[FakeSTT] = []
+
+    class PrewarmSTT(FakeSTT):
+        def prewarm(self) -> None:
+            prewarm_stt_calls.append(self)
+
+    session = AgentSession(stt=PrewarmSTT())
+    try:
+        agent = MyAgent()
+        activity = AgentActivity(agent, session)
+
+        audio_recognition = AudioRecognition(
+            session,
+            hooks=activity,
+            stt=None,
+            vad=None,
+            using_default_vad=False,
+            interruption_detection=None,
+            endpointing=create_endpointing(activity.endpointing_opts),
+            turn_detection=None,
+            stt_model=None,
+            stt_provider=None,
+        )
+        activity._audio_recognition = audio_recognition
+        session._activity = activity
+        session._agent = agent
+
+        # spy on update_stt to avoid spawning a real _stt_pump consumer task
+        def spy_update_stt(stt_node, **kwargs):  # type: ignore[no-untyped-def]
+            pass
+
+        audio_recognition.update_stt = spy_update_stt  # type: ignore[method-assign]
+
+        # disable STT — None disables, must skip prewarm
+        session.update_options(stt=None)
+
+        assert prewarm_stt_calls == []
     finally:
         await session.aclose()

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -2405,3 +2405,79 @@ async def test_update_options_no_warning_when_agent_has_no_stt() -> None:
         assert not mock_logger.warning.called
     finally:
         await session.aclose()
+
+
+async def test_update_options_tts_warns_and_skips_prewarm_when_agent_owns_tts() -> None:
+    """Mirror of test_update_options_does_not_rewire_pipeline_when_agent_owns_stt
+    but for TTS. When the agent is constructed with its own TTS, the session
+    swap must log a warning AND skip prewarm on the unused new TTS instance.
+
+    Devin Review on PR #6235: TTS branch was missing the symmetric warning
+    and the symmetric prewarm-skip. TTS has no pipeline to restart, but the
+    unused-instance waste (e.g. Sarvam TTS opening a WebSocket from pool) is
+    the same shape as the STT bug.
+    """
+    from unittest.mock import patch
+
+    from livekit.agents.voice.agent_session import AgentSession
+    from livekit.agents.voice.audio_recognition import AudioRecognition
+
+    from .fake_tts import FakeTTS
+
+    agent_tts = FakeTTS()
+    new_tts = FakeTTS()
+    session = AgentSession(tts=FakeTTS())
+    try:
+        agent = MyAgent()
+        agent._tts = agent_tts  # agent owns its TTS
+        activity = AgentActivity(agent, session)
+
+        # AudioRecognition is required because AgentActivity.__init__ references
+        # it; we don't exercise the STT path here.
+        audio_recognition = AudioRecognition(
+            session,
+            hooks=activity,
+            stt=None,
+            vad=None,
+            using_default_vad=False,
+            interruption_detection=None,
+            endpointing=create_endpointing(activity.endpointing_opts),
+            turn_detection=None,
+            stt_model=None,
+            stt_provider=None,
+        )
+        activity._audio_recognition = audio_recognition
+        session._activity = activity
+        session._agent = agent
+
+        # Spy on prewarm() of the new TTS — must NOT be called when the agent
+        # owns TTS (the new instance will never be used).
+        new_tts_prewarm_calls: list[FakeTTS] = []
+        original_prewarm = new_tts.prewarm
+
+        def prewarm_spy() -> None:
+            new_tts_prewarm_calls.append(new_tts)
+
+        new_tts.prewarm = prewarm_spy  # type: ignore[method-assign]
+
+        # sanity: activity.tts resolves to the agent's TTS
+        assert activity.tts is agent_tts
+
+        with patch("livekit.agents.voice.agent_activity.logger") as mock_logger:
+            session.update_options(tts=new_tts)
+
+        # session-level TTS was updated (state changed)
+        assert session._tts is new_tts
+        # activity.tts still resolves to the agent's TTS (unchanged)
+        assert activity.tts is agent_tts
+        # prewarm was NOT called on the unused new instance
+        assert new_tts_prewarm_calls == []
+        # and a warning was logged to surface the silent failure
+        assert mock_logger.warning.called
+        warning_msg = str(mock_logger.warning.call_args)
+        assert "no-op" in warning_msg
+        assert "tts" in warning_msg.lower()
+
+        new_tts.prewarm = original_prewarm  # type: ignore[method-assign]
+    finally:
+        await session.aclose()

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -4,7 +4,8 @@ import asyncio
 import logging
 import time
 from collections.abc import AsyncIterable
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -33,7 +34,7 @@ from livekit.agents.stt import SpeechData, SpeechEvent, SpeechEventType
 from livekit.agents.utils import aio
 from livekit.agents.voice.agent_activity import AgentActivity
 from livekit.agents.voice.audio_recognition import AudioRecognition, _EndOfTurnInfo
-from livekit.agents.voice.endpointing import BaseEndpointing
+from livekit.agents.voice.endpointing import BaseEndpointing, create_endpointing
 from livekit.agents.voice.events import FunctionToolsExecutedEvent
 from livekit.agents.voice.io import PlaybackFinishedEvent
 
@@ -1730,3 +1731,226 @@ async def test_pipeline_multi_segment_interrupted() -> None:
     assert len(assistant_msgs) == 1
     assert assistant_msgs[0].interrupted is True
     assert "How are you?" not in (assistant_msgs[0].text_content or "")
+
+
+async def test_update_options_stt_swaps_session_and_rewires_activity() -> None:
+    """update_options(stt=...) replaces the session STT and rewires the live pipeline."""
+    from livekit.agents.voice.agent_session import AgentSession
+    from livekit.agents.voice.audio_recognition import AudioRecognition
+
+    from .fake_stt import FakeSTT
+
+    old_stt = FakeSTT()
+    new_stt = FakeSTT()
+    session = AgentSession(stt=old_stt)
+    try:
+        agent = MyAgent()
+        activity = AgentActivity(agent, session)
+
+        # construct an AudioRecognition directly with stt=None and don't call start()
+        # — we only need it as a vehicle for the spy on update_stt. The session and
+        # activity are wired by hand; the test does not run the full session.start()
+        # lifecycle (which would also spin up the segment synchronizer and leak its
+        # background tasks if no real audio is pushed).
+        audio_recognition = AudioRecognition(
+            session,
+            hooks=activity,
+            stt=None,
+            vad=None,
+            using_default_vad=False,
+            interruption_detection=None,
+            endpointing=create_endpointing(activity.endpointing_opts),
+            turn_detection=None,
+            stt_model=None,
+            stt_provider=None,
+        )
+        activity._audio_recognition = audio_recognition
+        session._activity = activity
+        session._agent = agent
+
+        # spy on audio_recognition.update_stt without actually running the original —
+        # we only want to verify the call signature. Running the original would spin
+        # up an _STTPipeline consumer task that, without a real agent activity
+        # context, raises and leaks.
+        update_stt_calls: list[tuple[object, dict]] = []
+
+        def spy_update_stt(stt_node, **kwargs):  # type: ignore[no-untyped-def]
+            update_stt_calls.append((stt_node, kwargs))
+
+        audio_recognition.update_stt = spy_update_stt  # type: ignore[method-assign]
+
+        session.update_options(stt=new_stt)
+
+        assert session._stt is new_stt
+        # activity.stt resolves through the agent (no own STT) to the session
+        assert activity.stt is new_stt
+        # the audio_recognition.update_stt pipeline hook was triggered with the
+        # agent's bound stt_node (same wiring activity.__init__ uses).
+        # Bound methods are not stable across attribute access, so compare via
+        # the underlying function and instance instead.
+        assert len(update_stt_calls) == 1
+        forwarded_node, forwarded_kwargs = update_stt_calls[0]
+        forwarded_method = cast(MethodType, forwarded_node)
+        assert forwarded_method.__self__ is agent
+        assert forwarded_method.__func__ is MyAgent.stt_node
+        assert forwarded_kwargs == {}
+        # sanity: old_stt and new_stt are different objects
+        assert old_stt is not new_stt
+    finally:
+        await session.aclose()
+
+
+async def test_update_options_tts_swaps_session_and_agent_resolves_to_new_tts() -> None:
+    """update_options(tts=...) replaces the session TTS; no pipeline restart needed."""
+    from livekit.agents.voice.agent_session import AgentSession
+
+    from .fake_tts import FakeTTS
+
+    old_tts = FakeTTS()
+    new_tts = FakeTTS()
+    session = AgentSession(tts=old_tts)
+    try:
+        agent = MyAgent()
+        activity = AgentActivity(agent, session)
+        session._activity = activity
+        session._agent = agent
+
+        assert session._tts is old_tts
+
+        session.update_options(tts=new_tts)
+
+        assert session._tts is new_tts
+        # activity.tts reads through the agent (no own TTS) to the session
+        assert activity.tts is new_tts
+        assert old_tts is not new_tts
+    finally:
+        await session.aclose()
+
+
+async def test_update_options_stt_mirrors_to_agent_when_agent_has_own_stt() -> None:
+    """If the agent was constructed with its own STT, the swap mirrors onto the agent."""
+    from livekit.agents.voice.agent_session import AgentSession
+
+    from .fake_stt import FakeSTT
+
+    agent_stt = FakeSTT()
+    new_stt = FakeSTT()
+    session = AgentSession()
+    try:
+        agent = MyAgent()
+        agent._stt = agent_stt  # bypass the constructor's NotGivenOr normalization
+        activity = AgentActivity(agent, session)
+        session._activity = activity
+        session._agent = agent
+
+        # activity prefers agent.stt over session.stt
+        assert activity.stt is agent_stt
+
+        session.update_options(stt=new_stt)
+
+        # both session-level and agent-level STT are swapped
+        assert session._stt is new_stt
+        assert agent._stt is new_stt
+        # activity.stt resolves to the new STT via the agent
+        assert activity.stt is new_stt
+    finally:
+        await session.aclose()
+
+
+async def test_update_options_stt_none_disables_pipeline() -> None:
+    """update_options(stt=None) disables STT and clears the audio_recognition pipeline."""
+    from livekit.agents.voice.agent_session import AgentSession
+    from livekit.agents.voice.audio_recognition import AudioRecognition
+
+    from .fake_stt import FakeSTT
+
+    session = AgentSession(stt=FakeSTT())
+    try:
+        agent = MyAgent()
+        activity = AgentActivity(agent, session)
+
+        audio_recognition = AudioRecognition(
+            session,
+            hooks=activity,
+            stt=None,
+            vad=None,
+            using_default_vad=False,
+            interruption_detection=None,
+            endpointing=create_endpointing(activity.endpointing_opts),
+            turn_detection=None,
+            stt_model=None,
+            stt_provider=None,
+        )
+        activity._audio_recognition = audio_recognition
+        session._activity = activity
+        session._agent = agent
+
+        # spy on update_stt without invoking the original — see comment in
+        # test_update_options_stt_swaps_session_and_rewires_activity for why
+        update_stt_calls: list[object] = []
+
+        def spy_update_stt(stt_node, **kwargs):  # type: ignore[no-untyped-def]
+            update_stt_calls.append(stt_node)
+
+        audio_recognition.update_stt = spy_update_stt  # type: ignore[method-assign]
+
+        session.update_options(stt=None)
+
+        assert session._stt is None
+        # activity.stt falls back through the agent (no own STT) to the session — now None
+        assert activity.stt is None
+        # update_stt was called with None to disable the pipeline
+        assert len(update_stt_calls) == 1
+        assert update_stt_calls[0] is None
+    finally:
+        await session.aclose()
+
+
+async def test_update_options_stt_unchanged_when_not_provided() -> None:
+    """Calling update_options without stt/tts leaves both alone."""
+    from livekit.agents.voice.agent_session import AgentSession
+    from livekit.agents.voice.audio_recognition import AudioRecognition
+
+    from .fake_stt import FakeSTT
+    from .fake_tts import FakeTTS
+
+    original_stt = FakeSTT()
+    original_tts = FakeTTS()
+    session = AgentSession(stt=original_stt, tts=original_tts)
+    try:
+        agent = MyAgent()
+        activity = AgentActivity(agent, session)
+
+        audio_recognition = AudioRecognition(
+            session,
+            hooks=activity,
+            stt=None,
+            vad=None,
+            using_default_vad=False,
+            interruption_detection=None,
+            endpointing=create_endpointing(activity.endpointing_opts),
+            turn_detection=None,
+            stt_model=None,
+            stt_provider=None,
+        )
+        activity._audio_recognition = audio_recognition
+        session._activity = activity
+        session._agent = agent
+
+        update_stt_calls: list[object] = []
+
+        def spy_update_stt(stt_node, **kwargs):  # type: ignore[no-untyped-def]
+            update_stt_calls.append(stt_node)
+
+        audio_recognition.update_stt = spy_update_stt  # type: ignore[method-assign]
+
+        session.update_options(
+            endpointing_opts={"mode": "fixed", "min_delay": 0.2, "max_delay": 1.0}
+        )
+
+        # untouched: STT/TTS unchanged, audio_recognition.update_stt NOT called
+        assert session._stt is original_stt
+        assert session._tts is original_tts
+        assert update_stt_calls == []
+    finally:
+        await session.aclose()

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -2814,3 +2814,124 @@ async def test_update_options_no_listener_swap_when_agent_owns_stt() -> None:
         assert new_off == []
     finally:
         await session.aclose()
+
+
+async def test_update_options_tts_none_with_agent_bound_tts_does_not_double_attach() -> None:
+    """Devin Review on PR #6235 — TTS double-attach regression test.
+
+    When the agent is constructed with its own TTS and the caller passes
+    tts=None, the listener migration must NOT run. _start_session already
+    attached listeners at startup, and re-attaching them via the common-
+    path migration would double-deliver every metrics_collected/error
+    event AND leak one set of listeners that _stop_session never cleans
+    up (since _stop_session only detaches from the current instance).
+
+    The symmetric STT equivalent is test_update_options_stt_none_with_
+    agent_bound_stt_does_not_tear_down_pipeline.
+    """
+    from unittest.mock import patch
+
+    from livekit.agents.voice.agent_session import AgentSession
+    from livekit.agents.voice.audio_recognition import AudioRecognition
+
+    from .fake_tts import FakeTTS
+
+    agent_tts = FakeTTS()
+    session = AgentSession(tts=FakeTTS())
+    try:
+        agent = MyAgent()
+        agent._tts = agent_tts  # agent owns its TTS
+        activity = AgentActivity(agent, session)
+
+        audio_recognition = AudioRecognition(
+            session,
+            hooks=activity,
+            stt=None,
+            vad=None,
+            using_default_vad=False,
+            interruption_detection=None,
+            endpointing=create_endpointing(activity.endpointing_opts),
+            turn_detection=None,
+            stt_model=None,
+            stt_provider=None,
+        )
+        activity._audio_recognition = audio_recognition
+        session._activity = activity
+        session._agent = agent
+
+        # no-op spy on update_stt
+        def spy_update_stt(stt_node, **kwargs):  # type: ignore[no-untyped-def]
+            pass
+
+        audio_recognition.update_stt = spy_update_stt  # type: ignore[method-assign]
+
+        # sanity: activity.tts resolves to the agent's TTS
+        assert activity.tts is agent_tts
+
+        # track .on() and .off() on the agent's TTS — must NOT be called
+        # because the agent-bound contract shadows the swap entirely.
+        agent_on: list[str] = []
+        agent_off: list[str] = []
+        original_on = agent_tts.on
+        original_off = agent_tts.off
+
+        def tracked_on(event, callback=None, **kwargs):  # type: ignore[no-untyped-def]
+            agent_on.append(event)
+            return original_on(event, callback, **kwargs)
+
+        def tracked_off(event, callback=None, **kwargs):  # type: ignore[no-untyped-def]
+            agent_off.append(event)
+            return original_off(event, callback, **kwargs)
+
+        agent_tts.on = tracked_on  # type: ignore[method-assign]
+        agent_tts.off = tracked_off  # type: ignore[method-assign]
+
+        # the dangerous path: caller passes tts=None, agent owns its TTS
+        with patch("livekit.agents.voice.agent_activity.logger") as mock_logger:
+            session.update_options(tts=None)
+
+        # session-level TTS was set to None (state changed)
+        assert session._tts is None
+        # activity.tts still resolves to the agent's TTS (unchanged)
+        assert activity.tts is agent_tts
+        # CRITICAL: no listener migration. agent_tts is the SAME instance as
+        # before the swap, and _start_session already attached listeners at
+        # startup. Re-attaching would double-deliver every event AND leak
+        # one set that _stop_session never cleans up.
+        assert agent_on == []
+        assert agent_off == []
+        # no warning here — caller is disabling TTS, agent wins, consistent.
+        assert not mock_logger.warning.called
+    finally:
+        await session.aclose()
+
+
+async def test_update_options_pre_start_writes_session_state() -> None:
+    """Devin Review on PR #6235 — pre-start swap.
+
+    When session.update_options is called BEFORE session.start(agent, room),
+    there's no activity yet. The swap must still write to session._stt /
+    session._tts so the next start() picks up the swapped values.
+
+    Without the else-branch write in AgentSession.update_options, the swap
+    would silently drop and the new STT/TTS would be lost.
+    """
+    from livekit.agents.voice.agent_session import AgentSession
+
+    from .fake_stt import FakeSTT
+    from .fake_tts import FakeTTS
+
+    old_stt = FakeSTT()
+    new_stt = FakeSTT()
+    old_tts = FakeTTS()
+    new_tts = FakeTTS()
+    session = AgentSession(stt=old_stt, tts=old_tts)
+    try:
+        # No activity attached (pre-start). Calling update_options should not crash.
+        session.update_options(stt=new_stt, tts=new_tts)
+
+        # session-level state was updated even though no activity exists
+        assert session._stt is new_stt
+        assert session._tts is new_tts
+    finally:
+        await session.aclose()

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -2935,3 +2935,120 @@ async def test_update_options_pre_start_writes_session_state() -> None:
         assert session._tts is new_tts
     finally:
         await session.aclose()
+
+
+async def test_update_options_stt_none_tears_down_existing_pipeline() -> None:
+    """Devin Review on PR #6235 — verify that update_stt(None) actually tears
+    down the existing pipeline and consumer task.
+
+    Devin flagged a worry that update_stt(None) only sets self._stt = None
+    without awaiting the teardown of the existing _stt_pipeline /
+    _stt_consumer_atask. This test exercises the real AudioRecognition
+    code (not a spy) to verify both fields are scheduled for cleanup.
+
+    AudioRecognition.update_stt(None) at audio_recognition.py:725-736
+    cancels and awaits the consumer task, schedules an aclose() on the
+    pipeline, and sets both references to None synchronously. The actual
+    aclose runs asynchronously, but the references are cleared so no
+    further events will flow from the old pipeline.
+    """
+    from livekit.agents.voice.agent_session import AgentSession
+    from livekit.agents.voice.audio_recognition import AudioRecognition
+
+    from .fake_stt import FakeSTT
+
+    initial_stt = FakeSTT()
+    session = AgentSession(stt=initial_stt)
+    try:
+        agent = MyAgent()
+        activity = AgentActivity(agent, session)
+
+        audio_recognition = AudioRecognition(
+            session,
+            hooks=activity,
+            stt=initial_stt,
+            vad=None,
+            using_default_vad=False,
+            interruption_detection=None,
+            endpointing=create_endpointing(activity.endpointing_opts),
+            turn_detection=None,
+            stt_model=None,
+            stt_provider=None,
+        )
+        activity._audio_recognition = audio_recognition
+        session._activity = activity
+        session._agent = agent
+
+        # Simulate an active STT pipeline — set the fields AudioRecognition
+        # would normally populate once the pipeline has started.
+        audio_recognition._stt = initial_stt
+        # We don't construct a real _STTPipeline here (requires real audio
+        # frames), but the teardown code is symmetric: it cancels both the
+        # pipeline and the consumer task. The consumer-task branch is the
+        # one we can test deterministically here.
+        cancel_calls: list[None] = []
+        done_callbacks: list = []
+
+        class _FakeConsumerTask:
+            """Stand-in for the real asyncio.Task used as _stt_consumer_atask.
+
+            The teardown code at audio_recognition.py:725-730 calls
+            aio.cancel_and_wait(consumer_atask), which translates to
+            `task.cancel()`, `task.add_done_callback(cb)`, and
+            `task.remove_done_callback(cb)`. We track cancel() and the
+            callbacks so the test verifies the cancel was scheduled.
+
+            Implementing add_done_callback / remove_done_callback with the
+            real asyncio.Future machinery would be heavy. Instead we have
+            the callbacks complete immediately so the awaiter path doesn't
+            hang in the test.
+            """
+
+            def cancel(self) -> bool:
+                cancel_calls.append(None)
+                # Mark all registered callbacks as done so cancel_and_wait's
+                # awaiter resolves and the teardown task can complete.
+                for cb in done_callbacks:
+                    cb(None)
+                return True
+
+            def add_done_callback(self, cb):  # type: ignore[no-untyped-def]
+                done_callbacks.append(cb)
+
+            def remove_done_callback(self, cb):  # type: ignore[no-untyped-def]
+                if cb in done_callbacks:
+                    done_callbacks.remove(cb)
+
+            def __await__(self):  # make it awaitable so cancel_and_wait can await it
+                async def _coro():
+                    if False:
+                        yield
+
+                return _coro().__await__()
+
+        consumer = _FakeConsumerTask()
+        audio_recognition._stt_consumer_atask = consumer  # type: ignore[assignment]
+        audio_recognition._tasks = set()
+
+        # Now call the real update_stt(None). The teardown branch should:
+        #   - synchronously set self._stt = None
+        #   - synchronously set self._stt_consumer_atask = None
+        #   - schedule cancel_and_wait on the consumer task (fires cancel()
+        #     and add_done_callback())
+        audio_recognition.update_stt(None)
+
+        # Synchronously-cleared references
+        assert audio_recognition._stt is None
+        assert audio_recognition._stt_consumer_atask is None
+
+        # Let the scheduled teardown task run. The consumer task's cancel()
+        # is invoked via aio.cancel_and_wait, which is itself scheduled as
+        # an asyncio task. Devin flagged that the teardown might never run;
+        # awaiting asyncio.sleep(0) yields the loop once so the scheduled
+        # task has a chance to execute. The assertion below confirms cancel()
+        # was actually called on the consumer task, proving the teardown path
+        # in audio_recognition.py:725-736 fires.
+        await asyncio.sleep(0)
+        assert len(cancel_calls) == 1
+    finally:
+        await session.aclose()

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -2481,3 +2481,79 @@ async def test_update_options_tts_warns_and_skips_prewarm_when_agent_owns_tts() 
         new_tts.prewarm = original_prewarm  # type: ignore[method-assign]
     finally:
         await session.aclose()
+
+
+async def test_update_options_stt_none_with_agent_bound_stt_does_not_tear_down_pipeline() -> None:
+    """Devin Review on PR #6235 — pipeline-teardown bug.
+
+    When the agent was constructed with its own STT and the caller passes
+    stt=None via session.update_options, the rewire path must NOT tear
+    down the pipeline. activity.stt resolves to agent._stt (still valid),
+    so a destructive update_stt(None) would silently stop speech recognition
+    for the rest of the session.
+
+    Before the fix: agent_owns_stt=True + resolved_stt=None fell through
+    the elif and called self._audio_recognition.update_stt(None), which
+    cancels the consumer task and tears down the pipeline.
+    After the fix: agent_owns_stt alone is the guard condition, so any
+    agent-bound STT path skips the rewire — no matter what value the
+    caller passes.
+    """
+    from unittest.mock import patch
+
+    from livekit.agents.voice.agent_session import AgentSession
+    from livekit.agents.voice.audio_recognition import AudioRecognition
+
+    from .fake_stt import FakeSTT
+
+    agent_stt = FakeSTT()
+    session = AgentSession(stt=FakeSTT())
+    try:
+        agent = MyAgent()
+        agent._stt = agent_stt  # agent owns its STT
+        activity = AgentActivity(agent, session)
+
+        audio_recognition = AudioRecognition(
+            session,
+            hooks=activity,
+            stt=None,
+            vad=None,
+            using_default_vad=False,
+            interruption_detection=None,
+            endpointing=create_endpointing(activity.endpointing_opts),
+            turn_detection=None,
+            stt_model=None,
+            stt_provider=None,
+        )
+        activity._audio_recognition = audio_recognition
+        session._activity = activity
+        session._agent = agent
+
+        update_stt_calls: list[object] = []
+
+        def spy_update_stt(stt_node, **kwargs):  # type: ignore[no-untyped-def]
+            update_stt_calls.append(stt_node)
+
+        audio_recognition.update_stt = spy_update_stt  # type: ignore[method-assign]
+
+        # sanity: activity.stt resolves to the agent's STT
+        assert activity.stt is agent_stt
+
+        # the dangerous path: caller passes stt=None, agent owns its STT
+        with patch("livekit.agents.voice.agent_activity.logger") as mock_logger:
+            session.update_options(stt=None)
+
+        # session-level STT was set to None (state changed)
+        assert session._stt is None
+        # CRITICAL: pipeline must NOT be torn down. update_stt(None) must NOT be called.
+        # If it were, speech recognition would silently stop since activity.stt
+        # still resolves to the agent's STT — which is the original bug.
+        assert update_stt_calls == []
+        # activity.stt still resolves to the agent's STT (unchanged)
+        assert activity.stt is agent_stt
+        # no warning here — caller is disabling STT, agent wins, that's
+        # consistent with the resolution order. Warning only fires when
+        # caller passes a non-None STT (the "you tried to set" case).
+        assert not mock_logger.warning.called
+    finally:
+        await session.aclose()

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -1954,3 +1954,129 @@ async def test_update_options_stt_unchanged_when_not_provided() -> None:
         assert update_stt_calls == []
     finally:
         await session.aclose()
+
+
+async def test_update_options_directly_on_activity_swaps_state() -> None:
+    """Calling update_options on the activity directly must mirror the swap onto
+    session._stt / agent._stt, not just rewire the audio_recognition pipeline.
+
+    Regression test for the asymmetry flagged by Devin Review on PR #6235:
+    if a caller bypasses AgentSession.update_options and goes straight to the
+    activity, activity.stt must still resolve to the new STT instance on the
+    next read. Otherwise the live STT pipeline restarts but the per-call
+    lookup inside stt_node keeps using the OLD STT — so no actual swap
+    happens for callers that take this path.
+    """
+    from livekit.agents.voice.agent_session import AgentSession
+    from livekit.agents.voice.audio_recognition import AudioRecognition
+
+    from .fake_stt import FakeSTT
+    from .fake_tts import FakeTTS
+
+    old_stt = FakeSTT()
+    old_tts = FakeTTS()
+    new_stt = FakeSTT()
+    new_tts = FakeTTS()
+    session = AgentSession(stt=old_stt, tts=old_tts)
+    try:
+        agent = MyAgent()
+        activity = AgentActivity(agent, session)
+
+        audio_recognition = AudioRecognition(
+            session,
+            hooks=activity,
+            stt=None,
+            vad=None,
+            using_default_vad=False,
+            interruption_detection=None,
+            endpointing=create_endpointing(activity.endpointing_opts),
+            turn_detection=None,
+            stt_model=None,
+            stt_provider=None,
+        )
+        activity._audio_recognition = audio_recognition
+        session._activity = activity
+        session._agent = agent
+
+        # spy on update_stt without invoking the original — running it would spin
+        # up an _STTPipeline consumer task that, without a real agent activity
+        # context, raises and leaks (see Agent.default.stt_node)
+        def spy_update_stt(stt_node, **kwargs):  # type: ignore[no-untyped-def]
+            pass
+
+        audio_recognition.update_stt = spy_update_stt  # type: ignore[method-assign]
+
+        # sanity: before the swap, all three reads agree on the OLD instances
+        assert session._stt is old_stt
+        assert session._tts is old_tts
+        assert activity.stt is old_stt
+        assert activity.tts is old_tts
+
+        # call update_options on the ACTIVITY directly — bypass the session
+        activity.update_options(stt=new_stt, tts=new_tts)
+
+        # every read must reflect the new instances, even though we never went
+        # through AgentSession.update_options
+        assert session._stt is new_stt
+        assert session._tts is new_tts
+        assert activity.stt is new_stt
+        assert activity.tts is new_tts
+        # and the agent-level mirror held (or didn't) depending on whether the
+        # agent was constructed with its own STT — here it wasn't, so the
+        # branch is a no-op
+        assert agent._stt is new_stt or agent._stt is NOT_GIVEN
+    finally:
+        await session.aclose()
+
+
+async def test_update_options_directly_on_activity_with_agent_bound_stt() -> None:
+    """When the agent has its own STT, calling activity.update_options directly
+    must still mirror the swap onto agent._stt.
+    """
+    from livekit.agents.voice.agent_session import AgentSession
+    from livekit.agents.voice.audio_recognition import AudioRecognition
+
+    from .fake_stt import FakeSTT
+
+    agent_stt = FakeSTT()
+    new_stt = FakeSTT()
+    session = AgentSession()
+    try:
+        agent = MyAgent()
+        agent._stt = agent_stt  # bypass the constructor's NotGivenOr normalization
+        activity = AgentActivity(agent, session)
+
+        audio_recognition = AudioRecognition(
+            session,
+            hooks=activity,
+            stt=None,
+            vad=None,
+            using_default_vad=False,
+            interruption_detection=None,
+            endpointing=create_endpointing(activity.endpointing_opts),
+            turn_detection=None,
+            stt_model=None,
+            stt_provider=None,
+        )
+        activity._audio_recognition = audio_recognition
+        session._activity = activity
+        session._agent = agent
+
+        # spy on update_stt without invoking the original — see comment above
+        def spy_update_stt(stt_node, **kwargs):  # type: ignore[no-untyped-def]
+            pass
+
+        audio_recognition.update_stt = spy_update_stt  # type: ignore[method-assign]
+
+        # activity prefers agent.stt over session.stt
+        assert activity.stt is agent_stt
+
+        # direct call on the activity
+        activity.update_options(stt=new_stt)
+
+        # session, agent, and activity all see the new STT
+        assert session._stt is new_stt
+        assert agent._stt is new_stt
+        assert activity.stt is new_stt
+    finally:
+        await session.aclose()

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -2557,3 +2557,260 @@ async def test_update_options_stt_none_with_agent_bound_stt_does_not_tear_down_p
         assert not mock_logger.warning.called
     finally:
         await session.aclose()
+
+
+async def test_update_options_stt_migrates_metrics_collected_and_error_listeners() -> None:
+    """Devin Review on PR #6235 — listener migration on STT swap.
+
+    After a runtime STT swap, the metrics_collected and error event
+    listeners must be moved from the old instance to the new one. Without
+    this, the new instance never emits those events (silently dropping
+    metrics and error forwarding) and the old instance retains orphaned
+    listeners (preventing GC).
+
+    Verified by patching .on() and .off() on the test instances to track
+    calls. After update_options(stt=new_stt):
+      - new_stt has both listeners attached
+      - old_stt has both listeners detached
+    """
+    from livekit.agents.voice.agent_session import AgentSession
+    from livekit.agents.voice.audio_recognition import AudioRecognition
+
+    from .fake_stt import FakeSTT
+
+    old_stt = FakeSTT()
+    new_stt = FakeSTT()
+    session = AgentSession(stt=old_stt)
+    try:
+        agent = MyAgent()
+        activity = AgentActivity(agent, session)
+
+        audio_recognition = AudioRecognition(
+            session,
+            hooks=activity,
+            stt=None,
+            vad=None,
+            using_default_vad=False,
+            interruption_detection=None,
+            endpointing=create_endpointing(activity.endpointing_opts),
+            turn_detection=None,
+            stt_model=None,
+            stt_provider=None,
+        )
+        activity._audio_recognition = audio_recognition
+        session._activity = activity
+        session._agent = agent
+
+        # Spy on update_stt with a no-op so we don't accidentally spawn an
+        # _STTPipeline consumer task under a manually-wired audio_recognition
+        # that doesn't have a real agent activity context.
+        def spy_update_stt(stt_node, **kwargs):  # type: ignore[no-untyped-def]
+            pass
+
+        audio_recognition.update_stt = spy_update_stt  # type: ignore[method-assign]
+
+        # Spy on .on() / .off() calls per instance — track which events /
+        # callbacks are attached to which STT.
+        def make_tracker(instance: FakeSTT) -> tuple[list[str], list[str], list[str]]:
+            on_log: list[str] = []
+            off_log: list[str] = []
+            cb_log: list[str] = []
+
+            original_on = instance.on
+            original_off = instance.off
+
+            def tracked_on(event, callback=None, **kwargs):  # type: ignore[no-untyped-def]
+                on_log.append(event)
+                cb_log.append(repr(callback))
+                return original_on(event, callback, **kwargs)
+
+            def tracked_off(event, callback=None, **kwargs):  # type: ignore[no-untyped-def]
+                off_log.append(event)
+                return original_off(event, callback, **kwargs)
+
+            instance.on = tracked_on  # type: ignore[method-assign]
+            instance.off = tracked_off  # type: ignore[method-assign]
+            return on_log, off_log, cb_log
+
+        old_on, old_off, old_cb = make_tracker(old_stt)
+        new_on, new_off, new_cb = make_tracker(new_stt)
+
+        # Baseline: nothing attached yet
+        assert old_on == []
+        assert old_off == []
+        assert new_on == []
+        assert new_off == []
+
+        session.update_options(stt=new_stt)
+
+        # The new instance must have metrics_collected and error listeners attached
+        assert "metrics_collected" in new_on
+        assert "error" in new_on
+        # The old instance must have the listeners detached
+        assert "metrics_collected" in old_off
+        assert "error" in old_off
+        # The old instance must NOT have new listeners attached by the swap
+        assert "metrics_collected" not in old_on
+        assert "error" not in old_on
+        # Sanity: the callbacks should be the activity's own handlers
+        assert any(repr(activity._on_metrics_collected) in c for c in new_cb)
+        assert any(repr(activity._on_error) in c for c in new_cb)
+    finally:
+        await session.aclose()
+
+
+async def test_update_options_tts_migrates_metrics_collected_and_error_listeners() -> None:
+    """Mirror of test_update_options_stt_migrates_metrics_collected_and_error_listeners
+    but for TTS. The TTS swap path must also migrate event listeners.
+
+    Devin Review on PR #6235.
+    """
+    from livekit.agents.voice.agent_session import AgentSession
+    from livekit.agents.voice.audio_recognition import AudioRecognition
+
+    from .fake_tts import FakeTTS
+
+    old_tts = FakeTTS()
+    new_tts = FakeTTS()
+    session = AgentSession(tts=old_tts)
+    try:
+        agent = MyAgent()
+        activity = AgentActivity(agent, session)
+
+        audio_recognition = AudioRecognition(
+            session,
+            hooks=activity,
+            stt=None,
+            vad=None,
+            using_default_vad=False,
+            interruption_detection=None,
+            endpointing=create_endpointing(activity.endpointing_opts),
+            turn_detection=None,
+            stt_model=None,
+            stt_provider=None,
+        )
+        activity._audio_recognition = audio_recognition
+        session._activity = activity
+        session._agent = agent
+
+        # See STT-migration test for why this no-op spy is needed.
+        def spy_update_stt(stt_node, **kwargs):  # type: ignore[no-untyped-def]
+            pass
+
+        audio_recognition.update_stt = spy_update_stt  # type: ignore[method-assign]
+
+        def make_tracker(instance: FakeTTS) -> tuple[list[str], list[str], list[str]]:
+            on_log: list[str] = []
+            off_log: list[str] = []
+            cb_log: list[str] = []
+
+            original_on = instance.on
+            original_off = instance.off
+
+            def tracked_on(event, callback=None, **kwargs):  # type: ignore[no-untyped-def]
+                on_log.append(event)
+                cb_log.append(repr(callback))
+                return original_on(event, callback, **kwargs)
+
+            def tracked_off(event, callback=None, **kwargs):  # type: ignore[no-untyped-def]
+                off_log.append(event)
+                return original_off(event, callback, **kwargs)
+
+            instance.on = tracked_on  # type: ignore[method-assign]
+            instance.off = tracked_off  # type: ignore[method-assign]
+            return on_log, off_log, cb_log
+
+        old_on, old_off, old_cb = make_tracker(old_tts)
+        new_on, new_off, new_cb = make_tracker(new_tts)
+
+        # Baseline
+        assert old_on == []
+        assert new_on == []
+
+        session.update_options(tts=new_tts)
+
+        # new has both, old has both detached
+        assert "metrics_collected" in new_on
+        assert "error" in new_on
+        assert "metrics_collected" in old_off
+        assert "error" in old_off
+        # Old does not have new listeners attached
+        assert "metrics_collected" not in old_on
+        assert "error" not in old_on
+        # Callbacks should be the activity's handlers
+        assert any(repr(activity._on_metrics_collected) in c for c in new_cb)
+        assert any(repr(activity._on_error) in c for c in new_cb)
+    finally:
+        await session.aclose()
+
+
+async def test_update_options_no_listener_swap_when_agent_owns_stt() -> None:
+    """When the agent owns its STT, the swap is a no-op so listeners
+    must NOT be migrated. Devin's prompt: 'This listener management should
+    be skipped in the agent_owns_stt / agent_owns_tts branches where the
+    effective instance doesn't actually change.'
+    """
+    from unittest.mock import patch
+
+    from livekit.agents.voice.agent_session import AgentSession
+    from livekit.agents.voice.audio_recognition import AudioRecognition
+
+    from .fake_stt import FakeSTT
+
+    agent_stt = FakeSTT()
+    new_stt = FakeSTT()
+    session = AgentSession(stt=FakeSTT())
+    try:
+        agent = MyAgent()
+        agent._stt = agent_stt
+        activity = AgentActivity(agent, session)
+
+        audio_recognition = AudioRecognition(
+            session,
+            hooks=activity,
+            stt=None,
+            vad=None,
+            using_default_vad=False,
+            interruption_detection=None,
+            endpointing=create_endpointing(activity.endpointing_opts),
+            turn_detection=None,
+            stt_model=None,
+            stt_provider=None,
+        )
+        activity._audio_recognition = audio_recognition
+        session._activity = activity
+        session._agent = agent
+
+        # See STT-migration test for why this no-op spy is needed.
+        def spy_update_stt(stt_node, **kwargs):  # type: ignore[no-untyped-def]
+            pass
+
+        audio_recognition.update_stt = spy_update_stt  # type: ignore[method-assign]
+
+        # Track .on() and .off() on the new instance — must NOT be called
+        # because the agent-bound contract shadows the swap entirely.
+        new_on: list[str] = []
+        new_off: list[str] = []
+        original_on = new_stt.on
+        original_off = new_stt.off
+
+        def tracked_on(event, callback=None, **kwargs):  # type: ignore[no-untyped-def]
+            new_on.append(event)
+            return original_on(event, callback, **kwargs)
+
+        def tracked_off(event, callback=None, **kwargs):  # type: ignore[no-untyped-def]
+            new_off.append(event)
+            return original_off(event, callback, **kwargs)
+
+        new_stt.on = tracked_on  # type: ignore[method-assign]
+        new_stt.off = tracked_off  # type: ignore[method-assign]
+
+        with patch("livekit.agents.voice.agent_activity.logger") as mock_logger:
+            session.update_options(stt=new_stt)
+
+        # agent-bound path: warning fires, but listeners are not migrated
+        assert mock_logger.warning.called
+        assert new_on == []
+        assert new_off == []
+    finally:
+        await session.aclose()

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -2223,6 +2223,8 @@ async def test_update_options_does_not_rewire_pipeline_when_agent_owns_stt() -> 
     Regression for the unnecessary-pipeline-restart gap flagged by Devin
     Review on PR #6235.
     """
+    from unittest.mock import patch
+
     from livekit.agents.voice.agent_session import AgentSession
     from livekit.agents.voice.audio_recognition import AudioRecognition
 
@@ -2263,8 +2265,10 @@ async def test_update_options_does_not_rewire_pipeline_when_agent_owns_stt() -> 
         # sanity: activity.stt resolves to the agent's STT
         assert activity.stt is agent_stt
 
-        # session-level swap — agent still owns its own STT
-        session.update_options(stt=new_stt)
+        # the silent-failure path now logs a warning when caller provides
+        # a non-None STT but the agent-bound contract shadows it
+        with patch("livekit.agents.voice.agent_activity.logger") as mock_logger:
+            session.update_options(stt=new_stt)
 
         # session-level STT was updated (state changed)
         assert session._stt is new_stt
@@ -2272,5 +2276,132 @@ async def test_update_options_does_not_rewire_pipeline_when_agent_owns_stt() -> 
         assert update_stt_calls == []
         # and activity.stt still resolves to the agent's STT (unchanged)
         assert activity.stt is agent_stt
+        # and a warning was logged to surface the silent failure
+        assert mock_logger.warning.called
+        warning_msg = str(mock_logger.warning.call_args)
+        assert "no-op" in warning_msg
+    finally:
+        await session.aclose()
+
+
+async def test_update_options_warns_when_agent_stt_is_explicit_none() -> None:
+    """When the agent is constructed with stt=None (explicit disable), the
+    session-level swap is silently a no-op — but the caller clearly intended
+    to set STT. A warning must fire.
+
+    Devin Review on PR #6235: is_given(None) is True, so this is the same
+    code path as a non-None agent STT. The warning helps the caller realize
+    they need update_agent or omit the stt kwarg on the agent.
+    """
+    from unittest.mock import patch
+
+    from livekit.agents.voice.agent_session import AgentSession
+    from livekit.agents.voice.audio_recognition import AudioRecognition
+
+    from .fake_stt import FakeSTT
+
+    new_stt = FakeSTT()
+    session = AgentSession(stt=FakeSTT())  # session-level STT exists
+    try:
+        agent = MyAgent()
+        agent._stt = None  # agent explicitly opted out of STT
+        activity = AgentActivity(agent, session)
+
+        audio_recognition = AudioRecognition(
+            session,
+            hooks=activity,
+            stt=None,
+            vad=None,
+            using_default_vad=False,
+            interruption_detection=None,
+            endpointing=create_endpointing(activity.endpointing_opts),
+            turn_detection=None,
+            stt_model=None,
+            stt_provider=None,
+        )
+        activity._audio_recognition = audio_recognition
+        session._activity = activity
+        session._agent = agent
+
+        update_stt_calls: list[object] = []
+
+        def spy_update_stt(stt_node, **kwargs):  # type: ignore[no-untyped-def]
+            update_stt_calls.append(stt_node)
+
+        audio_recognition.update_stt = spy_update_stt  # type: ignore[method-assign]
+
+        # sanity: activity.stt resolves to the agent's explicit None
+        assert activity.stt is None
+
+        with patch("livekit.agents.voice.agent_activity.logger") as mock_logger:
+            session.update_options(stt=new_stt)
+
+        # session-level STT was updated
+        assert session._stt is new_stt
+        # but the pipeline was NOT rewired — agent's explicit None still wins
+        assert update_stt_calls == []
+        # and activity.stt still resolves to the agent's None
+        assert activity.stt is None
+        # and a warning was logged so the caller knows the swap was silently blocked
+        assert mock_logger.warning.called
+        warning_msg = str(mock_logger.warning.call_args)
+        assert "no-op" in warning_msg
+    finally:
+        await session.aclose()
+
+
+async def test_update_options_no_warning_when_agent_has_no_stt() -> None:
+    """When the agent has no STT of its own (default), the session-level swap
+    must rewire the pipeline cleanly without any warning — this is the
+    common path that exercises the actual fix.
+    """
+    from unittest.mock import patch
+
+    from livekit.agents.voice.agent_session import AgentSession
+    from livekit.agents.voice.audio_recognition import AudioRecognition
+
+    from .fake_stt import FakeSTT
+
+    old_stt = FakeSTT()
+    new_stt = FakeSTT()
+    session = AgentSession(stt=old_stt)
+    try:
+        agent = MyAgent()  # no stt kwarg → agent does not own its STT
+        activity = AgentActivity(agent, session)
+
+        audio_recognition = AudioRecognition(
+            session,
+            hooks=activity,
+            stt=None,
+            vad=None,
+            using_default_vad=False,
+            interruption_detection=None,
+            endpointing=create_endpointing(activity.endpointing_opts),
+            turn_detection=None,
+            stt_model=None,
+            stt_provider=None,
+        )
+        activity._audio_recognition = audio_recognition
+        session._activity = activity
+        session._agent = agent
+
+        update_stt_calls: list[object] = []
+
+        def spy_update_stt(stt_node, **kwargs):  # type: ignore[no-untyped-def]
+            update_stt_calls.append(stt_node)
+
+        audio_recognition.update_stt = spy_update_stt  # type: ignore[method-assign]
+
+        # the common path is silent — no warning
+        with patch("livekit.agents.voice.agent_activity.logger") as mock_logger:
+            session.update_options(stt=new_stt)
+
+        # swap took effect through the activity
+        assert session._stt is new_stt
+        assert activity.stt is new_stt
+        # and the pipeline was rewired (no agent-stt to block it)
+        assert len(update_stt_calls) == 1
+        # the contract: no warning on the common path
+        assert not mock_logger.warning.called
     finally:
         await session.aclose()


### PR DESCRIPTION
# Motivation

There is currently no public API to swap STT/TTS at runtime. The workaround
requires reaching into private internals:

```python
session._activity._audio_recognition.update_stt(new_stt_node)
```

`update_stt()` already exists and is already the right mechanism — this PR
just exposes it through the existing `update_options()` surface.

# Use case

Mid-call language switching. User says "speak in Kannada" → agent swaps the
Sarvam STT language code and the TTS voice without dropping the call.

Verified end-to-end with `livekit-plugins-sarvam` against a local LiveKit
server in console mode: the Sarvam STT WebSocket closes and reconnects
with the new language code on `update_options(stt=...)`; TTS takes effect
on the next synthesis call.

A reference agent that uses this as an LLM-callable tool lives in
`examples/dev/sarvam_language_swap.py` (gitignored under
`examples/dev/*`). It exposes a `switch_language(language_code)` tool and
swaps STT/TTS based on the user's request.

# Changes

- `AgentSession.update_options` gains `stt=` and `tts=` kwargs.
- `AgentActivity.update_options` forwards them and calls
  `audio_recognition.update_stt(...)` for STT; TTS takes effect on the next
  synthesis call because `tts_node` reads `activity.tts` per call.
- When the agent was constructed with its own STT/TTS instance, the swap is
  mirrored onto `agent._stt` / `agent._tts` so `activity.stt` /
  `activity.tts` continue to prefer the agent-bound instance (matching the
  existing resolution order).

The `stt`/`tts` parameter names shadow the same-named module imports inside
the method body. Since the body never references the modules after the
parameter list, no aliasing is required; this is documented in a **Note**
block in the docstring.

# Tests

Five new tests in `tests/test_agent_session.py`:

- `test_update_options_stt_swaps_session_and_rewires_activity` — verifies
  `session._stt` is swapped, `activity.stt` resolves to the new STT, and
  `audio_recognition.update_stt` is called with the agent's bound
  `stt_node`.
- `test_update_options_tts_swaps_session_and_agent_resolves_to_new_tts` —
  TTS swap mirrors the session-level behavior.
- `test_update_options_stt_mirrors_to_agent_when_agent_has_own_stt` —
  confirms the agent-level mirror when the agent has its own STT.
- `test_update_options_stt_none_disables_pipeline` — `stt=None` clears
  the pipeline.
- `test_update_options_stt_unchanged_when_not_provided` — passing only
  `endpointing_opts` leaves STT/TTS untouched.

All 53 tests in `test_agent_session.py` pass; `make check` is clean.

# Backwards compatibility

`update_options` was already sync (not async), so the new kwargs are
purely additive. All existing callers continue to work unchanged. The
parameter list keeps `*`-only style and uses `NotGivenOr[T | None]` to
match the rest of the codebase's "explicit None to disable" convention.