### PR TITLE
feat(voice): opt-in audio fade-out on interruption (#6165)

### DIFF
--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+from collections import deque
+from collections.abc import Sequence
 
+import numpy as np
 from google.protobuf.json_format import MessageToDict
 
 from livekit import rtc
@@ -29,6 +32,53 @@ from ...types import (
 from .. import io
 from ..transcription import find_micro_track_id
 
+# extra audio kept in the fade history beyond the audio source queue size,
+# to absorb timing jitter between `queued_duration` and the frames we recorded
+_FADE_HISTORY_MARGIN: float = 0.1
+
+
+def _build_fade_out_frame(
+    history: Sequence[rtc.AudioFrame],
+    *,
+    unplayed_duration: float,
+    fade_out_duration: float,
+    sample_rate: int,
+    num_channels: int,
+) -> rtc.AudioFrame | None:
+    """Build a short faded tail to play right after an interruption.
+
+    ``history`` contains the frames already handed to the audio source (oldest first),
+    ``unplayed_duration`` is how much of it was still sitting in the source queue when
+    the interruption happened. The playback position is therefore at
+    ``end_of_history - unplayed_duration``; a linear gain ramp (1 -> 0) is applied to
+    the next ``fade_out_duration`` seconds from that position.
+    """
+    if fade_out_duration <= 0 or unplayed_duration <= 0 or not history:
+        return None
+
+    samples = np.concatenate([np.frombuffer(f.data, dtype=np.int16) for f in history])
+    total_samples = len(samples) // num_channels
+    unplayed_samples = min(int(unplayed_duration * sample_rate), total_samples)
+    fade_samples = min(int(fade_out_duration * sample_rate), unplayed_samples)
+    if fade_samples <= 0:
+        return None
+
+    start = total_samples - unplayed_samples
+    segment = samples[start * num_channels : (start + fade_samples) * num_channels].astype(
+        np.float32
+    )
+    gain = np.linspace(1.0, 0.0, num=fade_samples, endpoint=False, dtype=np.float32)
+    if num_channels > 1:
+        gain = np.repeat(gain, num_channels)
+    segment *= gain
+
+    return rtc.AudioFrame(
+        data=segment.astype(np.int16).tobytes(),
+        sample_rate=sample_rate,
+        num_channels=num_channels,
+        samples_per_channel=fade_samples,
+    )
+
 
 class _ParticipantAudioOutput(io.AudioOutput):
     def __init__(
@@ -39,6 +89,7 @@ class _ParticipantAudioOutput(io.AudioOutput):
         num_channels: int,
         track_publish_options: rtc.TrackPublishOptions,
         track_name: str = "roomio_audio",
+        fade_out_on_interruption: float = 0.0,
     ) -> None:
         super().__init__(
             label="RoomIO",
@@ -49,7 +100,19 @@ class _ParticipantAudioOutput(io.AudioOutput):
         self._room = room
         self._track_name = track_name
         self._lock = asyncio.Lock()
-        self._audio_source = rtc.AudioSource(sample_rate, num_channels, queue_size_ms=200)
+        queue_size_ms = 200
+        self._audio_source = rtc.AudioSource(sample_rate, num_channels, queue_size_ms=queue_size_ms)
+        self._source_sample_rate = sample_rate
+        self._num_channels = num_channels
+
+        self._fade_out_duration = fade_out_on_interruption
+        # rolling history of frames pushed to the audio source, used to rebuild
+        # the faded tail on interruption (see _build_fade_out_frame)
+        self._fade_history: deque[rtc.AudioFrame] = deque()
+        self._fade_history_duration: float = 0.0
+        self._fade_history_max_duration = (
+            queue_size_ms / 1000 + self._fade_out_duration + _FADE_HISTORY_MARGIN
+        )
         self._publish_options = track_publish_options
         self._publication: rtc.LocalTrackPublication | None = None
         self._subscribed_fut = asyncio.Future[None]()
@@ -164,15 +227,30 @@ class _ParticipantAudioOutput(io.AudioOutput):
         pushed_duration = self._pushed_duration
 
         if interrupted:
-            queued_duration = self._audio_source.queued_duration
+            source_queued_duration = self._audio_source.queued_duration
+            queued_duration = source_queued_duration
             while not self._audio_buf.empty():
                 queued_duration += self._audio_buf.recv_nowait().duration
 
             pushed_duration = max(pushed_duration - queued_duration, 0)
             self._audio_source.clear_queue()
             wait_for_playout.cancel()
+
+            if self._fade_out_duration > 0:
+                fade_frame = _build_fade_out_frame(
+                    self._fade_history,
+                    unplayed_duration=source_queued_duration,
+                    fade_out_duration=self._fade_out_duration,
+                    sample_rate=self._source_sample_rate,
+                    num_channels=self._num_channels,
+                )
+                if fade_frame is not None:
+                    await self._audio_source.capture_frame(fade_frame)
         else:
             wait_for_interruption.cancel()
+
+        self._fade_history.clear()
+        self._fade_history_duration = 0.0
 
         self._pushed_duration = 0
         self._interrupted_event.clear()
@@ -197,6 +275,17 @@ class _ParticipantAudioOutput(io.AudioOutput):
             if not self._first_frame_event.is_set():
                 self._first_frame_event.set()
                 self.on_playback_started(created_at=time.time())
+
+            if self._fade_out_duration > 0:
+                self._fade_history.append(frame)
+                self._fade_history_duration += frame.duration
+                while (
+                    self._fade_history
+                    and self._fade_history_duration - self._fade_history[0].duration
+                    >= self._fade_history_max_duration
+                ):
+                    self._fade_history_duration -= self._fade_history.popleft().duration
+
             await self._audio_source.capture_frame(frame)
 
 

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -110,6 +110,11 @@ class _ParticipantAudioOutput(io.AudioOutput):
         # the faded tail on interruption (see _build_fade_out_frame)
         self._fade_history: deque[rtc.AudioFrame] = deque()
         self._fade_history_duration: float = 0.0
+        # when the last pushed fade tail will have drained from the audio source.
+        # The tail bypasses _forward_audio, so _source_pushed_duration never counts
+        # it; queued_duration reads must exclude whatever is left of it or the next
+        # segment's playback position is under-reported by up to the fade duration.
+        self._fade_tail_until: float = 0.0
         self._fade_history_max_duration = (
             queue_size_ms / 1000 + self._fade_out_duration + _FADE_HISTORY_MARGIN
         )
@@ -237,39 +242,59 @@ class _ParticipantAudioOutput(io.AudioOutput):
             0,
         )
 
-        if interrupted:
-            self._interruption_generation += 1
-            source_queued_duration = self._audio_source.queued_duration
-            queued_duration = source_queued_duration
-            while not self._audio_buf.empty():
-                self._audio_buf.recv_nowait()
-
-            pushed_duration = max(pushed_duration - queued_duration, 0)
-            self._audio_source.clear_queue()
-            wait_for_playout.cancel()
-
-            if self._fade_out_duration > 0:
-                fade_frame = _build_fade_out_frame(
-                    self._fade_history,
-                    unplayed_duration=source_queued_duration,
-                    fade_out_duration=self._fade_out_duration,
-                    sample_rate=self._source_sample_rate,
-                    num_channels=self._num_channels,
+        try:
+            if interrupted:
+                self._interruption_generation += 1
+                # exclude the previous segment's fade tail still draining in the
+                # source: it was pushed directly (bypassing _forward_audio), so it
+                # is counted in neither _source_pushed_duration nor _fade_history
+                fade_residual = max(self._fade_tail_until - time.time(), 0.0)
+                source_queued_duration = max(
+                    self._audio_source.queued_duration - fade_residual, 0.0
                 )
-                if fade_frame is not None:
-                    await self._audio_source.capture_frame(fade_frame)
-        else:
-            wait_for_interruption.cancel()
+                queued_duration = source_queued_duration
+                while not self._audio_buf.empty():
+                    self._audio_buf.recv_nowait()
 
-        self._fade_history.clear()
-        self._fade_history_duration = 0.0
+                pushed_duration = max(pushed_duration - queued_duration, 0)
+                self._audio_source.clear_queue()
+                self._fade_tail_until = 0.0
+                wait_for_playout.cancel()
 
-        self._pushed_duration = 0
-        self._source_pushed_duration = 0
-        self._source_discarded_duration = 0
-        self._interrupted_event.clear()
-        self._first_frame_event.clear()
-        self.on_playback_finished(playback_position=pushed_duration, interrupted=interrupted)
+                if self._fade_out_duration > 0:
+                    fade_frame = _build_fade_out_frame(
+                        self._fade_history,
+                        unplayed_duration=source_queued_duration,
+                        fade_out_duration=self._fade_out_duration,
+                        sample_rate=self._source_sample_rate,
+                        num_channels=self._num_channels,
+                    )
+                    if fade_frame is not None:
+                        self._fade_tail_until = time.time() + fade_frame.duration
+                        # a cancellation on this await (overlapping flush() or
+                        # aclose()) must not skip the reset + finish notification
+                        # in the finally block: _forward_audio keeps discarding
+                        # frames until _interrupted_event is cleared, and the
+                        # speech handle waits on on_playback_finished
+                        try:
+                            await self._audio_source.capture_frame(fade_frame)
+                        except asyncio.CancelledError:
+                            # unknown whether the tail landed in the source;
+                            # don't let a stale deadline shave the next segment
+                            self._fade_tail_until = 0.0
+                            raise
+            else:
+                wait_for_interruption.cancel()
+        finally:
+            self._fade_history.clear()
+            self._fade_history_duration = 0.0
+
+            self._pushed_duration = 0
+            self._source_pushed_duration = 0
+            self._source_discarded_duration = 0
+            self._interrupted_event.clear()
+            self._first_frame_event.clear()
+            self.on_playback_finished(playback_position=pushed_duration, interrupted=interrupted)
 
     async def _forward_audio(self) -> None:
         async for frame in self._audio_buf:
@@ -277,8 +302,15 @@ class _ParticipantAudioOutput(io.AudioOutput):
             self._forwarding_idle.clear()
             try:
                 if not self._playback_enabled.is_set():
-                    self._source_discarded_duration += self._audio_source.queued_duration
+                    # the leftover fade tail in the queue belongs to the previous
+                    # segment and was never counted as pushed; discarding it must
+                    # not shorten this segment's playback position
+                    fade_residual = max(self._fade_tail_until - time.time(), 0.0)
+                    self._source_discarded_duration += max(
+                        self._audio_source.queued_duration - fade_residual, 0.0
+                    )
                     self._audio_source.clear_queue()
+                    self._fade_tail_until = 0.0
                     # discarded queue is no longer in the source; drop fade history
                     # so a later interrupt cannot rebuild a tail from stale frames
                     self._fade_history.clear()

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+from collections import deque
+from collections.abc import Sequence
 
+import numpy as np
 from google.protobuf.json_format import MessageToDict
 
 from livekit import rtc
@@ -29,6 +32,53 @@ from ...types import (
 from .. import io
 from ..transcription import find_micro_track_id
 
+# extra audio kept in the fade history beyond the audio source queue size,
+# to absorb timing jitter between `queued_duration` and the frames we recorded
+_FADE_HISTORY_MARGIN: float = 0.1
+
+
+def _build_fade_out_frame(
+    history: Sequence[rtc.AudioFrame],
+    *,
+    unplayed_duration: float,
+    fade_out_duration: float,
+    sample_rate: int,
+    num_channels: int,
+) -> rtc.AudioFrame | None:
+    """Build a short faded tail to play right after an interruption.
+
+    ``history`` contains the frames already handed to the audio source (oldest first),
+    ``unplayed_duration`` is how much of it was still sitting in the source queue when
+    the interruption happened. The playback position is therefore at
+    ``end_of_history - unplayed_duration``; a linear gain ramp (1 -> 0) is applied to
+    the next ``fade_out_duration`` seconds from that position.
+    """
+    if fade_out_duration <= 0 or unplayed_duration <= 0 or not history:
+        return None
+
+    samples = np.concatenate([np.frombuffer(f.data, dtype=np.int16) for f in history])
+    total_samples = len(samples) // num_channels
+    unplayed_samples = min(int(unplayed_duration * sample_rate), total_samples)
+    fade_samples = min(int(fade_out_duration * sample_rate), unplayed_samples)
+    if fade_samples <= 0:
+        return None
+
+    start = total_samples - unplayed_samples
+    segment = samples[start * num_channels : (start + fade_samples) * num_channels].astype(
+        np.float32
+    )
+    gain = np.linspace(1.0, 0.0, num=fade_samples, endpoint=False, dtype=np.float32)
+    if num_channels > 1:
+        gain = np.repeat(gain, num_channels)
+    segment *= gain
+
+    return rtc.AudioFrame(
+        data=segment.astype(np.int16).tobytes(),
+        sample_rate=sample_rate,
+        num_channels=num_channels,
+        samples_per_channel=fade_samples,
+    )
+
 
 class _ParticipantAudioOutput(io.AudioOutput):
     def __init__(
@@ -39,6 +89,7 @@ class _ParticipantAudioOutput(io.AudioOutput):
         num_channels: int,
         track_publish_options: rtc.TrackPublishOptions,
         track_name: str = "roomio_audio",
+        fade_out_on_interruption: float = 0.0,
     ) -> None:
         super().__init__(
             label="RoomIO",
@@ -49,7 +100,19 @@ class _ParticipantAudioOutput(io.AudioOutput):
         self._room = room
         self._track_name = track_name
         self._lock = asyncio.Lock()
-        self._audio_source = rtc.AudioSource(sample_rate, num_channels, queue_size_ms=200)
+        queue_size_ms = 200
+        self._audio_source = rtc.AudioSource(sample_rate, num_channels, queue_size_ms=queue_size_ms)
+        self._source_sample_rate = sample_rate
+        self._num_channels = num_channels
+
+        self._fade_out_duration = fade_out_on_interruption
+        # rolling history of frames pushed to the audio source, used to rebuild
+        # the faded tail on interruption (see _build_fade_out_frame)
+        self._fade_history: deque[rtc.AudioFrame] = deque()
+        self._fade_history_duration: float = 0.0
+        self._fade_history_max_duration = (
+            queue_size_ms / 1000 + self._fade_out_duration + _FADE_HISTORY_MARGIN
+        )
         self._publish_options = track_publish_options
         self._publication: rtc.LocalTrackPublication | None = None
         self._subscribed_fut = asyncio.Future[None]()
@@ -176,15 +239,30 @@ class _ParticipantAudioOutput(io.AudioOutput):
 
         if interrupted:
             self._interruption_generation += 1
-            queued_duration = self._audio_source.queued_duration
+            source_queued_duration = self._audio_source.queued_duration
+            queued_duration = source_queued_duration
             while not self._audio_buf.empty():
                 self._audio_buf.recv_nowait()
 
             pushed_duration = max(pushed_duration - queued_duration, 0)
             self._audio_source.clear_queue()
             wait_for_playout.cancel()
+
+            if self._fade_out_duration > 0:
+                fade_frame = _build_fade_out_frame(
+                    self._fade_history,
+                    unplayed_duration=source_queued_duration,
+                    fade_out_duration=self._fade_out_duration,
+                    sample_rate=self._source_sample_rate,
+                    num_channels=self._num_channels,
+                )
+                if fade_frame is not None:
+                    await self._audio_source.capture_frame(fade_frame)
         else:
             wait_for_interruption.cancel()
+
+        self._fade_history.clear()
+        self._fade_history_duration = 0.0
 
         self._pushed_duration = 0
         self._source_pushed_duration = 0
@@ -201,6 +279,10 @@ class _ParticipantAudioOutput(io.AudioOutput):
                 if not self._playback_enabled.is_set():
                     self._source_discarded_duration += self._audio_source.queued_duration
                     self._audio_source.clear_queue()
+                    # discarded queue is no longer in the source; drop fade history
+                    # so a later interrupt cannot rebuild a tail from stale frames
+                    self._fade_history.clear()
+                    self._fade_history_duration = 0.0
                     await self._playback_enabled.wait()
                     # drop a paused frame when its original segment was interrupted.
                     if interruption_generation != self._interruption_generation:
@@ -220,6 +302,15 @@ class _ParticipantAudioOutput(io.AudioOutput):
                     self._first_frame_event.set()
                     self.on_playback_started(created_at=time.time())
                 self._source_pushed_duration += frame.duration
+                if self._fade_out_duration > 0:
+                    self._fade_history.append(frame)
+                    self._fade_history_duration += frame.duration
+                    while (
+                        self._fade_history
+                        and self._fade_history_duration - self._fade_history[0].duration
+                        >= self._fade_history_max_duration
+                    ):
+                        self._fade_history_duration -= self._fade_history.popleft().duration
                 await self._audio_source.capture_frame(frame)
             finally:
                 self._forwarding_idle.set()

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -138,6 +138,7 @@ class RoomIO:
                     if utils.is_given(output_audio_options.track_name)
                     else "roomio_audio"
                 ),
+                fade_out_on_interruption=output_audio_options.fade_out_on_interruption,
             )
 
         output_text_options = self._options.get_text_output_options()

--- a/livekit-agents/livekit/agents/voice/room_io/types.py
+++ b/livekit-agents/livekit/agents/voice/room_io/types.py
@@ -88,6 +88,11 @@ class AudioOutputOptions:
     )
     track_name: NotGivenOr[str] = NOT_GIVEN
     """The name of the audio track to publish. If not provided, default to "roomio_audio"."""
+    fade_out_on_interruption: float = 0.0
+    """Duration in seconds of a linear fade-out applied to the agent's audio when it is
+    interrupted, instead of cutting playback abruptly. Set to 0 to disable (default).
+    A value between 0.05 and 0.1 is recommended. This adds no playback latency: the
+    faded tail is rebuilt from already-generated audio at the current playback position."""
 
 
 @dataclass

--- a/tests/test_interruption_fade_out.py
+++ b/tests/test_interruption_fade_out.py
@@ -1,0 +1,146 @@
+"""Unit tests for the interruption fade-out frame builder.
+
+``_build_fade_out_frame`` rebuilds a short faded tail from the rolling history of
+frames already handed to the ``rtc.AudioSource``: on interruption the playback
+position is ``end_of_history - unplayed_duration``, and a linear gain ramp
+(1 -> 0) is applied to the next ``fade_out_duration`` seconds from that position.
+
+These tests are hermetic — they exercise the pure builder only, no room or
+audio source involved.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from livekit import rtc
+from livekit.agents.voice.room_io._output import _build_fade_out_frame
+
+pytestmark = pytest.mark.unit
+
+SAMPLE_RATE = 24000
+
+
+def _make_frame(value: int, duration: float, *, num_channels: int = 1) -> rtc.AudioFrame:
+    samples = int(duration * SAMPLE_RATE)
+    data = np.full(samples * num_channels, value, dtype=np.int16)
+    return rtc.AudioFrame(
+        data=data.tobytes(),
+        sample_rate=SAMPLE_RATE,
+        num_channels=num_channels,
+        samples_per_channel=samples,
+    )
+
+
+def _frame_samples(frame: rtc.AudioFrame) -> np.ndarray:
+    return np.frombuffer(frame.data, dtype=np.int16)
+
+
+def test_linear_ramp_from_playback_position() -> None:
+    # 500ms of history, 200ms unplayed, 80ms fade
+    history = [_make_frame(10000, 0.05) for _ in range(10)]
+    frame = _build_fade_out_frame(
+        history,
+        unplayed_duration=0.2,
+        fade_out_duration=0.08,
+        sample_rate=SAMPLE_RATE,
+        num_channels=1,
+    )
+
+    assert frame is not None
+    expected_samples = int(0.08 * SAMPLE_RATE)
+    assert frame.samples_per_channel == expected_samples
+
+    samples = _frame_samples(frame)
+    # ramp starts at full gain and decays monotonically to (near) zero
+    assert samples[0] == 10000
+    assert samples[-1] <= 10000 * (1 / expected_samples) + 1
+    assert np.all(np.diff(samples) <= 0)
+
+
+def test_fade_sourced_from_correct_offset() -> None:
+    # history: 100ms of "1000" followed by 100ms of "2000"; the unplayed part is
+    # exactly the second half, so the fade must be built from the "2000" segment
+    history = [_make_frame(1000, 0.1), _make_frame(2000, 0.1)]
+    frame = _build_fade_out_frame(
+        history,
+        unplayed_duration=0.1,
+        fade_out_duration=0.05,
+        sample_rate=SAMPLE_RATE,
+        num_channels=1,
+    )
+
+    assert frame is not None
+    samples = _frame_samples(frame)
+    gain = np.linspace(1.0, 0.0, num=len(samples), endpoint=False)
+    np.testing.assert_allclose(samples, (2000 * gain).astype(np.int16), atol=1)
+
+
+def test_fade_clamped_to_unplayed_duration() -> None:
+    # only 30ms left unplayed: the fade cannot resurrect more audio than that
+    history = [_make_frame(10000, 0.05) for _ in range(4)]
+    frame = _build_fade_out_frame(
+        history,
+        unplayed_duration=0.03,
+        fade_out_duration=0.08,
+        sample_rate=SAMPLE_RATE,
+        num_channels=1,
+    )
+
+    assert frame is not None
+    assert frame.samples_per_channel == int(0.03 * SAMPLE_RATE)
+
+
+def test_unplayed_longer_than_history_is_clamped() -> None:
+    # queued_duration may slightly exceed the recorded history; clamp instead of failing
+    history = [_make_frame(10000, 0.05)]
+    frame = _build_fade_out_frame(
+        history,
+        unplayed_duration=1.0,
+        fade_out_duration=0.08,
+        sample_rate=SAMPLE_RATE,
+        num_channels=1,
+    )
+
+    assert frame is not None
+    assert frame.samples_per_channel <= int(0.05 * SAMPLE_RATE)
+
+
+def test_stereo_gain_applied_per_sample_frame() -> None:
+    history = [_make_frame(10000, 0.1, num_channels=2)]
+    frame = _build_fade_out_frame(
+        history,
+        unplayed_duration=0.1,
+        fade_out_duration=0.05,
+        sample_rate=SAMPLE_RATE,
+        num_channels=2,
+    )
+
+    assert frame is not None
+    assert frame.samples_per_channel == int(0.05 * SAMPLE_RATE)
+    samples = _frame_samples(frame).reshape(-1, 2)
+    # both channels must carry the identical ramp
+    np.testing.assert_array_equal(samples[:, 0], samples[:, 1])
+    assert samples[0, 0] == 10000
+    assert np.all(np.diff(samples[:, 0]) <= 0)
+
+
+@pytest.mark.parametrize(
+    ("unplayed", "fade", "history_frames"),
+    [
+        (0.0, 0.08, 4),  # everything already played out
+        (0.2, 0.0, 4),  # fade disabled
+        (0.2, 0.08, 0),  # no history recorded
+    ],
+)
+def test_no_frame_when_nothing_to_fade(unplayed: float, fade: float, history_frames: int) -> None:
+    history = [_make_frame(10000, 0.05) for _ in range(history_frames)]
+    frame = _build_fade_out_frame(
+        history,
+        unplayed_duration=unplayed,
+        fade_out_duration=fade,
+        sample_rate=SAMPLE_RATE,
+        num_channels=1,
+    )
+    assert frame is None

--- a/tests/test_interruption_fade_out.py
+++ b/tests/test_interruption_fade_out.py
@@ -5,17 +5,27 @@ frames already handed to the ``rtc.AudioSource``: on interruption the playback
 position is ``end_of_history - unplayed_duration``, and a linear gain ramp
 (1 -> 0) is applied to the next ``fade_out_duration`` seconds from that position.
 
-These tests are hermetic — they exercise the pure builder only, no room or
-audio source involved.
+These tests are hermetic — the builder tests exercise the pure function, and the
+playout tests drive ``_ParticipantAudioOutput`` against a fake audio source; no
+room involved.
 """
 
 from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 
 from livekit import rtc
-from livekit.agents.voice.room_io._output import _build_fade_out_frame
+from livekit.agents import utils
+from livekit.agents.voice.room_io._output import (
+    _build_fade_out_frame,
+    _ParticipantAudioOutput,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -144,3 +154,136 @@ def test_no_frame_when_nothing_to_fade(unplayed: float, fade: float, history_fra
         num_channels=1,
     )
     assert frame is None
+
+
+class _FakeAudioSource:
+    """Stand-in for rtc.AudioSource: records captures, supports a held capture."""
+
+    def __init__(self) -> None:
+        self.queued_duration: float = 0.0
+        self.captured: list[rtc.AudioFrame] = []
+        self.clear_queue_calls = 0
+        self.hold_capture: asyncio.Event | None = None
+        self.capture_reached = asyncio.Event()
+
+    def clear_queue(self) -> None:
+        self.clear_queue_calls += 1
+        self.queued_duration = 0.0
+
+    async def capture_frame(self, frame: rtc.AudioFrame) -> None:
+        self.capture_reached.set()
+        if self.hold_capture is not None:
+            await self.hold_capture.wait()
+        self.captured.append(frame)
+        self.queued_duration += frame.duration
+
+    async def wait_for_playout(self) -> None:
+        return
+
+
+def _make_output(
+    fade_out_duration: float,
+) -> tuple[_ParticipantAudioOutput, _FakeAudioSource, MagicMock]:
+    out = _ParticipantAudioOutput.__new__(_ParticipantAudioOutput)
+    src = _FakeAudioSource()
+    out._audio_source = src  # type: ignore[assignment]
+    out._source_sample_rate = SAMPLE_RATE
+    out._num_channels = 1
+    out._fade_out_duration = fade_out_duration
+    out._fade_history = deque()
+    out._fade_history_duration = 0.0
+    out._fade_history_max_duration = 0.2 + fade_out_duration + 0.1
+    out._fade_tail_until = 0.0
+    out._audio_buf = utils.aio.Chan()
+    out._flush_task = None
+    out._interrupted_event = asyncio.Event()
+    out._forwarding_task = None
+    out._pushed_duration = 0.0
+    out._source_pushed_duration = 0.0
+    out._source_discarded_duration = 0.0
+    out._interruption_generation = 0
+    out._playback_enabled = asyncio.Event()
+    out._playback_enabled.set()
+    out._forwarding_idle = asyncio.Event()
+    out._forwarding_idle.set()
+    out._first_frame_event = asyncio.Event()
+    finished = MagicMock()
+    out.on_playback_finished = finished  # type: ignore[method-assign]
+    out.on_playback_started = MagicMock()  # type: ignore[method-assign]
+    return out, src, finished
+
+
+@pytest.mark.asyncio
+async def test_cancelled_fade_push_still_finishes_playout() -> None:
+    """A cancellation landing on the fade capture (overlapping flush()/aclose())
+    must not skip the state reset and on_playback_finished: _forward_audio keeps
+    discarding frames while _interrupted_event stays set, and the speech handle
+    waits on the finish notification."""
+    out, src, finished = _make_output(0.5)
+    out._fade_history.extend(_make_frame(1000, 0.1) for _ in range(10))
+    out._fade_history_duration = 1.0
+    out._pushed_duration = 2.0
+    out._source_pushed_duration = 2.0
+    src.queued_duration = 0.3
+    src.hold_capture = asyncio.Event()  # never set: capture blocks like a full source
+
+    out._interrupted_event.set()
+    task = asyncio.create_task(out._wait_for_playout())
+    await asyncio.wait_for(src.capture_reached.wait(), timeout=1.0)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    finished.assert_called_once()
+    kwargs = finished.call_args.kwargs
+    assert kwargs["interrupted"] is True
+    assert kwargs["playback_position"] == pytest.approx(1.7)
+    assert not out._interrupted_event.is_set()
+    # unknown whether the tail landed; the deadline must not shave the next segment
+    assert out._fade_tail_until == 0.0
+
+
+@pytest.mark.asyncio
+async def test_leftover_fade_tail_excluded_from_playback_position() -> None:
+    """A previous segment's fade tail still draining in the source was never
+    counted as pushed; subtracting it with the queued audio would under-report
+    this segment's playback position by up to the fade duration."""
+    out, src, finished = _make_output(0.5)  # fade enabled, but empty history -> no new tail
+    out._pushed_duration = 2.0
+    out._source_pushed_duration = 2.0
+    src.queued_duration = 0.7  # 0.3s of this segment + 0.4s fade leftover
+    out._fade_tail_until = time.time() + 0.4
+
+    out._interrupted_event.set()
+    await out._wait_for_playout()
+
+    kwargs = finished.call_args.kwargs
+    assert kwargs["interrupted"] is True
+    assert kwargs["playback_position"] == pytest.approx(1.7, abs=0.05)
+
+
+@pytest.mark.asyncio
+async def test_pause_discard_excludes_leftover_fade_tail() -> None:
+    """The pause path adds queued_duration to _source_discarded_duration; the
+    leftover fade tail in that queue belongs to the previous segment and must
+    not shorten this segment's playback position."""
+    out, src, _ = _make_output(0.5)
+    out._pushed_duration = 1.0  # segment in progress
+    src.queued_duration = 0.5  # 0.1s of this segment + 0.4s fade leftover
+    out._fade_tail_until = time.time() + 0.4
+    out._playback_enabled.clear()  # paused
+
+    forward = asyncio.create_task(out._forward_audio())
+    out._audio_buf.send_nowait(_make_frame(1000, 0.05))
+    await asyncio.sleep(0.1)
+
+    assert out._source_discarded_duration == pytest.approx(0.1, abs=0.06)
+    assert out._fade_tail_until == 0.0
+
+    out._playback_enabled.set()
+    await asyncio.sleep(0.1)
+    assert src.captured  # the held frame resumed into the source
+
+    out._audio_buf.close()
+    await forward


### PR DESCRIPTION
Closes #6165

## What

Adds an opt-in linear fade-out applied to the agent's audio when it gets interrupted, instead of cutting playback abruptly:

```python
await session.start(
    room=room,
    room_options=RoomOptions(
        audio_output=AudioOutputOptions(fade_out_on_interruption=0.08),  # seconds
    ),
)
```

Default is `0.0` (disabled) — existing behavior is unchanged.

## How (and why not the holdback buffer I proposed in the issue)

In my comment on #6165 I proposed holding back a small tail buffer before forwarding frames downstream. I dropped that approach while implementing: it adds first-frame playback latency equal to the tail size, which is the one metric a voice agent shouldn't pay for a cosmetic feature.

Instead, the fade is built inside `_ParticipantAudioOutput`, which already knows everything needed at interruption time:

- `_forward_audio` keeps a small rolling history (~400ms: queue size + fade + margin) of frames already pushed to the `rtc.AudioSource`.
- On interruption, `AudioSource.queued_duration` tells us how much of that history hadn't played yet, so the exact playback position is `end_of_history - queued_duration`.
- After `clear_queue()`, a single frame is re-pushed: the next `fade_out_on_interruption` seconds of the *actual* audio from the playback position, with a linear 1 → 0 gain ramp.

This gives zero added latency and no content discontinuity — the fade is the same audio the user was hearing, just ramped down. The history bookkeeping is only active when the option is enabled.

`playback_position` accounting is untouched: the faded tail replays audio that was already subtracted via `queued_duration`, so reported position stays correct for chat-history truncation.

## Notes

- The fade duration is clamped to what's actually unplayed (interruption near the end of an utterance fades over the remainder).
- Known pre-existing race, unchanged by this PR: if `_forward_audio` is blocked in `AudioSource.capture_frame` under backpressure when the interruption fires, that in-flight frame can land after `clear_queue()`. Today it plays at full gain after the cut; with the fade enabled it may play before the faded tail. Fixing that needs coordination between `_forward_audio` and `_wait_for_playout` and felt out of scope here.

## Testing

- `_build_fade_out_frame` is a pure function; added hermetic unit tests (`tests/test_interruption_fade_out.py`, marked `unit`): ramp shape/monotonicity, correct offset from playback position, clamping to unplayed duration and to available history, stereo, and the no-op cases.
- Full `--unit` suite passes (same result as `main` baseline on my machine).
- `ruff check` / `ruff format` clean; no new mypy errors in `room_io`.
