### PR TITLE
fix: Instructions.resolve_template double-renders under render(modality)

### DIFF
--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -104,9 +104,6 @@ class Instructions:
         """
         any_instructions = any(isinstance(v, Instructions) for v in kwargs.values())
         if any_instructions:
-            common_kw: dict[str, object] = {
-                k: str(v) if isinstance(v, Instructions) else v for k, v in kwargs.items()
-            }
             audio_kw: dict[str, object] = {
                 # an explicit "" removes the section; only None falls back to common
                 k: (v.audio if v.audio is not None else str(v))
@@ -118,11 +115,15 @@ class Instructions:
                 k: (v.text if v.text is not None else str(v)) if isinstance(v, Instructions) else v
                 for k, v in kwargs.items()
             }
-            return Instructions(
-                common=utils.misc.safe_render(template, common_kw),
-                audio=utils.misc.safe_render(template, audio_kw),
-                text=utils.misc.safe_render(template, text_kw),
-            )
+            # audio/text hold fully rendered variants of the whole template, so they go in
+            # place of common (which render() would otherwise prepend, doubling the template).
+            audio = utils.misc.safe_render(template, audio_kw)
+            text = utils.misc.safe_render(template, text_kw)
+            if audio == text:
+                # no modality-specific differences; a single common variant renders correctly
+                # with or without a modality
+                return Instructions(common=audio)
+            return Instructions(common="", audio=audio, text=text)
         else:
             rendered = utils.misc.safe_render(template, kwargs)
             return Instructions(common=rendered)

--- a/tests/test_chat_ctx.py
+++ b/tests/test_chat_ctx.py
@@ -689,3 +689,52 @@ def test_instructions_render():
     empty_common = Instructions("", audio="audio only", text="text only")
     assert empty_common.render(modality="audio") == "audio only"
     assert empty_common.render(modality="text") == "text only"
+
+
+def test_resolve_template_no_double_render():
+    """resolve_template with Instructions kwargs renders each variant exactly once."""
+    from livekit.agents.llm.chat_context import Instructions
+
+    instr = Instructions.resolve_template(
+        "{persona}\n\n{modality_specific}",
+        persona="You are a helpful assistant.",
+        modality_specific=Instructions(
+            audio="Handle noisy voice input.", text="Handle typed input."
+        ),
+    )
+
+    # each modality resolves to a single copy of the template, not two
+    assert instr.render(modality="audio") == (
+        "You are a helpful assistant.\n\nHandle noisy voice input."
+    )
+    assert instr.render(modality="text") == ("You are a helpful assistant.\n\nHandle typed input.")
+    # persona (and everything else) appears exactly once per modality
+    assert instr.render(modality="audio").count("You are a helpful assistant.") == 1
+
+
+def test_resolve_template_plain_kwargs():
+    """resolve_template without Instructions kwargs is a plain common-only render."""
+    from livekit.agents.llm.chat_context import Instructions
+
+    instr = Instructions.resolve_template("Hello {name}", name="Alex")
+    assert instr.common == "Hello Alex"
+    assert instr.audio is None
+    assert instr.text is None
+    assert instr.render() == "Hello Alex"
+    assert instr.render(modality="audio") == "Hello Alex"
+
+
+def test_resolve_template_identical_variants_collapse():
+    """When modality variants are identical, resolve_template collapses to common-only."""
+    from livekit.agents.llm.chat_context import Instructions
+
+    # an Instructions kwarg with no modality-specific parts yields identical variants
+    instr = Instructions.resolve_template(
+        "{persona}\n\n{note}",
+        persona="You are a helpful assistant.",
+        note=Instructions("shared note"),
+    )
+    assert instr.audio is None
+    assert instr.text is None
+    assert instr.render() == "You are a helpful assistant.\n\nshared note"
+    assert instr.render(modality="audio") == "You are a helpful assistant.\n\nshared note"


### PR DESCRIPTION
Fixes #6407