### PR TITLE
(expressive mode): fix markup tags impacting pacing

### DIFF
--- a/livekit-agents/livekit/agents/voice/transcription/synchronizer.py
+++ b/livekit-agents/livekit/agents/voice/transcription/synchronizer.py
@@ -13,7 +13,7 @@ from livekit import rtc
 
 from ... import tokenize, utils
 from ...log import logger
-from ...tts._provider_format import split_all_markup
+from ...tts._provider_format import TranscriptMarkupStripper, split_all_markup
 from ...types import NOT_GIVEN, NotGivenOr, TimedString
 from ...utils import is_given
 from .. import io
@@ -140,6 +140,12 @@ class _SegmentSynchronizerImpl:
         self._id = utils.shortuuid("SSI_")  # to correlate warnings to a specific impl
         self._text_data = _TextData(word_stream=self._opts.word_tokenizer.stream())
         self._audio_data = _AudioData(sr_stream=self._opts.speaking_rate_detector.stream())
+
+        # paces against the visible text only; stateful because a markup tag with
+        # spaces in its attributes (e.g. <expr type="expression" label="warm surprise"/>)
+        # is shredded across word tokens and a per-token strip can't recognize the
+        # fragments — each would otherwise be paced as if it were spoken
+        self._pacing_stripper = TranscriptMarkupStripper()
 
         self._next_in_chain = next_in_chain
         self._start_wall_time: float | None = None
@@ -381,10 +387,11 @@ class _SegmentSynchronizerImpl:
                 continue
 
             # forward the raw token (the room output strips markup and surfaces the
-            # expression downstream), but pace against the visible text only so a
-            # markup-only token adds no delay
-            clean_word, _ = split_all_markup(word)
-            word_hyphens = len(self._opts.hyphenate_word(clean_word)) if clean_word else 0
+            # expression downstream), but pace against the visible text only so markup
+            # adds no delay. The stripper holds back an unclosed tag across tokens and
+            # releases the clean text once it completes.
+            clean_word = self._pacing_stripper.push(word)
+            word_hyphens = len(self._calc_hyphens(clean_word)) if clean_word.strip() else 0
             elapsed = time.time() - self._start_wall_time - self._paused_duration
 
             d_hyphens = 0

--- a/tests/test_transcript_sync_markup.py
+++ b/tests/test_transcript_sync_markup.py
@@ -1,0 +1,102 @@
+"""Transcript synchronizer pacing must ignore expressive markup.
+
+The synchronizer forwards the raw LLM text (markup intact — the room output strips
+it downstream) but paces the display against the *visible* words only. Markup tags
+carry spaces in their attributes, so the word stream shreds them into fragments
+(``<expr``, ``type="expression"``, ``label="speak``, ``playfully"/>``); a per-token
+strip can't recognize those, and each fragment was paced as if it were spoken — the
+transcript drifted seconds behind the audio on every expressive sentence.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from livekit import rtc
+from livekit.agents import tokenize
+from livekit.agents.voice import io
+from livekit.agents.voice.transcription._speaking_rate import SpeakingRateDetector
+from livekit.agents.voice.transcription.synchronizer import (
+    _SegmentSynchronizerImpl,
+    _TextSyncOptions,
+)
+
+pytestmark = pytest.mark.unit
+
+SAMPLE_RATE = 16000
+AUDIO_DURATION = 3.0
+
+# ~10 visible hyphens of speech, but ~40 hyphens of markup fragments. With the bug
+# the markup alone adds >10s of pacing; with the fix the whole transcript paces out
+# in about the audio duration.
+MARKED_UP_TURN = (
+    '<expr type="expression" label="speak with warm surprise and bright energy"/> '
+    "Hello there my friend! "
+    '<expr type="sound" label="laugh"/> '
+    '<expr type="expression" label="speak calmly and evenly, unhurried"/> '
+    "How are you today?"
+)
+
+
+class _CollectorTextOutput(io.TextOutput):
+    def __init__(self) -> None:
+        super().__init__(label="test-collector", next_in_chain=None)
+        self.words: list[str] = []
+
+    async def capture_text(self, text: str) -> None:
+        self.words.append(str(text))
+
+    def flush(self) -> None:
+        pass
+
+
+def _silent_frames(duration: float) -> list[rtc.AudioFrame]:
+    samples_per_frame = SAMPLE_RATE // 100  # 10ms
+    frame = rtc.AudioFrame(
+        data=b"\x00\x00" * samples_per_frame,
+        sample_rate=SAMPLE_RATE,
+        num_channels=1,
+        samples_per_channel=samples_per_frame,
+    )
+    return [frame] * int(duration * 100)
+
+
+async def test_markup_fragments_add_no_pacing_delay() -> None:
+    opts = _TextSyncOptions(
+        speed=1.0,
+        hyphenate_word=tokenize.basic.hyphenate_word,
+        word_tokenizer=tokenize.basic.WordTokenizer(
+            retain_format=True, ignore_punctuation=False, split_character=True
+        ),
+        speaking_rate_detector=SpeakingRateDetector(),
+    )
+    collector = _CollectorTextOutput()
+    impl = _SegmentSynchronizerImpl(opts, next_in_chain=collector)
+    try:
+        for frame in _silent_frames(AUDIO_DURATION):
+            impl.push_audio(frame)
+        impl.end_audio_input()
+        impl.push_text(MARKED_UP_TURN)
+        impl.end_text_input()
+
+        start = time.monotonic()
+        impl.on_playback_started(time.time())
+
+        # forwarding is done once the main task exhausts the word stream and the
+        # capture task drains the output channel
+        await impl._main_atask
+        await impl._capture_atask
+        elapsed = time.monotonic() - start
+
+        # every raw token is still forwarded (markup included — stripped downstream)
+        assert "".join(collector.words) == MARKED_UP_TURN
+
+        # the pacing budget must cover only the visible words, i.e. roughly the
+        # audio duration; with markup fragments paced as speech it exceeds 12s
+        assert elapsed < AUDIO_DURATION + 3.0, (
+            f"transcript took {elapsed:.1f}s — markup is being paced as spoken text"
+        )
+    finally:
+        await impl.aclose()


### PR DESCRIPTION
A markup tag with spaces in its attributes (e.g. Inworld's <expr type="expression" label="speak with warm surprise"/>) is split across word tokens by the synchronizer's word stream, so the per-token split_all_markup() never saw a complete tag and paced every fragment as if it were spoken — delaying the transcript ~3-4s per expressive sentence, compounding over the turn.

Give each segment a stateful TranscriptMarkupStripper (already used by the room output for the same cross-chunk problem) so tag fragments are held until the tag completes and contribute zero hyphens to pacing. Raw tokens are still forwarded unchanged for downstream stripping and lk.expression extraction.