### PR TITLE
fix(workflows): support chunked card number reading

### DIFF
--- a/livekit-agents/livekit/agents/beta/workflows/credit_card.py
+++ b/livekit-agents/livekit/agents/beta/workflows/credit_card.py
@@ -35,6 +35,9 @@ _CARD_NUMBER_AUDIO_SPECIFIC = """
 Handle input as noisy voice transcription. Expect users to read the card number digit by digit.
 Normalize spoken digits silently: 'four' → 4, 'zero' / 'oh' → 0.
 Filter out filler words or hesitations.
+Users may read the number in groups (for example four digits at a time), pausing for you between groups.
+Support this: acknowledge each group briefly without repeating any digits (for example 'Okay, and the next four?') and keep collecting until the whole number has been read.
+Keep the groups in the order they were given and treat them as one number.
 """
 
 _CARD_NUMBER_TEXT_SPECIFIC = """
@@ -217,9 +220,10 @@ class GetCardNumberTask(AgentTask[GetCardNumberResult]):
         @function_tool(flags=flags)
         async def update_card_number(context: RunContext, card_number: str) -> str | None:
             """Call to record the user's card number. Only call once the entire number has been given, do not call in increments.
+            If the user read the number in groups across several turns, concatenate all groups in the order they were given and call this once with the complete number.
 
             Args:
-                card_number (str): The credit card number as a string with no dashes or spaces
+                card_number (str): The complete credit card number as a string with no dashes or spaces
             """
             return await self._update_card_number_impl(context, card_number)
 


### PR DESCRIPTION
Callers naturally read card numbers in groups and expect acknowledgment between them ("the first four are 4 5 3 9"); GetCardNumberTask previously pushed them to read the whole number in one utterance (`update_card_number` forbids incremental calls and the instructions had no grouped-capture guidance).

Prompt-level fix: the audio instructions now describe group-wise collection with brief, digit-free acknowledgments (the agent never utters digits, per the existing PCI constraint in the base instructions), and the tool docstring instructs concatenating the groups in order into a single call. Verified via `lk agent daemon` with four distinct groups: correct in-order concatenation, Luhn pass, caller repeat-back confirmation, and a mid-flow restart. No stateful chunk-buffer tool needed.

Stacked on #6447 (base branch `chenghao/fix/AGT-3139-credit-card-confirm-routing`); will retarget to main once that merges.

Fixes AGT-3141

🤖 Generated with [Claude Code](https://claude.com/claude-code)