### PR TITLE
fix(voice): preserve completed tool results in chat context on interruption

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3851,8 +3851,8 @@ class AgentActivity(RecognitionHooks):
                         )
                 else:
                     logger.warning(
-                        "tool results preserved locally but not sent to the realtime session; "
-                        "the model may re-execute the interrupted function calls",
+                        "interrupted tool results added to the local chat context "
+                        "but not sent to the realtime session",
                         extra={"function_calls": [out.call_id for out in interrupted_fnc_outputs]},
                     )
             return

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2790,6 +2790,14 @@ class AgentActivity(RecognitionHooks):
     ) -> None:
         from .agent import ModelSettings
 
+        # commit the tool messages that triggered this reply before any interruption
+        # gate: the tools already executed, and discarding their results on
+        # interruption makes the next LLM inference re-issue the same calls (see #3702).
+        # ChatContext.insert orders by `created_at`, so ordering is unchanged.
+        if _previous_tools_messages:
+            self._agent._chat_ctx.insert(_previous_tools_messages)
+            self._session._tool_items_added(_previous_tools_messages)
+
         current_span = trace.get_current_span(context=speech_handle._agent_turn_context)
         current_span.set_attribute(trace_types.ATTR_SPEECH_ID, speech_handle.id)
         if instructions is not None:
@@ -3163,11 +3171,6 @@ class AgentActivity(RecognitionHooks):
 
         current_span.set_attribute(trace_types.ATTR_SPEECH_INTERRUPTED, speech_handle.interrupted)
 
-        # add the tools messages that triggers this reply to the chat context
-        if _previous_tools_messages:
-            self._agent._chat_ctx.insert(_previous_tools_messages)
-            self._session._tool_items_added(_previous_tools_messages)
-
         forwarded_text = "".join(out.forwarded_text for out in segment_outputs)
         if speech_handle.interrupted:
             # forward_generation already cleared the buffer and waited for playout
@@ -3220,6 +3223,24 @@ class AgentActivity(RecognitionHooks):
 
         if speech_handle.interrupted:
             await utils.aio.cancel_and_wait(exe_task)
+
+            # cancel_and_wait lets in-flight tool tasks run to completion, so
+            # tool_output.output may hold completed results. Commit them before
+            # returning: the tool reply turn is never scheduled here, and dropping
+            # them makes the next LLM inference re-execute the same tools (see #3702).
+            # Agent handoffs are excluded: the handoff is not applied on an
+            # interrupted speech, and recording its call as completed would prevent
+            # the LLM from retrying it.
+            interrupted_calls: list[llm.FunctionCall] = []
+            interrupted_fnc_outputs: list[llm.FunctionCallOutput] = []
+            for sanitized_out in tool_output.output:
+                if sanitized_out.fnc_call_out is not None and sanitized_out.agent_task is None:
+                    interrupted_calls.append(sanitized_out.fnc_call)
+                    interrupted_fnc_outputs.append(sanitized_out.fnc_call_out)
+
+            if interrupted_tool_messages := interrupted_calls + interrupted_fnc_outputs:
+                self._agent._chat_ctx.insert(interrupted_tool_messages)
+                self._session._tool_items_added(interrupted_tool_messages)
             return
 
         # wait for the tool execution to complete
@@ -3822,6 +3843,34 @@ class AgentActivity(RecognitionHooks):
 
         if speech_handle.interrupted:
             await utils.aio.cancel_and_wait(exe_task)
+
+            # cancel_and_wait lets in-flight tool tasks run to completion, so
+            # tool_output.output may hold completed results. Commit them before
+            # returning so the next inference doesn't re-execute the same tools
+            # (see #3702). The fnc_call itself is already in the chat context,
+            # added by _tool_execution_started_cb. Agent handoffs are excluded:
+            # the handoff is not applied on an interrupted speech, and recording
+            # its call as completed would prevent the LLM from retrying it.
+            interrupted_fnc_outputs: list[llm.FunctionCallOutput] = []
+            for sanitized_out in tool_output.output:
+                if sanitized_out.fnc_call_out is not None and sanitized_out.agent_task is None:
+                    interrupted_fnc_outputs.append(sanitized_out.fnc_call_out)
+                    self._agent._chat_ctx._upsert_item(sanitized_out.fnc_call_out)
+                    self._session._tool_items_added([sanitized_out.fnc_call_out])
+
+            if len(interrupted_fnc_outputs) > 0:
+                # the realtime session generates from its server-side conversation
+                # state: push the outputs so it doesn't see a dangling function
+                # call and re-issue it
+                chat_ctx = self._rt_session.chat_ctx.copy()
+                chat_ctx.items.extend(interrupted_fnc_outputs)
+                try:
+                    await self._rt_session.update_chat_ctx(chat_ctx)
+                except llm.RealtimeError as e:
+                    logger.warning(
+                        "failed to update chat context with the interrupted function calls results",
+                        extra={"error": str(e)},
+                    )
             return
 
         # wait for the tool execution to complete

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -5,7 +5,7 @@ import contextvars
 import heapq
 import json
 import time
-from collections.abc import AsyncIterable, Coroutine, Sequence
+from collections.abc import AsyncIterable, Coroutine
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -2755,7 +2755,6 @@ class AgentActivity(RecognitionHooks):
         new_message: llm.ChatMessage | None = None,
         instructions: str | Instructions | None = None,
         _previous_user_metrics: llm.MetricsReport | None = None,
-        _previous_tools_messages: Sequence[llm.FunctionCall | llm.FunctionCallOutput] | None = None,
     ) -> None:
         with tracer.start_as_current_span(
             "agent_turn", context=self._session._root_span_context
@@ -2773,7 +2772,6 @@ class AgentActivity(RecognitionHooks):
                 new_message=new_message,
                 instructions=instructions,
                 _previous_user_metrics=_previous_user_metrics,
-                _previous_tools_messages=_previous_tools_messages,
             )
 
     async def _pipeline_reply_task_impl(
@@ -2786,15 +2784,8 @@ class AgentActivity(RecognitionHooks):
         new_message: llm.ChatMessage | None = None,
         instructions: str | Instructions | None = None,
         _previous_user_metrics: llm.MetricsReport | None = None,
-        _previous_tools_messages: Sequence[llm.FunctionCall | llm.FunctionCallOutput] | None = None,
     ) -> None:
         from .agent import ModelSettings
-
-        # commit before any interruption gate: dropping already-executed tool
-        # results makes the next inference re-issue the calls (see #3702)
-        if _previous_tools_messages:
-            self._agent._chat_ctx.insert(_previous_tools_messages)
-            self._session._tool_items_added(_previous_tools_messages)
 
         current_span = trace.get_current_span(context=speech_handle._agent_turn_context)
         current_span.set_attribute(trace_types.ATTR_SPEECH_ID, speech_handle.id)
@@ -3294,6 +3285,13 @@ class AgentActivity(RecognitionHooks):
                 draining = True
 
             tool_messages = new_calls + new_fnc_outputs
+            # commit immediately: if the reply speech below is interrupted or never
+            # runs, dropping already-executed tool results makes the next inference
+            # re-issue the calls (see #3702)
+            if tool_messages:
+                self._agent._chat_ctx.insert(tool_messages)
+                self._session._tool_items_added(tool_messages)
+
             if fnc_executed_ev._reply_required and not speech_handle.interrupted:
                 # forwarding chat_ctx to the tool reply: drop the in-progress placeholders
                 # (the next turn re-injects from the live running set)
@@ -3336,7 +3334,6 @@ class AgentActivity(RecognitionHooks):
                         # in case the current reply only generated tools (no speech), re-use the current user_metrics for the next
                         # tool response generation
                         _previous_user_metrics=user_metrics if not forwarded_text else None,
-                        _previous_tools_messages=tool_messages,
                     ),
                     speech_handle=speech_handle,
                     name="AgentActivity.pipeline_reply",
@@ -3345,10 +3342,6 @@ class AgentActivity(RecognitionHooks):
                 self._schedule_speech(
                     speech_handle, SpeechHandle.SPEECH_PRIORITY_NORMAL, force=True
                 )
-            elif len(new_fnc_outputs) > 0:
-                # add the tool calls and outputs to the chat context even no reply is generated
-                self._agent._chat_ctx.insert(tool_messages)
-                self._session._tool_items_added(tool_messages)
 
     @utils.log_exceptions(logger=logger)
     async def _realtime_reply_task(
@@ -3848,15 +3841,24 @@ class AgentActivity(RecognitionHooks):
                     self._session._tool_items_added([sanitized_out.fnc_call_out])
 
             if len(interrupted_fnc_outputs) > 0:
-                # without this the server-side state keeps a dangling call and can re-issue it
-                chat_ctx = self._rt_session.chat_ctx.copy()
-                chat_ctx.items.extend(interrupted_fnc_outputs)
-                try:
-                    await self._rt_session.update_chat_ctx(chat_ctx)
-                except llm.RealtimeError as e:
+                if not self._rt_session.capabilities.auto_tool_reply_generation:
+                    # without this the server-side state keeps a dangling call and can re-issue it
+                    chat_ctx = self._rt_session.chat_ctx.copy()
+                    chat_ctx.items.extend(interrupted_fnc_outputs)
+                    try:
+                        await self._rt_session.update_chat_ctx(chat_ctx)
+                    except llm.RealtimeError as e:
+                        logger.warning(
+                            "failed to update chat context with the interrupted function calls results",  # noqa: E501
+                            extra={"error": str(e)},
+                        )
+                else:
+                    # sending the tool outputs would trigger a spoken reply right after
+                    # the user interrupted, so keep them local-only
                     logger.warning(
-                        "failed to update chat context with the interrupted function calls results",
-                        extra={"error": str(e)},
+                        "tool results preserved locally but not sent to the realtime session; "
+                        "the model may re-execute the interrupted function calls",
+                        extra={"function_calls": [out.call_id for out in interrupted_fnc_outputs]},
                     )
             return
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2790,9 +2790,8 @@ class AgentActivity(RecognitionHooks):
     ) -> None:
         from .agent import ModelSettings
 
-        # commit before any interruption gate: the tools already executed, and
-        # discarding their results makes the next inference re-issue the same calls
-        # (see #3702). insert() orders by created_at, so ordering is unaffected.
+        # commit before any interruption gate: dropping already-executed tool
+        # results makes the next inference re-issue the calls (see #3702)
         if _previous_tools_messages:
             self._agent._chat_ctx.insert(_previous_tools_messages)
             self._session._tool_items_added(_previous_tools_messages)
@@ -3223,11 +3222,9 @@ class AgentActivity(RecognitionHooks):
         if speech_handle.interrupted:
             await utils.aio.cancel_and_wait(exe_task)
 
-            # cancel_and_wait lets in-flight tool tasks finish, so tool_output.output
-            # may hold completed results; commit them or the next inference re-executes
-            # the same tools (see #3702). Handoffs are excluded: an interrupted handoff
-            # is not applied, and recording it as completed would prevent the LLM from
-            # retrying it.
+            # cancel_and_wait lets in-flight tools finish; commit their results or the
+            # next inference re-executes them (see #3702). handoffs are excluded: they
+            # aren't applied when interrupted, and recording them would suppress the retry
             interrupted_calls: list[llm.FunctionCall] = []
             interrupted_fnc_outputs: list[llm.FunctionCallOutput] = []
             for sanitized_out in tool_output.output:
@@ -3841,11 +3838,8 @@ class AgentActivity(RecognitionHooks):
         if speech_handle.interrupted:
             await utils.aio.cancel_and_wait(exe_task)
 
-            # commit completed tool results, as in the pipeline path (see #3702);
-            # only the outputs, the fnc_call is already added by
-            # _tool_execution_started_cb. Handoffs are excluded: an interrupted
-            # handoff is not applied, and recording it as completed would prevent
-            # the LLM from retrying it.
+            # as in the pipeline path (see #3702), but only the outputs: the fnc_call
+            # is already added by _tool_execution_started_cb
             interrupted_fnc_outputs: list[llm.FunctionCallOutput] = []
             for sanitized_out in tool_output.output:
                 if sanitized_out.fnc_call_out is not None and sanitized_out.agent_task is None:
@@ -3854,8 +3848,7 @@ class AgentActivity(RecognitionHooks):
                     self._session._tool_items_added([sanitized_out.fnc_call_out])
 
             if len(interrupted_fnc_outputs) > 0:
-                # generation is driven by the server-side conversation state: push the
-                # outputs so the server doesn't keep a dangling call and re-issue it
+                # without this the server-side state keeps a dangling call and can re-issue it
                 chat_ctx = self._rt_session.chat_ctx.copy()
                 chat_ctx.items.extend(interrupted_fnc_outputs)
                 try:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3853,7 +3853,7 @@ class AgentActivity(RecognitionHooks):
                     logger.warning(
                         "interrupted tool results added to the local chat context "
                         "but not sent to the realtime session",
-                        extra={"function_calls": [out.call_id for out in interrupted_fnc_outputs]},
+                        extra={"call_ids": [out.call_id for out in interrupted_fnc_outputs]},
                     )
             return
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3827,34 +3827,6 @@ class AgentActivity(RecognitionHooks):
 
         if speech_handle.interrupted:
             await utils.aio.cancel_and_wait(exe_task)
-
-            # as in the pipeline path (#3702); the fnc_call is already in the chat_ctx
-            interrupted_fnc_outputs: list[llm.FunctionCallOutput] = []
-            for sanitized_out in tool_output.output:
-                if sanitized_out.fnc_call_out is not None and sanitized_out.agent_task is None:
-                    interrupted_fnc_outputs.append(sanitized_out.fnc_call_out)
-                    self._agent._chat_ctx._upsert_item(sanitized_out.fnc_call_out)
-                    self._session._tool_items_added([sanitized_out.fnc_call_out])
-
-            if len(interrupted_fnc_outputs) > 0:
-                # push the outputs to the server-side context, unless that would
-                # trigger a spoken tool reply right after the interruption
-                if not self._rt_session.capabilities.auto_tool_reply_generation:
-                    chat_ctx = self._rt_session.chat_ctx.copy()
-                    chat_ctx.items.extend(interrupted_fnc_outputs)
-                    try:
-                        await self._rt_session.update_chat_ctx(chat_ctx)
-                    except llm.RealtimeError as e:
-                        logger.warning(
-                            "failed to update chat context with the interrupted function calls results",  # noqa: E501
-                            extra={"error": str(e)},
-                        )
-                else:
-                    logger.warning(
-                        "interrupted tool results added to the local chat context "
-                        "but not sent to the realtime session",
-                        extra={"call_ids": [out.call_id for out in interrupted_fnc_outputs]},
-                    )
             return
 
         # wait for the tool execution to complete

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2790,10 +2790,9 @@ class AgentActivity(RecognitionHooks):
     ) -> None:
         from .agent import ModelSettings
 
-        # commit the tool messages that triggered this reply before any interruption
-        # gate: the tools already executed, and discarding their results on
-        # interruption makes the next LLM inference re-issue the same calls (see #3702).
-        # ChatContext.insert orders by `created_at`, so ordering is unchanged.
+        # commit before any interruption gate: the tools already executed, and
+        # discarding their results makes the next inference re-issue the same calls
+        # (see #3702). insert() orders by created_at, so ordering is unaffected.
         if _previous_tools_messages:
             self._agent._chat_ctx.insert(_previous_tools_messages)
             self._session._tool_items_added(_previous_tools_messages)
@@ -3224,13 +3223,11 @@ class AgentActivity(RecognitionHooks):
         if speech_handle.interrupted:
             await utils.aio.cancel_and_wait(exe_task)
 
-            # cancel_and_wait lets in-flight tool tasks run to completion, so
-            # tool_output.output may hold completed results. Commit them before
-            # returning: the tool reply turn is never scheduled here, and dropping
-            # them makes the next LLM inference re-execute the same tools (see #3702).
-            # Agent handoffs are excluded: the handoff is not applied on an
-            # interrupted speech, and recording its call as completed would prevent
-            # the LLM from retrying it.
+            # cancel_and_wait lets in-flight tool tasks finish, so tool_output.output
+            # may hold completed results; commit them or the next inference re-executes
+            # the same tools (see #3702). Handoffs are excluded: an interrupted handoff
+            # is not applied, and recording it as completed would prevent the LLM from
+            # retrying it.
             interrupted_calls: list[llm.FunctionCall] = []
             interrupted_fnc_outputs: list[llm.FunctionCallOutput] = []
             for sanitized_out in tool_output.output:
@@ -3844,13 +3841,11 @@ class AgentActivity(RecognitionHooks):
         if speech_handle.interrupted:
             await utils.aio.cancel_and_wait(exe_task)
 
-            # cancel_and_wait lets in-flight tool tasks run to completion, so
-            # tool_output.output may hold completed results. Commit them before
-            # returning so the next inference doesn't re-execute the same tools
-            # (see #3702). The fnc_call itself is already in the chat context,
-            # added by _tool_execution_started_cb. Agent handoffs are excluded:
-            # the handoff is not applied on an interrupted speech, and recording
-            # its call as completed would prevent the LLM from retrying it.
+            # commit completed tool results, as in the pipeline path (see #3702);
+            # only the outputs, the fnc_call is already added by
+            # _tool_execution_started_cb. Handoffs are excluded: an interrupted
+            # handoff is not applied, and recording it as completed would prevent
+            # the LLM from retrying it.
             interrupted_fnc_outputs: list[llm.FunctionCallOutput] = []
             for sanitized_out in tool_output.output:
                 if sanitized_out.fnc_call_out is not None and sanitized_out.agent_task is None:
@@ -3859,9 +3854,8 @@ class AgentActivity(RecognitionHooks):
                     self._session._tool_items_added([sanitized_out.fnc_call_out])
 
             if len(interrupted_fnc_outputs) > 0:
-                # the realtime session generates from its server-side conversation
-                # state: push the outputs so it doesn't see a dangling function
-                # call and re-issue it
+                # generation is driven by the server-side conversation state: push the
+                # outputs so the server doesn't keep a dangling call and re-issue it
                 chat_ctx = self._rt_session.chat_ctx.copy()
                 chat_ctx.items.extend(interrupted_fnc_outputs)
                 try:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3213,9 +3213,8 @@ class AgentActivity(RecognitionHooks):
         if speech_handle.interrupted:
             await utils.aio.cancel_and_wait(exe_task)
 
-            # cancel_and_wait lets in-flight tools finish; commit their results or the
-            # next inference re-executes them (see #3702). handoffs are excluded: they
-            # aren't applied when interrupted, and recording them would suppress the retry
+            # commit results of tools that finished despite the interruption (#3702);
+            # handoffs excluded: not applied when interrupted, must stay retryable
             interrupted_calls: list[llm.FunctionCall] = []
             interrupted_fnc_outputs: list[llm.FunctionCallOutput] = []
             for sanitized_out in tool_output.output:
@@ -3285,9 +3284,7 @@ class AgentActivity(RecognitionHooks):
                 draining = True
 
             tool_messages = new_calls + new_fnc_outputs
-            # commit immediately: if the reply speech below is interrupted or never
-            # runs, dropping already-executed tool results makes the next inference
-            # re-issue the calls (see #3702)
+            # commit now so results survive even if the reply speech never runs (#3702)
             if tool_messages:
                 self._agent._chat_ctx.insert(tool_messages)
                 self._session._tool_items_added(tool_messages)
@@ -3831,8 +3828,7 @@ class AgentActivity(RecognitionHooks):
         if speech_handle.interrupted:
             await utils.aio.cancel_and_wait(exe_task)
 
-            # as in the pipeline path (see #3702), but only the outputs: the fnc_call
-            # is already added by _tool_execution_started_cb
+            # as in the pipeline path (#3702); the fnc_call is already in the chat_ctx
             interrupted_fnc_outputs: list[llm.FunctionCallOutput] = []
             for sanitized_out in tool_output.output:
                 if sanitized_out.fnc_call_out is not None and sanitized_out.agent_task is None:
@@ -3841,8 +3837,9 @@ class AgentActivity(RecognitionHooks):
                     self._session._tool_items_added([sanitized_out.fnc_call_out])
 
             if len(interrupted_fnc_outputs) > 0:
+                # push the outputs to the server-side context, unless that would
+                # trigger a spoken tool reply right after the interruption
                 if not self._rt_session.capabilities.auto_tool_reply_generation:
-                    # without this the server-side state keeps a dangling call and can re-issue it
                     chat_ctx = self._rt_session.chat_ctx.copy()
                     chat_ctx.items.extend(interrupted_fnc_outputs)
                     try:
@@ -3853,8 +3850,6 @@ class AgentActivity(RecognitionHooks):
                             extra={"error": str(e)},
                         )
                 else:
-                    # sending the tool outputs would trigger a spoken reply right after
-                    # the user interrupted, so keep them local-only
                     logger.warning(
                         "tool results preserved locally but not sent to the realtime session; "
                         "the model may re-execute the interrupted function calls",

--- a/tests/test_tool_results_preserved_on_interruption.py
+++ b/tests/test_tool_results_preserved_on_interruption.py
@@ -7,19 +7,14 @@ re-issues the call and duplicates side effects.
 from __future__ import annotations
 
 import asyncio
-import contextlib
-from collections.abc import AsyncIterator
 
 import pytest
 
-from livekit.agents import Agent, AgentSession, function_tool, utils
-from livekit.agents.llm import FunctionCall, FunctionToolCall, GenerationCreatedEvent
-from livekit.agents.llm.realtime import MessageGeneration
+from livekit.agents import Agent, AgentSession, function_tool
+from livekit.agents.llm import FunctionToolCall
 from livekit.agents.voice.agent_activity import AgentActivity
 from livekit.agents.voice.speech_handle import SpeechHandle
 
-from .fake_io import FakeAudioInput, FakeAudioOutput
-from .fake_realtime import FakeRealtimeModel, fake_capabilities
 from .fake_session import FakeActions, create_session, run_session
 
 pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
@@ -185,60 +180,3 @@ async def test_handoff_tool_not_recorded_when_interrupted() -> None:
 
     for items in (agent.chat_ctx.items, session.history.items):
         assert not any(i.type in ("function_call", "function_call_output") for i in items)
-
-
-@pytest.mark.parametrize("auto_tool_reply_generation", [False, True])
-async def test_realtime_tool_results_preserved_on_interruption(
-    auto_tool_reply_generation: bool,
-) -> None:
-    """Realtime path: the interrupted tool output is committed locally, and pushed
-    to the server unless the model auto-generates tool replies (Gemini-style)."""
-    model = FakeRealtimeModel(
-        capabilities=fake_capabilities(auto_tool_reply_generation=auto_tool_reply_generation)
-    )
-    session = AgentSession[None](llm=model)
-    session.input.audio = FakeAudioInput()
-    session.output.audio = FakeAudioOutput()
-    agent = WeatherAgent()
-
-    speech_handles: list[SpeechHandle] = []
-    session.on("speech_created", lambda ev: speech_handles.append(ev.speech_handle))
-
-    await session.start(agent)
-    rt_session = model.active_session
-
-    # one function call, no message; stream left open so the generation is in flight
-    fnc_ch = utils.aio.Chan[FunctionCall]()
-    fnc_ch.send_nowait(
-        FunctionCall(call_id="1", name="get_weather", arguments='{"location": "Tokyo"}')
-    )
-
-    async def _no_messages() -> AsyncIterator[MessageGeneration]:
-        return
-        yield
-
-    rt_session.emit(
-        "generation_created",
-        GenerationCreatedEvent(
-            message_stream=_no_messages(), function_stream=fnc_ch, user_initiated=False
-        ),
-    )
-
-    await asyncio.wait_for(agent.tool_executed.wait(), timeout=SESSION_TIMEOUT)
-    assert speech_handles, "no speech was created for the realtime generation"
-    speech_handles[0].interrupt()
-    await asyncio.sleep(1.0)  # let the interrupted turn commit before asserting
-
-    _assert_weather_tool_preserved(agent, session)
-    pushed = any(i.type == "function_call_output" for i in rt_session.chat_ctx.items)
-    if auto_tool_reply_generation:
-        # pushing would trigger a generation; must stay local-only
-        assert not pushed
-    else:
-        # otherwise the server still sees a dangling call and can re-issue it
-        assert pushed
-
-    fnc_ch.close()
-    with contextlib.suppress(RuntimeError):
-        await session.drain()
-    await session.aclose()

--- a/tests/test_tool_results_preserved_on_interruption.py
+++ b/tests/test_tool_results_preserved_on_interruption.py
@@ -1,0 +1,248 @@
+"""Regression tests for https://github.com/livekit/agents/issues/3702
+
+Completed tool calls/outputs must be committed to the agent's chat context even
+when the speech that carries them is interrupted. Otherwise the next LLM
+inference has no record the tool ran and re-issues the same call, duplicating
+side effects for non-idempotent tools (bookings, payments, ...).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator
+
+import pytest
+
+from livekit.agents import Agent, AgentSession, function_tool, utils
+from livekit.agents.llm import FunctionCall, FunctionToolCall, GenerationCreatedEvent
+from livekit.agents.llm.realtime import MessageGeneration
+from livekit.agents.voice.agent_activity import AgentActivity
+from livekit.agents.voice.speech_handle import SpeechHandle
+
+from .fake_io import FakeAudioInput, FakeAudioOutput
+from .fake_realtime import FakeRealtimeModel
+from .fake_session import FakeActions, create_session, run_session
+
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
+
+SESSION_TIMEOUT = 60.0
+
+
+class WeatherAgent(Agent):
+    def __init__(self, *, tool_delay: float = 0.0) -> None:
+        super().__init__(instructions="You are a helpful assistant.")
+        self.tool_delay = tool_delay
+        self.tool_executed = asyncio.Event()
+
+    @function_tool
+    async def get_weather(self, location: str) -> str:
+        """
+        Called when the user asks about the weather.
+
+        Args:
+            location: The location to get the weather for
+        """
+        if self.tool_delay > 0.0:
+            await asyncio.sleep(self.tool_delay)
+        self.tool_executed.set()
+        return f"The weather in {location} is sunny today."
+
+
+def _assert_weather_tool_preserved(agent: Agent, session: AgentSession) -> None:
+    for label, items in (
+        ("agent chat_ctx", agent.chat_ctx.items),
+        ("session history", session.history.items),
+    ):
+        calls = [i for i in items if i.type == "function_call"]
+        outs = [i for i in items if i.type == "function_call_output"]
+        assert len(calls) == 1, f"{label}: the tool call must be preserved exactly once"
+        assert calls[0].name == "get_weather"
+        assert len(outs) == 1, f"{label}: the tool output must be preserved exactly once"
+        assert outs[0].output == "The weather in Tokyo is sunny today."
+        assert items.index(calls[0]) < items.index(outs[0])
+
+
+def _weather_tool_turn(actions: FakeActions, *, tts_duration: float) -> None:
+    actions.add_user_speech(0.5, 2.5, "What's the weather in Tokyo?")
+    actions.add_llm(
+        content="Let me check the weather for you.",
+        tool_calls=[
+            FunctionToolCall(name="get_weather", arguments='{"location": "Tokyo"}', call_id="1")
+        ],
+    )
+    actions.add_tts(tts_duration)
+
+
+async def test_tool_results_preserved_when_tool_reply_turn_interrupted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The main gap: the tool turn completes normally and schedules the tool
+    reply turn, which carries the completed call/output via
+    `_previous_tools_messages`. An interruption landing right after scheduling
+    makes that reply turn return at one of its early interruption gates — the
+    tool messages must already be committed by then."""
+    actions = FakeActions()
+    _weather_tool_turn(actions, tts_duration=1.0)  # playout ~3.5s -> 4.5s
+    # tool reply turn, interrupted before it generates anything
+    actions.add_llm(
+        content="It's sunny in Tokyo!",
+        input="The weather in Tokyo is sunny today.",
+        ttft=2.0,
+        duration=2.5,
+    )
+    actions.add_tts(2.0)
+
+    session = create_session(actions)
+    agent = WeatherAgent()
+
+    # the tool reply turn is the only speech re-scheduled with force=True;
+    # interrupt synchronously right after that scheduling decision — the same
+    # window a user utterance landing at tool completion hits in production
+    forced_schedules: list[SpeechHandle] = []
+    orig_schedule = AgentActivity._schedule_speech
+
+    def _interrupt_after_forced_schedule(
+        self: AgentActivity, speech: SpeechHandle, priority: int, force: bool = False
+    ) -> None:
+        orig_schedule(self, speech, priority, force=force)
+        if force:
+            forced_schedules.append(speech)
+            speech.interrupt()
+
+    monkeypatch.setattr(AgentActivity, "_schedule_speech", _interrupt_after_forced_schedule)
+
+    await asyncio.wait_for(run_session(session, agent), timeout=SESSION_TIMEOUT)
+
+    assert forced_schedules, "the tool reply turn was never scheduled; the test needs updating"
+    _assert_weather_tool_preserved(agent, session)
+
+    # the interrupted tool reply turn never spoke, its message must not appear
+    assistant_texts = [
+        i.text_content
+        for i in agent.chat_ctx.items
+        if i.type == "message" and i.role == "assistant"
+    ]
+    assert "It's sunny in Tokyo!" not in assistant_texts
+
+
+async def test_tool_results_preserved_when_interrupted_during_playout() -> None:
+    """Interruption lands while the agent is still speaking the tool turn: the
+    turn returns right after playout without scheduling the tool reply turn,
+    and the completed results in `tool_output.output` must be committed."""
+    actions = FakeActions()
+    _weather_tool_turn(actions, tts_duration=10.0)  # playout 3.5s -> 13.5s
+    actions.add_user_speech(5.0, 6.0, "Stop!", stt_delay=0.2)  # interrupts at 5.5s
+    actions.add_llm(content="Okay, stopping.")
+    actions.add_tts(1.0)
+
+    session = create_session(actions)
+    agent = WeatherAgent()  # the tool completes at ~3.4s, before the interruption
+
+    await asyncio.wait_for(run_session(session, agent), timeout=SESSION_TIMEOUT)
+
+    _assert_weather_tool_preserved(agent, session)
+
+
+async def test_tool_results_preserved_when_tool_in_flight_at_interruption() -> None:
+    """Interruption fires while the tool is still executing: the cancellation
+    path lets in-flight tools run to completion, and their results must be
+    committed."""
+    actions = FakeActions()
+    _weather_tool_turn(actions, tts_duration=10.0)  # playout 3.5s -> 13.5s
+    actions.add_user_speech(5.0, 6.0, "Stop!", stt_delay=0.2)  # interrupts at 5.5s
+    actions.add_llm(content="Okay, stopping.")
+    actions.add_tts(1.0)
+
+    session = create_session(actions)
+    # the tool starts at ~3.4s and completes at ~7.4s, well after the interruption
+    agent = WeatherAgent(tool_delay=4.0)
+
+    await asyncio.wait_for(run_session(session, agent), timeout=SESSION_TIMEOUT)
+
+    _assert_weather_tool_preserved(agent, session)
+
+
+async def test_handoff_tool_not_recorded_when_interrupted() -> None:
+    """Agent handoff tools are excluded from the interrupted-path commit: the
+    handoff itself is not applied on an interrupted speech, and recording its
+    call as completed would prevent the LLM from retrying it."""
+
+    class TransferAgent(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="You are a helpful assistant.")
+
+        @function_tool
+        async def transfer_to_billing(self) -> Agent:
+            """Transfer the user to the billing department."""
+            return Agent(instructions="You are the billing agent.")
+
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "I have a billing question.")
+    actions.add_llm(
+        content="Transferring you to billing now.",
+        tool_calls=[FunctionToolCall(name="transfer_to_billing", arguments="{}", call_id="1")],
+    )
+    actions.add_tts(10.0)  # playout 3.5s -> 13.5s
+    actions.add_user_speech(5.0, 6.0, "Stop!", stt_delay=0.2)  # interrupts at 5.5s
+    actions.add_llm(content="Okay, stopping.")
+    actions.add_tts(1.0)
+
+    session = create_session(actions)
+    agent = TransferAgent()
+
+    await asyncio.wait_for(run_session(session, agent), timeout=SESSION_TIMEOUT)
+
+    for items in (agent.chat_ctx.items, session.history.items):
+        assert not any(i.type in ("function_call", "function_call_output") for i in items)
+
+
+async def test_realtime_tool_results_preserved_on_interruption() -> None:
+    """Realtime path: an interruption after the tool completed must commit the
+    tool output locally (the call is already added when execution starts) and
+    push it to the realtime session, whose server-side conversation state
+    drives the next generation."""
+    model = FakeRealtimeModel()
+    session = AgentSession[None](llm=model)
+    session.input.audio = FakeAudioInput()
+    session.output.audio = FakeAudioOutput()
+    agent = WeatherAgent()
+
+    speech_handles: list[SpeechHandle] = []
+    session.on("speech_created", lambda ev: speech_handles.append(ev.speech_handle))
+
+    await session.start(agent)
+    rt_session = model.active_session
+
+    # a generation producing no message and one function call; the function
+    # stream is left open so the generation is still in flight at interruption
+    fnc_ch = utils.aio.Chan[FunctionCall]()
+    fnc_ch.send_nowait(
+        FunctionCall(call_id="1", name="get_weather", arguments='{"location": "Tokyo"}')
+    )
+
+    async def _no_messages() -> AsyncIterator[MessageGeneration]:
+        return
+        yield
+
+    rt_session.emit(
+        "generation_created",
+        GenerationCreatedEvent(
+            message_stream=_no_messages(), function_stream=fnc_ch, user_initiated=False
+        ),
+    )
+
+    await asyncio.wait_for(agent.tool_executed.wait(), timeout=SESSION_TIMEOUT)
+    assert speech_handles, "no speech was created for the realtime generation"
+    speech_handles[0].interrupt()
+    await asyncio.sleep(1.0)  # let the interrupted turn commit before asserting
+
+    _assert_weather_tool_preserved(agent, session)
+    # the output must also reach the realtime session's server-side context,
+    # otherwise the model still sees a dangling function call and can re-issue it
+    assert any(i.type == "function_call_output" for i in rt_session.chat_ctx.items)
+
+    fnc_ch.close()
+    with contextlib.suppress(RuntimeError):
+        await session.drain()
+    await session.aclose()

--- a/tests/test_tool_results_preserved_on_interruption.py
+++ b/tests/test_tool_results_preserved_on_interruption.py
@@ -21,7 +21,7 @@ from livekit.agents.voice.agent_activity import AgentActivity
 from livekit.agents.voice.speech_handle import SpeechHandle
 
 from .fake_io import FakeAudioInput, FakeAudioOutput
-from .fake_realtime import FakeRealtimeModel
+from .fake_realtime import FakeRealtimeModel, fake_capabilities
 from .fake_session import FakeActions, create_session, run_session
 
 pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
@@ -78,10 +78,9 @@ async def test_tool_results_preserved_when_tool_reply_turn_interrupted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The main gap: the tool turn completes normally and schedules the tool
-    reply turn, which carries the completed call/output via
-    `_previous_tools_messages`. An interruption landing right after scheduling
-    makes that reply turn return at one of its early interruption gates — the
-    tool messages must already be committed by then."""
+    reply turn. An interruption landing right after scheduling makes that reply
+    turn return at one of its early interruption gates — the tool messages must
+    already be committed by then."""
     actions = FakeActions()
     _weather_tool_turn(actions, tts_duration=1.0)  # playout ~3.5s -> 4.5s
     # tool reply turn, interrupted before it generates anything
@@ -197,12 +196,21 @@ async def test_handoff_tool_not_recorded_when_interrupted() -> None:
         assert not any(i.type in ("function_call", "function_call_output") for i in items)
 
 
-async def test_realtime_tool_results_preserved_on_interruption() -> None:
+@pytest.mark.parametrize("auto_tool_reply_generation", [False, True])
+async def test_realtime_tool_results_preserved_on_interruption(
+    auto_tool_reply_generation: bool,
+) -> None:
     """Realtime path: an interruption after the tool completed must commit the
-    tool output locally (the call is already added when execution starts) and
-    push it to the realtime session, whose server-side conversation state
-    drives the next generation."""
-    model = FakeRealtimeModel()
+    tool output locally (the call is already added when execution starts).
+
+    When the model doesn't auto-generate tool replies (OpenAI-style), the output
+    is also pushed to the realtime session, whose server-side conversation state
+    drives the next generation. When it does (Gemini-style), pushing the output
+    would trigger a spoken reply right after the interruption, so it stays local.
+    """
+    model = FakeRealtimeModel(
+        capabilities=fake_capabilities(auto_tool_reply_generation=auto_tool_reply_generation)
+    )
     session = AgentSession[None](llm=model)
     session.input.audio = FakeAudioInput()
     session.output.audio = FakeAudioOutput()
@@ -238,9 +246,14 @@ async def test_realtime_tool_results_preserved_on_interruption() -> None:
     await asyncio.sleep(1.0)  # let the interrupted turn commit before asserting
 
     _assert_weather_tool_preserved(agent, session)
-    # the output must also reach the realtime session's server-side context,
-    # otherwise the model still sees a dangling function call and can re-issue it
-    assert any(i.type == "function_call_output" for i in rt_session.chat_ctx.items)
+    pushed = any(i.type == "function_call_output" for i in rt_session.chat_ctx.items)
+    if auto_tool_reply_generation:
+        # pushing the output would trigger a generation; it must stay local-only
+        assert not pushed
+    else:
+        # the output must also reach the realtime session's server-side context,
+        # otherwise the model still sees a dangling function call and can re-issue it
+        assert pushed
 
     fnc_ch.close()
     with contextlib.suppress(RuntimeError):

--- a/tests/test_tool_results_preserved_on_interruption.py
+++ b/tests/test_tool_results_preserved_on_interruption.py
@@ -192,7 +192,7 @@ async def test_realtime_tool_results_preserved_on_interruption(
     auto_tool_reply_generation: bool,
 ) -> None:
     """Realtime path: the interrupted tool output is committed locally, and pushed
-    to the server only when that wouldn't auto-trigger a tool reply (Gemini-style)."""
+    to the server unless the model auto-generates tool replies (Gemini-style)."""
     model = FakeRealtimeModel(
         capabilities=fake_capabilities(auto_tool_reply_generation=auto_tool_reply_generation)
     )

--- a/tests/test_tool_results_preserved_on_interruption.py
+++ b/tests/test_tool_results_preserved_on_interruption.py
@@ -1,9 +1,7 @@
 """Regression tests for https://github.com/livekit/agents/issues/3702
 
-Completed tool calls/outputs must be committed to the agent's chat context even
-when the speech that carries them is interrupted. Otherwise the next LLM
-inference has no record the tool ran and re-issues the same call, duplicating
-side effects for non-idempotent tools (bookings, payments, ...).
+Completed tool calls/outputs must survive interruption, or the next inference
+re-issues the call and duplicates side effects.
 """
 
 from __future__ import annotations
@@ -77,10 +75,8 @@ def _weather_tool_turn(actions: FakeActions, *, tts_duration: float) -> None:
 async def test_tool_results_preserved_when_tool_reply_turn_interrupted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The main gap: the tool turn completes normally and schedules the tool
-    reply turn. An interruption landing right after scheduling makes that reply
-    turn return at one of its early interruption gates — the tool messages must
-    already be committed by then."""
+    """Interruption lands right after the tool reply turn is scheduled: the reply
+    returns at an early interruption gate, tool messages must already be committed."""
     actions = FakeActions()
     _weather_tool_turn(actions, tts_duration=1.0)  # playout ~3.5s -> 4.5s
     # tool reply turn, interrupted before it generates anything
@@ -95,9 +91,8 @@ async def test_tool_results_preserved_when_tool_reply_turn_interrupted(
     session = create_session(actions)
     agent = WeatherAgent()
 
-    # the tool reply turn is the only speech re-scheduled with force=True;
-    # interrupt synchronously right after that scheduling decision — the same
-    # window a user utterance landing at tool completion hits in production
+    # the tool reply turn is the only speech scheduled with force=True;
+    # interrupt synchronously right after that scheduling decision
     forced_schedules: list[SpeechHandle] = []
     orig_schedule = AgentActivity._schedule_speech
 
@@ -126,9 +121,7 @@ async def test_tool_results_preserved_when_tool_reply_turn_interrupted(
 
 
 async def test_tool_results_preserved_when_interrupted_during_playout() -> None:
-    """Interruption lands while the agent is still speaking the tool turn: the
-    turn returns right after playout without scheduling the tool reply turn,
-    and the completed results in `tool_output.output` must be committed."""
+    """Interruption lands while the agent is still speaking the tool turn."""
     actions = FakeActions()
     _weather_tool_turn(actions, tts_duration=10.0)  # playout 3.5s -> 13.5s
     actions.add_user_speech(5.0, 6.0, "Stop!", stt_delay=0.2)  # interrupts at 5.5s
@@ -144,9 +137,8 @@ async def test_tool_results_preserved_when_interrupted_during_playout() -> None:
 
 
 async def test_tool_results_preserved_when_tool_in_flight_at_interruption() -> None:
-    """Interruption fires while the tool is still executing: the cancellation
-    path lets in-flight tools run to completion, and their results must be
-    committed."""
+    """Interruption fires while the tool is still executing: in-flight tools run
+    to completion and their results must be committed."""
     actions = FakeActions()
     _weather_tool_turn(actions, tts_duration=10.0)  # playout 3.5s -> 13.5s
     actions.add_user_speech(5.0, 6.0, "Stop!", stt_delay=0.2)  # interrupts at 5.5s
@@ -163,9 +155,8 @@ async def test_tool_results_preserved_when_tool_in_flight_at_interruption() -> N
 
 
 async def test_handoff_tool_not_recorded_when_interrupted() -> None:
-    """Agent handoff tools are excluded from the interrupted-path commit: the
-    handoff itself is not applied on an interrupted speech, and recording its
-    call as completed would prevent the LLM from retrying it."""
+    """Handoffs aren't applied on interrupted speech, so their calls must not be
+    recorded as completed — the LLM needs to retry them."""
 
     class TransferAgent(Agent):
         def __init__(self) -> None:
@@ -200,14 +191,8 @@ async def test_handoff_tool_not_recorded_when_interrupted() -> None:
 async def test_realtime_tool_results_preserved_on_interruption(
     auto_tool_reply_generation: bool,
 ) -> None:
-    """Realtime path: an interruption after the tool completed must commit the
-    tool output locally (the call is already added when execution starts).
-
-    When the model doesn't auto-generate tool replies (OpenAI-style), the output
-    is also pushed to the realtime session, whose server-side conversation state
-    drives the next generation. When it does (Gemini-style), pushing the output
-    would trigger a spoken reply right after the interruption, so it stays local.
-    """
+    """Realtime path: the interrupted tool output is committed locally, and pushed
+    to the server only when that wouldn't auto-trigger a tool reply (Gemini-style)."""
     model = FakeRealtimeModel(
         capabilities=fake_capabilities(auto_tool_reply_generation=auto_tool_reply_generation)
     )
@@ -222,8 +207,7 @@ async def test_realtime_tool_results_preserved_on_interruption(
     await session.start(agent)
     rt_session = model.active_session
 
-    # a generation producing no message and one function call; the function
-    # stream is left open so the generation is still in flight at interruption
+    # one function call, no message; stream left open so the generation is in flight
     fnc_ch = utils.aio.Chan[FunctionCall]()
     fnc_ch.send_nowait(
         FunctionCall(call_id="1", name="get_weather", arguments='{"location": "Tokyo"}')
@@ -248,11 +232,10 @@ async def test_realtime_tool_results_preserved_on_interruption(
     _assert_weather_tool_preserved(agent, session)
     pushed = any(i.type == "function_call_output" for i in rt_session.chat_ctx.items)
     if auto_tool_reply_generation:
-        # pushing the output would trigger a generation; it must stay local-only
+        # pushing would trigger a generation; must stay local-only
         assert not pushed
     else:
-        # the output must also reach the realtime session's server-side context,
-        # otherwise the model still sees a dangling function call and can re-issue it
+        # otherwise the server still sees a dangling call and can re-issue it
         assert pushed
 
     fnc_ch.close()


### PR DESCRIPTION
Fixes #3702
Extends #4877 (credit @CarlosGarciaPro) — covers the remaining interruption path, keeps the realtime server-side context in sync, and adds regression tests.

## Problem

Completed tool results only reach the agent's `chat_ctx` if the speech carrying them survives its interruption gates. If the user interrupts at the wrong moment, the completed `FunctionCall`/`FunctionCallOutput` are silently dropped: the next inference has no record the tool ran, so the LLM re-issues the same call — duplicating side effects for non-idempotent tools (bookings, payments, ...).

Two ways this happens:

1. The tool reply turn — which carries the previous turn's tool messages via `_previous_tools_messages` — is interrupted before reaching the commit site (not covered by #4877; the path we hit in production).
2. The turn is interrupted during playout after its own tools completed; the results in `tool_output.output` were discarded (the variant #4877 fixes).

## Changes

All in `agent_activity.py`, no API changes:

- Commit `_previous_tools_messages` at the start of the reply turn, before any interruption gate (old site removed; `insert` orders by `created_at`, so conversation ordering is unchanged).
- On the post-playout interrupted return, commit completed pairs from `tool_output.output` (pipeline and realtime paths, as in #4877). The realtime path also pushes the outputs to the realtime session, since its server-side state drives the next generation.
- Handoff tools are excluded: an interrupted handoff is not applied, and recording it as completed would stop the LLM from retrying it.

## Tests

Five hermetic tests in `tests/test_tool_results_preserved_on_interruption.py`: both pipeline variants (including a tool still in flight at interruption), the realtime path, and the handoff exclusion. The four preservation tests fail on `main` and pass with this change. Existing suites and `make check` pass.