### PR TITLE
fix(openai): omit unset fields when serializing Responses WS requests

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -95,7 +95,19 @@ class _ResponsesWebsocket:
     async def generate_response(self, msg: dict) -> AsyncGenerator[dict, None]:
         def _default(o: object) -> object:
             if isinstance(o, openai.BaseModel):
-                return o.model_dump(mode="json")
+                # exclude_none is load-bearing, not cosmetic. This hand-rolled WS
+                # transport serializes request models itself instead of going
+                # through the openai SDK (which omits unset fields). Without
+                # exclude_none, every Optional field the model defaults to None
+                # is emitted as an explicit `null` on the wire. The Responses API
+                # rejects explicit nulls on fields that expect an enum: e.g. after
+                # openai-python added `Reasoning.mode` (default None), a plain
+                # `Reasoning(effort=...)` began serializing `"mode": null`, which
+                # the API 400s with "Invalid type for 'reasoning.mode': expected
+                # one of 'standard' or 'pro', but got null instead." Omitting None
+                # mirrors the SDK's on-the-wire shape and is forward-compatible
+                # with future Optional additions to these models.
+                return o.model_dump(mode="json", exclude_none=True)
             raise TypeError(f"unexpected type {type(o)}")
 
         try:
@@ -496,7 +508,14 @@ class LLMStream(llm.LLMStream):
 
         event_type = event.get("type", "")
         if event_type == "error":
-            return ResponseErrorEvent.model_validate({**event.get("error", {}), **event})
+            # Top-level protocol error frames (e.g. a request-validation 400) do
+            # NOT carry `sequence_number`, which ResponseErrorEvent marks required.
+            # Validating them as-is raises a pydantic ValidationError that masks
+            # the real API message ("... 1 validation error ... sequence_number
+            # Field required ..."). Default the field so the genuine error
+            # surfaces as a clean APIStatusError via _handle_error instead.
+            merged = {"sequence_number": -1, **event.get("error", {}), **event}
+            return ResponseErrorEvent.model_validate(merged)
         elif event_type == "response.created":
             return ResponseCreatedEvent.model_validate(event)
         elif event_type == "response.output_item.done":

--- a/tests/test_plugin_openai_responses.py
+++ b/tests/test_plugin_openai_responses.py
@@ -4,8 +4,8 @@ import json
 
 import aiohttp
 import pytest
-
 from openai.types import Reasoning
+
 from livekit.plugins.openai.responses.llm import LLMStream, _ResponsesWebsocket
 
 pytestmark = pytest.mark.plugin("openai")

--- a/tests/test_plugin_openai_responses.py
+++ b/tests/test_plugin_openai_responses.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+
+import aiohttp
+import pytest
+
+from openai.types import Reasoning
+from livekit.plugins.openai.responses.llm import LLMStream, _ResponsesWebsocket
+
+pytestmark = pytest.mark.plugin("openai")
+
+
+class _FakeWSMsg:
+    def __init__(self, data: str) -> None:
+        self.type = aiohttp.WSMsgType.TEXT
+        self.data = data
+        self.extra = None
+
+
+class _RecordingWS:
+    """Minimal aiohttp-websocket stand-in: records what was sent, then replays
+    a single terminal frame so `generate_response` returns."""
+
+    def __init__(self, reply: dict) -> None:
+        self.sent: str | None = None
+        self._reply = reply
+
+    async def send_str(self, data: str) -> None:
+        self.sent = data
+
+    async def receive(self) -> _FakeWSMsg:
+        return _FakeWSMsg(json.dumps(self._reply))
+
+
+class _FakePool:
+    def __init__(self, ws: _RecordingWS) -> None:
+        self._ws = ws
+
+    def connection(self, timeout: float | None = None):  # noqa: ANN201
+        ws = self._ws
+
+        class _Ctx:
+            async def __aenter__(self):  # noqa: ANN202
+                return ws
+
+            async def __aexit__(self, *exc):  # noqa: ANN002, ANN202
+                return False
+
+        return _Ctx()
+
+    async def aclose(self) -> None:
+        return None
+
+
+async def _capture_sent_payload(msg: dict) -> dict:
+    """Run the real `_ResponsesWebsocket.generate_response` against a fake pool
+    and return the JSON that was actually put on the wire."""
+    ws = _ResponsesWebsocket(api_key="test-key", timeout=1.0)
+    rec = _RecordingWS({"type": "response.completed", "response": {"output": []}})
+    ws._pool = _FakePool(rec)  # type: ignore[assignment]
+    async for _ in ws.generate_response(msg):
+        pass
+    assert rec.sent is not None
+    return json.loads(rec.sent)
+
+
+async def test_reasoning_object_serialized_without_null_fields() -> None:
+    """The WS transport serializes request models itself (not via the openai
+    SDK). It must drop unset/None fields, otherwise Optional fields default to
+    an explicit `null` on the wire and the Responses API 400s — e.g. after
+    openai-python added `Reasoning.mode` (default None), `Reasoning(effort=...)`
+    began emitting `"mode": null`, rejected with 'expected one of standard or
+    pro, but got null instead.' Regression guard for that class of bug."""
+    payload = {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        "reasoning": Reasoning(effort="none"),
+    }
+
+    sent = await _capture_sent_payload(payload)
+
+    assert sent["reasoning"] == {"effort": "none"}
+    # No serialized request model may carry an explicit null-valued key.
+    assert None not in sent["reasoning"].values()
+
+
+def test_error_event_missing_sequence_number_parses_cleanly() -> None:
+    """Top-level protocol error frames (e.g. a request-validation 400) don't
+    carry `sequence_number`, which ResponseErrorEvent marks required. Parsing
+    must not raise a pydantic ValidationError that masks the real API message —
+    it should surface the message so it reaches the caller as an APIStatusError."""
+    frame = {
+        "type": "error",
+        "message": "Invalid type for 'reasoning.mode': expected one of "
+        "'standard' or 'pro', but got null instead.",
+        "code": "invalid_type",
+        "param": "reasoning.mode",
+        "status": 400,
+    }
+
+    # `_parse_ws_event` does not read `self`; invoke it directly on the frame.
+    parsed = LLMStream._parse_ws_event(object(), frame)  # type: ignore[arg-type]
+
+    assert parsed is not None
+    assert parsed.type == "error"
+    assert parsed.message == frame["message"]
+    assert parsed.param == "reasoning.mode"


### PR DESCRIPTION
## Summary

The OpenAI **Responses WebSocket** transport (`use_websocket=True`, the default for `responses.LLM`) serializes request models by hand — `json.dumps(msg, default=lambda o: o.model_dump(mode="json"))` — instead of going through the openai SDK. The SDK omits unset fields; this hand-rolled path did not (`exclude_none` was missing), so every Optional field that defaults to `None` was emitted as an explicit `null` on the wire.

That is fine until the OpenAI schema grows an Optional enum field. `openai-python` **2.45.0** added `Reasoning.mode` (`Literal["standard","pro"] | None`, default `None`). The plugin auto-attaches `Reasoning(effort="none")` for gpt-5.x models, which now serializes as:

```json
"reasoning": {"context": null, "effort": "none", "generate_summary": null, "mode": null, "summary": null}
```

and the Responses API rejects it with **HTTP 400**:

```
Invalid type for 'reasoning.mode': expected one of 'standard' or 'pro', but got null instead.
```

Worse, that 400 was invisible: the error-frame parser crashed while trying to report it (see fix #2), so users saw a misleading pydantic `ValidationError` about `sequence_number` instead of the real message.

This breaks any Responses-API user on the WS transport running openai ≥ 2.45.0 (gpt-5.x, where `reasoning` is auto-set). The HTTP transport (`use_websocket=False`) is unaffected because the SDK omits unset fields.

## What changed

Two small fixes in `responses/llm.py`, plus a hermetic regression test.

1. **Serialization** — `_ResponsesWebsocket.generate_response._default` now uses `model_dump(mode="json", exclude_none=True)`. This mirrors the SDK's on-the-wire shape and is forward-compatible with any future Optional field OpenAI adds to these models. (Matches the file's own existing convention — `_handle_response_completed` already uses `exclude_none=True`.)

2. **Error reporting** — `_parse_ws_event` defaults `sequence_number` when validating top-level `error` frames. Those frames (e.g. a request-validation 400) don't carry `sequence_number`, which `ResponseErrorEvent` marks required, so validating them raised a `ValidationError` that masked the real API message. With the default, genuine errors surface cleanly as an `APIStatusError` via `_handle_error`.

3. **Test** — `tests/test_plugin_openai_responses.py`, hermetic (no network/keys):
   - drives the real `generate_response` through a fake WS pool and asserts the serialized `reasoning` has no null-valued keys;
   - asserts a `sequence_number`-less error frame parses cleanly and preserves the message.

## What this changes for users

Before: on openai ≥ 2.45.0, a gpt-5.x agent using the Responses API over WebSocket (the default) fails every turn with an opaque `ValidationError` about `sequence_number`; the underlying cause (a 400 on `reasoning.mode`) is hidden.

After: the request serializes the way the SDK would, the turn succeeds, and if any request *is* rejected the real API error message is surfaced instead of a parser crash.

## Testing

- `uv run pytest tests/test_plugin_openai_responses.py --plugin openai` → 2 passed.
- Verified end-to-end against the live OpenAI Responses WebSocket on **openai 2.45.0**: a gpt-5.4 turn with `Reasoning(effort="none")` now returns `response.completed` (400 before the fix); a deliberately invalid request surfaces the real error message (pydantic crash before the fix).
- Negative control: both the test and the live checks fail on the pre-patch code, confirming they guard the regression.
- `ruff format --check` and `ruff check` pass on the changed file.

## Notes

- The two fixes are independent; #1 stops the 400, #2 makes any future error debuggable. Happy to split into two commits if preferred.
- No changelog/changeset tooling found in the repo, so no fragment added.
