### PR TITLE
fix(openai): remove misleading default model for Azure LLM

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -190,7 +190,7 @@ class LLM(llm.LLM):
     @staticmethod
     def with_azure(
         *,
-        model: str | ChatModels = "gpt-4o",
+        model: str | ChatModels | None = None,
         azure_endpoint: str | None = None,
         azure_deployment: str | None = None,
         api_version: str | None = None,
@@ -239,7 +239,7 @@ class LLM(llm.LLM):
         )  # type: ignore
 
         llm = LLM(
-            model=model,
+            model=model if model is not None else (azure_deployment or ""),
             client=azure_client,
             user=user,
             temperature=temperature,


### PR DESCRIPTION
## What

Removes the confusing `model="gpt-4o"` default from `LLM.with_azure()`. Azure OpenAI uses `azure_deployment` to select models — the `model` parameter is ignored by the Azure API. The old default caused `.model` to return `"gpt-4o"` regardless of the actual deployment in use.

## Changes

- `with_azure(model=...)` now defaults to `None` instead of `"gpt-4o"`
- When `model` is not provided, `.model` falls back to `azure_deployment`, giving callers an accurate identifier
- Explicit `model=` still works as an override

## Migration

- Users who relied on `.model` returning `"gpt-4o"` should pass `model="gpt-4o"` explicitly (though this was already misleading)
- Users who didn't pass `model=` now get their `azure_deployment` name from `.model`, which is the correct behavior

Closes #6209