### PR TITLE
fix(stt): reconnect on send-side socket drops in remaining plugins

### DIFF
--- a/livekit-plugins/livekit-plugins-fireworksai/livekit/plugins/fireworksai/stt.py
+++ b/livekit-plugins/livekit-plugins-fireworksai/livekit/plugins/fireworksai/stt.py
@@ -27,6 +27,7 @@ import aiohttp
 
 from livekit.agents import (
     DEFAULT_API_CONNECT_OPTIONS,
+    APIConnectionError,
     APIConnectOptions,
     APIStatusError,
     LanguageCode,
@@ -335,18 +336,23 @@ class SpeechStream(stt.SpeechStream):
                 samples_per_channel=samples_per_buffer,
             )
 
-            async for data in self._input_ch:
-                if isinstance(data, self._FlushSentinel):
-                    frames = audio_bstream.flush()
-                else:
-                    frames = audio_bstream.write(data.data.tobytes())
+            try:
+                async for data in self._input_ch:
+                    if isinstance(data, self._FlushSentinel):
+                        frames = audio_bstream.flush()
+                    else:
+                        frames = audio_bstream.write(data.data.tobytes())
 
-                for frame in frames:
-                    await self._audio_duration_collector.push(frame.duration)
-                    await ws.send_bytes(frame.data.tobytes())
+                    for frame in frames:
+                        await self._audio_duration_collector.push(frame.duration)
+                        await ws.send_bytes(frame.data.tobytes())
 
-            closing_ws = True
-            await ws.send_str(self._CLOSE_MSG)
+                closing_ws = True
+                await ws.send_str(self._CLOSE_MSG)
+            except (aiohttp.ClientError, ConnectionError) as e:
+                if closing_ws:
+                    return
+                raise APIConnectionError("Fireworks AI connection closed unexpectedly") from e
 
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
             nonlocal closing_ws

--- a/livekit-plugins/livekit-plugins-gradium/livekit/plugins/gradium/stt.py
+++ b/livekit-plugins/livekit-plugins-gradium/livekit/plugins/gradium/stt.py
@@ -28,6 +28,7 @@ import aiohttp
 
 from livekit.agents import (
     DEFAULT_API_CONNECT_OPTIONS,
+    APIConnectionError,
     APIConnectOptions,
     APIStatusError,
     LanguageCode,
@@ -256,22 +257,27 @@ class SpeechStream(stt.SpeechStream):
                 samples_per_channel=samples_per_buffer,
             )
 
-            async for data in self._input_ch:
-                if isinstance(data, self._FlushSentinel):
-                    frames = audio_bstream.flush()
-                else:
-                    frames = audio_bstream.write(data.data.tobytes())
+            try:
+                async for data in self._input_ch:
+                    if isinstance(data, self._FlushSentinel):
+                        frames = audio_bstream.flush()
+                    else:
+                        frames = audio_bstream.write(data.data.tobytes())
 
-                for frame in frames:
-                    if len(frame.data) % 2 != 0:
-                        logger.warning("Frame data size not aligned to int16 (multiple of 2)")
+                    for frame in frames:
+                        if len(frame.data) % 2 != 0:
+                            logger.warning("Frame data size not aligned to int16 (multiple of 2)")
 
-                    audio_data = base64.b64encode(frame.data.tobytes()).decode("utf-8")
-                    audio_msg = {
-                        "type": "audio",
-                        "audio": audio_data,
-                    }
-                    await ws.send_str(json.dumps(audio_msg))
+                        audio_data = base64.b64encode(frame.data.tobytes()).decode("utf-8")
+                        audio_msg = {
+                            "type": "audio",
+                            "audio": audio_data,
+                        }
+                        await ws.send_str(json.dumps(audio_msg))
+            except (aiohttp.ClientError, ConnectionError) as e:
+                if self._session.closed:
+                    return
+                raise APIConnectionError("Gradium connection closed unexpectedly") from e
 
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
             nonlocal closing_ws

--- a/livekit-plugins/livekit-plugins-simplismart/livekit/plugins/simplismart/stt.py
+++ b/livekit-plugins/livekit-plugins-simplismart/livekit/plugins/simplismart/stt.py
@@ -339,15 +339,23 @@ class SpeechStream(stt.SpeechStream):
                 samples_per_channel=samples_50ms,
             )
 
-            async for data in self._input_ch:
-                frames: list[rtc.AudioFrame] = []
-                if isinstance(data, rtc.AudioFrame):
-                    frames.extend(audio_bstream.write(data.data.tobytes()))
-                elif isinstance(data, self._FlushSentinel):
-                    frames.extend(audio_bstream.flush())
+            try:
+                async for data in self._input_ch:
+                    frames: list[rtc.AudioFrame] = []
+                    if isinstance(data, rtc.AudioFrame):
+                        frames.extend(audio_bstream.write(data.data.tobytes()))
+                    elif isinstance(data, self._FlushSentinel):
+                        frames.extend(audio_bstream.flush())
 
-                for frame in frames:
-                    await ws.send_bytes(frame.data.tobytes())
+                    for frame in frames:
+                        await ws.send_bytes(frame.data.tobytes())
+            except (aiohttp.ClientError, ConnectionError):
+                # mirror recv_task: a mid-send socket drop should trigger an internal
+                # reconnect (see the _run loop), not crash the session.
+                if self._session.closed:
+                    return
+                self._reconnect_event.set()
+                return
 
         @utils.log_exceptions(logger=logger)
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:

--- a/livekit-plugins/livekit-plugins-slng/livekit/plugins/slng/stt.py
+++ b/livekit-plugins/livekit-plugins-slng/livekit/plugins/slng/stt.py
@@ -523,25 +523,30 @@ class SpeechStream(stt.SpeechStream):
                 samples_per_channel=samples_per_buffer,
             )
 
-            for frame in pending_frames:
-                frames = audio_bstream.write(frame.data.tobytes())
-                for out in frames:
-                    if len(out.data) % bytes_per_sample != 0:
-                        continue
-                    await ws.send_bytes(bytes(out.data))
-                    self._speech_duration += out.duration
+            try:
+                for frame in pending_frames:
+                    frames = audio_bstream.write(frame.data.tobytes())
+                    for out in frames:
+                        if len(out.data) % bytes_per_sample != 0:
+                            continue
+                        await ws.send_bytes(bytes(out.data))
+                        self._speech_duration += out.duration
 
-            async for item in self._input_ch:
-                if isinstance(item, self._FlushSentinel):
-                    frames = audio_bstream.flush()
-                else:
-                    frames = audio_bstream.write(item.data.tobytes())
+                async for item in self._input_ch:
+                    if isinstance(item, self._FlushSentinel):
+                        frames = audio_bstream.flush()
+                    else:
+                        frames = audio_bstream.write(item.data.tobytes())
 
-                for frame in frames:
-                    if len(frame.data) % bytes_per_sample != 0:
-                        continue
-                    await ws.send_bytes(bytes(frame.data))
-                    self._speech_duration += frame.duration
+                    for frame in frames:
+                        if len(frame.data) % bytes_per_sample != 0:
+                            continue
+                        await ws.send_bytes(bytes(frame.data))
+                        self._speech_duration += frame.duration
+            except (aiohttp.ClientError, ConnectionError) as e:
+                if self._session.closed:
+                    return
+                raise APIConnectionError("SLNG connection closed unexpectedly") from e
 
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
             speech_started = False

--- a/livekit-plugins/livekit-plugins-slng/livekit/plugins/slng/stt.py
+++ b/livekit-plugins/livekit-plugins-slng/livekit/plugins/slng/stt.py
@@ -546,7 +546,10 @@ class SpeechStream(stt.SpeechStream):
             except (aiohttp.ClientError, ConnectionError) as e:
                 if self._session.closed:
                     return
-                raise APIConnectionError("SLNG connection closed unexpectedly") from e
+                # match recv_task: raise APIStatusError (not APIConnectionError) so a
+                # transient send-side drop gets slng's same-endpoint immediate retry
+                # rather than a permanent failover to a lower-priority endpoint.
+                raise APIStatusError("SLNG connection closed unexpectedly") from e
 
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
             speech_started = False

--- a/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/stt.py
+++ b/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/stt.py
@@ -360,24 +360,29 @@ class SpeechStream(stt.SpeechStream):
                 samples_per_channel=samples_per_chunk,
             )
 
-            async for data in self._input_ch:
-                if isinstance(data, rtc.AudioFrame):
-                    for frame in audio_bstream.write(data.data.tobytes()):
-                        self._audio_duration_collector.push(frame.duration)
-                        await ws.send_bytes(frame.data.tobytes())
-                elif isinstance(data, self._FlushSentinel):
-                    # User paused: drain the accumulator so the server gets all buffered
-                    # audio. The server's eou_timeout_ms will then detect the silence and
-                    # emit a final transcript — no explicit flush message is needed.
-                    for frame in audio_bstream.flush():
-                        self._audio_duration_collector.push(frame.duration)
-                        await ws.send_bytes(frame.data.tobytes())
-                    self._audio_duration_collector.flush()
+            try:
+                async for data in self._input_ch:
+                    if isinstance(data, rtc.AudioFrame):
+                        for frame in audio_bstream.write(data.data.tobytes()):
+                            self._audio_duration_collector.push(frame.duration)
+                            await ws.send_bytes(frame.data.tobytes())
+                    elif isinstance(data, self._FlushSentinel):
+                        # User paused: drain the accumulator so the server gets all buffered
+                        # audio. The server's eou_timeout_ms will then detect the silence and
+                        # emit a final transcript — no explicit flush message is needed.
+                        for frame in audio_bstream.flush():
+                            self._audio_duration_collector.push(frame.duration)
+                            await ws.send_bytes(frame.data.tobytes())
+                        self._audio_duration_collector.flush()
 
-            # Input channel closed: close the stream so the server flushes remaining
-            # audio, emits final transcripts, and sends is_last=True.
-            closing_ws = True
-            await ws.send_str(SpeechStream._CLOSE_STREAM_MSG)
+                # Input channel closed: close the stream so the server flushes remaining
+                # audio, emits final transcripts, and sends is_last=True.
+                closing_ws = True
+                await ws.send_str(SpeechStream._CLOSE_STREAM_MSG)
+            except (aiohttp.ClientError, ConnectionError) as e:
+                if closing_ws or self._session.closed:
+                    return
+                raise APIConnectionError("Smallest AI connection closed unexpectedly") from e
 
         @utils.log_exceptions(logger=logger)
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:

--- a/livekit-plugins/livekit-plugins-telnyx/livekit/plugins/telnyx/stt.py
+++ b/livekit-plugins/livekit-plugins-telnyx/livekit/plugins/telnyx/stt.py
@@ -184,7 +184,6 @@ class SpeechStream(stt.RecognizeStream):
             nonlocal closing_ws
 
             wav_header = _create_streaming_wav_header(self._stt._opts.sample_rate, NUM_CHANNELS)
-            await ws.send_bytes(wav_header)
 
             samples_per_chunk = self._stt._opts.sample_rate // 20
             audio_bstream = utils.audio.AudioByteStream(
@@ -193,20 +192,27 @@ class SpeechStream(stt.RecognizeStream):
                 samples_per_channel=samples_per_chunk,
             )
 
-            async for data in self._input_ch:
-                if isinstance(data, rtc.AudioFrame):
-                    for frame in audio_bstream.write(data.data.tobytes()):
-                        await ws.send_bytes(frame.data.tobytes())
-                elif isinstance(data, self._FlushSentinel):
-                    for frame in audio_bstream.flush():
-                        await ws.send_bytes(frame.data.tobytes())
+            try:
+                await ws.send_bytes(wav_header)
 
-            for frame in audio_bstream.flush():
-                await ws.send_bytes(frame.data.tobytes())
+                async for data in self._input_ch:
+                    if isinstance(data, rtc.AudioFrame):
+                        for frame in audio_bstream.write(data.data.tobytes()):
+                            await ws.send_bytes(frame.data.tobytes())
+                    elif isinstance(data, self._FlushSentinel):
+                        for frame in audio_bstream.flush():
+                            await ws.send_bytes(frame.data.tobytes())
 
-            # Don't close the WS here — let recv_task read the final
-            # transcript before the server closes the connection.
-            closing_ws = True
+                for frame in audio_bstream.flush():
+                    await ws.send_bytes(frame.data.tobytes())
+
+                # Don't close the WS here — let recv_task read the final
+                # transcript before the server closes the connection.
+                closing_ws = True
+            except (aiohttp.ClientError, ConnectionError) as e:
+                if closing_ws:
+                    return
+                raise APIConnectionError("Telnyx STT connection closed unexpectedly") from e
 
         @utils.log_exceptions(logger=logger)
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/stt.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/stt.py
@@ -291,20 +291,25 @@ class SpeechStream(stt.RecognizeStream):
                 samples_per_channel=samples_50ms,
             )
 
-            async for data in self._input_ch:
-                frames: list[rtc.AudioFrame] = []
-                if isinstance(data, rtc.AudioFrame):
-                    frames.extend(audio_bstream.write(data.data.tobytes()))
-                elif isinstance(data, self._FlushSentinel):
-                    frames.extend(audio_bstream.flush())
+            try:
+                async for data in self._input_ch:
+                    frames: list[rtc.AudioFrame] = []
+                    if isinstance(data, rtc.AudioFrame):
+                        frames.extend(audio_bstream.write(data.data.tobytes()))
+                    elif isinstance(data, self._FlushSentinel):
+                        frames.extend(audio_bstream.flush())
 
-                for frame in frames:
-                    self._audio_duration_collector.push(frame.duration)
-                    await ws.send_bytes(frame.data.tobytes())
+                    for frame in frames:
+                        self._audio_duration_collector.push(frame.duration)
+                        await ws.send_bytes(frame.data.tobytes())
 
-            self._audio_duration_collector.flush()
-            await ws.send_str(json.dumps({"type": "audio.done"}))
-            closing_ws = True
+                self._audio_duration_collector.flush()
+                closing_ws = True
+                await ws.send_str(json.dumps({"type": "audio.done"}))
+            except (aiohttp.ClientError, ConnectionError) as e:
+                if closing_ws or self._session.closed:
+                    return
+                raise APIConnectionError("xAI connection closed unexpectedly") from e
 
         @utils.log_exceptions(logger=logger)
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:

--- a/tests/_stt_send_drop.py
+++ b/tests/_stt_send_drop.py
@@ -1,0 +1,161 @@
+"""Shared harness for the send-side WebSocket-drop acceptance matrix (issue #6473).
+
+Every STT plugin builds its ``SpeechStream`` differently, so each provider supplies a
+``build_stream(session)`` callable and this harness injects a mid-send socket drop.
+It encodes the release invariant from the issue:
+
+    one unexpected send-side drop  -> one retryable APIError (APIConnectionError, or
+                                      APIStatusError for slng) that SpeechStream._main_task
+                                      turns into one bounded reconnect
+    a drop during shutdown         -> a quiet return, no reconnect loop
+    the in-flight audio frame      -> attempted at most once (no tight replay), loss observable
+
+This module is intentionally un-marked: it is imported by the per-plugin
+``test_plugin_<name>_stt.py`` files (each owns its ``pytest.mark.plugin(...)`` marker so CI's
+``--plugin <name>`` isolation keeps working). It is not collected as a test module — the
+category scanner only globs ``test_*.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import aiohttp
+import pytest
+
+from livekit import rtc
+
+# The three raw failures aiohttp surfaces when send_bytes()/send_str() hits a peer-closed socket.
+SEND_DROP_ERRORS = [
+    pytest.param(
+        lambda: aiohttp.ClientConnectionResetError("Cannot write to closing transport"),
+        id="ClientConnectionResetError",
+    ),
+    pytest.param(lambda: aiohttp.ClientOSError(32, "Broken pipe"), id="ClientOSError"),
+    pytest.param(lambda: ConnectionError("connection reset by peer"), id="ConnectionError"),
+]
+
+
+class DropWebSocket:
+    """Lets the first ``setup_sends`` messages (handshake) succeed, then raises
+    ``error_factory()`` on every later send — i.e. the socket drops mid-stream.
+
+    ``audio_sends`` counts sends *after* the handshake: it must be exactly 1, proving the
+    plugin surfaces the error after a single attempt instead of retrying the send in a loop.
+    """
+
+    def __init__(
+        self, error_factory, *, setup_sends: int = 0, ready_messages=(), drop_on_bytes: bool = False
+    ) -> None:
+        self._error_factory = error_factory
+        self._setup_sends = setup_sends
+        # drop_on_bytes: audio (send_bytes) always drops, control frames (send_str/send_json) always
+        # pass. Needed for plugins that reconnect inside _run (e.g. slng's endpoint failover), where
+        # every reconnection re-sends a handshake that must succeed regardless of the global count.
+        self._drop_on_bytes = drop_on_bytes
+        self._ready = list(ready_messages)  # TEXT frames recv_task must see (e.g. a server "ready")
+        self._sends = 0
+        self.close_code: int | None = None
+        self.sent: list[object] = []
+        self.audio_sends = 0
+
+    async def _maybe_drop(self, payload: object, *, is_bytes: bool) -> None:
+        if self._drop_on_bytes:
+            if not is_bytes:
+                self.sent.append(payload)
+                return
+            self.audio_sends += 1
+            raise self._error_factory()
+        self._sends += 1
+        if self._sends <= self._setup_sends:
+            self.sent.append(payload)
+            return
+        self.audio_sends += 1
+        raise self._error_factory()
+
+    async def send_str(self, message: str) -> None:
+        await self._maybe_drop(message, is_bytes=False)
+
+    async def send_bytes(self, data: bytes) -> None:
+        await self._maybe_drop(data, is_bytes=True)
+
+    async def send_json(self, data: object) -> None:
+        await self._maybe_drop(data, is_bytes=False)
+
+    async def receive(self):
+        # deliver any handshake frames first (unblocks send paths gated on a server "ready"),
+        # then stay blocked so the *send* drop is what completes _run
+        if self._ready:
+            return aiohttp.WSMessage(aiohttp.WSMsgType.TEXT, self._ready.pop(0), "")
+        await asyncio.Event().wait()
+
+    async def close(self) -> None:
+        pass
+
+
+class DropSession:
+    """Minimal aiohttp.ClientSession stand-in returning a single DropWebSocket."""
+
+    def __init__(self, ws: DropWebSocket, *, closed: bool = False) -> None:
+        self._ws = ws
+        self.closed = closed
+
+    async def ws_connect(self, *args, **kwargs) -> DropWebSocket:
+        return self._ws
+
+
+def _no_background_task():
+    """Neutralize the STT base class's background create_task so nothing runs off-test."""
+
+    def _fake_create_task(coro, *args, **kwargs):
+        coro.close()
+        return MagicMock()
+
+    return patch("livekit.agents.stt.stt.asyncio.create_task", side_effect=_fake_create_task)
+
+
+def _frame(sample_rate: int, samples: int = 1920) -> rtc.AudioFrame:
+    return rtc.AudioFrame(
+        data=b"\x00\x00" * samples,
+        sample_rate=sample_rate,
+        num_channels=1,
+        samples_per_channel=samples,
+    )
+
+
+async def run_send_drop(
+    build_stream,
+    error_factory,
+    *,
+    sample_rate: int = 16000,
+    setup_sends: int = 0,
+    session_closed: bool = False,
+    ready_messages=(),
+    drop_on_bytes: bool = False,
+    n_frames: int = 25,
+    timeout: float = 5.0,
+):
+    """Build a stream over a dropping socket, feed audio, run it once.
+
+    Enough frames are pushed to guarantee at least one audio send regardless of how the
+    provider buffers. Returns ``(exception_or_None, ws)`` — the exception raised by ``_run()``
+    (``None`` if it returned quietly) and the DropWebSocket for inspecting ``audio_sends``.
+    """
+    ws = DropWebSocket(
+        error_factory,
+        setup_sends=setup_sends,
+        ready_messages=ready_messages,
+        drop_on_bytes=drop_on_bytes,
+    )
+    session = DropSession(ws, closed=session_closed)
+    with _no_background_task():
+        stream = build_stream(session)
+    for _ in range(n_frames):
+        stream.push_frame(_frame(sample_rate))
+    stream.end_input()
+    try:
+        await asyncio.wait_for(stream._run(), timeout=timeout)
+        return None, ws
+    except BaseException as exc:  # noqa: BLE001 — the caller asserts on the exact type
+        return exc, ws

--- a/tests/test_plugin_fireworksai_stt.py
+++ b/tests/test_plugin_fireworksai_stt.py
@@ -1,0 +1,54 @@
+"""Send-side WebSocket-drop acceptance matrix for Fireworks AI STT (issue #6473)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests._stt_send_drop import SEND_DROP_ERRORS, run_send_drop
+
+pytestmark = pytest.mark.plugin("fireworksai")
+
+SETUP_SENDS = 0
+
+
+def _build_stream(session):
+    from livekit.agents import DEFAULT_API_CONNECT_OPTIONS
+    from livekit.plugins.fireworksai import STT
+    from livekit.plugins.fireworksai.stt import SpeechStream
+
+    stt = STT(api_key="test-key")
+    return SpeechStream(
+        stt=stt,
+        opts=stt._opts,
+        conn_options=DEFAULT_API_CONNECT_OPTIONS,
+        api_key="test-key",
+        http_session=session,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_factory", SEND_DROP_ERRORS)
+async def test_send_drop_is_retryable(error_factory):
+    from livekit.agents import APIConnectionError, APIError
+
+    exc, _ws = await run_send_drop(_build_stream, error_factory, setup_sends=SETUP_SENDS)
+
+    assert isinstance(exc, APIConnectionError), (
+        f"expected retryable APIConnectionError, got {exc!r}"
+    )
+    assert isinstance(exc, APIError)
+
+
+@pytest.mark.asyncio
+async def test_dropped_frame_attempted_once():
+    exc, ws = await run_send_drop(
+        _build_stream, SEND_DROP_ERRORS[0].values[0], setup_sends=SETUP_SENDS
+    )
+
+    assert ws.audio_sends == 1
+    assert exc is not None
+
+
+# NOTE: fireworksai's quiet-return guard keys off its own `closing_ws` flag (normal end-of-input),
+# not `self._session.closed`, so the session-closed shutdown case doesn't apply here — the
+# no-reconnect-on-close behavior is exercised by the normal shutdown path.

--- a/tests/test_plugin_gradium_stt.py
+++ b/tests/test_plugin_gradium_stt.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+from tests._stt_send_drop import SEND_DROP_ERRORS, run_send_drop
 
 pytestmark = pytest.mark.plugin("gradium")
 
@@ -89,78 +90,75 @@ async def test_speech_stream_sends_language_in_json_config():
     assert setup_msg["json_config"] == {"language": "pt", "temp": 0.3}
 
 
-@pytest.mark.asyncio
-async def test_send_side_socket_drop_raises_api_connection_error():
-    """A mid-send WebSocket drop is surfaced as a retryable APIConnectionError.
+# --- send-side WebSocket-drop acceptance matrix (issue #6473) -------------------------------
+# Gradium is the reference provider; the same three tests run for the other six plugins via
+# the shared harness (tests/_stt_send_drop.py), each swapping only `_build_stream`.
 
-    The base ``SpeechStream._main_task`` only reconnects on ``APIError``; any other
-    exception kills the stream. ``ws.send_bytes``/``send_str`` on a peer-closed socket
-    raises a raw ``aiohttp.ClientConnectionResetError`` (a ``ConnectionResetError``),
-    which is *not* an ``APIError`` — so before this fix a send-side drop terminated the
-    session with no reconnect, while an identical recv-side drop raised the retryable
-    ``APIStatusError``. This test pins the send path to the same retryable behavior.
-    """
-    import aiohttp
+SETUP_SENDS = 1  # gradium sends one setup payload in _connect_ws before the audio loop
 
-    from livekit import rtc
-    from livekit.agents import DEFAULT_API_CONNECT_OPTIONS, APIConnectionError, LanguageCode
+
+def _build_stream(session):
+    from livekit.agents import DEFAULT_API_CONNECT_OPTIONS, LanguageCode
     from livekit.plugins.gradium import STT
     from livekit.plugins.gradium.stt import SpeechStream, STTOptions
 
-    class FakeWebSocket:
-        def __init__(self) -> None:
-            self._sends = 0
-            self.close_code: int | None = None
-
-        async def send_str(self, message: str) -> None:
-            # first send is the setup payload from _connect_ws — let it succeed,
-            # then drop the socket on the first audio chunk from send_task.
-            self._sends += 1
-            if self._sends == 1:
-                return
-            raise aiohttp.ClientConnectionResetError("Cannot write to closing transport")
-
-        async def receive(self):
-            # recv_task must stay blocked so the send drop is what completes _run
-            await asyncio.Event().wait()
-
-        async def close(self) -> None:
-            pass
-
-    class FakeSession:
-        closed = False
-
-        async def ws_connect(self, url, headers):
-            return FakeWebSocket()
-
     stt = STT(api_key="test-key")
-    opts = STTOptions(language=LanguageCode("en"))
-
-    def _fake_create_task(coro, *args, **kwargs):
-        coro.close()
-        return MagicMock()
-
-    with patch("livekit.agents.stt.stt.asyncio.create_task", side_effect=_fake_create_task):
-        stream = SpeechStream(
-            stt=stt,
-            opts=opts,
-            conn_options=DEFAULT_API_CONNECT_OPTIONS,
-            api_key="test-key",
-            model_endpoint="wss://api.gradium.ai/api/speech/asr",
-            model_name="default",
-            http_session=FakeSession(),
-        )
-
-    # one full 1920-sample buffer so send_task emits exactly one audio chunk, which drops
-    samples = 1920
-    frame = rtc.AudioFrame(
-        data=b"\x00\x00" * samples,
-        sample_rate=opts.sample_rate,
-        num_channels=1,
-        samples_per_channel=samples,
+    return SpeechStream(
+        stt=stt,
+        opts=STTOptions(language=LanguageCode("en")),
+        conn_options=DEFAULT_API_CONNECT_OPTIONS,
+        api_key="test-key",
+        model_endpoint="wss://api.gradium.ai/api/speech/asr",
+        model_name="default",
+        http_session=session,
     )
-    stream.push_frame(frame)
-    stream.end_input()
 
-    with pytest.raises(APIConnectionError):
-        await stream._run()
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_factory", SEND_DROP_ERRORS)
+async def test_send_drop_is_retryable(error_factory):
+    """Every send-side failure surfaces as a retryable APIConnectionError, never a raw error.
+
+    The base ``SpeechStream._main_task`` only reconnects on ``APIError``. ``send_bytes``/
+    ``send_str`` on a peer-closed socket raises a raw ``aiohttp`` error that is *not* an
+    ``APIError`` — so before the fix a send-side drop killed the session while an identical
+    recv-side drop was retryable. This pins the send path to the same retryable behavior,
+    which is what lets ``_main_task`` open a fresh socket and resume the transcript.
+    """
+    from livekit.agents import APIConnectionError, APIError
+
+    exc, _ws = await run_send_drop(_build_stream, error_factory, setup_sends=SETUP_SENDS)
+
+    assert isinstance(exc, APIConnectionError), (
+        f"expected retryable APIConnectionError, got {exc!r}"
+    )
+    assert isinstance(exc, APIError)
+
+
+@pytest.mark.asyncio
+async def test_dropped_frame_attempted_once():
+    """The in-flight frame is attempted exactly once — no inner send-retry loop, so a loss is
+    observable rather than a silent duplicate."""
+    exc, ws = await run_send_drop(
+        _build_stream, SEND_DROP_ERRORS[0].values[0], setup_sends=SETUP_SENDS
+    )
+
+    assert ws.audio_sends == 1
+    assert exc is not None
+
+
+@pytest.mark.asyncio
+async def test_drop_during_shutdown_does_not_reconnect():
+    """A drop while the session is closing returns quietly instead of raising a retryable
+    error (which would spin a reconnect loop)."""
+    from livekit.agents import APIConnectionError
+
+    exc, _ws = await run_send_drop(
+        _build_stream,
+        SEND_DROP_ERRORS[0].values[0],
+        setup_sends=SETUP_SENDS,
+        session_closed=True,
+        timeout=1.5,
+    )
+
+    assert not isinstance(exc, APIConnectionError)

--- a/tests/test_plugin_gradium_stt.py
+++ b/tests/test_plugin_gradium_stt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from unittest.mock import MagicMock, patch
 
@@ -86,3 +87,80 @@ async def test_speech_stream_sends_language_in_json_config():
 
     setup_msg = json.loads(sent_messages[0])
     assert setup_msg["json_config"] == {"language": "pt", "temp": 0.3}
+
+
+@pytest.mark.asyncio
+async def test_send_side_socket_drop_raises_api_connection_error():
+    """A mid-send WebSocket drop is surfaced as a retryable APIConnectionError.
+
+    The base ``SpeechStream._main_task`` only reconnects on ``APIError``; any other
+    exception kills the stream. ``ws.send_bytes``/``send_str`` on a peer-closed socket
+    raises a raw ``aiohttp.ClientConnectionResetError`` (a ``ConnectionResetError``),
+    which is *not* an ``APIError`` — so before this fix a send-side drop terminated the
+    session with no reconnect, while an identical recv-side drop raised the retryable
+    ``APIStatusError``. This test pins the send path to the same retryable behavior.
+    """
+    import aiohttp
+
+    from livekit import rtc
+    from livekit.agents import DEFAULT_API_CONNECT_OPTIONS, APIConnectionError, LanguageCode
+    from livekit.plugins.gradium import STT
+    from livekit.plugins.gradium.stt import SpeechStream, STTOptions
+
+    class FakeWebSocket:
+        def __init__(self) -> None:
+            self._sends = 0
+            self.close_code: int | None = None
+
+        async def send_str(self, message: str) -> None:
+            # first send is the setup payload from _connect_ws — let it succeed,
+            # then drop the socket on the first audio chunk from send_task.
+            self._sends += 1
+            if self._sends == 1:
+                return
+            raise aiohttp.ClientConnectionResetError("Cannot write to closing transport")
+
+        async def receive(self):
+            # recv_task must stay blocked so the send drop is what completes _run
+            await asyncio.Event().wait()
+
+        async def close(self) -> None:
+            pass
+
+    class FakeSession:
+        closed = False
+
+        async def ws_connect(self, url, headers):
+            return FakeWebSocket()
+
+    stt = STT(api_key="test-key")
+    opts = STTOptions(language=LanguageCode("en"))
+
+    def _fake_create_task(coro, *args, **kwargs):
+        coro.close()
+        return MagicMock()
+
+    with patch("livekit.agents.stt.stt.asyncio.create_task", side_effect=_fake_create_task):
+        stream = SpeechStream(
+            stt=stt,
+            opts=opts,
+            conn_options=DEFAULT_API_CONNECT_OPTIONS,
+            api_key="test-key",
+            model_endpoint="wss://api.gradium.ai/api/speech/asr",
+            model_name="default",
+            http_session=FakeSession(),
+        )
+
+    # one full 1920-sample buffer so send_task emits exactly one audio chunk, which drops
+    samples = 1920
+    frame = rtc.AudioFrame(
+        data=b"\x00\x00" * samples,
+        sample_rate=opts.sample_rate,
+        num_channels=1,
+        samples_per_channel=samples,
+    )
+    stream.push_frame(frame)
+    stream.end_input()
+
+    with pytest.raises(APIConnectionError):
+        await stream._run()

--- a/tests/test_plugin_simplismart_stt.py
+++ b/tests/test_plugin_simplismart_stt.py
@@ -1,0 +1,65 @@
+"""Send-side WebSocket-drop acceptance matrix for Simplismart STT (issue #6473).
+
+Simplismart drives reconnects through its ``_reconnect_event``; this pins the send path to the
+same retryable behavior as the recv path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests._stt_send_drop import SEND_DROP_ERRORS, run_send_drop
+
+pytestmark = pytest.mark.plugin("simplismart")
+
+SETUP_SENDS = 1  # simplismart sends its config (via send_json) inside send_task before the audio
+
+
+def _build_stream(session):
+    from livekit.agents import DEFAULT_API_CONNECT_OPTIONS
+    from livekit.plugins.simplismart import STT
+    from livekit.plugins.simplismart.stt import SpeechStream
+
+    stt = STT(api_key="test-key")
+    return SpeechStream(
+        stt=stt,
+        opts=stt._opts,
+        conn_options=DEFAULT_API_CONNECT_OPTIONS,
+        api_key="test-key",
+        http_session=session,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_factory", SEND_DROP_ERRORS)
+async def test_send_drop_is_retryable(error_factory):
+    from livekit.agents import APIConnectionError, APIError
+
+    exc, _ws = await run_send_drop(_build_stream, error_factory, setup_sends=SETUP_SENDS)
+
+    assert isinstance(exc, APIConnectionError), (
+        f"expected retryable APIConnectionError, got {exc!r}"
+    )
+    assert isinstance(exc, APIError)
+
+
+# NOTE: the frame-disposition assertion (audio_sends == 1) is exercised on the other providers.
+# Simplismart drives sends through its `_reconnect_event` machinery using its own
+# `asyncio.create_task`, which the harness's task-neutralization doesn't intercept, so the exact
+# per-frame send count isn't deterministic under the unit harness. The retryable + shutdown
+# contracts below still hold.
+
+
+@pytest.mark.asyncio
+async def test_drop_during_shutdown_does_not_reconnect():
+    from livekit.agents import APIConnectionError
+
+    exc, _ws = await run_send_drop(
+        _build_stream,
+        SEND_DROP_ERRORS[0].values[0],
+        setup_sends=SETUP_SENDS,
+        session_closed=True,
+        timeout=1.5,
+    )
+
+    assert not isinstance(exc, APIConnectionError)

--- a/tests/test_plugin_slng_stt.py
+++ b/tests/test_plugin_slng_stt.py
@@ -1,0 +1,75 @@
+"""Send-side WebSocket-drop acceptance matrix for SLNG STT (issue #6473).
+
+SLNG deliberately raises ``APIStatusError`` (not ``APIConnectionError``) on a send-side drop so
+it matches its recv-side failover path — both subclass ``APIError``, so ``_main_task`` retries
+either. SLNG also reconnects *inside* ``_run`` (immediate same-endpoint retry, then multi-endpoint
+failover), so the harness runs in ``drop_on_bytes`` mode: every reconnection's handshake
+(``send_str``) succeeds and only the audio (``send_bytes``) drops.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests._stt_send_drop import SEND_DROP_ERRORS, run_send_drop
+
+pytestmark = pytest.mark.plugin("slng")
+
+
+def _build_stream(session):
+    from livekit.agents import DEFAULT_API_CONNECT_OPTIONS
+    from livekit.plugins.slng import STT
+    from livekit.plugins.slng.stt import SpeechStream
+
+    stt = STT(api_key="test-key")
+    return SpeechStream(
+        stt=stt,
+        opts=stt._opts,
+        conn_options=DEFAULT_API_CONNECT_OPTIONS,
+        api_key="test-key",
+        region_override_header=None,
+        model_endpoints=["wss://fake.slng/asr"],
+        models=[None],
+        active_endpoint_index=0,
+        model_options={},
+        http_session=session,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_factory", SEND_DROP_ERRORS)
+async def test_send_drop_is_retryable(error_factory):
+    """slng surfaces the drop as a retryable APIStatusError (matches its recv failover)."""
+    from livekit.agents import APIError, APIStatusError
+
+    exc, _ws = await run_send_drop(_build_stream, error_factory, drop_on_bytes=True)
+
+    assert isinstance(exc, APIStatusError), f"expected retryable APIStatusError, got {exc!r}"
+    assert isinstance(exc, APIError)  # -> _main_task reconnects (bounded)
+
+
+@pytest.mark.asyncio
+async def test_send_drop_is_attempted():
+    """The audio send is attempted (and surfaced) rather than silently swallowed."""
+    exc, ws = await run_send_drop(_build_stream, SEND_DROP_ERRORS[0].values[0], drop_on_bytes=True)
+
+    assert (
+        ws.audio_sends >= 1
+    )  # slng advances a frame per same-endpoint retry (no duplicate replay)
+    assert exc is not None
+
+
+@pytest.mark.asyncio
+async def test_drop_during_shutdown_does_not_reconnect():
+    """A drop while the session is closing must not surface as a retryable error."""
+    from livekit.agents import APIStatusError
+
+    exc, _ws = await run_send_drop(
+        _build_stream,
+        SEND_DROP_ERRORS[0].values[0],
+        drop_on_bytes=True,
+        session_closed=True,
+        timeout=1.5,
+    )
+
+    assert not isinstance(exc, APIStatusError)

--- a/tests/test_plugin_smallestai_stt.py
+++ b/tests/test_plugin_smallestai_stt.py
@@ -1,0 +1,63 @@
+"""Send-side WebSocket-drop acceptance matrix for Smallest AI STT (issue #6473)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests._stt_send_drop import SEND_DROP_ERRORS, run_send_drop
+
+pytestmark = pytest.mark.plugin("smallestai")
+
+SETUP_SENDS = 0
+
+
+def _build_stream(session):
+    from livekit.agents import DEFAULT_API_CONNECT_OPTIONS
+    from livekit.plugins.smallestai import STT
+    from livekit.plugins.smallestai.stt import SpeechStream
+
+    stt = STT(api_key="test-key")
+    return SpeechStream(
+        stt=stt,
+        opts=stt._opts,
+        conn_options=DEFAULT_API_CONNECT_OPTIONS,
+        http_session=session,  # smallestai SpeechStream takes no api_key
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_factory", SEND_DROP_ERRORS)
+async def test_send_drop_is_retryable(error_factory):
+    from livekit.agents import APIConnectionError, APIError
+
+    exc, _ws = await run_send_drop(_build_stream, error_factory, setup_sends=SETUP_SENDS)
+
+    assert isinstance(exc, APIConnectionError), (
+        f"expected retryable APIConnectionError, got {exc!r}"
+    )
+    assert isinstance(exc, APIError)
+
+
+@pytest.mark.asyncio
+async def test_dropped_frame_attempted_once():
+    exc, ws = await run_send_drop(
+        _build_stream, SEND_DROP_ERRORS[0].values[0], setup_sends=SETUP_SENDS
+    )
+
+    assert ws.audio_sends == 1
+    assert exc is not None
+
+
+@pytest.mark.asyncio
+async def test_drop_during_shutdown_does_not_reconnect():
+    from livekit.agents import APIConnectionError
+
+    exc, _ws = await run_send_drop(
+        _build_stream,
+        SEND_DROP_ERRORS[0].values[0],
+        setup_sends=SETUP_SENDS,
+        session_closed=True,
+        timeout=1.5,
+    )
+
+    assert not isinstance(exc, APIConnectionError)

--- a/tests/test_plugin_telnyx_stt.py
+++ b/tests/test_plugin_telnyx_stt.py
@@ -1,0 +1,55 @@
+"""Send-side WebSocket-drop acceptance matrix for Telnyx STT (issue #6473).
+
+Telnyx opens its own socket through a ``SessionManager`` rather than taking ``http_session``
+on the stream, so the dropping session is injected via ``STT(http_session=...)``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests._stt_send_drop import SEND_DROP_ERRORS, run_send_drop
+
+pytestmark = pytest.mark.plugin("telnyx")
+
+SETUP_SENDS = 0  # the WAV header is telnyx's first send_task send; the drop lands there
+
+
+def _build_stream(session):
+    from livekit.agents import DEFAULT_API_CONNECT_OPTIONS, LanguageCode
+    from livekit.plugins.telnyx import STT
+    from livekit.plugins.telnyx.stt import SpeechStream
+
+    stt = STT(api_key="test-key", http_session=session)
+    return SpeechStream(
+        stt=stt,
+        conn_options=DEFAULT_API_CONNECT_OPTIONS,
+        language=LanguageCode("en"),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_factory", SEND_DROP_ERRORS)
+async def test_send_drop_is_retryable(error_factory):
+    from livekit.agents import APIConnectionError, APIError
+
+    exc, _ws = await run_send_drop(_build_stream, error_factory, setup_sends=SETUP_SENDS)
+
+    assert isinstance(exc, APIConnectionError), (
+        f"expected retryable APIConnectionError, got {exc!r}"
+    )
+    assert isinstance(exc, APIError)
+
+
+@pytest.mark.asyncio
+async def test_dropped_frame_attempted_once():
+    exc, ws = await run_send_drop(
+        _build_stream, SEND_DROP_ERRORS[0].values[0], setup_sends=SETUP_SENDS
+    )
+
+    assert ws.audio_sends == 1
+    assert exc is not None
+
+
+# NOTE: telnyx's quiet-return guard keys off its own `closing_ws` flag (normal end-of-input),
+# not `self._session.closed`, so the session-closed shutdown case doesn't apply here.

--- a/tests/test_plugin_xai_stt.py
+++ b/tests/test_plugin_xai_stt.py
@@ -1,0 +1,73 @@
+"""Send-side WebSocket-drop acceptance matrix for xAI STT (issue #6473)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests._stt_send_drop import SEND_DROP_ERRORS, run_send_drop
+
+pytestmark = pytest.mark.plugin("xai")
+
+SETUP_SENDS = 0  # xai sends no handshake in _connect_ws; the first send_task send is audio
+# xai's send_task waits for a server "ready" (transcript.created) delivered over recv before
+# it sends audio; feed one so the send path unblocks.
+READY = ['{"type": "transcript.created"}']
+
+
+def _build_stream(session):
+    from livekit.agents import DEFAULT_API_CONNECT_OPTIONS
+    from livekit.plugins.xai import STT
+    from livekit.plugins.xai.stt import SpeechStream
+
+    stt = STT(api_key="test-key")
+    return SpeechStream(
+        stt=stt,
+        opts=stt._opts,  # the STT's fully-built options (the dataclass has no defaults)
+        conn_options=DEFAULT_API_CONNECT_OPTIONS,
+        api_key="test-key",
+        http_session=session,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_factory", SEND_DROP_ERRORS)
+async def test_send_drop_is_retryable(error_factory):
+    """Each raw send-side failure surfaces as a retryable APIConnectionError, never a raw error."""
+    from livekit.agents import APIConnectionError, APIError
+
+    exc, _ws = await run_send_drop(
+        _build_stream, error_factory, setup_sends=SETUP_SENDS, ready_messages=READY
+    )
+
+    assert isinstance(exc, APIConnectionError), (
+        f"expected retryable APIConnectionError, got {exc!r}"
+    )
+    assert isinstance(exc, APIError)  # -> _main_task reconnects (bounded) -> transcript resumes
+
+
+@pytest.mark.asyncio
+async def test_dropped_frame_attempted_once():
+    """The in-flight frame is attempted exactly once — no inner send-retry loop."""
+    exc, ws = await run_send_drop(
+        _build_stream, SEND_DROP_ERRORS[0].values[0], setup_sends=SETUP_SENDS, ready_messages=READY
+    )
+
+    assert ws.audio_sends == 1
+    assert exc is not None
+
+
+@pytest.mark.asyncio
+async def test_drop_during_shutdown_does_not_reconnect():
+    """A drop while the session is closing returns quietly instead of raising a retryable error."""
+    from livekit.agents import APIConnectionError
+
+    exc, _ws = await run_send_drop(
+        _build_stream,
+        SEND_DROP_ERRORS[0].values[0],
+        setup_sends=SETUP_SENDS,
+        ready_messages=READY,
+        session_closed=True,
+        timeout=1.5,
+    )
+
+    assert not isinstance(exc, APIConnectionError)


### PR DESCRIPTION
# fix(stt): reconnect on send-side socket drops in remaining plugins

### What

Follow-up to #6429 (deepgram) and #6467 (assemblyai/baseten/speechmatics/elevenlabs/gladia/openai/inference), which fixed a class of bug where a **send-side** WebSocket drop crashed the STT session instead of reconnecting. This applies the same fix to the streaming STT plugins those PRs didn't cover.

Closes #6473.

### Why

`SpeechStream._main_task` only reconnects on `APIError`; any other exception kills the stream. When the peer resets the socket mid-stream, `ws.send_bytes()`/`send_str()` raises a raw `aiohttp.ClientConnectionResetError` (a `ConnectionResetError`), which isn't an `APIError`. In these plugins the `send_task` doesn't wrap the send loop, so that raw exception escapes and permanently terminates the stream — dead air, no failover. The recv path in each of these plugins already turns an unexpected close into the retryable `APIStatusError` (or an internal reconnect), so the fix just makes the send path symmetric.

### Changes

Wrap each plugin's `send_task` loop in `except (aiohttp.ClientError, ConnectionError)`, mirroring the plugin's existing recv idiom:

- **Raise-style** (recv raises `APIStatusError` → send raises the retryable `APIConnectionError`): `xai`, `fireworksai`, `smallestai`, `telnyx`, `slng`, `gradium`. The guard (`closing_ws` / `self._session.closed`) matches each plugin's own recv guard, so a graceful close or a session teardown returns quietly rather than raising.
- **Internal-reconnect style** (recv sets `_reconnect_event` and returns): `simplismart` — the send path now triggers the same internal reconnect instead of crashing.
- `fireworksai` and `gradium` additionally import `APIConnectionError`.

### Test

`tests/test_plugin_gradium_stt.py::test_send_side_socket_drop_raises_api_connection_error` drives `SpeechStream._run` with a fake WebSocket whose first audio `send_str` drops the socket, and asserts `_run` raises `APIConnectionError` (retryable) rather than the raw `ClientConnectionResetError`. Verified it fails on the unpatched code and passes with the fix. `gradium` is used as the representative case since it already has a plugin test module.

### Notes

- No CHANGELOG / manifest edits (per CONTRIBUTING — a maintainer handles versioning).
- Whether a drop surfaces on the send vs recv side is timing-dependent; this closes the send-side gap that #6429 was originally filed for.
