### PR TITLE
feat(soniox): populate SpeechData.words with per-word timing and confidence

### DIFF
--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import time
 from dataclasses import asdict, dataclass
 from typing import Any, Literal, NamedTuple
@@ -39,6 +40,7 @@ from livekit.agents.types import (
     DEFAULT_API_CONNECT_OPTIONS,
     NOT_GIVEN,
     NotGivenOr,
+    TimedString,
 )
 
 from .log import logger
@@ -659,11 +661,46 @@ class _LangStats(NamedTuple):
     updated_at: float
 
 
+class _Word(NamedTuple):
+    """One whitespace-delimited word assembled from consecutive sub-word tokens."""
+
+    text: str
+    start_ms: float | None
+    end_ms: float | None
+    confidence: float | None
+    speaker_id: str | None
+
+
+def _is_unspaced_script_char(char: str) -> bool:
+    """True for scripts written without inter-word spaces among Soniox's
+    supported languages (Han for zh, Kana for ja, Thai for th). Tokens in
+    these scripts never arrive with whitespace between them, so token
+    boundaries are used as word boundaries instead; every other supported
+    language delimits words with whitespace."""
+    code_point = ord(char)
+    return (
+        0x0E00 <= code_point <= 0x0E7F  # Thai
+        or 0x3040 <= code_point <= 0x30FF  # Hiragana + Katakana
+        or 0x31F0 <= code_point <= 0x31FF  # Katakana Phonetic Extensions
+        or 0x3400 <= code_point <= 0x4DBF  # CJK Unified Ideographs Extension A
+        or 0x4E00 <= code_point <= 0x9FFF  # CJK Unified Ideographs
+        or 0xF900 <= code_point <= 0xFAFF  # CJK Compatibility Ideographs
+        or 0xFF66 <= code_point <= 0xFF9D  # Halfwidth Katakana
+        or 0x20000 <= code_point <= 0x2FA1F  # CJK Unified Ideographs Extensions B-F
+    )
+
+
 class _TokenAccumulator:
     """Accumulates token metadata (text, language, speaker, timing, confidence).
 
     Tokens are assumed to arrive in chronological order, so start_time is taken
     from the first token and end_time is continuously overwritten by the latest.
+
+    Per-word metadata is accumulated alongside: Soniox emits sub-word tokens
+    ("walk" + "ing"), which are grouped into words at whitespace boundaries
+    (or at token boundaries for unspaced scripts). A word's confidence is the
+    mean of its tokens' confidences; its timing spans its first token's
+    start_ms to its last token's end_ms.
     """
 
     def __init__(self) -> None:
@@ -677,6 +714,13 @@ class _TokenAccumulator:
         self._has_start_time: bool = False
         self._lang_segments: list[tuple[str, str]] = []  # (language, text) pairs
         self._lang_stats: dict[str, _LangStats] = {}
+        self._words: list[_Word] = []
+        self._word_parts: list[str] = []
+        self._word_confidence_sum: float = 0.0
+        self._word_confidence_count: int = 0
+        self._word_start_ms: float | None = None
+        self._word_end_ms: float | None = None
+        self._word_speaker_id: str | None = None
 
     def _get_language(self) -> str:
         """Language with the most characters; ties go to the one that reached the count first."""
@@ -714,6 +758,92 @@ class _TokenAccumulator:
                 self._lang_segments[-1] = (lang, t + text)
             else:
                 self._lang_segments.append((lang, text))
+        self._update_words(token)
+
+    def _update_words(self, token: dict[str, Any]) -> None:
+        text = token["text"]
+        if not text:
+            return
+        confidence = token.get("confidence")
+        start_ms = float(token["start_ms"]) if "start_ms" in token else None
+        end_ms = float(token["end_ms"]) if "end_ms" in token else None
+        speaker_id = str(token["speaker"]) if "speaker" in token else None
+
+        for piece in re.split(r"(\s+)", text):
+            if not piece:
+                continue
+            if piece.isspace():
+                self._flush_word()
+                continue
+            if self._word_parts and (
+                _is_unspaced_script_char(self._word_parts[-1][-1])
+                or _is_unspaced_script_char(piece[0])
+            ):
+                self._flush_word()
+            self._word_parts.append(piece)
+            # A token spanning a word boundary contributes its metadata to
+            # every word it touches.
+            if confidence is not None:
+                self._word_confidence_sum += confidence
+                self._word_confidence_count += 1
+            if start_ms is not None and self._word_start_ms is None:
+                self._word_start_ms = start_ms
+            if end_ms is not None:
+                self._word_end_ms = end_ms
+            if speaker_id is not None and self._word_speaker_id is None:
+                self._word_speaker_id = speaker_id
+
+    def _pending_word(self) -> _Word | None:
+        if not self._word_parts:
+            return None
+        return _Word(
+            text="".join(self._word_parts),
+            start_ms=self._word_start_ms,
+            end_ms=self._word_end_ms,
+            confidence=(
+                self._word_confidence_sum / self._word_confidence_count
+                if self._word_confidence_count
+                else None
+            ),
+            speaker_id=self._word_speaker_id,
+        )
+
+    def _flush_word(self) -> None:
+        word = self._pending_word()
+        if word is None:
+            return
+        self._words.append(word)
+        self._word_parts = []
+        self._word_confidence_sum = 0.0
+        self._word_confidence_count = 0
+        self._word_start_ms = None
+        self._word_end_ms = None
+        self._word_speaker_id = None
+
+    def timed_words(self, start_time_offset: float = 0.0) -> list[TimedString] | None:
+        """Words accumulated so far (including the in-progress one) as
+        `TimedString`s, or None when no words have been seen."""
+        pending = self._pending_word()
+        words = self._words + ([pending] if pending is not None else [])
+        if not words:
+            return None
+        return [
+            TimedString(
+                text=word.text,
+                start_time=(
+                    word.start_ms / 1000 + start_time_offset
+                    if word.start_ms is not None
+                    else NOT_GIVEN
+                ),
+                end_time=(
+                    word.end_ms / 1000 + start_time_offset if word.end_ms is not None else NOT_GIVEN
+                ),
+                confidence=word.confidence if word.confidence is not None else NOT_GIVEN,
+                start_time_offset=start_time_offset,
+                speaker_id=word.speaker_id,
+            )
+            for word in words
+        ]
 
     @property
     def confidence(self) -> float:
@@ -732,6 +862,13 @@ class _TokenAccumulator:
         self._has_start_time = False
         self._lang_segments = []
         self._lang_stats = {}
+        self._words = []
+        self._word_parts = []
+        self._word_confidence_sum = 0.0
+        self._word_confidence_count = 0
+        self._word_start_ms = None
+        self._word_end_ms = None
+        self._word_speaker_id = None
 
     def to_speech_data(
         self,
@@ -752,6 +889,7 @@ class _TokenAccumulator:
             start_time=self.start_time / 1000 + start_time_offset,
             end_time=self.end_time / 1000 + start_time_offset,
             confidence=self.confidence,
+            words=self.timed_words(start_time_offset),
         )
 
     def merged_speech_data(
@@ -769,6 +907,9 @@ class _TokenAccumulator:
         end = max(self.end_time, other.end_time)
         total_count = self._confidence_count + other._confidence_count
         total_sum = self._confidence_sum + other._confidence_sum
+        merged_words = (self.timed_words(start_time_offset) or []) + (
+            other.timed_words(start_time_offset) or []
+        )
         return stt.SpeechData(
             text=self.text + other.text,
             language=LanguageCode(self.language if self.language else other.language),
@@ -780,4 +921,5 @@ class _TokenAccumulator:
             start_time=start / 1000 + start_time_offset,
             end_time=end / 1000 + start_time_offset,
             confidence=total_sum / total_count if total_count > 0 else 0.0,
+            words=merged_words or None,
         )

--- a/tests/test_plugin_soniox_stt.py
+++ b/tests/test_plugin_soniox_stt.py
@@ -516,3 +516,164 @@ async def test_final_transcript_no_translation_code_switched_populates_source_ru
     assert sd.target_texts is None
     assert sd.source_texts is not None
     assert "".join(sd.source_texts) == sd.text
+
+
+# ---------------------------------------------------------------------------
+# Per-word confidence / timing on `SpeechData.words`
+# ---------------------------------------------------------------------------
+
+
+def test_token_accumulator_groups_subword_tokens_into_words():
+    from livekit.plugins.soniox.stt import _TokenAccumulator
+
+    accumulator = _TokenAccumulator()
+    accumulator.update(
+        {"text": "My", "is_final": True, "confidence": 0.9, "start_ms": 0, "end_ms": 100}
+    )
+    accumulator.update(
+        {"text": " walk", "is_final": True, "confidence": 0.4, "start_ms": 100, "end_ms": 250}
+    )
+    accumulator.update(
+        {"text": "ing", "is_final": True, "confidence": 0.6, "start_ms": 250, "end_ms": 400}
+    )
+
+    words = accumulator.timed_words()
+    assert words is not None
+    assert [str(word) for word in words] == ["My", "walking"]
+    assert words[0].confidence == pytest.approx(0.9)
+    assert words[1].confidence == pytest.approx(0.5)  # mean of "walk" + "ing"
+    assert words[1].start_time == pytest.approx(0.1)
+    assert words[1].end_time == pytest.approx(0.4)
+
+
+def test_token_accumulator_words_apply_start_time_offset():
+    from livekit.plugins.soniox.stt import _TokenAccumulator
+
+    accumulator = _TokenAccumulator()
+    accumulator.update(
+        {"text": "hi", "is_final": True, "confidence": 0.8, "start_ms": 500, "end_ms": 700}
+    )
+
+    words = accumulator.timed_words(start_time_offset=10.0)
+    assert words is not None
+    assert words[0].start_time == pytest.approx(10.5)
+    assert words[0].end_time == pytest.approx(10.7)
+    assert words[0].start_time_offset == pytest.approx(10.0)
+
+
+def test_token_accumulator_unspaced_script_tokens_become_separate_words():
+    from livekit.plugins.soniox.stt import _TokenAccumulator
+
+    accumulator = _TokenAccumulator()
+    accumulator.update({"text": "你好", "is_final": True, "confidence": 0.9})
+    accumulator.update({"text": "世界", "is_final": True, "confidence": 0.7})
+
+    words = accumulator.timed_words()
+    assert words is not None
+    assert [str(word) for word in words] == ["你好", "世界"]
+    assert words[0].confidence == pytest.approx(0.9)
+    assert words[1].confidence == pytest.approx(0.7)
+
+
+def test_token_accumulator_word_without_confidence_is_not_given():
+    from livekit.agents.types import NOT_GIVEN
+    from livekit.plugins.soniox.stt import _TokenAccumulator
+
+    accumulator = _TokenAccumulator()
+    accumulator.update({"text": "hello", "is_final": True})
+
+    words = accumulator.timed_words()
+    assert words is not None
+    assert words[0].confidence is NOT_GIVEN
+    assert words[0].start_time is NOT_GIVEN
+    assert words[0].end_time is NOT_GIVEN
+
+
+def test_token_accumulator_reset_clears_words():
+    from livekit.plugins.soniox.stt import _TokenAccumulator
+
+    accumulator = _TokenAccumulator()
+    accumulator.update({"text": "hello world", "is_final": True, "confidence": 0.9})
+    accumulator.reset()
+
+    assert accumulator.timed_words() is None
+
+
+def test_merged_speech_data_concatenates_final_and_nonfinal_words():
+    from livekit.plugins.soniox.stt import _TokenAccumulator
+
+    final = _TokenAccumulator()
+    final.update({"text": "Hello", "is_final": True, "confidence": 0.9})
+    non_final = _TokenAccumulator()
+    non_final.update({"text": " wor", "is_final": False, "confidence": 0.5})
+
+    sd = final.merged_speech_data(non_final)
+    assert sd.words is not None
+    assert [str(word) for word in sd.words] == ["Hello", "wor"]
+
+
+async def test_final_transcript_carries_word_confidences():
+    """End-to-end: sub-word tokens with confidence produce `SpeechData.words`
+    grouped at whitespace boundaries, alongside the existing scalar mean."""
+    stream = _make_stream()
+
+    messages = [
+        {
+            "tokens": [
+                {
+                    "text": "Hel",
+                    "language": "en",
+                    "is_final": True,
+                    "confidence": 0.8,
+                    "start_ms": 0,
+                    "end_ms": 80,
+                },
+                {
+                    "text": "lo",
+                    "language": "en",
+                    "is_final": True,
+                    "confidence": 0.6,
+                    "start_ms": 80,
+                    "end_ms": 150,
+                },
+                {
+                    "text": " world.",
+                    "language": "en",
+                    "is_final": True,
+                    "confidence": 0.9,
+                    "start_ms": 150,
+                    "end_ms": 400,
+                },
+                END_TOKEN_FINAL,
+            ],
+            "total_audio_proc_ms": 500,
+        }
+    ]
+
+    events = await _drive_recv(stream, messages, expect_events=3)
+    final = next(e for e in events if e.type == SpeechEventType.FINAL_TRANSCRIPT)
+    sd = final.alternatives[0]
+
+    assert sd.text == "Hello world."
+    assert sd.confidence == pytest.approx((0.8 + 0.6 + 0.9) / 3)
+
+    assert sd.words is not None
+    assert [str(word) for word in sd.words] == ["Hello", "world."]
+    assert sd.words[0].confidence == pytest.approx(0.7)  # mean of "Hel" + "lo"
+    assert sd.words[1].confidence == pytest.approx(0.9)
+    assert sd.words[0].start_time == pytest.approx(0.0)
+    assert sd.words[0].end_time == pytest.approx(0.15)
+    assert sd.words[1].start_time == pytest.approx(0.15)
+    assert sd.words[1].end_time == pytest.approx(0.4)
+
+
+def test_token_accumulator_thai_tokens_become_separate_words():
+    from livekit.plugins.soniox.stt import _TokenAccumulator
+
+    accumulator = _TokenAccumulator()
+    accumulator.update({"text": "สวัสดี", "is_final": True, "confidence": 0.8})
+    accumulator.update({"text": "ครับ", "is_final": True, "confidence": 0.6})
+
+    words = accumulator.timed_words()
+    assert words is not None
+    assert [str(word) for word in words] == ["สวัสดี", "ครับ"]


### PR DESCRIPTION
## What

The Soniox websocket API returns per-token `confidence`, `start_ms` and `end_ms`, but the plugin currently keeps only the per-transcript mean confidence — the per-token metadata is dropped. This PR groups consecutive sub-word tokens ("walk" + "ing") into words and exposes them as `TimedString` entries on `SpeechData.words`, following the Deepgram plugin's precedent (offset applied to times, `start_time_offset` attribute set).

Word confidence = mean of its tokens' confidences; word timing spans first token `start_ms` → last token `end_ms`.

## Why

Word-level ASR confidence enables downstream consumers to detect likely mistranscriptions. Our production use case (language-learning voice agent): the agent issues grammar corrections against phrases the learner never said — ~16% of corrections traced to ASR artifacts. A plausible-in-context mishear ("walking" → "working") is invisible to text-only downstream logic but shows up as a per-word confidence dip. The scalar per-transcript mean (added recently) is too coarse: one garbled word barely moves the mean of a long utterance.

## Word-boundary rules

- Words split at whitespace (Soniox marks word starts with a leading space in token text) — correct for 57 of the 60 documented supported languages.
- The three unspaced scripts in Soniox's catalog — Han (zh), Kana (ja), Thai (th) — never produce that whitespace, so token boundaries are used as word boundaries there (Soniox emits roughly word/character-granularity tokens for these scripts).
- Punctuation tokens attach to the preceding word, matching Deepgram's behavior.

Open question for Soniox folks: is a leading space in `token["text"]` a guaranteed word-start marker for spaced languages? If the server could emit an explicit boundary flag, the script-range heuristic here could be deleted.

## Notes

- Purely additive — `text`, scalar `confidence` and timing fields are untouched; `words` was previously always `None` for this plugin.
- In translation mode, `words` follows the same side as `text`/`confidence` (the target side).
- On `INTERIM_TRANSCRIPT`/`PREFLIGHT_TRANSCRIPT` (`merged_speech_data`), a word straddling the final/non-final seam may appear split until the endpoint — same instability interim `text` already has.
- `speaker_id` per word is first-token-wins, consistent with the transcript-level field.

## Testing

8 new tests in `tests/test_plugin_soniox_stt.py` (existing fake-WebSocket harness): sub-word grouping + confidence mean, `start_time_offset` application, Han/Thai token-boundary words, `NOT_GIVEN` fallbacks when metadata absent, `reset()` clearing, merged final+non-final words, and end-to-end `FINAL_TRANSCRIPT` assertions. `ruff check`, `ruff format` and `scripts/check_types.py` (mypy) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)