### PR TITLE
fix(soniox): end stream_id on idle stall and FlushSentinel

### DIFF
--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -35,6 +35,7 @@ from livekit.agents import (
 )
 from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, NotGivenOr
 from livekit.agents.utils import is_given
+from livekit.agents.utils.aio.channel import ChanClosed
 
 from .log import logger
 
@@ -293,9 +294,10 @@ class SynthesizeStream(tts.SynthesizeStream):
         sent, then lazily starts a new ``stream_id`` when text resumes. This matches
         Soniox's multiplexed-stream model and avoids per-stream 408 timeouts during
         LLM stalls (see livekit/agents#6225, #6425).
-        """
-        from livekit.agents.utils.aio.channel import ChanClosed
 
+        Soniox ``stream_id`` may rotate on idle/flush, but the AudioEmitter stays on
+        a single segment for the life of this ``SynthesizeStream``.
+        """
         request_id = utils.shortuuid()
         self._stream_id = utils.shortuuid()
 
@@ -339,9 +341,9 @@ class SynthesizeStream(tts.SynthesizeStream):
                 connection.send_text(self._stream_id, "", text_end=True)
             try:
                 await waiter
-            except APIStatusError:
+            except (APIStatusError, APIConnectionError, asyncio.TimeoutError):
                 raise
-            except Exception as e:
+            except aiohttp.ClientError as e:
                 raise APIConnectionError() from e
             finally:
                 connection.unregister_stream(self._stream_id)
@@ -359,9 +361,10 @@ class SynthesizeStream(tts.SynthesizeStream):
             nonlocal waiter
             segment_has_text = False
             need_new_stream = False
-            idle_timeout = self._opts.stream_idle_timeout
 
             while not self._cancelled.is_set():
+                # Re-read each iteration so update_options(stream_idle_timeout=...) applies.
+                idle_timeout = self._opts.stream_idle_timeout
                 try:
                     if segment_has_text and idle_timeout > 0:
                         data = await asyncio.wait_for(self._input_ch.recv(), timeout=idle_timeout)
@@ -399,9 +402,9 @@ class SynthesizeStream(tts.SynthesizeStream):
 
         try:
             await input_t
-        except APIStatusError:
+        except (APIStatusError, APIConnectionError, asyncio.TimeoutError):
             raise
-        except Exception as e:
+        except aiohttp.ClientError as e:
             raise APIConnectionError() from e
         finally:
             await utils.aio.gracefully_cancel(input_t)

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import json
 import os
 import time
@@ -278,10 +279,16 @@ class _StreamLifecycle:
         self._loop = asyncio.get_running_loop()
         self._waiter: asyncio.Future[None] = self._loop.create_future()
         self._registered = False
+        self._registered_gate = asyncio.Event()
 
     @property
     def registered(self) -> bool:
         return self._registered
+
+    @property
+    def waiter(self) -> asyncio.Future[None] | None:
+        """Active completion future, or None between ``end`` and the next ``start``."""
+        return self._waiter if self._registered else None
 
     def start(self) -> None:
         """Allocate and register a new Soniox stream_id."""
@@ -294,6 +301,13 @@ class _StreamLifecycle:
             opts=self._opts,
         )
         self._registered = True
+        self._registered_gate.set()
+
+    async def wait_until_registered(self) -> None:
+        """Block until ``start()`` registers a stream_id (no busy-wait)."""
+        while not self._registered:
+            self._registered_gate.clear()
+            await self._registered_gate.wait()
 
     async def end(self, *, send_text_end: bool) -> None:
         """Finish the current Soniox stream_id (AudioEmitter segment stays open)."""
@@ -438,16 +452,73 @@ class SynthesizeStream(tts.SynthesizeStream):
                 # Input finished: end the open stream if any text was (or would be) active.
                 await lifecycle.end(send_text_end=True)
 
+        async def _monitor_server() -> None:
+            """Surface server errors promptly while input is still open (pre-rotation behavior).
+
+            On main, ``_run`` awaited the stream waiter concurrently with input. With
+            stream_id rotation we only ``await`` inside ``lifecycle.end``; without this
+            monitor, a mid-turn server error would sit on the Future until flush/idle/end.
+            """
+            while not self._cancelled.is_set():
+                if input_t.done():
+                    return
+
+                waiter = lifecycle.waiter
+                if waiter is None:
+                    # Between end() and the next start() — park until one of them happens.
+                    wait_reg = asyncio.create_task(
+                        lifecycle.wait_until_registered(),
+                        name="soniox-tts-wait-registered",
+                    )
+                    try:
+                        await asyncio.wait(
+                            {wait_reg, input_t},
+                            return_when=asyncio.FIRST_COMPLETED,
+                        )
+                    finally:
+                        if not wait_reg.done():
+                            wait_reg.cancel()
+                            with contextlib.suppress(asyncio.CancelledError):
+                                await wait_reg
+                    if input_t.done():
+                        return
+                    continue
+
+                done, _ = await asyncio.wait(
+                    {waiter, input_t},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if input_t in done and waiter not in done:
+                    return
+                if waiter in done:
+                    if waiter.cancelled():
+                        continue
+                    exc = waiter.exception()
+                    if exc is not None:
+                        raise exc
+                    # Successful completion (text_end drained) — watch the next stream_id.
+                    continue
+
         input_t = asyncio.create_task(_input_task(), name="soniox-tts-stream-input")
+        monitor_t = asyncio.create_task(_monitor_server(), name="soniox-tts-stream-monitor")
 
         try:
-            await input_t
+            done, _ = await asyncio.wait(
+                {input_t, monitor_t},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in done:
+                if task.cancelled():
+                    continue
+                exc = task.exception()
+                if exc is not None:
+                    raise exc
         except (APIStatusError, APIConnectionError, asyncio.TimeoutError):
             raise
         except aiohttp.ClientError as e:
             raise APIConnectionError() from e
         finally:
-            await utils.aio.gracefully_cancel(input_t)
+            await utils.aio.gracefully_cancel(input_t, monitor_t)
             output_emitter.end_segment()
             lifecycle.unregister()
 

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -52,6 +52,9 @@ MIN_SPEED = 0.7
 MAX_SPEED = 1.3
 KEEPALIVE_INTERVAL = 10  # seconds
 KEEPALIVE_MESSAGE = json.dumps({"keep_alive": True})
+# End an open stream_id before Soniox's per-stream request timeout (~8–18s observed)
+# when the LLM stalls mid-turn. See github.com/livekit/agents/issues/6225.
+DEFAULT_STREAM_IDLE_TIMEOUT = 5.0
 
 
 def _audio_format_to_mime_type(audio_format: str) -> str:
@@ -81,6 +84,7 @@ class TTS(tts.TTS):
         sample_rate: int = DEFAULT_SAMPLE_RATE,
         bitrate: int | None = None,
         speed: float = DEFAULT_SPEED,
+        stream_idle_timeout: float = DEFAULT_STREAM_IDLE_TIMEOUT,
         api_key: str | None = None,
         websocket_url: str = WEBSOCKET_URL,
         http_session: aiohttp.ClientSession | None = None,
@@ -96,6 +100,11 @@ class TTS(tts.TTS):
             bitrate (int): Codec bitrate in bps for compressed formats. Optional.
             speed (float): Speaking rate. 1.0 is the normal rate; values below 1.0 slow speech
                 down and values above 1.0 speed it up. Range is [0.7, 1.3]. Defaults to 1.0.
+            stream_idle_timeout (float): Seconds of silence on an open Soniox ``stream_id``
+                (no new text and no ``FlushSentinel``) before sending ``text_end`` and
+                starting a new ``stream_id`` when text resumes. Prevents Soniox per-stream
+                408 request timeouts during LLM stalls. Set to ``0`` to disable. Defaults
+                to 5.0.
             api_key (str): Soniox API key. If not provided, will look for SONIOX_API_KEY env variable.
             websocket_url (str): Base WebSocket URL for Soniox TTS API.
             http_session (aiohttp.ClientSession): Optional aiohttp.ClientSession to use for requests.
@@ -112,6 +121,8 @@ class TTS(tts.TTS):
 
         if not MIN_SPEED <= speed <= MAX_SPEED:
             raise ValueError(f"speed must be between {MIN_SPEED} and {MAX_SPEED}, but got {speed}")
+        if stream_idle_timeout < 0:
+            raise ValueError(f"stream_idle_timeout must be >= 0, but got {stream_idle_timeout}")
 
         self._opts = _TTSOptions(
             model=model,
@@ -121,6 +132,7 @@ class TTS(tts.TTS):
             sample_rate=sample_rate,
             bitrate=bitrate,
             speed=speed,
+            stream_idle_timeout=stream_idle_timeout,
             websocket_url=websocket_url,
             api_key=api_key,
         )
@@ -173,6 +185,7 @@ class TTS(tts.TTS):
         language: NotGivenOr[str] = NOT_GIVEN,
         voice: NotGivenOr[str] = NOT_GIVEN,
         speed: NotGivenOr[float] = NOT_GIVEN,
+        stream_idle_timeout: NotGivenOr[float] = NOT_GIVEN,
     ) -> None:
         """
         Args:
@@ -180,6 +193,8 @@ class TTS(tts.TTS):
             language: Language code to use.
             voice: Voice to use.
             speed: Speaking rate in the range [0.7, 1.3]; 1.0 is the normal rate.
+            stream_idle_timeout: Idle seconds before ending the active Soniox stream_id.
+                Set to ``0`` to disable idle rotation.
         """
         if is_given(model):
             self._opts.model = model
@@ -193,6 +208,12 @@ class TTS(tts.TTS):
                     f"speed must be between {MIN_SPEED} and {MAX_SPEED}, but got {speed}"
                 )
             self._opts.speed = speed
+        if is_given(stream_idle_timeout):
+            if stream_idle_timeout < 0:
+                raise ValueError(f"stream_idle_timeout must be >= 0, but got {stream_idle_timeout}")
+            self._opts.stream_idle_timeout = stream_idle_timeout
+            for stream in list(self._streams):
+                stream._opts.stream_idle_timeout = stream_idle_timeout
 
     def synthesize(
         self, text: str, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
@@ -265,7 +286,16 @@ class SynthesizeStream(tts.SynthesizeStream):
         await super().aclose()
 
     async def _run(self, output_emitter: tts.AudioEmitter) -> None:
-        """Register with the connection, stream text, await the completion future."""
+        """Register with the connection, stream text, await segment completion.
+
+        Ends the active Soniox ``stream_id`` (``text_end``) when input goes idle for
+        ``stream_idle_timeout`` or when a ``FlushSentinel`` arrives after text was
+        sent, then lazily starts a new ``stream_id`` when text resumes. This matches
+        Soniox's multiplexed-stream model and avoids per-stream 408 timeouts during
+        LLM stalls (see livekit/agents#6225, #6425).
+        """
+        from livekit.agents.utils.aio.channel import ChanClosed
+
         request_id = utils.shortuuid()
         self._stream_id = utils.shortuuid()
 
@@ -295,33 +325,90 @@ class SynthesizeStream(tts.SynthesizeStream):
 
         self._connection = connection
 
-        waiter: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+        loop = asyncio.get_running_loop()
+        waiter: asyncio.Future[None] = loop.create_future()
         connection.register_stream(self._stream_id, output_emitter, waiter, opts=self._opts)
+        stream_registered = True
+
+        async def _end_active_stream(*, send_text_end: bool) -> None:
+            """Finish the current Soniox stream_id (keep the AudioEmitter segment open)."""
+            nonlocal waiter, stream_registered
+            if not stream_registered:
+                return
+            if send_text_end:
+                connection.send_text(self._stream_id, "", text_end=True)
+            try:
+                await waiter
+            except APIStatusError:
+                raise
+            except Exception as e:
+                raise APIConnectionError() from e
+            finally:
+                connection.unregister_stream(self._stream_id)
+                stream_registered = False
+
+        def _start_next_stream() -> None:
+            """Allocate and register a new stream_id for the next text chunk."""
+            nonlocal waiter, stream_registered
+            self._stream_id = utils.shortuuid()
+            waiter = loop.create_future()
+            connection.register_stream(self._stream_id, output_emitter, waiter, opts=self._opts)
+            stream_registered = True
 
         async def _input_task() -> None:
-            async for data in self._input_ch:
-                if self._cancelled.is_set():
-                    break
-                if isinstance(data, self._FlushSentinel):
+            nonlocal waiter
+            segment_has_text = False
+            need_new_stream = False
+            idle_timeout = self._opts.stream_idle_timeout
+
+            while not self._cancelled.is_set():
+                try:
+                    if segment_has_text and idle_timeout > 0:
+                        data = await asyncio.wait_for(self._input_ch.recv(), timeout=idle_timeout)
+                    else:
+                        data = await self._input_ch.recv()
+                except asyncio.TimeoutError:
+                    # Input stalled while a stream_id is open — end it before Soniox 408s.
+                    await _end_active_stream(send_text_end=True)
+                    segment_has_text = False
+                    need_new_stream = True
                     continue
+                except ChanClosed:
+                    break
+
+                if isinstance(data, self._FlushSentinel):
+                    if segment_has_text:
+                        await _end_active_stream(send_text_end=True)
+                        segment_has_text = False
+                        need_new_stream = True
+                    continue
+
+                if need_new_stream:
+                    _start_next_stream()
+                    need_new_stream = False
+
                 self._mark_started()
                 connection.send_text(self._stream_id, data, text_end=False)
+                segment_has_text = True
 
-            if not self._cancelled.is_set():
-                connection.send_text(self._stream_id, "", text_end=True)
+            if not self._cancelled.is_set() and stream_registered:
+                # Input finished: end the open stream if any text was (or would be) active.
+                await _end_active_stream(send_text_end=True)
 
         input_t = asyncio.create_task(_input_task(), name="soniox-tts-stream-input")
 
         try:
-            await waiter
+            await input_t
         except APIStatusError:
             raise
         except Exception as e:
             raise APIConnectionError() from e
         finally:
-            output_emitter.end_segment()
             await utils.aio.gracefully_cancel(input_t)
-            connection.unregister_stream(self._stream_id)
+            output_emitter.end_segment()
+            if stream_registered:
+                connection.unregister_stream(self._stream_id)
+                stream_registered = False
 
 
 @dataclass
@@ -333,6 +420,7 @@ class _TTSOptions:
     sample_rate: int
     bitrate: int | None
     speed: float
+    stream_idle_timeout: float
     websocket_url: str
     api_key: str
 

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -53,9 +53,10 @@ MIN_SPEED = 0.7
 MAX_SPEED = 1.3
 KEEPALIVE_INTERVAL = 10  # seconds
 KEEPALIVE_MESSAGE = json.dumps({"keep_alive": True})
-# End an open stream_id before Soniox's per-stream request timeout (~8–18s observed)
-# when the LLM stalls mid-turn. See github.com/livekit/agents/issues/6225.
-DEFAULT_STREAM_IDLE_TIMEOUT = 5.0
+# Idle stream_id rotation is opt-in (0 = disabled). Callers who hit Soniox mid-turn 408s
+# during LLM stalls should set ~5.0s (under Soniox's observed ~8–18s per-stream timeout).
+# See github.com/livekit/agents/issues/6225.
+DEFAULT_STREAM_IDLE_TIMEOUT = 0.0
 
 
 def _audio_format_to_mime_type(audio_format: str) -> str:
@@ -104,8 +105,8 @@ class TTS(tts.TTS):
             stream_idle_timeout (float): Seconds of silence on an open Soniox ``stream_id``
                 (no new text and no ``FlushSentinel``) before sending ``text_end`` and
                 starting a new ``stream_id`` when text resumes. Prevents Soniox per-stream
-                408 request timeouts during LLM stalls. Set to ``0`` to disable. Defaults
-                to 5.0.
+                408 request timeouts during LLM stalls. ``0`` disables (default); ``5.0``
+                is a typical value under Soniox's observed per-stream timeout.
             api_key (str): Soniox API key. If not provided, will look for SONIOX_API_KEY env variable.
             websocket_url (str): Base WebSocket URL for Soniox TTS API.
             http_session (aiohttp.ClientSession): Optional aiohttp.ClientSession to use for requests.
@@ -195,7 +196,7 @@ class TTS(tts.TTS):
             voice: Voice to use.
             speed: Speaking rate in the range [0.7, 1.3]; 1.0 is the normal rate.
             stream_idle_timeout: Idle seconds before ending the active Soniox stream_id.
-                Set to ``0`` to disable idle rotation.
+                ``0`` disables idle rotation.
         """
         if is_given(model):
             self._opts.model = model
@@ -255,6 +256,70 @@ class TTS(tts.TTS):
             self.__current_connection = None
 
 
+class _StreamLifecycle:
+    """Owns Soniox ``stream_id`` registration / rotation for one ``SynthesizeStream``.
+
+    The LiveKit AudioEmitter stays on a single segment; this only rotates the Soniox
+    multiplexed ``stream_id`` on idle stall or flush.
+    """
+
+    def __init__(
+        self,
+        *,
+        stream: SynthesizeStream,
+        connection: _Connection,
+        output_emitter: tts.AudioEmitter,
+        opts: _TTSOptions,
+    ) -> None:
+        self._stream = stream
+        self._connection = connection
+        self._output_emitter = output_emitter
+        self._opts = opts
+        self._loop = asyncio.get_running_loop()
+        self._waiter: asyncio.Future[None] = self._loop.create_future()
+        self._registered = False
+
+    @property
+    def registered(self) -> bool:
+        return self._registered
+
+    def start(self) -> None:
+        """Allocate and register a new Soniox stream_id."""
+        self._stream._stream_id = utils.shortuuid()
+        self._waiter = self._loop.create_future()
+        self._connection.register_stream(
+            self._stream._stream_id,
+            self._output_emitter,
+            self._waiter,
+            opts=self._opts,
+        )
+        self._registered = True
+
+    async def end(self, *, send_text_end: bool) -> None:
+        """Finish the current Soniox stream_id (AudioEmitter segment stays open)."""
+        if not self._registered:
+            return
+        if send_text_end:
+            self._connection.send_text(self._stream._stream_id, "", text_end=True)
+        try:
+            await self._waiter
+        except (APIStatusError, APIConnectionError, asyncio.TimeoutError):
+            raise
+        except aiohttp.ClientError as e:
+            raise APIConnectionError() from e
+        finally:
+            self.unregister()
+
+    def unregister(self) -> None:
+        if not self._registered:
+            return
+        self._connection.unregister_stream(self._stream._stream_id)
+        self._registered = False
+
+    def send_text(self, text: str, *, text_end: bool = False) -> None:
+        self._connection.send_text(self._stream._stream_id, text, text_end=text_end)
+
+
 class SynthesizeStream(tts.SynthesizeStream):
     """Streaming TTS implementation on a shared _Connection."""
 
@@ -299,7 +364,6 @@ class SynthesizeStream(tts.SynthesizeStream):
         a single segment for the life of this ``SynthesizeStream``.
         """
         request_id = utils.shortuuid()
-        self._stream_id = utils.shortuuid()
 
         output_emitter.initialize(
             request_id=request_id,
@@ -326,39 +390,15 @@ class SynthesizeStream(tts.SynthesizeStream):
             raise APIConnectionError() from e
 
         self._connection = connection
-
-        loop = asyncio.get_running_loop()
-        waiter: asyncio.Future[None] = loop.create_future()
-        connection.register_stream(self._stream_id, output_emitter, waiter, opts=self._opts)
-        stream_registered = True
-
-        async def _end_active_stream(*, send_text_end: bool) -> None:
-            """Finish the current Soniox stream_id (keep the AudioEmitter segment open)."""
-            nonlocal waiter, stream_registered
-            if not stream_registered:
-                return
-            if send_text_end:
-                connection.send_text(self._stream_id, "", text_end=True)
-            try:
-                await waiter
-            except (APIStatusError, APIConnectionError, asyncio.TimeoutError):
-                raise
-            except aiohttp.ClientError as e:
-                raise APIConnectionError() from e
-            finally:
-                connection.unregister_stream(self._stream_id)
-                stream_registered = False
-
-        def _start_next_stream() -> None:
-            """Allocate and register a new stream_id for the next text chunk."""
-            nonlocal waiter, stream_registered
-            self._stream_id = utils.shortuuid()
-            waiter = loop.create_future()
-            connection.register_stream(self._stream_id, output_emitter, waiter, opts=self._opts)
-            stream_registered = True
+        lifecycle = _StreamLifecycle(
+            stream=self,
+            connection=connection,
+            output_emitter=output_emitter,
+            opts=self._opts,
+        )
+        lifecycle.start()
 
         async def _input_task() -> None:
-            nonlocal waiter
             segment_has_text = False
             need_new_stream = False
 
@@ -372,7 +412,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                         data = await self._input_ch.recv()
                 except asyncio.TimeoutError:
                     # Input stalled while a stream_id is open — end it before Soniox 408s.
-                    await _end_active_stream(send_text_end=True)
+                    await lifecycle.end(send_text_end=True)
                     segment_has_text = False
                     need_new_stream = True
                     continue
@@ -381,22 +421,22 @@ class SynthesizeStream(tts.SynthesizeStream):
 
                 if isinstance(data, self._FlushSentinel):
                     if segment_has_text:
-                        await _end_active_stream(send_text_end=True)
+                        await lifecycle.end(send_text_end=True)
                         segment_has_text = False
                         need_new_stream = True
                     continue
 
                 if need_new_stream:
-                    _start_next_stream()
+                    lifecycle.start()
                     need_new_stream = False
 
                 self._mark_started()
-                connection.send_text(self._stream_id, data, text_end=False)
+                lifecycle.send_text(data, text_end=False)
                 segment_has_text = True
 
-            if not self._cancelled.is_set() and stream_registered:
+            if not self._cancelled.is_set() and lifecycle.registered:
                 # Input finished: end the open stream if any text was (or would be) active.
-                await _end_active_stream(send_text_end=True)
+                await lifecycle.end(send_text_end=True)
 
         input_t = asyncio.create_task(_input_task(), name="soniox-tts-stream-input")
 
@@ -409,9 +449,7 @@ class SynthesizeStream(tts.SynthesizeStream):
         finally:
             await utils.aio.gracefully_cancel(input_t)
             output_emitter.end_segment()
-            if stream_registered:
-                connection.unregister_stream(self._stream_id)
-                stream_registered = False
+            lifecycle.unregister()
 
 
 @dataclass

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -3,6 +3,9 @@
 Covers the #6225 / #6425 fix: ending an open ``stream_id`` with ``text_end`` when
 input stalls or a FlushSentinel arrives, then using a new ``stream_id`` when text
 resumes (idle path). Flush ends the Soniox stream so the segment completes cleanly.
+
+Idle-timeout tests use ``virtual_time`` so ``asyncio.sleep`` / ``wait_for`` timers
+advance deterministically (no wall-clock flake).
 """
 
 from __future__ import annotations
@@ -16,7 +19,11 @@ from livekit.agents import APIConnectOptions
 from livekit.agents.tts import AudioEmitter
 from livekit.plugins.soniox import tts as soniox_tts
 
-pytestmark = pytest.mark.plugin("soniox")
+pytestmark = [
+    pytest.mark.plugin("soniox"),
+    pytest.mark.virtual_time,
+    pytest.mark.no_concurrent,
+]
 
 # 10 ms of mono s16le silence at 24 kHz — enough for AudioEmitter to emit frames.
 _SILENCE_PCM = b"\x00\x00" * 240
@@ -95,7 +102,7 @@ async def _consume_stream(stream: soniox_tts.SynthesizeStream) -> None:
 async def test_flush_sentinel_sends_text_end() -> None:
     """FlushSentinel must send text_end (previously a no-op on Soniox)."""
     fake_conn = _FakeConnection()
-    tts = soniox_tts.TTS(api_key="test-key", stream_idle_timeout=0)
+    tts = soniox_tts.TTS(api_key="test-key")
     _patch_connection(tts, fake_conn)
     stream = soniox_tts.SynthesizeStream(
         tts=tts, conn_options=APIConnectOptions(max_retry=0, timeout=1.0)
@@ -120,7 +127,7 @@ async def test_flush_sentinel_sends_text_end() -> None:
 @pytest.mark.asyncio
 async def test_flush_before_any_text_does_not_send_text_end() -> None:
     fake_conn = _FakeConnection()
-    tts = soniox_tts.TTS(api_key="test-key", stream_idle_timeout=0)
+    tts = soniox_tts.TTS(api_key="test-key")
     _patch_connection(tts, fake_conn)
     stream = soniox_tts.SynthesizeStream(
         tts=tts, conn_options=APIConnectOptions(max_retry=0, timeout=1.0)
@@ -144,7 +151,7 @@ async def test_flush_before_any_text_does_not_send_text_end() -> None:
 @pytest.mark.asyncio
 async def test_idle_timeout_sends_text_end_and_rotates_stream_id() -> None:
     fake_conn = _FakeConnection()
-    tts = soniox_tts.TTS(api_key="test-key", stream_idle_timeout=0.05)
+    tts = soniox_tts.TTS(api_key="test-key", stream_idle_timeout=1.0)
     _patch_connection(tts, fake_conn)
     stream = soniox_tts.SynthesizeStream(
         tts=tts, conn_options=APIConnectOptions(max_retry=0, timeout=1.0)
@@ -153,7 +160,8 @@ async def test_idle_timeout_sends_text_end_and_rotates_stream_id() -> None:
     consumer = asyncio.create_task(_consume_stream(stream))
     await asyncio.sleep(0)
     stream.push_text("before idle")
-    await asyncio.sleep(0.15)
+    # Virtual time autojumps past the 1s idle timeout.
+    await asyncio.sleep(2.0)
     stream.push_text(" after idle")
     stream.end_input()
     await consumer
@@ -182,7 +190,8 @@ async def test_stream_idle_timeout_zero_disables_idle_rotation() -> None:
     consumer = asyncio.create_task(_consume_stream(stream))
     await asyncio.sleep(0)
     stream.push_text("chunk1")
-    await asyncio.sleep(0.12)
+    # With idle disabled, a long virtual pause must not rotate stream_id.
+    await asyncio.sleep(5.0)
     stream.push_text(" chunk2")
     stream.end_input()
     await consumer
@@ -193,6 +202,12 @@ async def test_stream_idle_timeout_zero_disables_idle_rotation() -> None:
     assert len(texts) == 2
     assert texts[0][0] == texts[1][0]
     assert len(text_ends) == 1
+
+
+def test_stream_idle_timeout_default_is_disabled() -> None:
+    tts = soniox_tts.TTS(api_key="test-key")
+    assert tts._opts.stream_idle_timeout == 0.0  # noqa: SLF001
+    assert soniox_tts.DEFAULT_STREAM_IDLE_TIMEOUT == 0.0
 
 
 def test_stream_idle_timeout_rejects_negative() -> None:
@@ -219,15 +234,15 @@ async def test_update_options_applies_to_in_flight_stream_idle() -> None:
     consumer = asyncio.create_task(_consume_stream(stream))
     await asyncio.sleep(0)
     stream.push_text("before")
-    await asyncio.sleep(0.12)
+    await asyncio.sleep(2.0)
     # Still one stream_id — idle was disabled.
     assert len(_text_calls(fake_conn)) == 1
     assert len(_text_end_calls(fake_conn)) == 0
 
-    tts.update_options(stream_idle_timeout=0.05)
+    tts.update_options(stream_idle_timeout=1.0)
     # Wake the blocked unlimited recv so the next wait re-reads the new timeout.
     stream.push_text(" mid")
-    await asyncio.sleep(0.15)
+    await asyncio.sleep(2.0)
     stream.push_text(" after")
     stream.end_input()
     await consumer

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -1,0 +1,206 @@
+"""Unit tests for Soniox TTS stream idle / FlushSentinel rotation.
+
+Covers the #6225 / #6425 fix: ending an open ``stream_id`` with ``text_end`` when
+input stalls or a FlushSentinel arrives, then using a new ``stream_id`` when text
+resumes (idle path). Flush ends the Soniox stream so the segment completes cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import pytest
+
+from livekit.agents import APIConnectOptions
+from livekit.agents.tts import AudioEmitter
+from livekit.plugins.soniox import tts as soniox_tts
+
+pytestmark = pytest.mark.plugin("soniox")
+
+# 10 ms of mono s16le silence at 24 kHz — enough for AudioEmitter to emit frames.
+_SILENCE_PCM = b"\x00\x00" * 240
+
+
+@dataclass
+class _StreamSlot:
+    emitter: AudioEmitter
+    waiter: asyncio.Future[None]
+
+
+class _FakeConnection:
+    """Minimal stand-in for ``_Connection`` that records ``send_text`` and pushes audio."""
+
+    def __init__(self) -> None:
+        self.is_current = True
+        self.closed = False
+        self.send_calls: list[tuple[str, str, bool]] = []
+        self._streams: dict[str, _StreamSlot] = {}
+        self.registered_ids: list[str] = []
+        self.unregistered_ids: list[str] = []
+
+    def register_stream(
+        self,
+        stream_id: str,
+        emitter: AudioEmitter,
+        waiter: asyncio.Future[None],
+        *,
+        opts: object,
+    ) -> None:
+        self._streams[stream_id] = _StreamSlot(emitter=emitter, waiter=waiter)
+        self.registered_ids.append(stream_id)
+
+    def unregister_stream(self, stream_id: str) -> None:
+        self._streams.pop(stream_id, None)
+        self.unregistered_ids.append(stream_id)
+
+    def send_text(self, stream_id: str, text: str, *, text_end: bool = False) -> None:
+        self.send_calls.append((stream_id, text, text_end))
+        slot = self._streams.get(stream_id)
+        if slot is None:
+            return
+        if text and not text_end:
+            slot.emitter.push(_SILENCE_PCM)
+        if text_end:
+            if not slot.waiter.done():
+                slot.waiter.set_result(None)
+
+    def cancel_stream(self, stream_id: str) -> None:
+        slot = self._streams.pop(stream_id, None)
+        if slot is not None and not slot.waiter.done():
+            slot.waiter.set_result(None)
+
+
+def _text_end_calls(conn: _FakeConnection) -> list[tuple[str, str, bool]]:
+    return [c for c in conn.send_calls if c[2]]
+
+
+def _text_calls(conn: _FakeConnection) -> list[tuple[str, str, bool]]:
+    return [c for c in conn.send_calls if c[1] and not c[2]]
+
+
+def _patch_connection(tts: soniox_tts.TTS, fake_conn: _FakeConnection) -> None:
+    async def _current_connection(*, timeout: float) -> tuple[_FakeConnection, float, bool]:
+        return fake_conn, 0.0, False
+
+    tts._current_connection = _current_connection  # type: ignore[method-assign]
+
+
+async def _consume_stream(stream: soniox_tts.SynthesizeStream) -> None:
+    async for _ev in stream:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_flush_sentinel_sends_text_end() -> None:
+    """FlushSentinel must send text_end (previously a no-op on Soniox)."""
+    fake_conn = _FakeConnection()
+    tts = soniox_tts.TTS(api_key="test-key", stream_idle_timeout=0)
+    _patch_connection(tts, fake_conn)
+    stream = soniox_tts.SynthesizeStream(
+        tts=tts, conn_options=APIConnectOptions(max_retry=0, timeout=1.0)
+    )
+
+    consumer = asyncio.create_task(_consume_stream(stream))
+    await asyncio.sleep(0)
+    stream.push_text("hello")
+    stream.flush()
+    stream.end_input()
+    await consumer
+    await stream.aclose()
+
+    texts = _text_calls(fake_conn)
+    text_ends = _text_end_calls(fake_conn)
+    assert len(texts) == 1
+    assert texts[0][1] == "hello"
+    assert len(text_ends) == 1
+    assert text_ends[0][0] == texts[0][0]
+
+
+@pytest.mark.asyncio
+async def test_flush_before_any_text_does_not_send_text_end() -> None:
+    fake_conn = _FakeConnection()
+    tts = soniox_tts.TTS(api_key="test-key", stream_idle_timeout=0)
+    _patch_connection(tts, fake_conn)
+    stream = soniox_tts.SynthesizeStream(
+        tts=tts, conn_options=APIConnectOptions(max_retry=0, timeout=1.0)
+    )
+
+    consumer = asyncio.create_task(_consume_stream(stream))
+    await asyncio.sleep(0)
+    stream.flush()
+    stream.push_text("only")
+    stream.end_input()
+    await consumer
+    await stream.aclose()
+
+    texts = _text_calls(fake_conn)
+    text_ends = _text_end_calls(fake_conn)
+    assert len(texts) == 1
+    assert texts[0][1] == "only"
+    assert len(text_ends) == 1
+
+
+@pytest.mark.asyncio
+async def test_idle_timeout_sends_text_end_and_rotates_stream_id() -> None:
+    fake_conn = _FakeConnection()
+    tts = soniox_tts.TTS(api_key="test-key", stream_idle_timeout=0.05)
+    _patch_connection(tts, fake_conn)
+    stream = soniox_tts.SynthesizeStream(
+        tts=tts, conn_options=APIConnectOptions(max_retry=0, timeout=1.0)
+    )
+
+    consumer = asyncio.create_task(_consume_stream(stream))
+    await asyncio.sleep(0)
+    stream.push_text("before idle")
+    await asyncio.sleep(0.15)
+    stream.push_text(" after idle")
+    stream.end_input()
+    await consumer
+    await stream.aclose()
+
+    texts = _text_calls(fake_conn)
+    text_ends = _text_end_calls(fake_conn)
+    assert len(texts) == 2
+    assert texts[0][1] == "before idle"
+    assert texts[1][1] == " after idle"
+    assert texts[0][0] != texts[1][0]
+    assert len(text_ends) == 2
+    assert texts[0][0] == text_ends[0][0]
+    assert texts[1][0] == text_ends[1][0]
+
+
+@pytest.mark.asyncio
+async def test_stream_idle_timeout_zero_disables_idle_rotation() -> None:
+    fake_conn = _FakeConnection()
+    tts = soniox_tts.TTS(api_key="test-key", stream_idle_timeout=0)
+    _patch_connection(tts, fake_conn)
+    stream = soniox_tts.SynthesizeStream(
+        tts=tts, conn_options=APIConnectOptions(max_retry=0, timeout=1.0)
+    )
+
+    consumer = asyncio.create_task(_consume_stream(stream))
+    await asyncio.sleep(0)
+    stream.push_text("chunk1")
+    await asyncio.sleep(0.12)
+    stream.push_text(" chunk2")
+    stream.end_input()
+    await consumer
+    await stream.aclose()
+
+    texts = _text_calls(fake_conn)
+    text_ends = _text_end_calls(fake_conn)
+    assert len(texts) == 2
+    assert texts[0][0] == texts[1][0]
+    assert len(text_ends) == 1
+
+
+def test_stream_idle_timeout_rejects_negative() -> None:
+    with pytest.raises(ValueError, match="stream_idle_timeout"):
+        soniox_tts.TTS(api_key="test-key", stream_idle_timeout=-1)
+
+
+def test_update_options_stream_idle_timeout() -> None:
+    tts = soniox_tts.TTS(api_key="test-key", stream_idle_timeout=5.0)
+    tts.update_options(stream_idle_timeout=2.5)
+    assert tts._opts.stream_idle_timeout == 2.5  # noqa: SLF001

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from livekit.agents import APIConnectOptions
+from livekit.agents import APIConnectOptions, APIStatusError
 from livekit.agents.tts import AudioEmitter
 from livekit.plugins.soniox import tts as soniox_tts
 
@@ -257,3 +257,28 @@ async def test_update_options_applies_to_in_flight_stream_idle() -> None:
     assert len(text_ends) == 2
     assert texts[0][0] == text_ends[0][0]
     assert texts[2][0] == text_ends[1][0]
+
+
+@pytest.mark.asyncio
+async def test_server_error_surfaces_while_input_still_open() -> None:
+    """Server errors on the waiter must fail the stream before end_input (no prolonged silence)."""
+    fake_conn = _FakeConnection()
+    tts = soniox_tts.TTS(api_key="test-key", stream_idle_timeout=0)
+    _patch_connection(tts, fake_conn)
+    stream = soniox_tts.SynthesizeStream(
+        tts=tts, conn_options=APIConnectOptions(max_retry=0, timeout=1.0)
+    )
+
+    consumer = asyncio.create_task(_consume_stream(stream))
+    await asyncio.sleep(0)
+    stream.push_text("hello")
+    await asyncio.sleep(0)
+
+    assert len(fake_conn.registered_ids) == 1
+    slot = fake_conn._streams[fake_conn.registered_ids[0]]  # noqa: SLF001
+    slot.waiter.set_exception(APIStatusError("synthetic server error", status_code=500))
+
+    # Do not call end_input — error must surface from the concurrent waiter monitor.
+    with pytest.raises(APIStatusError, match="synthetic server error"):
+        await asyncio.wait_for(consumer, timeout=2.0)
+    await stream.aclose()

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -204,3 +204,41 @@ def test_update_options_stream_idle_timeout() -> None:
     tts = soniox_tts.TTS(api_key="test-key", stream_idle_timeout=5.0)
     tts.update_options(stream_idle_timeout=2.5)
     assert tts._opts.stream_idle_timeout == 2.5  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_update_options_applies_to_in_flight_stream_idle() -> None:
+    """update_options must affect the active stream's next idle wait, not only TTS._opts."""
+    fake_conn = _FakeConnection()
+    # Start with idle disabled so the first pause does not rotate.
+    tts = soniox_tts.TTS(api_key="test-key", stream_idle_timeout=0)
+    _patch_connection(tts, fake_conn)
+    # Must go through TTS.stream() so update_options can find the live stream.
+    stream = tts.stream(conn_options=APIConnectOptions(max_retry=0, timeout=1.0))
+
+    consumer = asyncio.create_task(_consume_stream(stream))
+    await asyncio.sleep(0)
+    stream.push_text("before")
+    await asyncio.sleep(0.12)
+    # Still one stream_id — idle was disabled.
+    assert len(_text_calls(fake_conn)) == 1
+    assert len(_text_end_calls(fake_conn)) == 0
+
+    tts.update_options(stream_idle_timeout=0.05)
+    # Wake the blocked unlimited recv so the next wait re-reads the new timeout.
+    stream.push_text(" mid")
+    await asyncio.sleep(0.15)
+    stream.push_text(" after")
+    stream.end_input()
+    await consumer
+    await stream.aclose()
+
+    texts = _text_calls(fake_conn)
+    text_ends = _text_end_calls(fake_conn)
+    assert len(texts) == 3
+    # "before" and " mid" share a stream_id; idle then rotates before " after".
+    assert texts[0][0] == texts[1][0]
+    assert texts[1][0] != texts[2][0]
+    assert len(text_ends) == 2
+    assert texts[0][0] == text_ends[0][0]
+    assert texts[2][0] == text_ends[1][0]


### PR DESCRIPTION
## Summary

- Honor `FlushSentinel` by ending the active Soniox `stream_id` with `text_end` (previously a no-op) — **Closes #6425**.
- Optional idle rotation: when `stream_idle_timeout > 0`, end an open `stream_id` after that many seconds without new text, then lazily start a new `stream_id` when text resumes — addresses mid-turn Soniox 408s during LLM stalls (**#6225**).
- **Default is opt-in** (`stream_idle_timeout=0`). Callers who hit #6225 should set ~`5.0` (under Soniox’s observed ~8–18s per-stream timeout).
- Rotation is **internal to Soniox `stream_id` only**; the LiveKit `AudioEmitter` keeps a single segment for the life of the `SynthesizeStream` (`_StreamLifecycle` owns register/end/rotate).
- Connection-level keepalive is unchanged; this complements retry/soft-fail work.

## Test plan

- [x] `pytest tests/test_plugin_soniox_tts.py --plugin soniox` (mocked + `virtual_time`; 8 passed)
- [ ] Smoke with `SONIOX_API_KEY` and `stream_idle_timeout=5.0`: long LLM tool pause mid-utterance should no longer 408
- [ ] Default / `stream_idle_timeout=0` preserves prior long-lived stream_id behavior