### PR TITLE
feat: add item_id to UserInputTranscribedEvent for per-utterance dedup

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1728,7 +1728,7 @@ class AgentActivity(RecognitionHooks):
 
     def _on_input_audio_transcription_completed(self, ev: llm.InputTranscriptionCompleted) -> None:
         self._session._user_input_transcribed(
-            UserInputTranscribedEvent(transcript=ev.transcript, is_final=ev.is_final)
+            UserInputTranscribedEvent(transcript=ev.transcript, is_final=ev.is_final, item_id=ev.item_id)
         )
 
         if ev.is_final:
@@ -1964,6 +1964,7 @@ class AgentActivity(RecognitionHooks):
                 language=ev.alternatives[0].language,
                 transcript=ev.alternatives[0].text,
                 is_final=False,
+                item_id=ev.request_id or None,
                 speaker_id=ev.alternatives[0].speaker_id,
             ),
         )
@@ -1993,6 +1994,7 @@ class AgentActivity(RecognitionHooks):
                 language=ev.alternatives[0].language,
                 transcript=ev.alternatives[0].text,
                 is_final=True,
+                item_id=ev.request_id or None,
                 speaker_id=ev.alternatives[0].speaker_id,
             ),
         )

--- a/livekit-agents/livekit/agents/voice/events.py
+++ b/livekit-agents/livekit/agents/voice/events.py
@@ -315,6 +315,12 @@ class UserInputTranscribedEvent(BaseModel):
     type: Literal["user_input_transcribed"] = "user_input_transcribed"
     transcript: str
     is_final: bool
+    item_id: str | None = None
+    """Identifier that groups interim and final transcription results for the same
+    utterance.  Callers can use this to deduplicate interim results or correlate a
+    final transcript back to its preceding interim updates.  Derived from the
+    upstream ``InputTranscriptionCompleted.item_id`` for realtime models and from
+    ``SpeechEvent.request_id`` for STT-based pipelines."""
     speaker_id: str | None = None
     language: LanguageCode | None = None
     created_at: float = Field(default_factory=time.time)


### PR DESCRIPTION
## Problem

`UserInputTranscribedEvent` doesn't include any identifier for the utterance being transcribed. This makes it impossible for callers to deduplicate interim transcription results or correlate a final transcript back to its preceding interim updates.

Fixes #6109

## Solution

Add an optional `item_id` field to `UserInputTranscribedEvent`:

- **Realtime models**: populated from `InputTranscriptionCompleted.item_id`
- **STT pipelines**: populated from `SpeechEvent.request_id`
- **Defaults to `None`** when no upstream identifier is available (e.g. IVR, speech-stopped events)

## Changes

- `events.py`: Add `item_id: str | None = None` field with docstring
- `agent_activity.py`: Populate `item_id` in all three event creation sites

## Testing

All 78 existing tests pass.