### PR TITLE
feat(cerebras, xai): expose reasoning_format to hide thinking tokens

### DIFF
--- a/livekit-plugins/livekit-plugins-cerebras/livekit/plugins/cerebras/llm.py
+++ b/livekit-plugins/livekit-plugins-cerebras/livekit/plugins/cerebras/llm.py
@@ -33,6 +33,7 @@ from livekit.agents.types import (
 )
 from livekit.agents.utils import is_given
 from livekit.plugins.openai import LLM as OpenAILLM
+from livekit.plugins.openai.llm import ReasoningFormat
 
 from .models import CerebrasChatModels
 
@@ -112,6 +113,7 @@ class LLM(OpenAILLM):
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
         reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
+        reasoning_format: NotGivenOr[ReasoningFormat] = NOT_GIVEN,
         safety_identifier: NotGivenOr[str] = NOT_GIVEN,
         prompt_cache_key: NotGivenOr[str] = NOT_GIVEN,
         top_p: NotGivenOr[float] = NOT_GIVEN,
@@ -131,9 +133,17 @@ class LLM(OpenAILLM):
 
         When ``msgpack_encoding`` is True (default), request payloads are encoded with msgpack
         binary format instead of JSON.
+
+        ``reasoning_format`` controls how reasoning models (e.g. gpt-oss) return their thinking
+        tokens. Set it to ``"hidden"`` to keep the reasoning out of the streamed response so it
+        is never read aloud by the TTS pipeline.
         """
 
         cerebras_api_key = _get_api_key(api_key)
+
+        extra_body: dict[str, Any] = {}
+        if is_given(reasoning_format):
+            extra_body["reasoning_format"] = reasoning_format
 
         created_client = False
         if client is None and (gzip_compression or msgpack_encoding):
@@ -172,6 +182,7 @@ class LLM(OpenAILLM):
             top_p=top_p,
             timeout=timeout,
             max_retries=max_retries,
+            extra_body=extra_body or NOT_GIVEN,
             _strict_tool_schema=False,
         )
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -61,6 +61,11 @@ lk_oai_debug = int(os.getenv("LK_OPENAI_DEBUG", 0))
 
 Verbosity = Literal["low", "medium", "high"]
 PromptCacheRetention = Literal["in_memory", "24h"]
+# Provider-specific control over how reasoning/thinking tokens are returned.
+# Supported by OpenAI-compatible gateways such as xAI (Grok) and Cerebras for
+# reasoning models (e.g. gpt-oss). "hidden" drops the reasoning from the response
+# so it is never streamed to the TTS pipeline.
+ReasoningFormat = Literal["parsed", "raw", "hidden"]
 
 
 @dataclass
@@ -401,6 +406,7 @@ class LLM(llm.LLM):
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: ToolChoice = "auto",
         reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
+        reasoning_format: NotGivenOr[ReasoningFormat] = NOT_GIVEN,
         safety_identifier: NotGivenOr[str] = NOT_GIVEN,
         prompt_cache_key: NotGivenOr[str] = NOT_GIVEN,
         top_p: NotGivenOr[float] = NOT_GIVEN,
@@ -410,12 +416,20 @@ class LLM(llm.LLM):
 
         ``api_key`` must be set to your XAI API key, either using the argument or by setting
         the ``XAI_API_KEY`` environmental variable.
+
+        ``reasoning_format`` controls how reasoning models (e.g. gpt-oss) return their
+        thinking tokens. Set it to ``"hidden"`` to keep the reasoning out of the streamed
+        response so it is never read aloud by the TTS pipeline.
         """
         api_key = api_key or os.environ.get("XAI_API_KEY")
         if api_key is None:
             raise ValueError(
                 "XAI API key is required, either as argument or set XAI_API_KEY environmental variable"  # noqa: E501
             )
+
+        extra_body: dict[str, Any] = {}
+        if is_given(reasoning_format):
+            extra_body["reasoning_format"] = reasoning_format
 
         return LLM(
             model=model,
@@ -431,6 +445,7 @@ class LLM(llm.LLM):
             safety_identifier=safety_identifier,
             prompt_cache_key=prompt_cache_key,
             top_p=top_p,
+            extra_body=extra_body or NOT_GIVEN,
         )
 
     @staticmethod

--- a/tests/test_reasoning_format.py
+++ b/tests/test_reasoning_format.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents.types import NOT_GIVEN
+from livekit.plugins import openai
+from livekit.plugins.cerebras import LLM as CerebrasLLM
+
+pytestmark = pytest.mark.unit
+
+# `reasoning_format` is a provider-specific option (xAI/Grok, Cerebras) that is not part of the
+# standard OpenAI chat-completions schema, so it must be routed through `extra_body` rather than
+# sent as a top-level request field. These tests pin that wiring.
+
+
+async def test_xai_reasoning_format_threaded_to_extra_body() -> None:
+    llm = openai.LLM.with_x_ai(api_key="test", reasoning_format="hidden")
+    try:
+        assert llm._opts.extra_body == {"reasoning_format": "hidden"}
+    finally:
+        await llm.aclose()
+
+
+async def test_xai_reasoning_format_omitted_by_default() -> None:
+    llm = openai.LLM.with_x_ai(api_key="test")
+    try:
+        assert llm._opts.extra_body is NOT_GIVEN
+    finally:
+        await llm.aclose()
+
+
+async def test_cerebras_reasoning_format_threaded_to_extra_body() -> None:
+    llm = CerebrasLLM(api_key="test", reasoning_format="hidden")
+    try:
+        assert llm._opts.extra_body == {"reasoning_format": "hidden"}
+    finally:
+        await llm.aclose()
+
+
+async def test_cerebras_reasoning_format_omitted_by_default() -> None:
+    llm = CerebrasLLM(api_key="test")
+    try:
+        assert llm._opts.extra_body is NOT_GIVEN
+    finally:
+        await llm.aclose()


### PR DESCRIPTION
## Summary

Fixes #5989.

Reasoning models such as `gpt-oss` on **xAI (Grok)** and **Cerebras** stream their internal thinking tokens as part of the response. In a voice pipeline these tokens get picked up by the TTS pipeline and read aloud, so the user hears the model's raw internal monologue instead of just the final answer.

This PR exposes a `reasoning_format` parameter on `openai.LLM.with_x_ai(...)` and `cerebras.LLM(...)`, mirroring the existing `reasoning_effort` wiring. Setting it to `"hidden"` keeps the reasoning out of the streamed response.

## Details

`reasoning_format` (values: `"parsed"`, `"raw"`, `"hidden"`) is a provider-specific option and is **not** part of the standard OpenAI chat-completions schema. The OpenAI Python SDK's `chat.completions.create()` rejects unknown top-level kwargs, so the value is routed through the existing `extra_body` passthrough rather than added as a top-level request field.

- Added `ReasoningFormat = Literal["parsed", "raw", "hidden"]` in the openai plugin.
- `openai.LLM.with_x_ai(...)`: new `reasoning_format` param, merged into `extra_body`.
- `cerebras.LLM(...)`: new `reasoning_format` param, merged into `extra_body`.

## Usage

```python
from livekit.plugins import openai, cerebras

llm = openai.LLM.with_x_ai(model="gpt-oss-120b", reasoning_format="hidden")
llm = cerebras.LLM(model="gpt-oss-120b", reasoning_format="hidden")
```

## Test plan

- Added `tests/test_reasoning_format.py` (hermetic, `--unit`) asserting the option is threaded into `extra_body` and omitted (`NOT_GIVEN`) by default for both providers.
- `ruff check` and `ruff format --check` pass on the changed files.