### PR TITLE
fix(openai-realtime): cancel timed-out response.create to prevent late playback

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1584,6 +1584,9 @@ class RealtimeSession(
             self._response_created_futures.pop(event_id, None)
             if fut and not fut.done():
                 fut.set_exception(llm.RealtimeError("generate_reply timed out."))
+                # The response.create was already sent; ask the server to cancel it so
+                # that any audio it produces does not arrive and play back unexpectedly.
+                self.send_event(ResponseCancelEvent(type="response.cancel"))
 
         handle = asyncio.get_event_loop().call_later(10.0, _on_timeout)
 
@@ -1722,6 +1725,7 @@ class RealtimeSession(
             response_id=event.response.id,
         )
 
+        timed_out = False
         if (
             isinstance(event.response.metadata, dict)
             and (client_event_id := event.response.metadata.get("client_event_id"))
@@ -1731,9 +1735,22 @@ class RealtimeSession(
                 generation_ev.user_initiated = True
                 fut.set_result(generation_ev)
             else:
-                logger.warning("response of generate_reply received after it's timed out.")
+                # The generate_reply caller already received a timeout error.  The
+                # server kept running and delivered response.created anyway.  Cancel it
+                # so no audio frames are queued for playback.  We keep
+                # _current_generation alive so that the subsequent response.output_item.*
+                # and response.done events (which may arrive before the server honours
+                # the cancel) do not trip their assertions; response.done will close the
+                # generation normally.
+                logger.warning(
+                    "response of generate_reply received after it's timed out; "
+                    "cancelling to prevent unexpected playback."
+                )
+                self.send_event(ResponseCancelEvent(type="response.cancel"))
+                timed_out = True
 
-        self.emit("generation_created", generation_ev)
+        if not timed_out:
+            self.emit("generation_created", generation_ev)
 
     def _handle_response_output_item_added(self, event: ResponseOutputItemAddedEvent) -> None:
         assert self._current_generation is not None, "current_generation is None"


### PR DESCRIPTION
Fixes #6222

## What is happening

When `generate_reply` times out (10 s default), `_on_timeout` sets an exception on the caller's future but never sends `response.cancel` to the server. The server continues processing the response and eventually delivers `response.created`. `_handle_response_created` detected that the matched future was already done, logged a one-line warning, but then **unconditionally called `self.emit("generation_created", generation_ev)`**, wiring up a `SpeechHandle` that played back the audio the caller had already given up on.

## Fix

Two targeted changes to `RealtimeSession` in `realtime_model.py`:

**1. `_on_timeout` — ask the server to stop early**

After setting the exception on the future, send `response.cancel`. This is the same event the `_on_fut_done` callback sends when the future is *explicitly cancelled* (e.g. interrupted by the user). The timeout path was the only path that skipped it.

**2. `_handle_response_created` — suppress the late emission**

When the matched future is already done (timed-out case), suppress the `emit("generation_created")` call so no `SpeechHandle` is created and no audio is queued for playback. A second `response.cancel` is also sent here as a belt-and-suspenders guard for the window between the timeout callback firing and the server actually cancelling.

`_current_generation` is intentionally kept alive rather than closed immediately. Any `response.output_item.*` events that arrive before the server honours the cancel would trip their `assert self._current_generation is not None` guards if we cleared it early — the same race that the comment in `_handle_response_done` already acknowledges. `response.done` arrives shortly after and closes the generation through the normal path.

## Testing

Reproduce per the reporter's steps: reduce the `call_later` timeout from `10.0` to `0.01` in `generate_reply`, call `await agent_session.generate_reply()`, and observe that no audio plays back after the `RealtimeError("generate_reply timed out.")` is raised.