### PR TITLE
feat(agent): add update_options() to swap STT/VAD/LLM/TTS at runtime

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -260,7 +260,7 @@ class Agent:
             chat_ctx, exclude_invalid_function_calls=exclude_invalid_function_calls
         )
 
-    def update_models(
+    def update_options(
         self,
         *,
         stt: NotGivenOr[stt.STT | STTModels | str | None] = NOT_GIVEN,

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -260,6 +260,46 @@ class Agent:
             chat_ctx, exclude_invalid_function_calls=exclude_invalid_function_calls
         )
 
+    def update_models(
+        self,
+        *,
+        stt: NotGivenOr[stt.STT | STTModels | str | None] = NOT_GIVEN,
+        vad: NotGivenOr[vad.VAD | None] = NOT_GIVEN,
+        llm: NotGivenOr[llm.LLM | llm.RealtimeModel | LLMModels | str | None] = NOT_GIVEN,
+        tts: NotGivenOr[tts.TTS | TTSModels | str | None] = NOT_GIVEN,
+    ) -> None:
+        """Swap the STT, VAD, LLM, or TTS on this agent. Only the models passed are changed.
+
+        Useful for switching a component mid-call (e.g. a different STT language or TTS voice).
+        Strings resolve to inference models like the constructor. Pass ``None`` to disable a
+        model (overriding the session), matching ``Agent(stt=None)``. If the agent is running,
+        the swap applies to the live pipeline.
+
+        Raises:
+            RuntimeError: When swapping to or from a ``RealtimeModel`` while the agent is
+                running; use ``AgentSession.update_agent`` instead.
+        """
+        if isinstance(stt, str):
+            stt = inference.STT.from_model_string(stt)
+        if isinstance(llm, str):
+            llm = inference.LLM.from_model_string(llm)
+        if isinstance(tts, str):
+            tts = inference.TTS.from_model_string(tts)
+
+        if self._activity is None:
+            # not running: replace stored config, applied on the next start
+            if is_given(stt):
+                self._stt = stt
+            if is_given(vad):
+                self._vad = vad
+            if is_given(llm):
+                self._llm = llm
+            if is_given(tts):
+                self._tts = tts
+            return
+
+        self._activity._update_models(new_stt=stt, new_vad=vad, new_llm=llm, new_tts=tts)
+
     # -- Pipeline nodes --
     # They can all be overriden by subclasses, by default they use the STT/LLM/TTS specified in the
     # constructor of the VoiceAgent

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -579,6 +579,9 @@ class AgentActivity(RecognitionHooks):
                 "cannot swap to or from a RealtimeModel while the agent is running, "
                 "use AgentSession.update_agent() instead"
             )
+        # a new vad must satisfy the streaming turn detector's min_silence requirement
+        if is_given(new_vad) and self._audio_recognition is not None:
+            self._audio_recognition._check_vad_silence_requirement(vad=new_vad)
 
         if is_given(new_stt):
             old_stt = self.stt

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -588,16 +588,24 @@ class AgentActivity(RecognitionHooks):
                 self._session.off("conversation_item_added", old_stt._push_conversation_item)
 
             self._agent._stt = new_stt
+            resolved_stt = self.stt
             if self._audio_recognition is not None:
-                self._audio_recognition._update_stt(self._agent.stt_node if self.stt else None)
-            self._session._keyterm_detector.swap_stt(self.stt)
+                self._audio_recognition._update_stt(
+                    self._agent.stt_node if resolved_stt else None,
+                    model=resolved_stt.model if isinstance(resolved_stt, stt.STT) else None,
+                    provider=resolved_stt.provider if isinstance(resolved_stt, stt.STT) else None,
+                    reset_context=True,
+                )
+            self._session._keyterm_detector.swap_stt(resolved_stt)
 
-            if isinstance(self.stt, stt.STT):
-                self.stt.prewarm()
-                self.stt.on("metrics_collected", self._on_metrics_collected)
-                self.stt.on("error", self._on_error)
-                if self.stt.capabilities.chat_context:
-                    self._session.on("conversation_item_added", self.stt._push_conversation_item)
+            if isinstance(resolved_stt, stt.STT):
+                resolved_stt.prewarm()
+                resolved_stt.on("metrics_collected", self._on_metrics_collected)
+                resolved_stt.on("error", self._on_error)
+                if resolved_stt.capabilities.chat_context:
+                    self._session.on(
+                        "conversation_item_added", resolved_stt._push_conversation_item
+                    )
 
         if is_given(new_vad):
             old_vad = self.vad

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -563,6 +563,77 @@ class AgentActivity(RecognitionHooks):
                 turn_detection=turn_detection,
             )
 
+    def _update_models(
+        self,
+        *,
+        new_stt: NotGivenOr[stt.STT | None] = NOT_GIVEN,
+        new_vad: NotGivenOr[vad.VAD | None] = NOT_GIVEN,
+        new_llm: NotGivenOr[llm.LLM | llm.RealtimeModel | None] = NOT_GIVEN,
+        new_tts: NotGivenOr[tts.TTS | None] = NOT_GIVEN,
+    ) -> None:
+        # a RealtimeModel owns a live session; reject before mutating to stay all-or-nothing
+        if is_given(new_llm) and (
+            isinstance(new_llm, llm.RealtimeModel) or isinstance(self.llm, llm.RealtimeModel)
+        ):
+            raise RuntimeError(
+                "cannot swap to or from a RealtimeModel while the agent is running, "
+                "use AgentSession.update_agent() instead"
+            )
+
+        if is_given(new_stt):
+            old_stt = self.stt
+            if isinstance(old_stt, stt.STT):
+                old_stt.off("metrics_collected", self._on_metrics_collected)
+                old_stt.off("error", self._on_error)
+                self._session.off("conversation_item_added", old_stt._push_conversation_item)
+
+            self._agent._stt = new_stt
+            if self._audio_recognition is not None:
+                self._audio_recognition._update_stt(self._agent.stt_node if self.stt else None)
+            self._session._keyterm_detector.swap_stt(self.stt)
+
+            if isinstance(self.stt, stt.STT):
+                self.stt.prewarm()
+                self.stt.on("metrics_collected", self._on_metrics_collected)
+                self.stt.on("error", self._on_error)
+                if self.stt.capabilities.chat_context:
+                    self._session.on("conversation_item_added", self.stt._push_conversation_item)
+
+        if is_given(new_vad):
+            old_vad = self.vad
+            if isinstance(old_vad, vad.VAD):
+                old_vad.off("metrics_collected", self._on_metrics_collected)
+
+            self._agent._vad = new_vad
+            if self._audio_recognition is not None:
+                self._audio_recognition._update_vad(self.vad)
+            if isinstance(self.vad, vad.VAD):
+                self.vad.on("metrics_collected", self._on_metrics_collected)
+
+        if is_given(new_llm):
+            old_llm = self.llm
+            if isinstance(old_llm, llm.LLM):
+                old_llm.off("metrics_collected", self._on_metrics_collected)
+                old_llm.off("error", self._on_error)
+
+            self._agent._llm = new_llm  # llm_node reads activity.llm per generation
+            if isinstance(self.llm, llm.LLM):
+                self.llm.prewarm()
+                self.llm.on("metrics_collected", self._on_metrics_collected)
+                self.llm.on("error", self._on_error)
+
+        if is_given(new_tts):
+            old_tts = self.tts
+            if isinstance(old_tts, tts.TTS):
+                old_tts.off("metrics_collected", self._on_metrics_collected)
+                old_tts.off("error", self._on_error)
+
+            self._agent._tts = new_tts  # tts_node reads activity.tts per synthesis
+            if isinstance(self.tts, tts.TTS):
+                self.tts.prewarm()
+                self.tts.on("metrics_collected", self._on_metrics_collected)
+                self.tts.on("error", self._on_error)
+
     def _create_speech_task(
         self,
         coro: Coroutine[Any, Any, Any],

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -795,12 +795,15 @@ class AudioRecognition:
     def _check_vad_silence_requirement(
         self,
         detector: NotGivenOr[_TurnDetector | _StreamingTurnDetector | None] = NOT_GIVEN,
+        vad: NotGivenOr[vad.VAD | None] = NOT_GIVEN,
     ) -> None:
         if not is_given(detector):
             detector = self._turn_detector
-        if not isinstance(detector, _StreamingTurnDetector) or self._vad is None:
+        # validate a candidate vad (before it's applied) when given, else the active one
+        target_vad = vad if is_given(vad) else self._vad
+        if not isinstance(detector, _StreamingTurnDetector) or target_vad is None:
             return
-        if (current := getattr(self._vad, "min_silence_duration", None)) is None:
+        if (current := getattr(target_vad, "min_silence_duration", None)) is None:
             return
         required = (MIN_SILENCE_DURATION_MS + 50) / 1000
         if current < required:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -745,8 +745,25 @@ class AudioRecognition:
             self._backchannel_boundary_timer = None
             self._backchannel_boundary_callback = None
 
-    def _update_stt(self, stt: io.STTNode | None, *, pipeline: _STTPipeline | None = None) -> None:
+    def _update_stt(
+        self,
+        stt: io.STTNode | None,
+        *,
+        pipeline: _STTPipeline | None = None,
+        model: NotGivenOr[str | None] = NOT_GIVEN,
+        provider: NotGivenOr[str | None] = NOT_GIVEN,
+        reset_context: bool = False,
+    ) -> None:
         self._stt = stt
+        # model/provider drive the user_turn span attributes; swapping to a different STT must
+        # refresh them (they default to unchanged for same-STT resets like _clear_user_turn)
+        if is_given(model):
+            self._stt_model = model
+        if is_given(provider):
+            self._stt_provider = provider
+        # speaker metadata belongs to the old stream; drop it so a new STT starts clean
+        if reset_context:
+            self.stt_context = None
         if pipeline is None and stt is not None:
             pipeline = _STTPipeline(stt)
 

--- a/livekit-agents/livekit/agents/voice/keyterm_detection.py
+++ b/livekit-agents/livekit/agents/voice/keyterm_detection.py
@@ -250,6 +250,14 @@ class KeytermDetector(rtc.EventEmitter[Literal["metrics_collected"]]):
         self._turn_count = 0
         session.on("conversation_item_added", self._on_conversation_item_added)
 
+    def swap_stt(self, stt: STT | None) -> None:
+        """Rebind the recognizer in place, keeping any running detection."""
+        if stt is self._stt:
+            return
+        self._stt = stt
+        if stt is not None and self.keyterms:
+            stt._update_session_keyterms(self.keyterms)
+
     async def aclose(self) -> None:
         """Stop detection for the current activity; keyterm state is kept."""
         if self._llm is not None:

--- a/tests/test_agent_update_models.py
+++ b/tests/test_agent_update_models.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents import Agent, AgentSession
+
+from .fake_llm import FakeLLM
+from .fake_realtime import FakeRealtimeModel
+from .fake_stt import FakeSTT
+from .fake_tts import FakeTTS
+from .fake_vad import FakeVAD
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_update_models_not_running_replaces_fields() -> None:
+    stt1, stt2 = FakeSTT(), FakeSTT()
+    vad1, vad2 = FakeVAD(), FakeVAD()
+    llm1, llm2 = FakeLLM(), FakeLLM()
+    tts1, tts2 = FakeTTS(), FakeTTS()
+
+    agent = Agent(instructions="test", stt=stt1, vad=vad1, llm=llm1, tts=tts1)
+    agent.update_models(stt=stt2, vad=vad2, llm=llm2, tts=tts2)
+
+    assert agent.stt is stt2
+    assert agent.vad is vad2
+    assert agent.llm is llm2
+    assert agent.tts is tts2
+
+
+def test_update_models_not_running_only_touches_given() -> None:
+    stt1 = FakeSTT()
+    llm1 = FakeLLM()
+    agent = Agent(instructions="test", stt=stt1, llm=llm1)
+
+    tts_new = FakeTTS()
+    agent.update_models(tts=tts_new)
+
+    assert agent.stt is stt1  # untouched
+    assert agent.llm is llm1  # untouched
+    assert agent.tts is tts_new
+
+
+@pytest.mark.asyncio
+async def test_update_models_running_swaps_tts() -> None:
+    old_tts, new_tts = FakeTTS(), FakeTTS()
+    agent = Agent(instructions="test", llm=FakeLLM(), tts=old_tts)
+    session = AgentSession(turn_handling={"turn_detection": None})
+    await session.start(agent)
+    try:
+        activity = session._activity
+        assert activity is not None and activity.tts is old_tts
+
+        agent.update_models(tts=new_tts)
+
+        assert agent.tts is new_tts
+        assert activity.tts is new_tts
+        # metrics/error listeners moved to the new instance
+        assert activity._on_metrics_collected not in old_tts._events.get("metrics_collected", set())
+        assert activity._on_metrics_collected in new_tts._events.get("metrics_collected", set())
+    finally:
+        await session.aclose()
+
+
+@pytest.mark.asyncio
+async def test_update_models_running_swaps_llm() -> None:
+    old_llm, new_llm = FakeLLM(), FakeLLM()
+    agent = Agent(instructions="test", llm=old_llm)
+    session = AgentSession(turn_handling={"turn_detection": None})
+    await session.start(agent)
+    try:
+        activity = session._activity
+        assert activity is not None and activity.llm is old_llm
+
+        agent.update_models(llm=new_llm)
+
+        assert agent.llm is new_llm
+        assert activity.llm is new_llm
+        assert activity._on_metrics_collected not in old_llm._events.get("metrics_collected", set())
+        assert activity._on_metrics_collected in new_llm._events.get("metrics_collected", set())
+    finally:
+        await session.aclose()
+
+
+@pytest.mark.asyncio
+async def test_update_models_running_swaps_stt_rewires_pipeline() -> None:
+    old_stt, new_stt = FakeSTT(), FakeSTT()
+    agent = Agent(instructions="test", stt=old_stt, vad=FakeVAD(), llm=FakeLLM(), tts=FakeTTS())
+    session = AgentSession(turn_handling={"turn_detection": None})
+    await session.start(agent)
+    try:
+        activity = session._activity
+        assert activity is not None and activity.stt is old_stt
+        recognition = activity._audio_recognition
+        assert recognition is not None
+        old_pipeline = recognition._stt_pipeline
+
+        agent.update_models(stt=new_stt)
+
+        assert agent.stt is new_stt
+        assert activity.stt is new_stt
+        # the live STT pipeline was rebuilt
+        assert recognition._stt_pipeline is not old_pipeline
+        assert activity._on_metrics_collected not in old_stt._events.get("metrics_collected", set())
+        assert activity._on_metrics_collected in new_stt._events.get("metrics_collected", set())
+    finally:
+        await session.aclose()
+
+
+@pytest.mark.asyncio
+async def test_update_models_running_swaps_vad() -> None:
+    old_vad, new_vad = FakeVAD(), FakeVAD()
+    agent = Agent(instructions="test", stt=FakeSTT(), vad=old_vad, llm=FakeLLM(), tts=FakeTTS())
+    session = AgentSession(turn_handling={"turn_detection": None})
+    await session.start(agent)
+    try:
+        activity = session._activity
+        assert activity is not None and activity.vad is old_vad
+
+        agent.update_models(vad=new_vad)
+
+        assert agent.vad is new_vad
+        assert activity.vad is new_vad
+        assert activity._on_metrics_collected not in old_vad._events.get("metrics_collected", set())
+        assert activity._on_metrics_collected in new_vad._events.get("metrics_collected", set())
+    finally:
+        await session.aclose()
+
+
+@pytest.mark.asyncio
+async def test_update_models_running_disable_stt() -> None:
+    agent = Agent(instructions="test", stt=FakeSTT(), vad=FakeVAD(), llm=FakeLLM(), tts=FakeTTS())
+    session = AgentSession(turn_handling={"turn_detection": None})
+    await session.start(agent)
+    try:
+        activity = session._activity
+        assert activity is not None
+
+        agent.update_models(stt=None)
+
+        assert agent.stt is None
+        assert activity.stt is None
+        assert activity._audio_recognition is not None
+        assert activity._audio_recognition._stt_pipeline is None
+    finally:
+        await session.aclose()
+
+
+@pytest.mark.asyncio
+async def test_update_models_running_rejects_swap_to_realtime() -> None:
+    agent = Agent(instructions="test", llm=FakeLLM())
+    session = AgentSession(turn_handling={"turn_detection": None})
+    await session.start(agent)
+    try:
+        with pytest.raises(RuntimeError, match="RealtimeModel"):
+            agent.update_models(llm=FakeRealtimeModel())
+        # nothing was swapped
+        assert isinstance(agent.llm, FakeLLM)
+    finally:
+        await session.aclose()
+
+
+@pytest.mark.asyncio
+async def test_update_models_running_rejects_swap_away_from_realtime() -> None:
+    agent = Agent(instructions="test", llm=FakeRealtimeModel())
+    session = AgentSession(turn_handling={"turn_detection": None})
+    await session.start(agent)
+    try:
+        with pytest.raises(RuntimeError, match="RealtimeModel"):
+            agent.update_models(llm=FakeLLM())
+        assert isinstance(agent.llm, FakeRealtimeModel)
+    finally:
+        await session.aclose()

--- a/tests/test_agent_update_models.py
+++ b/tests/test_agent_update_models.py
@@ -171,3 +171,39 @@ async def test_update_models_running_rejects_swap_away_from_realtime() -> None:
         assert isinstance(agent.llm, FakeRealtimeModel)
     finally:
         await session.aclose()
+
+
+class _LabeledSTT(FakeSTT):
+    @property
+    def model(self) -> str:
+        return "new-model"
+
+    @property
+    def provider(self) -> str:
+        return "new-provider"
+
+
+@pytest.mark.asyncio
+async def test_update_models_stt_swap_refreshes_model_provider_and_context() -> None:
+    from pydantic import BaseModel
+
+    class _Ctx(BaseModel):
+        value: int = 1
+
+    agent = Agent(instructions="test", stt=FakeSTT(), vad=FakeVAD(), llm=FakeLLM(), tts=FakeTTS())
+    session = AgentSession(turn_handling={"turn_detection": None})
+    await session.start(agent)
+    try:
+        recognition = session._activity._audio_recognition
+        assert recognition is not None
+        # stand in for live speaker metadata captured from the old stream
+        recognition.stt_context = _Ctx()
+
+        agent.update_models(stt=_LabeledSTT())
+
+        # trace attributes and speaker context follow the new STT
+        assert recognition._stt_model == "new-model"
+        assert recognition._stt_provider == "new-provider"
+        assert recognition.stt_context is None
+    finally:
+        await session.aclose()

--- a/tests/test_agent_update_options.py
+++ b/tests/test_agent_update_options.py
@@ -207,3 +207,35 @@ async def test_update_options_stt_swap_refreshes_model_provider_and_context() ->
         assert recognition.stt_context is None
     finally:
         await session.aclose()
+
+
+class _LowSilenceVAD(FakeVAD):
+    @property
+    def min_silence_duration(self) -> float:
+        return 0.0
+
+
+@pytest.mark.asyncio
+async def test_update_options_vad_check_is_atomic() -> None:
+    from unittest.mock import MagicMock
+
+    from livekit.agents.voice.turn import _StreamingTurnDetector
+
+    old_stt, old_vad = FakeSTT(), FakeVAD()
+    agent = Agent(instructions="test", stt=old_stt, vad=old_vad, llm=FakeLLM(), tts=FakeTTS())
+    session = AgentSession(turn_handling={"turn_detection": None})
+    await session.start(agent)
+    try:
+        recognition = session._activity._audio_recognition
+        assert recognition is not None
+        # a streaming turn detector constrains the VAD's min_silence_duration
+        recognition._turn_detector = MagicMock(spec=_StreamingTurnDetector)
+
+        with pytest.raises(ValueError, match="min_silence_duration"):
+            agent.update_options(stt=FakeSTT(), vad=_LowSilenceVAD())
+
+        # rejected before any mutation — STT and VAD are untouched
+        assert agent.stt is old_stt
+        assert agent.vad is old_vad
+    finally:
+        await session.aclose()

--- a/tests/test_agent_update_options.py
+++ b/tests/test_agent_update_options.py
@@ -13,14 +13,14 @@ from .fake_vad import FakeVAD
 pytestmark = [pytest.mark.unit]
 
 
-def test_update_models_not_running_replaces_fields() -> None:
+def test_update_options_not_running_replaces_fields() -> None:
     stt1, stt2 = FakeSTT(), FakeSTT()
     vad1, vad2 = FakeVAD(), FakeVAD()
     llm1, llm2 = FakeLLM(), FakeLLM()
     tts1, tts2 = FakeTTS(), FakeTTS()
 
     agent = Agent(instructions="test", stt=stt1, vad=vad1, llm=llm1, tts=tts1)
-    agent.update_models(stt=stt2, vad=vad2, llm=llm2, tts=tts2)
+    agent.update_options(stt=stt2, vad=vad2, llm=llm2, tts=tts2)
 
     assert agent.stt is stt2
     assert agent.vad is vad2
@@ -28,13 +28,13 @@ def test_update_models_not_running_replaces_fields() -> None:
     assert agent.tts is tts2
 
 
-def test_update_models_not_running_only_touches_given() -> None:
+def test_update_options_not_running_only_touches_given() -> None:
     stt1 = FakeSTT()
     llm1 = FakeLLM()
     agent = Agent(instructions="test", stt=stt1, llm=llm1)
 
     tts_new = FakeTTS()
-    agent.update_models(tts=tts_new)
+    agent.update_options(tts=tts_new)
 
     assert agent.stt is stt1  # untouched
     assert agent.llm is llm1  # untouched
@@ -42,7 +42,7 @@ def test_update_models_not_running_only_touches_given() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_models_running_swaps_tts() -> None:
+async def test_update_options_running_swaps_tts() -> None:
     old_tts, new_tts = FakeTTS(), FakeTTS()
     agent = Agent(instructions="test", llm=FakeLLM(), tts=old_tts)
     session = AgentSession(turn_handling={"turn_detection": None})
@@ -51,7 +51,7 @@ async def test_update_models_running_swaps_tts() -> None:
         activity = session._activity
         assert activity is not None and activity.tts is old_tts
 
-        agent.update_models(tts=new_tts)
+        agent.update_options(tts=new_tts)
 
         assert agent.tts is new_tts
         assert activity.tts is new_tts
@@ -63,7 +63,7 @@ async def test_update_models_running_swaps_tts() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_models_running_swaps_llm() -> None:
+async def test_update_options_running_swaps_llm() -> None:
     old_llm, new_llm = FakeLLM(), FakeLLM()
     agent = Agent(instructions="test", llm=old_llm)
     session = AgentSession(turn_handling={"turn_detection": None})
@@ -72,7 +72,7 @@ async def test_update_models_running_swaps_llm() -> None:
         activity = session._activity
         assert activity is not None and activity.llm is old_llm
 
-        agent.update_models(llm=new_llm)
+        agent.update_options(llm=new_llm)
 
         assert agent.llm is new_llm
         assert activity.llm is new_llm
@@ -83,7 +83,7 @@ async def test_update_models_running_swaps_llm() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_models_running_swaps_stt_rewires_pipeline() -> None:
+async def test_update_options_running_swaps_stt_rewires_pipeline() -> None:
     old_stt, new_stt = FakeSTT(), FakeSTT()
     agent = Agent(instructions="test", stt=old_stt, vad=FakeVAD(), llm=FakeLLM(), tts=FakeTTS())
     session = AgentSession(turn_handling={"turn_detection": None})
@@ -95,7 +95,7 @@ async def test_update_models_running_swaps_stt_rewires_pipeline() -> None:
         assert recognition is not None
         old_pipeline = recognition._stt_pipeline
 
-        agent.update_models(stt=new_stt)
+        agent.update_options(stt=new_stt)
 
         assert agent.stt is new_stt
         assert activity.stt is new_stt
@@ -108,7 +108,7 @@ async def test_update_models_running_swaps_stt_rewires_pipeline() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_models_running_swaps_vad() -> None:
+async def test_update_options_running_swaps_vad() -> None:
     old_vad, new_vad = FakeVAD(), FakeVAD()
     agent = Agent(instructions="test", stt=FakeSTT(), vad=old_vad, llm=FakeLLM(), tts=FakeTTS())
     session = AgentSession(turn_handling={"turn_detection": None})
@@ -117,7 +117,7 @@ async def test_update_models_running_swaps_vad() -> None:
         activity = session._activity
         assert activity is not None and activity.vad is old_vad
 
-        agent.update_models(vad=new_vad)
+        agent.update_options(vad=new_vad)
 
         assert agent.vad is new_vad
         assert activity.vad is new_vad
@@ -128,7 +128,7 @@ async def test_update_models_running_swaps_vad() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_models_running_disable_stt() -> None:
+async def test_update_options_running_disable_stt() -> None:
     agent = Agent(instructions="test", stt=FakeSTT(), vad=FakeVAD(), llm=FakeLLM(), tts=FakeTTS())
     session = AgentSession(turn_handling={"turn_detection": None})
     await session.start(agent)
@@ -136,7 +136,7 @@ async def test_update_models_running_disable_stt() -> None:
         activity = session._activity
         assert activity is not None
 
-        agent.update_models(stt=None)
+        agent.update_options(stt=None)
 
         assert agent.stt is None
         assert activity.stt is None
@@ -147,13 +147,13 @@ async def test_update_models_running_disable_stt() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_models_running_rejects_swap_to_realtime() -> None:
+async def test_update_options_running_rejects_swap_to_realtime() -> None:
     agent = Agent(instructions="test", llm=FakeLLM())
     session = AgentSession(turn_handling={"turn_detection": None})
     await session.start(agent)
     try:
         with pytest.raises(RuntimeError, match="RealtimeModel"):
-            agent.update_models(llm=FakeRealtimeModel())
+            agent.update_options(llm=FakeRealtimeModel())
         # nothing was swapped
         assert isinstance(agent.llm, FakeLLM)
     finally:
@@ -161,13 +161,13 @@ async def test_update_models_running_rejects_swap_to_realtime() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_models_running_rejects_swap_away_from_realtime() -> None:
+async def test_update_options_running_rejects_swap_away_from_realtime() -> None:
     agent = Agent(instructions="test", llm=FakeRealtimeModel())
     session = AgentSession(turn_handling={"turn_detection": None})
     await session.start(agent)
     try:
         with pytest.raises(RuntimeError, match="RealtimeModel"):
-            agent.update_models(llm=FakeLLM())
+            agent.update_options(llm=FakeLLM())
         assert isinstance(agent.llm, FakeRealtimeModel)
     finally:
         await session.aclose()
@@ -184,7 +184,7 @@ class _LabeledSTT(FakeSTT):
 
 
 @pytest.mark.asyncio
-async def test_update_models_stt_swap_refreshes_model_provider_and_context() -> None:
+async def test_update_options_stt_swap_refreshes_model_provider_and_context() -> None:
     from pydantic import BaseModel
 
     class _Ctx(BaseModel):
@@ -199,7 +199,7 @@ async def test_update_models_stt_swap_refreshes_model_provider_and_context() -> 
         # stand in for live speaker metadata captured from the old stream
         recognition.stt_context = _Ctx()
 
-        agent.update_models(stt=_LabeledSTT())
+        agent.update_options(stt=_LabeledSTT())
 
         # trace attributes and speaker context follow the new STT
         assert recognition._stt_model == "new-model"


### PR DESCRIPTION

`Agent.update_models(*, stt, vad, llm, tts)` swaps a model in place. Only the models passed are changed; strings resolve to inference models like the constructor, and `None` disables a model (overriding the session), matching `Agent(stt=None)`.

When the agent isn't running it replaces the stored model, applied on the next start. When running, it applies to the live pipeline: the STT and VAD streams are rewired, the LLM and TTS take effect on the next generation and synthesis respectively, and each model's `metrics_collected`/`error` listeners follow the new instance. The call is synchronous and atomic.

The Agent is the source of truth — the activity resolves `agent.<model> if given else session.<model>` live — so `update_models` just writes to the agent. This is distinct from `AgentSession.update_agent` (full handoff, new instance) and from a model's own `update_options` (same instance, provider options).

Alternative to https://github.com/livekit/agents/pull/6235

## Realtime models

A `RealtimeModel` owns a live session created when the agent starts, so it can't be swapped in place. While running, passing a `RealtimeModel` as `llm` (or swapping away from one) raises `RuntimeError` pointing to `AgentSession.update_agent`. Validation happens before any mutation, so the call stays all-or-nothing.

