### PR TITLE
fix(google): gate mixed tool use to the Gemini 3 Developer API + build tool config in chat()

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -36,7 +37,6 @@ from livekit.agents.utils import is_given
 
 from .log import logger
 from .models import ChatModels
-from .tools import GeminiTool
 from .utils import create_tools_config, to_response_format
 from .version import __version__
 
@@ -44,6 +44,27 @@ from .version import __version__
 def _is_gemini_3_model(model: str) -> bool:
     """Check if model is Gemini 3 series"""
     return "gemini-3" in model.lower() or model.lower().startswith("gemini-3")
+
+
+def _function_calling_config(
+    tool_choice: NotGivenOr[ToolChoice], function_tools: Iterable[str]
+) -> types.FunctionCallingConfig | None:
+    """Map a LiveKit `tool_choice` to Gemini's FunctionCallingConfig (None if unset)."""
+    if isinstance(tool_choice, dict) and tool_choice.get("type") == "function":
+        return types.FunctionCallingConfig(
+            mode=types.FunctionCallingConfigMode.ANY,
+            allowed_function_names=[tool_choice["function"]["name"]],
+        )
+    if tool_choice == "required":
+        return types.FunctionCallingConfig(
+            mode=types.FunctionCallingConfigMode.ANY,
+            allowed_function_names=list(function_tools) or None,
+        )
+    if tool_choice == "auto":
+        return types.FunctionCallingConfig(mode=types.FunctionCallingConfigMode.AUTO)
+    if tool_choice == "none":
+        return types.FunctionCallingConfig(mode=types.FunctionCallingConfigMode.NONE)
+    return None
 
 
 def _is_gemini_3_flash_model(model: str) -> bool:
@@ -275,57 +296,44 @@ class LLM(llm.LLM):
             extra.update(extra_kwargs)
 
         tool_choice = tool_choice if is_given(tool_choice) else self._opts.tool_choice
-        retrieval_config = (
-            self._opts.retrieval_config if is_given(self._opts.retrieval_config) else None
-        )
-        if isinstance(retrieval_config, dict):
-            retrieval_config = types.RetrievalConfig.model_validate(retrieval_config)
+        tool_ctx = llm.ToolContext(tools or [])
+        # Mixing built-in (provider) tools with function tools is only supported on the
+        # Gemini 3 Developer API (not Vertex).
+        # https://ai.google.dev/gemini-api/docs/tool-combination
+        is_gemini_3_api = _is_gemini_3_model(self._opts.model) and not self._client.vertexai
 
-        if is_given(tool_choice):
-            gemini_tool_choice: types.ToolConfig
-            if isinstance(tool_choice, dict) and tool_choice.get("type") == "function":
-                gemini_tool_choice = types.ToolConfig(
-                    function_calling_config=types.FunctionCallingConfig(
-                        mode=types.FunctionCallingConfigMode.ANY,
-                        allowed_function_names=[tool_choice["function"]["name"]],
-                    ),
-                    retrieval_config=retrieval_config,
+        # cached_content may arrive from the constructor or via extra_kwargs; `_run()` keys
+        # off the merged request, so match it here.
+        using_cache = is_given(self._opts.cached_content) or "cached_content" in extra
+        if using_cache:
+            # tools/tool_config/system_instruction must be baked into the CachedContent
+            # resource, not sent on the request, so we don't build them here.
+            if tool_ctx.function_tools or tool_ctx.provider_tools:
+                logger.warning(
+                    "gemini llm: ignoring tools; bake them into the CachedContent resource",
+                    extra={"model": self._opts.model},
                 )
-                extra["tool_config"] = gemini_tool_choice
-            elif tool_choice == "required":
-                tool_names = []
-                for tool in tools or []:
-                    if isinstance(tool, (llm.FunctionTool, llm.RawFunctionTool)):
-                        tool_names.append(tool.info.name)
-
-                gemini_tool_choice = types.ToolConfig(
-                    function_calling_config=types.FunctionCallingConfig(
-                        mode=types.FunctionCallingConfigMode.ANY,
-                        allowed_function_names=tool_names or None,
-                    ),
-                    retrieval_config=retrieval_config,
-                )
-                extra["tool_config"] = gemini_tool_choice
-            elif tool_choice == "auto":
-                gemini_tool_choice = types.ToolConfig(
-                    function_calling_config=types.FunctionCallingConfig(
-                        mode=types.FunctionCallingConfigMode.AUTO,
-                    ),
-                    retrieval_config=retrieval_config,
-                )
-                extra["tool_config"] = gemini_tool_choice
-            elif tool_choice == "none":
-                gemini_tool_choice = types.ToolConfig(
-                    function_calling_config=types.FunctionCallingConfig(
-                        mode=types.FunctionCallingConfigMode.NONE,
-                    ),
-                    retrieval_config=retrieval_config,
-                )
-                extra["tool_config"] = gemini_tool_choice
-        elif retrieval_config:
-            extra["tool_config"] = types.ToolConfig(
-                retrieval_config=retrieval_config,
+        else:
+            retrieval_config = (
+                self._opts.retrieval_config if is_given(self._opts.retrieval_config) else None
             )
+            if isinstance(retrieval_config, dict):
+                retrieval_config = types.RetrievalConfig.model_validate(retrieval_config)
+
+            # create_tools_config is the single authority on whether built-in and function
+            # tools are actually combined; `mixed` gates the server-side invocation flag.
+            tools_config, mixed = create_tools_config(tool_ctx, allow_mixed_tools=is_gemini_3_api)
+            fcc = _function_calling_config(tool_choice, tool_ctx.function_tools)
+
+            if fcc is not None or retrieval_config or mixed:
+                extra["tool_config"] = types.ToolConfig(
+                    function_calling_config=fcc,
+                    retrieval_config=retrieval_config,
+                    include_server_side_tool_invocations=mixed or None,
+                )
+
+            if tools_config:
+                extra["tools"] = tools_config
 
         if is_given(response_format):
             extra["response_schema"] = to_response_format(response_format)
@@ -451,61 +459,10 @@ class LLMStream(llm.LLMStream):
             )
 
             turns = [types.Content.model_validate(turn) for turn in turns_dict]
-            tool_context = llm.ToolContext(self._tools)
-            tools_config = create_tools_config(
-                tool_context, allow_mixed_tools=_is_gemini_3_model(self._model)
-            )
-            # Gemini's API rejects `generateContent` requests that pass
-            # `cached_content` together with `system_instruction`, `tools`,
-            # or `tool_config` — those fields must live INSIDE the
-            # CachedContent resource, not on the request. The application
-            # bakes them into the cache via `client.caches.create(...)`;
-            # here we just suppress the duplicates on the outgoing request
-            # whenever a cache is attached.
+            # Request shaping (tools/tool_config) is done in `chat()`. When a cache is
+            # attached, `system_instruction` must also live inside the CachedContent
+            # resource, so it's dropped from the outgoing request below.
             using_cache = "cached_content" in self._extra_kwargs
-            # combining built-in + function tools requires include_server_side_tool_invocations
-            # (skip when caching: tool_config must be baked into the cache, dropped below)
-            has_function_tools = bool(tool_context.function_tools)
-            has_provider_tools = any(
-                isinstance(tool, GeminiTool) for tool in tool_context.provider_tools
-            )
-            if (
-                not using_cache
-                and has_function_tools
-                and has_provider_tools
-                and _is_gemini_3_model(self._model)
-            ):
-                tool_config = self._extra_kwargs.get("tool_config")
-                if not isinstance(tool_config, types.ToolConfig):
-                    tool_config = types.ToolConfig()
-                    self._extra_kwargs["tool_config"] = tool_config
-                tool_config.include_server_side_tool_invocations = True
-                # AUTO is unsupported alongside built-in tools; VALIDATED keeps the same
-                # behavior. https://ai.google.dev/gemini-api/docs/tool-combination
-                fcc = tool_config.function_calling_config
-                if fcc is not None and fcc.mode == types.FunctionCallingConfigMode.AUTO:
-                    logger.debug(
-                        "upgrading function_calling_config AUTO->VALIDATED: AUTO is "
-                        "unsupported when combining built-in and function tools"
-                    )
-                    fcc.mode = types.FunctionCallingConfigMode.VALIDATED
-            if tools_config and not using_cache:
-                self._extra_kwargs["tools"] = tools_config
-            elif using_cache:
-                dropped = [k for k in ("tools", "tool_config") if k in self._extra_kwargs]
-                if tools_config and "tools" not in dropped:
-                    dropped.append("tools")
-                if extra_data.system_messages:
-                    dropped.append("system_instruction")
-                if dropped:
-                    logger.warning(
-                        "dropping %s from Gemini request because cached_content=%r is set; "
-                        "these fields must be baked into the CachedContent resource",
-                        dropped,
-                        self._extra_kwargs.get("cached_content"),
-                    )
-                self._extra_kwargs.pop("tools", None)
-                self._extra_kwargs.pop("tool_config", None)
             if is_given(self._llm._opts.http_options):
                 http_options = self._llm._opts.http_options.model_copy()
                 if http_options.timeout is None:

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -307,8 +307,12 @@ class LLM(llm.LLM):
         using_cache = is_given(self._opts.cached_content) or "cached_content" in extra
         if using_cache:
             # tools/tool_config/system_instruction must be baked into the CachedContent
-            # resource, not sent on the request, so we don't build them here.
-            if tool_ctx.function_tools or tool_ctx.provider_tools:
+            # resource, not sent on the request. Don't build them here, and drop any the
+            # caller passed directly via extra_kwargs.
+            dropped = [k for k in ("tools", "tool_config") if k in extra]
+            for key in dropped:
+                extra.pop(key, None)
+            if tool_ctx.function_tools or tool_ctx.provider_tools or dropped:
                 logger.warning(
                     "gemini llm: ignoring tools; bake them into the CachedContent resource",
                     extra={"model": self._opts.model},

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -1130,7 +1130,7 @@ class RealtimeSession(llm.RealtimeSession):
     def _build_connect_config(self) -> types.LiveConnectConfig:
         temp = self._opts.temperature if is_given(self._opts.temperature) else None
 
-        tools_config = create_tools_config(
+        tools_config, _ = create_tools_config(
             self._tools,
             tool_behavior=self._opts.tool_behavior,
             use_parameters_json_schema=False,

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
@@ -24,7 +24,13 @@ def create_tools_config(
     tool_behavior: NotGivenOr[types.Behavior] = NOT_GIVEN,
     use_parameters_json_schema: bool = True,
     allow_mixed_tools: bool = True,
-) -> list[types.Tool]:
+) -> tuple[list[types.Tool], bool]:
+    """Build the Gemini tools list.
+
+    Returns ``(tools, mixed)`` where ``mixed`` is True when both function tools and
+    provider (built-in) tools were emitted together — the single source of truth the
+    caller uses to enable ``include_server_side_tool_invocations``.
+    """
     gemini_tools: list[types.Tool] = []
 
     function_tools = [
@@ -39,18 +45,18 @@ def create_tools_config(
         gemini_tools.append(types.Tool(function_declarations=function_tools))
 
     provider_tools = [tool for tool in tool_ctx.provider_tools if isinstance(tool, GeminiTool)]
-    # generateContent only supports combining built-in tools with function tools
-    # on Gemini 3 models: https://ai.google.dev/gemini-api/docs/tool-combination
+    # generateContent only supports combining built-in tools with function tools on the
+    # Gemini 3 Developer API: https://ai.google.dev/gemini-api/docs/tool-combination
     if function_tools and provider_tools and not allow_mixed_tools:
         logger.warning(
-            "this model does not support combining provider tools with function tools; "
-            "ignoring provider tools (combining them requires a Gemini 3 model)"
+            "ignoring provider tools; combining them with function tools requires the "
+            "Gemini 3 Developer API (Vertex AI is not supported)"
         )
-        return gemini_tools
+        return gemini_tools, False
 
     # only convert tools we actually send, so a dropped tool can't break the request
     gemini_tools.extend(tool.to_tool_config() for tool in provider_tools)
-    return gemini_tools
+    return gemini_tools, bool(function_tools and provider_tools)
 
 
 def create_function_response(

--- a/tests/test_plugin_google_llm.py
+++ b/tests/test_plugin_google_llm.py
@@ -471,3 +471,27 @@ class TestMixedToolsRequestConstruction:
         assert config.cached_content == "cachedContents/abc123"
         assert config.tools is None
         assert config.tool_config is None
+
+    @pytest.mark.asyncio
+    async def test_cached_content_strips_raw_tools_from_extra_kwargs(self) -> None:
+        """Raw ``tools``/``tool_config`` placed directly in ``extra_kwargs`` must also be
+        stripped when a cache is active — otherwise Gemini rejects the request for
+        combining them with cached_content."""
+        llm_ = LLM(
+            model="gemini-3-flash-preview", api_key="test", cached_content="cachedContents/abc"
+        )
+        config = await self._capture_config(
+            llm_,
+            extra_kwargs={
+                "tools": [types.Tool(google_search=types.GoogleSearch())],
+                "tool_config": types.ToolConfig(
+                    function_calling_config=types.FunctionCallingConfig(
+                        mode=types.FunctionCallingConfigMode.AUTO
+                    )
+                ),
+            },
+        )
+
+        assert config.cached_content == "cachedContents/abc"
+        assert config.tools is None
+        assert config.tool_config is None

--- a/tests/test_plugin_google_llm.py
+++ b/tests/test_plugin_google_llm.py
@@ -10,6 +10,7 @@ from livekit.agents.llm import ChatContext, function_tool
 from livekit.agents.types import APIConnectOptions
 from livekit.plugins.google.llm import LLM, LLMStream
 from livekit.plugins.google.realtime.realtime_api import RealtimeModel, RealtimeSession
+from livekit.plugins.google.tools import GoogleSearch
 
 pytestmark = pytest.mark.plugin("google")
 
@@ -333,3 +334,140 @@ class TestMediaResolution:
 
         assert config.generation_config
         assert config.generation_config.media_resolution is None
+
+
+class TestMixedToolsRequestConstruction:
+    """Combining built-in (provider) tools with function tools is only supported on the
+    Gemini 3 Developer API (not Vertex). These tests drive ``chat()`` against a stubbed
+    ``generate_content_stream`` and assert on the resulting request config."""
+
+    @staticmethod
+    async def _single_response_async_iter():
+        yield types.GenerateContentResponse(
+            candidates=[
+                types.Candidate(
+                    content=types.Content(role="model", parts=[types.Part(text="ok")]),
+                    finish_reason=types.FinishReason.STOP,
+                )
+            ],
+        )
+
+    @classmethod
+    async def _capture_config(cls, llm_: LLM, **chat_kwargs):
+        captured: dict = {}
+
+        async def fake_stream(**kwargs):
+            captured["config"] = kwargs.get("config")
+            return cls._single_response_async_iter()
+
+        fake = AsyncMock(side_effect=fake_stream)
+        with patch.object(llm_._client.aio.models, "generate_content_stream", fake):
+            stream = llm_.chat(chat_ctx=ChatContext.empty(), **chat_kwargs)
+            try:
+                async for _ in stream:
+                    pass
+            finally:
+                await stream.aclose()
+        return captured["config"]
+
+    @staticmethod
+    def _weather_tool():
+        @function_tool
+        async def get_weather(city: str) -> str:
+            """Look up the weather."""
+            return city
+
+        return get_weather
+
+    @staticmethod
+    def _has_google_search(config) -> bool:
+        return bool(config.tools) and any(getattr(t, "google_search", None) for t in config.tools)
+
+    @staticmethod
+    def _has_function_declarations(config) -> bool:
+        return bool(config.tools) and any(t.function_declarations for t in config.tools)
+
+    @staticmethod
+    def _server_side_enabled(config) -> bool:
+        return bool(config.tool_config and config.tool_config.include_server_side_tool_invocations)
+
+    @pytest.mark.asyncio
+    async def test_dev_api_enables_server_side_invocations(self) -> None:
+        """Gemini 3 Developer API: both tool types are sent and the circulation flag is set."""
+        llm_ = LLM(model="gemini-3-flash-preview", api_key="test")
+        config = await self._capture_config(llm_, tools=[self._weather_tool(), GoogleSearch()])
+
+        assert self._server_side_enabled(config)
+        assert self._has_function_declarations(config)
+        assert self._has_google_search(config)
+
+    @pytest.mark.asyncio
+    async def test_auto_mode_kept_for_mixed_tools(self) -> None:
+        """``tool_choice='auto'`` is passed through as AUTO alongside the circulation flag.
+        Verified live against the Gemini 3 Developer API: AUTO + built-in tools is accepted,
+        so no VALIDATED upgrade is applied."""
+        llm_ = LLM(model="gemini-3-flash-preview", api_key="test")
+        config = await self._capture_config(
+            llm_, tools=[self._weather_tool(), GoogleSearch()], tool_choice="auto"
+        )
+
+        assert self._server_side_enabled(config)
+        assert (
+            config.tool_config.function_calling_config.mode == types.FunctionCallingConfigMode.AUTO
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_gemini_3_drops_provider_tool(self) -> None:
+        """Below Gemini 3 the provider tool is dropped and no flag is set."""
+        llm_ = LLM(model="gemini-2.5-flash", api_key="test")
+        config = await self._capture_config(llm_, tools=[self._weather_tool(), GoogleSearch()])
+
+        assert not self._server_side_enabled(config)
+        assert self._has_function_declarations(config)
+        assert not self._has_google_search(config)
+
+    @pytest.mark.asyncio
+    async def test_vertex_gemini_3_drops_provider_tool(self) -> None:
+        """Vertex AI does not support mixing, even on Gemini 3: provider tool is dropped."""
+        from google.auth.credentials import AnonymousCredentials
+
+        llm_ = LLM(
+            model="gemini-3-flash-preview",
+            vertexai=True,
+            project="test-project",
+            location="us-central1",
+            credentials=AnonymousCredentials(),
+        )
+        assert llm_._client.vertexai is True
+
+        config = await self._capture_config(llm_, tools=[self._weather_tool(), GoogleSearch()])
+
+        assert not self._server_side_enabled(config)
+        assert self._has_function_declarations(config)
+        assert not self._has_google_search(config)
+
+    @pytest.mark.asyncio
+    async def test_provider_only_does_not_set_flag(self) -> None:
+        """The circulation flag requires BOTH function and provider tools; a provider tool
+        alone is sent without it."""
+        llm_ = LLM(model="gemini-3-flash-preview", api_key="test")
+        config = await self._capture_config(llm_, tools=[GoogleSearch()])
+
+        assert not self._server_side_enabled(config)
+        assert self._has_google_search(config)
+
+    @pytest.mark.asyncio
+    async def test_cached_content_via_extra_kwargs_suppresses_tools(self) -> None:
+        """cached_content passed through ``extra_kwargs`` (not just the constructor) must
+        still skip building tools/tool_config, so the request isn't rejected for combining
+        them with a cache."""
+        llm_ = LLM(model="gemini-3-flash-preview", api_key="test")
+        config = await self._capture_config(
+            llm_,
+            tools=[self._weather_tool(), GoogleSearch()],
+            extra_kwargs={"cached_content": "cachedContents/abc123"},
+        )
+
+        assert config.cached_content == "cachedContents/abc123"
+        assert config.tools is None
+        assert config.tool_config is None


### PR DESCRIPTION
Follow-up to #6416 (mixed built-in + function tool support). Two things: a correctness fix (Vertex) and a structural cleanup (move request shaping into `chat()`).

## Why

- **Vertex gap.** Mixing built-in (provider) tools with function tools is only supported on the **Gemini 3 Developer API** — Vertex AI drops search tools when function declarations are present ([docs](https://ai.google.dev/gemini-api/docs/tool-combination)). The merged code set `include_server_side_tool_invocations` on Vertex too, producing a request Vertex rejects.
- **Split construction.** Tool/`tool_config` construction lived in `LLMStream._run()` even though all its inputs (tools, `tool_choice`, model, `vertexai`, `cached_content`) are known at `chat()` time. That forced a build-then-mutate pattern, a duplicated mixed-tools predicate, and a build-then-`pop()` cache dance.

## What changed

- **Vertex gate:** `is_gemini_3_api = _is_gemini_3_model(model) and not client.vertexai`. On Vertex, mixing falls back to single-type tool use with a warning instead of an unsupported request.
- **Moved all tool/`tool_config` construction from `_run()` into `chat()`.** Builds the `ToolConfig` once; `_run()` now owns only what depends on the formatted context (`system_instruction` dropping) and no longer mutates shared request state on retry.
- **Cache handling** is now a plain `if/else` in `chat()` (skip building tools when cached) instead of build-then-`pop()`. Honors `cached_content` from either the constructor **or** `extra_kwargs`.
- **`create_tools_config` returns `(tools, mixed)`** and is the single source of truth for whether built-in + function tools are actually combined, so the server-side-invocation flag can't drift from what's sent.

### Note on `tool_choice="auto"`
`AUTO` is passed through as-is alongside the circulation flag (no `AUTO→VALIDATED` upgrade). Verified live against the Gemini 3 Developer API: `AUTO` + built-in tools is accepted.

## Tests

New request-capture tests in `test_plugin_google_llm.py` covering: Dev-API mixed path, Vertex fallback, non-Gemini-3 fallback, provider-tools-only, `tool_choice="auto"` passthrough, and cache-via-`extra_kwargs` suppression. All 21 google LLM tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)