### PR TITLE
fix(openai): align WebSocket model query param handling with docs and agents-js

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -59,7 +59,12 @@ class _ResponsesWebsocket:
         self._api_key = api_key
         self._timeout = timeout or DEFAULT_API_CONNECT_OPTIONS.timeout
         url = URL(base_url if base_url else OPENAI_RESPONSES_WS_URL)
-        self._base_url = str(url.update_query(model=model))
+        if url.host != "api.openai.com":
+            # OpenAI's native endpoint takes the model in the response.create
+            # payload; gateways need it on the upgrade URL to route the
+            # connection before the first frame.
+            url = url.update_query(model=model)
+        self._base_url = str(url)
 
         self._session: aiohttp.ClientSession | None = None
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -6,10 +6,10 @@ import os
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from typing import Any, Literal, cast
-from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import aiohttp
 import httpx
+from yarl import URL
 
 import openai
 from livekit.agents import APIConnectionError, APIStatusError, APITimeoutError, llm, utils
@@ -58,19 +58,8 @@ class _ResponsesWebsocket:
     ) -> None:
         self._api_key = api_key
         self._timeout = timeout or DEFAULT_API_CONNECT_OPTIONS.timeout
-        url = urlparse(base_url if base_url else OPENAI_RESPONSES_WS_URL)
-        query_params = parse_qs(url.query)
-        query_params["model"] = [model]
-        self._base_url = urlunparse(
-            (
-                url.scheme,
-                url.netloc,
-                url.path,
-                url.params,
-                urlencode(query_params, doseq=True),
-                url.fragment,
-            )
-        )
+        url = URL(base_url if base_url else OPENAI_RESPONSES_WS_URL)
+        self._base_url = str(url.update_query(model=model))
 
         self._session: aiohttp.ClientSession | None = None
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -59,6 +59,8 @@ class _ResponsesWebsocket:
         self._api_key = api_key
         self._timeout = timeout or DEFAULT_API_CONNECT_OPTIONS.timeout
         url = URL(base_url if base_url else OPENAI_RESPONSES_WS_URL)
+        if url.scheme in ("http", "https"):
+            url = url.with_scheme("ws" if url.scheme == "http" else "wss")
         if url.host != "api.openai.com":
             # OpenAI's native endpoint takes the model in the response.create
             # payload; gateways need it on the upgrade URL to route the

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -416,6 +416,11 @@ class STT(stt.STT):
         query_params: dict[str, str] = {
             "intent": "transcription",
         }
+        # OpenAI's native realtime endpoint treats ?model= as selecting a
+        # conversation session and rejects the transcription-mode
+        # session.update with invalid_model — the model is conveyed via
+        # audio.input.transcription.model instead. Gateways need the model
+        # on the upgrade URL to route the connection before the first frame.
         if urlparse(str(self._client.base_url)).hostname != "api.openai.com":
             query_params["model"] = self._opts.model
         headers = {

--- a/tests/test_plugin_openai_websocket_urls.py
+++ b/tests/test_plugin_openai_websocket_urls.py
@@ -75,3 +75,18 @@ async def test_responses_websocket_connect_url_includes_model() -> None:
     assert parsed_url.netloc == "gateway.example.com"
     assert parsed_url.path == "/v1/responses"
     assert parse_qs(parsed_url.query) == {"model": [model]}
+
+
+async def test_native_responses_websocket_connect_url_omits_model() -> None:
+    instance = responses.LLM(api_key="test-key", model="gpt-4.1", use_websocket=True)
+    assert instance._ws is not None
+    session = _FakeSession()
+    instance._ws._session = session
+
+    await instance._ws._create_ws(5)
+
+    parsed_url = urlparse(session.url)
+    assert parsed_url.scheme == "wss"
+    assert parsed_url.netloc == "api.openai.com"
+    assert parsed_url.path == "/v1/responses"
+    assert parse_qs(parsed_url.query) == {}

--- a/tests/test_plugin_openai_websocket_urls.py
+++ b/tests/test_plugin_openai_websocket_urls.py
@@ -77,6 +77,27 @@ async def test_responses_websocket_connect_url_includes_model() -> None:
     assert parse_qs(parsed_url.query) == {"model": [model]}
 
 
+async def test_responses_websocket_connect_url_converts_http_scheme() -> None:
+    model = "gateway-responses"
+    instance = responses.LLM(
+        api_key="test-key",
+        base_url="https://gateway.example.com/v1/responses",
+        model=model,
+        use_websocket=True,
+    )
+    assert instance._ws is not None
+    session = _FakeSession()
+    instance._ws._session = session
+
+    await instance._ws._create_ws(5)
+
+    parsed_url = urlparse(session.url)
+    assert parsed_url.scheme == "wss"
+    assert parsed_url.netloc == "gateway.example.com"
+    assert parsed_url.path == "/v1/responses"
+    assert parse_qs(parsed_url.query) == {"model": [model]}
+
+
 async def test_native_responses_websocket_connect_url_omits_model() -> None:
     instance = responses.LLM(api_key="test-key", model="gpt-4.1", use_websocket=True)
     assert instance._ws is not None


### PR DESCRIPTION
## Summary

Follow-ups to #6403, targeting its branch. Aligns the WebSocket URL handling with OpenAI's documented behavior, the openai-python SDK, and agents-js:

- **refactor:** build the Responses WS URL with `yarl.URL.update_query` instead of the `urlparse`/`parse_qs`/`urlencode`/`urlunparse` round-trip (still preserves query params on a user-supplied `base_url`, without re-encoding them)
- **fix:** omit `?model=` on the native `wss://api.openai.com/v1/responses` URL — [WebSocket mode docs](https://developers.openai.com/api/docs/guides/websocket-mode) specify a bare connection URL with the model in the `response.create` payload (which this client already sends); keep the param only for non-openai.com hosts so gateways can route the upgrade. Mirrors the realtime STT gating and agents-js
- **fix:** convert `http(s)` → `ws(s)` schemes on the Responses WS `base_url`, matching the realtime STT path and openai-python's `_prepare_url`
- **docs:** port the agents-js rationale comment for the STT hostname gate (OpenAI's realtime endpoint treats `?model=` as selecting a conversation session and rejects the transcription-mode `session.update`)

## Test plan

- [x] `uv run pytest tests/test_plugin_openai_websocket_urls.py --unit` (5 passed; adds native-endpoint and https-scheme cases)
- [x] `uv run ruff check` / `ruff format --check` on the touched files