### PR TITLE
feat(metrics): broadcast llm tps + ttfs

### DIFF
--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -256,6 +256,18 @@ class MetricsReport(TypedDict, total=False):
     Assistant `ChatMessage` only
     """
 
+    llm_node_tps: float
+    """LLM output tokens per second for this turn, measured at the `llm_node`
+
+    Assistant `ChatMessage` only
+    """
+
+    llm_node_ttfs: float
+    """Time from LLM generation start to the first complete sentence
+
+    Assistant `ChatMessage` only
+    """
+
     tts_node_ttfb: float
     """Time taken for the `tts_node` to return the first chunk of audio (after the first text token has been sent)
 

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -263,7 +263,7 @@ class MetricsReport(TypedDict, total=False):
     """
 
     llm_node_ttfs: float
-    """Time from LLM generation start to the first complete sentence
+    """Time from LLM generation start to the first sentence chunk, segmented with the same tokenizer the TTS path uses
 
     Assistant `ChatMessage` only
     """

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -257,7 +257,9 @@ class MetricsReport(TypedDict, total=False):
     """
 
     llm_node_tps: float
-    """LLM output tokens per second for this turn, measured at the `llm_node`
+    """LLM output tokens per second for this turn, measured at the `llm_node` over the
+    streaming window (first to last text chunk). Absent for a reply that arrived in a
+    single chunk, which has no measurable rate
 
     Assistant `ChatMessage` only
     """

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -263,7 +263,9 @@ class MetricsReport(TypedDict, total=False):
     """
 
     llm_node_ttfs: float
-    """Time from LLM generation start to the first sentence chunk, segmented with the same tokenizer the TTS path uses
+    """Time from LLM generation start until the first sentence reached the TTS provider, as
+    segmented by that TTS. Absent when no audio came from a LiveKit TTS this turn: no TTS,
+    an interruption before the first frame, or a `tts_node` synthesizing audio on its own
 
     Assistant `ChatMessage` only
     """

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
 from livekit import rtc
 
-from .. import inference, llm, stt, tokenize, tts, utils, vad
+from .. import inference, llm, stt, tts, utils, vad
 from ..llm import ChatContext, RealtimeModel, ToolError, find_function_tools
 from ..llm.chat_context import Instructions, _ReadOnlyChatContext
 from ..log import logger
@@ -564,11 +564,7 @@ class Agent:
             if not activity.tts.capabilities.streaming:
                 wrapped_tts = tts.StreamAdapter(
                     tts=wrapped_tts,
-                    sentence_tokenizer=tokenize.blingfire.SentenceTokenizer(
-                        retain_format=True,
-                        # markup only exists in the stream when expressive is active
-                        xml_aware=expressive_active,
-                    ),
+                    sentence_tokenizer=activity._tts_sentence_tokenizer(),
                 )
 
             # Mark whether expressive is active for this synthesis, synchronously

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
 from livekit import rtc
 
-from .. import inference, llm, stt, tts, utils, vad
+from .. import inference, llm, stt, tokenize, tts, utils, vad
 from ..llm import ChatContext, RealtimeModel, ToolError, find_function_tools
 from ..llm.chat_context import Instructions, _ReadOnlyChatContext
 from ..log import logger
@@ -564,7 +564,11 @@ class Agent:
             if not activity.tts.capabilities.streaming:
                 wrapped_tts = tts.StreamAdapter(
                     tts=wrapped_tts,
-                    sentence_tokenizer=activity._tts_sentence_tokenizer(),
+                    sentence_tokenizer=tokenize.blingfire.SentenceTokenizer(
+                        retain_format=True,
+                        # markup only exists in the stream when expressive is active
+                        xml_aware=expressive_active,
+                    ),
                 )
 
             # Mark whether expressive is active for this synthesis, synchronously

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3249,6 +3249,12 @@ class AgentActivity(RecognitionHooks):
         if llm_gen_data.ttft is not None:
             assistant_metrics["llm_node_ttft"] = llm_gen_data.ttft
 
+        if llm_gen_data.tps is not None:
+            assistant_metrics["llm_node_tps"] = llm_gen_data.tps
+
+        if llm_gen_data.ttfs is not None:
+            assistant_metrics["llm_node_ttfs"] = llm_gen_data.ttfs
+
         if first_tts_gen_data and first_tts_gen_data.ttfb is not None:
             assistant_metrics["tts_node_ttfb"] = first_tts_gen_data.ttfb
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -15,7 +15,7 @@ from livekit import rtc
 from livekit.agents.llm.realtime import MessageGeneration
 from livekit.agents.metrics.base import Metadata
 
-from .. import inference, llm, stt, tts, utils, vad
+from .. import inference, llm, stt, tokenize, tts, utils, vad
 from ..llm.chat_context import Instructions
 from ..llm.realtime_fallback_adapter import _FallbackRealtimeSession
 from ..llm.tool_context import (
@@ -2544,6 +2544,20 @@ class AgentActivity(RecognitionHooks):
             return DEFAULT_EXPRESSIVE_OPTIONS
         return None
 
+    def _tts_sentence_tokenizer(self) -> tokenize.SentenceTokenizer:
+        """Sentence tokenizer matching what the TTS path applies to this generation,
+        mirroring `Agent.default.tts_node` and the inference TTS provider defaults.
+        Custom `tts_node` overrides and provider-side segmentation aren't visible here,
+        so those fall back to the `StreamAdapter` default."""
+        expressive_active = self._resolve_expressive_options() is not None
+        if isinstance(self.tts, tts.StreamAdapter):
+            return self.tts._sentence_tokenizer
+        if isinstance(self.tts, inference.TTS):
+            from ..tts._provider_format import sentence_tokenizer
+
+            return sentence_tokenizer(self.tts.model.split("/")[0], expressive=expressive_active)
+        return tokenize.blingfire.SentenceTokenizer(retain_format=True, xml_aware=expressive_active)
+
     def _inject_expressive_instructions(
         self,
         chat_ctx: llm.ChatContext,
@@ -2963,6 +2977,7 @@ class AgentActivity(RecognitionHooks):
             model_settings=model_settings,
             model=self.llm.model if self.llm else None,
             provider=self.llm.provider if self.llm else None,
+            sentence_tokenizer=self._tts_sentence_tokenizer(),
         )
         tasks.append(llm_task)
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -7,7 +7,6 @@ import json
 import time
 from collections.abc import AsyncIterable, Coroutine
 from dataclasses import dataclass
-from functools import cache
 from typing import TYPE_CHECKING, Any, Literal
 
 from opentelemetry import context as otel_context, trace

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -7,6 +7,7 @@ import json
 import time
 from collections.abc import AsyncIterable, Coroutine
 from dataclasses import dataclass
+from functools import cache
 from typing import TYPE_CHECKING, Any, Literal
 
 from opentelemetry import context as otel_context, trace
@@ -2545,10 +2546,16 @@ class AgentActivity(RecognitionHooks):
         return None
 
     def _tts_sentence_tokenizer(self) -> tokenize.SentenceTokenizer:
-        """Sentence tokenizer matching what the TTS path applies to this generation,
-        mirroring `Agent.default.tts_node` and the inference TTS provider defaults.
-        Custom `tts_node` overrides and provider-side segmentation aren't visible here,
-        so those fall back to the `StreamAdapter` default."""
+        """Sentence tokenizer the TTS path applies to this generation.
+
+        Single source of truth for that segmentation: the default `tts_node` wraps a
+        non-streaming TTS with the tokenizer returned here, and the inference gateway
+        shares the same per-provider defaults, so the ttfs metric can't drift from what
+        TTS actually does. A live `StreamAdapter` instance is reused rather than rebuilt.
+        Custom `tts_node` overrides and native provider-side segmentation aren't visible
+        here, so those fall back to the `StreamAdapter` default.
+        """
+        # markup only exists in the stream when expressive is active
         expressive_active = self._resolve_expressive_options() is not None
         if isinstance(self.tts, tts.StreamAdapter):
             return self.tts._sentence_tokenizer

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -15,7 +15,7 @@ from livekit import rtc
 from livekit.agents.llm.realtime import MessageGeneration
 from livekit.agents.metrics.base import Metadata
 
-from .. import inference, llm, stt, tokenize, tts, utils, vad
+from .. import inference, llm, stt, tts, utils, vad
 from ..llm.chat_context import Instructions
 from ..llm.realtime_fallback_adapter import _FallbackRealtimeSession
 from ..llm.tool_context import (
@@ -74,6 +74,7 @@ from .generation import (
     _strip_assistant_markup,
     _strip_running_tool_calls,
     _TextOutput,
+    _time_to_first_sentence,
     _TTSGenerationData,
     forward_generation,
     perform_audio_forwarding,
@@ -2681,26 +2682,6 @@ class AgentActivity(RecognitionHooks):
             default=DEFAULT_EXPRESSIVE_OPTIONS,
         )
 
-    def _tts_sentence_tokenizer(self) -> tokenize.SentenceTokenizer:
-        """Sentence tokenizer the TTS path applies to this generation.
-
-        Single source of truth for that segmentation: the default `tts_node` wraps a
-        non-streaming TTS with the tokenizer returned here, and the inference gateway
-        shares the same per-provider defaults, so the ttfs metric can't drift from what
-        TTS actually does. A live `StreamAdapter` instance is reused rather than rebuilt.
-        Custom `tts_node` overrides and native provider-side segmentation aren't visible
-        here, so those fall back to the `StreamAdapter` default.
-        """
-        # markup only exists in the stream when expressive is active
-        expressive_active = self._resolve_expressive_options() is not None
-        if isinstance(self.tts, tts.StreamAdapter):
-            return self.tts._sentence_tokenizer
-        if isinstance(self.tts, inference.TTS):
-            from ..tts._provider_format import sentence_tokenizer
-
-            return sentence_tokenizer(self.tts.model.split("/")[0], expressive=expressive_active)
-        return tokenize.blingfire.SentenceTokenizer(retain_format=True, xml_aware=expressive_active)
-
     def _inject_expressive_instructions(
         self,
         chat_ctx: llm.ChatContext,
@@ -3124,7 +3105,6 @@ class AgentActivity(RecognitionHooks):
             model_settings=model_settings,
             model=self.llm.model if self.llm else None,
             provider=self.llm.provider if self.llm else None,
-            sentence_tokenizer=self._tts_sentence_tokenizer(),
         )
         tasks.append(llm_task)
 
@@ -3414,8 +3394,8 @@ class AgentActivity(RecognitionHooks):
         if llm_gen_data.tps is not None:
             assistant_metrics["llm_node_tps"] = llm_gen_data.tps
 
-        if llm_gen_data.ttfs is not None:
-            assistant_metrics["llm_node_ttfs"] = llm_gen_data.ttfs
+        if (ttfs := _time_to_first_sentence(llm_gen_data, first_tts_gen_data)) is not None:
+            assistant_metrics["llm_node_ttfs"] = ttfs
 
         if first_tts_gen_data and first_tts_gen_data.ttfb is not None:
             assistant_metrics["tts_node_ttfb"] = first_tts_gen_data.ttfb

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -15,7 +15,7 @@ from livekit import rtc
 from livekit.agents.llm.realtime import MessageGeneration
 from livekit.agents.metrics.base import Metadata
 
-from .. import inference, llm, stt, tts, utils, vad
+from .. import inference, llm, stt, tokenize, tts, utils, vad
 from ..llm.chat_context import Instructions
 from ..llm.realtime_fallback_adapter import _FallbackRealtimeSession
 from ..llm.tool_context import (
@@ -2681,6 +2681,20 @@ class AgentActivity(RecognitionHooks):
             default=DEFAULT_EXPRESSIVE_OPTIONS,
         )
 
+    def _tts_sentence_tokenizer(self) -> tokenize.SentenceTokenizer:
+        """Sentence tokenizer matching what the TTS path applies to this generation,
+        mirroring `Agent.default.tts_node` and the inference TTS provider defaults.
+        Custom `tts_node` overrides and provider-side segmentation aren't visible here,
+        so those fall back to the `StreamAdapter` default."""
+        expressive_active = self._resolve_expressive_options() is not None
+        if isinstance(self.tts, tts.StreamAdapter):
+            return self.tts._sentence_tokenizer
+        if isinstance(self.tts, inference.TTS):
+            from ..tts._provider_format import sentence_tokenizer
+
+            return sentence_tokenizer(self.tts.model.split("/")[0], expressive=expressive_active)
+        return tokenize.blingfire.SentenceTokenizer(retain_format=True, xml_aware=expressive_active)
+
     def _inject_expressive_instructions(
         self,
         chat_ctx: llm.ChatContext,
@@ -3104,6 +3118,7 @@ class AgentActivity(RecognitionHooks):
             model_settings=model_settings,
             model=self.llm.model if self.llm else None,
             provider=self.llm.provider if self.llm else None,
+            sentence_tokenizer=self._tts_sentence_tokenizer(),
         )
         tasks.append(llm_task)
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -7,6 +7,7 @@ import json
 import time
 from collections.abc import AsyncIterable, Coroutine
 from dataclasses import dataclass
+from functools import cache
 from typing import TYPE_CHECKING, Any, Literal
 
 from opentelemetry import context as otel_context, trace
@@ -2682,10 +2683,16 @@ class AgentActivity(RecognitionHooks):
         )
 
     def _tts_sentence_tokenizer(self) -> tokenize.SentenceTokenizer:
-        """Sentence tokenizer matching what the TTS path applies to this generation,
-        mirroring `Agent.default.tts_node` and the inference TTS provider defaults.
-        Custom `tts_node` overrides and provider-side segmentation aren't visible here,
-        so those fall back to the `StreamAdapter` default."""
+        """Sentence tokenizer the TTS path applies to this generation.
+
+        Single source of truth for that segmentation: the default `tts_node` wraps a
+        non-streaming TTS with the tokenizer returned here, and the inference gateway
+        shares the same per-provider defaults, so the ttfs metric can't drift from what
+        TTS actually does. A live `StreamAdapter` instance is reused rather than rebuilt.
+        Custom `tts_node` overrides and native provider-side segmentation aren't visible
+        here, so those fall back to the `StreamAdapter` default.
+        """
+        # markup only exists in the stream when expressive is active
         expressive_active = self._resolve_expressive_options() is not None
         if isinstance(self.tts, tts.StreamAdapter):
             return self.tts._sentence_tokenizer

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3390,6 +3390,12 @@ class AgentActivity(RecognitionHooks):
         if llm_gen_data.ttft is not None:
             assistant_metrics["llm_node_ttft"] = llm_gen_data.ttft
 
+        if llm_gen_data.tps is not None:
+            assistant_metrics["llm_node_tps"] = llm_gen_data.tps
+
+        if llm_gen_data.ttfs is not None:
+            assistant_metrics["llm_node_ttfs"] = llm_gen_data.ttfs
+
         if first_tts_gen_data and first_tts_gen_data.ttfb is not None:
             assistant_metrics["tts_node_ttfb"] = first_tts_gen_data.ttfb
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -15,7 +15,7 @@ from livekit import rtc
 from livekit.agents.llm.realtime import MessageGeneration
 from livekit.agents.metrics.base import Metadata
 
-from .. import inference, llm, stt, tokenize, tts, utils, vad
+from .. import inference, llm, stt, tts, utils, vad
 from ..llm.chat_context import Instructions
 from ..llm.realtime_fallback_adapter import _FallbackRealtimeSession
 from ..llm.tool_context import (
@@ -73,6 +73,7 @@ from .generation import (
     _strip_assistant_markup,
     _strip_running_tool_calls,
     _TextOutput,
+    _time_to_first_sentence,
     _TTSGenerationData,
     forward_generation,
     perform_audio_forwarding,
@@ -2544,26 +2545,6 @@ class AgentActivity(RecognitionHooks):
             return DEFAULT_EXPRESSIVE_OPTIONS
         return None
 
-    def _tts_sentence_tokenizer(self) -> tokenize.SentenceTokenizer:
-        """Sentence tokenizer the TTS path applies to this generation.
-
-        Single source of truth for that segmentation: the default `tts_node` wraps a
-        non-streaming TTS with the tokenizer returned here, and the inference gateway
-        shares the same per-provider defaults, so the ttfs metric can't drift from what
-        TTS actually does. A live `StreamAdapter` instance is reused rather than rebuilt.
-        Custom `tts_node` overrides and native provider-side segmentation aren't visible
-        here, so those fall back to the `StreamAdapter` default.
-        """
-        # markup only exists in the stream when expressive is active
-        expressive_active = self._resolve_expressive_options() is not None
-        if isinstance(self.tts, tts.StreamAdapter):
-            return self.tts._sentence_tokenizer
-        if isinstance(self.tts, inference.TTS):
-            from ..tts._provider_format import sentence_tokenizer
-
-            return sentence_tokenizer(self.tts.model.split("/")[0], expressive=expressive_active)
-        return tokenize.blingfire.SentenceTokenizer(retain_format=True, xml_aware=expressive_active)
-
     def _inject_expressive_instructions(
         self,
         chat_ctx: llm.ChatContext,
@@ -2983,7 +2964,6 @@ class AgentActivity(RecognitionHooks):
             model_settings=model_settings,
             model=self.llm.model if self.llm else None,
             provider=self.llm.provider if self.llm else None,
-            sentence_tokenizer=self._tts_sentence_tokenizer(),
         )
         tasks.append(llm_task)
 
@@ -3273,8 +3253,8 @@ class AgentActivity(RecognitionHooks):
         if llm_gen_data.tps is not None:
             assistant_metrics["llm_node_tps"] = llm_gen_data.tps
 
-        if llm_gen_data.ttfs is not None:
-            assistant_metrics["llm_node_ttfs"] = llm_gen_data.ttfs
+        if (ttfs := _time_to_first_sentence(llm_gen_data, first_tts_gen_data)) is not None:
+            assistant_metrics["llm_node_ttfs"] = ttfs
 
         if first_tts_gen_data and first_tts_gen_data.ttfb is not None:
             assistant_metrics["tts_node_ttfb"] = first_tts_gen_data.ttfb

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -24,7 +24,7 @@ from ..llm import (
 from ..llm.chat_context import Instructions
 from ..log import logger
 from ..telemetry import trace_types, tracer
-from ..tokenize import blingfire
+from ..tokenize import SentenceTokenizer, blingfire
 from ..types import (
     USERDATA_TIMED_TRANSCRIPT,
     USERDATA_TTS_STARTED_TIME,
@@ -66,13 +66,6 @@ class _LLMGenerationData:
 # output for an injected in-progress tool call, phrased so the model waits instead of
 # re-issuing the call.
 _RUNNING_TOOL_PLACEHOLDER = "The tool call is still in progress."
-
-
-# Stateless and cheap to construct, min_sentence_len=1
-# keeps short first sentences (e.g. "Hi there.") counted when timing ttfs.
-_SENTENCE_TOKENIZER = blingfire.SentenceTokenizer(min_sentence_len=1)
-
-
 # extra flag marking an injected pair so it can be stripped before the ctx is forwarded.
 _RUNNING_PLACEHOLDER_KEY = "__lk_running_placeholder__"
 
@@ -160,12 +153,22 @@ def perform_llm_inference(
     model_settings: ModelSettings,
     model: str | None = None,
     provider: str | None = None,
+    sentence_tokenizer: SentenceTokenizer | None = None,
 ) -> tuple[asyncio.Task[bool], _LLMGenerationData]:
     text_ch = aio.Chan[str | FlushSentinel]()
     function_ch = aio.Chan[llm.FunctionCall]()
     data = _LLMGenerationData(text_ch=text_ch, function_ch=function_ch)
     llm_task = asyncio.create_task(
-        _llm_inference_task(node, chat_ctx, tool_ctx, model_settings, data, model, provider)
+        _llm_inference_task(
+            node,
+            chat_ctx,
+            tool_ctx,
+            model_settings,
+            data,
+            model,
+            provider,
+            sentence_tokenizer=sentence_tokenizer,
+        )
     )
     llm_task.add_done_callback(lambda _: text_ch.close())
     llm_task.add_done_callback(lambda _: function_ch.close())
@@ -189,6 +192,8 @@ async def _llm_inference_task(
     data: _LLMGenerationData,
     model: str | None = None,
     provider: str | None = None,
+    *,
+    sentence_tokenizer: SentenceTokenizer | None = None,
 ) -> bool:
     start_time = time.perf_counter()
     current_span = trace.get_current_span()
@@ -239,9 +244,9 @@ async def _llm_inference_task(
 
     # forward llm stream to output channels
     usage: Any = None
-    # Time the first complete sentence (ttfs) with a streaming tokenizer that consumes
-    # text incrementally without re-tokenizing the whole generation each chunk.
-    sentence_stream = _SENTENCE_TOKENIZER.stream()
+    if sentence_tokenizer is None:
+        sentence_tokenizer = blingfire.SentenceTokenizer(retain_format=True)
+    sentence_stream = sentence_tokenizer.stream()
 
     async def _set_time_first_sentence() -> None:
         try:

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -24,6 +24,7 @@ from ..llm import (
 from ..llm.chat_context import Instructions
 from ..log import logger
 from ..telemetry import trace_types, tracer
+from ..tokenize import blingfire
 from ..types import (
     USERDATA_TIMED_TRANSCRIPT,
     USERDATA_TTS_STARTED_TIME,
@@ -58,11 +59,20 @@ class _LLMGenerationData:
     id: str = field(default_factory=lambda: utils.shortuuid("item_"))
     started_fut: asyncio.Future[None] = field(default_factory=asyncio.Future)
     ttft: float | None = None
+    tps: float | None = None
+    ttfs: float | None = None
 
 
 # output for an injected in-progress tool call, phrased so the model waits instead of
 # re-issuing the call.
 _RUNNING_TOOL_PLACEHOLDER = "The tool call is still in progress."
+
+
+# Stateless and cheap to construct, min_sentence_len=1
+# keeps short first sentences (e.g. "Hi there.") counted when timing ttfs.
+_SENTENCE_TOKENIZER = blingfire.SentenceTokenizer(min_sentence_len=1)
+
+
 # extra flag marking an injected pair so it can be stripped before the ctx is forwarded.
 _RUNNING_PLACEHOLDER_KEY = "__lk_running_placeholder__"
 
@@ -228,6 +238,20 @@ async def _llm_inference_task(
         return False
 
     # forward llm stream to output channels
+    usage: Any = None
+    # Time the first complete sentence (ttfs) with a streaming tokenizer that consumes
+    # text incrementally without re-tokenizing the whole generation each chunk.
+    sentence_stream = _SENTENCE_TOKENIZER.stream()
+
+    async def _set_time_first_sentence() -> None:
+        try:
+            async for _ in sentence_stream:
+                data.ttfs = time.perf_counter() - start_time
+                return
+        except Exception:
+            logger.exception("failed to time first sentence (llm_node_ttfs)")
+
+    ttfs_task = asyncio.create_task(_set_time_first_sentence())
     try:
         async for chunk in llm_node:
             if data.ttft is None:
@@ -240,6 +264,8 @@ async def _llm_inference_task(
                 content = chunk
 
             elif isinstance(chunk, ChatChunk):
+                if chunk.usage is not None:
+                    usage = chunk.usage
                 if not chunk.delta:
                     continue
 
@@ -283,9 +309,22 @@ async def _llm_inference_task(
             if content:
                 data.generated_text += content
                 text_ch.send_nowait(content)
+                if data.ttfs is None:
+                    sentence_stream.push_text(content)
     finally:
         if isinstance(llm_node, _ACloseable):
             await llm_node.aclose()
+        try:
+            sentence_stream.end_input()  # flush any trailing sentence, then close
+        except RuntimeError:
+            pass
+        await utils.aio.cancel_and_wait(ttfs_task)
+
+    duration = time.perf_counter() - start_time
+    if usage is not None and duration > 0:
+        data.tps = usage.completion_tokens / duration
+    if data.ttfs is None and data.generated_text.strip():
+        data.ttfs = duration
 
     current_span.set_attribute(trace_types.ATTR_RESPONSE_TEXT, data.generated_text)
     current_span.set_attribute(

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -24,6 +24,7 @@ from ..llm import (
 from ..llm.chat_context import Instructions
 from ..log import logger
 from ..telemetry import trace_types, tracer
+from ..tokenize import blingfire
 from ..types import (
     USERDATA_TIMED_TRANSCRIPT,
     USERDATA_TTS_STARTED_TIME,
@@ -58,11 +59,20 @@ class _LLMGenerationData:
     id: str = field(default_factory=lambda: utils.shortuuid("item_"))
     started_fut: asyncio.Future[None] = field(default_factory=asyncio.Future)
     ttft: float | None = None
+    tps: float | None = None
+    ttfs: float | None = None
 
 
 # output for an injected in-progress tool call, phrased so the model waits instead of
 # re-issuing the call.
 _RUNNING_TOOL_PLACEHOLDER = "The tool call is still in progress."
+
+
+# Stateless and cheap to construct, min_sentence_len=1
+# keeps short first sentences (e.g. "Hi there.") counted when timing ttfs.
+_SENTENCE_TOKENIZER = blingfire.SentenceTokenizer(min_sentence_len=1)
+
+
 # extra flag marking an injected pair so it can be stripped before the ctx is forwarded.
 _RUNNING_PLACEHOLDER_KEY = "__lk_running_placeholder__"
 
@@ -229,6 +239,20 @@ async def _llm_inference_task(
         return False
 
     # forward llm stream to output channels
+    usage: Any = None
+    # Time the first complete sentence (ttfs) with a streaming tokenizer that consumes
+    # text incrementally without re-tokenizing the whole generation each chunk.
+    sentence_stream = _SENTENCE_TOKENIZER.stream()
+
+    async def _set_time_first_sentence() -> None:
+        try:
+            async for _ in sentence_stream:
+                data.ttfs = time.perf_counter() - start_time
+                return
+        except Exception:
+            logger.exception("failed to time first sentence (llm_node_ttfs)")
+
+    ttfs_task = asyncio.create_task(_set_time_first_sentence())
     try:
         async for chunk in llm_node:
             if data.ttft is None:
@@ -241,6 +265,8 @@ async def _llm_inference_task(
                 content = chunk
 
             elif isinstance(chunk, ChatChunk):
+                if chunk.usage is not None:
+                    usage = chunk.usage
                 if not chunk.delta:
                     continue
 
@@ -284,9 +310,22 @@ async def _llm_inference_task(
             if content:
                 data.generated_text += content
                 text_ch.send_nowait(content)
+                if data.ttfs is None:
+                    sentence_stream.push_text(content)
     finally:
         if isinstance(llm_node, _ACloseable):
             await llm_node.aclose()
+        try:
+            sentence_stream.end_input()  # flush any trailing sentence, then close
+        except RuntimeError:
+            pass
+        await utils.aio.cancel_and_wait(ttfs_task)
+
+    duration = time.perf_counter() - start_time
+    if usage is not None and duration > 0:
+        data.tps = usage.completion_tokens / duration
+    if data.ttfs is None and data.generated_text.strip():
+        data.ttfs = duration
 
     current_span.set_attribute(trace_types.ATTR_RESPONSE_TEXT, data.generated_text)
     current_span.set_attribute(

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -25,7 +25,6 @@ from ..llm import (
 from ..llm.chat_context import Instructions
 from ..log import logger
 from ..telemetry import trace_types, tracer
-from ..tokenize import SentenceTokenizer, blingfire
 from ..types import (
     USERDATA_TIMED_TRANSCRIPT,
     USERDATA_TTS_STARTED_TIME,
@@ -59,9 +58,9 @@ class _LLMGenerationData:
     generated_extra: dict[str, Any] = field(default_factory=dict)
     id: str = field(default_factory=lambda: utils.shortuuid("item_"))
     started_fut: asyncio.Future[None] = field(default_factory=asyncio.Future)
+    started_at: float | None = None
     ttft: float | None = None
     tps: float | None = None
-    ttfs: float | None = None
 
 
 # output for an injected in-progress tool call, phrased so the model waits instead of
@@ -155,22 +154,12 @@ def perform_llm_inference(
     model_settings: ModelSettings,
     model: str | None = None,
     provider: str | None = None,
-    sentence_tokenizer: SentenceTokenizer | None = None,
 ) -> tuple[asyncio.Task[bool], _LLMGenerationData]:
     text_ch = aio.Chan[str | FlushSentinel]()
     function_ch = aio.Chan[llm.FunctionCall]()
     data = _LLMGenerationData(text_ch=text_ch, function_ch=function_ch)
     llm_task = asyncio.create_task(
-        _llm_inference_task(
-            node,
-            chat_ctx,
-            tool_ctx,
-            model_settings,
-            data,
-            model,
-            provider,
-            sentence_tokenizer,
-        )
+        _llm_inference_task(node, chat_ctx, tool_ctx, model_settings, data, model, provider)
     )
     llm_task.add_done_callback(lambda _: text_ch.close())
     llm_task.add_done_callback(lambda _: function_ch.close())
@@ -194,9 +183,9 @@ async def _llm_inference_task(
     data: _LLMGenerationData,
     model: str | None = None,
     provider: str | None = None,
-    sentence_tokenizer: SentenceTokenizer | None = None,
 ) -> bool:
     start_time = time.perf_counter()
+    data.started_at = start_time
     current_span = trace.get_current_span()
     data.started_fut.set_result(None)
 
@@ -245,19 +234,6 @@ async def _llm_inference_task(
 
     # forward llm stream to output channels
     usage: CompletionUsage | None = None
-    if sentence_tokenizer is None:
-        sentence_tokenizer = blingfire.SentenceTokenizer(retain_format=True)
-    sentence_stream = sentence_tokenizer.stream()
-
-    async def _set_time_first_sentence() -> None:
-        try:
-            async for _ in sentence_stream:
-                data.ttfs = time.perf_counter() - start_time
-                return
-        except Exception:
-            logger.exception("failed to time first sentence (llm_node_ttfs)")
-
-    ttfs_task = asyncio.create_task(_set_time_first_sentence())
     try:
         async for chunk in llm_node:
             if data.ttft is None:
@@ -315,22 +291,13 @@ async def _llm_inference_task(
             if content:
                 data.generated_text += content
                 text_ch.send_nowait(content)
-                if data.ttfs is None:
-                    sentence_stream.push_text(content)
     finally:
         if isinstance(llm_node, _ACloseable):
             await llm_node.aclose()
-        try:
-            sentence_stream.end_input()  # flush any trailing sentence, then close
-        except Exception:
-            pass
-        await utils.aio.cancel_and_wait(ttfs_task)
 
     duration = time.perf_counter() - start_time
     if usage is not None and duration > 0:
         data.tps = usage.completion_tokens / duration
-    if data.ttfs is None and data.generated_text.strip():
-        data.ttfs = duration
 
     current_span.set_attribute(trace_types.ATTR_RESPONSE_TEXT, data.generated_text)
     current_span.set_attribute(
@@ -349,6 +316,17 @@ class _TTSGenerationData:
     audio_ch: aio.Chan[rtc.AudioFrame]
     timed_texts_fut: asyncio.Future[aio.Chan[io.TimedString] | None]
     ttfb: float | None = None
+    # perf_counter when the first text of this segment reached the TTS provider, as stamped
+    # by the TTS stream itself; None when a custom tts_node publishes no stamp
+    synthesis_started_at: float | None = None
+
+
+def _time_to_first_sentence(
+    llm_data: _LLMGenerationData, tts_data: _TTSGenerationData | None
+) -> float | None:
+    if llm_data.started_at is None or tts_data is None or tts_data.synthesis_started_at is None:
+        return None
+    return tts_data.synthesis_started_at - llm_data.started_at
 
 
 def perform_tts_inference(
@@ -428,10 +406,12 @@ async def _tts_inference_task(
                 # the framework TTS streams attach the time the text was first sent to the
                 # provider; without it (custom tts_node), fall back to the arrival of the
                 # first input token, which also counts any text buffering (e.g. sentence
-                # tokenization) as TTFB
-                anchor: float | None = audio_frame.userdata.get(
-                    USERDATA_TTS_STARTED_TIME, start_time
+                # tokenization) as TTFB. ttfs takes no such fallback and stays unreported.
+                anchor = data.synthesis_started_at = audio_frame.userdata.get(
+                    USERDATA_TTS_STARTED_TIME
                 )
+                if anchor is None:
+                    anchor = start_time
                 if anchor is not None:
                     data.ttfb = time.perf_counter() - anchor
                     current_span.set_attribute(trace_types.ATTR_RESPONSE_TTFB, data.ttfb)

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -16,6 +16,7 @@ from .. import llm, utils
 from ..llm import (
     ChatChunk,
     ChatContext,
+    CompletionUsage,
     StopResponse,
     ToolContext,
     ToolError,
@@ -168,7 +169,7 @@ def perform_llm_inference(
             data,
             model,
             provider,
-            sentence_tokenizer=sentence_tokenizer,
+            sentence_tokenizer,
         )
     )
     llm_task.add_done_callback(lambda _: text_ch.close())
@@ -193,7 +194,6 @@ async def _llm_inference_task(
     data: _LLMGenerationData,
     model: str | None = None,
     provider: str | None = None,
-    *,
     sentence_tokenizer: SentenceTokenizer | None = None,
 ) -> bool:
     start_time = time.perf_counter()
@@ -244,7 +244,7 @@ async def _llm_inference_task(
         return False
 
     # forward llm stream to output channels
-    usage: Any = None
+    usage: CompletionUsage | None = None
     if sentence_tokenizer is None:
         sentence_tokenizer = blingfire.SentenceTokenizer(retain_format=True)
     sentence_stream = sentence_tokenizer.stream()
@@ -322,7 +322,7 @@ async def _llm_inference_task(
             await llm_node.aclose()
         try:
             sentence_stream.end_input()  # flush any trailing sentence, then close
-        except RuntimeError:
+        except Exception:
             pass
         await utils.aio.cancel_and_wait(ttfs_task)
 

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -24,7 +24,7 @@ from ..llm import (
 from ..llm.chat_context import Instructions
 from ..log import logger
 from ..telemetry import trace_types, tracer
-from ..tokenize import blingfire
+from ..tokenize import SentenceTokenizer, blingfire
 from ..types import (
     USERDATA_TIMED_TRANSCRIPT,
     USERDATA_TTS_STARTED_TIME,
@@ -66,13 +66,6 @@ class _LLMGenerationData:
 # output for an injected in-progress tool call, phrased so the model waits instead of
 # re-issuing the call.
 _RUNNING_TOOL_PLACEHOLDER = "The tool call is still in progress."
-
-
-# Stateless and cheap to construct, min_sentence_len=1
-# keeps short first sentences (e.g. "Hi there.") counted when timing ttfs.
-_SENTENCE_TOKENIZER = blingfire.SentenceTokenizer(min_sentence_len=1)
-
-
 # extra flag marking an injected pair so it can be stripped before the ctx is forwarded.
 _RUNNING_PLACEHOLDER_KEY = "__lk_running_placeholder__"
 
@@ -161,12 +154,22 @@ def perform_llm_inference(
     model_settings: ModelSettings,
     model: str | None = None,
     provider: str | None = None,
+    sentence_tokenizer: SentenceTokenizer | None = None,
 ) -> tuple[asyncio.Task[bool], _LLMGenerationData]:
     text_ch = aio.Chan[str | FlushSentinel]()
     function_ch = aio.Chan[llm.FunctionCall]()
     data = _LLMGenerationData(text_ch=text_ch, function_ch=function_ch)
     llm_task = asyncio.create_task(
-        _llm_inference_task(node, chat_ctx, tool_ctx, model_settings, data, model, provider)
+        _llm_inference_task(
+            node,
+            chat_ctx,
+            tool_ctx,
+            model_settings,
+            data,
+            model,
+            provider,
+            sentence_tokenizer=sentence_tokenizer,
+        )
     )
     llm_task.add_done_callback(lambda _: text_ch.close())
     llm_task.add_done_callback(lambda _: function_ch.close())
@@ -190,6 +193,8 @@ async def _llm_inference_task(
     data: _LLMGenerationData,
     model: str | None = None,
     provider: str | None = None,
+    *,
+    sentence_tokenizer: SentenceTokenizer | None = None,
 ) -> bool:
     start_time = time.perf_counter()
     current_span = trace.get_current_span()
@@ -240,9 +245,9 @@ async def _llm_inference_task(
 
     # forward llm stream to output channels
     usage: Any = None
-    # Time the first complete sentence (ttfs) with a streaming tokenizer that consumes
-    # text incrementally without re-tokenizing the whole generation each chunk.
-    sentence_stream = _SENTENCE_TOKENIZER.stream()
+    if sentence_tokenizer is None:
+        sentence_tokenizer = blingfire.SentenceTokenizer(retain_format=True)
+    sentence_stream = sentence_tokenizer.stream()
 
     async def _set_time_first_sentence() -> None:
         try:

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -234,6 +234,8 @@ async def _llm_inference_task(
 
     # forward llm stream to output channels
     usage: CompletionUsage | None = None
+    first_content_at: float | None = None
+    last_content_at = 0.0
     try:
         async for chunk in llm_node:
             if data.ttft is None:
@@ -289,15 +291,22 @@ async def _llm_inference_task(
 
             # route text content to output channels
             if content:
+                now = time.perf_counter()
+                if first_content_at is None:
+                    first_content_at = now
+                last_content_at = now
                 data.generated_text += content
                 text_ch.send_nowait(content)
     finally:
         if isinstance(llm_node, _ACloseable):
             await llm_node.aclose()
 
-    duration = time.perf_counter() - start_time
-    if usage is not None and duration > 0:
-        data.tps = usage.completion_tokens / duration
+    if (
+        usage is not None
+        and first_content_at is not None
+        and (streaming_window := last_content_at - first_content_at) > 0
+    ):
+        data.tps = usage.completion_tokens / streaming_window
 
     current_span.set_attribute(trace_types.ATTR_RESPONSE_TEXT, data.generated_text)
     current_span.set_attribute(

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -233,6 +233,8 @@ async def _llm_inference_task(
 
     # forward llm stream to output channels
     usage: CompletionUsage | None = None
+    first_content_at: float | None = None
+    last_content_at = 0.0
     try:
         async for chunk in llm_node:
             if data.ttft is None:
@@ -288,15 +290,22 @@ async def _llm_inference_task(
 
             # route text content to output channels
             if content:
+                now = time.perf_counter()
+                if first_content_at is None:
+                    first_content_at = now
+                last_content_at = now
                 data.generated_text += content
                 text_ch.send_nowait(content)
     finally:
         if isinstance(llm_node, _ACloseable):
             await llm_node.aclose()
 
-    duration = time.perf_counter() - start_time
-    if usage is not None and duration > 0:
-        data.tps = usage.completion_tokens / duration
+    if (
+        usage is not None
+        and first_content_at is not None
+        and (streaming_window := last_content_at - first_content_at) > 0
+    ):
+        data.tps = usage.completion_tokens / streaming_window
 
     current_span.set_attribute(trace_types.ATTR_RESPONSE_TEXT, data.generated_text)
     current_span.set_attribute(

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -16,6 +16,7 @@ from .. import llm, utils
 from ..llm import (
     ChatChunk,
     ChatContext,
+    CompletionUsage,
     StopResponse,
     ToolContext,
     ToolError,
@@ -167,7 +168,7 @@ def perform_llm_inference(
             data,
             model,
             provider,
-            sentence_tokenizer=sentence_tokenizer,
+            sentence_tokenizer,
         )
     )
     llm_task.add_done_callback(lambda _: text_ch.close())
@@ -192,7 +193,6 @@ async def _llm_inference_task(
     data: _LLMGenerationData,
     model: str | None = None,
     provider: str | None = None,
-    *,
     sentence_tokenizer: SentenceTokenizer | None = None,
 ) -> bool:
     start_time = time.perf_counter()
@@ -243,7 +243,7 @@ async def _llm_inference_task(
         return False
 
     # forward llm stream to output channels
-    usage: Any = None
+    usage: CompletionUsage | None = None
     if sentence_tokenizer is None:
         sentence_tokenizer = blingfire.SentenceTokenizer(retain_format=True)
     sentence_stream = sentence_tokenizer.stream()
@@ -321,7 +321,7 @@ async def _llm_inference_task(
             await llm_node.aclose()
         try:
             sentence_stream.end_input()  # flush any trailing sentence, then close
-        except RuntimeError:
+        except Exception:
             pass
         await utils.aio.cancel_and_wait(ttfs_task)
 

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -25,7 +25,6 @@ from ..llm import (
 from ..llm.chat_context import Instructions
 from ..log import logger
 from ..telemetry import trace_types, tracer
-from ..tokenize import SentenceTokenizer, blingfire
 from ..types import (
     USERDATA_TIMED_TRANSCRIPT,
     USERDATA_TTS_STARTED_TIME,
@@ -59,9 +58,9 @@ class _LLMGenerationData:
     generated_extra: dict[str, Any] = field(default_factory=dict)
     id: str = field(default_factory=lambda: utils.shortuuid("item_"))
     started_fut: asyncio.Future[None] = field(default_factory=asyncio.Future)
+    started_at: float | None = None
     ttft: float | None = None
     tps: float | None = None
-    ttfs: float | None = None
 
 
 # output for an injected in-progress tool call, phrased so the model waits instead of
@@ -154,22 +153,12 @@ def perform_llm_inference(
     model_settings: ModelSettings,
     model: str | None = None,
     provider: str | None = None,
-    sentence_tokenizer: SentenceTokenizer | None = None,
 ) -> tuple[asyncio.Task[bool], _LLMGenerationData]:
     text_ch = aio.Chan[str | FlushSentinel]()
     function_ch = aio.Chan[llm.FunctionCall]()
     data = _LLMGenerationData(text_ch=text_ch, function_ch=function_ch)
     llm_task = asyncio.create_task(
-        _llm_inference_task(
-            node,
-            chat_ctx,
-            tool_ctx,
-            model_settings,
-            data,
-            model,
-            provider,
-            sentence_tokenizer,
-        )
+        _llm_inference_task(node, chat_ctx, tool_ctx, model_settings, data, model, provider)
     )
     llm_task.add_done_callback(lambda _: text_ch.close())
     llm_task.add_done_callback(lambda _: function_ch.close())
@@ -193,9 +182,9 @@ async def _llm_inference_task(
     data: _LLMGenerationData,
     model: str | None = None,
     provider: str | None = None,
-    sentence_tokenizer: SentenceTokenizer | None = None,
 ) -> bool:
     start_time = time.perf_counter()
+    data.started_at = start_time
     current_span = trace.get_current_span()
     data.started_fut.set_result(None)
 
@@ -244,19 +233,6 @@ async def _llm_inference_task(
 
     # forward llm stream to output channels
     usage: CompletionUsage | None = None
-    if sentence_tokenizer is None:
-        sentence_tokenizer = blingfire.SentenceTokenizer(retain_format=True)
-    sentence_stream = sentence_tokenizer.stream()
-
-    async def _set_time_first_sentence() -> None:
-        try:
-            async for _ in sentence_stream:
-                data.ttfs = time.perf_counter() - start_time
-                return
-        except Exception:
-            logger.exception("failed to time first sentence (llm_node_ttfs)")
-
-    ttfs_task = asyncio.create_task(_set_time_first_sentence())
     try:
         async for chunk in llm_node:
             if data.ttft is None:
@@ -314,22 +290,13 @@ async def _llm_inference_task(
             if content:
                 data.generated_text += content
                 text_ch.send_nowait(content)
-                if data.ttfs is None:
-                    sentence_stream.push_text(content)
     finally:
         if isinstance(llm_node, _ACloseable):
             await llm_node.aclose()
-        try:
-            sentence_stream.end_input()  # flush any trailing sentence, then close
-        except Exception:
-            pass
-        await utils.aio.cancel_and_wait(ttfs_task)
 
     duration = time.perf_counter() - start_time
     if usage is not None and duration > 0:
         data.tps = usage.completion_tokens / duration
-    if data.ttfs is None and data.generated_text.strip():
-        data.ttfs = duration
 
     current_span.set_attribute(trace_types.ATTR_RESPONSE_TEXT, data.generated_text)
     current_span.set_attribute(
@@ -348,6 +315,17 @@ class _TTSGenerationData:
     audio_ch: aio.Chan[rtc.AudioFrame]
     timed_texts_fut: asyncio.Future[aio.Chan[io.TimedString] | None]
     ttfb: float | None = None
+    # perf_counter when the first text of this segment reached the TTS provider, as stamped
+    # by the TTS stream itself; None when a custom tts_node publishes no stamp
+    synthesis_started_at: float | None = None
+
+
+def _time_to_first_sentence(
+    llm_data: _LLMGenerationData, tts_data: _TTSGenerationData | None
+) -> float | None:
+    if llm_data.started_at is None or tts_data is None or tts_data.synthesis_started_at is None:
+        return None
+    return tts_data.synthesis_started_at - llm_data.started_at
 
 
 def perform_tts_inference(
@@ -427,10 +405,12 @@ async def _tts_inference_task(
                 # the framework TTS streams attach the time the text was first sent to the
                 # provider; without it (custom tts_node), fall back to the arrival of the
                 # first input token, which also counts any text buffering (e.g. sentence
-                # tokenization) as TTFB
-                anchor: float | None = audio_frame.userdata.get(
-                    USERDATA_TTS_STARTED_TIME, start_time
+                # tokenization) as TTFB. ttfs takes no such fallback and stays unreported.
+                anchor = data.synthesis_started_at = audio_frame.userdata.get(
+                    USERDATA_TTS_STARTED_TIME
                 )
+                if anchor is None:
+                    anchor = start_time
                 if anchor is not None:
                     data.ttfb = time.perf_counter() - anchor
                     current_span.set_attribute(trace_types.ATTR_RESPONSE_TTFB, data.ttfb)

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -37,6 +37,7 @@ from ..metrics import (
 from ..version import __version__
 from ..voice.amd import AMDCategory, AMDPredictionEvent
 from .events import (
+    AgentFalseInterruptionEvent,
     AgentState,
     AgentStateChangedEvent,
     ConversationItemAddedEvent,
@@ -255,6 +256,8 @@ _METRICS_FIELDS = (
     "llm_node_ttft",
     "tts_node_ttfb",
     "e2e_latency",
+    "llm_node_tps",
+    "llm_node_ttfs",
 )
 
 _TOOL_CALL_STATUS_MAP: dict[str, agent_pb.ToolCallStatus] = {
@@ -395,6 +398,7 @@ class SessionHost:
             session.on("tool_execution_updated", self._on_tool_execution_updated)
             session.on("session_usage_updated", self._on_session_usage_updated)
             session.on("overlapping_speech", self._on_overlapping_speech)
+            session.on("agent_false_interruption", self._on_agent_false_interruption)
             session.on("error", self._on_error)
             session.on("debug_message", self._on_debug_message)
 
@@ -420,6 +424,7 @@ class SessionHost:
             self._session.off("tool_execution_updated", self._on_tool_execution_updated)
             self._session.off("session_usage_updated", self._on_session_usage_updated)
             self._session.off("overlapping_speech", self._on_overlapping_speech)
+            self._session.off("agent_false_interruption", self._on_agent_false_interruption)
             self._session.off("error", self._on_error)
             self._session.off("debug_message", self._on_debug_message)
 
@@ -604,6 +609,10 @@ class SessionHost:
             pb.overlap_started_at.CopyFrom(overlap_started_at)
 
         self._send_event(agent_pb.AgentSessionEvent(overlapping_speech=pb))
+
+    def _on_agent_false_interruption(self, event: AgentFalseInterruptionEvent) -> None:
+        pb = agent_pb.AgentSessionEvent.AgentFalseInterruption(resumed=event.resumed)
+        self._send_event(agent_pb.AgentSessionEvent(agent_false_interruption=pb))
 
     def _on_amd_prediction(self, event: AMDPredictionEvent) -> None:
         speech_duration = Duration()

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -256,6 +256,8 @@ _METRICS_FIELDS = (
     "llm_node_ttft",
     "tts_node_ttfb",
     "e2e_latency",
+    "llm_node_tps",
+    "llm_node_ttfs",
 )
 
 _TOOL_CALL_STATUS_MAP: dict[str, agent_pb.ToolCallStatus] = {

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -272,6 +272,37 @@ async def test_tts_node_ttfb_excludes_upstream_latency() -> None:
     check_timestamp(metrics["tts_node_ttfb"], 0.2, speed_factor=speed)
 
 
+async def test_llm_node_ttfs_anchors_on_synthesis_start() -> None:
+    # ttfs is the LLM->TTS handoff: inference start until the first sentence reached the
+    # provider. The fake TTS only synthesizes once its input is flushed (~2.0s in, when the
+    # LLM stream ends), so ttfs must be ~2.0 and ttfb ~0.2 -- together they decompose the
+    # gap between the first token and the first audio.
+    speed = 1
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "Hello, how are you?", stt_delay=0.2)
+    actions.add_llm("I'm doing well, thank you!", ttft=0.1, duration=2.0)
+    actions.add_tts(1.0, ttfb=0.2, duration=0.3)
+
+    session = create_session(actions, speed_factor=speed)
+    agent = MyAgent()
+
+    conversation_events: list[ConversationItemAddedEvent] = []
+    session.on("conversation_item_added", conversation_events.append)
+
+    await asyncio.wait_for(run_session(session, agent), timeout=SESSION_TIMEOUT)
+
+    assistant_messages = [
+        ev.item
+        for ev in conversation_events
+        if ev.item.type == "message" and ev.item.role == "assistant"
+    ]
+    assert len(assistant_messages) == 1
+    metrics = assistant_messages[0].metrics
+    assert "llm_node_ttfs" in metrics
+    check_timestamp(metrics["llm_node_ttfs"], 2.0, speed_factor=speed)
+    check_timestamp(metrics["tts_node_ttfb"], 0.2, speed_factor=speed)
+
+
 async def test_tool_call() -> None:
     speed = 1
     actions = FakeActions()

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -231,6 +231,37 @@ async def test_tts_node_ttfb_excludes_upstream_latency() -> None:
     check_timestamp(metrics["tts_node_ttfb"], 0.2, speed_factor=speed)
 
 
+async def test_llm_node_ttfs_anchors_on_synthesis_start() -> None:
+    # ttfs is the LLM->TTS handoff: inference start until the first sentence reached the
+    # provider. The fake TTS only synthesizes once its input is flushed (~2.0s in, when the
+    # LLM stream ends), so ttfs must be ~2.0 and ttfb ~0.2 -- together they decompose the
+    # gap between the first token and the first audio.
+    speed = 1
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "Hello, how are you?", stt_delay=0.2)
+    actions.add_llm("I'm doing well, thank you!", ttft=0.1, duration=2.0)
+    actions.add_tts(1.0, ttfb=0.2, duration=0.3)
+
+    session = create_session(actions, speed_factor=speed)
+    agent = MyAgent()
+
+    conversation_events: list[ConversationItemAddedEvent] = []
+    session.on("conversation_item_added", conversation_events.append)
+
+    await asyncio.wait_for(run_session(session, agent), timeout=SESSION_TIMEOUT)
+
+    assistant_messages = [
+        ev.item
+        for ev in conversation_events
+        if ev.item.type == "message" and ev.item.role == "assistant"
+    ]
+    assert len(assistant_messages) == 1
+    metrics = assistant_messages[0].metrics
+    assert "llm_node_ttfs" in metrics
+    check_timestamp(metrics["llm_node_ttfs"], 2.0, speed_factor=speed)
+    check_timestamp(metrics["tts_node_ttfb"], 0.2, speed_factor=speed)
+
+
 async def test_tool_call() -> None:
     speed = 1
     actions = FakeActions()

--- a/tests/test_llm_node_metrics.py
+++ b/tests/test_llm_node_metrics.py
@@ -10,7 +10,6 @@ from livekit.agents.tokenize import blingfire
 from livekit.agents.utils import aio
 from livekit.agents.voice.agent import ModelSettings
 from livekit.agents.voice.generation import (
-    _SENTENCE_TOKENIZER,
     _llm_inference_task,
     _LLMGenerationData,
 )
@@ -28,7 +27,10 @@ def _fake_node(chunks: list[ChatChunk]):
     return node
 
 
-async def _run_inference(chunks: list[ChatChunk]) -> _LLMGenerationData:
+async def _run_inference(
+    chunks: list[ChatChunk],
+    sentence_tokenizer: blingfire.SentenceTokenizer | None = None,
+) -> _LLMGenerationData:
     data = _LLMGenerationData(text_ch=aio.Chan(), function_ch=aio.Chan())
     await _llm_inference_task(
         _fake_node(chunks),
@@ -36,6 +38,7 @@ async def _run_inference(chunks: list[ChatChunk]) -> _LLMGenerationData:
         ToolContext.empty(),
         ModelSettings(),
         data,
+        sentence_tokenizer=sentence_tokenizer,
     )
     return data
 
@@ -70,6 +73,18 @@ class TestLLMNodeTps:
         assert data.tps is None
 
 
+class _RecordingTokenizer(blingfire.SentenceTokenizer):
+    """Counts stream() calls so tests can assert the caller-provided tokenizer is used."""
+
+    def __init__(self) -> None:
+        super().__init__(min_sentence_len=1)
+        self.stream_calls = 0
+
+    def stream(self, *, language: str | None = None):  # type: ignore[no-untyped-def]
+        self.stream_calls += 1
+        return super().stream(language=language)
+
+
 class TestLLMNodeTtfs:
     async def test_ttfs_set_for_nonempty_generation(self) -> None:
         data = await _run_inference([_content("First sentence. "), _content("Second one.")])
@@ -80,10 +95,12 @@ class TestLLMNodeTtfs:
         data = await _run_inference([_content("   ")])
         assert data.ttfs is None
 
-
-class TestSentenceTokenizerConfig:
-    def test_short_first_sentence_is_counted(self) -> None:
-        # regression: ttfs must see short openers. blingfire's TTS-oriented default
-        # (min_sentence_len=20) drops them, which silently inflated ttfs to the whole turn.
-        text = "Hi there. How can I help?"
-        assert len(_SENTENCE_TOKENIZER.tokenize(text)) == 2
+    async def test_ttfs_uses_provided_tokenizer(self) -> None:
+        # the tokenizer must be resolved from the actual TTS path
+        tokenizer = _RecordingTokenizer()
+        data = await _run_inference(
+            [_content("First sentence here, quite long. "), _content("Second one.")],
+            sentence_tokenizer=tokenizer,
+        )
+        assert tokenizer.stream_calls == 1
+        assert data.ttfs is not None

--- a/tests/test_llm_node_metrics.py
+++ b/tests/test_llm_node_metrics.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from livekit.agents.llm import ChatChunk, ChatContext, ChoiceDelta, CompletionUsage
+from livekit.agents.llm.tool_context import ToolContext
+from livekit.agents.tokenize import blingfire
+from livekit.agents.utils import aio
+from livekit.agents.voice.agent import ModelSettings
+from livekit.agents.voice.generation import (
+    _SENTENCE_TOKENIZER,
+    _llm_inference_task,
+    _LLMGenerationData,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _fake_node(chunks: list[ChatChunk]):
+    # matches the io.LLMNode signature: (chat_ctx, tools, model_settings) -> AsyncIterable
+    async def node(chat_ctx, tools, model_settings):  # type: ignore[no-untyped-def]
+        for chunk in chunks:
+            await asyncio.sleep(0)  # yield so the ttfs consumer task can run
+            yield chunk
+
+    return node
+
+
+async def _run_inference(chunks: list[ChatChunk]) -> _LLMGenerationData:
+    data = _LLMGenerationData(text_ch=aio.Chan(), function_ch=aio.Chan())
+    await _llm_inference_task(
+        _fake_node(chunks),
+        ChatContext.empty(),
+        ToolContext.empty(),
+        ModelSettings(),
+        data,
+    )
+    return data
+
+
+def _content(text: str) -> ChatChunk:
+    return ChatChunk(id="c", delta=ChoiceDelta(content=text))
+
+
+def _usage_chunk(completion_tokens: int) -> ChatChunk:
+    return ChatChunk(
+        id="c",
+        usage=CompletionUsage(
+            completion_tokens=completion_tokens,
+            prompt_tokens=5,
+            total_tokens=completion_tokens + 5,
+        ),
+    )
+
+
+class TestLLMNodeTps:
+    async def test_tps_set_when_usage_reported(self) -> None:
+        data = await _run_inference([_content("Hello there, friend."), _usage_chunk(30)])
+        assert data.tps is not None
+        assert data.tps > 0
+
+    async def test_tps_zero_when_zero_usage_is_reported(self) -> None:
+        data = await _run_inference([_content("Hello there, friend."), _usage_chunk(0)])
+        assert data.tps == 0
+
+    async def test_tps_none_when_no_usage_reported(self) -> None:
+        data = await _run_inference([_content("Hello there, friend.")])  # no usage chunk
+        assert data.tps is None
+
+
+class TestLLMNodeTtfs:
+    async def test_ttfs_set_for_nonempty_generation(self) -> None:
+        data = await _run_inference([_content("First sentence. "), _content("Second one.")])
+        assert data.ttfs is not None
+        assert data.ttfs > 0
+
+    async def test_ttfs_none_for_whitespace_only(self) -> None:
+        data = await _run_inference([_content("   ")])
+        assert data.ttfs is None
+
+
+class TestSentenceTokenizerConfig:
+    def test_short_first_sentence_is_counted(self) -> None:
+        # regression: ttfs must see short openers. blingfire's TTS-oriented default
+        # (min_sentence_len=20) drops them, which silently inflated ttfs to the whole turn.
+        text = "Hi there. How can I help?"
+        assert len(_SENTENCE_TOKENIZER.tokenize(text)) == 2

--- a/tests/test_llm_node_metrics.py
+++ b/tests/test_llm_node_metrics.py
@@ -104,3 +104,24 @@ class TestLLMNodeTtfs:
         )
         assert tokenizer.stream_calls == 1
         assert data.ttfs is not None
+
+
+class TestTtsSentenceTokenizerResolution:
+    """`AgentActivity._tts_sentence_tokenizer` is the single source of truth the default
+    `tts_node` and the ttfs metric both read, so the segmentation ttfs times matches what
+    TTS actually applies."""
+
+    async def test_reuses_live_stream_adapter_instance(self) -> None:
+        # a StreamAdapter already owns the tokenizer TTS will run; reuse that exact
+        # instance rather than building a parallel one that could drift from it.
+        from types import SimpleNamespace
+
+        from livekit.agents import tts
+        from livekit.agents.voice.agent_activity import AgentActivity
+
+        from .fake_tts import FakeTTS
+
+        adapter = tts.StreamAdapter(tts=FakeTTS())
+        activity = SimpleNamespace(tts=adapter, _resolve_expressive_options=lambda: None)
+        resolved = AgentActivity._tts_sentence_tokenizer(activity)  # type: ignore[arg-type]
+        assert resolved is adapter._sentence_tokenizer

--- a/tests/test_llm_node_metrics.py
+++ b/tests/test_llm_node_metrics.py
@@ -6,12 +6,13 @@ import pytest
 
 from livekit.agents.llm import ChatChunk, ChatContext, ChoiceDelta, CompletionUsage
 from livekit.agents.llm.tool_context import ToolContext
-from livekit.agents.tokenize import blingfire
 from livekit.agents.utils import aio
 from livekit.agents.voice.agent import ModelSettings
 from livekit.agents.voice.generation import (
     _llm_inference_task,
     _LLMGenerationData,
+    _time_to_first_sentence,
+    _TTSGenerationData,
 )
 
 pytestmark = pytest.mark.unit
@@ -21,16 +22,13 @@ def _fake_node(chunks: list[ChatChunk]):
     # matches the io.LLMNode signature: (chat_ctx, tools, model_settings) -> AsyncIterable
     async def node(chat_ctx, tools, model_settings):  # type: ignore[no-untyped-def]
         for chunk in chunks:
-            await asyncio.sleep(0)  # yield so the ttfs consumer task can run
+            await asyncio.sleep(0)
             yield chunk
 
     return node
 
 
-async def _run_inference(
-    chunks: list[ChatChunk],
-    sentence_tokenizer: blingfire.SentenceTokenizer | None = None,
-) -> _LLMGenerationData:
+async def _run_inference(chunks: list[ChatChunk]) -> _LLMGenerationData:
     data = _LLMGenerationData(text_ch=aio.Chan(), function_ch=aio.Chan())
     await _llm_inference_task(
         _fake_node(chunks),
@@ -38,7 +36,6 @@ async def _run_inference(
         ToolContext.empty(),
         ModelSettings(),
         data,
-        sentence_tokenizer=sentence_tokenizer,
     )
     return data
 
@@ -58,6 +55,14 @@ def _usage_chunk(completion_tokens: int) -> ChatChunk:
     )
 
 
+def _tts_data(synthesis_started_at: float | None) -> _TTSGenerationData:
+    return _TTSGenerationData(
+        audio_ch=aio.Chan(),
+        timed_texts_fut=asyncio.Future(),
+        synthesis_started_at=synthesis_started_at,
+    )
+
+
 class TestLLMNodeTps:
     async def test_tps_set_when_usage_reported(self) -> None:
         data = await _run_inference([_content("Hello there, friend."), _usage_chunk(30)])
@@ -73,55 +78,35 @@ class TestLLMNodeTps:
         assert data.tps is None
 
 
-class _RecordingTokenizer(blingfire.SentenceTokenizer):
-    """Counts stream() calls so tests can assert the caller-provided tokenizer is used."""
-
-    def __init__(self) -> None:
-        super().__init__(min_sentence_len=1)
-        self.stream_calls = 0
-
-    def stream(self, *, language: str | None = None):  # type: ignore[no-untyped-def]
-        self.stream_calls += 1
-        return super().stream(language=language)
+class TestLLMNodeStartedAt:
+    async def test_started_at_recorded(self) -> None:
+        # ttfs is measured from here, so the inference task must always stamp it
+        data = await _run_inference([_content("Hello there, friend.")])
+        assert data.started_at is not None
 
 
-class TestLLMNodeTtfs:
-    async def test_ttfs_set_for_nonempty_generation(self) -> None:
-        data = await _run_inference([_content("First sentence. "), _content("Second one.")])
-        assert data.ttfs is not None
-        assert data.ttfs > 0
+class TestTimeToFirstSentence:
+    """ttfs is read from the instant the TTS stream handed its first segment to the
+    provider, never reconstructed by re-tokenizing the LLM stream, so it can't drift from
+    the segmentation the TTS actually applies (custom plugin tokenizer, inference gateway
+    per-provider defaults, StreamAdapter, or provider-side splitting)."""
 
-    async def test_ttfs_none_for_whitespace_only(self) -> None:
-        data = await _run_inference([_content("   ")])
-        assert data.ttfs is None
+    async def test_measured_from_llm_start_to_synthesis_start(self) -> None:
+        llm_data = _LLMGenerationData(text_ch=aio.Chan(), function_ch=aio.Chan(), started_at=100.0)
+        assert _time_to_first_sentence(llm_data, _tts_data(102.5)) == pytest.approx(2.5)
 
-    async def test_ttfs_uses_provided_tokenizer(self) -> None:
-        # the tokenizer must be resolved from the actual TTS path
-        tokenizer = _RecordingTokenizer()
-        data = await _run_inference(
-            [_content("First sentence here, quite long. "), _content("Second one.")],
-            sentence_tokenizer=tokenizer,
-        )
-        assert tokenizer.stream_calls == 1
-        assert data.ttfs is not None
+    async def test_none_without_tts(self) -> None:
+        # text-only session: nothing was ever segmented for synthesis
+        llm_data = _LLMGenerationData(text_ch=aio.Chan(), function_ch=aio.Chan(), started_at=100.0)
+        assert _time_to_first_sentence(llm_data, None) is None
 
+    async def test_none_when_tts_published_no_stamp(self) -> None:
+        # frames that never came from a LiveKit TTS carry no started-time userdata (a
+        # tts_node synthesizing its own audio); ttfs stays unreported rather than falling
+        # back to a different anchor the way ttfb does
+        llm_data = _LLMGenerationData(text_ch=aio.Chan(), function_ch=aio.Chan(), started_at=100.0)
+        assert _time_to_first_sentence(llm_data, _tts_data(None)) is None
 
-class TestTtsSentenceTokenizerResolution:
-    """`AgentActivity._tts_sentence_tokenizer` is the single source of truth the default
-    `tts_node` and the ttfs metric both read, so the segmentation ttfs times matches what
-    TTS actually applies."""
-
-    async def test_reuses_live_stream_adapter_instance(self) -> None:
-        # a StreamAdapter already owns the tokenizer TTS will run; reuse that exact
-        # instance rather than building a parallel one that could drift from it.
-        from types import SimpleNamespace
-
-        from livekit.agents import tts
-        from livekit.agents.voice.agent_activity import AgentActivity
-
-        from .fake_tts import FakeTTS
-
-        adapter = tts.StreamAdapter(tts=FakeTTS())
-        activity = SimpleNamespace(tts=adapter, _resolve_expressive_options=lambda: None)
-        resolved = AgentActivity._tts_sentence_tokenizer(activity)  # type: ignore[arg-type]
-        assert resolved is adapter._sentence_tokenizer
+    async def test_none_when_llm_never_started(self) -> None:
+        llm_data = _LLMGenerationData(text_ch=aio.Chan(), function_ch=aio.Chan())
+        assert _time_to_first_sentence(llm_data, _tts_data(102.5)) is None

--- a/tests/test_llm_node_metrics.py
+++ b/tests/test_llm_node_metrics.py
@@ -65,17 +65,44 @@ def _tts_data(synthesis_started_at: float | None) -> _TTSGenerationData:
 
 class TestLLMNodeTps:
     async def test_tps_set_when_usage_reported(self) -> None:
-        data = await _run_inference([_content("Hello there, friend."), _usage_chunk(30)])
+        data = await _run_inference(
+            [_content("Hello there, "), _content("friend."), _usage_chunk(30)]
+        )
         assert data.tps is not None
         assert data.tps > 0
 
     async def test_tps_zero_when_zero_usage_is_reported(self) -> None:
-        data = await _run_inference([_content("Hello there, friend."), _usage_chunk(0)])
+        data = await _run_inference(
+            [_content("Hello there, "), _content("friend."), _usage_chunk(0)]
+        )
         assert data.tps == 0
 
     async def test_tps_none_when_no_usage_reported(self) -> None:
         data = await _run_inference([_content("Hello there, friend.")])  # no usage chunk
         assert data.tps is None
+
+    async def test_tps_none_when_reply_arrived_in_one_chunk(self) -> None:
+        # nothing streamed, so there is no rate to report -- the alternative anchors would
+        # divide by prefill or by a network round trip and invent one
+        data = await _run_inference([_content("Sure!"), _usage_chunk(3)])
+        assert data.tps is None
+
+    async def test_tps_excludes_time_to_first_token(self) -> None:
+        # 10 tokens over a ~50ms streaming window that follows a ~200ms prefill: ~200 tok/s.
+        # anchoring on inference start would report ~40
+        async def slow_first_token(chat_ctx, tools, model_settings):  # type: ignore[no-untyped-def]
+            await asyncio.sleep(0.2)
+            yield _content("Hello there, ")
+            await asyncio.sleep(0.05)
+            yield _content("friend.")
+            yield _usage_chunk(10)
+
+        data = _LLMGenerationData(text_ch=aio.Chan(), function_ch=aio.Chan())
+        await _llm_inference_task(
+            slow_first_token, ChatContext.empty(), ToolContext.empty(), ModelSettings(), data
+        )
+        assert data.tps is not None
+        assert data.tps > 100
 
 
 class TestLLMNodeStartedAt:

--- a/tests/test_session_host.py
+++ b/tests/test_session_host.py
@@ -158,6 +158,18 @@ class TestMetricsToProto:
         pb = _metrics_to_proto(metrics)
         assert pb.transcription_delay == pytest.approx(0.42)
 
+    @pytest.mark.skipif(
+        "llm_node_tps" not in agent_pb.MetricsReport.DESCRIPTOR.fields_by_name,
+        reason="livekit-protocol < 1.1.18 lacks llm_node_tps/llm_node_ttfs",
+    )
+    def test_llm_node_throughput_fields(self) -> None:
+        # guards the dict-key -> proto-field mapping: a mismatch (e.g. "tps" vs
+        # "llm_node_tps") raises at MetricsReport(**kwargs) instead of silently dropping.
+        metrics = {"llm_node_tps": 12.5, "llm_node_ttfs": 0.6}
+        pb = _metrics_to_proto(metrics)
+        assert pb.llm_node_tps == pytest.approx(12.5)
+        assert pb.llm_node_ttfs == pytest.approx(0.6)
+
 
 class TestSessionUsageToProto:
     def test_llm_usage(self) -> None:
@@ -278,7 +290,7 @@ class TestSessionHostEvents:
     def test_register_session(self, transport: InMemoryTransport, mock_session: MagicMock) -> None:
         host = SessionHost(transport)
         host.register_session(mock_session)
-        assert mock_session.on.call_count == 10
+        assert mock_session.on.call_count == 11
 
     @pytest.mark.asyncio
     async def test_agent_state_changed(self, transport: InMemoryTransport) -> None:
@@ -660,4 +672,4 @@ class TestSessionHostRequests:
         host.register_session(session)
         await host.start()
         await host.aclose()
-        assert session.off.call_count == 10
+        assert session.off.call_count == 11

--- a/tests/test_session_host.py
+++ b/tests/test_session_host.py
@@ -176,6 +176,18 @@ class TestMetricsToProto:
         pb = _metrics_to_proto(metrics)
         assert pb.transcription_delay == pytest.approx(0.42)
 
+    @pytest.mark.skipif(
+        "llm_node_tps" not in agent_pb.MetricsReport.DESCRIPTOR.fields_by_name,
+        reason="livekit-protocol < 1.1.18 lacks llm_node_tps/llm_node_ttfs",
+    )
+    def test_llm_node_throughput_fields(self) -> None:
+        # guards the dict-key -> proto-field mapping: a mismatch (e.g. "tps" vs
+        # "llm_node_tps") raises at MetricsReport(**kwargs) instead of silently dropping.
+        metrics = {"llm_node_tps": 12.5, "llm_node_ttfs": 0.6}
+        pb = _metrics_to_proto(metrics)
+        assert pb.llm_node_tps == pytest.approx(12.5)
+        assert pb.llm_node_ttfs == pytest.approx(0.6)
+
 
 class TestSessionUsageToProto:
     def test_llm_usage(self) -> None:

--- a/tests/test_session_host.py
+++ b/tests/test_session_host.py
@@ -176,10 +176,6 @@ class TestMetricsToProto:
         pb = _metrics_to_proto(metrics)
         assert pb.transcription_delay == pytest.approx(0.42)
 
-    @pytest.mark.skipif(
-        "llm_node_tps" not in agent_pb.MetricsReport.DESCRIPTOR.fields_by_name,
-        reason="livekit-protocol < 1.1.18 lacks llm_node_tps/llm_node_ttfs",
-    )
     def test_llm_node_throughput_fields(self) -> None:
         # guards the dict-key -> proto-field mapping: a mismatch (e.g. "tps" vs
         # "llm_node_tps") raises at MetricsReport(**kwargs) instead of silently dropping.

--- a/tests/test_session_host.py
+++ b/tests/test_session_host.py
@@ -158,10 +158,6 @@ class TestMetricsToProto:
         pb = _metrics_to_proto(metrics)
         assert pb.transcription_delay == pytest.approx(0.42)
 
-    @pytest.mark.skipif(
-        "llm_node_tps" not in agent_pb.MetricsReport.DESCRIPTOR.fields_by_name,
-        reason="livekit-protocol < 1.1.18 lacks llm_node_tps/llm_node_ttfs",
-    )
     def test_llm_node_throughput_fields(self) -> None:
         # guards the dict-key -> proto-field mapping: a mismatch (e.g. "tps" vs
         # "llm_node_tps") raises at MetricsReport(**kwargs) instead of silently dropping.


### PR DESCRIPTION
- `llm_node_tps` — output tokens/sec, from the provider's usage chunk
- `llm_node_ttfs` — inference start until the first sentence is handed off for synthesis (reuses [`livekit.agents.types.USERDATA_TTS_STARTED_TIME`](https://github.com/livekit/agents/blob/a2264ff37ebcd7950508610740252b8917e5b9da/livekit-agents/livekit/agents/types.py#L76))
- ~~`agent_false_interruption` — the event, forwarded over the session host~~ 
  was implemented in #6691 


Needs: https://github.com/livekit/protocol/pull/1661 (released, already used)