### PR TITLE
fix: replace words wrapped in leading punctuation

### DIFF
--- a/livekit-agents/livekit/agents/tokenize/utils.py
+++ b/livekit-agents/livekit/agents/tokenize/utils.py
@@ -40,17 +40,21 @@ def replace_words(
     def _process_words(text: str, words: list[tuple[str, int, int]]) -> tuple[str, int]:
         offset = 0
         processed_index = 0
+        punctuations = "".join(tokenizer.PUNCTUATIONS)
         for word, start_index, end_index in words:
-            no_punctuation = word.rstrip("".join(tokenizer.PUNCTUATIONS))
-            punctuation_off = len(word) - len(no_punctuation)
-            replacement = replacements.get(no_punctuation.lower())
+            # strip punctuation on both sides so quoted/parenthesized words like
+            # "(world)" still match, and keep whatever punctuation surrounded them
+            core = word.strip(punctuations)
+            leading_off = len(word) - len(word.lstrip(punctuations))
+            trailing_off = len(word) - len(word.rstrip(punctuations))
+            replacement = replacements.get(core.lower())
             if replacement:
                 text = (
-                    text[: start_index + offset]
+                    text[: start_index + offset + leading_off]
                     + replacement
-                    + text[end_index + offset - punctuation_off :]
+                    + text[end_index + offset - trailing_off :]
                 )
-                offset += len(replacement) - len(word) + punctuation_off
+                offset += len(replacement) - len(core)
 
             processed_index = end_index + offset
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -296,6 +296,22 @@ def test_replace_words():
     assert replaced == REPLACE_EXPECTED
 
 
+def test_replace_words_leading_punctuation():
+    replacements = {"world": "universe"}
+
+    def r(text: str) -> str:
+        return tokenize.utils.replace_words(text=text, replacements=replacements)
+
+    # words wrapped in leading punctuation must still be replaced
+    assert r("(world)") == "(universe)"
+    assert r('"world"') == '"universe"'
+    assert r("-world") == "-universe"
+    assert r("hello (world).") == "hello (universe)."
+    # trailing-only punctuation still works, and unrelated words are untouched
+    assert r("world!") == "universe!"
+    assert r("worldly") == "worldly"
+
+
 async def test_replace_words_async():
     pattern = [1, 2, 4]
     text = REPLACE_TEXT


### PR DESCRIPTION
## What

`tokenize.utils.replace_words` handles a word's **trailing** punctuation but not its **leading** punctuation, so a word wrapped in quotes/parens/brackets or with a leading dash is never replaced — while the same word with trailing punctuation is:

```python
replace_words(text="world!",   replacements={"world": "universe"})  # -> "universe!"   ✅
replace_words(text="(world)",  replacements={"world": "universe"})  # -> "(world)"     ❌ should be "(universe)"
replace_words(text='"world"',  replacements={"world": "universe"})  # -> '"world"'     ❌
replace_words(text="-world",   replacements={"world": "universe"})  # -> "-world"      ❌
```

`split_words(ignore_punctuation=False)` returns tokens with their surrounding punctuation (`"(world)"`, `'"world"'`, `"-world"`), but `_process_words` computes `no_punctuation = word.rstrip(PUNCTUATIONS)` — trailing only — so the dict lookup misses whenever there's leading punctuation. Asymmetric and surprising for TTS pronunciation substitution.

## Fix

In `_process_words` (shared by both the sync and async paths), strip punctuation on **both** sides for the lookup and preserve whatever punctuation surrounded the word:

```python
core = word.strip(punctuations)
leading_off  = len(word) - len(word.lstrip(punctuations))
trailing_off = len(word) - len(word.rstrip(punctuations))
...
text = text[: start + offset + leading_off] + replacement + text[end + offset - trailing_off :]
offset += len(replacement) - len(core)
```

This reduces exactly to the previous logic when `leading_off == 0`, so existing behavior (trailing punctuation, the `A.B.C`→`A.B.C.D` internal-dot case) is unchanged.

## Testing

Added `test_replace_words_leading_punctuation` to `tests/test_tokenizer.py` covering `(world)`, `"world"`, `-world`, `hello (world).`, trailing-only, and a no-false-positive case (`worldly`). The existing `test_replace_words` still passes (verified). Pure string functions — offline.