### PR TITLE
Add configurable TTS stream adapter chunking

### DIFF
--- a/livekit-agents/livekit/agents/tts/__init__.py
+++ b/livekit-agents/livekit/agents/tts/__init__.py
@@ -4,7 +4,7 @@ from .fallback_adapter import (
     FallbackChunkedStream,
     FallbackSynthesizeStream,
 )
-from .stream_adapter import StreamAdapter, StreamAdapterWrapper
+from .stream_adapter import ChunkingOptions, StreamAdapter, StreamAdapterWrapper
 from .stream_pacer import SentenceStreamPacer
 from .tts import (
     TTS,
@@ -23,6 +23,7 @@ __all__ = [
     "TTSCapabilities",
     "StreamAdapterWrapper",
     "StreamAdapter",
+    "ChunkingOptions",
     "ChunkedStream",
     "AvailabilityChangedEvent",
     "FallbackAdapter",

--- a/livekit-agents/livekit/agents/tts/stream_adapter.py
+++ b/livekit-agents/livekit/agents/tts/stream_adapter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterable
 from dataclasses import dataclass
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar
 
 from .. import tokenize, utils
 from ..types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, APIConnectOptions, NotGivenOr
@@ -27,7 +27,6 @@ DEFAULT_STREAM_ADAPTER_API_CONNECT_OPTIONS = APIConnectOptions(
 class ChunkingOptions:
     min_chars: int | None = None
     max_chars: int | None = None
-    oversized_sentence: Literal["allow", "error"] = "allow"
 
     def __post_init__(self) -> None:
         if self.min_chars is not None and self.min_chars <= 0:
@@ -35,9 +34,6 @@ class ChunkingOptions:
 
         if self.max_chars is not None and self.max_chars <= 0:
             raise ValueError("max_chars must be greater than 0")
-
-        if self.oversized_sentence not in ("allow", "error"):
-            raise ValueError('oversized_sentence must be "allow" or "error"')
 
 
 class StreamAdapter(TTS):
@@ -154,17 +150,6 @@ class StreamAdapterWrapper(SynthesizeStream):
 
                 if not (text := ev.token.strip()):
                     continue
-
-                if (
-                    self._tts._chunking is not None
-                    and self._tts._chunking.max_chars is not None
-                    and self._tts._chunking.oversized_sentence == "error"
-                    and len(text) > self._tts._chunking.max_chars
-                ):
-                    raise ValueError(
-                        f"TTS sentence length {len(text)} exceeds max_chars "
-                        f"{self._tts._chunking.max_chars}"
-                    )
 
                 self._mark_started()
                 async with self._tts._wrapped_tts.synthesize(

--- a/livekit-agents/livekit/agents/tts/stream_adapter.py
+++ b/livekit-agents/livekit/agents/tts/stream_adapter.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterable
-from typing import Any, ClassVar
+from dataclasses import dataclass
+from typing import Any, ClassVar, Literal
 
 from .. import tokenize, utils
 from ..types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, APIConnectOptions, NotGivenOr
@@ -22,22 +23,48 @@ DEFAULT_STREAM_ADAPTER_API_CONNECT_OPTIONS = APIConnectOptions(
 )
 
 
+@dataclass
+class ChunkingOptions:
+    min_chars: int | None = None
+    max_chars: int | None = None
+    oversized_sentence: Literal["allow", "error"] = "allow"
+
+    def __post_init__(self) -> None:
+        if self.min_chars is not None and self.min_chars <= 0:
+            raise ValueError("min_chars must be greater than 0")
+
+        if self.max_chars is not None and self.max_chars <= 0:
+            raise ValueError("max_chars must be greater than 0")
+
+        if self.oversized_sentence not in ("allow", "error"):
+            raise ValueError('oversized_sentence must be "allow" or "error"')
+
+
 class StreamAdapter(TTS):
     def __init__(
         self,
         *,
         tts: TTS,
         sentence_tokenizer: NotGivenOr[tokenize.SentenceTokenizer] = NOT_GIVEN,
+        chunking: NotGivenOr[ChunkingOptions] = NOT_GIVEN,
         text_pacing: SentenceStreamPacer | bool = False,
+        _xml_aware: bool = False,
     ) -> None:
+        if utils.is_given(sentence_tokenizer) and utils.is_given(chunking):
+            raise ValueError("sentence_tokenizer and chunking cannot both be provided")
+
         super().__init__(
             capabilities=TTSCapabilities(streaming=True, aligned_transcript=True),
             sample_rate=tts.sample_rate,
             num_channels=tts.num_channels,
         )
         self._wrapped_tts = tts
+        self._chunking: ChunkingOptions | None = chunking if utils.is_given(chunking) else None
         self._sentence_tokenizer = sentence_tokenizer or tokenize.blingfire.SentenceTokenizer(
-            retain_format=True
+            retain_format=True,
+            min_token_len=self._chunking.min_chars if self._chunking is not None else None,
+            max_token_len=self._chunking.max_chars if self._chunking is not None else None,
+            xml_aware=_xml_aware,
         )
         self._stream_pacer: SentenceStreamPacer | None = None
         if text_pacing is True:
@@ -127,6 +154,17 @@ class StreamAdapterWrapper(SynthesizeStream):
 
                 if not (text := ev.token.strip()):
                     continue
+
+                if (
+                    self._tts._chunking is not None
+                    and self._tts._chunking.max_chars is not None
+                    and self._tts._chunking.oversized_sentence == "error"
+                    and len(text) > self._tts._chunking.max_chars
+                ):
+                    raise ValueError(
+                        f"TTS sentence length {len(text)} exceeds max_chars "
+                        f"{self._tts._chunking.max_chars}"
+                    )
 
                 self._mark_started()
                 async with self._tts._wrapped_tts.synthesize(

--- a/livekit-agents/livekit/agents/tts/stream_adapter.py
+++ b/livekit-agents/livekit/agents/tts/stream_adapter.py
@@ -25,6 +25,13 @@ DEFAULT_STREAM_ADAPTER_API_CONNECT_OPTIONS = APIConnectOptions(
 
 @dataclass
 class ChunkingOptions:
+    """Sentence batching hints for the default StreamAdapter tokenizer.
+
+    max_chars is a soft sentence-batch cap: the tokenizer avoids adding another
+    sentence when that would exceed the cap, but it does not split a single
+    oversized sentence.
+    """
+
     min_chars: int | None = None
     max_chars: int | None = None
 

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
 from livekit import rtc
 
-from .. import inference, llm, stt, tokenize, tts, utils, vad
+from .. import inference, llm, stt, tts, utils, vad
 from ..llm import ChatContext, RealtimeModel, ToolError, find_function_tools
 from ..llm.chat_context import Instructions, _ReadOnlyChatContext
 from ..log import logger
@@ -23,6 +23,7 @@ from .turn import TurnHandlingOptions, _migrate_turn_handling
 if TYPE_CHECKING:
     from ..inference import LLMModels, STTModels, TTSModels
     from ..llm import mcp
+    from ..tts import ChunkingOptions as TTSChunkingOptions
     from .agent_activity import AgentActivity
     from .agent_session import AgentSession
     from .audio_recognition import AudioRecognition
@@ -50,6 +51,7 @@ class Agent:
         tool_handling: NotGivenOr[ToolHandlingOptions] = NOT_GIVEN,
         llm: NotGivenOr[llm.LLM | llm.RealtimeModel | LLMModels | str | None] = NOT_GIVEN,
         tts: NotGivenOr[tts.TTS | TTSModels | str | None] = NOT_GIVEN,
+        tts_chunking: NotGivenOr[TTSChunkingOptions] = NOT_GIVEN,
         min_consecutive_speech_delay: NotGivenOr[float] = NOT_GIVEN,
         use_tts_aligned_transcript: NotGivenOr[bool] = NOT_GIVEN,
         # deprecated
@@ -93,6 +95,7 @@ class Agent:
         self._stt = stt
         self._llm = llm
         self._tts = tts
+        self._tts_chunking = tts_chunking
         self._vad = vad
 
         self._allow_interruptions: NotGivenOr[bool] = NOT_GIVEN
@@ -524,11 +527,9 @@ class Agent:
             if not activity.tts.capabilities.streaming:
                 wrapped_tts = tts.StreamAdapter(
                     tts=wrapped_tts,
-                    sentence_tokenizer=tokenize.blingfire.SentenceTokenizer(
-                        retain_format=True,
-                        # markup only exists in the stream when expressive is active
-                        xml_aware=expressive_active,
-                    ),
+                    chunking=agent.tts_chunking,
+                    # markup only exists in the stream when expressive is active
+                    _xml_aware=expressive_active,
                 )
 
             # Mark whether expressive is active for this synthesis, synchronously
@@ -646,6 +647,14 @@ class Agent:
             NotGivenOr[tts.TTS | None]: An optional TTS component for generating audio output.
         """  # noqa: E501
         return self._tts
+
+    @property
+    def tts_chunking(self) -> NotGivenOr[TTSChunkingOptions]:
+        """
+        Retrieves chunking options used when a non-streaming TTS is automatically
+        wrapped in a streaming adapter.
+        """
+        return self._tts_chunking
 
     @property
     def mcp_servers(self) -> NotGivenOr[list[mcp.MCPServer] | None]:

--- a/tests/test_tts_stream_adapter_chunking.py
+++ b/tests/test_tts_stream_adapter_chunking.py
@@ -114,11 +114,11 @@ async def test_end_input_emits_buffered_text() -> None:
     assert _normalized_inputs(wrapped) == ["This buffered text has no terminator"]
 
 
-async def test_oversized_sentence_allow_passes_long_single_sentence() -> None:
+async def test_oversized_sentence_passes_through() -> None:
     wrapped = RecordingTTS()
     adapter = tts.StreamAdapter(
         tts=wrapped,
-        chunking=tts.ChunkingOptions(max_chars=20, oversized_sentence="allow"),
+        chunking=tts.ChunkingOptions(max_chars=20),
     )
 
     await _collect_stream(adapter, "This single sentence is longer than the configured cap.")
@@ -126,19 +126,6 @@ async def test_oversized_sentence_allow_passes_long_single_sentence() -> None:
     assert _normalized_inputs(wrapped) == [
         "This single sentence is longer than the configured cap."
     ]
-
-
-async def test_oversized_sentence_error_raises_on_long_single_sentence() -> None:
-    wrapped = RecordingTTS()
-    adapter = tts.StreamAdapter(
-        tts=wrapped,
-        chunking=tts.ChunkingOptions(max_chars=20, oversized_sentence="error"),
-    )
-
-    with pytest.raises(ValueError, match="exceeds max_chars"):
-        await _collect_stream(adapter, "This single sentence is longer than the configured cap.")
-
-    assert wrapped.inputs == []
 
 
 async def test_agent_tts_chunking_is_passed_to_automatic_stream_adapter(monkeypatch: Any) -> None:
@@ -228,7 +215,6 @@ def test_valid_chunking_options(
     [
         ({"min_chars": 0}, "min_chars"),
         ({"max_chars": 0}, "max_chars"),
-        ({"oversized_sentence": "split"}, "oversized_sentence"),
     ],
 )
 def test_invalid_chunking_options_raise(kwargs: dict[str, Any], match: str) -> None:

--- a/tests/test_tts_stream_adapter_chunking.py
+++ b/tests/test_tts_stream_adapter_chunking.py
@@ -114,7 +114,7 @@ async def test_end_input_emits_buffered_text() -> None:
     assert _normalized_inputs(wrapped) == ["This buffered text has no terminator"]
 
 
-async def test_oversized_sentence_passes_through() -> None:
+async def test_max_chars_does_not_split_oversized_sentence() -> None:
     wrapped = RecordingTTS()
     adapter = tts.StreamAdapter(
         tts=wrapped,

--- a/tests/test_tts_stream_adapter_chunking.py
+++ b/tests/test_tts_stream_adapter_chunking.py
@@ -21,9 +21,7 @@ class RecordingTTS(FakeTTS):
         self.inputs: list[str] = []
         self._capabilities = tts.TTSCapabilities(streaming=streaming)
 
-    def synthesize(
-        self, text: str, *, conn_options: APIConnectOptions = TEST_CONN_OPTIONS
-    ) -> Any:
+    def synthesize(self, text: str, *, conn_options: APIConnectOptions = TEST_CONN_OPTIONS) -> Any:
         self.inputs.append(text)
         return super().synthesize(text, conn_options=conn_options)
 

--- a/tests/test_tts_stream_adapter_chunking.py
+++ b/tests/test_tts_stream_adapter_chunking.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from livekit.agents import APIConnectOptions, tokenize, tts
+from livekit.agents.voice.agent import Agent, ModelSettings
+
+from .fake_tts import FakeTTS
+
+pytestmark = pytest.mark.unit
+
+TEST_CONN_OPTIONS = APIConnectOptions(max_retry=0, retry_interval=0.0, timeout=1.0)
+
+
+class RecordingTTS(FakeTTS):
+    def __init__(self, *, streaming: bool = True) -> None:
+        super().__init__(fake_audio_duration=0.01)
+        self.inputs: list[str] = []
+        self._capabilities = tts.TTSCapabilities(streaming=streaming)
+
+    def synthesize(
+        self, text: str, *, conn_options: APIConnectOptions = TEST_CONN_OPTIONS
+    ) -> Any:
+        self.inputs.append(text)
+        return super().synthesize(text, conn_options=conn_options)
+
+
+async def _collect_stream(adapter: tts.StreamAdapter, text: str, *, flush: bool = False) -> None:
+    async with adapter.stream(conn_options=TEST_CONN_OPTIONS) as stream:
+        stream.push_text(text)
+        if flush:
+            stream.flush()
+        stream.end_input()
+
+        async for _ in stream:
+            pass
+
+
+def _normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _normalized_inputs(recording_tts: RecordingTTS) -> list[str]:
+    return [_normalize(text) for text in recording_tts.inputs]
+
+
+async def test_default_behavior_remains_per_sentence() -> None:
+    wrapped = RecordingTTS()
+    adapter = tts.StreamAdapter(tts=wrapped)
+
+    await _collect_stream(
+        adapter,
+        "This is the first complete sentence. This is the second complete sentence.",
+    )
+
+    assert _normalized_inputs(wrapped) == [
+        "This is the first complete sentence.",
+        "This is the second complete sentence.",
+    ]
+
+
+async def test_min_chars_batches_multiple_sentences() -> None:
+    wrapped = RecordingTTS()
+    adapter = tts.StreamAdapter(tts=wrapped, chunking=tts.ChunkingOptions(min_chars=70))
+
+    await _collect_stream(
+        adapter,
+        "This is the first complete sentence. This is the second complete sentence.",
+    )
+
+    assert _normalized_inputs(wrapped) == [
+        "This is the first complete sentence. This is the second complete sentence."
+    ]
+
+
+async def test_max_chars_flushes_batch_before_next_sentence_exceeds_cap() -> None:
+    wrapped = RecordingTTS()
+    adapter = tts.StreamAdapter(
+        tts=wrapped,
+        chunking=tts.ChunkingOptions(min_chars=200, max_chars=80),
+    )
+
+    await _collect_stream(
+        adapter,
+        (
+            "This is the first complete sentence. "
+            "This is the second complete sentence. "
+            "This is the third complete sentence."
+        ),
+    )
+
+    assert _normalized_inputs(wrapped) == [
+        "This is the first complete sentence. This is the second complete sentence.",
+        "This is the third complete sentence.",
+    ]
+
+
+async def test_flush_emits_buffered_text() -> None:
+    wrapped = RecordingTTS()
+    adapter = tts.StreamAdapter(tts=wrapped, chunking=tts.ChunkingOptions(min_chars=200))
+
+    await _collect_stream(adapter, "This buffered text has no terminator", flush=True)
+
+    assert _normalized_inputs(wrapped) == ["This buffered text has no terminator"]
+
+
+async def test_end_input_emits_buffered_text() -> None:
+    wrapped = RecordingTTS()
+    adapter = tts.StreamAdapter(tts=wrapped, chunking=tts.ChunkingOptions(min_chars=200))
+
+    await _collect_stream(adapter, "This buffered text has no terminator")
+
+    assert _normalized_inputs(wrapped) == ["This buffered text has no terminator"]
+
+
+async def test_oversized_sentence_allow_passes_long_single_sentence() -> None:
+    wrapped = RecordingTTS()
+    adapter = tts.StreamAdapter(
+        tts=wrapped,
+        chunking=tts.ChunkingOptions(max_chars=20, oversized_sentence="allow"),
+    )
+
+    await _collect_stream(adapter, "This single sentence is longer than the configured cap.")
+
+    assert _normalized_inputs(wrapped) == [
+        "This single sentence is longer than the configured cap."
+    ]
+
+
+async def test_oversized_sentence_error_raises_on_long_single_sentence() -> None:
+    wrapped = RecordingTTS()
+    adapter = tts.StreamAdapter(
+        tts=wrapped,
+        chunking=tts.ChunkingOptions(max_chars=20, oversized_sentence="error"),
+    )
+
+    with pytest.raises(ValueError, match="exceeds max_chars"):
+        await _collect_stream(adapter, "This single sentence is longer than the configured cap.")
+
+    assert wrapped.inputs == []
+
+
+async def test_agent_tts_chunking_is_passed_to_automatic_stream_adapter(monkeypatch: Any) -> None:
+    chunking = tts.ChunkingOptions(min_chars=70, max_chars=120)
+    wrapped = RecordingTTS(streaming=False)
+    captured: dict[str, Any] = {}
+
+    class EmptyStream:
+        def push_text(self, text: str) -> None:
+            pass
+
+        def end_input(self) -> None:
+            pass
+
+        def __aiter__(self) -> EmptyStream:
+            return self
+
+        async def __anext__(self) -> Any:
+            raise StopAsyncIteration
+
+        async def __aenter__(self) -> EmptyStream:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            pass
+
+    class CapturingStreamAdapter:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        def stream(self, *, conn_options: APIConnectOptions) -> EmptyStream:
+            return EmptyStream()
+
+    monkeypatch.setattr(tts, "StreamAdapter", CapturingStreamAdapter)
+
+    agent = Agent(instructions="test", tts=wrapped, tts_chunking=chunking)
+    agent._activity = SimpleNamespace(
+        tts=wrapped,
+        session=SimpleNamespace(conn_options=SimpleNamespace(tts_conn_options=TEST_CONN_OPTIONS)),
+        _resolve_expressive_options=lambda: None,
+    )
+
+    async def text() -> Any:
+        yield "Hello."
+
+    async for _ in Agent.default.tts_node(agent, text(), ModelSettings()):
+        pass
+
+    assert captured["tts"] is wrapped
+    assert captured["chunking"] is chunking
+    assert captured["_xml_aware"] is False
+    assert agent.tts_chunking is chunking
+
+
+def test_chunking_options_is_exported() -> None:
+    from livekit.agents.tts import ChunkingOptions
+
+    assert ChunkingOptions is tts.ChunkingOptions
+
+
+def test_sentence_tokenizer_and_chunking_are_mutually_exclusive() -> None:
+    with pytest.raises(ValueError, match="cannot both be provided"):
+        tts.StreamAdapter(
+            tts=RecordingTTS(),
+            sentence_tokenizer=tokenize.blingfire.SentenceTokenizer(retain_format=True),
+            chunking=tts.ChunkingOptions(min_chars=70),
+        )
+
+
+@pytest.mark.parametrize(
+    ("chunking", "expected_min", "expected_max"),
+    [
+        (tts.ChunkingOptions(min_chars=1), 1, None),
+        (tts.ChunkingOptions(max_chars=1), None, 1),
+        (tts.ChunkingOptions(min_chars=10, max_chars=5), 10, 5),
+    ],
+)
+def test_valid_chunking_options(
+    chunking: tts.ChunkingOptions, expected_min: int | None, expected_max: int | None
+) -> None:
+    assert chunking.min_chars == expected_min
+    assert chunking.max_chars == expected_max
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"min_chars": 0}, "min_chars"),
+        ({"max_chars": 0}, "max_chars"),
+        ({"oversized_sentence": "split"}, "oversized_sentence"),
+    ],
+)
+def test_invalid_chunking_options_raise(kwargs: dict[str, Any], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        tts.ChunkingOptions(**kwargs)


### PR DESCRIPTION
## Why

Reduce the number of synthesis requests when non-streaming TTS providers are adapted for streaming by batching complete sentence chunks, while keeping predictable sentence boundaries and avoiding a separate chunking pipeline.

## Implementation

- Add `ChunkingOptions` for optional minimum/maximum chunk sizes and explicit oversized-sentence handling.
- Map chunking directly onto the existing sentence tokenizer and keep `StreamAdapter` focused on synthesizing each emitted text chunk.
- Pass `Agent(tts_chunking=...)` through the automatic non-streaming TTS `StreamAdapter` path and export the new options type.
- Add focused tests for default behavior, min/max chunking, flush/end buffering, oversized handling, agent passthrough, export coverage, and incompatible tokenizer configuration.

## Testing

- `uv run pytest tests/test_tts_stream_adapter_chunking.py --allow-uncategorized`