### PR TITLE
fix: honor IGNORE_ON_ENTER for tools inside a Toolset

### DIFF
--- a/livekit-agents/livekit/agents/beta/tools/end_call.py
+++ b/livekit-agents/livekit/agents/beta/tools/end_call.py
@@ -3,7 +3,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from ...job import get_job_context
-from ...llm import RealtimeModel, Toolset, function_tool
+from ...llm import RealtimeModel, ToolFlag, Toolset, function_tool
 from ...log import logger
 from ...voice.events import CloseEvent, RunContext, SpeechCreatedEvent
 from ...voice.speech_handle import SpeechHandle
@@ -31,6 +31,7 @@ class EndCallTool(Toolset):
         extra_description: str = "",
         delete_room: bool = True,
         end_instructions: str | None = "say goodbye to the user",
+        ignore_on_enter: bool = False,
         on_tool_called: Callable[[Toolset.ToolCalledEvent], Awaitable[None]] | None = None,
         on_tool_completed: Callable[[Toolset.ToolCompletedEvent], Awaitable[None]] | None = None,
     ):
@@ -41,6 +42,7 @@ class EndCallTool(Toolset):
             extra_description: Additional description to add to the end call tool.
             delete_room: Whether to delete the room when the user ends the call. deleting the room disconnects all remote users, including SIP callers.
             end_instructions: Tool output to the LLM for generating the tool response.
+            ignore_on_enter: Hide the tool during ``on_enter`` so the model can't end the call while greeting.
             on_tool_called: Callback to call when the tool is called.
             on_tool_completed: Callback to call when the tool is completed.
         """
@@ -48,6 +50,7 @@ class EndCallTool(Toolset):
             self._end_call,
             name="end_call",
             description=f"{END_CALL_DESCRIPTION}\n{extra_description}",
+            flags=ToolFlag.IGNORE_ON_ENTER if ignore_on_enter else ToolFlag.NONE,
         )
         super().__init__(id="end_call", tools=[end_call_tool])
 

--- a/livekit-agents/livekit/agents/llm/tool_context.py
+++ b/livekit-agents/livekit/agents/llm/tool_context.py
@@ -617,6 +617,13 @@ class ToolContext:
         structured = [t for t in self._tools if not any(t is r for r in removed)]
         self._update_tools([*structured, *added], exclude=removed)
 
+    def _exclude(self, tools: Sequence[Tool]) -> None:
+        """Hide ``tools`` from the callable set while keeping their toolsets intact."""
+        if not tools:
+            return
+        kept = [t for t in self.flatten() if not any(t is e for e in tools)]
+        self._sync_flattened(kept)
+
     def copy(self) -> ToolContext:
         return ToolContext(self._tools.copy())
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1350,22 +1350,6 @@ class AgentActivity(RecognitionHooks):
                     )
                 resolved_tools.append(tool)
 
-        # if tool has the IGNORE_ON_ENTER flag, every generate_reply inside on_enter will ignore it
-        if on_enter_data := _OnEnterContextVar.get(None):
-            if on_enter_data.agent == self._agent and on_enter_data.session == self._session:
-                filtered_tools: list[llm.Tool | llm.Toolset] = []
-                to_filter = resolved_tools if is_given(resolved_tools) else all_tools
-                for tool in to_filter:
-                    if (
-                        isinstance(tool, llm.RawFunctionTool | llm.FunctionTool)
-                        and tool.info.flags & ToolFlag.IGNORE_ON_ENTER
-                    ):
-                        continue
-
-                    # TODO(long): add IGNORE_ON_ENTER to ToolSet?
-                    filtered_tools.append(tool)
-                to_filter[:] = filtered_tools
-
         handle = SpeechHandle.create(
             allow_interruptions=allow_interruptions
             if is_given(allow_interruptions)
@@ -2744,6 +2728,22 @@ class AgentActivity(RecognitionHooks):
         if audio_out is not None and not audio_out.first_frame_fut.done():
             audio_out.first_frame_fut.cancel()
 
+    def _on_enter_ignored_tools(self, tool_ctx: llm.ToolContext) -> list[llm.Tool]:
+        """Tools flagged IGNORE_ON_ENTER, when this reply runs inside on_enter."""
+        on_enter_data = _OnEnterContextVar.get(None)
+        if (
+            on_enter_data is None
+            or on_enter_data.agent != self._agent
+            or on_enter_data.session != self._session
+        ):
+            return []
+        return [
+            tool
+            for tool in tool_ctx.flatten()
+            if isinstance(tool, llm.RawFunctionTool | llm.FunctionTool)
+            and tool.info.flags & ToolFlag.IGNORE_ON_ENTER
+        ]
+
     @utils.log_exceptions(logger=logger)
     async def _pipeline_reply_task(
         self,
@@ -2814,6 +2814,7 @@ class AgentActivity(RecognitionHooks):
         )
         chat_ctx = chat_ctx.copy()
         tool_ctx = llm.ToolContext(tools)
+        tool_ctx._exclude(self._on_enter_ignored_tools(tool_ctx))
 
         if new_message is not None:
             chat_ctx.insert(new_message)
@@ -3382,6 +3383,14 @@ class AgentActivity(RecognitionHooks):
             self._agent._chat_ctx._upsert_item(msg)
             self._session._conversation_item_added(msg)
 
+        # inside on_enter, hide flagged tools even when no tools= was passed (fall back to self.tools)
+        turn_tools: NotGivenOr[list[llm.Tool]] = NOT_GIVEN
+        tool_ctx = llm.ToolContext(tools if tools is not None else self.tools)
+        on_enter_ignored = self._on_enter_ignored_tools(tool_ctx)
+        if tools is not None or on_enter_ignored:
+            tool_ctx._exclude(on_enter_ignored)
+            turn_tools = tool_ctx.flatten()
+
         ori_tool_choice: NotGivenOr[llm.ToolChoice | None] = NOT_GIVEN
         ori_tools: NotGivenOr[list[llm.Tool]] = NOT_GIVEN
         try:
@@ -3397,18 +3406,14 @@ class AgentActivity(RecognitionHooks):
                     ori_tool_choice = self._tool_choice
                     self._rt_session.update_options(tool_choice=model_settings.tool_choice)
 
-                if tools is not None:
+                if is_given(turn_tools):
                     ori_tools = self._rt_session.tools.flatten()
-                    await self._rt_session.update_tools(llm.ToolContext(tools).flatten())
+                    await self._rt_session.update_tools(turn_tools)
 
             generate_reply_fut = self._rt_session.generate_reply(
                 instructions=instructions or NOT_GIVEN,
                 tool_choice=(model_settings.tool_choice if per_response_tool_choice else NOT_GIVEN),
-                tools=(
-                    llm.ToolContext(tools).flatten()
-                    if per_response_tool_choice and tools is not None
-                    else NOT_GIVEN
-                ),
+                tools=(turn_tools if per_response_tool_choice else NOT_GIVEN),
             )
             await speech_handle.wait_if_not_interrupted([generate_reply_fut])
             if speech_handle.interrupted:

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -27,7 +27,15 @@ from livekit.agents import (
     inference,
     vad,
 )
-from livekit.agents.llm import FunctionToolCall, InputTranscriptionCompleted
+from livekit.agents.llm import (
+    FunctionTool,
+    FunctionToolCall,
+    InputTranscriptionCompleted,
+    RawFunctionTool,
+    ToolContext,
+    ToolFlag,
+    Toolset,
+)
 from livekit.agents.llm.chat_context import ChatContext, ChatMessage
 from livekit.agents.stt import SpeechData, SpeechEvent, SpeechEventType
 from livekit.agents.utils import aio
@@ -692,6 +700,179 @@ async def test_generate_reply() -> None:
     assert agent.chat_ctx.items[6].role == "assistant"
     assert agent.chat_ctx.items[6].text_content == "Goodbye! have a nice day!"
     assert agent.chat_ctx.items[7].type == "function_call_output"
+
+
+async def test_on_enter_hides_ignore_on_enter_tools() -> None:
+    """IGNORE_ON_ENTER tools (bare + toolset-nested) are hidden inside on_enter, restored after."""
+
+    class _Toolset(Toolset):
+        def __init__(self) -> None:
+            end_call = function_tool(
+                self._end_call,
+                name="end_call",
+                description="ends the call",
+                flags=ToolFlag.IGNORE_ON_ENTER,
+            )
+            keep = function_tool(self._keep, name="keep", description="a normal tool")
+            super().__init__(id="ts", tools=[end_call, keep])
+
+        async def _end_call(self) -> None: ...
+
+        async def _keep(self) -> None: ...
+
+    @function_tool(flags=ToolFlag.IGNORE_ON_ENTER)
+    async def bare_ignored() -> None:
+        """A bare flagged tool."""
+
+    class _Agent(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="you are helpful", tools=[_Toolset(), bare_ignored])
+
+        async def on_enter(self) -> None:
+            self.session.generate_reply(instructions="instructions:say hello to the user")
+
+    actions = FakeActions()
+    actions.add_llm("Hello!", input="instructions:say hello to the user")
+    actions.add_tts(1.0)
+    actions.add_user_speech(2.0, 3.0, "hi there")
+    actions.add_llm("How can I help?")
+    actions.add_tts(1.0)
+
+    session = create_session(actions)
+
+    captured: list[set[str]] = []
+    orig_chat = session.llm.chat
+
+    def _recording_chat(*, chat_ctx, tools=None, **kwargs):  # type: ignore[no-untyped-def]
+        captured.append(
+            {t.info.name for t in (tools or []) if isinstance(t, (FunctionTool, RawFunctionTool))}
+        )
+        return orig_chat(chat_ctx=chat_ctx, tools=tools, **kwargs)
+
+    session.llm.chat = _recording_chat  # type: ignore[method-assign]
+
+    await asyncio.wait_for(run_session(session, _Agent()), timeout=SESSION_TIMEOUT)
+
+    assert len(captured) == 2
+    # on_enter reply: flagged tools hidden, normal tool still offered
+    assert captured[0] == {"keep"}
+    # a later (non-on_enter) turn sees every tool again
+    assert captured[1] == {"keep", "end_call", "bare_ignored"}
+
+
+async def test_on_enter_hides_tools_in_nested_tool_reply() -> None:
+    """When an on_enter reply calls a tool, the tool-response follow-up (a nested speech task)
+    also hides the flagged tools — proving the on_enter contextvar reaches nested tasks."""
+
+    class _Toolset(Toolset):
+        def __init__(self) -> None:
+            end_call = function_tool(
+                self._end_call, name="end_call", description="ends", flags=ToolFlag.IGNORE_ON_ENTER
+            )
+            keep = function_tool(self._keep, name="keep", description="a normal tool")
+            super().__init__(id="ts", tools=[end_call, keep])
+
+        async def _end_call(self) -> None: ...
+
+        async def _keep(self) -> str:
+            return "kept"
+
+    @function_tool(flags=ToolFlag.IGNORE_ON_ENTER)
+    async def bare_ignored() -> None:
+        """A bare flagged tool."""
+
+    class _Agent(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="you are helpful", tools=[_Toolset(), bare_ignored])
+
+        async def on_enter(self) -> None:
+            self.session.generate_reply(instructions="instructions:say hello to the user")
+
+    actions = FakeActions()
+    # on_enter reply calls the visible `keep` tool instead of speaking, spawning a follow-up
+    actions.add_llm(
+        "",
+        tool_calls=[FunctionToolCall(name="keep", arguments="{}", call_id="1")],
+        input="instructions:say hello to the user",
+    )
+    # tool-response follow-up (keyed on the `keep` return value)
+    actions.add_llm("Hello there!", input="kept")
+    actions.add_tts(1.0)
+    # a user turn ends the run and confirms tools are restored afterwards
+    actions.add_user_speech(4.0, 5.0, "hi there")
+    actions.add_llm("How can I help?")
+    actions.add_tts(1.0)
+
+    session = create_session(actions)
+
+    captured: list[set[str]] = []
+    orig_chat = session.llm.chat
+
+    def _recording_chat(*, chat_ctx, tools=None, **kwargs):  # type: ignore[no-untyped-def]
+        captured.append(
+            {t.info.name for t in (tools or []) if isinstance(t, (FunctionTool, RawFunctionTool))}
+        )
+        return orig_chat(chat_ctx=chat_ctx, tools=tools, **kwargs)
+
+    session.llm.chat = _recording_chat  # type: ignore[method-assign]
+
+    await asyncio.wait_for(run_session(session, _Agent()), timeout=SESSION_TIMEOUT)
+
+    assert len(captured) == 3
+    greeting, tool_reply, user_turn = captured
+    # both the greeting reply and its nested tool-response follow-up hide the flagged tools
+    assert greeting == {"keep"}
+    assert tool_reply == {"keep"}
+    # the later (non-on_enter) user turn sees every tool again
+    assert user_turn == {"keep", "end_call", "bare_ignored"}
+
+
+def test_on_enter_ignored_tools() -> None:
+    """_on_enter_ignored_tools returns flagged tools only inside this agent/session's on_enter."""
+    from livekit.agents.voice.agent_activity import _OnEnterContextVar, _OnEnterData
+
+    class _Toolset(Toolset):
+        def __init__(self) -> None:
+            end_call = function_tool(
+                self._end_call, name="end_call", description="ends", flags=ToolFlag.IGNORE_ON_ENTER
+            )
+            ts_keep = function_tool(self._keep, name="ts_keep", description="normal")
+            super().__init__(id="ts", tools=[end_call, ts_keep])
+
+        async def _end_call(self) -> None: ...
+
+        async def _keep(self) -> None: ...
+
+    @function_tool(flags=ToolFlag.IGNORE_ON_ENTER)
+    async def bare_ignored() -> None:
+        """A flagged bare tool."""
+
+    @function_tool
+    async def bare_keep() -> None:
+        """A normal bare tool."""
+
+    activity = object.__new__(AgentActivity)
+    activity._agent = object()  # type: ignore[assignment]
+    activity._session = object()  # type: ignore[assignment]
+    tool_ctx = ToolContext([_Toolset(), bare_ignored, bare_keep])
+
+    # outside on_enter: nothing is ignored
+    assert activity._on_enter_ignored_tools(tool_ctx) == []
+
+    # inside this agent/session's on_enter: flagged tools (bare + nested) are returned
+    tk = _OnEnterContextVar.set(_OnEnterData(session=activity._session, agent=activity._agent))
+    try:
+        ignored = {t.info.name for t in activity._on_enter_ignored_tools(tool_ctx)}
+    finally:
+        _OnEnterContextVar.reset(tk)
+    assert ignored == {"end_call", "bare_ignored"}
+
+    # a different agent's on_enter must not leak in
+    tk = _OnEnterContextVar.set(_OnEnterData(session=activity._session, agent=object()))
+    try:
+        assert activity._on_enter_ignored_tools(tool_ctx) == []
+    finally:
+        _OnEnterContextVar.reset(tk)
 
 
 async def test_aec_warmup() -> None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -304,6 +304,36 @@ class TestToolContext:
         ctx6 = ToolContext([mock_tool_1, mock_tool_2])
         assert ctx5 != ctx6
 
+    def test_exclude_hides_toolset_member_but_keeps_toolset(self):
+        toolset = MockToolset1()  # contains mock_tool_1, mock_tool_2
+        ctx = ToolContext([toolset, mock_tool_3])
+
+        ctx._exclude([mock_tool_1])
+
+        # the excluded member is no longer callable / no longer visible to the LLM
+        assert "mock_tool_1" not in ctx.function_tools
+        assert mock_tool_1 not in ctx.flatten()
+        # its sibling and the top-level tool remain callable
+        assert "mock_tool_2" in ctx.function_tools
+        assert "mock_tool_3" in ctx.function_tools
+        # the toolset itself stays so executor routing and lifecycle are unaffected
+        assert toolset in ctx.toolsets
+
+    def test_exclude_empty_is_noop(self):
+        ctx = ToolContext([mock_tool_1, mock_tool_2])
+        ctx._exclude([])
+        assert set(ctx.function_tools) == {"mock_tool_1", "mock_tool_2"}
+
+
+def test_end_call_tool_ignore_on_enter_flag():
+    from livekit.agents.beta import EndCallTool
+
+    (tool,) = EndCallTool().tools  # defaults to ignore_on_enter=False
+    assert not (tool.info.flags & ToolFlag.IGNORE_ON_ENTER)
+
+    (tool,) = EndCallTool(ignore_on_enter=True).tools
+    assert tool.info.flags & ToolFlag.IGNORE_ON_ENTER
+
 
 class TestToolExecution:
     def test_function_arguments_to_pydantic_model(self):


### PR DESCRIPTION
Closes #6354

`ToolFlag.IGNORE_ON_ENTER` was only honored for bare `FunctionTool`/`RawFunctionTool` instances in the `on_enter` reply filter — tools nested in a `Toolset` (e.g. `EndCallTool`) passed through unfiltered, so the model could fire a speculative `end_call` during the greeting turn (with `delete_room=True`, an instant hangup at pickup).

The filter now flattens toolsets and hides flagged tools via `ToolContext._exclude`, which drops them from the callable/LLM-visible set while keeping the owning toolset in place so executor routing and lifecycle are unaffected. Rather than threading the ignored set through the reply tasks, `_on_enter_ignored_tools` reads the `on_enter` contextvar directly; the reply task and its tool-response follow-ups inherit it through `asyncio.create_task`.

The realtime path is covered too: it only overrides its session tools when `generate_reply` is given `tools=`, so inside `on_enter` it now falls back to the agent's full set and hides flagged tools even without an explicit `tools=`.

`EndCallTool` gains an `ignore_on_enter` parameter (defaults to `False`, preserving current behavior) to opt into hiding `end_call` during the greeting.