### PR TITLE
fix(voice): enforce interruption min_duration on STT transcript triggers (#3515)

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1808,7 +1808,10 @@ class AgentActivity(RecognitionHooks):
         self._schedule_speech(handle, SpeechHandle.SPEECH_PRIORITY_NORMAL)
 
     def _interrupt_by_audio_activity(
-        self, *, ignore_user_transcript_until: float | None = None
+        self,
+        *,
+        ignore_user_transcript_until: float | None = None,
+        enforce_min_duration: bool = True,
     ) -> None:
         """
         Interrupt the current speech or generation, and optionally ignore the user transcript until the given timestamp.
@@ -1816,6 +1819,9 @@ class AgentActivity(RecognitionHooks):
         Args:
             ignore_user_transcript_until: The timestamp until which the user transcript should be ignored.
                 If None, the user transcript will be ignored until the current time.
+            enforce_min_duration: Whether to enforce ``interruption.min_duration`` against the
+                tracked user speech duration. Set to False by callers that already made an
+                explicit interruption decision (e.g. the interruption detection model).
         """
         if not self._interruption_by_audio_activity_enabled:
             return
@@ -1839,6 +1845,20 @@ class AgentActivity(RecognitionHooks):
             # TODO(long): better word splitting for multi-language
             if len(split_words(text, split_character=True)) < interruption_options["min_words"]:
                 return
+
+        # enforce min_duration on every audio-activity trigger, not only the VAD path;
+        # STT interim/final transcripts would otherwise interrupt regardless of how
+        # short the user speech was (https://github.com/livekit/agents/issues/3515).
+        # an unknown duration (None) is allowed through to keep the VAD-failure
+        # failsafe in on_final_transcript working.
+        if (
+            enforce_min_duration
+            and interruption_options["min_duration"] > 0
+            and self._audio_recognition is not None
+            and (speech_duration := self._audio_recognition.current_speech_duration) is not None
+            and speech_duration < interruption_options["min_duration"]
+        ):
+            return
 
         if self._rt_session is not None:
             self._rt_session.start_user_activity()
@@ -1972,10 +1992,13 @@ class AgentActivity(RecognitionHooks):
             self._user_silence_event.set()
 
     def on_interruption(self, ev: inference.OverlappingSpeechEvent) -> None:
-        # restore interruption by audio activity and then immediately interrupt
+        # restore interruption by audio activity and then immediately interrupt.
+        # the interruption detection model already decided this is a real interruption,
+        # so min_duration is not re-checked here.
         self._restore_interruption_by_audio_activity()
         self._interrupt_by_audio_activity(
-            ignore_user_transcript_until=ev.overlap_started_at or ev.detected_at
+            ignore_user_transcript_until=ev.overlap_started_at or ev.detected_at,
+            enforce_min_duration=False,
         )
         # flush held transcripts again if possible
         if self._audio_recognition:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2003,7 +2003,10 @@ class AgentActivity(RecognitionHooks):
         self._schedule_speech(handle, SpeechHandle.SPEECH_PRIORITY_NORMAL)
 
     def _interrupt_by_audio_activity(
-        self, *, ignore_user_transcript_until: float | None = None
+        self,
+        *,
+        ignore_user_transcript_until: float | None = None,
+        enforce_min_duration: bool = True,
     ) -> None:
         """
         Interrupt the current speech or generation, and optionally ignore the user transcript until the given timestamp.
@@ -2011,6 +2014,9 @@ class AgentActivity(RecognitionHooks):
         Args:
             ignore_user_transcript_until: The timestamp until which the user transcript should be ignored.
                 If None, the user transcript will be ignored until the current time.
+            enforce_min_duration: Whether to enforce ``interruption.min_duration`` against the
+                tracked user speech duration. Set to False by callers that already made an
+                explicit interruption decision (e.g. the interruption detection model).
         """
         if not self._interruption_by_audio_activity_enabled:
             return
@@ -2034,6 +2040,20 @@ class AgentActivity(RecognitionHooks):
             # TODO(long): better word splitting for multi-language
             if len(split_words(text, split_character=True)) < interruption_options["min_words"]:
                 return
+
+        # enforce min_duration on every audio-activity trigger, not only the VAD path;
+        # STT interim/final transcripts would otherwise interrupt regardless of how
+        # short the user speech was (https://github.com/livekit/agents/issues/3515).
+        # an unknown duration (None) is allowed through to keep the VAD-failure
+        # failsafe in on_final_transcript working.
+        if (
+            enforce_min_duration
+            and interruption_options["min_duration"] > 0
+            and self._audio_recognition is not None
+            and (speech_duration := self._audio_recognition.current_speech_duration) is not None
+            and speech_duration < interruption_options["min_duration"]
+        ):
+            return
 
         if self._rt_session is not None:
             self._rt_session.start_user_activity()
@@ -2183,10 +2203,13 @@ class AgentActivity(RecognitionHooks):
             self._rt_session.clear_audio()
 
     def on_interruption(self, ev: inference.OverlappingSpeechEvent) -> None:
-        # restore interruption by audio activity and then immediately interrupt
+        # restore interruption by audio activity and then immediately interrupt.
+        # the interruption detection model already decided this is a real interruption,
+        # so min_duration is not re-checked here.
         self._restore_interruption_by_audio_activity()
         self._interrupt_by_audio_activity(
-            ignore_user_transcript_until=ev.overlap_started_at or ev.detected_at
+            ignore_user_transcript_until=ev.overlap_started_at or ev.detected_at,
+            enforce_min_duration=False,
         )
         # flush held transcripts again if possible
         if self._audio_recognition:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -527,6 +527,24 @@ class AudioRecognition:
         )
 
     @property
+    def current_speech_duration(self) -> float | None:
+        """Duration (s) of the current or most recent user speech segment.
+
+        Returns None when no speech start has been tracked (e.g. VAD produced no
+        events for this segment), meaning the duration is unknown.
+        """
+        if self._speech_start_time is None:
+            return None
+
+        if self._speaking:
+            return max(time.time() - self._speech_start_time, 0.0)
+
+        if self._last_speaking_time is None or self._last_speaking_time < self._speech_start_time:
+            return None
+
+        return self._last_speaking_time - self._speech_start_time
+
+    @property
     def _speaking(self) -> bool:
         return not self._user_silence_ev.is_set()
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -624,6 +624,24 @@ class AudioRecognition:
         )
 
     @property
+    def current_speech_duration(self) -> float | None:
+        """Duration (s) of the current or most recent user speech segment.
+
+        Returns None when no speech start has been tracked (e.g. VAD produced no
+        events for this segment), meaning the duration is unknown.
+        """
+        if self._speech_start_time is None:
+            return None
+
+        if self._speaking:
+            return max(time.time() - self._speech_start_time, 0.0)
+
+        if self._last_speaking_time is None or self._last_speaking_time < self._speech_start_time:
+            return None
+
+        return self._last_speaking_time - self._speech_start_time
+
+    @property
     def _speaking(self) -> bool:
         return not self._user_silence_ev.is_set()
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -1445,12 +1445,16 @@ class AudioRecognition:
                 self._session.amd._on_user_speech_started()
 
         elif ev.type == vad.VADEventType.INFERENCE_DONE:
-            self._hooks.on_vad_inference_done(ev)
+            # Store duration before the hook: on_vad_inference_done →
+            # _interrupt_by_audio_activity reads current_speech_duration, which
+            # must match ev.speech_duration on the same frame or barge-in is
+            # delayed by one VAD window (~32ms).
             # Silero resets pub_speech_duration to 0 after END_OF_SPEECH; do not
             # clobber the segment's final voiced duration with that zero or a late
             # STT final will look "too short" for interruption.min_duration.
             if self._speaking or ev.speech_duration > 0.0:
                 self._vad_speech_duration = ev.speech_duration
+            self._hooks.on_vad_inference_done(ev)
 
             # for metrics, get the "earliest" signal of speech as possible
             if ev.raw_accumulated_speech > 0.0:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -56,6 +56,14 @@ _NON_SPECIFIC_LANGUAGE_CODES = frozenset({"auto", "multi"})
 _EOU_MAX_HISTORY_TURNS = 6
 # backoff before recreating the stt stream after an unrecoverable error
 _STT_RECONNECT_INTERVAL = 0.5
+# After VAD END_OF_SPEECH, the segment's voiced duration keeps feeding
+# current_speech_duration only this long — enough for a late STT final of that
+# same segment to see the metric the VAD path used for interruption.min_duration.
+# Past it, the stored value describes an older segment (e.g. a noise blip that
+# never produced a transcript, so the turn never committed and never cleared it),
+# and gating a VAD-missed barge-in against it would defeat the
+# on_final_transcript failsafe.
+_SPEECH_DURATION_STALE_AFTER = 2.0
 
 
 @dataclass
@@ -635,8 +643,17 @@ class AudioRecognition:
         ``on_vad_inference_done`` uses for ``interruption.min_duration``). Falls
         back to wall-clock elapsed when VAD has not reported a duration for this
         segment (e.g. STT-only turn detection). Returns None when no speech start
-        has been tracked.
+        has been tracked, or when the measured segment ended more than
+        ``_SPEECH_DURATION_STALE_AFTER`` ago — a transcript arriving that late
+        belongs to speech this measurement doesn't describe.
         """
+        if (
+            not self._speaking
+            and self._last_speaking_time is not None
+            and time.time() - self._last_speaking_time > _SPEECH_DURATION_STALE_AFTER
+        ):
+            return None
+
         if self._vad_speech_duration is not None:
             return self._vad_speech_duration
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -1449,10 +1449,12 @@ class AudioRecognition:
             # _interrupt_by_audio_activity reads current_speech_duration, which
             # must match ev.speech_duration on the same frame or barge-in is
             # delayed by one VAD window (~32ms).
-            # Silero resets pub_speech_duration to 0 after END_OF_SPEECH; do not
-            # clobber the segment's final voiced duration with that zero or a late
-            # STT final will look "too short" for interruption.min_duration.
-            if self._speaking or ev.speech_duration > 0.0:
+            # Only positive VAD durations. Silero zeros pub_speech_duration after
+            # EOS; writing that 0 makes a late STT final look "too short".
+            # `_speaking` is not a substitute: turn_detection="stt" sets it from
+            # STT START_OF_SPEECH while Silero still reports 0, which would
+            # store 0.0 instead of None and disable the VAD-miss failsafe.
+            if ev.speech_duration > 0.0:
                 self._vad_speech_duration = ev.speech_duration
             self._hooks.on_vad_inference_done(ev)
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -273,6 +273,10 @@ class AudioRecognition:
         self._last_final_transcript_time: float | None = None
         self._last_speaking_time: float | None = None
         self._speech_start_time: float | None = None
+        # VAD-measured voiced duration for the current/most recent segment; preferred
+        # by ``current_speech_duration`` so STT-triggered min_duration matches the
+        # VAD path (wall-clock includes trailing silence / STT latency).
+        self._vad_speech_duration: float | None = None
 
         # used for manual commit_user_turn
         self._final_transcript_received = asyncio.Event()
@@ -625,11 +629,17 @@ class AudioRecognition:
 
     @property
     def current_speech_duration(self) -> float | None:
-        """Duration (s) of the current or most recent user speech segment.
+        """Voiced duration (s) of the current or most recent user speech segment.
 
-        Returns None when no speech start has been tracked (e.g. VAD produced no
-        events for this segment), meaning the duration is unknown.
+        Prefers the VAD-measured ``speech_duration`` (same metric
+        ``on_vad_inference_done`` uses for ``interruption.min_duration``). Falls
+        back to wall-clock elapsed when VAD has not reported a duration for this
+        segment (e.g. STT-only turn detection). Returns None when no speech start
+        has been tracked.
         """
+        if self._vad_speech_duration is not None:
+            return self._vad_speech_duration
+
         if self._speech_start_time is None:
             return None
 
@@ -1053,6 +1063,7 @@ class AudioRecognition:
         self._last_final_transcript_time = None
         self._speech_start_time = None
         self._last_speaking_time = None
+        self._vad_speech_duration = None
         self._vad_speech_started = False
         self._user_turn_committed = False
         self._last_emitted_prediction = None
@@ -1414,6 +1425,7 @@ class AudioRecognition:
                 self._speech_start_time = speech_start_time
                 self._vad_speech_started = True
 
+            self._vad_speech_duration = ev.speech_duration
             self._cancel_transcription_timeout()
 
             with trace.use_span(self._ensure_user_turn_span(start_time=speech_start_time)):
@@ -1434,6 +1446,7 @@ class AudioRecognition:
 
         elif ev.type == vad.VADEventType.INFERENCE_DONE:
             self._hooks.on_vad_inference_done(ev)
+            self._vad_speech_duration = ev.speech_duration
 
             # for metrics, get the "earliest" signal of speech as possible
             if ev.raw_accumulated_speech > 0.0:
@@ -1462,6 +1475,9 @@ class AudioRecognition:
             self._speaking = False
             speech_end_time = time.time() - ev.silence_duration - ev.inference_duration
             self._last_speaking_time = speech_end_time
+            # keep the final voiced duration so a late STT final still sees the
+            # same metric the VAD path used for min_duration
+            self._vad_speech_duration = ev.speech_duration
 
             # A committed turn clears _vad_speech_started before its late VAD EOS arrives.
             if self._stt_pipeline is not None and vad_speech_started:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -1446,7 +1446,11 @@ class AudioRecognition:
 
         elif ev.type == vad.VADEventType.INFERENCE_DONE:
             self._hooks.on_vad_inference_done(ev)
-            self._vad_speech_duration = ev.speech_duration
+            # Silero resets pub_speech_duration to 0 after END_OF_SPEECH; do not
+            # clobber the segment's final voiced duration with that zero or a late
+            # STT final will look "too short" for interruption.min_duration.
+            if self._speaking or ev.speech_duration > 0.0:
+                self._vad_speech_duration = ev.speech_duration
 
             # for metrics, get the "earliest" signal of speech as possible
             if ev.raw_accumulated_speech > 0.0:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -1809,6 +1809,10 @@ class AudioRecognition:
                     self._speech_start_time = None
                     self._vad_speech_started = False
                     self._last_speaking_time = None
+                    # drop the prior segment's voiced duration so a late STT
+                    # failsafe (no new VAD events) sees unknown duration, not
+                    # a stale min_duration gate from the previous turn
+                    self._vad_speech_duration = None
 
                 if self._turn_detector_stream is not None:
                     self._turn_detector_stream.flush(reason="turn committed")

--- a/tests/fake_session.py
+++ b/tests/fake_session.py
@@ -133,7 +133,13 @@ class FakeActions:
         self._items: list[FakeUserSpeech | FakeLLMResponse | FakeTTSResponse] = []
 
     def add_user_speech(
-        self, start_time: float, end_time: float, transcript: str, *, stt_delay: float = 0.2
+        self,
+        start_time: float,
+        end_time: float,
+        transcript: str,
+        *,
+        stt_delay: float = 0.2,
+        interim_interval: float | None = None,
     ) -> None:
         self._items.append(
             FakeUserSpeech(
@@ -141,6 +147,7 @@ class FakeActions:
                 end_time=end_time,
                 transcript=transcript,
                 stt_delay=stt_delay,
+                interim_interval=interim_interval,
             )
         )
 

--- a/tests/fake_session.py
+++ b/tests/fake_session.py
@@ -141,6 +141,7 @@ class FakeActions:
         *,
         stt_delay: float = 0.2,
         final: bool = True,
+        interim_interval: float | None = None,
     ) -> None:
         self._items.append(
             FakeUserSpeech(
@@ -149,6 +150,7 @@ class FakeActions:
                 transcript=transcript,
                 stt_delay=stt_delay,
                 final=final,
+                interim_interval=interim_interval,
             )
         )
 

--- a/tests/fake_stt.py
+++ b/tests/fake_stt.py
@@ -32,12 +32,17 @@ class FakeUserSpeech(BaseModel):
     end_time: float
     transcript: str  # empty string fires VAD SOS/EOS only — no STT events
     stt_delay: float
+    interim_interval: float | None = None
+    """If set, stream growing interim transcripts every ``interim_interval`` seconds
+    while the user is speaking (like providers that emit continuous partial results)."""
 
     def speed_up(self, factor: float) -> FakeUserSpeech:
         obj = copy.deepcopy(self)
         obj.start_time /= factor
         obj.end_time /= factor
         obj.stt_delay /= factor
+        if obj.interim_interval is not None:
+            obj.interim_interval /= factor
         return obj
 
 
@@ -221,6 +226,20 @@ class FakeRecognizeStream(RecognizeStream):
                 if curr_time() < final_transcript_time:
                     await asyncio.sleep(final_transcript_time - curr_time())
                 continue
+
+            if fake_speech.interim_interval is not None:
+                # stream growing interim transcripts while the user is speaking
+                words = fake_speech.transcript.split()
+                num_sent = 0
+                next_interim_time = fake_speech.start_time + fake_speech.interim_interval
+                while next_interim_time < fake_speech.end_time:
+                    if curr_time() < next_interim_time:
+                        await asyncio.sleep(next_interim_time - curr_time())
+                    num_sent += 1
+                    prefix = " ".join(words[: min(num_sent, len(words))])
+                    self.send_fake_transcript(prefix, is_final=False)
+                    next_interim_time += fake_speech.interim_interval
+
             interim_transcript_time = fake_speech.end_time + fake_speech.stt_delay * 0.5
             if curr_time() < interim_transcript_time:
                 await asyncio.sleep(interim_transcript_time - curr_time())

--- a/tests/fake_stt.py
+++ b/tests/fake_stt.py
@@ -33,12 +33,17 @@ class FakeUserSpeech(BaseModel):
     transcript: str  # empty string fires VAD SOS/EOS only — no STT events
     stt_delay: float
     final: bool = True
+    interim_interval: float | None = None
+    """If set, stream growing interim transcripts every ``interim_interval`` seconds
+    while the user is speaking (like providers that emit continuous partial results)."""
 
     def speed_up(self, factor: float) -> FakeUserSpeech:
         obj = copy.deepcopy(self)
         obj.start_time /= factor
         obj.end_time /= factor
         obj.stt_delay /= factor
+        if obj.interim_interval is not None:
+            obj.interim_interval /= factor
         return obj
 
 
@@ -222,6 +227,20 @@ class FakeRecognizeStream(RecognizeStream):
                 if curr_time() < final_transcript_time:
                     await asyncio.sleep(final_transcript_time - curr_time())
                 continue
+
+            if fake_speech.interim_interval is not None:
+                # stream growing interim transcripts while the user is speaking
+                words = fake_speech.transcript.split()
+                num_sent = 0
+                next_interim_time = fake_speech.start_time + fake_speech.interim_interval
+                while next_interim_time < fake_speech.end_time:
+                    if curr_time() < next_interim_time:
+                        await asyncio.sleep(next_interim_time - curr_time())
+                    num_sent += 1
+                    prefix = " ".join(words[: min(num_sent, len(words))])
+                    self.send_fake_transcript(prefix, is_final=False)
+                    next_interim_time += fake_speech.interim_interval
+
             interim_transcript_time = fake_speech.end_time + fake_speech.stt_delay * 0.5
             if curr_time() < interim_transcript_time:
                 await asyncio.sleep(interim_transcript_time - curr_time())

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -403,6 +403,51 @@ async def test_interruption_options() -> None:
     check_timestamp(playback_finished_events[0].playback_position, 5.0, speed_factor=speed)
 
 
+async def test_min_interruption_duration_applies_to_stt_transcripts() -> None:
+    """Regression test for https://github.com/livekit/agents/issues/3515.
+
+    STTs that stream continuous interim results (e.g. Amazon Transcribe) used to
+    trigger an interruption on the first non-empty interim transcript, bypassing
+    ``interruption.min_duration`` entirely (it was only enforced on the VAD path).
+    The interruption must not fire before the user has spoken for min_duration.
+    """
+    speed = 1
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "Tell me a story.")
+    actions.add_llm("Here is a long story for you ... the end.")
+    actions.add_tts(10.0)  # playout starts at 3.5s
+    # user speaks for 4s while interim transcripts stream every 0.3s;
+    # the first interim lands at ~5.3s, min_duration is reached at 7.0s
+    actions.add_user_speech(
+        5.0, 9.0, "please stop talking right now", stt_delay=0.2, interim_interval=0.3
+    )
+
+    session = create_session(
+        actions,
+        speed_factor=speed,
+        turn_handling={"interruption": {"min_duration": 2.0}},
+    )
+    agent_state_events: list[AgentStateChangedEvent] = []
+    playback_finished_events: list[PlaybackFinishedEvent] = []
+    session.on("agent_state_changed", agent_state_events.append)
+    session.output.audio.on("playback_finished", playback_finished_events.append)
+
+    t_origin = await asyncio.wait_for(run_session(session, MyAgent()), timeout=SESSION_TIMEOUT)
+
+    assert len(playback_finished_events) == 1
+    assert playback_finished_events[0].interrupted is True
+    # interrupted at 7.0s (5.0 + min_duration), i.e. 3.5s into the playout —
+    # not at ~5.3s when the first interim transcript arrived
+    check_timestamp(playback_finished_events[0].playback_position, 3.5, speed_factor=speed)
+
+    interrupted_at = next(
+        ev.created_at
+        for ev in agent_state_events
+        if ev.new_state == "listening" and ev.old_state == "speaking"
+    )
+    check_timestamp(interrupted_at - t_origin, 7.0, speed_factor=speed)
+
+
 async def test_interruption_by_text_input() -> None:
     speed = 1
     actions = FakeActions()
@@ -1140,6 +1185,9 @@ async def test_vad_fallback_uses_next_vad_inference_event(
     )
 
     audio_recognition = MagicMock()
+    # unknown speech duration: the min_duration gate lets it through (the VAD
+    # event below carries its own speech_duration check)
+    audio_recognition.current_speech_duration = None
     current_speech = MagicMock()
     current_speech.interrupted = False
     current_speech.allow_interruptions = True

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -497,6 +497,51 @@ async def test_interruption_options() -> None:
     check_timestamp(playback_finished_events[0].playback_position, 5.0, speed_factor=speed)
 
 
+async def test_min_interruption_duration_applies_to_stt_transcripts() -> None:
+    """Regression test for https://github.com/livekit/agents/issues/3515.
+
+    STTs that stream continuous interim results (e.g. Amazon Transcribe) used to
+    trigger an interruption on the first non-empty interim transcript, bypassing
+    ``interruption.min_duration`` entirely (it was only enforced on the VAD path).
+    The interruption must not fire before the user has spoken for min_duration.
+    """
+    speed = 1
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "Tell me a story.")
+    actions.add_llm("Here is a long story for you ... the end.")
+    actions.add_tts(10.0)  # playout starts at 3.5s
+    # user speaks for 4s while interim transcripts stream every 0.3s;
+    # the first interim lands at ~5.3s, min_duration is reached at 7.0s
+    actions.add_user_speech(
+        5.0, 9.0, "please stop talking right now", stt_delay=0.2, interim_interval=0.3
+    )
+
+    session = create_session(
+        actions,
+        speed_factor=speed,
+        turn_handling={"interruption": {"min_duration": 2.0}},
+    )
+    agent_state_events: list[AgentStateChangedEvent] = []
+    playback_finished_events: list[PlaybackFinishedEvent] = []
+    session.on("agent_state_changed", agent_state_events.append)
+    session.output.audio.on("playback_finished", playback_finished_events.append)
+
+    t_origin = await asyncio.wait_for(run_session(session, MyAgent()), timeout=SESSION_TIMEOUT)
+
+    assert len(playback_finished_events) == 1
+    assert playback_finished_events[0].interrupted is True
+    # interrupted at 7.0s (5.0 + min_duration), i.e. 3.5s into the playout —
+    # not at ~5.3s when the first interim transcript arrived
+    check_timestamp(playback_finished_events[0].playback_position, 3.5, speed_factor=speed)
+
+    interrupted_at = next(
+        ev.created_at
+        for ev in agent_state_events
+        if ev.new_state == "listening" and ev.old_state == "speaking"
+    )
+    check_timestamp(interrupted_at - t_origin, 7.0, speed_factor=speed)
+
+
 async def test_interruption_by_text_input() -> None:
     speed = 1
     actions = FakeActions()
@@ -1535,6 +1580,9 @@ async def test_vad_fallback_uses_next_vad_inference_event(
     )
 
     audio_recognition = MagicMock()
+    # unknown speech duration: the min_duration gate lets it through (the VAD
+    # event below carries its own speech_duration check)
+    audio_recognition.current_speech_duration = None
     current_speech = MagicMock()
     current_speech.interrupted = False
     current_speech.allow_interruptions = True

--- a/tests/test_speech_start_time_persistence.py
+++ b/tests/test_speech_start_time_persistence.py
@@ -27,7 +27,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from livekit.agents.vad import VADEvent, VADEventType
-from livekit.agents.voice.audio_recognition import AudioRecognition
+from livekit.agents.voice.audio_recognition import (
+    _SPEECH_DURATION_STALE_AFTER,
+    AudioRecognition,
+)
 
 pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
@@ -286,6 +289,33 @@ class TestUserTurnStartPersistence:
         )
 
         assert seen == [pytest.approx(0.48), pytest.approx(0.51)]
+
+    @pytest.mark.asyncio
+    async def test_stale_blip_duration_does_not_gate_vad_missed_barge_in(self):
+        """A VAD blip that never produced a transcript must stop gating.
+
+        A short noise blip fires SOS/EOS with no transcript, so the turn never
+        commits and the blip's 0.2s measurement is never cleared. If VAD then
+        misses the user's real barge-in, the ``on_final_transcript`` failsafe
+        gates on ``current_speech_duration`` — past the late-final window it
+        must see unknown (None), not the blip's 0.2s, or the agent keeps
+        talking over the user.
+        """
+        audio_recognition = self._create_audio_recognition()
+
+        await audio_recognition._on_vad_event(
+            self._vad_event(VADEventType.START_OF_SPEECH, speech_duration=0.05)
+        )
+        await audio_recognition._on_vad_event(
+            self._vad_event(VADEventType.END_OF_SPEECH, speech_duration=0.2, silence_duration=0.4)
+        )
+
+        # within the late-final window the blip's measurement still applies
+        assert audio_recognition.current_speech_duration == pytest.approx(0.2)
+
+        await asyncio.sleep(_SPEECH_DURATION_STALE_AFTER + 0.5)
+
+        assert audio_recognition.current_speech_duration is None
 
     @pytest.mark.asyncio
     async def test_stt_speaking_zero_vad_inference_keeps_duration_unknown(self):

--- a/tests/test_speech_start_time_persistence.py
+++ b/tests/test_speech_start_time_persistence.py
@@ -64,6 +64,9 @@ class TestUserTurnStartPersistence:
         audio_recognition._last_speaking_time = None
         audio_recognition._transcription_timeout_handle = None
         audio_recognition._turn_speech_duration = 0.0
+        audio_recognition._vad_speech_duration = None
+        audio_recognition._turn_detector_prediction_fut = None
+        audio_recognition._turn_detector_flushed = False
 
         # collaborators
         audio_recognition._hooks = MagicMock()
@@ -180,3 +183,36 @@ class TestUserTurnStartPersistence:
         # _speech_start_time should now reflect the second burst's start, not the first
         assert audio_recognition._speech_start_time is not None
         assert audio_recognition._speech_start_time > first_burst_speech_start
+
+    @pytest.mark.asyncio
+    async def test_vad_speech_duration_survives_post_eos_zero_inference(self):
+        """Silero zeros pub_speech_duration after EOS; keep the segment final.
+
+        Late STT finals use ``current_speech_duration`` for
+        ``interruption.min_duration``. If a post-EOS INFERENCE_DONE with
+        ``speech_duration=0`` overwrites the EOS value, a real interrupt is
+        blocked as "too short".
+        """
+        audio_recognition = self._create_audio_recognition()
+
+        await audio_recognition._on_vad_event(
+            self._vad_event(VADEventType.START_OF_SPEECH, speech_duration=0.1)
+        )
+        await audio_recognition._on_vad_event(
+            self._vad_event(
+                VADEventType.INFERENCE_DONE,
+                speech_duration=0.55,
+            )
+        )
+        assert audio_recognition.current_speech_duration == pytest.approx(0.55)
+
+        await audio_recognition._on_vad_event(
+            self._vad_event(VADEventType.END_OF_SPEECH, speech_duration=0.6, silence_duration=0.5)
+        )
+        assert audio_recognition.current_speech_duration == pytest.approx(0.6)
+
+        # Silero-style post-EOS inference with zeroed duration
+        await audio_recognition._on_vad_event(
+            self._vad_event(VADEventType.INFERENCE_DONE, speech_duration=0.0)
+        )
+        assert audio_recognition.current_speech_duration == pytest.approx(0.6)

--- a/tests/test_speech_start_time_persistence.py
+++ b/tests/test_speech_start_time_persistence.py
@@ -286,3 +286,30 @@ class TestUserTurnStartPersistence:
         )
 
         assert seen == [pytest.approx(0.48), pytest.approx(0.51)]
+
+    @pytest.mark.asyncio
+    async def test_stt_speaking_zero_vad_inference_keeps_duration_unknown(self):
+        """STT can mark speaking before VAD has a voiced duration.
+
+        ``turn_detection="stt"`` sets ``_speaking`` on START_OF_SPEECH while
+        Silero still emits ``speech_duration=0`` until its own onset. Writing
+        that zero into ``_vad_speech_duration`` turns "unknown" into 0.0, so
+        ``interruption.min_duration`` blocks the STT-failsafe barge-in.
+        """
+        audio_recognition = self._create_audio_recognition()
+        audio_recognition._turn_detection_mode = "stt"
+        audio_recognition._speaking = True
+        assert audio_recognition._vad_speech_duration is None
+        assert audio_recognition.current_speech_duration is None
+
+        await audio_recognition._on_vad_event(
+            self._vad_event(VADEventType.INFERENCE_DONE, speech_duration=0.0)
+        )
+
+        assert audio_recognition._vad_speech_duration is None
+        assert audio_recognition.current_speech_duration is None
+
+        await audio_recognition._on_vad_event(
+            self._vad_event(VADEventType.INFERENCE_DONE, speech_duration=0.42)
+        )
+        assert audio_recognition.current_speech_duration == pytest.approx(0.42)

--- a/tests/test_speech_start_time_persistence.py
+++ b/tests/test_speech_start_time_persistence.py
@@ -216,3 +216,46 @@ class TestUserTurnStartPersistence:
             self._vad_event(VADEventType.INFERENCE_DONE, speech_duration=0.0)
         )
         assert audio_recognition.current_speech_duration == pytest.approx(0.6)
+
+    @pytest.mark.asyncio
+    async def test_vad_speech_duration_cleared_when_turn_commits(self):
+        """EOT cleanup must drop ``_vad_speech_duration`` with other speech anchors.
+
+        Otherwise the next turn's STT-failsafe path (no fresh VAD events) reuses
+        the previous segment length for ``interruption.min_duration``.
+        """
+        audio_recognition = self._create_audio_recognition()
+        audio_recognition._closing = asyncio.Event()
+        audio_recognition._endpointing = MagicMock()
+        audio_recognition._endpointing.min_delay = 0.0
+        audio_recognition._endpointing.max_delay = 0.0
+        audio_recognition._turn_detector = None
+        audio_recognition._hooks.on_end_of_turn.return_value = True
+        audio_recognition._turn_backchannel_over_agent = False
+        audio_recognition._overlap_in_current_turn = False
+        audio_recognition._stt_request_ids = []
+        audio_recognition._last_final_transcript_time = None
+        audio_recognition._final_transcript_confidence = []
+        audio_recognition._reset_transcription_timeout = MagicMock()
+        audio_recognition._audio_transcript = "hello"
+
+        await audio_recognition._on_vad_event(
+            self._vad_event(VADEventType.START_OF_SPEECH, speech_duration=0.1)
+        )
+        await audio_recognition._on_vad_event(
+            self._vad_event(VADEventType.END_OF_SPEECH, speech_duration=0.8, silence_duration=0.1)
+        )
+        assert audio_recognition.current_speech_duration == pytest.approx(0.8)
+
+        chat_ctx = MagicMock()
+        chat_ctx.copy.return_value = chat_ctx
+        chat_ctx.add_message = MagicMock()
+        chat_ctx.items = []
+
+        audio_recognition._run_eou_detection(chat_ctx, trigger="vad")
+        task = audio_recognition._end_of_turn_task
+        assert task is not None
+        await task
+
+        assert audio_recognition.current_speech_duration is None
+        assert audio_recognition._vad_speech_duration is None

--- a/tests/test_speech_start_time_persistence.py
+++ b/tests/test_speech_start_time_persistence.py
@@ -259,3 +259,30 @@ class TestUserTurnStartPersistence:
 
         assert audio_recognition.current_speech_duration is None
         assert audio_recognition._vad_speech_duration is None
+
+    @pytest.mark.asyncio
+    async def test_inference_done_hook_sees_current_vad_duration(self):
+        """``on_vad_inference_done`` must observe this frame's duration, not the last.
+
+        ``_interrupt_by_audio_activity`` gates on ``current_speech_duration``. If
+        that is updated after the hook, barge-in waits one extra VAD window.
+        """
+        audio_recognition = self._create_audio_recognition()
+        seen: list[float | None] = []
+
+        def _capture(_ev: object) -> None:
+            seen.append(audio_recognition.current_speech_duration)
+
+        audio_recognition._hooks.on_vad_inference_done.side_effect = _capture
+
+        await audio_recognition._on_vad_event(
+            self._vad_event(VADEventType.START_OF_SPEECH, speech_duration=0.1)
+        )
+        await audio_recognition._on_vad_event(
+            self._vad_event(VADEventType.INFERENCE_DONE, speech_duration=0.48)
+        )
+        await audio_recognition._on_vad_event(
+            self._vad_event(VADEventType.INFERENCE_DONE, speech_duration=0.51)
+        )
+
+        assert seen == [pytest.approx(0.48), pytest.approx(0.51)]


### PR DESCRIPTION
Closes #3515

## Problem

`interruption.min_duration` (formerly `min_interruption_duration`) is only enforced on the VAD path: `on_vad_inference_done` checks `ev.speech_duration >= min_duration` before calling `_interrupt_by_audio_activity()`. The STT paths bypass it entirely — `on_interim_transcript` and `on_final_transcript` interrupt as soon as any non-empty transcript arrives, and `_interrupt_by_audio_activity()` itself only gates on `min_words`.

With providers that stream continuous interim results (Amazon Transcribe, etc.), the first interim lands well before `min_duration` is reached, so the option effectively does nothing — which is what was reported in #3515 (details in [my comment there](https://github.com/livekit/agents/issues/3515#issuecomment-4935433280)). This implements Option A from that comment: all entry paths share the same `min_duration` semantics.

## Fix

- `AudioRecognition` gains a `current_speech_duration` property derived from the speech timestamps it already tracks (`_speech_start_time` / `_last_speaking_time`): wall-clock elapsed while the user is speaking, actual segment length once they've stopped, `None` when no speech start was ever tracked.
- `_interrupt_by_audio_activity()` enforces `min_duration` against that value, next to the existing `min_words` gate, so the interim/final transcript paths can no longer bypass it.

Two deliberate exemptions:

- **Unknown duration (`None`) is allowed through.** This preserves the existing failsafe in `on_final_transcript` ("agent speech might not be interrupted if VAD failed and a final transcript is received"), and keeps VAD-less sessions behaving as before rather than becoming un-interruptible.
- **The interruption detection model path (`on_interruption`) skips the check** via `enforce_min_duration=False` — that model already made an explicit "this is a real interruption" decision.

The VAD path keeps its existing pre-check; the new gate can't disagree with it (wall-clock elapsed ≥ VAD-measured speech duration), so VAD-triggered interruptions are unaffected.

## Testing

- New regression test `test_min_interruption_duration_applies_to_stt_transcripts`: user speaks for 4s with interim transcripts streaming every 0.3s and `min_duration=2.0`. Before the fix the first interim interrupts at ~5.3s (playback position ~1.8s); after the fix the interruption fires at 7.0s (position 3.5s). Verified it fails without the fix and passes with it.
- `FakeSTT`/`FakeActions` gained an opt-in `interim_interval` to simulate continuous-interim providers; default behavior of existing fixtures is unchanged.
- Full `--unit` suite passes; `ruff` clean; no new mypy errors.
