### PR TITLE
fix(openai): emit start/end of speech events for realtime STT AGT-3051

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -492,7 +492,7 @@ class SpeechStream(stt.SpeechStream):
         self._reconnect_event.set()
 
     def _start_speaking(self) -> None:
-        # duplicates happen, e.g. a reconnect mid-speech re-detects the onset
+        # keep START/END strictly alternating even if a source double-fires
         if self._speaking:
             return
         self._speaking = True
@@ -686,6 +686,9 @@ class SpeechStream(stt.SpeechStream):
 
         while True:
             closing_ws = False  # reset the flag
+            # close any speech segment left open by a dropped or recycled connection;
+            # the new session re-detects ongoing speech and starts a fresh segment
+            self._stop_speaking()
             async with self._pool.connection(timeout=self._conn_options.timeout) as ws:
                 self._report_connection_acquired(
                     self._pool.last_acquire_time, self._pool.last_connection_reused

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -480,6 +480,7 @@ class SpeechStream(stt.SpeechStream):
         self._request_id = ""
         self._reconnect_event = asyncio.Event()
         self._vad = vad_instance
+        self._speaking = False
 
     def update_options(
         self,
@@ -489,6 +490,19 @@ class SpeechStream(stt.SpeechStream):
         self._language = LanguageCode(language)
         self._pool.invalidate()
         self._reconnect_event.set()
+
+    def _start_speaking(self) -> None:
+        # duplicates happen, e.g. a reconnect mid-speech re-detects the onset
+        if self._speaking:
+            return
+        self._speaking = True
+        self._event_ch.send_nowait(stt.SpeechEvent(type=stt.SpeechEventType.START_OF_SPEECH))
+
+    def _stop_speaking(self) -> None:
+        if not self._speaking:
+            return
+        self._speaking = False
+        self._event_ch.send_nowait(stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH))
 
     @utils.log_exceptions(logger=logger)
     async def _run(self) -> None:
@@ -530,7 +544,10 @@ class SpeechStream(stt.SpeechStream):
         @utils.log_exceptions(logger=logger)
         async def vad_task(ws: aiohttp.ClientWebSocketResponse, vad_stream: vad.VADStream) -> None:
             async for ev in vad_stream:
-                if ev.type == vad.VADEventType.END_OF_SPEECH:
+                if ev.type == vad.VADEventType.START_OF_SPEECH:
+                    self._start_speaking()
+                elif ev.type == vad.VADEventType.END_OF_SPEECH:
+                    self._stop_speaking()
                     await ws.send_json({"type": "input_audio_buffer.commit"})
 
         @utils.log_exceptions(logger=logger)
@@ -570,12 +587,16 @@ class SpeechStream(stt.SpeechStream):
                         current_item_id = item_id
                         audio_start_ms = data.get("audio_start_ms", 0)
                         item_audio_timing[item_id] = {"start_ms": audio_start_ms}
+                        if self._vad is None:
+                            self._start_speaking()
 
                     elif msg_type == "input_audio_buffer.speech_stopped":
                         item_id = data.get("item_id", "")
                         audio_end_ms = data.get("audio_end_ms", 0)
                         if item_id in item_audio_timing:
                             item_audio_timing[item_id]["end_ms"] = audio_end_ms
+                        if self._vad is None:
+                            self._stop_speaking()
 
                     elif msg_type == "conversation.item.input_audio_transcription.delta":
                         delta = data.get("delta", "")

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -685,8 +685,7 @@ class SpeechStream(stt.SpeechStream):
 
         while True:
             closing_ws = False  # reset the flag
-            # close any speech segment left open by a dropped or recycled connection;
-            # the new session re-detects ongoing speech and starts a fresh segment
+            # a segment left open across the reconnect gap would fuse into the next utterance
             self._stop_speaking()
             async with self._pool.connection(timeout=self._conn_options.timeout) as ws:
                 self._report_connection_acquired(

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -492,7 +492,6 @@ class SpeechStream(stt.SpeechStream):
         self._reconnect_event.set()
 
     def _start_speaking(self) -> None:
-        # keep START/END strictly alternating even if a source double-fires
         if self._speaking:
             return
         self._speaking = True

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -75,11 +75,16 @@ STTs: list[Callable[[], stt.STT]] = [
 ] + [
     pytest.param(lambda: cartesia.STT(model="ink-whisper"), id="livekit.plugins.cartesia._legacy"),
     pytest.param(lambda: deepgram.STTv2(), id="livekit.plugins.deepgram.STTv2"),
-    pytest.param(lambda: openai.STT(use_realtime=True), id="livekit.plugins.openai.realtime"),
     pytest.param(
         lambda: gradium.STT(model_endpoint="wss://us.api.gradium.ai/api/speech/asr"),
         id="livekit.plugins.gradium.STT",
     ),
+]
+
+# entries whose recognize() path is identical to an existing STTs entry, so they only
+# add value to test_stream (openai realtime shares the REST path with openai.STT())
+STREAM_ONLY_STTs: list[Callable[[], stt.STT]] = [
+    pytest.param(lambda: openai.STT(use_realtime=True), id="livekit.plugins.openai.realtime"),
 ]
 
 
@@ -175,7 +180,7 @@ async def test_recognize(stt_factory: Callable[[], stt.STT], request):
 
 
 @pytest.mark.usefixtures("job_process")
-@pytest.mark.parametrize("stt_factory", STTs)
+@pytest.mark.parametrize("stt_factory", STTs + STREAM_ONLY_STTs)
 async def test_stream(stt_factory: Callable[[], STT], request):
     sample_rate = SAMPLE_RATE
     plugin_id = request.node.callspec.id.split("-")[0]

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -75,6 +75,7 @@ STTs: list[Callable[[], stt.STT]] = [
 ] + [
     pytest.param(lambda: cartesia.STT(model="ink-whisper"), id="livekit.plugins.cartesia._legacy"),
     pytest.param(lambda: deepgram.STTv2(), id="livekit.plugins.deepgram.STTv2"),
+    pytest.param(lambda: openai.STT(use_realtime=True), id="livekit.plugins.openai.realtime"),
     pytest.param(
         lambda: gradium.STT(model_endpoint="wss://us.api.gradium.ai/api/speech/asr"),
         id="livekit.plugins.gradium.STT",
@@ -211,6 +212,7 @@ async def test_stream(stt_factory: Callable[[], STT], request):
                     recv_start, recv_end = False, True
                     start_time = time.time()
                     got_final_transcript = False
+                    sos_count, final_count = 0, 0
 
                     async for event in stream:
                         if event.type == agents.stt.SpeechEventType.START_OF_SPEECH:
@@ -220,6 +222,7 @@ async def test_stream(stt_factory: Callable[[], STT], request):
                             assert not recv_start
                             recv_end = False
                             recv_start = True
+                            sos_count += 1
                             continue
 
                         if event.type == agents.stt.SpeechEventType.FINAL_TRANSCRIPT:
@@ -232,6 +235,7 @@ async def test_stream(stt_factory: Callable[[], STT], request):
                                 assert language is not None
                                 assert language.lower().startswith("en")
                             got_final_transcript = True
+                            final_count += 1
                             # Some providers don't send END_OF_SPEECH, break after final transcript
                             if state["closing"]:
                                 break
@@ -240,7 +244,8 @@ async def test_stream(stt_factory: Callable[[], STT], request):
                             recv_start = False
                             recv_end = True
                             await asyncio.sleep(1)
-                            if state["closing"]:
+                            # some providers emit END_OF_SPEECH before the segment's final transcript
+                            if state["closing"] and final_count >= sos_count:
                                 break
 
                     dt = time.time() - start_time


### PR DESCRIPTION
The realtime transcription stream consumed the server VAD's `speech_started`/`speech_stopped` messages only for item timing and never surfaced them as SpeechEvents. Under `turn_detection="stt"` the session relies on `END_OF_SPEECH` to commit the user turn, so an STT fallback landing on this leg stalled turns until the caller hung up (observed in production).

Now emitted from the server VAD messages, or from the local VAD stream when one is assigned (server events are ignored then, so a single source owns the speech boundaries).

The cross-provider stream test broke 1s after `END_OF_SPEECH`, racing the segment's final transcript, which openai delivers after the speech boundary; it now breaks only once every started segment has a final. Verified live: `test_stream[livekit.plugins.openai.realtime]` (new param) and both deepgram variants pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)