### PR TITLE
fix(workflows): return corrective instructions as tool output instead of generate_reply

### DIFF
--- a/.github/workflows/data-capture-sim.yml
+++ b/.github/workflows/data-capture-sim.yml
@@ -1,0 +1,59 @@
+name: data-capture-sim
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "livekit-agents/livekit/agents/beta/workflows/**"
+      - "examples/data_capture_sim/**"
+      - ".github/workflows/data-capture-sim.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "livekit-agents/livekit/agents/beta/workflows/**"
+      - "examples/data_capture_sim/**"
+      - ".github/workflows/data-capture-sim.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  simulate:
+    # don't run for PRs on forks: the simulation needs LiveKit Cloud secrets
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: Install LiveKit CLI
+        run: |
+          curl -sSL https://get.livekit.io/cli | bash
+          lk --version
+
+      - name: Run simulation
+        shell: bash
+        env:
+          LIVEKIT_URL: ${{ secrets.LIVEKIT_URL }}
+          LIVEKIT_API_KEY: ${{ secrets.LIVEKIT_API_KEY }}
+          LIVEKIT_API_SECRET: ${{ secrets.LIVEKIT_API_SECRET }}
+        # `uv run` puts the synced workspace venv on PATH so lk resolves the
+        # local livekit-agents checkout rather than a published SDK.
+        run: |
+          uv run lk agent simulate examples/data_capture_sim/agent.py \
+            --scenarios examples/data_capture_sim/scenarios.yaml

--- a/examples/data_capture_sim/agent.py
+++ b/examples/data_capture_sim/agent.py
@@ -58,7 +58,7 @@ class DataCaptureAgent(Agent):
     async def collect_phone_number(self, context: RunContext) -> str:
         """Collect the user's phone number."""
         result = await beta.workflows.GetPhoneNumberTask(require_confirmation=True)
-        logger.info(f"captured phone: {result.phone_number}")
+        logger.info("captured phone number")
         return f"Phone number captured: {result.phone_number}. Read it back to the user."
 
     @function_tool

--- a/examples/data_capture_sim/agent.py
+++ b/examples/data_capture_sim/agent.py
@@ -1,0 +1,116 @@
+import logging
+
+from dotenv import load_dotenv
+
+from livekit.agents import (
+    Agent,
+    AgentServer,
+    AgentSession,
+    JobContext,
+    RunContext,
+    beta,
+    cli,
+    inference,
+)
+from livekit.agents.llm import function_tool
+
+logger = logging.getLogger("data-capture-sim")
+
+load_dotenv()
+
+# Simulation harness for the beta data-capture workflows. Every capture runs
+# with require_confirmation=True so the confirm_* tool paths (including the
+# corrective branches that now return tool output instead of calling
+# generate_reply) are exercised even in text-only simulations, where
+# confirmation is otherwise skipped. Tasks are deliberately created
+# without chat_ctx: they start from an empty context, so every scenario value
+# must be delivered inside the running task (the scenarios gate values on
+# being asked). Seed chat_ctx here if a scenario ever needs the task to see
+# something said before the capture began.
+
+
+class DataCaptureAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(
+            instructions=(
+                "You are an intake operator collecting details from the user, one at a time. "
+                "When the user offers a detail (email, phone number, mailing address, "
+                "date of birth, name, or credit card), call the matching collect_* tool "
+                "to run the capture flow. After a capture completes, read the captured "
+                "value back to the user verbatim, then ask if there is anything else. "
+                "Do not collect anything the user has not offered."
+            )
+        )
+
+    async def on_enter(self) -> None:
+        self.session.generate_reply(
+            instructions="Greet the user and ask which detail they would like to provide."
+        )
+
+    @function_tool
+    async def collect_email(self, context: RunContext) -> str:
+        """Collect the user's email address."""
+        result = await beta.workflows.GetEmailTask(require_confirmation=True)
+        logger.info(f"captured email: {result.email_address}")
+        return f"Email captured: {result.email_address}. Read it back to the user."
+
+    @function_tool
+    async def collect_phone_number(self, context: RunContext) -> str:
+        """Collect the user's phone number."""
+        result = await beta.workflows.GetPhoneNumberTask(require_confirmation=True)
+        logger.info(f"captured phone: {result.phone_number}")
+        return f"Phone number captured: {result.phone_number}. Read it back to the user."
+
+    @function_tool
+    async def collect_address(self, context: RunContext) -> str:
+        """Collect the user's mailing address."""
+        result = await beta.workflows.GetAddressTask(require_confirmation=True)
+        logger.info(f"captured address: {result.address}")
+        return f"Address captured: {result.address}. Read it back to the user."
+
+    @function_tool
+    async def collect_date_of_birth(self, context: RunContext) -> str:
+        """Collect the user's date of birth (and time of birth if they know it)."""
+        result = await beta.workflows.GetDOBTask(include_time=True, require_confirmation=True)
+        logger.info(f"captured dob: {result.date_of_birth} time: {result.time_of_birth}")
+        captured = result.date_of_birth.isoformat()
+        if result.time_of_birth is not None:
+            captured += f" at {result.time_of_birth.strftime('%H:%M')}"
+        return f"Date of birth captured: {captured}. Read it back to the user."
+
+    @function_tool
+    async def collect_name(self, context: RunContext) -> str:
+        """Collect the user's first and last name."""
+        result = await beta.workflows.GetNameTask(last_name=True, require_confirmation=True)
+        logger.info(f"captured name: {result.first_name} {result.last_name}")
+        return f"Name captured: {result.first_name} {result.last_name}. Read it back to the user."
+
+    @function_tool
+    async def collect_credit_card(self, context: RunContext) -> str:
+        """Collect the user's credit card details (number, expiration, security code, cardholder)."""
+        result = await beta.workflows.GetCreditCardTask(require_confirmation=True)
+        logger.info(f"captured card: {result}")
+        return (
+            f"Card captured: {result.issuer} ending {result.card_number[-4:]}, "
+            f"expiring {result.expiration_date}, cardholder {result.cardholder_name}. "
+            "Confirm completion to the user without repeating the full number."
+        )
+
+
+server = AgentServer()
+
+
+@server.rtc_session()
+async def entrypoint(ctx: JobContext):
+    session = AgentSession(
+        llm=inference.LLM("openai/gpt-4.1-mini"),
+        stt=inference.STT("deepgram/nova-3"),
+        tts=inference.TTS("cartesia/sonic-3"),
+    )
+
+    await session.start(agent=DataCaptureAgent(), room=ctx.room)
+    await ctx.connect()
+
+
+if __name__ == "__main__":
+    cli.run_app(server)

--- a/examples/data_capture_sim/agent.py
+++ b/examples/data_capture_sim/agent.py
@@ -72,7 +72,7 @@ class DataCaptureAgent(Agent):
     async def collect_date_of_birth(self, context: RunContext) -> str:
         """Collect the user's date of birth (and time of birth if they know it)."""
         result = await beta.workflows.GetDOBTask(include_time=True, require_confirmation=True)
-        logger.info(f"captured dob: {result.date_of_birth} time: {result.time_of_birth}")
+        logger.info("captured dob value")
         captured = result.date_of_birth.isoformat()
         if result.time_of_birth is not None:
             captured += f" at {result.time_of_birth.strftime('%H:%M')}"

--- a/examples/data_capture_sim/scenarios.yaml
+++ b/examples/data_capture_sim/scenarios.yaml
@@ -1,0 +1,268 @@
+# Scenarios for the data-capture workflow refactor: confirm_* / update_* tools
+# now return corrective instructions as tool output instead of calling
+# session.generate_reply() mid-tool. Every scenario drives one of the changed
+# branches; the shared failure mode to catch is the agent going SILENT (or
+# completing with a stale value) at the point where the old code fired a
+# separate generate_reply.
+#
+# Run from the repo root (requires lk >= 2.17.0, which resolves the SDK
+# version from the synced workspace environment):
+#   lk agent simulate examples/data_capture_sim/agent.py \
+#     --scenarios examples/data_capture_sim/scenarios.yaml
+
+name: Data capture workflows — corrective branches
+
+scenarios:
+  # --- email: happy path through the confirm tool ---------------------------
+  - label: Email captured and confirmed
+    instructions: |
+      PERSONA: Maya Chen, cooperative caller registering for an event.
+      OPENING LINE: "Hi, I'd like to give you my email address."
+      FACTS:
+      - email: maya.chen@example.com
+      DO, IN ORDER:
+      1. Give the email when asked.
+      2. When the agent reads it back and asks you to confirm, say "yes, that's correct."
+      3. Don't hang up until the agent has read the captured email back after confirming.
+    agent_expectations: >
+      Starts the email capture, records maya.chen@example.com, asks the user to
+      confirm it, and after the user confirms, completes the capture and reads
+      the same email back. The agent must keep speaking at every step — no dead
+      air after the confirmation — and must not ask the user to confirm twice
+      when nothing changed.
+    tags:
+      workflow: email
+      branch: happy_path
+
+  # --- email: correction at the confirmation step ---------------------------
+  - label: Email corrected while confirming
+    instructions: |
+      PERSONA: Jordan Reyes, slightly distracted, initially gives an old email.
+      OPENING LINE: "I need to update my email with you."
+      FACTS:
+      - old email (give first): jordan.reyes@oldmail.com
+      - real email: jordan.reyes@gmail.com
+      DO, IN ORDER:
+      1. Give the OLD email when asked.
+      2. When the agent asks you to confirm it, do NOT say yes - say in one
+         message: "oh wait, actually it's jordan.reyes@gmail.com, yes that one's right."
+      3. If the agent asks you to confirm the NEW email, confirm it.
+      4. Don't hang up until the agent reads back the gmail address as captured.
+    agent_expectations: >
+      When the user replaces the email at the confirmation step, the agent must
+      switch to the new address: it acknowledges jordan.reyes@gmail.com and asks
+      for (or completes) confirmation of the UPDATED email. It must never
+      complete the capture with the stale oldmail.com address, and it must
+      respond verbally right after the correction — a silent turn there is a
+      failure. The final read-back is jordan.reyes@gmail.com.
+    tags:
+      workflow: email
+      branch: confirm_stale_guard
+
+  # --- phone: invalid number, then correction at confirmation ---------------
+  - label: Bad phone number, then a swap during confirmation
+    instructions: |
+      PERSONA: Sam Okafor, gives a too-short number first, then corrects himself twice.
+      OPENING LINE: "Let me give you my phone number."
+      FACTS:
+      - first attempt (invalid, too short): "555 12"
+      - second attempt: "+1 415 555 0142"
+      - final number (the correction): "+1 415 555 0199"
+      DO, IN ORDER:
+      1. When the agent asks for your phone number, give the invalid short
+         number as if it were complete.
+      2. When the agent says it's invalid or asks again, give +1 415 555 0142.
+      3. When the agent reads it back for confirmation, say: "hmm, actually use
+         my new number, +1 415 555 0199 - that's the right one."
+      4. Confirm the new number when asked.
+      5. Don't hang up until the agent reads back the 0199 number as captured.
+    agent_expectations: >
+      Rejects the too-short number conversationally and asks again rather than
+      recording it. After the mid-confirmation swap, the agent re-confirms and
+      completes with +14155550199, never the 0142 number. The agent must speak
+      after both the invalid attempt and the swap — no silent turns — and the
+      final read-back contains the 0199 number.
+    tags:
+      workflow: phone
+      branch: confirm_stale_guard
+
+  # --- address: change during confirmation ----------------------------------
+  - label: Address changed while confirming
+    instructions: |
+      PERSONA: Priya Nair, recently moved, gives the old address by habit.
+      OPENING LINE: "I'd like to give you my mailing address."
+      FACTS:
+      - old address (give first): 12 Elm Street, Springfield Illinois 62704, United States
+      - new address: 88 Harbor Lane, Apartment 3, Portland Oregon 97209, United States
+      DO, IN ORDER:
+      1. Give the OLD address when asked.
+      2. When the agent reads it back and asks you to confirm, say: "wait, no -
+         we just moved. It's 88 Harbor Lane, Apartment 3, Portland Oregon 97209,
+         United States. Yes, that's the one."
+      3. If the agent asks you to confirm the NEW address, confirm it.
+      4. Don't hang up until the agent reads back the Portland address as captured.
+    agent_expectations: >
+      When the user replaces the address at the confirmation step, the agent
+      acknowledges the Portland address and confirms THAT one; it never
+      completes with the Springfield address. It responds verbally immediately
+      after the correction, and the final read-back is the Portland address
+      including the apartment number.
+    tags:
+      workflow: address
+      branch: confirm_stale_guard
+
+  # --- name: spelling correction at confirmation -----------------------------
+  - label: Name spelling corrected while confirming
+    instructions: |
+      PERSONA: Shayne Cole - pronounced "Shane", so say "Shane" conversationally;
+      the Y appears only when you spell it.
+      OPENING LINE: "You'll need my name, right? It's Shane Cole."
+      DO, IN ORDER:
+      1. Give the name as "Shane Cole".
+      2. When the agent asks you to confirm, say: "almost - first name is
+         spelled S-H-A-Y-N-E. With that fixed, yes."
+      3. If the agent asks you to confirm the corrected spelling, confirm it.
+      4. Don't hang up until the agent reads back "Shayne Cole" as captured.
+    agent_expectations: >
+      Accepts the correction at the confirmation step and re-confirms the
+      updated spelling: the capture completes with first name Shayne (with the
+      Y), not Shane. The agent must not complete with the uncorrected spelling
+      and must not go silent after the correction.
+    tags:
+      workflow: name
+      branch: confirm_stale_guard
+
+  # --- dob: time of birth offered before the date ----------------------------
+  - label: Time of birth given before the date
+    instructions: |
+      PERSONA: Leo Marsh, proud of knowing his exact time of birth; leads with it.
+      OPENING LINE: "I can give you my date of birth - fun fact, I even know the time!"
+      FACTS:
+      - time of birth: 6:45 in the morning
+      - date of birth: March 3rd, 1992
+      DO, IN ORDER:
+      1. When asked for the date of birth, give ONLY the time first: "I was born
+         at 6:45 in the morning." Do not mention the date yet.
+      2. If the agent asks you to confirm before you've given a date, say "yes,
+         that's right" - do NOT volunteer the date until the agent explicitly
+         asks for the date itself.
+      3. When the agent asks for the date, give March 3rd, 1992.
+      4. Confirm the full date (and time) when read back.
+      5. Don't hang up until the agent reads back March 3rd, 1992 as captured.
+    agent_expectations: >
+      Records the 6:45 AM time of birth but recognizes the date is still
+      missing: if the user tries to confirm before any date exists, the agent
+      must say the date of birth hasn't been provided yet and ask for it — not
+      complete the capture, not fabricate a date, and not go silent. Once the
+      user gives March 3rd, 1992 and confirms, the capture completes with that
+      date and the 6:45 AM time.
+    tags:
+      workflow: dob
+      branch: confirm_missing_dob
+
+  # --- dob: date changed while confirming ------------------------------------
+  - label: Date of birth corrected while confirming
+    instructions: |
+      PERSONA: Ana Sofia Torres, mixes up day and month at first.
+      OPENING LINE: "Sure, my date of birth - it's July 9th, 1988."
+      FACTS:
+      - first date given: July 9th, 1988
+      - corrected date: September 7th, 1988
+      DO, IN ORDER:
+      1. Give July 9th, 1988 when asked.
+      2. When the agent asks you to confirm, say: "hold on, I always flip those -
+         it's September 7th, 1988. Yes, that's right."
+      3. If the agent asks you to confirm the corrected date, confirm it.
+      4. Don't hang up until the agent reads back September 7th, 1988 as captured.
+    agent_expectations: >
+      After the correction at the confirmation step, the agent confirms and
+      completes with September 7th, 1988 — never July 9th. It responds verbally
+      right after the correction, and the final read-back is September 7th, 1988.
+    tags:
+      workflow: dob
+      branch: confirm_stale_guard
+
+  # --- credit card: number too short, then valid -----------------------------
+  - label: Card number too short on the first try
+    instructions: |
+      PERSONA: Dana Whitfield, rattles off a partial card number first.
+      OPENING LINE: "I'm ready to give you my card details."
+      FACTS:
+      - first attempt (too short, only 10 digits): 4242 4242 42
+      - real card number: 4242 4242 4242 4242
+      - expiration: 11/29
+      - security code: 833
+      - cardholder name: Dana Whitfield
+      DO, IN ORDER:
+      1. When the agent asks for your card number, give the 10-digit partial
+         number as if it were complete.
+      2. When the agent says it's invalid or asks you to repeat, give the full
+         4242 4242 4242 4242.
+      3. Repeat the full number when asked to confirm it.
+      4. Provide the expiration, security code, and name as asked, repeating
+         each back when asked to confirm.
+      5. Don't hang up until the agent confirms the card details are complete.
+    agent_expectations: >
+      Tells the user the number is invalid (wrong length) and asks them to
+      repeat it — it must not accept the 10-digit number, must not go silent
+      after the invalid attempt, and must not read the card number back aloud.
+      After the full 16-digit number is given and repeated, the flow proceeds
+      through expiration, security code, and cardholder name to completion.
+    tags:
+      workflow: credit_card
+      branch: update_invalid_length
+
+  # --- credit card: repeated number doesn't match ----------------------------
+  - label: Card number repeat mismatch
+    instructions: |
+      PERSONA: Omar Haddad, fumbles one digit when repeating his card number.
+      OPENING LINE: "Let's do the card details."
+      FACTS:
+      - card number: 4242 4242 4242 4242
+      - WRONG repeat (first confirmation attempt): 4242 4242 4242 4245
+      - expiration: 08/30
+      - security code: 456
+      - cardholder name: Omar Haddad
+      DO, IN ORDER:
+      1. Give the correct card number when asked.
+      2. When asked to repeat it for confirmation, repeat it WRONG once (ending 4245).
+      3. When the agent says it doesn't match and asks again, repeat it correctly.
+      4. Provide the expiration, security code, and name as asked, repeating
+         each back when asked to confirm.
+      5. Don't hang up until the agent confirms the card details are complete.
+    agent_expectations: >
+      Detects that the repeated number doesn't match the original and asks the
+      user to try again — without revealing the stored number and without going
+      silent after the mismatch. After the correct repeat, the flow proceeds
+      through the remaining card fields to completion.
+    tags:
+      workflow: credit_card
+      branch: confirm_mismatch
+
+  # --- credit card: expired date, then a valid one ----------------------------
+  - label: Expired card date, then corrected
+    instructions: |
+      PERSONA: Grace Lindqvist, reads the date off an old card first.
+      OPENING LINE: "I'll give you my card now."
+      FACTS:
+      - card number: 4242 4242 4242 4242
+      - expired date (give first): 05/24
+      - real expiration: 05/28
+      - security code: 291
+      - cardholder name: Grace Lindqvist
+      DO, IN ORDER:
+      1. Give the card number and repeat it when asked to confirm.
+      2. When asked for the expiration, give 05/24 (the expired one).
+      3. When the agent says the card is expired or asks for another, say "oh,
+         I grabbed the old card - the current one is 05/28, same number."
+      4. Repeat the expiration when asked to confirm, then provide the security
+         code and name as asked, repeating each back when asked to confirm.
+      5. Don't hang up until the agent confirms the card details are complete.
+    agent_expectations: >
+      Recognizes 05/24 as in the past, tells the user the card appears expired,
+      and asks for another — it must not accept the expired date, and must not
+      go silent after rejecting it. After the user supplies 05/28, the flow
+      proceeds through the remaining fields to completion.
+    tags:
+      workflow: credit_card
+      branch: update_expired_date

--- a/livekit-agents/livekit/agents/beta/workflows/address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/address.py
@@ -140,16 +140,19 @@ class GetAddressTask(AgentTask[GetAddressResult]):
         # confirm tool is only injected after update_address is called,
         # preventing the LLM from hallucinating a confirmation without user input
         @function_tool()
-        async def confirm_address() -> None:
+        async def confirm_address() -> str | None:
             """Call after the user confirms the address is correct."""
             if address != self._current_address:
-                self.session.generate_reply(
-                    instructions="The address has changed since confirmation was requested, ask the user to confirm the updated address."
+                # stale closure: update_address ran again after this confirm tool
+                # was installed (e.g. parallel tool calls in the same turn)
+                return (
+                    "The address has changed since confirmation was requested, "
+                    "ask the user to confirm the updated address."
                 )
-                return
 
             if not self.done():
                 self.complete(GetAddressResult(address=address))
+            return None
 
         return confirm_address
 

--- a/livekit-agents/livekit/agents/beta/workflows/credit_card.py
+++ b/livekit-agents/livekit/agents/beta/workflows/credit_card.py
@@ -225,24 +225,23 @@ class GetCardNumberTask(AgentTask[GetCardNumberResult]):
     async def _update_card_number_impl(self, context: RunContext, card_number: str) -> str | None:
         card_number = "".join([d for d in card_number if d.isdigit()])
         if len(card_number) < 13 or len(card_number) > 19:
-            self.session.generate_reply(
-                instructions="The length of the card number is invalid, ask the user to repeat their card number."
+            return (
+                "The length of the card number is invalid, "
+                "ask the user to repeat their card number."
             )
-            return None
         else:
             self._card_number = card_number
 
             if not self._confirmation_required(context):
                 if not self.validate_card_number(self._card_number):
-                    self.session.generate_reply(
-                        instructions="The card number is not valid, ask the user if they made a mistake or to provide another card."
+                    return (
+                        "The card number is not valid, "
+                        "ask the user if they made a mistake or to provide another card."
                     )
-                else:
-                    issuer = CARD_ISSUERS_LOOKUP.get(self._card_number[0], "Other")
-                    if not self.done():
-                        self.complete(
-                            GetCardNumberResult(issuer=issuer, card_number=self._card_number)
-                        )
+
+                issuer = CARD_ISSUERS_LOOKUP.get(self._card_number[0], "Other")
+                if not self.done():
+                    self.complete(GetCardNumberResult(issuer=issuer, card_number=self._card_number))
                 return None
 
             confirm_tool = self._build_confirm_tool(card_number=card_number)
@@ -257,7 +256,7 @@ class GetCardNumberTask(AgentTask[GetCardNumberResult]):
 
     def _build_confirm_tool(self, *, card_number: str) -> llm.FunctionTool:
         @function_tool()
-        async def confirm_card_number(repeated_card_number: str) -> None:
+        async def confirm_card_number(repeated_card_number: str) -> str | None:
             """Call after the user repeats their card number for confirmation.
 
             Args:
@@ -265,19 +264,18 @@ class GetCardNumberTask(AgentTask[GetCardNumberResult]):
             """
             repeated_card_number = "".join([d for d in repeated_card_number if d.isdigit()])
             if repeated_card_number != card_number:
-                self.session.generate_reply(
-                    instructions="The repeated card number does not match, ask the user to try again."
-                )
-                return
+                return "The repeated card number does not match, ask the user to try again."
 
             if not self.validate_card_number(card_number):
-                self.session.generate_reply(
-                    instructions="The card number is not valid, ask the user if they made a mistake or to provide another card."
+                return (
+                    "The card number is not valid, "
+                    "ask the user if they made a mistake or to provide another card."
                 )
-            else:
-                issuer = CARD_ISSUERS_LOOKUP.get(card_number[0], "Other")
-                if not self.done():
-                    self.complete(GetCardNumberResult(issuer=issuer, card_number=card_number))
+
+            issuer = CARD_ISSUERS_LOOKUP.get(card_number[0], "Other")
+            if not self.done():
+                self.complete(GetCardNumberResult(issuer=issuer, card_number=card_number))
+            return None
 
         return confirm_card_number
 
@@ -379,10 +377,10 @@ class GetSecurityCodeTask(AgentTask[GetSecurityCodeResult]):
     ) -> str | None:
         stripped = security_code.strip()
         if not stripped.isdigit() or not (3 <= len(stripped) <= 4):
-            self.session.generate_reply(
-                instructions="The security code's length is invalid, ask the user to repeat or to provide a new card and start over."
+            return (
+                "The security code's length is invalid, "
+                "ask the user to repeat or to provide a new card and start over."
             )
-            return None
         else:
             self._security_code = stripped
 
@@ -404,20 +402,18 @@ class GetSecurityCodeTask(AgentTask[GetSecurityCodeResult]):
 
     def _build_confirm_tool(self, *, security_code: str) -> llm.FunctionTool:
         @function_tool()
-        async def confirm_security_code(repeated_security_code: str) -> None:
+        async def confirm_security_code(repeated_security_code: str) -> str | None:
             """Call after the user repeats their security code for confirmation.
 
             Args:
                 repeated_security_code (str): The security code repeated by the user
             """
             if repeated_security_code.strip() != security_code:
-                self.session.generate_reply(
-                    instructions="The repeated security code does not match, ask the user to try again."
-                )
-                return
+                return "The repeated security code does not match, ask the user to try again."
 
             if not self.done():
                 self.complete(GetSecurityCodeResult(security_code=security_code))
+            return None
 
         return confirm_security_code
 
@@ -504,20 +500,14 @@ class GetExpirationDateTask(AgentTask[GetExpirationDateResult]):
         self, context: RunContext, expiration_month: int, expiration_year: int
     ) -> str | None:
         if not (1 <= expiration_month <= 12):
-            self.session.generate_reply(
-                instructions="The expiration month is invalid, ask the user to repeat the expiration month."
-            )
-            return None
+            return "The expiration month is invalid, ask the user to repeat the expiration month."
         elif not (0 <= expiration_year <= 99):
-            self.session.generate_reply(
-                instructions="The expiration year is invalid, ask the user to repeat the expiration year."
-            )
-            return None
+            return "The expiration year is invalid, ask the user to repeat the expiration year."
         elif self._is_expired(expiration_month, expiration_year):
-            self.session.generate_reply(
-                instructions="The expiration date is in the past, the card is expired. Ask the user to provide another card."
+            return (
+                "The expiration date is in the past, the card is expired. "
+                "Ask the user to provide another card."
             )
-            return None
         else:
             self._expiration_date = f"{expiration_month:02d}/{expiration_year:02d}"
 
@@ -548,7 +538,7 @@ class GetExpirationDateTask(AgentTask[GetExpirationDateResult]):
         async def confirm_expiration_date(
             repeated_expiration_month: int,
             repeated_expiration_year: int,
-        ) -> None:
+        ) -> str | None:
             """Call after the user repeats their expiration date for confirmation.
 
             Args:
@@ -559,13 +549,11 @@ class GetExpirationDateTask(AgentTask[GetExpirationDateResult]):
                 repeated_expiration_month != expiration_month
                 or repeated_expiration_year != expiration_year
             ):
-                self.session.generate_reply(
-                    instructions="The repeated expiration date does not match, ask the user to try again."
-                )
-                return
+                return "The repeated expiration date does not match, ask the user to try again."
 
             if not self.done():
                 self.complete(GetExpirationDateResult(date=expiration_date))
+            return None
 
         return confirm_expiration_date
 

--- a/livekit-agents/livekit/agents/beta/workflows/dob.py
+++ b/livekit-agents/livekit/agents/beta/workflows/dob.py
@@ -262,19 +262,18 @@ class GetDOBTask(AgentTask[GetDOBResult]):
         captured_time = self._current_time
 
         @function_tool()
-        async def confirm_dob() -> None:
+        async def confirm_dob() -> str | None:
             """Call after the user confirms the date of birth is correct."""
             if captured_dob != self._current_dob or captured_time != self._current_time:
-                self.session.generate_reply(
-                    instructions="The date of birth has changed since confirmation was requested, ask the user to confirm the updated date."
+                # stale closure: update_dob/update_time ran again after this confirm
+                # tool was installed (e.g. parallel tool calls in the same turn)
+                return (
+                    "The date of birth has changed since confirmation was requested, "
+                    "ask the user to confirm the updated date."
                 )
-                return
 
             if self._current_dob is None:
-                self.session.generate_reply(
-                    instructions="No date of birth was provided yet, ask the user to provide it."
-                )
-                return
+                return "No date of birth was provided yet, ask the user to provide it."
 
             if not self.done():
                 self.complete(
@@ -283,6 +282,7 @@ class GetDOBTask(AgentTask[GetDOBResult]):
                         time_of_birth=self._current_time,
                     )
                 )
+            return None
 
         return confirm_dob
 

--- a/livekit-agents/livekit/agents/beta/workflows/email_address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/email_address.py
@@ -121,16 +121,19 @@ class GetEmailTask(AgentTask[GetEmailResult]):
 
     def _build_confirm_tool(self, *, email: str) -> llm.FunctionTool:
         @function_tool()
-        async def confirm_email_address() -> None:
+        async def confirm_email_address() -> str | None:
             """Call after the user confirms the email address is correct."""
             if email != self._current_email:
-                self.session.generate_reply(
-                    instructions="The email has changed since confirmation was requested, ask the user to confirm the updated email."
+                # stale closure: update_email_address ran again after this confirm
+                # tool was installed (e.g. parallel tool calls in the same turn)
+                return (
+                    "The email has changed since confirmation was requested, "
+                    "ask the user to confirm the updated email."
                 )
-                return
 
             if not self.done():
                 self.complete(GetEmailResult(email_address=email))
+            return None
 
         return confirm_email_address
 

--- a/livekit-agents/livekit/agents/beta/workflows/name.py
+++ b/livekit-agents/livekit/agents/beta/workflows/name.py
@@ -285,17 +285,19 @@ class GetNameTask(AgentTask[GetNameResult]):
         self, *, first_name: str, middle_name: str, last_name: str
     ) -> llm.FunctionTool:
         @function_tool()
-        async def confirm_name() -> None:
+        async def confirm_name() -> str | None:
             """Call after the user confirms the name is correct."""
             if (
                 first_name != self._first_name
                 or middle_name != self._middle_name
                 or last_name != self._last_name
             ):
-                self.session.generate_reply(
-                    instructions="The name has changed since confirmation was requested, ask the user to confirm the updated name."
+                # stale closure: update_name ran again after this confirm tool
+                # was installed (e.g. parallel tool calls in the same turn)
+                return (
+                    "The name has changed since confirmation was requested, "
+                    "ask the user to confirm the updated name."
                 )
-                return
 
             if not self.done():
                 self.complete(
@@ -305,6 +307,7 @@ class GetNameTask(AgentTask[GetNameResult]):
                         last_name=self._last_name if self._collect_last_name else None,
                     )
                 )
+            return None
 
         return confirm_name
 

--- a/livekit-agents/livekit/agents/beta/workflows/phone_number.py
+++ b/livekit-agents/livekit/agents/beta/workflows/phone_number.py
@@ -155,16 +155,19 @@ class GetPhoneNumberTask(AgentTask[GetPhoneNumberResult]):
 
     def _build_confirm_tool(self, *, phone_number: str) -> llm.FunctionTool:
         @function_tool()
-        async def confirm_phone_number() -> None:
+        async def confirm_phone_number() -> str | None:
             """Call after the user confirms the phone number is correct."""
             if phone_number != self._current_phone_number:
-                self.session.generate_reply(
-                    instructions="The phone number has changed since confirmation was requested, ask the user to confirm the updated number."
+                # stale closure: update_phone_number ran again after this confirm
+                # tool was installed (e.g. parallel tool calls in the same turn)
+                return (
+                    "The phone number has changed since confirmation was requested, "
+                    "ask the user to confirm the updated number."
                 )
-                return
 
             if not self.done():
                 self.complete(GetPhoneNumberResult(phone_number=phone_number))
+            return None
 
         return confirm_phone_number
 


### PR DESCRIPTION
## What

The data-capture workflows' `confirm_*` tools (and `credit_card`'s `update_*` validation branches) called `session.generate_reply()` from inside tool execution to voice corrective messages — scheduling a separate speech that competes with the turn's own tool_response reply and leaves nothing in the chat context. This PR returns the instruction as the tool's output instead, so it flows through the normal tool-response reply and merges with sibling tool outputs in the same turn.

`on_enter` hooks and the DTMF event handlers keep `generate_reply` — they run outside tool execution where there is no tool-output channel.

## Testing

Adds a simulation harness (`examples/data_capture_sim`) — an intake agent exposing one `collect_*` tool per data-capture workflow (email, phone, address, DOB with time, name, credit card), all with `require_confirmation=True` so text-only simulations still exercise the `confirm_*` paths, plus an `lk agent simulate` scenarios file driving each corrective branch: value corrected at the confirmation step, time of birth before the date, and the card number length / repeat-mismatch / expired-date validations. Expectations grade the two regressions this refactor could introduce: going silent where `generate_reply` used to speak, and completing with a stale value.

The sim runs in CI (`.github/workflows/data-capture-sim.yml`) on any change to `livekit-agents/livekit/agents/beta/workflows/**` or the sim harness itself.