### PR TITLE
Scope markup stripping to unified &lt;expr&gt; and flip text_content

### DIFF
--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -297,29 +297,33 @@ class ChatMessage(BaseModel):
     @property
     def text_content(self) -> str | None:
         """
-        Returns a string of all text content in the message.
+        Returns a string of all text content in the message, with expressive markup
+        (the unified ``<expr>`` dialect) stripped.
 
-        Multiple text content items will be joined by a newline.
+        Multiple text content items will be joined by a newline. Use
+        :attr:`raw_text_content` for the text exactly as the LLM emitted it.
         """
-        text_parts = [c for c in self.content if isinstance(c, str)]
-        if not text_parts:
-            return None
-        return "\n".join(text_parts)
-
-    @property
-    def plain_text_content(self) -> str | None:
-        """
-        Returns a string of all text content without any expressive tags in the message.
-
-        Multiple text content items will be joined by a newline.
-        """
-        raw = self.text_content
+        raw = self.raw_text_content
         if raw is None:
             return None
 
         from ..tts._provider_format import strip_all_markup
 
         return strip_all_markup(raw)
+
+    @property
+    def raw_text_content(self) -> str | None:
+        """
+        Returns a string of all text content in the message, with any expressive markup
+        preserved as the LLM emitted it.
+
+        Multiple text content items will be joined by a newline. Use
+        :attr:`text_content` for the markup-stripped text.
+        """
+        text_parts = [c for c in self.content if isinstance(c, str)]
+        if not text_parts:
+            return None
+        return "\n".join(text_parts)
 
 
 ChatContent: TypeAlias = ImageContent | AudioContent | str
@@ -781,9 +785,8 @@ class ChatContext:
                 if item.extra.get("is_summary") is True:  # avoid making summary of summaries
                     continue
 
-                # strip markup from assistant turns only; user turns stay raw
-                content = item.plain_text_content if item.role == "assistant" else item.text_content
-                if (content or "").strip():
+                # text_content is already markup-stripped
+                if (item.text_content or "").strip():
                     to_summarize.append(item)
             elif isinstance(item, (FunctionCall, FunctionCallOutput)):
                 to_summarize.append(item)
@@ -797,8 +800,7 @@ class ChatContext:
             if isinstance(m, (FunctionCall, FunctionCallOutput)):
                 contents.append(_function_call_item_to_message(m).text_content or "")
             else:
-                content = m.plain_text_content if m.role == "assistant" else m.text_content
-                contents.append(to_xml(m.role, (content or "").strip()))
+                contents.append(to_xml(m.role, (m.text_content or "").strip()))
 
         source_text = "\n".join(contents).strip()
 

--- a/livekit-agents/livekit/agents/tts/_provider_format.py
+++ b/livekit-agents/livekit/agents/tts/_provider_format.py
@@ -803,22 +803,17 @@ def extract_markup(provider: str, text: str) -> list[ExpressiveTag]:
     return split_markup(provider, text)[1]
 
 
-# Union of every provider's XML tag names — used by the transcript sinks to strip markup
-# without knowing which provider produced it (see :class:`TranscriptMarkupStripper`).
-_ALL_MARKUP_TAGS: list[str] = sorted({tag for tags, _ in _PROVIDER_MARKUP.values() for tag in tags})
-
-
 def split_all_markup(text: str) -> tuple[str, list[ExpressiveTag]]:
-    """Strip the union of every provider's expressive markup (provider-agnostic).
+    """Strip the unified ``<expr>`` markup dialect (provider-agnostic).
 
-    The transcript sinks strip downstream, where the originating TTS/provider is no
-    longer in scope, so they remove every provider's tags (XML + square brackets) at
-    once. These tag shapes never appear in real spoken text — the LLM only emits them
-    as audio directives — so a universal strip is safe.
+    The transcript sinks and chat-context accessors strip downstream, where the
+    originating TTS/provider is no longer in scope. The LLM is only ever taught the
+    unified ``<expr>`` dialect (see :func:`llm_instructions`) and its lowering to native
+    tags (:func:`convert_markup`) runs later in the audio path — so the text reaching
+    here only carries ``<expr>`` markers. Scoping the strip to those markers keeps XML
+    or square-bracket text the LLM legitimately wrote (``[1, 2]``, ``a < b``) intact.
     """
-    text, expr_tags = _split_expr(text)
-    clean, raw_tags = extract_and_strip(text, xml_tags=_ALL_MARKUP_TAGS, brackets=True)
-    return clean, expr_tags + [{"type": tag, "value": value} for tag, value in raw_tags]
+    return _split_expr(text)
 
 
 def strip_all_markup(text: str) -> str:
@@ -845,11 +840,11 @@ class TranscriptMarkupStripper:
     """Stateful, provider-agnostic markup stripper for one transcript segment.
 
     Fed text chunk-by-chunk, it returns the user-visible text and accumulates the
-    stripped tags. A tag-shaped trailing fragment (a partial ``<...`` or ``[...``
-    arriving split across chunks) is held back until it closes, so a tag straddling a
-    chunk boundary is never emitted half-stripped. Shared by the transcript sinks (room
-    output + transcript synchronizer) so stripping and expression extraction stay
-    identical across them.
+    stripped tags. A tag-shaped trailing fragment (a partial ``<expr ...`` arriving split
+    across chunks) is held back until it closes, so a marker straddling a chunk boundary
+    is never emitted half-stripped. Shared by the transcript sinks (room output +
+    transcript synchronizer) so stripping and expression extraction stay identical across
+    them.
     """
 
     def __init__(self) -> None:
@@ -857,14 +852,14 @@ class TranscriptMarkupStripper:
         self._tags: list[ExpressiveTag] = []
 
     def _has_open_tag(self) -> bool:
-        # hold a tag-shaped trailing "<" (partial XML tag) so "3 < 5" isn't stalled, and
-        # any unclosed "[" (bracket tags have no such ambiguity)
+        # hold only a tag-shaped trailing "<" (a partial <expr ...> marker) so "3 < 5"
+        # isn't stalled; square brackets are no longer stripped, so they never buffer
         last_lt = self._buf.rfind("<")
         if last_lt > self._buf.rfind(">"):
             nxt = self._buf[last_lt + 1 : last_lt + 2]
             if not nxt or nxt == "/" or nxt.isalpha():
                 return True
-        return self._buf.rfind("[") > self._buf.rfind("]")
+        return False
 
     def push(self, text: str) -> str:
         """Feed a chunk; return the clean text ready to emit (may be empty)."""

--- a/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/base.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/base.py
@@ -268,7 +268,7 @@ class EOUModelBase(ABC):
             if msg.role not in ("user", "assistant"):
                 continue
 
-            text_content = msg.plain_text_content if msg.role == "assistant" else msg.text_content
+            text_content = msg.text_content  # markup-stripped
             if text_content:
                 messages.append(
                     {

--- a/tests/test_chat_ctx.py
+++ b/tests/test_chat_ctx.py
@@ -82,6 +82,31 @@ def test_dict():
     print(ChatContext.from_dict(chat_ctx.to_dict()).items)
 
 
+def test_text_content_strips_expr_markup():
+    from livekit.agents.llm import ChatMessage
+
+    msg = ChatMessage(
+        role="assistant",
+        content=['<expr type="expression" label="warm"/>Hi there [1, 2]'],
+    )
+    # text_content strips the unified <expr> markup but keeps legitimate bracket text
+    assert msg.text_content == "Hi there [1, 2]"
+    # raw_text_content preserves the markup exactly as the LLM emitted it
+    assert msg.raw_text_content == '<expr type="expression" label="warm"/>Hi there [1, 2]'
+
+
+def test_text_content_no_markup_is_unchanged():
+    from livekit.agents.llm import ChatMessage
+
+    msg = ChatMessage(role="user", content=["What is 3 < 5?"])
+    assert msg.text_content == "What is 3 < 5?"
+    assert msg.raw_text_content == "What is 3 < 5?"
+
+    empty = ChatMessage(role="user", content=[])
+    assert empty.text_content is None
+    assert empty.raw_text_content is None
+
+
 @pytest.mark.parametrize(
     ("mime_type", "expected_format"),
     [

--- a/tests/test_expr_markup.py
+++ b/tests/test_expr_markup.py
@@ -176,13 +176,13 @@ def test_split_markup_wrapping_keeps_inner_text() -> None:
     ]
 
 
-def test_split_all_markup_mixed_expr_and_native() -> None:
+def test_split_all_markup_strips_expr_only() -> None:
+    # only the unified <expr> dialect is stripped; native tags and brackets the LLM
+    # never emits directly (convert_markup lowers <expr> downstream) are left intact
     text = '<expr type="expression" label="say playfully"/> Hello! <sound value="laugh"/> [sigh]'
     clean, tags = split_all_markup(text)
-    assert clean.strip() == "Hello!"
-    assert {"type": "expression", "value": "say playfully"} in tags
-    assert {"type": "sound", "value": "laugh"} in tags
-    assert {"type": "", "value": "sigh"} in tags
+    assert clean.strip() == 'Hello! <sound value="laugh"/> [sigh]'
+    assert tags == [{"type": "expression", "value": "say playfully"}]
 
 
 def test_expr_regex_does_not_match_native_expression_tag() -> None:

--- a/tests/test_tokenizer_xml_markup.py
+++ b/tests/test_tokenizer_xml_markup.py
@@ -484,48 +484,47 @@ class TestToTextStreamBareLt:
 
 
 class TestUniversalMarkupStrip:
-    """The transcript sinks strip downstream without knowing the provider, so they remove
-    the union of every provider's tags. See split_all_markup / TranscriptMarkupStripper."""
+    """The transcript sinks strip downstream without knowing the provider. The LLM is only
+    taught the unified <expr> dialect, so stripping is scoped to those markers — native
+    tags/brackets it never emits directly stay put. See split_all_markup /
+    TranscriptMarkupStripper."""
 
-    def test_split_all_markup_across_providers(self) -> None:
+    def test_split_all_markup_strips_expr_only(self) -> None:
         from livekit.agents.tts._provider_format import split_all_markup
 
-        # Cartesia <emotion>, Inworld/xAI <expression>/<sound>, and bracket tags all strip
-        # regardless of which provider produced them
+        # <expr> markers are removed; a legitimate square-bracket span is left intact
         clean, tags = split_all_markup(
-            '<emotion value="happy"/>Hi <expression value="warm"/>there '
-            '<sound value="giggle"/>[pause] friend'
+            '<expr type="expression" label="warm"/>Hi '
+            '<expr type="sound" label="giggle"/>there [1, 2] friend'
         )
-        assert clean == "Hi there  friend"
+        assert clean == "Hi there [1, 2] friend"
         types = [(t["type"], t["value"]) for t in tags]
-        assert ("emotion", "happy") in types
         assert ("expression", "warm") in types
         assert ("sound", "giggle") in types
-        assert ("", "pause") in types
 
     def test_expression_attribute_shape(self) -> None:
         from livekit.agents.tts._provider_format import expression_attribute, split_all_markup
 
-        _, tags = split_all_markup('<emotion value="sad"/>oh no')
+        _, tags = split_all_markup('<expr type="expression" label="sad"/>oh no')
         attr = expression_attribute(tags)
         assert attr == {"lk.expression": '{"value":"sad"}'}
 
-        # no expression/emotion tag -> no attribute (bracket sounds don't count)
-        _, tags = split_all_markup("[pause]hi")
+        # a non-expression marker -> no attribute
+        _, tags = split_all_markup('<expr type="break" label="500ms"/>hi')
         assert expression_attribute(tags) is None
 
     def test_streaming_stripper_holds_partial_tags(self) -> None:
         from livekit.agents.tts._provider_format import TranscriptMarkupStripper
 
         s = TranscriptMarkupStripper()
-        # a tag split across pushes is held until it closes, never emitted half-stripped
-        out = s.push("Hi <emo")
-        out += s.push('tion value="happy"/> the')
+        # a marker split across pushes is held until it closes, never emitted half-stripped
+        out = s.push("Hi <expr ")
+        out += s.push('type="expression" label="warm"/> the')
         out += s.push("re")
         out += s.flush()
-        assert "<emotion" not in out
+        assert "<expr" not in out
         assert out.replace(" ", "") == "Hithere"
-        assert s.expression_attribute() == {"lk.expression": '{"value":"happy"}'}
+        assert s.expression_attribute() == {"lk.expression": '{"value":"warm"}'}
 
     def test_streaming_stripper_bare_lt_not_stalled(self) -> None:
         from livekit.agents.tts._provider_format import TranscriptMarkupStripper


### PR DESCRIPTION
Follow-up to #6348. Tagged text was reaching the text EOT model via an overly broad strip.

- `split_all_markup` now strips **only** the unified `<expr>` dialect instead of the union of every provider's tags + all square brackets (previously `extract_and_strip(text, xml_tags=_ALL_MARKUP_TAGS, brackets=True)`). The LLM is only ever taught `<expr>`, and its lowering to native tags runs later in the audio path, so the text reaching the transcript sinks / chat accessors only carries `<expr>`. Scoping the strip keeps legitimate text like `[1, 2]` or `a < b` intact.
- Flipped the property names: `ChatMessage.text_content` now returns markup-stripped text (what most of the ~50 callers already expect), and a new `raw_text_content` returns the text exactly as the LLM emitted it. This replaces `plain_text_content`.

`_summarize` and the turn-detector callers simplify to plain `text_content` since it's now stripped for all roles (user turns never contain `<expr>`, so this is a no-op for them).