### PR TITLE
Feat/anam add director notes cue support

### DIFF
--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/__init__.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/__init__.py
@@ -19,17 +19,20 @@ https://anam.ai/docs/integrations/livekit/configuration for persona config and t
 """
 
 from .avatar import AvatarSession
+from .director_notes import DIRECTOR_NOTE_TAGS, director_note_cue_transform
 from .errors import AnamException
 from .types import DirectorNotes, PersonaConfig, SessionOptions
 from .version import __version__
 
 __all__ = [
+    "DIRECTOR_NOTE_TAGS",
     "AnamException",
     "AvatarSession",
     "DirectorNotes",
     "PersonaConfig",
     "SessionOptions",
     "__version__",
+    "director_note_cue_transform",
 ]
 
 from livekit.agents import Plugin

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/__init__.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/__init__.py
@@ -12,14 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Anam virtual avatar plugin for LiveKit Agents
+
+See https://docs.livekit.io/agents/integrations/avatar/anam/ for setup, and
+https://anam.ai/docs/integrations/livekit/configuration for persona config and the API reference.
+"""
+
 from .avatar import AvatarSession
 from .errors import AnamException
-from .types import PersonaConfig, SessionOptions
+from .types import DirectorNotes, PersonaConfig, SessionOptions
 from .version import __version__
 
 __all__ = [
     "AnamException",
     "AvatarSession",
+    "DirectorNotes",
     "PersonaConfig",
     "SessionOptions",
     "__version__",

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/api.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/api.py
@@ -79,7 +79,7 @@ class AnamAPI:
         Returns:
             The created session token (a JWT string).
         """
-        persona_config_payload = {
+        persona_config_payload: dict[str, Any] = {
             "type": "ephemeral",
             "name": persona_config.name,
             "avatarId": persona_config.avatarId,
@@ -88,6 +88,14 @@ class AnamAPI:
 
         if persona_config.avatarModel:
             persona_config_payload["avatarModel"] = persona_config.avatarModel
+
+        if persona_config.directorNotes is not None:
+            # drop unset (None) ones so Anam falls back to its model/cue defaults.
+            director_notes = {
+                k: v for k, v in vars(persona_config.directorNotes).items() if v is not None
+            }
+            if director_notes:
+                persona_config_payload["directorNotes"] = director_notes
 
         payload: dict[str, Any] = {
             "personaConfig": persona_config_payload,

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/director_notes.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/director_notes.py
@@ -219,4 +219,3 @@ def director_note_cue_transform(
             yield partial
 
     return _transform
-

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/director_notes.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/director_notes.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from collections.abc import AsyncGenerator, AsyncIterable, Callable
+from typing import get_args
+
+from livekit import rtc
+from livekit.agents.voice.room_io import ATTRIBUTE_PUBLISH_ON_BEHALF
+
+from .log import logger
+from .types import PresetStyle
+
+# Data-packet topic carrying director-note cues to the Anam engine. Must match the engine's LiveKit
+# session component. Payload:
+#   {"cue": {"tag": <tag>}, "char_offset": <int>}
+# char_offset locates the cue within this segment's emitted text.
+DIRECTOR_NOTE_CUE_TOPIC = "director_note_cue"
+
+# Default cue allowlist — Anam's built-in styles (:data:`PresetStyle`). Only these `[tag]`s are
+# stripped before TTS and forwarded; other brackets (e.g. ElevenLabs audio tags like [whispers])
+# pass through to the TTS.
+DIRECTOR_NOTE_TAGS: frozenset[str] = frozenset(get_args(PresetStyle))
+
+# A bracket cue tag is a short word in square brackets, e.g. [happy] or [sad].
+_TAG_BODY = r"[A-Za-z][A-Za-z0-9_-]{0,63}"
+_TAG_RE = re.compile(rf"\[({_TAG_BODY})\]")
+# An unterminated tag at the very end of a chunk (e.g. "[hap"), held back so a tag split across a
+# streaming-chunk boundary isn't sent to TTS or miscounted.
+_PARTIAL_TAG_RE = re.compile(rf"\[(?:{_TAG_BODY})?$")
+
+_TextTransform = Callable[[AsyncIterable[str]], AsyncIterable[str]]
+
+
+def director_note_cue_transform(
+    room: rtc.Room,
+    *,
+    stripped_tags: frozenset[str] | None = DIRECTOR_NOTE_TAGS,
+    forwarded_tags: frozenset[str] | None = DIRECTOR_NOTE_TAGS,
+) -> _TextTransform:
+    """Build a ``tts_text_transforms`` callable that handles inline ``[tag]`` director-note cues:
+    optionally stripping them from the text before TTS and/or forwarding them to the Anam engine,
+    keyed by the character offset where each applies in that turn's spoken text.
+
+    Use this only when the TTS would otherwise *speak* the tags aloud. If instead the TTS accepts the
+    tags as control tokens — not speaking them, yet still emitting them in its timed transcript with
+    word timings (e.g. Cartesia ``sonic-3.5``) — you don't need this transform at all: the engine
+    reads each cue and its timing straight from the forwarded transcript, so just forward it. (If you
+    keep this in the pipeline anyway, pass both ``stripped_tags`` and ``forwarded_tags`` empty for a
+    no-op.)
+
+    ``stripped_tags`` and ``forwarded_tags`` are independent levers, so each tag falls into one of
+    four behaviours: stripped + forwarded (a normal director cue), forwarded-only (kept for the TTS
+    *and* sent to Anam, e.g. ``[laughter]``), stripped-only (removed but not forwarded), or neither
+    (left for the TTS, e.g. an ElevenLabs ``[whispers]`` audio tag). Both default to
+    :data:`DIRECTOR_NOTE_TAGS`, so by default the preset styles are cues and everything else passes
+    through.
+
+    The engine resolves the cue against the forwarded timed transcript, so keep
+    ``use_tts_aligned_transcript=True`` and the JSON transcription sink enabled. Cue packets are
+    published on ``DIRECTOR_NOTE_CUE_TOPIC`` as ``{"cue": {"tag": tag}, "char_offset": int}``:
+    ``char_offset`` locates the cue within *this segment's* emitted text (each transform call is its
+    own coordinate space). Note a forwarded-only tag that the TTS itself strips from its output will
+    shift ``char_offset`` for that and later cues in the segment by the tag's length.
+
+    Cues are sent only to the Anam engine — the participant publishing on behalf of this agent
+    (``lk.publish_on_behalf``), discovered automatically from ``room``. Publishing waits for it to
+    join (exactly as the audio output does); if it never joins there is no avatar at all, so a
+    stalled cue is moot.
+
+    Composes with other ``tts_text_transforms`` (they run in series, in list order). Place this one
+    **last**: it must see the raw ``[tag]`` markers (so don't put a bracket-rewriting transform
+    ahead of it), and its output must be exactly what the TTS speaks (so any transform that changes
+    character content should run before it, or the cue offsets drift).
+
+    Example — ElevenLabs, which would otherwise *speak* the tags. The default strips the preset
+    styles and forwards them to Anam, while leaving native audio tags (e.g. ``[whispers]``) for the
+    TTS::
+
+        session = AgentSession(
+            stt=..., llm=..., tts=elevenlabs.TTS(), vad=...,
+            use_tts_aligned_transcript=True,
+            tts_text_transforms=[anam.director_note_cue_transform(ctx.room)],
+        )
+
+    Other scenarios (just the ``tts_text_transforms`` entry shown)::
+
+        # Cartesia sonic-3.5 — accepts the tags, doesn't speak them, and returns them in the timed
+        # transcript: omit this transform entirely and forward the transcript.
+        tts_text_transforms=[]
+
+        # A tag both Anam and the TTS should act on (e.g. ElevenLabs [laughter] — face *and* voice
+        # laugh): forward it but don't strip it, so the TTS still receives it.
+        tts_text_transforms=[
+            anam.director_note_cue_transform(
+                ctx.room, stripped_tags=anam.DIRECTOR_NOTE_TAGS - {"laughter"}
+            )
+        ]
+
+        # Strip every bracketed tag from the speech, forward none (e.g. to keep stage directions out
+        # of the audio without driving Anam):
+        tts_text_transforms=[
+            anam.director_note_cue_transform(ctx.room, stripped_tags=None, forwarded_tags=frozenset())
+        ]
+
+    Args:
+        room: The LiveKit room cues are published to (e.g. ``ctx.room``).
+        stripped_tags: Tags removed from the text before it reaches the TTS. Defaults to
+            :data:`DIRECTOR_NOTE_TAGS`; pass ``None`` to strip every well-formed ``[tag]``, or an
+            empty set to strip none.
+        forwarded_tags: Tags forwarded to the Anam engine as cues. Defaults to
+            :data:`DIRECTOR_NOTE_TAGS`; pass ``None`` to forward every tag, or an empty set to
+            forward none.
+    """
+    strip_set = None if stripped_tags is None else {t.strip().lower() for t in stripped_tags}
+    forward_set = None if forwarded_tags is None else {t.strip().lower() for t in forwarded_tags}
+
+    # The Anam engine is whoever publishes on behalf of us. Discover it once (waiting if it hasn't
+    # joined yet) and target every cue at it, so cues aren't broadcast to other participants and a
+    # cue published before the engine is in the room isn't lost.
+    engine: asyncio.Task[str] | None = None
+
+    async def _find_engine() -> str:
+        me = room.local_participant.identity
+
+        def _match(p: rtc.RemoteParticipant) -> bool:
+            return p.attributes.get(ATTRIBUTE_PUBLISH_ON_BEHALF) == me
+
+        for p in room.remote_participants.values():
+            if _match(p):
+                return p.identity
+
+        fut: asyncio.Future[str] = asyncio.Future()
+
+        def _on_connected(p: rtc.RemoteParticipant) -> None:
+            if _match(p) and not fut.done():
+                fut.set_result(p.identity)
+
+        def _on_attrs(_: list[str], p: rtc.Participant) -> None:
+            if isinstance(p, rtc.RemoteParticipant) and _match(p) and not fut.done():
+                fut.set_result(p.identity)
+
+        room.on("participant_connected", _on_connected)
+        room.on("participant_attributes_changed", _on_attrs)
+        try:
+            return await fut
+        finally:
+            room.off("participant_connected", _on_connected)
+            room.off("participant_attributes_changed", _on_attrs)
+
+    def _engine_identity() -> asyncio.Task[str]:  # one shared discovery reused by every cue
+        nonlocal engine
+        if engine is None:
+            engine = asyncio.ensure_future(_find_engine())
+        return engine
+
+    def _strip(tag: str) -> bool:  # remove from the TTS input
+        return strip_set is None or tag in strip_set
+
+    def _forward(tag: str) -> bool:  # forward to Anam as a cue
+        return forward_set is None or tag in forward_set
+
+    def _publish(tag: str, char_offset: int) -> None:
+        payload = json.dumps({"cue": {"tag": tag}, "char_offset": char_offset})
+
+        async def _send() -> None:
+            identity = await _engine_identity()
+            try:
+                await room.local_participant.publish_data(
+                    payload,
+                    topic=DIRECTOR_NOTE_CUE_TOPIC,
+                    reliable=True,
+                    destination_identities=[identity],
+                )
+            except Exception:
+                logger.exception("failed to publish director-note cue")
+
+        # Fire-and-forget so cue delivery never stalls the TTS text stream.
+        asyncio.ensure_future(_send())
+        logger.debug("director-note cue %r at char %d", tag, char_offset)
+
+    async def _transform(text: AsyncIterable[str]) -> AsyncGenerator[str, None]:
+        # char_offset counts emitted chars from the start of this segment (each call is its own
+        # coordinate space); the engine locates the cue by that offset in the timed transcript.
+        emitted = 0  # emitted-char count so far this segment
+
+        # State resets per call, so a [tag] split across separate TTS generations isn't reassembled.
+        # The transform wraps each generation's whole text stream once, so all chunk-boundary splits
+        # within a generation are handled here; a tag can't span two independent generations, and its
+        # body has no whitespace or sentence punctuation for an upstream tokenizer to split on.
+        partial = ""
+        async for chunk in text:
+            buf = partial + chunk
+            m = _PARTIAL_TAG_RE.search(buf)
+            buf, partial = (buf[: m.start()], buf[m.start() :]) if m else (buf, "")
+
+            out: list[str] = []
+            pos = 0
+            for tm in _TAG_RE.finditer(buf):
+                piece = buf[pos : tm.start()]
+                out.append(piece)
+                emitted += len(piece)
+                tag = tm.group(1).lower()
+                if not _strip(tag):
+                    # Kept for the TTS (passthrough, or forwarded-only so both react).
+                    out.append(tm.group(0))
+                    emitted += len(tm.group(0))
+                if _forward(tag):
+                    # Offset = next emitted char after the tag (a kept tag is already counted).
+                    _publish(tag, emitted)
+                pos = tm.end()
+            tail = buf[pos:]
+            out.append(tail)
+            emitted += len(tail)
+            yield "".join(out)
+
+        if partial:  # unterminated "[..." left at end of segment — emit as plain text
+            yield partial
+
+    return _transform
+

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
@@ -1,4 +1,23 @@
 from dataclasses import dataclass
+from typing import Literal
+
+# Anam's built-in director-note styles — single source of truth for both the persona-config
+# ``presetStyle`` and the inline cue tags (see :data:`director_notes.DIRECTOR_NOTE_TAGS`, derived
+# from this). Keep in sync with Anam's preset styles.
+PresetStyle = Literal[
+    "happy",
+    "warm",
+    "playful",
+    "laughter",
+    "curious",
+    "supportive",
+    "concerned",
+    "sad",
+    "surprised",
+    "angry",
+    "distressed",
+    "neutral",
+]
 
 
 @dataclass
@@ -15,15 +34,15 @@ class DirectorNotes:
             cues: 1 responds more strongly, 0 less strongly. ``None`` falls back to
             the default value of 0.35. Out-of-range values are rejected by Anam with
             an HTTP 400.
-        presetStyle: A built-in expressive style (e.g. ``"happy"``, ``"warm"``,
-            ``"playful"``). Mutually exclusive with ``customStylePrompt`` — Anam
+        presetStyle: A built-in expressive style (one of :data:`PresetStyle`, e.g. ``"happy"``,
+            ``"warm"``, ``"playful"``). Mutually exclusive with ``customStylePrompt`` — Anam
             rejects the pair with an HTTP 400.
         customStylePrompt: A free-form expressive style prompt. Mutually exclusive
             with ``presetStyle``.
     """
 
     expressivity: float | None = None
-    presetStyle: str | None = None
+    presetStyle: PresetStyle | None = None
     customStylePrompt: str | None = None
 
 

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
@@ -2,12 +2,43 @@ from dataclasses import dataclass
 
 
 @dataclass
+class DirectorNotes:
+    """Per-session director-notes overrides forwarded to Anam.
+
+    Mirrors the ``directorNotes`` field of the Anam persona config. Every field
+    is optional; unset (``None``) fields are omitted from the request so Anam
+    falls back to the avatar model / cue defaults.
+
+    Attributes:
+        expressivity: Normalized expressivity in [0, 1] controlling how strongly the
+            avatar responds to ``presetStyle``/``customStylePrompt`` and any inline
+            cues: 1 responds more strongly, 0 less strongly. ``None`` falls back to
+            the default value of 0.35. Out-of-range values are rejected by Anam with
+            an HTTP 400.
+        presetStyle: A built-in expressive style (e.g. ``"happy"``, ``"warm"``,
+            ``"playful"``). Mutually exclusive with ``customStylePrompt`` — Anam
+            rejects the pair with an HTTP 400.
+        customStylePrompt: A free-form expressive style prompt. Mutually exclusive
+            with ``presetStyle``.
+    """
+
+    expressivity: float | None = None
+    presetStyle: str | None = None
+    customStylePrompt: str | None = None
+
+
+@dataclass
 class PersonaConfig:
-    """Configuration for Anam avatar persona"""
+    """Configuration for Anam avatar persona.
+
+    See https://anam.ai/docs/integrations/livekit/configuration for the persona
+    config reference.
+    """
 
     name: str
     avatarId: str
     avatarModel: str | None = None
+    directorNotes: DirectorNotes | None = None
 
 
 @dataclass

--- a/tests/test_anam_director_notes.py
+++ b/tests/test_anam_director_notes.py
@@ -1,0 +1,192 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from livekit.plugins.anam import director_note_cue_transform, director_notes as dn
+
+pytestmark = pytest.mark.unit
+
+
+_DEFAULT = object()  # call the transform with its own default for that lever
+_ME = "agent-test"  # our (local) participant identity
+_ENGINE = "anam-engine"  # the engine participant, publishing on behalf of us
+
+
+def _runner(*, stripped_tags=_DEFAULT, forwarded_tags=_DEFAULT):
+    """Build a transform plus a coroutine that pushes one segment through it.
+
+    The fake room has the Anam engine present (a remote participant publishing on behalf of us), so
+    auto-detection resolves immediately. Returns ``(run, cues)``; ``cues`` accumulates the raw
+    published payload dicts (``topic`` and ``destination_identities`` folded in) across calls — the
+    transform instance is reused, so multiple ``run`` calls exercise the per-segment reset.
+    """
+    cues: list[dict] = []
+
+    class _LP:
+        identity = _ME
+
+        async def publish_data(self, payload, *, topic, reliable, destination_identities):  # noqa: ANN001
+            d = json.loads(payload)
+            d["topic"] = topic
+            d["destination_identities"] = destination_identities
+            cues.append(d)
+
+    engine = SimpleNamespace(identity=_ENGINE, attributes={dn.ATTRIBUTE_PUBLISH_ON_BEHALF: _ME})
+    room = SimpleNamespace(
+        local_participant=_LP(),
+        remote_participants={_ENGINE: engine},
+        on=lambda *a, **k: None,
+        off=lambda *a, **k: None,
+    )
+
+    kw = {}
+    if stripped_tags is not _DEFAULT:
+        kw["stripped_tags"] = stripped_tags
+    if forwarded_tags is not _DEFAULT:
+        kw["forwarded_tags"] = forwarded_tags
+    transform = director_note_cue_transform(room, **kw)
+
+    async def run(*chunks: str) -> str:
+        async def _text():
+            for c in chunks:
+                yield c
+
+        out = [piece async for piece in transform(_text())]
+        # drain the fire-and-forget publish tasks before returning
+        pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        if pending:
+            await asyncio.gather(*pending)
+        return "".join(out)
+
+    return run, cues
+
+
+def _drive(chunks: list[str], **kw):
+    """One-shot: run `chunks` through a fresh transform; return (emitted_text, published cues)."""
+    run, cues = _runner(**kw)
+    return asyncio.run(run(*chunks)), cues
+
+
+def _tags(cues: list[dict]) -> list[str]:
+    return [c["cue"]["tag"] for c in cues]
+
+
+def _offsets(cues: list[dict]) -> list[int]:
+    return [c["char_offset"] for c in cues]
+
+
+def test_strips_tag_and_offset_at_following_text() -> None:
+    emitted, cues = _drive(["[happy] Hi there"])
+    assert emitted == " Hi there"
+    assert _tags(cues) == ["happy"]
+    assert _offsets(cues) == [0]  # the next emitted char after the stripped tag
+    assert cues[0]["topic"] == "director_note_cue"
+    assert cues[0]["destination_identities"] == [_ENGINE]  # auto-targeted at the engine
+
+
+def test_tag_mid_text_offset() -> None:
+    emitted, cues = _drive(["Hi [happy] there"])
+    assert "[" not in emitted
+    assert _tags(cues) == ["happy"]
+    assert _offsets(cues) == [3]  # "Hi " == 3 emitted chars before the cue
+
+
+def test_tag_split_across_chunks() -> None:
+    emitted, cues = _drive(["Hi [hap", "py] there"])
+    assert "[" not in emitted
+    assert (_tags(cues), _offsets(cues)) == (["happy"], [3])
+
+
+def test_consecutive_tags_share_offset() -> None:
+    _, cues = _drive(["[happy][sad] hello"])
+    assert _tags(cues) == ["happy", "sad"]
+    assert _offsets(cues) == [0, 0]
+
+
+def test_default_is_preset_cue_others_passthrough() -> None:
+    # Both levers default to the presets: preset -> stripped + forwarded; everything else passes
+    # through to the TTS.
+    emitted, cues = _drive(["[happy] hi [whispers] bye"])
+    assert "[happy]" not in emitted  # preset -> stripped + forwarded
+    assert "[whispers]" in emitted  # non-preset (e.g. an ElevenLabs audio tag) left for the TTS
+    assert _tags(cues) == ["happy"]
+
+
+def test_forwarded_only_kept_and_forwarded() -> None:
+    # Forwarded but not stripped: kept in the speech for the TTS AND sent to Anam.
+    emitted, cues = _drive(
+        ["[laughter] that's great"],
+        stripped_tags=frozenset(),
+        forwarded_tags=frozenset({"laughter"}),
+    )
+    assert "[laughter]" in emitted  # kept so the TTS also reacts
+    assert _tags(cues) == ["laughter"]  # and forwarded to Anam
+
+
+def test_forwarded_only_shifts_offset_past_kept_tag() -> None:
+    # The kept tag is counted in the emitted text, so the offset points just past it.
+    _, cues = _drive(
+        ["[laughter] hello there"],
+        stripped_tags=frozenset(),
+        forwarded_tags=frozenset({"laughter"}),
+    )
+    assert _offsets(cues) == [len("[laughter]")]  # offset just after the kept tag
+
+
+def test_cues_target_only_the_engine() -> None:
+    # The engine (publish-on-behalf participant) is auto-detected from the room and every cue is
+    # sent only to it — never broadcast to other participants.
+    _, cues = _drive(["[happy] hi [sad] there"])
+    assert _tags(cues) == ["happy", "sad"]
+    assert all(c["destination_identities"] == [_ENGINE] for c in cues)
+
+
+def test_both_empty_is_a_no_op() -> None:
+    # Tag-preserving TTS (e.g. Cartesia sonic-3.5): nothing stripped, nothing forwarded.
+    emitted, cues = _drive(
+        ["hi [happy] there"], stripped_tags=frozenset(), forwarded_tags=frozenset()
+    )
+    assert emitted == "hi [happy] there"  # passthrough — tag left for the TTS
+    assert cues == []
+
+
+def test_stripped_only_removed_not_forwarded() -> None:
+    # Stripped but not forwarded: gone from the speech, no cue sent.
+    emitted, cues = _drive(
+        ["[beep] hi"], stripped_tags=frozenset({"beep"}), forwarded_tags=frozenset()
+    )
+    assert emitted == " hi"
+    assert cues == []
+
+
+def test_stripped_none_strips_every_tag() -> None:
+    emitted, cues = _drive(["[whatever] go"], stripped_tags=None, forwarded_tags=frozenset())
+    assert "[" not in emitted
+    assert cues == []
+
+
+def test_forwarded_none_forwards_every_tag() -> None:
+    emitted, cues = _drive(["[whatever] go"], stripped_tags=frozenset(), forwarded_tags=None)
+    assert "[whatever]" in emitted  # not stripped -> kept for the TTS
+    assert _tags(cues) == ["whatever"]  # forwarded anyway
+
+
+def test_literal_bracket_with_space_passes_through() -> None:
+    emitted, cues = _drive(["see [ 5 ] ref"])
+    assert emitted == "see [ 5 ] ref"  # not a well-formed tag — untouched
+    assert cues == []
+
+
+def test_offsets_are_per_segment() -> None:
+    # Each transform invocation is its own coordinate space: offsets reset, no cross-call state.
+    run, cues = _runner()
+
+    async def _go():
+        await run("[happy] a")  # happy@0
+        await run("xx [sad] b")  # new call resets; "xx " == 3 -> sad@3
+
+    asyncio.run(_go())
+    assert _tags(cues) == ["happy", "sad"]
+    assert _offsets(cues) == [0, 3]


### PR DESCRIPTION
Requires - https://github.com/livekit/agents/pull/6267

## What

Adds inline **director-note cues** to the Anam avatar plugin:
`director_note_cue_transform`, a `tts_text_transforms` callable that reads
bracket cues (e.g. `[happy]`, `[sad]`) in the agent's speech and forwards them to
the Anam engine, keyed by where each lands in the spoken text — so the avatar's
expression changes moment-to-moment, mid-utterance, driven by the LLM's own
output.

## Why

The plugin can stream an Anam avatar but gives no way to drive its expression at
runtime. Letting the LLM emit `[tag]` cues inline means expression follows the
content of what's being said, with no separate control channel and no extra
turn-taking.

## Design

- A standard `tts_text_transforms` entry — composes with other transforms and
  needs no changes to the avatar session.
- Two independent levers cover the real cases: `stripped_tags` (remove the tag
  before TTS) and `forwarded_tags` (send it to Anam). So: strip+forward for a TTS
  that would otherwise *speak* the tag (ElevenLabs), forward-only for a tag both
  face and voice should act on (`[laughter]`), and a no-op for a TTS that handles
  the tags itself (Cartesia `sonic-3.5`). Non-preset brackets (e.g. ElevenLabs
  `[whispers]`) pass through by default.
- Cues ride the existing LiveKit data channel on the `director_note_cue` topic,
  targeted only at the engine participant (discovered via `lk.publish_on_behalf`),
  consistent with how the framework's avatar audio output coordinates with its
  worker.
- Offsets are resolved against the TTS-aligned timed transcript, so
  `use_tts_aligned_transcript=True` is required.

Scoped entirely to `livekit-plugins-anam`; no change to default behavior for
existing users.
