### PR TITLE
assemblyai: make agent_context_carryover opt-in (off by default)

### DIFF
--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -547,7 +547,8 @@ class STT(stt.STT):
             http_session (aiohttp.ClientSession, optional): HTTP session to use.
             extra_kwargs (dict, optional): Extra kwargs to pass to the STT model.
             agent_context_carryover (bool, optional): Let an ``AgentSession`` push each assistant
-                reply into AssemblyAI's ``agent_context``. Only the U3 Pro family supports it (on by default there).
+                reply into AssemblyAI's ``agent_context``. Disabled by default; pass True to opt in
+                on the U3 Pro family (the only models that support it).
             fallback (FallbackModelType, optional): Fallback models - either a list of model names,
                 a list of FallbackModel instances.
             conn_options (APIConnectOptions, optional): Connection options for request attempts.
@@ -571,18 +572,15 @@ class STT(stt.STT):
 
         vad = _resolve_vad_for_model(model, vad if is_given(vad) else None)
 
-        extra_dict = dict(extra_kwargs) if is_given(extra_kwargs) else None
         supports_carryover = _supports_agent_context_carryover(model)
         if is_given(agent_context_carryover) and agent_context_carryover and not supports_carryover:
             logger.warning(
                 "agent_context_carryover is enabled but model %r does not support it; ignoring",
                 model,
             )
-        context_disabled = (
-            extra_dict is not None and extra_dict.get("previous_context_n_turns") == 0
-        )
-        carryover_enabled = supports_carryover and (
-            agent_context_carryover if is_given(agent_context_carryover) else not context_disabled
+        # Opt-in: off unless explicitly enabled on a model that supports it.
+        carryover_enabled = (
+            supports_carryover and is_given(agent_context_carryover) and agent_context_carryover
         )
 
         super().__init__(

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -219,10 +219,9 @@ class STT(stt.STT):
                 transcription of the user's reply. Set at construction or updated per-turn
                 via `update_options(agent_context=...)`. Only supported with the
                 Universal-3 Pro family models (max 1750 characters; longer values raise
-                ValueError). With ``agent_context_carryover`` enabled — the default on
-                Universal-3 Pro family models — each assistant reply replaces this value
-                automatically; pass ``agent_context_carryover=False`` to manage it
-                manually.
+                ValueError). With ``agent_context_carryover=True`` each assistant reply
+                replaces this value automatically; leave it disabled (the default) to
+                manage it manually.
             previous_context_n_turns: Maximum number of prior conversation entries (user
                 transcripts and any `agent_context` values) carried forward as context for
                 each transcription. Set to 0 to disable automatic context carryover
@@ -231,13 +230,12 @@ class STT(stt.STT):
                 (connect) time only; it cannot be changed via `update_options`.
             agent_context_carryover: When the model supports it, let an ``AgentSession`` push each
                 assistant reply into ``agent_context`` so it is carried into the model's
-                conversation context. Enabled by default on models that support it (the
-                Universal-3 Pro family); pass False to opt out. On other models it is off;
-                explicitly passing True logs a warning and is ignored. Also disabled by
-                default when ``previous_context_n_turns=0`` (context carryover explicitly
-                turned off). Prior user turns are carried automatically by the model
-                regardless of this flag. Replies longer than the 1750-character server cap
-                are truncated (keeping the tail) before being sent.
+                conversation context. Disabled by default; pass True to opt in on a model
+                that supports it (the Universal-3 Pro family). On other models it is off;
+                explicitly passing True logs a warning and is ignored. Prior user turns are
+                carried automatically by the model regardless of this flag. Replies longer
+                than the 1750-character server cap are truncated (keeping the tail) before
+                being sent.
             voice_focus: Voice Focus isolates the primary voice and suppresses background
                 noise (chatter, keyboard clicks, fan hum, room echo) before the audio reaches
                 the model. Use 'near-field' for headsets, handsets, and close-talking
@@ -274,20 +272,16 @@ class STT(stt.STT):
         if is_given(agent_context):
             _validate_agent_context(agent_context)
         # agent_context carryover is only available on the u3-rt-pro family
-        # ("u3-pro" is normalized to "u3-rt-pro" below). Unset means "on where
-        # supported"; only an explicit True on an unsupported model warns.
+        # ("u3-pro" is normalized to "u3-rt-pro" below). It is opt-in: off unless
+        # explicitly enabled, and an explicit True on an unsupported model warns.
         supports_carryover = model in _U3_PRO_MODELS or model == "u3-pro"
         if is_given(agent_context_carryover) and agent_context_carryover and not supports_carryover:
             logger.warning(
                 "agent_context_carryover is enabled but model %r does not support it; ignoring",
                 model,
             )
-        # previous_context_n_turns=0 is documented as "disable automatic context
-        # carryover" — honor it in the default resolution (an explicit
-        # agent_context_carryover=True still wins).
-        _context_disabled = is_given(previous_context_n_turns) and previous_context_n_turns == 0
-        carryover_enabled = supports_carryover and (
-            agent_context_carryover if is_given(agent_context_carryover) else not _context_disabled
+        carryover_enabled = (
+            supports_carryover and is_given(agent_context_carryover) and agent_context_carryover
         )
         super().__init__(
             capabilities=stt.STTCapabilities(

--- a/tests/test_inference_stt_context.py
+++ b/tests/test_inference_stt_context.py
@@ -36,10 +36,17 @@ def _assistant_item_event(text: str) -> ConversationItemAddedEvent:
 # -- capability gating --
 
 
-def test_carryover_defaults_on_for_u3_pro_family():
-    """agent_context_carryover defaults to enabled on models that support it."""
+def test_carryover_defaults_off_for_u3_pro_family():
+    """agent_context_carryover is opt-in: off by default even on models that support it."""
     for model in ("assemblyai/u3-rt-pro", "assemblyai/universal-3-5-pro"):
         stt = _make_stt(model=model)
+        assert stt.capabilities.chat_context is False
+
+
+def test_carryover_explicit_true_enables_on_u3_pro_family():
+    """agent_context_carryover=True opts in on models that support it."""
+    for model in ("assemblyai/u3-rt-pro", "assemblyai/universal-3-5-pro"):
+        stt = _make_stt(model=model, agent_context_carryover=True)
         assert stt.capabilities.chat_context is True
 
 
@@ -73,14 +80,8 @@ def test_carryover_explicit_false_disables():
     assert stt.capabilities.chat_context is False
 
 
-def test_carryover_disabled_by_previous_context_n_turns_zero():
-    """previous_context_n_turns=0 (documented 'disable carryover') suppresses the default."""
-    stt = _make_stt(extra_kwargs={"previous_context_n_turns": 0})
-    assert stt.capabilities.chat_context is False
-
-
 def test_carryover_explicit_true_wins_over_n_turns_zero():
-    """An explicit agent_context_carryover=True overrides the n_turns=0 suppression."""
+    """agent_context_carryover=True enables carryover regardless of previous_context_n_turns."""
     stt = _make_stt(extra_kwargs={"previous_context_n_turns": 0}, agent_context_carryover=True)
     assert stt.capabilities.chat_context is True
 

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -1319,7 +1319,7 @@ async def test_language_code_singular_not_in_update_options():
 
 
 # ---------------------------------------------------------------------------
-# agent_context server cap (1750 chars) + agent_context_carryover default
+# agent_context server cap (1750 chars) + agent_context_carryover opt-in
 #
 # The server rejects `agent_context` longer than 1750 chars, and an invalid
 # UpdateConfiguration cancels the whole streaming session — so the plugin
@@ -1404,7 +1404,7 @@ async def test_carryover_truncates_oversize_reply_keeping_tail():
 
 async def test_carryover_ignores_non_assistant_items():
     """_push_conversation_item ignores user messages and textless assistant items
-    — the shapes it receives now that carryover is on by default."""
+    — the shapes it receives when carryover is enabled."""
     from livekit.agents.llm import ChatMessage
     from livekit.agents.voice.events import ConversationItemAddedEvent
     from livekit.plugins.assemblyai import STT
@@ -1437,12 +1437,21 @@ async def test_carryover_ignores_agent_handoff_items():
     assert stt._opts.agent_context is NOT_GIVEN
 
 
-async def test_carryover_defaults_on_for_u3_pro_family():
-    """agent_context_carryover defaults to enabled on models that support it."""
+async def test_carryover_defaults_off_for_u3_pro_family():
+    """agent_context_carryover is opt-in: off by default even on models that support it."""
     from livekit.plugins.assemblyai import STT
 
     for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro", "u3-pro"):
         stt = STT(api_key="test-key", model=model)
+        assert stt.capabilities.chat_context is False
+
+
+async def test_carryover_explicit_true_enables_on_u3_pro_family():
+    """agent_context_carryover=True opts in on models that support it."""
+    from livekit.plugins.assemblyai import STT
+
+    for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro", "u3-pro"):
+        stt = STT(api_key="test-key", model=model, agent_context_carryover=True)
         assert stt.capabilities.chat_context is True
 
 
@@ -1484,16 +1493,8 @@ async def test_carryover_explicit_false_disables():
     assert stt.capabilities.chat_context is False
 
 
-async def test_carryover_disabled_by_previous_context_n_turns_zero():
-    """previous_context_n_turns=0 (documented 'disable carryover') suppresses the default."""
-    from livekit.plugins.assemblyai import STT
-
-    stt = STT(api_key="test-key", previous_context_n_turns=0)
-    assert stt.capabilities.chat_context is False
-
-
 async def test_carryover_explicit_true_wins_over_n_turns_zero():
-    """An explicit agent_context_carryover=True overrides the n_turns=0 suppression."""
+    """agent_context_carryover=True enables carryover regardless of previous_context_n_turns."""
     from livekit.plugins.assemblyai import STT
 
     stt = STT(api_key="test-key", previous_context_n_turns=0, agent_context_carryover=True)


### PR DESCRIPTION
Default agent_context_carryover to off for both the AssemblyAI plugin and LiveKit Inference STT; require an explicit True to enable it on the Universal-3 Pro family models.