### PR TITLE
(expressive mode): hide and remove from examples

### DIFF
--- a/examples/drive-thru/agent.py
+++ b/examples/drive-thru/agent.py
@@ -34,7 +34,7 @@ from livekit.agents import (
     function_tool,
     inference,
 )
-from livekit.agents.voice import UserStateChangedEvent, presets
+from livekit.agents.voice import UserStateChangedEvent
 
 load_dotenv()
 
@@ -490,7 +490,6 @@ async def drive_thru_agent(ctx: JobContext) -> None:
             voice="Sarah",
             extra_kwargs={"delivery_mode": "CREATIVE", "speaking_rate": 1.1},
         ),
-        expressive=presets.CUSTOMER_SERVICE,
         max_tool_steps=10,
         # Flip user_state to "away" after 10s of mutual silence so we can
         # check whether they're still there (default is 15s).

--- a/examples/frontdesk/agent.py
+++ b/examples/frontdesk/agent.py
@@ -39,7 +39,7 @@ from livekit.agents.evals import (
     task_completion_judge,
     tool_use_judge,
 )
-from livekit.agents.voice import UserStateChangedEvent, presets
+from livekit.agents.voice import UserStateChangedEvent
 
 load_dotenv()
 
@@ -297,7 +297,6 @@ async def frontdesk_agent(ctx: JobContext):
             voice="Nadia",
             extra_kwargs={"delivery_mode": "CREATIVE", "speaking_rate": 1.1},
         ),
-        expressive=presets.CUSTOMER_SERVICE,
         max_tool_steps=1,
         # Flip user_state to "away" after 10s of mutual silence so we can
         # check whether they're still there (default is 15s).

--- a/examples/healthcare/agent.py
+++ b/examples/healthcare/agent.py
@@ -33,7 +33,7 @@ from livekit.agents.beta.workflows import (
     WarmTransferTask,
 )
 from livekit.agents.llm import ToolError, function_tool
-from livekit.agents.voice import UserStateChangedEvent, presets
+from livekit.agents.voice import UserStateChangedEvent
 
 logger = logging.getLogger("HealthcareAgent")
 
@@ -763,7 +763,6 @@ async def entrypoint(ctx: JobContext):
             voice="Luna",
             extra_kwargs={"delivery_mode": "CREATIVE", "speaking_rate": 1.1},
         ),
-        expressive=presets.CUSTOMER_SERVICE,
         preemptive_generation=True,
         # Flip user_state to "away" after 10s of mutual silence so we can
         # check whether they're still there (default is 15s).

--- a/examples/inference/agent.py
+++ b/examples/inference/agent.py
@@ -13,7 +13,7 @@ from livekit.agents import (
     cli,
     inference,
 )
-from livekit.agents.voice import UserStateChangedEvent, presets
+from livekit.agents.voice import UserStateChangedEvent
 from livekit.rtc import RpcInvocationData
 
 logger = logging.getLogger("inference")
@@ -79,7 +79,6 @@ async def entrypoint(ctx: JobContext) -> None:
             voice="Sarah",
             extra_kwargs={"delivery_mode": "CREATIVE"},
         ),
-        expressive=presets.CASUAL,
         # Flip user_state to "away" after 10s of mutual silence so we can
         # check whether they're still there (default is 15s).
         user_away_timeout=10.0,

--- a/examples/survey/agent.py
+++ b/examples/survey/agent.py
@@ -22,7 +22,7 @@ from livekit.agents import (
 )
 from livekit.agents.beta.workflows import GetEmailTask, TaskGroup
 from livekit.agents.llm import function_tool
-from livekit.agents.voice import UserStateChangedEvent, presets
+from livekit.agents.voice import UserStateChangedEvent
 
 logger = logging.getLogger("SurveyAgent")
 
@@ -356,7 +356,6 @@ async def entrypoint(ctx: JobContext):
         tts=inference.TTS(
             "inworld/inworld-tts-2", voice="Nate", extra_kwargs={"delivery_mode": "CREATIVE"}
         ),
-        expressive=presets.CASUAL,
         preemptive_generation=True,
         # Flip user_state to "away" after 10s of mutual silence so we can
         # check whether they're still there (default is 15s).

--- a/livekit-agents/livekit/agents/voice/__init__.py
+++ b/livekit-agents/livekit/agents/voice/__init__.py
@@ -1,8 +1,7 @@
-from . import io, presets, run_result
+from . import io, run_result
 from .agent import Agent, AgentTask, ModelSettings
 from .agent_session import (
     AgentSession,
-    ExpressiveOptions,
     RecordingOptions,
     VoiceActivityVideoSampler,
 )
@@ -47,8 +46,6 @@ __all__ = [
     "VoiceActivityVideoSampler",
     "Agent",
     "ModelSettings",
-    "ExpressiveOptions",
-    "presets",
     "AgentTask",
     "SpeechHandle",
     "RunContext",

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from ..inference import LLMModels, STTModels, TTSModels
     from ..llm import mcp
     from .agent_activity import AgentActivity
-    from .agent_session import AgentSession, ExpressiveOptions
+    from .agent_session import AgentSession
     from .audio_recognition import AudioRecognition
     from .io import TimedString
     from .turn import TurnDetectionMode
@@ -50,7 +50,6 @@ class Agent:
         tool_handling: NotGivenOr[ToolHandlingOptions] = NOT_GIVEN,
         llm: NotGivenOr[llm.LLM | llm.RealtimeModel | LLMModels | str | None] = NOT_GIVEN,
         tts: NotGivenOr[tts.TTS | TTSModels | str | None] = NOT_GIVEN,
-        expressive: NotGivenOr[bool | ExpressiveOptions] = NOT_GIVEN,
         min_consecutive_speech_delay: NotGivenOr[float] = NOT_GIVEN,
         use_tts_aligned_transcript: NotGivenOr[bool] = NOT_GIVEN,
         # deprecated
@@ -124,7 +123,6 @@ class Agent:
                 "passing MCP servers to AgentSession or Agent is deprecated "
                 "and will be removed in a future version. Use `MCPToolset` instead."
             )
-        self._expressive = expressive
         self._activity: AgentActivity | None = None
 
     @property
@@ -168,10 +166,6 @@ class Agent:
     @property
     def interruption_detection(self) -> NotGivenOr[Literal["adaptive", "vad"]]:
         return self._interruption_detection
-
-    @property
-    def expressive(self) -> NotGivenOr[bool | ExpressiveOptions]:
-        return self._expressive
 
     @property
     def audio_recognition(self) -> AudioRecognition:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2425,7 +2425,10 @@ class AgentActivity(RecognitionHooks):
         return instructions
 
     def _resolve_expressive_options(self) -> ExpressiveOptions | None:
-        """Resolve expressive from agent (overrides session). Returns None if disabled.
+        """Resolve the session's internal expressive setting. Returns None if disabled.
+
+        Expressive mode is framework-internal and not publicly exposed; the session
+        hardcodes it to ``False``, so this currently always returns ``None``.
 
         Expressive mode requires two things:
         - the inference gateway TTS (``livekit.agents.inference.TTS``): the markup
@@ -2443,9 +2446,7 @@ class AgentActivity(RecognitionHooks):
         if not isinstance(self.tts, inference.TTS) or self.tts.markup.llm_instructions() is None:
             return None
 
-        expr = self._agent.expressive
-        if not utils.is_given(expr):
-            expr = self._session.options.expressive
+        expr = self._session._expressive
         if isinstance(expr, dict):
             # a `preset` selector resolves to the active TTS provider's tuned preset
             # (falling back to the agnostic default); explicit fields override on top

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -142,13 +142,13 @@ class SessionConnectOptions:
 
 
 class ExpressiveOptions(TypedDict, total=False):
-    """Configuration for the expressive pipeline.
+    """Configuration for the expressive pipeline (framework-internal, not publicly exposed).
 
     Controls how TTS markup instructions are injected into the LLM when expressive is
     enabled. All keys are optional; common shapes:
 
     - ``{"preset": Preset.CASUAL}`` — a domain preset, resolved to the active
-      TTS provider's tuned tags (see ``voice.presets``). Prefer the ``presets.*`` constants.
+      TTS provider's tuned tags (see ``voice.presets``).
     - ``{"preset": ..., "tts_instructions_append": "..."}`` — a preset plus your own
       rules appended after it resolves.
     - ``{"tts_instructions_template": "..."}`` — a fully custom prompt.
@@ -185,7 +185,6 @@ class AgentSessionOptions:
     ivr_detection: bool
     aec_warmup_duration: float | None
     session_close_transcript_timeout: float
-    expressive: bool | ExpressiveOptions
 
     @property
     def endpointing(self) -> EndpointingOptions:
@@ -274,8 +273,6 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         use_tts_aligned_transcript: NotGivenOr[bool] = NOT_GIVEN,
         tts_text_transforms: NotGivenOr[Sequence[TextTransforms] | None] = NOT_GIVEN,
         min_consecutive_speech_delay: float = 0.0,
-        # Expressive
-        expressive: bool | ExpressiveOptions = False,
         # Misc settings
         userdata: NotGivenOr[Userdata_T] = NOT_GIVEN,
         video_sampler: NotGivenOr[_VideoSampler | None] = NOT_GIVEN,
@@ -437,8 +434,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             ),
             aec_warmup_duration=aec_warmup_duration,
             session_close_transcript_timeout=session_close_transcript_timeout,
-            expressive=expressive,
         )
+        # expressive mode is not publicly exposed; the pipeline stays disabled
+        self._expressive: bool | ExpressiveOptions = False
         self._conn_options = conn_options or SessionConnectOptions()
         self._started = False
 

--- a/livekit-agents/livekit/agents/voice/presets.py
+++ b/livekit-agents/livekit/agents/voice/presets.py
@@ -1,23 +1,13 @@
-"""Public expressive presets.
+"""Expressive presets (framework-internal, not publicly exposed).
 
-A preset is a *use-case* (customer service, casual) that is
-provider-agnostic at the call site:
-
-    from livekit.agents.voice import presets
-
-    session = AgentSession(tts=inference.TTS("inworld/inworld-tts-2"), expressive=presets.CASUAL)
-
-Each ``presets.*`` constant is just an :class:`~livekit.agents.voice.ExpressiveOptions`
-carrying a ``preset``. At session start the framework resolves it against the active TTS
+A preset is a *use-case* (customer service, casual) that is provider-agnostic:
+each ``presets.*`` constant is just an ``ExpressiveOptions`` carrying a ``preset``.
+When expressive mode is active the framework resolves it against the active TTS
 provider (via ``tts.markup._provider_key()``) and injects the variant tuned for that
 provider's markup tags. A provider with no tuned preset falls back to the agnostic default,
 which still injects that provider's tag reference through the
 ``{tts.markup.llm_instructions}`` placeholder — so a preset always does something sensible
 and can never disagree with the markup pipeline (both read the same provider key).
-
-Customize by spreading a constant into a new dict (don't mutate the constant in place):
-
-    expressive={**presets.CUSTOMER_SERVICE, "tts_instructions_append": "Confirm the name."}
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Remove the user-facing expressive surface while keeping the pipeline machinery internal and disabled:

- drop the `expressive` param from AgentSession and Agent (and the Agent.expressive property)
- drop the `expressive` field from AgentSessionOptions
- stop exporting ExpressiveOptions and presets from livekit.agents.voice
- AgentSession hardcodes an internal `_expressive = False`, which AgentActivity._resolve_expressive_options() now reads, so the markup/presets machinery stays intact but always resolves disabled
- remove `expressive=presets.*` usage from the examples