### PR TITLE
Add Hakim plugin (STT + TTS)

### DIFF
--- a/livekit-plugins/livekit-plugins-hakim/README.md
+++ b/livekit-plugins/livekit-plugins-hakim/README.md
@@ -1,0 +1,28 @@
+# Hakim plugin for LiveKit Agents
+
+Support for Arabic-first realtime speech-to-text and text-to-speech from [Hakim](https://tryhakim.ai).
+
+See [https://tryhakim.ai/docs](https://tryhakim.ai/docs) for more information.
+
+## Installation
+
+```bash
+pip install livekit-plugins-hakim
+```
+
+## Pre-requisites
+
+You'll need a Hakim API key. It can be set as an environment variable: `HAKIM_API_KEY`.
+
+## Usage
+
+```python
+from livekit.plugins import hakim
+
+session = AgentSession(
+    vad=silero.VAD.load(),
+    stt=hakim.STT(language="ar"),
+    llm=your_llm_plugin,
+    tts=hakim.TTS(voice="your-voice-id"),
+)
+```

--- a/livekit-plugins/livekit-plugins-hakim/livekit/plugins/hakim/__init__.py
+++ b/livekit-plugins/livekit-plugins-hakim/livekit/plugins/hakim/__init__.py
@@ -1,0 +1,50 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hakim plugin for LiveKit Agents
+
+See https://tryhakim.ai/docs for more information.
+"""
+
+from .log import logger
+from .stt import STT, SpeechStream
+from .tts import TTS, ChunkedStream, SynthesizeStream
+from .version import __version__
+
+__all__ = [
+    "STT",
+    "SpeechStream",
+    "TTS",
+    "ChunkedStream",
+    "SynthesizeStream",
+    "logger",
+    "__version__",
+]
+
+from livekit.agents import Plugin
+
+
+class HakimPlugin(Plugin):
+    def __init__(self) -> None:
+        super().__init__(__name__, __version__, __package__, logger)
+
+
+Plugin.register_plugin(HakimPlugin())
+
+# Cleanup docs of unexported modules
+_module = dir()
+NOT_IN_ALL = [m for m in _module if m not in __all__]
+
+__pdoc__ = {}
+
+for n in NOT_IN_ALL:
+    __pdoc__[n] = False

--- a/livekit-plugins/livekit-plugins-hakim/livekit/plugins/hakim/_common.py
+++ b/livekit-plugins/livekit-plugins-hakim/livekit/plugins/hakim/_common.py
@@ -1,0 +1,92 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared wire-protocol helpers for the Hakim plugin.
+
+Both `stt.py` and `tts.py` talk directly to Hakim's public REST/WebSocket
+API (see https://tryhakim.ai/docs) over plain `websockets` / `aiohttp`
+connections. This module exists only to avoid duplicating the handful of
+things both need: region -> host resolution, the `ws(s)://` upgrade URL,
+the auth header, and a shared exception type for the server's `error`
+frame.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+
+Region = Literal["auto", "de", "uae", "ksa"]
+
+_REGION_HOSTS: dict[str, str] = {
+    "auto": "api.tryhakim.ai",
+    "de": "de.api.tryhakim.ai",
+    "uae": "uae.api.tryhakim.ai",
+    "ksa": "ksa.api.tryhakim.ai",
+}
+
+
+def resolve_api_key(explicit: str | None) -> str:
+    key = explicit or os.environ.get("HAKIM_API_KEY")
+    if not key:
+        raise ValueError(
+            "Hakim API key not set. Pass api_key=... or set the HAKIM_API_KEY "
+            "environment variable. Get a key from the Hakim dashboard "
+            "(Settings -> API keys)."
+        )
+    return key
+
+
+def resolve_ws_url(path: str, *, region: Region = "auto", base_url: str | None = None) -> str:
+    """Build the `wss://` upgrade URL for a realtime endpoint.
+
+    `base_url` (if given) wins outright -- it's how staging/self-hosted
+    deployments override the default region hosts. Otherwise the region
+    code maps to one of Hakim's published regional endpoints.
+    """
+    if base_url:
+        host = (
+            base_url.removeprefix("https://")
+            .removeprefix("http://")
+            .removeprefix("wss://")
+            .removeprefix("ws://")
+        )
+        host = host.rstrip("/")
+    else:
+        host = _REGION_HOSTS.get(region, _REGION_HOSTS["auto"])
+    return f"wss://{host}{path}"
+
+
+def resolve_http_url(path: str, *, region: Region = "auto", base_url: str | None = None) -> str:
+    if base_url:
+        host = base_url.removeprefix("https://").removeprefix("http://").rstrip("/")
+    else:
+        host = _REGION_HOSTS.get(region, _REGION_HOSTS["auto"])
+    return f"https://{host}{path}"
+
+
+def auth_headers(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+class HakimStreamError(Exception):
+    """Raised when a Hakim realtime session sends an `error` frame.
+
+    Mirrors the `code` / `message` / `retryable` fields on the `error`
+    frame documented at https://tryhakim.ai/docs so callers can branch on
+    `code` without parsing the raw frame themselves.
+    """
+
+    def __init__(self, code: str, message: str, *, retryable: bool = False) -> None:
+        super().__init__(f"[{code}] {message}")
+        self.code = code
+        self.retryable = retryable

--- a/livekit-plugins/livekit-plugins-hakim/livekit/plugins/hakim/log.py
+++ b/livekit-plugins/livekit-plugins-hakim/livekit/plugins/hakim/log.py
@@ -1,0 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+logger = logging.getLogger("livekit.plugins.hakim")

--- a/livekit-plugins/livekit-plugins-hakim/livekit/plugins/hakim/stt.py
+++ b/livekit-plugins/livekit-plugins-hakim/livekit/plugins/hakim/stt.py
@@ -1,0 +1,343 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hakim STT plugin for LiveKit Agents.
+
+Speaks the public `WSS /v1/audio/transcriptions/stream` API directly (see
+https://tryhakim.ai/docs, operation `audio_transcriptions_stream`) using
+the plain `websockets` library.
+
+Wire contract implemented here:
+  - Client -> server: `session.update`, `input_audio_buffer.append`,
+    `input_audio_buffer.commit`, `session.close`.
+  - Server -> client: `session.created`, `transcription.delta`
+    (`is_final: false`), `transcription.done` (final text for the commit
+    window), `error`.
+  - Model is pinned to `hakim-arab-v2` -- the only accepted value today.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from dataclasses import dataclass, replace
+
+import aiohttp
+import websockets
+
+from livekit import rtc
+from livekit.agents import (
+    APIConnectionError,
+    APIConnectOptions,
+    APIStatusError,
+    APITimeoutError,
+    LanguageCode,
+    stt,
+    utils,
+)
+from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, NotGivenOr
+from livekit.agents.utils import AudioBuffer, is_given
+
+from ._common import (
+    HakimStreamError,
+    Region,
+    auth_headers,
+    resolve_api_key,
+    resolve_http_url,
+    resolve_ws_url,
+)
+
+STT_MODEL = "hakim-arab-v2"
+
+
+@dataclass
+class _STTOptions:
+    language: str
+    timestamps: str
+    diarize: bool
+    partials: bool
+    input_audio_format: str
+    input_sample_rate: int
+    region: Region
+    base_url: str | None
+
+
+class STT(stt.STT):
+    """LiveKit Agents STT plugin backed by Hakim's realtime transcription
+    WebSocket. Use `STT().stream()` inside an `AgentSession` exactly like
+    any other LiveKit STT plugin.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: NotGivenOr[str] = NOT_GIVEN,
+        language: str = "ar",
+        timestamps: str = "segment",
+        diarize: bool = False,
+        partials: bool = True,
+        input_audio_format: str = "pcm16",
+        input_sample_rate: int = 16000,
+        region: Region = "auto",
+        base_url: NotGivenOr[str] = NOT_GIVEN,
+        http_session: aiohttp.ClientSession | None = None,
+    ) -> None:
+        """
+        Args:
+            api_key: Hakim API key (`hk_live_...`). Falls back to the
+                `HAKIM_API_KEY` env var.
+            language: BCP-47-ish language hint (`"ar"`, `"en"`, ...). Pass
+                per-call overrides via `stream(language=...)`.
+            timestamps: `"word" | "segment" | "none"`.
+            diarize: Speaker diarization (stereo call-recording use case;
+                mono diarization is not yet supported).
+            input_audio_format: `"pcm16" | "opus" | "mulaw"`. LiveKit
+                delivers `rtc.AudioFrame`s as PCM16, so the default matches
+                without any client-side transcoding.
+            input_sample_rate: Must match the sample rate of the frames you
+                push. LiveKit's default room audio is 48 kHz; resample to
+                16 kHz upstream (or pass 48000 here) -- either works, but
+                keep the two in sync.
+            region: `"auto" | "de" | "uae" | "ksa"` -- pins the session to a
+                specific regional endpoint. `"auto"` picks the closest
+                healthy region.
+            base_url: Overrides the region table entirely (staging /
+                self-hosted). Takes precedence over `region`.
+        """
+        super().__init__(
+            capabilities=stt.STTCapabilities(
+                streaming=True,
+                interim_results=True,
+                diarization=True,
+                aligned_transcript="word" if timestamps == "word" else False,
+                offline_recognize=True,
+            )
+        )
+        self._api_key = resolve_api_key(api_key if is_given(api_key) else None)
+        self._opts = _STTOptions(
+            language=language,
+            timestamps=timestamps,
+            diarize=diarize,
+            partials=partials,
+            input_audio_format=input_audio_format,
+            input_sample_rate=input_sample_rate,
+            region=region,
+            base_url=base_url if is_given(base_url) else None,
+        )
+        self._session = http_session
+
+    @property
+    def provider(self) -> str:
+        return "Hakim"
+
+    @property
+    def model(self) -> str:
+        return STT_MODEL
+
+    def _ensure_session(self) -> aiohttp.ClientSession:
+        if self._session is None:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def _recognize_impl(
+        self,
+        buffer: AudioBuffer,
+        *,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        conn_options: APIConnectOptions,
+    ) -> stt.SpeechEvent:
+        """One-shot batch transcription via `POST /v1/audio/transcriptions`.
+
+        Most voice agents only ever use `.stream()`; this makes `STT` also
+        work wherever LiveKit expects a plain `recognize()` call
+        (`FallbackAdapter`, ad-hoc batch jobs, tests).
+        """
+        lang = language if is_given(language) else self._opts.language
+        wav_bytes = rtc.combine_audio_frames(buffer).to_wav_bytes()
+
+        form = aiohttp.FormData()
+        form.add_field("model", STT_MODEL)
+        form.add_field("language", lang)
+        form.add_field("timestamps", self._opts.timestamps)
+        form.add_field("response_format", "json")
+        form.add_field("file", wav_bytes, filename="audio.wav", content_type="audio/wav")
+
+        url = resolve_http_url(
+            "/v1/audio/transcriptions", region=self._opts.region, base_url=self._opts.base_url
+        )
+        session = self._ensure_session()
+        try:
+            async with session.post(
+                url,
+                data=form,
+                headers=auth_headers(self._api_key),
+                timeout=aiohttp.ClientTimeout(total=conn_options.timeout),
+            ) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    raise APIStatusError(
+                        f"Hakim transcription request failed: {body}",
+                        status_code=resp.status,
+                        request_id=resp.headers.get("X-Request-Id"),
+                    )
+                data = await resp.json()
+        except asyncio.TimeoutError as e:
+            raise APITimeoutError() from e
+        except aiohttp.ClientError as e:
+            raise APIConnectionError(str(e)) from e
+
+        return stt.SpeechEvent(
+            type=stt.SpeechEventType.FINAL_TRANSCRIPT,
+            request_id=data.get("request_id", ""),
+            alternatives=[stt.SpeechData(language=LanguageCode(lang), text=data.get("text", ""))],
+        )
+
+    def stream(
+        self,
+        *,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+    ) -> SpeechStream:
+        opts = replace(self._opts, language=language if is_given(language) else self._opts.language)
+        return SpeechStream(stt=self, opts=opts, api_key=self._api_key, conn_options=conn_options)
+
+    async def aclose(self) -> None:
+        if self._session is not None:
+            await self._session.close()
+
+
+class SpeechStream(stt.SpeechStream):
+    def __init__(
+        self,
+        *,
+        stt: STT,
+        opts: _STTOptions,
+        api_key: str,
+        conn_options: APIConnectOptions,
+    ) -> None:
+        super().__init__(stt=stt, conn_options=conn_options, sample_rate=opts.input_sample_rate)
+        self._opts = opts
+        self._api_key = api_key
+
+    async def _run(self) -> None:
+        url = resolve_ws_url(
+            "/v1/audio/transcriptions/stream",
+            region=self._opts.region,
+            base_url=self._opts.base_url,
+        )
+        try:
+            async with websockets.connect(
+                url, additional_headers=auth_headers(self._api_key)
+            ) as ws:
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "session.update",
+                            "session": {
+                                "model": STT_MODEL,
+                                "language": self._opts.language,
+                                "timestamps": self._opts.timestamps,
+                                "diarize": self._opts.diarize,
+                                "partials": self._opts.partials,
+                                "input_audio_format": self._opts.input_audio_format,
+                                "input_sample_rate": self._opts.input_sample_rate,
+                            },
+                        }
+                    )
+                )
+
+                send_task = asyncio.create_task(self._send_task(ws), name="hakim-stt-send")
+                recv_task = asyncio.create_task(self._recv_task(ws), name="hakim-stt-recv")
+                try:
+                    await asyncio.gather(send_task, recv_task)
+                finally:
+                    await utils.aio.gracefully_cancel(send_task, recv_task)
+        except websockets.exceptions.InvalidStatus as e:
+            raise APIStatusError(f"Hakim STT upgrade rejected: {e}") from e
+        except (websockets.exceptions.ConnectionClosed, OSError) as e:
+            raise APIConnectionError(str(e)) from e
+
+    async def _send_task(self, ws: websockets.ClientConnection) -> None:
+        # Hakim recommends 50-250ms chunks; LiveKit delivers ~10-20ms
+        # frames, so re-buffer into ~100ms frames before sending -- one
+        # WS text message per 100ms instead of one per 10-20ms frame.
+        samples_100ms = self._opts.input_sample_rate // 10
+        audio_bstream = utils.audio.AudioByteStream(
+            sample_rate=self._opts.input_sample_rate,
+            num_channels=1,
+            samples_per_channel=samples_100ms,
+        )
+
+        async def _send_frame(frame: rtc.AudioFrame) -> None:
+            await ws.send(
+                json.dumps(
+                    {
+                        "type": "input_audio_buffer.append",
+                        "audio": base64.b64encode(bytes(frame.data)).decode("ascii"),
+                    }
+                )
+            )
+
+        async for data in self._input_ch:
+            if isinstance(data, self._FlushSentinel):
+                for flushed_frame in audio_bstream.flush():
+                    await _send_frame(flushed_frame)
+                await ws.send(json.dumps({"type": "input_audio_buffer.commit"}))
+                continue
+
+            frame: rtc.AudioFrame = data
+            for out_frame in audio_bstream.write(frame.data.tobytes()):
+                await _send_frame(out_frame)
+        await ws.send(json.dumps({"type": "session.close"}))
+
+    async def _recv_task(self, ws: websockets.ClientConnection) -> None:
+        async for raw in ws:
+            event = json.loads(raw)
+            etype = event.get("type")
+
+            if etype in ("session.created", None):
+                continue
+
+            if etype == "transcription.delta":
+                text = event.get("text", "")
+                if not text:
+                    continue
+                self._event_ch.send_nowait(
+                    stt.SpeechEvent(
+                        type=stt.SpeechEventType.INTERIM_TRANSCRIPT,
+                        alternatives=[
+                            stt.SpeechData(language=LanguageCode(self._opts.language), text=text)
+                        ],
+                    )
+                )
+            elif etype == "transcription.done":
+                self._event_ch.send_nowait(
+                    stt.SpeechEvent(
+                        type=stt.SpeechEventType.FINAL_TRANSCRIPT,
+                        alternatives=[
+                            stt.SpeechData(
+                                language=LanguageCode(event.get("language", self._opts.language)),
+                                text=event.get("text", ""),
+                            )
+                        ],
+                    )
+                )
+            elif etype == "error":
+                code = event.get("code", "unknown_error")
+                message = event.get("message", "")
+                retryable = bool(event.get("retryable", False))
+                # `_main_task` (base class) retries on `APIError` subclasses
+                # and gives up on anything else -- mirror that split here.
+                if retryable:
+                    raise APIConnectionError(f"[{code}] {message}")
+                raise HakimStreamError(code, message, retryable=retryable)

--- a/livekit-plugins/livekit-plugins-hakim/livekit/plugins/hakim/tts.py
+++ b/livekit-plugins/livekit-plugins-hakim/livekit/plugins/hakim/tts.py
@@ -1,0 +1,364 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hakim TTS plugin for LiveKit Agents.
+
+Speaks the public `WSS /v1/audio/speech/stream` API directly (see
+https://tryhakim.ai/docs, operation `audio_speech_stream_ws`) using the
+plain `websockets` library, and the public `POST /v1/audio/speech` API for
+one-shot synthesis (`aiohttp`).
+
+Wire contract implemented here (streaming):
+  - Client -> server: `session.update`, `speech.create`, `session.close`.
+  - Server -> client: `session.created`, `speech.started`, binary
+    PCM-S16LE @ 24 kHz mono chunks, `speech.done`, `session.usage`, `error`.
+  - `response_format` / `sample_rate` are locked to `pcm` / `24000` on the
+    realtime surface -- the plugin's `sample_rate` is fixed to match.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+
+import aiohttp
+import websockets
+
+from livekit.agents import (
+    APIConnectionError,
+    APIConnectOptions,
+    APIStatusError,
+    APITimeoutError,
+    tts,
+    utils,
+)
+from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, NotGivenOr
+from livekit.agents.utils import is_given
+
+from ._common import (
+    HakimStreamError,
+    Region,
+    auth_headers,
+    resolve_api_key,
+    resolve_http_url,
+    resolve_ws_url,
+)
+
+# The realtime WS surface pins response_format=pcm / sample_rate=24000
+# (engine-native rate). Keep the plugin's declared sample_rate in lockstep
+# so `.synthesize()` (HTTP) and `.stream()` (WS) always agree with what the
+# AgentSession pipeline was configured for.
+SAMPLE_RATE = 24000
+DEFAULT_MODEL = "hakim-fast-v1"
+
+
+@dataclass
+class _TTSOptions:
+    model: str
+    voice: str
+    cfg: float
+    voice_prompt: str | None
+    region: Region
+    base_url: str | None
+
+
+class TTS(tts.TTS):
+    """LiveKit Agents TTS plugin backed by Hakim. Use `.stream()` for
+    sentence-by-sentence LLM pipelining (the common `AgentSession` case) or
+    `.synthesize()` for one-shot text-to-speech.
+    """
+
+    def __init__(
+        self,
+        *,
+        voice: str,
+        api_key: NotGivenOr[str] = NOT_GIVEN,
+        model: str = DEFAULT_MODEL,
+        cfg: float = 3.0,
+        voice_prompt: str | None = None,
+        region: Region = "auto",
+        base_url: NotGivenOr[str] = NOT_GIVEN,
+        http_session: aiohttp.ClientSession | None = None,
+    ) -> None:
+        """
+        Args:
+            voice: Hakim voice id or slug. Required -- there is no bundled
+                default voice.
+            api_key: Hakim API key (`hk_live_...`). Falls back to the
+                `HAKIM_API_KEY` env var.
+            model: `"hakim-fast-v1"` (default, sub-120ms TTFB), `"hakim-v2"`
+                (higher quality + non-verbal tags), or `"hakim-v3"`
+                (adds free-form `voice_prompt` control).
+            cfg: Classifier-free-guidance weight, `0.0`-`10.0` (default `3.0`).
+            voice_prompt: Free-form voice-character description, only
+                honoured on `model="hakim-v3"` -- dropped elsewhere.
+            region: `"auto" | "de" | "uae" | "ksa"`.
+            base_url: Overrides the region table entirely (staging /
+                self-hosted). Takes precedence over `region`.
+        """
+        super().__init__(
+            capabilities=tts.TTSCapabilities(streaming=True, aligned_transcript=False),
+            sample_rate=SAMPLE_RATE,
+            num_channels=1,
+        )
+        self._api_key = resolve_api_key(api_key if is_given(api_key) else None)
+        self._opts = _TTSOptions(
+            model=model,
+            voice=voice,
+            cfg=cfg,
+            voice_prompt=voice_prompt,
+            region=region,
+            base_url=base_url if is_given(base_url) else None,
+        )
+        self._session = http_session
+
+    @property
+    def provider(self) -> str:
+        return "Hakim"
+
+    @property
+    def model(self) -> str:
+        return self._opts.model
+
+    def _ensure_session(self) -> aiohttp.ClientSession:
+        if self._session is None:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    def synthesize(
+        self,
+        text: str,
+        *,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+    ) -> ChunkedStream:
+        return ChunkedStream(
+            tts=self,
+            input_text=text,
+            opts=self._opts,
+            api_key=self._api_key,
+            conn_options=conn_options,
+            http_session=self._ensure_session(),
+        )
+
+    def stream(
+        self,
+        *,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+    ) -> SynthesizeStream:
+        return SynthesizeStream(
+            tts=self, opts=self._opts, api_key=self._api_key, conn_options=conn_options
+        )
+
+    async def aclose(self) -> None:
+        if self._session is not None:
+            await self._session.close()
+
+
+class ChunkedStream(tts.ChunkedStream):
+    """One-shot synthesis via `POST /v1/audio/speech` (`response_format:
+    "pcm"`). Used by `TTS.synthesize()` -- LiveKit falls back to this when
+    a plain one-shot call is needed instead of the persistent socket.
+    """
+
+    def __init__(
+        self,
+        *,
+        tts: TTS,
+        input_text: str,
+        opts: _TTSOptions,
+        api_key: str,
+        conn_options: APIConnectOptions,
+        http_session: aiohttp.ClientSession,
+    ) -> None:
+        super().__init__(tts=tts, input_text=input_text, conn_options=conn_options)
+        self._opts = opts
+        self._api_key = api_key
+        self._session = http_session
+        self._conn_options = conn_options
+
+    async def _run(self, output_emitter: tts.AudioEmitter) -> None:
+        output_emitter.initialize(
+            request_id=utils.shortuuid(),
+            sample_rate=SAMPLE_RATE,
+            num_channels=1,
+            mime_type="audio/pcm",
+        )
+
+        payload: dict[str, object] = {
+            "model": self._opts.model,
+            "input": self.input_text,
+            "voice": self._opts.voice,
+            "response_format": "pcm",
+            "sample_rate": SAMPLE_RATE,
+            "cfg": self._opts.cfg,
+        }
+        if self._opts.voice_prompt:
+            payload["voice_prompt"] = self._opts.voice_prompt
+
+        url = resolve_http_url(
+            "/v1/audio/speech", region=self._opts.region, base_url=self._opts.base_url
+        )
+        try:
+            async with self._session.post(
+                url,
+                json=payload,
+                headers=auth_headers(self._api_key),
+                timeout=aiohttp.ClientTimeout(total=self._conn_options.timeout),
+            ) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    raise APIStatusError(
+                        f"Hakim speech request failed: {body}",
+                        status_code=resp.status,
+                        request_id=resp.headers.get("X-Request-Id"),
+                    )
+                async for chunk in resp.content.iter_chunked(4096):
+                    output_emitter.push(chunk)
+        except asyncio.TimeoutError as e:
+            raise APITimeoutError() from e
+        except aiohttp.ClientError as e:
+            raise APIConnectionError(str(e)) from e
+
+        output_emitter.flush()
+
+
+class SynthesizeStream(tts.SynthesizeStream):
+    """Persistent-socket streaming synthesis via `WSS
+    /v1/audio/speech/stream`. Each flushed input segment (LiveKit flushes
+    per sentence during LLM token pipelining) becomes one `speech.create`
+    request over the same connection -- no per-utterance TCP/TLS handshake.
+    """
+
+    def __init__(
+        self,
+        *,
+        tts: TTS,
+        opts: _TTSOptions,
+        api_key: str,
+        conn_options: APIConnectOptions,
+    ) -> None:
+        super().__init__(tts=tts, conn_options=conn_options)
+        self._opts = opts
+        self._api_key = api_key
+        # Hakim's `speech.create` is one discrete request per utterance
+        # (unlike providers that stream text into one long-lived synthesis
+        # context) -- each flushed input segment maps to exactly one
+        # speech.started/speech.done pair. `end_input()` on the emitter must
+        # fire exactly once, after both "no more text is coming" AND "every
+        # utterance we already sent has finished" are true -- whichever of
+        # the two tasks observes that last is responsible for calling it.
+        self._pending_utterances = 0
+        self._input_closed = False
+        self._ended = False
+
+    def _maybe_end_input(self, output_emitter: tts.AudioEmitter) -> None:
+        if self._input_closed and self._pending_utterances <= 0 and not self._ended:
+            self._ended = True
+            output_emitter.end_input()
+
+    async def _run(self, output_emitter: tts.AudioEmitter) -> None:
+        output_emitter.initialize(
+            request_id=utils.shortuuid(),
+            sample_rate=SAMPLE_RATE,
+            num_channels=1,
+            mime_type="audio/pcm",
+            stream=True,
+        )
+
+        url = resolve_ws_url(
+            "/v1/audio/speech/stream", region=self._opts.region, base_url=self._opts.base_url
+        )
+        try:
+            async with websockets.connect(
+                url, additional_headers=auth_headers(self._api_key)
+            ) as ws:
+                session_update: dict[str, object] = {
+                    "model": self._opts.model,
+                    "voice": self._opts.voice,
+                    "cfg": self._opts.cfg,
+                }
+                if self._opts.voice_prompt:
+                    session_update["voice_prompt"] = self._opts.voice_prompt
+                await ws.send(json.dumps({"type": "session.update", "session": session_update}))
+
+                input_task = asyncio.create_task(
+                    self._input_task(ws, output_emitter), name="hakim-tts-input"
+                )
+                recv_task = asyncio.create_task(
+                    self._recv_task(ws, output_emitter), name="hakim-tts-recv"
+                )
+                try:
+                    await asyncio.gather(input_task, recv_task)
+                finally:
+                    await utils.aio.gracefully_cancel(input_task, recv_task)
+        except websockets.exceptions.InvalidStatus as e:
+            raise APIStatusError(f"Hakim TTS upgrade rejected: {e}") from e
+        except (websockets.exceptions.ConnectionClosed, OSError) as e:
+            raise APIConnectionError(str(e)) from e
+
+    async def _input_task(
+        self, ws: websockets.ClientConnection, output_emitter: tts.AudioEmitter
+    ) -> None:
+        pending: list[str] = []
+        async for data in self._input_ch:
+            if isinstance(data, self._FlushSentinel):
+                text = "".join(pending).strip()
+                pending = []
+                if text:
+                    self._pending_utterances += 1
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "type": "speech.create",
+                                "input": text,
+                                "request_id": utils.shortuuid(),
+                            }
+                        )
+                    )
+                continue
+            pending.append(data)
+        self._input_closed = True
+        self._maybe_end_input(output_emitter)
+        await ws.send(json.dumps({"type": "session.close"}))
+
+    async def _recv_task(
+        self, ws: websockets.ClientConnection, output_emitter: tts.AudioEmitter
+    ) -> None:
+        async for raw in ws:
+            if isinstance(raw, (bytes, bytearray)):
+                output_emitter.push(bytes(raw))
+                continue
+
+            event = json.loads(raw)
+            etype = event.get("type")
+
+            if etype in ("session.created", "session.usage", None):
+                continue
+            elif etype == "speech.started":
+                output_emitter.start_segment(
+                    segment_id=event.get("request_id") or utils.shortuuid()
+                )
+            elif etype == "speech.done":
+                output_emitter.end_segment()
+                self._pending_utterances -= 1
+                self._maybe_end_input(output_emitter)
+                if self._ended:
+                    return
+            elif etype == "error":
+                code = event.get("code", "unknown_error")
+                message = event.get("message", "")
+                retryable = bool(event.get("retryable", False))
+                fatal = bool(event.get("fatal", False))
+                if retryable and not fatal:
+                    raise APIConnectionError(f"[{code}] {message}")
+                raise HakimStreamError(code, message, retryable=retryable)

--- a/livekit-plugins/livekit-plugins-hakim/livekit/plugins/hakim/version.py
+++ b/livekit-plugins/livekit-plugins-hakim/livekit/plugins/hakim/version.py
@@ -1,0 +1,13 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.1.0"

--- a/livekit-plugins/livekit-plugins-hakim/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-hakim/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "livekit-plugins-hakim"
+dynamic = ["version"]
+description = "LiveKit Agents Plugin for Hakim"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.10.0"
+authors = [{ name = "LiveKit", email = "hello@livekit.io" }]
+keywords = ["voice", "ai", "realtime", "audio", "video", "livekit", "hakim", "arabic"]
+classifiers = [
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: Multimedia :: Sound/Audio",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3 :: Only",
+]
+dependencies = ["livekit-agents>=1.6.5", "websockets>=13"]
+
+[project.urls]
+Documentation = "https://tryhakim.ai/docs"
+Website = "https://tryhakim.ai/"
+Source = "https://github.com/livekit/agents"
+
+[tool.hatch.version]
+path = "livekit/plugins/hakim/version.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["livekit"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/livekit"]
+
+[tool.uv]
+exclude-newer = "7 days"
+exclude-newer-package = { livekit-agents = "0 days" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ livekit-plugins-gradium = { workspace = true }
 livekit-plugins-xai = { workspace = true }
 livekit-plugins-phonic = { workspace = true }
 livekit-plugins-did = { workspace = true }
+livekit-plugins-hakim = { workspace = true }
 
 [tool.uv.workspace]
 members = ["livekit-plugins/*", "livekit-agents"]


### PR DESCRIPTION
## Summary

Adds `livekit-plugins-hakim`: STT and TTS support for [Hakim](https://tryhakim.ai), an Arabic-first realtime speech platform (TTS, STT, voice cloning).

- **STT**: streaming transcription over `WSS /v1/audio/transcriptions/stream` (interim + final transcripts, word/segment timestamps, diarization), plus a batch `recognize()` over the HTTP endpoint.
- **TTS**: persistent-socket streaming synthesis over `WSS /v1/audio/speech/stream` (one WS connection reused across utterances within a session), plus one-shot `synthesize()` over the HTTP endpoint.

Both talk to Hakim's public REST/WebSocket API directly — no separate Hakim SDK dependency, matching the pattern used by AssemblyAI/AWS/Azure and other plugins that don't wrap a vendor SDK.

## Structure

Followed the conventions in `CONTRIBUTING.md` and the existing plugins (modeled closely on `livekit-plugins-assemblyai` for STT and `livekit-plugins-cartesia` for TTS):

- `STT`/`SpeechStream` subclass `stt.STT`/`stt.SpeechStream`
- `TTS`/`ChunkedStream`/`SynthesizeStream` subclass `tts.TTS`/`tts.ChunkedStream`/`tts.SynthesizeStream`
- Errors raised as `APIStatusError` / `APIConnectionError` / `APITimeoutError` so the base class retry/metrics logic works as expected
- `py.typed` marker, `pyproject.toml` matching the hatchling + `livekit-agents>=1.6.5` pattern used by other plugins
- Registered as a workspace member in the root `pyproject.toml`

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy --strict` (via the repo's own `pyproject.toml` config) — clean, 0 errors
- [x] Smoke-tested against a real `livekit-agents>=1.6.5` install in a clean venv: imported the plugin, instantiated `hakim.STT()` / `hakim.TTS(voice=...)`, called `.stream()` / `.synthesize()` on both, and closed everything cleanly with no errors

I understand this needs a CLA signature — happy to sign whatever the CLA Assistant bot requests.