### PR TITLE
fix: nest endpointingSensitivity under endpointing in sessionStart

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/events.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/events.py
@@ -95,9 +95,13 @@ class ToolConfiguration(BaseModel):
     tools: list[Tool]
 
 
+class Endpointing(BaseModel):
+    endpointingSensitivity: TURN_DETECTION | None = "MEDIUM"
+
+
 class SessionStart(BaseModel):
     inferenceConfiguration: InferenceConfiguration
-    endpointingSensitivity: TURN_DETECTION | None = "MEDIUM"
+    endpointing: Endpointing
 
 
 class InputTextContentStart(BaseModel):
@@ -374,7 +378,9 @@ class SonicEventBuilder:
                         topP=top_p,
                         temperature=temperature,
                     ),
-                    endpointingSensitivity=endpointing_sensitivity,
+                    endpointing=Endpointing(
+                        endpointingSensitivity=endpointing_sensitivity,
+                    ),
                 )
             )
         )


### PR DESCRIPTION
## Problem

When starting a Nova Sonic 2 session, the `sessionStart` event is rejected by the API because `endpointingSensitivity` is placed at the top level of `sessionStart`. The Nova Sonic 2 API expects it nested under an `endpointing` key.

## Fix

- Added `Endpointing` Pydantic model with the `endpointingSensitivity` field
- Updated `SessionStart` model to use `endpointing: Endpointing` instead of `endpointingSensitivity` at the top level
- Updated `SonicEventBuilder.create_session_start_event()` to construct the nested structure

## Before (rejected)

```json
{
  "sessionStart": {
    "inferenceConfiguration": {...},
    "endpointingSensitivity": "MEDIUM"
  }
}
```

## After (correct)

```json
{
  "sessionStart": {
    "inferenceConfiguration": {...},
    "endpointing": {
      "endpointingSensitivity": "MEDIUM"
    }
  }
}
```

Fixes #6200