### PR TITLE
fix(stt): don't clear the primary speaker on an unattributed segment

### DIFF
--- a/livekit-agents/livekit/agents/stt/multi_speaker_adapter.py
+++ b/livekit-agents/livekit/agents/stt/multi_speaker_adapter.py
@@ -283,8 +283,13 @@ class _PrimarySpeakerDetector:
         return float(np.median(self._rms_buffer[start:end]))
 
     def _update_primary_speaker(self, sd: SpeechData) -> None:
-        if sd.speaker_id is None or not self._detect_primary:
+        if not self._detect_primary:
             self._primary_speaker = None
+            return
+
+        if sd.speaker_id is None:
+            # an unattributed segment carries no evidence about who is primary,
+            # so leave the current primary in place rather than clearing it
             return
 
         rms = self._get_rms_for_timerange(sd.start_time, sd.end_time)

--- a/tests/test_multi_speaker_primary_speaker.py
+++ b/tests/test_multi_speaker_primary_speaker.py
@@ -1,0 +1,88 @@
+import pytest
+
+from livekit import rtc
+from livekit.agents.stt import SpeechData
+from livekit.agents.stt.multi_speaker_adapter import (
+    PrimarySpeakerDetectionOptions,
+    _PrimarySpeakerDetector,
+)
+
+pytestmark = pytest.mark.unit
+
+SAMPLE_RATE = 1000
+SAMPLES_PER_FRAME = 100  # 100ms at 1000Hz, matches frame_size_ms below
+
+
+def _constant_frame(value: int) -> rtc.AudioFrame:
+    """Build a mono int16 frame where every sample equals ``value``."""
+    return rtc.AudioFrame(
+        data=value.to_bytes(2, "little", signed=True) * SAMPLES_PER_FRAME,
+        sample_rate=SAMPLE_RATE,
+        num_channels=1,
+        samples_per_channel=SAMPLES_PER_FRAME,
+    )
+
+
+def _speech_data(speaker_id: str | None, start_time: float, end_time: float) -> SpeechData:
+    return SpeechData(
+        language="en",
+        text="hello",
+        start_time=start_time,
+        end_time=end_time,
+        speaker_id=speaker_id,
+    )
+
+
+def _detector() -> _PrimarySpeakerDetector:
+    opts = PrimarySpeakerDetectionOptions(frame_size_ms=100, min_rms_samples=1)
+    return _PrimarySpeakerDetector(primary_detection_options=opts)
+
+
+def _push_speech(
+    detector: _PrimarySpeakerDetector,
+    speaker_id: str | None,
+    amplitude: int,
+    start_time: float,
+) -> None:
+    detector.push_audio(_constant_frame(amplitude))
+    detector.push_audio(_constant_frame(amplitude))
+    detector._update_primary_speaker(_speech_data(speaker_id, start_time, start_time + 0.2))
+
+
+class TestPrimarySpeakerReset:
+    def test_quiet_speaker_does_not_take_over(self) -> None:
+        """Control: a much quieter speaker never becomes primary."""
+        detector = _detector()
+
+        _push_speech(detector, "A", amplitude=3000, start_time=0.0)
+        assert detector._primary_speaker == "A"
+
+        _push_speech(detector, "B", amplitude=50, start_time=0.2)
+        assert detector._primary_speaker == "A"
+
+    def test_unattributed_segment_keeps_primary_speaker(self) -> None:
+        """A final transcript the diarizer could not attribute is not evidence
+        that the primary speaker stopped being primary.
+        """
+        detector = _detector()
+
+        _push_speech(detector, "A", amplitude=3000, start_time=0.0)
+        assert detector._primary_speaker == "A"
+
+        _push_speech(detector, None, amplitude=3000, start_time=0.2)
+        assert detector._primary_speaker == "A"
+
+        # Without the primary retained, B skips the loudness comparison entirely
+        # and is crowned as "first speaker" despite being 60x quieter.
+        _push_speech(detector, "B", amplitude=50, start_time=0.4)
+        assert detector._primary_speaker == "A"
+
+    def test_detect_primary_disabled_keeps_primary_unset(self) -> None:
+        opts = PrimarySpeakerDetectionOptions(frame_size_ms=100, min_rms_samples=1)
+        detector = _PrimarySpeakerDetector(
+            detect_primary_speaker=False, primary_detection_options=opts
+        )
+
+        _push_speech(detector, "A", amplitude=3000, start_time=0.0)
+
+        assert detector._primary_speaker is None


### PR DESCRIPTION
## Summary

`_PrimarySpeakerDetector._update_primary_speaker` clears `_primary_speaker` whenever a final transcript arrives without a `speaker_id`, because that case is folded in with `detect_primary_speaker=False`:

```python
if sd.speaker_id is None or not self._detect_primary:
    self._primary_speaker = None
    return
```

Those are different situations. The flag being off means "never track a primary"; a missing `speaker_id` just means the diarizer couldn't attribute this one segment.

Clearing matters because `None` is also the "no primary yet" sentinel — the next attributed segment takes the `it's the first speaker` branch and is crowned with no loudness comparison. One unattributed segment is enough to hand primary to a quiet background speaker:

| | primary |
|---|---|
| A speaks (amplitude 3000) | `A` |
| unattributed segment (no `speaker_id`) | `None` |
| B speaks (amplitude 50, 60x quieter) | `B` — skipped the RMS threshold |

Without the unattributed segment in the middle, B is correctly rejected and A stays primary.

`on_stt_event` already guards `speaker_id is None` before touching `_primary_speaker`, so the unattributed segment was never going to be labelled either way — the only effect of clearing was losing the tracked state.

## Scope

The `detect_primary_speaker=False` branch keeps its current behaviour; only the missing-`speaker_id` path changes. This is reachable through `MultiSpeakerAdapter` (exported from `livekit.agents.stt`), which needs a diarization-capable STT — it has no in-repo callers, so nothing inside the framework changes.

## Testing

New `tests/test_multi_speaker_primary_speaker.py`, three unit tests: the quiet-speaker control, the bug case, and the `detect_primary_speaker=False` behaviour. The bug test fails on `main` and passes with this change; the other two pass on both. Existing stt tests (`test_speaker_id_grouping`, `test_stt*`) — 49 passed. `ruff check`/`ruff format` clean; `mypy` reports the same 14 pre-existing errors in other files with and without this diff, none in the file I touched.

Disclosure: written with Claude Code. I verified the reproduction, the reachability, and the test red/green myself.
