### PR TITLE
livekit-plugins-fishaudio: pooled websocket reuse + prebuffer to fix cold-start crackle

### DIFF
--- a/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/tts.py
+++ b/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/tts.py
@@ -226,8 +226,13 @@ class TTS(tts.TTS):
         speed: NotGivenOr[float] = NOT_GIVEN,
         volume: NotGivenOr[float] = NOT_GIVEN,
     ) -> None:
-        if is_given(model):
+        if is_given(model) and model != self._opts.model:
             self._opts.model = model
+            # The model is sent as a connection header at ws-handshake time, not in the
+            # per-request body, so a pooled socket keeps the old model. Drop pooled
+            # connections so the next stream reconnects with the new model. Other
+            # options ride in the per-request body and need no reconnect.
+            self._pool.invalidate()
         if is_given(voice_id):
             self._opts.voice_id = voice_id
         if is_given(latency_mode):

--- a/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/tts.py
+++ b/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/tts.py
@@ -31,6 +31,12 @@ DEFAULT_BASE_URL = "https://api.fish.audio"
 NUM_CHANNELS = 1
 USER_AGENT = f"livekit-plugins-fishaudio/{__version__}"
 
+# Hold the first N audio chunks before releasing any audio, so playout starts with
+# enough buffered to ride out the gap after Fish's small first chunk (else jitter
+# underruns it into a crackle). Internal stopgap for Fish's cold-start pacing; drop
+# to 1 once inference streams the opening chunks smoothly. Values <= 1 disable it.
+_PREBUFFER_CHUNKS = 2
+
 # Fish Audio's default sample rate per output format. Opus only supports 48 kHz;
 # the other formats default to 24 kHz, which matches the previous plugin default.
 _DEFAULT_SAMPLE_RATE: dict[OutputFormat, int] = {
@@ -148,6 +154,12 @@ class TTS(tts.TTS):
         )
 
         self._session = http_session
+        self._pool = utils.ConnectionPool[aiohttp.ClientWebSocketResponse](
+            connect_cb=self._connect_ws,
+            close_cb=self._close_ws,
+            max_session_duration=300,
+            mark_refreshed_on_get=True,
+        )
         # min_sentence_len=1 emits each sentence as soon as the next one starts,
         # rather than batching short sentences together — minimizes TTFB on the
         # first sentence and keeps Fish synthesizing continuously.
@@ -182,6 +194,27 @@ class TTS(tts.TTS):
         if not self._session:
             self._session = utils.http_context.http_session()
         return self._session
+
+    async def _connect_ws(self, timeout: float) -> aiohttp.ClientWebSocketResponse:
+        session = self._ensure_session()
+        return await asyncio.wait_for(
+            session.ws_connect(
+                self._opts.get_ws_url("/v1/tts/live"),
+                headers={
+                    "Authorization": f"Bearer {self._opts.api_key}",
+                    "User-Agent": USER_AGENT,
+                    "model": self._opts.model,
+                },
+                heartbeat=30.0,
+            ),
+            timeout,
+        )
+
+    async def _close_ws(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        await ws.close()
+
+    def prewarm(self) -> None:
+        self._pool.prewarm()
 
     def update_options(
         self,
@@ -229,6 +262,7 @@ class TTS(tts.TTS):
         for stream in list(self._streams):
             await stream.aclose()
         self._streams.clear()
+        await self._pool.aclose()
 
 
 def _build_tts_request(opts: _TTSOptions, *, text: str = "") -> dict[str, Any]:
@@ -329,22 +363,9 @@ class SynthesizeStream(tts.SynthesizeStream):
         )
         output_emitter.start_segment(segment_id=request_id)
 
-        ws: aiohttp.ClientWebSocketResponse | None = None
         try:
-            ws = await asyncio.wait_for(
-                self._tts._ensure_session().ws_connect(
-                    self._opts.get_ws_url("/v1/tts/live"),
-                    headers={
-                        "Authorization": f"Bearer {self._opts.api_key}",
-                        "User-Agent": USER_AGENT,
-                        "model": self._opts.model,
-                    },
-                    heartbeat=30.0,
-                ),
-                self._conn_options.timeout,
-            )
-
-            await self._run_ws(ws, output_emitter)
+            async with self._tts._pool.connection(timeout=self._conn_options.timeout) as ws:
+                await self._run_ws(ws, output_emitter)
 
         except asyncio.TimeoutError:
             raise APITimeoutError() from None
@@ -357,8 +378,6 @@ class SynthesizeStream(tts.SynthesizeStream):
         except Exception as e:
             raise APIConnectionError() from e
         finally:
-            if ws is not None:
-                await ws.close()
             output_emitter.end_segment()
 
     async def _run_ws(
@@ -404,6 +423,33 @@ class SynthesizeStream(tts.SynthesizeStream):
 
             await ws.send_bytes(msgpack.packb({"event": "stop"}, use_bin_type=True))
 
+        prebuffer_chunks = _PREBUFFER_CHUNKS
+        prebuffer = bytearray()
+        chunks_seen = 0
+        prebuffering = prebuffer_chunks > 1
+
+        def push_audio(audio: bytes) -> None:
+            nonlocal prebuffering, chunks_seen
+            if prebuffering:
+                prebuffer.extend(audio)
+                chunks_seen += 1
+                if chunks_seen < prebuffer_chunks:
+                    return
+                output_emitter.push(bytes(prebuffer))
+                prebuffer.clear()
+                prebuffering = False
+            else:
+                output_emitter.push(audio)
+
+        def flush_prebuffer() -> None:
+            # Stream ended before we reached `prebuffer_chunks` (short utterance) —
+            # release whatever is held so nothing is dropped or left hanging.
+            nonlocal prebuffering
+            if prebuffering and prebuffer:
+                output_emitter.push(bytes(prebuffer))
+                prebuffer.clear()
+            prebuffering = False
+
         async def recv_task() -> None:
             # No per-receive timeout: Fish has natural inter-sentence gaps that
             # can exceed `_conn_options.timeout` when the LLM is slow. Dead
@@ -431,7 +477,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                 if event == "audio":
                     audio = data.get("audio")
                     if audio:
-                        output_emitter.push(audio)
+                        push_audio(audio)
                 elif event == "finish":
                     reason = data.get("reason")
                     if reason == "error":
@@ -441,6 +487,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                             request_id=None,
                             body=str(data),
                         )
+                    flush_prebuffer()
                     break
                 else:
                     logger.debug("unknown Fish Audio event: %s", data)


### PR DESCRIPTION
two changes to the fish plugin:

1. reuse/pre-warm the /v1/tts/live websocket via utils.ConnectionPool (same
   pattern as cartesia/rime). the plugin used to open a fresh WSS per utterance,
   paying ~330ms of TLS+WS handshake on every reply. now one socket is reused per
   session and pre-warmed via prewarm(), so the first reply skips the handshake.
   general latency win, independent of the crackle fix.

2. prebuffer the first two audio chunks before starting playout. fish streams a
   small first chunk (~460ms) then, ~250ms later, a much larger second chunk.
   starting webrtc's real-time playout at the first chunk leaves only ~190ms of
   buffer headroom; app/network jitter tips it into an underrun the receiver
   conceals as an audible click/gap ~0.5s into the first utterance (repro'd ~1 in
   5). waiting for the second chunk starts playout with ~1.3s buffered and
   eliminates it.

the prebuffer is an internal constant (_PREBUFFER_CHUNKS = 2), not a public
option. it costs a little TTFB and is a stopgap for fish's cold-start chunk
pacing; once the inference side streams the opening chunks smoothly we'll drop it
to 1 to start on the first chunk. working with the fish inference team on that now.

verified no crackles on livekit-demo-web.onrender.com; chunk-2 headroom measured
before/after and the negative tail is gone.
