### PR TITLE
fix(plugins-aws): depend on aiobotocore directly instead of aioboto3

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -16,9 +16,9 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from aiobotocore.session import AioSession, get_session  # type: ignore
+from aiobotocore.session import AioSession  # type: ignore
 from botocore.config import Config  # type: ignore
 
 from livekit.agents import APIConnectionError, APIStatusError, llm
@@ -32,6 +32,10 @@ from livekit.agents.types import (
 from livekit.agents.utils import is_given
 
 from .log import logger
+from .utils import _resolve_session
+
+if TYPE_CHECKING:
+    import aioboto3  # type: ignore
 
 DEFAULT_TEXT_MODEL = "amazon.nova-2-lite-v1:0"
 
@@ -63,7 +67,7 @@ class LLM(llm.LLM):
         additional_request_fields: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
         cache_system: bool = False,
         cache_tools: bool = False,
-        session: AioSession | None = None,
+        session: AioSession | aioboto3.Session | None = None,
     ) -> None:
         """
         Create a new instance of AWS Bedrock LLM.
@@ -86,11 +90,12 @@ class LLM(llm.LLM):
             additional_request_fields (dict[str, Any], optional): Additional request fields to send to the AWS Bedrock Converse API. Defaults to None.
             cache_system (bool, optional): Caches system messages to reduce token usage. Defaults to False.
             cache_tools (bool, optional): Caches tool definitions to reduce token usage. Defaults to False.
-            session (AioSession, optional): Optional aiobotocore session to use.
+            session (AioSession, optional): Optional aiobotocore session to use. Passing a legacy
+                aioboto3.Session is deprecated but still accepted.
         """  # noqa: E501
         super().__init__()
 
-        self._session = session or get_session()
+        self._session = _resolve_session(session)
         if session is None:
             if is_given(api_key) and api_key and is_given(api_secret) and api_secret:
                 self._session.set_credentials(api_key, api_secret)

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -18,7 +18,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-import aioboto3  # type: ignore
+from aiobotocore.session import AioSession, get_session  # type: ignore
 from botocore.config import Config  # type: ignore
 
 from livekit.agents import APIConnectionError, APIStatusError, llm
@@ -63,7 +63,7 @@ class LLM(llm.LLM):
         additional_request_fields: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
         cache_system: bool = False,
         cache_tools: bool = False,
-        session: aioboto3.Session | None = None,
+        session: AioSession | None = None,
     ) -> None:
         """
         Create a new instance of AWS Bedrock LLM.
@@ -86,15 +86,16 @@ class LLM(llm.LLM):
             additional_request_fields (dict[str, Any], optional): Additional request fields to send to the AWS Bedrock Converse API. Defaults to None.
             cache_system (bool, optional): Caches system messages to reduce token usage. Defaults to False.
             cache_tools (bool, optional): Caches tool definitions to reduce token usage. Defaults to False.
-            session (aioboto3.Session, optional): Optional aioboto3 session to use.
+            session (AioSession, optional): Optional aiobotocore session to use.
         """  # noqa: E501
         super().__init__()
 
-        self._session = session or aioboto3.Session(
-            aws_access_key_id=api_key if is_given(api_key) else None,
-            aws_secret_access_key=api_secret if is_given(api_secret) else None,
-            region_name=region if is_given(region) else None,
-        )
+        self._session = session or get_session()
+        if session is None:
+            if is_given(api_key) and api_key and is_given(api_secret) and api_secret:
+                self._session.set_credentials(api_key, api_secret)
+            if is_given(region) and region:
+                self._session.set_config_variable("region", region)
 
         bedrock_model = (
             model if is_given(model) else os.environ.get("BEDROCK_INFERENCE_PROFILE_ARN")
@@ -216,7 +217,7 @@ class LLMStream(llm.LLMStream):
         llm: LLM,
         *,
         chat_ctx: ChatContext,
-        session: aioboto3.Session,
+        session: AioSession,
         conn_options: APIConnectOptions,
         tools: list[llm.Tool],
         extra_kwargs: dict[str, Any],
@@ -234,7 +235,7 @@ class LLMStream(llm.LLMStream):
         retryable = True
         try:
             config = Config(user_agent_extra="x-client-framework:livekit-plugins-aws")
-            async with self._session.client("bedrock-runtime", config=config) as client:
+            async with self._session.create_client("bedrock-runtime", config=config) as client:
                 response = await client.converse_stream(**self._opts)
                 request_id = response["ResponseMetadata"]["RequestId"]
                 if response["ResponseMetadata"]["HTTPStatusCode"] != 200:

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/tts.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/tts.py
@@ -13,11 +13,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING
 
 import botocore  # type: ignore
 import botocore.exceptions  # type: ignore
 from aiobotocore.config import AioConfig  # type: ignore
-from aiobotocore.session import AioSession, get_session  # type: ignore
+from aiobotocore.session import AioSession  # type: ignore
 
 from livekit.agents import (
     APIConnectionError,
@@ -34,7 +35,10 @@ from livekit.agents.types import (
 from livekit.agents.utils import is_given
 
 from .models import TTSLanguages, TTSSpeechEngine, TTSTextType
-from .utils import _strip_nones
+from .utils import _resolve_session, _strip_nones
+
+if TYPE_CHECKING:
+    import aioboto3  # type: ignore
 
 DEFAULT_SPEECH_ENGINE: TTSSpeechEngine = "generative"
 DEFAULT_VOICE = "Ruth"
@@ -64,7 +68,7 @@ class TTS(tts.TTS):
         region: str | None = None,
         api_key: str | None = None,
         api_secret: str | None = None,
-        session: AioSession | None = None,
+        session: AioSession | aioboto3.Session | None = None,
     ) -> None:
         """
         Create a new instance of AWS Polly TTS.
@@ -83,7 +87,8 @@ class TTS(tts.TTS):
             region(str, optional): The region to use for the synthesis. Defaults to "us-east-1".
             api_key(str, optional): AWS access key id.
             api_secret(str, optional): AWS secret access key.
-            session(AioSession, optional): Optional aiobotocore session to use.
+            session(AioSession, optional): Optional aiobotocore session to use. Passing a legacy
+                aioboto3.Session is deprecated but still accepted.
         """  # noqa: E501
         super().__init__(
             capabilities=tts.TTSCapabilities(
@@ -92,7 +97,7 @@ class TTS(tts.TTS):
             sample_rate=sample_rate,
             num_channels=1,
         )
-        self._session = session or get_session()
+        self._session = _resolve_session(session)
         if session is None:
             if is_given(api_key) and api_key and is_given(api_secret) and api_secret:
                 self._session.set_credentials(api_key, api_secret)

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/tts.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/tts.py
@@ -14,10 +14,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 
-import aioboto3  # type: ignore
 import botocore  # type: ignore
 import botocore.exceptions  # type: ignore
 from aiobotocore.config import AioConfig  # type: ignore
+from aiobotocore.session import AioSession, get_session  # type: ignore
 
 from livekit.agents import (
     APIConnectionError,
@@ -64,7 +64,7 @@ class TTS(tts.TTS):
         region: str | None = None,
         api_key: str | None = None,
         api_secret: str | None = None,
-        session: aioboto3.Session | None = None,
+        session: AioSession | None = None,
     ) -> None:
         """
         Create a new instance of AWS Polly TTS.
@@ -83,7 +83,7 @@ class TTS(tts.TTS):
             region(str, optional): The region to use for the synthesis. Defaults to "us-east-1".
             api_key(str, optional): AWS access key id.
             api_secret(str, optional): AWS secret access key.
-            session(aioboto3.Session, optional): Optional aioboto3 session to use.
+            session(AioSession, optional): Optional aiobotocore session to use.
         """  # noqa: E501
         super().__init__(
             capabilities=tts.TTSCapabilities(
@@ -92,11 +92,12 @@ class TTS(tts.TTS):
             sample_rate=sample_rate,
             num_channels=1,
         )
-        self._session = session or aioboto3.Session(
-            aws_access_key_id=api_key if is_given(api_key) else None,
-            aws_secret_access_key=api_secret if is_given(api_secret) else None,
-            region_name=region if is_given(region) else None,
-        )
+        self._session = session or get_session()
+        if session is None:
+            if is_given(api_key) and api_key and is_given(api_secret) and api_secret:
+                self._session.set_credentials(api_key, api_secret)
+            if is_given(region) and region:
+                self._session.set_config_variable("region", region)
 
         self._opts = _TTSOptions(
             voice=voice,
@@ -153,7 +154,7 @@ class ChunkedStream(tts.ChunkedStream):
                 read_timeout=10,
                 retries={"mode": "standard", "total_max_attempts": 1},
             )
-            async with self._tts._session.client("polly", config=config) as client:  # type: ignore
+            async with self._tts._session.create_client("polly", config=config) as client:  # type: ignore
                 response = await client.synthesize_speech(
                     **_strip_nones(
                         {

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/utils.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/utils.py
@@ -37,7 +37,7 @@ def _resolve_session(session: object | None) -> AioSession:
             DeprecationWarning,
             stacklevel=3,
         )
-        return session._session  # type: ignore[attr-defined]
+        return session._session
 
     raise TypeError(
         "session must be an aiobotocore.session.AioSession "

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/utils.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/utils.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import warnings
-
 from aiobotocore.session import AioSession, get_session  # type: ignore
+
+from .log import logger
 
 DEFAULT_REGION = "us-east-1"
 
@@ -30,12 +30,10 @@ def _resolve_session(session: object | None) -> AioSession:
         aioboto3 = None
 
     if aioboto3 is not None and isinstance(session, aioboto3.Session):
-        warnings.warn(
+        logger.warning(
             "Passing an aioboto3.Session is deprecated; pass an "
             "aiobotocore.session.AioSession instead. The AWS plugin no longer depends "
-            "on aioboto3.",
-            DeprecationWarning,
-            stacklevel=3,
+            "on aioboto3."
         )
         return session._session
 

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/utils.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/utils.py
@@ -1,7 +1,45 @@
 from __future__ import annotations
 
+import warnings
+
+from aiobotocore.session import AioSession, get_session  # type: ignore
+
 DEFAULT_REGION = "us-east-1"
 
 
 def _strip_nones(d: dict) -> dict:
     return {k: v for k, v in d.items() if v is not None}
+
+
+def _resolve_session(session: object | None) -> AioSession:
+    """Return an ``AioSession`` for the given ``session`` argument.
+
+    Accepts ``None`` (creates a fresh session), an ``aiobotocore.session.AioSession``,
+    or — for backwards compatibility — a legacy ``aioboto3.Session``, which wraps an
+    ``AioSession`` and is unwrapped here with a ``DeprecationWarning``. ``aioboto3`` is
+    imported lazily so it does not become a dependency of this plugin.
+    """
+    if session is None:
+        return get_session()
+    if isinstance(session, AioSession):
+        return session
+
+    try:
+        import aioboto3  # type: ignore
+    except ImportError:
+        aioboto3 = None
+
+    if aioboto3 is not None and isinstance(session, aioboto3.Session):
+        warnings.warn(
+            "Passing an aioboto3.Session is deprecated; pass an "
+            "aiobotocore.session.AioSession instead. The AWS plugin no longer depends "
+            "on aioboto3.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return session._session  # type: ignore[attr-defined]
+
+    raise TypeError(
+        "session must be an aiobotocore.session.AioSession "
+        f"(or a legacy aioboto3.Session), got {type(session).__name__}."
+    )

--- a/livekit-plugins/livekit-plugins-aws/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-aws/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "livekit-agents>=1.6.5",
-    "aioboto3>=14.1.0",
+    "aiobotocore>=3.0.0",
     "aws_sdk_transcribe_streaming>=0.2.0; python_version >= '3.12'",
 ]
 


### PR DESCRIPTION
## Summary

`livekit-plugins-aws` depends on `aioboto3`, but `aioboto3` hard-pins its `aiobotocore` dependency with `==` (e.g. `aioboto3` 15.5.0 → `aiobotocore[boto3]==2.25.1`). Because each `aiobotocore` release in turn narrow-pins `botocore`/`boto3` to a ~15-patch window (2.25.1 → `botocore>=1.40.46,<1.40.62`), this transitively makes it impossible to install `livekit-plugins-aws` alongside any app that is on a more recent `botocore`. The resolver has exactly one `aiobotocore` release to choose from, and it drags an old `botocore` with it.

The plugin's actual usage of the AWS SDK is minimal: only the async **client** API is used — `session.client("polly", ...).synthesize_speech(...)` in `tts.py` and `session.client("bedrock-runtime", ...).converse_stream(...)` in `llm.py`. It never uses `.resource()`, which is the only thing `aioboto3` adds on top of `aiobotocore`. STT and the experimental realtime (Nova Sonic) paths use the smithy async SDKs, not `aioboto3` at all.

This PR drops `aioboto3` and uses `aiobotocore` directly:

- `aioboto3.Session(...)` → `aiobotocore.session.get_session()` (credentials/region applied via `set_credentials` / `set_config_variable`, matching the previous behaviour of only setting them when explicitly provided).
- `session.client(name, config=...)` → `session.create_client(name, config=...)` (same async-context-manager API).
- Dependency `aioboto3>=14.1.0` → `aiobotocore>=3.0.0`.

Because the dependency is now a **range** rather than a wrapper that `==`-pins a single old `aiobotocore`, the resolver can pick the `aiobotocore` whose `botocore` window matches the surrounding application (e.g. `aiobotocore` 3.7.0 accepts `botocore` 1.42.90–1.43.0).

## Compatibility note

The optional `session=` parameter on `aws.TTS` / `aws.LLM` changes type from `aioboto3.Session` to `aiobotocore.session.AioSession`. Callers relying on the default (no `session` passed) are unaffected. Callers passing their own session must pass an `aiobotocore` session instead.

## Test plan

- [ ] `tts.py` (Polly `synthesize_speech`) and `llm.py` (Bedrock `converse_stream`) smoke-tested with default credential chain.
- [ ] Verify install resolves against a modern `botocore` without backtracking to the old `aioboto3`-pinned window.

Refs #6437