### PR TITLE
fix(openai): include model in WebSocket URLs

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -6,10 +6,10 @@ import os
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from typing import Any, Literal, cast
-from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import aiohttp
 import httpx
+from yarl import URL
 
 import openai
 from livekit.agents import APIConnectionError, APIStatusError, APITimeoutError, llm, utils
@@ -58,19 +58,15 @@ class _ResponsesWebsocket:
     ) -> None:
         self._api_key = api_key
         self._timeout = timeout or DEFAULT_API_CONNECT_OPTIONS.timeout
-        url = urlparse(base_url if base_url else OPENAI_RESPONSES_WS_URL)
-        query_params = parse_qs(url.query)
-        query_params["model"] = [model]
-        self._base_url = urlunparse(
-            (
-                url.scheme,
-                url.netloc,
-                url.path,
-                url.params,
-                urlencode(query_params, doseq=True),
-                url.fragment,
-            )
-        )
+        url = URL(base_url if base_url else OPENAI_RESPONSES_WS_URL)
+        if url.scheme in ("http", "https"):
+            url = url.with_scheme("ws" if url.scheme == "http" else "wss")
+        if url.host != "api.openai.com":
+            # OpenAI's native endpoint takes the model in the response.create
+            # payload; gateways need it on the upgrade URL to route the
+            # connection before the first frame.
+            url = url.update_query(model=model)
+        self._base_url = str(url)
 
         self._session: aiohttp.ClientSession | None = None
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -6,6 +6,7 @@ import os
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from typing import Any, Literal, cast
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import aiohttp
 import httpx
@@ -53,11 +54,23 @@ OPENAI_RESPONSES_WS_URL = "wss://api.openai.com/v1/responses"
 
 class _ResponsesWebsocket:
     def __init__(
-        self, api_key: str | None, timeout: float | None, base_url: str | None = None
+        self, api_key: str | None, timeout: float | None, model: str, base_url: str | None = None
     ) -> None:
         self._api_key = api_key
         self._timeout = timeout or DEFAULT_API_CONNECT_OPTIONS.timeout
-        self._base_url = base_url if base_url else OPENAI_RESPONSES_WS_URL
+        url = urlparse(base_url if base_url else OPENAI_RESPONSES_WS_URL)
+        query_params = parse_qs(url.query)
+        query_params["model"] = [model]
+        self._base_url = urlunparse(
+            (
+                url.scheme,
+                url.netloc,
+                url.path,
+                url.params,
+                urlencode(query_params, doseq=True),
+                url.fragment,
+            )
+        )
 
         self._session: aiohttp.ClientSession | None = None
 
@@ -241,6 +254,7 @@ class LLM(llm.LLM):
             self._ws = _ResponsesWebsocket(
                 api_key=resolved_api_key,
                 timeout=timeout.connect if timeout is not None else None,
+                model=str(model),
                 base_url=base_url if is_given(base_url) else None,
             )
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -22,7 +22,7 @@ import time
 import weakref
 from dataclasses import dataclass
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 import aiohttp
 import httpx
@@ -415,8 +415,9 @@ class STT(stt.STT):
 
         query_params: dict[str, str] = {
             "intent": "transcription",
-            "model": self._opts.model,
         }
+        if urlparse(str(self._client.base_url)).hostname != "api.openai.com":
+            query_params["model"] = self._opts.model
         headers = {
             "User-Agent": "LiveKit Agents",
             "Authorization": f"Bearer {self._client.api_key}",

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -416,6 +416,11 @@ class STT(stt.STT):
         query_params: dict[str, str] = {
             "intent": "transcription",
         }
+        # OpenAI's native realtime endpoint treats ?model= as selecting a
+        # conversation session and rejects the transcription-mode
+        # session.update with invalid_model — the model is conveyed via
+        # audio.input.transcription.model instead. Gateways need the model
+        # on the upgrade URL to route the connection before the first frame.
         if urlparse(str(self._client.base_url)).hostname != "api.openai.com":
             query_params["model"] = self._opts.model
         headers = {

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -415,6 +415,7 @@ class STT(stt.STT):
 
         query_params: dict[str, str] = {
             "intent": "transcription",
+            "model": self._opts.model,
         }
         headers = {
             "User-Agent": "LiveKit Agents",

--- a/tests/test_plugin_openai_websocket_urls.py
+++ b/tests/test_plugin_openai_websocket_urls.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from livekit.plugins.openai import responses, stt
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeWebSocket:
+    async def send_json(self, _data: object) -> None:
+        pass
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.url = ""
+
+    async def ws_connect(self, url: str, **_kwargs: object) -> _FakeWebSocket:
+        self.url = url
+        return _FakeWebSocket()
+
+
+async def test_realtime_stt_connect_url_includes_model() -> None:
+    model = "gateway-transcribe"
+    instance = stt.STT(
+        api_key="test-key",
+        base_url="https://gateway.example.com/v1",
+        model=model,
+    )
+    session = _FakeSession()
+    instance._session = session
+
+    await instance._connect_ws(5)
+
+    parsed_url = urlparse(session.url)
+    assert parsed_url.scheme == "wss"
+    assert parsed_url.netloc == "gateway.example.com"
+    assert parsed_url.path == "/v1/realtime"
+    assert parse_qs(parsed_url.query) == {"intent": ["transcription"], "model": [model]}
+
+
+async def test_responses_websocket_connect_url_includes_model() -> None:
+    model = "gateway-responses"
+    instance = responses.LLM(
+        api_key="test-key",
+        base_url="wss://gateway.example.com/v1/responses",
+        model=model,
+        use_websocket=True,
+    )
+    assert instance._ws is not None
+    session = _FakeSession()
+    instance._ws._session = session
+
+    await instance._ws._create_ws(5)
+
+    parsed_url = urlparse(session.url)
+    assert parsed_url.scheme == "wss"
+    assert parsed_url.netloc == "gateway.example.com"
+    assert parsed_url.path == "/v1/responses"
+    assert parse_qs(parsed_url.query) == {"model": [model]}

--- a/tests/test_plugin_openai_websocket_urls.py
+++ b/tests/test_plugin_openai_websocket_urls.py
@@ -75,3 +75,39 @@ async def test_responses_websocket_connect_url_includes_model() -> None:
     assert parsed_url.netloc == "gateway.example.com"
     assert parsed_url.path == "/v1/responses"
     assert parse_qs(parsed_url.query) == {"model": [model]}
+
+
+async def test_responses_websocket_connect_url_converts_http_scheme() -> None:
+    model = "gateway-responses"
+    instance = responses.LLM(
+        api_key="test-key",
+        base_url="https://gateway.example.com/v1/responses",
+        model=model,
+        use_websocket=True,
+    )
+    assert instance._ws is not None
+    session = _FakeSession()
+    instance._ws._session = session
+
+    await instance._ws._create_ws(5)
+
+    parsed_url = urlparse(session.url)
+    assert parsed_url.scheme == "wss"
+    assert parsed_url.netloc == "gateway.example.com"
+    assert parsed_url.path == "/v1/responses"
+    assert parse_qs(parsed_url.query) == {"model": [model]}
+
+
+async def test_native_responses_websocket_connect_url_omits_model() -> None:
+    instance = responses.LLM(api_key="test-key", model="gpt-4.1", use_websocket=True)
+    assert instance._ws is not None
+    session = _FakeSession()
+    instance._ws._session = session
+
+    await instance._ws._create_ws(5)
+
+    parsed_url = urlparse(session.url)
+    assert parsed_url.scheme == "wss"
+    assert parsed_url.netloc == "api.openai.com"
+    assert parsed_url.path == "/v1/responses"
+    assert parse_qs(parsed_url.query) == {}

--- a/tests/test_plugin_openai_websocket_urls.py
+++ b/tests/test_plugin_openai_websocket_urls.py
@@ -42,6 +42,20 @@ async def test_realtime_stt_connect_url_includes_model() -> None:
     assert parse_qs(parsed_url.query) == {"intent": ["transcription"], "model": [model]}
 
 
+async def test_native_realtime_stt_connect_url_omits_model() -> None:
+    instance = stt.STT(api_key="test-key", model="gpt-realtime-whisper")
+    session = _FakeSession()
+    instance._session = session
+
+    await instance._connect_ws(5)
+
+    parsed_url = urlparse(session.url)
+    assert parsed_url.scheme == "wss"
+    assert parsed_url.netloc == "api.openai.com"
+    assert parsed_url.path == "/v1/realtime"
+    assert parse_qs(parsed_url.query) == {"intent": ["transcription"]}
+
+
 async def test_responses_websocket_connect_url_includes_model() -> None:
     model = "gateway-responses"
     instance = responses.LLM(


### PR DESCRIPTION
## Summary
- include the selected model in realtime STT WebSocket upgrade URLs
- include the selected model in Responses API WebSocket upgrade URLs while preserving existing query parameters
- add hermetic regression tests for both upgrade paths

## Test plan
- [x] `uv run pytest tests/test_plugin_openai_websocket_urls.py --unit`
- [x] `uv run ruff check livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py tests/test_plugin_openai_websocket_urls.py`
- [x] `uv run ruff format --check livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py tests/test_plugin_openai_websocket_urls.py`
- [x] `make type-check`