### PR TITLE
fix(openai): bound realtime WebSocket close so aclose() doesn't hang

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -124,6 +124,12 @@ DEFAULT_VOICE = "marin"
 
 lk_oai_debug = int(os.getenv("LK_OPENAI_DEBUG", 0))
 
+# ws_conn.close() sends a CLOSE frame then waits for the peer's CLOSE frame. Well-behaved
+# servers complete the handshake in well under a second, but OpenAI's Realtime server never
+# sends a CLOSE frame (it drops the connection with an EOF), so this caps the otherwise
+# unbounded wait that would stall RealtimeSession.aclose()
+_WS_CLOSE_TIMEOUT = 5.0
+
 # Azure OpenAI Realtime API uses old-style (beta) event names.
 # This mapping normalizes them to the current OpenAI GA event names
 # so the handler code only deals with one set of names.
@@ -1010,6 +1016,17 @@ class RealtimeSession(
     async def _run_ws(self, ws_conn: aiohttp.ClientWebSocketResponse) -> None:
         closing = False
 
+        async def _close_ws() -> None:
+            try:
+                await asyncio.wait_for(ws_conn.close(), timeout=_WS_CLOSE_TIMEOUT)
+            except asyncio.TimeoutError:
+                # the server didn't complete the close handshake; cancelling close()
+                # makes aiohttp drop the underlying connection, so just log and move on
+                logger.debug(
+                    f"{self._realtime_model._provider_label} didn't complete the WebSocket "
+                    "close handshake, dropping the connection"
+                )
+
         @utils.log_exceptions(logger=logger)
         async def _send_task() -> None:
             nonlocal closing
@@ -1038,7 +1055,7 @@ class RealtimeSession(
                     logger.exception("failed to send event")
 
             closing = True
-            await ws_conn.close()
+            await _close_ws()
 
         @utils.log_exceptions(logger=logger)
         async def _recv_task() -> None:
@@ -1180,7 +1197,7 @@ class RealtimeSession(
 
         finally:
             await utils.aio.cancel_and_wait(*tasks)
-            await ws_conn.close()
+            await _close_ws()
 
     def _wrap_session_update(
         self, event_id: str, session: RealtimeSessionCreateRequest


### PR DESCRIPTION
### What
Bounds the OpenAI realtime plugin's WebSocket close so `RealtimeSession.aclose()` returns promptly instead of stalling ~20s.

### Why
aiohttp's `ws_conn.close()` sends a CLOSE frame then waits for the peer's CLOSE frame up to its timeout. OpenAI's realtime server never sends a CLOSE frame on session end (it drops with EOF), so the close handshake in `_run_ws` waits out the full timeout, and `aclose()` (awaiting `_main_atask`) stalls ~20s for every realtime session teardown. See the linked issue for the full analysis.

### Change
- Adds `_WS_CLOSE_TIMEOUT` and bounds the `ws_conn.close()` calls in `_run_ws` with `asyncio.wait_for(...)`, force-detaching on timeout. Waiting for a CLOSE frame that never arrives is pointless.
- Conservative timeout (5s) so servers that DO complete the handshake (e.g. Azure) are unaffected.
- On timeout, `asyncio.wait_for` cancels the inner `close()`; aiohttp handles that by setting `ABNORMAL_CLOSURE` and releasing the underlying transport, so the timeout path is itself a clean detach (no aiohttp internals are touched).

### Related
- Fixes #6336
- Prior art: #5875 bounded `AgentSession.aclose()` at the supervisor level (60s ceiling); this fixes the actual WS-close cause one layer deeper.
- OpenAI-side root cause: https://community.openai.com/t/lack-of-realtime-websocket-close-frame/1369160

Note: no regression test included — happy to add one if maintainers point me at the preferred harness.
