### PR TITLE
feat(worker): add lk_agents_worker_full_total counter for full-capacity transitions

### DIFF
--- a/livekit-agents/livekit/agents/telemetry/metrics.py
+++ b/livekit-agents/livekit/agents/telemetry/metrics.py
@@ -35,6 +35,15 @@ CPU_LOAD_GAUGE = prometheus_client.Gauge(
     ["nodename"],
 )
 
+# Counter, not a gauge: a worker can cross into full capacity for less than one
+# scrape/export interval, so the instantaneous load gauge above can miss the spike
+# entirely. A monotonic counter records every transition regardless of sampling.
+WORKER_FULL_COUNTER = prometheus_client.Counter(
+    "lk_agents_worker_full_total",
+    "Number of times the worker transitioned to full capacity (stopped accepting jobs)",
+    ["nodename"],
+)
+
 
 # Note: set_function() is not supported in multiprocess mode.# We need to update this metric explicitly.
 def _update_child_proc_count() -> None:
@@ -49,6 +58,11 @@ def _update_child_proc_count() -> None:
 
 def _update_worker_load(worker_load: float) -> None:
     CPU_LOAD_GAUGE.labels(nodename=utils.nodename()).set(worker_load)
+
+
+def worker_became_full() -> None:
+    """Record a transition into full capacity. Called once per transition, not per tick."""
+    WORKER_FULL_COUNTER.labels(nodename=utils.nodename()).inc()
 
 
 def job_started() -> None:

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -1511,6 +1511,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
             self._previous_status = status
             extra = {"load": effective_load, "threshold": load_threshold}
             if is_full:
+                telemetry.metrics.worker_became_full()
                 logger.info("worker is at full capacity, marking as unavailable", extra=extra)
             else:
                 logger.info("worker is below capacity, marking as available", extra=extra)

--- a/tests/test_worker_full_metric.py
+++ b/tests/test_worker_full_metric.py
@@ -1,0 +1,31 @@
+"""Unit test for the worker full-capacity counter (`lk_agents_worker_full_total`).
+
+The worker's instantaneous load gauge (`lk_agents_worker_load`) can miss a
+transient full-capacity spike that lasts less than one scrape/export interval.
+`worker_became_full()` records each transition as a monotonic counter so the
+event is never lost to sampling. This test asserts the counter increments per
+call and is labelled by node name.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents import utils
+from livekit.agents.telemetry import metrics
+
+pytestmark = pytest.mark.unit
+
+
+def _full_count() -> float:
+    value = metrics.WORKER_FULL_COUNTER.labels(nodename=utils.nodename())._value.get()
+    return float(value)
+
+
+def test_worker_became_full_increments_counter() -> None:
+    before = _full_count()
+
+    metrics.worker_became_full()
+    metrics.worker_became_full()
+
+    assert _full_count() == before + 2


### PR DESCRIPTION
## Summary

Fixes #6388.

The worker's load is exported as an instantaneous gauge (`lk_agents_worker_load`), but admission control marks the worker `WS_FULL` on the continuous 0.5s load loop. A spike that puts the worker over threshold for less than one scrape/export interval is invisible to the gauge — the FULL transition falls between samples, so dashboards can't see (or alert on) saturation that actually rejected/deferred jobs.

## Change

Add `lk_agents_worker_full_total`, a monotonic `Counter` labelled `nodename`, incremented once per FULL transition at the existing status-change edge in `_update_worker_status` (guarded by `self._previous_status != status`, alongside the "full capacity" log line). Being a counter, it never loses an event to sampling, and it rides the same Prometheus→OTLP path as the existing gauges, so it works in both scrape and push deployments.

Operators can then alert on `rate(lk_agents_worker_full_total[5m])`.

## Testing

- `tests/test_worker_full_metric.py` — asserts the counter increments per transition and is labelled by node name.
- `ruff check` + `ruff format` clean.
- `mypy` (full repo via `scripts/check_types.py`): no issues found in 617 source files.