### PR TITLE
fix(tokenize): drop trailing whitespace-only sentence in blingfire retain_format

### DIFF
--- a/livekit-agents/livekit/agents/tokenize/blingfire.py
+++ b/livekit-agents/livekit/agents/tokenize/blingfire.py
@@ -35,10 +35,12 @@ def _split_sentences(
 
     if start < len(text):
         raw_sentence = text[start:]
-        if retain_format:
-            merged_sentences.append((raw_sentence, start, len(text)))
-        elif sentence := raw_sentence.strip():
-            merged_sentences.append((sentence, start, len(text)))
+        # only emit the trailing segment when it has actual content; a trailing
+        # whitespace-only segment (e.g. "\n\n") must be dropped here too, otherwise
+        # retain_format would forward it to the TTS as an empty sentence — unlike the
+        # non-retain path, which strips and skips empties.
+        if stripped := raw_sentence.strip():
+            merged_sentences.append((raw_sentence if retain_format else stripped, start, len(text)))
 
     return merged_sentences
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -120,6 +120,32 @@ async def test_streamed_sent_tokenizer(tokenizer: tokenize.SentenceTokenizer, ex
         assert ev.token == expected[i]
 
 
+@pytest.mark.parametrize("trailing", ["\n\n", "   ", "\n", " \n "])
+def test_retain_format_drops_trailing_whitespace(trailing: str):
+    # retain_format must not emit a trailing whitespace-only "sentence"; it should
+    # match the non-retain path, which strips and skips empty segments. Otherwise the
+    # blank segment is forwarded to the TTS as an empty sentence.
+    text = "This is a real sentence to speak." + trailing
+
+    plain = blingfire.SentenceTokenizer(min_sentence_len=20).tokenize(text=text)
+    retained = blingfire.SentenceTokenizer(min_sentence_len=20, retain_format=True).tokenize(
+        text=text
+    )
+
+    assert all(tok.strip() for tok in retained), retained
+    assert [tok.strip() for tok in retained] == plain
+
+
+async def test_retain_format_stream_drops_trailing_whitespace():
+    text = "This is a real sentence to speak.\n\n"
+    stream = blingfire.SentenceTokenizer(min_sentence_len=20, retain_format=True).stream()
+    stream.push_text(text)
+    stream.end_input()
+
+    tokens = [ev.token async for ev in stream]
+    assert all(tok.strip() for tok in tokens), tokens
+
+
 WORDS_TEXT = "This is a test. Blabla another test! multiple consecutive spaces:     done"
 WORDS_EXPECTED = [
     "This",


### PR DESCRIPTION
Closes #6296

## Summary

`blingfire.SentenceTokenizer` (the **default** sentence tokenizer for the TTS `StreamAdapter`) emits a trailing **whitespace-only** token when `retain_format=True` and the input ends in whitespace.

In `_split_sentences`, the trailing segment is appended unconditionally in `retain_format` mode, while the non-retain path already strips and skips empty segments — so the two paths disagree:

```python
# before
if start < len(text):
    raw_sentence = text[start:]
    if retain_format:
        merged_sentences.append((raw_sentence, start, len(text)))   # "\n\n" leaks through
    elif sentence := raw_sentence.strip():
        merged_sentences.append((sentence, start, len(text)))
```

### Reproduction

```python
from livekit.agents.tokenize import blingfire

tok = blingfire.SentenceTokenizer(min_sentence_len=20, retain_format=True)
print(tok.tokenize("This is a real sentence to speak.\n\n"))
# ['This is a real sentence to speak.', '\n\n']   <-- trailing '\n\n' is a spurious empty sentence

blingfire.SentenceTokenizer(min_sentence_len=20).tokenize("This is a real sentence to speak.\n\n")
# ['This is a real sentence to speak.']           <-- non-retain path correctly drops it
```

The same empty token is produced by the streamed path, and `StreamAdapterWrapper._synthesize` pushes it into the **timed transcript** (`push_timed_transcript`) unconditionally — the audio synth call itself is already guarded by a `.strip()` check, so this is about tokenizer-contract correctness and clean transcript/`.tokenize()` output rather than empty TTS requests.

## Fix

Guard the trailing segment with the same `strip()`/non-empty check so `retain_format` matches the non-retain behavior, while still preserving the original formatting of *real* trailing content (e.g. a retained `"\n\nMore"` is kept intact).

## Test plan

- Added parametrized regression tests in `tests/test_tokenizer.py` (`pytest.mark.unit`) covering trailing `"\n\n"`, `"   "`, `"\n"`, `" \n "` for both `.tokenize()` and the streamed path, asserting no whitespace-only tokens are emitted and that `retain_format` output matches the stripped non-retain output.
- Verified against the real `livekit-blingfire` library that legitimate trailing content (including retained leading whitespace like `" Two good long sentence here."` and `"\n\nMore"`) is preserved.
- `ruff check` and `ruff format --check` pass on the changed files.