### PR TITLE
fix(azure): recover from STT error cancellations instead of hanging

### DIFF
--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
@@ -233,6 +233,7 @@ class SpeechStream(stt.SpeechStream):
 
         self._loop = asyncio.get_running_loop()
         self._reconnect_event = asyncio.Event()
+        self._cancellation_error: speechsdk.CancellationDetails | None = None
         self._audio_duration = 0.0
         self._last_audio_duration_report_time = time.monotonic()
 
@@ -257,6 +258,7 @@ class SpeechStream(stt.SpeechStream):
     async def _run(self) -> None:
         while True:
             self._session_stopped_event.clear()
+            self._cancellation_error = None
 
             self._stream = speechsdk.audio.PushAudioInputStream(
                 stream_format=speechsdk.audio.AudioStreamFormat(
@@ -305,6 +307,12 @@ class SpeechStream(stt.SpeechStream):
                             task.result()
 
                     if wait_stopped_task in done:
+                        if self._cancellation_error is not None:
+                            details = self._cancellation_error
+                            raise APIConnectionError(
+                                f"Azure STT canceled: "
+                                f"{details.error_details or details.reason} ({details.code})"
+                            )
                         raise APIConnectionError("SpeechRecognition session stopped")
 
                     # session-stopped is handled above, so the wait unblocked
@@ -448,6 +456,11 @@ class SpeechStream(stt.SpeechStream):
                     "error_details": evt.cancellation_details.error_details,
                 },
             )
+            # Azure does not always emit session_stopped after an error cancellation, so
+            # surface it here to wake _run; the base class then retries and can fall back.
+            self._cancellation_error = evt.cancellation_details
+            with contextlib.suppress(RuntimeError):
+                self._loop.call_soon_threadsafe(self._session_stopped_event.set)
 
 
 def _create_speech_recognizer(

--- a/tests/test_plugin_azure_stt.py
+++ b/tests/test_plugin_azure_stt.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -49,3 +50,41 @@ def test_azure_stream_emits_usage_for_processed_audio():
     assert events[0].recognition_usage is not None
     assert events[0].recognition_usage.audio_duration == 3.5
     assert stream._audio_duration == 0.0
+
+
+def _canceled_event(reason, code=None, error_details=""):
+    return SimpleNamespace(
+        cancellation_details=SimpleNamespace(reason=reason, code=code, error_details=error_details)
+    )
+
+
+def test_azure_canceled_error_unblocks_run():
+    # An Error cancellation (e.g. a service timeout) must wake _run via the
+    # stopped event and stash the details, so the base retry/fallback path runs
+    # instead of the stream hanging on a dead recognizer.
+    stream = azure_stt.SpeechStream.__new__(azure_stt.SpeechStream)
+    stream._loop = SimpleNamespace(call_soon_threadsafe=lambda callback, *args: callback(*args))
+    stream._session_stopped_event = asyncio.Event()
+    stream._cancellation_error = None
+
+    details = SimpleNamespace(
+        reason=azure_stt.speechsdk.CancellationReason.Error,
+        code=azure_stt.speechsdk.CancellationErrorCode.ServiceTimeout,
+        error_details="timeout",
+    )
+    stream._on_canceled(SimpleNamespace(cancellation_details=details))
+
+    assert stream._session_stopped_event.is_set()
+    assert stream._cancellation_error is details
+
+
+def test_azure_canceled_without_error_is_ignored():
+    stream = azure_stt.SpeechStream.__new__(azure_stt.SpeechStream)
+    stream._loop = SimpleNamespace(call_soon_threadsafe=lambda callback, *args: callback(*args))
+    stream._session_stopped_event = asyncio.Event()
+    stream._cancellation_error = None
+
+    stream._on_canceled(_canceled_event(azure_stt.speechsdk.CancellationReason.EndOfStream))
+
+    assert not stream._session_stopped_event.is_set()
+    assert stream._cancellation_error is None


### PR DESCRIPTION
If Azure STT hits an error cancellation (like a service timeout), the stream just goes silent. `_on_canceled` only logged a warning, and Azure doesn't reliably send `session_stopped` after that, so `_run` blocks on its `asyncio.wait` forever. Audio keeps flowing into a dead recognizer and nothing raises, so retry and fallback never kick in.

Now an error cancel records the details and sets the stopped event, so `_run` wakes and raises `APIConnectionError`. The base retry loop and FallbackAdapter handle it from there.

I kept it on the base retry path instead of adding retry inside the plugin like the earlier attempt (#5333). Happy to flip it if you'd rather.

Tests in `tests/test_plugin_azure_stt.py` cover both cases.

Fixes #5322
