### PR TITLE
fix(voice): resolve video task leak in AgentSession

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1053,6 +1053,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             if self._forward_audio_atask is not None:
                 await utils.aio.cancel_and_wait(self._forward_audio_atask)
 
+            if self._forward_video_atask is not None:
+                await utils.aio.cancel_and_wait(self._forward_video_atask)
+
             if self._recorder_io:
                 await self._recorder_io.aclose()
 


### PR DESCRIPTION
I was just checking this project and saw this, did some test and felt it might be a real bug, so i fixed it and created this PR!


### Description
This change resolves a resource leak where the video forwarding task (`_forward_video_atask`) was left dangling in the background on session teardown.

#### The Problem
During session teardown (`AgentSession._aclose_impl`), the cleanup sequence explicitly cancels and awaits the audio forwarding task (`_forward_audio_atask`), but completely omitted `_forward_video_atask`.

This omission leads to leaks under two scenarios:
1. **Early Abort (No Activity)**: If a session starts and is aborted before an activity is initialized (so `self._activity` is `None`), the block detaching the inputs is skipped. The active video task is never cancelled and continues running indefinitely.
2. **Clean Teardown**: Even when an activity is present, setting `self.input.video = None` cancels the active task but immediately schedules a new redundant task. Explicitly awaiting the task ensures the event loop is cleanly purged of any scheduled forwarding tasks.

#### The Fix
Added symmetric cancellation and cleanup in `AgentSession._aclose_impl` matching the audio task's handling:
```python
if self._forward_video_atask is not None:
    await utils.aio.cancel_and_wait(self._forward_video_atask)
