### PR TITLE
fix(stt): raise retryable APIConnectionError on mid-send socket drops

### DIFF
--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -817,33 +817,40 @@ class SpeechStream(stt.SpeechStream):
                 samples_per_channel=self._opts.sample_rate // 20,  # 50ms
             )
 
-            async for ev in self._input_ch:
-                frames: list[rtc.AudioFrame] = []
-                if isinstance(ev, rtc.AudioFrame):
-                    if vad_stream is not None:
-                        vad_stream.push_frame(ev)
-                    frames.extend(audio_bstream.push(ev.data))
-                elif isinstance(ev, self._FlushSentinel):
-                    frames.extend(audio_bstream.flush())
+            try:
+                async for ev in self._input_ch:
+                    frames: list[rtc.AudioFrame] = []
+                    if isinstance(ev, rtc.AudioFrame):
+                        if vad_stream is not None:
+                            vad_stream.push_frame(ev)
+                        frames.extend(audio_bstream.push(ev.data))
+                    elif isinstance(ev, self._FlushSentinel):
+                        frames.extend(audio_bstream.flush())
 
-                for frame in frames:
-                    self._speech_duration += frame.duration
-                    audio_bytes = frame.data.tobytes()
-                    base64_audio = base64.b64encode(audio_bytes).decode("utf-8")
-                    audio_msg = {
-                        "type": "input_audio",
-                        "audio": base64_audio,
-                    }
-                    await ws.send_str(json.dumps(audio_msg))
+                    for frame in frames:
+                        self._speech_duration += frame.duration
+                        audio_bytes = frame.data.tobytes()
+                        base64_audio = base64.b64encode(audio_bytes).decode("utf-8")
+                        audio_msg = {
+                            "type": "input_audio",
+                            "audio": base64_audio,
+                        }
+                        await ws.send_str(json.dumps(audio_msg))
 
-            if vad_stream is not None:
-                vad_stream.end_input()
+                if vad_stream is not None:
+                    vad_stream.end_input()
 
-            closing_ws = True
-            finalize_msg = {
-                "type": "session.finalize",
-            }
-            await ws.send_str(json.dumps(finalize_msg))
+                closing_ws = True
+                finalize_msg = {
+                    "type": "session.finalize",
+                }
+                await ws.send_str(json.dumps(finalize_msg))
+            except (aiohttp.ClientError, ConnectionError) as e:
+                if closing_ws or http_session.closed:
+                    return
+                raise APIConnectionError(
+                    "LiveKit Inference STT connection closed unexpectedly"
+                ) from e
 
         @utils.log_exceptions(logger=logger)
         async def vad_task(ws: aiohttp.ClientWebSocketResponse, stream: vad.VADStream) -> None:

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -29,6 +29,7 @@ import aiohttp
 
 from livekit.agents import (
     DEFAULT_API_CONNECT_OPTIONS,
+    APIConnectionError,
     APIConnectOptions,
     APIStatusError,
     LanguageCode,
@@ -685,27 +686,32 @@ class SpeechStream(stt.SpeechStream):
             # forward inputs to AssemblyAI
             # if we receive a close message, signal it to AssemblyAI and break.
             # the recv task will then make sure to process the remaining audio and stop
-            async for data in self._input_ch:
-                if isinstance(data, self._FlushSentinel):
-                    frames = audio_bstream.flush()
-                else:
-                    frames = audio_bstream.write(data.data.tobytes())
+            try:
+                async for data in self._input_ch:
+                    if isinstance(data, self._FlushSentinel):
+                        frames = audio_bstream.flush()
+                    else:
+                        frames = audio_bstream.write(data.data.tobytes())
 
-                for frame in frames:
-                    if not anchored:
-                        # Anchor the stream's wall-clock to the moment just
-                        # before the first frame is sent — aligned with the
-                        # server's stream-relative zero used by
-                        # SpeechStarted.timestamp.
-                        self.start_time = time.time()
-                        anchored = True
-                    self._speech_duration += frame.duration
-                    await ws.send_bytes(frame.data.tobytes())
-                    self._last_frame_sent_at = time.time()
+                    for frame in frames:
+                        if not anchored:
+                            # Anchor the stream's wall-clock to the moment just
+                            # before the first frame is sent — aligned with the
+                            # server's stream-relative zero used by
+                            # SpeechStarted.timestamp.
+                            self.start_time = time.time()
+                            anchored = True
+                        self._speech_duration += frame.duration
+                        await ws.send_bytes(frame.data.tobytes())
+                        self._last_frame_sent_at = time.time()
 
-            closing_ws = True
-            logger.debug("AssemblyAI sending close message session=%s", self._session_id)
-            await ws.send_str(SpeechStream._CLOSE_MSG)
+                closing_ws = True
+                logger.debug("AssemblyAI sending close message session=%s", self._session_id)
+                await ws.send_str(SpeechStream._CLOSE_MSG)
+            except (aiohttp.ClientError, ConnectionError) as e:
+                if closing_ws or self._session.closed:
+                    return
+                raise APIConnectionError("AssemblyAI connection closed unexpectedly") from e
 
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
             nonlocal closing_ws

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/stt.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/stt.py
@@ -30,6 +30,7 @@ import numpy as np
 
 from livekit.agents import (
     DEFAULT_API_CONNECT_OPTIONS,
+    APIConnectionError,
     APIConnectOptions,
     APIStatusError,
     LanguageCode,
@@ -341,18 +342,23 @@ class SpeechStream(stt.SpeechStream):
                 samples_per_channel=samples_per_buffer,
             )
 
-            async for data in self._input_ch:
-                if isinstance(data, self._FlushSentinel):
-                    frames = audio_bstream.flush()
-                else:
-                    frames = audio_bstream.write(data.data.tobytes())
+            try:
+                async for data in self._input_ch:
+                    if isinstance(data, self._FlushSentinel):
+                        frames = audio_bstream.flush()
+                    else:
+                        frames = audio_bstream.write(data.data.tobytes())
 
-                for frame in frames:
-                    if len(frame.data) % 2 != 0:
-                        logger.warning("Frame data size not aligned to float32 (multiple of 4)")
+                    for frame in frames:
+                        if len(frame.data) % 2 != 0:
+                            logger.warning("Frame data size not aligned to float32 (multiple of 4)")
 
-                    int16_array = np.frombuffer(frame.data, dtype=np.int16)
-                    await ws.send_bytes(int16_array.tobytes())
+                        int16_array = np.frombuffer(frame.data, dtype=np.int16)
+                        await ws.send_bytes(int16_array.tobytes())
+            except (aiohttp.ClientError, ConnectionError) as e:
+                if closing_ws or self._session.closed:
+                    return
+                raise APIConnectionError("Baseten connection closed unexpectedly") from e
 
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
             nonlocal closing_ws

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/_recognize_streams/auto_finalize_recognize_stream.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/_recognize_streams/auto_finalize_recognize_stream.py
@@ -254,23 +254,31 @@ class AutoFinalizeRecognizeStream(CartesiaRecognizeStream):
                 samples_per_channel=samples_per_chunk,
             )
 
-            async for data in self._input_ch:
-                if isinstance(data, rtc.AudioFrame):
-                    for frame in audio_bstream.write(data.data.tobytes()):
-                        self._speech_duration += frame.duration
-                        await ws.send_bytes(frame.data.tobytes())
-                elif isinstance(data, self._FlushSentinel):
-                    if not self._input_ch.closed:
-                        logger.warning(
-                            "Cartesia STT stream.flush() was ignored. See https://docs.cartesia.ai/use-the-api/compare-stt-endpoints for details."
-                        )
+            try:
+                async for data in self._input_ch:
+                    if isinstance(data, rtc.AudioFrame):
+                        for frame in audio_bstream.write(data.data.tobytes()):
+                            self._speech_duration += frame.duration
+                            await ws.send_bytes(frame.data.tobytes())
+                    elif isinstance(data, self._FlushSentinel):
+                        if not self._input_ch.closed:
+                            logger.warning(
+                                "Cartesia STT stream.flush() was ignored. See https://docs.cartesia.ai/use-the-api/compare-stt-endpoints for details."
+                            )
 
-            for frame in audio_bstream.flush():
-                self._speech_duration += frame.duration
-                await ws.send_bytes(frame.data.tobytes())
+                for frame in audio_bstream.flush():
+                    self._speech_duration += frame.duration
+                    await ws.send_bytes(frame.data.tobytes())
 
-            self._closing_ws = True
-            await ws.send_str('{"type":"close"}')
+                self._closing_ws = True
+                await ws.send_str('{"type":"close"}')
+            except (aiohttp.ClientError, ConnectionError) as e:
+                if self._closing_ws or self._session.closed:
+                    return
+                raise APIConnectionError(
+                    message="Cartesia STT connection closed unexpectedly",
+                    retryable=True,
+                ) from e
 
         @utils.log_exceptions(logger=logger)
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/_recognize_streams/legacy_recognize_stream.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/_recognize_streams/legacy_recognize_stream.py
@@ -197,27 +197,35 @@ class LegacyRecognizeStream(CartesiaRecognizeStream):
                 samples_per_channel=samples_per_chunk,
             )
 
-            async for data in self._input_ch:
-                frames: list[rtc.AudioFrame | LegacyRecognizeStream._FlushSentinel] = []
-                if isinstance(data, rtc.AudioFrame):
-                    frames.extend(audio_bstream.write(data.data.tobytes()))
-                elif isinstance(data, self._FlushSentinel):
-                    frames.extend(audio_bstream.flush())
-                    frames.append(data)
+            try:
+                async for data in self._input_ch:
+                    frames: list[rtc.AudioFrame | LegacyRecognizeStream._FlushSentinel] = []
+                    if isinstance(data, rtc.AudioFrame):
+                        frames.extend(audio_bstream.write(data.data.tobytes()))
+                    elif isinstance(data, self._FlushSentinel):
+                        frames.extend(audio_bstream.flush())
+                        frames.append(data)
 
-                for frame in frames:
-                    if isinstance(frame, self._FlushSentinel):
-                        await ws.send_str("finalize")
-                    else:
-                        self._speech_duration += frame.duration
-                        await ws.send_bytes(frame.data.tobytes())
+                    for frame in frames:
+                        if isinstance(frame, self._FlushSentinel):
+                            await ws.send_str("finalize")
+                        else:
+                            self._speech_duration += frame.duration
+                            await ws.send_bytes(frame.data.tobytes())
 
-            for frame in audio_bstream.flush():
-                self._speech_duration += frame.duration
-                await ws.send_bytes(frame.data.tobytes())
+                for frame in audio_bstream.flush():
+                    self._speech_duration += frame.duration
+                    await ws.send_bytes(frame.data.tobytes())
 
-            closing_ws = True
-            await ws.send_str("close")
+                closing_ws = True
+                await ws.send_str("close")
+            except (aiohttp.ClientError, ConnectionError) as e:
+                if closing_ws or self._session.closed:
+                    return
+                raise APIConnectionError(
+                    message="Cartesia STT connection closed unexpectedly",
+                    retryable=True,
+                ) from e
 
         @utils.log_exceptions(logger=logger)
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
@@ -421,34 +421,39 @@ class SpeechStream(stt.SpeechStream):
             )
 
             has_ended = False
-            async for data in self._input_ch:
-                # Write audio bytes to buffer and get 50ms frames
-                frames: list[rtc.AudioFrame] = []
-                if isinstance(data, rtc.AudioFrame):
-                    frames.extend(audio_bstream.write(data.data.tobytes()))
-                elif isinstance(data, self._FlushSentinel):
-                    frames.extend(audio_bstream.flush())
-                    has_ended = True
+            try:
+                async for data in self._input_ch:
+                    # Write audio bytes to buffer and get 50ms frames
+                    frames: list[rtc.AudioFrame] = []
+                    if isinstance(data, rtc.AudioFrame):
+                        frames.extend(audio_bstream.write(data.data.tobytes()))
+                    elif isinstance(data, self._FlushSentinel):
+                        frames.extend(audio_bstream.flush())
+                        has_ended = True
 
-                for frame in frames:
-                    self._audio_duration_collector.push(frame.duration)
-                    audio_b64 = base64.b64encode(frame.data.tobytes()).decode("utf-8")
-                    await ws.send_str(
-                        json.dumps(
-                            {
-                                "message_type": "input_audio_chunk",
-                                "audio_base_64": audio_b64,
-                                "commit": False,
-                                "sample_rate": self._opts.sample_rate,
-                            }
+                    for frame in frames:
+                        self._audio_duration_collector.push(frame.duration)
+                        audio_b64 = base64.b64encode(frame.data.tobytes()).decode("utf-8")
+                        await ws.send_str(
+                            json.dumps(
+                                {
+                                    "message_type": "input_audio_chunk",
+                                    "audio_base_64": audio_b64,
+                                    "commit": False,
+                                    "sample_rate": self._opts.sample_rate,
+                                }
+                            )
                         )
-                    )
 
-                    if has_ended:
-                        self._audio_duration_collector.flush()
-                        has_ended = False
+                        if has_ended:
+                            self._audio_duration_collector.flush()
+                            has_ended = False
 
-            closing_ws = True
+                closing_ws = True
+            except (aiohttp.ClientError, ConnectionError) as e:
+                if closing_ws or self._session.closed:
+                    return
+                raise APIConnectionError("ElevenLabs STT connection closed unexpectedly") from e
 
         @utils.log_exceptions(logger=logger)
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:

--- a/livekit-plugins/livekit-plugins-gladia/livekit/plugins/gladia/stt.py
+++ b/livekit-plugins/livekit-plugins-gladia/livekit/plugins/gladia/stt.py
@@ -949,46 +949,53 @@ class SpeechStream(stt.SpeechStream):
 
         has_ended = False
         last_frame: rtc.AudioFrame | None = None
+        closing_ws = False
 
-        async for data in self._input_ch:
-            if not self._ws:
-                break
+        try:
+            async for data in self._input_ch:
+                if not self._ws:
+                    break
 
-            frames: list[rtc.AudioFrame] = []
-            if isinstance(data, rtc.AudioFrame):
-                state = self._check_energy_state(data)
-                if state in (
-                    AudioEnergyFilter.State.START,
-                    AudioEnergyFilter.State.SPEAKING,
-                ):
-                    if last_frame:
-                        frames.extend(audio_bstream.write(last_frame.data.tobytes()))
-                        last_frame = None
-                    frames.extend(audio_bstream.write(data.data.tobytes()))
-                elif state == AudioEnergyFilter.State.END:
+                frames: list[rtc.AudioFrame] = []
+                if isinstance(data, rtc.AudioFrame):
+                    state = self._check_energy_state(data)
+                    if state in (
+                        AudioEnergyFilter.State.START,
+                        AudioEnergyFilter.State.SPEAKING,
+                    ):
+                        if last_frame:
+                            frames.extend(audio_bstream.write(last_frame.data.tobytes()))
+                            last_frame = None
+                        frames.extend(audio_bstream.write(data.data.tobytes()))
+                    elif state == AudioEnergyFilter.State.END:
+                        frames = audio_bstream.flush()
+                        has_ended = True
+                    elif state == AudioEnergyFilter.State.SILENCE:
+                        last_frame = data
+                elif isinstance(data, self._FlushSentinel):
                     frames = audio_bstream.flush()
                     has_ended = True
-                elif state == AudioEnergyFilter.State.SILENCE:
-                    last_frame = data
-            elif isinstance(data, self._FlushSentinel):
-                frames = audio_bstream.flush()
-                has_ended = True
 
-            for frame in frames:
-                self._audio_duration_collector.push(frame.duration)
-                # Encode the audio data as base64
-                chunk_b64 = base64.b64encode(frame.data.tobytes()).decode("utf-8")
-                message = json.dumps({"type": "audio_chunk", "data": {"chunk": chunk_b64}})
-                await self._ws.send_str(message)
+                for frame in frames:
+                    self._audio_duration_collector.push(frame.duration)
+                    # Encode the audio data as base64
+                    chunk_b64 = base64.b64encode(frame.data.tobytes()).decode("utf-8")
+                    message = json.dumps({"type": "audio_chunk", "data": {"chunk": chunk_b64}})
+                    await self._ws.send_str(message)
 
-                if has_ended:
-                    self._audio_duration_collector.flush()
-                    await self._ws.send_str(json.dumps({"type": "stop_recording"}))
-                    has_ended = False
+                    if has_ended:
+                        self._audio_duration_collector.flush()
+                        await self._ws.send_str(json.dumps({"type": "stop_recording"}))
+                        has_ended = False
 
-        # Tell Gladia we're done sending audio when the stream ends
-        if self._ws:
-            await self._ws.send_str(json.dumps({"type": "stop_recording"}))
+            # Tell Gladia we're done sending audio when the stream ends
+            closing_ws = True
+            if self._ws:
+                await self._ws.send_str(json.dumps({"type": "stop_recording"}))
+        except (aiohttp.ClientError, ConnectionError) as e:
+            if closing_ws or self._session.closed:
+                return
+            raise APIConnectionError("Gladia connection closed unexpectedly") from e
 
     async def _recv_messages_task(self) -> None:
         """Receive and process messages from Gladia WebSocket."""

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -554,34 +554,49 @@ class SpeechStream(stt.SpeechStream):
                 samples_per_channel=SAMPLE_RATE // 20,
             )
 
-            async for data in self._input_ch:
-                frames: list[rtc.AudioFrame] = []
-                if isinstance(data, rtc.AudioFrame):
-                    if vad_stream is not None:
-                        vad_stream.push_frame(data)
-                    frames.extend(audio_bstream.write(data.data.tobytes()))
-                elif isinstance(data, self._FlushSentinel):
-                    frames.extend(audio_bstream.flush())
+            try:
+                async for data in self._input_ch:
+                    frames: list[rtc.AudioFrame] = []
+                    if isinstance(data, rtc.AudioFrame):
+                        if vad_stream is not None:
+                            vad_stream.push_frame(data)
+                        frames.extend(audio_bstream.write(data.data.tobytes()))
+                    elif isinstance(data, self._FlushSentinel):
+                        frames.extend(audio_bstream.flush())
 
-                for frame in frames:
-                    encoded_frame = {
-                        "type": "input_audio_buffer.append",
-                        "audio": base64.b64encode(frame.data.tobytes()).decode("utf-8"),
-                    }
-                    await ws.send_json(encoded_frame)
+                    for frame in frames:
+                        encoded_frame = {
+                            "type": "input_audio_buffer.append",
+                            "audio": base64.b64encode(frame.data.tobytes()).decode("utf-8"),
+                        }
+                        await ws.send_json(encoded_frame)
+            except (aiohttp.ClientError, ConnectionError) as e:
+                if closing_ws:
+                    return
+                raise APIConnectionError(
+                    "OpenAI Realtime STT connection closed unexpectedly"
+                ) from e
+            finally:
+                if vad_stream is not None:
+                    vad_stream.end_input()
 
-            if vad_stream is not None:
-                vad_stream.end_input()
             closing_ws = True
 
         @utils.log_exceptions(logger=logger)
         async def vad_task(ws: aiohttp.ClientWebSocketResponse, vad_stream: vad.VADStream) -> None:
-            async for ev in vad_stream:
-                if ev.type == vad.VADEventType.START_OF_SPEECH:
-                    self._start_speaking()
-                elif ev.type == vad.VADEventType.END_OF_SPEECH:
-                    self._stop_speaking()
-                    await ws.send_json({"type": "input_audio_buffer.commit"})
+            try:
+                async for ev in vad_stream:
+                    if ev.type == vad.VADEventType.START_OF_SPEECH:
+                        self._start_speaking()
+                    elif ev.type == vad.VADEventType.END_OF_SPEECH:
+                        self._stop_speaking()
+                        await ws.send_json({"type": "input_audio_buffer.commit"})
+            except (aiohttp.ClientError, ConnectionError) as e:
+                if closing_ws:
+                    return
+                raise APIConnectionError(
+                    "OpenAI Realtime STT connection closed unexpectedly"
+                ) from e
 
         @utils.log_exceptions(logger=logger)
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:


### PR DESCRIPTION
reconnects instead of dying when the websocket drops mid-send. 

standardized across:
- deepgram (merged in #6429)
- inference
- assembly ai
- baseten
- cartesia
- gladia
- openai
- elevenlabs