### PR TITLE
feat: realtime model fallback adapter

### DIFF
--- a/livekit-agents/livekit/agents/beta/tools/end_call.py
+++ b/livekit-agents/livekit/agents/beta/tools/end_call.py
@@ -62,13 +62,17 @@ class EndCallTool(Toolset):
 
     async def _end_call(self, ctx: RunContext) -> Any | None:
         logger.debug("end_call tool called")
-        llm_v = ctx.session.current_agent._get_activity_or_raise().llm
+        activity = ctx.session.current_agent._get_activity_or_raise()
+        llm_v = activity.llm
 
         def _on_speech_done(_: SpeechHandle) -> None:
-            if (
-                not isinstance(llm_v, RealtimeModel)
-                or not llm_v.capabilities.auto_tool_reply_generation
-            ):
+            # read auto_tool_reply_generation from the active realtime session so a fallback
+            # adapter reports the model actually in use
+            rt_session = activity.realtime_llm_session
+            auto_tool_reply = (
+                rt_session is not None and rt_session.capabilities.auto_tool_reply_generation
+            )
+            if not isinstance(llm_v, RealtimeModel) or not auto_tool_reply:
                 # tool reply will reuse the same speech handle, so we can shutdown the session
                 # directly after this speech handle is done
                 ctx.session.shutdown()

--- a/livekit-agents/livekit/agents/llm/__init__.py
+++ b/livekit-agents/livekit/agents/llm/__init__.py
@@ -38,6 +38,10 @@ from .realtime import (
     RealtimeSessionReconnectedEvent,
     RemoteItemAddedEvent,
 )
+from .realtime_fallback_adapter import (
+    RealtimeAvailabilityChangedEvent,
+    RealtimeModelFallbackAdapter,
+)
 from .tool_context import (
     FunctionTool,
     ProviderTool,
@@ -79,6 +83,8 @@ __all__ = [
     "CompletionUsage",
     "FallbackAdapter",
     "AvailabilityChangedEvent",
+    "RealtimeModelFallbackAdapter",
+    "RealtimeAvailabilityChangedEvent",
     "ToolChoice",
     "Tool",
     "Toolset",

--- a/livekit-agents/livekit/agents/llm/realtime.py
+++ b/livekit-agents/livekit/agents/llm/realtime.py
@@ -196,6 +196,15 @@ class RealtimeSession(ABC, rtc.EventEmitter[EventTypes | TEvent], Generic[TEvent
         return self._realtime_model
 
     @property
+    def capabilities(self) -> RealtimeCapabilities:
+        """Capabilities of the session.
+
+        Defaults to the parent model's capabilities. Adapters that swap the underlying model
+        mid-session override this to report the currently active model's capabilities.
+        """
+        return self._realtime_model.capabilities
+
+    @property
     @abstractmethod
     def chat_ctx(self) -> ChatContext: ...
 

--- a/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import time
 import weakref
 from collections.abc import AsyncIterable, Callable
@@ -11,7 +12,7 @@ from livekit import rtc
 
 from ..log import logger
 from ..types import NOT_GIVEN, NotGivenOr
-from ..utils import is_given
+from ..utils import aio, is_given
 from .chat_context import ChatContext
 from .realtime import (
     EventTypes,
@@ -200,6 +201,9 @@ class _FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_ch
         if self._available[index] == available:
             return
         self._available[index] = available
+        if not available:
+            # keep the model out of rotation until the cooldown expires
+            self._cooldown_deadline[index] = time.time() + self._adapter._cooldown
         self._adapter.emit(
             "realtime_availability_changed",
             RealtimeAvailabilityChangedEvent(
@@ -236,7 +240,6 @@ class _FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_ch
 
         # mark the dead model unavailable for a cooldown, then find a fallback
         self._set_available(self._active_index, False)
-        self._cooldown_deadline[self._active_index] = time.time() + self._adapter._cooldown
         target = self._next_available_index()
         if target is None:
             # exhausted: escalate so AgentSession can close
@@ -280,33 +283,57 @@ class _FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_ch
             else:
                 chat_ctx = self._active.chat_ctx
 
+            # bring up a fresh child on ``index``; on failure clean it up, cool it down, and
+            # return the error so the caller can try the next model
+            async def _bring_up(index: int) -> Exception | None:
+                try:
+                    self._active = self._adapter._models[index].session()
+                    self._active_index = index
+                    self._bind(self._active)
+                    await self._active._update_session(
+                        instructions=self._instructions, chat_ctx=chat_ctx, tools=self._tools
+                    )
+                    if is_given(self._tool_choice):
+                        self._active.update_options(tool_choice=self._tool_choice)
+                    return None
+                except Exception as e:
+                    logger.exception("failed to start realtime model on swap, trying next")
+                    self._unbind(self._active)
+                    with contextlib.suppress(Exception):
+                        await self._active.aclose()
+                    self._set_available(index, False)
+                    return e
+
             self._swapping = True
             try:
+                # close the old child; best-effort since the provider may already be dead
                 self._unbind(self._active)
-                await self._active.aclose()
+                with contextlib.suppress(Exception):
+                    await self._active.aclose()
 
-                self._active = self._adapter._models[target_index].session()
-                self._active_index = target_index
-                self._bind(self._active)
+                # cascade to further models if one fails to start
+                error = await _bring_up(target_index)
+                while error is not None:
+                    nxt = self._next_available_index()
+                    if nxt is None:
+                        break
+                    error = await _bring_up(nxt)
+            finally:
+                self._swapping = False
 
-                await self._active._update_session(
-                    instructions=self._instructions, chat_ctx=chat_ctx, tools=self._tools
-                )
-                if is_given(self._tool_choice):
-                    self._active.update_options(tool_choice=self._tool_choice)
-            except Exception as e:
-                # a failed swap would otherwise wedge the session silently; escalate so the
-                # AgentSession can close instead of continuing on a broken session
-                logger.exception("failed to swap the realtime session")
+            if error is not None:
+                # every model failed to start; escalate so AgentSession can close instead of
+                # continuing on a broken session
                 self.emit(
                     "error",
                     RealtimeModelError(
-                        timestamp=time.time(), label=self._adapter.label, error=e, recoverable=False
+                        timestamp=time.time(),
+                        label=self._adapter.label,
+                        error=error,
+                        recoverable=False,
                     ),
                 )
                 return
-            finally:
-                self._swapping = False
 
             # a swap is a reconnect from the caller's perspective
             self.emit("session_reconnected", RealtimeSessionReconnectedEvent())
@@ -357,6 +384,8 @@ class _FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_ch
         self._active.push_audio(frame)
 
     def push_video(self, frame: rtc.VideoFrame) -> None:
+        if self._swapping:
+            return
         self._active.push_video(frame)
 
     def generate_reply(
@@ -401,5 +430,8 @@ class _FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_ch
         )
 
     async def aclose(self) -> None:
+        # cancel an in-flight swap first, else its fresh child would leak past aclose
+        if self._swap_task is not None:
+            await aio.cancel_and_wait(self._swap_task)
         self._unbind(self._active)
         await self._active.aclose()

--- a/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import asyncio
+import time
+import weakref
+from collections.abc import AsyncIterable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+from livekit import rtc
+
+from ..log import logger
+from ..types import NOT_GIVEN, NotGivenOr
+from ..utils import is_given
+from .chat_context import ChatContext
+from .realtime import (
+    EventTypes,
+    GenerationCreatedEvent,
+    RealtimeCapabilities,
+    RealtimeModel,
+    RealtimeModelError,
+    RealtimeSession,
+    RealtimeSessionReconnectedEvent,
+)
+from .tool_context import Tool, ToolChoice, ToolContext
+
+if TYPE_CHECKING:
+    from ..voice.agent_session import AgentSession
+
+
+@dataclass
+class RealtimeAvailabilityChangedEvent:
+    realtime_model: RealtimeModel
+    available: bool
+
+
+# pipeline-shaping caps that must match across models (set at activity start, can't change mid-call)
+_HARD_CAPABILITIES = (
+    "audio_output",
+    "turn_detection",
+)
+
+# caps exposed as the conservative AND; the active model's exact value is read per-turn from the session
+_SOFT_CAPABILITIES = (
+    "message_truncation",
+    "user_transcription",
+    "manual_function_calls",
+    "auto_tool_reply_generation",
+    "mutable_chat_context",
+    "mutable_instructions",
+    "mutable_tools",
+    "per_response_tool_choice",
+    "supports_say",
+)
+
+# child events re-emitted on the wrapper
+_FORWARDED_EVENTS: tuple[EventTypes, ...] = (
+    "input_speech_started",
+    "input_speech_stopped",
+    "input_audio_transcription_completed",
+    "generation_created",
+    "session_reconnected",
+    "metrics_collected",
+    "remote_item_added",
+)
+
+
+def _merge_capabilities(models: list[RealtimeModel]) -> RealtimeCapabilities:
+    first = models[0].capabilities
+    for model in models[1:]:
+        caps = model.capabilities
+        for name in _HARD_CAPABILITIES:
+            if getattr(caps, name) != getattr(first, name):
+                raise ValueError(
+                    f"all realtime models must agree on `{name}` to be used in a "
+                    f"RealtimeModelFallbackAdapter, got "
+                    f"{getattr(first, name)} and {getattr(caps, name)}"
+                )
+
+    merged = {name: getattr(first, name) for name in _HARD_CAPABILITIES}
+    for name in _SOFT_CAPABILITIES:
+        merged[name] = all(getattr(model.capabilities, name) for model in models)
+
+    return RealtimeCapabilities(**merged)
+
+
+class RealtimeModelFallbackAdapter(
+    RealtimeModel,
+    rtc.EventEmitter[Literal["realtime_availability_changed"]],
+):
+    """Falls back between realtime models (or restarts one), preserving chat context and handlers."""
+
+    def __init__(
+        self,
+        models: list[RealtimeModel],
+        *,
+        cooldown: float = 10.0,
+        regenerate_on_swap: bool = True,
+    ) -> None:
+        """Fall back between realtime models while preserving chat context.
+
+        Args:
+            models: Ordered models; the first is primary, the rest fallbacks. All must agree on
+                the ``audio_output`` and ``turn_detection`` capabilities.
+            cooldown: Seconds a failed model stays unavailable before it can be preferred again.
+            regenerate_on_swap: Re-issue the reply on the new session if one was in progress.
+
+        Raises:
+            ValueError: If no models are given or their hard capabilities disagree.
+        """
+        if len(models) < 1:
+            raise ValueError("at least one RealtimeModel instance must be provided.")
+
+        RealtimeModel.__init__(self, capabilities=_merge_capabilities(models))
+        rtc.EventEmitter.__init__(self)
+        self._models = models
+        self._cooldown = cooldown
+        self._regenerate_on_swap = regenerate_on_swap
+        self._sessions: weakref.WeakSet[_FallbackRealtimeSession] = weakref.WeakSet()
+
+    @property
+    def model(self) -> str:
+        return "RealtimeModelFallbackAdapter"
+
+    @property
+    def provider(self) -> str:
+        return "livekit"
+
+    def session(self) -> _FallbackRealtimeSession:
+        sess = _FallbackRealtimeSession(self)
+        self._sessions.add(sess)
+        return sess
+
+    async def restart_session(self, *, switch_model: bool = False) -> None:
+        """Bring up a fresh underlying session, preserving chat context and bound handlers.
+
+        Args:
+            switch_model: Bring the new session up on the next available model instead of the
+                current one.
+        """
+        for sess in list(self._sessions):
+            await sess.restart(switch_model=switch_model)
+
+    async def aclose(self) -> None:
+        for model in self._models:
+            await model.aclose()
+
+
+class _FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_changed"]]):
+    """Bound once by AgentActivity; swaps the inner child session internally."""
+
+    def __init__(self, adapter: RealtimeModelFallbackAdapter) -> None:
+        super().__init__(adapter)
+        self._adapter = adapter
+
+        # session state replayed onto a new child on swap
+        self._instructions: NotGivenOr[str] = NOT_GIVEN
+        self._tools: NotGivenOr[list[Tool]] = NOT_GIVEN
+        self._tool_choice: NotGivenOr[ToolChoice | None] = NOT_GIVEN
+
+        # stable per-event forwarders so they can be detached on swap
+        def _make_forwarder(event: EventTypes) -> Callable[[object], None]:
+            # callbacks receive only the payload, so bind the event name per forwarder
+            def _forward(ev: object) -> None:
+                self.emit(event, ev)
+
+            return _forward
+
+        self._forwarders: dict[EventTypes, Callable[[object], None]] = {
+            event: _make_forwarder(event) for event in _FORWARDED_EVENTS
+        }
+
+        # per-model availability, with a cooldown after a failure
+        self._available = [True] * len(adapter._models)
+        self._cooldown_deadline = [0.0] * len(adapter._models)
+
+        self._swap_task: asyncio.Task[None] | None = None
+        self._swap_lock = asyncio.Lock()
+        # bound by AgentActivity; used to read agent state and drive interrupt/generate_reply on swap
+        self._agent_session: AgentSession | None = None
+
+        # audio during a swap is dropped; replaying it would lag the model behind realtime
+        self._swapping = False
+
+        self._active_index = 0
+        self._active = adapter._models[0].session()
+        self._bind(self._active)
+
+    def _bind(self, child: RealtimeSession) -> None:
+        for event, forwarder in self._forwarders.items():
+            child.on(event, forwarder)
+        child.on("error", self._on_child_error)
+
+    def _unbind(self, child: RealtimeSession) -> None:
+        for event, forwarder in self._forwarders.items():
+            child.off(event, forwarder)
+        child.off("error", self._on_child_error)
+
+    def _set_available(self, index: int, available: bool) -> None:
+        if self._available[index] == available:
+            return
+        self._available[index] = available
+        self._adapter.emit(
+            "realtime_availability_changed",
+            RealtimeAvailabilityChangedEvent(
+                realtime_model=self._adapter._models[index], available=available
+            ),
+        )
+
+    def _next_available_index(self, *, exclude_current: bool = False) -> int | None:
+        # re-enable models whose cooldown expired, then pick the first available (primary preferred)
+        now = time.time()
+        for i, deadline in enumerate(self._cooldown_deadline):
+            if not self._available[i] and deadline <= now:
+                self._set_available(i, True)
+
+        for i in range(len(self._adapter._models)):
+            if exclude_current and i == self._active_index:
+                continue
+            if self._available[i]:
+                return i
+        return None
+
+    def _is_agent_speaking(self) -> bool:
+        # "thinking" (generating) or "speaking" (playing out) both mean a reply is in progress
+        return self._agent_session is not None and self._agent_session.agent_state in (
+            "speaking",
+            "thinking",
+        )
+
+    def _on_child_error(self, error: RealtimeModelError) -> None:
+        if error.recoverable:
+            # surface it and let the plugin's own reconnect handle it
+            self.emit("error", error)
+            return
+
+        # mark the dead model unavailable for a cooldown, then find a fallback
+        self._set_available(self._active_index, False)
+        self._cooldown_deadline[self._active_index] = time.time() + self._adapter._cooldown
+        target = self._next_available_index()
+        if target is None:
+            # exhausted: escalate so AgentSession can close
+            self.emit("error", error)
+            return
+
+        # recoverable while a fallback remains, so the session isn't torn down
+        self.emit("error", error.model_copy(update={"recoverable": True}))
+        if self._swap_task is None or self._swap_task.done():
+            # capture the speaking state now; the dead generation may flip it before the swap runs
+            self._swap_task = asyncio.create_task(self._swap(target, self._is_agent_speaking()))
+
+    async def restart(self, *, switch_model: bool) -> None:
+        """Restart the underlying session, optionally on the next available model."""
+        if switch_model:
+            # fall back to the current model if no other is available
+            target = self._next_available_index(exclude_current=True)
+            target = self._active_index if target is None else target
+        else:
+            target = self._active_index
+        await self._swap(target, self._is_agent_speaking())
+
+    async def _swap(self, target_index: int, was_speaking: bool) -> None:
+        """Replace the active child with a fresh session on ``target_index``.
+
+        If the agent was speaking, its reply is interrupted first (committing the heard content to
+        the agent chat context) and re-issued on the new session afterwards.
+        """
+        async with self._swap_lock:
+            # interrupt through the AgentSession so playout/state stay coordinated and the heard
+            # content is committed (best-effort: the provider may already be dead)
+            if self._agent_session is not None:
+                try:
+                    await self._agent_session.interrupt(force=True)
+                except Exception:
+                    logger.debug("failed to interrupt the agent before swap", exc_info=True)
+
+            # replay the agent chat context (what the user heard); fall back to the child's when unbound
+            if self._agent_session is not None:
+                chat_ctx = self._agent_session.current_agent.chat_ctx
+            else:
+                chat_ctx = self._active.chat_ctx
+
+            self._swapping = True
+            try:
+                self._unbind(self._active)
+                await self._active.aclose()
+
+                self._active = self._adapter._models[target_index].session()
+                self._active_index = target_index
+                self._bind(self._active)
+
+                await self._active._update_session(
+                    instructions=self._instructions, chat_ctx=chat_ctx, tools=self._tools
+                )
+                if is_given(self._tool_choice):
+                    self._active.update_options(tool_choice=self._tool_choice)
+            except Exception as e:
+                # a failed swap would otherwise wedge the session silently; escalate so the
+                # AgentSession can close instead of continuing on a broken session
+                logger.exception("failed to swap the realtime session")
+                self.emit(
+                    "error",
+                    RealtimeModelError(
+                        timestamp=time.time(), label=self._adapter.label, error=e, recoverable=False
+                    ),
+                )
+                return
+            finally:
+                self._swapping = False
+
+            # a swap is a reconnect from the caller's perspective
+            self.emit("session_reconnected", RealtimeSessionReconnectedEvent())
+
+            # re-issue the interrupted reply on the new session
+            if (
+                was_speaking
+                and self._adapter._regenerate_on_swap
+                and self._agent_session is not None
+            ):
+                self._agent_session.generate_reply()
+
+    @property
+    def capabilities(self) -> RealtimeCapabilities:
+        # the active model's caps, so per-turn consumers see the model actually in use
+        return self._active.realtime_model.capabilities
+
+    @property
+    def chat_ctx(self) -> ChatContext:
+        return self._active.chat_ctx
+
+    @property
+    def tools(self) -> ToolContext:
+        return self._active.tools
+
+    async def update_instructions(self, instructions: str) -> None:
+        self._instructions = instructions
+        await self._active.update_instructions(instructions)
+
+    async def update_chat_ctx(self, chat_ctx: ChatContext) -> None:
+        if self._swapping:
+            # dropped; the swap replays the agent chat context afterwards
+            return
+        await self._active.update_chat_ctx(chat_ctx)
+
+    async def update_tools(self, tools: list[Tool]) -> None:
+        self._tools = tools
+        await self._active.update_tools(tools)
+
+    def update_options(self, *, tool_choice: NotGivenOr[ToolChoice | None] = NOT_GIVEN) -> None:
+        self._tool_choice = tool_choice
+        self._active.update_options(tool_choice=tool_choice)
+
+    def push_audio(self, frame: rtc.AudioFrame) -> None:
+        if self._swapping:
+            # drop during swap; replaying would lag the model
+            return
+        self._active.push_audio(frame)
+
+    def push_video(self, frame: rtc.VideoFrame) -> None:
+        self._active.push_video(frame)
+
+    def generate_reply(
+        self,
+        *,
+        instructions: NotGivenOr[str] = NOT_GIVEN,
+        tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
+        tools: NotGivenOr[list[Tool]] = NOT_GIVEN,
+    ) -> asyncio.Future[GenerationCreatedEvent]:
+        return self._active.generate_reply(
+            instructions=instructions, tool_choice=tool_choice, tools=tools
+        )
+
+    def commit_audio(self) -> None:
+        self._active.commit_audio()
+
+    def clear_audio(self) -> None:
+        self._active.clear_audio()
+
+    def interrupt(self) -> None:
+        self._active.interrupt()
+
+    def start_user_activity(self) -> None:
+        self._active.start_user_activity()
+
+    def say(self, text: str | AsyncIterable[str]) -> asyncio.Future[GenerationCreatedEvent]:
+        return self._active.say(text)
+
+    def truncate(
+        self,
+        *,
+        message_id: str,
+        modalities: list[Literal["text", "audio"]],
+        audio_end_ms: int,
+        audio_transcript: NotGivenOr[str] = NOT_GIVEN,
+    ) -> None:
+        self._active.truncate(
+            message_id=message_id,
+            modalities=modalities,
+            audio_end_ms=audio_end_ms,
+            audio_transcript=audio_transcript,
+        )
+
+    async def aclose(self) -> None:
+        self._unbind(self._active)
+        await self._active.aclose()

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -17,6 +17,7 @@ from livekit.agents.metrics.base import Metadata
 
 from .. import inference, llm, stt, tts, utils, vad
 from ..llm.chat_context import Instructions
+from ..llm.realtime_fallback_adapter import _FallbackRealtimeSession
 from ..llm.tool_context import (
     StopResponse,
     ToolFlag,
@@ -734,6 +735,8 @@ class AgentActivity(RecognitionHooks):
                     self._rt_session.off("metrics_collected", self._on_metrics_collected)
                     self._rt_session.off("remote_item_added", self._on_remote_item_added)
                     self._rt_session.off("error", self._on_error)
+                    if isinstance(self._rt_session, _FallbackRealtimeSession):
+                        self._rt_session._agent_session = None
                     resources.rt_session = self._rt_session
                     self._rt_session = None  # prevent _close_session from closing it
 
@@ -825,6 +828,7 @@ class AgentActivity(RecognitionHooks):
                 self._rt_session.clear_audio()
             else:
                 self._rt_session = self.llm.session()
+                logger.debug("created new realtime session for activity, id=%s", self._rt_session)
 
             self._rt_session.on("generation_created", self._on_generation_created)
             self._rt_session.on("input_speech_started", self._on_input_speech_started)
@@ -836,6 +840,10 @@ class AgentActivity(RecognitionHooks):
             self._rt_session.on("metrics_collected", self._on_metrics_collected)
             self._rt_session.on("remote_item_added", self._on_remote_item_added)
             self._rt_session.on("error", self._on_error)
+
+            # the fallback adapter's session needs the AgentSession to drive interrupt/generate_reply on swap
+            if isinstance(self._rt_session, _FallbackRealtimeSession):
+                self._rt_session._agent_session = self._session
 
             remove_instructions(self._agent._chat_ctx)
 
@@ -1087,6 +1095,8 @@ class AgentActivity(RecognitionHooks):
             self._rt_session.off("metrics_collected", self._on_metrics_collected)
             self._rt_session.off("remote_item_added", self._on_remote_item_added)
             self._rt_session.off("error", self._on_error)
+            if isinstance(self._rt_session, _FallbackRealtimeSession):
+                self._rt_session._agent_session = None
 
         if isinstance(self.stt, stt.STT):
             self.stt.off("metrics_collected", self._on_metrics_collected)
@@ -3768,7 +3778,7 @@ class AgentActivity(RecognitionHooks):
                 # placeholder so the active RunResult waits for that reply
                 auto_reply_fut: asyncio.Future[None] | None = None
                 if (
-                    self.llm.capabilities.auto_tool_reply_generation
+                    self._rt_session.capabilities.auto_tool_reply_generation
                     and fnc_executed_ev._reply_required
                     and self._pending_auto_tool_reply_fut is None
                     and (run_state := self._session._global_run_state) is not None
@@ -3809,7 +3819,7 @@ class AgentActivity(RecognitionHooks):
 
             if (
                 fnc_executed_ev._reply_required
-                and not self.llm.capabilities.auto_tool_reply_generation
+                and not self._rt_session.capabilities.auto_tool_reply_generation
             ):
                 self._rt_session.interrupt()
 
@@ -3832,7 +3842,7 @@ class AgentActivity(RecognitionHooks):
                     speech_handle, SpeechHandle.SPEECH_PRIORITY_NORMAL, force=True
                 )
             elif (
-                self.llm.capabilities.auto_tool_reply_generation
+                self._rt_session.capabilities.auto_tool_reply_generation
                 and not fnc_executed_ev._reply_required
                 and generate_tool_reply
             ):

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -833,6 +833,8 @@ class RealtimeSession(
         self._input_resampler: rtc.AudioResampler | None = None
 
         self._instructions: str | None = None
+        # set on aclose; trailing server events are ignored while it's set
+        self._closing = False
         self._main_atask = asyncio.create_task(self._main_task(), name="RealtimeSession._main_task")
         self.send_event(self._create_session_update_event())
 
@@ -1056,6 +1058,10 @@ class RealtimeSession(
                     )
 
                 if msg.type != aiohttp.WSMsgType.TEXT:
+                    continue
+
+                if self._closing:
+                    # draining after aclose; the generation is already discarded
                     continue
 
                 event = json.loads(msg.data)
@@ -1664,6 +1670,7 @@ class RealtimeSession(
                     self.send_event(ev)
 
     async def aclose(self) -> None:
+        self._closing = True
         self._close_current_generation("session closed")
         self._msg_ch.close()
         await self._main_atask

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/utils.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import math
 from collections.abc import Sequence
 from typing import Any
@@ -128,6 +129,17 @@ def to_turn_detection(
     return turn_detection
 
 
+_MAX_CALL_ID_LEN = 32
+
+
+def _shorten_call_id(call_id: str) -> str:
+    # OpenAI caps call_id at 32 chars; deterministically shorten longer ids (e.g. from another
+    # provider replayed after a fallback swap) so a call and its output still map to the same id
+    if len(call_id) <= _MAX_CALL_ID_LEN:
+        return call_id
+    return hashlib.sha256(call_id.encode()).hexdigest()[:_MAX_CALL_ID_LEN]
+
+
 def livekit_item_to_openai_item(item: llm.ChatItem) -> realtime.ConversationItem:
     conversation_item: realtime.ConversationItem
 
@@ -135,7 +147,7 @@ def livekit_item_to_openai_item(item: llm.ChatItem) -> realtime.ConversationItem
         conversation_item = realtime.RealtimeConversationItemFunctionCall(
             id=item.id,
             type="function_call",
-            call_id=item.call_id,
+            call_id=_shorten_call_id(item.call_id),
             name=item.name,
             arguments=item.arguments,
         )
@@ -144,11 +156,11 @@ def livekit_item_to_openai_item(item: llm.ChatItem) -> realtime.ConversationItem
         conversation_item = realtime.RealtimeConversationItemFunctionCallOutput(
             id=item.id,
             type="function_call_output",
-            call_id=item.call_id,
+            call_id=_shorten_call_id(item.call_id),
             output=item.output,
         )
         conversation_item.type = "function_call_output"
-        conversation_item.call_id = item.call_id
+        conversation_item.call_id = _shorten_call_id(item.call_id)
         conversation_item.output = item.output
 
     elif item.type == "message":

--- a/tests/fake_realtime.py
+++ b/tests/fake_realtime.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterable
+from typing import Literal
+
+from livekit import rtc
+from livekit.agents import NOT_GIVEN, NotGivenOr
+from livekit.agents.llm import (
+    ChatContext,
+    GenerationCreatedEvent,
+    RealtimeCapabilities,
+    RealtimeModel,
+    RealtimeModelError,
+    RealtimeSession,
+)
+from livekit.agents.llm.tool_context import Tool, ToolChoice, ToolContext
+
+
+def fake_capabilities(**overrides: bool) -> RealtimeCapabilities:
+    """Build a RealtimeCapabilities with everything enabled, overriding individual flags."""
+    defaults: dict[str, bool] = {
+        "message_truncation": True,
+        "turn_detection": True,
+        "user_transcription": True,
+        "auto_tool_reply_generation": True,
+        "audio_output": True,
+        "manual_function_calls": True,
+        "mutable_chat_context": True,
+        "mutable_instructions": True,
+        "mutable_tools": True,
+        "per_response_tool_choice": True,
+        "supports_say": True,
+    }
+    defaults.update(overrides)
+    return RealtimeCapabilities(**defaults)
+
+
+class FakeRealtimeSession(RealtimeSession):
+    """A hermetic RealtimeSession that records calls and can be scripted to fail."""
+
+    def __init__(self, model: FakeRealtimeModel) -> None:
+        super().__init__(model)
+        self._chat_ctx = ChatContext.empty()
+        self._tools = ToolContext.empty()
+        self.closed = False
+        self.interrupted = False
+        self.committed = False
+        self.audio_cleared = False
+        self.pushed_audio: list[rtc.AudioFrame] = []
+        self.generate_reply_calls = 0
+        self.updated_instructions: str | None = None
+        self.tool_choice: NotGivenOr[ToolChoice | None] = NOT_GIVEN
+        self.say_calls: list[str | AsyncIterable[str]] = []
+        self.user_activity_started = False
+        self._reply_futs: list[asyncio.Future[GenerationCreatedEvent]] = []
+        # test hooks to pause or fail aclose() mid-swap
+        self.aclose_entered = asyncio.Event()
+        self.block_aclose: asyncio.Event | None = None
+        self.aclose_error: Exception | None = None
+
+    @property
+    def chat_ctx(self) -> ChatContext:
+        return self._chat_ctx
+
+    @property
+    def tools(self) -> ToolContext:
+        return self._tools
+
+    async def update_instructions(self, instructions: str) -> None:
+        self.updated_instructions = instructions
+
+    async def update_chat_ctx(self, chat_ctx: ChatContext) -> None:
+        self._chat_ctx = chat_ctx
+
+    async def update_tools(self, tools: list[Tool]) -> None:
+        self._tools = ToolContext(tools)
+
+    def update_options(self, *, tool_choice: NotGivenOr[ToolChoice | None] = NOT_GIVEN) -> None:
+        self.tool_choice = tool_choice
+
+    def push_audio(self, frame: rtc.AudioFrame) -> None:
+        self.pushed_audio.append(frame)
+
+    def push_video(self, frame: rtc.VideoFrame) -> None:
+        pass
+
+    def generate_reply(
+        self,
+        *,
+        instructions: NotGivenOr[str] = NOT_GIVEN,
+        tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
+        tools: NotGivenOr[list[Tool]] = NOT_GIVEN,
+    ) -> asyncio.Future[GenerationCreatedEvent]:
+        self.generate_reply_calls += 1
+        fut: asyncio.Future[GenerationCreatedEvent] = asyncio.get_event_loop().create_future()
+        self._reply_futs.append(fut)
+        return fut
+
+    def commit_audio(self) -> None:
+        self.committed = True
+
+    def clear_audio(self) -> None:
+        self.audio_cleared = True
+
+    def interrupt(self) -> None:
+        self.interrupted = True
+
+    def truncate(
+        self,
+        *,
+        message_id: str,
+        modalities: list[Literal["text", "audio"]],
+        audio_end_ms: int,
+        audio_transcript: NotGivenOr[str] = NOT_GIVEN,
+    ) -> None:
+        pass
+
+    def start_user_activity(self) -> None:
+        self.user_activity_started = True
+
+    def say(self, text: str | AsyncIterable[str]) -> asyncio.Future[GenerationCreatedEvent]:
+        self.say_calls.append(text)
+        return asyncio.get_event_loop().create_future()
+
+    async def aclose(self) -> None:
+        self.aclose_entered.set()
+        if self.block_aclose is not None:
+            await self.block_aclose.wait()
+        if self.aclose_error is not None:
+            raise self.aclose_error
+        self.closed = True
+
+    # --- test helpers -------------------------------------------------------
+
+    def emit_error(self, *, recoverable: bool) -> None:
+        """Simulate the provider emitting an error event."""
+        self.emit(
+            "error",
+            RealtimeModelError(
+                timestamp=time.time(),
+                label=self._realtime_model.label,
+                error=RuntimeError("simulated provider error"),
+                recoverable=recoverable,
+            ),
+        )
+
+
+class FakeRealtimeModel(RealtimeModel):
+    """A RealtimeModel whose sessions are FakeRealtimeSession, tracking every session created."""
+
+    def __init__(
+        self,
+        *,
+        capabilities: RealtimeCapabilities | None = None,
+        label: str = "fake.realtime.RealtimeModel",
+    ) -> None:
+        super().__init__(capabilities=capabilities or fake_capabilities())
+        self._label = label
+        self.created_sessions: list[FakeRealtimeSession] = []
+        self.closed = False
+
+    @property
+    def active_session(self) -> FakeRealtimeSession:
+        return self.created_sessions[-1]
+
+    def session(self) -> FakeRealtimeSession:
+        sess = FakeRealtimeSession(self)
+        self.created_sessions.append(sess)
+        return sess
+
+    async def aclose(self) -> None:
+        self.closed = True

--- a/tests/fake_realtime.py
+++ b/tests/fake_realtime.py
@@ -59,6 +59,8 @@ class FakeRealtimeSession(RealtimeSession):
         self.aclose_entered = asyncio.Event()
         self.block_aclose: asyncio.Event | None = None
         self.aclose_error: Exception | None = None
+        # test hook to fail bring-up (raised from update_chat_ctx during _update_session)
+        self.update_error: Exception | None = None
 
     @property
     def chat_ctx(self) -> ChatContext:
@@ -72,6 +74,8 @@ class FakeRealtimeSession(RealtimeSession):
         self.updated_instructions = instructions
 
     async def update_chat_ctx(self, chat_ctx: ChatContext) -> None:
+        if self.update_error is not None:
+            raise self.update_error
         self._chat_ctx = chat_ctx
 
     async def update_tools(self, tools: list[Tool]) -> None:
@@ -160,6 +164,8 @@ class FakeRealtimeModel(RealtimeModel):
         self._label = label
         self.created_sessions: list[FakeRealtimeSession] = []
         self.closed = False
+        # when set, every session this model creates fails to bring up
+        self.bring_up_error: Exception | None = None
 
     @property
     def active_session(self) -> FakeRealtimeSession:
@@ -167,6 +173,7 @@ class FakeRealtimeModel(RealtimeModel):
 
     def session(self) -> FakeRealtimeSession:
         sess = FakeRealtimeSession(self)
+        sess.update_error = self.bring_up_error
         self.created_sessions.append(sess)
         return sess
 

--- a/tests/test_openai_realtime_chat_ctx.py
+++ b/tests/test_openai_realtime_chat_ctx.py
@@ -114,3 +114,31 @@ def test_response_done_handles_string_status_details(monkeypatch) -> None:
     debug.assert_called_once()
     assert debug.call_args.args[3] == "incomplete"
     assert debug.call_args.args[4] is None
+
+
+def test_long_call_id_is_shortened_consistently() -> None:
+    # a foreign provider's call_id (e.g. Gemini) can exceed OpenAI's 32-char limit; the call and
+    # its output must map to the same shortened id so they still pair on OpenAI's side
+    from livekit.plugins.openai.realtime.utils import livekit_item_to_openai_item
+
+    call_id = "function-call-0123456789abcdef0123456789ab"  # 42 chars
+    assert len(call_id) > 32
+
+    call = livekit_item_to_openai_item(
+        llm.FunctionCall(id="item_1", call_id=call_id, name="get_weather", arguments="{}")
+    )
+    output = livekit_item_to_openai_item(
+        llm.FunctionCallOutput(id="item_2", call_id=call_id, output="sunny", is_error=False)
+    )
+
+    assert len(call.call_id) <= 32
+    assert call.call_id == output.call_id
+
+
+def test_short_call_id_is_unchanged() -> None:
+    from livekit.plugins.openai.realtime.utils import livekit_item_to_openai_item
+
+    call = livekit_item_to_openai_item(
+        llm.FunctionCall(id="item_1", call_id="call_abc", name="get_weather", arguments="{}")
+    )
+    assert call.call_id == "call_abc"

--- a/tests/test_realtime_fallback.py
+++ b/tests/test_realtime_fallback.py
@@ -1,0 +1,540 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from livekit import rtc
+from livekit.agents.llm import ChatContext, RealtimeModelFallbackAdapter
+
+from .fake_realtime import FakeRealtimeModel, fake_capabilities
+
+pytestmark = pytest.mark.unit
+
+
+def _audio_frame() -> rtc.AudioFrame:
+    return rtc.AudioFrame(
+        data=b"\x00\x00", sample_rate=24000, num_channels=1, samples_per_channel=1
+    )
+
+
+class _StubAgent:
+    def __init__(self, chat_ctx: ChatContext) -> None:
+        self.chat_ctx = chat_ctx
+
+
+class _StubAgentSession:
+    """Minimal stand-in for AgentSession that records orchestrated interrupt/generate_reply."""
+
+    def __init__(self, agent_state: str = "listening", chat_ctx: ChatContext | None = None) -> None:
+        self.agent_state = agent_state
+        self.interrupt_calls = 0
+        self.generate_reply_calls = 0
+        self.current_agent = _StubAgent(chat_ctx if chat_ctx is not None else ChatContext.empty())
+
+    def interrupt(self, *, force: bool = False) -> asyncio.Future[None]:
+        self.interrupt_calls += 1
+        fut: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+        fut.set_result(None)
+        return fut
+
+    def generate_reply(self, **kwargs: object) -> object:
+        self.generate_reply_calls += 1
+        return object()
+
+
+def test_requires_at_least_one_model() -> None:
+    with pytest.raises(ValueError):
+        RealtimeModelFallbackAdapter([])
+
+
+def test_ands_soft_capabilities_across_models() -> None:
+    primary = FakeRealtimeModel(capabilities=fake_capabilities(mutable_chat_context=True))
+    backup = FakeRealtimeModel(capabilities=fake_capabilities(mutable_chat_context=False))
+
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+
+    # soft flags are conservatively ANDed: if any model can't mutate chat ctx, the adapter can't
+    assert adapter.capabilities.mutable_chat_context is False
+    # a flag both models support stays True
+    assert adapter.capabilities.message_truncation is True
+
+
+def test_raises_on_mismatched_hard_capabilities() -> None:
+    primary = FakeRealtimeModel(capabilities=fake_capabilities(audio_output=True))
+    backup = FakeRealtimeModel(capabilities=fake_capabilities(audio_output=False))
+
+    with pytest.raises(ValueError):
+        RealtimeModelFallbackAdapter([primary, backup])
+
+
+def test_proxies_calls_to_active_child() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    session = RealtimeModelFallbackAdapter([primary, backup]).session()
+
+    session.interrupt()
+    session.commit_audio()
+    session.generate_reply()
+
+    child = primary.active_session
+    assert child.interrupted is True
+    assert child.committed is True
+    assert child.generate_reply_calls == 1
+    # the backup model has not been started
+    assert backup.created_sessions == []
+
+
+def test_forwards_child_events_to_wrapper_subscribers() -> None:
+    primary = FakeRealtimeModel()
+    session = RealtimeModelFallbackAdapter([primary]).session()
+
+    received: list[object] = []
+    session.on("generation_created", lambda ev: received.append(ev))
+
+    primary.active_session.emit("generation_created", "sentinel")
+
+    assert received == ["sentinel"]
+
+
+def test_proxies_say_to_active_child() -> None:
+    primary = FakeRealtimeModel()
+    session = RealtimeModelFallbackAdapter([primary]).session()
+
+    session.say("hello there")
+
+    assert primary.active_session.say_calls == ["hello there"]
+
+
+def test_proxies_start_user_activity_to_active_child() -> None:
+    primary = FakeRealtimeModel()
+    session = RealtimeModelFallbackAdapter([primary]).session()
+
+    session.start_user_activity()
+
+    assert primary.active_session.user_activity_started is True
+
+
+async def test_restart_session_creates_fresh_child_same_model() -> None:
+    primary = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary])
+    session = adapter.session()
+    old_child = primary.active_session
+
+    await adapter.restart_session()
+
+    assert old_child.closed is True
+    assert len(primary.created_sessions) == 2
+    assert session._active is primary.created_sessions[1]
+    assert session._active.closed is False
+
+
+async def test_switch_session_moves_to_next_model() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+    session = adapter.session()
+    old = primary.active_session
+
+    await adapter.restart_session(switch_model=True)
+
+    assert old.closed is True
+    assert session._active_index == 1
+    assert session._active is backup.active_session
+
+
+async def test_switch_session_wraps_around() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+    session = adapter.session()
+
+    await adapter.restart_session(switch_model=True)  # primary -> backup
+    assert session._active_index == 1
+
+    await adapter.restart_session(switch_model=True)  # backup -> wraps to primary
+    assert session._active_index == 0
+    assert session._active is primary.created_sessions[-1]
+
+
+async def test_switch_session_single_model_restarts_same() -> None:
+    primary = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary])
+    session = adapter.session()
+    old = primary.active_session
+
+    await adapter.restart_session(switch_model=True)
+
+    # only one model: degrades to a fresh session on the same model
+    assert old.closed is True
+    assert session._active_index == 0
+    assert len(primary.created_sessions) == 2
+
+
+async def test_restart_replays_chat_ctx_onto_new_child() -> None:
+    primary = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary])
+    session = adapter.session()
+    old_child = primary.active_session
+
+    ctx = ChatContext.empty()
+    ctx.add_message(role="user", content="remember me")
+    await old_child.update_chat_ctx(ctx)
+
+    await adapter.restart_session()
+
+    # the freshest chat context from the dying child is replayed onto the new child
+    assert session._active.chat_ctx is ctx
+
+
+async def test_restart_preserves_wrapper_subscribers() -> None:
+    primary = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary])
+    session = adapter.session()
+    received: list[object] = []
+    session.on("generation_created", lambda ev: received.append(ev))
+
+    await adapter.restart_session()
+
+    # events from the NEW child still reach the original wrapper subscriber, no rebinding
+    session._active.emit("generation_created", "after-restart")
+    assert received == ["after-restart"]
+
+
+async def test_restart_emits_no_error() -> None:
+    primary = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary])
+    session = adapter.session()
+    errors: list[object] = []
+    session.on("error", lambda ev: errors.append(ev))
+
+    await adapter.restart_session()
+
+    assert errors == []
+
+
+async def test_auto_swaps_to_next_model_on_non_recoverable_error() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+    session = adapter.session()
+    old = primary.active_session
+
+    old.emit_error(recoverable=False)
+    await session._swap_task
+
+    assert old.closed is True
+    assert len(backup.created_sessions) == 1
+    assert session._active is backup.active_session
+
+
+async def test_non_recoverable_error_forwarded_as_recoverable_while_fallback_remains() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+    session = adapter.session()
+    errors: list = []
+    session.on("error", lambda e: errors.append(e))
+
+    primary.active_session.emit_error(recoverable=False)
+    await session._swap_task
+
+    # the user is informed, but the error is re-stamped recoverable so the session is not closed
+    assert len(errors) == 1
+    assert errors[0].recoverable is True
+
+
+async def test_recoverable_error_is_forwarded_unchanged_without_swap() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+    session = adapter.session()
+    errors: list = []
+    session.on("error", lambda e: errors.append(e))
+
+    primary.active_session.emit_error(recoverable=True)
+
+    assert len(errors) == 1
+    assert errors[0].recoverable is True
+    assert session._swap_task is None
+    assert backup.created_sessions == []  # no swap on a recoverable error
+
+
+async def test_exhausted_models_escalate_as_non_recoverable() -> None:
+    primary = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary])  # no backup
+    session = adapter.session()
+    errors: list = []
+    session.on("error", lambda e: errors.append(e))
+
+    primary.active_session.emit_error(recoverable=False)
+
+    # nothing left to fall back to: escalate so AgentSession can close
+    assert session._swap_task is None
+    assert len(errors) == 1
+    assert errors[0].recoverable is False
+    assert len(primary.created_sessions) == 1  # not auto-restarted
+
+
+async def test_escalates_when_all_models_have_failed() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+    session = adapter.session()
+    errors: list = []
+    session.on("error", lambda e: errors.append(e))
+
+    primary.active_session.emit_error(recoverable=False)
+    await session._swap_task
+    # now on backup; kill it too
+    backup.active_session.emit_error(recoverable=False)
+
+    assert session._swap_task.done()
+    assert errors[-1].recoverable is False  # exhausted -> escalate
+
+
+@pytest.mark.virtual_time
+async def test_prefers_primary_again_after_cooldown_expires() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup], cooldown=5.0)
+    session = adapter.session()
+
+    # primary dies -> fall over to backup
+    primary.active_session.emit_error(recoverable=False)
+    await session._swap_task
+    assert session._active_index == 1
+
+    # let primary's cooldown expire
+    await asyncio.sleep(6.0)
+
+    # backup dies -> primary is available again and preferred by list order
+    backup.active_session.emit_error(recoverable=False)
+    await session._swap_task
+    assert session._active_index == 0
+    assert session._active is primary.created_sessions[-1]
+
+
+async def test_regenerates_via_agent_session_when_speaking() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup])  # regenerate_on_swap default True
+    session = adapter.session()
+    session._agent_session = _StubAgentSession(agent_state="speaking")
+
+    primary.active_session.emit_error(recoverable=False)
+    await session._swap_task
+
+    # regeneration goes through the AgentSession (orchestrated), not the raw child session
+    assert session._agent_session.interrupt_calls == 1
+    assert session._agent_session.generate_reply_calls == 1
+    assert backup.active_session.generate_reply_calls == 0
+
+
+async def test_regenerates_when_agent_thinking() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+    session = adapter.session()
+    session._agent_session = _StubAgentSession(agent_state="thinking")
+
+    # "thinking" is a reply in progress (generating, pre-audio), so it regenerates too
+    primary.active_session.emit_error(recoverable=False)
+    await session._swap_task
+
+    assert session._agent_session.generate_reply_calls == 1
+
+
+async def test_no_regenerate_when_agent_not_speaking() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+    session = adapter.session()
+    session._agent_session = _StubAgentSession(agent_state="listening")
+
+    primary.active_session.emit_error(recoverable=False)
+    await session._swap_task
+
+    assert session._agent_session.generate_reply_calls == 0
+
+
+async def test_no_regenerate_when_disabled() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup], regenerate_on_swap=False)
+    session = adapter.session()
+    session._agent_session = _StubAgentSession(agent_state="speaking")
+
+    primary.active_session.emit_error(recoverable=False)
+    await session._swap_task
+
+    # stale playout is still interrupted; only the re-issue of generate_reply is suppressed
+    assert session._agent_session.interrupt_calls == 1
+    assert session._agent_session.generate_reply_calls == 0
+
+
+async def test_drops_audio_during_swap() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+    session = adapter.session()
+    old = primary.active_session
+
+    gate = asyncio.Event()
+    old.block_aclose = gate
+
+    old.emit_error(recoverable=False)
+    # wait until the swap is mid-flight (inside the dying child's aclose)
+    await old.aclose_entered.wait()
+
+    frame = _audio_frame()
+    session.push_audio(frame)
+    # audio arriving mid-swap is dropped, not sent to the dying child
+    assert frame not in old.pushed_audio
+
+    gate.set()
+    await session._swap_task
+
+    # ...and not replayed into the new child (replaying would add permanent input latency)
+    assert frame not in backup.active_session.pushed_audio
+
+
+async def test_swap_failure_escalates_non_recoverable() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+    session = adapter.session()
+    errors: list = []
+    session.on("error", lambda e: errors.append(e))
+
+    # the swap itself fails (e.g. the dying child's aclose raises)
+    primary.active_session.aclose_error = RuntimeError("boom")
+    primary.active_session.emit_error(recoverable=False)
+    await session._swap_task
+
+    # rather than wedging silently, a failed swap escalates a non-recoverable error
+    assert any(not e.recoverable for e in errors)
+
+
+async def test_emits_session_reconnected_on_swap() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+    session = adapter.session()
+
+    events: list = []
+    session.on("session_reconnected", lambda ev: events.append(ev))
+
+    await adapter.restart_session(switch_model=True)
+
+    assert len(events) == 1
+
+
+async def test_swap_replays_child_current_ctx_not_stale_pushed_ctx() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+    session = adapter.session()
+    old = primary.active_session
+
+    # an update pushed earlier (not during a swap)
+    ctx1 = ChatContext.empty()
+    ctx1.add_message(role="user", content="old turn")
+    await session.update_chat_ctx(ctx1)
+
+    # the child then accumulates newer state (e.g. a server-side transcript)
+    ctx2 = ChatContext.empty()
+    ctx2.add_message(role="user", content="old turn")
+    ctx2.add_message(role="assistant", content="newer transcript")
+    await old.update_chat_ctx(ctx2)
+
+    await adapter.restart_session()
+
+    # replay must use the child's current context, not the stale earlier push
+    assert session._active.chat_ctx is ctx2
+
+
+async def test_swap_replays_agent_chat_ctx() -> None:
+    primary = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary])
+    session = adapter.session()
+
+    agent_ctx = ChatContext.empty()
+    agent_ctx.add_message(role="user", content="what the user heard")
+    session._agent_session = _StubAgentSession(agent_state="listening", chat_ctx=agent_ctx)
+
+    await adapter.restart_session()
+
+    # the agent chat context (user-heard version) is replayed, not the child's own context
+    assert session._active.chat_ctx is agent_ctx
+
+
+async def test_emits_availability_changed_on_failure() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+    session = adapter.session()
+
+    events: list = []
+    adapter.on("realtime_availability_changed", lambda e: events.append(e))
+
+    primary.active_session.emit_error(recoverable=False)
+    await session._swap_task
+
+    assert any(e.realtime_model is primary and e.available is False for e in events)
+
+
+@pytest.mark.virtual_time
+def test_session_exposes_model_capabilities() -> None:
+    model = FakeRealtimeModel()
+    session = model.session()
+
+    assert session.capabilities is model.capabilities
+
+
+def test_allows_mismatched_auto_tool_reply_generation() -> None:
+    primary = FakeRealtimeModel(capabilities=fake_capabilities(auto_tool_reply_generation=True))
+    backup = FakeRealtimeModel(capabilities=fake_capabilities(auto_tool_reply_generation=False))
+
+    # no longer a hard capability: the active child's value is read per-turn from the session
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+    assert adapter.capabilities.auto_tool_reply_generation is False  # conservative AND on the model
+
+
+def test_wrapper_capabilities_track_active_child() -> None:
+    primary = FakeRealtimeModel(capabilities=fake_capabilities(auto_tool_reply_generation=True))
+    backup = FakeRealtimeModel(capabilities=fake_capabilities(auto_tool_reply_generation=False))
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+    session = adapter.session()
+
+    assert session.capabilities.auto_tool_reply_generation is True  # primary active
+
+
+async def test_wrapper_capabilities_follow_swap() -> None:
+    primary = FakeRealtimeModel(capabilities=fake_capabilities(auto_tool_reply_generation=True))
+    backup = FakeRealtimeModel(capabilities=fake_capabilities(auto_tool_reply_generation=False))
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+    session = adapter.session()
+
+    primary.active_session.emit_error(recoverable=False)
+    await session._swap_task
+
+    assert session.capabilities.auto_tool_reply_generation is False  # backup now active
+
+
+async def test_emits_availability_changed_on_recovery() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup], cooldown=5.0)
+    session = adapter.session()
+
+    events: list = []
+    adapter.on("realtime_availability_changed", lambda e: events.append(e))
+
+    primary.active_session.emit_error(recoverable=False)
+    await session._swap_task
+    await asyncio.sleep(6.0)
+    backup.active_session.emit_error(recoverable=False)
+    await session._swap_task
+
+    assert any(e.realtime_model is primary and e.available is True for e in events)

--- a/tests/test_realtime_fallback.py
+++ b/tests/test_realtime_fallback.py
@@ -399,7 +399,27 @@ async def test_drops_audio_during_swap() -> None:
     assert frame not in backup.active_session.pushed_audio
 
 
-async def test_swap_failure_escalates_non_recoverable() -> None:
+async def test_swap_cascades_past_a_model_that_cannot_start() -> None:
+    primary = FakeRealtimeModel()
+    backup1 = FakeRealtimeModel()
+    backup2 = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup1, backup2])
+    session = adapter.session()
+    errors: list = []
+    session.on("error", lambda e: errors.append(e))
+
+    # the first fallback fails to bring up; the swap should skip it and land on the next
+    backup1.bring_up_error = RuntimeError("cannot start")
+    primary.active_session.emit_error(recoverable=False)
+    await session._swap_task
+
+    assert session._active_index == 2
+    assert session._active is backup2.active_session
+    # only the recoverable hand-off was surfaced; nothing session-ending
+    assert all(e.recoverable for e in errors)
+
+
+async def test_swap_escalates_when_no_model_can_start() -> None:
     primary = FakeRealtimeModel()
     backup = FakeRealtimeModel()
     adapter = RealtimeModelFallbackAdapter([primary, backup])
@@ -407,12 +427,11 @@ async def test_swap_failure_escalates_non_recoverable() -> None:
     errors: list = []
     session.on("error", lambda e: errors.append(e))
 
-    # the swap itself fails (e.g. the dying child's aclose raises)
-    primary.active_session.aclose_error = RuntimeError("boom")
+    # the only fallback also fails to bring up: escalate a non-recoverable error
+    backup.bring_up_error = RuntimeError("cannot start")
     primary.active_session.emit_error(recoverable=False)
     await session._swap_task
 
-    # rather than wedging silently, a failed swap escalates a non-recoverable error
     assert any(not e.recoverable for e in errors)
 
 


### PR DESCRIPTION
## Summary

Adds `RealtimeModelFallbackAdapter`, the realtime-model counterpart to the existing STT/TTS/LLM fallback adapters. It wraps an ordered list of realtime models and swaps the underlying provider session in place — preserving the chat context and the agent's bound event handlers — on a non-recoverable error (automatic fallback to the next available model) or an explicit `restart_session()`. A failed model enters a cooldown and the primary is preferred again once it expires; the error is escalated to `AgentSession` only once every model is exhausted or a swap itself fails.

On swap the agent is interrupted through the `AgentSession` so playout and state stay coordinated and the heard content is committed to the chat context, that context is replayed onto the new session, `session_reconnected` is emitted, and the reply is re-issued if the agent was mid-reply. Audio arriving mid-swap is dropped rather than replayed to avoid the model falling behind realtime.

## Usage

```python
from livekit.agents import Agent
from livekit.agents.llm import RealtimeModelFallbackAdapter
from livekit.plugins import google, openai

# primary first, then fallbacks; fails over automatically on a non-recoverable error
llm = RealtimeModelFallbackAdapter(
    [
        openai.realtime.RealtimeModel(),
        openai.realtime.RealtimeModel.with_azure(azure_deployment="gpt-realtime"),
        google.realtime.RealtimeModel(),
    ]
)

agent = Agent(instructions="You are a helpful assistant.", llm=llm)
```

## Manually restarting or switching the session

You can force a fresh provider session on demand — without faking a network error or handing off to a new agent — while keeping the chat context and bound handlers:

```python
# restart the current model on a fresh provider session
await llm.restart_session()

# or bring the session up on the next model
await llm.restart_session(switch_model=True)
```

## Notes

`RealtimeSession` now exposes a `capabilities` property so `auto_tool_reply_generation` is read per turn from the active model. `audio_output` and `turn_detection` must match across models (they shape the pipeline at activity start); the remaining capabilities are exposed as the conservative AND.

Also includes two openai realtime fixes needed for cross-provider swaps: ignoring trailing server events after session close, and shortening `call_id`s longer than 32 characters.

close #6040, close https://github.com/livekit/agents/issues/2342
