### PR TITLE
fix(liveavatar): preserve provider status errors

### DIFF
--- a/livekit-plugins/livekit-plugins-liveavatar/livekit/plugins/liveavatar/api.py
+++ b/livekit-plugins/livekit-plugins-liveavatar/livekit/plugins/liveavatar/api.py
@@ -121,6 +121,9 @@ class LiveAvatarAPI:
                             body=text,
                         )
                     return await response.json()  # type: ignore
+            except APIStatusError as e:
+                if not e.retryable or i >= self._conn_options.max_retry - 1:
+                    raise
             except (aiohttp.ClientError, asyncio.TimeoutError) as e:
                 logger.warning(
                     f"API request to {url} failed on attempt {i}",

--- a/livekit-plugins/livekit-plugins-liveavatar/tests/test_api.py
+++ b/livekit-plugins/livekit-plugins-liveavatar/tests/test_api.py
@@ -1,0 +1,45 @@
+import pytest
+
+from livekit.agents import APIConnectOptions, APIStatusError
+from livekit.plugins.liveavatar.api import LiveAvatarAPI
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeResponse:
+    def __init__(self, *, status: int, body: str) -> None:
+        self.status = status
+        self.ok = False
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def text(self) -> str:
+        return self._body
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse) -> None:
+        self.response = response
+
+    def post(self, *, url: str, headers: dict, json: dict):
+        return self.response
+
+
+async def test_post_preserves_non_retryable_status_error():
+    api = LiveAvatarAPI(
+        api_key="test-key",
+        conn_options=APIConnectOptions(max_retry=1, retry_interval=0),
+        session=_FakeSession(_FakeResponse(status=401, body='{"error":"bad api key"}')),
+    )
+
+    with pytest.raises(APIStatusError) as exc:
+        await api._post(endpoint="/token", payload={}, headers={})
+
+    assert exc.value.status_code == 401
+    assert exc.value.body == '{"error":"bad api key"}'
+    assert exc.value.retryable is False


### PR DESCRIPTION
﻿This PR keeps LiveAvatar provider status failures from being swallowed by the generic retry fallback, so callers can see the original status code, response body, and retryability.

## What Problem This Solves

`LiveAvatarAPI._post()` correctly creates an `APIStatusError` when the provider returns a non-OK HTTP response:

```py
if not response.ok:
    text = await response.text()
    raise APIStatusError(
        f"Server returned an error for {url}: {response.status}",
        status_code=response.status,
        body=text,
    )
```

However, that exception currently falls into the later broad handler:

```py
except Exception:
    logger.exception("failed to call LiveAvatar API")
```

After the retry loop exits, callers only receive:

```py
APIConnectionError("Failed to call LiveAvatar API after all retries.")
```

That hides the actual provider response. A 400 or 401 caused by an invalid payload, API key, or session token is reported as a generic connection failure instead of preserving the status code, response body, and non-retryable 4xx semantics. Retryable 5xx responses also lose their final response body when the loop is exhausted.

## Changes

Handle `APIStatusError` explicitly before the broad `except Exception` block.

The new behavior is:

- immediately preserve non-retryable status errors, such as most 4xx responses
- preserve the final retryable status error after retry attempts are exhausted
- keep retry behavior for retryable provider failures before the final attempt
- keep existing handling for `aiohttp.ClientError` and `asyncio.TimeoutError`
- avoid changing successful LiveAvatar request payloads or response parsing

This PR intentionally stays scoped to LiveAvatar status-error preservation. It does not change `max_retry=0` behavior or other avatar providers.

## Evidence

A focused async unit test now uses a fake HTTP session that returns a 401 response body:

```py
api = LiveAvatarAPI(
    api_key="test-key",
    conn_options=APIConnectOptions(max_retry=1, retry_interval=0),
    session=_FakeSession(_FakeResponse(status=401, body='{"error":"bad api key"}')),
)

with pytest.raises(APIStatusError) as exc:
    await api._post(endpoint="/token", payload={}, headers={})

assert exc.value.status_code == 401
assert exc.value.body == '{"error":"bad api key"}'
assert exc.value.retryable is False
```

Before this fix, the `APIStatusError` is swallowed inside `_post()` and the caller receives a generic `APIConnectionError` without `status_code` or response `body`.

After this fix, non-retryable provider responses preserve the original `APIStatusError`.

## Possible call chain / impact

```text
LiveAvatar session lifecycle
  -> LiveAvatarAPI.create_streaming_session(...)
  -> LiveAvatarAPI.start_streaming_session(...)
  -> LiveAvatarAPI.stop_streaming_session(...)
    -> LiveAvatarAPI._post(...)
      -> aiohttp response with ok == False
      -> APIStatusError(status_code=response.status, body=await response.text())
      -> broad except currently catches it
      -> generic APIConnectionError is raised after retries
```

The affected surface is LiveAvatar provider diagnostics and retry classification for non-OK HTTP responses.

Sibling surfaces checked:

- `APIStatusError` already carries status code, response body, and retryability.
- D-ID preserves `APIStatusError` instead of collapsing it into a connection error.
- Anam only catches transport errors in the equivalent path, so status errors naturally propagate.
- Tavus has a similar broad-catch shape, but this PR intentionally stays scoped to LiveAvatar.

This PR does not change LiveAvatar request construction, endpoint paths, auth header construction, JSON parsing for successful responses, or avatar session control flow.

## Validation

```bash
PYTHONPATH="livekit-agents;livekit-plugins/livekit-plugins-liveavatar" uv run --no-sync pytest livekit-plugins/livekit-plugins-liveavatar/tests/test_api.py -q
uv run --no-sync ruff check livekit-plugins/livekit-plugins-liveavatar/livekit/plugins/liveavatar/api.py livekit-plugins/livekit-plugins-liveavatar/tests/test_api.py
uv run --no-sync ruff format --check livekit-plugins/livekit-plugins-liveavatar/livekit/plugins/liveavatar/api.py livekit-plugins/livekit-plugins-liveavatar/tests/test_api.py
git diff --check
```

All commands passed locally. The focused pytest command uses `PYTHONPATH` because this local Windows checkout did not install the LiveAvatar plugin package into the active environment; the test itself does not require real LiveAvatar credentials or network access.
