### PR TITLE
fix incorrect attribution of latency in tts.ttfb

### DIFF
--- a/livekit-agents/livekit/agents/tts/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/tts/fallback_adapter.py
@@ -12,12 +12,7 @@ from livekit import rtc
 from .. import utils
 from .._exceptions import APIConnectionError
 from ..log import logger
-from ..types import (
-    DEFAULT_API_CONNECT_OPTIONS,
-    USERDATA_TIMED_TRANSCRIPT,
-    USERDATA_TTS_STARTED_TIME,
-    APIConnectOptions,
-)
+from ..types import DEFAULT_API_CONNECT_OPTIONS, USERDATA_TIMED_TRANSCRIPT, APIConnectOptions
 from ..utils import aio
 from .stream_adapter import StreamAdapter
 from .tts import (
@@ -237,14 +232,6 @@ class FallbackChunkedStream(ChunkedStream):
                         if texts := synthesized_audio.frame.userdata.get(USERDATA_TIMED_TRANSCRIPT):
                             output_emitter.push_timed_transcript(texts)
 
-                        # we re-emit new frames through our own AudioEmitter, so carry over
-                        # the started time of the TTS that is actually producing audio;
-                        # our creation time would include time spent on failed attempts
-                        if started_time := synthesized_audio.frame.userdata.get(
-                            USERDATA_TTS_STARTED_TIME
-                        ):
-                            self._started_time = started_time
-
                         if resampler is not None:
                             for rf in resampler.push(synthesized_audio.frame):
                                 output_emitter.push(rf.data.tobytes())
@@ -321,9 +308,17 @@ class FallbackSynthesizeStream(SynthesizeStream):
 
         input_task = asyncio.create_task(_forward_input_task())
 
+        def _capture_started_time() -> None:
+            # ttfb measures the fallback adapter as a whole: anchor on the first time a
+            # sentence was handed to any underlying TTS — even one that failed before
+            # emitting audio — and never overwrite it when falling back to another TTS
+            if not recovering and not self._started_time and stream._started_time:
+                self._started_time = stream._started_time
+
         try:
             async with stream:
                 async for audio in stream:
+                    _capture_started_time()
                     yield audio
         except Exception as e:
             if recovering:
@@ -341,6 +336,7 @@ class FallbackSynthesizeStream(SynthesizeStream):
             )
             raise
         finally:
+            _capture_started_time()
             await utils.aio.cancel_and_wait(input_task)
 
     async def _run(self, output_emitter: AudioEmitter) -> None:
@@ -411,14 +407,6 @@ class FallbackSynthesizeStream(SynthesizeStream):
                                 USERDATA_TIMED_TRANSCRIPT
                             ):
                                 output_emitter.push_timed_transcript(texts)
-
-                            # we re-emit new frames through our own AudioEmitter, so carry over
-                            # the time the active TTS first sent text to its provider;
-                            # __anext__ stamps it onto the outgoing frames
-                            if started_time := synthesized_audio.frame.userdata.get(
-                                USERDATA_TTS_STARTED_TIME
-                            ):
-                                self._started_time = started_time
 
                             if resampler is not None:
                                 for resampled_frame in resampler.push(synthesized_audio.frame):

--- a/livekit-agents/livekit/agents/tts/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/tts/fallback_adapter.py
@@ -12,7 +12,12 @@ from livekit import rtc
 from .. import utils
 from .._exceptions import APIConnectionError
 from ..log import logger
-from ..types import DEFAULT_API_CONNECT_OPTIONS, USERDATA_TIMED_TRANSCRIPT, APIConnectOptions
+from ..types import (
+    DEFAULT_API_CONNECT_OPTIONS,
+    USERDATA_TIMED_TRANSCRIPT,
+    USERDATA_TTS_STARTED_TIME,
+    APIConnectOptions,
+)
 from ..utils import aio
 from .stream_adapter import StreamAdapter
 from .tts import (
@@ -398,6 +403,14 @@ class FallbackSynthesizeStream(SynthesizeStream):
                                 USERDATA_TIMED_TRANSCRIPT
                             ):
                                 output_emitter.push_timed_transcript(texts)
+
+                            # we re-emit new frames through our own AudioEmitter, so carry over
+                            # the time the active TTS first sent text to its provider;
+                            # __anext__ stamps it onto the outgoing frames
+                            if started_time := synthesized_audio.frame.userdata.get(
+                                USERDATA_TTS_STARTED_TIME
+                            ):
+                                self._started_time = started_time
 
                             if resampler is not None:
                                 for resampled_frame in resampler.push(synthesized_audio.frame):

--- a/livekit-agents/livekit/agents/tts/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/tts/fallback_adapter.py
@@ -237,6 +237,14 @@ class FallbackChunkedStream(ChunkedStream):
                         if texts := synthesized_audio.frame.userdata.get(USERDATA_TIMED_TRANSCRIPT):
                             output_emitter.push_timed_transcript(texts)
 
+                        # we re-emit new frames through our own AudioEmitter, so carry over
+                        # the started time of the TTS that is actually producing audio;
+                        # our creation time would include time spent on failed attempts
+                        if started_time := synthesized_audio.frame.userdata.get(
+                            USERDATA_TTS_STARTED_TIME
+                        ):
+                            self._started_time = started_time
+
                         if resampler is not None:
                             for rf in resampler.push(synthesized_audio.frame):
                                 output_emitter.push(rf.data.tobytes())

--- a/livekit-agents/livekit/agents/tts/stream_adapter.py
+++ b/livekit-agents/livekit/agents/tts/stream_adapter.py
@@ -128,6 +128,7 @@ class StreamAdapterWrapper(SynthesizeStream):
                 if not (text := ev.token.strip()):
                     continue
 
+                self._mark_started()
                 async with self._tts._wrapped_tts.synthesize(
                     text, conn_options=self._wrapped_tts_conn_options
                 ) as tts_stream:

--- a/livekit-agents/livekit/agents/tts/tts.py
+++ b/livekit-agents/livekit/agents/tts/tts.py
@@ -20,7 +20,12 @@ from .._exceptions import APIError, APIStatusError
 from ..log import logger
 from ..metrics import TTSMetrics
 from ..telemetry import trace_types, tracer, utils as telemetry_utils
-from ..types import DEFAULT_API_CONNECT_OPTIONS, USERDATA_TIMED_TRANSCRIPT, APIConnectOptions
+from ..types import (
+    DEFAULT_API_CONNECT_OPTIONS,
+    USERDATA_TIMED_TRANSCRIPT,
+    USERDATA_TTS_STARTED_TIME,
+    APIConnectOptions,
+)
 from ..utils import aio, audio, codecs, log_exceptions, shortuuid
 
 if TYPE_CHECKING:
@@ -181,6 +186,8 @@ class ChunkedStream(ABC):
         self._input_text = input_text
         self._tts = tts
         self._conn_options = conn_options
+        # the full text is submitted to the provider at creation time
+        self._started_time: float = time.perf_counter()
         self._event_ch = aio.Chan[SynthesizedAudio]()
         self._input_tokens = 0
         self._output_tokens = 0
@@ -356,6 +363,7 @@ class ChunkedStream(ABC):
 
             raise StopAsyncIteration from None
 
+        val.frame.userdata[USERDATA_TTS_STARTED_TIME] = self._started_time
         return val
 
     def __aiter__(self) -> AsyncIterator[SynthesizedAudio]:
@@ -694,6 +702,10 @@ class SynthesizeStream(ABC):
 
             raise StopAsyncIteration from None
 
+        # _started_time is 0 until _mark_started() (first text sent to the provider);
+        # it is also reset to 0 between segments after metrics are emitted
+        if self._started_time:
+            val.frame.userdata[USERDATA_TTS_STARTED_TIME] = self._started_time
         return val
 
     def __aiter__(self) -> AsyncIterator[SynthesizedAudio]:

--- a/livekit-agents/livekit/agents/types.py
+++ b/livekit-agents/livekit/agents/types.py
@@ -49,6 +49,13 @@ USERDATA_TIMED_TRANSCRIPT = "lk.timed_transcripts"
 The key for the timed transcripts in the audio frame userdata.
 """
 
+USERDATA_TTS_STARTED_TIME = "lk.tts_started_time"
+"""
+The key for the time (``time.perf_counter()``) at which the synthesized text was first
+sent to the TTS provider, attached to the audio frame userdata. Used to compute TTFB
+without attributing upstream (e.g. LLM streaming) latency to the TTS.
+"""
+
 
 _T = TypeVar("_T")
 

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -24,7 +24,12 @@ from ..llm import (
 from ..llm.chat_context import Instructions
 from ..log import logger
 from ..telemetry import trace_types, tracer
-from ..types import USERDATA_TIMED_TRANSCRIPT, FlushSentinel, NotGivenOr
+from ..types import (
+    USERDATA_TIMED_TRANSCRIPT,
+    USERDATA_TTS_STARTED_TIME,
+    FlushSentinel,
+    NotGivenOr,
+)
 from ..utils import aio
 from ..utils.aio import itertools
 from . import io
@@ -347,9 +352,17 @@ async def _tts_inference_task(
 
         audio_duration = 0.0
         async for audio_frame in tts_node:
-            if start_time is not None and data.ttfb is None:
-                data.ttfb = time.perf_counter() - start_time
-                current_span.set_attribute(trace_types.ATTR_RESPONSE_TTFB, data.ttfb)
+            if data.ttfb is None:
+                # the framework TTS streams attach the time the text was first sent to the
+                # provider; without it (custom tts_node), fall back to the arrival of the
+                # first input token, which also counts any text buffering (e.g. sentence
+                # tokenization) as TTFB
+                anchor: float | None = audio_frame.userdata.get(
+                    USERDATA_TTS_STARTED_TIME, start_time
+                )
+                if anchor is not None:
+                    data.ttfb = time.perf_counter() - anchor
+                    current_span.set_attribute(trace_types.ATTR_RESPONSE_TTFB, data.ttfb)
 
             for text in audio_frame.userdata.get(USERDATA_TIMED_TRANSCRIPT, []):
                 if isinstance(text, io.TimedString):

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -192,6 +192,36 @@ async def test_events_and_metrics() -> None:
     check_timestamp(metrics_events[2].metrics.audio_duration, 2.0, speed_factor=speed)
 
 
+async def test_tts_node_ttfb_excludes_upstream_latency() -> None:
+    # the LLM stream stays open for its full duration and the fake TTS only starts
+    # synthesizing once its input is flushed. tts_node_ttfb must anchor on the text
+    # being handed to the TTS provider (~2.0s in), not on the first LLM token (~0.1s in),
+    # otherwise the LLM streaming time is misattributed to the TTS
+    speed = 1
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "Hello, how are you?", stt_delay=0.2)
+    actions.add_llm("I'm doing well, thank you!", ttft=0.1, duration=2.0)
+    actions.add_tts(1.0, ttfb=0.2, duration=0.3)
+
+    session = create_session(actions, speed_factor=speed)
+    agent = MyAgent()
+
+    conversation_events: list[ConversationItemAddedEvent] = []
+    session.on("conversation_item_added", conversation_events.append)
+
+    await asyncio.wait_for(run_session(session, agent), timeout=SESSION_TIMEOUT)
+
+    assistant_messages = [
+        ev.item
+        for ev in conversation_events
+        if ev.item.type == "message" and ev.item.role == "assistant"
+    ]
+    assert len(assistant_messages) == 1
+    metrics = assistant_messages[0].metrics
+    assert "tts_node_ttfb" in metrics
+    check_timestamp(metrics["tts_node_ttfb"], 0.2, speed_factor=speed)
+
+
 async def test_tool_call() -> None:
     speed = 1
     actions = FakeActions()

--- a/tests/test_tts_fallback.py
+++ b/tests/test_tts_fallback.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import time
 
 import pytest
 
@@ -161,6 +162,35 @@ async def test_tts_stream_started_time_propagated() -> None:
 
     assert frames
     assert all(USERDATA_TTS_STARTED_TIME in f.frame.userdata for f in frames)
+
+    await fallback_adapter.aclose()
+
+
+async def test_tts_chunked_started_time_propagated() -> None:
+    # after a failover, the started time stamped on outgoing frames must reflect the
+    # TTS that actually produced audio, not include the time spent on the failed attempt
+    fake1 = FakeTTS(fake_timeout=10.0)  # always times out
+    fake2 = FakeTTS(fake_audio_duration=5.0)
+
+    fallback_adapter = FallbackAdapterTester([fake1, fake2])
+
+    start = time.perf_counter()
+    async with fallback_adapter.synthesize(
+        "hello test",
+        conn_options=APIConnectOptions(timeout=0.5, max_retry=0, retry_interval=0.1),
+    ) as stream:
+        frames: list[SynthesizedAudio] = []
+        async for data in stream:
+            frames.append(data)
+
+    assert frames
+    started_times = {f.frame.userdata.get(USERDATA_TTS_STARTED_TIME) for f in frames}
+    assert len(started_times) == 1, "all frames should carry the same started time"
+    started_time = started_times.pop()
+    assert started_time is not None
+    # fake1 burns 2 attempts of 0.5s timeout (+ 0.1s retry interval) before the fallback
+    # switches to fake2; the stamped time must anchor on fake2, not our creation time
+    assert started_time >= start + 1.0
 
     await fallback_adapter.aclose()
 

--- a/tests/test_tts_fallback.py
+++ b/tests/test_tts_fallback.py
@@ -9,6 +9,7 @@ from livekit import rtc
 from livekit.agents import APIConnectionError, APIConnectOptions, APIError, utils
 from livekit.agents.tts import TTS, AvailabilityChangedEvent, FallbackAdapter
 from livekit.agents.tts.tts import SynthesizedAudio, SynthesizeStream
+from livekit.agents.types import USERDATA_TTS_STARTED_TIME
 from livekit.agents.utils.aio.channel import ChanEmpty
 
 from .fake_tts import FakeTTS
@@ -138,6 +139,28 @@ async def test_tts_stream_fallback() -> None:
         assert fake2.stream_ch.recv_nowait()
 
     assert not fallback_adapter.availability_changed_ch(fake1).recv_nowait().available
+
+    await fallback_adapter.aclose()
+
+
+async def test_tts_stream_started_time_propagated() -> None:
+    # the fallback adapter re-emits new frames, so the tts started time stamped by the
+    # underlying stream (used for ttfb attribution) must be carried over
+    fake1 = FakeTTS(fake_exception=APIConnectionError("fake1 failed"))
+    fake2 = FakeTTS(fake_audio_duration=5.0)
+
+    fallback_adapter = FallbackAdapterTester([fake1, fake2])
+
+    async with fallback_adapter.stream() as stream:
+        stream.push_text("hello test")
+        stream.end_input()
+
+        frames: list[SynthesizedAudio] = []
+        async for data in stream:
+            frames.append(data)
+
+    assert frames
+    assert all(USERDATA_TTS_STARTED_TIME in f.frame.userdata for f in frames)
 
     await fallback_adapter.aclose()
 

--- a/tests/test_tts_fallback.py
+++ b/tests/test_tts_fallback.py
@@ -144,15 +144,19 @@ async def test_tts_stream_fallback() -> None:
     await fallback_adapter.aclose()
 
 
-async def test_tts_stream_started_time_propagated() -> None:
-    # the fallback adapter re-emits new frames, so the tts started time stamped by the
-    # underlying stream (used for ttfb attribution) must be carried over
-    fake1 = FakeTTS(fake_exception=APIConnectionError("fake1 failed"))
+async def test_tts_stream_ttfb_includes_failover_time() -> None:
+    # the fallback adapter is measured as a single TTS node: ttfb anchors on the first
+    # time a sentence was handed to any underlying TTS and is kept when falling back,
+    # so time spent failing over counts towards ttfb
+    fake1 = FakeTTS(fake_timeout=0.5, fake_exception=APIConnectionError("fake1 failed"))
     fake2 = FakeTTS(fake_audio_duration=5.0)
 
     fallback_adapter = FallbackAdapterTester([fake1, fake2])
 
-    async with fallback_adapter.stream() as stream:
+    async with fallback_adapter.stream(
+        conn_options=APIConnectOptions(timeout=10.0, max_retry=0, retry_interval=0.1)
+    ) as stream:
+        start = time.perf_counter()
         stream.push_text("hello test")
         stream.end_input()
 
@@ -161,14 +165,21 @@ async def test_tts_stream_started_time_propagated() -> None:
             frames.append(data)
 
     assert frames
-    assert all(USERDATA_TTS_STARTED_TIME in f.frame.userdata for f in frames)
+    started_times = {f.frame.userdata.get(USERDATA_TTS_STARTED_TIME) for f in frames}
+    assert len(started_times) == 1, "all frames should carry the same started time"
+    started_time = started_times.pop()
+    assert started_time is not None
+    # fake1 receives the sentence 0.5s in (after its fake connection delay) and fails
+    # without audio after two attempts (~1.1s); the anchor must stay on fake1's first
+    # attempt rather than moving to fake2's
+    assert started_time == pytest.approx(start + 0.5, abs=0.1)
 
     await fallback_adapter.aclose()
 
 
-async def test_tts_chunked_started_time_propagated() -> None:
-    # after a failover, the started time stamped on outgoing frames must reflect the
-    # TTS that actually produced audio, not include the time spent on the failed attempt
+async def test_tts_chunked_ttfb_includes_failover_time() -> None:
+    # same as above for the chunked path: the ChunkedStream base stamps its creation time
+    # (when the full text was submitted), which must not be overridden on failover
     fake1 = FakeTTS(fake_timeout=10.0)  # always times out
     fake2 = FakeTTS(fake_audio_duration=5.0)
 
@@ -188,9 +199,7 @@ async def test_tts_chunked_started_time_propagated() -> None:
     assert len(started_times) == 1, "all frames should carry the same started time"
     started_time = started_times.pop()
     assert started_time is not None
-    # fake1 burns 2 attempts of 0.5s timeout (+ 0.1s retry interval) before the fallback
-    # switches to fake2; the stamped time must anchor on fake2, not our creation time
-    assert started_time >= start + 1.0
+    assert started_time == pytest.approx(start, abs=0.1)
 
     await fallback_adapter.aclose()
 


### PR DESCRIPTION
the pipeline's measurement of ttfb (attached to tts_node) was incorrect. it only looked at when the first token was available, ignoring when the sentence was actually sent to the TTS.