### PR TITLE
fix: attribute playback evidence to its own segment on the same audio output

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2769,10 +2769,15 @@ class AgentActivity(RecognitionHooks):
         if speech_handle.interrupted and audio_output is not None:
             playback_ev = await audio_output.wait_for_playout()
 
-            if (
-                audio_out is not None
-                and audio_out.first_frame_fut.done()
-                and not audio_out.first_frame_fut.cancelled()
+            # A reported playback position is proof of partial playback even when the
+            # playback-started notification hasn't arrived yet (remote avatar outputs
+            # deliver it via RPC, which can race with the interruption). It only counts
+            # when one of THIS segment's frames was accepted into a counted playout
+            # segment (own_segment_index).
+            played_own_frame = audio_out is not None and audio_out.own_segment_index is not None
+            if audio_out is not None and (
+                (audio_out.first_frame_fut.done() and not audio_out.first_frame_fut.cancelled())
+                or (played_own_frame and playback_ev.playback_position > 0)
             ):
                 if playback_ev.synchronized_transcript is not None:
                     forwarded_text = playback_ev.synchronized_transcript

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2769,9 +2769,15 @@ class AgentActivity(RecognitionHooks):
         if speech_handle.interrupted and audio_output is not None:
             playback_ev = await audio_output.wait_for_playout()
 
-            # a non-zero position proves partial playback even when the playback-started
-            # notification lost the race with the interruption (see own_segment_index)
-            played_own_frame = audio_out is not None and audio_out.own_segment_index is not None
+            # A reported playback position is proof of partial playback even when
+            # the playback-started notification hasn't arrived yet (remote avatar
+            # outputs deliver it via RPC, which can race with the interruption).
+            # It only counts as evidence when THIS segment bumped the output's
+            # segment count (see _AudioOutput.captured_segments_before).
+            played_own_frame = (
+                audio_out is not None
+                and audio_output.captured_playout_segments > audio_out.captured_segments_before
+            )
             if audio_out is not None and (
                 (audio_out.first_frame_fut.done() and not audio_out.first_frame_fut.cancelled())
                 or (played_own_frame and playback_ev.playback_position > 0)

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2769,11 +2769,8 @@ class AgentActivity(RecognitionHooks):
         if speech_handle.interrupted and audio_output is not None:
             playback_ev = await audio_output.wait_for_playout()
 
-            # A reported playback position is proof of partial playback even when the
-            # playback-started notification hasn't arrived yet (remote avatar outputs
-            # deliver it via RPC, which can race with the interruption). It only counts
-            # when one of THIS segment's frames was accepted into a counted playout
-            # segment (own_segment_index).
+            # a non-zero position proves partial playback even when the playback-started
+            # notification lost the race with the interruption (see own_segment_index)
             played_own_frame = audio_out is not None and audio_out.own_segment_index is not None
             if audio_out is not None and (
                 (audio_out.first_frame_fut.done() and not audio_out.first_frame_fut.cancelled())

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3042,9 +3042,13 @@ class AgentActivity(RecognitionHooks):
                 audio_out is not None
                 and audio_output.captured_playout_segments > audio_out.captured_segments_before
             )
-            if audio_out is not None and (
-                (audio_out.first_frame_fut.done() and not audio_out.first_frame_fut.cancelled())
-                or (played_own_frame and playback_ev.playback_position > 0)
+            if (
+                audio_out is not None
+                and played_own_frame
+                and (
+                    (audio_out.first_frame_fut.done() and not audio_out.first_frame_fut.cancelled())
+                    or playback_ev.playback_position > 0
+                )
             ):
                 if playback_ev.synchronized_transcript is not None:
                     forwarded_text = playback_ev.synchronized_transcript

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3038,11 +3038,8 @@ class AgentActivity(RecognitionHooks):
         if speech_handle.interrupted and audio_output is not None:
             playback_ev = await audio_output.wait_for_playout()
 
-            # A reported playback position is proof of partial playback even when the
-            # playback-started notification hasn't arrived yet (remote avatar outputs
-            # deliver it via RPC, which can race with the interruption). It only counts
-            # when one of THIS segment's frames was accepted into a counted playout
-            # segment (own_segment_index).
+            # a non-zero position proves partial playback even when the playback-started
+            # notification lost the race with the interruption (see own_segment_index)
             played_own_frame = audio_out is not None and audio_out.own_segment_index is not None
             if audio_out is not None and (
                 (audio_out.first_frame_fut.done() and not audio_out.first_frame_fut.cancelled())

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3038,9 +3038,15 @@ class AgentActivity(RecognitionHooks):
         if speech_handle.interrupted and audio_output is not None:
             playback_ev = await audio_output.wait_for_playout()
 
-            # a non-zero position proves partial playback even when the playback-started
-            # notification lost the race with the interruption (see own_segment_index)
-            played_own_frame = audio_out is not None and audio_out.own_segment_index is not None
+            # A reported playback position is proof of partial playback even when
+            # the playback-started notification hasn't arrived yet (remote avatar
+            # outputs deliver it via RPC, which can race with the interruption).
+            # It only counts as evidence when THIS segment bumped the output's
+            # segment count (see _AudioOutput.captured_segments_before).
+            played_own_frame = (
+                audio_out is not None
+                and audio_output.captured_playout_segments > audio_out.captured_segments_before
+            )
             if audio_out is not None and (
                 (audio_out.first_frame_fut.done() and not audio_out.first_frame_fut.cancelled())
                 or (played_own_frame and playback_ev.playback_position > 0)

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3038,11 +3038,6 @@ class AgentActivity(RecognitionHooks):
         if speech_handle.interrupted and audio_output is not None:
             playback_ev = await audio_output.wait_for_playout()
 
-            # A reported playback position is proof of partial playback even when
-            # the playback-started notification hasn't arrived yet (remote avatar
-            # outputs deliver it via RPC, which can race with the interruption).
-            # It only counts as evidence when THIS segment bumped the output's
-            # segment count (see _AudioOutput.captured_segments_before).
             played_own_frame = (
                 audio_out is not None
                 and audio_output.captured_playout_segments > audio_out.captured_segments_before

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3038,10 +3038,15 @@ class AgentActivity(RecognitionHooks):
         if speech_handle.interrupted and audio_output is not None:
             playback_ev = await audio_output.wait_for_playout()
 
-            if (
-                audio_out is not None
-                and audio_out.first_frame_fut.done()
-                and not audio_out.first_frame_fut.cancelled()
+            # A reported playback position is proof of partial playback even when the
+            # playback-started notification hasn't arrived yet (remote avatar outputs
+            # deliver it via RPC, which can race with the interruption). It only counts
+            # when one of THIS segment's frames was accepted into a counted playout
+            # segment (own_segment_index).
+            played_own_frame = audio_out is not None and audio_out.own_segment_index is not None
+            if audio_out is not None and (
+                (audio_out.first_frame_fut.done() and not audio_out.first_frame_fut.cancelled())
+                or (played_own_frame and playback_ev.playback_position > 0)
             ):
                 if playback_ev.synchronized_transcript is not None:
                     forwarded_text = playback_ev.synchronized_transcript

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -466,11 +466,10 @@ class _AudioOutput:
     own_segment_index: int | None = None
     """`AudioOutput.captured_playout_segments` read after the first counted `capture_frame`.
 
-    `None` until one of this segment's frames is confirmed counted. Unlike a delta
-    against `captured_segments_before`, this records the playout segment the frames
-    actually landed in, and stays `None` when every frame bailed at a pause/interrupt
-    gate without ever being counted — so it can be used as evidence of (partial)
-    playback of this segment.
+    `None` until one of this segment's frames is confirmed counted; stays `None` when
+    every frame bailed at a pause/interrupt gate without being counted. Evidence that
+    this segment's audio was accepted for playout, and that the playback event
+    `wait_for_playout()` returns is this segment's rather than a stale one.
     """
 
 
@@ -487,16 +486,16 @@ def perform_audio_forwarding(
 
     def _on_playback_started(ev: io.PlaybackStartedEvent) -> None:
         # The audio output is shared across overlapping segments and the event carries
-        # no segment identity (e.g. a stale `lk.playback_started` RPC from an avatar
-        # worker can arrive after its segment was interrupted and the next one started).
-        # Only honor the event while the output's segment counter still points at THIS
+        # no segment identity (a stale `lk.playback_started` RPC from an avatar worker
+        # can arrive after its segment was interrupted and the next one started). Only
+        # honor the event while the output's segment counter still points at THIS
         # segment. During the first capture_frame the event can arrive before
         # `own_segment_index` is recorded — sinks emit playback_started synchronously
         # inside the first counted capture, and chained outputs (transcript sync,
-        # recorder) forward the leaf's event before counting their own segment — so
-        # until then accept the snapshot and snapshot + 1. Ambiguous events afterwards
-        # are dropped (fail closed): genuine partial playback is then still committed
-        # through the playback-position evidence in the interrupted gates.
+        # recorder) forward the leaf's event before counting their own — so until then
+        # accept the snapshot and snapshot + 1. Ambiguous events are dropped (fail
+        # closed); partial playback still commits via the position evidence in the
+        # interrupted gates.
         counter = audio_output.captured_playout_segments
         if out.own_segment_index is not None:
             is_own_event = counter == out.own_segment_index
@@ -543,9 +542,6 @@ async def _audio_forwarding_task(
                     num_channels=frame.num_channels,
                 )
 
-            # mark before capturing so the playback_started emitted synchronously inside
-            # the first capture_frame is attributed to this segment (see the listener in
-            # `perform_audio_forwarding`)
             out.has_captured_own_frame = True
 
             if resampler:
@@ -554,9 +550,6 @@ async def _audio_forwarding_task(
             else:
                 await audio_output.capture_frame(frame)
 
-            # read the counter after the capture resolved: this records the playout
-            # segment the frame actually landed in, and stays unset if the frame bailed
-            # at a pause/interrupt gate without being counted
             if (
                 out.own_segment_index is None
                 and audio_output.captured_playout_segments > out.captured_segments_before
@@ -652,13 +645,8 @@ async def forward_generation(
             if audio_output is not None:
                 audio_output.clear_buffer()
                 playback_ev = await audio_output.wait_for_playout()
-                # A reported playback position is proof of partial playback even when
-                # the playback-started notification hasn't arrived yet (remote avatar
-                # outputs deliver it via RPC, which can race with the interruption).
-                # It only counts when one of THIS segment's frames was accepted into a
-                # counted playout segment (own_segment_index) — the same condition under
-                # which wait_for_playout waits for this segment's playback event instead
-                # of returning a stale one from a previous segment.
+                # a non-zero position proves partial playback even when the playback-started
+                # notification lost the race with the interruption (see own_segment_index)
                 played_own_frame = audio_out is not None and audio_out.own_segment_index is not None
                 if audio_out is not None and (
                     (audio_out.first_frame_fut.done() and not audio_out.first_frame_fut.cancelled())

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -451,7 +451,14 @@ class _AudioOutput:
     """Future that will be set with the timestamp of the first frame's capture"""
 
     captured_segments_before: int
-    """`AudioOutput.captured_playout_segments` snapshot taken when forwarding was set up."""
+    """`AudioOutput.captured_playout_segments` snapshot taken when forwarding was set up.
+
+    The interrupted-commit gate compares the current count against this baseline: a
+    bump proves a frame of THIS segment made it through `AudioOutput.capture_frame`
+    — the same condition under which `wait_for_playout()` waits for this segment's
+    playback event instead of returning a stale one — so the reported playback
+    position can be trusted as evidence of partial playback.
+    """
 
     started_forwarding_at: float | None = None
 
@@ -461,15 +468,6 @@ class _AudioOutput:
     Set *before* the first `capture_frame` await: sinks emit `playback_started`
     synchronously inside the first counted capture, so a flag set after the await
     would miss the segment's own event.
-    """
-
-    own_segment_index: int | None = None
-    """`AudioOutput.captured_playout_segments` read after the first counted `capture_frame`.
-
-    `None` until one of this segment's frames is confirmed counted; stays `None` when
-    every frame bailed at a pause/interrupt gate without being counted. Evidence that
-    this segment's audio was accepted for playout, and that the playback event
-    `wait_for_playout()` returns is this segment's rather than a stale one.
     """
 
 
@@ -485,23 +483,10 @@ def perform_audio_forwarding(
     )
 
     def _on_playback_started(ev: io.PlaybackStartedEvent) -> None:
-        # The audio output is shared across overlapping segments and the event carries
-        # no segment identity (a stale `lk.playback_started` RPC from an avatar worker
-        # can arrive after its segment was interrupted and the next one started). Only
-        # honor the event while the output's segment counter still points at THIS
-        # segment. During the first capture_frame the event can arrive before
-        # `own_segment_index` is recorded — sinks emit playback_started synchronously
-        # inside the first counted capture, and chained outputs (transcript sync,
-        # recorder) forward the leaf's event before counting their own — so until then
-        # accept the snapshot and snapshot + 1. Ambiguous events are dropped (fail
-        # closed); partial playback still commits via the position evidence in the
-        # interrupted gates.
-        counter = audio_output.captured_playout_segments
-        if out.own_segment_index is not None:
-            is_own_event = counter == out.own_segment_index
-        else:
-            is_own_event = counter <= out.captured_segments_before + 1
-        if out.has_captured_own_frame and is_own_event and not out.first_frame_fut.done():
+        # The audio output is shared across overlapping segments. Only honor the
+        # event once this segment has captured its own first frame, so a stray event
+        # from another segment can't resolve our first_frame_fut prematurely.
+        if out.has_captured_own_frame and not out.first_frame_fut.done():
             out.first_frame_fut.set_result(ev.created_at)
 
     # out.first_frame_fut should be cancelled in the caller after the playout is finished or interrupted
@@ -549,12 +534,6 @@ async def _audio_forwarding_task(
                     await audio_output.capture_frame(f)
             else:
                 await audio_output.capture_frame(frame)
-
-            if (
-                out.own_segment_index is None
-                and audio_output.captured_playout_segments > out.captured_segments_before
-            ):
-                out.own_segment_index = audio_output.captured_playout_segments
 
         if resampler:
             for frame in resampler.flush():
@@ -645,9 +624,17 @@ async def forward_generation(
             if audio_output is not None:
                 audio_output.clear_buffer()
                 playback_ev = await audio_output.wait_for_playout()
-                # a non-zero position proves partial playback even when the playback-started
-                # notification lost the race with the interruption (see own_segment_index)
-                played_own_frame = audio_out is not None and audio_out.own_segment_index is not None
+                # A reported playback position is proof of partial playback even when
+                # the playback-started notification hasn't arrived yet (remote avatar
+                # outputs deliver it via RPC, which can race with the interruption).
+                # It only counts as evidence when THIS segment bumped the output's
+                # segment count — the same condition under which wait_for_playout waits
+                # for this segment's playback event instead of returning a stale one
+                # from a previous segment (see _AudioOutput.captured_segments_before).
+                played_own_frame = (
+                    audio_out is not None
+                    and audio_output.captured_playout_segments > audio_out.captured_segments_before
+                )
                 if audio_out is not None and (
                     (audio_out.first_frame_fut.done() and not audio_out.first_frame_fut.cancelled())
                     or (played_own_frame and playback_ev.playback_position > 0)

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -450,11 +450,28 @@ class _AudioOutput:
     first_frame_fut: asyncio.Future[float]
     """Future that will be set with the timestamp of the first frame's capture"""
 
+    captured_segments_before: int
+    """`AudioOutput.captured_playout_segments` snapshot taken when forwarding was set up."""
+
     started_forwarding_at: float | None = None
 
-    def _resolve_first_frame_fut(self, ev: io.PlaybackStartedEvent) -> None:
-        if not self.first_frame_fut.done():
-            self.first_frame_fut.set_result(ev.created_at)
+    has_captured_own_frame: bool = False
+    """Whether this segment has pushed at least one of its own frames to `capture_frame`.
+
+    Set *before* the first `capture_frame` await: sinks emit `playback_started`
+    synchronously inside the first counted capture, so a flag set after the await
+    would miss the segment's own event.
+    """
+
+    own_segment_index: int | None = None
+    """`AudioOutput.captured_playout_segments` read after the first counted `capture_frame`.
+
+    `None` until one of this segment's frames is confirmed counted. Unlike a delta
+    against `captured_segments_before`, this records the playout segment the frames
+    actually landed in, and stays `None` when every frame bailed at a pause/interrupt
+    gate without ever being counted — so it can be used as evidence of (partial)
+    playback of this segment.
+    """
 
 
 def perform_audio_forwarding(
@@ -462,11 +479,36 @@ def perform_audio_forwarding(
     audio_output: io.AudioOutput,
     tts_output: AsyncIterable[rtc.AudioFrame],
 ) -> tuple[asyncio.Task[None], _AudioOutput]:
-    out = _AudioOutput(audio=[], first_frame_fut=asyncio.Future())
+    out = _AudioOutput(
+        audio=[],
+        first_frame_fut=asyncio.Future(),
+        captured_segments_before=audio_output.captured_playout_segments,
+    )
+
+    def _on_playback_started(ev: io.PlaybackStartedEvent) -> None:
+        # The audio output is shared across overlapping segments and the event carries
+        # no segment identity (e.g. a stale `lk.playback_started` RPC from an avatar
+        # worker can arrive after its segment was interrupted and the next one started).
+        # Only honor the event while the output's segment counter still points at THIS
+        # segment. During the first capture_frame the event can arrive before
+        # `own_segment_index` is recorded — sinks emit playback_started synchronously
+        # inside the first counted capture, and chained outputs (transcript sync,
+        # recorder) forward the leaf's event before counting their own segment — so
+        # until then accept the snapshot and snapshot + 1. Ambiguous events afterwards
+        # are dropped (fail closed): genuine partial playback is then still committed
+        # through the playback-position evidence in the interrupted gates.
+        counter = audio_output.captured_playout_segments
+        if out.own_segment_index is not None:
+            is_own_event = counter == out.own_segment_index
+        else:
+            is_own_event = counter <= out.captured_segments_before + 1
+        if out.has_captured_own_frame and is_own_event and not out.first_frame_fut.done():
+            out.first_frame_fut.set_result(ev.created_at)
+
     # out.first_frame_fut should be cancelled in the caller after the playout is finished or interrupted
-    audio_output.on("playback_started", out._resolve_first_frame_fut)
+    audio_output.on("playback_started", _on_playback_started)
     out.first_frame_fut.add_done_callback(
-        lambda _: audio_output.off("playback_started", out._resolve_first_frame_fut)
+        lambda _: audio_output.off("playback_started", _on_playback_started)
     )
     task = asyncio.create_task(_audio_forwarding_task(audio_output, tts_output, out))
     return task, out
@@ -501,11 +543,25 @@ async def _audio_forwarding_task(
                     num_channels=frame.num_channels,
                 )
 
+            # mark before capturing so the playback_started emitted synchronously inside
+            # the first capture_frame is attributed to this segment (see the listener in
+            # `perform_audio_forwarding`)
+            out.has_captured_own_frame = True
+
             if resampler:
                 for f in resampler.push(frame):
                     await audio_output.capture_frame(f)
             else:
                 await audio_output.capture_frame(frame)
+
+            # read the counter after the capture resolved: this records the playout
+            # segment the frame actually landed in, and stays unset if the frame bailed
+            # at a pause/interrupt gate without being counted
+            if (
+                out.own_segment_index is None
+                and audio_output.captured_playout_segments > out.captured_segments_before
+            ):
+                out.own_segment_index = audio_output.captured_playout_segments
 
         if resampler:
             for frame in resampler.flush():
@@ -596,10 +652,17 @@ async def forward_generation(
             if audio_output is not None:
                 audio_output.clear_buffer()
                 playback_ev = await audio_output.wait_for_playout()
-                if (
-                    audio_out is not None
-                    and audio_out.first_frame_fut.done()
-                    and not audio_out.first_frame_fut.cancelled()
+                # A reported playback position is proof of partial playback even when
+                # the playback-started notification hasn't arrived yet (remote avatar
+                # outputs deliver it via RPC, which can race with the interruption).
+                # It only counts when one of THIS segment's frames was accepted into a
+                # counted playout segment (own_segment_index) — the same condition under
+                # which wait_for_playout waits for this segment's playback event instead
+                # of returning a stale one from a previous segment.
+                played_own_frame = audio_out is not None and audio_out.own_segment_index is not None
+                if audio_out is not None and (
+                    (audio_out.first_frame_fut.done() and not audio_out.first_frame_fut.cancelled())
+                    or (played_own_frame and playback_ev.playback_position > 0)
                 ):
                     out.played = "partial"
                     out.playback_position = playback_ev.playback_position

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -669,9 +669,16 @@ async def forward_generation(
                     audio_out is not None
                     and audio_output.captured_playout_segments > audio_out.captured_segments_before
                 )
-                if audio_out is not None and (
-                    (audio_out.first_frame_fut.done() and not audio_out.first_frame_fut.cancelled())
-                    or (played_own_frame and playback_ev.playback_position > 0)
+                if (
+                    audio_out is not None
+                    and played_own_frame
+                    and (
+                        (
+                            audio_out.first_frame_fut.done()
+                            and not audio_out.first_frame_fut.cancelled()
+                        )
+                        or playback_ev.playback_position > 0
+                    )
                 ):
                     out.played = "partial"
                     out.playback_position = playback_ev.playback_position

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -504,11 +504,10 @@ class _AudioOutput:
     own_segment_index: int | None = None
     """`AudioOutput.captured_playout_segments` read after the first counted `capture_frame`.
 
-    `None` until one of this segment's frames is confirmed counted. Unlike a delta
-    against `captured_segments_before`, this records the playout segment the frames
-    actually landed in, and stays `None` when every frame bailed at a pause/interrupt
-    gate without ever being counted — so it can be used as evidence of (partial)
-    playback of this segment.
+    `None` until one of this segment's frames is confirmed counted; stays `None` when
+    every frame bailed at a pause/interrupt gate without being counted. Evidence that
+    this segment's audio was accepted for playout, and that the playback event
+    `wait_for_playout()` returns is this segment's rather than a stale one.
     """
 
 
@@ -526,16 +525,16 @@ def perform_audio_forwarding(
 
     def _on_playback_started(ev: io.PlaybackStartedEvent) -> None:
         # The audio output is shared across overlapping segments and the event carries
-        # no segment identity (e.g. a stale `lk.playback_started` RPC from an avatar
-        # worker can arrive after its segment was interrupted and the next one started).
-        # Only honor the event while the output's segment counter still points at THIS
+        # no segment identity (a stale `lk.playback_started` RPC from an avatar worker
+        # can arrive after its segment was interrupted and the next one started). Only
+        # honor the event while the output's segment counter still points at THIS
         # segment. During the first capture_frame the event can arrive before
         # `own_segment_index` is recorded — sinks emit playback_started synchronously
         # inside the first counted capture, and chained outputs (transcript sync,
-        # recorder) forward the leaf's event before counting their own segment — so
-        # until then accept the snapshot and snapshot + 1. Ambiguous events afterwards
-        # are dropped (fail closed): genuine partial playback is then still committed
-        # through the playback-position evidence in the interrupted gates.
+        # recorder) forward the leaf's event before counting their own — so until then
+        # accept the snapshot and snapshot + 1. Ambiguous events are dropped (fail
+        # closed); partial playback still commits via the position evidence in the
+        # interrupted gates.
         counter = audio_output.captured_playout_segments
         if out.own_segment_index is not None:
             is_own_event = counter == out.own_segment_index
@@ -592,9 +591,6 @@ async def _audio_forwarding_task(
                     num_channels=frame.num_channels,
                 )
 
-            # mark before capturing so the playback_started emitted synchronously inside
-            # the first capture_frame is attributed to this segment (see the listener in
-            # `perform_audio_forwarding`)
             out.has_captured_own_frame = True
 
             if resampler:
@@ -603,9 +599,6 @@ async def _audio_forwarding_task(
             else:
                 await audio_output.capture_frame(frame)
 
-            # read the counter after the capture resolved: this records the playout
-            # segment the frame actually landed in, and stays unset if the frame bailed
-            # at a pause/interrupt gate without being counted
             if (
                 out.own_segment_index is None
                 and audio_output.captured_playout_segments > out.captured_segments_before
@@ -704,13 +697,8 @@ async def forward_generation(
             if audio_output is not None:
                 audio_output.clear_buffer()
                 playback_ev = await audio_output.wait_for_playout()
-                # A reported playback position is proof of partial playback even when
-                # the playback-started notification hasn't arrived yet (remote avatar
-                # outputs deliver it via RPC, which can race with the interruption).
-                # It only counts when one of THIS segment's frames was accepted into a
-                # counted playout segment (own_segment_index) — the same condition under
-                # which wait_for_playout waits for this segment's playback event instead
-                # of returning a stale one from a previous segment.
+                # a non-zero position proves partial playback even when the playback-started
+                # notification lost the race with the interruption (see own_segment_index)
                 played_own_frame = audio_out is not None and audio_out.own_segment_index is not None
                 if audio_out is not None and (
                     (audio_out.first_frame_fut.done() and not audio_out.first_frame_fut.cancelled())

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -488,11 +488,28 @@ class _AudioOutput:
     first_frame_fut: asyncio.Future[float]
     """Future that will be set with the timestamp of the first frame's capture"""
 
+    captured_segments_before: int
+    """`AudioOutput.captured_playout_segments` snapshot taken when forwarding was set up."""
+
     started_forwarding_at: float | None = None
 
-    def _resolve_first_frame_fut(self, ev: io.PlaybackStartedEvent) -> None:
-        if not self.first_frame_fut.done():
-            self.first_frame_fut.set_result(ev.created_at)
+    has_captured_own_frame: bool = False
+    """Whether this segment has pushed at least one of its own frames to `capture_frame`.
+
+    Set *before* the first `capture_frame` await: sinks emit `playback_started`
+    synchronously inside the first counted capture, so a flag set after the await
+    would miss the segment's own event.
+    """
+
+    own_segment_index: int | None = None
+    """`AudioOutput.captured_playout_segments` read after the first counted `capture_frame`.
+
+    `None` until one of this segment's frames is confirmed counted. Unlike a delta
+    against `captured_segments_before`, this records the playout segment the frames
+    actually landed in, and stays `None` when every frame bailed at a pause/interrupt
+    gate without ever being counted — so it can be used as evidence of (partial)
+    playback of this segment.
+    """
 
 
 def perform_audio_forwarding(
@@ -501,11 +518,36 @@ def perform_audio_forwarding(
     tts_output: AsyncIterable[rtc.AudioFrame],
     reconcile_playout_pause: Callable[[], None],
 ) -> tuple[asyncio.Task[None], _AudioOutput]:
-    out = _AudioOutput(audio=[], first_frame_fut=asyncio.Future())
+    out = _AudioOutput(
+        audio=[],
+        first_frame_fut=asyncio.Future(),
+        captured_segments_before=audio_output.captured_playout_segments,
+    )
+
+    def _on_playback_started(ev: io.PlaybackStartedEvent) -> None:
+        # The audio output is shared across overlapping segments and the event carries
+        # no segment identity (e.g. a stale `lk.playback_started` RPC from an avatar
+        # worker can arrive after its segment was interrupted and the next one started).
+        # Only honor the event while the output's segment counter still points at THIS
+        # segment. During the first capture_frame the event can arrive before
+        # `own_segment_index` is recorded — sinks emit playback_started synchronously
+        # inside the first counted capture, and chained outputs (transcript sync,
+        # recorder) forward the leaf's event before counting their own segment — so
+        # until then accept the snapshot and snapshot + 1. Ambiguous events afterwards
+        # are dropped (fail closed): genuine partial playback is then still committed
+        # through the playback-position evidence in the interrupted gates.
+        counter = audio_output.captured_playout_segments
+        if out.own_segment_index is not None:
+            is_own_event = counter == out.own_segment_index
+        else:
+            is_own_event = counter <= out.captured_segments_before + 1
+        if out.has_captured_own_frame and is_own_event and not out.first_frame_fut.done():
+            out.first_frame_fut.set_result(ev.created_at)
+
     # out.first_frame_fut should be cancelled in the caller after the playout is finished or interrupted
-    audio_output.on("playback_started", out._resolve_first_frame_fut)
+    audio_output.on("playback_started", _on_playback_started)
     out.first_frame_fut.add_done_callback(
-        lambda _: audio_output.off("playback_started", out._resolve_first_frame_fut)
+        lambda _: audio_output.off("playback_started", _on_playback_started)
     )
     task = asyncio.create_task(
         _audio_forwarding_task(
@@ -550,11 +592,25 @@ async def _audio_forwarding_task(
                     num_channels=frame.num_channels,
                 )
 
+            # mark before capturing so the playback_started emitted synchronously inside
+            # the first capture_frame is attributed to this segment (see the listener in
+            # `perform_audio_forwarding`)
+            out.has_captured_own_frame = True
+
             if resampler:
                 for f in resampler.push(frame):
                     await audio_output.capture_frame(f)
             else:
                 await audio_output.capture_frame(frame)
+
+            # read the counter after the capture resolved: this records the playout
+            # segment the frame actually landed in, and stays unset if the frame bailed
+            # at a pause/interrupt gate without being counted
+            if (
+                out.own_segment_index is None
+                and audio_output.captured_playout_segments > out.captured_segments_before
+            ):
+                out.own_segment_index = audio_output.captured_playout_segments
 
         if resampler:
             for frame in resampler.flush():
@@ -648,10 +704,17 @@ async def forward_generation(
             if audio_output is not None:
                 audio_output.clear_buffer()
                 playback_ev = await audio_output.wait_for_playout()
-                if (
-                    audio_out is not None
-                    and audio_out.first_frame_fut.done()
-                    and not audio_out.first_frame_fut.cancelled()
+                # A reported playback position is proof of partial playback even when
+                # the playback-started notification hasn't arrived yet (remote avatar
+                # outputs deliver it via RPC, which can race with the interruption).
+                # It only counts when one of THIS segment's frames was accepted into a
+                # counted playout segment (own_segment_index) — the same condition under
+                # which wait_for_playout waits for this segment's playback event instead
+                # of returning a stale one from a previous segment.
+                played_own_frame = audio_out is not None and audio_out.own_segment_index is not None
+                if audio_out is not None and (
+                    (audio_out.first_frame_fut.done() and not audio_out.first_frame_fut.cancelled())
+                    or (played_own_frame and playback_ev.playback_position > 0)
                 ):
                     out.played = "partial"
                     out.playback_position = playback_ev.playback_position

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -489,24 +489,16 @@ class _AudioOutput:
     """Future that will be set with the timestamp of the first frame's capture"""
 
     captured_segments_before: int
-    """`AudioOutput.captured_playout_segments` snapshot taken when forwarding was set up.
+    """Output segment count before this segment starts forwarding.
 
-    The interrupted-commit gate compares the current count against this baseline: a
-    bump proves a frame of THIS segment made it through `AudioOutput.capture_frame`
-    — the same condition under which `wait_for_playout()` waits for this segment's
-    playback event instead of returning a stale one — so the reported playback
-    position can be trusted as evidence of partial playback.
+    With serialized forwarding, an increase proves this segment reached
+    ``AudioOutput.capture_frame``.
     """
 
     started_forwarding_at: float | None = None
 
     has_captured_own_frame: bool = False
-    """Whether this segment has pushed at least one of its own frames to `capture_frame`.
-
-    Set *before* the first `capture_frame` await: sinks emit `playback_started`
-    synchronously inside the first counted capture, so a flag set after the await
-    would miss the segment's own event.
-    """
+    """Set before ``capture_frame`` so synchronous events are attributed to this segment."""
 
 
 def perform_audio_forwarding(
@@ -522,9 +514,6 @@ def perform_audio_forwarding(
     )
 
     def _on_playback_started(ev: io.PlaybackStartedEvent) -> None:
-        # The audio output is shared across overlapping segments. Only honor the
-        # event once this segment has captured its own first frame, so a stray event
-        # from another segment can't resolve our first_frame_fut prematurely.
         if out.has_captured_own_frame and not out.first_frame_fut.done():
             out.first_frame_fut.set_result(ev.created_at)
 
@@ -676,13 +665,6 @@ async def forward_generation(
             if audio_output is not None:
                 audio_output.clear_buffer()
                 playback_ev = await audio_output.wait_for_playout()
-                # A reported playback position is proof of partial playback even when
-                # the playback-started notification hasn't arrived yet (remote avatar
-                # outputs deliver it via RPC, which can race with the interruption).
-                # It only counts as evidence when THIS segment bumped the output's
-                # segment count — the same condition under which wait_for_playout waits
-                # for this segment's playback event instead of returning a stale one
-                # from a previous segment (see _AudioOutput.captured_segments_before).
                 played_own_frame = (
                     audio_out is not None
                     and audio_output.captured_playout_segments > audio_out.captured_segments_before

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -489,7 +489,14 @@ class _AudioOutput:
     """Future that will be set with the timestamp of the first frame's capture"""
 
     captured_segments_before: int
-    """`AudioOutput.captured_playout_segments` snapshot taken when forwarding was set up."""
+    """`AudioOutput.captured_playout_segments` snapshot taken when forwarding was set up.
+
+    The interrupted-commit gate compares the current count against this baseline: a
+    bump proves a frame of THIS segment made it through `AudioOutput.capture_frame`
+    — the same condition under which `wait_for_playout()` waits for this segment's
+    playback event instead of returning a stale one — so the reported playback
+    position can be trusted as evidence of partial playback.
+    """
 
     started_forwarding_at: float | None = None
 
@@ -499,15 +506,6 @@ class _AudioOutput:
     Set *before* the first `capture_frame` await: sinks emit `playback_started`
     synchronously inside the first counted capture, so a flag set after the await
     would miss the segment's own event.
-    """
-
-    own_segment_index: int | None = None
-    """`AudioOutput.captured_playout_segments` read after the first counted `capture_frame`.
-
-    `None` until one of this segment's frames is confirmed counted; stays `None` when
-    every frame bailed at a pause/interrupt gate without being counted. Evidence that
-    this segment's audio was accepted for playout, and that the playback event
-    `wait_for_playout()` returns is this segment's rather than a stale one.
     """
 
 
@@ -524,23 +522,10 @@ def perform_audio_forwarding(
     )
 
     def _on_playback_started(ev: io.PlaybackStartedEvent) -> None:
-        # The audio output is shared across overlapping segments and the event carries
-        # no segment identity (a stale `lk.playback_started` RPC from an avatar worker
-        # can arrive after its segment was interrupted and the next one started). Only
-        # honor the event while the output's segment counter still points at THIS
-        # segment. During the first capture_frame the event can arrive before
-        # `own_segment_index` is recorded — sinks emit playback_started synchronously
-        # inside the first counted capture, and chained outputs (transcript sync,
-        # recorder) forward the leaf's event before counting their own — so until then
-        # accept the snapshot and snapshot + 1. Ambiguous events are dropped (fail
-        # closed); partial playback still commits via the position evidence in the
-        # interrupted gates.
-        counter = audio_output.captured_playout_segments
-        if out.own_segment_index is not None:
-            is_own_event = counter == out.own_segment_index
-        else:
-            is_own_event = counter <= out.captured_segments_before + 1
-        if out.has_captured_own_frame and is_own_event and not out.first_frame_fut.done():
+        # The audio output is shared across overlapping segments. Only honor the
+        # event once this segment has captured its own first frame, so a stray event
+        # from another segment can't resolve our first_frame_fut prematurely.
+        if out.has_captured_own_frame and not out.first_frame_fut.done():
             out.first_frame_fut.set_result(ev.created_at)
 
     # out.first_frame_fut should be cancelled in the caller after the playout is finished or interrupted
@@ -598,12 +583,6 @@ async def _audio_forwarding_task(
                     await audio_output.capture_frame(f)
             else:
                 await audio_output.capture_frame(frame)
-
-            if (
-                out.own_segment_index is None
-                and audio_output.captured_playout_segments > out.captured_segments_before
-            ):
-                out.own_segment_index = audio_output.captured_playout_segments
 
         if resampler:
             for frame in resampler.flush():
@@ -697,9 +676,17 @@ async def forward_generation(
             if audio_output is not None:
                 audio_output.clear_buffer()
                 playback_ev = await audio_output.wait_for_playout()
-                # a non-zero position proves partial playback even when the playback-started
-                # notification lost the race with the interruption (see own_segment_index)
-                played_own_frame = audio_out is not None and audio_out.own_segment_index is not None
+                # A reported playback position is proof of partial playback even when
+                # the playback-started notification hasn't arrived yet (remote avatar
+                # outputs deliver it via RPC, which can race with the interruption).
+                # It only counts as evidence when THIS segment bumped the output's
+                # segment count — the same condition under which wait_for_playout waits
+                # for this segment's playback event instead of returning a stale one
+                # from a previous segment (see _AudioOutput.captured_segments_before).
+                played_own_frame = (
+                    audio_out is not None
+                    and audio_output.captured_playout_segments > audio_out.captured_segments_before
+                )
                 if audio_out is not None and (
                     (audio_out.first_frame_fut.done() and not audio_out.first_frame_fut.cancelled())
                     or (played_own_frame and playback_ev.playback_position > 0)

--- a/livekit-agents/livekit/agents/voice/io.py
+++ b/livekit-agents/livekit/agents/voice/io.py
@@ -244,6 +244,17 @@ class AudioOutput(ABC, rtc.EventEmitter[Literal["playback_finished", "playback_s
         return self.__playback_segments_count - self.__playback_finished_count
 
     @property
+    def captured_playout_segments(self) -> int:
+        """Count of playback segments captured so far.
+
+        Increments when the first frame of a new segment is accepted by
+        ``capture_frame`` (segments are delimited by ``flush``/``clear_buffer``).
+        Lets callers detect — free of races with concurrent finishes — whether a
+        frame they forwarded was actually accepted into a counted playout segment.
+        """
+        return self.__playback_segments_count
+
+    @property
     def sample_rate(self) -> int | None:
         """The sample rate required by the audio sink, if None, any sample rate is accepted"""
         return self._sample_rate

--- a/livekit-agents/livekit/agents/voice/io.py
+++ b/livekit-agents/livekit/agents/voice/io.py
@@ -278,6 +278,17 @@ class AudioOutput(
         return self.__playback_segments_count - self.__playback_finished_count
 
     @property
+    def captured_playout_segments(self) -> int:
+        """Count of playback segments captured so far.
+
+        Increments when the first frame of a new segment is accepted by
+        ``capture_frame`` (segments are delimited by ``flush``/``clear_buffer``).
+        Lets callers detect — free of races with concurrent finishes — whether a
+        frame they forwarded was actually accepted into a counted playout segment.
+        """
+        return self.__playback_segments_count
+
+    @property
     def sample_rate(self) -> int | None:
         """The sample rate required by the audio sink, if None, any sample rate is accepted"""
         return self._sample_rate

--- a/livekit-agents/livekit/agents/voice/io.py
+++ b/livekit-agents/livekit/agents/voice/io.py
@@ -279,13 +279,7 @@ class AudioOutput(
 
     @property
     def captured_playout_segments(self) -> int:
-        """Count of playback segments captured so far.
-
-        Increments when the first frame of a new segment is accepted by
-        ``capture_frame`` (segments are delimited by ``flush``/``clear_buffer``).
-        Lets callers detect — free of races with concurrent finishes — whether a
-        frame they forwarded was actually accepted into a counted playout segment.
-        """
+        """Number of playback segments accepted by ``capture_frame``."""
         return self.__playback_segments_count
 
     @property

--- a/tests/test_playback_started_attribution.py
+++ b/tests/test_playback_started_attribution.py
@@ -1,9 +1,9 @@
-"""Tests for cross-segment attribution of playback_started events (AGT-3147).
+"""Tests for playback_started attribution and interrupted position evidence.
 
-The shared AudioOutput emits playback_started with no segment identity, so the
-per-segment listener in perform_audio_forwarding and the interrupted-commit gates
-must decide whether an event/position belongs to their own segment. See
-_AudioOutput.own_segment_index and the listener guard in perform_audio_forwarding.
+Mirrors agents-js#1966: the shared AudioOutput emits playback_started with no
+segment identity, so the per-segment listener only resolves after this segment
+has captured its own frame; interrupted commits also accept playback_position > 0
+when this segment bumped the output's segment counter.
 """
 
 from __future__ import annotations
@@ -105,14 +105,14 @@ async def test_own_playback_started_resolves_first_frame_fut() -> None:
     await task
 
     assert out.first_frame_fut.done()
-    assert out.own_segment_index == 1
+    assert audio_output.captured_playout_segments > out.captured_segments_before
     audio_output.clear_buffer()
 
 
 async def test_own_event_forwarded_before_wrapper_counts_still_resolves() -> None:
     # Chained outputs (transcript sync, recorder) forward the leaf's synchronous
     # playback_started before counting their own segment: the event must still be
-    # attributed to the segment whose first capture is in flight.
+    # attributed once has_captured_own_frame is set.
     audio_output = _ForwardFirstWrapper(FakeAudioOutput())
     frames_ch: asyncio.Queue[rtc.AudioFrame | None] = asyncio.Queue()
     task, out = await _drive_forwarding(audio_output, frames_ch)
@@ -122,7 +122,6 @@ async def test_own_event_forwarded_before_wrapper_counts_still_resolves() -> Non
     await task
 
     assert out.first_frame_fut.done()
-    assert out.own_segment_index == 1
     audio_output.clear_buffer()
 
 
@@ -143,38 +142,11 @@ async def test_stale_event_before_own_capture_is_ignored() -> None:
     out.first_frame_fut.cancel()
 
 
-async def test_event_after_foreign_segment_bump_is_ignored() -> None:
-    # Segment A captures into a paused output (counted, but nothing plays and no
-    # playback_started fires). A foreign segment then bumps the counter. A later
-    # event must NOT resolve A's future: the counter no longer points at A.
-    audio_output = FakeAudioOutput(can_pause=True)
-    frames_ch: asyncio.Queue[rtc.AudioFrame | None] = asyncio.Queue()
-    task, out = await _drive_forwarding(audio_output, frames_ch)
-    await asyncio.sleep(0)  # forwarding task calls resume(); pause after it
-    audio_output.pause()
-
-    frames_ch.put_nowait(_make_frame())
-    frames_ch.put_nowait(None)
-    await task
-
-    assert out.own_segment_index == 1
-    assert not out.first_frame_fut.done()
-
-    # a foreign segment (next speech) opens on the shared output
-    await audio_output.capture_frame(_make_frame())
-    assert audio_output.captured_playout_segments == 2
-
-    # the foreign segment's playback starts
-    audio_output.on_playback_started(created_at=time.time())
-
-    assert not out.first_frame_fut.done()
-    out.first_frame_fut.cancel()
-
-
 async def test_interrupted_commit_uses_position_evidence_without_started_event() -> None:
     # Avatar-style race: frames genuinely played, but the started notification
     # never arrived before the interruption. The playback position reported by
-    # the finished event is proof of partial playback.
+    # the finished event is proof of partial playback when this segment bumped
+    # the output's segment count.
     audio_output = _NoStartNotifyOutput()
     speech_handle = SpeechHandle.create()
 
@@ -203,14 +175,14 @@ async def test_interrupted_commit_uses_position_evidence_without_started_event()
 
     assert out.audio_out is not None
     assert not out.audio_out.first_frame_fut.done() or out.audio_out.first_frame_fut.cancelled()
-    assert out.audio_out.own_segment_index == 1
+    assert audio_output.captured_playout_segments > out.audio_out.captured_segments_before
     assert out.played == "partial"
     assert out.playback_position > 0
 
 
 async def test_interrupted_commit_stays_skipped_without_any_capture() -> None:
-    # Interrupted before any frame was counted: no started event, no position
-    # evidence — the segment must stay "skipped" (nothing reached the user).
+    # Interrupted before any frame was counted: no started event, no segment bump
+    # — the segment must stay "skipped" (nothing reached the user).
     audio_output = FakeAudioOutput()
     speech_handle = SpeechHandle.create()
 
@@ -234,5 +206,5 @@ async def test_interrupted_commit_stays_skipped_without_any_capture() -> None:
     out = await asyncio.wait_for(forward_task, timeout=5)
 
     assert out.audio_out is not None
-    assert out.audio_out.own_segment_index is None
+    assert audio_output.captured_playout_segments == out.audio_out.captured_segments_before
     assert out.played == "skipped"

--- a/tests/test_playback_started_attribution.py
+++ b/tests/test_playback_started_attribution.py
@@ -1,0 +1,238 @@
+"""Tests for cross-segment attribution of playback_started events (AGT-3147).
+
+The shared AudioOutput emits playback_started with no segment identity, so the
+per-segment listener in perform_audio_forwarding and the interrupted-commit gates
+must decide whether an event/position belongs to their own segment. See
+_AudioOutput.own_segment_index and the listener guard in perform_audio_forwarding.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterable
+
+import pytest
+
+from livekit import rtc
+from livekit.agents.voice.generation import forward_generation, perform_audio_forwarding
+from livekit.agents.voice.io import AudioOutput
+from livekit.agents.voice.speech_handle import SpeechHandle
+
+from .fake_io import FakeAudioOutput
+
+pytestmark = pytest.mark.unit
+
+SAMPLE_RATE = 16000
+
+
+def _make_frame(duration: float = 0.1) -> rtc.AudioFrame:
+    num_samples = int(SAMPLE_RATE * duration + 0.5)
+    return rtc.AudioFrame(
+        data=b"\x00\x00" * num_samples,
+        sample_rate=SAMPLE_RATE,
+        num_channels=1,
+        samples_per_channel=num_samples,
+    )
+
+
+class _ForwardFirstWrapper(AudioOutput):
+    """Mimics _SyncedAudioOutput / recorder ordering.
+
+    Forwards to the leaf (which emits playback_started synchronously inside the
+    first capture) BEFORE counting its own segment, so the forwarded event fires
+    while this output's counter still reads the pre-capture snapshot.
+    """
+
+    def __init__(self, next_in_chain: AudioOutput) -> None:
+        super().__init__(
+            label="ForwardFirstWrapper",
+            next_in_chain=next_in_chain,
+            capabilities=next_in_chain._capabilities,
+        )
+
+    async def capture_frame(self, frame: rtc.AudioFrame) -> None:
+        assert self.next_in_chain is not None
+        await self.next_in_chain.capture_frame(frame)
+        await super().capture_frame(frame)
+
+    def flush(self) -> None:
+        super().flush()
+        assert self.next_in_chain is not None
+        self.next_in_chain.flush()
+
+    def clear_buffer(self) -> None:
+        assert self.next_in_chain is not None
+        self.next_in_chain.clear_buffer()
+
+
+class _NoStartNotifyOutput(FakeAudioOutput):
+    """A sink whose playback-started notification is delayed/lost.
+
+    Simulates a remote (avatar) output that delivers playback_started via RPC:
+    frames are accepted and counted, playback genuinely progresses (so the
+    playback-finished event reports a real position), but no playback_started
+    is emitted locally.
+    """
+
+    async def capture_frame(self, frame: rtc.AudioFrame) -> None:
+        await AudioOutput.capture_frame(self, frame)  # count the playout segment
+        self._pushed_duration += frame.duration
+        if self._started_at is None:
+            self._started_at = time.time()  # playing, but never notifies
+
+
+async def _drive_forwarding(
+    audio_output: AudioOutput, frames_ch: asyncio.Queue[rtc.AudioFrame | None]
+):
+    async def _source() -> AsyncIterable[rtc.AudioFrame]:
+        while True:
+            frame = await frames_ch.get()
+            if frame is None:
+                return
+            yield frame
+
+    return perform_audio_forwarding(audio_output=audio_output, tts_output=_source())
+
+
+async def test_own_playback_started_resolves_first_frame_fut() -> None:
+    audio_output = FakeAudioOutput()
+    frames_ch: asyncio.Queue[rtc.AudioFrame | None] = asyncio.Queue()
+    task, out = await _drive_forwarding(audio_output, frames_ch)
+
+    frames_ch.put_nowait(_make_frame())
+    frames_ch.put_nowait(None)
+    await task
+
+    assert out.first_frame_fut.done()
+    assert out.own_segment_index == 1
+    audio_output.clear_buffer()
+
+
+async def test_own_event_forwarded_before_wrapper_counts_still_resolves() -> None:
+    # Chained outputs (transcript sync, recorder) forward the leaf's synchronous
+    # playback_started before counting their own segment: the event must still be
+    # attributed to the segment whose first capture is in flight.
+    audio_output = _ForwardFirstWrapper(FakeAudioOutput())
+    frames_ch: asyncio.Queue[rtc.AudioFrame | None] = asyncio.Queue()
+    task, out = await _drive_forwarding(audio_output, frames_ch)
+
+    frames_ch.put_nowait(_make_frame())
+    frames_ch.put_nowait(None)
+    await task
+
+    assert out.first_frame_fut.done()
+    assert out.own_segment_index == 1
+    audio_output.clear_buffer()
+
+
+async def test_stale_event_before_own_capture_is_ignored() -> None:
+    audio_output = FakeAudioOutput()
+    frames_ch: asyncio.Queue[rtc.AudioFrame | None] = asyncio.Queue()
+    task, out = await _drive_forwarding(audio_output, frames_ch)
+    await asyncio.sleep(0)  # let the forwarding task attach the listener
+
+    # a stale event (e.g. an avatar RPC from a previous, interrupted segment)
+    # arrives before this segment captured anything
+    audio_output.on_playback_started(created_at=time.time())
+
+    assert not out.first_frame_fut.done()
+
+    frames_ch.put_nowait(None)
+    await task
+    out.first_frame_fut.cancel()
+
+
+async def test_event_after_foreign_segment_bump_is_ignored() -> None:
+    # Segment A captures into a paused output (counted, but nothing plays and no
+    # playback_started fires). A foreign segment then bumps the counter. A later
+    # event must NOT resolve A's future: the counter no longer points at A.
+    audio_output = FakeAudioOutput(can_pause=True)
+    frames_ch: asyncio.Queue[rtc.AudioFrame | None] = asyncio.Queue()
+    task, out = await _drive_forwarding(audio_output, frames_ch)
+    await asyncio.sleep(0)  # forwarding task calls resume(); pause after it
+    audio_output.pause()
+
+    frames_ch.put_nowait(_make_frame())
+    frames_ch.put_nowait(None)
+    await task
+
+    assert out.own_segment_index == 1
+    assert not out.first_frame_fut.done()
+
+    # a foreign segment (next speech) opens on the shared output
+    await audio_output.capture_frame(_make_frame())
+    assert audio_output.captured_playout_segments == 2
+
+    # the foreign segment's playback starts
+    audio_output.on_playback_started(created_at=time.time())
+
+    assert not out.first_frame_fut.done()
+    out.first_frame_fut.cancel()
+
+
+async def test_interrupted_commit_uses_position_evidence_without_started_event() -> None:
+    # Avatar-style race: frames genuinely played, but the started notification
+    # never arrived before the interruption. The playback position reported by
+    # the finished event is proof of partial playback.
+    audio_output = _NoStartNotifyOutput()
+    speech_handle = SpeechHandle.create()
+
+    frame_captured = asyncio.Event()
+
+    async def _audio_source() -> AsyncIterable[rtc.AudioFrame]:
+        yield _make_frame()
+        frame_captured.set()
+        await asyncio.Event().wait()  # keep the TTS stream open until interrupted
+
+    forward_task = asyncio.create_task(
+        forward_generation(
+            speech_handle=speech_handle,
+            audio_output=audio_output,
+            text_output=None,
+            audio_source=_audio_source(),
+            text_source=None,
+            on_first_frame=lambda _fut, _out: None,
+        )
+    )
+
+    await asyncio.wait_for(frame_captured.wait(), timeout=5)
+    await asyncio.sleep(0.05)  # accrue some playback position
+    speech_handle.interrupt()
+    out = await asyncio.wait_for(forward_task, timeout=5)
+
+    assert out.audio_out is not None
+    assert not out.audio_out.first_frame_fut.done() or out.audio_out.first_frame_fut.cancelled()
+    assert out.audio_out.own_segment_index == 1
+    assert out.played == "partial"
+    assert out.playback_position > 0
+
+
+async def test_interrupted_commit_stays_skipped_without_any_capture() -> None:
+    # Interrupted before any frame was counted: no started event, no position
+    # evidence — the segment must stay "skipped" (nothing reached the user).
+    audio_output = FakeAudioOutput()
+    speech_handle = SpeechHandle.create()
+
+    async def _audio_source() -> AsyncIterable[rtc.AudioFrame]:
+        await asyncio.Event().wait()  # never yields
+        yield _make_frame()  # pragma: no cover
+
+    forward_task = asyncio.create_task(
+        forward_generation(
+            speech_handle=speech_handle,
+            audio_output=audio_output,
+            text_output=None,
+            audio_source=_audio_source(),
+            text_source=None,
+            on_first_frame=lambda _fut, _out: None,
+        )
+    )
+
+    await asyncio.sleep(0.05)
+    speech_handle.interrupt()
+    out = await asyncio.wait_for(forward_task, timeout=5)
+
+    assert out.audio_out is not None
+    assert out.audio_out.own_segment_index is None
+    assert out.played == "skipped"

--- a/tests/test_playback_started_attribution.py
+++ b/tests/test_playback_started_attribution.py
@@ -1,11 +1,3 @@
-"""Tests for playback_started attribution and interrupted position evidence.
-
-Mirrors agents-js#1966: the shared AudioOutput emits playback_started with no
-segment identity, so the per-segment listener only resolves after this segment
-has captured its own frame; interrupted commits also accept playback_position > 0
-when this segment bumped the output's segment counter.
-"""
-
 from __future__ import annotations
 
 import asyncio
@@ -37,12 +29,7 @@ def _make_frame(duration: float = 0.1) -> rtc.AudioFrame:
 
 
 class _ForwardFirstWrapper(AudioOutput):
-    """Mimics _SyncedAudioOutput / recorder ordering.
-
-    Forwards to the leaf (which emits playback_started synchronously inside the
-    first capture) BEFORE counting its own segment, so the forwarded event fires
-    while this output's counter still reads the pre-capture snapshot.
-    """
+    """Count each segment after forwarding its first frame."""
 
     def __init__(self, next_in_chain: AudioOutput) -> None:
         super().__init__(
@@ -67,19 +54,13 @@ class _ForwardFirstWrapper(AudioOutput):
 
 
 class _NoStartNotifyOutput(FakeAudioOutput):
-    """A sink whose playback-started notification is delayed/lost.
-
-    Simulates a remote (avatar) output that delivers playback_started via RPC:
-    frames are accepted and counted, playback genuinely progresses (so the
-    playback-finished event reports a real position), but no playback_started
-    is emitted locally.
-    """
+    """Play audio without emitting ``playback_started``."""
 
     async def capture_frame(self, frame: rtc.AudioFrame) -> None:
-        await AudioOutput.capture_frame(self, frame)  # count the playout segment
+        await AudioOutput.capture_frame(self, frame)
         self._pushed_duration += frame.duration
         if self._started_at is None:
-            self._started_at = time.time()  # playing, but never notifies
+            self._started_at = time.time()
 
 
 async def _drive_forwarding(
@@ -114,9 +95,6 @@ async def test_own_playback_started_resolves_first_frame_fut() -> None:
 
 
 async def test_own_event_forwarded_before_wrapper_counts_still_resolves() -> None:
-    # Chained outputs (transcript sync, recorder) forward the leaf's synchronous
-    # playback_started before counting their own segment: the event must still be
-    # attributed once has_captured_own_frame is set.
     audio_output = _ForwardFirstWrapper(FakeAudioOutput())
     frames_ch: asyncio.Queue[rtc.AudioFrame | None] = asyncio.Queue()
     task, out = await _drive_forwarding(audio_output, frames_ch)
@@ -133,10 +111,9 @@ async def test_stale_event_before_own_capture_is_ignored() -> None:
     audio_output = FakeAudioOutput()
     frames_ch: asyncio.Queue[rtc.AudioFrame | None] = asyncio.Queue()
     task, out = await _drive_forwarding(audio_output, frames_ch)
-    await asyncio.sleep(0)  # let the forwarding task attach the listener
+    await asyncio.sleep(0)  # Allow the forwarding task to attach its listener.
 
-    # a stale event (e.g. an avatar RPC from a previous, interrupted segment)
-    # arrives before this segment captured anything
+    # Simulate a delayed RPC from an interrupted segment.
     audio_output.on_playback_started(created_at=time.time())
 
     assert not out.first_frame_fut.done()
@@ -147,10 +124,7 @@ async def test_stale_event_before_own_capture_is_ignored() -> None:
 
 
 async def test_interrupted_commit_uses_position_evidence_without_started_event() -> None:
-    # Avatar-style race: frames genuinely played, but the started notification
-    # never arrived before the interruption. The playback position reported by
-    # the finished event is proof of partial playback when this segment bumped
-    # the output's segment count.
+    # A remote avatar can report playback progress before its start RPC arrives.
     audio_output = _NoStartNotifyOutput()
     speech_handle = SpeechHandle.create()
 
@@ -159,7 +133,7 @@ async def test_interrupted_commit_uses_position_evidence_without_started_event()
     async def _audio_source() -> AsyncIterable[rtc.AudioFrame]:
         yield _make_frame()
         frame_captured.set()
-        await asyncio.Event().wait()  # keep the TTS stream open until interrupted
+        await asyncio.Event().wait()  # Keep the stream open until interruption.
 
     forward_task = asyncio.create_task(
         forward_generation(
@@ -174,7 +148,7 @@ async def test_interrupted_commit_uses_position_evidence_without_started_event()
     )
 
     await asyncio.wait_for(frame_captured.wait(), timeout=5)
-    await asyncio.sleep(0.05)  # accrue some playback position
+    await asyncio.sleep(0.05)  # Accrue playback progress.
     speech_handle.interrupt()
     out = await asyncio.wait_for(forward_task, timeout=5)
 
@@ -186,13 +160,11 @@ async def test_interrupted_commit_uses_position_evidence_without_started_event()
 
 
 async def test_interrupted_commit_stays_skipped_without_any_capture() -> None:
-    # Interrupted before any frame was counted: no started event, no segment bump
-    # — the segment must stay "skipped" (nothing reached the user).
     audio_output = FakeAudioOutput()
     speech_handle = SpeechHandle.create()
 
     async def _audio_source() -> AsyncIterable[rtc.AudioFrame]:
-        await asyncio.Event().wait()  # never yields
+        await asyncio.Event().wait()
         yield _make_frame()  # pragma: no cover
 
     forward_task = asyncio.create_task(

--- a/tests/test_playback_started_attribution.py
+++ b/tests/test_playback_started_attribution.py
@@ -63,6 +63,17 @@ class _NoStartNotifyOutput(FakeAudioOutput):
             self._started_at = time.time()
 
 
+class _BlockingBeforeCaptureOutput(FakeAudioOutput):
+    def __init__(self) -> None:
+        super().__init__()
+        self.capture_entered = asyncio.Event()
+
+    async def capture_frame(self, frame: rtc.AudioFrame) -> None:
+        self.capture_entered.set()
+        await asyncio.Event().wait()
+        await super().capture_frame(frame)
+
+
 async def _drive_forwarding(
     audio_output: AudioOutput, frames_ch: asyncio.Queue[rtc.AudioFrame | None]
 ):
@@ -157,6 +168,36 @@ async def test_interrupted_commit_uses_position_evidence_without_started_event()
     assert audio_output.captured_playout_segments > out.audio_out.captured_segments_before
     assert out.played == "partial"
     assert out.playback_position > 0
+
+
+async def test_stale_event_during_unaccepted_capture_stays_skipped() -> None:
+    audio_output = _BlockingBeforeCaptureOutput()
+    speech_handle = SpeechHandle.create()
+
+    async def _audio_source() -> AsyncIterable[rtc.AudioFrame]:
+        yield _make_frame()
+
+    forward_task = asyncio.create_task(
+        forward_generation(
+            speech_handle=speech_handle,
+            audio_output=audio_output,
+            text_output=None,
+            audio_source=_audio_source(),
+            text_source=None,
+            on_first_frame=lambda _fut, _out: None,
+            reconcile_playout_pause=lambda: None,
+        )
+    )
+
+    await asyncio.wait_for(audio_output.capture_entered.wait(), timeout=5)
+    audio_output.on_playback_started(created_at=time.time())
+    speech_handle.interrupt()
+    out = await asyncio.wait_for(forward_task, timeout=5)
+
+    assert out.audio_out is not None
+    assert out.audio_out.first_frame_fut.done()
+    assert audio_output.captured_playout_segments == out.audio_out.captured_segments_before
+    assert out.played == "skipped"
 
 
 async def test_interrupted_commit_stays_skipped_without_any_capture() -> None:

--- a/tests/test_playback_started_attribution.py
+++ b/tests/test_playback_started_attribution.py
@@ -1,9 +1,9 @@
-"""Tests for cross-segment attribution of playback_started events (AGT-3147).
+"""Tests for playback_started attribution and interrupted position evidence.
 
-The shared AudioOutput emits playback_started with no segment identity, so the
-per-segment listener in perform_audio_forwarding and the interrupted-commit gates
-must decide whether an event/position belongs to their own segment. See
-_AudioOutput.own_segment_index and the listener guard in perform_audio_forwarding.
+Mirrors agents-js#1966: the shared AudioOutput emits playback_started with no
+segment identity, so the per-segment listener only resolves after this segment
+has captured its own frame; interrupted commits also accept playback_position > 0
+when this segment bumped the output's segment counter.
 """
 
 from __future__ import annotations
@@ -92,7 +92,11 @@ async def _drive_forwarding(
                 return
             yield frame
 
-    return perform_audio_forwarding(audio_output=audio_output, tts_output=_source())
+    return perform_audio_forwarding(
+        audio_output=audio_output,
+        tts_output=_source(),
+        reconcile_playout_pause=lambda: None,
+    )
 
 
 async def test_own_playback_started_resolves_first_frame_fut() -> None:
@@ -105,14 +109,14 @@ async def test_own_playback_started_resolves_first_frame_fut() -> None:
     await task
 
     assert out.first_frame_fut.done()
-    assert out.own_segment_index == 1
+    assert audio_output.captured_playout_segments > out.captured_segments_before
     audio_output.clear_buffer()
 
 
 async def test_own_event_forwarded_before_wrapper_counts_still_resolves() -> None:
     # Chained outputs (transcript sync, recorder) forward the leaf's synchronous
     # playback_started before counting their own segment: the event must still be
-    # attributed to the segment whose first capture is in flight.
+    # attributed once has_captured_own_frame is set.
     audio_output = _ForwardFirstWrapper(FakeAudioOutput())
     frames_ch: asyncio.Queue[rtc.AudioFrame | None] = asyncio.Queue()
     task, out = await _drive_forwarding(audio_output, frames_ch)
@@ -122,7 +126,6 @@ async def test_own_event_forwarded_before_wrapper_counts_still_resolves() -> Non
     await task
 
     assert out.first_frame_fut.done()
-    assert out.own_segment_index == 1
     audio_output.clear_buffer()
 
 
@@ -143,38 +146,11 @@ async def test_stale_event_before_own_capture_is_ignored() -> None:
     out.first_frame_fut.cancel()
 
 
-async def test_event_after_foreign_segment_bump_is_ignored() -> None:
-    # Segment A captures into a paused output (counted, but nothing plays and no
-    # playback_started fires). A foreign segment then bumps the counter. A later
-    # event must NOT resolve A's future: the counter no longer points at A.
-    audio_output = FakeAudioOutput(can_pause=True)
-    frames_ch: asyncio.Queue[rtc.AudioFrame | None] = asyncio.Queue()
-    task, out = await _drive_forwarding(audio_output, frames_ch)
-    await asyncio.sleep(0)  # forwarding task calls resume(); pause after it
-    audio_output.pause()
-
-    frames_ch.put_nowait(_make_frame())
-    frames_ch.put_nowait(None)
-    await task
-
-    assert out.own_segment_index == 1
-    assert not out.first_frame_fut.done()
-
-    # a foreign segment (next speech) opens on the shared output
-    await audio_output.capture_frame(_make_frame())
-    assert audio_output.captured_playout_segments == 2
-
-    # the foreign segment's playback starts
-    audio_output.on_playback_started(created_at=time.time())
-
-    assert not out.first_frame_fut.done()
-    out.first_frame_fut.cancel()
-
-
 async def test_interrupted_commit_uses_position_evidence_without_started_event() -> None:
     # Avatar-style race: frames genuinely played, but the started notification
     # never arrived before the interruption. The playback position reported by
-    # the finished event is proof of partial playback.
+    # the finished event is proof of partial playback when this segment bumped
+    # the output's segment count.
     audio_output = _NoStartNotifyOutput()
     speech_handle = SpeechHandle.create()
 
@@ -193,6 +169,7 @@ async def test_interrupted_commit_uses_position_evidence_without_started_event()
             audio_source=_audio_source(),
             text_source=None,
             on_first_frame=lambda _fut, _out: None,
+            reconcile_playout_pause=lambda: None,
         )
     )
 
@@ -203,14 +180,14 @@ async def test_interrupted_commit_uses_position_evidence_without_started_event()
 
     assert out.audio_out is not None
     assert not out.audio_out.first_frame_fut.done() or out.audio_out.first_frame_fut.cancelled()
-    assert out.audio_out.own_segment_index == 1
+    assert audio_output.captured_playout_segments > out.audio_out.captured_segments_before
     assert out.played == "partial"
     assert out.playback_position > 0
 
 
 async def test_interrupted_commit_stays_skipped_without_any_capture() -> None:
-    # Interrupted before any frame was counted: no started event, no position
-    # evidence — the segment must stay "skipped" (nothing reached the user).
+    # Interrupted before any frame was counted: no started event, no segment bump
+    # — the segment must stay "skipped" (nothing reached the user).
     audio_output = FakeAudioOutput()
     speech_handle = SpeechHandle.create()
 
@@ -226,6 +203,7 @@ async def test_interrupted_commit_stays_skipped_without_any_capture() -> None:
             audio_source=_audio_source(),
             text_source=None,
             on_first_frame=lambda _fut, _out: None,
+            reconcile_playout_pause=lambda: None,
         )
     )
 
@@ -234,5 +212,5 @@ async def test_interrupted_commit_stays_skipped_without_any_capture() -> None:
     out = await asyncio.wait_for(forward_task, timeout=5)
 
     assert out.audio_out is not None
-    assert out.audio_out.own_segment_index is None
+    assert audio_output.captured_playout_segments == out.audio_out.captured_segments_before
     assert out.played == "skipped"

--- a/tests/test_playout_launch_pause.py
+++ b/tests/test_playout_launch_pause.py
@@ -167,7 +167,11 @@ async def test_audio_forwarding_reconciles_playout_pause_before_first_frame() ->
     async def _frames():
         yield frame
 
-    out = _AudioOutput(audio=[], first_frame_fut=asyncio.Future())
+    out = _AudioOutput(
+        audio=[],
+        first_frame_fut=asyncio.Future(),
+        captured_segments_before=0,
+    )
     await _audio_forwarding_task(
         audio_output,
         _frames(),


### PR DESCRIPTION
Porting over  livekit/agents-js#1966

Fixes AGT-3147

🤖 Generated with [Claude Code](https://claude.com/claude-code)