### PR TITLE
(inference stt): auto-load client VAD for fishaudio/* batch ASR

### DIFF
--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -61,6 +61,7 @@ SpeechmaticsModels = Literal[
     "speechmatics/enhanced",
     "speechmatics/standard",
 ]
+FishAudioModels = Literal["fishaudio/asr-1",]
 InworldModels = Literal["inworld/inworld-stt-1",]
 
 
@@ -170,6 +171,14 @@ class InworldOptions(TypedDict, total=False):
     vad_threshold: float  # range 0.0-1.0, default 0.5
 
 
+class FishAudioOptions(TypedDict, total=False):
+    # Fish ASR is batch-only; ignore_timestamps maps to /v1/asr. Default True
+    # (Fish server default). Set False to request precise timestamps (adds
+    # latency on clips under 30s). The gateway forwards only the joined
+    # transcript today, so this mainly affects upstream latency.
+    ignore_timestamps: bool
+
+
 # Diarization is requested via different extra_kwargs keys across
 # providers. Keep this list in one place so adding a new provider is a
 # single-line change and there's no divergence between __init__ and
@@ -270,16 +279,20 @@ def _resolve_vad_for_model(
     model: NotGivenOr[STTModels | str],
     vad_instance: vad.VAD | None,
 ) -> vad.VAD | None:
-    is_speechmatics = (
-        is_given(model) and isinstance(model, str) and model.startswith("speechmatics/")
+    # Models that do not endpoint server-side need client VAD to drive
+    # `session.finalize` (Speechmatics external mode; Fish Audio batch ASR).
+    needs_client_vad = (
+        is_given(model)
+        and isinstance(model, str)
+        and (model.startswith("speechmatics/") or model.startswith("fishaudio/"))
     )
-    if vad_instance is not None and not is_speechmatics:
+    if vad_instance is not None and not needs_client_vad:
         logger.warning(
             "`vad` will be ignored: model %r handles endpointing server-side.",
             model,
         )
         return None
-    if is_speechmatics and vad_instance is None:
+    if needs_client_vad and vad_instance is None:
         from .vad import VAD
 
         vad_instance = VAD()
@@ -309,6 +322,7 @@ STTModels = (
     | ElevenlabsModels
     | XaiModels
     | SpeechmaticsModels
+    | FishAudioModels
     | InworldModels
     | Literal["auto"]  # automatically select a provider based on the language
 )
@@ -457,6 +471,24 @@ class STT(stt.STT):
     @overload
     def __init__(
         self,
+        model: FishAudioModels,
+        *,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        base_url: NotGivenOr[str] = NOT_GIVEN,
+        encoding: NotGivenOr[STTEncoding] = NOT_GIVEN,
+        sample_rate: NotGivenOr[int] = NOT_GIVEN,
+        api_key: NotGivenOr[str] = NOT_GIVEN,
+        api_secret: NotGivenOr[str] = NOT_GIVEN,
+        http_session: aiohttp.ClientSession | None = None,
+        extra_kwargs: NotGivenOr[FishAudioOptions] = NOT_GIVEN,
+        fallback: NotGivenOr[list[FallbackModelType] | FallbackModelType] = NOT_GIVEN,
+        conn_options: NotGivenOr[APIConnectOptions] = NOT_GIVEN,
+        vad: NotGivenOr[vad.VAD | None] = NOT_GIVEN,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
         model: InworldModels,
         *,
         language: NotGivenOr[str] = NOT_GIVEN,
@@ -508,6 +540,7 @@ class STT(stt.STT):
             | ElevenlabsOptions
             | XaiOptions
             | SpeechmaticsOptions
+            | FishAudioOptions
             | InworldOptions
         ] = NOT_GIVEN,
         fallback: NotGivenOr[list[FallbackModelType] | FallbackModelType] = NOT_GIVEN,
@@ -531,7 +564,8 @@ class STT(stt.STT):
             conn_options (APIConnectOptions, optional): Connection options for request attempts.
             vad (VAD, optional): External Voice Activity Detector. When provided, each audio
                 frame is forwarded to the VAD and `session.finalize` is sent to the inference
-                gateway on end of speech. Only applicable to Speechmatics models.
+                gateway on end of speech. Auto-loaded for models that do not endpoint
+                server-side (Speechmatics, Fish Audio). Ignored for other models.
         """
         # Infer diarization capability from provider-specific extra_kwargs
         # keys (see _DIARIZATION_EXTRA_KEYS). xAI uses "diarize" (same as


### PR DESCRIPTION
## Summary

- Extend `_resolve_vad_for_model` so `fishaudio/*` models auto-load client VAD and send `session.finalize` on end-of-speech (same path as Speechmatics).
- Add `fishaudio/asr-1` to inference STT model types plus `FishAudioOptions` (`ignore_timestamps`).
- Required companion for [livekit/agent-gateway#983](https://github.com/livekit/agent-gateway/pull/983): Fish's ASR is batch-only, so without client-driven finalize a live agent never segments per turn.

## Test plan

- [ ] Confirm `_resolve_vad_for_model("fishaudio/asr-1", None)` returns a VAD instance
- [ ] Confirm `_resolve_vad_for_model("deepgram/nova-3", <vad>)` still ignores VAD with a warning
- [ ] Against a gateway with Fish Audio STT enabled: `inference.STT(model="fishaudio/asr-1")` produces per-turn finals on end-of-speech
- [ ] Explicit `vad=` still accepted for `fishaudio/asr-1`