### PR TITLE
feat(cli): print console link when running dev mode

### DIFF
--- a/livekit-agents/livekit/agents/utils/__init__.py
+++ b/livekit-agents/livekit/agents/utils/__init__.py
@@ -7,7 +7,15 @@ from .connection_pool import ConnectionPool
 from .env import resolve_env_var
 from .exp_filter import ExpFilter
 from .log import log_exceptions
-from .misc import is_dev_mode, is_given, is_hosted, nodename, shortuuid, time_ms
+from .misc import (
+    is_dev_mode,
+    is_given,
+    is_hosted,
+    nodename,
+    shortuuid,
+    terminal_link,
+    time_ms,
+)
 from .moving_average import MovingAverage
 from .participant import wait_for_agent, wait_for_participant, wait_for_track_publication
 
@@ -36,6 +44,7 @@ __all__ = [
     "is_dev_mode",
     "is_given",
     "is_hosted",
+    "terminal_link",
     "ConnectionPool",
     "wait_for_agent",
     "wait_for_participant",

--- a/livekit-agents/livekit/agents/utils/misc.py
+++ b/livekit-agents/livekit/agents/utils/misc.py
@@ -56,3 +56,19 @@ def is_dev_mode() -> bool:
 def is_hosted() -> bool:
     """Return whether the agent is hosted on LiveKit Cloud."""
     return os.getenv("LIVEKIT_REMOTE_EOT_URL") is not None
+
+
+def terminal_link(url: str, *, text: str | None = None, color: str = "36") -> str:
+    """Format a URL for terminal output.
+
+    Colors the link with the given ANSI SGR ``color`` code (cyan by default) and
+    wraps it in an OSC 8 hyperlink escape so supporting terminals render it as a
+    clickable link. Terminals without OSC 8 support simply show the colored text.
+
+    Args:
+        url: The target URL.
+        text: The visible text. Defaults to ``url``.
+        color: ANSI SGR color code applied to the visible text.
+    """
+    text = text if text is not None else url
+    return f"\033]8;;{url}\033\\\033[{color}m{text}\033[0m\033]8;;\033\\"

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -27,7 +27,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Generic, Literal, TypeVar, overload
-from urllib.parse import urljoin, urlparse
+from urllib.parse import quote, urljoin, urlparse
 
 import aiohttp
 import jwt
@@ -1270,6 +1270,16 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                 "protocol": reg.server_info.protocol,
             },
         )
+
+        if self._devmode:
+            console_url = "https://cloud.livekit.io/projects/p_/agents/console/?autoStart=true"
+            if self._agent_name:
+                console_url += f"&agentName={quote(self._agent_name)}"
+            logger.info(
+                "to debug your agent using the web-based console, visit "
+                f"{utils.terminal_link(console_url)}"
+            )
+
         self.emit("worker_registered", reg.worker_id, reg.server_info)
 
     def _handle_availability(self, msg: agent.AvailabilityRequest) -> None:


### PR DESCRIPTION
https://linear.app/livekit/issue/DEVX-557/lk-agent-dev-should-generate-a-console-link

Print link to Agent Console when running in `dev`


```console
> uv run src/agent.py dev
in-process auto-reload has been removed from the Python CLI; use `lk agent dev` for hot-reload
2026-06-26 13:35:39,012 - DEBUG asyncio - Using selector: KqueueSelector
2026-06-26 13:35:39,012 - INFO livekit.agents - starting worker {"version": "1.6.4", "rtc-version": "1.1.12"}
2026-06-26 13:35:39,012 - INFO livekit.agents - plugin registered {"plugin": "livekit.plugins.ai_coustics", "version": "0.2.15"}
2026-06-26 13:35:39,014 - INFO livekit.agents - HTTP server listening on :54167
2026-06-26 13:35:39,241 - INFO livekit.agents - registered worker {"agent_name": "my-agent", "deployment": "", "id": "AW_Z5974RZyAtGW", "url": "wss://atrium-nnili68b.livekit.cloud", "region": "US West B", "protocol": 17}
2026-06-26 13:35:39,242 - INFO livekit.agents - to debug your agent using the web-based console, visit https://cloud.livekit.io/projects/p_/agents/console/?autoStart=true&agentName=my-agent
^C2026-06-26 13:35:43,347 - INFO livekit.agents - shutting down worker {"id": "AW_Z5974RZyAtGW"}
```