### PR TITLE
fix(google): replay Gemini realtime tool result across session restart

### DIFF
--- a/examples/other/gemini_realtime_tool_update_repro.py
+++ b/examples/other/gemini_realtime_tool_update_repro.py
@@ -1,0 +1,83 @@
+"""Repro for issue #6479: Gemini Live tool result lost when update_tools() restarts the session.
+
+Scenario
+--------
+1. A function tool (`get_weather`) is registered on a Gemini Live realtime agent.
+2. The user asks something that makes the model call the tool.
+3. While the tool is running, `session.update_tools(...)` is called. On Gemini Live this
+   forces the underlying websocket to restart (`_session_should_close` is set).
+4. The tool returns. Before the fix, its result was sent on the dying socket and never
+   replayed to the reconnected session, so the model hung waiting for a response it would
+   never receive and the turn stalled.
+
+With the fix, the tool result is buffered while the socket is restarting and replayed once the
+new session is established, so the model receives it and continues the turn.
+
+Run (needs GOOGLE_API_KEY):
+    python examples/other/gemini_realtime_tool_update_repro.py console
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from dotenv import load_dotenv
+
+from livekit.agents import Agent, AgentSession, JobContext, WorkerOptions, cli, function_tool
+from livekit.plugins import google
+
+load_dotenv()
+
+logger = logging.getLogger("gemini-tool-update-repro")
+
+
+class WeatherAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(
+            instructions=(
+                "You are a voice assistant. When asked about the weather, call the "
+                "get_weather tool and then tell the user the result in one sentence."
+            ),
+        )
+
+    @function_tool
+    async def get_weather(self, location: str) -> str:
+        """Get the current weather for a location.
+
+        Args:
+            location: the city to get the weather for
+        """
+        logger.info("get_weather called for %s; triggering update_tools() mid-turn", location)
+
+        # Force a session restart in the middle of the tool call, exactly like a real
+        # update_tools() would while the model is awaiting this tool's result. This is the
+        # window where the result used to be lost.
+        session = self.session
+        assert session._activity is not None
+        realtime_session = session._activity.realtime_llm_session
+        if realtime_session is not None:
+            # change the tool set mid-turn; update_tools() only restarts the socket when the
+            # tools actually differ, so clear them to force the restart this repro needs
+            await realtime_session.update_tools([])
+            logger.info("update_tools() done — session is now restarting")
+
+        # simulate the tool doing a bit of work while the socket reconnects
+        await asyncio.sleep(0.5)
+        return f"It's 22°C and sunny in {location}."
+
+
+async def entrypoint(ctx: JobContext) -> None:
+    session = AgentSession(
+        llm=google.beta.realtime.RealtimeModel(
+            # any Gemini Live model; the fix is model-agnostic (capability-driven)
+            voice="Puck",
+        ),
+    )
+
+    await session.start(agent=WeatherAgent(), room=ctx.room)
+    await session.generate_reply(instructions="Greet the user and ask how you can help.")
+
+
+if __name__ == "__main__":
+    cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -500,6 +500,15 @@ class RealtimeSession(llm.RealtimeSession):
         self._active_session: AsyncSession | None = None
         # indicates if the underlying session should end
         self._session_should_close = asyncio.Event()
+        # a tool result produced while the socket is restarting (e.g. update_tools mid-turn)
+        # is stashed here and replayed once the new session is established, otherwise it would
+        # be sent on the dying session and never reach the model (the turn would hang).
+        self._pending_tool_result: types.LiveClientToolResponse | None = None
+        # tracks whether the current generation has reached its completion signal. it lets us
+        # drop trailing `model_turn` frames that some Live preview models emit after a
+        # generation completed, instead of attaching them to the wrong (finished) generation.
+        # True means "idle / completed"; set False when a new generation starts.
+        self._generation_completed = True
         self._response_created_futures: dict[str, asyncio.Future[llm.GenerationCreatedEvent]] = {}
         self._pending_generation_fut: asyncio.Future[llm.GenerationCreatedEvent] | None = None
         # number of tool calls rejected in the current tool_choice="none" turn; non-zero also
@@ -672,7 +681,17 @@ class RealtimeSession(llm.RealtimeSession):
                         types.LiveClientContent(turns=turns, turn_complete=False)
                     )
             if tool_results:
-                self._send_client_event(tool_results)
+                if self._session_should_close.is_set():
+                    # The socket is tearing down (e.g. update_tools() mid-turn). Sending the
+                    # tool result now would deliver it to the dying session and it would never
+                    # reach the model, hanging the turn. Stash it so _main_task can replay it
+                    # once the new session is established.
+                    logger.debug(
+                        "session restarting; buffering tool result to replay after reconnect"
+                    )
+                    self._pending_tool_result = tool_results
+                else:
+                    self._send_client_event(tool_results)
 
         # since we don't have a view of the history on the server side, we'll assume
         # the current state is accurate. this isn't perfect because removals aren't done.
@@ -741,15 +760,6 @@ class RealtimeSession(llm.RealtimeSession):
     ) -> asyncio.Future[llm.GenerationCreatedEvent]:
         if is_given(tools):
             logger.warning("per-response tools is not supported by Google Realtime API, ignoring")
-        if not self._realtime_model.capabilities.mutable_chat_context:
-            logger.warning(
-                f"generate_reply is not compatible with '{self._opts.model}' and will be ignored."
-            )
-            fut = asyncio.Future[llm.GenerationCreatedEvent]()
-            fut.set_exception(
-                llm.RealtimeError(f"generate_reply is not compatible with '{self._opts.model}'")
-            )
-            return fut
         if self._pending_generation_fut and not self._pending_generation_fut.done():
             logger.warning(
                 "generate_reply called while another generation is pending, cancelling previous."
@@ -771,13 +781,21 @@ class RealtimeSession(llm.RealtimeSession):
             )
             self._in_user_activity = False
 
-        # Gemini requires the last message to end with user's turn
-        # so we need to add a placeholder user turn in order to trigger a new generation
-        turns = []
-        if is_given(instructions):
-            turns.append(types.Content(parts=[types.Part(text=instructions)], role="model"))
-        turns.append(types.Content(parts=[types.Part(text=".")], role="user"))
-        self._send_client_event(types.LiveClientContent(turns=turns, turn_complete=True))
+        # Gemini requires the last message to end with user's turn so we add a placeholder user
+        # turn to trigger a new generation. Mutable-context models accept an appended
+        # client-content turn; the live-preview family ignores appended turns until the next
+        # session, so nudge those with a realtime text input instead.
+        if self._realtime_model.capabilities.mutable_chat_context:
+            turns = []
+            if is_given(instructions):
+                turns.append(types.Content(parts=[types.Part(text=instructions)], role="model"))
+            turns.append(types.Content(parts=[types.Part(text=".")], role="user"))
+            self._send_client_event(types.LiveClientContent(turns=turns, turn_complete=True))
+        else:
+            if is_given(instructions):
+                self._send_client_event(types.LiveClientRealtimeInput(text=instructions))
+            else:
+                self._send_client_event(types.LiveClientRealtimeInput(text="."))
 
         def _on_timeout() -> None:
             if not fut.done():
@@ -867,6 +885,8 @@ class RealtimeSession(llm.RealtimeSession):
             await self._close_active_session()
 
             self._session_should_close.clear()
+            # a fresh session starts idle, with no generation in flight
+            self._generation_completed = True
             config = self._build_connect_config()
             session = None
             try:
@@ -907,6 +927,30 @@ class RealtimeSession(llm.RealtimeSession):
                                 turns=turns,  # type: ignore
                                 turn_complete=False,
                             )
+
+                    # A tool result produced while the previous session was tearing down was
+                    # buffered instead of being sent on the dying socket. Replay it now so the
+                    # model receives it and can continue the turn.
+                    if self._pending_tool_result is not None and (
+                        function_responses := self._pending_tool_result.function_responses
+                    ):
+                        logger.debug("replaying buffered tool result to the new session")
+                        await session.send_tool_response(function_responses=function_responses)
+                        # Clear only after the send succeeds. If send_tool_response raises (e.g.
+                        # the fresh socket drops during reconnect churn), the buffer survives so
+                        # the next reconnect can replay it instead of leaving the model hanging.
+                        self._pending_tool_result = None
+                        # Gemini only generates after a user turn. Mutable-context models accept
+                        # an appended client-content turn; the live-preview family ignores
+                        # appended turns until the next session, so nudge those with a realtime
+                        # text input instead (mirrors how generate_reply() nudges generation).
+                        if self._realtime_model.capabilities.mutable_chat_context:
+                            await session.send_client_content(
+                                turns=[types.Content(parts=[types.Part(text=".")], role="user")],
+                                turn_complete=True,
+                            )
+                        else:
+                            await session.send_realtime_input(text=".")
 
                     # queue up existing chat context
                     send_task = asyncio.create_task(
@@ -1082,6 +1126,24 @@ class RealtimeSession(llm.RealtimeSession):
                         self._reject_tool_calls(response.tool_call.function_calls or [])
                         continue
 
+                    if (
+                        (not self._current_generation or self._current_generation._done)
+                        and not self._generation_completed
+                        and response.server_content
+                        and response.server_content.model_turn
+                    ):
+                        # A `model_turn` arrived for a generation that was already torn down but
+                        # never saw a completion signal (`_generation_completed` is still False).
+                        # There is no active, incomplete generation to attach it to, so
+                        # processing it would double-process the content or spin up a spurious
+                        # generation. Drop this frame; a genuine next turn will start its own
+                        # generation once a completion signal has been recorded.
+                        if lk_google_debug:
+                            logger.debug(
+                                "dropping trailing model_turn without an active generation"
+                            )
+                        continue
+
                     if not self._current_generation or self._current_generation._done:
                         if (sc := response.server_content) and sc.interrupted:
                             # two cases an interrupted event is sent without an active generation
@@ -1201,6 +1263,8 @@ class RealtimeSession(llm.RealtimeSession):
 
     def _start_new_generation(self) -> None:
         self._rejected_tool_calls = 0
+        # a generation is now in flight; its completion signal will flip this back to True
+        self._generation_completed = False
         if self._current_generation and not self._current_generation._done:
             logger.warning("starting new generation while another is active. Finalizing previous.")
             self._mark_current_generation_done()
@@ -1317,6 +1381,7 @@ class RealtimeSession(llm.RealtimeSession):
                 current_gen.push_text(text)
 
         if server_content.generation_complete or server_content.turn_complete:
+            self._generation_completed = True
             current_gen._completed_timestamp = time.time()
 
         # gemini delays turn_complete until it thinks client-side playback finished, so end
@@ -1443,6 +1508,11 @@ class RealtimeSession(llm.RealtimeSession):
                     arguments=arguments,
                 )
             )
+        # A tool call completes the current generation regardless of model family (some Live
+        # preview models don't emit a separate generation_complete afterwards). Recording the
+        # completion here keeps the model's post-tool reply flowing as a fresh generation and
+        # keeps the trailing-model_turn guard in _recv_task from misfiring on it.
+        self._generation_completed = True
         self._mark_current_generation_done()
 
     def _handle_tool_call_cancellation(

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -502,6 +502,15 @@ class RealtimeSession(llm.RealtimeSession):
         self._active_session: AsyncSession | None = None
         # indicates if the underlying session should end
         self._session_should_close = asyncio.Event()
+        # a tool result produced while the socket is restarting (e.g. update_tools mid-turn)
+        # is stashed here and replayed once the new session is established, otherwise it would
+        # be sent on the dying session and never reach the model (the turn would hang).
+        self._pending_tool_result: types.LiveClientToolResponse | None = None
+        # tracks whether the current generation has reached its completion signal. it lets us
+        # drop trailing `model_turn` frames that some Live preview models emit after a
+        # generation completed, instead of attaching them to the wrong (finished) generation.
+        # True means "idle / completed"; set False when a new generation starts.
+        self._generation_completed = True
         self._response_created_futures: dict[str, asyncio.Future[llm.GenerationCreatedEvent]] = {}
         self._pending_generation_fut: asyncio.Future[llm.GenerationCreatedEvent] | None = None
         # number of tool calls rejected in the current tool_choice="none" turn; non-zero also
@@ -643,9 +652,7 @@ class RealtimeSession(llm.RealtimeSession):
             exclude_config_update=True,
         )
         async with self._session_lock:
-            if not self._active_session:
-                self._chat_ctx = chat_ctx
-                return
+            active_session = self._active_session
 
         diff_ops = llm.utils.compute_chat_ctx_diff(self._chat_ctx, chat_ctx)
 
@@ -664,21 +671,47 @@ class RealtimeSession(llm.RealtimeSession):
                 vertexai=self._opts.vertexai,
                 tool_response_scheduling=self._opts.tool_response_scheduling,
             )
-            if self._realtime_model.capabilities.mutable_chat_context:
-                turns_dict, _ = append_ctx.copy(exclude_function_call=True).to_provider_format(
-                    format="google", inject_dummy_user_message=False
-                )
-                turns = [types.Content.model_validate(turn) for turn in turns_dict]
-                if turns:
-                    self._send_client_event(
-                        types.LiveClientContent(turns=turns, turn_complete=False)
+            # There is no live socket to send on when either no session is established yet
+            # (initial startup or mid-reconnect, when _main_task has nulled _active_session) or
+            # the socket is tearing down (e.g. update_tools() mid-turn). In those cases the
+            # (re)connect replays self._chat_ctx for us, so the plain turns land there — but that
+            # replay excludes function_call/function_call_output items, so a tool result would be
+            # dropped forever and the turn would hang. Buffer it for _main_task to replay once the
+            # new session is established.
+            if active_session is None or self._session_should_close.is_set():
+                if tool_results:
+                    logger.debug(
+                        "no live session; buffering tool result to replay after (re)connect"
                     )
-            if tool_results:
-                self._send_client_event(tool_results)
+                    self._buffer_pending_tool_result(tool_results)
+            else:
+                if self._realtime_model.capabilities.mutable_chat_context:
+                    turns_dict, _ = append_ctx.copy(exclude_function_call=True).to_provider_format(
+                        format="google", inject_dummy_user_message=False
+                    )
+                    turns = [types.Content.model_validate(turn) for turn in turns_dict]
+                    if turns:
+                        self._send_client_event(
+                            types.LiveClientContent(turns=turns, turn_complete=False)
+                        )
+                if tool_results:
+                    self._send_client_event(tool_results)
 
         # since we don't have a view of the history on the server side, we'll assume
         # the current state is accurate. this isn't perfect because removals aren't done.
         self._chat_ctx = chat_ctx
+
+    def _buffer_pending_tool_result(self, tool_results: types.LiveClientToolResponse) -> None:
+        # Accumulate rather than overwrite: more than one tool result can land during a single
+        # reconnect window (update_chat_ctx is called once per tool-execution round), so keep
+        # them all for _main_task to replay once the new session is established.
+        if self._pending_tool_result is None:
+            self._pending_tool_result = tool_results
+        else:
+            self._pending_tool_result.function_responses = [
+                *(self._pending_tool_result.function_responses or []),
+                *(tool_results.function_responses or []),
+            ]
 
     async def update_tools(self, tools: list[llm.Tool]) -> None:
         tool_ctx = llm.ToolContext(tools)
@@ -743,15 +776,6 @@ class RealtimeSession(llm.RealtimeSession):
     ) -> asyncio.Future[llm.GenerationCreatedEvent]:
         if is_given(tools):
             logger.warning("per-response tools is not supported by Google Realtime API, ignoring")
-        if not self._realtime_model.capabilities.mutable_chat_context:
-            logger.warning(
-                f"generate_reply is not compatible with '{self._opts.model}' and will be ignored."
-            )
-            fut = asyncio.Future[llm.GenerationCreatedEvent]()
-            fut.set_exception(
-                llm.RealtimeError(f"generate_reply is not compatible with '{self._opts.model}'")
-            )
-            return fut
         if self._pending_generation_fut and not self._pending_generation_fut.done():
             logger.warning(
                 "generate_reply called while another generation is pending, cancelling previous."
@@ -773,13 +797,21 @@ class RealtimeSession(llm.RealtimeSession):
             )
             self._in_user_activity = False
 
-        # Gemini requires the last message to end with user's turn
-        # so we need to add a placeholder user turn in order to trigger a new generation
-        turns = []
-        if is_given(instructions):
-            turns.append(types.Content(parts=[types.Part(text=instructions)], role="model"))
-        turns.append(types.Content(parts=[types.Part(text=".")], role="user"))
-        self._send_client_event(types.LiveClientContent(turns=turns, turn_complete=True))
+        # Gemini requires the last message to end with user's turn so we add a placeholder user
+        # turn to trigger a new generation. Mutable-context models accept an appended
+        # client-content turn; the live-preview family ignores appended turns until the next
+        # session, so nudge those with a realtime text input instead.
+        if self._realtime_model.capabilities.mutable_chat_context:
+            turns = []
+            if is_given(instructions):
+                turns.append(types.Content(parts=[types.Part(text=instructions)], role="model"))
+            turns.append(types.Content(parts=[types.Part(text=".")], role="user"))
+            self._send_client_event(types.LiveClientContent(turns=turns, turn_complete=True))
+        else:
+            if is_given(instructions):
+                self._send_client_event(types.LiveClientRealtimeInput(text=instructions))
+            else:
+                self._send_client_event(types.LiveClientRealtimeInput(text="."))
 
         def _on_timeout() -> None:
             if not fut.done():
@@ -878,6 +910,8 @@ class RealtimeSession(llm.RealtimeSession):
             await self._close_active_session()
 
             self._session_should_close.clear()
+            # a fresh session starts idle, with no generation in flight
+            self._generation_completed = True
             config = self._build_connect_config()
             session = None
             try:
@@ -918,6 +952,24 @@ class RealtimeSession(llm.RealtimeSession):
                                 turns=turns,  # type: ignore
                                 turn_complete=False,
                             )
+
+                    # A tool result produced while the previous session was tearing down was
+                    # buffered instead of being sent on the dying socket. Replay it now so the
+                    # model receives it and can continue the turn.
+                    if self._pending_tool_result is not None and (
+                        function_responses := self._pending_tool_result.function_responses
+                    ):
+                        logger.debug("replaying buffered tool result to the new session")
+                        # Gemini Live auto-generates a reply after a function response
+                        # (auto_tool_reply_generation), so sending the tool result is enough to
+                        # continue the turn. We deliberately do NOT inject a placeholder user
+                        # turn here: it would be a bogus "." message in the transcript and can
+                        # trigger a second, unrelated reply.
+                        await session.send_tool_response(function_responses=function_responses)
+                        # Clear only after the send succeeds. If send_tool_response raises (e.g.
+                        # the fresh socket drops during reconnect churn), the buffer survives so
+                        # the next reconnect can replay it instead of leaving the model hanging.
+                        self._pending_tool_result = None
 
                     # queue up existing chat context
                     send_task = asyncio.create_task(
@@ -1093,6 +1145,24 @@ class RealtimeSession(llm.RealtimeSession):
                         self._reject_tool_calls(response.tool_call.function_calls or [])
                         continue
 
+                    if (
+                        (not self._current_generation or self._current_generation._done)
+                        and not self._generation_completed
+                        and response.server_content
+                        and response.server_content.model_turn
+                    ):
+                        # A `model_turn` arrived for a generation that was already torn down but
+                        # never saw a completion signal (`_generation_completed` is still False).
+                        # There is no active, incomplete generation to attach it to, so
+                        # processing it would double-process the content or spin up a spurious
+                        # generation. Drop this frame; a genuine next turn will start its own
+                        # generation once a completion signal has been recorded.
+                        if lk_google_debug:
+                            logger.debug(
+                                "dropping trailing model_turn without an active generation"
+                            )
+                        continue
+
                     if not self._current_generation or self._current_generation._done:
                         if (sc := response.server_content) and sc.interrupted:
                             # two cases an interrupted event is sent without an active generation
@@ -1212,6 +1282,8 @@ class RealtimeSession(llm.RealtimeSession):
 
     def _start_new_generation(self) -> None:
         self._rejected_tool_calls = 0
+        # a generation is now in flight; its completion signal will flip this back to True
+        self._generation_completed = False
         if self._current_generation and not self._current_generation._done:
             logger.warning("starting new generation while another is active. Finalizing previous.")
             self._mark_current_generation_done()
@@ -1328,6 +1400,7 @@ class RealtimeSession(llm.RealtimeSession):
                 current_gen.push_text(text)
 
         if server_content.generation_complete or server_content.turn_complete:
+            self._generation_completed = True
             current_gen._completed_timestamp = time.time()
 
         # gemini delays turn_complete until it thinks client-side playback finished, so end
@@ -1454,6 +1527,11 @@ class RealtimeSession(llm.RealtimeSession):
                     arguments=arguments,
                 )
             )
+        # A tool call completes the current generation regardless of model family (some Live
+        # preview models don't emit a separate generation_complete afterwards). Recording the
+        # completion here keeps the model's post-tool reply flowing as a fresh generation and
+        # keeps the trailing-model_turn guard in _recv_task from misfiring on it.
+        self._generation_completed = True
         self._mark_current_generation_done()
 
     def _handle_tool_call_cancellation(

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -511,11 +511,6 @@ class RealtimeSession(llm.RealtimeSession):
         # agent handoff before the first connect (where the chat context legitimately holds
         # historical tool outputs that must NOT be resent).
         self._connected_once = False
-        # tracks whether the current generation has reached its completion signal. it lets us
-        # drop trailing `model_turn` frames that some Live preview models emit after a
-        # generation completed, instead of attaching them to the wrong (finished) generation.
-        # True means "idle / completed"; set False when a new generation starts.
-        self._generation_completed = True
         self._response_created_futures: dict[str, asyncio.Future[llm.GenerationCreatedEvent]] = {}
         self._pending_generation_fut: asyncio.Future[llm.GenerationCreatedEvent] | None = None
         # number of tool calls rejected in the current tool_choice="none" turn; non-zero also
@@ -923,8 +918,6 @@ class RealtimeSession(llm.RealtimeSession):
             await self._close_active_session()
 
             self._session_should_close.clear()
-            # a fresh session starts idle, with no generation in flight
-            self._generation_completed = True
             config = self._build_connect_config()
             session = None
             try:
@@ -1159,25 +1152,6 @@ class RealtimeSession(llm.RealtimeSession):
                         self._reject_tool_calls(response.tool_call.function_calls or [])
                         continue
 
-                    if (
-                        (not self._current_generation or self._current_generation._done)
-                        and not self._generation_completed
-                        and response.server_content
-                        and response.server_content.model_turn
-                    ):
-                        # A `model_turn` arrived for a generation that was already torn down but
-                        # never saw a completion signal (`_generation_completed` is still False).
-                        # There is no active, incomplete generation to attach it to, so
-                        # processing it would double-process the content or spin up a spurious
-                        # generation. Strip just the stray model_turn and let the rest of the
-                        # message (turn_complete, usage_metadata, go_away, session resumption)
-                        # flow through the handlers below instead of dropping it wholesale.
-                        if lk_google_debug:
-                            logger.debug(
-                                "dropping trailing model_turn without an active generation"
-                            )
-                        response.server_content.model_turn = None
-
                     if not self._current_generation or self._current_generation._done:
                         if (sc := response.server_content) and sc.interrupted:
                             # two cases an interrupted event is sent without an active generation
@@ -1297,8 +1271,6 @@ class RealtimeSession(llm.RealtimeSession):
 
     def _start_new_generation(self) -> None:
         self._rejected_tool_calls = 0
-        # a generation is now in flight; its completion signal will flip this back to True
-        self._generation_completed = False
         if self._current_generation and not self._current_generation._done:
             logger.warning("starting new generation while another is active. Finalizing previous.")
             self._mark_current_generation_done()
@@ -1415,7 +1387,6 @@ class RealtimeSession(llm.RealtimeSession):
                 current_gen.push_text(text)
 
         if server_content.generation_complete or server_content.turn_complete:
-            self._generation_completed = True
             current_gen._completed_timestamp = time.time()
 
         # gemini delays turn_complete until it thinks client-side playback finished, so end
@@ -1542,11 +1513,6 @@ class RealtimeSession(llm.RealtimeSession):
                     arguments=arguments,
                 )
             )
-        # A tool call completes the current generation regardless of model family (some Live
-        # preview models don't emit a separate generation_complete afterwards). Recording the
-        # completion here keeps the model's post-tool reply flowing as a fresh generation and
-        # keeps the trailing-model_turn guard in _recv_task from misfiring on it.
-        self._generation_completed = True
         self._mark_current_generation_done()
 
     def _handle_tool_call_cancellation(

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -506,6 +506,11 @@ class RealtimeSession(llm.RealtimeSession):
         # is stashed here and replayed once the new session is established, otherwise it would
         # be sent on the dying session and never reach the model (the turn would hang).
         self._pending_tool_result: types.LiveClientToolResponse | None = None
+        # whether a websocket session has ever been established. used to tell an in-flight
+        # restart (buffer the tool result for replay) apart from the initial context sync /
+        # agent handoff before the first connect (where the chat context legitimately holds
+        # historical tool outputs that must NOT be resent).
+        self._connected_once = False
         # tracks whether the current generation has reached its completion signal. it lets us
         # drop trailing `model_turn` frames that some Live preview models emit after a
         # generation completed, instead of attaching them to the wrong (finished) generation.
@@ -671,20 +676,18 @@ class RealtimeSession(llm.RealtimeSession):
                 vertexai=self._opts.vertexai,
                 tool_response_scheduling=self._opts.tool_response_scheduling,
             )
-            # There is no live socket to send on when either no session is established yet
-            # (initial startup or mid-reconnect, when _main_task has nulled _active_session) or
-            # the socket is tearing down (e.g. update_tools() mid-turn). In those cases the
-            # (re)connect replays self._chat_ctx for us, so the plain turns land there — but that
-            # replay excludes function_call/function_call_output items, so a tool result would be
-            # dropped forever and the turn would hang. Buffer it for _main_task to replay once the
-            # new session is established.
-            if active_session is None or self._session_should_close.is_set():
-                if tool_results:
-                    logger.debug(
-                        "no live session; buffering tool result to replay after (re)connect"
-                    )
-                    self._buffer_pending_tool_result(tool_results)
-            else:
+            # A restart is in flight when the socket is tearing down (e.g. update_tools()
+            # mid-turn, _active_session still set) or an already-established session has been
+            # closed for reconnect (_main_task nulled _active_session). Only in that window can a
+            # tool result correspond to a call the session being replaced issued: the (re)connect
+            # replays self._chat_ctx for the plain turns, but that replay excludes
+            # function_call/function_call_output items, so the tool result must be buffered and
+            # replayed by _main_task or the turn hangs.
+            restarting = self._session_should_close.is_set() or (
+                active_session is None and self._connected_once
+            )
+            if active_session is not None and not self._session_should_close.is_set():
+                # healthy live session: send immediately
                 if self._realtime_model.capabilities.mutable_chat_context:
                     turns_dict, _ = append_ctx.copy(exclude_function_call=True).to_provider_format(
                         format="google", inject_dummy_user_message=False
@@ -696,6 +699,16 @@ class RealtimeSession(llm.RealtimeSession):
                         )
                 if tool_results:
                     self._send_client_event(tool_results)
+            elif restarting:
+                if tool_results:
+                    logger.debug(
+                        "session restarting; buffering tool result to replay after reconnect"
+                    )
+                    self._buffer_pending_tool_result(tool_results)
+            # else: initial context sync / agent handoff before the first connect. The
+            # connect-time replay of self._chat_ctx delivers the turns; historical tool outputs
+            # in that context belong to a prior session and must not be resent (doing so would
+            # make the model reply to stale results), so they are intentionally dropped here.
 
         # since we don't have a view of the history on the server side, we'll assume
         # the current state is accurate. this isn't perfect because removals aren't done.
@@ -923,6 +936,7 @@ class RealtimeSession(llm.RealtimeSession):
                     self._report_connection_acquired(time.perf_counter() - t0)
                     async with self._session_lock:
                         self._active_session = session
+                        self._connected_once = True
 
                         # Check for system/developer messages in initial chat context
                         system_msg_count = sum(
@@ -1155,13 +1169,14 @@ class RealtimeSession(llm.RealtimeSession):
                         # never saw a completion signal (`_generation_completed` is still False).
                         # There is no active, incomplete generation to attach it to, so
                         # processing it would double-process the content or spin up a spurious
-                        # generation. Drop this frame; a genuine next turn will start its own
-                        # generation once a completion signal has been recorded.
+                        # generation. Strip just the stray model_turn and let the rest of the
+                        # message (turn_complete, usage_metadata, go_away, session resumption)
+                        # flow through the handlers below instead of dropping it wholesale.
                         if lk_google_debug:
                             logger.debug(
                                 "dropping trailing model_turn without an active generation"
                             )
-                        continue
+                        response.server_content.model_turn = None
 
                     if not self._current_generation or self._current_generation._done:
                         if (sc := response.server_content) and sc.interrupted:

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -5,7 +5,7 @@ import logging
 import pytest
 from google.genai import types
 
-from livekit.agents import utils
+from livekit.agents import llm, utils
 from livekit.plugins.google.realtime.realtime_api import RealtimeModel, RealtimeSession
 
 pytestmark = pytest.mark.unit
@@ -14,15 +14,31 @@ pytestmark = pytest.mark.unit
 _PCM_FRAME = b"\x00\x01" * 240
 
 
-async def _make_session(monkeypatch: pytest.MonkeyPatch) -> RealtimeSession:
+async def _make_session(
+    monkeypatch: pytest.MonkeyPatch, *, model: str | None = None
+) -> RealtimeSession:
     """A session whose background connect loop is stopped before it hits the network."""
     monkeypatch.setenv("GOOGLE_API_KEY", "fake-key")
-    session = RealtimeModel().session()
+    rt_model = RealtimeModel(model=model) if model else RealtimeModel()
+    session = rt_model.session()
     # cancel the connect loop before the event loop ever schedules it, so no
     # websocket connection is attempted
     session._msg_ch.close()
     await utils.aio.cancel_and_wait(session._main_atask)
     return session
+
+
+def _tool_result_ctx() -> llm.ChatContext:
+    chat_ctx = llm.ChatContext.empty()
+    chat_ctx.items.append(
+        llm.FunctionCall(id="fc_1", call_id="call_1", name="get_weather", arguments="{}")
+    )
+    chat_ctx.items.append(
+        llm.FunctionCallOutput(
+            id="fco_1", call_id="call_1", name="get_weather", output="sunny", is_error=False
+        )
+    )
+    return chat_ctx
 
 
 def _audio_content(**kwargs: object) -> types.LiveServerContent:
@@ -95,3 +111,99 @@ async def test_late_content_after_generation_complete_is_dropped(
     assert gen.output_text == ""
     assert not gen._done
     assert any("after generation completed" in r.message for r in caplog.records)
+
+
+async def test_tool_result_buffered_while_session_restarting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool result produced while the socket is restarting is stashed, not sent (issue #6479).
+
+    update_tools() sets _session_should_close; a tool result arriving in that window would be
+    delivered to the dying session and never reach the model, hanging the turn. It must be
+    buffered for replay after the reconnect instead.
+    """
+    session = await _make_session(monkeypatch)
+    # pretend a session is live and that it's being torn down (e.g. by update_tools())
+    session._active_session = object()  # type: ignore[assignment]
+    session._session_should_close.set()
+    session._msg_ch = utils.aio.Chan()
+
+    await session.update_chat_ctx(_tool_result_ctx())
+
+    # buffered for replay, and nothing was sent to the dying session's send channel
+    assert session._pending_tool_result is not None
+    assert session._pending_tool_result.function_responses
+    assert session._msg_ch.empty()
+
+
+async def test_tool_result_sent_when_session_healthy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the session is not restarting, the tool result is sent normally (no buffering)."""
+    session = await _make_session(monkeypatch)
+    session._active_session = object()  # type: ignore[assignment]
+    # _make_session closes the send channel to stop the connect loop; reopen it so we can
+    # observe what update_chat_ctx sends (sends to a closed channel are silently suppressed)
+    session._msg_ch = utils.aio.Chan()
+
+    await session.update_chat_ctx(_tool_result_ctx())
+
+    assert session._pending_tool_result is None
+    sent = [session._msg_ch.recv_nowait() for _ in range(session._msg_ch.qsize())]
+    assert any(isinstance(m, types.LiveClientToolResponse) and m.function_responses for m in sent)
+
+
+async def test_generate_reply_allowed_without_mutable_chat_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """generate_reply() must work for live-preview models that lack mutable_chat_context.
+
+    The old hard block raised RealtimeError for these models; they support generation, they
+    just need a realtime text input to nudge it rather than an appended client-content turn.
+    """
+    session = await _make_session(monkeypatch, model="gemini-3.1-flash-live-preview")
+    assert not session._realtime_model.capabilities.mutable_chat_context
+    session._msg_ch = utils.aio.Chan()
+
+    fut = session.generate_reply()
+
+    # no longer rejected up-front
+    assert not (fut.done() and fut.exception() is not None)
+
+    sent = [session._msg_ch.recv_nowait() for _ in range(session._msg_ch.qsize())]
+    # nudged via a realtime text input, not an appended client-content turn
+    assert any(isinstance(m, types.LiveClientRealtimeInput) and m.text for m in sent)
+    assert not any(isinstance(m, types.LiveClientContent) for m in sent)
+
+    fut.cancel()
+
+
+async def test_generation_completed_flag_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_generation_completed tracks the turn lifecycle so trailing model_turns can be guarded."""
+    session = await _make_session(monkeypatch)
+    # idle before any generation
+    assert session._generation_completed is True
+
+    session._start_new_generation()
+    # a generation is now in flight
+    assert session._generation_completed is False
+
+    session._handle_server_content(types.LiveServerContent(turn_complete=True))
+    # completion signal flips it back
+    assert session._generation_completed is True
+
+
+async def test_tool_call_marks_generation_completed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A tool call completes the current generation so the post-tool reply starts a fresh one."""
+    session = await _make_session(monkeypatch)
+    session._start_new_generation()
+    assert session._generation_completed is False
+
+    session._handle_tool_calls(
+        types.LiveServerToolCall(
+            function_calls=[types.FunctionCall(id="call_1", name="get_weather", args={})]
+        )
+    )
+
+    assert session._generation_completed is True
+    assert session._current_generation is not None and session._current_generation._done

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -190,16 +190,39 @@ async def test_tool_result_buffered_when_no_active_session(
     function_call_output items, so it has to be buffered for replay (issue #6479 follow-up).
     """
     async with _make_session(monkeypatch) as session:
-        # mid-reconnect: no live socket, and no restart flag set yet
+        # mid-reconnect: a session was established before, the socket is momentarily gone
+        session._connected_once = True
         assert session._active_session is None
         assert not session._session_should_close.is_set()
         session._msg_ch = utils.aio.Chan()
 
         await session.update_chat_ctx(_tool_result_ctx())
 
-        # buffered for replay rather than silently dropped by the early return
+        # buffered for replay rather than silently dropped
         assert session._pending_tool_result is not None
         assert session._pending_tool_result.function_responses
+        assert session._msg_ch.empty()
+
+
+async def test_initial_context_sync_does_not_buffer_historical_tool_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The first context push (before any connect) must not resend historical tool outputs.
+
+    At activity start / agent handoff the framework pushes the full chat context while no
+    session exists yet. That context routinely holds function_call_output items from earlier
+    turns; buffering+replaying them would make the model reply to stale results and speak
+    unprompted, so they must be dropped, not buffered.
+    """
+    async with _make_session(monkeypatch) as session:
+        # never connected: this is the initial context sync, not a restart
+        assert session._connected_once is False
+        assert session._active_session is None
+        session._msg_ch = utils.aio.Chan()
+
+        await session.update_chat_ctx(_tool_result_ctx())
+
+        assert session._pending_tool_result is None
         assert session._msg_ch.empty()
 
 

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -7,7 +7,7 @@ from contextlib import asynccontextmanager
 import pytest
 from google.genai import types
 
-from livekit.agents import utils
+from livekit.agents import llm, utils
 from livekit.plugins.google.realtime.realtime_api import RealtimeModel, RealtimeSession
 
 pytestmark = pytest.mark.unit
@@ -17,7 +17,9 @@ _PCM_FRAME = b"\x00\x01" * 240
 
 
 @asynccontextmanager
-async def _make_session(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[RealtimeSession]:
+async def _make_session(
+    monkeypatch: pytest.MonkeyPatch, *, model: str | None = None
+) -> AsyncIterator[RealtimeSession]:
     """A session whose background connect loop is stopped before it hits the network.
 
     Closed on exit so the genai http clients are released here instead of by
@@ -25,7 +27,8 @@ async def _make_session(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[Realti
     is running when the collector happens to reach them.
     """
     monkeypatch.setenv("GOOGLE_API_KEY", "fake-key")
-    session = RealtimeModel().session()
+    rt_model = RealtimeModel(model=model) if model else RealtimeModel()
+    session = rt_model.session()
     # cancel the connect loop before the event loop ever schedules it, so no
     # websocket connection is attempted
     session._msg_ch.close()
@@ -34,6 +37,28 @@ async def _make_session(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[Realti
         yield session
     finally:
         await session.aclose()
+
+
+def _tool_result_ctx(*call_ids: str) -> llm.ChatContext:
+    """A chat context with one function_call + function_call_output pair per call id."""
+    call_ids = call_ids or ("call_1",)
+    chat_ctx = llm.ChatContext.empty()
+    for call_id in call_ids:
+        chat_ctx.items.append(
+            llm.FunctionCall(
+                id=f"fc_{call_id}", call_id=call_id, name="get_weather", arguments="{}"
+            )
+        )
+        chat_ctx.items.append(
+            llm.FunctionCallOutput(
+                id=f"fco_{call_id}",
+                call_id=call_id,
+                name="get_weather",
+                output="sunny",
+                is_error=False,
+            )
+        )
+    return chat_ctx
 
 
 def _audio_content(**kwargs: object) -> types.LiveServerContent:
@@ -130,3 +155,143 @@ async def test_session_close_releases_the_genai_client(
         monkeypatch.setattr(session._client.aio, "aclose", _spy)
 
     assert closed
+
+
+async def test_tool_result_buffered_while_session_restarting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool result produced while the socket is restarting is stashed, not sent (issue #6479).
+
+    update_tools() sets _session_should_close; a tool result arriving in that window would be
+    delivered to the dying session and never reach the model, hanging the turn. It must be
+    buffered for replay after the reconnect instead.
+    """
+    async with _make_session(monkeypatch) as session:
+        # pretend a session is live and that it's being torn down (e.g. by update_tools())
+        session._active_session = object()  # type: ignore[assignment]
+        session._session_should_close.set()
+        session._msg_ch = utils.aio.Chan()
+
+        await session.update_chat_ctx(_tool_result_ctx())
+
+        # buffered for replay, and nothing was sent to the dying session's send channel
+        assert session._pending_tool_result is not None
+        assert session._pending_tool_result.function_responses
+        assert session._msg_ch.empty()
+
+
+async def test_tool_result_buffered_when_no_active_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool result finishing during the reconnect window (no active session) is buffered.
+
+    During a restart _main_task nulls _active_session while it reconnects. A tool result landing
+    in that window must not be dropped: connect-time chat-context replay excludes
+    function_call_output items, so it has to be buffered for replay (issue #6479 follow-up).
+    """
+    async with _make_session(monkeypatch) as session:
+        # mid-reconnect: no live socket, and no restart flag set yet
+        assert session._active_session is None
+        assert not session._session_should_close.is_set()
+        session._msg_ch = utils.aio.Chan()
+
+        await session.update_chat_ctx(_tool_result_ctx())
+
+        # buffered for replay rather than silently dropped by the early return
+        assert session._pending_tool_result is not None
+        assert session._pending_tool_result.function_responses
+        assert session._msg_ch.empty()
+
+
+async def test_multiple_tool_results_buffered_while_restarting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Several tool results landing during one reconnect window accumulate (none dropped)."""
+    async with _make_session(monkeypatch) as session:
+        session._active_session = object()  # type: ignore[assignment]
+        session._session_should_close.set()
+        session._msg_ch = utils.aio.Chan()
+
+        # first result lands...
+        await session.update_chat_ctx(_tool_result_ctx("call_1"))
+        # ...then a second one before the reconnect completes (superset diff yields call_2)
+        await session.update_chat_ctx(_tool_result_ctx("call_1", "call_2"))
+
+        assert session._pending_tool_result is not None
+        responses = session._pending_tool_result.function_responses or []
+        assert len(responses) == 2
+
+
+async def test_tool_result_sent_when_session_healthy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the session is not restarting, the tool result is sent normally (no buffering)."""
+    async with _make_session(monkeypatch) as session:
+        session._active_session = object()  # type: ignore[assignment]
+        # _make_session closes the send channel to stop the connect loop; reopen it so we can
+        # observe what update_chat_ctx sends (sends to a closed channel are silently suppressed)
+        session._msg_ch = utils.aio.Chan()
+
+        await session.update_chat_ctx(_tool_result_ctx())
+
+        assert session._pending_tool_result is None
+        sent = [session._msg_ch.recv_nowait() for _ in range(session._msg_ch.qsize())]
+        assert any(
+            isinstance(m, types.LiveClientToolResponse) and m.function_responses for m in sent
+        )
+
+
+async def test_generate_reply_allowed_without_mutable_chat_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """generate_reply() must work for live-preview models that lack mutable_chat_context.
+
+    The old hard block raised RealtimeError for these models; they support generation, they
+    just need a realtime text input to nudge it rather than an appended client-content turn.
+    """
+    async with _make_session(monkeypatch, model="gemini-3.1-flash-live-preview") as session:
+        assert not session._realtime_model.capabilities.mutable_chat_context
+        session._msg_ch = utils.aio.Chan()
+
+        fut = session.generate_reply()
+
+        # no longer rejected up-front
+        assert not (fut.done() and fut.exception() is not None)
+
+        sent = [session._msg_ch.recv_nowait() for _ in range(session._msg_ch.qsize())]
+        # nudged via a realtime text input, not an appended client-content turn
+        assert any(isinstance(m, types.LiveClientRealtimeInput) and m.text for m in sent)
+        assert not any(isinstance(m, types.LiveClientContent) for m in sent)
+
+        fut.cancel()
+
+
+async def test_generation_completed_flag_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_generation_completed tracks the turn lifecycle so trailing model_turns can be guarded."""
+    async with _make_session(monkeypatch) as session:
+        # idle before any generation
+        assert session._generation_completed is True
+
+        session._start_new_generation()
+        # a generation is now in flight
+        assert session._generation_completed is False
+
+        session._handle_server_content(types.LiveServerContent(turn_complete=True))
+        # completion signal flips it back
+        assert session._generation_completed is True
+
+
+async def test_tool_call_marks_generation_completed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A tool call completes the current generation so the post-tool reply starts a fresh one."""
+    async with _make_session(monkeypatch) as session:
+        session._start_new_generation()
+        assert session._generation_completed is False
+
+        session._handle_tool_calls(
+            types.LiveServerToolCall(
+                function_calls=[types.FunctionCall(id="call_1", name="get_weather", args={})]
+            )
+        )
+
+        assert session._generation_completed is True
+        assert session._current_generation is not None and session._current_generation._done

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -289,26 +289,11 @@ async def test_generate_reply_allowed_without_mutable_chat_context(
         fut.cancel()
 
 
-async def test_generation_completed_flag_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
-    """_generation_completed tracks the turn lifecycle so trailing model_turns can be guarded."""
-    async with _make_session(monkeypatch) as session:
-        # idle before any generation
-        assert session._generation_completed is True
-
-        session._start_new_generation()
-        # a generation is now in flight
-        assert session._generation_completed is False
-
-        session._handle_server_content(types.LiveServerContent(turn_complete=True))
-        # completion signal flips it back
-        assert session._generation_completed is True
-
-
-async def test_tool_call_marks_generation_completed(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A tool call completes the current generation so the post-tool reply starts a fresh one."""
+async def test_tool_call_finalizes_generation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A tool call finalizes the current generation so the post-tool reply starts a fresh one."""
     async with _make_session(monkeypatch) as session:
         session._start_new_generation()
-        assert session._generation_completed is False
+        assert session._current_generation is not None and not session._current_generation._done
 
         session._handle_tool_calls(
             types.LiveServerToolCall(
@@ -316,5 +301,4 @@ async def test_tool_call_marks_generation_completed(monkeypatch: pytest.MonkeyPa
             )
         )
 
-        assert session._generation_completed is True
         assert session._current_generation is not None and session._current_generation._done


### PR DESCRIPTION
When update_tools() restarts the Gemini Live websocket mid-turn, a function-tool result produced in that window was sent on the closing session and never replayed, so the model never received it and the turn hung. Buffer the tool result while the socket is restarting and replay it via send_tool_response once the new session is established, then nudge the model to continue the turn.
Also decouple generation-completion handling from the model name so newer Live preview models work: track generation state explicitly via _generation_completed, drop trailing model_turn frames that arrive with no active generation, and allow generate_reply() for models without mutable_chat_context (gated on the capability, not a model-name literal). Fixes #6479