### PR TITLE
fix(llm): apply tool defaults across all schema shapes; keep response formats sentinel-free

### DIFF
--- a/livekit-agents/livekit/agents/llm/_strict.py
+++ b/livekit-agents/livekit/agents/llm/_strict.py
@@ -7,46 +7,13 @@ from pydantic import BaseModel, TypeAdapter
 _T = TypeVar("_T")
 
 
-def _model_json_schema(model: type[BaseModel] | TypeAdapter[Any]) -> dict[str, Any]:
-    if isinstance(model, TypeAdapter):
-        return model.json_schema()
-    return model.model_json_schema()
-
-
 def to_strict_json_schema(model: type[BaseModel] | TypeAdapter[Any]) -> dict[str, Any]:
-    schema = _model_json_schema(model)
+    if isinstance(model, TypeAdapter):
+        schema = model.json_schema()
+    else:
+        schema = model.model_json_schema()
 
     return _ensure_strict_json_schema(schema, path=(), root=schema)
-
-
-def to_strict_tool_json_schema(model: type[BaseModel] | TypeAdapter[Any]) -> dict[str, Any]:
-    schema = _model_json_schema(model)
-    _make_defaults_nullable(schema)
-
-    return _ensure_strict_json_schema(schema, path=(), root=schema)
-
-
-def _make_defaults_nullable(json_schema: object) -> None:
-    """Encode defaulted tool arguments as nullable fields for strict schemas.
-
-    OpenAI strict schemas require every property and do not support JSON Schema defaults, so
-    ``null`` represents "use the Python default". Tool argument preparation replaces that value
-    before validation. Response formats intentionally skip this conversion because their output
-    is validated directly against the declared Pydantic nullability.
-    """
-    if isinstance(json_schema, dict):
-        if "default" in json_schema:
-            typ = json_schema.get("type")
-            if isinstance(typ, str):
-                json_schema["type"] = [typ, "null"]
-            elif isinstance(typ, list) and "null" not in typ:
-                json_schema["type"] = [*typ, "null"]
-
-        for value in json_schema.values():
-            _make_defaults_nullable(value)
-    elif isinstance(json_schema, list):
-        for value in json_schema:
-            _make_defaults_nullable(value)
 
 
 # from https://platform.openai.com/docs/guides/function-calling?api-mode=responses&strict-mode=disabled#strict-mode
@@ -150,6 +117,19 @@ def _ensure_strict_json_schema(
     # strict mode doesn't support default
     if "default" in json_schema:
         json_schema.pop("default", None)
+
+        # Strict schemas require all fields, but LLMs cannot see or apply Python defaults.
+        # Allow null as a sentinel; validate_response_format and tool preparation replace it.
+        t = json_schema.get("type")
+        if isinstance(t, str):
+            json_schema["type"] = [t, "null"]
+
+        elif isinstance(t, list):
+            types = t.copy()
+            if "null" not in types:
+                types.append("null")
+
+            json_schema["type"] = types
 
     json_schema.pop("title", None)
     json_schema.pop("discriminator", None)

--- a/livekit-agents/livekit/agents/llm/_strict.py
+++ b/livekit-agents/livekit/agents/llm/_strict.py
@@ -114,25 +114,18 @@ def _ensure_strict_json_schema(
                 for i, entry in enumerate(all_of)
             ]
 
+    # popped before the default handling below so a wrapped schema doesn't retain them
+    json_schema.pop("title", None)
+    json_schema.pop("discriminator", None)
+
     # strict mode doesn't support default
     if "default" in json_schema:
         json_schema.pop("default", None)
 
         # Strict schemas require all fields, but LLMs cannot see or apply Python defaults.
-        # Allow null as a sentinel; validate_response_format and tool preparation replace it.
-        t = json_schema.get("type")
-        if isinstance(t, str):
-            json_schema["type"] = [t, "null"]
-
-        elif isinstance(t, list):
-            types = t.copy()
-            if "null" not in types:
-                types.append("null")
-
-            json_schema["type"] = types
-
-    json_schema.pop("title", None)
-    json_schema.pop("discriminator", None)
+        # Let the field additionally accept null as a sentinel; validate_response_format and
+        # tool preparation swap a returned null back for the field's default.
+        _add_null_sentinel(json_schema)
 
     # we can't use `$ref`s if there are also other properties defined, e.g.
     # `{"$ref": "...", "description": "my description"}`
@@ -182,6 +175,43 @@ def _ensure_strict_json_schema(
             break
 
     return json_schema
+
+
+def _add_null_sentinel(json_schema: dict[str, Any]) -> None:
+    """Make a defaulted field additionally accept ``null``, preserving its original
+    constraints.
+
+    Appending ``"null"`` to a bare ``type`` only works when the schema has a direct type
+    and no value constraints. Literals (``const``/``enum``), unions (``anyOf``), and
+    ``$ref``-ed models need a full null branch instead, otherwise the wire schema either
+    contradicts itself or never advertises the sentinel at all.
+    """
+    typ = json_schema.get("type")
+    if typ == "null" or (is_list(typ) and "null" in typ):
+        return  # already nullable via type
+
+    for union_key in ("anyOf", "oneOf"):
+        variants = json_schema.get(union_key)
+        if is_list(variants):
+            if not any(variant == {"type": "null"} for variant in variants):
+                variants.append({"type": "null"})
+            return
+
+    has_value_constraint = "const" in json_schema or "enum" in json_schema
+    if isinstance(typ, str) and not has_value_constraint:
+        json_schema["type"] = [typ, "null"]
+        return
+    if is_list(typ) and not has_value_constraint:
+        json_schema["type"] = [*typ, "null"]
+        return
+
+    # const / enum / $ref / allOf: wrap so null is a valid instance without violating
+    # the original constraints. An empty schema already accepts null — leave it.
+    inner = dict(json_schema)
+    if not inner:
+        return
+    json_schema.clear()
+    json_schema["anyOf"] = [inner, {"type": "null"}]
 
 
 def resolve_ref(*, root: dict[str, object], ref: str) -> object:

--- a/livekit-agents/livekit/agents/llm/_strict.py
+++ b/livekit-agents/livekit/agents/llm/_strict.py
@@ -7,13 +7,29 @@ from pydantic import BaseModel, TypeAdapter
 _T = TypeVar("_T")
 
 
-def to_strict_json_schema(model: type[BaseModel] | TypeAdapter[Any]) -> dict[str, Any]:
+def to_strict_json_schema(
+    model: type[BaseModel] | TypeAdapter[Any],
+    *,
+    null_sentinel_for_defaults: bool = False,
+) -> dict[str, Any]:
+    """Convert a model's JSON schema to the strict dialect the OpenAI API expects.
+
+    Strict mode doesn't support the ``default`` keyword, so defaults are always
+    removed. With ``null_sentinel_for_defaults``, a defaulted field additionally
+    accepts ``null`` as a sentinel meaning "use the Python default" — only enable
+    this when the decode side resolves the sentinel before validation, as the tool
+    pipeline does in ``_prepare_function_arguments``. Without it, the schema stays
+    faithful: defaulted fields remain required and non-nullable, and the raw
+    payload validates directly with pydantic.
+    """
     if isinstance(model, TypeAdapter):
         schema = model.json_schema()
     else:
         schema = model.model_json_schema()
 
-    return _ensure_strict_json_schema(schema, path=(), root=schema)
+    return _ensure_strict_json_schema(
+        schema, path=(), root=schema, null_sentinel_for_defaults=null_sentinel_for_defaults
+    )
 
 
 # from https://platform.openai.com/docs/guides/function-calling?api-mode=responses&strict-mode=disabled#strict-mode
@@ -34,6 +50,7 @@ def _ensure_strict_json_schema(
     *,
     path: tuple[str, ...],
     root: dict[str, object],
+    null_sentinel_for_defaults: bool,
 ) -> dict[str, Any]:
     """Mutates the given JSON schema to ensure it conforms to the `strict` standard
     that the API expects.
@@ -44,7 +61,12 @@ def _ensure_strict_json_schema(
     defs = json_schema.get("$defs")
     if is_dict(defs):
         for def_name, def_schema in defs.items():
-            _ensure_strict_json_schema(def_schema, path=(*path, "$defs", def_name), root=root)
+            _ensure_strict_json_schema(
+                def_schema,
+                path=(*path, "$defs", def_name),
+                root=root,
+                null_sentinel_for_defaults=null_sentinel_for_defaults,
+            )
 
     definitions = json_schema.get("definitions")
     if is_dict(definitions):
@@ -53,6 +75,7 @@ def _ensure_strict_json_schema(
                 definition_schema,
                 path=(*path, "definitions", definition_name),
                 root=root,
+                null_sentinel_for_defaults=null_sentinel_for_defaults,
             )
 
     typ = json_schema.get("type")
@@ -65,7 +88,12 @@ def _ensure_strict_json_schema(
     if is_dict(properties) and properties:
         json_schema["required"] = list(properties.keys())
         json_schema["properties"] = {
-            key: _ensure_strict_json_schema(prop_schema, path=(*path, "properties", key), root=root)
+            key: _ensure_strict_json_schema(
+                prop_schema,
+                path=(*path, "properties", key),
+                root=root,
+                null_sentinel_for_defaults=null_sentinel_for_defaults,
+            )
             for key, prop_schema in properties.items()
         }
 
@@ -73,7 +101,12 @@ def _ensure_strict_json_schema(
     # { 'type': 'array', 'items': {...} }
     items = json_schema.get("items")
     if is_dict(items):
-        json_schema["items"] = _ensure_strict_json_schema(items, path=(*path, "items"), root=root)
+        json_schema["items"] = _ensure_strict_json_schema(
+            items,
+            path=(*path, "items"),
+            root=root,
+            null_sentinel_for_defaults=null_sentinel_for_defaults,
+        )
 
     # unions (anyOf / oneOf)
     # Strip empty schema objects ({}) — they are JSON Schema's identity element
@@ -88,13 +121,23 @@ def _ensure_strict_json_schema(
             variants = [v for v in variants if v != {}]
             if len(variants) == 1:
                 json_schema.update(
-                    _ensure_strict_json_schema(variants[0], path=(*path, union_key, "0"), root=root)
+                    _ensure_strict_json_schema(
+                        variants[0],
+                        path=(*path, union_key, "0"),
+                        root=root,
+                        null_sentinel_for_defaults=null_sentinel_for_defaults,
+                    )
                 )
                 json_schema.pop(union_key, None)
             elif len(variants) >= 2:
                 json_schema.pop(union_key, None)
                 json_schema["anyOf"] = [
-                    _ensure_strict_json_schema(variant, path=(*path, "anyOf", str(i)), root=root)
+                    _ensure_strict_json_schema(
+                        variant,
+                        path=(*path, "anyOf", str(i)),
+                        root=root,
+                        null_sentinel_for_defaults=null_sentinel_for_defaults,
+                    )
                     for i, variant in enumerate(variants)
                 ]
             else:
@@ -105,12 +148,22 @@ def _ensure_strict_json_schema(
     if is_list(all_of):
         if len(all_of) == 1:
             json_schema.update(
-                _ensure_strict_json_schema(all_of[0], path=(*path, "allOf", "0"), root=root)
+                _ensure_strict_json_schema(
+                    all_of[0],
+                    path=(*path, "allOf", "0"),
+                    root=root,
+                    null_sentinel_for_defaults=null_sentinel_for_defaults,
+                )
             )
             json_schema.pop("allOf")
         else:
             json_schema["allOf"] = [
-                _ensure_strict_json_schema(entry, path=(*path, "allOf", str(i)), root=root)
+                _ensure_strict_json_schema(
+                    entry,
+                    path=(*path, "allOf", str(i)),
+                    root=root,
+                    null_sentinel_for_defaults=null_sentinel_for_defaults,
+                )
                 for i, entry in enumerate(all_of)
             ]
 
@@ -123,9 +176,11 @@ def _ensure_strict_json_schema(
         json_schema.pop("default", None)
 
         # Strict schemas require all fields, but LLMs cannot see or apply Python defaults.
-        # Let the field additionally accept null as a sentinel; validate_response_format and
-        # tool preparation swap a returned null back for the field's default.
-        _add_null_sentinel(json_schema)
+        # For tool schemas, let the field additionally accept null as a sentinel; tool
+        # preparation (_prepare_function_arguments) swaps a returned null back for the
+        # field's default. Response formats stay faithful: the model must produce a value.
+        if null_sentinel_for_defaults:
+            _add_null_sentinel(json_schema)
 
     # we can't use `$ref`s if there are also other properties defined, e.g.
     # `{"$ref": "...", "description": "my description"}`
@@ -147,7 +202,9 @@ def _ensure_strict_json_schema(
         json_schema.pop("$ref")
         # Since the schema expanded from `$ref` might not have `additionalProperties: false` applied,  # noqa: E501
         # we call `_ensure_strict_json_schema` again to fix the inlined schema and ensure it's valid.  # noqa: E501
-        return _ensure_strict_json_schema(json_schema, path=path, root=root)
+        return _ensure_strict_json_schema(
+            json_schema, path=path, root=root, null_sentinel_for_defaults=null_sentinel_for_defaults
+        )
 
     # simplify nullable unions (“anyOf” or “oneOf”)
     for union_key in ("anyOf", "oneOf"):

--- a/livekit-agents/livekit/agents/llm/_strict.py
+++ b/livekit-agents/livekit/agents/llm/_strict.py
@@ -7,13 +7,46 @@ from pydantic import BaseModel, TypeAdapter
 _T = TypeVar("_T")
 
 
-def to_strict_json_schema(model: type[BaseModel] | TypeAdapter[Any]) -> dict[str, Any]:
+def _model_json_schema(model: type[BaseModel] | TypeAdapter[Any]) -> dict[str, Any]:
     if isinstance(model, TypeAdapter):
-        schema = model.json_schema()
-    else:
-        schema = model.model_json_schema()
+        return model.json_schema()
+    return model.model_json_schema()
+
+
+def to_strict_json_schema(model: type[BaseModel] | TypeAdapter[Any]) -> dict[str, Any]:
+    schema = _model_json_schema(model)
 
     return _ensure_strict_json_schema(schema, path=(), root=schema)
+
+
+def to_strict_tool_json_schema(model: type[BaseModel] | TypeAdapter[Any]) -> dict[str, Any]:
+    schema = _model_json_schema(model)
+    _make_defaults_nullable(schema)
+
+    return _ensure_strict_json_schema(schema, path=(), root=schema)
+
+
+def _make_defaults_nullable(json_schema: object) -> None:
+    """Encode defaulted tool arguments as nullable fields for strict schemas.
+
+    OpenAI strict schemas require every property and do not support JSON Schema defaults, so
+    ``null`` represents "use the Python default". Tool argument preparation replaces that value
+    before validation. Response formats intentionally skip this conversion because their output
+    is validated directly against the declared Pydantic nullability.
+    """
+    if isinstance(json_schema, dict):
+        if "default" in json_schema:
+            typ = json_schema.get("type")
+            if isinstance(typ, str):
+                json_schema["type"] = [typ, "null"]
+            elif isinstance(typ, list) and "null" not in typ:
+                json_schema["type"] = [*typ, "null"]
+
+        for value in json_schema.values():
+            _make_defaults_nullable(value)
+    elif isinstance(json_schema, list):
+        for value in json_schema:
+            _make_defaults_nullable(value)
 
 
 # from https://platform.openai.com/docs/guides/function-calling?api-mode=responses&strict-mode=disabled#strict-mode
@@ -117,19 +150,6 @@ def _ensure_strict_json_schema(
     # strict mode doesn't support default
     if "default" in json_schema:
         json_schema.pop("default", None)
-
-        # Treat any parameter with a default value as optional. If the parameter’s type doesn't
-        # support None, the default will be used instead.
-        t = json_schema.get("type")
-        if isinstance(t, str):
-            json_schema["type"] = [t, "null"]
-
-        elif isinstance(t, list):
-            types = t.copy()
-            if "null" not in types:
-                types.append("null")
-
-            json_schema["type"] = types
 
     json_schema.pop("title", None)
     json_schema.pop("discriminator", None)

--- a/livekit-agents/livekit/agents/llm/_strict.py
+++ b/livekit-agents/livekit/agents/llm/_strict.py
@@ -268,7 +268,13 @@ def _add_null_sentinel(json_schema: dict[str, Any]) -> None:
     if not inner:
         return
     json_schema.clear()
-    json_schema["anyOf"] = [inner, {"type": "null"}]
+    if "$ref" in inner and len(inner) > 1:
+        # strict mode forbids siblings on $ref (but allows them on anyOf), so keep
+        # the siblings (e.g. description) on the wrapper and the ref alone inside
+        json_schema.update(inner)
+        json_schema["anyOf"] = [{"$ref": json_schema.pop("$ref")}, {"type": "null"}]
+    else:
+        json_schema["anyOf"] = [inner, {"type": "null"}]
 
 
 def resolve_ref(*, root: dict[str, object], ref: str) -> object:

--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -325,15 +325,13 @@ def validate_response_format(response_format: type[ResponseFormatT], value: Any)
     else:
         schema = json_schema_type.model_json_schema()
 
-    value = _inject_response_format_defaults(value, schema=schema, root=schema)
+    value = _inject_schema_defaults(value, schema=schema, root=schema)
     if isinstance(json_schema_type, TypeAdapter):
         return cast(ResponseFormatT, json_schema_type.validate_python(value))
     return cast(ResponseFormatT, json_schema_type.model_validate(value))
 
 
-def _inject_response_format_defaults(
-    value: Any, *, schema: dict[str, Any], root: dict[str, Any]
-) -> Any:
+def _inject_schema_defaults(value: Any, *, schema: dict[str, Any], root: dict[str, Any]) -> Any:
     ref = schema.get("$ref")
     if isinstance(ref, str):
         resolved = _strict.resolve_ref(root=root, ref=ref)
@@ -349,20 +347,20 @@ def _inject_response_format_defaults(
     if isinstance(all_of, list):
         for variant in all_of:
             if isinstance(variant, dict):
-                value = _inject_response_format_defaults(value, schema=variant, root=root)
+                value = _inject_schema_defaults(value, schema=variant, root=root)
 
     for union_key in ("anyOf", "oneOf"):
         variants = schema.get(union_key)
         if isinstance(variants, list):
             for variant in variants:
                 if isinstance(variant, dict) and _json_schema_matches(value, variant, root=root):
-                    return _inject_response_format_defaults(value, schema=variant, root=root)
+                    return _inject_schema_defaults(value, schema=variant, root=root)
 
     if isinstance(value, dict):
         properties = schema.get("properties")
         if isinstance(properties, dict):
             return {
-                key: _inject_response_format_defaults(item, schema=properties[key], root=root)
+                key: _inject_schema_defaults(item, schema=properties[key], root=root)
                 if key in properties and isinstance(properties[key], dict)
                 else item
                 for key, item in value.items()
@@ -371,9 +369,7 @@ def _inject_response_format_defaults(
     if isinstance(value, list):
         items = schema.get("items")
         if isinstance(items, dict):
-            return [
-                _inject_response_format_defaults(item, schema=items, root=root) for item in value
-            ]
+            return [_inject_schema_defaults(item, schema=items, root=root) for item in value]
 
     return value
 

--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -6,14 +6,12 @@ import copy
 import inspect
 import json
 import re
-import types
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
-    Union,
     cast,
     get_args,
     get_origin,
@@ -684,22 +682,11 @@ def _prepare_function_arguments(
     if isinstance(fnc, FunctionTool):
         model_type = function_arguments_to_pydantic_model(fnc)
 
-        # Function arguments with default values are treated as optional
-        # when converted to strict LLM function descriptions. (e.g., we convert default
-        # parameters to type: ["string", "null"]).
-        # The following make sure to use the default value when we receive None.
-        # (Only if the type can't be Optional)
-        for param_name, param in signature.parameters.items():
-            type_hint = type_hints[param_name]
-            if param_name in args_dict and args_dict[param_name] is None:
-                if not _is_optional_type(type_hint):
-                    if param.default is not inspect.Parameter.empty:
-                        args_dict[param_name] = param.default
-                    else:
-                        raise ValueError(
-                            f"Received no value for required parameter '{param_name}': "
-                            "this argument cannot be None and no default is available."
-                        )
+        # Strict LLM schemas represent defaulted fields as nullable (see
+        # _ensure_strict_json_schema): null means "use the default". Resolve
+        # the sentinel, including in nested models, before validation.
+        schema = model_type.model_json_schema()
+        args_dict = _inject_schema_defaults(args_dict, schema=schema, root=schema)
 
         model = model_type.model_validate(args_dict)  # can raise ValidationError
         raw_fields = _shallow_model_dump(model)
@@ -731,18 +718,6 @@ def _prepare_function_arguments(
     bound = signature.bind(**{**raw_fields, **context_dict})
     bound.apply_defaults()
     return bound.args, bound.kwargs
-
-
-def _is_optional_type(hint: Any) -> bool:
-    if get_origin(hint) is Annotated:
-        hint = get_args(hint)[0]
-
-    origin = get_origin(hint)
-
-    is_union = origin is Union
-    is_union = is_union or origin is types.UnionType
-
-    return is_union and type(None) in get_args(hint)
 
 
 def _shallow_model_dump(model: BaseModel, *, by_alias: bool = False) -> dict[str, Any]:

--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -239,7 +239,7 @@ def build_strict_openai_schema(
     """strict mode tool description"""
     model = function_arguments_to_pydantic_model(function_tool)
     info = function_tool.info
-    schema = _strict.to_strict_json_schema(model)
+    schema = _strict.to_strict_tool_json_schema(model)
 
     return {
         "type": "function",

--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -378,11 +378,15 @@ def _inject_response_format_defaults(
     return value
 
 
-def _json_schema_allows_null(schema: dict[str, Any], *, root: dict[str, Any]) -> bool:
+def _json_schema_allows_null(
+    schema: dict[str, Any], *, root: dict[str, Any], seen_refs: set[str] | None = None
+) -> bool:
     ref = schema.get("$ref")
-    if isinstance(ref, str):
+    if isinstance(ref, str) and ref not in (seen_refs or set()):
         resolved = _strict.resolve_ref(root=root, ref=ref)
-        if isinstance(resolved, dict) and _json_schema_allows_null(resolved, root=root):
+        if isinstance(resolved, dict) and _json_schema_allows_null(
+            resolved, root=root, seen_refs={*(seen_refs or set()), ref}
+        ):
             return True
 
     typ = schema.get("type")
@@ -392,7 +396,8 @@ def _json_schema_allows_null(schema: dict[str, Any], *, root: dict[str, Any]) ->
     for union_key in ("anyOf", "oneOf"):
         variants = schema.get(union_key)
         if isinstance(variants, list) and any(
-            isinstance(variant, dict) and _json_schema_allows_null(variant, root=root)
+            isinstance(variant, dict)
+            and _json_schema_allows_null(variant, root=root, seen_refs=seen_refs)
             for variant in variants
         ):
             return True
@@ -406,6 +411,9 @@ def _json_schema_matches(value: Any, schema: dict[str, Any], *, root: dict[str, 
         resolved = _strict.resolve_ref(root=root, ref=ref)
         if isinstance(resolved, dict):
             schema = {**resolved, **schema}
+
+    if value is None and "default" in schema and not _json_schema_allows_null(schema, root=root):
+        return True
 
     if "const" in schema and value != schema["const"]:
         return False

--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -427,6 +427,14 @@ def _json_schema_matches(value: Any, schema: dict[str, Any], *, root: dict[str, 
             return False
         properties = schema.get("properties")
         if isinstance(properties, dict):
+            # the strict wire schema closes objects (additionalProperties: false),
+            # so a key outside the declared properties rules this variant out;
+            # otherwise a payload meant for a sibling union variant matches any
+            # variant that merely ignores the extra keys
+            if schema.get("additionalProperties") in (None, False) and any(
+                key not in properties for key in value
+            ):
+                return False
             for key, item in value.items():
                 property_schema = properties.get(key)
                 if isinstance(property_schema, dict) and not _json_schema_matches(

--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import copy
 import inspect
 import json
 import re
@@ -239,7 +240,7 @@ def build_strict_openai_schema(
     """strict mode tool description"""
     model = function_arguments_to_pydantic_model(function_tool)
     info = function_tool.info
-    schema = _strict.to_strict_tool_json_schema(model)
+    schema = _strict.to_strict_json_schema(model)
 
     return {
         "type": "function",
@@ -308,6 +309,148 @@ def to_openai_response_format(response_format: type | dict[str, Any]) -> dict[st
             "strict": True,
         },
     }
+
+
+def validate_response_format(response_format: type[ResponseFormatT], value: Any) -> ResponseFormatT:
+    """Validate a structured response, applying defaults represented by ``null``.
+
+    Strict JSON schemas require every field and cannot communicate Python defaults to the LLM.
+    ``to_openai_response_format`` therefore makes a defaulted field nullable. When the field's
+    declared type is not nullable, a returned ``null`` means "use the default" and must be
+    replaced before Pydantic validation.
+    """
+    _, json_schema_type = to_response_format_param(response_format)
+    if isinstance(json_schema_type, TypeAdapter):
+        schema = json_schema_type.json_schema()
+    else:
+        schema = json_schema_type.model_json_schema()
+
+    value = _inject_response_format_defaults(value, schema=schema, root=schema)
+    if isinstance(json_schema_type, TypeAdapter):
+        return cast(ResponseFormatT, json_schema_type.validate_python(value))
+    return cast(ResponseFormatT, json_schema_type.model_validate(value))
+
+
+def _inject_response_format_defaults(
+    value: Any, *, schema: dict[str, Any], root: dict[str, Any]
+) -> Any:
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        resolved = _strict.resolve_ref(root=root, ref=ref)
+        if isinstance(resolved, dict):
+            schema = {**resolved, **schema}
+
+    if value is None:
+        if "default" in schema and not _json_schema_allows_null(schema, root=root):
+            return copy.deepcopy(schema["default"])
+        return None
+
+    all_of = schema.get("allOf")
+    if isinstance(all_of, list):
+        for variant in all_of:
+            if isinstance(variant, dict):
+                value = _inject_response_format_defaults(value, schema=variant, root=root)
+
+    for union_key in ("anyOf", "oneOf"):
+        variants = schema.get(union_key)
+        if isinstance(variants, list):
+            for variant in variants:
+                if isinstance(variant, dict) and _json_schema_matches(value, variant, root=root):
+                    return _inject_response_format_defaults(value, schema=variant, root=root)
+
+    if isinstance(value, dict):
+        properties = schema.get("properties")
+        if isinstance(properties, dict):
+            return {
+                key: _inject_response_format_defaults(item, schema=properties[key], root=root)
+                if key in properties and isinstance(properties[key], dict)
+                else item
+                for key, item in value.items()
+            }
+
+    if isinstance(value, list):
+        items = schema.get("items")
+        if isinstance(items, dict):
+            return [
+                _inject_response_format_defaults(item, schema=items, root=root) for item in value
+            ]
+
+    return value
+
+
+def _json_schema_allows_null(schema: dict[str, Any], *, root: dict[str, Any]) -> bool:
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        resolved = _strict.resolve_ref(root=root, ref=ref)
+        if isinstance(resolved, dict) and _json_schema_allows_null(resolved, root=root):
+            return True
+
+    typ = schema.get("type")
+    if typ == "null" or isinstance(typ, list) and "null" in typ:
+        return True
+
+    for union_key in ("anyOf", "oneOf"):
+        variants = schema.get(union_key)
+        if isinstance(variants, list) and any(
+            isinstance(variant, dict) and _json_schema_allows_null(variant, root=root)
+            for variant in variants
+        ):
+            return True
+
+    return False
+
+
+def _json_schema_matches(value: Any, schema: dict[str, Any], *, root: dict[str, Any]) -> bool:
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        resolved = _strict.resolve_ref(root=root, ref=ref)
+        if isinstance(resolved, dict):
+            schema = {**resolved, **schema}
+
+    if "const" in schema and value != schema["const"]:
+        return False
+    enum = schema.get("enum")
+    if isinstance(enum, list) and value not in enum:
+        return False
+
+    typ = schema.get("type")
+    if isinstance(typ, list):
+        return any(_json_type_matches(value, item) for item in typ if isinstance(item, str))
+    if isinstance(typ, str) and not _json_type_matches(value, typ):
+        return False
+
+    if isinstance(value, dict):
+        required = schema.get("required")
+        if isinstance(required, list) and not all(key in value for key in required):
+            return False
+        properties = schema.get("properties")
+        if isinstance(properties, dict):
+            for key, item in value.items():
+                property_schema = properties.get(key)
+                if isinstance(property_schema, dict) and not _json_schema_matches(
+                    item, property_schema, root=root
+                ):
+                    return False
+
+    return True
+
+
+def _json_type_matches(value: Any, typ: str) -> bool:
+    if typ == "null":
+        return value is None
+    if typ == "object":
+        return isinstance(value, dict)
+    if typ == "array":
+        return isinstance(value, list)
+    if typ == "boolean":
+        return isinstance(value, bool)
+    if typ == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if typ == "number":
+        return isinstance(value, int | float) and not isinstance(value, bool)
+    if typ == "string":
+        return isinstance(value, str)
+    return True
 
 
 def function_arguments_to_pydantic_model(func: Callable[..., Any]) -> type[BaseModel]:

--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -356,18 +356,36 @@ def _inject_schema_defaults(value: Any, *, schema: dict[str, Any], root: dict[st
 
     if isinstance(value, dict):
         properties = schema.get("properties")
-        if isinstance(properties, dict):
-            return {
-                key: _inject_schema_defaults(item, schema=properties[key], root=root)
-                if key in properties and isinstance(properties[key], dict)
-                else item
-                for key, item in value.items()
-            }
+        additional = schema.get("additionalProperties")
+        if isinstance(properties, dict) or isinstance(additional, dict):
+            # additionalProperties only governs keys not declared in properties
+            def _inject_entry(key: str, item: Any) -> Any:
+                prop = properties.get(key) if isinstance(properties, dict) else None
+                if isinstance(prop, dict):
+                    return _inject_schema_defaults(item, schema=prop, root=root)
+                if isinstance(additional, dict):
+                    return _inject_schema_defaults(item, schema=additional, root=root)
+                return item
+
+            return {key: _inject_entry(key, item) for key, item in value.items()}
 
     if isinstance(value, list):
+        prefix_items = schema.get("prefixItems")
         items = schema.get("items")
-        if isinstance(items, dict):
-            return [_inject_schema_defaults(item, schema=items, root=root) for item in value]
+        if isinstance(prefix_items, list) or isinstance(items, dict):
+            # prefixItems covers positional slots (fixed tuples); items the rest
+            def _inject_item(i: int, item: Any) -> Any:
+                if (
+                    isinstance(prefix_items, list)
+                    and i < len(prefix_items)
+                    and isinstance(prefix_items[i], dict)
+                ):
+                    return _inject_schema_defaults(item, schema=prefix_items[i], root=root)
+                if isinstance(items, dict):
+                    return _inject_schema_defaults(item, schema=items, root=root)
+                return item
+
+            return [_inject_item(i, item) for i, item in enumerate(value)]
 
     return value
 

--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -393,28 +393,52 @@ def _inject_schema_defaults(value: Any, *, schema: dict[str, Any], root: dict[st
 def _json_schema_allows_null(
     schema: dict[str, Any], *, root: dict[str, Any], seen_refs: set[str] | None = None
 ) -> bool:
+    """Whether ``null`` is a valid instance of ``schema``.
+
+    JSON schema keywords are conjunctive: null must satisfy every constraint
+    present (type, enum, const, allOf, unions, $ref), so any keyword that
+    rejects null makes the whole schema reject it.
+    """
     ref = schema.get("$ref")
-    if isinstance(ref, str) and ref not in (seen_refs or set()):
+    if isinstance(ref, str):
+        if ref in (seen_refs or set()):
+            return False
         resolved = _strict.resolve_ref(root=root, ref=ref)
-        if isinstance(resolved, dict) and _json_schema_allows_null(
+        if isinstance(resolved, dict) and not _json_schema_allows_null(
             resolved, root=root, seen_refs={*(seen_refs or set()), ref}
         ):
-            return True
+            return False
 
     typ = schema.get("type")
-    if typ == "null" or isinstance(typ, list) and "null" in typ:
-        return True
+    if isinstance(typ, str) and typ != "null":
+        return False
+    if isinstance(typ, list) and "null" not in typ:
+        return False
+
+    if "const" in schema and schema["const"] is not None:
+        return False
+    enum = schema.get("enum")
+    if isinstance(enum, list) and None not in enum:
+        return False
+
+    all_of = schema.get("allOf")
+    if isinstance(all_of, list) and not all(
+        _json_schema_allows_null(variant, root=root, seen_refs=seen_refs)
+        for variant in all_of
+        if isinstance(variant, dict)
+    ):
+        return False
 
     for union_key in ("anyOf", "oneOf"):
         variants = schema.get(union_key)
-        if isinstance(variants, list) and any(
+        if isinstance(variants, list) and not any(
             isinstance(variant, dict)
             and _json_schema_allows_null(variant, root=root, seen_refs=seen_refs)
             for variant in variants
         ):
-            return True
+            return False
 
-    return False
+    return True
 
 
 def _json_schema_matches(value: Any, schema: dict[str, Any], *, root: dict[str, Any]) -> bool:

--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -238,7 +238,7 @@ def build_strict_openai_schema(
     """strict mode tool description"""
     model = function_arguments_to_pydantic_model(function_tool)
     info = function_tool.info
-    schema = _strict.to_strict_json_schema(model)
+    schema = _strict.to_strict_json_schema(model, null_sentinel_for_defaults=True)
 
     return {
         "type": "function",
@@ -298,6 +298,9 @@ def to_response_format_param(
 def to_openai_response_format(response_format: type | dict[str, Any]) -> dict[str, Any]:
     name, json_schema_type = to_response_format_param(response_format)
 
+    # No null sentinel here: nothing resolves it on the decode side (users validate
+    # the raw payload themselves), so the schema must be exactly what validation
+    # accepts. Defaulted fields stay required; the model produces their values.
     schema = _strict.to_strict_json_schema(json_schema_type)
     return {
         "type": "json_schema",
@@ -307,26 +310,6 @@ def to_openai_response_format(response_format: type | dict[str, Any]) -> dict[st
             "strict": True,
         },
     }
-
-
-def validate_response_format(response_format: type[ResponseFormatT], value: Any) -> ResponseFormatT:
-    """Validate a structured response, applying defaults represented by ``null``.
-
-    Strict JSON schemas require every field and cannot communicate Python defaults to the LLM.
-    ``to_openai_response_format`` therefore makes a defaulted field nullable. When the field's
-    declared type is not nullable, a returned ``null`` means "use the default" and must be
-    replaced before Pydantic validation.
-    """
-    _, json_schema_type = to_response_format_param(response_format)
-    if isinstance(json_schema_type, TypeAdapter):
-        schema = json_schema_type.json_schema()
-    else:
-        schema = json_schema_type.model_json_schema()
-
-    value = _inject_schema_defaults(value, schema=schema, root=schema)
-    if isinstance(json_schema_type, TypeAdapter):
-        return cast(ResponseFormatT, json_schema_type.validate_python(value))
-    return cast(ResponseFormatT, json_schema_type.model_validate(value))
 
 
 def _inject_schema_defaults(value: Any, *, schema: dict[str, Any], root: dict[str, Any]) -> Any:

--- a/tests/test_response_format.py
+++ b/tests/test_response_format.py
@@ -5,9 +5,18 @@ from typing import Literal
 import pytest
 from pydantic import BaseModel
 
-from livekit.agents.llm.utils import to_openai_response_format, validate_response_format
+from livekit.agents.llm.utils import (
+    _json_schema_allows_null,  # verified null-acceptance checker; asserts the wire schema
+    to_openai_response_format,
+    validate_response_format,
+)
 
 pytestmark = pytest.mark.unit
+
+
+def _wire_property(response_format: type, field: str) -> tuple[dict, dict]:
+    schema = to_openai_response_format(response_format)["json_schema"]["schema"]
+    return schema["properties"][field], schema
 
 
 class _ResponseFormat(BaseModel):
@@ -54,6 +63,39 @@ def test_validate_response_format_injects_nested_defaults() -> None:
     )
 
     assert response == Response(items=[PrimaryItem(kind="primary", color="red", note=None)])
+
+
+def test_response_format_encodes_literal_default_as_nullable() -> None:
+    # a Literal carries const/enum, which reject null even when the type lists it
+    class Response(BaseModel):
+        label: Literal["a", "b"] = "a"
+
+    prop, root = _wire_property(Response, "label")
+    assert _json_schema_allows_null(prop, root=root)
+    assert validate_response_format(Response, {"label": None}).label == "a"
+
+
+def test_response_format_encodes_union_default_as_nullable() -> None:
+    # a top-level anyOf has no direct type to append null to
+    class Response(BaseModel):
+        value: int | str = 5
+
+    prop, root = _wire_property(Response, "value")
+    assert _json_schema_allows_null(prop, root=root)
+    assert validate_response_format(Response, {"value": None}).value == 5
+
+
+def test_response_format_encodes_nested_model_default_as_nullable() -> None:
+    # a defaulted nested model is a $ref with a sibling default
+    class Child(BaseModel):
+        x: int = 1
+
+    class Response(BaseModel):
+        child: Child = Child()
+
+    prop, root = _wire_property(Response, "child")
+    assert _json_schema_allows_null(prop, root=root)
+    assert validate_response_format(Response, {"child": None}).child == Child(x=1)
 
 
 def test_validate_response_format_injects_defaults_in_dict_values() -> None:

--- a/tests/test_response_format.py
+++ b/tests/test_response_format.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from livekit.agents.llm import function_tool
+from livekit.agents.llm.utils import build_strict_openai_schema, to_openai_response_format
+
+pytestmark = pytest.mark.unit
+
+
+class _ResponseFormat(BaseModel):
+    label: str = ""
+    description: str | None = None
+
+
+def test_response_format_preserves_pydantic_nullability() -> None:
+    response_format = to_openai_response_format(_ResponseFormat)
+    schema = response_format["json_schema"]["schema"]
+
+    assert schema["required"] == ["label", "description"]
+    assert schema["properties"]["label"]["type"] == "string"
+    assert schema["properties"]["description"]["type"] == ["string", "null"]
+    assert "default" not in schema["properties"]["label"]
+    assert "default" not in schema["properties"]["description"]
+
+
+def test_strict_tool_schema_keeps_defaulted_arguments_nullable() -> None:
+    @function_tool
+    async def lookup(label: str = "") -> str:
+        """Look up an item by label."""
+        return label
+
+    schema = build_strict_openai_schema(lookup)["function"]["parameters"]
+
+    assert schema["properties"]["label"]["type"] == ["string", "null"]

--- a/tests/test_response_format.py
+++ b/tests/test_response_format.py
@@ -6,9 +6,8 @@ import pytest
 from pydantic import BaseModel
 
 from livekit.agents.llm.utils import (
-    _json_schema_allows_null,  # verified null-acceptance checker; asserts the wire schema
+    _json_schema_allows_null,  # null-acceptance checker; asserts the wire schema
     to_openai_response_format,
-    validate_response_format,
 )
 
 pytestmark = pytest.mark.unit
@@ -24,69 +23,37 @@ class _ResponseFormat(BaseModel):
     description: str | None = None
 
 
-def test_response_format_encodes_default_as_nullable() -> None:
+def test_response_format_drops_defaults_and_keeps_fields_required() -> None:
     response_format = to_openai_response_format(_ResponseFormat)
     schema = response_format["json_schema"]["schema"]
 
     assert schema["required"] == ["label", "description"]
-    assert schema["properties"]["label"]["type"] == ["string", "null"]
-    assert schema["properties"]["description"]["type"] == ["string", "null"]
+    # a defaulted non-nullable field stays non-nullable: the model must produce
+    # a value, and plain pydantic validation accepts whatever it returns
+    assert schema["properties"]["label"]["type"] == "string"
     assert "default" not in schema["properties"]["label"]
-    assert "default" not in schema["properties"]["description"]
+    # a genuinely nullable field keeps accepting null
+    assert _json_schema_allows_null(schema["properties"]["description"], root=schema)
 
 
-def test_validate_response_format_injects_defaults_for_non_nullable_fields() -> None:
-    response = validate_response_format(
-        _ResponseFormat,
-        {"label": None, "description": None},
-    )
-
-    assert response == _ResponseFormat(label="default", description=None)
-
-
-def test_validate_response_format_injects_nested_defaults() -> None:
-    class PrimaryItem(BaseModel):
-        kind: Literal["primary"]
-        color: str = "red"
-        note: str | None = "fallback"
-
-    class SecondaryItem(BaseModel):
-        kind: Literal["secondary"]
-        color: str = "blue"
-
-    class Response(BaseModel):
-        items: list[PrimaryItem | SecondaryItem]
-
-    response = validate_response_format(
-        Response,
-        {"items": [{"kind": "primary", "color": None, "note": None}]},
-    )
-
-    assert response == Response(items=[PrimaryItem(kind="primary", color="red", note=None)])
-
-
-def test_response_format_encodes_literal_default_as_nullable() -> None:
-    # a Literal carries const/enum, which reject null even when the type lists it
+def test_response_format_literal_default_not_nullable() -> None:
     class Response(BaseModel):
         label: Literal["a", "b"] = "a"
 
     prop, root = _wire_property(Response, "label")
-    assert _json_schema_allows_null(prop, root=root)
-    assert validate_response_format(Response, {"label": None}).label == "a"
+    assert not _json_schema_allows_null(prop, root=root)
+    assert "default" not in prop
 
 
-def test_response_format_encodes_union_default_as_nullable() -> None:
-    # a top-level anyOf has no direct type to append null to
+def test_response_format_union_default_not_nullable() -> None:
     class Response(BaseModel):
         value: int | str = 5
 
     prop, root = _wire_property(Response, "value")
-    assert _json_schema_allows_null(prop, root=root)
-    assert validate_response_format(Response, {"value": None}).value == 5
+    assert not _json_schema_allows_null(prop, root=root)
 
 
-def test_response_format_encodes_nested_model_default_as_nullable() -> None:
-    # a defaulted nested model is a $ref with a sibling default
+def test_response_format_nested_model_default_not_nullable() -> None:
     class Child(BaseModel):
         x: int = 1
 
@@ -94,67 +61,27 @@ def test_response_format_encodes_nested_model_default_as_nullable() -> None:
         child: Child = Child()
 
     prop, root = _wire_property(Response, "child")
-    assert _json_schema_allows_null(prop, root=root)
-    assert validate_response_format(Response, {"child": None}).child == Child(x=1)
+    assert not _json_schema_allows_null(prop, root=root)
 
 
-def test_validate_response_format_injects_defaults_in_dict_values() -> None:
-    class Child(BaseModel):
-        x: int = 1
-
-    class Response(BaseModel):
-        children: dict[str, Child]
-
-    response = validate_response_format(Response, {"children": {"k": {"x": None}}})
-
-    assert response == Response(children={"k": Child(x=1)})
-
-
-def test_validate_response_format_injects_defaults_in_tuple_items() -> None:
-    class Child(BaseModel):
-        x: int = 1
-
-    class Response(BaseModel):
-        pair: tuple[str, Child]
-
-    response = validate_response_format(Response, {"pair": ["k", {"x": None}]})
-
-    assert response == Response(pair=("k", Child(x=1)))
-
-
-def test_validate_response_format_preserves_genuine_null_declared_via_enum() -> None:
-    # nullability can be expressed through enum membership instead of type
+def test_response_format_genuine_null_via_enum_preserved() -> None:
+    # nullability expressed through enum membership is real nullability, not a default
     class Response(BaseModel):
         value: Literal["x", None] = "x"
 
-    response = validate_response_format(Response, {"value": None})
-
-    assert response.value is None
-
-
-def test_validate_response_format_injects_default_when_enum_excludes_null() -> None:
-    class Response(BaseModel):
-        value: Literal["x", "y"] = "x"
-
-    response = validate_response_format(Response, {"value": None})
-
-    assert response.value == "x"
+    prop, root = _wire_property(Response, "value")
+    assert _json_schema_allows_null(prop, root=root)
 
 
-def test_validate_response_format_selects_union_variant_by_payload_keys() -> None:
-    class PointsA(BaseModel):
-        common: int
-        a: int = 1
-
-    class PointsB(BaseModel):
-        common: int
-        b: str = "bee"
+def test_response_format_payload_validates_with_plain_model_validate() -> None:
+    # the decode contract: a schema-conforming payload passes direct validation,
+    # with no sentinel resolution step
+    class Child(BaseModel):
+        x: int = 1
 
     class Response(BaseModel):
-        item: PointsA | PointsB
+        child: Child = Child()
+        label: str = "a"
 
-    # the payload carries PointsB's field; PointsA must not win just because
-    # its only required field is present and the extra key is ignored
-    response = validate_response_format(Response, {"item": {"common": 7, "b": None}})
-
-    assert response == Response(item=PointsB(common=7, b="bee"))
+    payload = {"child": {"x": 2}, "label": "b"}
+    assert Response.model_validate(payload) == Response(child=Child(x=2), label="b")

--- a/tests/test_response_format.py
+++ b/tests/test_response_format.py
@@ -56,6 +56,30 @@ def test_validate_response_format_injects_nested_defaults() -> None:
     assert response == Response(items=[PrimaryItem(kind="primary", color="red", note=None)])
 
 
+def test_validate_response_format_injects_defaults_in_dict_values() -> None:
+    class Child(BaseModel):
+        x: int = 1
+
+    class Response(BaseModel):
+        children: dict[str, Child]
+
+    response = validate_response_format(Response, {"children": {"k": {"x": None}}})
+
+    assert response == Response(children={"k": Child(x=1)})
+
+
+def test_validate_response_format_injects_defaults_in_tuple_items() -> None:
+    class Child(BaseModel):
+        x: int = 1
+
+    class Response(BaseModel):
+        pair: tuple[str, Child]
+
+    response = validate_response_format(Response, {"pair": ["k", {"x": None}]})
+
+    assert response == Response(pair=("k", Child(x=1)))
+
+
 def test_validate_response_format_selects_union_variant_by_payload_keys() -> None:
     class PointsA(BaseModel):
         common: int

--- a/tests/test_response_format.py
+++ b/tests/test_response_format.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 import pytest
 from pydantic import BaseModel
 
@@ -34,16 +36,21 @@ def test_validate_response_format_injects_defaults_for_non_nullable_fields() -> 
 
 
 def test_validate_response_format_injects_nested_defaults() -> None:
-    class Item(BaseModel):
+    class PrimaryItem(BaseModel):
+        kind: Literal["primary"]
         color: str = "red"
         note: str | None = "fallback"
 
+    class SecondaryItem(BaseModel):
+        kind: Literal["secondary"]
+        color: str = "blue"
+
     class Response(BaseModel):
-        items: list[Item]
+        items: list[PrimaryItem | SecondaryItem]
 
     response = validate_response_format(
         Response,
-        {"items": [{"color": None, "note": None}]},
+        {"items": [{"kind": "primary", "color": None, "note": None}]},
     )
 
-    assert response == Response(items=[Item(color="red", note=None)])
+    assert response == Response(items=[PrimaryItem(kind="primary", color="red", note=None)])

--- a/tests/test_response_format.py
+++ b/tests/test_response_format.py
@@ -3,34 +3,47 @@ from __future__ import annotations
 import pytest
 from pydantic import BaseModel
 
-from livekit.agents.llm import function_tool
-from livekit.agents.llm.utils import build_strict_openai_schema, to_openai_response_format
+from livekit.agents.llm.utils import to_openai_response_format, validate_response_format
 
 pytestmark = pytest.mark.unit
 
 
 class _ResponseFormat(BaseModel):
-    label: str = ""
+    label: str = "default"
     description: str | None = None
 
 
-def test_response_format_preserves_pydantic_nullability() -> None:
+def test_response_format_encodes_default_as_nullable() -> None:
     response_format = to_openai_response_format(_ResponseFormat)
     schema = response_format["json_schema"]["schema"]
 
     assert schema["required"] == ["label", "description"]
-    assert schema["properties"]["label"]["type"] == "string"
+    assert schema["properties"]["label"]["type"] == ["string", "null"]
     assert schema["properties"]["description"]["type"] == ["string", "null"]
     assert "default" not in schema["properties"]["label"]
     assert "default" not in schema["properties"]["description"]
 
 
-def test_strict_tool_schema_keeps_defaulted_arguments_nullable() -> None:
-    @function_tool
-    async def lookup(label: str = "") -> str:
-        """Look up an item by label."""
-        return label
+def test_validate_response_format_injects_defaults_for_non_nullable_fields() -> None:
+    response = validate_response_format(
+        _ResponseFormat,
+        {"label": None, "description": None},
+    )
 
-    schema = build_strict_openai_schema(lookup)["function"]["parameters"]
+    assert response == _ResponseFormat(label="default", description=None)
 
-    assert schema["properties"]["label"]["type"] == ["string", "null"]
+
+def test_validate_response_format_injects_nested_defaults() -> None:
+    class Item(BaseModel):
+        color: str = "red"
+        note: str | None = "fallback"
+
+    class Response(BaseModel):
+        items: list[Item]
+
+    response = validate_response_format(
+        Response,
+        {"items": [{"color": None, "note": None}]},
+    )
+
+    assert response == Response(items=[Item(color="red", note=None)])

--- a/tests/test_response_format.py
+++ b/tests/test_response_format.py
@@ -54,3 +54,22 @@ def test_validate_response_format_injects_nested_defaults() -> None:
     )
 
     assert response == Response(items=[PrimaryItem(kind="primary", color="red", note=None)])
+
+
+def test_validate_response_format_selects_union_variant_by_payload_keys() -> None:
+    class PointsA(BaseModel):
+        common: int
+        a: int = 1
+
+    class PointsB(BaseModel):
+        common: int
+        b: str = "bee"
+
+    class Response(BaseModel):
+        item: PointsA | PointsB
+
+    # the payload carries PointsB's field; PointsA must not win just because
+    # its only required field is present and the extra key is ignored
+    response = validate_response_format(Response, {"item": {"common": 7, "b": None}})
+
+    assert response == Response(item=PointsB(common=7, b="bee"))

--- a/tests/test_response_format.py
+++ b/tests/test_response_format.py
@@ -80,6 +80,25 @@ def test_validate_response_format_injects_defaults_in_tuple_items() -> None:
     assert response == Response(pair=("k", Child(x=1)))
 
 
+def test_validate_response_format_preserves_genuine_null_declared_via_enum() -> None:
+    # nullability can be expressed through enum membership instead of type
+    class Response(BaseModel):
+        value: Literal["x", None] = "x"
+
+    response = validate_response_format(Response, {"value": None})
+
+    assert response.value is None
+
+
+def test_validate_response_format_injects_default_when_enum_excludes_null() -> None:
+    class Response(BaseModel):
+        value: Literal["x", "y"] = "x"
+
+    response = validate_response_format(Response, {"value": None})
+
+    assert response.value == "x"
+
+
 def test_validate_response_format_selects_union_variant_by_payload_keys() -> None:
     class PointsA(BaseModel):
         common: int

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -759,6 +759,43 @@ class TestNullSentinelForDefaults:
             assert not _json_schema_allows_null(prop, root=schema), f"{field}: {prop}"
             assert "default" not in prop
 
+    def test_described_ref_default_keeps_ref_free_of_siblings(self):
+        # a documented tool param whose type is a nested model and that has a
+        # default arrives as {"$ref", "default", "description"}; strict mode
+        # forbids siblings on $ref, so the description must stay on the wrapper
+        @function_tool
+        async def tool_with_documented_model_arg(
+            query: str,
+            config: _SentinelChildModel = _SentinelChildModel(),  # noqa: B008
+        ) -> str:
+            """Does a thing.
+
+            Args:
+                query: What to search for.
+                config: Optional configuration for the search.
+            """
+            return "ok"
+
+        schema = build_strict_openai_schema(tool_with_documented_model_arg)["function"][
+            "parameters"
+        ]
+
+        def assert_no_ref_siblings(node, path="$"):
+            if isinstance(node, dict):
+                if "$ref" in node:
+                    assert len(node) == 1, f"$ref with siblings at {path}: {sorted(node)}"
+                for key, value in node.items():
+                    assert_no_ref_siblings(value, f"{path}.{key}")
+            elif isinstance(node, list):
+                for i, value in enumerate(node):
+                    assert_no_ref_siblings(value, f"{path}[{i}]")
+
+        assert_no_ref_siblings(schema)
+
+        config = schema["properties"]["config"]
+        assert config["description"] == "Optional configuration for the search."
+        assert _json_schema_allows_null(config, root=schema)
+
 
 class _CarModel(BaseModel):
     vehicle: Literal["Car"]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -466,11 +466,41 @@ class TestToolExecution:
         output = await agent.mock_tool_in_agent(*args, **kwargs)
         assert output == {"arg1": "test", "opt_arg2": None}
 
+    async def test_null_uses_default_for_non_optional_param(self):
+        @function_tool
+        async def tool(arg1: str, count: int = 5) -> int:
+            """Tool with a defaulted non-optional parameter"""
+            return count
+
+        args, kwargs = prepare_function_arguments(
+            fnc=tool, json_arguments='{"arg1": "test", "count": null}'
+        )
+        assert args == ("test", 5)
+        assert kwargs == {}
+
+    async def test_null_uses_default_in_nested_model_arg(self):
+        class Preferences(BaseModel):
+            color: str = "red"
+            note: str | None = None
+
+        @function_tool
+        async def set_prefs(prefs: Preferences) -> str:
+            """Tool with a nested model argument"""
+            return prefs.color
+
+        args, kwargs = prepare_function_arguments(
+            fnc=set_prefs, json_arguments='{"prefs": {"color": null, "note": null}}'
+        )
+        assert args == (Preferences(color="red", note=None),)
+        assert kwargs == {}
+
     def test_unexpected_arguments(self):
         with pytest.raises(ToolError, match="validation error"):
             prepare_function_arguments(fnc=mock_tool_1, json_arguments='{"opt_arg2": "test2"}')
 
-        with pytest.raises(ToolError, match="Received no value for required parameter"):
+        # a null for a required parameter with no default stays null and is
+        # rejected by pydantic validation
+        with pytest.raises(ToolError, match="validation error"):
             prepare_function_arguments(fnc=mock_tool_2, json_arguments='{"arg1": null}')
 
         with pytest.raises(ToolError, match="validation error"):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -17,6 +17,7 @@ from livekit.agents.llm import (
 )
 from livekit.agents.llm._strict import to_strict_json_schema
 from livekit.agents.llm.utils import (
+    _json_schema_allows_null,
     build_legacy_openai_schema,
     build_strict_openai_schema,
     function_arguments_to_pydantic_model,
@@ -725,6 +726,38 @@ class TestStrictJsonSchema:
         status = schema["properties"]["status"]
         assert None not in status["enum"], f"enum should not contain None: {status}"
         assert "null" not in status.get("type", []), f"type should not contain 'null': {status}"
+
+
+class _SentinelChildModel(BaseModel):
+    x: int = 1
+
+
+class _DefaultedFieldsModel(BaseModel):
+    count: int = 5
+    label: Literal["a", "b"] = "a"
+    value: int | str = 5
+    child: _SentinelChildModel = _SentinelChildModel()
+
+
+class TestNullSentinelForDefaults:
+    """Tool schemas advertise null for defaulted fields — the tool-args pipeline
+    resolves the sentinel in _prepare_function_arguments. Without the flag,
+    defaults are dropped and fields stay required and non-nullable."""
+
+    def test_sentinel_flag_advertises_null_for_all_defaulted_shapes(self):
+        schema = to_strict_json_schema(_DefaultedFieldsModel, null_sentinel_for_defaults=True)
+        for field in ("count", "label", "value", "child"):
+            prop = schema["properties"][field]
+            assert _json_schema_allows_null(prop, root=schema), f"{field}: {prop}"
+            assert "default" not in prop
+
+    def test_no_flag_keeps_defaulted_fields_required_and_non_nullable(self):
+        schema = to_strict_json_schema(_DefaultedFieldsModel)
+        assert schema["required"] == ["count", "label", "value", "child"]
+        for field in ("count", "label", "value", "child"):
+            prop = schema["properties"][field]
+            assert not _json_schema_allows_null(prop, root=schema), f"{field}: {prop}"
+            assert "default" not in prop
 
 
 class _CarModel(BaseModel):


### PR DESCRIPTION
## Summary

Strict JSON schemas require every property and don't support the `default` keyword. This PR settles how defaulted fields are handled on each of the two encode paths.

**Tool schemas keep the null sentinel, and it now works for every schema shape.** A defaulted field additionally accepts `null`, meaning "use the Python default" — the LLM never has to invent a value it can't know. This is safe because the framework controls the decode: `_prepare_function_arguments` resolves the sentinel before validation.

- The sentinel is advertised for all shapes, not just bare types: `Literal` (const/enum), unions (`anyOf`), and `$ref`-typed defaults (nested models, enums) previously either contradicted themselves or never became nullable.
- Resolution is now recursive: nested model arguments, `dict[str, Model]` values, and tuple items are decoded (previously a top-level-only signature walk).
- Union variants are rejected when the payload carries keys outside their declared `properties`, matching the closed-object semantics of the strict wire schema — prevents a payload meant for variant B from silently matching variant A and dropping data.
- Genuine nulls declared via enum membership (`Literal["x", None]`) are preserved instead of being replaced with the default.
- When wrapping a defaulted `$ref`-typed field (e.g. a documented nested-model param), sibling keys like `description` stay on the wrapper — strict mode forbids siblings on `$ref` but allows them next to `anyOf`.

**Response format schemas get no sentinel.** `to_openai_response_format` output is decoded by users with plain Pydantic validation, so the wire schema must be exactly what validation accepts. Defaulted fields stay required and non-nullable; the model produces their values and the Python default never fires. `to_strict_json_schema` takes a `null_sentinel_for_defaults` flag (tools pass it; response formats don't).

## Behavior changes

- `response_format`: the model can no longer send `null` for a defaulted non-nullable field. Previously bare-type defaulted fields were widened to `["type", "null"]`, producing payloads that plain `model_validate` rejects.
- Tool args: a `null` for a required parameter with no default now surfaces as a Pydantic `ValidationError` (still wrapped in `ToolError`) instead of a hand-written `ValueError`.

## Known limitation

`Field(default_factory=...)` emits no schema `default`, so factory-defaulted tool fields get no sentinel and remain required on the wire. Left for a follow-up.

## Testing

- 134 tests across the response-format, tools, gemini-schema, tool-proxy, and placeholder suites (new regression tests written to fail first)
- Ruff check/format clean; full repo type check (618 files) passes
