### PR TITLE
Fix: Add `started_at`/`duration` in `SessionReport.to_dict()` and drop a duplicated assignment

### DIFF
--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -384,12 +384,8 @@ class JobContext:
             model_usage=session.usage.model_usage,
         )
 
-        if recorder_io:
-            if recorder_io.output_path:
-                sr.audio_recording_path = recorder_io.output_path
-            if recorder_io.recording_started_at:
-                sr.audio_recording_started_at = recorder_io.recording_started_at
-                sr.duration = sr.timestamp - sr.audio_recording_started_at
+        if sr.audio_recording_started_at:
+            sr.duration = sr.timestamp - sr.audio_recording_started_at
 
         return sr
 

--- a/livekit-agents/livekit/agents/voice/report.py
+++ b/livekit-agents/livekit/agents/voice/report.py
@@ -66,6 +66,8 @@ class SessionReport:
                 "preemptive_generation": dict(self.options.preemptive_generation),
             },
             "chat_history": self.chat_history.to_dict(exclude_timestamp=False),
+            "duration": self.duration,
+            "started_at": self.started_at,
             "timestamp": self.timestamp,
             "usage": self._usage_to_dict() if self.model_usage else None,
             "sdk_version": self.sdk_version,


### PR DESCRIPTION
Hello there! While working on monitoring voice AI agents I went through
[`JobContext.make_session_report`](https://github.com/livekit/agents/blob/b5045e139401457a474acac43228549e473175b8/livekit-agents/livekit/agents/job.py#L358)/[`SessionReport`](https://github.com/livekit/agents/blob/b5045e139401457a474acac43228549e473175b8/livekit-agents/livekit/agents/voice/report.py#L15)
and found two small, self-contained issues. Both do **not** change the semantics of any existing field.

## Summary

1. **`started_at` and `duration` are never serialized.** `SessionReport` defines
   both as fields, but [`to_dict`](https://github.com/livekit/agents/blob/b5045e139401457a474acac43228549e473175b8/livekit-agents/livekit/agents/voice/report.py#L36) never emits them. `timestamp` (the "end") _is_ serialized, but the start and
   the duration are silently omitted, so they're computed/stored and then lost
   on serialization. Consumers of the serialized report (e.g. the local
   `session_report.json` written during console recording, and anything
   downstream reading `to_dict()`) can't see the session start or duration at
   all, even for audio sessions where `duration` *is* computed.

2. **Duplicated assignment in `make_session_report`.**
   `audio_recording_path` and `audio_recording_started_at` are set in the
   `SessionReport`-constructor call and then [re-assigned again immediately afterwards](https://github.com/livekit/agents/blob/b5045e139401457a474acac43228549e473175b8/livekit-agents/livekit/agents/job.py#L387).
   The second block is redundant for those two fields, only the `duration` line
   adds anything.

## Changes

- Emit `started_at` and `duration` in `SessionReport.to_dict()`.
- Remove the redundant re-assignment of `audio_recording_path`/
  `audio_recording_started_at` in `make_session_report`.

## Backward compat

Adding the two keys to `to_dict()` is purely additive. No existing field changes
meaning or type, so consumers (including Cloud observability) are unaffected.

## Out of scope

There's a related but separate design question —> _what `duration` even is_
and whether it should be gated on audio recording.
That changes the meaning of an existing field.
I'm intentionally keeping that out of this PR.
I'll open a design discussion and link it in a comment below.