### PR TITLE
fix(codecs): skip RIFF pad byte after odd-sized WAV chunks

### DIFF
--- a/livekit-agents/livekit/agents/utils/codecs/decoder.py
+++ b/livekit-agents/livekit/agents/utils/codecs/decoder.py
@@ -266,7 +266,10 @@ class _WavInlineDecoder:
             self._init_streaming()
             self._state = _WavState.STREAMING
         else:
-            self._skip_remaining = chunk_size
+            # RIFF chunks are word-aligned: an odd-sized chunk is followed by a
+            # single pad byte that is not counted in chunk_size. Skip it too so
+            # the next chunk header stays aligned (common with LIST/bext/cue).
+            self._skip_remaining = chunk_size + (chunk_size & 1)
             self._state = _WavState.SKIP_CHUNK_DATA
         return pos
 
@@ -292,8 +295,13 @@ class _WavInlineDecoder:
         self._wave_channels = channels
         self._wave_rate = rate
         self._hdr_buf.clear()
-        self._need = 8
-        self._state = _WavState.CHUNK_HEADER
+        if self._chunk_size & 1:
+            # odd-sized fmt chunk carries a trailing pad byte (see _consume_chunk_header)
+            self._skip_remaining = 1
+            self._state = _WavState.SKIP_CHUNK_DATA
+        else:
+            self._need = 8
+            self._state = _WavState.CHUNK_HEADER
         return pos
 
     def _consume_skip(self, buf: memoryview, pos: int) -> int:

--- a/tests/test_audio_decoder.py
+++ b/tests/test_audio_decoder.py
@@ -401,6 +401,71 @@ async def test_wav_inline_decoder():
     await decoder.aclose()
 
 
+def _make_wav_with_ancillary(
+    sample_rate: int, num_channels: int, num_samples: int, ancillary_size: int
+) -> bytes:
+    """PCM16 WAV with an ancillary (LIST) chunk inserted before the `data` chunk.
+
+    RIFF requires odd-sized chunks to be followed by a pad byte that is not
+    counted in the chunk size; an odd ``ancillary_size`` therefore appends one.
+    """
+    bits_per_sample = 16
+    byte_rate = sample_rate * num_channels * bits_per_sample // 8
+    block_align = num_channels * bits_per_sample // 8
+    data_size = num_samples * num_channels * (bits_per_sample // 8)
+
+    fmt = struct.pack(
+        "<HHIIHH", 1, num_channels, sample_rate, byte_rate, block_align, bits_per_sample
+    )
+    anc = b"\x00" * ancillary_size
+    if ancillary_size % 2 == 1:
+        anc += b"\x00"  # RIFF word-alignment pad byte
+
+    body = (
+        b"fmt "
+        + struct.pack("<I", len(fmt))
+        + fmt
+        + b"LIST"
+        + struct.pack("<I", ancillary_size)
+        + anc
+        + b"data"
+        + struct.pack("<I", data_size)
+        + b"\x00" * data_size
+    )
+    return b"RIFF" + struct.pack("<I", 4 + len(body)) + b"WAVE" + body
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ancillary_size", [4, 3])  # even (no pad byte), odd (pad byte)
+async def test_wav_inline_decoder_odd_ancillary_chunk(ancillary_size: int):
+    """An odd-sized ancillary chunk before `data` must not misalign the parser.
+
+    RIFF pads an odd-sized chunk with a trailing byte; if the decoder does not
+    skip it, the following `data` header is read one byte early and all audio is
+    silently dropped (0 frames, no error).
+    """
+    sample_rate = 24000
+    num_channels = 1
+    num_samples = 2400  # 100ms
+
+    wav_bytes = _make_wav_with_ancillary(sample_rate, num_channels, num_samples, ancillary_size)
+
+    decoder = AudioStreamDecoder(
+        sample_rate=sample_rate, num_channels=num_channels, format="audio/wav"
+    )
+    # feed byte-by-byte so the incremental state machine crosses the pad byte
+    for b in wav_bytes:
+        decoder.push(bytes([b]))
+    decoder.end_input()
+
+    total_samples = 0
+    async for frame in decoder:
+        total_samples += frame.samples_per_channel
+
+    assert total_samples == num_samples
+    await decoder.aclose()
+
+
 @pytest.mark.asyncio
 async def test_wav_inline_decoder_with_resampling():
     """WAV inline decoder should correctly resample to a different output rate."""


### PR DESCRIPTION
What

RIFF chunks are word-aligned: a chunk whose size is odd is followed by a single pad byte that is **not** counted in the chunk size. The inline WAV decoder (`_WavInlineDecoder`) consumed exactly `chunk_size` bytes for skipped ancillary chunks (`LIST`/`bext`/`cue `/...) and for the `fmt ` chunk, then read the next chunk header immediately — one byte too early whenever the preceding chunk was odd. The misaligned header parses garbage, so the real `data` chunk is never found and every frame is silently dropped (0 frames, no error).

This hits any spec-compliant WAV that carries an odd-length metadata chunk before `data`, which tools like ffmpeg/sox routinely emit.

Repro (before fix):
```python
import asyncio, struct
from livekit.agents.utils.codecs import AudioStreamDecoder

def make_wav(anc_len):          # LIST chunk before data; odd len => 1 RIFF pad byte
    sr, ch, bps, n = 24000, 1, 16, 2400
    fmt = struct.pack("<HHIIHH", 1, ch, sr, sr*ch*bps//8, ch*bps//8, bps)
    anc = b"\x00"*anc_len + (b"\x00" if anc_len % 2 else b"")
    body = (b"fmt " + struct.pack("<I", len(fmt)) + fmt
            + b"LIST" + struct.pack("<I", anc_len) + anc
            + b"data" + struct.pack("<I", n*2) + b"\x00"*(n*2))
    return b"RIFF" + struct.pack("<I", 4+len(body)) + b"WAVE" + body, n

async def total(anc_len):
    wav, n = make_wav(anc_len)
    dec = AudioStreamDecoder(sample_rate=24000, num_channels=1, format="audio/wav")
    dec.push(wav); dec.end_input()
    return n, sum(f.samples_per_channel async for f in dec)

async def main():
    print("even LIST (no pad):", await total(4))   # (2400, 2400) ok
    print("odd  LIST (+pad):  ", await total(3))   # (2400, 0)    all audio lost
asyncio.run(main())
```

Fix

Fold the pad byte into the skip length for ancillary chunks (`chunk_size + (chunk_size & 1)`), and skip the trailing pad byte for an odd-sized `fmt ` chunk, so the following chunk header stays word-aligned.

Testing

- New parametrized regression test `test_wav_inline_decoder_odd_ancillary_chunk` (even control + odd case, fed byte-by-byte to exercise the incremental state machine across the pad byte) — red on the odd case before the fix, green after.
- Full `tests/test_audio_decoder.py` unit suite: 15 passed, 1 skipped (cloud-cred test), no regressions.
- `make check` (ruff format-check + ruff lint + strict mypy) clean.

AI disclosure

Investigated and implemented with Claude Code (Claude Opus 4.8); I reviewed the diff, wrote and ran the repro, ran the full test suite and `make check` myself before opening this PR.