### PR TITLE
fix(google): drain realtime audio after tool calls

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -181,12 +181,10 @@ class _ResponseGeneration:
     """The timestamp when the generation is completed"""
     _done: bool = False
     """Whether the generation is done (set when the turn is complete)"""
-    _last_audio_frame_at: float | None = None
-    """Monotonic timestamp of the last audio frame received"""
+    _last_audio_drain_activity_at: float | None = None
+    """Monotonic timestamp of the last audio-drain-extending event"""
     _audio_drain_atask: asyncio.Task[None] | None = None
     """Task that closes the generation after tool-call audio has drained"""
-    _emit_input_speech_stopped: bool = False
-    """Whether finalizing this generation should emit input_speech_stopped"""
 
     def push_text(self, text: str) -> None:
         if self.output_text:
@@ -496,7 +494,6 @@ class RealtimeSession(llm.RealtimeSession):
         self._main_atask = asyncio.create_task(self._main_task(), name="gemini-realtime-session")
 
         self._current_generation: _ResponseGeneration | None = None
-        self._draining_generations: list[_ResponseGeneration] = []
         self._active_session: AsyncSession | None = None
         # indicates if the underlying session should end
         self._session_should_close = asyncio.Event()
@@ -857,8 +854,6 @@ class RealtimeSession(llm.RealtimeSession):
 
         if self._current_generation:
             self._mark_current_generation_done()
-        for gen in list(self._draining_generations):
-            self._mark_generation_done(gen)
 
     @utils.log_exceptions(logger=logger)
     async def _main_task(self) -> None:
@@ -1201,21 +1196,11 @@ class RealtimeSession(llm.RealtimeSession):
 
         return conf
 
-    def _start_new_generation(self, *, interrupt_previous_audio: bool = True) -> None:
+    def _start_new_generation(self) -> None:
         self._rejected_tool_calls = 0
-        active_gen = self._current_generation
-        if active_gen and not active_gen._done:
-            if (
-                active_gen.function_ch.closed
-                and active_gen._audio_drain_atask
-                and not active_gen._audio_drain_atask.done()
-            ):
-                logger.debug("starting new generation while previous tool-call audio is draining")
-            else:
-                logger.warning(
-                    "starting new generation while another is active. Finalizing previous."
-                )
-                self._mark_generation_done(active_gen)
+        if self._current_generation and not self._current_generation._done:
+            logger.warning("starting new generation while another is active. Finalizing previous.")
+            self._mark_current_generation_done()
 
         response_id = utils.shortuuid("GR_")
         self._current_generation = _ResponseGeneration(
@@ -1252,13 +1237,11 @@ class RealtimeSession(llm.RealtimeSession):
 
         if self._pending_generation_fut and not self._pending_generation_fut.done():
             generation_event.user_initiated = True
-            self._current_generation._emit_input_speech_stopped = True
             self._pending_generation_fut.set_result(generation_event)
             self._pending_generation_fut = None
-        elif interrupt_previous_audio:
+        else:
             # emit input_speech_started event before starting an agent initiated generation
             # to interrupt the previous audio playout if any
-            self._current_generation._emit_input_speech_stopped = True
             self._handle_input_speech_started()
 
         self.emit("generation_created", generation_event)
@@ -1296,7 +1279,7 @@ class RealtimeSession(llm.RealtimeSession):
                             samples_per_channel=len(frame_data) // (2 * OUTPUT_AUDIO_CHANNELS),
                         )
                         current_gen.audio_ch.send_nowait(frame)
-                        current_gen._last_audio_frame_at = time.monotonic()
+                        current_gen._last_audio_drain_activity_at = time.monotonic()
                     except ValueError as e:
                         logger.error(f"Error creating audio frame from Gemini data: {e}")
 
@@ -1342,9 +1325,8 @@ class RealtimeSession(llm.RealtimeSession):
         if gen._done:
             return
 
-        if gen._emit_input_speech_stopped:
-            # emit input_speech_stopped event after the generation is done
-            self._handle_input_speech_stopped()
+        # emit input_speech_stopped event after the generation is done
+        self._handle_input_speech_stopped()
 
         # The only way we'd know that the transcription is complete is by when they are
         # done with generation
@@ -1387,9 +1369,6 @@ class RealtimeSession(llm.RealtimeSession):
             and gen._audio_drain_atask is not asyncio.current_task()
         ):
             gen._audio_drain_atask.cancel()
-        self._draining_generations = [
-            draining_gen for draining_gen in self._draining_generations if draining_gen is not gen
-        ]
 
         gen.function_ch.close()
         gen.message_ch.close()
@@ -1399,7 +1378,7 @@ class RealtimeSession(llm.RealtimeSession):
 
     async def _mark_generation_done_after_audio_drain(self, gen: _ResponseGeneration) -> None:
         started_at = time.monotonic()
-        last_audio_frame_at = gen._last_audio_frame_at
+        last_drain_activity_at = gen._last_audio_drain_activity_at
 
         while True:
             if gen._done:
@@ -1413,10 +1392,10 @@ class RealtimeSession(llm.RealtimeSession):
                 min(TOOL_CALL_AUDIO_DRAIN_QUIESCENCE, TOOL_CALL_AUDIO_DRAIN_TIMEOUT - elapsed)
             )
 
-            current_last_audio_frame_at = gen._last_audio_frame_at
-            if current_last_audio_frame_at == last_audio_frame_at:
+            current_last_drain_activity_at = gen._last_audio_drain_activity_at
+            if current_last_drain_activity_at == last_drain_activity_at:
                 break
-            last_audio_frame_at = current_last_audio_frame_at
+            last_drain_activity_at = current_last_drain_activity_at
 
         self._mark_generation_done(gen)
 
@@ -1424,8 +1403,10 @@ class RealtimeSession(llm.RealtimeSession):
         if gen._audio_drain_atask and not gen._audio_drain_atask.done():
             return
 
-        if not any(draining_gen is gen for draining_gen in self._draining_generations):
-            self._draining_generations.append(gen)
+        if gen.audio_ch.closed or types.Modality.AUDIO not in self._opts.response_modalities:
+            self._mark_generation_done(gen)
+            return
+
         gen._audio_drain_atask = asyncio.create_task(
             self._mark_generation_done_after_audio_drain(gen),
             name="gemini-realtime-audio-drain",
@@ -1478,13 +1459,7 @@ class RealtimeSession(llm.RealtimeSession):
             return
 
         gen = self._current_generation
-        if gen.function_ch.closed:
-            # Tool execution starts after each function stream closes. A chained tool-call
-            # batch therefore needs a fresh generation while the prior audio drains.
-            self._start_new_generation(interrupt_previous_audio=False)
-            gen = self._current_generation
-            assert gen is not None
-
+        gen._last_audio_drain_activity_at = time.monotonic()
         for fnc_call in tool_call.function_calls or []:
             arguments = json.dumps(fnc_call.args)
 
@@ -1496,7 +1471,6 @@ class RealtimeSession(llm.RealtimeSession):
                 )
             )
 
-        gen.function_ch.close()
         self._schedule_generation_done_after_audio_drain(gen)
 
     def _handle_tool_call_cancellation(

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -185,6 +185,8 @@ class _ResponseGeneration:
     """Monotonic timestamp of the last audio frame received"""
     _audio_drain_atask: asyncio.Task[None] | None = None
     """Task that closes the generation after tool-call audio has drained"""
+    _emit_input_speech_stopped: bool = False
+    """Whether finalizing this generation should emit input_speech_stopped"""
 
     def push_text(self, text: str) -> None:
         if self.output_text:
@@ -494,6 +496,7 @@ class RealtimeSession(llm.RealtimeSession):
         self._main_atask = asyncio.create_task(self._main_task(), name="gemini-realtime-session")
 
         self._current_generation: _ResponseGeneration | None = None
+        self._draining_generations: list[_ResponseGeneration] = []
         self._active_session: AsyncSession | None = None
         # indicates if the underlying session should end
         self._session_should_close = asyncio.Event()
@@ -854,6 +857,8 @@ class RealtimeSession(llm.RealtimeSession):
 
         if self._current_generation:
             self._mark_current_generation_done()
+        for gen in list(self._draining_generations):
+            self._mark_generation_done(gen)
 
     @utils.log_exceptions(logger=logger)
     async def _main_task(self) -> None:
@@ -1247,11 +1252,13 @@ class RealtimeSession(llm.RealtimeSession):
 
         if self._pending_generation_fut and not self._pending_generation_fut.done():
             generation_event.user_initiated = True
+            self._current_generation._emit_input_speech_stopped = True
             self._pending_generation_fut.set_result(generation_event)
             self._pending_generation_fut = None
         elif interrupt_previous_audio:
             # emit input_speech_started event before starting an agent initiated generation
             # to interrupt the previous audio playout if any
+            self._current_generation._emit_input_speech_stopped = True
             self._handle_input_speech_started()
 
         self.emit("generation_created", generation_event)
@@ -1335,8 +1342,9 @@ class RealtimeSession(llm.RealtimeSession):
         if gen._done:
             return
 
-        # emit input_speech_stopped event after the generation is done
-        self._handle_input_speech_stopped()
+        if gen._emit_input_speech_stopped:
+            # emit input_speech_stopped event after the generation is done
+            self._handle_input_speech_stopped()
 
         # The only way we'd know that the transcription is complete is by when they are
         # done with generation
@@ -1379,6 +1387,9 @@ class RealtimeSession(llm.RealtimeSession):
             and gen._audio_drain_atask is not asyncio.current_task()
         ):
             gen._audio_drain_atask.cancel()
+        self._draining_generations = [
+            draining_gen for draining_gen in self._draining_generations if draining_gen is not gen
+        ]
 
         gen.function_ch.close()
         gen.message_ch.close()
@@ -1413,6 +1424,8 @@ class RealtimeSession(llm.RealtimeSession):
         if gen._audio_drain_atask and not gen._audio_drain_atask.done():
             return
 
+        if not any(draining_gen is gen for draining_gen in self._draining_generations):
+            self._draining_generations.append(gen)
         gen._audio_drain_atask = asyncio.create_task(
             self._mark_generation_done_after_audio_drain(gen),
             name="gemini-realtime-audio-drain",

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -47,6 +47,9 @@ lk_google_debug = int(os.getenv("LK_GOOGLE_DEBUG", 0))
 # stop rejecting tool calls after this many in a row to avoid a loop (tool_choice="none")
 MAX_TOOL_CALL_REJECTIONS = 3
 
+TOOL_CALL_AUDIO_DRAIN_QUIESCENCE = 0.5
+TOOL_CALL_AUDIO_DRAIN_TIMEOUT = 5.0
+
 # Known VertexAI models for the Live API
 # See: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/live-api
 KNOWN_VERTEXAI_MODELS: frozenset[str] = frozenset(
@@ -178,6 +181,10 @@ class _ResponseGeneration:
     """The timestamp when the generation is completed"""
     _done: bool = False
     """Whether the generation is done (set when the turn is complete)"""
+    _last_audio_frame_at: float | None = None
+    """Monotonic timestamp of the last audio frame received"""
+    _audio_drain_atask: asyncio.Task[None] | None = None
+    """Task that closes the generation after tool-call audio has drained"""
 
     def push_text(self, text: str) -> None:
         if self.output_text:
@@ -1272,6 +1279,7 @@ class RealtimeSession(llm.RealtimeSession):
                             samples_per_channel=len(frame_data) // (2 * OUTPUT_AUDIO_CHANNELS),
                         )
                         current_gen.audio_ch.send_nowait(frame)
+                        current_gen._last_audio_frame_at = time.monotonic()
                     except ValueError as e:
                         logger.error(f"Error creating audio frame from Gemini data: {e}")
 
@@ -1351,11 +1359,51 @@ class RealtimeSession(llm.RealtimeSession):
         if not gen.audio_ch.closed:
             gen.audio_ch.close()
 
+        if (
+            gen._audio_drain_atask
+            and not gen._audio_drain_atask.done()
+            and gen._audio_drain_atask is not asyncio.current_task()
+        ):
+            gen._audio_drain_atask.cancel()
+
         gen.function_ch.close()
         gen.message_ch.close()
         gen._done = True
         if lk_google_debug:
             logger.debug(f"generation done {gen}")
+
+    async def _mark_generation_done_after_audio_drain(self, gen: _ResponseGeneration) -> None:
+        started_at = time.monotonic()
+        last_audio_frame_at = gen._last_audio_frame_at
+
+        while True:
+            if gen._done or self._current_generation is not gen:
+                return
+
+            elapsed = time.monotonic() - started_at
+            if elapsed >= TOOL_CALL_AUDIO_DRAIN_TIMEOUT:
+                break
+
+            await asyncio.sleep(
+                min(TOOL_CALL_AUDIO_DRAIN_QUIESCENCE, TOOL_CALL_AUDIO_DRAIN_TIMEOUT - elapsed)
+            )
+
+            current_last_audio_frame_at = gen._last_audio_frame_at
+            if current_last_audio_frame_at == last_audio_frame_at:
+                break
+            last_audio_frame_at = current_last_audio_frame_at
+
+        if self._current_generation is gen and not gen._done:
+            self._mark_current_generation_done()
+
+    def _schedule_generation_done_after_audio_drain(self, gen: _ResponseGeneration) -> None:
+        if gen._audio_drain_atask and not gen._audio_drain_atask.done():
+            return
+
+        gen._audio_drain_atask = asyncio.create_task(
+            self._mark_generation_done_after_audio_drain(gen),
+            name="gemini-realtime-audio-drain",
+        )
 
     def _handle_input_speech_started(self) -> None:
         self.emit("input_speech_started", llm.InputSpeechStartedEvent())
@@ -1414,7 +1462,9 @@ class RealtimeSession(llm.RealtimeSession):
                     arguments=arguments,
                 )
             )
-        self._mark_current_generation_done()
+
+        gen.function_ch.close()
+        self._schedule_generation_done_after_audio_drain(gen)
 
     def _handle_tool_call_cancellation(
         self, tool_call_cancellation: types.LiveServerToolCallCancellation

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -1196,11 +1196,21 @@ class RealtimeSession(llm.RealtimeSession):
 
         return conf
 
-    def _start_new_generation(self) -> None:
+    def _start_new_generation(self, *, interrupt_previous_audio: bool = True) -> None:
         self._rejected_tool_calls = 0
-        if self._current_generation and not self._current_generation._done:
-            logger.warning("starting new generation while another is active. Finalizing previous.")
-            self._mark_current_generation_done()
+        active_gen = self._current_generation
+        if active_gen and not active_gen._done:
+            if (
+                active_gen.function_ch.closed
+                and active_gen._audio_drain_atask
+                and not active_gen._audio_drain_atask.done()
+            ):
+                logger.debug("starting new generation while previous tool-call audio is draining")
+            else:
+                logger.warning(
+                    "starting new generation while another is active. Finalizing previous."
+                )
+                self._mark_generation_done(active_gen)
 
         response_id = utils.shortuuid("GR_")
         self._current_generation = _ResponseGeneration(
@@ -1239,7 +1249,7 @@ class RealtimeSession(llm.RealtimeSession):
             generation_event.user_initiated = True
             self._pending_generation_fut.set_result(generation_event)
             self._pending_generation_fut = None
-        else:
+        elif interrupt_previous_audio:
             # emit input_speech_started event before starting an agent initiated generation
             # to interrupt the previous audio playout if any
             self._handle_input_speech_started()
@@ -1319,10 +1329,14 @@ class RealtimeSession(llm.RealtimeSession):
         if not self._current_generation or self._current_generation._done:
             return
 
+        self._mark_generation_done(self._current_generation)
+
+    def _mark_generation_done(self, gen: _ResponseGeneration) -> None:
+        if gen._done:
+            return
+
         # emit input_speech_stopped event after the generation is done
         self._handle_input_speech_stopped()
-
-        gen = self._current_generation
 
         # The only way we'd know that the transcription is complete is by when they are
         # done with generation
@@ -1377,7 +1391,7 @@ class RealtimeSession(llm.RealtimeSession):
         last_audio_frame_at = gen._last_audio_frame_at
 
         while True:
-            if gen._done or self._current_generation is not gen:
+            if gen._done:
                 return
 
             elapsed = time.monotonic() - started_at
@@ -1393,8 +1407,7 @@ class RealtimeSession(llm.RealtimeSession):
                 break
             last_audio_frame_at = current_last_audio_frame_at
 
-        if self._current_generation is gen and not gen._done:
-            self._mark_current_generation_done()
+        self._mark_generation_done(gen)
 
     def _schedule_generation_done_after_audio_drain(self, gen: _ResponseGeneration) -> None:
         if gen._audio_drain_atask and not gen._audio_drain_atask.done():
@@ -1452,6 +1465,13 @@ class RealtimeSession(llm.RealtimeSession):
             return
 
         gen = self._current_generation
+        if gen.function_ch.closed:
+            # Tool execution starts after each function stream closes. A chained tool-call
+            # batch therefore needs a fresh generation while the prior audio drains.
+            self._start_new_generation(interrupt_previous_audio=False)
+            gen = self._current_generation
+            assert gen is not None
+
         for fnc_call in tool_call.function_calls or []:
             arguments = json.dumps(fnc_call.args)
 

--- a/tests/test_plugin_google_llm.py
+++ b/tests/test_plugin_google_llm.py
@@ -363,13 +363,7 @@ class TestRealtimeToolCallAudioDrain:
     def _new_session_with_generation() -> tuple[
         RealtimeSession, google_realtime._ResponseGeneration
     ]:
-        model = RealtimeModel(api_key="test-api-key")
-        session = RealtimeSession.__new__(RealtimeSession)
-        llm.RealtimeSession.__init__(session, model)
-        session._opts = model._opts
-        session._chat_ctx = llm.ChatContext.empty()
-        session._pending_generation_fut = None
-        session._rejected_tool_calls = 0
+        session = TestRealtimeToolCallAudioDrain._new_session()
 
         gen = google_realtime._ResponseGeneration(
             message_ch=utils.aio.Chan[llm.MessageGeneration](),
@@ -381,6 +375,30 @@ class TestRealtimeToolCallAudioDrain:
         )
         session._current_generation = gen
         return session, gen
+
+    @staticmethod
+    def _new_session() -> RealtimeSession:
+        model = RealtimeModel(api_key="test-api-key")
+        session = RealtimeSession.__new__(RealtimeSession)
+        llm.RealtimeSession.__init__(session, model)
+        session._opts = model._opts
+        session._chat_ctx = llm.ChatContext.empty()
+        session._msg_ch = utils.aio.Chan()
+        session._session_should_close = asyncio.Event()
+        session._session_lock = asyncio.Lock()
+        session._main_atask = None
+        session._active_session = None
+        session._response_created_futures = {}
+        session._pending_generation_fut = None
+        session._rejected_tool_calls = 0
+        session._draining_generations = []
+        session._current_generation = None
+        return session
+
+    @staticmethod
+    async def _wait_for_generation_done(gen: google_realtime._ResponseGeneration) -> None:
+        if gen._audio_drain_atask and not gen._audio_drain_atask.done():
+            await gen._audio_drain_atask
 
     @pytest.mark.asyncio
     async def test_tool_call_keeps_audio_open_until_trailing_audio_drains(
@@ -436,3 +454,59 @@ class TestRealtimeToolCallAudioDrain:
         assert first_gen.audio_ch.closed
         assert first_gen.message_ch.closed
         assert first_gen._done
+
+    @pytest.mark.asyncio
+    async def test_chained_tool_call_does_not_emit_unpaired_speech_stopped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_QUIESCENCE", 0.01)
+        monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_TIMEOUT", 0.2)
+        session = self._new_session()
+        speech_events: list[str] = []
+        session.on("input_speech_started", lambda _: speech_events.append("started"))
+        session.on("input_speech_stopped", lambda _: speech_events.append("stopped"))
+
+        session._start_new_generation()
+        first_gen = session._current_generation
+        assert first_gen is not None
+
+        session._handle_server_content(self._audio_content(b"\x01" * 960))
+        session._handle_tool_calls(self._tool_call(call_id="call-1", name="first_tool"))
+        session._handle_tool_calls(self._tool_call(call_id="call-2", name="second_tool"))
+        second_gen = session._current_generation
+        assert second_gen is not None
+        assert second_gen is not first_gen
+
+        await self._wait_for_generation_done(first_gen)
+        await self._wait_for_generation_done(second_gen)
+
+        assert first_gen._done
+        assert second_gen._done
+        assert speech_events == ["started", "stopped"]
+
+    @pytest.mark.asyncio
+    async def test_close_finalizes_non_current_draining_generation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_QUIESCENCE", 0.2)
+        monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_TIMEOUT", 1.0)
+        session = self._new_session()
+
+        session._start_new_generation()
+        first_gen = session._current_generation
+        assert first_gen is not None
+
+        session._handle_server_content(self._audio_content(b"\x01" * 960))
+        session._handle_tool_calls(self._tool_call(call_id="call-1", name="first_tool"))
+        session._handle_tool_calls(self._tool_call(call_id="call-2", name="second_tool"))
+        second_gen = session._current_generation
+        assert second_gen is not None
+        assert second_gen is not first_gen
+
+        await session.aclose()
+        await asyncio.sleep(0)
+
+        assert first_gen._done
+        assert first_gen.audio_ch.closed
+        assert first_gen.message_ch.closed
+        assert second_gen._done

--- a/tests/test_plugin_google_llm.py
+++ b/tests/test_plugin_google_llm.py
@@ -354,9 +354,9 @@ class TestRealtimeToolCallAudioDrain:
         )
 
     @staticmethod
-    def _tool_call() -> types.LiveServerToolCall:
+    def _tool_call(call_id: str = "call-1", name: str = "end_call") -> types.LiveServerToolCall:
         return types.LiveServerToolCall(
-            function_calls=[types.FunctionCall(id="call-1", name="end_call", args={})]
+            function_calls=[types.FunctionCall(id=call_id, name=name, args={})]
         )
 
     @staticmethod
@@ -404,3 +404,35 @@ class TestRealtimeToolCallAudioDrain:
         assert gen.audio_ch.closed
         assert gen.message_ch.closed
         assert gen._done
+
+    @pytest.mark.asyncio
+    async def test_repeated_tool_call_starts_new_generation_while_audio_drains(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_QUIESCENCE", 0.01)
+        monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_TIMEOUT", 0.2)
+        session, first_gen = self._new_session_with_generation()
+
+        session._handle_server_content(self._audio_content(b"\x01" * 960))
+        session._handle_tool_calls(self._tool_call(call_id="call-1", name="first_tool"))
+
+        assert first_gen.function_ch.closed
+        assert not first_gen.audio_ch.closed
+
+        session._handle_tool_calls(self._tool_call(call_id="call-2", name="second_tool"))
+
+        second_gen = session._current_generation
+        assert second_gen is not first_gen
+        assert second_gen is not None
+        assert second_gen.function_ch.closed
+        assert not first_gen.audio_ch.closed
+
+        second_call = second_gen.function_ch.recv_nowait()
+        assert second_call.call_id == "call-2"
+        assert second_call.name == "second_tool"
+
+        await asyncio.sleep(0.03)
+
+        assert first_gen.audio_ch.closed
+        assert first_gen.message_ch.closed
+        assert first_gen._done

--- a/tests/test_plugin_google_llm.py
+++ b/tests/test_plugin_google_llm.py
@@ -377,8 +377,11 @@ class TestRealtimeToolCallAudioDrain:
         return session, gen
 
     @staticmethod
-    def _new_session() -> RealtimeSession:
-        model = RealtimeModel(api_key="test-api-key")
+    def _new_session(*, modalities: list[types.Modality] | None = None) -> RealtimeSession:
+        model = RealtimeModel(
+            api_key="test-api-key",
+            modalities=modalities if modalities is not None else [types.Modality.AUDIO],
+        )
         session = RealtimeSession.__new__(RealtimeSession)
         llm.RealtimeSession.__init__(session, model)
         session._opts = model._opts
@@ -391,7 +394,6 @@ class TestRealtimeToolCallAudioDrain:
         session._response_created_futures = {}
         session._pending_generation_fut = None
         session._rejected_tool_calls = 0
-        session._draining_generations = []
         session._current_generation = None
         return session
 
@@ -399,6 +401,15 @@ class TestRealtimeToolCallAudioDrain:
     async def _wait_for_generation_done(gen: google_realtime._ResponseGeneration) -> None:
         if gen._audio_drain_atask and not gen._audio_drain_atask.done():
             await gen._audio_drain_atask
+
+    @staticmethod
+    def _drain_function_calls(
+        gen: google_realtime._ResponseGeneration,
+    ) -> list[llm.FunctionCall]:
+        calls = []
+        while not gen.function_ch.empty():
+            calls.append(gen.function_ch.recv_nowait())
+        return calls
 
     @pytest.mark.asyncio
     async def test_tool_call_keeps_audio_open_until_trailing_audio_drains(
@@ -411,20 +422,23 @@ class TestRealtimeToolCallAudioDrain:
         session._handle_server_content(self._audio_content(b"\x01" * 960))
         session._handle_tool_calls(self._tool_call())
 
-        assert gen.function_ch.closed
+        assert not gen.function_ch.closed
         assert not gen.audio_ch.closed
+        call = gen.function_ch.recv_nowait()
+        assert call.call_id == "call-1"
 
         session._handle_server_content(self._audio_content(b"\x02" * 960))
         assert gen.audio_ch.qsize() == 2
 
-        await asyncio.sleep(0.03)
+        await asyncio.wait_for(self._wait_for_generation_done(gen), timeout=1.0)
 
         assert gen.audio_ch.closed
         assert gen.message_ch.closed
+        assert gen.function_ch.closed
         assert gen._done
 
     @pytest.mark.asyncio
-    async def test_repeated_tool_call_starts_new_generation_while_audio_drains(
+    async def test_repeated_tool_call_uses_same_generation_while_audio_drains(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_QUIESCENCE", 0.01)
@@ -434,26 +448,144 @@ class TestRealtimeToolCallAudioDrain:
         session._handle_server_content(self._audio_content(b"\x01" * 960))
         session._handle_tool_calls(self._tool_call(call_id="call-1", name="first_tool"))
 
-        assert first_gen.function_ch.closed
+        assert not first_gen.function_ch.closed
         assert not first_gen.audio_ch.closed
 
         session._handle_tool_calls(self._tool_call(call_id="call-2", name="second_tool"))
 
-        second_gen = session._current_generation
-        assert second_gen is not first_gen
-        assert second_gen is not None
-        assert second_gen.function_ch.closed
+        assert session._current_generation is first_gen
         assert not first_gen.audio_ch.closed
 
-        second_call = second_gen.function_ch.recv_nowait()
-        assert second_call.call_id == "call-2"
-        assert second_call.name == "second_tool"
+        calls = self._drain_function_calls(first_gen)
+        assert [call.call_id for call in calls] == ["call-1", "call-2"]
+        assert [call.name for call in calls] == ["first_tool", "second_tool"]
 
-        await asyncio.sleep(0.03)
+        await asyncio.wait_for(self._wait_for_generation_done(first_gen), timeout=1.0)
 
         assert first_gen.audio_ch.closed
         assert first_gen.message_ch.closed
+        assert first_gen.function_ch.closed
         assert first_gen._done
+
+    @pytest.mark.asyncio
+    async def test_trailing_audio_after_repeated_tool_call_stays_on_draining_generation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_QUIESCENCE", 0.01)
+        monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_TIMEOUT", 0.2)
+        session, gen = self._new_session_with_generation()
+
+        session._handle_server_content(self._audio_content(b"\x01" * 960))
+        session._handle_tool_calls(self._tool_call(call_id="call-1", name="first_tool"))
+        session._handle_tool_calls(self._tool_call(call_id="call-2", name="second_tool"))
+        session._handle_server_content(self._audio_content(b"\x02" * 960))
+
+        assert session._current_generation is gen
+        assert gen.audio_ch.qsize() == 2
+        assert not gen.audio_ch.closed
+
+        await asyncio.wait_for(self._wait_for_generation_done(gen), timeout=1.0)
+
+        assert gen.audio_ch.closed
+        assert gen.message_ch.closed
+        assert gen.function_ch.closed
+
+    @pytest.mark.asyncio
+    async def test_repeated_tool_call_refreshes_audio_drain_window(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_QUIESCENCE", 0.02)
+        monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_TIMEOUT", 0.2)
+        session, gen = self._new_session_with_generation()
+
+        session._handle_server_content(self._audio_content(b"\x01" * 960))
+        session._handle_tool_calls(self._tool_call(call_id="call-1", name="first_tool"))
+        await asyncio.sleep(0.015)
+
+        session._handle_tool_calls(self._tool_call(call_id="call-2", name="second_tool"))
+        await asyncio.sleep(0.01)
+
+        assert not gen.audio_ch.closed
+        assert not gen.function_ch.closed
+
+        session._handle_server_content(self._audio_content(b"\x02" * 960))
+        assert gen.audio_ch.qsize() == 2
+
+        await asyncio.wait_for(self._wait_for_generation_done(gen), timeout=1.0)
+
+        assert gen.audio_ch.closed
+        assert gen.function_ch.closed
+
+    @pytest.mark.asyncio
+    async def test_repeated_tool_calls_are_emitted_on_generation_event_stream(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_QUIESCENCE", 0.01)
+        monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_TIMEOUT", 0.2)
+        session = self._new_session()
+        generation_events: list[llm.GenerationCreatedEvent] = []
+        session.on("generation_created", generation_events.append)
+
+        session._start_new_generation()
+        gen = session._current_generation
+        assert gen is not None
+
+        session._handle_server_content(self._audio_content(b"\x01" * 960))
+        session._handle_tool_calls(self._tool_call(call_id="call-1", name="first_tool"))
+        session._handle_tool_calls(self._tool_call(call_id="call-2", name="second_tool"))
+        await asyncio.wait_for(self._wait_for_generation_done(gen), timeout=1.0)
+
+        assert len(generation_events) == 1
+        calls = [call async for call in generation_events[0].function_stream]
+        assert [call.call_id for call in calls] == ["call-1", "call-2"]
+        assert [call.name for call in calls] == ["first_tool", "second_tool"]
+
+    def test_tool_call_finalizes_immediately_when_audio_is_already_closed(self) -> None:
+        session, gen = self._new_session_with_generation()
+        gen.audio_ch.close()
+
+        session._handle_tool_calls(self._tool_call())
+
+        assert gen._audio_drain_atask is None
+        assert gen.function_ch.closed
+        assert gen.message_ch.closed
+        assert gen._done
+
+    def test_tool_call_finalizes_immediately_for_text_only_modality(self) -> None:
+        session = self._new_session(modalities=[types.Modality.TEXT])
+        session._start_new_generation()
+        gen = session._current_generation
+        assert gen is not None
+
+        session._handle_tool_calls(self._tool_call())
+
+        assert gen._audio_drain_atask is None
+        assert gen.function_ch.closed
+        assert gen.message_ch.closed
+        assert gen._done
+
+    @pytest.mark.asyncio
+    async def test_audio_modality_waits_for_first_trailing_audio_after_tool_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_QUIESCENCE", 0.01)
+        monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_TIMEOUT", 0.2)
+        session, gen = self._new_session_with_generation()
+
+        session._handle_tool_calls(self._tool_call())
+
+        assert not gen.audio_ch.closed
+        assert not gen.function_ch.closed
+
+        session._handle_server_content(self._audio_content(b"\x01" * 960))
+
+        assert gen.audio_ch.qsize() == 1
+
+        await asyncio.wait_for(self._wait_for_generation_done(gen), timeout=1.0)
+
+        assert gen.audio_ch.closed
+        assert gen.function_ch.closed
+        assert gen._done
 
     @pytest.mark.asyncio
     async def test_chained_tool_call_does_not_emit_unpaired_speech_stopped(
@@ -473,19 +605,14 @@ class TestRealtimeToolCallAudioDrain:
         session._handle_server_content(self._audio_content(b"\x01" * 960))
         session._handle_tool_calls(self._tool_call(call_id="call-1", name="first_tool"))
         session._handle_tool_calls(self._tool_call(call_id="call-2", name="second_tool"))
-        second_gen = session._current_generation
-        assert second_gen is not None
-        assert second_gen is not first_gen
 
         await self._wait_for_generation_done(first_gen)
-        await self._wait_for_generation_done(second_gen)
 
         assert first_gen._done
-        assert second_gen._done
         assert speech_events == ["started", "stopped"]
 
     @pytest.mark.asyncio
-    async def test_close_finalizes_non_current_draining_generation(
+    async def test_close_finalizes_draining_generation(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_QUIESCENCE", 0.2)
@@ -499,9 +626,6 @@ class TestRealtimeToolCallAudioDrain:
         session._handle_server_content(self._audio_content(b"\x01" * 960))
         session._handle_tool_calls(self._tool_call(call_id="call-1", name="first_tool"))
         session._handle_tool_calls(self._tool_call(call_id="call-2", name="second_tool"))
-        second_gen = session._current_generation
-        assert second_gen is not None
-        assert second_gen is not first_gen
 
         await session.aclose()
         await asyncio.sleep(0)
@@ -509,4 +633,3 @@ class TestRealtimeToolCallAudioDrain:
         assert first_gen._done
         assert first_gen.audio_ch.closed
         assert first_gen.message_ch.closed
-        assert second_gen._done

--- a/tests/test_plugin_google_llm.py
+++ b/tests/test_plugin_google_llm.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from google.genai import types
 
-from livekit.agents import llm
+from livekit.agents import llm, utils
 from livekit.agents.llm import ChatContext, function_tool
 from livekit.agents.types import APIConnectOptions
 from livekit.plugins.google.llm import LLM, LLMStream
+from livekit.plugins.google.realtime import realtime_api as google_realtime
 from livekit.plugins.google.realtime.realtime_api import RealtimeModel, RealtimeSession
 
 pytestmark = pytest.mark.plugin("google")
@@ -333,3 +335,72 @@ class TestMediaResolution:
 
         assert config.generation_config
         assert config.generation_config.media_resolution is None
+
+
+class TestRealtimeToolCallAudioDrain:
+    @staticmethod
+    def _audio_content(data: bytes) -> types.LiveServerContent:
+        return types.LiveServerContent(
+            model_turn=types.Content(
+                parts=[
+                    types.Part(
+                        inline_data=types.Blob(
+                            data=data,
+                            mime_type="audio/pcm;rate=24000",
+                        )
+                    )
+                ]
+            )
+        )
+
+    @staticmethod
+    def _tool_call() -> types.LiveServerToolCall:
+        return types.LiveServerToolCall(
+            function_calls=[types.FunctionCall(id="call-1", name="end_call", args={})]
+        )
+
+    @staticmethod
+    def _new_session_with_generation() -> tuple[
+        RealtimeSession, google_realtime._ResponseGeneration
+    ]:
+        model = RealtimeModel(api_key="test-api-key")
+        session = RealtimeSession.__new__(RealtimeSession)
+        llm.RealtimeSession.__init__(session, model)
+        session._opts = model._opts
+        session._chat_ctx = llm.ChatContext.empty()
+        session._pending_generation_fut = None
+        session._rejected_tool_calls = 0
+
+        gen = google_realtime._ResponseGeneration(
+            message_ch=utils.aio.Chan[llm.MessageGeneration](),
+            function_ch=utils.aio.Chan[llm.FunctionCall](),
+            input_id="GI_test",
+            response_id="GR_test",
+            text_ch=utils.aio.Chan[str](),
+            audio_ch=utils.aio.Chan(),
+        )
+        session._current_generation = gen
+        return session, gen
+
+    @pytest.mark.asyncio
+    async def test_tool_call_keeps_audio_open_until_trailing_audio_drains(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_QUIESCENCE", 0.01)
+        monkeypatch.setattr(google_realtime, "TOOL_CALL_AUDIO_DRAIN_TIMEOUT", 0.2)
+        session, gen = self._new_session_with_generation()
+
+        session._handle_server_content(self._audio_content(b"\x01" * 960))
+        session._handle_tool_calls(self._tool_call())
+
+        assert gen.function_ch.closed
+        assert not gen.audio_ch.closed
+
+        session._handle_server_content(self._audio_content(b"\x02" * 960))
+        assert gen.audio_ch.qsize() == 2
+
+        await asyncio.sleep(0.03)
+
+        assert gen.audio_ch.closed
+        assert gen.message_ch.closed
+        assert gen._done


### PR DESCRIPTION
Closes #5742

## Summary
- keep Gemini realtime audio open after a tool call until trailing audio has drained
- close the function stream immediately so tool execution can start without waiting for audio drain
- add a regression test for `audio -> toolCall -> trailing audio` ordering

## Why
Gemini Live exposes `toolCall` as a distinct server message from `serverContent.turnComplete`. The API reference defines `turnComplete` as the model-turn completion signal, while `toolCall` asks the client to execute function calls and return responses. The Live API capabilities guide also notes that Gemini 3.1 Live server events can carry multiple content parts and clients should process all parts.

Closing the generation at `toolCall` can therefore close `audio_ch` before trailing Gemini audio chunks are delivered. This makes `RunContext.wait_for_playout()` resolve too early for custom end-call tools that wait for playout before tearing down the room.

## Tests
- `uv run pytest --plugin google tests/test_plugin_google_llm.py`
- `uv run ruff check livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py tests/test_plugin_google_llm.py`
- `uv run ruff format --check livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py tests/test_plugin_google_llm.py`
- `uv run python scripts/check_types.py -- --no-sync`