### PR TITLE
fix(voice): race between session.run and an in-flight AgentTask handoff

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -873,6 +873,12 @@ class AgentTask(Agent, Generic[TaskResult_T]):
         # won't wait for tasks blocked on this handoff
         old_activity._add_drain_blocked_tasks(blocked_tasks)
 
+        # watch the blocked tasks so an active run won't complete mid-handoff
+        # (the parent speech may predate the run, e.g. created in on_enter)
+        if (run_state := session._global_run_state) and not run_state.done():
+            for task in blocked_tasks:
+                run_state._watch_handle(task)
+
         if (
             task_info.function_call
             and isinstance(old_activity.llm, RealtimeModel)

--- a/tests/test_nested_agent_task.py
+++ b/tests/test_nested_agent_task.py
@@ -74,6 +74,84 @@ async def test_nested_agent_task_no_deadlock():
         assert second_result is not None
 
 
+class SimpleTask(AgentTask):
+    """A task that needs a user turn to complete (user must trigger 'finish')."""
+
+    def __init__(self) -> None:
+        super().__init__(instructions="simple task")
+
+    async def on_enter(self) -> None:
+        self.session.generate_reply(instructions="task_greeting")
+
+    @function_tool
+    async def finish(self, ctx: RunContext) -> str:
+        """Called to complete the task."""
+        self.complete(None)
+        return "done"
+
+
+class EnterHandoffAgent(Agent):
+    """Agent whose on_enter reply calls a tool that awaits an AgentTask.
+
+    The on_enter speech predates any session.run(), so the run doesn't watch it.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(instructions="root agent")
+
+    async def on_enter(self) -> None:
+        await self.session.generate_reply(instructions="enter_greeting")
+
+    @function_tool
+    async def start_task(self, ctx: RunContext) -> str:
+        """Transitions into SimpleTask."""
+        await SimpleTask()
+        return "task completed"
+
+
+@pytest.mark.asyncio
+async def test_handoff_from_pre_run_speech():
+    """A handoff triggered by a speech created before session.run() (e.g. in
+    on_enter) must keep the run alive until the new activity has started;
+    otherwise the next run() races the transition and gets rejected."""
+    llm = FakeLLM(
+        fake_responses=[
+            # on_enter generate_reply(instructions="enter_greeting") -> calls start_task;
+            # slow enough that run(user_input="hi") starts before the tool call lands
+            FakeLLMResponse(
+                input="enter_greeting",
+                content="",
+                ttft=1.0,
+                duration=1.0,
+                tool_calls=[FunctionToolCall(name="start_task", arguments="{}", call_id="call_1")],
+            ),
+            # user says "hi" while the handoff is in flight; this is the only
+            # speech the first run watches
+            FakeLLMResponse(input="hi", content="hello!", ttft=1.0, duration=2.0),
+            # SimpleTask on_enter greeting
+            FakeLLMResponse(input="task_greeting", content="hello from task", ttft=0, duration=0),
+            # user says "bye" -> LLM calls finish
+            FakeLLMResponse(
+                input="bye",
+                content="",
+                ttft=0,
+                duration=0,
+                tool_calls=[FunctionToolCall(name="finish", arguments="{}", call_id="call_2")],
+            ),
+            # after start_task tool output, LLM responds
+            FakeLLMResponse(input="task completed", content="all done", ttft=0, duration=0),
+        ]
+    )
+    async with AgentSession(llm=llm) as sess:
+        await sess.start(EnterHandoffAgent())
+
+        await asyncio.wait_for(sess.run(user_input="hi"), timeout=5.0)
+        assert isinstance(sess.current_agent, SimpleTask)
+
+        await asyncio.wait_for(sess.run(user_input="bye"), timeout=5.0)
+        assert isinstance(sess.current_agent, EnterHandoffAgent)
+
+
 def _build_fake_llm() -> FakeLLM:
     return FakeLLM(
         fake_responses=[


### PR DESCRIPTION
fix https://github.com/livekit/agents/issues/6313

**Problem**

An agent handoff triggered by a speech that predates the active run is not watched by `session.run()`'s `RunResult`. For example, when `AgentSession.start()` runs `on_enter` and its reply calls a tool that awaits an `AgentTask`, nothing watches the tasks driving that handoff. The first `session.run()` then completes as soon as its own reply finishes — while the handoff is still mid-transition (old activity paused, new activity not started) — and the next `session.run()` races the handoff and fails with `RuntimeError: cannot schedule new speech, the speech scheduling is draining/pausing` (a hang on 1.6.1).

This can be worked around with `await session.start(agent, capture_run=True)`: the captured run exists before `on_enter` speaks, so the on_enter speech is watched and `start()` waits for the handoff chain to settle before returning.

1.6.0 has the same bug but wins another race: the run still completes mid-handoff, but the next `session.run()`'s speech lands before the old activity is paused, so it is queued on the old activity and answered by the outgoing agent.

**Fix**

`AgentTask.__await_impl` already assumes the tasks driving the handoff (`blocked_tasks`) are watched by the active run — it unwatches them right after installing the new activity's `on_enter` guard. This PR adds them to the run's watch list when the handoff starts, so the run cannot complete mid-handoff; they are unwatched once the handoff settles as before, so the run does not stay blocked on the long-lived tool task.

Added a regression test where the handoff is triggered from a pre-run `on_enter` speech.