### PR TITLE
fix(openai): default Azure LLM model to deployment

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -190,7 +190,7 @@ class LLM(llm.LLM):
     @staticmethod
     def with_azure(
         *,
-        model: str | ChatModels = "gpt-4o",
+        model: str | ChatModels | None = None,
         azure_endpoint: str | None = None,
         azure_deployment: str | None = None,
         api_version: str | None = None,
@@ -238,8 +238,10 @@ class LLM(llm.LLM):
             else httpx.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
         )  # type: ignore
 
+        resolved_model = model if model is not None else azure_deployment or "gpt-4o"
+
         llm = LLM(
-            model=model,
+            model=resolved_model,
             client=azure_client,
             user=user,
             temperature=temperature,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -239,8 +239,8 @@ class LLM(llm.LLM):
         )  # type: ignore
 
         # For Azure, the model name is only used as a metric label, so keep the
-        # fallback neutral when neither model nor deployment is provided.
-        resolved_model = model if model is not None else azure_deployment or "unknown"
+        # fallback neutral unless the caller provided an explicit model name.
+        resolved_model = model if model is not None else "unknown"
 
         llm = LLM(
             model=resolved_model,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -238,9 +238,16 @@ class LLM(llm.LLM):
             else httpx.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
         )  # type: ignore
 
-        # For Azure, the model name is only used as a metric label, so keep the
-        # fallback neutral unless the caller provided an explicit model name.
-        resolved_model = model if model is not None else "unknown"
+        # Keep Azure metric labels neutral when a deployment is provided, but
+        # preserve the historical request-routing fallback for invalid
+        # no-deployment calls.
+        resolved_model = (
+            model
+            if model is not None
+            else "unknown"
+            if azure_deployment is not None
+            else "gpt-4o"
+        )
 
         llm = LLM(
             model=resolved_model,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -238,7 +238,9 @@ class LLM(llm.LLM):
             else httpx.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
         )  # type: ignore
 
-        resolved_model = model if model is not None else azure_deployment or "gpt-4o"
+        # For Azure, the model name is only used as a metric label, so keep the
+        # fallback neutral when neither model nor deployment is provided.
+        resolved_model = model if model is not None else azure_deployment or "unknown"
 
         llm = LLM(
             model=resolved_model,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,4 @@
+from livekit.plugins.openai.llm import LLM
 from livekit.plugins.openai.realtime.realtime_model import process_base_url
 
 
@@ -42,3 +43,14 @@ def test_process_base_url():
         )
         == "wss://test.azure.com/custom/path?model=gpt-4"
     )
+
+
+def test_llm_with_azure_uses_deployment_as_default_model():
+    llm = LLM.with_azure(
+        azure_endpoint="https://test.azure.com/openai",
+        azure_deployment="my-deployment",
+        api_version="2025-04-12",
+        api_key="test-key",
+    )
+
+    assert llm.model == "my-deployment"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,7 +45,7 @@ def test_process_base_url():
     )
 
 
-def test_llm_with_azure_uses_deployment_as_default_model():
+def test_llm_with_azure_keeps_unknown_without_explicit_model():
     llm = LLM.with_azure(
         azure_endpoint="https://test.azure.com/openai",
         azure_deployment="my-deployment",
@@ -53,7 +53,7 @@ def test_llm_with_azure_uses_deployment_as_default_model():
         api_key="test-key",
     )
 
-    assert llm.model == "my-deployment"
+    assert llm.model == "unknown"
 
 
 def test_llm_with_azure_uses_unknown_without_model_or_deployment():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,3 +54,13 @@ def test_llm_with_azure_uses_deployment_as_default_model():
     )
 
     assert llm.model == "my-deployment"
+
+
+def test_llm_with_azure_uses_unknown_without_model_or_deployment():
+    llm = LLM.with_azure(
+        azure_endpoint="https://test.azure.com/openai",
+        api_version="2025-04-12",
+        api_key="test-key",
+    )
+
+    assert llm.model == "unknown"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,11 +56,11 @@ def test_llm_with_azure_keeps_unknown_without_explicit_model():
     assert llm.model == "unknown"
 
 
-def test_llm_with_azure_uses_unknown_without_model_or_deployment():
+def test_llm_with_azure_uses_default_model_without_deployment():
     llm = LLM.with_azure(
         azure_endpoint="https://test.azure.com/openai",
         api_version="2025-04-12",
         api_key="test-key",
     )
 
-    assert llm.model == "unknown"
+    assert llm.model == "gpt-4o"


### PR DESCRIPTION
Fixes #6209

## Summary
- stop `LLM.with_azure()` from exposing the unrelated `gpt-4o` default when Azure callers only set `azure_deployment`
- use the Azure deployment name as the fallback model identifier so telemetry and `llm.model` reflect the configured deployment
- add a regression test covering the Azure fallback behavior

## Testing
- uv run ruff check livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py tests/test_config.py
- uv run pytest tests/test_config.py