### PR TITLE
fix(fallback_adapter): update stream start time offset in stt fallbackadapter

### DIFF
--- a/livekit-agents/livekit/agents/stt/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/stt/fallback_adapter.py
@@ -342,6 +342,10 @@ class FallbackRecognizeStream(RecognizeStream):
                             retry_interval=self._fallback_adapter._retry_interval,
                         ),
                     )
+                    # update main_stream start time offset so transcript timestamps are properly adjusted
+                    main_stream.start_time_offset = self.start_time_offset + (
+                        time.time() - self._start_time
+                    )
 
                     if forward_input_task is None or forward_input_task.done():
                         forward_input_task = asyncio.create_task(_forward_input_task())

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -259,6 +259,7 @@ class AudioRecognition:
         self._transcript_buffer: deque[SpeechEvent] = deque()
         self._interruption_enabled: bool = interruption_detection is not None and vad is not None
         self._agent_speaking: bool = False
+        self._agent_speech_started_at: float | None = None
 
         _backchannel_boundary: float | tuple[float, float] | None = (
             session.options.interruption.get("backchannel_boundary")
@@ -383,6 +384,7 @@ class AudioRecognition:
 
     def on_start_of_agent_speech(self, started_at: float) -> None:
         self._agent_speaking = True
+        self._agent_speech_started_at = started_at
         self._endpointing.on_start_of_agent_speech(started_at=started_at)
 
         # reset user turn tracker when agent starts speaking
@@ -556,10 +558,8 @@ class AudioRecognition:
                 self._reset_interruption_detection()
                 return
 
-            if (
-                ev.alternatives[0].end_time > 0
-                and ev.alternatives[0].end_time + self._input_started_at
-                < self._ignore_user_transcript_until
+            if ev.alternatives[0].end_time > 0 and self._within_ignore_window(
+                ev.alternatives[0].end_time + self._input_started_at
             ):
                 # reset the index to emit from the next valid event
                 emit_from_index = None
@@ -605,6 +605,26 @@ class AudioRecognition:
         """Reset relevant states for adaptive interruption detection."""
         self._transcript_buffer.clear()
         self._ignore_user_transcript_until = NOT_GIVEN
+        self._agent_speech_started_at = None
+
+    def _within_ignore_window(self, event_time: float) -> bool:
+        """Whether a wall-clock event time falls inside the active ignore-user-transcript window.
+
+        ``_ignore_user_transcript_until`` marks how long user transcripts are ignored
+        while the interruption detector adjudicates overlapping speech. The window is
+        bounded so a mis-anchored STT timestamp cannot be mistaken for a transcript
+        inside it: the event must land after the agent started speaking (lower bound)
+        and before both ``now`` and the ignore cutoff (upper bound). A timestamp computed
+        into the past (e.g. a fallback STT leg that reset its timeline) or into the future
+        therefore falls outside and is not held. The agent speech start is used as the
+        lower bound rather than the overlap start, since a turn may contain several
+        overlap episodes and each is still within the same ignore window.
+        """
+        if not is_given(self._ignore_user_transcript_until):
+            return False
+        lower = self._agent_speech_started_at or 0.0
+        upper = min(time.time(), self._ignore_user_transcript_until)
+        return lower < event_time < upper
 
     def _should_hold_stt_event(self, ev: stt.SpeechEvent) -> bool:
         """Test if the event should be held until the ignore_user_transcript_until timestamp."""
@@ -635,12 +655,11 @@ class AudioRecognition:
             # check if the event should be held if
             # 1. the stt input stream has started
             # 2. the current event has a valid start and end time, relative to the input stream start time
-            # 3. the event is for audio sent before the ignore_user_transcript_until timestamp
+            # 3. the event's wall-clock time falls inside the bounded ignore-user-transcript window
             and self._input_started_at is not None
             and not (ev.alternatives[0].start_time == ev.alternatives[0].end_time == 0)
             and ev.alternatives[0].start_time > 0
-            and ev.alternatives[0].start_time + self._input_started_at
-            < self._ignore_user_transcript_until
+            and self._within_ignore_window(ev.alternatives[0].start_time + self._input_started_at)
         ):
             return True
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -434,13 +434,8 @@ class AudioRecognition:
             )
             self._ignore_user_transcript_until = ignore_until - end_cooldown
 
-            # capture the anchor so a stale flush can't clear one a newer cycle has set
-            agent_speech_started_at = self._agent_speech_started_at
-            task = asyncio.create_task(
-                self._flush_held_transcripts(
-                    cooldown=end_cooldown, agent_speech_started_at=agent_speech_started_at
-                )
-            )
+            # flush held transcripts if possible
+            task = asyncio.create_task(self._flush_held_transcripts(cooldown=end_cooldown))
             task.add_done_callback(lambda _: self._tasks.discard(task))
             self._tasks.add(task)
 
@@ -521,12 +516,7 @@ class AudioRecognition:
         await self._user_silence_ev.wait()
 
     @utils.log_exceptions(logger=logger)
-    async def _flush_held_transcripts(
-        self,
-        cooldown: float,
-        force: bool = False,
-        agent_speech_started_at: float | None = None,
-    ) -> None:
+    async def _flush_held_transcripts(self, cooldown: float, force: bool = False) -> None:
         """Flush held transcripts.
 
         When ``force`` is True, all buffered events are emitted unconditionally; this
@@ -538,13 +528,13 @@ class AudioRecognition:
         without timestamps are treated as the next valid event.
         """
         if not self._transcript_buffer:
-            self._reset_interruption_detection(agent_speech_started_at=agent_speech_started_at)
+            self._reset_interruption_detection()
             return
 
         if force:
             events_to_emit = list(self._transcript_buffer)
             # reset before emitting to avoid recursive calls
-            self._reset_interruption_detection(agent_speech_started_at=agent_speech_started_at)
+            self._reset_interruption_detection()
             for ev in events_to_emit:
                 await self._on_stt_event(ev)
             return
@@ -554,7 +544,7 @@ class AudioRecognition:
             or not is_given(self._ignore_user_transcript_until)
             or self._input_started_at is None
         ):
-            self._reset_interruption_detection(agent_speech_started_at=agent_speech_started_at)
+            self._reset_interruption_detection()
             return
 
         emit_from_index: int | None = None
@@ -565,7 +555,7 @@ class AudioRecognition:
                 emit_from_index = min(emit_from_index, i) if emit_from_index is not None else i
                 continue
             if ev.alternatives[0].start_time == ev.alternatives[0].end_time == 0:
-                self._reset_interruption_detection(agent_speech_started_at=agent_speech_started_at)
+                self._reset_interruption_detection()
                 return
 
             if ev.alternatives[0].end_time > 0 and self._within_ignore_window(
@@ -611,16 +601,13 @@ class AudioRecognition:
             )
             await self._on_stt_event(ev)
 
-    def _reset_interruption_detection(
-        self, *, agent_speech_started_at: float | None = None
-    ) -> None:
+    def _reset_interruption_detection(self) -> None:
         """Reset relevant states for adaptive interruption detection."""
         self._transcript_buffer.clear()
         self._ignore_user_transcript_until = NOT_GIVEN
-        if (
-            agent_speech_started_at is None
-            or self._agent_speech_started_at == agent_speech_started_at
-        ):
+        # keep the anchor while a newer agent-speech cycle is active, so a stale flush
+        # can't clear an anchor that cycle has already set
+        if not self._agent_speaking:
             self._agent_speech_started_at = None
 
     def _within_ignore_window(self, event_time: float) -> bool:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -434,8 +434,13 @@ class AudioRecognition:
             )
             self._ignore_user_transcript_until = ignore_until - end_cooldown
 
-            # flush held transcripts if possible
-            task = asyncio.create_task(self._flush_held_transcripts(cooldown=end_cooldown))
+            # capture the anchor so a stale flush can't clear one a newer cycle has set
+            agent_speech_started_at = self._agent_speech_started_at
+            task = asyncio.create_task(
+                self._flush_held_transcripts(
+                    cooldown=end_cooldown, agent_speech_started_at=agent_speech_started_at
+                )
+            )
             task.add_done_callback(lambda _: self._tasks.discard(task))
             self._tasks.add(task)
 
@@ -516,7 +521,12 @@ class AudioRecognition:
         await self._user_silence_ev.wait()
 
     @utils.log_exceptions(logger=logger)
-    async def _flush_held_transcripts(self, cooldown: float, force: bool = False) -> None:
+    async def _flush_held_transcripts(
+        self,
+        cooldown: float,
+        force: bool = False,
+        agent_speech_started_at: float | None = None,
+    ) -> None:
         """Flush held transcripts.
 
         When ``force`` is True, all buffered events are emitted unconditionally; this
@@ -528,13 +538,13 @@ class AudioRecognition:
         without timestamps are treated as the next valid event.
         """
         if not self._transcript_buffer:
-            self._reset_interruption_detection()
+            self._reset_interruption_detection(agent_speech_started_at=agent_speech_started_at)
             return
 
         if force:
             events_to_emit = list(self._transcript_buffer)
             # reset before emitting to avoid recursive calls
-            self._reset_interruption_detection()
+            self._reset_interruption_detection(agent_speech_started_at=agent_speech_started_at)
             for ev in events_to_emit:
                 await self._on_stt_event(ev)
             return
@@ -544,7 +554,7 @@ class AudioRecognition:
             or not is_given(self._ignore_user_transcript_until)
             or self._input_started_at is None
         ):
-            self._reset_interruption_detection()
+            self._reset_interruption_detection(agent_speech_started_at=agent_speech_started_at)
             return
 
         emit_from_index: int | None = None
@@ -555,7 +565,7 @@ class AudioRecognition:
                 emit_from_index = min(emit_from_index, i) if emit_from_index is not None else i
                 continue
             if ev.alternatives[0].start_time == ev.alternatives[0].end_time == 0:
-                self._reset_interruption_detection()
+                self._reset_interruption_detection(agent_speech_started_at=agent_speech_started_at)
                 return
 
             if ev.alternatives[0].end_time > 0 and self._within_ignore_window(
@@ -601,11 +611,17 @@ class AudioRecognition:
             )
             await self._on_stt_event(ev)
 
-    def _reset_interruption_detection(self) -> None:
+    def _reset_interruption_detection(
+        self, *, agent_speech_started_at: float | None = None
+    ) -> None:
         """Reset relevant states for adaptive interruption detection."""
         self._transcript_buffer.clear()
         self._ignore_user_transcript_until = NOT_GIVEN
-        self._agent_speech_started_at = None
+        if (
+            agent_speech_started_at is None
+            or self._agent_speech_started_at == agent_speech_started_at
+        ):
+            self._agent_speech_started_at = None
 
     def _within_ignore_window(self, event_time: float) -> bool:
         """Whether a wall-clock event time falls inside the active ignore-user-transcript window.

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -611,18 +611,7 @@ class AudioRecognition:
             self._agent_speech_started_at = None
 
     def _within_ignore_window(self, event_time: float) -> bool:
-        """Whether a wall-clock event time falls inside the active ignore-user-transcript window.
-
-        ``_ignore_user_transcript_until`` marks how long user transcripts are ignored
-        while the interruption detector adjudicates overlapping speech. The window is
-        bounded so a mis-anchored STT timestamp cannot be mistaken for a transcript
-        inside it: the event must land after the agent started speaking (lower bound)
-        and before both ``now`` and the ignore cutoff (upper bound). A timestamp computed
-        into the past (e.g. a fallback STT leg that reset its timeline) or into the future
-        therefore falls outside and is not held. The agent speech start is used as the
-        lower bound rather than the overlap start, since a turn may contain several
-        overlap episodes and each is still within the same ignore window.
-        """
+        """Whether a wall-clock event time falls inside the active ignore-user-transcript window."""
         if not is_given(self._ignore_user_transcript_until):
             return False
         lower = self._agent_speech_started_at or 0.0

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -838,7 +838,9 @@ async def test_backchannel_boundary_releases_end_boundary_transcript() -> None:
     recognition._stt_pipeline = SimpleNamespace(input_started_at=input_started_at)  # type: ignore[assignment]
 
     try:
-        recognition.on_start_of_agent_speech(started_at=time.time())
+        # the agent speaks for a couple of seconds so the held transcript still lands
+        # after the agent-speech start (the lower bound of the ignore window)
+        recognition.on_start_of_agent_speech(started_at=time.time() - 2.0)
         speech_ended_at = time.time()
         recognition.on_end_of_agent_speech(ignore_user_transcript_until=speech_ended_at)
 

--- a/tests/test_interruption_hold_window.py
+++ b/tests/test_interruption_hold_window.py
@@ -1,0 +1,92 @@
+"""Unit tests for the bounded ignore-user-transcript window in ``AudioRecognition``.
+
+The adaptive-interruption hold logic decides whether an STT transcript falls inside
+the window during which user transcripts are ignored while overlapping speech is
+adjudicated. It must bound the event's wall-clock time so a *mis-anchored* timestamp
+— e.g. from a fallback STT leg that reset its timeline and reports near-zero relative
+timestamps — cannot be mistaken for a transcript inside the window and held (which
+would wedge the user's turn). The valid window is
+``agent_start < event_time < min(now, ignore_until)``.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from livekit.agents.stt import SpeechData, SpeechEvent, SpeechEventType
+from livekit.agents.voice.audio_recognition import AudioRecognition
+
+pytestmark = pytest.mark.unit
+
+
+def _make_recognition(
+    *,
+    ignore_until: float,
+    agent_started: float | None,
+    input_started: float,
+) -> AudioRecognition:
+    ar = AudioRecognition.__new__(AudioRecognition)
+    ar._interruption_enabled = True
+    ar._agent_speaking = False
+    ar._ignore_user_transcript_until = ignore_until
+    ar._agent_speech_started_at = agent_started
+    pipeline = MagicMock()
+    pipeline.input_started_at = input_started
+    ar._stt_pipeline = pipeline
+    return ar
+
+
+def _final(start: float, end: float) -> SpeechEvent:
+    return SpeechEvent(
+        type=SpeechEventType.FINAL_TRANSCRIPT,
+        alternatives=[SpeechData(language="", text="hi", start_time=start, end_time=end)],
+    )
+
+
+def test_holds_in_window_transcript() -> None:
+    # input started at t=1000; agent spoke from t=1005; ignore window until t=1010.
+    ar = _make_recognition(ignore_until=1010.0, agent_started=1005.0, input_started=1000.0)
+    # event audio at +7s -> wall 1007, inside [1005, 1010) -> ignored, held
+    assert ar._should_hold_stt_event(_final(7.0, 8.0)) is True
+
+
+def test_does_not_hold_timestamp_anchored_before_agent_speech() -> None:
+    # The regression: a mis-anchored leg reports a near-zero relative timestamp,
+    # computing to a wall-clock *before* the agent started speaking. That cannot belong
+    # to this agent's overlap window and must NOT be held.
+    ar = _make_recognition(ignore_until=1010.0, agent_started=1005.0, input_started=1000.0)
+    # event audio at +2s -> wall 1002, before agent_started 1005 -> not held
+    assert ar._should_hold_stt_event(_final(2.0, 3.0)) is False
+
+
+def test_does_not_hold_after_ignore_cutoff() -> None:
+    ar = _make_recognition(ignore_until=1010.0, agent_started=1005.0, input_started=1000.0)
+    # event audio at +15s -> wall 1015, after ignore cutoff 1010 -> not held
+    assert ar._should_hold_stt_event(_final(15.0, 16.0)) is False
+
+
+def test_does_not_hold_timestamp_in_the_future() -> None:
+    # Upper bound is clamped to now: a timestamp computed into the future (the
+    # over-anchored variant) is outside the window and not held.
+    now = time.time()
+    ar = _make_recognition(
+        ignore_until=now + 100.0,
+        agent_started=now - 1.0,
+        input_started=now,
+    )
+    # event audio at +200s -> wall now+200, beyond now -> not held
+    assert ar._should_hold_stt_event(_final(200.0, 201.0)) is False
+
+
+def test_lower_bound_is_agent_start_across_multiple_overlaps() -> None:
+    # A turn may contain several overlap episodes. The lower bound stays at the agent
+    # speech start, so a transcript from an *earlier* overlap is still held even after a
+    # later overlap occurs (the bound must not advance to the latest overlap start).
+    ar = _make_recognition(ignore_until=1010.0, agent_started=1005.0, input_started=1000.0)
+    # first overlap transcript at +6s -> wall 1006, still inside [1005, 1010) -> held
+    assert ar._should_hold_stt_event(_final(6.0, 6.5)) is True
+    # later overlap transcript at +8s -> wall 1008 -> also held
+    assert ar._should_hold_stt_event(_final(8.0, 8.5)) is True

--- a/tests/test_stt_fallback.py
+++ b/tests/test_stt_fallback.py
@@ -96,6 +96,33 @@ async def test_stt_fallback() -> None:
     await fallback_adapter.aclose()
 
 
+async def test_stt_stream_fallback_propagates_start_time_offset() -> None:
+    # A mid-stream fallback must anchor each leg's timestamps to the original input
+    # timeline by seeding start_time_offset; otherwise a leg created after the switch
+    # emits timestamps relative to the switch moment, placing post-switch transcripts
+    # far in the past for consumers that anchor them to the input start.
+    fake1 = FakeSTT(fake_exception=APIConnectionError("fake1 failed"))
+    fake2 = FakeSTT(fake_transcript="hello world")
+
+    fallback_adapter = FallbackAdapterTester([fake1, fake2])
+
+    stream = fallback_adapter.stream()
+    # simulate that audio input started 30s before this stream was created
+    stream.start_time_offset = 30.0
+
+    async with stream:
+        stream.end_input()
+        async for _ in stream:
+            pass
+
+    leg1 = fake1.stream_ch.recv_nowait()
+    leg2 = fake2.stream_ch.recv_nowait()
+    assert leg1.start_time_offset >= 30.0
+    assert leg2.start_time_offset >= 30.0
+
+    await fallback_adapter.aclose()
+
+
 async def test_stt_stream_fallback() -> None:
     fake1 = FakeSTT(fake_exception=APIConnectionError("fake1 failed"))
     fake2 = FakeSTT(fake_transcript="hello world")


### PR DESCRIPTION
- update stream start time offset in a stt fallback adapter so stream changes persist the offset (today they have timestamps from the past)
- plus a defensive fix for barge-in so that transcripts are only held with a tighter wall clock window so we don't hold outdated transcripts (before agent speech start)