### PR TITLE
fix: send DTMF to the active session room

### DIFF
--- a/livekit-agents/livekit/agents/beta/tools/send_dtmf.py
+++ b/livekit-agents/livekit/agents/beta/tools/send_dtmf.py
@@ -2,6 +2,7 @@ import asyncio
 
 from ... import function_tool
 from ...job import get_job_context
+from ...voice.events import RunContext
 from ..workflows.utils import DtmfEvent, dtmf_event_to_code
 
 DEFAULT_DTMF_PUBLISH_DELAY = 0.3  # seconds to wait between sending DTMF events
@@ -9,6 +10,7 @@ DEFAULT_DTMF_PUBLISH_DELAY = 0.3  # seconds to wait between sending DTMF events
 
 @function_tool
 async def send_dtmf_events(
+    ctx: RunContext,
     events: list[DtmfEvent],
 ) -> str:
     """
@@ -17,12 +19,15 @@ async def send_dtmf_events(
     Call when:
     - User wants to send DTMF events
     """
-    job_ctx = get_job_context()
+    try:
+        room = ctx.session.room_io.room
+    except RuntimeError:
+        room = get_job_context().room
 
     for event in events:
         try:
             code = dtmf_event_to_code(event)
-            await job_ctx.room.local_participant.publish_dtmf(code=code, digit=event.value)
+            await room.local_participant.publish_dtmf(code=code, digit=event.value)
             await asyncio.sleep(DEFAULT_DTMF_PUBLISH_DELAY)
         except Exception as e:
             return f"Failed to send DTMF event: {event.value}. Error: {str(e)}"


### PR DESCRIPTION
The `send_dtmf_events` tool resolved the room from the job context, which is always the original caller room. During a warm transfer the tool runs in a separate session bound to a different room, so DTMF was published to the caller instead of the transferee.

This resolves the room from the run context session (`ctx.session.room_io.room`), falling back to the job context when the session has no room I/O.

Fixes #6357