### PR TITLE
feat(stt): add stt_context_options for keyterms and chat context

### DIFF
--- a/examples/voice_agents/basic_agent.py
+++ b/examples/voice_agents/basic_agent.py
@@ -103,7 +103,7 @@ async def entrypoint(ctx: JobContext) -> None:
             text_transforms.replace({"LiveKit": "<<ˈ|l|aɪ|v|k|ɪ|t>>"}),
         ],
         # automatically detect keyterms and apply them to the STT per user turn
-        keyterms_options={
+        stt_context_options={
             "keyterms": ["LiveKit"],
             "keyterm_detection": {
                 "enabled": True,

--- a/livekit-agents/livekit/agents/__init__.py
+++ b/livekit-agents/livekit/agents/__init__.py
@@ -117,7 +117,6 @@ from .voice.amd import (
 )
 from .voice.background_audio import AudioConfig, BackgroundAudioPlayer, BuiltinAudioClip, PlayHandle
 from .voice.keyterm_detection import (
-    ChatContextOptions,
     KeytermDetectionOptions,
     KeytermsOptions,
     STTContextOptions,
@@ -281,7 +280,6 @@ __all__ = [
     "KeytermsOptions",
     "KeytermDetectionOptions",
     "STTContextOptions",
-    "ChatContextOptions",
     "UserTurnExceededEvent",
 ]
 

--- a/livekit-agents/livekit/agents/__init__.py
+++ b/livekit-agents/livekit/agents/__init__.py
@@ -116,7 +116,12 @@ from .voice.amd import (
     AMDPredictionEvent,
 )
 from .voice.background_audio import AudioConfig, BackgroundAudioPlayer, BuiltinAudioClip, PlayHandle
-from .voice.keyterm_detection import KeytermDetectionOptions, KeytermsOptions
+from .voice.keyterm_detection import (
+    ChatContextOptions,
+    KeytermDetectionOptions,
+    KeytermsOptions,
+    STTContextOptions,
+)
 from .voice.room_io import RoomInputOptions, RoomIO, RoomOutputOptions
 from .voice.run_result import (
     AgentHandoffEvent,
@@ -275,6 +280,8 @@ __all__ = [
     "UserTurnLimitOptions",
     "KeytermsOptions",
     "KeytermDetectionOptions",
+    "STTContextOptions",
+    "ChatContextOptions",
     "UserTurnExceededEvent",
 ]
 

--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -415,7 +415,6 @@ class STT(stt.STT):
         api_secret: NotGivenOr[str] = NOT_GIVEN,
         http_session: aiohttp.ClientSession | None = None,
         extra_kwargs: NotGivenOr[AssemblyaiOptions] = NOT_GIVEN,
-        agent_context_carryover: NotGivenOr[bool] = NOT_GIVEN,
         fallback: NotGivenOr[list[FallbackModelType] | FallbackModelType] = NOT_GIVEN,
         conn_options: NotGivenOr[APIConnectOptions] = NOT_GIVEN,
     ) -> None: ...
@@ -502,7 +501,6 @@ class STT(stt.STT):
         api_secret: NotGivenOr[str] = NOT_GIVEN,
         http_session: aiohttp.ClientSession | None = None,
         extra_kwargs: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
-        agent_context_carryover: NotGivenOr[bool] = NOT_GIVEN,
         fallback: NotGivenOr[list[FallbackModelType] | FallbackModelType] = NOT_GIVEN,
         conn_options: NotGivenOr[APIConnectOptions] = NOT_GIVEN,
     ) -> None: ...
@@ -529,7 +527,6 @@ class STT(stt.STT):
             | SpeechmaticsOptions
             | InworldOptions
         ] = NOT_GIVEN,
-        agent_context_carryover: NotGivenOr[bool] = NOT_GIVEN,
         fallback: NotGivenOr[list[FallbackModelType] | FallbackModelType] = NOT_GIVEN,
         conn_options: NotGivenOr[APIConnectOptions] = NOT_GIVEN,
         vad: NotGivenOr[vad.VAD | None] = NOT_GIVEN,
@@ -546,9 +543,6 @@ class STT(stt.STT):
             api_secret (str, optional): LIVEKIT_API_SECRET, if not provided, read from environment variable.
             http_session (aiohttp.ClientSession, optional): HTTP session to use.
             extra_kwargs (dict, optional): Extra kwargs to pass to the STT model.
-            agent_context_carryover (bool, optional): Let an ``AgentSession`` push each assistant
-                reply into AssemblyAI's ``agent_context``. Disabled by default; pass True to opt in
-                on the U3 Pro family (the only models that support it).
             fallback (FallbackModelType, optional): Fallback models - either a list of model names,
                 a list of FallbackModel instances.
             conn_options (APIConnectOptions, optional): Connection options for request attempts.
@@ -572,17 +566,7 @@ class STT(stt.STT):
 
         vad = _resolve_vad_for_model(model, vad if is_given(vad) else None)
 
-        supports_carryover = _supports_agent_context_carryover(model)
-        if is_given(agent_context_carryover) and agent_context_carryover and not supports_carryover:
-            logger.warning(
-                "agent_context_carryover is enabled but model %r does not support it; ignoring",
-                model,
-            )
-        # Opt-in: off unless explicitly enabled on a model that supports it.
-        carryover_enabled = (
-            supports_carryover and is_given(agent_context_carryover) and agent_context_carryover
-        )
-
+        # chat_context follows the model's native support; the session decides whether to forward
         super().__init__(
             capabilities=stt.STTCapabilities(
                 streaming=True,
@@ -591,7 +575,7 @@ class STT(stt.STT):
                 aligned_transcript="word",
                 offline_recognize=False,
                 keyterms=_keyterms_extra_for_model(model) is not None,
-                chat_context=carryover_enabled,
+                chat_context=_supports_agent_context_carryover(model),
             ),
         )
 
@@ -713,6 +697,7 @@ class STT(stt.STT):
             self._capabilities = replace(
                 self._capabilities,
                 keyterms=_keyterms_extra_for_model(self._opts.model) is not None,
+                chat_context=_supports_agent_context_carryover(self._opts.model),
             )
         if is_given(language):
             self._opts.language = LanguageCode(language)

--- a/livekit-agents/livekit/agents/voice/__init__.py
+++ b/livekit-agents/livekit/agents/voice/__init__.py
@@ -29,7 +29,6 @@ from .events import (
     UserTurnExceededEvent,
 )
 from .keyterm_detection import (
-    ChatContextOptions,
     KeytermDetectionOptions,
     KeytermsOptions,
     STTContextOptions,
@@ -77,7 +76,6 @@ __all__ = [
     "KeytermsOptions",
     "KeytermDetectionOptions",
     "STTContextOptions",
-    "ChatContextOptions",
     "TranscriptSynchronizer",
     "io",
     "room_io",

--- a/livekit-agents/livekit/agents/voice/__init__.py
+++ b/livekit-agents/livekit/agents/voice/__init__.py
@@ -28,7 +28,12 @@ from .events import (
     UserStateChangedEvent,
     UserTurnExceededEvent,
 )
-from .keyterm_detection import KeytermDetectionOptions, KeytermsOptions
+from .keyterm_detection import (
+    ChatContextOptions,
+    KeytermDetectionOptions,
+    KeytermsOptions,
+    STTContextOptions,
+)
 from .remote_session import RemoteSession
 from .room_io import (
     _ParticipantAudioOutput,
@@ -71,6 +76,8 @@ __all__ = [
     "UserTurnExceededEvent",
     "KeytermsOptions",
     "KeytermDetectionOptions",
+    "STTContextOptions",
+    "ChatContextOptions",
     "TranscriptSynchronizer",
     "io",
     "room_io",

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -608,7 +608,10 @@ class AgentActivity(RecognitionHooks):
                 resolved_stt.prewarm()
                 resolved_stt.on("metrics_collected", self._on_metrics_collected)
                 resolved_stt.on("error", self._on_error)
-                if resolved_stt.capabilities.chat_context:
+                chat_ctx_enabled = self._session._opts.stt_context_options["chat_context"][
+                    "enabled"
+                ]
+                if resolved_stt.capabilities.chat_context and chat_ctx_enabled:
                     self._session.on(
                         "conversation_item_added", resolved_stt._push_conversation_item
                     )
@@ -1022,13 +1025,13 @@ class AgentActivity(RecognitionHooks):
 
         if isinstance(self.stt, stt.STT):
             # bind the session's keyterm detector to this activity's STT (detection uses its
-            # own LLM, configured via keyterms_options, not the agent's)
+            # own LLM, configured via stt_context_options, not the agent's)
             self._session._keyterm_detector.start(self._session, stt=self.stt)
 
-            # forward conversation turns to STTs that consume context natively; gated by the
-            # STT's own capability (toggled via the STT's args). stateless and activity-scoped,
-            # so it lives here rather than in the detector.
-            if self.stt.capabilities.chat_context:
+            # forward conversation turns to STTs that consume context natively; gated by the STT's
+            # capability and the session's chat_context toggle. stateless and activity-scoped.
+            chat_ctx_enabled = self._session._opts.stt_context_options["chat_context"]["enabled"]
+            if self.stt.capabilities.chat_context and chat_ctx_enabled:
                 self._session.on("conversation_item_added", self.stt._push_conversation_item)
 
     @tracer.start_as_current_span("drain_agent_activity")

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -608,10 +608,8 @@ class AgentActivity(RecognitionHooks):
                 resolved_stt.prewarm()
                 resolved_stt.on("metrics_collected", self._on_metrics_collected)
                 resolved_stt.on("error", self._on_error)
-                chat_ctx_enabled = self._session._opts.stt_context_options["chat_context"][
-                    "enabled"
-                ]
-                if resolved_stt.capabilities.chat_context and chat_ctx_enabled:
+                forward_chat_ctx = self._session._opts.stt_context_options["forward_chat_context"]
+                if resolved_stt.capabilities.chat_context and forward_chat_ctx:
                     self._session.on(
                         "conversation_item_added", resolved_stt._push_conversation_item
                     )
@@ -1029,9 +1027,9 @@ class AgentActivity(RecognitionHooks):
             self._session._keyterm_detector.start(self._session, stt=self.stt)
 
             # forward conversation turns to STTs that consume context natively; gated by the STT's
-            # capability and the session's chat_context toggle. stateless and activity-scoped.
-            chat_ctx_enabled = self._session._opts.stt_context_options["chat_context"]["enabled"]
-            if self.stt.capabilities.chat_context and chat_ctx_enabled:
+            # capability and the session's forward_chat_context toggle. stateless, activity-scoped.
+            forward_chat_ctx = self._session._opts.stt_context_options["forward_chat_context"]
+            if self.stt.capabilities.chat_context and forward_chat_ctx:
                 self._session.on("conversation_item_added", self.stt._push_conversation_item)
 
     @tracer.start_as_current_span("drain_agent_activity")

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -61,7 +61,13 @@ from .events import (
     UserStateChangedEvent,
 )
 from .ivr import IVRActivity
-from .keyterm_detection import KeytermDetector, KeytermsOptions, _resolve_keyterms_options
+from .keyterm_detection import (
+    KeytermDetector,
+    KeytermsOptions,
+    STTContextOptions,
+    _resolve_stt_context_options,
+    _stt_context_from_keyterms_options,
+)
 from .recorder_io import RecorderIO
 from .remote_session import RoomSessionTransport, SessionHost, SessionTransport
 from .run_result import RunOutputOptions, RunResult
@@ -174,7 +180,7 @@ DEFAULT_EXPRESSIVE_OPTIONS: ExpressiveOptions = ExpressiveOptions(
 @dataclass
 class AgentSessionOptions:
     turn_handling: TurnHandlingOptions
-    keyterms_options: KeytermsOptions
+    stt_context_options: STTContextOptions
     endpointing_overrides: EndpointingOptions
     """sparse endpointing keys the user provided explicitly"""
     max_tool_steps: int
@@ -253,6 +259,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             "min_interruption_words": "Use turn_handling=TurnHandlingOptions(...) instead",
             "turn_detection": "Use turn_handling=TurnHandlingOptions(...) instead",
             "agent_false_interruption_timeout": "Use turn_handling=TurnHandlingOptions(...) instead",
+            "keyterms_options": "Use stt_context_options=STTContextOptions(...) instead",
         },
         target_version="v2.0",
     )
@@ -264,7 +271,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         llm: NotGivenOr[llm.LLM | llm.RealtimeModel | LLMModels | str] = NOT_GIVEN,
         tts: NotGivenOr[tts.TTS | TTSModels | str] = NOT_GIVEN,
         turn_handling: NotGivenOr[TurnHandlingOptions] = NOT_GIVEN,
-        keyterms_options: NotGivenOr[KeytermsOptions] = NOT_GIVEN,
+        stt_context_options: NotGivenOr[STTContextOptions] = NOT_GIVEN,
         # Tool settings
         tools: NotGivenOr[list[llm.Tool | llm.Toolset]] = NOT_GIVEN,
         tool_handling: NotGivenOr[ToolHandlingOptions] = NOT_GIVEN,
@@ -296,6 +303,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         resume_false_interruption: NotGivenOr[bool] = NOT_GIVEN,
         agent_false_interruption_timeout: NotGivenOr[float | None] = NOT_GIVEN,
         mcp_servers: NotGivenOr[list[mcp.MCPServer]] = NOT_GIVEN,
+        keyterms_options: NotGivenOr[KeytermsOptions] = NOT_GIVEN,
     ) -> None:
         """`AgentSession` is the LiveKit Agents runtime that glues together
         media streams, speech/LLM components, and tool orchestration into a
@@ -325,9 +333,12 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 providing external tools for the agent to use.
             userdata (Userdata_T, optional): Arbitrary per-session user data.
             turn_handling (TurnHandlingOptions, optional): Configuration for turn handling.
-            keyterms_options (KeytermsOptions, optional): Keyterm biasing for the STT. Holds
-                static ``keyterms`` plus ``keyterm_detection`` (LLM extraction). Applies to STTs
-                that accept a term list; on others it warns and is ignored.
+            stt_context_options (STTContextOptions, optional): Conversation-aware context for the
+                STT: static ``keyterms`` plus ``keyterm_detection`` for STTs that accept a term
+                list, and ``chat_context`` carryover (on by default) for STTs that consume context
+                directly. Applied where the STT supports it, ignored otherwise.
+            keyterms_options (KeytermsOptions, optional): Deprecated, use ``stt_context_options``
+                instead. Its ``keyterms``/``keyterm_detection`` keys map onto the new option.
             max_endpointing_delay (float): Maximum time-in-seconds the agent
                 will wait before terminating the turn. Default ``3.0`` s.
             max_tool_steps (int): Maximum consecutive tool calls per LLM turn.
@@ -406,6 +417,14 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         endpointing = _resolve_endpointing(endpointing_overrides, turn_detection=raw_turn_detection)
         interruption = _resolve_interruption(turn_handling.get("interruption"))
         preemptive_gen = _resolve_preemptive_generation(turn_handling.get("preemptive_generation"))
+
+        # stt_context_options supersedes the deprecated keyterms_options; when both are set it wins
+        if is_given(stt_context_options):
+            stt_context = stt_context_options
+        elif is_given(keyterms_options):
+            stt_context = _stt_context_from_keyterms_options(keyterms_options)
+        else:
+            stt_context = None
         user_turn_limit = _resolve_user_turn_limit(turn_handling.get("user_turn_limit"))
 
         # This is the "global" chat_context, it holds the entire conversation history
@@ -418,7 +437,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 preemptive_generation=preemptive_gen,
                 user_turn_limit=user_turn_limit,
             ),
-            keyterms_options=_resolve_keyterms_options(keyterms_options or None),
+            stt_context_options=_resolve_stt_context_options(stt_context),
             endpointing_overrides=endpointing_overrides,
             max_tool_steps=max_tool_steps,
             user_away_timeout=user_away_timeout,
@@ -458,8 +477,8 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         self._tts = tts or None
 
         self._keyterm_detector = KeytermDetector(
-            static_keyterms=self._opts.keyterms_options["keyterms"],
-            options=self._opts.keyterms_options["keyterm_detection"],
+            static_keyterms=self._opts.stt_context_options["keyterms"],
+            options=self._opts.stt_context_options["keyterm_detection"],
         )
 
         self._turn_detection = raw_turn_detection

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -335,8 +335,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             turn_handling (TurnHandlingOptions, optional): Configuration for turn handling.
             stt_context_options (STTContextOptions, optional): Conversation-aware context for the
                 STT: static ``keyterms`` plus ``keyterm_detection`` for STTs that accept a term
-                list, and ``chat_context`` carryover (on by default) for STTs that consume context
-                directly. Applied where the STT supports it, ignored otherwise.
+                list, and ``forward_chat_context`` (on by default) that forwards conversation turns
+                to STTs that consume context directly. Applied where the STT supports it, ignored
+                otherwise.
             keyterms_options (KeytermsOptions, optional): Deprecated, use ``stt_context_options``
                 instead. Its ``keyterms``/``keyterm_detection`` keys map onto the new option.
             max_endpointing_delay (float): Maximum time-in-seconds the agent

--- a/livekit-agents/livekit/agents/voice/keyterm_detection.py
+++ b/livekit-agents/livekit/agents/voice/keyterm_detection.py
@@ -24,14 +24,9 @@ if TYPE_CHECKING:
 class KeytermsOptions(TypedDict, total=False):
     """Keyterm biasing for STTs that accept a term list.
 
-    Can be passed as a plain dict::
-
-        AgentSession(
-            keyterms_options={
-                "keyterms": ["LiveKit", "Acme Corp"],
-                "keyterm_detection": {"enabled": True, "turn_interval": 1},
-            },
-        )
+    .. deprecated:: v2.0
+        Use :class:`STTContextOptions` (``AgentSession(stt_context_options=...)``) instead;
+        its ``keyterms`` and ``keyterm_detection`` keys are identical.
     """
 
     keyterms: list[str]
@@ -64,6 +59,39 @@ class KeytermDetectionOptions(TypedDict, total=False):
     Defaults to ``10.0``. Raise it if a slow detection ``llm`` needs longer."""
 
 
+class ChatContextOptions(TypedDict, total=False):
+    """Native conversation-context carryover, for STTs that consume context directly.
+
+    Only STTs that advertise the ``chat_context`` capability act on it (e.g. AssemblyAI
+    u3-pro via inference); others ignore it.
+    """
+
+    enabled: bool
+    """Whether to forward conversation turns to the STT. Defaults to ``True``."""
+
+
+class STTContextOptions(TypedDict, total=False):
+    """Conversation-aware context for the STT.
+
+    Can be passed as a plain dict::
+
+        AgentSession(
+            stt_context_options={
+                "keyterms": ["LiveKit", "Acme Corp"],
+                "keyterm_detection": {"enabled": True, "turn_interval": 1},
+                "chat_context": {"enabled": True},
+            },
+        )
+    """
+
+    keyterms: list[str]
+    """Static keyterms applied wherever the STT accepts a term list; never touched by detection."""
+    keyterm_detection: KeytermDetectionOptions
+    """LLM-based keyterm extraction, for STTs that accept a term list."""
+    chat_context: ChatContextOptions
+    """Native conversation-context carryover, for STTs that consume context directly."""
+
+
 # bound a single pass so a stuck LLM call can't hold the single-flight guard forever and
 # stall detection for the rest of the call; a timed-out pass simply makes no change
 _DETECTION_TIMEOUT = 10.0
@@ -92,13 +120,33 @@ def _resolve_detection(config: KeytermDetectionOptions | None) -> KeytermDetecti
     return KeytermDetectionOptions(**{**_KEYTERM_DETECTION_DEFAULTS, **(config or {})})
 
 
-def _resolve_keyterms_options(config: KeytermsOptions | None) -> KeytermsOptions:
-    """Return a fully-defaulted keyterms config."""
+_CHAT_CONTEXT_DEFAULTS: ChatContextOptions = {"enabled": True}
+
+
+def _resolve_chat_context(config: ChatContextOptions | None) -> ChatContextOptions:
+    """Return a fully-defaulted chat-context config (``enabled`` defaults to True)."""
+    return ChatContextOptions(**{**_CHAT_CONTEXT_DEFAULTS, **(config or {})})
+
+
+def _resolve_stt_context_options(config: STTContextOptions | None) -> STTContextOptions:
+    """Return a fully-defaulted STT-context config."""
     config = config or {}
-    return KeytermsOptions(
+    return STTContextOptions(
         keyterms=list(config.get("keyterms", [])),
         keyterm_detection=_resolve_detection(config.get("keyterm_detection")),
+        chat_context=_resolve_chat_context(config.get("chat_context")),
     )
+
+
+def _stt_context_from_keyterms_options(config: KeytermsOptions | None) -> STTContextOptions:
+    """Map the deprecated ``keyterms_options`` onto the new :class:`STTContextOptions` shape."""
+    config = config or {}
+    out: STTContextOptions = {}
+    if "keyterms" in config:
+        out["keyterms"] = config["keyterms"]
+    if "keyterm_detection" in config:
+        out["keyterm_detection"] = config["keyterm_detection"]
+    return out
 
 
 def _resolve_detection_llm(configured: LLM | str | None) -> LLM | None:

--- a/livekit-agents/livekit/agents/voice/keyterm_detection.py
+++ b/livekit-agents/livekit/agents/voice/keyterm_detection.py
@@ -59,17 +59,6 @@ class KeytermDetectionOptions(TypedDict, total=False):
     Defaults to ``10.0``. Raise it if a slow detection ``llm`` needs longer."""
 
 
-class ChatContextOptions(TypedDict, total=False):
-    """Native conversation-context carryover, for STTs that consume context directly.
-
-    Only STTs that advertise the ``chat_context`` capability act on it (e.g. AssemblyAI
-    u3-pro via inference); others ignore it.
-    """
-
-    enabled: bool
-    """Whether to forward conversation turns to the STT. Defaults to ``True``."""
-
-
 class STTContextOptions(TypedDict, total=False):
     """Conversation-aware context for the STT.
 
@@ -79,7 +68,7 @@ class STTContextOptions(TypedDict, total=False):
             stt_context_options={
                 "keyterms": ["LiveKit", "Acme Corp"],
                 "keyterm_detection": {"enabled": True, "turn_interval": 1},
-                "chat_context": {"enabled": True},
+                "forward_chat_context": True,
             },
         )
     """
@@ -88,8 +77,9 @@ class STTContextOptions(TypedDict, total=False):
     """Static keyterms applied wherever the STT accepts a term list; never touched by detection."""
     keyterm_detection: KeytermDetectionOptions
     """LLM-based keyterm extraction, for STTs that accept a term list."""
-    chat_context: ChatContextOptions
-    """Native conversation-context carryover, for STTs that consume context directly."""
+    forward_chat_context: bool
+    """Forward conversation turns to STTs that consume context directly (e.g. AssemblyAI u3-pro).
+    Defaults to ``True``; only STTs that advertise the ``chat_context`` capability act on it."""
 
 
 # bound a single pass so a stuck LLM call can't hold the single-flight guard forever and
@@ -120,21 +110,13 @@ def _resolve_detection(config: KeytermDetectionOptions | None) -> KeytermDetecti
     return KeytermDetectionOptions(**{**_KEYTERM_DETECTION_DEFAULTS, **(config or {})})
 
 
-_CHAT_CONTEXT_DEFAULTS: ChatContextOptions = {"enabled": True}
-
-
-def _resolve_chat_context(config: ChatContextOptions | None) -> ChatContextOptions:
-    """Return a fully-defaulted chat-context config (``enabled`` defaults to True)."""
-    return ChatContextOptions(**{**_CHAT_CONTEXT_DEFAULTS, **(config or {})})
-
-
 def _resolve_stt_context_options(config: STTContextOptions | None) -> STTContextOptions:
     """Return a fully-defaulted STT-context config."""
     config = config or {}
     return STTContextOptions(
         keyterms=list(config.get("keyterms", [])),
         keyterm_detection=_resolve_detection(config.get("keyterm_detection")),
-        chat_context=_resolve_chat_context(config.get("chat_context")),
+        forward_chat_context=config.get("forward_chat_context", True),
     )
 
 

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -229,7 +229,7 @@ class STT(stt.STT):
                 Only supported with the Universal-3 Pro family models. Set at construction
                 (connect) time only; it cannot be changed via `update_options`.
             agent_context_carryover: Deprecated, use
-                ``AgentSession(stt_context_options={"chat_context": {"enabled": ...}})`` instead.
+                ``AgentSession(stt_context_options={"forward_chat_context": ...})`` instead.
                 On the Universal-3 Pro family, assistant replies are carried into ``agent_context``
                 by default; pass ``False`` to opt out. On other models it is off. Replies longer
                 than the 1750-character server cap are truncated (keeping the tail) before
@@ -272,12 +272,12 @@ class STT(stt.STT):
 
         # agent_context carryover is only available on the u3-rt-pro family ("u3-pro" is
         # normalized to "u3-rt-pro" below), where it is on by default; the session's
-        # stt_context_options.chat_context toggle is the supported way to control it.
+        # stt_context_options.forward_chat_context toggle is the supported way to control it.
         supports_carryover = model in _U3_PRO_MODELS or model == "u3-pro"
         if is_given(agent_context_carryover):
             logger.warning(
                 "'agent_context_carryover' is deprecated, use "
-                "AgentSession(stt_context_options={'chat_context': {'enabled': ...}}) instead."
+                "AgentSession(stt_context_options={'forward_chat_context': ...}) instead."
             )
             if agent_context_carryover and not supports_carryover:
                 logger.warning(

--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -161,7 +161,6 @@ class STT(stt.STT):
         prompt: NotGivenOr[str] = NOT_GIVEN,
         agent_context: NotGivenOr[str] = NOT_GIVEN,
         previous_context_n_turns: NotGivenOr[int] = NOT_GIVEN,
-        agent_context_carryover: NotGivenOr[bool] = NOT_GIVEN,
         vad_threshold: NotGivenOr[float] = NOT_GIVEN,
         speaker_labels: NotGivenOr[bool] = NOT_GIVEN,
         max_speakers: NotGivenOr[int] = NOT_GIVEN,
@@ -174,6 +173,7 @@ class STT(stt.STT):
         base_url: str = "wss://streaming.assemblyai.com",
         # Deprecated — use min_turn_silence instead
         min_end_of_turn_silence_when_confident: NotGivenOr[int] = NOT_GIVEN,
+        agent_context_carryover: NotGivenOr[bool] = NOT_GIVEN,
     ):
         """
         Args:
@@ -219,21 +219,19 @@ class STT(stt.STT):
                 transcription of the user's reply. Set at construction or updated per-turn
                 via `update_options(agent_context=...)`. Only supported with the
                 Universal-3 Pro family models (max 1750 characters; longer values raise
-                ValueError). With ``agent_context_carryover=True`` each assistant reply
-                replaces this value automatically; leave it disabled (the default) to
-                manage it manually.
+                ValueError). When chat-context carryover is on (the default on the Universal-3
+                Pro family) each assistant reply replaces this value automatically; disable it
+                to manage this manually.
             previous_context_n_turns: Maximum number of prior conversation entries (user
                 transcripts and any `agent_context` values) carried forward as context for
                 each transcription. Set to 0 to disable automatic context carryover
                 entirely; leave unset to use the server default (recommended). Range 0–100.
                 Only supported with the Universal-3 Pro family models. Set at construction
                 (connect) time only; it cannot be changed via `update_options`.
-            agent_context_carryover: When the model supports it, let an ``AgentSession`` push each
-                assistant reply into ``agent_context`` so it is carried into the model's
-                conversation context. Disabled by default; pass True to opt in on a model
-                that supports it (the Universal-3 Pro family). On other models it is off;
-                explicitly passing True logs a warning and is ignored. Prior user turns are
-                carried automatically by the model regardless of this flag. Replies longer
+            agent_context_carryover: Deprecated, use
+                ``AgentSession(stt_context_options={"chat_context": {"enabled": ...}})`` instead.
+                On the Universal-3 Pro family, assistant replies are carried into ``agent_context``
+                by default; pass ``False`` to opt out. On other models it is off. Replies longer
                 than the 1750-character server cap are truncated (keeping the tail) before
                 being sent.
             voice_focus: Voice Focus isolates the primary voice and suppresses background
@@ -271,17 +269,24 @@ class STT(stt.STT):
             language_codes = NOT_GIVEN
         if is_given(agent_context):
             _validate_agent_context(agent_context)
-        # agent_context carryover is only available on the u3-rt-pro family
-        # ("u3-pro" is normalized to "u3-rt-pro" below). It is opt-in: off unless
-        # explicitly enabled, and an explicit True on an unsupported model warns.
+
+        # agent_context carryover is only available on the u3-rt-pro family ("u3-pro" is
+        # normalized to "u3-rt-pro" below), where it is on by default; the session's
+        # stt_context_options.chat_context toggle is the supported way to control it.
         supports_carryover = model in _U3_PRO_MODELS or model == "u3-pro"
-        if is_given(agent_context_carryover) and agent_context_carryover and not supports_carryover:
+        if is_given(agent_context_carryover):
             logger.warning(
-                "agent_context_carryover is enabled but model %r does not support it; ignoring",
-                model,
+                "'agent_context_carryover' is deprecated, use "
+                "AgentSession(stt_context_options={'chat_context': {'enabled': ...}}) instead."
             )
-        carryover_enabled = (
-            supports_carryover and is_given(agent_context_carryover) and agent_context_carryover
+            if agent_context_carryover and not supports_carryover:
+                logger.warning(
+                    "agent_context_carryover is enabled but model %r does not support it; ignoring",
+                    model,
+                )
+        # on by default for supported models; an explicit agent_context_carryover=False opts out
+        carryover_enabled = supports_carryover and (
+            agent_context_carryover if is_given(agent_context_carryover) else True
         )
         super().__init__(
             capabilities=stt.STTCapabilities(

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -1977,6 +1977,62 @@ async def test_user_supplied_turn_detector_passes_through() -> None:
         await session.aclose()
 
 
+async def test_stt_context_options_defaults_chat_context_on() -> None:
+    """chat_context carryover is on by default in the resolved stt_context_options."""
+    from livekit.agents.voice.agent_session import AgentSession
+
+    session = AgentSession(vad=None)
+    try:
+        assert session._opts.stt_context_options["chat_context"]["enabled"] is True
+    finally:
+        await session.aclose()
+
+
+async def test_stt_context_options_passthrough() -> None:
+    from livekit.agents.voice.agent_session import AgentSession
+
+    session = AgentSession(
+        vad=None,
+        stt_context_options={"keyterms": ["LiveKit"], "chat_context": {"enabled": False}},
+    )
+    try:
+        opts = session._opts.stt_context_options
+        assert opts["keyterms"] == ["LiveKit"]
+        assert opts["chat_context"]["enabled"] is False
+    finally:
+        await session.aclose()
+
+
+async def test_deprecated_keyterms_options_maps_to_stt_context(caplog) -> None:
+    """keyterms_options still works, maps onto stt_context_options, and warns."""
+    from livekit.agents.voice.agent_session import AgentSession
+
+    with caplog.at_level(logging.WARNING):
+        session = AgentSession(vad=None, keyterms_options={"keyterms": ["Acme"]})
+    try:
+        opts = session._opts.stt_context_options
+        assert opts["keyterms"] == ["Acme"]
+        assert opts["chat_context"]["enabled"] is True  # default still applies
+        assert "keyterms_options is deprecated" in caplog.text
+    finally:
+        await session.aclose()
+
+
+async def test_stt_context_options_wins_over_keyterms_options() -> None:
+    """When both are passed, stt_context_options takes precedence over the deprecated option."""
+    from livekit.agents.voice.agent_session import AgentSession
+
+    session = AgentSession(
+        vad=None,
+        stt_context_options={"keyterms": ["new"]},
+        keyterms_options={"keyterms": ["old"]},
+    )
+    try:
+        assert session._opts.stt_context_options["keyterms"] == ["new"]
+    finally:
+        await session.aclose()
+
+
 async def test_streaming_detector_uses_streaming_endpointing_defaults() -> None:
     """Default session → streaming detector → tighter 0.3/2.5 endpointing defaults."""
     from livekit.agents.voice.agent_session import AgentSession

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -1977,13 +1977,13 @@ async def test_user_supplied_turn_detector_passes_through() -> None:
         await session.aclose()
 
 
-async def test_stt_context_options_defaults_chat_context_on() -> None:
-    """chat_context carryover is on by default in the resolved stt_context_options."""
+async def test_stt_context_options_defaults_forward_chat_context_on() -> None:
+    """forward_chat_context is on by default in the resolved stt_context_options."""
     from livekit.agents.voice.agent_session import AgentSession
 
     session = AgentSession(vad=None)
     try:
-        assert session._opts.stt_context_options["chat_context"]["enabled"] is True
+        assert session._opts.stt_context_options["forward_chat_context"] is True
     finally:
         await session.aclose()
 
@@ -1993,12 +1993,12 @@ async def test_stt_context_options_passthrough() -> None:
 
     session = AgentSession(
         vad=None,
-        stt_context_options={"keyterms": ["LiveKit"], "chat_context": {"enabled": False}},
+        stt_context_options={"keyterms": ["LiveKit"], "forward_chat_context": False},
     )
     try:
         opts = session._opts.stt_context_options
         assert opts["keyterms"] == ["LiveKit"]
-        assert opts["chat_context"]["enabled"] is False
+        assert opts["forward_chat_context"] is False
     finally:
         await session.aclose()
 
@@ -2012,7 +2012,7 @@ async def test_deprecated_keyterms_options_maps_to_stt_context(caplog) -> None:
     try:
         opts = session._opts.stt_context_options
         assert opts["keyterms"] == ["Acme"]
-        assert opts["chat_context"]["enabled"] is True  # default still applies
+        assert opts["forward_chat_context"] is True  # default still applies
         assert "keyterms_options is deprecated" in caplog.text
     finally:
         await session.aclose()

--- a/tests/test_inference_stt_context.py
+++ b/tests/test_inference_stt_context.py
@@ -1,8 +1,10 @@
-"""agent_context carryover for LiveKit Inference STT.
+"""chat_context carryover for LiveKit Inference STT.
 
-Mirrors the AssemblyAI plugin's carryover behavior (see
-tests/test_plugin_assemblyai_stt.py), gated to the AssemblyAI Universal-3 Pro
-family models that support it, and applied through the inference ``extra`` path.
+The chat_context capability follows the model's native support (the AssemblyAI Universal-3
+Pro family); whether turns are actually forwarded is decided by
+``AgentSession(stt_context_options=...)``, not a per-STT flag. The sink
+(``_push_conversation_item``) mirrors the AssemblyAI plugin's carryover behavior (see
+tests/test_plugin_assemblyai_stt.py), applied through the inference ``extra`` path.
 """
 
 from __future__ import annotations
@@ -36,53 +38,39 @@ def _assistant_item_event(text: str) -> ConversationItemAddedEvent:
 # -- capability gating --
 
 
-def test_carryover_defaults_off_for_u3_pro_family():
-    """agent_context_carryover is opt-in: off by default even on models that support it."""
+def test_chat_context_capability_on_for_u3_pro_family():
+    """The chat_context capability follows the model's native support (U3 Pro family)."""
     for model in ("assemblyai/u3-rt-pro", "assemblyai/universal-3-5-pro"):
         stt = _make_stt(model=model)
-        assert stt.capabilities.chat_context is False
-
-
-def test_carryover_explicit_true_enables_on_u3_pro_family():
-    """agent_context_carryover=True opts in on models that support it."""
-    for model in ("assemblyai/u3-rt-pro", "assemblyai/universal-3-5-pro"):
-        stt = _make_stt(model=model, agent_context_carryover=True)
         assert stt.capabilities.chat_context is True
 
 
-def test_carryover_defaults_off_for_unsupported_models_without_warning(caplog):
-    """On non-U3-Pro models the default is silently off — no 'ignoring' warning."""
+def test_chat_context_capability_off_for_unsupported_models(caplog):
+    """On non-U3-Pro AssemblyAI models the capability is off, silently (no warning)."""
     with caplog.at_level(logging.WARNING):
         stt = _make_stt(model="assemblyai/universal-streaming")
 
     assert stt.capabilities.chat_context is False
-    assert "agent_context_carryover" not in caplog.text
+    assert "agent_context" not in caplog.text
 
 
-def test_carryover_off_for_non_assemblyai_models():
+def test_chat_context_capability_off_for_non_assemblyai_models():
     """Providers other than AssemblyAI don't carry agent_context."""
     stt = _make_stt(model="deepgram/nova-3")
     assert stt.capabilities.chat_context is False
 
 
-def test_carryover_explicit_true_on_unsupported_model_warns(caplog):
-    """Explicitly enabling carryover on an unsupported model warns and is ignored."""
-    with caplog.at_level(logging.WARNING):
-        stt = _make_stt(model="assemblyai/universal-streaming", agent_context_carryover=True)
+def test_chat_context_capability_independent_of_previous_context_n_turns():
+    """The capability depends only on the model, not on the previous_context_n_turns extra."""
+    stt = _make_stt(extra_kwargs={"previous_context_n_turns": 0})
+    assert stt.capabilities.chat_context is True
 
+
+def test_chat_context_capability_reevaluated_on_model_update():
+    """update_options(model=...) re-derives the chat_context capability from the new model."""
+    stt = _make_stt(model="assemblyai/universal-streaming")
     assert stt.capabilities.chat_context is False
-    assert "agent_context_carryover" in caplog.text
-
-
-def test_carryover_explicit_false_disables():
-    """agent_context_carryover=False opts out on a supported model."""
-    stt = _make_stt(agent_context_carryover=False)
-    assert stt.capabilities.chat_context is False
-
-
-def test_carryover_explicit_true_wins_over_n_turns_zero():
-    """agent_context_carryover=True enables carryover regardless of previous_context_n_turns."""
-    stt = _make_stt(extra_kwargs={"previous_context_n_turns": 0}, agent_context_carryover=True)
+    stt.update_options(model="assemblyai/universal-3-5-pro")
     assert stt.capabilities.chat_context is True
 
 

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -1319,7 +1319,7 @@ async def test_language_code_singular_not_in_update_options():
 
 
 # ---------------------------------------------------------------------------
-# agent_context server cap (1750 chars) + agent_context_carryover opt-in
+# agent_context server cap (1750 chars) + agent_context_carryover deprecation
 #
 # The server rejects `agent_context` longer than 1750 chars, and an invalid
 # UpdateConfiguration cancels the whole streaming session — so the plugin
@@ -1437,22 +1437,39 @@ async def test_carryover_ignores_agent_handoff_items():
     assert stt._opts.agent_context is NOT_GIVEN
 
 
-async def test_carryover_defaults_off_for_u3_pro_family():
-    """agent_context_carryover is opt-in: off by default even on models that support it."""
+async def test_carryover_on_by_default_for_u3_pro_family():
+    """chat_context carryover is on by default on models that support it."""
     from livekit.plugins.assemblyai import STT
 
     for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro", "u3-pro"):
         stt = STT(api_key="test-key", model=model)
-        assert stt.capabilities.chat_context is False
+        assert stt.capabilities.chat_context is True
 
 
-async def test_carryover_explicit_true_enables_on_u3_pro_family():
-    """agent_context_carryover=True opts in on models that support it."""
+async def test_carryover_default_does_not_warn(caplog):
+    """Not passing the deprecated flag produces no deprecation warning."""
+    import logging
+
     from livekit.plugins.assemblyai import STT
 
-    for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro", "u3-pro"):
-        stt = STT(api_key="test-key", model=model, agent_context_carryover=True)
-        assert stt.capabilities.chat_context is True
+    with caplog.at_level(logging.WARNING):
+        stt = STT(api_key="test-key", model="universal-3-5-pro")
+
+    assert stt.capabilities.chat_context is True
+    assert "deprecated" not in caplog.text
+
+
+async def test_carryover_explicit_true_still_enables_and_warns(caplog):
+    """The deprecated agent_context_carryover=True still enables, and warns to migrate."""
+    import logging
+
+    from livekit.plugins.assemblyai import STT
+
+    with caplog.at_level(logging.WARNING):
+        stt = STT(api_key="test-key", model="universal-3-5-pro", agent_context_carryover=True)
+
+    assert stt.capabilities.chat_context is True
+    assert "deprecated" in caplog.text
 
 
 async def test_carryover_defaults_off_for_unsupported_models_without_warning(caplog):
@@ -1485,12 +1502,17 @@ async def test_carryover_explicit_true_on_unsupported_model_warns(caplog):
     assert "agent_context_carryover" in caplog.text
 
 
-async def test_carryover_explicit_false_disables():
-    """agent_context_carryover=False opts out on a supported model."""
+async def test_carryover_explicit_false_disables(caplog):
+    """The deprecated agent_context_carryover=False opts out on a supported model, and warns."""
+    import logging
+
     from livekit.plugins.assemblyai import STT
 
-    stt = STT(api_key="test-key", agent_context_carryover=False)
+    with caplog.at_level(logging.WARNING):
+        stt = STT(api_key="test-key", agent_context_carryover=False)
+
     assert stt.capabilities.chat_context is False
+    assert "deprecated" in caplog.text
 
 
 async def test_carryover_explicit_true_wins_over_n_turns_zero():

--- a/tests/test_stt_context.py
+++ b/tests/test_stt_context.py
@@ -19,7 +19,6 @@ from livekit.agents.voice.keyterm_detection import (
     _detect_keyterms,
     _format_input,
     _parse_tool_call,
-    _resolve_chat_context,
     _resolve_detection,
     _resolve_stt_context_options,
     _stt_context_from_keyterms_options,
@@ -564,17 +563,11 @@ def test_resolve_detection() -> None:
     assert resolved["max_keyterms"] is None
 
 
-def test_resolve_chat_context_defaults_enabled() -> None:
-    assert _resolve_chat_context(None)["enabled"] is True
-    assert _resolve_chat_context({})["enabled"] is True
-    assert _resolve_chat_context({"enabled": False})["enabled"] is False
-
-
 def test_resolve_stt_context_options_defaults() -> None:
     resolved = _resolve_stt_context_options(None)
     assert resolved["keyterms"] == []
     assert resolved["keyterm_detection"]["enabled"] is False
-    assert resolved["chat_context"]["enabled"] is True
+    assert resolved["forward_chat_context"] is True
 
 
 def test_resolve_stt_context_options_passthrough() -> None:
@@ -582,17 +575,17 @@ def test_resolve_stt_context_options_passthrough() -> None:
         {
             "keyterms": ["LiveKit"],
             "keyterm_detection": {"enabled": True, "turn_interval": 2},
-            "chat_context": {"enabled": False},
+            "forward_chat_context": False,
         }
     )
     assert resolved["keyterms"] == ["LiveKit"]
     assert resolved["keyterm_detection"]["enabled"] is True
     assert resolved["keyterm_detection"]["turn_interval"] == 2
-    assert resolved["chat_context"]["enabled"] is False
+    assert resolved["forward_chat_context"] is False
 
 
 def test_stt_context_from_keyterms_options_maps_keys() -> None:
-    """The deprecated keyterms_options maps onto keyterms/keyterm_detection; chat_context defaults."""
+    """The deprecated keyterms_options maps onto keyterms/keyterm_detection; the rest defaults."""
     mapped = _stt_context_from_keyterms_options(
         {"keyterms": ["Acme"], "keyterm_detection": {"enabled": True}}
     )
@@ -601,6 +594,6 @@ def test_stt_context_from_keyterms_options_maps_keys() -> None:
     resolved = _resolve_stt_context_options(mapped)
     assert resolved["keyterms"] == ["Acme"]
     assert resolved["keyterm_detection"]["enabled"] is True
-    assert resolved["chat_context"]["enabled"] is True
+    assert resolved["forward_chat_context"] is True
 
     assert _stt_context_from_keyterms_options(None) == {}

--- a/tests/test_stt_context.py
+++ b/tests/test_stt_context.py
@@ -19,7 +19,10 @@ from livekit.agents.voice.keyterm_detection import (
     _detect_keyterms,
     _format_input,
     _parse_tool_call,
+    _resolve_chat_context,
     _resolve_detection,
+    _resolve_stt_context_options,
+    _stt_context_from_keyterms_options,
 )
 
 pytestmark = pytest.mark.unit
@@ -559,3 +562,45 @@ def test_resolve_detection() -> None:
     assert resolved["enabled"] is True
     assert resolved["turn_interval"] == 1
     assert resolved["max_keyterms"] is None
+
+
+def test_resolve_chat_context_defaults_enabled() -> None:
+    assert _resolve_chat_context(None)["enabled"] is True
+    assert _resolve_chat_context({})["enabled"] is True
+    assert _resolve_chat_context({"enabled": False})["enabled"] is False
+
+
+def test_resolve_stt_context_options_defaults() -> None:
+    resolved = _resolve_stt_context_options(None)
+    assert resolved["keyterms"] == []
+    assert resolved["keyterm_detection"]["enabled"] is False
+    assert resolved["chat_context"]["enabled"] is True
+
+
+def test_resolve_stt_context_options_passthrough() -> None:
+    resolved = _resolve_stt_context_options(
+        {
+            "keyterms": ["LiveKit"],
+            "keyterm_detection": {"enabled": True, "turn_interval": 2},
+            "chat_context": {"enabled": False},
+        }
+    )
+    assert resolved["keyterms"] == ["LiveKit"]
+    assert resolved["keyterm_detection"]["enabled"] is True
+    assert resolved["keyterm_detection"]["turn_interval"] == 2
+    assert resolved["chat_context"]["enabled"] is False
+
+
+def test_stt_context_from_keyterms_options_maps_keys() -> None:
+    """The deprecated keyterms_options maps onto keyterms/keyterm_detection; chat_context defaults."""
+    mapped = _stt_context_from_keyterms_options(
+        {"keyterms": ["Acme"], "keyterm_detection": {"enabled": True}}
+    )
+    assert mapped == {"keyterms": ["Acme"], "keyterm_detection": {"enabled": True}}
+
+    resolved = _resolve_stt_context_options(mapped)
+    assert resolved["keyterms"] == ["Acme"]
+    assert resolved["keyterm_detection"]["enabled"] is True
+    assert resolved["chat_context"]["enabled"] is True
+
+    assert _stt_context_from_keyterms_options(None) == {}


### PR DESCRIPTION
Adds `stt_context_options` on `AgentSession` — a single conversation-aware STT option grouping static `keyterms`, LLM `keyterm_detection`, and a `forward_chat_context` toggle that forwards agent replies to STTs that consume context natively (e.g. AssemblyAI Universal-3 Pro).

`forward_chat_context` is on by default and is the only control for carryover, applied consistently across the inference STT and the AssemblyAI plugin. Agent replies are now sent to AssemblyAI u3-pro by default when used via `AgentSession`; opt out with `stt_context_options={"forward_chat_context": False}`.

Deprecated (still work, warn):
- `AgentSession(keyterms_options=...)` → use `stt_context_options`
- AssemblyAI plugin `agent_context_carryover` → use `stt_context_options.forward_chat_context` (pass `False` to opt out)

Removes the unpublished `agent_context_carryover` param from the inference STT.