### PR TITLE
feat(deepgram): surface Deepgram TTS request_id via lk.provider_request_ids

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
@@ -383,7 +383,13 @@ class SynthesizeStream(tts.SynthesizeStream):
                     elif mtype in ("Error", "error"):
                         raise APIError(message="Deepgram TTS returned error", body=resp)
                     elif mtype == "Metadata":
-                        pass
+                        request_id = resp.get("request_id")
+                        if request_id:
+                            # Expose Deepgram's server-assigned request id on the
+                            # tts_request_run span so users can correlate traces with
+                            # Deepgram's server-side logs for debugging. Deduped
+                            # internally, so calling on every Metadata frame is fine.
+                            output_emitter._note_provider_request_id(request_id)
                     else:
                         logger.warning("Unknown Deepgram message type: %s", resp)
 


### PR DESCRIPTION
## Summary
PR #5546 added `lk.provider_request_ids` to TTS/STT/LLM spans, but the Deepgram **TTS** plugin was not included (it covered the base plus OpenAI/Sarvam/UpliftAI). Deepgram STT already surfaces `metadata["request_id"]`, but Deepgram TTS discards the provider `Metadata` frame (`elif mtype == "Metadata": pass`) and the span's request id is a local `utils.shortuuid()`. As a result there is no way to correlate a Deepgram TTS request/failure with Deepgram's server-side logs.

## What this does
Reads `request_id` from Deepgram's TTS `Metadata` frame and passes it to `output_emitter._note_provider_request_id(...)`, so it appears on the `tts_request_run` span under `lk.provider_request_ids` — matching the Deepgram STT plugin and the Sarvam/UpliftAI TTS plugins.

Deepgram's TTS WebSocket Metadata message carries the id at the top level:

```json
{ "type": "Metadata", "request_id": "...", "model_name": "aura-2-...", ... }
```

(ref: https://developers.deepgram.com/docs/tts-websocket)

## Why
Real-time users hitting Deepgram TTS WebSocket issues currently can't hand Deepgram support a request id, because the id surfaced by the plugin is a local one rather than Deepgram's. This closes that gap for Deepgram TTS specifically.

## Tested
Applied the change locally and ran a synthesis through the plugin. It captured a `request_id` from the Metadata frame that resolves in the Deepgram console to the exact `/speak` request (matching endpoint, `encoding=linear16`, `sample_rate=24000`, and timestamp) — confirming the captured value is Deepgram's real, searchable request id rather than a local one.

Note: `_note_provider_request_id` dedupes internally, so calling it on every Metadata frame is safe.
