### PR TITLE
feat(soniox): add endpoint latency adjustment parameter

### DIFF
--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
@@ -132,6 +132,12 @@ class STTOptions:
     less likely. Leave as None to use the server-side default.
     Introduced in the Soniox v5 model; earlier models reject it."""
 
+    endpoint_latency_adjustment_level: int | None = None
+    """How aggressively the model reduces endpoint latency. Range: 0 to 3.
+    Higher values reduce latency but may emit more endpoints and slightly reduce accuracy.
+    Leave as None to use the server-side default.
+    Introduced in the Soniox v5 model; earlier models reject it."""
+
     client_reference_id: str | None = None
     translation: TranslationConfig | None = None
 
@@ -140,6 +146,10 @@ class STTOptions:
             raise ValueError("max_endpoint_delay_ms must be between 500 and 3000")
         if self.endpoint_sensitivity is not None and not (-1.0 <= self.endpoint_sensitivity <= 1.0):
             raise ValueError("endpoint_sensitivity must be between -1.0 and 1.0")
+        if self.endpoint_latency_adjustment_level is not None and not (
+            0 <= self.endpoint_latency_adjustment_level <= 3
+        ):
+            raise ValueError("endpoint_latency_adjustment_level must be between 0 and 3")
 
 
 class STT(stt.STT):
@@ -273,6 +283,10 @@ class SpeechStream(stt.SpeechStream):
         config["max_endpoint_delay_ms"] = self._stt._params.max_endpoint_delay_ms
         if self._stt._params.endpoint_sensitivity is not None:
             config["endpoint_sensitivity"] = self._stt._params.endpoint_sensitivity
+        if self._stt._params.endpoint_latency_adjustment_level is not None:
+            config["endpoint_latency_adjustment_level"] = (
+                self._stt._params.endpoint_latency_adjustment_level
+            )
         if self._stt._params.translation is not None:
             tr = self._stt._params.translation
             translation_dict: dict[str, Any] = {"type": tr.type}

--- a/tests/test_plugin_soniox_stt.py
+++ b/tests/test_plugin_soniox_stt.py
@@ -61,6 +61,26 @@ def test_speech_data_target_languages_preserves_existing_language_code_instances
     assert sd.target_languages[0] is code
 
 
+@pytest.mark.parametrize("level", [0, 1, 2, 3])
+def test_endpoint_latency_adjustment_level_accepts_supported_values(level: int):
+    from livekit.plugins.soniox import STTOptions
+
+    assert (
+        STTOptions(endpoint_latency_adjustment_level=level).endpoint_latency_adjustment_level
+        == level
+    )
+
+
+@pytest.mark.parametrize("level", [-1, 4])
+def test_endpoint_latency_adjustment_level_rejects_unsupported_values(level: int):
+    from livekit.plugins.soniox import STTOptions
+
+    with pytest.raises(
+        ValueError, match="endpoint_latency_adjustment_level must be between 0 and 3"
+    ):
+        STTOptions(endpoint_latency_adjustment_level=level)
+
+
 # ---------------------------------------------------------------------------
 # _TokenAccumulator._lang_segments coalescing
 # ---------------------------------------------------------------------------
@@ -175,6 +195,38 @@ def _make_stream(translation: Any = None):
     with patch("livekit.agents.stt.stt.asyncio.create_task", side_effect=_fake_create_task):
         stream = SpeechStream(stt=stt_instance, conn_options=DEFAULT_API_CONNECT_OPTIONS)
     return stream
+
+
+@pytest.mark.parametrize("level", [None, 0, 2])
+async def test_endpoint_latency_adjustment_level_websocket_config(level: int | None):
+    from livekit.plugins.soniox import STTOptions
+
+    stream = _make_stream()
+    stream._stt._params = STTOptions(endpoint_latency_adjustment_level=level)
+
+    class FakeWebSocket:
+        config: dict[str, Any] | None = None
+
+        async def send_str(self, message: str) -> None:
+            self.config = json.loads(message)
+
+    class FakeSession:
+        def __init__(self, ws: FakeWebSocket) -> None:
+            self.ws = ws
+
+        async def ws_connect(self, url: str) -> FakeWebSocket:
+            return self.ws
+
+    ws = FakeWebSocket()
+    stream._stt._http_session = FakeSession(ws)
+
+    await stream._connect_ws()
+
+    assert ws.config is not None
+    if level is None:
+        assert "endpoint_latency_adjustment_level" not in ws.config
+    else:
+        assert ws.config["endpoint_latency_adjustment_level"] == level
 
 
 async def _drive_recv(


### PR DESCRIPTION
Expose Soniox v5's endpoint_latency_adjustment_level (https://soniox.com/docs/stt/rt/endpoint-detection#endpoint_latency_adjustment_level) through `STTOptions`.

- Supports levels 0 through 3
- Validates configured values
- Sends the option in the WebSocket configuration when explicitly set
- Preserves current server-default behavior when omitted
- Adds validation and WebSocket serialization tests

Usage

```
soniox.STT(
    params=soniox.STTOptions(
        endpoint_latency_adjustment_level=2,
    )
)
```
Testing

- Ruff format and lint pass
- Soniox STT source passes mypy
- Added tests for valid/invalid levels and WebSocket payload inclusion/omission