### PR TITLE
fix(soniox): sentence-buffer tts input, rotate streams on idle and age

### DIFF
--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -54,6 +54,7 @@ MIN_SPEED = 0.7
 MAX_SPEED = 1.3
 KEEPALIVE_INTERVAL = 10  # seconds
 KEEPALIVE_MESSAGE = json.dumps({"keep_alive": True})
+# Must stay under Soniox's observed ~8-18s per-stream timeout (livekit/agents#6225).
 DEFAULT_STREAM_IDLE_TIMEOUT = 5.0  # seconds
 # Rotate to a fresh stream at a sentence boundary
 # well before Soniox's fixed 2-minute per-stream cap.
@@ -112,7 +113,8 @@ class TTS(tts.TTS):
                 `livekit.agents.tokenize.blingfire.SentenceTokenizer`.
             stream_idle_timeout (float): Seconds without a new sentence before the current
                 stream is finalized; the next sentence starts a fresh stream. Prevents slow
-                LLM gaps from hitting the server's per-stream timeout. Defaults to 5.0.
+                LLM gaps from hitting the server's per-stream timeout (observed ~8-18s).
+                Defaults to 5.0.
         """
         super().__init__(
             capabilities=tts.TTSCapabilities(streaming=True),
@@ -126,6 +128,9 @@ class TTS(tts.TTS):
 
         if not MIN_SPEED <= speed <= MAX_SPEED:
             raise ValueError(f"speed must be between {MIN_SPEED} and {MAX_SPEED}, but got {speed}")
+
+        if stream_idle_timeout <= 0:
+            raise ValueError(f"stream_idle_timeout must be > 0, but got {stream_idle_timeout}")
 
         self._opts = _TTSOptions(
             model=model,
@@ -193,6 +198,7 @@ class TTS(tts.TTS):
         language: NotGivenOr[str] = NOT_GIVEN,
         voice: NotGivenOr[str] = NOT_GIVEN,
         speed: NotGivenOr[float] = NOT_GIVEN,
+        stream_idle_timeout: NotGivenOr[float] = NOT_GIVEN,
     ) -> None:
         """
         Args:
@@ -200,6 +206,7 @@ class TTS(tts.TTS):
             language: Language code to use.
             voice: Voice to use.
             speed: Speaking rate in the range [0.7, 1.3]; 1.0 is the normal rate.
+            stream_idle_timeout: Idle seconds before the current stream is finalized.
         """
         if is_given(model):
             self._opts.model = model
@@ -213,6 +220,13 @@ class TTS(tts.TTS):
                     f"speed must be between {MIN_SPEED} and {MAX_SPEED}, but got {speed}"
                 )
             self._opts.speed = speed
+        if is_given(stream_idle_timeout):
+            if stream_idle_timeout <= 0:
+                raise ValueError(f"stream_idle_timeout must be > 0, but got {stream_idle_timeout}")
+            self._opts.stream_idle_timeout = stream_idle_timeout
+            # _run re-reads this every loop iteration, so live streams pick it up
+            for stream in list(self._streams):
+                stream._opts.stream_idle_timeout = stream_idle_timeout
 
     def synthesize(
         self, text: str, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -20,7 +20,7 @@ import json
 import os
 import time
 import weakref
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 import aiohttp
@@ -28,8 +28,10 @@ import aiohttp
 from livekit.agents import (
     APIConnectionError,
     APIConnectOptions,
+    APIError,
     APIStatusError,
     APITimeoutError,
+    tokenize,
     tts,
     utils,
 )
@@ -52,6 +54,10 @@ MIN_SPEED = 0.7
 MAX_SPEED = 1.3
 KEEPALIVE_INTERVAL = 10  # seconds
 KEEPALIVE_MESSAGE = json.dumps({"keep_alive": True})
+DEFAULT_STREAM_IDLE_TIMEOUT = 5.0  # seconds
+# Rotate to a fresh stream at a sentence boundary
+# well before Soniox's fixed 2-minute per-stream cap.
+MAX_STREAM_AGE = 90.0  # seconds
 
 
 def _audio_format_to_mime_type(audio_format: str) -> str:
@@ -84,6 +90,8 @@ class TTS(tts.TTS):
         api_key: str | None = None,
         websocket_url: str = WEBSOCKET_URL,
         http_session: aiohttp.ClientSession | None = None,
+        tokenizer: NotGivenOr[tokenize.SentenceTokenizer] = NOT_GIVEN,
+        stream_idle_timeout: float = DEFAULT_STREAM_IDLE_TIMEOUT,
     ) -> None:
         """Initialize instance of Soniox Text-to-Speech API service.
 
@@ -99,6 +107,12 @@ class TTS(tts.TTS):
             api_key (str): Soniox API key. If not provided, will look for SONIOX_API_KEY env variable.
             websocket_url (str): Base WebSocket URL for Soniox TTS API.
             http_session (aiohttp.ClientSession): Optional aiohttp.ClientSession to use for requests.
+            tokenizer (tokenize.SentenceTokenizer): Tokenizer used to buffer input into complete
+                sentences before sending. Defaults to
+                `livekit.agents.tokenize.blingfire.SentenceTokenizer`.
+            stream_idle_timeout (float): Seconds without a new sentence before the current
+                stream is finalized; the next sentence starts a fresh stream. Prevents slow
+                LLM gaps from hitting the server's per-stream timeout. Defaults to 5.0.
         """
         super().__init__(
             capabilities=tts.TTSCapabilities(streaming=True),
@@ -123,8 +137,14 @@ class TTS(tts.TTS):
             speed=speed,
             websocket_url=websocket_url,
             api_key=api_key,
+            stream_idle_timeout=stream_idle_timeout,
         )
         self._session = http_session
+        self._sentence_tokenizer = (
+            tokenizer
+            if is_given(tokenizer)
+            else tokenize.blingfire.SentenceTokenizer(retain_format=True)
+        )
         self._streams = weakref.WeakSet[SynthesizeStream]()
 
         # One persistent connection shared across streams (see _Connection).
@@ -233,6 +253,19 @@ class TTS(tts.TTS):
             self.__current_connection = None
 
 
+@dataclass
+class _ActiveStream:
+    """One Soniox stream carrying a batch of sentences; kept for replay on failure."""
+
+    connection: _Connection
+    stream_id: str
+    waiter: asyncio.Future[None]
+    opened_at: float
+    baseline: float  # emitter duration at open; audio beyond it belongs to this stream
+    attempt: int = 0
+    texts: list[str] = field(default_factory=list)
+
+
 class SynthesizeStream(tts.SynthesizeStream):
     """Streaming TTS implementation on a shared _Connection."""
 
@@ -265,9 +298,16 @@ class SynthesizeStream(tts.SynthesizeStream):
         await super().aclose()
 
     async def _run(self, output_emitter: tts.AudioEmitter) -> None:
-        """Register with the connection, stream text, await the completion future."""
+        """Feed sentences into a shared stream, rotating on idle gaps and age.
+
+        Soniox keeps prosody continuous only within a stream, so sentences are
+        pushed into one open stream while the LLM produces them steadily. When
+        no sentence arrives for ``stream_idle_timeout``, the stream is
+        finalized (text_end) before the server's own timer can kill it
+        mid-synthesis; the next sentence starts a fresh stream. Only complete
+        sentences are ever sent, so every rotation lands on a natural boundary.
+        """
         request_id = utils.shortuuid()
-        self._stream_id = utils.shortuuid()
 
         output_emitter.initialize(
             request_id=request_id,
@@ -278,6 +318,87 @@ class SynthesizeStream(tts.SynthesizeStream):
         )
         output_emitter.start_segment(segment_id=utils.shortuuid())
 
+        sent_stream = self._tts._sentence_tokenizer.stream()
+
+        async def _input_task() -> None:
+            async for data in self._input_ch:
+                if self._cancelled.is_set():
+                    break
+                if isinstance(data, self._FlushSentinel):
+                    sent_stream.flush()
+                    continue
+                sent_stream.push_text(data)
+            sent_stream.end_input()
+
+        input_t = asyncio.create_task(_input_task(), name="soniox-tts-stream-input")
+
+        active: _ActiveStream | None = None
+        next_task: asyncio.Future[tokenize.TokenData] | None = None
+        sent_iter = sent_stream.__aiter__()
+
+        try:
+            while not self._cancelled.is_set():
+                if next_task is None:
+                    next_task = asyncio.ensure_future(sent_iter.__anext__())
+
+                waiters: set[asyncio.Future[Any]] = {next_task}
+                if active is not None:
+                    waiters.add(active.waiter)
+                await asyncio.wait(
+                    waiters,
+                    timeout=self._opts.stream_idle_timeout if active is not None else None,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+
+                if active is not None and active.waiter.done():
+                    active = await self._settle_stream(active, output_emitter, request_id)
+                    continue
+
+                if not next_task.done():
+                    # LLM stalled: finalize before the server times the stream out
+                    if active is not None:
+                        await self._finalize_stream(active, output_emitter, request_id)
+                        active = None
+                    continue
+
+                try:
+                    ev = next_task.result()
+                except StopAsyncIteration:
+                    break
+                finally:
+                    next_task = None
+
+                if not ev.token.strip():
+                    continue
+
+                self._mark_started()
+
+                # rotate to a new stream before the fixed 2-minute stream lifespan
+                if active is not None and time.monotonic() - active.opened_at > MAX_STREAM_AGE:
+                    await self._finalize_stream(active, output_emitter, request_id)
+                    active = None
+
+                if active is None:
+                    active = await self._open_stream(output_emitter, request_id)
+
+                active.texts.append(ev.token)
+                active.connection.send_text(active.stream_id, ev.token, text_end=False)
+
+            if active is not None and not self._cancelled.is_set():
+                await self._finalize_stream(active, output_emitter, request_id)
+                active = None
+        finally:
+            if next_task is not None:
+                await utils.aio.gracefully_cancel(next_task)
+            if active is not None:
+                active.connection.unregister_stream(active.stream_id)
+            output_emitter.end_segment()
+            await utils.aio.gracefully_cancel(input_t)
+            await sent_stream.aclose()
+
+    async def _open_stream(
+        self, output_emitter: tts.AudioEmitter, request_id: str, *, attempt: int = 0
+    ) -> _ActiveStream:
         try:
             (
                 connection,
@@ -294,34 +415,90 @@ class SynthesizeStream(tts.SynthesizeStream):
             raise APIConnectionError() from e
 
         self._connection = connection
+        self._stream_id = stream_id = utils.shortuuid()
 
         waiter: asyncio.Future[None] = asyncio.get_event_loop().create_future()
-        connection.register_stream(self._stream_id, output_emitter, waiter, opts=self._opts)
+        connection.register_stream(stream_id, output_emitter, waiter, opts=self._opts)
+        return _ActiveStream(
+            connection=connection,
+            stream_id=stream_id,
+            waiter=waiter,
+            opened_at=time.monotonic(),
+            baseline=output_emitter.pushed_duration(),
+            attempt=attempt,
+        )
 
-        async def _input_task() -> None:
-            async for data in self._input_ch:
-                if self._cancelled.is_set():
-                    break
-                if isinstance(data, self._FlushSentinel):
-                    continue
-                self._mark_started()
-                connection.send_text(self._stream_id, data, text_end=False)
+    async def _finalize_stream(
+        self, active: _ActiveStream, output_emitter: tts.AudioEmitter, request_id: str
+    ) -> None:
+        """Send text_end and wait for termination, replaying the batch if it fails."""
+        current: _ActiveStream | None = active
+        while current is not None:
+            current.connection.send_text(current.stream_id, "", text_end=True)
+            current = await self._settle_stream(current, output_emitter, request_id)
 
-            if not self._cancelled.is_set():
-                connection.send_text(self._stream_id, "", text_end=True)
+    async def _settle_stream(
+        self, active: _ActiveStream, output_emitter: tts.AudioEmitter, request_id: str
+    ) -> _ActiveStream | None:
+        """Wait for the stream's terminal event and interpret it.
 
-        input_t = asyncio.create_task(_input_task(), name="soniox-tts-stream-input")
-
+        Returns None when the stream ended cleanly (everything sent was
+        spoken), or a fresh stream with the batch replayed when it failed
+        transiently.
+        """
+        failure: APIError | None = None
         try:
-            await waiter
-        except APIStatusError:
-            raise
+            await active.waiter
+        except APIError as e:
+            failure = e
         except Exception as e:
             raise APIConnectionError() from e
         finally:
-            output_emitter.end_segment()
-            await utils.aio.gracefully_cancel(input_t)
-            connection.unregister_stream(self._stream_id)
+            # release before any replay so only one stream is ever registered
+            active.connection.unregister_stream(active.stream_id)
+
+        if failure is None:
+            return None
+        return await self._retry_stream(active, output_emitter, request_id, failure)
+
+    async def _retry_stream(
+        self,
+        active: _ActiveStream,
+        output_emitter: tts.AudioEmitter,
+        request_id: str,
+        exc: APIError,
+    ) -> _ActiveStream:
+        """Replay the failed stream's sentences on a fresh stream_id.
+
+        The framework never retries once any audio reached the user, so a
+        transient failure would otherwise mute the rest of the reply. Replaying
+        is safe only while the failed stream itself produced no audio.
+        """
+        can_retry = (
+            exc.retryable
+            and output_emitter.pushed_duration() == active.baseline
+            and active.attempt < self._conn_options.max_retry
+            and not self._cancelled.is_set()
+        )
+        if not can_retry:
+            raise exc
+
+        retry_interval = self._conn_options._interval_for_retry(active.attempt)
+        logger.warning(
+            "Soniox TTS stream failed: %s, retrying in %ss",
+            exc,
+            retry_interval,
+            extra={"stream_id": active.stream_id, "attempt": active.attempt + 1},
+        )
+        await asyncio.sleep(retry_interval)
+
+        replacement = await self._open_stream(
+            output_emitter, request_id, attempt=active.attempt + 1
+        )
+        for text in active.texts:
+            replacement.texts.append(text)
+            replacement.connection.send_text(replacement.stream_id, text, text_end=False)
+        return replacement
 
 
 @dataclass
@@ -335,6 +512,7 @@ class _TTSOptions:
     speed: float
     websocket_url: str
     api_key: str
+    stream_idle_timeout: float
 
 
 @dataclass

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -1,0 +1,173 @@
+"""Unit tests for Soniox TTS sentence buffering and stream rotation.
+
+The plugin buffers LLM chunks into complete sentences, feeds them into one
+shared Soniox stream, and rotates to a fresh ``stream_id`` when input goes
+idle for ``stream_idle_timeout`` or after a transient failure (batch replay).
+These tests drive the real ``SynthesizeStream`` against a fake ``_Connection``.
+
+Idle-timeout tests use ``virtual_time`` so timers advance deterministically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from livekit.agents import APIStatusError
+from livekit.agents.tts import AudioEmitter
+from livekit.plugins import soniox
+
+pytestmark = [
+    pytest.mark.plugin("soniox"),
+    pytest.mark.virtual_time,
+    pytest.mark.no_concurrent,
+]
+
+# 10 ms of mono s16le silence at 24 kHz
+_SILENCE_PCM = b"\x00\x00" * 240
+
+SENTENCES = [
+    "Hello there, this is the first sentence. ",
+    "And here comes a second sentence! ",
+    "Finally a third one?",
+]
+
+
+@dataclass
+class _StreamSlot:
+    emitter: AudioEmitter
+    waiter: asyncio.Future[None]
+
+
+class _FakeConnection:
+    """Stand-in for ``_Connection``: text produces audio, ``text_end`` terminates."""
+
+    def __init__(self, *, fail_on_send: int | None = None) -> None:
+        self.is_current = True
+        self.closed = False
+        self.registered_ids: list[str] = []
+        self.send_calls: list[tuple[str, str, bool]] = []
+        self.max_open_streams = 0
+        self._streams: dict[str, _StreamSlot] = {}
+        self._sends = 0
+        self._fail_on_send = fail_on_send
+
+    def register_stream(
+        self,
+        stream_id: str,
+        emitter: AudioEmitter,
+        waiter: asyncio.Future[None],
+        *,
+        opts: Any,
+    ) -> None:
+        self.registered_ids.append(stream_id)
+        self._streams[stream_id] = _StreamSlot(emitter, waiter)
+        self.max_open_streams = max(self.max_open_streams, len(self._streams))
+
+    def unregister_stream(self, stream_id: str) -> None:
+        self._streams.pop(stream_id, None)
+
+    def send_text(self, stream_id: str, text: str, *, text_end: bool = False) -> None:
+        self.send_calls.append((stream_id, text, text_end))
+        slot = self._streams.get(stream_id)
+        if slot is None:
+            return
+        if text_end and not text:
+            # server: final audio + audio_end + terminated
+            if not slot.waiter.done():
+                slot.waiter.set_result(None)
+            return
+        self._sends += 1
+        if self._sends == self._fail_on_send:
+            self._fail_on_send = None
+            if not slot.waiter.done():
+                slot.waiter.set_exception(
+                    APIStatusError("transient", status_code=429, retryable=True)
+                )
+            return
+        slot.emitter.push(_SILENCE_PCM)
+
+    def cancel_stream(self, stream_id: str) -> None:
+        slot = self._streams.get(stream_id)
+        if slot is not None and not slot.waiter.done():
+            slot.waiter.set_result(None)
+
+
+async def _synthesize(
+    fake: _FakeConnection,
+    *,
+    chunk_delays: list[float] | None = None,
+    **tts_kwargs: Any,
+) -> int:
+    tts = soniox.TTS(api_key="fake-key", **tts_kwargs)
+
+    async def _fake_current_connection(*, timeout: float) -> tuple[Any, float, bool]:
+        return fake, 0.0, True
+
+    tts._current_connection = _fake_current_connection  # type: ignore[method-assign]
+
+    stream = tts.stream()
+    delays = chunk_delays or [0.01] * len(SENTENCES)
+
+    async def _push() -> None:
+        for chunk, delay in zip(SENTENCES, delays, strict=True):
+            stream.push_text(chunk)
+            await asyncio.sleep(delay)
+        stream.end_input()
+
+    push_t = asyncio.create_task(_push())
+    frames = 0
+    async for _ in stream:
+        frames += 1
+    await push_t
+    await stream.aclose()
+    return frames
+
+
+async def test_steady_flow_uses_single_stream() -> None:
+    fake = _FakeConnection()
+    frames = await _synthesize(fake)
+
+    assert frames > 0
+    assert len(fake.registered_ids) == 1
+    text_sends = [c for c in fake.send_calls if not c[2]]
+    end_sends = [c for c in fake.send_calls if c[2]]
+    assert len(text_sends) == len(SENTENCES)
+    assert len(end_sends) == 1
+
+
+async def test_idle_stall_rotates_stream() -> None:
+    fake = _FakeConnection()
+    frames = await _synthesize(
+        fake,
+        chunk_delays=[3.0, 0.01, 0.01],
+        stream_idle_timeout=1.0,
+    )
+
+    assert frames > 0
+    # sentence 1 on the first stream, finalized during the stall; 2 and 3 on the next
+    assert len(fake.registered_ids) == 2
+    assert sum(1 for c in fake.send_calls if c[2]) == 2
+    assert fake.max_open_streams == 1
+
+
+async def test_transient_failure_replays_batch() -> None:
+    fake = _FakeConnection(fail_on_send=1)
+    frames = await _synthesize(fake)
+
+    assert frames > 0
+    assert len(fake.registered_ids) == 2
+    failed_id, replacement_id = fake.registered_ids
+    replayed = [text for sid, text, end in fake.send_calls if sid == replacement_id and not end]
+    assert replayed[0].strip() == SENTENCES[0].strip()
+    assert fake.max_open_streams == 1
+
+
+async def test_invalid_stream_idle_timeout_rejected() -> None:
+    with pytest.raises(ValueError):
+        soniox.TTS(api_key="fake-key", stream_idle_timeout=0)
+    with pytest.raises(ValueError):
+        soniox.TTS(api_key="fake-key", stream_idle_timeout=-1.0)


### PR DESCRIPTION
Fixes AGT-3049 (408s breaking the stream mid-reply) and #6225; also covers the FlushSentinel exposure from #6425 / AGT-3132. Concurrent with #6430 by @mqasim41, whose idle-rotation work, observed ~8-18s per-stream timeout data, and test approach are incorporated here with co-author credit.

**Why:** Soniox times out streams left waiting on slow LLM output (observed ~8-18s, plus a fixed 2-minute per-stream cap), cutting speech mid-reply.

**What:** LLM chunks are buffered into complete sentences (blingfire, overridable) and fed into one shared stream so prosody stays continuous. If no sentence arrives for `stream_idle_timeout` (default 5s, must be >0, reconfigurable via `update_options`), the stream is finalized with `text_end` before the server can time it out; the next sentence opens a fresh stream. Streams also rotate at a sentence boundary near the 2-minute cap, and a stream that fails before emitting any audio replays its sentence batch on a new `stream_id` (the framework never retries once audio reached the user). FlushSentinel now flushes the sentence buffer instead of being dropped.

Tests: `pytest tests/test_plugin_soniox_tts.py --plugin soniox` (fake connection + virtual time: steady flow, idle rotation, batch replay, validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)