### PR TITLE
fix: detect and recover from audio input stream stalls (#6075)

### DIFF
--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Iterable
 from typing import Any, Generic, TypeVar, cast
@@ -31,6 +32,7 @@ class _ParticipantInputStream(Generic[T], ABC):
         *,
         track_source: rtc.TrackSource.ValueType | list[rtc.TrackSource.ValueType],
         processor: rtc.FrameProcessor[T] | None = None,
+        stall_timeout: float = 10.0,
     ) -> None:
         self._room = room
         self._accepted_sources = (
@@ -53,6 +55,7 @@ class _ParticipantInputStream(Generic[T], ABC):
 
         self._processor = processor
         self._processor_owned = False
+        self._stall_timeout = stall_timeout
 
     async def __anext__(self) -> T:
         return await self._data_ch.__anext__()
@@ -148,15 +151,103 @@ class _ParticipantInputStream(Generic[T], ABC):
             "source": rtc.TrackSource.Name(publication.source),
         }
         logger.debug("start reading stream", extra=extra)
-        async for event in stream:
-            if not self._attached:
-                # drop frames if the stream is detached
-                continue
-            frame = cast(T, event.frame)
-            self._process_frame(frame)
-            await self._data_ch.send(frame)
+
+        current_stream = stream
+        recovery_count = 0
+        max_recoveries = 3
+
+        while recovery_count <= max_recoveries:
+            stall_detected = await self._read_stream_with_stall_detection(
+                current_stream, extra
+            )
+
+            if not stall_detected:
+                break
+
+            recovery_count += 1
+            if recovery_count <= max_recoveries:
+                logger.warning(
+                    "attempting audio stream recovery",
+                    extra={
+                        "attempt": recovery_count,
+                        "max_attempts": max_recoveries,
+                        **extra,
+                    },
+                )
+                try:
+                    if publication.track is None:
+                        logger.warning(
+                            "track unavailable, cannot recover",
+                            extra=extra,
+                        )
+                        break
+                    current_stream = self._create_stream(
+                        publication.track, participant
+                    )
+                    self._stream = current_stream
+                except Exception as e:
+                    logger.error(
+                        "failed to reopen audio stream",
+                        extra={"error": str(e), **extra},
+                    )
+                    break
 
         logger.debug("stream closed", extra=extra)
+
+    async def _read_stream_with_stall_detection(
+        self,
+        stream: rtc.VideoStream | rtc.AudioStream,
+        extra: dict[str, Any],
+    ) -> bool:
+        """Read from stream with stall detection. Returns True if stall was detected."""
+        last_frame_time = time.time()
+        stall_event = asyncio.Event()
+
+        async def watchdog() -> None:
+            nonlocal last_frame_time
+            while not stall_event.is_set():
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(stall_event.wait()),
+                        timeout=self._stall_timeout,
+                    )
+                    return  # event was set, no stall
+                except asyncio.TimeoutError:
+                    if time.time() - last_frame_time >= self._stall_timeout:
+                        logger.warning(
+                            "audio input stall detected",
+                            extra={
+                                "elapsed": round(
+                                    time.time() - last_frame_time, 1
+                                ),
+                                **extra,
+                            },
+                        )
+                        await stream.aclose()
+                        return
+
+        watchdog_task = asyncio.create_task(watchdog())
+
+        try:
+            async for event in stream:
+                if not self._attached:
+                    # drop frames if the stream is detached
+                    continue
+                last_frame_time = time.time()
+                frame = cast(T, event.frame)
+                self._process_frame(frame)
+                await self._data_ch.send(frame)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            pass
+        finally:
+            stall_event.set()
+            watchdog_task.cancel()
+            await asyncio.gather(watchdog_task, return_exceptions=True)
+
+        # check if stall caused the stream to exit
+        return time.time() - last_frame_time >= self._stall_timeout
 
     def _process_frame(self, frame: T) -> None:
         """Hook for subclasses to process frames in-place before forwarding."""
@@ -241,6 +332,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         auto_gain_control: bool = True,
         pre_connect_audio_handler: PreConnectAudioHandler | None,
         frame_size_ms: int = 50,
+        stall_timeout: float = 10.0,
     ) -> None:
         _ParticipantInputStream.__init__(
             self,
@@ -249,6 +341,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             processor=(
                 noise_cancellation if isinstance(noise_cancellation, rtc.FrameProcessor) else None
             ),
+            stall_timeout=stall_timeout,
         )
         AudioInput.__init__(self, label="RoomIO")
         if frame_size_ms <= 0:

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -338,3 +338,145 @@ async def test_selector_returns_noise_cancellation_options() -> None:
     assert stream._processor is None
 
     await stream.aclose()
+
+
+# -- stall detection tests ----------------------------------------------------
+
+
+class _StallingAudioStream:
+    """A mock audio stream that yields a few frames then blocks indefinitely,
+    simulating a loose microphone cable."""
+
+    def __init__(self, frame_count: int = 2) -> None:
+        self._frame_count = frame_count
+        self._yielded = 0
+        self._closed = False
+        self._stall_event = asyncio.Event()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._closed:
+            raise StopAsyncIteration
+        if self._yielded < self._frame_count:
+            self._yielded += 1
+            # yield control so the watchdog can be scheduled
+            await asyncio.sleep(0)
+            return SimpleNamespace(
+                frame=rtc.AudioFrame(
+                    data=b"\x00\x00" * 480,
+                    sample_rate=24000,
+                    num_channels=1,
+                    samples_per_channel=480,
+                )
+            )
+        # simulate stall: block until closed
+        await self._stall_event.wait()
+        raise StopAsyncIteration
+
+    async def aclose(self) -> None:
+        self._closed = True
+        self._stall_event.set()
+
+
+def _make_stalling_audio_input_stream(
+    room: _FakeRoom,
+    noise_cancellation=None,
+    stall_timeout: float = 0.5,
+) -> _ParticipantAudioInputStream:
+    return _ParticipantAudioInputStream(
+        room,
+        sample_rate=24000,
+        num_channels=1,
+        noise_cancellation=noise_cancellation,
+        auto_gain_control=False,
+        pre_connect_audio_handler=None,
+        stall_timeout=stall_timeout,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stall_detection_and_recovery() -> None:
+    """When the audio stream stalls, the watchdog detects it and reopens the stream."""
+    room = _FakeRoom()
+    stream = _make_stalling_audio_input_stream(room, stall_timeout=0.3)
+    stream.set_participant("test-user")
+
+    track, publication, participant = _make_track_available_args()
+    # provide a track mock so recovery can reopen
+    publication.track = track
+
+    call_count = 0
+
+    def _make_stream(**kw):
+        nonlocal call_count
+        call_count += 1
+        # first call: stalling stream; second call: normal stream that completes
+        if call_count == 1:
+            return _StallingAudioStream(frame_count=2)
+        return _MockAudioStream()
+
+    with patch("livekit.rtc.AudioStream.from_track", side_effect=_make_stream):
+        stream._on_track_available(track, publication, participant)
+        # wait for the forward task to complete (stall + recovery + normal close)
+        await asyncio.wait_for(stream._forward_atask, timeout=5.0)
+
+    # _create_stream was called twice: initial + recovery
+    assert call_count == 2
+
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stall_detection_max_retries_exhausted() -> None:
+    """When every stream stalls, the task exits after max recovery attempts."""
+    room = _FakeRoom()
+    stream = _make_stalling_audio_input_stream(room, stall_timeout=0.3)
+    stream.set_participant("test-user")
+
+    track, publication, participant = _make_track_available_args()
+    publication.track = track
+
+    call_count = 0
+
+    def _make_stream(**kw):
+        nonlocal call_count
+        call_count += 1
+        return _StallingAudioStream(frame_count=2)
+
+    with patch("livekit.rtc.AudioStream.from_track", side_effect=_make_stream):
+        stream._on_track_available(track, publication, participant)
+        await asyncio.wait_for(stream._forward_atask, timeout=5.0)
+
+    # initial + 3 recovery attempts = 4 total
+    assert call_count == 4
+
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_no_stall_normal_stream() -> None:
+    """A stream that closes normally should not trigger stall detection."""
+    room = _FakeRoom()
+    stream = _make_stalling_audio_input_stream(room, stall_timeout=0.3)
+    stream.set_participant("test-user")
+
+    track, publication, participant = _make_track_available_args()
+    publication.track = track
+
+    call_count = 0
+
+    def _make_stream(**kw):
+        nonlocal call_count
+        call_count += 1
+        return _MockAudioStream()
+
+    with patch("livekit.rtc.AudioStream.from_track", side_effect=_make_stream):
+        stream._on_track_available(track, publication, participant)
+        await asyncio.wait_for(stream._forward_atask, timeout=5.0)
+
+    # only one call, no recovery
+    assert call_count == 1
+
+    await stream.aclose()


### PR DESCRIPTION
## Summary

Fixes #6075 — When a microphone cable becomes loose (partial disconnection), the audio stream silently stops producing frames and the agent never recovers.

## Root Cause

`_ParticipantInputStream._forward_task` uses `async for event in stream:` which blocks indefinitely when the underlying audio source stops producing frames. No timeout, no error, no recovery.

## Fix

Added a **watchdog-based stall detection** mechanism to `_ParticipantInputStream`:

- A concurrent watchdog task monitors time since the last received frame
- When no frames arrive within `stall_timeout` (default 10s), the watchdog logs a warning and closes the stalled stream
- The `_forward_task` loop then attempts to reopen the stream from the same track (up to 3 retries)
- If recovery fails or max retries are exhausted, the task exits cleanly

The stall detection is inherited by `_ParticipantAudioInputStream` through the `super()._forward_task()` call chain. The `stall_timeout` is configurable via the constructor.

## Changes

**`livekit-agents/livekit/agents/voice/room_io/_input.py`**:
- Added `stall_timeout: float = 10.0` parameter to `_ParticipantInputStream.__init__`
- Refactored `_forward_task` into a recovery loop + `_read_stream_with_stall_detection` helper
- Watchdog uses `asyncio.wait_for` with `asyncio.shield` on a cancellation event
- Recovery re-creates the stream via `_create_stream` when the track is still available

**`tests/test_room_io.py`**:
- `test_stall_detection_and_recovery` — verifies stall is detected and stream is reopened
- `test_stall_detection_max_retries_exhausted` — verifies graceful exit after 3 failed recovery attempts
- `test_no_stall_normal_stream` — verifies normal streams are unaffected

## Testing

All 10 tests pass:
```
tests/test_room_io.py::test_stall_detection_and_recovery PASSED
tests/test_room_io.py::test_stall_detection_max_retries_exhausted PASSED
tests/test_room_io.py::test_no_stall_normal_stream PASSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)