### PR TITLE
feat(anam) add director notes config

### DIFF
--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/__init__.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/__init__.py
@@ -12,14 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Anam virtual avatar plugin for LiveKit Agents
+
+See https://docs.livekit.io/agents/integrations/avatar/anam/ for setup, and
+https://anam.ai/docs/integrations/livekit/configuration for persona config and the API reference.
+"""
+
 from .avatar import AvatarSession
 from .errors import AnamException
-from .types import PersonaConfig, SessionOptions
+from .types import DirectorNotes, PersonaConfig, SessionOptions
 from .version import __version__
 
 __all__ = [
     "AnamException",
     "AvatarSession",
+    "DirectorNotes",
     "PersonaConfig",
     "SessionOptions",
     "__version__",

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/api.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/api.py
@@ -79,7 +79,7 @@ class AnamAPI:
         Returns:
             The created session token (a JWT string).
         """
-        persona_config_payload = {
+        persona_config_payload: dict[str, Any] = {
             "type": "ephemeral",
             "name": persona_config.name,
             "avatarId": persona_config.avatarId,
@@ -88,6 +88,14 @@ class AnamAPI:
 
         if persona_config.avatarModel:
             persona_config_payload["avatarModel"] = persona_config.avatarModel
+
+        if persona_config.directorNotes is not None:
+            # drop unset (None) ones so Anam falls back to its model/cue defaults.
+            director_notes = {
+                k: v for k, v in vars(persona_config.directorNotes).items() if v is not None
+            }
+            if director_notes:
+                persona_config_payload["directorNotes"] = director_notes
 
         payload: dict[str, Any] = {
             "personaConfig": persona_config_payload,

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 class DirectorNotes:
     """Per-session director-notes overrides forwarded to Anam.
 
+    For a full list of available style presets, see https://anam.ai/docs/personas/director-notes
+
     Mirrors the ``directorNotes`` field of the Anam persona config. Every field
     is optional; unset (``None``) fields are omitted from the request so Anam
     falls back to the avatar model / cue defaults.

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
@@ -13,7 +13,7 @@ class DirectorNotes:
         expressivity: Normalized expressivity in [0, 1] controlling how strongly the
             avatar responds to ``presetStyle``/``customStylePrompt`` and any inline
             cues: 1 responds more strongly, 0 less strongly. ``None`` falls back to
-            the default value of 0.35. Out-of-range values are rejected by Anam with
+            the default value of 0.5. Out-of-range values are rejected by Anam with
             an HTTP 400.
         presetStyle: A built-in expressive style (e.g. ``"happy"``, ``"warm"``,
             ``"playful"``). Mutually exclusive with ``customStylePrompt`` — Anam

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
@@ -2,12 +2,43 @@ from dataclasses import dataclass
 
 
 @dataclass
+class DirectorNotes:
+    """Per-session director-notes overrides forwarded to Anam.
+
+    Mirrors the ``directorNotes`` field of the Anam persona config. Every field
+    is optional; unset (``None``) fields are omitted from the request so Anam
+    falls back to the avatar model / cue defaults.
+
+    Attributes:
+        expressivity: Normalized expressivity in [0, 1] controlling how strongly the
+            avatar responds to ``presetStyle``/``customStylePrompt`` and any inline
+            cues: 1 responds more strongly, 0 less strongly. ``None`` falls back to
+            the default value of 0.35. Out-of-range values are rejected by Anam with
+            an HTTP 400.
+        presetStyle: A built-in expressive style (e.g. ``"happy"``, ``"warm"``,
+            ``"playful"``). Mutually exclusive with ``customStylePrompt`` — Anam
+            rejects the pair with an HTTP 400.
+        customStylePrompt: A free-form expressive style prompt. Mutually exclusive
+            with ``presetStyle``.
+    """
+
+    expressivity: float | None = None
+    presetStyle: str | None = None
+    customStylePrompt: str | None = None
+
+
+@dataclass
 class PersonaConfig:
-    """Configuration for Anam avatar persona"""
+    """Configuration for Anam avatar persona.
+
+    See https://anam.ai/docs/integrations/livekit/configuration for the persona
+    config reference.
+    """
 
     name: str
     avatarId: str
     avatarModel: str | None = None
+    directorNotes: DirectorNotes | None = None
 
 
 @dataclass


### PR DESCRIPTION
### What

Adds support for director notes config for Anam avatars.

Director notes allow the user to configure avatar expressivity through a preset or custom style and a expressivity slider. Only applicable to avatars using the new Cara 4 model.

### Why

Gives the user control over how their avatar feels and reacts

### Design

- Resilient to omitted/None values - falls back to Anam defaults
- Validated on the Anam side
- Backwards compatible - None default value, which falls back to Anam defaults