### PR TITLE
fix(tts): restart ChunkedStream retries under a fresh request_id

### DIFF
--- a/livekit-agents/livekit/agents/tts/tts.py
+++ b/livekit-agents/livekit/agents/tts/tts.py
@@ -440,16 +440,29 @@ class ChunkedStream(ABC):
                 if isinstance(e, APIStatusError) and e.status_code == 499:
                     return
 
-                retry_interval = self._conn_options._interval_for_retry(i)
-                if self._conn_options.max_retry == 0 or self._conn_options.max_retry == i:
+                # settle the emitter so no frames from this attempt are delivered after
+                # the retry starts; the retry restarts the synthesis under a fresh
+                # request_id, signaling downstream that any partial audio is stale
+                await output_emitter.aclose()
+
+                should_retry = (
+                    e.retryable
+                    and self._conn_options.max_retry > 0
+                    and i < self._conn_options.max_retry
+                )
+
+                if not should_retry:
                     self._emit_error(e, recoverable=False)
                     raise
-                else:
-                    self._emit_error(e, recoverable=True)
-                    logger.warning(
-                        f"failed to synthesize speech: {e}, retrying in {retry_interval}s",
-                        extra={"tts": self._tts._label, "attempt": i + 1, "streamed": False},
-                    )
+
+                retry_interval = self._conn_options._interval_for_retry(i)
+                self._emit_error(e, recoverable=True)
+                logger.warning(
+                    "failed to synthesize speech: %s, retrying in %ss",
+                    e,
+                    retry_interval,
+                    extra={"tts": self._tts._label, "attempt": i + 1, "streamed": False},
+                )
 
                 await asyncio.sleep(retry_interval)
                 # Reset the flag when retrying

--- a/tests/fake_tts.py
+++ b/tests/fake_tts.py
@@ -43,6 +43,7 @@ class FakeTTS(TTS):
         fake_timeout: float | None = None,
         fake_audio_duration: float | None = None,
         fake_exception: Exception | None = None,
+        fake_exception_count: int | None = None,
         fake_responses: list[FakeTTSResponse] | None = None,
     ) -> None:
         super().__init__(
@@ -54,6 +55,8 @@ class FakeTTS(TTS):
         self._fake_timeout = fake_timeout
         self._fake_audio_duration = fake_audio_duration
         self._fake_exception = fake_exception
+        # None means raise fake_exception on every attempt
+        self._fake_exception_count = fake_exception_count
         self._fake_response_map: dict[str, FakeTTSResponse] = {}
         if fake_responses is not None:
             for response in fake_responses:
@@ -77,6 +80,19 @@ class FakeTTS(TTS):
 
         if utils.is_given(fake_exception):
             self._fake_exception = fake_exception
+
+    def _consume_fake_exception(self) -> Exception | None:
+        if self._fake_exception is None:
+            return None
+
+        if self._fake_exception_count is None:
+            return self._fake_exception
+
+        if self._fake_exception_count <= 0:
+            return None
+
+        self._fake_exception_count -= 1
+        return self._fake_exception
 
     @property
     def synthesize_ch(self) -> utils.aio.ChanReceiver[FakeChunkedStream]:
@@ -156,9 +172,12 @@ class FakeChunkedStream(ChunkedStream):
                 num_samples = min(self._tts.sample_rate // 100, max_samples - pushed_samples)
                 output_emitter.push(b"\x00\x00" * num_samples)
                 pushed_samples += num_samples
+                # yield control so the emitter delivers audio downstream, like a
+                # real provider awaiting on the network between chunks
+                await asyncio.sleep(0)
 
-        if self._tts._fake_exception is not None:
-            raise self._tts._fake_exception
+        if (exc := self._tts._consume_fake_exception()) is not None:
+            raise exc
 
         output_emitter.flush()
 
@@ -243,5 +262,5 @@ class FakeSynthesizeStream(SynthesizeStream):
 
             output_emitter.flush()
 
-        if self._tts._fake_exception is not None:
-            raise self._tts._fake_exception
+        if (exc := self._tts._consume_fake_exception()) is not None:
+            raise exc

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+import itertools
 import logging
 import os
 import pathlib
@@ -17,7 +18,14 @@ import pytest
 from dotenv import load_dotenv
 
 from livekit import rtc
-from livekit.agents import APIConnectOptions, APIError, APITimeoutError, inference, tts
+from livekit.agents import (
+    APIConnectionError,
+    APIConnectOptions,
+    APIError,
+    APITimeoutError,
+    inference,
+    tts,
+)
 from livekit.agents.utils import AudioBuffer, aio
 from livekit.plugins import (
     aws,
@@ -269,6 +277,19 @@ async def _do_synthesis(tts_v: tts.TTS, segment: str, *, conn_options: APIConnec
     tts_stream = tts_v.synthesize(text=segment, conn_options=conn_options)
     audio_events = [event async for event in tts_stream]
 
+    request_ids = [event.request_id for event in audio_events]
+    assert all(request_ids), "expected all frames to have a request_id"
+
+    # a transient mid-synthesis failure may retry under a fresh request_id; frames
+    # from different attempts must not interleave, and only the last attempt is a
+    # complete synthesis
+    unique_ids = list(dict.fromkeys(request_ids))
+    contiguous_ids = [rid for rid, _ in itertools.groupby(request_ids)]
+    assert contiguous_ids == unique_ids, (
+        f"expected request_ids to not interleave between attempts, got {request_ids}"
+    )
+    audio_events = [event for event in audio_events if event.request_id == unique_ids[-1]]
+
     assert all(not event.is_final for event in audio_events[:-1]), (
         "expected all audio events to be non-final"
     )
@@ -283,12 +304,6 @@ async def _do_synthesis(tts_v: tts.TTS, segment: str, *, conn_options: APIConnec
     assert audio_events[-1].is_final, "expected last audio event to be final"
     assert 0 < audio_events[-1].frame.duration < 0.25, (
         f"expected last frame to not be empty, got {audio_events[-1].frame.duration}"
-    )
-
-    first_id = audio_events[0].request_id
-    assert first_id, "expected to have a request_id"
-    assert all(e.request_id == first_id for e in audio_events), (
-        "expected all frames to have the same request_id, "
     )
 
     frames = [event.frame for event in audio_events]
@@ -405,6 +420,51 @@ async def test_tts_synthesize_error_propagation():
             )
     finally:
         await tts.aclose()
+
+
+async def test_tts_synthesize_retry_after_partial_audio():
+    tts_v = FakeTTS(
+        fake_audio_duration=1.0,
+        fake_exception=APIConnectionError("connection dropped mid-stream"),
+        fake_exception_count=1,
+    )
+
+    error_events = EventCollector(tts_v, "error")
+    metrics_collected_events = EventCollector(tts_v, "metrics_collected")
+    try:
+        stream = tts_v.synthesize(
+            "fake_text", conn_options=APIConnectOptions(max_retry=3, timeout=0.5)
+        )
+        audio_events = [ev async for ev in stream]
+
+        assert stream.attempt == 2, f"expected 1 retry, got {stream.attempt} attempts"
+        assert error_events.count == 1, f"expected 1 error event, got {error_events.count}"
+        assert error_events.events[0][0][0].recoverable is True, (
+            "expected the error to be recoverable"
+        )
+
+        # the retry restarts the synthesis under a fresh request_id; frames already
+        # delivered by the failed attempt keep the old one
+        request_ids = [ev.request_id for ev in audio_events]
+        assert len(set(request_ids)) == 2, f"expected 2 request_ids, got {set(request_ids)}"
+        retry_start = request_ids.index(request_ids[-1])
+        assert all(rid == request_ids[0] for rid in request_ids[:retry_start]), (
+            "expected request_ids to not interleave between attempts"
+        )
+
+        retry_events = audio_events[retry_start:]
+        assert retry_events[-1].is_final, "expected last audio event to be final"
+        retry_duration = sum(ev.frame.duration for ev in retry_events)
+        assert abs(retry_duration - 1.0) < 0.1, (
+            f"expected the retry to resynthesize the full audio, got {retry_duration:.2f}s"
+        )
+
+        await stream.aclose()  # settles the metrics task
+        assert metrics_collected_events.count == 1, (
+            f"expected 1 metrics collected event, got {metrics_collected_events.count}"
+        )
+    finally:
+        await tts_v.aclose()
 
 
 STREAM_TTS = [


### PR DESCRIPTION
## Problem

`test_tts_synthesize[deepgram]` failed on main ([run](https://github.com/livekit/agents/actions/runs/28864391089/job/85610676702)): a transient connection error mid-response caused `ChunkedStream` to retry after partial audio had already been emitted, so the consumer received frames from two attempts with mixed `request_id`s — and frames from the failed attempt could still trickle out after the retry started, interleaving the two attempts.

## Changes

- **`ChunkedStream._main_task`**: settle the emitter (`aclose`) before retrying, so no stale frames from the failed attempt are delivered once the retry begins. The retry restarts synthesis under a fresh `request_id`, signaling downstream that any partial audio from the failed attempt is stale. Also skip retries for non-retryable errors (matching `SynthesizeStream`).
- **`tests/test_tts.py`**: `_do_synthesis` now accepts a request_id restart — it asserts request_ids don't interleave between attempts and validates completeness/audio on the final attempt's frames. New test `test_tts_synthesize_retry_after_partial_audio` covers fail-once-then-succeed: exactly one retry, recoverable error event, two non-interleaved request_ids, full audio from the retry, one metrics event.
- **`tests/fake_tts.py`**: `fake_exception_count` option to fail the first N attempts, and yield control between pushes so partial audio reaches the consumer like a real provider streaming over the network.

## Notes

`SynthesizeStream` still refuses to retry after partial audio (#5242); making it restart under a fresh request_id like this would be a follow-up.