### PR TITLE
update keyterm detection default model

### DIFF
--- a/livekit-agents/livekit/agents/voice/keyterm_detection.py
+++ b/livekit-agents/livekit/agents/voice/keyterm_detection.py
@@ -81,7 +81,7 @@ _PENDING_TTL = 3  # a pending term not confirmed within this many passes is drop
 _MAX_TRANSCRIPT_MESSAGES = 12
 
 # default model for keyterm extraction when ``keyterm_detection.llm`` is not set
-_DEFAULT_DETECTION_MODEL = "google/gemini-3.5-flash"
+_DEFAULT_DETECTION_MODEL = "google/gemma-4-31b-it"
 
 # set LK_KEYTERMS_DEBUG=1 to log the input/output of every detection pass
 lk_keyterms_debug = int(os.getenv("LK_KEYTERMS_DEBUG", 0))


### PR DESCRIPTION
`google/gemma-4-31b-it` performs better than `google/gemini-3.5-flash` on eval set

model | F0.5 | P | R | F0.5·reg | F0.5·noisy | TP | FP | TN | FN
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | google/gemma-4-31b-it | 0.979 | 0.985 | 0.954 | 0.985 | 0.976 | 2915 | 44 | 1785 | 142
2 | google/gemini-3.5-flash | 0.954 | 0.963 | 0.921 | 0.979 | 0.945 | 2816 | 109 | 1766 | 241

