### PR TITLE
feat(agents): Add Anthropic Claude model definitions

### DIFF
--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -126,6 +126,12 @@ GoogleModels = Literal[
     "google/gemini-2.5-flash-lite",
 ]
 
+AnthropicModels = Literal[
+    "anthropic/claude-opus-4-6",
+    "anthropic/claude-sonnet-4-6",
+    "anthropic/claude-haiku-4-5",
+]
+
 KimiModels = Literal[
     "moonshotai/kimi-k2.5",
     "moonshotai/kimi-k2.6",
@@ -146,7 +152,7 @@ XAIModels = Literal[
     "xai/grok-4.20-multi-agent-0309",
 ]
 
-LLMModels = OpenAIModels | GoogleModels | KimiModels | DeepSeekModels | ZAIModels | XAIModels
+LLMModels = OpenAIModels | GoogleModels | AnthropicModels | KimiModels | DeepSeekModels | ZAIModels | XAIModels
 
 InferenceClass = Literal["priority", "standard"]
 

--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/models.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/models.py
@@ -14,4 +14,6 @@ ChatModels = Literal[
     "claude-opus-4-20250514",
     "claude-opus-4-1-20250805",
     "claude-opus-4-6",
+    "claude-haiku-4-5-20251001",
+    "claude-haiku-4-5",
 ]


### PR DESCRIPTION
## Summary
- Adds `AnthropicModels` Literal type to `livekit-agents` inference LLM module with Claude Opus 4.6, Sonnet 4.6, and Haiku 4.5
- Updates `LLMModels` union type to include Anthropic models
- Adds `claude-haiku-4-5` models to the Anthropic plugin's model list

## Test plan
- [ ] Verify Python type checking passes with new model literals
- [ ] Verify agents using Anthropic models can connect to agent-gateway

## Related PRs
- livekit/agent-gateway: rm/claude (Anthropic provider implementation)
- livekit/e2e: rm/claude (E2E tests)