### PR TITLE
fix(drive-thru): instruct agent to add stated quantities without confirming

### DIFF
--- a/examples/drive-thru/database.py
+++ b/examples/drive-thru/database.py
@@ -42,6 +42,8 @@ COMMON_INSTRUCTIONS = (
     "When a customer swaps an item, remove the old one before adding the new so the order has no "
     "duplicates. \n"
     "- Only add items the customer explicitly asked for; never add anything on their behalf. \n"
+    "- A stated quantity is explicit intent: if the customer asks for two of something, add it "
+    "twice right away — no need to confirm the count first. \n"
     "- Don’t assume unstated details — especially the drink in a combo. If a required detail is "
     "missing, ask before calling the tool. \n"
     "- Ask about size only for items that actually have more than one size; if an item has a single "


### PR DESCRIPTION
## Summary

`test_consecutive_order` flaked on main ([failing run](https://github.com/livekit/agents/actions/runs/29038961457/job/86191045556)): when asked "Can I get two mayonnaise sauces?", the LLM occasionally responds with a confirmation question ("Just to confirm, you want two separate mayonnaise sauces added to your order?") instead of calling `order_regular_item` twice, so the state assertion sees 0 items.

The prompt never addresses quantities, while "ask about one thing at a time" and "Only add items the customer explicitly asked for" nudge the model toward over-confirming. This adds one constraint making stated quantities explicit intent:

> A stated quantity is explicit intent: if the customer asks for two of something, add it twice right away — no need to confirm the count first.

## Testing

- `test_consecutive_order` passed 4 consecutive local runs with the change
- Full `examples/drive-thru/test_agent.py` suite passes (8/8)