### PR TITLE
fix(otel): add _root_span_context to user_turn/user_speaking

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1746,7 +1746,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         if state == "speaking" and self._user_speaking_span is None:
             self._user_speaking_span = tracer.start_span(
-                "user_speaking", start_time=last_speaking_time_ns
+                "user_speaking", context=self._root_span_context, start_time=last_speaking_time_ns
             )
 
             if self._room_io and self._room_io.linked_participant:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -1758,7 +1758,9 @@ class AudioRecognition:
         if start_time is None:
             start_time = time.time()
         start_time_ns = int(start_time * 1_000_000_000)
-        self._user_turn_span = tracer.start_span("user_turn", start_time=start_time_ns)
+        self._user_turn_span = tracer.start_span(
+            "user_turn", context=self._session._root_span_context, start_time=start_time_ns
+        )
 
         if self._user_turn_start is None:
             self._user_turn_start = start_time


### PR DESCRIPTION
After 1.6 user_turn spans are orphaned from the root span. This creates an issue when traces are ingested in langfuse. The orphaned traces produce multiple "observations" inside of 1 "session".