### PR TITLE
fix(aws): preserve image format for Bedrock images

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/aws.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/aws.py
@@ -9,6 +9,13 @@ from livekit.agents import llm
 
 from .utils import convert_mid_conversation_instructions, group_tool_calls
 
+_AWS_IMAGE_FORMATS = {
+    "image/jpeg": "jpeg",
+    "image/png": "png",
+    "image/gif": "gif",
+    "image/webp": "webp",
+}
+
 
 @dataclass
 class BedrockFormatData:
@@ -95,12 +102,23 @@ def _build_image(image: llm.ImageContent) -> dict:
     if img.external_url:
         raise ValueError("external_url is not supported by AWS Bedrock.")
 
+    assert img.data_bytes is not None
     return {
         "image": {
-            "format": "jpeg",
+            "format": _image_format(img.mime_type),
             "source": {"bytes": img.data_bytes},
         }
     }
+
+
+def _image_format(mime_type: str | None) -> str:
+    if not mime_type:
+        return "jpeg"
+
+    try:
+        return _AWS_IMAGE_FORMATS[mime_type]
+    except KeyError:
+        raise ValueError(f"Unsupported mime_type {mime_type} for AWS Bedrock images") from None
 
 
 def to_fnc_ctx(tool_ctx: llm.ToolContext) -> list[dict[str, Any]]:

--- a/tests/test_chat_ctx.py
+++ b/tests/test_chat_ctx.py
@@ -1,3 +1,4 @@
+import base64
 import os
 from typing import Any
 
@@ -15,6 +16,8 @@ from livekit.agents.types import (
 from .fake_llm import FakeLLM, FakeLLMResponse
 
 pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
+
+_IMAGE_BYTES = b"fake image bytes"
 
 
 def ai_function1(a: int, b: str = "default") -> None:
@@ -77,6 +80,45 @@ def test_dict():
     print(chat_ctx.to_dict())
     print(chat_ctx.items)
     print(ChatContext.from_dict(chat_ctx.to_dict()).items)
+
+
+@pytest.mark.parametrize(
+    ("mime_type", "expected_format"),
+    [
+        ("image/jpeg", "jpeg"),
+        ("image/png", "png"),
+        ("image/gif", "gif"),
+        ("image/webp", "webp"),
+    ],
+)
+def test_aws_image_content_uses_serialized_image_format(mime_type: str, expected_format: str):
+    from livekit.agents.llm import ChatContext, ImageContent
+
+    encoded = base64.b64encode(_IMAGE_BYTES).decode("utf-8")
+    chat_ctx = ChatContext.empty()
+    chat_ctx.add_message(
+        role="user",
+        content=[ImageContent(image=f"data:{mime_type};base64,{encoded}")],
+    )
+
+    messages, _ = chat_ctx.to_provider_format(format="aws")
+
+    image = messages[0]["content"][0]["image"]
+    assert image["format"] == expected_format
+    assert image["source"]["bytes"] == _IMAGE_BYTES
+
+
+def test_aws_image_content_rejects_external_urls():
+    from livekit.agents.llm import ChatContext, ImageContent
+
+    chat_ctx = ChatContext.empty()
+    chat_ctx.add_message(
+        role="user",
+        content=[ImageContent(image="https://example.com/image.png", mime_type="image/png")],
+    )
+
+    with pytest.raises(ValueError, match="external_url is not supported by AWS Bedrock"):
+        chat_ctx.to_provider_format(format="aws")
 
 
 def test_chat_ctx_can_be_serialized_and_deserialized_with_defaults():


### PR DESCRIPTION
Fixes AWS Bedrock chat-context formatting for non-JPEG `ImageContent` inputs by deriving the Bedrock image block format from the serialized image MIME type instead of always declaring `jpeg`.

## What Problem This Solves

AWS Bedrock image blocks require the declared `format` to match the image bytes being sent.

LiveKit already preserves that information when it serializes an `ImageContent` data URL. For example, a PNG data URL is decoded into raw PNG bytes with `mime_type="image/png"`:

```py
SerializedImage(
    data_bytes=...,        # original PNG bytes
    mime_type="image/png",
)
```

The bug is in the AWS formatter. It receives the serialized image, but always declares the Bedrock image format as `jpeg`:

```py
{
    "image": {
        "format": "jpeg",
        "source": {"bytes": img.data_bytes},
    }
}
```

That is correct only when the serialized image is actually JPEG. For PNG, GIF, or WebP data URLs, the formatter keeps the original non-JPEG bytes but labels them as JPEG in the Bedrock request.

So the problem is not that LiveKit loses or rewrites the image bytes. The problem is that the AWS request metadata no longer matches those bytes.

AWS Bedrock supports `png`, `jpeg`, `gif`, and `webp` as `ImageBlock.format` values, so the formatter should use the serialized MIME type to choose the matching Bedrock format.
## Change

Map `SerializedImage.mime_type` to the corresponding Bedrock image format:

```text
image/jpeg -> jpeg
image/png  -> png
image/gif  -> gif
image/webp -> webp
```

This keeps the existing JPEG behavior for `VideoFrame` inputs, because `serialize_image()` currently encodes frames as JPEG.

This also keeps the current Bedrock behavior for external image URLs unchanged: external URLs are still rejected because this formatter path only builds inline Bedrock image blocks.

## Evidence

A PNG `ImageContent` can currently be serialized with the correct MIME type but formatted for AWS with the wrong Bedrock format:

```py
from livekit.agents.llm import ChatContext, ImageContent

ctx = ChatContext.empty()
ctx.add_message(
    role="user",
    content=[ImageContent(image="data:image/png;base64,<png-bytes>")],
)

messages, _ = ctx.to_provider_format(format="aws")
```

Before this fix, the generated Bedrock message declares the image as JPEG:

```py
{
    "image": {
        "format": "jpeg",
        "source": {"bytes": b"<original png bytes>"},
    }
}
```

After this fix, the declared format matches the serialized image bytes:

```py
{
    "image": {
        "format": "png",
        "source": {"bytes": b"<original png bytes>"},
    }
}
```

The same mapping applies to JPEG, GIF, and WebP inputs.

AWS documents `ImageBlock.format` valid values as `png | jpeg | gif | webp`: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ImageBlock.html

## Possible call chain / impact

```text
livekit.agents.llm.ChatContext
  -> ChatContext.to_provider_format(format="aws")
    -> livekit.agents.llm._provider_format.aws.to_chat_ctx(...)
      -> _build_image(...)
        -> llm.utils.serialize_image(...)
        -> Bedrock image block
```

The affected path is only AWS Bedrock chat-context conversion for inline image inputs.

This PR does not change:

- image serialization itself
- `VideoFrame` encoding behavior
- external URL handling for AWS Bedrock
- OpenAI, Anthropic, Google, or Mistral provider formatting
- tool/function-call formatting

Sibling provider surfaces already preserve image MIME type differently: OpenAI and Mistral include the MIME type in data URLs, Anthropic passes `media_type`, and Google passes `mime_type` in image parts. AWS was the outlier because it dropped the MIME type and hardcoded the Bedrock format.

## Validation

- `uv run --no-sync pytest tests/test_chat_ctx.py -q` - passed, 27 passed / 1 skipped
- `uv run --no-sync pytest tests/test_chat_ctx.py -q -k aws_image_content` - passed, 5 passed
- `uv run --no-sync ruff check livekit-agents/livekit/agents/llm/_provider_format/aws.py tests/test_chat_ctx.py` - passed
- `uv run --no-sync ruff format --check livekit-agents/livekit/agents/llm/_provider_format/aws.py tests/test_chat_ctx.py` - passed
- `git diff --check` - passed
