### PR TITLE
feat(openai): add LLM.with_crusoe for Crusoe Managed Inference

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -20,8 +20,10 @@ from typing import Any, Literal
 from urllib.parse import urlparse
 
 import httpx
-
 import openai
+from openai.types import ReasoningEffort
+from openai.types.chat import ChatCompletionToolChoiceOptionParam, completion_create_params
+
 from livekit.agents import llm
 from livekit.agents.inference.llm import LLMStream as _LLMStream
 from livekit.agents.llm import (
@@ -36,15 +38,13 @@ from livekit.agents.types import (
     NotGivenOr,
 )
 from livekit.agents.utils import is_given
-from openai.types import ReasoningEffort
-from openai.types.chat import ChatCompletionToolChoiceOptionParam, completion_create_params
 
 from .models import (
     CerebrasChatModels,
     ChatModels,
     CometAPIChatModels,
-    DeepSeekChatModels,
     CrusoeChatModels,
+    DeepSeekChatModels,
     NebiusChatModels,
     OctoChatModels,
     OpenRouterProviderPreferences,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -44,6 +44,7 @@ from .models import (
     ChatModels,
     CometAPIChatModels,
     DeepSeekChatModels,
+    CrusoeChatModels,
     NebiusChatModels,
     OctoChatModels,
     OpenRouterProviderPreferences,
@@ -878,6 +879,50 @@ class LLM(llm.LLM):
         if api_key is None:
             raise ValueError(
                 "Nebius API key is required, either as argument or set NEBIUS_API_KEY environmental variable"  # noqa: E501
+            )
+
+        return LLM(
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            client=client,
+            user=user,
+            temperature=temperature,
+            parallel_tool_calls=parallel_tool_calls,
+            tool_choice=tool_choice,
+            reasoning_effort=reasoning_effort,
+            safety_identifier=safety_identifier,
+            prompt_cache_key=prompt_cache_key,
+            top_p=top_p,
+        )
+
+    @staticmethod
+    def with_crusoe(
+        *,
+        model: str | CrusoeChatModels = "zai/GLM-5.2",
+        api_key: str | None = None,
+        base_url: str = "https://api.inference.crusoecloud.com/v1/",
+        client: openai.AsyncClient | None = None,
+        user: NotGivenOr[str] = NOT_GIVEN,
+        temperature: NotGivenOr[float] = NOT_GIVEN,
+        parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
+        tool_choice: ToolChoice = "auto",
+        reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
+        safety_identifier: NotGivenOr[str] = NOT_GIVEN,
+        prompt_cache_key: NotGivenOr[str] = NOT_GIVEN,
+        top_p: NotGivenOr[float] = NOT_GIVEN,
+    ) -> LLM:
+        """
+        Create a new instance of Crusoe LLM.
+
+        ``api_key`` must be set to your Crusoe API key, either using the argument or by setting
+        the ``CRUSOE_API_KEY`` environmental variable.
+        """
+
+        api_key = api_key or os.environ.get("CRUSOE_API_KEY")
+        if api_key is None:
+            raise ValueError(
+                "Crusoe API key is required, either as argument or set CRUSOE_API_KEY environmental variable"  # noqa: E501
             )
 
         return LLM(

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -20,10 +20,8 @@ from typing import Any, Literal
 from urllib.parse import urlparse
 
 import httpx
-import openai
-from openai.types import ReasoningEffort
-from openai.types.chat import ChatCompletionToolChoiceOptionParam, completion_create_params
 
+import openai
 from livekit.agents import llm
 from livekit.agents.inference.llm import LLMStream as _LLMStream
 from livekit.agents.llm import (
@@ -38,6 +36,8 @@ from livekit.agents.types import (
     NotGivenOr,
 )
 from livekit.agents.utils import is_given
+from openai.types import ReasoningEffort
+from openai.types.chat import ChatCompletionToolChoiceOptionParam, completion_create_params
 
 from .models import (
     CerebrasChatModels,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -107,6 +107,23 @@ NebiusChatModels = Literal[
     "google/gemma-2-2b-it",
 ]
 
+CrusoeChatModels = Literal[
+    "zai/GLM-5.2",
+    "zai/GLM-5.1",
+    "nvidia/Nemotron-3-Nano-30B-A3B",
+    "nvidia/Nemotron-3-Nano-Omni-Reasoning-30B-A3B",
+    "nvidia/Nemotron-3-Super-120B-A12B",
+    "nvidia/Nemotron-3-Ultra-550B",
+    "google/gemma-4-31b-it",
+    "meta-llama/Llama-3.3-70B-Instruct",
+    "deepseek-ai/DeepSeek-V3-0324",
+    "deepseek-ai/DeepSeek-V4-Flash",
+    "deepseek-ai/DeepSeek-V4-Pro",
+    "openai/gpt-oss-120b",
+    "qwen/Qwen3-235B-A22B",
+    "moonshotai/Kimi-K2.6",
+]
+
 CerebrasChatModels = Literal[
     "llama3.1-8b",
     "llama-3.3-70b",


### PR DESCRIPTION
Adds `LLM.with_crusoe()` to the OpenAI plugin, following the same pattern as `with_nebius` / `with_cerebras`.

[Crusoe Managed Inference](https://docs.crusoecloud.com/managed-inference/overview) is OpenAI-API compatible: endpoint `https://api.inference.crusoecloud.com/v1/`, auth via `CRUSOE_API_KEY`.

- `llm.py` — `with_crusoe()` static method (default model `zai/GLM-5.2`)
- `models.py` — `CrusoeChatModels` literal with the current catalog (GLM 5.x, NVIDIA Nemotron 3 family, Gemma 4, Llama 3.3, DeepSeek V3/V4, GPT-OSS, Qwen3, Kimi K2.6)

I maintain Crusoe's ecosystem integrations (LiteLLM: BerriAI/litellm#23195, SGLang: sgl-project/sglang#20475).
