### PR TITLE
Add livekit-plugins-rnnoise (OSS self-hosted noise cancellation)

### DIFF
--- a/livekit-plugins/livekit-plugins-rnnoise/README.md
+++ b/livekit-plugins/livekit-plugins-rnnoise/README.md
@@ -1,1 +1,61 @@
-# LiveKit Plugins RNNoise
+# RNNoise Plugin for LiveKit Agents
+
+OSS, self-hosted noise cancellation for LiveKit Agents (RNNoise) — a free, fully-local alternative
+to the Cloud-gated Krisp plugin.
+
+## Features
+
+- **`RNNoise`**: A `FrameProcessor` that runs [RNNoise](https://github.com/xiph/rnnoise) noise
+  suppression on the agent's incoming audio, entirely on-device.
+
+## Installation
+
+```bash
+pip install livekit-plugins-rnnoise
+```
+
+No API key, license, or separate model download is required — the RNNoise model is bundled in the
+wheel via [`pyrnnoise`](https://pypi.org/project/pyrnnoise/).
+
+## Quick Start
+
+```python
+from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli, room_io
+from livekit.plugins import rnnoise
+
+
+server = AgentServer()
+
+
+@server.rtc_session()
+async def entrypoint(ctx: JobContext) -> None:
+    session = AgentSession(...)
+
+    await session.start(
+        agent=Agent(instructions="..."),
+        room=ctx.room,
+        room_options=room_io.RoomOptions(
+            audio_input=room_io.AudioInputOptions(
+                noise_cancellation=rnnoise.RNNoise(),
+            ),
+        ),
+    )
+
+
+if __name__ == "__main__":
+    cli.run_app(server)
+```
+
+**Audio Pipeline:** `Room → RoomIO (with RNNoise) → VAD → STT → LLM`
+
+See `examples/rnnoise_agent_example.py` for a complete, runnable agent.
+
+## Notes
+
+- **Mono only (v1):** `RNNoise` currently supports single-channel audio. A frame with more than one
+  channel raises `ValueError`.
+- **Latency:** RNNoise operates on fixed 48kHz/10ms frames internally, so incoming audio is resampled
+  in and out. Expect roughly 10-70ms of warm-up latency (padded with silence) before denoised audio
+  starts flowing, depending on the source sample rate.
+- **CPU cost:** small — a resample pass plus RNNoise inference per frame. No GPU required.
+- **License:** Apache-2.0.

--- a/livekit-plugins/livekit-plugins-rnnoise/README.md
+++ b/livekit-plugins/livekit-plugins-rnnoise/README.md
@@ -1,0 +1,1 @@
+# LiveKit Plugins RNNoise

--- a/livekit-plugins/livekit-plugins-rnnoise/examples/rnnoise_agent_example.py
+++ b/livekit-plugins/livekit-plugins-rnnoise/examples/rnnoise_agent_example.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Example: Voice Agent with RNNoise Noise Cancellation
+
+This example demonstrates how to integrate RNNoise noise cancellation
+into a LiveKit voice agent for human-to-bot conversations. RNNoise runs
+entirely on-device -- no API key, license, or model download required.
+
+The audio pipeline:
+    Room → RoomIO (with RNNoise) → VAD → STT → LLM → TTS → Room
+
+Prerequisites:
+    Install required packages:
+       - livekit-agents
+       - livekit-plugins-rnnoise
+       - livekit-plugins-openai (or your preferred STT/LLM/TTS)
+
+Usage:
+    python rnnoise_agent_example.py dev
+"""
+
+import logging
+
+from dotenv import load_dotenv
+
+from livekit.agents import (
+    Agent,
+    AgentServer,
+    AgentSession,
+    JobContext,
+    cli,
+    inference,
+    room_io,
+)
+from livekit.plugins import openai, rnnoise
+
+logger = logging.getLogger("rnnoise-agent-example")
+load_dotenv()
+
+
+class RNNoiseAgent(Agent):
+    """Voice agent that uses RNNoise for noise cancellation."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            instructions=(
+                "You are a helpful voice assistant. "
+                "Keep your responses concise and conversational. "
+                "Do not use emojis or special characters in your responses."
+            ),
+        )
+
+    async def on_enter(self) -> None:
+        """Called when the agent enters the session."""
+        logger.info("RNNoise agent entered session")
+        self.session.generate_reply(allow_interruptions=False)
+
+
+server = AgentServer()
+
+
+@server.rtc_session()
+async def entrypoint(ctx: JobContext) -> None:
+    """Main entrypoint for the agent session."""
+
+    session = AgentSession(
+        vad=inference.VAD(),
+        stt=openai.STT(model="whisper-1"),
+        llm=openai.LLM(model="gpt-4o-mini"),
+        tts=openai.TTS(voice="alloy"),
+        allow_interruptions=True,
+        min_endpointing_delay=0.5,
+        max_endpointing_delay=3.0,
+    )
+
+    logger.info("Starting agent session with RoomIO and RNNoise noise cancellation")
+
+    # Start the session with RoomIO configuration
+    await session.start(
+        agent=RNNoiseAgent(),
+        room=ctx.room,
+        room_options=room_io.RoomOptions(
+            audio_input=room_io.AudioInputOptions(
+                noise_cancellation=rnnoise.RNNoise(),
+            ),
+        ),
+    )
+
+    logger.info("RNNoise noise cancellation active")
+
+
+if __name__ == "__main__":
+    cli.run_app(server)

--- a/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/__init__.py
+++ b/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/__init__.py
@@ -12,7 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from livekit.agents import Plugin
+
 from .log import logger
+from .rnnoise_filter import RNNoise, RNNoiseFrameProcessor
 from .version import __version__
 
-__all__ = ["__version__", "logger"]
+__all__ = ["RNNoise", "RNNoiseFrameProcessor", "logger", "__version__"]
+
+
+class RNNoisePlugin(Plugin):
+    def __init__(self) -> None:
+        super().__init__(__name__, __version__, __package__, logger)
+
+
+Plugin.register_plugin(RNNoisePlugin())

--- a/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/__init__.py
+++ b/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .log import logger
+from .version import __version__
+
+__all__ = ["__version__", "logger"]

--- a/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/__init__.py
+++ b/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""OSS, self-hosted noise cancellation for LiveKit Agents, powered by RNNoise."""
+
 from livekit.agents import Plugin
 
 from .log import logger

--- a/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/_rnnoise_native.py
+++ b/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/_rnnoise_native.py
@@ -98,11 +98,12 @@ class _RNNoiseDenoiser:
     """Owns one native RNNoise DenoiseState and processes 480-sample frames."""
 
     def __init__(self) -> None:
+        self._state: int | None = None
         self._lib = _load_lib()
         state = self._lib.rnnoise_create(None)  # NULL model -> baked-in default RNNModel
         if not state:
             raise RuntimeError("rnnoise_create(None) returned NULL")
-        self._state: int | None = state
+        self._state = state
 
     def process_frame(self, frame_480_int16: np.ndarray) -> np.ndarray:
         """Denoise exactly one 480-sample mono int16 frame, in place semantics aside."""

--- a/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/_rnnoise_native.py
+++ b/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/_rnnoise_native.py
@@ -1,0 +1,127 @@
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Thin ctypes binding to the RNNoise C library bundled inside pyrnnoise's
+site-packages directory.
+
+This deliberately never imports the `pyrnnoise` Python package -- only its
+package directory is located (via `importlib.util.find_spec`) so we can load
+the native `librnnoise` shared library it ships. Importing `pyrnnoise` itself
+pulls in `audiolab` (and transitively `matplotlib`) and forces an upper pin on
+`av`, none of which this plugin needs.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+
+_RNNOISE_FRAME_SAMPLES = 480
+_NATIVE_LIB_EXTENSIONS = (".dylib", ".so", ".dll")
+
+_lib: ctypes.CDLL | None = None
+
+
+def _find_bundled_lib() -> Path:
+    """Locate the RNNoise native library inside pyrnnoise's package directory."""
+    spec = importlib.util.find_spec("pyrnnoise")
+    if spec is None or not spec.submodule_search_locations:
+        raise RuntimeError(
+            "Could not locate the pyrnnoise package, which bundles the native "
+            "RNNoise library required by this plugin. Install it with "
+            "`pip install pyrnnoise`."
+        )
+    pkg_dir = Path(next(iter(spec.submodule_search_locations)))
+
+    candidates = sorted(
+        path
+        for ext in _NATIVE_LIB_EXTENSIONS
+        for path in pkg_dir.glob(f"*{ext}")
+        if "rnnoise" in path.name.lower()
+    )
+    if not candidates:
+        raise RuntimeError(
+            f"No bundled RNNoise native library found in {pkg_dir}. Install/reinstall "
+            "pyrnnoise with `pip install pyrnnoise` to provide it."
+        )
+    return candidates[0]
+
+
+def _load_lib() -> ctypes.CDLL:
+    global _lib
+    if _lib is not None:
+        return _lib
+
+    lib = ctypes.CDLL(str(_find_bundled_lib()))
+
+    lib.rnnoise_get_frame_size.argtypes = []
+    lib.rnnoise_get_frame_size.restype = ctypes.c_int
+
+    lib.rnnoise_create.argtypes = [ctypes.c_void_p]
+    lib.rnnoise_create.restype = ctypes.c_void_p
+
+    lib.rnnoise_process_frame.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.POINTER(ctypes.c_float),
+    ]
+    lib.rnnoise_process_frame.restype = ctypes.c_float
+
+    lib.rnnoise_destroy.argtypes = [ctypes.c_void_p]
+    lib.rnnoise_destroy.restype = None
+
+    frame_size = lib.rnnoise_get_frame_size()
+    if frame_size != _RNNOISE_FRAME_SAMPLES:
+        raise RuntimeError(
+            f"Unexpected RNNoise frame size {frame_size}, expected {_RNNOISE_FRAME_SAMPLES}"
+        )
+
+    _lib = lib
+    return lib
+
+
+class _RNNoiseDenoiser:
+    """Owns one native RNNoise DenoiseState and processes 480-sample frames."""
+
+    def __init__(self) -> None:
+        self._lib = _load_lib()
+        state = self._lib.rnnoise_create(None)  # NULL model -> baked-in default RNNModel
+        if not state:
+            raise RuntimeError("rnnoise_create(None) returned NULL")
+        self._state: int | None = state
+
+    def process_frame(self, frame_480_int16: np.ndarray) -> np.ndarray:
+        """Denoise exactly one 480-sample mono int16 frame, in place semantics aside."""
+        if self._state is None:
+            raise RuntimeError("process_frame() called after close()")
+        assert frame_480_int16.dtype == np.int16
+        assert len(frame_480_int16) == _RNNOISE_FRAME_SAMPLES
+
+        # RNNoise's C ABI operates on float32 samples in the same numeric range as
+        # int16 (i.e. not normalized to [-1, 1]).
+        buf = frame_480_int16.astype(np.float32)
+        ptr = buf.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
+        self._lib.rnnoise_process_frame(self._state, ptr, ptr)
+        return buf.astype(np.int16)
+
+    def close(self) -> None:
+        if self._state is not None:
+            self._lib.rnnoise_destroy(self._state)
+            self._state = None
+
+    def __del__(self) -> None:
+        self.close()

--- a/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/log.py
+++ b/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/log.py
@@ -1,0 +1,17 @@
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+logger = logging.getLogger("livekit.plugins.rnnoise")

--- a/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/rnnoise_filter.py
+++ b/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/rnnoise_filter.py
@@ -25,10 +25,9 @@ from __future__ import annotations
 
 import numpy as np
 
-# pyrnnoise ships no stubs/py.typed marker upstream.
-from pyrnnoise import RNNoise as _RNNoiseDenoiser  # type: ignore[import-untyped]
-
 from livekit import rtc
+
+from ._rnnoise_native import _RNNoiseDenoiser
 
 _RNNOISE_SAMPLE_RATE = 48000
 _RNNOISE_FRAME_SAMPLES = 480
@@ -58,7 +57,7 @@ class RNNoiseFrameProcessor(rtc.FrameProcessor[rtc.AudioFrame]):
 
     def __init__(self, *, enabled: bool = True) -> None:
         self._enabled = enabled
-        self._denoiser = _RNNoiseDenoiser(_RNNOISE_SAMPLE_RATE)
+        self._denoiser = _RNNoiseDenoiser()
 
         self._source_rate: int | None = None
         self._num_channels: int | None = None
@@ -101,7 +100,8 @@ class RNNoiseFrameProcessor(rtc.FrameProcessor[rtc.AudioFrame]):
         return self._take_output_frame(frame, n)
 
     def _close(self) -> None:
-        self._denoiser = _RNNoiseDenoiser(_RNNOISE_SAMPLE_RATE)
+        self._denoiser.close()
+        self._denoiser = _RNNoiseDenoiser()
         self._source_rate = None
         self._num_channels = None
         self._in_resampler = None
@@ -151,8 +151,8 @@ class RNNoiseFrameProcessor(rtc.FrameProcessor[rtc.AudioFrame]):
         self._in_buffer = self._in_buffer[drain_len:]
 
         denoised_parts = [
-            np.asarray(denoised, dtype=np.int16).reshape(-1)
-            for _, denoised in self._denoiser.denoise_chunk(to_denoise)
+            self._denoiser.process_frame(to_denoise[i : i + _RNNOISE_FRAME_SAMPLES])
+            for i in range(0, drain_len, _RNNOISE_FRAME_SAMPLES)
         ]
         if denoised_parts:
             self._pending_denoised_48k = np.concatenate(

--- a/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/rnnoise_filter.py
+++ b/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/rnnoise_filter.py
@@ -24,7 +24,9 @@ num_channels and samples_per_channel as the input.
 from __future__ import annotations
 
 import numpy as np
-from pyrnnoise import RNNoise as _RNNoiseDenoiser
+
+# pyrnnoise ships no stubs/py.typed marker upstream.
+from pyrnnoise import RNNoise as _RNNoiseDenoiser  # type: ignore[import-untyped]
 
 from livekit import rtc
 
@@ -137,9 +139,7 @@ class RNNoiseFrameProcessor(rtc.FrameProcessor[rtc.AudioFrame]):
         resampled_frames = self._in_resampler.push(frame)
         if not resampled_frames:
             return _EMPTY_SAMPLES
-        return np.concatenate(
-            [np.frombuffer(f.data, dtype=np.int16) for f in resampled_frames]
-        )
+        return np.concatenate([np.frombuffer(f.data, dtype=np.int16) for f in resampled_frames])
 
     def _denoise_complete_chunks(self) -> None:
         num_chunks = len(self._in_buffer) // _RNNOISE_FRAME_SAMPLES

--- a/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/rnnoise_filter.py
+++ b/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/rnnoise_filter.py
@@ -82,6 +82,12 @@ class RNNoiseFrameProcessor(rtc.FrameProcessor[rtc.AudioFrame]):
         if not self._enabled:
             return frame
 
+        if frame.num_channels != 1:
+            raise ValueError(
+                "RNNoiseFrameProcessor v1 only supports mono audio, but "
+                f"received a frame with {frame.num_channels} channels"
+            )
+
         n = frame.samples_per_channel
         self._ensure_pipeline(frame.sample_rate, frame.num_channels)
 

--- a/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/rnnoise_filter.py
+++ b/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/rnnoise_filter.py
@@ -1,0 +1,203 @@
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RNNoise noise-cancellation FrameProcessor for LiveKit Agents.
+
+RNNoise operates on fixed 48kHz mono 480-sample (10ms) frames. Input frames can
+arrive at any sample rate/cadence, so this module resamples to 48kHz, feeds
+RNNoise exact 480-sample chunks, and resamples the denoised audio back to the
+source rate -- returning, on every call, a frame with the same sample_rate,
+num_channels and samples_per_channel as the input.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from pyrnnoise import RNNoise as _RNNoiseDenoiser
+
+from livekit import rtc
+
+_RNNOISE_SAMPLE_RATE = 48000
+_RNNOISE_FRAME_SAMPLES = 480
+
+_EMPTY_SAMPLES = np.empty(0, dtype=np.int16)
+
+
+class RNNoiseFrameProcessor(rtc.FrameProcessor[rtc.AudioFrame]):
+    """FrameProcessor implementation for RNNoise noise cancellation.
+
+    Example:
+        ```python
+        from livekit.agents import room_io
+        from livekit.plugins import rnnoise
+
+        await session.start(
+            agent=MyAgent(),
+            room=ctx.room,
+            room_options=room_io.RoomOptions(
+                audio_input=room_io.AudioInputOptions(
+                    noise_cancellation=rnnoise.RNNoise(),
+                ),
+            ),
+        )
+        ```
+    """
+
+    def __init__(self, *, enabled: bool = True) -> None:
+        self._enabled = enabled
+        self._denoiser = _RNNoiseDenoiser(_RNNOISE_SAMPLE_RATE)
+
+        self._source_rate: int | None = None
+        self._num_channels: int | None = None
+        self._in_resampler: rtc.AudioResampler | None = None
+        self._out_resampler: rtc.AudioResampler | None = None
+
+        # Samples awaiting denoising, always at 48kHz.
+        self._in_buffer = _EMPTY_SAMPLES
+        # Denoised samples awaiting resample back to the source rate.
+        self._pending_denoised_48k = _EMPTY_SAMPLES
+        # Samples at the source rate awaiting return to the caller.
+        self._out_buffer = _EMPTY_SAMPLES
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, value: bool) -> None:
+        self._enabled = value
+
+    def _process(self, frame: rtc.AudioFrame) -> rtc.AudioFrame:
+        if not self._enabled:
+            return frame
+
+        n = frame.samples_per_channel
+        self._ensure_pipeline(frame.sample_rate, frame.num_channels)
+
+        in_48k = self._resample_to_rnnoise(frame)
+        self._in_buffer = np.concatenate([self._in_buffer, in_48k])
+        self._denoise_complete_chunks()
+        self._resample_denoised_to_source(frame.sample_rate)
+
+        return self._take_output_frame(frame, n)
+
+    def _close(self) -> None:
+        self._denoiser = _RNNoiseDenoiser(_RNNOISE_SAMPLE_RATE)
+        self._source_rate = None
+        self._num_channels = None
+        self._in_resampler = None
+        self._out_resampler = None
+        self._in_buffer = _EMPTY_SAMPLES
+        self._pending_denoised_48k = _EMPTY_SAMPLES
+        self._out_buffer = _EMPTY_SAMPLES
+
+    def _ensure_pipeline(self, sample_rate: int, num_channels: int) -> None:
+        if self._source_rate == sample_rate and self._num_channels == num_channels:
+            return
+
+        self._source_rate = sample_rate
+        self._num_channels = num_channels
+        self._in_buffer = _EMPTY_SAMPLES
+        self._pending_denoised_48k = _EMPTY_SAMPLES
+        self._out_buffer = _EMPTY_SAMPLES
+
+        if sample_rate == _RNNOISE_SAMPLE_RATE:
+            self._in_resampler = None
+            self._out_resampler = None
+        else:
+            self._in_resampler = rtc.AudioResampler(
+                sample_rate, _RNNOISE_SAMPLE_RATE, num_channels=num_channels
+            )
+            self._out_resampler = rtc.AudioResampler(
+                _RNNOISE_SAMPLE_RATE, sample_rate, num_channels=num_channels
+            )
+
+    def _resample_to_rnnoise(self, frame: rtc.AudioFrame) -> np.ndarray:
+        if frame.sample_rate == _RNNOISE_SAMPLE_RATE:
+            return np.frombuffer(frame.data, dtype=np.int16)
+
+        assert self._in_resampler is not None
+        resampled_frames = self._in_resampler.push(frame)
+        if not resampled_frames:
+            return _EMPTY_SAMPLES
+        return np.concatenate(
+            [np.frombuffer(f.data, dtype=np.int16) for f in resampled_frames]
+        )
+
+    def _denoise_complete_chunks(self) -> None:
+        num_chunks = len(self._in_buffer) // _RNNOISE_FRAME_SAMPLES
+        if num_chunks == 0:
+            return
+
+        drain_len = num_chunks * _RNNOISE_FRAME_SAMPLES
+        to_denoise = self._in_buffer[:drain_len]
+        self._in_buffer = self._in_buffer[drain_len:]
+
+        denoised_parts = [
+            np.asarray(denoised, dtype=np.int16).reshape(-1)
+            for _, denoised in self._denoiser.denoise_chunk(to_denoise)
+        ]
+        if denoised_parts:
+            self._pending_denoised_48k = np.concatenate(
+                [self._pending_denoised_48k, *denoised_parts]
+            )
+
+    def _resample_denoised_to_source(self, source_rate: int) -> None:
+        if len(self._pending_denoised_48k) == 0:
+            return
+
+        if source_rate == _RNNOISE_SAMPLE_RATE:
+            self._out_buffer = np.concatenate([self._out_buffer, self._pending_denoised_48k])
+            self._pending_denoised_48k = _EMPTY_SAMPLES
+            return
+
+        assert self._out_resampler is not None
+        assert self._num_channels is not None
+        denoised_frame = rtc.AudioFrame(
+            data=self._pending_denoised_48k.tobytes(),
+            sample_rate=_RNNOISE_SAMPLE_RATE,
+            num_channels=self._num_channels,
+            samples_per_channel=len(self._pending_denoised_48k),
+        )
+        self._pending_denoised_48k = _EMPTY_SAMPLES
+
+        resampled_frames = self._out_resampler.push(denoised_frame)
+        if resampled_frames:
+            out_samples = np.concatenate(
+                [np.frombuffer(f.data, dtype=np.int16) for f in resampled_frames]
+            )
+            self._out_buffer = np.concatenate([self._out_buffer, out_samples])
+
+    def _take_output_frame(self, frame: rtc.AudioFrame, n: int) -> rtc.AudioFrame:
+        if len(self._out_buffer) >= n:
+            out_samples = self._out_buffer[:n]
+            self._out_buffer = self._out_buffer[n:]
+        else:
+            # Warm-up latency: the resampler/denoiser hasn't produced enough
+            # samples yet. Pad with leading silence and keep the same length.
+            pad = np.zeros(n - len(self._out_buffer), dtype=np.int16)
+            out_samples = np.concatenate([pad, self._out_buffer])
+            self._out_buffer = _EMPTY_SAMPLES
+
+        return rtc.AudioFrame(
+            data=out_samples.tobytes(),
+            sample_rate=frame.sample_rate,
+            num_channels=frame.num_channels,
+            samples_per_channel=n,
+        )
+
+
+def RNNoise(*, enabled: bool = True) -> RNNoiseFrameProcessor:
+    """Create an RNNoise noise-cancellation FrameProcessor."""
+    return RNNoiseFrameProcessor(enabled=enabled)

--- a/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/version.py
+++ b/livekit-plugins/livekit-plugins-rnnoise/livekit/plugins/rnnoise/version.py
@@ -1,0 +1,15 @@
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.1.0"

--- a/livekit-plugins/livekit-plugins-rnnoise/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-rnnoise/pyproject.toml
@@ -23,8 +23,9 @@ dependencies = [
     "livekit-agents>=1.6.4",
     "livekit>=1.0.23,<2",
     "numpy>=1.20.0",
+    # Only used to locate/load its bundled native librnnoise via ctypes -- the
+    # pyrnnoise Python package itself is never imported.
     "pyrnnoise>=0.4.3",
-    "av>=14.0.0,<16",
 ]
 
 [project.urls]

--- a/livekit-plugins/livekit-plugins-rnnoise/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-rnnoise/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "livekit-plugins-rnnoise"
+dynamic = ["version"]
+description = "OSS self-hosted noise cancellation (RNNoise) plugin for LiveKit Agents"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.9.0"
+authors = [{ name = "LiveKit", email = "hello@livekit.io" }]
+keywords = ["voice","ai","realtime","audio","livekit","webrtc","noise-reduction","noise-cancellation","rnnoise","audio-filter","self-hosted","oss"]
+classifiers = [
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: Multimedia :: Sound/Audio",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+]
+dependencies = [
+    "livekit-agents>=1.6.4",
+    "livekit>=1.0.23,<2",
+    "numpy>=1.20.0",
+    "pyrnnoise>=0.4.3",
+    "av>=14.0.0,<16",
+]
+
+[project.urls]
+Documentation = "https://docs.livekit.io"
+Website = "https://livekit.io/"
+Source = "https://github.com/livekit/agents"
+
+[tool.hatch.version]
+path = "livekit/plugins/rnnoise/version.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["livekit"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/livekit"]

--- a/livekit-plugins/livekit-plugins-rnnoise/tests/test_rnnoise_filter.py
+++ b/livekit-plugins/livekit-plugins-rnnoise/tests/test_rnnoise_filter.py
@@ -1,0 +1,183 @@
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import numpy as np
+
+import livekit.plugins.rnnoise as rn
+from livekit import rtc
+from livekit.plugins.rnnoise import RNNoise
+
+
+def _make_frame(samples: np.ndarray, sample_rate: int) -> rtc.AudioFrame:
+    samples = samples.astype(np.int16)
+    return rtc.AudioFrame(
+        data=samples.tobytes(),
+        sample_rate=sample_rate,
+        num_channels=1,
+        samples_per_channel=len(samples),
+    )
+
+
+def _white_noise(n: int, amplitude: int = 8000, seed: int | None = None) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return rng.integers(-amplitude, amplitude, size=n, dtype=np.int16)
+
+
+def _frame_energy(frame: rtc.AudioFrame) -> float:
+    samples = np.frombuffer(frame.data, dtype=np.int16).astype(np.float64)
+    return float(np.mean(samples**2))
+
+
+def test_enabled_property_roundtrip():
+    processor = RNNoise()
+    assert processor.enabled is True
+
+    processor.enabled = False
+    assert processor.enabled is False
+
+    processor.enabled = True
+    assert processor.enabled is True
+
+
+def test_passthrough_when_disabled():
+    processor = RNNoise(enabled=False)
+    samples = _white_noise(160, seed=1)
+    frame = _make_frame(samples, 16000)
+
+    out = processor._process(frame)
+
+    assert out.sample_rate == frame.sample_rate
+    assert out.num_channels == frame.num_channels
+    assert out.samples_per_channel == frame.samples_per_channel
+    assert bytes(out.data) == bytes(frame.data)
+
+
+def test_same_length_contract_at_48k():
+    processor = RNNoise()
+    samples = _white_noise(480, seed=2)
+    frame = _make_frame(samples, 48000)
+
+    out = processor._process(frame)
+
+    assert out.sample_rate == 48000
+    assert out.num_channels == 1
+    assert out.samples_per_channel == 480
+
+
+def test_same_length_contract_at_16k():
+    processor = RNNoise()
+    samples = _white_noise(160, seed=3)
+    frame = _make_frame(samples, 16000)
+
+    out = processor._process(frame)
+
+    # The resampler/denoiser pipeline has warm-up latency, so the very first
+    # call may return silence -- only rate + length are guaranteed per call.
+    assert out.sample_rate == 16000
+    assert out.num_channels == 1
+    assert out.samples_per_channel == 160
+
+
+def test_stream_length_conservation():
+    processor = RNNoise()
+    total_in = 0
+    total_out = 0
+
+    for i in range(50):
+        samples = _white_noise(160, seed=100 + i)
+        frame = _make_frame(samples, 16000)
+
+        out = processor._process(frame)
+
+        assert out.sample_rate == 16000
+        assert out.num_channels == 1
+        total_in += frame.samples_per_channel
+        total_out += out.samples_per_channel
+
+    assert total_out == total_in
+
+
+def test_noise_reduction_at_steady_state():
+    processor = RNNoise()
+    last_in_energy = None
+    last_out_frame = None
+
+    # 48kHz frames aligned to RNNoise's 480-sample chunk size need no
+    # resampler warm-up, so a handful of frames is enough to reach steady
+    # state before we compare energies.
+    for i in range(60):
+        samples = _white_noise(480, amplitude=8000, seed=200 + i)
+        frame = _make_frame(samples, 48000)
+
+        out = processor._process(frame)
+
+        last_in_energy = _frame_energy(frame)
+        last_out_frame = out
+
+    assert last_out_frame is not None
+    out_energy = _frame_energy(last_out_frame)
+    assert out_energy < last_in_energy
+
+
+def test_noise_reduction_through_resampled_16k_path():
+    # Exercises the actual resample(16k->48k) -> denoise -> resample(48k->16k)
+    # round-trip, not just the no-resampling 48kHz case above. Measured
+    # empirically: the resampler/denoiser warm-up clears well within 80
+    # frames (energy becomes nonzero around frame 7-9, steady state by ~70),
+    # after which output energy stays several orders of magnitude below the
+    # white-noise input -- so a broken/silent pipeline would show energy 0
+    # here, and a passthrough-without-denoising pipeline would show energy
+    # close to the input.
+    processor = RNNoise()
+    last_in_energy = None
+    last_out_frame = None
+
+    for i in range(80):
+        samples = _white_noise(160, amplitude=8000, seed=300 + i)
+        frame = _make_frame(samples, 16000)
+
+        out = processor._process(frame)
+
+        last_in_energy = _frame_energy(frame)
+        last_out_frame = out
+
+    assert last_out_frame is not None
+    out_energy = _frame_energy(last_out_frame)
+    assert out_energy > 0
+    assert out_energy < last_in_energy
+
+
+def test_close_resets_state_and_is_idempotent():
+    processor = RNNoise()
+    samples = _white_noise(480, seed=4)
+    frame = _make_frame(samples, 48000)
+
+    processor._process(frame)
+    processor._close()
+    processor._close()  # must be safe to call twice
+
+    out = processor._process(frame)
+
+    assert out.sample_rate == 48000
+    assert out.num_channels == 1
+    assert out.samples_per_channel == 480
+
+
+def test_public_api_and_type():
+    processor = rn.RNNoise()
+
+    assert isinstance(processor, rtc.FrameProcessor)
+    assert isinstance(processor, rn.RNNoiseFrameProcessor)

--- a/livekit-plugins/livekit-plugins-rnnoise/tests/test_rnnoise_filter.py
+++ b/livekit-plugins/livekit-plugins-rnnoise/tests/test_rnnoise_filter.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import sys
+
 import numpy as np
 import pytest
 
@@ -147,7 +149,7 @@ def test_noise_reduction_through_resampled_16k_path():
     # denoising contributes on top of the resampler-only pipeline.
     processor = RNNoise()
     baseline_processor = RNNoise()
-    baseline_processor._denoiser.denoise_chunk = lambda chunk, partial=False: iter([(0.0, chunk)])
+    baseline_processor._denoiser.process_frame = lambda frame: frame
 
     last_out_frame = None
     last_baseline_frame = None
@@ -201,3 +203,16 @@ def test_public_api_and_type():
 
     assert isinstance(processor, rtc.FrameProcessor)
     assert isinstance(processor, rn.RNNoiseFrameProcessor)
+
+
+def test_does_not_import_pyrnnoise_or_audiolab():
+    # The whole point of the ctypes wrapper: it loads pyrnnoise's bundled
+    # native librnnoise directly and must never import the pyrnnoise Python
+    # package (which pulls in audiolab -> matplotlib).
+    processor = RNNoise()
+    for i in range(5):
+        samples = _white_noise(480, seed=400 + i)
+        processor._process(_make_frame(samples, 48000))
+
+    assert "pyrnnoise" not in sys.modules
+    assert "audiolab" not in sys.modules

--- a/livekit-plugins/livekit-plugins-rnnoise/tests/test_rnnoise_filter.py
+++ b/livekit-plugins/livekit-plugins-rnnoise/tests/test_rnnoise_filter.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 import livekit.plugins.rnnoise as rn
 from livekit import rtc
@@ -136,28 +137,33 @@ def test_noise_reduction_through_resampled_16k_path():
     # Exercises the actual resample(16k->48k) -> denoise -> resample(48k->16k)
     # round-trip, not just the no-resampling 48kHz case above. Measured
     # empirically: the resampler/denoiser warm-up clears well within 80
-    # frames (energy becomes nonzero around frame 7-9, steady state by ~70),
-    # after which output energy stays several orders of magnitude below the
-    # white-noise input -- so a broken/silent pipeline would show energy 0
-    # here, and a passthrough-without-denoising pipeline would show energy
-    # close to the input.
+    # frames (energy becomes nonzero around frame 7-9, steady state by ~70).
+    #
+    # Comparing against the raw input energy is misleading here: the
+    # resampler's anti-alias filter alone attenuates white noise
+    # (~0.92x), so `out_energy < in_energy` would pass even for a no-op
+    # denoiser. Instead we compare against a baseline processor whose
+    # RNNoise denoising is bypassed (identity), isolating what real
+    # denoising contributes on top of the resampler-only pipeline.
     processor = RNNoise()
-    last_in_energy = None
+    baseline_processor = RNNoise()
+    baseline_processor._denoiser.denoise_chunk = lambda chunk, partial=False: iter([(0.0, chunk)])
+
     last_out_frame = None
+    last_baseline_frame = None
 
     for i in range(80):
         samples = _white_noise(160, amplitude=8000, seed=300 + i)
-        frame = _make_frame(samples, 16000)
 
-        out = processor._process(frame)
-
-        last_in_energy = _frame_energy(frame)
-        last_out_frame = out
+        last_out_frame = processor._process(_make_frame(samples, 16000))
+        last_baseline_frame = baseline_processor._process(_make_frame(samples, 16000))
 
     assert last_out_frame is not None
+    assert last_baseline_frame is not None
     out_energy = _frame_energy(last_out_frame)
+    baseline_energy = _frame_energy(last_baseline_frame)
     assert out_energy > 0
-    assert out_energy < last_in_energy
+    assert out_energy < baseline_energy
 
 
 def test_close_resets_state_and_is_idempotent():
@@ -174,6 +180,20 @@ def test_close_resets_state_and_is_idempotent():
     assert out.sample_rate == 48000
     assert out.num_channels == 1
     assert out.samples_per_channel == 480
+
+
+def test_process_raises_on_stereo_frame():
+    processor = RNNoise()
+    samples = _white_noise(320, seed=5)  # 160 samples/channel interleaved stereo
+    frame = rtc.AudioFrame(
+        data=samples.astype(np.int16).tobytes(),
+        sample_rate=16000,
+        num_channels=2,
+        samples_per_channel=160,
+    )
+
+    with pytest.raises(ValueError, match="mono"):
+        processor._process(frame)
 
 
 def test_public_api_and_type():

--- a/livekit-plugins/livekit-plugins-rnnoise/tests/test_rnnoise_filter.py
+++ b/livekit-plugins/livekit-plugins-rnnoise/tests/test_rnnoise_filter.py
@@ -23,6 +23,8 @@ import livekit.plugins.rnnoise as rn
 from livekit import rtc
 from livekit.plugins.rnnoise import RNNoise
 
+pytestmark = pytest.mark.unit
+
 
 def _make_frame(samples: np.ndarray, sample_rate: int) -> rtc.AudioFrame:
     samples = samples.astype(np.int16)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ livekit-plugins-protoface = { workspace = true }
 livekit-plugins-resemble = { workspace = true }
 livekit-plugins-respeecher = { workspace = true }
 livekit-plugins-rime = { workspace = true }
+livekit-plugins-rnnoise = { workspace = true }
 livekit-plugins-runway = { workspace = true }
 livekit-plugins-rtzr = { workspace = true }
 livekit-plugins-sarvam = { workspace = true }


### PR DESCRIPTION
Right now, if you're self-hosting, there's not really a good built-in option for cleaning up mic noise. Krisp and ai-coustics both require LiveKit Cloud, so self-hosted users are kind of out of luck. 

PR adds `livekit-plugins-rnnoise` - which runs Xiph's RNNoise entirely on-device. 
No API keys, no model downloads, no signup required.

Usage is basically the same as the Krisp plugin:

```python
from livekit.plugins import rnnoise

RoomInputOptions(
    noise_cancellation=rnnoise.RNNoise()
)
```

This has been requested a few times already (#5507, #6033), and it pops up on the forum every now and then too.

Implementation-wise - it's pretty simple: incoming audio gets resampled into RNNoise's required 48kHz/480-sample format, denoised, resampled back, and returned at the exact same frame length it came in. Right now it's mono-only and has a simple `enabled` flag. It talks directly to the native `librnnoise` via `ctypes` instead of using `pyrnnoise`'s Python wrapper, which keeps `audiolab`, `av`, and `matplotlib` out of the runtime path (and avoids the `av` version pin).

One small annoyance: the prebuilt native library currently comes from `pyrnnoise`, but that package also declares `matplotlib` and `audiolab` for its CLI, so `pip` installs them even though this plugin never imports them. Not ideal. If you'd rather avoid those extra dependencies, I'm happy to vendor `librnnoise` directly or work with upstream to move the CLI dependencies behind an optional extra - whatever makes more sense.

For testing, I added unit tests covering the mono guard, passthrough behavior, the same-length guarantee, actual noise reduction, and a regression test that catches anyone accidentally reintroducing the `audiolab` import. I also tested it in a live agent and on a few offline audio clips. `make check` and the full unit test suite pass locally.