### PR TITLE
set default shutdown reason

### DIFF
--- a/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
@@ -247,7 +247,10 @@ class _JobProc:
 
                     with contextlib.suppress(asyncio.InvalidStateError):
                         self._shutdown_fut.set_result(
-                            _ShutdownInfo(reason=msg.reason, user_initiated=False)
+                            _ShutdownInfo(
+                                reason=msg.reason or "parent process shutdown",
+                                user_initiated=False,
+                            )
                         )
 
                 if isinstance(msg, InferenceResponse):
@@ -290,7 +293,9 @@ class _JobProc:
             self._ctx_shutdown_called = True
 
             with contextlib.suppress(asyncio.InvalidStateError):
-                self._shutdown_fut.set_result(_ShutdownInfo(user_initiated=True, reason=reason))
+                self._shutdown_fut.set_result(
+                    _ShutdownInfo(user_initiated=True, reason=reason or "user requested")
+                )
 
         self._room._info.name = msg.running_job.job.room.name
 

--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -739,7 +739,7 @@ class JobContext:
         self._track_pending_task(task, name="transfer_sip_participant")
         return task
 
-    def shutdown(self, reason: str = "") -> None:
+    def shutdown(self, reason: str = "user requested") -> None:
         self._on_shutdown(reason)
 
     def add_participant_entrypoint(


### PR DESCRIPTION
when the agent server is requested to shutdown, we need to clearly record the reason for doing so, and not allow it to be left as an empty string