### PR TITLE
fix(tts): don't let a self-closing prosody marker swallow the next expr tag

### DIFF
--- a/livekit-agents/livekit/agents/tts/_provider_format.py
+++ b/livekit-agents/livekit/agents/tts/_provider_format.py
@@ -634,9 +634,12 @@ _EXPR_OPEN_RE = re.compile(r"<expr\b([^>]*?)/?\s*>")
 _EXPR_CLOSE_RE = re.compile(r"</expr\s*>")
 # self-closing markers only (the trailing / is required)
 _EXPR_SELF_RE = re.compile(r"<expr\b([^>]*?)/\s*>")
-# a wrapping marker (prosody/spell) and its span; non-greedy, instructed not to nest
+# a wrapping marker (prosody/spell) and its span; non-greedy, instructed not to nest.
+# the opening tag must not itself be self-closing, or a self-closing prosody point
+# control ahead of a later wrapping marker gets mistaken for that marker's opener,
+# swallowing everything up to the next </expr> into its span.
 _EXPR_WRAP_RE = re.compile(
-    r'<expr\b(?=[^>]*type="(?:prosody|spell)")([^>]*?)>(.*?)</expr\s*>', re.DOTALL
+    r'<expr\b(?=[^>]*type="(?:prosody|spell)")([^>]*?)(?<!/)>(.*?)</expr\s*>', re.DOTALL
 )
 # a non-wrapping type the LLM forgot to self-close (normalize_markup fixes these)
 _EXPR_UNCLOSED_RE = re.compile(

--- a/tests/test_expr_markup.py
+++ b/tests/test_expr_markup.py
@@ -142,6 +142,18 @@ def test_convert_expr_cartesia_prosody_unknown_label_unwraps() -> None:
     assert convert_markup("cartesia", text) == "keep it secret"
 
 
+def test_convert_expr_cartesia_self_closing_prosody_before_spell() -> None:
+    # a self-closing point control ahead of a later wrapping marker must not be
+    # mistaken for that marker's opening tag — each converts independently
+    text = (
+        'Say it slow: <expr type="prosody" label="slow"/> '
+        'and now spell it: <expr type="spell">A7X9</expr> done.'
+    )
+    assert convert_markup("cartesia", text) == (
+        'Say it slow: <speed ratio="0.85"/> and now spell it: <spell>A7X9</spell> done.'
+    )
+
+
 def test_convert_stray_expr_never_reaches_tts() -> None:
     # an unpaired prosody open/close (e.g. split across stream chunks) is dropped,
     # keeping the words


### PR DESCRIPTION
## What
`_EXPR_WRAP_RE` (the regex that matches a *wrapping* `<expr type="prosody"|"spell">...</expr>` marker) matched any `<expr ...type="prosody"|"spell"...>` up to its first `>` — which also matches the closing `/>` of a **self-closing** point control like `<expr type="prosody" label="slow"/>`. When a self-closing prosody marker appears before a later wrapping marker (e.g. a `spell` tag), the lazy inner group swallows everything up to the *next* `</expr>`, merging the two markers and dropping the second marker's own conversion.

Repro (before fix):
```python
text = 'Say it slow: <expr type="prosody" label="slow"/> and now spell it: <expr type="spell">A7X9</expr> done.'
convert_markup("cartesia", text)
# 'Say it slow: <speed ratio="0.85"/> and now spell it: A7X9 done.'
#                                                        ^^^^ spell wrapping lost — should be <spell>A7X9</spell>
```

## Fix
Added a negative lookbehind (`(?<!/)`) before the opening tag's closing `>` so `_EXPR_WRAP_RE` never matches a self-closing tag as a wrap opener — those are left for `_EXPR_SELF_RE` to handle on its own pass, as intended.

## Testing
- New regression test `test_convert_expr_cartesia_self_closing_prosody_before_spell` — red before the fix (asserted, see commit), green after.
- Full `tests/test_expr_markup.py` (42 tests) and `tests/test_tokenizer_xml_markup.py` (38 tests) pass.
- `ruff check` / `ruff format --check` clean on both changed files.

## AI disclosure
Investigated and implemented with Claude Code (Claude Opus 4.8); I reviewed the diff, ran the repro and full test suite myself before opening this PR.