### PR TITLE
feat(openai): add gpt-5.5 to model registry

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -19,6 +19,7 @@ TTSVoices = Literal[
 ]
 DalleModels = Literal["dall-e-2", "dall-e-3"]
 ChatModels = Literal[
+    "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",
     "gpt-5.3-chat-latest",
@@ -295,6 +296,7 @@ SambaNovaChatModels = Literal[
 
 def _supports_reasoning_effort(model: ChatModels | str) -> bool:
     return model in [
+        "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5.2",


### PR DESCRIPTION
## Summary

Adds `gpt-5.5` to the OpenAI model registry so it can be selected via the `livekit-plugins-openai` plugin (`openai.LLM(model="gpt-5.5")`).

The model is also added to `_supports_reasoning_effort()`, matching the other bare `gpt-5.x` entries so `reasoning_effort` is passed through.