### PR TITLE
fix(voice): recover STT stream after unrecoverable errors

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1007,6 +1007,10 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
     def shutdown(self, *, drain: bool = True) -> None:
         self._close_soon(error=None, drain=drain, reason=CloseReason.USER_INITIATED)
 
+    def _is_closing(self) -> bool:
+        # _closing_task is set synchronously when close begins, earlier than _closing
+        return self._closing_task is not None or self._closing
+
     @utils.log_exceptions(logger=logger)
     async def _aclose_impl(
         self,

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -138,7 +138,7 @@ class SessionConnectOptions:
     llm_conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
     tts_conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
     max_unrecoverable_errors: int = 3
-    """Maximum number of consecutive unrecoverable errors from llm or tts."""
+    """Maximum number of consecutive unrecoverable errors from stt, llm, or tts."""
 
 
 class ExpressiveOptions(TypedDict, total=False):
@@ -475,7 +475,8 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             tool_handling.get("async_options") if is_given(tool_handling) else None
         )
 
-        # unrecoverable error counts, reset after agent speaking
+        # unrecoverable error counts; stt resets on transcript, llm/tts on speaking
+        self._stt_error_counts = 0
         self._llm_error_counts = 0
         self._tts_error_counts = 0
 
@@ -1119,6 +1120,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             self._cancel_user_away_timer()
             self._user_state = "listening"
             self._agent_state = "initializing"
+            self._stt_error_counts = 0
             self._llm_error_counts = 0
             self._tts_error_counts = 0
             self._root_span_context = None
@@ -1591,7 +1593,11 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         if self._closing_task or error.recoverable:
             return
 
-        if error.type == "llm_error":
+        if error.type == "stt_error":
+            self._stt_error_counts += 1
+            if self._stt_error_counts <= self.conn_options.max_unrecoverable_errors:
+                return
+        elif error.type == "llm_error":
             self._llm_error_counts += 1
             if self._llm_error_counts <= self.conn_options.max_unrecoverable_errors:
                 return
@@ -1786,6 +1792,10 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 self._update_user_state("listening")
 
     def _user_input_transcribed(self, ev: UserInputTranscribedEvent) -> None:
+        if ev.transcript:
+            # a transcript means stt recovered; reset its error tolerance
+            self._stt_error_counts = 0
+
         if self.user_state == "away" and ev.is_final:
             # reset user state from away to listening in case VAD has a miss detection
             self._update_user_state("listening")

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -177,28 +177,29 @@ class _STTPipeline:
         """Iterate the STT node and forward events into *event_ch*.
 
         Owns the generator lifecycle — never cancelled during handoff, only the
-        consumer is swapped. On an unrecoverable error the long-lived stream is
+        consumer is swapped. On a connection failure the long-lived stream is
         recreated after a backoff; the session tolerance is what closes it.
         """
         from .agent import ModelSettings
 
         while True:
-            node = self._stt_node(self._audio_ch, ModelSettings())
-            if asyncio.iscoroutine(node):
-                node = await node
-
-            if not isinstance(node, AsyncIterable):
-                # None or a non-streaming node: nothing to iterate or recover
-                return
-
             try:
+                node = self._stt_node(self._audio_ch, ModelSettings())
+                if asyncio.iscoroutine(node):
+                    node = await node
+
+                if not isinstance(node, AsyncIterable):
+                    # None or a non-streaming node: nothing to iterate or recover
+                    return
+
                 async for ev in node:
                     assert isinstance(ev, stt.SpeechEvent), (
                         f"STT node must yield SpeechEvent, got: {type(ev)}"
                     )
                     self._event_ch.send_nowait(ev)
-            except Exception:
-                # the error is already emitted and counted by the session; recreate to resume
+            except APIError:
+                # only a connection failure is retried (it was emitted and counted by the
+                # session); any other error propagates and stops the pump
                 if self._is_closing():
                     return
                 logger.warning(

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -215,6 +215,12 @@ class _STTPipeline:
             # node ended without error (audio input closed): stop
             return
 
+    def _rebind_node(self, stt_node: io.STTNode) -> None:
+        # the pipeline outlives the agent that created it (reused across handoff);
+        # recreation must call the currently-active node, not the previous agent's
+        # bound node whose activity is torn down (would raise, stopping the pump)
+        self._stt_node = stt_node
+
     async def aclose(self) -> None:
         await aio.cancel_and_wait(self._pump_task)
 
@@ -775,6 +781,10 @@ class AudioRecognition:
         self._stt = stt
         if pipeline is None and stt is not None:
             pipeline = _STTPipeline(stt, is_closing=self._session._is_closing)
+        elif pipeline is not None and stt is not None:
+            # reused pipeline: rebind to this activity's node so a recreation
+            # after an error doesn't call into the previous (torn-down) agent
+            pipeline._rebind_node(stt)
 
         if pipeline is not None:
             self._stt_consumer_atask = asyncio.create_task(

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -53,6 +53,8 @@ if TYPE_CHECKING:
 MIN_LANGUAGE_DETECTION_LENGTH = 5
 # Mirrors turn_detector.base.MAX_HISTORY_TURNS for tracing
 _EOU_MAX_HISTORY_TURNS = 6
+# backoff before recreating the stt stream after an unrecoverable error
+_STT_RECONNECT_INTERVAL = 0.5
 
 
 @dataclass
@@ -149,8 +151,12 @@ class _STTPipeline:
     It is never cancelled during handoff — only the consumer is swapped.
     """
 
-    def __init__(self, stt_node: io.STTNode) -> None:
+    def __init__(
+        self, stt_node: io.STTNode, *, is_closing: Callable[[], bool] | None = None
+    ) -> None:
         self._stt_node = stt_node
+        # don't recreate the stream while the session is closing
+        self._is_closing = is_closing or (lambda: False)
         self._audio_ch = aio.Chan[rtc.AudioFrame]()
         self._event_ch = aio.Chan[stt.SpeechEvent]()
         self._pump_task = asyncio.create_task(self._stt_pump())
@@ -168,26 +174,45 @@ class _STTPipeline:
 
     @utils.log_exceptions(logger=logger)
     async def _stt_pump(self) -> None:
-        """Iterate the STT generator and forward events into *event_ch*.
+        """Iterate the STT node and forward events into *event_ch*.
 
-        This task owns the generator lifecycle and is never cancelled during
-        handoff — only the consumer is swapped.
+        Owns the generator lifecycle — never cancelled during handoff, only the
+        consumer is swapped. On an unrecoverable error the long-lived stream is
+        recreated after a backoff; the session tolerance is what closes it.
         """
         from .agent import ModelSettings
 
-        node = self._stt_node(self._audio_ch, ModelSettings())
-        if asyncio.iscoroutine(node):
-            node = await node
+        while True:
+            node = self._stt_node(self._audio_ch, ModelSettings())
+            if asyncio.iscoroutine(node):
+                node = await node
 
-        if node is None:
-            return
+            if not isinstance(node, AsyncIterable):
+                # None or a non-streaming node: nothing to iterate or recover
+                return
 
-        if isinstance(node, AsyncIterable):
-            async for ev in node:
-                assert isinstance(ev, stt.SpeechEvent), (
-                    f"STT node must yield SpeechEvent, got: {type(ev)}"
+            try:
+                async for ev in node:
+                    assert isinstance(ev, stt.SpeechEvent), (
+                        f"STT node must yield SpeechEvent, got: {type(ev)}"
+                    )
+                    self._event_ch.send_nowait(ev)
+            except Exception:
+                # the error is already emitted and counted by the session; recreate to resume
+                if self._is_closing():
+                    return
+                logger.warning(
+                    "STT stream ended on an unrecoverable error, recreating",
+                    exc_info=True,
                 )
-                self._event_ch.send_nowait(ev)
+                await asyncio.sleep(_STT_RECONNECT_INTERVAL)
+                # the session may have started closing during the backoff
+                if self._is_closing():
+                    return
+                continue
+
+            # node ended without error (audio input closed): stop
+            return
 
     async def aclose(self) -> None:
         await aio.cancel_and_wait(self._pump_task)
@@ -748,7 +773,11 @@ class AudioRecognition:
     def _update_stt(self, stt: io.STTNode | None, *, pipeline: _STTPipeline | None = None) -> None:
         self._stt = stt
         if pipeline is None and stt is not None:
-            pipeline = _STTPipeline(stt)
+            # _closing_task is set synchronously at close, earlier than _closing
+            session = self._session
+            pipeline = _STTPipeline(
+                stt, is_closing=lambda: session._closing_task is not None or session._closing
+            )
 
         if pipeline is not None:
             self._stt_consumer_atask = asyncio.create_task(

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -774,11 +774,7 @@ class AudioRecognition:
     def _update_stt(self, stt: io.STTNode | None, *, pipeline: _STTPipeline | None = None) -> None:
         self._stt = stt
         if pipeline is None and stt is not None:
-            # _closing_task is set synchronously at close, earlier than _closing
-            session = self._session
-            pipeline = _STTPipeline(
-                stt, is_closing=lambda: session._closing_task is not None or session._closing
-            )
+            pipeline = _STTPipeline(stt, is_closing=self._session._is_closing)
 
         if pipeline is not None:
             self._stt_consumer_atask = asyncio.create_task(

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -14,6 +14,7 @@ from livekit.agents import (
     Agent,
     AgentFalseInterruptionEvent,
     AgentStateChangedEvent,
+    APIConnectionError,
     ConversationItemAddedEvent,
     FlushSentinel,
     LanguageCode,
@@ -1210,7 +1211,7 @@ async def test_stt_pipeline_recreates_stream_after_unrecoverable_error(
         nonlocal attempts
         attempts += 1
         if attempts == 1:
-            raise RuntimeError("stt unavailable")
+            raise APIConnectionError("stt unavailable")
 
         yield SpeechEvent(
             type=SpeechEventType.FINAL_TRANSCRIPT,
@@ -1222,12 +1223,44 @@ async def test_stt_pipeline_recreates_stream_after_unrecoverable_error(
 
     pipeline = _STTPipeline(stt_node)
     try:
-        # the first stream dies unrecoverably; the pump must recreate it and
-        # forward the transcript produced by the second stream
+        # the first stream dies on a connection error; the pump must recreate it
+        # and forward the transcript produced by the second stream
         ev = await asyncio.wait_for(pipeline.event_ch.recv(), timeout=5)
         assert ev.type == SpeechEventType.FINAL_TRANSCRIPT
         assert ev.alternatives[0].text == "recovered"
         assert attempts == 2
+    finally:
+        await pipeline.aclose()
+
+
+async def test_stt_pipeline_does_not_recreate_on_non_connection_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from livekit.agents.voice import audio_recognition
+    from livekit.agents.voice.audio_recognition import _STTPipeline
+
+    monkeypatch.setattr(audio_recognition, "_STT_RECONNECT_INTERVAL", 0.0)
+
+    attempts = 0
+
+    async def stt_node(audio, model_settings):  # type: ignore[no-untyped-def]
+        nonlocal attempts
+        attempts += 1
+        raise ValueError("bug in stt_node")
+        yield  # pragma: no cover - makes this an async generator
+
+    # a non-connection error is not retried: the pump stops instead of looping
+    pipeline = _STTPipeline(stt_node)
+    try:
+        events: list[SpeechEvent] = []
+
+        async def _collect() -> None:
+            async for ev in pipeline.event_ch:
+                events.append(ev)
+
+        await asyncio.wait_for(_collect(), timeout=5)
+        assert events == []
+        assert attempts == 1
     finally:
         await pipeline.aclose()
 
@@ -1246,7 +1279,7 @@ async def test_stt_pipeline_does_not_recreate_stream_while_closing(
         nonlocal attempts
         attempts += 1
         if attempts == 1:
-            raise RuntimeError("stt unavailable")
+            raise APIConnectionError("stt unavailable")
 
         yield SpeechEvent(
             type=SpeechEventType.FINAL_TRANSCRIPT,

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -37,7 +37,7 @@ from livekit.agents.llm import (
     Toolset,
 )
 from livekit.agents.llm.chat_context import ChatContext, ChatMessage
-from livekit.agents.stt import SpeechData, SpeechEvent, SpeechEventType
+from livekit.agents.stt import SpeechData, SpeechEvent, SpeechEventType, STTError
 from livekit.agents.utils import aio
 from livekit.agents.voice.agent_activity import AgentActivity
 from livekit.agents.voice.audio_recognition import AudioRecognition, _EndOfTurnInfo
@@ -1125,6 +1125,148 @@ async def test_interruption_detection_error_is_not_session_error() -> None:
         fallback.assert_called_once_with(unrecoverable)
     finally:
         await _close_test_session(session)
+
+
+async def test_stt_errors_use_unrecoverable_error_tolerance() -> None:
+    from livekit.agents.voice.agent_session import SessionConnectOptions
+
+    session = create_session(
+        FakeActions(),
+        extra_kwargs={"conn_options": SessionConnectOptions(max_unrecoverable_errors=1)},
+    )
+
+    def _stt_error() -> STTError:
+        return STTError(
+            timestamp=time.time(),
+            label="test",
+            error=RuntimeError("stt unavailable"),
+            recoverable=False,
+        )
+
+    try:
+        # first unrecoverable error is tolerated, like llm/tts
+        session._on_error(_stt_error())
+        assert session._closing_task is None
+        assert session._stt_error_counts == 1
+
+        # exceeding the tolerance closes the session
+        session._on_error(_stt_error())
+        assert session._closing_task is not None
+        await session._closing_task
+    finally:
+        await _close_test_session(session)
+
+
+async def test_stt_error_count_resets_on_user_transcript() -> None:
+    from livekit.agents.voice.agent_session import SessionConnectOptions
+
+    session = create_session(
+        FakeActions(),
+        extra_kwargs={"conn_options": SessionConnectOptions(max_unrecoverable_errors=1)},
+    )
+
+    def _stt_error() -> STTError:
+        return STTError(
+            timestamp=time.time(),
+            label="test",
+            error=RuntimeError("stt unavailable"),
+            recoverable=False,
+        )
+
+    try:
+        session._on_error(_stt_error())
+        assert session._stt_error_counts == 1
+
+        # a real transcript means the stt recovered -> tolerance resets
+        session._user_input_transcribed(
+            UserInputTranscribedEvent(transcript="hello", is_final=True)
+        )
+        assert session._stt_error_counts == 0
+
+        # an empty placeholder transcript is not a recovery -> no reset
+        session._on_error(_stt_error())
+        session._user_input_transcribed(UserInputTranscribedEvent(transcript="", is_final=False))
+        assert session._stt_error_counts == 1
+
+        # tolerance still trips once the (reset) budget is exhausted again
+        session._on_error(_stt_error())
+        assert session._closing_task is not None
+        await session._closing_task
+    finally:
+        await _close_test_session(session)
+
+
+async def test_stt_pipeline_recreates_stream_after_unrecoverable_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from livekit.agents.voice import audio_recognition
+    from livekit.agents.voice.audio_recognition import _STTPipeline
+
+    monkeypatch.setattr(audio_recognition, "_STT_RECONNECT_INTERVAL", 0.0)
+
+    attempts = 0
+
+    async def stt_node(audio, model_settings):  # type: ignore[no-untyped-def]
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("stt unavailable")
+
+        yield SpeechEvent(
+            type=SpeechEventType.FINAL_TRANSCRIPT,
+            alternatives=[SpeechData(text="recovered", language="en")],
+        )
+        # stay open like a live stream until the pipeline is closed
+        async for _ in audio:
+            pass
+
+    pipeline = _STTPipeline(stt_node)
+    try:
+        # the first stream dies unrecoverably; the pump must recreate it and
+        # forward the transcript produced by the second stream
+        ev = await asyncio.wait_for(pipeline.event_ch.recv(), timeout=5)
+        assert ev.type == SpeechEventType.FINAL_TRANSCRIPT
+        assert ev.alternatives[0].text == "recovered"
+        assert attempts == 2
+    finally:
+        await pipeline.aclose()
+
+
+async def test_stt_pipeline_does_not_recreate_stream_while_closing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from livekit.agents.voice import audio_recognition
+    from livekit.agents.voice.audio_recognition import _STTPipeline
+
+    monkeypatch.setattr(audio_recognition, "_STT_RECONNECT_INTERVAL", 0.0)
+
+    attempts = 0
+
+    async def stt_node(audio, model_settings):  # type: ignore[no-untyped-def]
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("stt unavailable")
+
+        yield SpeechEvent(
+            type=SpeechEventType.FINAL_TRANSCRIPT,
+            alternatives=[SpeechData(text="recovered", language="en")],
+        )
+
+    # session already closing: the pump must not spawn a replacement stream
+    pipeline = _STTPipeline(stt_node, is_closing=lambda: True)
+    try:
+        events: list[SpeechEvent] = []
+
+        async def _collect() -> None:
+            async for ev in pipeline.event_ch:
+                events.append(ev)
+
+        await asyncio.wait_for(_collect(), timeout=5)
+        assert events == []
+        assert attempts == 1
+    finally:
+        await pipeline.aclose()
 
 
 async def test_vad_fallback_uses_next_vad_inference_event(

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -1302,6 +1302,47 @@ async def test_stt_pipeline_does_not_recreate_stream_while_closing(
         await pipeline.aclose()
 
 
+async def test_stt_pipeline_recreation_uses_rebound_node(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from livekit.agents.voice import audio_recognition
+    from livekit.agents.voice.audio_recognition import _STTPipeline
+
+    monkeypatch.setattr(audio_recognition, "_STT_RECONNECT_INTERVAL", 0.0)
+
+    started_old = asyncio.Event()
+    fail_old = asyncio.Event()
+
+    async def old_node(audio, model_settings):  # type: ignore[no-untyped-def]
+        # the stream captured from the previous agent, still running at handoff
+        started_old.set()
+        await fail_old.wait()
+        raise APIConnectionError("stt unavailable")
+        yield  # pragma: no cover - makes this an async generator
+
+    async def new_node(audio, model_settings):  # type: ignore[no-untyped-def]
+        yield SpeechEvent(
+            type=SpeechEventType.FINAL_TRANSCRIPT,
+            alternatives=[SpeechData(text="recovered", language="en")],
+        )
+        async for _ in audio:
+            pass
+
+    # a handoff reuses the pipeline but rebinds it to the new agent's node; the
+    # recreation after the old stream fails must use that rebound node, not the
+    # previous agent's (whose activity would be torn down)
+    pipeline = _STTPipeline(old_node)
+    try:
+        await asyncio.wait_for(started_old.wait(), timeout=5)
+        pipeline._rebind_node(new_node)
+        fail_old.set()
+        ev = await asyncio.wait_for(pipeline.event_ch.recv(), timeout=5)
+        assert ev.type == SpeechEventType.FINAL_TRANSCRIPT
+        assert ev.alternatives[0].text == "recovered"
+    finally:
+        await pipeline.aclose()
+
+
 async def test_vad_fallback_uses_next_vad_inference_event(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_audio_recognition_handoff.py
+++ b/tests/test_audio_recognition_handoff.py
@@ -240,6 +240,30 @@ async def test_input_anchor_preserved_when_pipeline_reused() -> None:
         await ar._stt_consumer_atask
 
 
+async def test_reused_pipeline_rebinds_stt_node() -> None:
+    """_update_stt must rebind a reused pipeline to the current activity's node.
+
+    The pipeline is created bound to the agent that first started it. After a
+    close-based handoff that agent's activity is torn down, so recreating the
+    stream through the stale node would raise and stop the pump, leaving the
+    agent permanently deaf. Reuse must point recreation at the live node.
+    """
+    reused = object.__new__(_STTPipeline)
+    reused.input_started_at = None  # type: ignore[attr-defined]
+    reused._stt_node = MagicMock(name="previous_agent_node")  # type: ignore[attr-defined]
+    ch = aio.Chan()  # type: ignore[var-annotated]
+    ch.close()  # closed channel → the swapped-in consumer exits immediately
+    reused._event_ch = ch  # type: ignore[attr-defined]
+
+    new_node = MagicMock(name="current_agent_node")
+    ar = _stub_recognition()
+    ar._update_stt(new_node, pipeline=reused)
+
+    assert reused._stt_node is new_node
+    if ar._stt_consumer_atask is not None:
+        await ar._stt_consumer_atask
+
+
 def test_input_anchor_reads_through_to_pipeline() -> None:
     """The anchor lives on the pipeline so it travels with the stream across handoff."""
     ar = _stub_recognition()


### PR DESCRIPTION
Fixes #5665.

Unlike the LLM and TTS streams, which are recreated every turn, the STT stream is long-lived: it is created once per agent activity and iterated by a single pump task. When it exhausted its per-utterance retries it emitted an unrecoverable `stt_error` and the pump ended, so nothing recreated it — and because `stt_error` had none of the session-level tolerance that `llm_error`/`tts_error` have, the session closed immediately on the first unrecoverable STT error.

This makes the long-lived STT stream self-healing and gives it the same session-level tolerance:

- `_STTPipeline` recreates the STT stream (with a short backoff) after an unrecoverable error, so the agent keeps hearing the user if the provider recovers.
- `AgentSession` applies `max_unrecoverable_errors` to `stt_error` as the circuit breaker: each failed stream increments the count, and it resets on a user transcript (STT's success signal, mirroring how llm/tts reset on agent speaking).
- The pump does not recreate the stream while the session is closing, so a teardown in progress can't spawn provider connections that are torn down at once.

Supersedes #5666, #5997, and #6001
