### PR TITLE
feat(google): support gemini-3.5-live-translate-preview via translation_config

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/api_proto.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/api_proto.py
@@ -17,6 +17,7 @@ LiveAPIModels = Literal[
     # Gemini API models
     "gemini-3.1-flash-live-preview",
     "gemini-2.5-flash-native-audio-preview-12-2025",  # https://ai.google.dev/gemini-api/docs/models#gemini-2.5-flash-live
+    "gemini-3.5-live-translate-preview",  # https://ai.google.dev/gemini-api/docs/live-api/live-translate
 ]
 
 Voice = Literal[

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -61,6 +61,7 @@ KNOWN_GEMINI_API_MODELS: frozenset[str] = frozenset(
     {
         "gemini-3.1-flash-live-preview",
         "gemini-2.5-flash-native-audio-preview-12-2025",
+        "gemini-3.5-live-translate-preview",
     }
 )
 
@@ -154,6 +155,7 @@ class _RealtimeOptions:
     tool_choice: NotGivenOr[llm.ToolChoice | None] = NOT_GIVEN
     thinking_config: NotGivenOr[types.ThinkingConfig] = NOT_GIVEN
     session_resumption: NotGivenOr[types.SessionResumptionConfig] = NOT_GIVEN
+    translation_config: NotGivenOr[types.TranslationConfig] = NOT_GIVEN
     credentials: google.auth.credentials.Credentials | None = None
 
 
@@ -223,6 +225,7 @@ class RealtimeModel(llm.RealtimeModel):
         http_options: NotGivenOr[types.HttpOptions] = NOT_GIVEN,
         media_resolution: NotGivenOr[types.MediaResolution] = NOT_GIVEN,
         thinking_config: NotGivenOr[types.ThinkingConfig] = NOT_GIVEN,
+        translation_config: NotGivenOr[types.TranslationConfig] = NOT_GIVEN,
         credentials: google.auth.credentials.Credentials | None = None,
     ) -> None:
         """
@@ -263,6 +266,12 @@ class RealtimeModel(llm.RealtimeModel):
             tool_response_scheduling (FunctionResponseScheduling, optional): The scheduling for tool response. Default scheduling is WHEN_IDLE.
             session_resumption (SessionResumptionConfig, optional): The configuration for session resumption. Defaults to None.
             thinking_config (ThinkingConfig, optional): Native audio thinking configuration.
+            translation_config (TranslationConfig, optional): Speech translation configuration, required by live-translate models
+                (e.g. "gemini-3.5-live-translate-preview"). Sets the target language (BCP-47 code) via `target_language_code` and
+                whether to also play back speech in the target language via `echo_target_language`. The input language is detected
+                automatically. Note that live-translate models are audio-to-audio only (AUDIO response modality) and do not support
+                tools or system instructions the way conversational Live models do.
+                See https://ai.google.dev/gemini-api/docs/live-api/live-translate. Defaults to None.
             conn_options (APIConnectOptions, optional): The configuration for the API connection. Defaults to DEFAULT_API_CONNECT_OPTIONS.
 
         Raises:
@@ -381,6 +390,7 @@ class RealtimeModel(llm.RealtimeModel):
             media_resolution=media_resolution,
             thinking_config=thinking_config,
             session_resumption=session_resumption,
+            translation_config=translation_config,
             credentials=credentials,
         )
 
@@ -1186,6 +1196,8 @@ class RealtimeSession(llm.RealtimeSession):
             conf.realtime_input_config = self._opts.realtime_input_config
         if is_given(self._opts.context_window_compression):
             conf.context_window_compression = self._opts.context_window_compression
+        if is_given(self._opts.translation_config):
+            conf.translation_config = self._opts.translation_config
 
         return conf
 

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -302,7 +302,10 @@ class RealtimeModel(llm.RealtimeModel):
                 else "gemini-2.5-flash-native-audio-preview-12-2025"
             )
 
-        mutable = "3.1" not in model
+        # live-translate models are audio-to-audio only and do not accept system
+        # instructions or tools, so their chat context / instructions are not mutable.
+        is_translate = "live-translate" in model
+        mutable = "3.1" not in model and not is_translate
         super().__init__(
             capabilities=llm.RealtimeCapabilities(
                 message_truncation=False,
@@ -1140,10 +1143,19 @@ class RealtimeSession(llm.RealtimeSession):
     def _build_connect_config(self) -> types.LiveConnectConfig:
         temp = self._opts.temperature if is_given(self._opts.temperature) else None
 
-        tools_config = create_tools_config(
-            self._tools,
-            tool_behavior=self._opts.tool_behavior,
-            use_parameters_json_schema=False,
+        # live-translate models are audio-to-audio only: they translate speech via
+        # translation_config and do not accept system instructions, tools, or a
+        # prebuilt voice/speech config. Omit those fields so the API doesn't reject them.
+        is_translate = "live-translate" in self._opts.model
+
+        tools_config = (
+            None
+            if is_translate
+            else create_tools_config(
+                self._tools,
+                tool_behavior=self._opts.tool_behavior,
+                use_parameters_json_schema=False,
+            )
         )
         conf = types.LiveConnectConfig(
             response_modalities=self._opts.response_modalities,
@@ -1172,9 +1184,11 @@ class RealtimeSession(llm.RealtimeSession):
                 else None,
             ),
             system_instruction=types.Content(parts=[types.Part(text=self._opts.instructions)])
-            if is_given(self._opts.instructions)
+            if is_given(self._opts.instructions) and not is_translate
             else None,
-            speech_config=types.SpeechConfig(
+            speech_config=None
+            if is_translate
+            else types.SpeechConfig(
                 voice_config=types.VoiceConfig(
                     prebuilt_voice_config=types.PrebuiltVoiceConfig(voice_name=self._opts.voice)
                 ),


### PR DESCRIPTION
## Summary

Google launched [Gemini 3.5 Live Translate](https://ai.google.dev/gemini-api/docs/live-api/live-translate) (`gemini-3.5-live-translate-preview`), a low-latency speech-to-speech translation model on the Live API. Using it requires setting `translation_config` on `LiveConnectConfig`, which the Google plugin's `RealtimeModel` previously had no way to pass.

This PR:

- adds a `translation_config: NotGivenOr[types.TranslationConfig]` parameter to `RealtimeModel` (threaded through `_RealtimeOptions` into `_build_connect_config()`, following the same pattern as `realtime_input_config` / `context_window_compression`)
- adds `gemini-3.5-live-translate-preview` to the `LiveAPIModels` Literal and to `KNOWN_GEMINI_API_MODELS` (it is a Gemini API model, so the existing model/API mismatch validation applies)
- documents in the docstring that live-translate models are audio-to-audio only (AUDIO response modality) and don't support tools/system instructions the way conversational Live models do

The required `types.TranslationConfig` and `LiveConnectConfig.translation_config` are available in `google-genai` 2.8.0 (the version currently locked in `uv.lock`; the plugin requires `google-genai >= 1.67`).

## Usage

```python
from google.genai import types
from livekit.plugins import google

model = google.realtime.RealtimeModel(
    model="gemini-3.5-live-translate-preview",
    translation_config=types.TranslationConfig(
        target_language_code="es-US",
        echo_target_language=True,
    ),
)
```

Input language is auto-detected; audio is 16kHz PCM in / 24kHz PCM out, matching what the plugin already sends/expects.

## Testing

- `uv run ruff format` / `uv run ruff check` — clean
- `uv run python scripts/check_types.py` (mypy strict) — no issues
- `uv run pytest --unit -k google` — 34 passed
- verified by import + construction: `RealtimeModel(model="gemini-3.5-live-translate-preview", translation_config=types.TranslationConfig(target_language_code="es-US", echo_target_language=True))` constructs, and `_build_connect_config()` produces a `LiveConnectConfig` carrying the translation config

Note: I don't currently have access to the preview model, so this is not verified against the live API end-to-end — the change is config plumbing only and existing behavior is unchanged when `translation_config` is not given.
