### PR TITLE
Add connection pooling for xAI TTS

### DIFF
--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/tts.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/tts.py
@@ -109,6 +109,12 @@ class TTS(tts.TTS):
 
         self._session = http_session
         self._streams = weakref.WeakSet[SynthesizeStream]()
+        self._pool = utils.ConnectionPool[aiohttp.ClientWebSocketResponse](
+            connect_cb=self._connect_pooled_ws,
+            close_cb=self._close_pooled_ws,
+            max_session_duration=3600,
+            mark_refreshed_on_get=False,
+        )
 
     @property
     def model(self) -> str:
@@ -154,6 +160,12 @@ class TTS(tts.TTS):
     async def _close_ws(self, ws: aiohttp.ClientWebSocketResponse) -> None:
         await ws.close()
 
+    async def _connect_pooled_ws(self, timeout: float) -> aiohttp.ClientWebSocketResponse:
+        return await self._connect_ws(timeout, self._opts)
+
+    async def _close_pooled_ws(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        await self._close_ws(ws)
+
     def _ensure_session(self) -> aiohttp.ClientSession:
         if not self._session:
             self._session = utils.http_context.http_session()
@@ -178,6 +190,14 @@ class TTS(tts.TTS):
             speed (float, optional): Speaking-rate multiplier for the generated audio.
             text_normalization (bool, optional): Whether to normalize text before synthesis.
         """  # noqa: E501
+        connection_options_before = (
+            self._opts.voice,
+            self._opts.language,
+            self._opts.optimize_streaming_latency,
+            self._opts.speed,
+            self._opts.text_normalization,
+        )
+
         self._opts.voice = voice or self._opts.voice
         self._opts.language = language or self._opts.language
         if is_given(optimize_streaming_latency):
@@ -186,6 +206,19 @@ class TTS(tts.TTS):
             self._opts.speed = speed
         if is_given(text_normalization):
             self._opts.text_normalization = text_normalization
+
+        connection_options_after = (
+            self._opts.voice,
+            self._opts.language,
+            self._opts.optimize_streaming_latency,
+            self._opts.speed,
+            self._opts.text_normalization,
+        )
+        if connection_options_after != connection_options_before:
+            self._pool.invalidate()
+
+    def prewarm(self) -> None:
+        self._pool.prewarm()
 
     def synthesize(
         self,
@@ -207,6 +240,7 @@ class TTS(tts.TTS):
             await stream.aclose()
 
         self._streams.clear()
+        await self._pool.aclose()
 
 
 class SynthesizeStream(tts.SynthesizeStream):
@@ -323,13 +357,14 @@ class SynthesizeStream(tts.SynthesizeStream):
                 else:
                     logger.warning("Unexpected xAI message %s", data)
 
-        ws = await self._tts._connect_ws(self._conn_options.timeout, self._opts)
-        tasks = [
-            asyncio.create_task(_send_task(ws)),
-            asyncio.create_task(_recv_task(ws)),
-        ]
-        try:
-            await asyncio.gather(*tasks)
-        finally:
-            await utils.aio.gracefully_cancel(*tasks)
-            await self._tts._close_ws(ws)
+        async with self._tts._pool.connection(timeout=self._conn_options.timeout) as ws:
+            self._acquire_time = self._tts._pool.last_acquire_time
+            self._connection_reused = self._tts._pool.last_connection_reused
+            tasks = [
+                asyncio.create_task(_send_task(ws)),
+                asyncio.create_task(_recv_task(ws)),
+            ]
+            try:
+                await asyncio.gather(*tasks)
+            finally:
+                await utils.aio.gracefully_cancel(*tasks)

--- a/tests/test_plugin_xai_tts.py
+++ b/tests/test_plugin_xai_tts.py
@@ -1,0 +1,120 @@
+"""Unit tests for xAI TTS websocket behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import Any
+
+import aiohttp
+import pytest
+
+from livekit.agents import APIConnectOptions
+from livekit.plugins.xai import tts as xai_tts
+
+pytestmark = [pytest.mark.unit, pytest.mark.plugin("xai")]
+
+
+class _FakeWebSocket:
+    def __init__(self, audio: bytes = b"audio") -> None:
+        self._audio = audio
+        self._messages: asyncio.Queue[Any] = asyncio.Queue()
+        self.close_code: int | None = None
+        self.sent: list[dict[str, Any]] = []
+        self.closed = False
+
+    async def send_str(self, data: str) -> None:
+        packet = json.loads(data)
+        self.sent.append(packet)
+        if packet["type"] == "text.done":
+            await self._messages.put(
+                SimpleNamespace(
+                    type=aiohttp.WSMsgType.TEXT,
+                    data=json.dumps(
+                        {
+                            "type": "audio.delta",
+                            "delta": base64.b64encode(self._audio).decode("ascii"),
+                        }
+                    ),
+                )
+            )
+            await self._messages.put(
+                SimpleNamespace(
+                    type=aiohttp.WSMsgType.TEXT,
+                    data=json.dumps({"type": "audio.done"}),
+                )
+            )
+
+    async def receive(self) -> Any:
+        return await self._messages.get()
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _FakeEmitter:
+    def __init__(self) -> None:
+        self.started_segments: list[str] = []
+        self.ended_segments = 0
+        self.audio_chunks: list[bytes] = []
+
+    def start_segment(self, *, segment_id: str) -> None:
+        self.started_segments.append(segment_id)
+
+    def push(self, audio: bytes) -> None:
+        self.audio_chunks.append(audio)
+
+    def end_segment(self) -> None:
+        self.ended_segments += 1
+
+
+def _new_word_stream(tts: xai_tts.TTS, text: str):
+    word_stream = tts._opts.tokenizer.stream()  # pyright: ignore[reportPrivateUsage]
+    word_stream.push_text(text)
+    word_stream.end_input()
+    return word_stream
+
+
+def _new_synthesize_stream(tts: xai_tts.TTS) -> xai_tts.SynthesizeStream:
+    stream = object.__new__(xai_tts.SynthesizeStream)
+    stream._tts = tts  # pyright: ignore[reportPrivateUsage]
+    stream._opts = replace(tts._opts)  # pyright: ignore[reportPrivateUsage]
+    stream._conn_options = APIConnectOptions(max_retry=0, timeout=1.0)  # pyright: ignore[reportPrivateUsage]
+    stream._started_time = 0.0  # pyright: ignore[reportPrivateUsage]
+    stream._acquire_time = 0.0  # pyright: ignore[reportPrivateUsage]
+    stream._connection_reused = False  # pyright: ignore[reportPrivateUsage]
+    return stream
+
+
+@pytest.mark.asyncio
+async def test_streaming_segments_reuse_websocket_connection(monkeypatch: pytest.MonkeyPatch):
+    tts = xai_tts.TTS(api_key="test-key")
+    stream = _new_synthesize_stream(tts)
+    emitter = _FakeEmitter()
+    websockets: list[_FakeWebSocket] = []
+
+    async def connect_ws(*_args: object, **_kwargs: object) -> _FakeWebSocket:
+        ws = _FakeWebSocket()
+        websockets.append(ws)
+        return ws
+
+    async def close_ws(ws: _FakeWebSocket) -> None:
+        await ws.close()
+
+    monkeypatch.setattr(tts, "_connect_ws", connect_ws)
+    monkeypatch.setattr(tts, "_close_ws", close_ws)
+
+    await stream._run_ws(_new_word_stream(tts, "first"), emitter)  # pyright: ignore[reportPrivateUsage]
+    await stream._run_ws(_new_word_stream(tts, "second"), emitter)  # pyright: ignore[reportPrivateUsage]
+
+    assert len(websockets) == 1
+    assert websockets[0].closed is False
+    assert emitter.audio_chunks == [b"audio", b"audio"]
+    assert emitter.ended_segments == 2
+
+    await tts.aclose()
+
+    assert websockets[0].closed is True

--- a/tests/test_plugin_xai_tts.py
+++ b/tests/test_plugin_xai_tts.py
@@ -15,7 +15,7 @@ import pytest
 from livekit.agents import APIConnectOptions
 from livekit.plugins.xai import tts as xai_tts
 
-pytestmark = [pytest.mark.unit, pytest.mark.plugin("xai")]
+pytestmark = pytest.mark.plugin("xai")
 
 
 class _FakeWebSocket:


### PR DESCRIPTION
## Summary

- Add a `ConnectionPool` to the xAI TTS plugin so streamed synthesis segments can reuse websocket connections.
- Expose `prewarm()` through the pool and close pooled connections from `aclose()`.
- Invalidate pooled connections when websocket URL options change.
- Add a plugin regression test that verifies two synthesized segments reuse one websocket and close it only when the TTS instance is closed.

Fixes #6078

## Root cause

The xAI TTS stream opened a websocket with `_connect_ws()` for each synthesized segment and always closed it in `_run_ws()` cleanup. Unlike other websocket-backed TTS plugins, it did not use the shared `utils.ConnectionPool`, so repeated streamed segments could not reuse an existing connection or be prewarmed.

## Notes

xAI documents the streaming TTS websocket as multi-utterance: after `audio.done`, clients can send another `text.delta` / `text.done` sequence on the same connection.

## Test plan

- `uv run pytest tests/test_plugin_xai_tts.py --plugin xai -q`
- `uv run pytest tests/test_realtime/test_xai_realtime_model.py --unit -q`
- `uv run ruff check tests/test_plugin_xai_tts.py livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/tts.py`
- `uv run ruff format --check tests/test_plugin_xai_tts.py livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/tts.py`
- `uv run --group typing mypy --untyped-calls-exclude=smithy_aws_core -p livekit.plugins.xai`