### PR TITLE
rename reload-addr flag to cli-addr

### DIFF
--- a/livekit-agents/livekit/agents/__main__.py
+++ b/livekit-agents/livekit/agents/__main__.py
@@ -69,7 +69,9 @@ def _dispatch(server: AgentServer, args: argparse.Namespace) -> None:
                 url=args.url,
                 api_key=args.api_key,
                 api_secret=args.api_secret,
-                reload_addr=args.reload_addr,
+                # --cli-addr is the current name; --reload-addr is the legacy
+                # alias the CLI still passes for backwards compatibility.
+                cli_addr=args.cli_addr or args.reload_addr,
                 log_format=args.log_format,
                 dev=args.dev,
                 simulation=args.simulation,
@@ -111,6 +113,9 @@ def main(argv: list[str] | None = None) -> int:
     start_p.add_argument("--api-key")
     start_p.add_argument("--api-secret")
     start_p.add_argument("--dev", action="store_true", default=False)
+    # address of the driving `lk` CLI's dev channel. --reload-addr is the legacy
+    # name, kept for backwards compatibility with older CLIs.
+    start_p.add_argument("--cli-addr")
     start_p.add_argument("--reload-addr")
     # set by `lk simulate`: disables the worker load limit so simulation runs
     # can saturate the agent

--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -288,8 +288,8 @@ def _run_worker(server: AgentServer, args: proto.CliArgs) -> None:
     if args.simulation:
         server._simulation = True
 
-    if args.reload_addr and not args.dev:
-        raise ValueError("--reload-addr requires --dev")
+    if args.cli_addr and not args.dev:
+        raise ValueError("--cli-addr requires --dev")
 
     devmode = args.dev
     colored_logs = devmode or args.log_format == "colored"
@@ -320,10 +320,10 @@ def _run_worker(server: AgentServer, args: proto.CliArgs) -> None:
             logger.exception("worker failed")
 
     watch_client = None
-    if args.reload_addr:
+    if args.cli_addr:
         from .watcher import WatchClient
 
-        watch_client = WatchClient(server, args.reload_addr, loop=loop)
+        watch_client = WatchClient(server, args.cli_addr, loop=loop)
         watch_client.start()
 
     try:

--- a/livekit-agents/livekit/agents/cli/proto.py
+++ b/livekit-agents/livekit/agents/cli/proto.py
@@ -14,7 +14,8 @@ class CliArgs:
     url: str | None = None
     api_key: str | None = field(repr=False, default=None)
     api_secret: str | None = field(repr=False, default=None)
-    reload_addr: str | None = None
+    # address of the driving `lk` CLI's dev channel (hot-reload IPC + ServerInfo).
+    cli_addr: str | None = None
     log_format: str = "json"
     dev: bool = False
     # set by `lk simulate` when launching the agent under test; disables the

--- a/livekit-agents/livekit/agents/cli/watcher.py
+++ b/livekit-agents/livekit/agents/cli/watcher.py
@@ -30,12 +30,12 @@ class WatchClient:
     def __init__(
         self,
         worker: AgentServer,
-        reload_addr: str,
+        cli_addr: str,
         loop: asyncio.AbstractEventLoop | None = None,
     ) -> None:
         self._loop = loop or asyncio.get_event_loop()
         self._worker = worker
-        self._reload_addr = reload_addr
+        self._cli_addr = cli_addr
         self._main_task: asyncio.Task | None = None
 
     def start(self) -> None:
@@ -43,7 +43,7 @@ class WatchClient:
 
     @utils.log_exceptions(logger=logger)
     async def _run(self) -> None:
-        host, port_str = self._reload_addr.rsplit(":", 1)
+        host, port_str = self._cli_addr.rsplit(":", 1)
         reader, writer = await asyncio.open_connection(host, int(port_str))
 
         try:


### PR DESCRIPTION
since CLI protocol is extending beyond only reloading, renaming to better reflect new functionality