### PR TITLE
feat(assemblyai): add language_codes steering param, enable agent_context_carryover by default

### DIFF
--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -105,8 +105,8 @@ def _normalize_language_codes(language_codes: list[str]) -> list[str]:
         )
     if "multi" in normalized and len(normalized) > 1:
         raise ValueError(
-            "language_code 'multi' routes to the unsteered multilingual model "
-            "and cannot be combined with other codes"
+            "'multi' routes to the unsteered multilingual model "
+            "and cannot be combined with other language codes"
         )
     return normalized
 
@@ -117,14 +117,13 @@ def _normalize_language_codes(language_codes: list[str]) -> list[str]:
 _MAX_AGENT_CONTEXT_CHARS = 1750
 
 
-def _validate_agent_context(agent_context: str) -> str:
+def _validate_agent_context(agent_context: str) -> None:
     """Reject explicit agent_context longer than the server cap."""
     if len(agent_context) > _MAX_AGENT_CONTEXT_CHARS:
         raise ValueError(
             f"agent_context exceeds maximum length of {_MAX_AGENT_CONTEXT_CHARS} "
             f"characters (got {len(agent_context)})"
         )
-    return agent_context
 
 
 class STT(stt.STT):
@@ -192,7 +191,8 @@ class STT(stt.STT):
                 Leave unset to use the model's default multilingual behavior. Only
                 supported with the Universal-3 Pro family models. Can be updated
                 mid-session via ``update_options``; pass an empty list there to clear
-                steering back to the model default.
+                steering back to the model default. At construction an empty list is
+                equivalent to leaving it unset.
             min_turn_silence: Minimum silence in ms before a confident end-of-turn is finalized.
             min_end_of_turn_silence_when_confident: Deprecated. Use min_turn_silence instead.
             continuous_partials: Whether to emit additional partial transcripts during long
@@ -225,10 +225,11 @@ class STT(stt.STT):
                 assistant reply into ``agent_context`` so it is carried into the model's
                 conversation context. Enabled by default on models that support it (the
                 Universal-3 Pro family); pass False to opt out. On other models it is off;
-                explicitly passing True logs a warning and is ignored. Prior user turns are
-                carried automatically by the model regardless of this flag. Replies longer
-                than the 1750-character server cap are truncated (keeping the tail) before
-                being sent.
+                explicitly passing True logs a warning and is ignored. Also disabled by
+                default when ``previous_context_n_turns=0`` (context carryover explicitly
+                turned off). Prior user turns are carried automatically by the model
+                regardless of this flag. Replies longer than the 1750-character server cap
+                are truncated (keeping the tail) before being sent.
             voice_focus: Voice Focus isolates the primary voice and suppresses background
                 noise (chatter, keyboard clicks, fan hum, room echo) before the audio reaches
                 the model. Use 'near-field' for headsets, handsets, and close-talking
@@ -255,6 +256,11 @@ class STT(stt.STT):
                 "language_code and language_codes are mutually exclusive; "
                 "use language_codes (language_code is shorthand for a one-element list)"
             )
+        # An explicit empty list is equivalent to unset at construction — the
+        # param is omitted from the connect query either way — so it is not
+        # subject to the U3-Pro-family gate below.
+        if is_given(language_codes) and not language_codes:
+            language_codes = NOT_GIVEN
         if is_given(agent_context):
             _validate_agent_context(agent_context)
         # agent_context carryover is only available on the u3-rt-pro family
@@ -266,8 +272,12 @@ class STT(stt.STT):
                 "agent_context_carryover is enabled but model %r does not support it; ignoring",
                 model,
             )
-        carryover_enabled = (
-            agent_context_carryover if is_given(agent_context_carryover) else supports_carryover
+        # previous_context_n_turns=0 is documented as "disable automatic context
+        # carryover" — honor it in the default resolution (an explicit
+        # agent_context_carryover=True still wins).
+        _context_disabled = is_given(previous_context_n_turns) and previous_context_n_turns == 0
+        carryover_enabled = supports_carryover and (
+            agent_context_carryover if is_given(agent_context_carryover) else not _context_disabled
         )
         super().__init__(
             capabilities=stt.STTCapabilities(
@@ -277,7 +287,7 @@ class STT(stt.STT):
                 offline_recognize=False,
                 diarization=is_given(speaker_labels) and speaker_labels is True,
                 keyterms=True,
-                chat_context=carryover_enabled and supports_carryover,
+                chat_context=carryover_enabled,
             ),
         )
         if model == "u3-pro":
@@ -440,6 +450,11 @@ class STT(stt.STT):
         # Validate/normalize before mutating any option so a ValueError from a
         # bad value cannot leave _opts partially updated.
         if is_given(language_codes):
+            if self._opts.speech_model not in _U3_PRO_MODELS:
+                raise ValueError(
+                    "The 'language_codes' parameter is only supported with the "
+                    f"{', '.join(_U3_PRO_MODELS)} models."
+                )
             language_codes = _normalize_language_codes(list(language_codes))
         if is_given(agent_context):
             _validate_agent_context(agent_context)
@@ -581,6 +596,11 @@ class SpeechStream(stt.SpeechStream):
         # Validate/normalize before mutating any option so a ValueError from a
         # bad value cannot leave _opts partially updated.
         if is_given(language_codes):
+            if self._opts.speech_model not in _U3_PRO_MODELS:
+                raise ValueError(
+                    "The 'language_codes' parameter is only supported with the "
+                    f"{', '.join(_U3_PRO_MODELS)} models."
+                )
             language_codes = _normalize_language_codes(list(language_codes))
         if is_given(agent_context):
             _validate_agent_context(agent_context)

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -211,7 +211,10 @@ class STT(stt.STT):
                 transcription of the user's reply. Set at construction or updated per-turn
                 via `update_options(agent_context=...)`. Only supported with the
                 Universal-3 Pro family models (max 1750 characters; longer values raise
-                ValueError).
+                ValueError). With ``agent_context_carryover`` enabled — the default on
+                Universal-3 Pro family models — each assistant reply replaces this value
+                automatically; pass ``agent_context_carryover=False`` to manage it
+                manually.
             previous_context_n_turns: Maximum number of prior conversation entries (user
                 transcripts and any `agent_context` values) carried forward as context for
                 each transcription. Set to 0 to disable automatic context carryover

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -155,7 +155,7 @@ class STT(stt.STT):
         prompt: NotGivenOr[str] = NOT_GIVEN,
         agent_context: NotGivenOr[str] = NOT_GIVEN,
         previous_context_n_turns: NotGivenOr[int] = NOT_GIVEN,
-        agent_context_carryover: bool = False,
+        agent_context_carryover: NotGivenOr[bool] = NOT_GIVEN,
         vad_threshold: NotGivenOr[float] = NOT_GIVEN,
         speaker_labels: NotGivenOr[bool] = NOT_GIVEN,
         max_speakers: NotGivenOr[int] = NOT_GIVEN,
@@ -220,9 +220,12 @@ class STT(stt.STT):
                 (connect) time only; it cannot be changed via `update_options`.
             agent_context_carryover: When the model supports it, let an ``AgentSession`` push each
                 assistant reply into ``agent_context`` so it is carried into the model's
-                conversation context. Defaults to False; set True to enable. Prior user turns are
-                carried automatically by the model regardless of this flag. Ignored on models
-                without context support.
+                conversation context. Enabled by default on models that support it (the
+                Universal-3 Pro family); pass False to opt out. On other models it is off;
+                explicitly passing True logs a warning and is ignored. Prior user turns are
+                carried automatically by the model regardless of this flag. Replies longer
+                than the 1750-character server cap are truncated (keeping the tail) before
+                being sent.
             voice_focus: Voice Focus isolates the primary voice and suppresses background
                 noise (chatter, keyboard clicks, fan hum, room echo) before the audio reaches
                 the model. Use 'near-field' for headsets, handsets, and close-talking
@@ -252,13 +255,17 @@ class STT(stt.STT):
         if is_given(agent_context):
             _validate_agent_context(agent_context)
         # agent_context carryover is only available on the u3-rt-pro family
-        # ("u3-pro" is normalized to "u3-rt-pro" below) and is opt-in via the user
+        # ("u3-pro" is normalized to "u3-rt-pro" below). Unset means "on where
+        # supported"; only an explicit True on an unsupported model warns.
         supports_carryover = model in _U3_PRO_MODELS or model == "u3-pro"
-        if agent_context_carryover and not supports_carryover:
+        if is_given(agent_context_carryover) and agent_context_carryover and not supports_carryover:
             logger.warning(
                 "agent_context_carryover is enabled but model %r does not support it; ignoring",
                 model,
             )
+        carryover_enabled = (
+            agent_context_carryover if is_given(agent_context_carryover) else supports_carryover
+        )
         super().__init__(
             capabilities=stt.STTCapabilities(
                 streaming=True,
@@ -267,7 +274,7 @@ class STT(stt.STT):
                 offline_recognize=False,
                 diarization=is_given(speaker_labels) and speaker_labels is True,
                 keyterms=True,
-                chat_context=agent_context_carryover and supports_carryover,
+                chat_context=carryover_enabled and supports_carryover,
             ),
         )
         if model == "u3-pro":

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -60,7 +60,7 @@ class STTOptions:
         "universal-3-5-pro",
     ] = "universal-3-5-pro"
     language_detection: NotGivenOr[bool] = NOT_GIVEN
-    language_code: NotGivenOr[str] = NOT_GIVEN
+    language_codes: NotGivenOr[list[str]] = NOT_GIVEN
     end_of_turn_confidence_threshold: NotGivenOr[float] = NOT_GIVEN
     min_turn_silence: NotGivenOr[int] = NOT_GIVEN
     max_turn_silence: NotGivenOr[int] = NOT_GIVEN
@@ -86,6 +86,30 @@ class STTOptions:
 # defaults. Mirrors the server-side `SpeechModel.is_u3_pro`.
 _U3_PRO_MODELS = ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro")
 
+# Server-side cap on the number of steering codes, mirrored client-side so bad
+# input fails at construction/update time instead of as a websocket error.
+_MAX_LANGUAGE_CODES = 10
+
+
+def _normalize_language_codes(language_codes: list[str]) -> list[str]:
+    """Normalize each code to bare ISO 639-1 and dedup preserving order.
+
+    Mirrors the AssemblyAI streaming API's validation rules: at most 10 codes,
+    and 'multi' (the unsteered multilingual default) must be sent alone.
+    """
+    normalized = list(dict.fromkeys(LanguageCode(code).language for code in language_codes))
+    if len(normalized) > _MAX_LANGUAGE_CODES:
+        raise ValueError(
+            f"language_codes accepts at most {_MAX_LANGUAGE_CODES} codes "
+            f"(got {len(normalized)} after normalization)"
+        )
+    if "multi" in normalized and len(normalized) > 1:
+        raise ValueError(
+            "language_code 'multi' routes to the unsteered multilingual model "
+            "and cannot be combined with other codes"
+        )
+    return normalized
+
 
 class STT(stt.STT):
     def __init__(
@@ -104,6 +128,7 @@ class STT(stt.STT):
         ] = "universal-3-5-pro",
         language_detection: NotGivenOr[bool] = NOT_GIVEN,
         language_code: NotGivenOr[str] = NOT_GIVEN,
+        language_codes: NotGivenOr[list[str]] = NOT_GIVEN,
         end_of_turn_confidence_threshold: NotGivenOr[float] = NOT_GIVEN,
         min_turn_silence: NotGivenOr[int] = NOT_GIVEN,
         max_turn_silence: NotGivenOr[int] = NOT_GIVEN,
@@ -195,6 +220,11 @@ class STT(stt.STT):
                 Leave unset to use the server default. Only supported with the Universal-3 Pro
                 family models. Set at construction (connect) time only.
         """
+        if is_given(language_code) and is_given(language_codes):
+            raise ValueError(
+                "language_code and language_codes are mutually exclusive; "
+                "use language_codes (language_code is shorthand for a one-element list)"
+            )
         # agent_context carryover is only available on the u3-rt-pro family
         # ("u3-pro" is normalized to "u3-rt-pro" below) and is opt-in via the user
         supports_carryover = model in _U3_PRO_MODELS or model == "u3-pro"
@@ -230,6 +260,7 @@ class STT(stt.STT):
                 "voice_focus_threshold": voice_focus_threshold,
                 "mode": mode,
                 "language_code": language_code,
+                "language_codes": language_codes,
             }
             for _param_name, _param_value in _u3_pro_only_params.items():
                 if is_given(_param_value):
@@ -264,11 +295,14 @@ class STT(stt.STT):
         if not is_given(min_turn_silence) and not is_given(mode):
             min_turn_silence = 100
 
-        # Normalize to a bare ISO 639-1 code (e.g. "es-ES" / "Spanish" -> "es"),
-        # the form AssemblyAI's language steering expects.
-        normalized_language_code: NotGivenOr[str] = NOT_GIVEN
+        # Normalize to bare ISO 639-1 codes (e.g. "es-ES" / "Spanish" -> "es"),
+        # the form AssemblyAI's language steering expects. The singular
+        # language_code is shorthand for a one-element list.
+        normalized_language_codes: NotGivenOr[list[str]] = NOT_GIVEN
         if is_given(language_code):
-            normalized_language_code = LanguageCode(language_code).language
+            normalized_language_codes = _normalize_language_codes([language_code])
+        elif is_given(language_codes):
+            normalized_language_codes = _normalize_language_codes(list(language_codes))
 
         self._opts = STTOptions(
             sample_rate=sample_rate,
@@ -276,7 +310,7 @@ class STT(stt.STT):
             encoding=encoding,
             speech_model=model,
             language_detection=language_detection,
-            language_code=normalized_language_code,
+            language_codes=normalized_language_codes,
             end_of_turn_confidence_threshold=end_of_turn_confidence_threshold,
             min_turn_silence=min_turn_silence,
             max_turn_silence=max_turn_silence,
@@ -720,8 +754,8 @@ class SpeechStream(stt.SpeechStream):
             if "multilingual" in self._opts.speech_model
             or self._opts.speech_model in _U3_PRO_MODELS
             else False,
-            "language_code": self._opts.language_code
-            if is_given(self._opts.language_code)
+            "language_codes": json.dumps(self._opts.language_codes)
+            if is_given(self._opts.language_codes) and self._opts.language_codes
             else None,
             "prompt": self._opts.prompt if is_given(self._opts.prompt) else None,
             "agent_context": self._opts.agent_context

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -386,6 +386,7 @@ class STT(stt.STT):
         prompt: NotGivenOr[str] = NOT_GIVEN,
         agent_context: NotGivenOr[str] = NOT_GIVEN,
         keyterms_prompt: NotGivenOr[list[str]] = NOT_GIVEN,
+        language_codes: NotGivenOr[list[str]] = NOT_GIVEN,
         vad_threshold: NotGivenOr[float] = NOT_GIVEN,
         continuous_partials: NotGivenOr[bool] = NOT_GIVEN,
         interruption_delay: NotGivenOr[int] = NOT_GIVEN,
@@ -417,6 +418,9 @@ class STT(stt.STT):
             # re-merge with the active session keyterms so a user update doesn't drop them
             keyterms_prompt = list(dict.fromkeys([*self._user_keyterms, *self._session_keyterms]))
             self._opts.keyterms_prompt = keyterms_prompt
+        if is_given(language_codes):
+            language_codes = _normalize_language_codes(list(language_codes))
+            self._opts.language_codes = language_codes
         if is_given(vad_threshold):
             self._opts.vad_threshold = vad_threshold
         if is_given(continuous_partials):
@@ -433,6 +437,7 @@ class STT(stt.STT):
                 prompt=prompt,
                 agent_context=agent_context,
                 keyterms_prompt=keyterms_prompt,
+                language_codes=language_codes,
                 vad_threshold=vad_threshold,
                 continuous_partials=continuous_partials,
                 interruption_delay=interruption_delay,
@@ -507,6 +512,7 @@ class SpeechStream(stt.SpeechStream):
         prompt: NotGivenOr[str] = NOT_GIVEN,
         agent_context: NotGivenOr[str] = NOT_GIVEN,
         keyterms_prompt: NotGivenOr[list[str]] = NOT_GIVEN,
+        language_codes: NotGivenOr[list[str]] = NOT_GIVEN,
         vad_threshold: NotGivenOr[float] = NOT_GIVEN,
         continuous_partials: NotGivenOr[bool] = NOT_GIVEN,
         interruption_delay: NotGivenOr[int] = NOT_GIVEN,
@@ -535,6 +541,9 @@ class SpeechStream(stt.SpeechStream):
             self._opts.agent_context = agent_context
         if is_given(keyterms_prompt):
             self._opts.keyterms_prompt = keyterms_prompt
+        if is_given(language_codes):
+            language_codes = _normalize_language_codes(list(language_codes))
+            self._opts.language_codes = language_codes
         if is_given(vad_threshold):
             self._opts.vad_threshold = vad_threshold
         if is_given(continuous_partials):
@@ -550,6 +559,8 @@ class SpeechStream(stt.SpeechStream):
             config_msg["agent_context"] = agent_context
         if is_given(keyterms_prompt):
             config_msg["keyterms_prompt"] = keyterms_prompt
+        if is_given(language_codes):
+            config_msg["language_codes"] = language_codes
         if is_given(max_turn_silence):
             config_msg["max_turn_silence"] = max_turn_silence
         if is_given(min_turn_silence):

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -408,6 +408,11 @@ class STT(stt.STT):
             if not is_given(min_turn_silence):
                 min_turn_silence = min_end_of_turn_silence_when_confident
 
+        # Validate/normalize before mutating any option so a ValueError from a
+        # bad language_codes list cannot leave _opts partially updated.
+        if is_given(language_codes):
+            language_codes = _normalize_language_codes(list(language_codes))
+
         if is_given(buffer_size_seconds):
             self._opts.buffer_size_seconds = buffer_size_seconds
         if is_given(end_of_turn_confidence_threshold):
@@ -426,7 +431,6 @@ class STT(stt.STT):
             keyterms_prompt = list(dict.fromkeys([*self._user_keyterms, *self._session_keyterms]))
             self._opts.keyterms_prompt = keyterms_prompt
         if is_given(language_codes):
-            language_codes = _normalize_language_codes(list(language_codes))
             self._opts.language_codes = language_codes
         if is_given(vad_threshold):
             self._opts.vad_threshold = vad_threshold
@@ -534,6 +538,11 @@ class SpeechStream(stt.SpeechStream):
             if not is_given(min_turn_silence):
                 min_turn_silence = min_end_of_turn_silence_when_confident
 
+        # Validate/normalize before mutating any option so a ValueError from a
+        # bad language_codes list cannot leave _opts partially updated.
+        if is_given(language_codes):
+            language_codes = _normalize_language_codes(list(language_codes))
+
         if is_given(buffer_size_seconds):
             self._opts.buffer_size_seconds = buffer_size_seconds
         if is_given(end_of_turn_confidence_threshold):
@@ -549,7 +558,6 @@ class SpeechStream(stt.SpeechStream):
         if is_given(keyterms_prompt):
             self._opts.keyterms_prompt = keyterms_prompt
         if is_given(language_codes):
-            language_codes = _normalize_language_codes(list(language_codes))
             self._opts.language_codes = language_codes
         if is_given(vad_threshold):
             self._opts.vad_threshold = vad_threshold

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -111,6 +111,22 @@ def _normalize_language_codes(language_codes: list[str]) -> list[str]:
     return normalized
 
 
+# Server-side cap on `agent_context` length (mirrors the AssemblyAI streaming
+# API's MAX_PROMPT_CHARS). Oversize values sent mid-stream make the server
+# cancel the whole session, so the cap is enforced client-side.
+_MAX_AGENT_CONTEXT_CHARS = 1750
+
+
+def _validate_agent_context(agent_context: str) -> str:
+    """Reject explicit agent_context longer than the server cap."""
+    if len(agent_context) > _MAX_AGENT_CONTEXT_CHARS:
+        raise ValueError(
+            f"agent_context exceeds maximum length of {_MAX_AGENT_CONTEXT_CHARS} "
+            f"characters (got {len(agent_context)})"
+        )
+    return agent_context
+
+
 class STT(stt.STT):
     def __init__(
         self,
@@ -194,7 +210,8 @@ class STT(stt.STT):
             agent_context: Free-text context describing what the agent said, used to bias
                 transcription of the user's reply. Set at construction or updated per-turn
                 via `update_options(agent_context=...)`. Only supported with the
-                Universal-3 Pro family models (max 1500 characters).
+                Universal-3 Pro family models (max 1750 characters; longer values raise
+                ValueError).
             previous_context_n_turns: Maximum number of prior conversation entries (user
                 transcripts and any `agent_context` values) carried forward as context for
                 each transcription. Set to 0 to disable automatic context carryover
@@ -232,6 +249,8 @@ class STT(stt.STT):
                 "language_code and language_codes are mutually exclusive; "
                 "use language_codes (language_code is shorthand for a one-element list)"
             )
+        if is_given(agent_context):
+            _validate_agent_context(agent_context)
         # agent_context carryover is only available on the u3-rt-pro family
         # ("u3-pro" is normalized to "u3-rt-pro" below) and is opt-in via the user
         supports_carryover = model in _U3_PRO_MODELS or model == "u3-pro"
@@ -409,9 +428,11 @@ class STT(stt.STT):
                 min_turn_silence = min_end_of_turn_silence_when_confident
 
         # Validate/normalize before mutating any option so a ValueError from a
-        # bad language_codes list cannot leave _opts partially updated.
+        # bad value cannot leave _opts partially updated.
         if is_given(language_codes):
             language_codes = _normalize_language_codes(list(language_codes))
+        if is_given(agent_context):
+            _validate_agent_context(agent_context)
 
         if is_given(buffer_size_seconds):
             self._opts.buffer_size_seconds = buffer_size_seconds
@@ -468,9 +489,18 @@ class STT(stt.STT):
         if (
             (chat_item := ev.item).type == "message"
             and chat_item.role == "assistant"
-            and chat_item.text_content
+            and (text := chat_item.text_content)
         ):
-            self.update_options(agent_context=chat_item.text_content)
+            if len(text) > _MAX_AGENT_CONTEXT_CHARS:
+                # Keep the tail: the end of the reply (the question posed to
+                # the user) has the most biasing value for their next utterance.
+                logger.debug(
+                    "truncating agent_context carryover from %d to %d chars",
+                    len(text),
+                    _MAX_AGENT_CONTEXT_CHARS,
+                )
+                text = text[-_MAX_AGENT_CONTEXT_CHARS:]
+            self.update_options(agent_context=text)
 
 
 class SpeechStream(stt.SpeechStream):
@@ -539,9 +569,11 @@ class SpeechStream(stt.SpeechStream):
                 min_turn_silence = min_end_of_turn_silence_when_confident
 
         # Validate/normalize before mutating any option so a ValueError from a
-        # bad language_codes list cannot leave _opts partially updated.
+        # bad value cannot leave _opts partially updated.
         if is_given(language_codes):
             language_codes = _normalize_language_codes(list(language_codes))
+        if is_given(agent_context):
+            _validate_agent_context(agent_context)
 
         if is_given(buffer_size_seconds):
             self._opts.buffer_size_seconds = buffer_size_seconds

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -163,13 +163,20 @@ class STT(stt.STT):
                 0 and 1 that determines how sensitive the VAD is. Lower values make the VAD
                 more sensitive (detects quieter speech). Higher values make it less sensitive.
                 Defaults to 0.4.
-            language_code: Steer transcription toward a specific language (e.g. 'en', 'es',
-                'fr'). Accepts any common format ('en', 'en-US', 'english'); it is normalized
-                to a bare ISO 639-1 code before being sent. When set, the model is biased
-                toward this language instead of automatically detecting/code-switching across
-                the supported languages. Leave unset to use the model's default multilingual
-                behavior. Only supported with the Universal-3 Pro family models. Set at
-                construction (connect) time only.
+            language_code: Shorthand for a one-element ``language_codes`` list
+                (e.g. 'en'); mutually exclusive with it. Constructor-only.
+            language_codes: Steer transcription toward one or more expected languages
+                (e.g. ['en', 'es']). Each entry accepts any common format ('en',
+                'en-US', 'english') and is normalized to a bare ISO 639-1 code before
+                being sent; duplicates after normalization are dropped, preserving
+                order. One code biases the model toward that language — several codes,
+                toward that set — instead of automatically detecting/code-switching
+                across all supported languages. At most 10 codes; 'multi' (the
+                unsteered multilingual default) cannot be combined with other codes.
+                Leave unset to use the model's default multilingual behavior. Only
+                supported with the Universal-3 Pro family models. Can be updated
+                mid-session via ``update_options``; pass an empty list there to clear
+                steering back to the model default.
             min_turn_silence: Minimum silence in ms before a confident end-of-turn is finalized.
             min_end_of_turn_silence_when_confident: Deprecated. Use min_turn_silence instead.
             continuous_partials: Whether to emit additional partial transcripts during long

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -91,12 +91,18 @@ _U3_PRO_MODELS = ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro")
 _MAX_LANGUAGE_CODES = 10
 
 
-def _normalize_language_codes(language_codes: list[str]) -> list[str]:
-    """Normalize each code to bare ISO 639-1 and dedup preserving order.
+def _normalize_language_codes(language_codes: str | list[str]) -> list[str]:
+    """Normalize code(s) to bare ISO 639-1 and dedup preserving order.
 
+    Accepts a single code or a list, mirroring the server, which takes either.
     Mirrors the AssemblyAI streaming API's validation rules: at most 10 codes,
     and 'multi' (the unsteered multilingual default) must be sent alone.
     """
+    if isinstance(language_codes, str):
+        # A bare code is shorthand for a one-element list; wrapping here (the
+        # single choke point for every input path) keeps a stray string from
+        # being iterated per-character. "" means "no codes", like [].
+        language_codes = [language_codes] if language_codes else []
     normalized = list(dict.fromkeys(LanguageCode(code).language for code in language_codes))
     if len(normalized) > _MAX_LANGUAGE_CODES:
         raise ValueError(
@@ -143,7 +149,7 @@ class STT(stt.STT):
         ] = "universal-3-5-pro",
         language_detection: NotGivenOr[bool] = NOT_GIVEN,
         language_code: NotGivenOr[str] = NOT_GIVEN,
-        language_codes: NotGivenOr[list[str]] = NOT_GIVEN,
+        language_codes: NotGivenOr[str | list[str]] = NOT_GIVEN,
         end_of_turn_confidence_threshold: NotGivenOr[float] = NOT_GIVEN,
         min_turn_silence: NotGivenOr[int] = NOT_GIVEN,
         max_turn_silence: NotGivenOr[int] = NOT_GIVEN,
@@ -178,21 +184,22 @@ class STT(stt.STT):
                 0 and 1 that determines how sensitive the VAD is. Lower values make the VAD
                 more sensitive (detects quieter speech). Higher values make it less sensitive.
                 Defaults to 0.4.
-            language_code: Shorthand for a one-element ``language_codes`` list
-                (e.g. 'en'); mutually exclusive with it. Constructor-only.
-            language_codes: Steer transcription toward one or more expected languages
-                (e.g. ['en', 'es']). Each entry accepts any common format ('en',
-                'en-US', 'english') and is normalized to a bare ISO 639-1 code before
-                being sent; duplicates after normalization are dropped, preserving
-                order. One code biases the model toward that language — several codes,
-                toward that set — instead of automatically detecting/code-switching
-                across all supported languages. At most 10 codes; 'multi' (the
-                unsteered multilingual default) cannot be combined with other codes.
-                Leave unset to use the model's default multilingual behavior. Only
-                supported with the Universal-3 Pro family models. Can be updated
-                mid-session via ``update_options``; pass an empty list there to clear
-                steering back to the model default. At construction an empty list is
-                equivalent to leaving it unset.
+            language_code: Deprecated — use ``language_codes`` instead (it accepts a
+                single code directly). Mutually exclusive with ``language_codes``.
+            language_codes: Steer transcription toward one or more expected languages.
+                Accepts a single code ('es') or a list (['en', 'es']). Each entry
+                accepts any common format ('en', 'en-US', 'english') and is normalized
+                to a bare ISO 639-1 code before being sent; duplicates after
+                normalization are dropped, preserving order. One code biases the model
+                toward that language — several codes, toward that set — instead of
+                automatically detecting/code-switching across all supported languages.
+                At most 10 codes; 'multi' (the unsteered multilingual default) cannot
+                be combined with other codes. Leave unset to use the model's default
+                multilingual behavior. Only supported with the Universal-3 Pro family
+                models. Can be updated mid-session via ``update_options``; pass an
+                empty list (or empty string) there to clear steering back to the model
+                default. At construction an empty value is equivalent to leaving it
+                unset.
             min_turn_silence: Minimum silence in ms before a confident end-of-turn is finalized.
             min_end_of_turn_silence_when_confident: Deprecated. Use min_turn_silence instead.
             continuous_partials: Whether to emit additional partial transcripts during long
@@ -254,11 +261,13 @@ class STT(stt.STT):
         if is_given(language_code) and is_given(language_codes):
             raise ValueError(
                 "language_code and language_codes are mutually exclusive; "
-                "use language_codes (language_code is shorthand for a one-element list)"
+                "use language_codes (it accepts a single code directly)"
             )
-        # An explicit empty list is equivalent to unset at construction — the
-        # param is omitted from the connect query either way — so it is not
-        # subject to the U3-Pro-family gate below.
+        if is_given(language_code):
+            logger.warning("'language_code' is deprecated, use 'language_codes' instead.")
+        # An explicit empty value ([] or "") is equivalent to unset at
+        # construction — the param is omitted from the connect query either
+        # way — so it is not subject to the U3-Pro-family gate below.
         if is_given(language_codes) and not language_codes:
             language_codes = NOT_GIVEN
         if is_given(agent_context):
@@ -346,9 +355,9 @@ class STT(stt.STT):
         # language_code is shorthand for a one-element list.
         normalized_language_codes: NotGivenOr[list[str]] = NOT_GIVEN
         if is_given(language_code):
-            normalized_language_codes = _normalize_language_codes([language_code])
+            normalized_language_codes = _normalize_language_codes(language_code)
         elif is_given(language_codes):
-            normalized_language_codes = _normalize_language_codes(list(language_codes))
+            normalized_language_codes = _normalize_language_codes(language_codes)
 
         self._opts = STTOptions(
             sample_rate=sample_rate,
@@ -432,7 +441,7 @@ class STT(stt.STT):
         prompt: NotGivenOr[str] = NOT_GIVEN,
         agent_context: NotGivenOr[str] = NOT_GIVEN,
         keyterms_prompt: NotGivenOr[list[str]] = NOT_GIVEN,
-        language_codes: NotGivenOr[list[str]] = NOT_GIVEN,
+        language_codes: NotGivenOr[str | list[str]] = NOT_GIVEN,
         vad_threshold: NotGivenOr[float] = NOT_GIVEN,
         continuous_partials: NotGivenOr[bool] = NOT_GIVEN,
         interruption_delay: NotGivenOr[int] = NOT_GIVEN,
@@ -455,7 +464,7 @@ class STT(stt.STT):
                     "The 'language_codes' parameter is only supported with the "
                     f"{', '.join(_U3_PRO_MODELS)} models."
                 )
-            language_codes = _normalize_language_codes(list(language_codes))
+            language_codes = _normalize_language_codes(language_codes)
         if is_given(agent_context):
             _validate_agent_context(agent_context)
 
@@ -578,7 +587,7 @@ class SpeechStream(stt.SpeechStream):
         prompt: NotGivenOr[str] = NOT_GIVEN,
         agent_context: NotGivenOr[str] = NOT_GIVEN,
         keyterms_prompt: NotGivenOr[list[str]] = NOT_GIVEN,
-        language_codes: NotGivenOr[list[str]] = NOT_GIVEN,
+        language_codes: NotGivenOr[str | list[str]] = NOT_GIVEN,
         vad_threshold: NotGivenOr[float] = NOT_GIVEN,
         continuous_partials: NotGivenOr[bool] = NOT_GIVEN,
         interruption_delay: NotGivenOr[int] = NOT_GIVEN,
@@ -601,7 +610,7 @@ class SpeechStream(stt.SpeechStream):
                     "The 'language_codes' parameter is only supported with the "
                     f"{', '.join(_U3_PRO_MODELS)} models."
                 )
-            language_codes = _normalize_language_codes(list(language_codes))
+            language_codes = _normalize_language_codes(language_codes)
         if is_given(agent_context):
             _validate_agent_context(agent_context)
 

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -904,31 +904,42 @@ async def test_mode_connect_time_only():
 
 
 # ---------------------------------------------------------------------------
-# language_code (language steering)
+# language_code / language_codes (language steering)
 #
-# `language_code` biases transcription toward a single language (e.g. "en",
-# "es") instead of automatic detection/code-switching. Steering is only applied
-# by the u3-pro ASR, so — like `mode` and the context/voice-focus params — it is
-# u3-rt-pro-family-only and connect-time only (not exposed via update_options,
-# matching the AssemblyAI streaming API, where `language_code` is a connect-time
-# parameter and not part of UpdateConfiguration).
+# `language_codes` biases transcription toward one or more expected languages
+# (e.g. ["en", "es"]) instead of automatic detection/code-switching across all
+# supported languages. `language_code` is shorthand for a one-element list;
+# both normalize into `_opts.language_codes`. Steering is only applied by the
+# u3-pro ASR, so — like `mode` and the context/voice-focus params — both are
+# u3-rt-pro-family-only at construction. `language_codes` (unlike the
+# singular) can also be re-steered mid-session via update_options, matching
+# the AssemblyAI streaming API's UpdateConfiguration; an empty list clears
+# steering back to the model default.
 # ---------------------------------------------------------------------------
 
 
-async def test_language_code_default():
-    """language_code is unset by default (automatic detection applies)."""
+async def test_language_codes_default():
+    """language_codes is unset by default (automatic detection applies)."""
     from livekit.plugins.assemblyai import STT
 
     stt = STT(api_key="test-key")
-    assert stt._opts.language_code is NOT_GIVEN
+    assert stt._opts.language_codes is NOT_GIVEN
 
 
 async def test_language_code_set():
-    """language_code can be set in the constructor."""
+    """The singular language_code is stored as a one-element language_codes list."""
     from livekit.plugins.assemblyai import STT
 
     stt = STT(api_key="test-key", model="u3-rt-pro", language_code="es")
-    assert stt._opts.language_code == "es"
+    assert stt._opts.language_codes == ["es"]
+
+
+async def test_language_codes_set():
+    """language_codes can be set in the constructor."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key", model="u3-rt-pro", language_codes=["en", "es"])
+    assert stt._opts.language_codes == ["en", "es"]
 
 
 async def test_language_code_normalized_to_iso_639_1():
@@ -944,7 +955,74 @@ async def test_language_code_normalized_to_iso_639_1():
         ("pt-BR", "pt"),
     ):
         stt = STT(api_key="test-key", model="u3-rt-pro", language_code=raw)
-        assert stt._opts.language_code == expected
+        assert stt._opts.language_codes == [expected]
+
+
+async def test_language_codes_normalized_and_deduped():
+    """Each entry is normalized; duplicates after normalization are dropped,
+    preserving first-seen order."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(
+        api_key="test-key",
+        model="u3-rt-pro",
+        language_codes=["en-US", "en-GB", "Spanish", "es"],
+    )
+    assert stt._opts.language_codes == ["en", "es"]
+
+
+async def test_language_code_and_language_codes_mutually_exclusive():
+    """Passing both spellings raises — they fill the same server field."""
+    from livekit.plugins.assemblyai import STT
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        STT(api_key="test-key", model="u3-rt-pro", language_code="en", language_codes=["es"])
+
+
+async def test_language_codes_max_10():
+    """More than 10 codes after normalization/dedup raises (server limit)."""
+    from livekit.plugins.assemblyai import STT
+
+    codes = ["en", "es", "fr", "de", "it", "pt", "nl", "pl", "ru", "ja", "ko"]
+    with pytest.raises(ValueError, match="at most 10"):
+        STT(api_key="test-key", model="u3-rt-pro", language_codes=codes)
+
+
+async def test_language_codes_max_10_applies_after_dedup():
+    """11 raw entries that dedup to 10 codes are accepted — the client is never
+    stricter than what it actually sends to the server."""
+    from livekit.plugins.assemblyai import STT
+
+    codes = ["en-US", "en-GB", "es", "fr", "de", "it", "pt", "nl", "pl", "ru", "ja"]
+    stt = STT(api_key="test-key", model="u3-rt-pro", language_codes=codes)
+    assert stt._opts.language_codes == [
+        "en",
+        "es",
+        "fr",
+        "de",
+        "it",
+        "pt",
+        "nl",
+        "pl",
+        "ru",
+        "ja",
+    ]
+
+
+async def test_language_codes_multi_cannot_be_combined():
+    """'multi' routes to the unsteered multilingual model and must be sent alone."""
+    from livekit.plugins.assemblyai import STT
+
+    with pytest.raises(ValueError, match="multi"):
+        STT(api_key="test-key", model="u3-rt-pro", language_codes=["multi", "en"])
+
+
+async def test_language_codes_multi_alone_is_allowed():
+    """'multi' by itself is valid and passes through un-mangled."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key", model="u3-rt-pro", language_codes=["multi"])
+    assert stt._opts.language_codes == ["multi"]
 
 
 async def test_language_code_requires_u3_pro_family():
@@ -955,17 +1033,53 @@ async def test_language_code_requires_u3_pro_family():
         STT(api_key="test-key", model="universal-streaming-multilingual", language_code="es")
 
 
-async def test_language_code_allowed_for_all_u3_pro_family_models():
-    """language_code is accepted for every u3-rt-pro-family model, not just the default."""
+async def test_language_codes_requires_u3_pro_family():
+    """language_codes raises ValueError when used with a non-u3-rt-pro-family model."""
+    from livekit.plugins.assemblyai import STT
+
+    with pytest.raises(ValueError, match="language_codes"):
+        STT(
+            api_key="test-key",
+            model="universal-streaming-multilingual",
+            language_codes=["es"],
+        )
+
+
+async def test_language_codes_allowed_for_all_u3_pro_family_models():
+    """language_codes is accepted for every u3-rt-pro-family model, not just the default."""
     from livekit.plugins.assemblyai import STT
 
     for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro"):
-        stt = STT(api_key="test-key", model=model, language_code="en")
-        assert stt._opts.language_code == "en"
+        stt = STT(api_key="test-key", model=model, language_codes=["en", "es"])
+        assert stt._opts.language_codes == ["en", "es"]
 
 
-async def test_language_code_in_connect_config():
-    """language_code is sent in the connect config query."""
+async def test_language_codes_in_connect_config():
+    """language_codes is sent as a JSON array in the connect config query."""
+    import json
+    from urllib.parse import parse_qs, urlparse
+
+    from livekit.plugins.assemblyai import STT
+
+    captured: dict = {}
+
+    async def _fake_ws_connect(url, **kwargs):
+        captured["url"] = url
+        return MagicMock()
+
+    stt = STT(api_key="test-key", model="universal-3-5-pro", language_codes=["en", "es"])
+    stream = _make_stream_for_unit_test(stt)
+    stream._session.ws_connect = _fake_ws_connect
+    await stream._connect_ws()
+
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert json.loads(query["language_codes"][0]) == ["en", "es"]
+
+
+async def test_language_code_singular_in_connect_config():
+    """A singular language_code is sent as a one-element language_codes JSON
+    array — the server aliases both names to the same field."""
+    import json
     from urllib.parse import parse_qs, urlparse
 
     from livekit.plugins.assemblyai import STT
@@ -982,11 +1096,12 @@ async def test_language_code_in_connect_config():
     await stream._connect_ws()
 
     query = parse_qs(urlparse(captured["url"]).query)
-    assert query["language_code"] == ["es"]
+    assert json.loads(query["language_codes"][0]) == ["es"]
+    assert "language_code" not in query
 
 
-async def test_language_code_absent_from_connect_config_when_unset():
-    """language_code key is omitted from the connect config when not set."""
+async def test_language_codes_absent_from_connect_config_when_unset():
+    """language_codes key is omitted from the connect config when not set."""
     from urllib.parse import parse_qs, urlparse
 
     from livekit.plugins.assemblyai import STT
@@ -1003,6 +1118,7 @@ async def test_language_code_absent_from_connect_config_when_unset():
     await stream._connect_ws()
 
     query = parse_qs(urlparse(captured["url"]).query)
+    assert "language_codes" not in query
     assert "language_code" not in query
 
 

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -1122,8 +1122,99 @@ async def test_language_codes_absent_from_connect_config_when_unset():
     assert "language_code" not in query
 
 
-async def test_language_code_connect_time_only():
-    """language_code is connect-time only — not exposed via update_options."""
+async def test_language_codes_stream_sends_update_configuration():
+    """SpeechStream.update_options enqueues an UpdateConfiguration message
+    containing language_codes."""
+    stream = _make_stream_for_unit_test()
+
+    stream.update_options(language_codes=["en", "es"])
+
+    assert stream._opts.language_codes == ["en", "es"]
+    msg = stream._config_update_queue.get_nowait()
+    assert msg["type"] == "UpdateConfiguration"
+    assert msg["language_codes"] == ["en", "es"]
+
+
+async def test_language_codes_update_normalizes_input():
+    """Mid-session updates get the same normalization/dedup as the constructor."""
+    stream = _make_stream_for_unit_test()
+
+    stream.update_options(language_codes=["en-US", "Spanish"])
+
+    msg = stream._config_update_queue.get_nowait()
+    assert msg["language_codes"] == ["en", "es"]
+
+
+async def test_language_codes_update_validates_input():
+    """Mid-session updates get the same fail-fast validation as the constructor."""
+    stream = _make_stream_for_unit_test()
+
+    with pytest.raises(ValueError, match="multi"):
+        stream.update_options(language_codes=["multi", "en"])
+
+
+async def test_language_codes_empty_list_clears_steering():
+    """An explicit empty list is forwarded (the server's documented 'clear
+    steering back to model default' form), not dropped by a truthiness check."""
+    stream = _make_stream_for_unit_test()
+
+    stream.update_options(language_codes=[])
+
+    assert stream._opts.language_codes == []
+    msg = stream._config_update_queue.get_nowait()
+    assert msg["type"] == "UpdateConfiguration"
+    assert msg["language_codes"] == []
+
+
+async def test_language_codes_propagates_from_stt_to_active_stream():
+    """STT.update_options(language_codes=...) propagates to an already-active
+    stream and sends it over that stream's websocket queue."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key", http_session=MagicMock())
+
+    def _fake_create_task(coro, *args, **kwargs):
+        coro.close()
+        return MagicMock()
+
+    with patch("livekit.agents.stt.stt.asyncio.create_task", side_effect=_fake_create_task):
+        stream = stt.stream()
+
+    stt.update_options(language_codes=["en", "es"])
+
+    assert stt._opts.language_codes == ["en", "es"]
+    assert stream._opts.language_codes == ["en", "es"]
+    msg = stream._config_update_queue.get_nowait()
+    assert msg["type"] == "UpdateConfiguration"
+    assert msg["language_codes"] == ["en", "es"]
+
+
+async def test_cleared_language_codes_omitted_on_reconnect():
+    """After clearing ([]), a (re)connect omits the language_codes param —
+    consistent with the cleared state."""
+    from urllib.parse import parse_qs, urlparse
+
+    from livekit.plugins.assemblyai import STT
+
+    captured: dict = {}
+
+    async def _fake_ws_connect(url, **kwargs):
+        captured["url"] = url
+        return MagicMock()
+
+    stt = STT(api_key="test-key", model="universal-3-5-pro", language_codes=["en", "es"])
+    stream = _make_stream_for_unit_test(stt)
+    stream.update_options(language_codes=[])
+    stream._session.ws_connect = _fake_ws_connect
+    await stream._connect_ws()
+
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert "language_codes" not in query
+
+
+async def test_language_code_singular_not_in_update_options():
+    """The singular language_code is constructor-only; mid-session re-steering
+    goes through language_codes."""
     import inspect
 
     from livekit.plugins.assemblyai import STT
@@ -1131,3 +1222,5 @@ async def test_language_code_connect_time_only():
 
     assert "language_code" not in inspect.signature(STT.update_options).parameters
     assert "language_code" not in inspect.signature(SpeechStream.update_options).parameters
+    assert "language_codes" in inspect.signature(STT.update_options).parameters
+    assert "language_codes" in inspect.signature(SpeechStream.update_options).parameters

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -1237,6 +1237,73 @@ async def test_language_codes_empty_list_at_construction_is_unset():
     assert stt_pro._opts.language_codes is NOT_GIVEN
 
 
+async def test_language_codes_accepts_bare_string():
+    """language_codes accepts a single code directly, normalized like a list entry."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key", model="u3-rt-pro", language_codes="es")
+    assert stt._opts.language_codes == ["es"]
+
+    stt_norm = STT(api_key="test-key", model="u3-rt-pro", language_codes="Spanish")
+    assert stt_norm._opts.language_codes == ["es"]
+
+
+async def test_language_codes_empty_string_at_construction_is_unset():
+    """An explicit "" at construction equals unset, like []."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key", model="universal-streaming-english", language_codes="")
+    assert stt._opts.language_codes is NOT_GIVEN
+
+
+async def test_language_code_singular_logs_deprecation_warning(caplog):
+    """The singular language_code still works but logs a deprecation warning."""
+    import logging
+
+    from livekit.plugins.assemblyai import STT
+
+    with caplog.at_level(logging.WARNING):
+        stt = STT(api_key="test-key", model="u3-rt-pro", language_code="es")
+
+    assert stt._opts.language_codes == ["es"]
+    assert "'language_code' is deprecated" in caplog.text
+
+
+async def test_language_codes_no_deprecation_warning(caplog):
+    """The plural spelling does not trigger the deprecation warning."""
+    import logging
+
+    from livekit.plugins.assemblyai import STT
+
+    with caplog.at_level(logging.WARNING):
+        STT(api_key="test-key", model="u3-rt-pro", language_codes=["es"])
+
+    assert "deprecated" not in caplog.text
+
+
+async def test_language_codes_update_accepts_bare_string():
+    """update_options accepts a single code directly and sends it as a list."""
+    stream = _make_stream_for_unit_test()
+
+    stream.update_options(language_codes="en-US")
+
+    assert stream._opts.language_codes == ["en"]
+    msg = stream._config_update_queue.get_nowait()
+    assert msg["type"] == "UpdateConfiguration"
+    assert msg["language_codes"] == ["en"]
+
+
+async def test_language_codes_update_empty_string_clears_steering():
+    """An explicit "" mid-session clears steering, same as []."""
+    stream = _make_stream_for_unit_test()
+
+    stream.update_options(language_codes="")
+
+    assert stream._opts.language_codes == []
+    msg = stream._config_update_queue.get_nowait()
+    assert msg["language_codes"] == []
+
+
 async def test_language_code_singular_not_in_update_options():
     """The singular language_code is constructor-only; mid-session re-steering
     goes through language_codes."""

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -1224,3 +1224,82 @@ async def test_language_code_singular_not_in_update_options():
     assert "language_code" not in inspect.signature(SpeechStream.update_options).parameters
     assert "language_codes" in inspect.signature(STT.update_options).parameters
     assert "language_codes" in inspect.signature(SpeechStream.update_options).parameters
+
+
+# ---------------------------------------------------------------------------
+# agent_context server cap (1750 chars) + agent_context_carryover default
+#
+# The server rejects `agent_context` longer than 1750 chars, and an invalid
+# UpdateConfiguration cancels the whole streaming session — so the plugin
+# enforces the cap client-side. The auto-carryover path truncates (keeping the
+# tail: the end of the agent's reply is what the user responds to); explicit
+# developer input fails fast with ValueError instead of being silently
+# mangled.
+# ---------------------------------------------------------------------------
+
+
+def _assistant_item_event(text: str):
+    from livekit.agents.llm import ChatMessage
+    from livekit.agents.voice.events import ConversationItemAddedEvent
+
+    return ConversationItemAddedEvent(item=ChatMessage(role="assistant", content=[text]))
+
+
+async def test_agent_context_at_cap_accepted():
+    """agent_context of exactly 1750 chars is accepted everywhere."""
+    from livekit.plugins.assemblyai import STT
+
+    text = "x" * 1750
+    stt = STT(api_key="test-key", agent_context=text)
+    assert stt._opts.agent_context == text
+
+    stt.update_options(agent_context=text)
+    assert stt._opts.agent_context == text
+
+
+async def test_agent_context_over_cap_raises_in_constructor():
+    """Explicit oversize agent_context fails fast instead of killing the session later."""
+    from livekit.plugins.assemblyai import STT
+
+    with pytest.raises(ValueError, match="agent_context"):
+        STT(api_key="test-key", agent_context="x" * 1751)
+
+
+async def test_agent_context_over_cap_raises_in_stt_update_options():
+    """STT.update_options rejects oversize agent_context without mutating any option."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key", vad_threshold=0.5)
+    with pytest.raises(ValueError, match="agent_context"):
+        stt.update_options(vad_threshold=0.9, agent_context="x" * 1751)
+
+    # the same call must not have applied its other updates (no partial update)
+    assert stt._opts.vad_threshold == 0.5
+    assert stt._opts.agent_context is NOT_GIVEN
+
+
+async def test_agent_context_over_cap_raises_in_stream_update_options():
+    """SpeechStream.update_options rejects oversize agent_context."""
+    stream = _make_stream_for_unit_test()
+
+    with pytest.raises(ValueError, match="agent_context"):
+        stream.update_options(agent_context="x" * 1751)
+
+
+async def test_carryover_forwards_short_reply_verbatim():
+    """_push_conversation_item forwards assistant text within the cap unchanged."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key")
+    stt._push_conversation_item(_assistant_item_event("Your room is booked for Tuesday."))
+    assert stt._opts.agent_context == "Your room is booked for Tuesday."
+
+
+async def test_carryover_truncates_oversize_reply_keeping_tail():
+    """_push_conversation_item truncates oversize replies to the last 1750 chars."""
+    from livekit.plugins.assemblyai import STT
+
+    text = "a" * 2000 + "b" * 1750
+    stt = STT(api_key="test-key")
+    stt._push_conversation_item(_assistant_item_event(text))
+    assert stt._opts.agent_context == "b" * 1750

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -1303,3 +1303,50 @@ async def test_carryover_truncates_oversize_reply_keeping_tail():
     stt = STT(api_key="test-key")
     stt._push_conversation_item(_assistant_item_event(text))
     assert stt._opts.agent_context == "b" * 1750
+
+
+async def test_carryover_defaults_on_for_u3_pro_family():
+    """agent_context_carryover defaults to enabled on models that support it."""
+    from livekit.plugins.assemblyai import STT
+
+    for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro"):
+        stt = STT(api_key="test-key", model=model)
+        assert stt.capabilities.chat_context is True
+
+
+async def test_carryover_defaults_off_for_unsupported_models_without_warning(caplog):
+    """On non-U3-Pro models the default is silently off — no 'ignoring' warning."""
+    import logging
+
+    from livekit.plugins.assemblyai import STT
+
+    with caplog.at_level(logging.WARNING):
+        stt = STT(api_key="test-key", model="universal-streaming-english")
+
+    assert stt.capabilities.chat_context is False
+    assert "agent_context_carryover" not in caplog.text
+
+
+async def test_carryover_explicit_true_on_unsupported_model_warns(caplog):
+    """Explicitly enabling carryover on an unsupported model keeps today's warning."""
+    import logging
+
+    from livekit.plugins.assemblyai import STT
+
+    with caplog.at_level(logging.WARNING):
+        stt = STT(
+            api_key="test-key",
+            model="universal-streaming-english",
+            agent_context_carryover=True,
+        )
+
+    assert stt.capabilities.chat_context is False
+    assert "agent_context_carryover" in caplog.text
+
+
+async def test_carryover_explicit_false_disables():
+    """agent_context_carryover=False opts out on a supported model."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key", agent_context_carryover=False)
+    assert stt.capabilities.chat_context is False

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -1212,6 +1212,31 @@ async def test_cleared_language_codes_omitted_on_reconnect():
     assert "language_codes" not in query
 
 
+async def test_language_codes_update_requires_u3_pro_family():
+    """update_options mirrors the constructor's family gate for language_codes."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key", model="universal-streaming-english")
+    with pytest.raises(ValueError, match="language_codes"):
+        stt.update_options(language_codes=["es"])
+
+    stream = _make_stream_for_unit_test(stt)
+    with pytest.raises(ValueError, match="language_codes"):
+        stream.update_options(language_codes=["es"])
+    assert stream._config_update_queue.empty()
+
+
+async def test_language_codes_empty_list_at_construction_is_unset():
+    """An explicit [] at construction equals unset — even on non-U3-Pro models."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key", model="universal-streaming-english", language_codes=[])
+    assert stt._opts.language_codes is NOT_GIVEN
+
+    stt_pro = STT(api_key="test-key", model="u3-rt-pro", language_codes=[])
+    assert stt_pro._opts.language_codes is NOT_GIVEN
+
+
 async def test_language_code_singular_not_in_update_options():
     """The singular language_code is constructor-only; mid-session re-steering
     goes through language_codes."""
@@ -1390,3 +1415,19 @@ async def test_carryover_explicit_false_disables():
 
     stt = STT(api_key="test-key", agent_context_carryover=False)
     assert stt.capabilities.chat_context is False
+
+
+async def test_carryover_disabled_by_previous_context_n_turns_zero():
+    """previous_context_n_turns=0 (documented 'disable carryover') suppresses the default."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key", previous_context_n_turns=0)
+    assert stt.capabilities.chat_context is False
+
+
+async def test_carryover_explicit_true_wins_over_n_turns_zero():
+    """An explicit agent_context_carryover=True overrides the n_turns=0 suppression."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key", previous_context_n_turns=0, agent_context_carryover=True)
+    assert stt.capabilities.chat_context is True

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -1279,11 +1279,16 @@ async def test_agent_context_over_cap_raises_in_stt_update_options():
 
 
 async def test_agent_context_over_cap_raises_in_stream_update_options():
-    """SpeechStream.update_options rejects oversize agent_context."""
+    """SpeechStream.update_options rejects oversize agent_context without
+    mutating options or enqueuing an UpdateConfiguration."""
     stream = _make_stream_for_unit_test()
 
     with pytest.raises(ValueError, match="agent_context"):
-        stream.update_options(agent_context="x" * 1751)
+        stream.update_options(vad_threshold=0.9, agent_context="x" * 1751)
+
+    assert stream._opts.agent_context is NOT_GIVEN
+    assert stream._opts.vad_threshold is NOT_GIVEN
+    assert stream._config_update_queue.empty()
 
 
 async def test_carryover_forwards_short_reply_verbatim():
@@ -1305,11 +1310,46 @@ async def test_carryover_truncates_oversize_reply_keeping_tail():
     assert stt._opts.agent_context == "b" * 1750
 
 
+async def test_carryover_ignores_non_assistant_items():
+    """_push_conversation_item ignores user messages and textless assistant items
+    — the shapes it receives now that carryover is on by default."""
+    from livekit.agents.llm import ChatMessage
+    from livekit.agents.voice.events import ConversationItemAddedEvent
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key")
+
+    stt._push_conversation_item(
+        ConversationItemAddedEvent(item=ChatMessage(role="user", content=["hi there"]))
+    )
+    assert stt._opts.agent_context is NOT_GIVEN
+
+    stt._push_conversation_item(
+        ConversationItemAddedEvent(item=ChatMessage(role="assistant", content=[]))
+    )
+    assert stt._opts.agent_context is NOT_GIVEN
+
+
+async def test_carryover_ignores_agent_handoff_items():
+    """_push_conversation_item ignores non-message items (e.g. AgentHandoff),
+    which have `.type != "message"` and no `text_content`."""
+    from livekit.agents.llm import AgentHandoff
+    from livekit.agents.voice.events import ConversationItemAddedEvent
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key")
+
+    stt._push_conversation_item(
+        ConversationItemAddedEvent(item=AgentHandoff(new_agent_id="agent-2"))
+    )
+    assert stt._opts.agent_context is NOT_GIVEN
+
+
 async def test_carryover_defaults_on_for_u3_pro_family():
     """agent_context_carryover defaults to enabled on models that support it."""
     from livekit.plugins.assemblyai import STT
 
-    for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro"):
+    for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro", "u3-pro"):
         stt = STT(api_key="test-key", model=model)
         assert stt.capabilities.chat_context is True
 


### PR DESCRIPTION
## What

Two related upgrades to the AssemblyAI streaming STT plugin:

### 1. `language_codes` — multi-language steering

- New `language_codes: list[str]` parameter: `language_codes=["en", "es"]` biases transcription toward that set of languages instead of open detection/code-switching (Universal-3 Pro family only). The existing singular `language_code` keeps working unchanged as documented shorthand for a one-element list; passing both raises `ValueError`.
- Each entry is normalized to a bare ISO 639-1 code (`"en-US"` / `"english"` → `"en"`) and deduped preserving order; server limits are validated client-side (max 10 codes, `"multi"` must be sent alone) so misconfiguration fails at construction instead of as a websocket error.
- Mid-session re-steering via `STT.update_options(language_codes=...)` / `SpeechStream.update_options(...)`, sent as an `UpdateConfiguration` message; an explicit `[]` clears steering back to the model default. Useful for agents that detect the caller's language and re-steer without reconnecting. Validation runs before any option mutation, so a rejected update never leaves options partially applied.
- Wire format: sent as a JSON-array query param (`language_codes=["en","es"]`), the same convention as `keyterms_prompt`. **Note for existing `language_code` users:** the singular is now also sent as `language_codes=["es"]` — behaviorally identical, since the server declares `language_code`/`language_codes`/`language` as aliases for the same field.

### 2. `agent_context_carryover` — on by default, with a server-cap guard

- **Fixes a live-session kill:** the server rejects `agent_context` longer than 1750 chars, and an invalid mid-stream `UpdateConfiguration` cancels the entire streaming session. The plugin now enforces the cap client-side: the auto-carryover handler truncates oversize assistant replies (keeping the tail — the end of the reply is what the user responds to), and explicit `agent_context` input fails fast with `ValueError`. Also fixes the stale "max 1500 characters" docstring (server cap is 1750).
- With the guard in place, `agent_context_carryover` defaults to **enabled on Universal-3 Pro family models** (tri-state `NotGivenOr[bool]`): the server already carries prior user turns automatically, so assistant-reply carryover completes the conversation context the models are designed to use. Opt out with `agent_context_carryover=False`; setting `previous_context_n_turns=0` (documented as "disable context carryover") also suppresses the default. On unsupported models the default is silently off; explicitly passing `True` there keeps today's warning.
- **Behavior change to be aware of:** on supported models, assistant reply text now flows to AssemblyAI as transcription context by default, and each reply replaces any manually set `agent_context` (documented in the docstring; disable carryover to manage context manually).

## Testing

- `tests/test_plugin_assemblyai_stt.py`: 43 new tests — normalization/dedup, mutual exclusion, U3-Pro gating on both construction and update paths, max-10/multi validation, JSON-array wire format for both spellings, `UpdateConfiguration` enqueue incl. empty-list clear, no-partial-update on validation failure, STT→stream propagation, truncation boundaries at exactly 1750/1751, tail-keeping, the four tri-state carryover cases, and handler safety for user/textless/handoff conversation items. Full file: 101 passed; ruff and strict mypy clean.
- Verified live against the AssemblyAI streaming API (console-mode voice agent, full multi-turn booking flow): steering param accepted at connect, 13 carryover context pushes and mid-stream config updates over one session with no errors or reconnects.