### PR TITLE
Fix stripping of Gemma reasoning markers in streamed output

### DIFF
--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -72,6 +72,10 @@ _UNSUPPORTED_PARAMS: dict[str, set[str]] = {
 # models that don't support reasoning_effort when function tools are present
 _REASONING_EFFORT_TOOL_INCOMPATIBLE_PREFIXES: set[str] = {"gpt-5.2", "gpt-5.4"}
 
+_MODEL_THINK_TAGS = {
+    "google/gemma-4-31b-it": ("<|channel>thought", "<channel|>"),
+}
+
 
 def drop_unsupported_params(
     model: str, params: dict[str, Any], tools: list[Any] | None = None
@@ -426,7 +430,11 @@ class LLMStream(llm.LLMStream):
                 **self._extra_kwargs,
             )
 
-            thinking_filter = llm_utils.ThinkingTokenFilter()
+            thinking_filter = llm_utils.ThinkingTokenFilter(
+                *_MODEL_THINK_TAGS.get(
+                    self._model, (llm_utils.THINK_TAG_START, llm_utils.THINK_TAG_END)
+                )
+            )
             async with stream:
                 async for chunk in stream:
                     for choice in chunk.choices:
@@ -473,6 +481,10 @@ class LLMStream(llm.LLMStream):
         # the delta can be None when using Azure OpenAI (content filtering)
         if delta is None:
             return None
+
+        delta.content = llm_utils.strip_thinking_tokens(
+            delta.content, thinking_filter, final=choice.finish_reason is not None
+        )
 
         if delta.tool_calls:
             for tool in delta.tool_calls:
@@ -533,10 +545,6 @@ class LLMStream(llm.LLMStream):
             self._tool_call_id = self._fnc_name = self._fnc_raw_arguments = None
             self._tool_extra = None
             return call_chunk
-
-        delta.content = llm_utils.strip_thinking_tokens(
-            delta.content, thinking_filter, final=choice.finish_reason is not None
-        )
 
         # Extract extra from delta (e.g., Google thought signatures on text parts)
         delta_extra = getattr(delta, "extra_content", None)

--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import os
 from dataclasses import dataclass
 from typing import Any, Literal, cast
@@ -427,11 +426,11 @@ class LLMStream(llm.LLMStream):
                 **self._extra_kwargs,
             )
 
-            thinking = asyncio.Event()
+            thinking_filter = llm_utils.ThinkingTokenFilter()
             async with stream:
                 async for chunk in stream:
                     for choice in chunk.choices:
-                        chat_chunk = self._parse_choice(chunk.id, choice, thinking)
+                        chat_chunk = self._parse_choice(chunk.id, choice, thinking_filter)
                         if chat_chunk is not None:
                             retryable = False
                             self._event_ch.send_nowait(chat_chunk)
@@ -466,7 +465,7 @@ class LLMStream(llm.LLMStream):
             raise APIConnectionError(retryable=retryable) from e
 
     def _parse_choice(
-        self, id: str, choice: Choice, thinking: asyncio.Event
+        self, id: str, choice: Choice, thinking_filter: llm_utils.ThinkingTokenFilter
     ) -> llm.ChatChunk | None:
         delta = choice.delta
 
@@ -535,7 +534,9 @@ class LLMStream(llm.LLMStream):
             self._tool_extra = None
             return call_chunk
 
-        delta.content = llm_utils.strip_thinking_tokens(delta.content, thinking)
+        delta.content = llm_utils.strip_thinking_tokens(
+            delta.content, thinking_filter, final=choice.finish_reason is not None
+        )
 
         # Extract extra from delta (e.g., Google thought signatures on text parts)
         delta_extra = getattr(delta, "extra_content", None)

--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -42,6 +42,10 @@ if TYPE_CHECKING:
 
 THINK_TAG_START = "<think>"
 THINK_TAG_END = "</think>"
+THINK_TAG_PAIRS = (
+    (THINK_TAG_START, THINK_TAG_END),
+    ("<|channel>thought", "<channel|>"),
+)
 
 
 def _compute_lcs(old_ids: list[str], new_ids: list[str]) -> list[str]:
@@ -606,24 +610,72 @@ def _shallow_model_dump(model: BaseModel, *, by_alias: bool = False) -> dict[str
     return result
 
 
-def strip_thinking_tokens(content: str | None, thinking: asyncio.Event) -> str | None:
-    if content is None:
-        return None
+@dataclass
+class ThinkingTokenFilter:
+    """State for stripping thinking tokens from streamed content."""
 
-    if thinking.is_set():
-        idx = content.find(THINK_TAG_END)
-        if idx >= 0:
-            thinking.clear()
-            content = content[idx + len(THINK_TAG_END) :]
-        else:
-            content = None
-    else:
-        idx = content.find(THINK_TAG_START)
-        if idx >= 0:
-            thinking.set()
-            content = content[idx + len(THINK_TAG_START) :]
+    _buffer: str = ""
+    _end_marker: str | None = None
 
-    return content
+
+def _partial_marker_length(content: str, markers: tuple[str, ...]) -> int:
+    return max(
+        (
+            length
+            for marker in markers
+            for length in range(1, min(len(content), len(marker) - 1) + 1)
+            if content.endswith(marker[:length])
+        ),
+        default=0,
+    )
+
+
+def strip_thinking_tokens(
+    content: str | None, state: ThinkingTokenFilter, *, final: bool = False
+) -> str | None:
+    if content is not None:
+        state._buffer += content
+
+    visible: list[str] = []
+    while state._buffer:
+        if state._end_marker is not None:
+            idx = state._buffer.find(state._end_marker)
+            if idx < 0:
+                keep = _partial_marker_length(state._buffer, (state._end_marker,))
+                state._buffer = state._buffer[-keep:] if keep else ""
+                break
+
+            state._buffer = state._buffer[idx + len(state._end_marker) :]
+            state._end_marker = None
+            continue
+
+        marker = min(
+            (
+                (idx, start, end)
+                for start, end in THINK_TAG_PAIRS
+                if (idx := state._buffer.find(start)) >= 0
+            ),
+            default=None,
+        )
+        if marker is not None:
+            idx, start, state._end_marker = marker
+            visible.append(state._buffer[:idx])
+            state._buffer = state._buffer[idx + len(start) :]
+            continue
+
+        keep = _partial_marker_length(state._buffer, tuple(start for start, _ in THINK_TAG_PAIRS))
+        visible.append(state._buffer[:-keep] if keep else state._buffer)
+        state._buffer = state._buffer[-keep:] if keep else ""
+        break
+
+    if final:
+        if state._end_marker is None:
+            visible.append(state._buffer)
+        state._buffer = ""
+        state._end_marker = None
+
+    result = "".join(visible)
+    return result or ("" if content == "" else None)
 
 
 def _is_valid_function_output(value: Any) -> bool:

--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -42,10 +42,6 @@ if TYPE_CHECKING:
 
 THINK_TAG_START = "<think>"
 THINK_TAG_END = "</think>"
-THINK_TAG_PAIRS = (
-    (THINK_TAG_START, THINK_TAG_END),
-    ("<|channel>thought", "<channel|>"),
-)
 
 
 def _compute_lcs(old_ids: list[str], new_ids: list[str]) -> list[str]:
@@ -614,6 +610,8 @@ def _shallow_model_dump(model: BaseModel, *, by_alias: bool = False) -> dict[str
 class ThinkingTokenFilter:
     """State for stripping thinking tokens from streamed content."""
 
+    start_tag: str = THINK_TAG_START
+    end_tag: str = THINK_TAG_END
     _buffer: str = ""
     _end_marker: str | None = None
 
@@ -649,21 +647,14 @@ def strip_thinking_tokens(
             state._end_marker = None
             continue
 
-        marker = min(
-            (
-                (idx, start, end)
-                for start, end in THINK_TAG_PAIRS
-                if (idx := state._buffer.find(start)) >= 0
-            ),
-            default=None,
-        )
-        if marker is not None:
-            idx, start, state._end_marker = marker
+        idx = state._buffer.find(state.start_tag)
+        if idx >= 0:
             visible.append(state._buffer[:idx])
-            state._buffer = state._buffer[idx + len(start) :]
+            state._buffer = state._buffer[idx + len(state.start_tag) :]
+            state._end_marker = state.end_tag
             continue
 
-        keep = _partial_marker_length(state._buffer, tuple(start for start, _ in THINK_TAG_PAIRS))
+        keep = _partial_marker_length(state._buffer, (state.start_tag,))
         visible.append(state._buffer[:-keep] if keep else state._buffer)
         state._buffer = state._buffer[-keep:] if keep else ""
         break

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,14 +1,26 @@
 from __future__ import annotations
 
 import pytest
+from openai.types.chat.chat_completion_chunk import (
+    Choice,
+    ChoiceDelta,
+    ChoiceDeltaToolCall,
+    ChoiceDeltaToolCallFunction,
+)
 
+from livekit.agents.inference.llm import LLMStream
 from livekit.agents.llm.utils import ThinkingTokenFilter, strip_thinking_tokens
 
 pytestmark = pytest.mark.unit
 
 
-def _collect_visible_text(chunks: list[str | None]) -> str:
-    state = ThinkingTokenFilter()
+GEMMA_THINK_TAGS = ("<|channel>thought", "<channel|>")
+
+
+def _collect_visible_text(
+    chunks: list[str | None], *, think_tags: tuple[str, str] | None = None
+) -> str:
+    state = ThinkingTokenFilter(*think_tags) if think_tags else ThinkingTokenFilter()
     visible = []
 
     for chunk in chunks:
@@ -30,25 +42,25 @@ def test_preserves_content_without_thinking_tokens() -> None:
 def test_strips_complete_gemma_reasoning_block() -> None:
     chunks = ["<|channel>thought\nprivate reasoning\n<channel|>answer"]
 
-    assert _collect_visible_text(chunks) == "answer"
+    assert _collect_visible_text(chunks, think_tags=GEMMA_THINK_TAGS) == "answer"
 
 
 def test_strips_empty_gemma_reasoning_block() -> None:
     chunks = ["<|channel>thought\n<channel|>answer"]
 
-    assert _collect_visible_text(chunks) == "answer"
+    assert _collect_visible_text(chunks, think_tags=GEMMA_THINK_TAGS) == "answer"
 
 
 def test_strips_gemma_reasoning_across_chunks() -> None:
     chunks = ["<|channel>thought\n", "private reasoning", "<channel|>", "answer"]
 
-    assert _collect_visible_text(chunks) == "answer"
+    assert _collect_visible_text(chunks, think_tags=GEMMA_THINK_TAGS) == "answer"
 
 
 def test_preserves_answer_after_streamed_gemma_closing_marker() -> None:
     chunks = ["<|channel>thought\n", "private reasoning", "<channel|>answer"]
 
-    assert _collect_visible_text(chunks) == "answer"
+    assert _collect_visible_text(chunks, think_tags=GEMMA_THINK_TAGS) == "answer"
 
 
 def test_strips_multiple_gemma_reasoning_blocks() -> None:
@@ -57,19 +69,27 @@ def test_strips_multiple_gemma_reasoning_blocks() -> None:
         "<|channel>thought\nsecond thought<channel|>second answer",
     ]
 
-    assert _collect_visible_text(chunks) == "first answer; second answer"
+    assert (
+        _collect_visible_text(chunks, think_tags=GEMMA_THINK_TAGS) == "first answer; second answer"
+    )
 
 
 def test_handles_gemma_markers_split_at_arbitrary_boundaries() -> None:
     chunks = list("<|channel>thought\nprivate reasoning<channel|>answer")
 
-    assert _collect_visible_text(chunks) == "answer"
+    assert _collect_visible_text(chunks, think_tags=GEMMA_THINK_TAGS) == "answer"
 
 
 def test_preserves_visible_text_before_gemma_reasoning() -> None:
     chunks = ["Let me check that.\n\n<|channel>thought\n<channel|>"]
 
-    assert _collect_visible_text(chunks) == "Let me check that.\n\n"
+    assert _collect_visible_text(chunks, think_tags=GEMMA_THINK_TAGS) == "Let me check that.\n\n"
+
+
+def test_preserves_gemma_markers_without_model_configuration() -> None:
+    content = "<|channel>thought\nprivate reasoning<channel|>answer"
+
+    assert _collect_visible_text([content]) == content
 
 
 def test_preserves_existing_think_token_behavior() -> None:
@@ -79,8 +99,44 @@ def test_preserves_existing_think_token_behavior() -> None:
 
 
 def test_preserves_incomplete_marker_at_end_of_stream() -> None:
-    assert _collect_visible_text(["literal <|chan"]) == "literal <|chan"
+    assert (
+        _collect_visible_text(["literal <|chan"], think_tags=GEMMA_THINK_TAGS) == "literal <|chan"
+    )
 
 
 def test_drops_unclosed_reasoning_at_end_of_stream() -> None:
-    assert _collect_visible_text(["before<|channel>thought\nprivate reasoning"]) == "before"
+    assert (
+        _collect_visible_text(
+            ["before<|channel>thought\nprivate reasoning"], think_tags=GEMMA_THINK_TAGS
+        )
+        == "before"
+    )
+
+
+def test_strips_reasoning_from_text_alongside_tool_call() -> None:
+    stream = LLMStream.__new__(LLMStream)
+    stream._tool_call_id = None
+    stream._fnc_name = None
+    stream._fnc_raw_arguments = None
+    stream._tool_extra = None
+    stream._tool_index = None
+    choice = Choice(
+        index=0,
+        finish_reason="tool_calls",
+        delta=ChoiceDelta(
+            content="Let me check that.\n\n<|channel>thought\n<channel|>",
+            tool_calls=[
+                ChoiceDeltaToolCall(
+                    index=0,
+                    id="call-1",
+                    function=ChoiceDeltaToolCallFunction(name="check", arguments="{}"),
+                )
+            ],
+        ),
+    )
+
+    chunk = stream._parse_choice("chunk-1", choice, ThinkingTokenFilter(*GEMMA_THINK_TAGS))
+
+    assert chunk is not None
+    assert chunk.delta is not None
+    assert chunk.delta.content == "Let me check that.\n\n"

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents.llm.utils import ThinkingTokenFilter, strip_thinking_tokens
+
+pytestmark = pytest.mark.unit
+
+
+def _collect_visible_text(chunks: list[str | None]) -> str:
+    state = ThinkingTokenFilter()
+    visible = []
+
+    for chunk in chunks:
+        content = strip_thinking_tokens(chunk, state)
+        if content is not None:
+            visible.append(content)
+
+    content = strip_thinking_tokens(None, state, final=True)
+    if content is not None:
+        visible.append(content)
+
+    return "".join(visible)
+
+
+def test_preserves_content_without_thinking_tokens() -> None:
+    assert _collect_visible_text([None, "", "Hello from LiveKit"]) == "Hello from LiveKit"
+
+
+def test_strips_complete_gemma_reasoning_block() -> None:
+    chunks = ["<|channel>thought\nprivate reasoning\n<channel|>answer"]
+
+    assert _collect_visible_text(chunks) == "answer"
+
+
+def test_strips_empty_gemma_reasoning_block() -> None:
+    chunks = ["<|channel>thought\n<channel|>answer"]
+
+    assert _collect_visible_text(chunks) == "answer"
+
+
+def test_strips_gemma_reasoning_across_chunks() -> None:
+    chunks = ["<|channel>thought\n", "private reasoning", "<channel|>", "answer"]
+
+    assert _collect_visible_text(chunks) == "answer"
+
+
+def test_preserves_answer_after_streamed_gemma_closing_marker() -> None:
+    chunks = ["<|channel>thought\n", "private reasoning", "<channel|>answer"]
+
+    assert _collect_visible_text(chunks) == "answer"
+
+
+def test_strips_multiple_gemma_reasoning_blocks() -> None:
+    chunks = [
+        "<|channel>thought\nfirst thought<channel|>first answer; ",
+        "<|channel>thought\nsecond thought<channel|>second answer",
+    ]
+
+    assert _collect_visible_text(chunks) == "first answer; second answer"
+
+
+def test_handles_gemma_markers_split_at_arbitrary_boundaries() -> None:
+    chunks = list("<|channel>thought\nprivate reasoning<channel|>answer")
+
+    assert _collect_visible_text(chunks) == "answer"
+
+
+def test_preserves_visible_text_before_gemma_reasoning() -> None:
+    chunks = ["Let me check that.\n\n<|channel>thought\n<channel|>"]
+
+    assert _collect_visible_text(chunks) == "Let me check that.\n\n"
+
+
+def test_preserves_existing_think_token_behavior() -> None:
+    chunks = ["<think>", "private reasoning", "</think>answer"]
+
+    assert _collect_visible_text(chunks) == "answer"
+
+
+def test_preserves_incomplete_marker_at_end_of_stream() -> None:
+    assert _collect_visible_text(["literal <|chan"]) == "literal <|chan"
+
+
+def test_drops_unclosed_reasoning_at_end_of_stream() -> None:
+    assert _collect_visible_text(["before<|channel>thought\nprivate reasoning"]) == "before"


### PR DESCRIPTION
Fixes livekit/agents#6375

## Problem

Gemma channel-thought markers and their hidden reasoning pass through the shared thinking-token filter into customer-visible output, including TTS, transcripts, and chat history.

## Root cause

`strip_thinking_tokens` only recognizes `<think>` blocks and uses an `asyncio.Event`, which records whether the stream is inside a reasoning block but cannot retain marker fragments split across chunks. It also does not handle complete or multiple reasoning blocks within one chunk.

## Change

* add a stateful streaming filter for existing `<think>` and Gemma `<|channel>thought` / `<channel|>` blocks
* buffer only possible marker prefixes across chunk boundaries
* preserve visible content before and after reasoning blocks
* flush incomplete visible marker-like text when the stream finishes while dropping unclosed reasoning

## Tests

* `uv run --frozen pytest tests/test_llm_utils.py --unit -q` — 11 passed
* `uv run --frozen pytest --unit --no-concurrent --ignore=tests/test_room.py -q` — 1116 passed, 2 skipped
* `make check` — formatting, Ruff, and mypy passed

`tests/test_room.py` could not run locally because this environment has no Docker executable; its nine failures were fixture setup errors before test execution.

## Scope

No new dependencies, provider calls, or unrelated inference changes.