### PR TITLE
fix(core): reset user away timer on final STT transcript AGT-3149

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1820,9 +1820,13 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             # a transcript means stt recovered; reset its error tolerance
             self._stt_error_counts = 0
 
-        if self.user_state == "away" and ev.is_final:
-            # reset user state from away to listening in case VAD has a miss detection
-            self._update_user_state("listening")
+        if ev.is_final and self.user_state != "speaking":
+            if self.user_state == "away":
+                # reset user state from away to listening in case VAD has a miss detection
+                self._update_user_state("listening")
+            elif self.user_state == "listening" and self._agent_state == "listening":
+                # VAD may have missed speech; STT still saw activity, so refresh away timeout
+                self._set_user_away_timer()
 
         self.emit("user_input_transcribed", ev)
 

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -1158,6 +1158,35 @@ async def test_stt_errors_use_unrecoverable_error_tolerance() -> None:
         await _close_test_session(session)
 
 
+async def test_final_transcript_resets_away_timer_when_not_speaking() -> None:
+    session = create_session(FakeActions(), extra_kwargs={"user_away_timeout": 15.0})
+    try:
+        session._agent_state = "listening"
+        session._user_state = "listening"
+
+        with patch.object(session, "_set_user_away_timer") as set_timer:
+            session._user_input_transcribed(
+                UserInputTranscribedEvent(transcript="hello", is_final=True)
+            )
+            set_timer.assert_called_once()
+            assert session.user_state == "listening"
+
+        with patch.object(session, "_set_user_away_timer") as set_timer:
+            session._user_input_transcribed(
+                UserInputTranscribedEvent(transcript="hello", is_final=False)
+            )
+            set_timer.assert_not_called()
+
+        session._user_state = "speaking"
+        with patch.object(session, "_set_user_away_timer") as set_timer:
+            session._user_input_transcribed(
+                UserInputTranscribedEvent(transcript="hello", is_final=True)
+            )
+            set_timer.assert_not_called()
+    finally:
+        await _close_test_session(session)
+
+
 async def test_stt_error_count_resets_on_user_transcript() -> None:
     from livekit.agents.voice.agent_session import SessionConnectOptions
 


### PR DESCRIPTION
VAD can miss speech while STT still emits a final transcript. In that case the user stays `listening`, so the away timer kept counting down and could fire despite recent STT activity. Observed from a user session where short utterance was ignored by the timer.

On a final transcript when the user is not already speaking, refresh `user_away_timeout` without changing user state. The existing `away` → `listening` recovery path is unchanged.


Made with [Cursor](https://cursor.com)