### PR TITLE
fix(eot): tighten eot cancellation by speech acitivity

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -293,7 +293,6 @@ class AudioRecognition:
         self._turn_detector_flushed: bool = False
         self._turn_detector_late_prediction_warned: bool = False
         self._last_emitted_prediction: TurnDetectionEvent | None = None
-        self._user_speaking_event = asyncio.Event()
 
     def update_options(
         self,
@@ -1228,7 +1227,6 @@ class AudioRecognition:
                 self._hooks.on_start_of_speech(ev, speech_start_time=speech_start_time)
 
             self._speaking = True
-            self._user_speaking_event.set()
 
             if self._turn_detector_stream is not None:
                 self._turn_detector_stream.cancel_inference()
@@ -1250,13 +1248,10 @@ class AudioRecognition:
 
                 if self._speech_start_time is None:
                     self._speech_start_time = time.time() - ev.raw_accumulated_speech
-                self._user_speaking_event.set()
                 if self._speaking and self._turn_detector_prediction_fut is not None:
                     if self._turn_detector_stream is not None:
                         self._turn_detector_stream.cancel_inference()
                     self._turn_detector_prediction_fut = None
-            elif not self._speaking:
-                self._user_speaking_event.clear()
 
             if ev.raw_accumulated_silence >= MIN_SILENCE_DURATION_MS / 1000 and self._speaking:
                 if (
@@ -1271,7 +1266,6 @@ class AudioRecognition:
 
             self._vad_speech_started = False
             self._speaking = False
-            self._user_speaking_event.clear()
             self._last_speaking_time = time.time() - ev.silence_duration - ev.inference_duration
 
             if self._vad_base_turn_detection or (
@@ -1588,57 +1582,12 @@ class AudioRecognition:
 
             self._user_turn_committed = False
 
-        async def _bounce_eou_task_with_speaking_guard(
-            last_speaking_time: float | None = None,
-            last_final_transcript_time: float | None = None,
-            speech_start_time: float | None = None,
-        ) -> None:
-            if self._speaking:
-                logger.debug(
-                    "user is still speaking, skipping end of turn task",
-                    extra={
-                        "last_speaking_time": last_speaking_time,
-                        "last_final_transcript_time": last_final_transcript_time,
-                        "speech_start_time": speech_start_time,
-                    },
-                )
-                return
-
-            tasks = [
-                (speaking_task := asyncio.create_task(self._user_speaking_event.wait())),
-                asyncio.create_task(
-                    _bounce_eou_task(
-                        last_speaking_time, last_final_transcript_time, speech_start_time
-                    )
-                ),
-            ]
-            try:
-                done, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-                if speaking_task in done:
-                    logger.debug(
-                        "user spoke during endpointing, cancelling end of turn task",
-                        extra={
-                            "last_speaking_time": last_speaking_time,
-                            "last_final_transcript_time": last_final_transcript_time,
-                            "speech_start_time": speech_start_time,
-                        },
-                    )
-                    return
-            finally:
-                await aio.cancel_and_wait(*tasks)
-
         if self._end_of_turn_task is not None:
             # TODO(theomonnom): disallow cancel if the extra sleep is done
             self._end_of_turn_task.cancel()
-
-        task_func = (
-            _bounce_eou_task_with_speaking_guard
-            if isinstance(self._turn_detector, _StreamingTurnDetector)
-            else _bounce_eou_task
-        )
         # copy the last_speaking_time before awaiting (the value can change)
         self._end_of_turn_task = asyncio.create_task(
-            task_func(
+            _bounce_eou_task(
                 self._last_speaking_time,
                 self._last_final_transcript_time,
                 self._user_turn_start,

--- a/tests/test_audio_recognition_turn_detection.py
+++ b/tests/test_audio_recognition_turn_detection.py
@@ -7,9 +7,9 @@ requests on VAD events only, awaits the future with the model-specific
 commits.
 Covered here:
 
-1. The speaking-guard race in ``_run_eou_detection``: setting
-   ``_user_speaking_event`` mid-bounce must abort the commit so a
-   late-arriving SOS doesn't ship the prior turn.
+1. Resumed speech during the endpointing window: a ``START_OF_SPEECH`` mid-bounce
+   cancels the in-flight eou task so the prior turn doesn't ship, while a
+   sub-``min_speech_duration`` VAD spike (no SOS/EOS) must not block the next commit.
 
 2. ``on_eot_prediction`` dedup across the vad-EOS and stt-final triggers that
    share one resolved prediction future, and the ``update_turn_detector``
@@ -45,7 +45,7 @@ from livekit.agents.voice.turn import (
 pytestmark = pytest.mark.audio_eot
 
 # ---------------------------------------------------------------------------
-# Speaking-guard race
+# Resumed-speech handling during the endpointing window
 # ---------------------------------------------------------------------------
 
 
@@ -99,7 +99,6 @@ def _make_full_recognition_for_eou() -> AudioRecognition:
     )
     ar._user_turn_span = None
     ar._user_turn_start = None
-    ar._user_speaking_event = asyncio.Event()
     ar._user_silence_ev = asyncio.Event()
     ar._speaking = False
     ar._final_transcript_confidence = []
@@ -148,44 +147,30 @@ def _resolved_prediction(
     return fut, event
 
 
-class TestSpeakingGuardRace:
-    async def test_speaking_event_during_bounce_aborts_commit(self) -> None:
-        """Regression: a VAD SOS during the endpointing-delay window must
-        cancel the in-flight bounce so the prior turn doesn't commit."""
+class TestResumedSpeechAbortsCommit:
+    async def test_sos_during_bounce_cancels_commit(self) -> None:
+        """Regression: a VAD ``START_OF_SPEECH`` during the endpointing-delay
+        window cancels the in-flight bounce so the prior turn doesn't commit.
+        The prior speaking-guard race was replaced by this SOS teardown."""
         ar = _make_full_recognition_for_eou()
         chat_ctx = _make_chat_ctx_stub()
         # sub-threshold prediction (0.2 < 0.5) extends endpointing to max_delay
         ar._turn_detector_prediction_fut, _ = _resolved_prediction(0.2)
 
         ar._run_eou_detection(chat_ctx, trigger="vad")
+        task = ar._end_of_turn_task
+        assert task is not None
 
-        # The bounce is sleeping ~0.5 s. Fire the speaking event well inside
-        # that window — the guard's `asyncio.wait(FIRST_COMPLETED)` returns
-        # with `speaking_task` done and the bounce gets cancelled.
+        # The bounce is parked in the ~0.5 s endpointing sleep. Resumed speech
+        # well inside that window tears the bounce down (audio_recognition's
+        # SOS handler cancels ``_end_of_turn_task``).
         await asyncio.sleep(0.05)
-        ar._user_speaking_event.set()
+        await ar._on_vad_event(_start_of_speech())
 
-        assert ar._end_of_turn_task is not None
         with contextlib.suppress(asyncio.CancelledError):
-            await ar._end_of_turn_task
-
+            await task
+        assert task.cancelled()
         ar._hooks.on_end_of_turn.assert_not_called()
-
-    async def test_speaking_at_entry_returns_immediately(self) -> None:
-        """Variant: speaking already True when `_run_eou_detection` is
-        called → the guard short-circuits without spawning the bounce."""
-        ar = _make_full_recognition_for_eou()
-        ar._speaking = True
-        chat_ctx = _make_chat_ctx_stub()
-
-        ar._run_eou_detection(chat_ctx, trigger="vad")
-
-        assert ar._end_of_turn_task is not None
-        await ar._end_of_turn_task
-        ar._hooks.on_end_of_turn.assert_not_called()
-        # predict should not have been called — the guard
-        # bailed before the bounce task started.
-        assert ar._turn_detector_stream.predict.call_count == 0
 
 
 def _inference_done(*, raw_speech: float, raw_silence: float = 0.0) -> vad.VADEvent:
@@ -224,39 +209,17 @@ def _end_of_speech() -> vad.VADEvent:
 
 class TestSubThresholdSpeakingSpike:
     """A noise spike can push ``raw_accumulated_speech`` above zero on ``INFERENCE_DONE``
-    without ever reaching ``START_OF_SPEECH`` — so no ``END_OF_SPEECH`` fires to clear
-    ``_user_speaking_event``. It must be cleared when speech drops back to zero, or the
-    speaking-guard aborts every subsequent ``_StreamingTurnDetector`` commit forever."""
-
-    async def test_subthreshold_spike_is_cleared(self) -> None:
-        ar = _make_full_recognition_for_eou()
-
-        # spike crosses the activation threshold: event gets set, no SOS.
-        await ar._on_vad_event(_inference_done(raw_speech=0.1))
-        assert ar._user_speaking_event.is_set()
-
-        # spike subsides before min_speech_duration: accumulation resets to 0.
-        await ar._on_vad_event(_inference_done(raw_speech=0.0))
-        assert not ar._user_speaking_event.is_set()
-
-    async def test_zero_speech_during_confirmed_turn_keeps_event(self) -> None:
-        """Inside a confirmed turn (post-SOS, ``_speaking`` True) a momentary zero-speech
-        window must NOT clear the event — ``END_OF_SPEECH`` owns the clear there."""
-        ar = _make_full_recognition_for_eou()
-        ar._speaking = True
-        ar._user_speaking_event.set()
-
-        await ar._on_vad_event(_inference_done(raw_speech=0.0))
-        assert ar._user_speaking_event.is_set()
+    without ever reaching ``START_OF_SPEECH`` — so no SOS/EOS fires. Resumed speech is
+    gated on a real SOS, not on a momentary spike, so the spike must not block a later
+    ``_StreamingTurnDetector`` commit (the regression that wedged the turn forever)."""
 
     async def test_stale_spike_does_not_block_next_commit(self) -> None:
-        """End-to-end symptom: after a spike sets-then-clears, the EOU bounce must run to
-        completion instead of being aborted by a stuck ``_user_speaking_event``."""
         ar = _make_full_recognition_for_eou()
 
+        # spike crosses the activation threshold then subsides before
+        # min_speech_duration: no SOS, no EOS.
         await ar._on_vad_event(_inference_done(raw_speech=0.1))
         await ar._on_vad_event(_inference_done(raw_speech=0.0))
-        assert not ar._user_speaking_event.is_set()
 
         chat_ctx = _make_chat_ctx_stub()
         ar._run_eou_detection(chat_ctx, trigger="vad")

--- a/tests/test_speech_start_time_persistence.py
+++ b/tests/test_speech_start_time_persistence.py
@@ -46,8 +46,6 @@ class TestUserTurnStartPersistence:
         # _speaking is a property backed by this event (set == silent/not speaking)
         audio_recognition._user_silence_ev = asyncio.Event()
         audio_recognition._speaking = False
-        # set on SOS / cleared on EOS by _on_vad_event
-        audio_recognition._user_speaking_event = asyncio.Event()
         audio_recognition._agent_speaking = False
         audio_recognition._turn_detector_stream = None
         audio_recognition._end_of_turn_task = None


### PR DESCRIPTION
Previously, the cancellation can be triggered by inference done event where background noise makes it flaky. This PR drops that path so it is now only based on STT/VAD SOS.