### PR TITLE
fix(elevenlabs): populate SpeechData.confidence from Scribe logprobs

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import math
 import os
 import weakref
 from dataclasses import dataclass
@@ -46,6 +47,25 @@ from .models import STTRealtimeSampleRates
 
 API_BASE_URL_V1 = "https://api.elevenlabs.io/v1"
 AUTHORIZATION_HEADER = "xi-api-key"
+
+
+def _speech_confidence(words: list[dict[str, Any]] | None) -> float:
+    """Aggregate ElevenLabs per-word logprobs into a [0, 1] transcription confidence.
+
+    Scribe returns a natural-log probability (``logprob``) per token; we average the
+    spoken-word logprobs and exponentiate to a probability (the geometric mean of the
+    token probabilities). Returns ``0.0`` when no per-word logprobs are available.
+    """
+    if not words:
+        return 0.0
+    logprobs = [
+        w["logprob"]
+        for w in words
+        if w.get("type") == "word" and isinstance(w.get("logprob"), (int, float))
+    ]
+    if not logprobs:
+        return 0.0
+    return min(1.0, max(0.0, math.exp(sum(logprobs) / len(logprobs))))
 
 
 class VADOptions(TypedDict, total=False):
@@ -284,6 +304,7 @@ class STT(stt.STT):
                     speaker_id=speaker_id,
                     start_time=start_time,
                     end_time=end_time,
+                    confidence=_speech_confidence(words),
                     words=[
                         TimedString(
                             text=word.get("text", ""),
@@ -591,6 +612,7 @@ class SpeechStream(stt.SpeechStream):
             text=text,
             start_time=start_time + self.start_time_offset,
             end_time=end_time + self.start_time_offset,
+            confidence=_speech_confidence(words),
         )
         if words:
             speech_data.words = [

--- a/tests/test_plugin_elevenlabs_stt.py
+++ b/tests/test_plugin_elevenlabs_stt.py
@@ -167,3 +167,43 @@ def test_trace_id_from_headers() -> None:
     assert trace_id_from_headers(CIMultiDict({"X-Trace-Id": "trace-1"})) == "trace-1"
     assert trace_id_from_headers(CIMultiDict()) is None
     assert trace_id_from_headers(None) is None
+
+
+def test_speech_confidence_from_word_logprobs() -> None:
+    # confident transcription: word logprobs near 0 -> confidence near 1 (spacing tokens ignored)
+    words = [
+        {"type": "word", "logprob": -0.01},
+        {"type": "spacing", "logprob": -2.0},
+        {"type": "word", "logprob": -0.05},
+    ]
+    assert 0.9 < elevenlabs_stt._speech_confidence(words) <= 1.0
+
+
+def test_speech_confidence_flags_low_quality_transcription() -> None:
+    # uncertain transcription (very negative logprobs) -> low confidence
+    words = [{"type": "word", "logprob": -2.5}, {"type": "word", "logprob": -3.0}]
+    assert elevenlabs_stt._speech_confidence(words) < 0.2
+
+
+def test_speech_confidence_defaults_to_zero_without_logprobs() -> None:
+    # no words, or words without logprobs (e.g. non-timestamped commit) -> default 0.0
+    assert elevenlabs_stt._speech_confidence(None) == 0.0
+    assert elevenlabs_stt._speech_confidence([{"text": "hi", "start": 0.1, "end": 0.4}]) == 0.0
+
+
+def test_committed_transcript_sets_confidence() -> None:
+    stream = _new_stream(server_vad={"vad_silence_threshold_secs": 0.5})
+
+    stream._process_stream_event(
+        {
+            "message_type": "committed_transcript",
+            "text": "hello",
+            "words": [
+                {"text": "hello", "start": 0.1, "end": 0.4, "type": "word", "logprob": -0.02}
+            ],
+        }
+    )
+
+    final = stream._event_ch.events[1]
+    assert final.type == stt.SpeechEventType.FINAL_TRANSCRIPT
+    assert final.alternatives[0].confidence > 0.9


### PR DESCRIPTION
## What / Why

The ElevenLabs STT plugin never populates `SpeechData.confidence`, so it always stays at its `0.0` default — even though Scribe returns a per-word `logprob` in every response. Consumers that use `confidence` (e.g. to tell a clean transcript from a low-confidence / garbled one) get no signal from ElevenLabs.

Verified live: both `scribe_v1`/`scribe_v2` (REST) and `scribe_v2_realtime` return a natural-log `logprob` per `words[]` token, but `_process_stream_event` / `_transcription_to_speech_event` read only `text` + word `start`/`end`, so it is discarded and `confidence` stays `0.0`.

## Change

Add `_speech_confidence(words)`: average the spoken-word (`type == "word"`) logprobs and exponentiate → a `[0, 1]` confidence (geometric mean of the token probabilities). Returns `0.0` when per-word logprobs aren't available (e.g. a non-timestamped commit), so behaviour is unchanged there.

Wired into both the REST and WebSocket `SpeechData` construction.

Note: this deliberately does **not** use Scribe's `language_probability` — that is language-identification confidence, a different quantity from transcription confidence, so folding it into `SpeechData.confidence` would be misleading.

Same class of fix as #5829 / #5830 (a sibling STT plugin not threading its confidence into `SpeechData`).

## Tests

Unit tests for the helper (confident vs low-confidence logprobs, no-logprob → `0.0`) and an end-to-end check that a committed transcript sets `confidence`. `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)