### PR TITLE
(xai tts inference): add optimize_streaming_latency param, fix typecheck

### DIFF
--- a/livekit-agents/livekit/agents/inference/tts.py
+++ b/livekit-agents/livekit/agents/inference/tts.py
@@ -191,6 +191,7 @@ class InworldOptions(TypedDict, total=False):
 class XaiOptions(TypedDict, total=False):
     bit_rate: Literal[32000, 64000, 96000, 128000, 192000]
     speed: float  # speaking-rate multiplier, default 1.0
+    optimize_streaming_latency: Literal[0, 1, 2]  # latency optimization level, default 0
 
 
 TTSEncoding = Literal["pcm_s16le"]

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -15,7 +15,6 @@ from typing import (
     Literal,
     Protocol,
     TypeVar,
-    cast,
     overload,
     runtime_checkable,
 )
@@ -1155,7 +1154,6 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         endpointing_opts: NotGivenOr[EndpointingOptions] = NOT_GIVEN,
         turn_detection: NotGivenOr[TurnDetectionMode | None] = NOT_GIVEN,
         keyterms: NotGivenOr[list[str]] = NOT_GIVEN,
-        expressive: NotGivenOr[bool | ExpressiveOptions] = NOT_GIVEN,
         # deprecated
         min_endpointing_delay: NotGivenOr[float] = NOT_GIVEN,
         max_endpointing_delay: NotGivenOr[float] = NOT_GIVEN,
@@ -1169,18 +1167,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 when the user has finished speaking. ``None`` reverts to automatic selection.
             keyterms (NotGivenOr[list[str]], optional): Replace the user-defined keyterms applied
                 to the STT. Auto-detected keyterms are left untouched.
-            expressive (NotGivenOr[bool | ExpressiveOptions], optional): Turn expressive TTS
-                delivery on/off or switch its preset/options mid-session. Takes effect on the
-                next reply. An ``expressive`` set on the active :class:`Agent` overrides the
-                session value. When a turn runs with expressive off, markup left in past
-                assistant messages is stripped from the chat history so the LLM doesn't
-                imitate tags nothing downstream converts.
             min_endpointing_delay: Deprecated, use ``endpointing_opts`` instead.
             max_endpointing_delay: Deprecated, use ``endpointing_opts`` instead.
         """
-        if is_given(expressive):
-            # mypy can't narrow NotGiven out of the TypedDict union here
-            self._opts.expressive = cast("bool | ExpressiveOptions", expressive)
         if is_given(keyterms):
             self._keyterm_detector.set_static_keyterms(keyterms)
         if is_given(min_endpointing_delay) or is_given(max_endpointing_delay):

--- a/tests/test_expressive_toggle.py
+++ b/tests/test_expressive_toggle.py
@@ -53,21 +53,18 @@ def test_strip_assistant_markup() -> None:
     assert plain.content is plain_content
 
 
-def test_update_options_expressive() -> None:
-    session = AgentSession(expressive=presets.CUSTOMER_SERVICE)
-    assert session.options.expressive == presets.CUSTOMER_SERVICE
+def test_expressive_internal_toggle() -> None:
+    # expressive mode is not publicly exposed; the pipeline stays disabled unless
+    # the framework-internal attribute is set
+    session = AgentSession()
+    assert session._expressive is False
 
-    # turn off
-    session.update_options(expressive=False)
-    assert session.options.expressive is False
+    session._expressive = presets.CUSTOMER_SERVICE
+    assert session._expressive == presets.CUSTOMER_SERVICE
 
-    # turn back on with a different preset
-    session.update_options(expressive=presets.CASUAL)
-    assert session.options.expressive == presets.CASUAL
-
-    # untouched when not given
+    # untouched by unrelated option updates
     session.update_options()
-    assert session.options.expressive == presets.CASUAL
+    assert session._expressive == presets.CUSTOMER_SERVICE
 
 
 def test_update_and_remove_expressive_instructions() -> None:
@@ -93,7 +90,8 @@ async def test_expressive_off_turn_scrubs_history() -> None:
 
     # FakeTTS has no markup dialect, so expressive resolves to off even though the
     # session asks for it — same situation as a handoff to a non-expressive TTS.
-    session = create_session(actions, extra_kwargs={"expressive": presets.CUSTOMER_SERVICE})
+    session = create_session(actions)
+    session._expressive = presets.CUSTOMER_SERVICE
 
     # seed history as if previous turns ran expressive: marked-up assistant text +
     # the injected markup guide


### PR DESCRIPTION
also hides `expressive` from `update_options` while keeping functionality