### PR TITLE
fix(voice): collapse duplicate same-target handoff tool calls

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3135,9 +3135,17 @@ class AgentActivity(RecognitionHooks):
                 fnc_executed_ev.function_call_outputs.append(sanitized_out.fnc_call_out)
 
                 if new_agent_task is not None and sanitized_out.agent_task is not None:
-                    logger.error("expected to receive only one AgentTask from the tool executions")
-                    ignore_task_switch = True
-                    # TODO(long): should we mark the function call as failed to notify the LLM?
+                    if sanitized_out.agent_task is not new_agent_task:
+                        # genuinely different handoff targets in a single turn: ambiguous,
+                        # refuse the switch (unchanged behavior).
+                        logger.error(
+                            "expected to receive only one AgentTask from the tool executions"
+                        )
+                        ignore_task_switch = True
+                        # TODO(long): should we mark the function call as failed to notify the LLM?
+                    # else: the LLM requested the SAME handoff target more than once in one
+                    # turn (parallel/duplicate tool calls, common with real LLMs). Collapse to
+                    # a single handoff instead of discarding it (livekit/agents#5990).
 
                 new_agent_task = sanitized_out.agent_task
 
@@ -3734,10 +3742,16 @@ class AgentActivity(RecognitionHooks):
                     self._session._tool_items_added([sanitized_out.fnc_call_out])
 
                 if new_agent_task is not None and sanitized_out.agent_task is not None:
-                    logger.error(
-                        "expected to receive only one Agent from the tool executions",
-                    )
-                    ignore_task_switch = True
+                    if sanitized_out.agent_task is not new_agent_task:
+                        # genuinely different handoff targets in a single turn: ambiguous,
+                        # refuse the switch (unchanged behavior).
+                        logger.error(
+                            "expected to receive only one Agent from the tool executions",
+                        )
+                        ignore_task_switch = True
+                    # else: the LLM requested the SAME handoff target more than once in one
+                    # turn (parallel/duplicate tool calls, common with real LLMs). Collapse to
+                    # a single handoff instead of discarding it (livekit/agents#5990).
 
                 new_agent_task = sanitized_out.agent_task
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3147,7 +3147,12 @@ class AgentActivity(RecognitionHooks):
                     # turn (parallel/duplicate tool calls, common with real LLMs). Collapse to
                     # a single handoff instead of discarding it (livekit/agents#5990).
 
-                new_agent_task = sanitized_out.agent_task
+                # Only a tool that actually returned an AgentTask may set the target.
+                # Assigning unconditionally let a later non-handoff tool (agent_task is
+                # None) overwrite an earlier handoff, so whether the switch happened
+                # depended on the order the LLM emitted the calls in.
+                if sanitized_out.agent_task is not None:
+                    new_agent_task = sanitized_out.agent_task
 
             if new_agent_task and not ignore_task_switch:
                 fnc_executed_ev._handoff_required = True
@@ -3753,7 +3758,12 @@ class AgentActivity(RecognitionHooks):
                     # turn (parallel/duplicate tool calls, common with real LLMs). Collapse to
                     # a single handoff instead of discarding it (livekit/agents#5990).
 
-                new_agent_task = sanitized_out.agent_task
+                # Only a tool that actually returned an AgentTask may set the target.
+                # Assigning unconditionally let a later non-handoff tool (agent_task is
+                # None) overwrite an earlier handoff, so whether the switch happened
+                # depended on the order the LLM emitted the calls in.
+                if sanitized_out.agent_task is not None:
+                    new_agent_task = sanitized_out.agent_task
 
             if new_agent_task and not ignore_task_switch:
                 fnc_executed_ev._handoff_required = True

--- a/tests/test_handoff_duplicate_transfer_5990.py
+++ b/tests/test_handoff_duplicate_transfer_5990.py
@@ -1,0 +1,94 @@
+"""Regression test for duplicate same-target handoff tool calls (livekit/agents#5990).
+
+A real LLM can emit the same handoff tool call more than once in a single turn
+(parallel / duplicate tool calls). Every call returns the same target ``Agent``, so the
+tool-output loop in ``AgentActivity`` sees more than one ``AgentTask`` and the
+``"expected to receive only one AgentTask"`` guard previously set
+``ignore_task_switch=True`` -- discarding the handoff entirely. ``update_agent`` was never
+called, the target agent never started, and the follow-up tool turn was stranded.
+
+The scripted ``FakeLLM`` in the other handoff tests emits exactly one ``transfer`` call, so
+this went unseen; only a real LLM produced the duplicates. Scripting two identical
+``transfer`` calls reproduces it deterministically -- no keys, audio, or LiveKit server
+needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from livekit.agents import Agent, RunContext, function_tool
+from livekit.agents.llm import FunctionToolCall
+
+from .fake_session import FakeActions, create_session, run_session
+
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
+
+SESSION_TIMEOUT = 30
+
+
+class Specialist(Agent):
+    def __init__(self) -> None:
+        super().__init__(instructions="specialist; call search per property query")
+        self.searches: list[str] = []
+
+    @function_tool
+    async def search(self, ctx: RunContext, query: str) -> str:
+        """Search listings."""
+        self.searches.append(query)
+        return f"no listings for {query}"
+
+
+class Root(Agent):
+    def __init__(self, specialist: Specialist) -> None:
+        super().__init__(instructions="receptionist; transfer on property ask")
+        self._s = specialist
+
+    @function_tool
+    async def transfer(self, ctx: RunContext) -> Agent:
+        """Hand off to the specialist."""
+        return self._s
+
+
+def _call(name: str, args: str, cid: str) -> FunctionToolCall:
+    return FunctionToolCall(name=name, arguments=args, call_id=cid)
+
+
+async def test_duplicate_transfer_calls_complete_handoff(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Two identical ``transfer`` calls in one turn must still complete the handoff.
+
+    The pre-fix guard treated the second same-target ``AgentTask`` as an error and aborted
+    the switch, so the Specialist never ran and its follow-up ``search`` was stranded.
+    """
+    specialist = Specialist()
+    root = Root(specialist)
+
+    actions = FakeActions()
+    # Handoff turn: the LLM emits `transfer` TWICE in one turn -- the #5990 trigger
+    # (parallel duplicate handoff calls, both returning the same Specialist instance).
+    actions.add_user_speech(0.5, 1.4, "transfer me to a specialist", stt_delay=0.1)
+    actions.add_llm("", tool_calls=[_call("transfer", "{}", "1"), _call("transfer", "{}", "2")])
+    # Follow-up turn the specialist must handle (the reporter's stranded tool turn).
+    actions.add_user_speech(2.0, 2.9, "please search oak road", stt_delay=0.1)
+    actions.add_llm(
+        "",
+        input="please search oak road",
+        tool_calls=[_call("search", '{"query": "oak road"}', "3")],
+    )
+    actions.add_llm("nothing on oak road", input="no listings for oak road", duration=0.4)
+    actions.add_tts(0.6, input="nothing on oak road")
+
+    session = create_session(actions, speed_factor=5.0, extra_kwargs={"max_tool_steps": 3})
+
+    with caplog.at_level(logging.WARNING):
+        await asyncio.wait_for(run_session(session, root, drain_delay=6), timeout=SESSION_TIMEOUT)
+
+    # The duplicate same-target transfer calls must still complete the handoff...
+    assert type(session.current_agent).__name__ == "Specialist"
+    # ...so the specialist's follow-up tool actually executes (the #5990 symptom).
+    assert specialist.searches == ["oak road"]

--- a/tests/test_handoff_duplicate_transfer_5990.py
+++ b/tests/test_handoff_duplicate_transfer_5990.py
@@ -52,6 +52,11 @@ class Root(Agent):
         """Hand off to the specialist."""
         return self._s
 
+    @function_tool
+    async def log_reason(self, ctx: RunContext, reason: str) -> str:
+        """Record why the caller is being transferred. Returns no AgentTask."""
+        return f"noted: {reason}"
+
 
 def _call(name: str, args: str, cid: str) -> FunctionToolCall:
     return FunctionToolCall(name=name, arguments=args, call_id=cid)
@@ -91,4 +96,47 @@ async def test_duplicate_transfer_calls_complete_handoff(
     # The duplicate same-target transfer calls must still complete the handoff...
     assert type(session.current_agent).__name__ == "Specialist"
     # ...so the specialist's follow-up tool actually executes (the #5990 symptom).
+    assert specialist.searches == ["oak road"]
+
+
+async def test_handoff_survives_a_later_non_handoff_tool(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-handoff tool executing AFTER a handoff tool must not drop the handoff.
+
+    The tool-output loop assigned ``new_agent_task = sanitized_out.agent_task`` on every
+    iteration, so a tool returning no ``AgentTask`` reset it to ``None`` and the handoff
+    was silently lost. Which tool won depended purely on iteration order, so the same
+    turn handed off or didn't depending on the order the LLM emitted the calls in.
+    """
+    specialist = Specialist()
+    root = Root(specialist)
+
+    actions = FakeActions()
+    # `log_reason` is emitted AFTER `transfer`, so it is the last iteration to touch
+    # `new_agent_task` -- the losing order.
+    actions.add_user_speech(0.5, 1.4, "transfer me to a specialist", stt_delay=0.1)
+    actions.add_llm(
+        "",
+        tool_calls=[
+            _call("transfer", "{}", "1"),
+            _call("log_reason", '{"reason": "property query"}', "2"),
+        ],
+    )
+    # Follow-up turn the specialist must handle, same shape as the #5990 test.
+    actions.add_user_speech(2.0, 2.9, "please search oak road", stt_delay=0.1)
+    actions.add_llm(
+        "",
+        input="please search oak road",
+        tool_calls=[_call("search", '{"query": "oak road"}', "3")],
+    )
+    actions.add_llm("nothing on oak road", input="no listings for oak road", duration=0.4)
+    actions.add_tts(0.6, input="nothing on oak road")
+
+    session = create_session(actions, speed_factor=5.0, extra_kwargs={"max_tool_steps": 3})
+
+    with caplog.at_level(logging.WARNING):
+        await asyncio.wait_for(run_session(session, root, drain_delay=6), timeout=SESSION_TIMEOUT)
+
+    assert type(session.current_agent).__name__ == "Specialist"
     assert specialist.searches == ["oak road"]


### PR DESCRIPTION
### What

When a `@function_tool` returns an `Agent` (a handoff), `AgentActivity` treats a second `AgentTask` produced in the same turn as an ambiguous multi-handoff and aborts the switch:

```python
if new_agent_task is not None and sanitized_out.agent_task is not None:
    logger.error("expected to receive only one AgentTask from the tool executions")
    ignore_task_switch = True
```

Real LLMs can emit the same handoff tool call more than once in a single turn (parallel or duplicate tool calls). Each duplicate returns the same target agent, so this guard fires, `ignore_task_switch = True`, and the handoff is discarded: `update_agent` never runs, the target agent never starts, and the follow-up tool turn is stranded.

### Fix

Refuse the switch only when the duplicate `AgentTask` targets a *different* agent (genuinely ambiguous). Identical same-target calls collapse to one handoff. This guard exists in both the pipeline and realtime tool-output loops, so the same change is applied to both. Each duplicate tool call still gets its own `function_call_output`, so the one-output-per-tool-call requirement holds.

### Test

`tests/test_handoff_duplicate_transfer_5990.py` is a hermetic, no-keys unit test: a scripted `FakeLLM` emits two identical `transfer` calls in one turn, and the test asserts the handoff completes and the specialist's follow-up tool runs. It fails on `main` and passes with this change. It covers the pipeline path; the realtime loop takes the identical change, and there is no hermetic realtime harness in the suite to unit-test it separately without a live model. `make check` is clean (ruff + mypy strict) and the full `--unit` suite is green.

### Scope

This surfaced while investigating #5990. It is an independent correctness fix and does not by itself close that issue. Keeping it small and self-contained so it can be reviewed on its own.
