### PR TITLE
fix(core): flip text content fields AGT-3103

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/anthropic.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/anthropic.py
@@ -33,7 +33,7 @@ def to_chat_ctx(
         chat_items.extend(group.flatten())
 
     for msg in chat_items:
-        if msg.type == "message" and msg.role == "system" and (text := msg.text_content):
+        if msg.type == "message" and msg.role == "system" and (text := msg.raw_text_content):
             system_messages.append(text)
             continue
 

--- a/livekit-agents/livekit/agents/llm/_provider_format/aws.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/aws.py
@@ -33,7 +33,7 @@ def to_chat_ctx(
     current_content: list[dict] = []
 
     for msg in itertools.chain(*(group.flatten() for group in group_tool_calls(chat_ctx))):
-        if msg.type == "message" and msg.role == "system" and (text := msg.text_content):
+        if msg.type == "message" and msg.role == "system" and (text := msg.raw_text_content):
             system_messages.append(text)
             continue
 

--- a/livekit-agents/livekit/agents/llm/_provider_format/google.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/google.py
@@ -30,7 +30,7 @@ def to_chat_ctx(
     parts: list[dict] = []
 
     for msg in itertools.chain(*(group.flatten() for group in group_tool_calls(chat_ctx))):
-        if msg.type == "message" and msg.role == "system" and (text := msg.text_content):
+        if msg.type == "message" and msg.role == "system" and (text := msg.raw_text_content):
             system_messages.append(text)
             continue
 

--- a/livekit-agents/livekit/agents/llm/_provider_format/utils.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/utils.py
@@ -35,7 +35,7 @@ def convert_mid_conversation_instructions(
             item.type == "message"
             and item.role in ("system", "developer")
             and first_system_seen
-            and (text := item.text_content)
+            and (text := item.raw_text_content)
         ):
             items.append(
                 llm.ChatMessage(

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -297,7 +297,25 @@ class ChatMessage(BaseModel):
     @property
     def text_content(self) -> str | None:
         """
-        Returns a string of all text content in the message.
+        Returns a string of all text content in the message, with LiveKit's
+        expressive ``<expr/>`` tags removed from assistant messages.
+
+        Multiple text content items will be joined by a newline.
+        Use :attr:`raw_text_content` for the exact model-facing content.
+        """
+        raw = self.raw_text_content
+        if raw is None or self.role != "assistant":
+            return raw
+
+        from ..tts._provider_format import strip_expr_markup
+
+        return strip_expr_markup(raw)
+
+    @property
+    def raw_text_content(self) -> str | None:
+        """
+        Returns a string of all text content in the message, exactly as generated
+        (assistant messages may contain expressive ``<expr/>`` tags).
 
         Multiple text content items will be joined by a newline.
         """
@@ -305,21 +323,6 @@ class ChatMessage(BaseModel):
         if not text_parts:
             return None
         return "\n".join(text_parts)
-
-    @property
-    def plain_text_content(self) -> str | None:
-        """
-        Returns a string of all text content without any expressive tags in the message.
-
-        Multiple text content items will be joined by a newline.
-        """
-        raw = self.text_content
-        if raw is None:
-            return None
-
-        from ..tts._provider_format import strip_all_markup
-
-        return strip_all_markup(raw)
 
 
 ChatContent: TypeAlias = ImageContent | AudioContent | str
@@ -621,12 +624,12 @@ class ChatContext:
                     item.content = [c for c in item.content if not isinstance(c, ImageContent)]
                 if exclude_audio:
                     item.content = [c for c in item.content if not isinstance(c, AudioContent)]
-                # only strip expressive tags in assistant messages
+                # only strip the <expr/> dialect, and only in assistant messages
                 if strip_markup and item.role == "assistant":
-                    from ..tts._provider_format import strip_all_markup
+                    from ..tts._provider_format import strip_expr_markup
 
                     item.content = [
-                        strip_all_markup(c) if isinstance(c, str) else c for c in item.content
+                        strip_expr_markup(c) if isinstance(c, str) else c for c in item.content
                     ]
 
             items.append(item)
@@ -781,9 +784,7 @@ class ChatContext:
                 if item.extra.get("is_summary") is True:  # avoid making summary of summaries
                     continue
 
-                # strip markup from assistant turns only; user turns stay raw
-                content = item.plain_text_content if item.role == "assistant" else item.text_content
-                if (content or "").strip():
+                if (item.text_content or "").strip():
                     to_summarize.append(item)
             elif isinstance(item, (FunctionCall, FunctionCallOutput)):
                 to_summarize.append(item)
@@ -795,10 +796,9 @@ class ChatContext:
         contents: list[str] = []
         for m in to_summarize:
             if isinstance(m, (FunctionCall, FunctionCallOutput)):
-                contents.append(_function_call_item_to_message(m).text_content or "")
+                contents.append(_function_call_item_to_message(m).raw_text_content or "")
             else:
-                content = m.plain_text_content if m.role == "assistant" else m.text_content
-                contents.append(to_xml(m.role, (content or "").strip()))
+                contents.append(to_xml(m.role, (m.text_content or "").strip()))
 
         source_text = "\n".join(contents).strip()
 

--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -109,7 +109,7 @@ def compute_chat_ctx_diff(old_ctx: ChatContext, new_ctx: ChatContext) -> DiffOps
             # check if the content is different
             old_msg = old_ctx_by_id[new_msg.id]
             if new_msg.type == "message" and old_msg.type == "message":
-                if new_msg.text_content != old_msg.text_content:
+                if new_msg.raw_text_content != old_msg.raw_text_content:
                     to_update.append((prev_id, new_msg.id))
                 # TODO: check other content types
 

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -296,7 +296,7 @@ def _chat_ctx_to_otel_events(chat_ctx: ChatContext) -> list[tuple[str, Attribute
     for item in chat_ctx.items:
         if item.type == "message" and (event_name := role_to_event.get(item.role)):
             # only support text content for now
-            events.append((event_name, {"content": item.text_content or ""}))
+            events.append((event_name, {"content": item.raw_text_content or ""}))
         elif item.type == "function_call":
             events.append(
                 (

--- a/livekit-agents/livekit/agents/tts/_provider_format.py
+++ b/livekit-agents/livekit/agents/tts/_provider_format.py
@@ -826,6 +826,15 @@ def strip_all_markup(text: str) -> str:
     return split_all_markup(text)[0]
 
 
+def strip_expr_markup(text: str) -> str:
+    """Strip only the ``<expr/>`` dialect, leaving all other markup untouched.
+
+    Unlike :func:`strip_all_markup`, provider-native tags and square-bracket spans
+    survive.
+    """
+    return _split_expr(text)[0]
+
+
 def expression_attribute(tags: list[ExpressiveTag]) -> dict[str, str] | None:
     """Build the ``lk.expression`` transcription attribute from stripped markup tags.
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1382,7 +1382,7 @@ class AgentActivity(RecognitionHooks):
                 self._realtime_reply_task(
                     speech_handle=handle,
                     # TODO(theomonnom): support llm.ChatMessage for the realtime model
-                    user_input=user_message.text_content if user_message else None,
+                    user_input=user_message.raw_text_content if user_message else None,
                     instructions=self._render_realtime_instructions(instructions)
                     if instructions
                     else None,
@@ -2291,7 +2291,7 @@ class AgentActivity(RecognitionHooks):
             # make sure the on_user_turn_completed didn't change some request parameters
             # otherwise invalidate the preemptive generation
             if (
-                preemptive.info.new_transcript == user_message.text_content
+                preemptive.info.new_transcript == user_message.raw_text_content
                 and preemptive.chat_ctx.is_equivalent(temp_mutable_chat_ctx)
                 and preemptive.tools == self.tools
                 and preemptive.tool_choice == self._tool_choice
@@ -2801,7 +2801,9 @@ class AgentActivity(RecognitionHooks):
             )
             current_span.set_attribute(trace_types.ATTR_INSTRUCTIONS, instr_trace)
         if new_message:
-            current_span.set_attribute(trace_types.ATTR_USER_INPUT, new_message.text_content or "")
+            current_span.set_attribute(
+                trace_types.ATTR_USER_INPUT, new_message.raw_text_content or ""
+            )
 
         if (room_io := self._session._room_io) and room_io.room.isconnected():
             _set_participant_attributes(current_span, room_io.room.local_participant)

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1796,7 +1796,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
     def _conversation_item_added(self, message: llm.ChatMessage) -> None:
         self._chat_ctx.insert(message)
-        if text := message.text_content:
+        if text := message.raw_text_content:
             logger.debug(
                 "conversation_item_added",
                 extra={"role": message.role, "text": text},

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -306,8 +306,8 @@ def _chat_item_to_proto(item: llm.ChatItem) -> agent_pb.ChatContext.ChatItem:
         }
         pb_role = role_map.get(item.role, agent_pb.ASSISTANT)
         content = []
-        if item.text_content:
-            content.append(agent_pb.ChatMessage.ChatContent(text=item.text_content))
+        if item.raw_text_content:
+            content.append(agent_pb.ChatMessage.ChatContent(text=item.raw_text_content))
         pb_msg = agent_pb.ChatMessage(
             id=item.id,
             role=pb_role,

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -959,10 +959,10 @@ class RealtimeSession(  # noqa: F811
                 if (
                     last_item.type == "message"
                     and last_item.role == "user"
-                    and last_item.text_content
-                    and last_item.text_content.strip()
+                    and last_item.raw_text_content
+                    and last_item.raw_text_content.strip()
                 ):
-                    interactive_user_text = last_item.text_content.strip()
+                    interactive_user_text = last_item.raw_text_content.strip()
                     restart_ctx = restart_ctx.copy()
                     restart_ctx.items.pop()
                     logger.debug(
@@ -1783,16 +1783,16 @@ class RealtimeSession(  # noqa: F811
             ):
                 # Check if this is an audio message (already transcribed by Nova)
                 if item.id not in self._audio_message_ids:
-                    if item.text_content and item.text_content.strip():
+                    if item.raw_text_content and item.raw_text_content.strip():
                         logger.debug(
-                            f"Sending user message as interactive text: {item.text_content}"
+                            f"Sending user message as interactive text: {item.raw_text_content}"
                         )
                         # Send interactive text to Nova Sonic (triggers generation)
                         # This is the flow for generate_reply(user_input=...) from the framework
                         fut = asyncio.Future[llm.GenerationCreatedEvent]()
                         self._pending_generation_fut = fut
 
-                        text = item.text_content
+                        text = item.raw_text_content
 
                         async def _send_user_text(
                             text: str = text, fut: asyncio.Future = fut
@@ -1813,7 +1813,8 @@ class RealtimeSession(  # noqa: F811
                     self._chat_ctx.items.append(item)
                 else:
                     logger.debug(
-                        f"Skipping user message (already in context from audio): {item.text_content}"
+                        "Skipping user message (already in context from audio): "
+                        f"{item.raw_text_content}"
                     )
                     self._sent_message_ids.add(item.id)
 

--- a/livekit-plugins/livekit-plugins-langchain/livekit/plugins/langchain/langgraph.py
+++ b/livekit-plugins/livekit-plugins-langchain/livekit/plugins/langchain/langgraph.py
@@ -178,7 +178,7 @@ class LangGraphStream(llm.LLMStream, Generic[ContextT]):
 
         messages: list[AIMessage | HumanMessage | SystemMessage] = []
         for msg in self._chat_ctx.messages():
-            content = msg.text_content
+            content = msg.raw_text_content
             if content:
                 if msg.role == "assistant":
                     messages.append(AIMessage(content=content, id=msg.id))

--- a/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
@@ -334,8 +334,8 @@ class RealtimeSession(llm.RealtimeSession):
                 item
                 for item in chat_ctx.items
                 if isinstance(item, llm.ChatMessage)
-                and item.text_content
-                and item.text_content.strip()
+                and item.raw_text_content
+                and item.raw_text_content.strip()
             ]
             if messages:
                 turn_history = self._build_turn_history(chat_ctx)
@@ -378,7 +378,7 @@ class RealtimeSession(llm.RealtimeSession):
                         forbid_speech = True
 
             if isinstance(item, llm.ChatMessage) and item.role in ("system", "developer"):
-                text = item.text_content
+                text = item.raw_text_content
                 if text:
                     logger.debug(f"Sending add system message: {text}")
                     if self._socket:
@@ -393,7 +393,7 @@ class RealtimeSession(llm.RealtimeSession):
                 and item.role == "user"
                 and item_id == last_item_id
             ):
-                text = item.text_content
+                text = item.raw_text_content
                 if text:
                     logger.info(f"Received user text input: {text}")
                     self._pending_user_text = text
@@ -509,9 +509,11 @@ class RealtimeSession(llm.RealtimeSession):
         messages = [
             item
             for item in chat_ctx.items
-            if isinstance(item, llm.ChatMessage) and item.text_content and item.text_content.strip()
+            if isinstance(item, llm.ChatMessage)
+            and item.raw_text_content
+            and item.raw_text_content.strip()
         ]
-        return "\n".join(f"{m.role}: {m.text_content}" for m in messages)
+        return "\n".join(f"{m.role}: {m.raw_text_content}" for m in messages)
 
     def _build_config_options(
         self, *, system_prompt: str, tools_payload: list[dict | str]

--- a/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/base.py
+++ b/livekit-plugins/livekit-plugins-turn-detector/livekit/plugins/turn_detector/base.py
@@ -268,7 +268,7 @@ class EOUModelBase(ABC):
             if msg.role not in ("user", "assistant"):
                 continue
 
-            text_content = msg.plain_text_content if msg.role == "assistant" else msg.text_content
+            text_content = msg.text_content
             if text_content:
                 messages.append(
                     {

--- a/livekit-plugins/livekit-plugins-ultravox/livekit/plugins/ultravox/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-ultravox/livekit/plugins/ultravox/realtime/realtime_model.py
@@ -375,19 +375,19 @@ class RealtimeSession(
                 continue
 
             if item.type == "message" and item.role in ("system", "developer"):
-                if item.text_content:
+                if item.raw_text_content:
                     self._send_client_event(
                         UserTextMessageEvent(
-                            text=f"<instruction>{item.text_content}</instruction>",
+                            text=f"<instruction>{item.raw_text_content}</instruction>",
                             defer_response=True,
                         )
                     )
 
             elif item.type == "message" and item.role == "user":
                 # Inject user message as context; do not trigger an immediate response
-                if item.text_content:
+                if item.raw_text_content:
                     self._send_client_event(
-                        UserTextMessageEvent(text=item.text_content, defer_response=True)
+                        UserTextMessageEvent(text=item.raw_text_content, defer_response=True)
                     )
             elif item.type == "function_call_output":
                 # Bridge tool result back to Ultravox using the original invocationId

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/realtime/realtime_model.py
@@ -223,7 +223,7 @@ class RealtimeSession(openai.realtime.RealtimeSession):
         if remote_item := self._remote_chat_ctx.get(event.item_id):
             if (
                 remote_item.item.type == "message"
-                and remote_item.item.text_content == event.transcript
+                and remote_item.item.raw_text_content == event.transcript
             ):
                 remote_item.item.content.clear()
         super()._handle_conversion_item_input_audio_transcription_completed(event)

--- a/tests/test_expr_markup.py
+++ b/tests/test_expr_markup.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import pytest
 
+from livekit.agents.llm import ChatContext, ChatMessage
 from livekit.agents.tts._provider_format import (
     TranscriptMarkupStripper,
     convert_markup,
@@ -19,6 +20,7 @@ from livekit.agents.tts._provider_format import (
     normalize_markup,
     split_all_markup,
     split_markup,
+    strip_expr_markup,
 )
 
 pytestmark = pytest.mark.unit
@@ -293,3 +295,64 @@ def test_llm_instructions_xai_kinds() -> None:
 def test_llm_instructions_none_for_unknown_provider() -> None:
     assert llm_instructions("") is None
     assert llm_instructions("openai") is None
+
+
+# ---------------------------------------------------------------------------
+# strip_expr_markup + ChatMessage.text_content / raw_text_content
+# ---------------------------------------------------------------------------
+
+# assistant text mixing expr markers with content that must survive an expr-only strip:
+# provider-native tags, bracket spans, markdown links, and stray angle brackets
+MIXED = (
+    '<expr type="expression" label="happy"/> Press [Enter] to see <b>bold</b>, '
+    'read [the docs](https://docs.livekit.io), then 1 < 2. <break time="1s"/> '
+    '<expr type="prosody" label="whisper">keep it secret</expr>'
+)
+MIXED_CLEAN = (
+    " Press [Enter] to see <b>bold</b>, "
+    'read [the docs](https://docs.livekit.io), then 1 < 2. <break time="1s"/> '
+    "keep it secret"
+)
+
+
+def test_strip_expr_markup_only_touches_expr() -> None:
+    assert strip_expr_markup(MIXED) == MIXED_CLEAN
+
+
+def test_strip_expr_markup_noop_without_expr() -> None:
+    text = 'plain text with [brackets] and <sound value="laugh"/>'
+    assert strip_expr_markup(text) == text
+
+
+def test_assistant_text_content_strips_expr_only() -> None:
+    msg = ChatMessage(role="assistant", content=[MIXED])
+    assert msg.text_content == MIXED_CLEAN
+    assert msg.raw_text_content == MIXED
+
+
+@pytest.mark.parametrize("role", ["user", "system", "developer"])
+def test_non_assistant_text_content_stays_raw(role: str) -> None:
+    # only assistant messages carry expressive markup; other roles are never stripped
+    msg = ChatMessage(role=role, content=[JOKE])
+    assert msg.text_content == JOKE
+    assert msg.raw_text_content == JOKE
+
+
+def test_text_content_none_without_text() -> None:
+    msg = ChatMessage(role="assistant", content=[])
+    assert msg.text_content is None
+    assert msg.raw_text_content is None
+
+
+def test_to_dict_strip_markup_is_expr_only_and_assistant_only() -> None:
+    chat_ctx = ChatContext.empty()
+    chat_ctx.add_message(role="user", content=[MIXED])
+    chat_ctx.add_message(role="assistant", content=[MIXED])
+
+    items = chat_ctx.to_dict(strip_markup=True)["items"]
+    assert items[0]["content"] == [MIXED]  # user content untouched
+    assert items[1]["content"] == [MIXED_CLEAN]  # assistant loses only expr tags
+
+    # default keeps the raw content for persistence
+    items = chat_ctx.to_dict()["items"]
+    assert items[1]["content"] == [MIXED]


### PR DESCRIPTION
Before:
- `text_content` raw content, with expressive tags and bracket tags;
- `plain_text_content` clean content, without any tags;

Now:
- `text_content` clean content, without any expressive-only tags `expr`
- `raw_text_content` raw content with `expr` tags