### PR TITLE
feat(deepgram): apply Flux option updates in-band

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -361,12 +361,8 @@ class SpeechStreamv2(stt.SpeechStream):
             self._opts.eager_eot_threshold = eager_eot_threshold
 
         # these only take effect on a fresh connection
-        needs_reconnect = (
-            is_given(model)
-            or is_given(sample_rate)
-            or is_given(mip_opt_out)
-            or is_given(tags)
-            or is_given(endpoint_url)
+        needs_reconnect = any(
+            is_given(opt) for opt in (model, sample_rate, mip_opt_out, tags, endpoint_url)
         )
         if needs_reconnect:
             # reconnect carries the latest options

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -282,11 +282,8 @@ class STTv2(stt.STT):
         merged = list(dict.fromkeys([*self._user_keyterm, *keyterms]))
         self._opts.keyterm = merged
         for stream in self._streams:
-            if stream._speaking:
-                # defer the reconnect to the end of the utterance so we don't cut it off
-                stream._pending_keyterm = merged
-            else:
-                stream.update_options(keyterm=merged)
+            # tuned in-band, safe to apply mid-utterance
+            stream.update_options(keyterm=merged)
 
 
 class SpeechStreamv2(stt.SpeechStream):
@@ -317,8 +314,9 @@ class SpeechStreamv2(stt.SpeechStream):
 
         self._request_id = ""
         self._reconnect_event = asyncio.Event()
-        # keyterms set while the user is speaking; applied at END_OF_SPEECH (latest wins)
-        self._pending_keyterm: list[str] | None = None
+        # active connection for in-band Configure updates; None while disconnected
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._reconfigure_atask: asyncio.Task[None] | None = None
 
     def update_options(
         self,
@@ -351,7 +349,6 @@ class SpeechStreamv2(stt.SpeechStream):
             keyterm = keyterms
         if is_given(keyterm):
             self._opts.keyterm = keyterm
-            self._pending_keyterm = None
         if is_given(mip_opt_out):
             self._opts.mip_opt_out = mip_opt_out
         if is_given(tags):
@@ -363,12 +360,59 @@ class SpeechStreamv2(stt.SpeechStream):
         if is_given(eager_eot_threshold):
             self._opts.eager_eot_threshold = eager_eot_threshold
 
-        self._reconnect_event.set()
+        # these only take effect on a fresh connection
+        needs_reconnect = (
+            is_given(model)
+            or is_given(sample_rate)
+            or is_given(mip_opt_out)
+            or is_given(tags)
+            or is_given(endpoint_url)
+        )
+        if needs_reconnect:
+            # reconnect carries the latest options
+            self._reconnect_event.set()
+            return
 
-    def _on_end_of_speech(self) -> None:
-        if self._pending_keyterm is not None:
-            self.update_options(keyterm=self._pending_keyterm)
-            self._pending_keyterm = None
+        # send only changed fields; Flux keeps omitted ones unchanged
+        # https://developers.deepgram.com/docs/flux/configure
+        thresholds: dict[str, Any] = {}
+        if is_given(eager_eot_threshold):
+            thresholds["eager_eot_threshold"] = eager_eot_threshold
+        if is_given(eot_threshold):
+            thresholds["eot_threshold"] = eot_threshold
+        if is_given(eot_timeout_ms):
+            thresholds["eot_timeout_ms"] = eot_timeout_ms
+
+        changed_options: dict[str, Any] = {}
+        if thresholds:
+            changed_options["thresholds"] = thresholds
+        if is_given(keyterm):
+            # keyterms replaces the whole list, so send the full effective set
+            changed_options["keyterms"] = self._opts.keyterm
+        if is_given(language_hint):
+            changed_options["language_hints"] = self._opts.language_hint
+
+        if changed_options:
+            # chain off the previous send so deltas reach the server in order
+            self._reconfigure_atask = asyncio.create_task(
+                self._send_configure(changed_options, self._reconfigure_atask)
+            )
+
+    async def _send_configure(
+        self, options: dict[str, Any], prev: asyncio.Task[None] | None
+    ) -> None:
+        if prev is not None:
+            await asyncio.gather(prev, return_exceptions=True)
+
+        ws = self._ws
+        if ws is None or ws.closed:
+            # not connected; next connection carries the latest options
+            return
+        try:
+            await ws.send_str(json.dumps({"type": "Configure", **options}))
+        except Exception:
+            # closing; next connection carries the latest options
+            logger.debug("failed to send Configure to deepgram")
 
     async def _run(self) -> None:
         closing_ws = False
@@ -453,6 +497,8 @@ class SpeechStreamv2(stt.SpeechStream):
         while True:
             try:
                 ws = await self._connect_ws()
+                # expose the connection for in-band Configure updates
+                self._ws = ws
                 tasks = [
                     asyncio.create_task(send_task(ws)),
                     asyncio.create_task(recv_task(ws)),
@@ -480,6 +526,10 @@ class SpeechStreamv2(stt.SpeechStream):
                     tasks_group.cancel()
                     tasks_group.exception()  # retrieve the exception
             finally:
+                self._ws = None
+                if self._reconfigure_atask is not None:
+                    await utils.aio.gracefully_cancel(self._reconfigure_atask)
+                    self._reconfigure_atask = None
                 if ws is not None:
                     await ws.close()
 
@@ -596,7 +646,12 @@ class SpeechStreamv2(stt.SpeechStream):
 
                 end_event = stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH)
                 self._event_ch.send_nowait(end_event)
-                self._on_end_of_speech()
+
+        elif data["type"] == "ConfigureSuccess":
+            logger.debug("deepgram applied Configure update", extra={"data": data})
+
+        elif data["type"] == "ConfigureFailure":
+            logger.warning("deepgram rejected Configure update", extra={"data": data})
 
         elif data["type"] == "Error":
             logger.warning("deepgram sent an error", extra={"data": data})

--- a/tests/test_plugin_deepgram_stt.py
+++ b/tests/test_plugin_deepgram_stt.py
@@ -1,8 +1,47 @@
 from __future__ import annotations
 
+import asyncio
+import json
+from types import SimpleNamespace
+
 import pytest
 
 pytestmark = pytest.mark.plugin("deepgram")
+
+
+class _FakeWS:
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.closed = False
+
+    async def send_str(self, data: str) -> None:
+        self.sent.append(data)
+
+
+def _make_flux_stream(*, ws=None, **opts_kwargs):
+    # exercise SpeechStreamv2's update logic without starting its connection task
+    from livekit.agents.types import NOT_GIVEN
+    from livekit.plugins.deepgram.stt_v2 import SpeechStreamv2, STTOptions
+
+    opts = STTOptions(
+        model="flux-general-en",
+        sample_rate=16000,
+        keyterm=[],
+        endpoint_url="wss://api.deepgram.com/v2/listen",
+        eot_threshold=opts_kwargs.get("eot_threshold", NOT_GIVEN),
+        eager_eot_threshold=opts_kwargs.get("eager_eot_threshold", NOT_GIVEN),
+        eot_timeout_ms=opts_kwargs.get("eot_timeout_ms", NOT_GIVEN),
+        language_hint=opts_kwargs.get("language_hint", []),
+    )
+    opts.keyterm = opts_kwargs.get("keyterm", [])
+    stream = SimpleNamespace(
+        _opts=opts,
+        _reconnect_event=asyncio.Event(),
+        _reconfigure_atask=None,
+        _ws=ws,
+    )
+    stream._send_configure = SpeechStreamv2._send_configure.__get__(stream)
+    return stream
 
 
 async def test_update_options_uses_stored_language_for_model_validation():
@@ -27,3 +66,91 @@ async def test_update_options_no_language_set_keeps_en_only_model():
     stt = STT(api_key="test-key")
     stt.update_options(model="nova-2-meeting")
     assert stt._opts.model == "nova-2-meeting"
+
+
+async def test_flux_live_fields_reconfigure_without_reconnect():
+    from livekit.plugins.deepgram.stt_v2 import SpeechStreamv2
+
+    ws = _FakeWS()
+    stream = _make_flux_stream(ws=ws, eot_threshold=0.7)
+    SpeechStreamv2.update_options(
+        stream, eot_threshold=0.85, keyterm=["LiveKit"], language_hint=["en"]
+    )
+
+    # a Configure send is scheduled in-band, no reconnect
+    assert not stream._reconnect_event.is_set()
+    assert stream._reconfigure_atask is not None
+    await stream._reconfigure_atask
+
+    assert stream._opts.eot_threshold == 0.85
+    assert len(ws.sent) == 1
+    assert json.loads(ws.sent[0]) == {
+        "type": "Configure",
+        "thresholds": {"eot_threshold": 0.85},
+        "keyterms": ["LiveKit"],
+        "language_hints": ["en"],
+    }
+
+
+async def test_flux_reconnect_fields_skip_inband_configure():
+    from livekit.plugins.deepgram.stt_v2 import SpeechStreamv2
+
+    ws = _FakeWS()
+    stream = _make_flux_stream(ws=ws)
+    SpeechStreamv2.update_options(stream, model="flux-general-multi", eot_threshold=0.8)
+
+    # model can't be tuned in-band; a reconnect carries every option instead
+    assert stream._reconnect_event.is_set()
+    assert stream._reconfigure_atask is None
+    assert ws.sent == []
+
+
+async def test_flux_configure_sends_only_changed_fields():
+    from livekit.plugins.deepgram.stt_v2 import SpeechStreamv2
+
+    # stream already has a threshold and keyterms configured
+    ws = _FakeWS()
+    stream = _make_flux_stream(ws=ws, eot_threshold=0.7, keyterm=["existing"])
+
+    # only keyterms change: the Configure delta must omit the unchanged threshold
+    SpeechStreamv2.update_options(stream, keyterm=["LiveKit", "Deepgram"])
+    await stream._reconfigure_atask
+
+    assert json.loads(ws.sent[0]) == {"type": "Configure", "keyterms": ["LiveKit", "Deepgram"]}
+
+
+async def test_flux_configure_thresholds_only_delta():
+    from livekit.plugins.deepgram.stt_v2 import SpeechStreamv2
+
+    ws = _FakeWS()
+    stream = _make_flux_stream(ws=ws, keyterm=["existing"])
+
+    SpeechStreamv2.update_options(stream, eot_timeout_ms=5000)
+    await stream._reconfigure_atask
+
+    assert json.loads(ws.sent[0]) == {"type": "Configure", "thresholds": {"eot_timeout_ms": 5000}}
+
+
+async def test_flux_configure_sends_are_ordered():
+    from livekit.plugins.deepgram.stt_v2 import SpeechStreamv2
+
+    ws = _FakeWS()
+    stream = _make_flux_stream(ws=ws, eot_threshold=0.7)
+
+    # rapid successive updates chain off each other and reach the server in order
+    SpeechStreamv2.update_options(stream, eot_threshold=0.8)
+    SpeechStreamv2.update_options(stream, eot_threshold=0.9)
+    await stream._reconfigure_atask
+
+    assert [json.loads(m)["thresholds"]["eot_threshold"] for m in ws.sent] == [0.8, 0.9]
+
+
+async def test_flux_configure_noop_when_disconnected():
+    from livekit.plugins.deepgram.stt_v2 import SpeechStreamv2
+
+    stream = _make_flux_stream(ws=None)
+    # no active connection: the next reconnect carries the latest options instead
+    SpeechStreamv2.update_options(stream, keyterm=["LiveKit"])
+    await stream._reconfigure_atask
+
+    assert stream._opts.keyterm == ["LiveKit"]


### PR DESCRIPTION
Deepgram shipped a `Configure` control message for Flux that reconfigures an active session without reconnecting. 

`update_options()` now sends a `Configure` message for the live-tunable fields (`eot_threshold`, `eager_eot_threshold`, `eot_timeout_ms`, `keyterms`, `language_hints`) instead of reconnecting, which avoids dropping the in-flight turn and the audio gap inherent to a reconnect. It sends only the fields that changed (Flux keeps omitted ones unchanged), and falls back to a reconnect for fields that cannot be tuned in-band (`model`, `sample_rate`, `mip_opt_out`, `tags`, `endpoint_url`).

Because keyterm updates no longer require a reconnect, session keyterm detection now applies them immediately mid-utterance instead of deferring to end-of-turn.

See https://developers.deepgram.com/docs/flux/configure. This is Flux-only, so the v1 `STT` path is unchanged.

close #6270