### PR TITLE
feat(fishaudio): expose temperature, top_p, bitrate, and normalize TTS options

### DIFF
--- a/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/__init__.py
+++ b/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/__init__.py
@@ -9,7 +9,7 @@ Environment variables used:
 from livekit.agents import Plugin
 
 from .log import logger
-from .models import LatencyMode, OutputFormat, TTSModels
+from .models import LatencyMode, MP3Bitrate, OpusBitrate, OutputFormat, TTSModels
 from .tts import TTS
 from .version import __version__
 
@@ -18,6 +18,8 @@ __all__ = [
     "TTSModels",
     "OutputFormat",
     "LatencyMode",
+    "MP3Bitrate",
+    "OpusBitrate",
     "__version__",
 ]
 

--- a/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/models.py
+++ b/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/models.py
@@ -5,3 +5,9 @@ TTSModels = Literal["s1", "s2-pro", "s2.1-pro"]
 OutputFormat = Literal["wav", "pcm", "mp3", "opus"]
 
 LatencyMode = Literal["normal", "balanced", "low"]
+
+MP3Bitrate = Literal[64, 128, 192]
+"""MP3 bitrate in kbps."""
+
+OpusBitrate = Literal[-1000, 24000, 32000, 48000, 64000]
+"""Opus bitrate in bps. ``-1000`` selects Fish Audio's automatic bitrate."""

--- a/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/tts.py
+++ b/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/tts.py
@@ -22,7 +22,7 @@ from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, NotGive
 from livekit.agents.utils import is_given
 
 from .log import logger
-from .models import LatencyMode, OutputFormat, TTSModels
+from .models import LatencyMode, MP3Bitrate, OpusBitrate, OutputFormat, TTSModels
 from .version import __version__
 
 DEFAULT_MODEL: TTSModels = "s2.1-pro"
@@ -53,6 +53,11 @@ class _TTSOptions:
     chunk_length: int
     speed: NotGivenOr[float]
     volume: NotGivenOr[float]
+    temperature: float
+    top_p: float
+    mp3_bitrate: MP3Bitrate
+    opus_bitrate: OpusBitrate
+    normalize: bool
 
     def get_http_url(self, path: str) -> str:
         return f"{self.base_url}{path}"
@@ -75,6 +80,11 @@ class TTS(tts.TTS):
         chunk_length: int = 100,
         speed: NotGivenOr[float] = NOT_GIVEN,
         volume: NotGivenOr[float] = NOT_GIVEN,
+        temperature: float = 0.7,
+        top_p: float = 0.7,
+        mp3_bitrate: MP3Bitrate = 64,
+        opus_bitrate: OpusBitrate = 64000,
+        normalize: bool = True,
         tokenizer: NotGivenOr[tokenize.SentenceTokenizer] = NOT_GIVEN,
         http_session: aiohttp.ClientSession | None = None,
     ) -> None:
@@ -104,6 +114,16 @@ class TTS(tts.TTS):
             volume (NotGivenOr[float]): Loudness adjustment in decibels (Fish
                 ``prosody.volume``). ``0`` is the voice's natural level. Unset leaves it
                 unchanged.
+            temperature (float): Sampling temperature (0–1). Higher values produce more
+                varied, expressive speech; lower values are more stable. Defaults to 0.7.
+            top_p (float): Nucleus sampling probability mass (0–1). Defaults to 0.7.
+            mp3_bitrate (MP3Bitrate): MP3 bitrate in kbps: 64, 128, or 192. Only used
+                when ``output_format`` is ``"mp3"``. Defaults to 64.
+            opus_bitrate (OpusBitrate): Opus bitrate in bps: -1000 (auto), 24000, 32000,
+                48000, or 64000. Only used when ``output_format`` is ``"opus"``.
+                Defaults to 64000.
+            normalize (bool): Whether Fish normalizes the input text (numbers, dates,
+                abbreviations) before synthesis. Defaults to True.
             tokenizer (tokenize.SentenceTokenizer): Sentence tokenizer used to detect
                 sentence boundaries. Defaults to ``tokenize.blingfire.SentenceTokenizer()``.
             http_session (aiohttp.ClientSession | None): Optional aiohttp session.
@@ -133,6 +153,10 @@ class TTS(tts.TTS):
 
         if not 100 <= chunk_length <= 300:
             raise ValueError("chunk_length must be between 100 and 300")
+        if not 0 <= temperature <= 1:
+            raise ValueError("temperature must be between 0 and 1")
+        if not 0 <= top_p <= 1:
+            raise ValueError("top_p must be between 0 and 1")
 
         self._opts = _TTSOptions(
             model=model,
@@ -145,6 +169,11 @@ class TTS(tts.TTS):
             chunk_length=chunk_length,
             speed=speed,
             volume=volume,
+            temperature=temperature,
+            top_p=top_p,
+            mp3_bitrate=mp3_bitrate,
+            opus_bitrate=opus_bitrate,
+            normalize=normalize,
         )
 
         self._session = http_session
@@ -219,6 +248,11 @@ class TTS(tts.TTS):
         chunk_length: NotGivenOr[int] = NOT_GIVEN,
         speed: NotGivenOr[float] = NOT_GIVEN,
         volume: NotGivenOr[float] = NOT_GIVEN,
+        temperature: NotGivenOr[float] = NOT_GIVEN,
+        top_p: NotGivenOr[float] = NOT_GIVEN,
+        mp3_bitrate: NotGivenOr[MP3Bitrate] = NOT_GIVEN,
+        opus_bitrate: NotGivenOr[OpusBitrate] = NOT_GIVEN,
+        normalize: NotGivenOr[bool] = NOT_GIVEN,
     ) -> None:
         if is_given(model) and model != self._opts.model:
             self._opts.model = model
@@ -239,6 +273,20 @@ class TTS(tts.TTS):
             self._opts.speed = speed
         if is_given(volume):
             self._opts.volume = volume
+        if is_given(temperature):
+            if not 0 <= temperature <= 1:
+                raise ValueError("temperature must be between 0 and 1")
+            self._opts.temperature = temperature
+        if is_given(top_p):
+            if not 0 <= top_p <= 1:
+                raise ValueError("top_p must be between 0 and 1")
+            self._opts.top_p = top_p
+        if is_given(mp3_bitrate):
+            self._opts.mp3_bitrate = mp3_bitrate
+        if is_given(opus_bitrate):
+            self._opts.opus_bitrate = opus_bitrate
+        if is_given(normalize):
+            self._opts.normalize = normalize
 
     def synthesize(
         self,
@@ -283,17 +331,17 @@ def _build_tts_request(opts: _TTSOptions, *, text: str = "") -> dict[str, Any]:
         "chunk_length": opts.chunk_length,
         "format": opts.output_format,
         "sample_rate": opts.sample_rate,
-        "mp3_bitrate": 64,
-        "opus_bitrate": 64000,
+        "mp3_bitrate": opts.mp3_bitrate,
+        "opus_bitrate": opts.opus_bitrate,
         "references": [],
         # Fish Audio's wire field is `reference_id`; we expose it as `voice_id` on
         # the plugin for consistency with other TTS plugins.
         "reference_id": opts.voice_id if is_given(opts.voice_id) else None,
-        "normalize": True,
+        "normalize": opts.normalize,
         "latency": opts.latency_mode,
         "prosody": prosody,
-        "top_p": 0.7,
-        "temperature": 0.7,
+        "top_p": opts.top_p,
+        "temperature": opts.temperature,
     }
 
 

--- a/tests/test_plugin_fishaudio_tts.py
+++ b/tests/test_plugin_fishaudio_tts.py
@@ -69,6 +69,72 @@ def test_update_options_sets_speed_and_volume():
     assert _build_tts_request(tts._opts, text="hi")["prosody"] == {"speed": 0.9, "volume": 2.0}
 
 
+def test_sampling_and_encoding_defaults_unchanged():
+    """Without overrides the request keeps the plugin's historical defaults."""
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    request = _build_tts_request(TTS_opts(), text="hi")
+    assert request["temperature"] == 0.7
+    assert request["top_p"] == 0.7
+    assert request["mp3_bitrate"] == 64
+    assert request["opus_bitrate"] == 64000
+    assert request["normalize"] is True
+
+
+def test_constructor_sets_sampling_and_encoding_params():
+    """temperature/top_p/mp3_bitrate/opus_bitrate/normalize flow onto the request."""
+    from livekit.plugins.fishaudio import TTS
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    tts = TTS(
+        api_key="test-key",
+        temperature=0.3,
+        top_p=0.9,
+        mp3_bitrate=192,
+        opus_bitrate=32000,
+        normalize=False,
+    )
+    request = _build_tts_request(tts._opts, text="hi")
+    assert request["temperature"] == 0.3
+    assert request["top_p"] == 0.9
+    assert request["mp3_bitrate"] == 192
+    assert request["opus_bitrate"] == 32000
+    assert request["normalize"] is False
+
+
+def test_update_options_sets_sampling_and_encoding_params():
+    """update_options forwards the new params onto the request."""
+    from livekit.plugins.fishaudio import TTS
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    tts = TTS(api_key="test-key")
+    tts.update_options(
+        temperature=0.5, top_p=0.8, mp3_bitrate=128, opus_bitrate=-1000, normalize=False
+    )
+    request = _build_tts_request(tts._opts, text="hi")
+    assert request["temperature"] == 0.5
+    assert request["top_p"] == 0.8
+    assert request["mp3_bitrate"] == 128
+    assert request["opus_bitrate"] == -1000
+    assert request["normalize"] is False
+
+
+def test_temperature_and_top_p_validated():
+    """Out-of-range temperature/top_p raise, in the constructor and update_options."""
+    from livekit.plugins.fishaudio import TTS
+
+    with pytest.raises(ValueError):
+        TTS(api_key="test-key", temperature=1.5)
+    with pytest.raises(ValueError):
+        TTS(api_key="test-key", top_p=-0.1)
+
+    tts = TTS(api_key="test-key")
+    with pytest.raises(ValueError):
+        tts.update_options(temperature=1.5)
+    with pytest.raises(ValueError):
+        tts.update_options(top_p=-0.1)
+
+
 def TTS_opts(**overrides):
     """Build a _TTSOptions with sensible test defaults, overriding as needed."""
     from livekit.plugins.fishaudio.tts import DEFAULT_BASE_URL, DEFAULT_MODEL, _TTSOptions
@@ -84,6 +150,11 @@ def TTS_opts(**overrides):
         "chunk_length": 100,
         "speed": NOT_GIVEN,
         "volume": NOT_GIVEN,
+        "temperature": 0.7,
+        "top_p": 0.7,
+        "mp3_bitrate": 64,
+        "opus_bitrate": 64000,
+        "normalize": True,
     }
     opts.update(overrides)
     return _TTSOptions(**opts)


### PR DESCRIPTION
## What

Exposes Fish Audio TTS request parameters that were previously hardcoded in the plugin's request builder:

- `temperature` (was fixed at 0.7) — sampling temperature, 0–1
- `top_p` (was fixed at 0.7) — nucleus sampling, 0–1
- `mp3_bitrate` (was fixed at 64) — 64 / 128 / 192 kbps
- `opus_bitrate` (was fixed at 64000) — -1000 (auto) / 24000 / 32000 / 48000 / 64000 bps
- `normalize` (was fixed at True) — Fish's input text normalization

All are available both as `TTS()` constructor options and via `update_options()` for runtime changes. `prosody.speed` / `prosody.volume` were already exposed (#6159), so this covers the remaining body params from the [Fish Audio TTS API](https://docs.fish.audio/api-reference/endpoint/openapi-v1/text-to-speech) that make sense for realtime agents.

## Why

Users tuning voice expressiveness (temperature/top_p) or audio bandwidth (bitrates) currently have no way to set these through the plugin and have to patch it or bypass it.

## Notes

- Defaults are unchanged: the request built with no new arguments is byte-for-byte identical to before.
- `temperature`/`top_p` are range-validated (0–1) in both the constructor and `update_options()`, matching the existing `chunk_length` validation style.
- New `MP3Bitrate` / `OpusBitrate` literal types are exported from the plugin.
- Added tests for the new params (defaults, constructor, `update_options`, validation); `uv run pytest tests/test_plugin_fishaudio_tts.py` → 11 passed, ruff check/format clean.