### PR TITLE
fix(test): stop false-positive "Audio data isn't PCM" failures in TTS tests

### DIFF
--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -69,7 +69,20 @@ async def assert_valid_synthesized_audio(
     # use Deepgram as the source of truth to verify synthesized speech
     frame = rtc.combine_audio_frames(frames)
 
-    # Make sure the data is PCM and can't be another container.
+    # Make sure the data is PCM and not a compressed container a provider could return.
+    # Raw PCM has no signature, so ffmpeg's probe can coincidentally match obscure
+    # raw-format demuxers (e.g. lmlm4 when the audio starts with silence). Only fail
+    # on formats with real signatures that a TTS API could actually emit.
+    compressed_formats = {
+        "mp3",
+        "aac",
+        "ogg",
+        "flac",
+        "wav",
+        "mov,mp4,m4a,3gp,3g2,mj2",
+        "matroska,webm",
+        "mpeg",
+    }
     try:
         probe_opts = {
             "probe_size": "32",
@@ -77,24 +90,14 @@ async def assert_valid_synthesized_audio(
         }
         container = av.open(io.BytesIO(frame.data), options=probe_opts)
 
-        if container.format.name not in ("ea_cdata"):  # add more here
+        if container.format.name in compressed_formats:
             print("Container format:", container.format.name)
             print("Container long name:", container.format.long_name)
-            print("Metadata:")
-            for key, value in container.metadata.items():
-                print(f"  {key}: {value}")
-
-            print("Streams:")
             for stream in container.streams:
-                if stream.type == "video":  # false positive
-                    continue
-
                 print(f"  Stream index: {stream.index}")
                 print(f"    Type: {stream.type}")
                 print(f"    Codec: {stream.codec.name}")
-                print(f"    Duration: {stream.duration}")
-                print(f"    Time base: {stream.time_base}")
-                raise ValueError("Audio data isn't PCM")
+            raise ValueError(f"Audio data isn't PCM (detected {container.format.name})")
 
         container.close()
     except av.InvalidDataError:


### PR DESCRIPTION
## Problem

The TTS suite has a recurring flake where `assert_valid_synthesized_audio` raises `ValueError: Audio data isn't PCM` on perfectly valid PCM. Recent examples on `main`:

- [run 28762333219](https://github.com/livekit/agents/actions/runs/28762333219) — `test_tts_stream[groq-stream-adapter]`
- [run 28626084467](https://github.com/livekit/agents/actions/runs/28626084467) — `test_tts_synthesize[deepgram]`

Both failed at the same check, in commits that don't touch TTS at all, and the adjacent runs passed.

## Root cause

The check hands raw, headerless PCM to `av.open` and fails if ffmpeg detects *any* container. Raw PCM has no signature, so ffmpeg's probe occasionally pattern-matches the sample bytes against a weak raw-format demuxer. In the groq failure it was `lmlm4`: [`lmlm4_probe()`](https://github.com/FFmpeg/FFmpeg/blob/master/libavformat/lmlm4.c) looks at only the first 10 bytes (first two must be zero — trivially true for audio starting with silence) and returns score 33/100, which clears ffmpeg's misdetection-warning threshold (25). Because the match depends on the literal sample values, it strikes rarely and randomly across providers. Increasing `probe_size` doesn't help (the match is decided in 10 bytes), and PyAV doesn't expose `probe_score`, so a confidence threshold isn't available.

I confirmed this with the `lk-dump-groq` artifact from the failed run: the dumped stream is valid `pcm_s16le` 48kHz mono, and its raw bytes deterministically reproduce the `lmlm4` misdetection.

## Fix

Invert the check from an allow-list of misdetections (unbounded — ffmpeg has dozens of weak raw-format probes) to a deny-list of compressed formats a TTS provider could actually return: `mp3`, `aac`, `ogg`, `flac`, `wav`, mp4 family, matroska/webm, `mpeg`. These all have real signatures that ffmpeg detects reliably, so the check's actual purpose — catching a plugin that emits compressed bytes as audio frames — is preserved.

This also fixes a latent bug: `container.format.name not in ("ea_cdata")` was a substring check against a plain string (missing comma for a tuple), so the `# add more here` extension path never worked.

## Verification

Ran against the real bytes from the failed CI run (artifact WAV minus header) plus mp3/m4a/wav renditions of the same audio:

```
raw PCM from failed CI run: ffmpeg probe -> 'lmlm4'
  OK: new check passes valid PCM
sample.mp3: ffmpeg probe -> 'mp3'
  OK: new check rejects compressed audio
sample.m4a: ffmpeg probe -> 'mov,mp4,m4a,3gp,3g2,mj2'
  OK: new check rejects compressed audio
wav container: ffmpeg probe -> 'wav'
  OK: new check rejects wav container
```

`ruff format --check` and `ruff check` pass.