### PR TITLE
fix(workflows): make credit card capture stateful

### DIFF
--- a/examples/voice_agents/README.md
+++ b/examples/voice_agents/README.md
@@ -23,6 +23,13 @@ session = AgentSession(
 ### Getting Started
 
 - [`basic_agent.py`](./basic_agent.py) - A fundamental voice agent with multilingual STT, turn detection, preemptive generation, and metrics collection
+- [`credit_card_collection.py`](./credit_card_collection.py) - Stateful credit-card collection with confirmation
+
+Run the credit-card collection example in console mode:
+
+```bash
+uv run examples/voice_agents/credit_card_collection.py console
+```
 
 ### Real-time Models
 

--- a/examples/voice_agents/credit_card_collection.py
+++ b/examples/voice_agents/credit_card_collection.py
@@ -39,7 +39,7 @@ server = AgentServer()
 async def entrypoint(ctx: JobContext) -> None:
     session: AgentSession = AgentSession(
         stt=inference.STT("deepgram/nova-3", language="multi"),
-        llm=inference.LLM("openai/gpt-4.1"),
+        llm=inference.LLM("openai/gpt-5.4"),
         tts=inference.TTS("cartesia/sonic-3", voice="9626c31c-bec5-4cca-baa8-f8ba9e84c8bc"),
     )
 

--- a/examples/voice_agents/credit_card_collection.py
+++ b/examples/voice_agents/credit_card_collection.py
@@ -1,0 +1,50 @@
+import logging
+
+from dotenv import load_dotenv
+
+from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli, inference
+from livekit.agents.beta.workflows import GetCreditCardTask
+
+logger = logging.getLogger("credit-card-collection")
+
+load_dotenv()
+
+
+class CreditCardCollectionAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(
+            instructions=(
+                "You are a payment assistant. Never repeat, summarize, or expose payment "
+                "details supplied by the user."
+            )
+        )
+
+    async def on_enter(self) -> None:
+        await GetCreditCardTask(require_confirmation=True)
+
+        # Keep PCI-sensitive result fields out of logs and follow-up model context.
+        logger.info("credit-card collection completed")
+        await self.session.generate_reply(
+            instructions=(
+                "Tell the user their payment details were collected successfully. "
+                "Do not repeat any payment details."
+            )
+        )
+
+
+server = AgentServer()
+
+
+@server.rtc_session()
+async def entrypoint(ctx: JobContext) -> None:
+    session: AgentSession = AgentSession(
+        stt=inference.STT("deepgram/nova-3", language="multi"),
+        llm=inference.LLM("openai/gpt-4.1"),
+        tts=inference.TTS("cartesia/sonic-3", voice="9626c31c-bec5-4cca-baa8-f8ba9e84c8bc"),
+    )
+
+    await session.start(agent=CreditCardCollectionAgent(), room=ctx.room)
+
+
+if __name__ == "__main__":
+    cli.run_app(server)

--- a/livekit-agents/livekit/agents/beta/workflows/credit_card.py
+++ b/livekit-agents/livekit/agents/beta/workflows/credit_card.py
@@ -75,6 +75,7 @@ Handle input as typed text. Users will type the security code directly.
 _EXPIRATION_DATE_BASE_INSTRUCTIONS = """
 You are a single step in a broader process of collecting credit card information.
 You are solely responsible for collecting the user's card's expiration date.
+An expiration date contains only a month and a year. Never interpret any part as a day of the month.
 {modality_specific}
 If the user refuses to provide a date, call decline_card_capture().
 If the user wishes to start over the card collection process, call restart_card_collection().
@@ -88,6 +89,7 @@ If the user asks how to say the expiration year, say it can be provided using th
 
 _EXPIRATION_DATE_AUDIO_SPECIFIC = """
 Handle input as noisy voice transcription. Expect users to say the expiration date in formats like 'April twenty five', 'oh four twenty five', 'four slash twenty five', or 'April 2025'.
+When a month name is followed by a two-digit number, interpret that number as the last two digits of the year, even if the transcription gives it an ordinal suffix.
 Normalize spoken months and digits silently.
 Filter out filler words or hesitations.
 """

--- a/livekit-agents/livekit/agents/beta/workflows/credit_card.py
+++ b/livekit-agents/livekit/agents/beta/workflows/credit_card.py
@@ -701,7 +701,7 @@ class GetExpirationDateTask(AgentTask[GetExpirationDateResult]):
         if 0 <= year <= 99:
             return year
         if 2000 <= year <= 2099:
-            return year - 2000
+            return year % 100
         raise ToolError(
             "The expiration year must use its last two digits or the full four-digit year. "
             "Ask the user to repeat the expiration year without providing an example."

--- a/livekit-agents/livekit/agents/beta/workflows/credit_card.py
+++ b/livekit-agents/livekit/agents/beta/workflows/credit_card.py
@@ -4,6 +4,7 @@ import asyncio
 from dataclasses import dataclass
 from datetime import date
 from enum import Enum, auto
+from functools import partial
 from typing import TYPE_CHECKING
 
 from ... import llm, stt, tts, vad
@@ -760,7 +761,6 @@ class GetCreditCardTask(AgentTask[GetCreditCardResult]):
         # TaskGroup overwrites each sub-task's chat_ctx with its own (see
         # TaskGroup.on_enter) - without seeding the TaskGroup, sub-tasks
         # would run with empty context.
-        ctx = self.chat_ctx
         # Role hint for the cardholder sub-task. With IGNORE_ON_ENTER on
         # update_name (via require_explicit_ask=True), the model is
         # structurally forced to ask before recording. The extra text
@@ -776,6 +776,9 @@ class GetCreditCardTask(AgentTask[GetCreditCardResult]):
             cardholder_extra = f"{self._extra_instructions}\n\n{cardholder_extra}"
 
         while not self.done():
+            # A restarted TaskGroup merges its final turn back into this task before
+            # raising, so take a fresh snapshot instead of dropping that turn.
+            ctx = self.chat_ctx
             # Order: number first (most natural for the caller to give
             # when asked for "card details"), then expiry and security
             # code, then the cardholder name LAST. The name most often
@@ -785,7 +788,8 @@ class GetCreditCardTask(AgentTask[GetCreditCardResult]):
             # into update_name.
             task_group = TaskGroup(chat_ctx=ctx)
             task_group.add(
-                lambda: GetCardNumberTask(
+                partial(
+                    GetCardNumberTask,
                     chat_ctx=ctx,
                     require_confirmation=self._require_confirmation,
                     extra_instructions=self._extra_instructions,
@@ -794,7 +798,8 @@ class GetCreditCardTask(AgentTask[GetCreditCardResult]):
                 description="Collects the user's card number",
             )
             task_group.add(
-                lambda: GetExpirationDateTask(
+                partial(
+                    GetExpirationDateTask,
                     chat_ctx=ctx,
                     require_confirmation=self._require_confirmation,
                     extra_instructions=self._extra_instructions,
@@ -803,7 +808,8 @@ class GetCreditCardTask(AgentTask[GetCreditCardResult]):
                 description="Collects the card's expiration date",
             )
             task_group.add(
-                lambda: GetSecurityCodeTask(
+                partial(
+                    GetSecurityCodeTask,
                     chat_ctx=ctx,
                     require_confirmation=self._require_confirmation,
                     extra_instructions=self._extra_instructions,
@@ -812,7 +818,8 @@ class GetCreditCardTask(AgentTask[GetCreditCardResult]):
                 description="Collects the card's security code",
             )
             task_group.add(
-                lambda: GetNameTask(
+                partial(
+                    GetNameTask,
                     last_name=True,
                     chat_ctx=ctx,
                     extra_instructions=cardholder_extra,

--- a/livekit-agents/livekit/agents/beta/workflows/credit_card.py
+++ b/livekit-agents/livekit/agents/beta/workflows/credit_card.py
@@ -700,7 +700,8 @@ class GetExpirationDateTask(AgentTask[GetExpirationDateResult]):
     def _normalize_expiration_year(self, year: int) -> int:
         if 0 <= year <= 99:
             return year
-        if 2000 <= year <= 2099:
+        current_century = self._current_date().year // 100 * 100
+        if current_century <= year <= current_century + 99:
             return year % 100
         raise ToolError(
             "The expiration year must use its last two digits or the full four-digit year. "
@@ -708,9 +709,13 @@ class GetExpirationDateTask(AgentTask[GetExpirationDateResult]):
         )
 
     def _is_expired(self, month: int, year: int) -> bool:
-        today = date.today()
-        full_year = 2000 + year
+        today = self._current_date()
+        current_century = today.year // 100 * 100
+        full_year = current_century + year
         return (full_year, month) < (today.year, today.month)
+
+    def _current_date(self) -> date:
+        return date.today()
 
     def _confirmation_required(self, ctx: RunContext) -> bool:
         if is_given(self._require_confirmation):

--- a/livekit-agents/livekit/agents/beta/workflows/credit_card.py
+++ b/livekit-agents/livekit/agents/beta/workflows/credit_card.py
@@ -259,7 +259,9 @@ class GetCardNumberTask(AgentTask[GetCardNumberResult]):
         return append_card_number
 
     def _build_submit_card_number_tool(self) -> llm.FunctionTool:
-        @function_tool(flags=ToolFlag.IGNORE_ON_ENTER)
+        flags = ToolFlag.IGNORE_ON_ENTER if self._require_explicit_ask else ToolFlag.NONE
+
+        @function_tool(flags=flags)
         async def submit_card_number(context: RunContext) -> str | None:
             """Submit the active card-number reading after the user finishes it.
 

--- a/livekit-agents/livekit/agents/beta/workflows/credit_card.py
+++ b/livekit-agents/livekit/agents/beta/workflows/credit_card.py
@@ -87,7 +87,7 @@ If the user asks how to say the expiration year, say it can be provided using th
 
 _EXPIRATION_DATE_AUDIO_SPECIFIC = """
 Handle input as noisy voice transcription. Expect users to say the expiration date in formats like 'April twenty five', 'oh four twenty five', 'four slash twenty five', or 'April 2025'.
-When a month name is followed by a two-digit number, interpret that number as the last two digits of the year, even if the transcription gives it an ordinal suffix.
+When a month name is followed by a two-digit number, it is complete month-and-year input. Strip any ordinal suffix from the number, use its numeric part as the last two digits of the year, and call `update_expiration_date` immediately. Never interpret or reject this pattern as a day of the month, and never call `decline_card_capture` for it.
 Normalize spoken months and digits silently.
 Filter out filler words or hesitations.
 """
@@ -602,9 +602,14 @@ class GetExpirationDateTask(AgentTask[GetExpirationDateResult]):
         ) -> str | None:
             """Call to update the card's expiration date. Collect both the numerical month and year.
 
+            The component after the month is always interpreted as a year and never as a day.
+            Strip any ordinal suffix introduced by transcription before calling this tool.
+
             Args:
-                expiration_month (int): The numerical expiration month of the card, example: '04' for April
-                expiration_year (int): The numerical expiration year as its last two digits or the full four-digit year
+                expiration_month (int): The numerical month from the first component.
+                expiration_year (int): The second component after the month, always interpreted
+                    as a year and never as a day. Strip any transcribed ordinal suffix and use
+                    either the last two digits or the full four-digit year.
             """
             return await self._update_expiration_date_impl(
                 context, expiration_month, expiration_year

--- a/livekit-agents/livekit/agents/beta/workflows/credit_card.py
+++ b/livekit-agents/livekit/agents/beta/workflows/credit_card.py
@@ -30,13 +30,11 @@ If the user wishes to start over the credit card collection process, call restar
 Call `append_card_number` as soon as the user provides a new group of digits. Pass only the newly provided digits; the task stores earlier groups.
 For a correction, use `replace_last` to replace only the incorrect trailing digits.
 Call `submit_card_number` when the user indicates they have finished, or set `finish=True` when appending the final group.
-During confirmation, collect the repeated number with the same append and submit tools.
 Always explicitly invoke a tool when applicable. Do not simulate tool usage, and never state that a value was recorded, submitted, or confirmed unless the corresponding tool call succeeded.
 Avoid listing out questions with bullet points or numbers, use a natural conversational tone.
 Never repeat any sensitive information, such as the user's credit card number, back to the user.
 Never state or infer how many digits have been collected.
 When explaining an input format, never provide invented or example card numbers, security codes, expiration months, or expiration years. Describe only the format's structure.
-{confirmation_instructions}
 """
 
 _CARD_NUMBER_AUDIO_SPECIFIC = """
@@ -182,9 +180,6 @@ class GetCardNumberTask(AgentTask[GetCardNumberResult]):
         require_explicit_ask: bool = False,
         extra_instructions: str = "",
     ) -> None:
-        confirmation_instructions = (
-            "The task will ask for a second complete reading before it finishes."
-        )
         extra_suffix = f"\n{extra_instructions}" if extra_instructions else ""
 
         self._card_number = ""
@@ -198,16 +193,10 @@ class GetCardNumberTask(AgentTask[GetCardNumberResult]):
             instructions=Instructions(
                 audio=_CARD_NUMBER_BASE_INSTRUCTIONS.format(
                     modality_specific=_CARD_NUMBER_AUDIO_SPECIFIC,
-                    confirmation_instructions=(
-                        confirmation_instructions if require_confirmation is not False else ""
-                    ),
                 )
                 + extra_suffix,
                 text=_CARD_NUMBER_BASE_INSTRUCTIONS.format(
                     modality_specific=_CARD_NUMBER_TEXT_SPECIFIC,
-                    confirmation_instructions=(
-                        confirmation_instructions if require_confirmation is True else ""
-                    ),
                 )
                 + extra_suffix,
             ),
@@ -245,9 +234,9 @@ class GetCardNumberTask(AgentTask[GetCardNumberResult]):
         ) -> str | None:
             """Append newly provided digits to the active card-number reading.
 
-            Use this while collecting both the original number and its confirmation. Pass
-            only new digits. To correct a suffix, remove it with replace_last while
-            appending the replacement. Set finish when these are the final digits.
+            Pass only new digits. To correct a suffix, remove it with replace_last while
+            appending the replacement. Set finish when these are the final digits. The task
+            decides whether another reading is required.
 
             Args:
                 digits: Newly provided card-number digits, with no spaces or dashes.
@@ -267,8 +256,8 @@ class GetCardNumberTask(AgentTask[GetCardNumberResult]):
         async def submit_card_number(context: RunContext) -> str | None:
             """Submit the active card-number reading after the user finishes it.
 
-            Call once after the original number and again after the repeated number when
-            confirmation is required. Do not call before the user finishes a reading.
+            Do not call before the user finishes a reading. The task decides whether another
+            reading is required.
             """
             return await self._submit_card_number_impl(context)
 

--- a/livekit-agents/livekit/agents/beta/workflows/credit_card.py
+++ b/livekit-agents/livekit/agents/beta/workflows/credit_card.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from datetime import date
+from enum import Enum, auto
 from typing import TYPE_CHECKING
 
 from ... import llm, stt, tts, vad
@@ -25,8 +27,15 @@ You are solely responsible for collecting the credit card number.
 {modality_specific}
 If the user refuses to provide a credit card number, call decline_card_capture().
 If the user wishes to start over the credit card collection process, call restart_card_collection().
+Call `append_card_number` as soon as the user provides a new group of digits. Pass only the newly provided digits; the task stores earlier groups.
+For a correction, use `replace_last` to replace only the incorrect trailing digits.
+Call `submit_card_number` when the user indicates they have finished, or set `finish=True` when appending the final group.
+During confirmation, collect the repeated number with the same append and submit tools.
+Always explicitly invoke a tool when applicable. Do not simulate tool usage, and never state that a value was recorded, submitted, or confirmed unless the corresponding tool call succeeded.
 Avoid listing out questions with bullet points or numbers, use a natural conversational tone.
 Never repeat any sensitive information, such as the user's credit card number, back to the user.
+Never state or infer how many digits have been collected.
+When explaining an input format, never provide invented or example card numbers, security codes, expiration months, or expiration years. Describe only the format's structure.
 {confirmation_instructions}
 """
 
@@ -46,8 +55,10 @@ You are solely responsible for collecting the user's card's security code.
 {modality_specific}
 If the user refuses to provide a code, call decline_card_capture().
 If the user wishes to start over the card collection process, call restart_card_collection().
+Always explicitly invoke a tool when applicable. Do not simulate tool usage, and never state that a value was recorded or confirmed unless the corresponding tool call succeeded.
 Avoid listing out questions with bullet points or numbers, use a natural conversational tone.
 Never repeat any sensitive information, such as the user's security code, back to the user.
+When explaining an input format, never provide invented or example card numbers, security codes, expiration months, or expiration years. Describe only the format's structure.
 {confirmation_instructions}
 """
 
@@ -67,8 +78,11 @@ You are solely responsible for collecting the user's card's expiration date.
 {modality_specific}
 If the user refuses to provide a date, call decline_card_capture().
 If the user wishes to start over the card collection process, call restart_card_collection().
+Always explicitly invoke a tool when applicable. Do not simulate tool usage, and never state that a value was recorded or confirmed unless the corresponding tool call succeeded.
 Avoid listing out questions with bullet points or numbers, use a natural conversational tone.
 Never repeat any sensitive information, such as the user's expiration date, back to the user.
+When explaining an input format, never provide invented or example card numbers, security codes, expiration months, or expiration years. Describe only the format's structure.
+If the user asks how to say the expiration year, say it can be provided using the last two digits or in full four digits. Do not give a concrete example.
 {confirmation_instructions}
 """
 
@@ -128,6 +142,11 @@ class CardCollectionRestartError(ToolError):
         return self._reason
 
 
+class _CardNumberStage(Enum):
+    COLLECTING = auto()
+    CONFIRMING = auto()
+
+
 @function_tool(flags=ToolFlag.IGNORE_ON_ENTER)
 async def decline_card_capture(context: RunContext, reason: str) -> None:
     """Handles the case when the user explicitly declines to provide a detail for their card information.
@@ -162,11 +181,14 @@ class GetCardNumberTask(AgentTask[GetCardNumberResult]):
         extra_instructions: str = "",
     ) -> None:
         confirmation_instructions = (
-            "Call `confirm_card_number` once the user has repeated their card number."
+            "The task will ask for a second complete reading before it finishes."
         )
         extra_suffix = f"\n{extra_instructions}" if extra_instructions else ""
 
         self._card_number = ""
+        self._card_number_buffer = ""
+        self._card_number_stage = _CardNumberStage.COLLECTING
+        self._card_number_lock = asyncio.Lock()
         self._require_confirmation = require_confirmation
         self._require_explicit_ask = require_explicit_ask
 
@@ -189,7 +211,8 @@ class GetCardNumberTask(AgentTask[GetCardNumberResult]):
             ),
             chat_ctx=chat_ctx,
             tools=[
-                self._build_update_card_number_tool(),
+                self._build_append_card_number_tool(),
+                self._build_submit_card_number_tool(),
                 decline_card_capture,
                 restart_card_collection,
             ],
@@ -200,86 +223,170 @@ class GetCardNumberTask(AgentTask[GetCardNumberResult]):
             instructions=(
                 "Get the user's credit card number. First scan the conversation - if a "
                 "credit card number was already given (e.g. the user volunteered it "
-                "before the task started), use it via update_card_number rather than "
-                "re-asking. Only ask fresh when no credit card number is in the "
-                "conversation yet."
+                "before the task started), record it via append_card_number and submit it "
+                "rather than re-asking. Only ask fresh when no credit card number is in "
+                "the conversation yet."
             )
         )
 
-    def _build_update_card_number_tool(self) -> llm.FunctionTool:
+    def _build_append_card_number_tool(self) -> llm.FunctionTool:
         # Built dynamically so we can apply IGNORE_ON_ENTER per-instance
         # based on require_explicit_ask.
         flags = ToolFlag.IGNORE_ON_ENTER if self._require_explicit_ask else ToolFlag.NONE
 
         @function_tool(flags=flags)
-        async def update_card_number(context: RunContext, card_number: str) -> str | None:
-            """Call to record the user's card number. Only call once the entire number has been given, do not call in increments.
+        async def append_card_number(
+            context: RunContext,
+            digits: str,
+            replace_last: int = 0,
+            finish: bool = False,
+        ) -> str | None:
+            """Append newly provided digits to the active card-number reading.
+
+            Use this while collecting both the original number and its confirmation. Pass
+            only new digits. To correct a suffix, remove it with replace_last while
+            appending the replacement. Set finish when these are the final digits.
 
             Args:
-                card_number (str): The credit card number as a string with no dashes or spaces
+                digits: Newly provided card-number digits, with no spaces or dashes.
+                replace_last: Number of trailing digits to replace before appending.
+                finish: Whether the user has finished the current reading.
             """
-            return await self._update_card_number_impl(context, card_number)
-
-        return update_card_number
-
-    async def _update_card_number_impl(self, context: RunContext, card_number: str) -> str | None:
-        card_number = "".join([d for d in card_number if d.isdigit()])
-        if len(card_number) < 13 or len(card_number) > 19:
-            self.session.generate_reply(
-                instructions="The length of the card number is invalid, ask the user to repeat their card number."
+            return await self._append_card_number_impl(
+                context, digits, replace_last=replace_last, finish=finish
             )
-            return None
-        else:
-            self._card_number = card_number
 
-            if not self._confirmation_required(context):
-                if not self.validate_card_number(self._card_number):
-                    self.session.generate_reply(
-                        instructions="The card number is not valid, ask the user if they made a mistake or to provide another card."
-                    )
-                else:
-                    issuer = CARD_ISSUERS_LOOKUP.get(self._card_number[0], "Other")
-                    if not self.done():
-                        self.complete(
-                            GetCardNumberResult(issuer=issuer, card_number=self._card_number)
-                        )
-                return None
+        return append_card_number
 
-            confirm_tool = self._build_confirm_tool(card_number=card_number)
-            current_tools = [t for t in self.tools if t.id != "confirm_card_number"]
-            current_tools.append(confirm_tool)
-            await self.update_tools(current_tools)
+    def _build_submit_card_number_tool(self) -> llm.FunctionTool:
+        @function_tool(flags=ToolFlag.IGNORE_ON_ENTER)
+        async def submit_card_number(context: RunContext) -> str | None:
+            """Submit the active card-number reading after the user finishes it.
+
+            Call once after the original number and again after the repeated number when
+            confirmation is required. Do not call before the user finishes a reading.
+            """
+            return await self._submit_card_number_impl(context)
+
+        return submit_card_number
+
+    async def _append_card_number_impl(
+        self,
+        context: RunContext,
+        digits: str,
+        *,
+        replace_last: int = 0,
+        finish: bool = False,
+    ) -> str | None:
+        async with self._card_number_lock:
+            normalized_digits = "".join(d for d in digits if d.isdigit())
+            if not normalized_digits:
+                raise ToolError(
+                    "No card-number digits were provided. Call submit_card_number if the "
+                    "user has finished the current reading."
+                )
+            if replace_last < 0:
+                raise ToolError("replace_last cannot be negative")
+            if replace_last > len(self._card_number_buffer):
+                raise ToolError(
+                    "replace_last exceeds the digits currently collected; ask the user to "
+                    "restart or repeat the correction"
+                )
+
+            retained = (
+                self._card_number_buffer[:-replace_last]
+                if replace_last
+                else self._card_number_buffer
+            )
+            candidate = retained + normalized_digits
+            if len(candidate) > 19:
+                raise ToolError(
+                    "The card number is too long. Ask the user to correct the latest digits "
+                    "or restart card collection."
+                )
+
+            self._card_number_buffer = candidate
+            if finish or self._should_auto_submit(candidate):
+                return self._submit_card_number_locked(context)
 
             return (
-                "The card number has been updated.\n"
-                "Ask them to repeat the number, do not repeat the number back to them.\n"
+                "Card-number input recorded. Continue collecting new groups with "
+                "append_card_number, or call submit_card_number when the user finishes. "
+                "Do not repeat digits or state how many digits have been collected."
             )
 
-    def _build_confirm_tool(self, *, card_number: str) -> llm.FunctionTool:
-        @function_tool()
-        async def confirm_card_number(repeated_card_number: str) -> None:
-            """Call after the user repeats their card number for confirmation.
+    async def _submit_card_number_impl(self, context: RunContext) -> str | None:
+        async with self._card_number_lock:
+            return self._submit_card_number_locked(context)
 
-            Args:
-                repeated_card_number (str): The card number repeated by the user as a string
-            """
-            repeated_card_number = "".join([d for d in repeated_card_number if d.isdigit()])
-            if repeated_card_number != card_number:
-                self.session.generate_reply(
-                    instructions="The repeated card number does not match, ask the user to try again."
-                )
-                return
+    def _submit_card_number_locked(self, context: RunContext) -> str | None:
+        candidate = self._card_number_buffer
+        try:
+            self._validate_card_number_input(candidate)
+        except ToolError:
+            if self._card_number_stage is _CardNumberStage.CONFIRMING:
+                self._card_number_buffer = ""
+            raise
 
-            if not self.validate_card_number(card_number):
-                self.session.generate_reply(
-                    instructions="The card number is not valid, ask the user if they made a mistake or to provide another card."
-                )
-            else:
-                issuer = CARD_ISSUERS_LOOKUP.get(card_number[0], "Other")
-                if not self.done():
-                    self.complete(GetCardNumberResult(issuer=issuer, card_number=card_number))
+        if self._card_number_stage is _CardNumberStage.COLLECTING:
+            self._card_number = candidate
+            if not self._confirmation_required(context):
+                self._complete_card_number(candidate)
+                return None
 
-        return confirm_card_number
+            self._card_number_stage = _CardNumberStage.CONFIRMING
+            self._card_number_buffer = ""
+            return (
+                "The initial card number has been submitted. Ask the user to repeat the "
+                "entire number for confirmation. Record that reading with append_card_number "
+                "and submit_card_number. Do not repeat any digits yourself."
+            )
+
+        self._card_number_buffer = ""
+        if candidate == self._card_number:
+            self._complete_card_number(candidate)
+            return None
+
+        self._card_number = candidate
+        return (
+            "The repeated number differed and has been treated as a correction. Ask the "
+            "user to repeat the entire corrected number once more, using append_card_number "
+            "and submit_card_number. Do not repeat any digits yourself."
+        )
+
+    def _validate_card_number_input(self, card_number: str) -> None:
+        if not 13 <= len(card_number) <= 19:
+            raise ToolError(
+                "The card number has an invalid length. Continue collecting digits or ask "
+                "the user to repeat the number."
+            )
+        if not self.validate_card_number(card_number):
+            raise ToolError(
+                "The card number failed validation. Ask the user to correct the latest "
+                "digits or repeat the number."
+            )
+
+    def _complete_card_number(self, card_number: str) -> None:
+        if not self.done():
+            issuer = CARD_ISSUERS_LOOKUP.get(card_number[0], "Other")
+            self.complete(GetCardNumberResult(issuer=issuer, card_number=card_number))
+
+    def _should_auto_submit(self, card_number: str) -> bool:
+        if (
+            self._card_number_stage is _CardNumberStage.CONFIRMING
+            and card_number == self._card_number
+        ):
+            return True
+        if len(card_number) == 19:
+            return True
+        if len(card_number) == 15 and card_number.startswith(("34", "37")):
+            return True
+        if len(card_number) != 16:
+            return False
+
+        first_two = int(card_number[:2])
+        first_four = int(card_number[:4])
+        return 51 <= first_two <= 55 or 2221 <= first_four <= 2720
 
     def validate_card_number(self, card_number: str) -> bool:
         """Validates card number via the Luhn algorithm"""
@@ -383,6 +490,15 @@ class GetSecurityCodeTask(AgentTask[GetSecurityCodeResult]):
                 instructions="The security code's length is invalid, ask the user to repeat or to provide a new card and start over."
             )
             return None
+        elif (
+            self._security_code
+            and stripped == self._security_code
+            and self._confirmation_required(context)
+        ):
+            raise ToolError(
+                "This security code is already recorded and awaiting confirmation. "
+                "Call `confirm_security_code` with the repeated code instead."
+            )
         else:
             self._security_code = stripped
 
@@ -398,8 +514,11 @@ class GetSecurityCodeTask(AgentTask[GetSecurityCodeResult]):
 
             return (
                 "The security code has been updated.\n"
+                "If the user already repeated the security code earlier in the conversation, call "
+                "`confirm_security_code` with that repeated security code now instead of asking again.\n"
                 "Do not repeat the security code back to the user, ask them to repeat themselves.\n"
-                "Call `confirm_security_code` once the user confirms, do not call it preemptively.\n"
+                "Call `confirm_security_code` once the user has repeated the code. Do not call it "
+                "preemptively, and do not treat the code as confirmed until that call succeeds.\n"
             )
 
     def _build_confirm_tool(self, *, security_code: str) -> llm.FunctionTool:
@@ -492,7 +611,7 @@ class GetExpirationDateTask(AgentTask[GetExpirationDateResult]):
 
             Args:
                 expiration_month (int): The numerical expiration month of the card, example: '04' for April
-                expiration_year (int): The numerical expiration year of the card shortened to the last two digits, for example, '35' for 2035
+                expiration_year (int): The numerical expiration year as its last two digits or the full four-digit year
             """
             return await self._update_expiration_date_impl(
                 context, expiration_month, expiration_year
@@ -503,14 +622,10 @@ class GetExpirationDateTask(AgentTask[GetExpirationDateResult]):
     async def _update_expiration_date_impl(
         self, context: RunContext, expiration_month: int, expiration_year: int
     ) -> str | None:
+        expiration_year = self._normalize_expiration_year(expiration_year)
         if not (1 <= expiration_month <= 12):
             self.session.generate_reply(
                 instructions="The expiration month is invalid, ask the user to repeat the expiration month."
-            )
-            return None
-        elif not (0 <= expiration_year <= 99):
-            self.session.generate_reply(
-                instructions="The expiration year is invalid, ask the user to repeat the expiration year."
             )
             return None
         elif self._is_expired(expiration_month, expiration_year):
@@ -518,6 +633,15 @@ class GetExpirationDateTask(AgentTask[GetExpirationDateResult]):
                 instructions="The expiration date is in the past, the card is expired. Ask the user to provide another card."
             )
             return None
+        elif (
+            self._expiration_date
+            and f"{expiration_month:02d}/{expiration_year:02d}" == self._expiration_date
+            and self._confirmation_required(context)
+        ):
+            raise ToolError(
+                "This expiration date is already recorded and awaiting confirmation. "
+                "Call `confirm_expiration_date` with the repeated date instead."
+            )
         else:
             self._expiration_date = f"{expiration_month:02d}/{expiration_year:02d}"
 
@@ -535,8 +659,11 @@ class GetExpirationDateTask(AgentTask[GetExpirationDateResult]):
 
             return (
                 "The expiration date has been updated.\n"
+                "If the user already repeated the expiration date earlier in the conversation, call "
+                "`confirm_expiration_date` with that repeated expiration date now instead of asking again.\n"
                 "Do not repeat the expiration date back to the user, ask them to repeat themselves.\n"
-                "Call `confirm_expiration_date` once the user confirms, do not call it preemptively.\n"
+                "Call `confirm_expiration_date` once the user has repeated the date. Do not call it "
+                "preemptively, and do not treat the date as confirmed until that call succeeds.\n"
             )
 
     def _build_confirm_tool(
@@ -555,6 +682,7 @@ class GetExpirationDateTask(AgentTask[GetExpirationDateResult]):
                 repeated_expiration_month (int): The expiration month repeated by the user
                 repeated_expiration_year (int): The expiration year repeated by the user
             """
+            repeated_expiration_year = self._normalize_expiration_year(repeated_expiration_year)
             if (
                 repeated_expiration_month != expiration_month
                 or repeated_expiration_year != expiration_year
@@ -569,6 +697,16 @@ class GetExpirationDateTask(AgentTask[GetExpirationDateResult]):
 
         return confirm_expiration_date
 
+    def _normalize_expiration_year(self, year: int) -> int:
+        if 0 <= year <= 99:
+            return year
+        if 2000 <= year <= 2099:
+            return year - 2000
+        raise ToolError(
+            "The expiration year must use its last two digits or the full four-digit year. "
+            "Ask the user to repeat the expiration year without providing an example."
+        )
+
     def _is_expired(self, month: int, year: int) -> bool:
         today = date.today()
         full_year = 2000 + year
@@ -581,6 +719,12 @@ class GetExpirationDateTask(AgentTask[GetExpirationDateResult]):
 
 
 class GetCreditCardTask(AgentTask[GetCreditCardResult]):
+    """Collect a complete credit card through a sequence of focused tasks.
+
+    Confirmation remains model-directed with automatic tool choice. The prompts require an
+    explicit tool call, but a model that produces only text can leave a confirmation pending.
+    """
+
     def __init__(
         self,
         chat_ctx: NotGivenOr[llm.ChatContext] = NOT_GIVEN,

--- a/tests/test_credit_card_workflows.py
+++ b/tests/test_credit_card_workflows.py
@@ -232,3 +232,5 @@ def test_credit_card_instructions_prohibit_concrete_format_examples() -> None:
     assert isinstance(expiration, Instructions)
     rendered_expiration = expiration.render(modality="audio")
     assert "last two digits or in full four digits" in rendered_expiration
+    assert "never interpret any part as a day of the month" in rendered_expiration.lower()
+    assert "even if the transcription gives it an ordinal suffix" in rendered_expiration.lower()

--- a/tests/test_credit_card_workflows.py
+++ b/tests/test_credit_card_workflows.py
@@ -7,12 +7,14 @@ from unittest.mock import patch
 import pytest
 
 from livekit.agents.beta.workflows.credit_card import (
+    CardCollectionRestartError,
     GetCardNumberResult,
     GetCardNumberTask,
+    GetCreditCardTask,
     GetExpirationDateTask,
     GetSecurityCodeTask,
 )
-from livekit.agents.llm.chat_context import Instructions
+from livekit.agents.llm.chat_context import ChatContext, Instructions
 from livekit.agents.llm.tool_context import ToolError, ToolFlag
 
 pytestmark = pytest.mark.unit
@@ -21,6 +23,57 @@ pytestmark = pytest.mark.unit
 def _run_context(modality: str = "audio") -> Any:
     return SimpleNamespace(
         speech_handle=SimpleNamespace(input_details=SimpleNamespace(modality=modality))
+    )
+
+
+@pytest.mark.asyncio
+async def test_credit_card_restart_uses_latest_chat_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    initial_ctx = ChatContext.empty()
+    initial_ctx.add_message(role="user", content="The previous card number was invalid.")
+    task = GetCreditCardTask(chat_ctx=initial_ctx)
+    group_contexts: list[ChatContext] = []
+
+    class FakeTaskGroup:
+        def __init__(self, *, chat_ctx: ChatContext, **_: Any) -> None:
+            group_contexts.append(chat_ctx.copy())
+
+        def add(self, *_: Any, **__: Any) -> "FakeTaskGroup":
+            return self
+
+        def __await__(self):
+            async def run() -> Any:
+                if len(group_contexts) == 1:
+                    task._chat_ctx.add_message(
+                        role="user", content="The first four digits are four two four two."
+                    )
+                    raise CardCollectionRestartError("start the card number again")
+
+                return SimpleNamespace(
+                    task_results={
+                        "cardholder_name_task": SimpleNamespace(
+                            first_name="Ada", last_name="Lovelace"
+                        ),
+                        "card_number_task": SimpleNamespace(
+                            issuer="Visa", card_number="4242424242424242"
+                        ),
+                        "security_code_task": SimpleNamespace(security_code="123"),
+                        "expiration_date_task": SimpleNamespace(date="07/32"),
+                    }
+                )
+
+            return run().__await__()
+
+    monkeypatch.setattr("livekit.agents.beta.workflows.credit_card.TaskGroup", FakeTaskGroup)
+
+    await task.on_enter()
+
+    assert len(group_contexts) == 2
+    assert group_contexts[0].messages()[-1].text_content == "The previous card number was invalid."
+    assert (
+        group_contexts[1].messages()[-1].text_content
+        == "The first four digits are four two four two."
     )
 
 

--- a/tests/test_credit_card_workflows.py
+++ b/tests/test_credit_card_workflows.py
@@ -13,7 +13,7 @@ from livekit.agents.beta.workflows.credit_card import (
     GetSecurityCodeTask,
 )
 from livekit.agents.llm.chat_context import Instructions
-from livekit.agents.llm.tool_context import ToolError
+from livekit.agents.llm.tool_context import ToolError, ToolFlag
 
 pytestmark = pytest.mark.unit
 
@@ -206,9 +206,18 @@ async def test_expiration_year_uses_the_current_century() -> None:
 
 def test_credit_card_instructions_prohibit_concrete_format_examples() -> None:
     card_number_task = GetCardNumberTask()
-    tool_ids = {tool.id for tool in card_number_task.tools}
+    tools_by_id = {tool.id: tool for tool in card_number_task.tools}
+    tool_ids = set(tools_by_id)
     assert {"append_card_number", "submit_card_number"} <= tool_ids
     assert {"update_card_number", "confirm_card_number"}.isdisjoint(tool_ids)
+    assert not (tools_by_id["append_card_number"].info.flags & ToolFlag.IGNORE_ON_ENTER)
+    assert not (tools_by_id["submit_card_number"].info.flags & ToolFlag.IGNORE_ON_ENTER)
+
+    explicit_ask_tools = {
+        tool.id: tool for tool in GetCardNumberTask(require_explicit_ask=True).tools
+    }
+    assert explicit_ask_tools["append_card_number"].info.flags & ToolFlag.IGNORE_ON_ENTER
+    assert explicit_ask_tools["submit_card_number"].info.flags & ToolFlag.IGNORE_ON_ENTER
 
     for task in (
         card_number_task,

--- a/tests/test_credit_card_workflows.py
+++ b/tests/test_credit_card_workflows.py
@@ -236,9 +236,17 @@ def test_credit_card_instructions_prohibit_concrete_format_examples() -> None:
         rendered = task.instructions.render(modality="audio")
         assert "never provide invented or example" in rendered.lower()
 
-    expiration = GetExpirationDateTask().instructions
+    expiration_task = GetExpirationDateTask()
+    expiration = expiration_task.instructions
     assert isinstance(expiration, Instructions)
     rendered_expiration = expiration.render(modality="audio")
     assert "last two digits or in full four digits" in rendered_expiration
     assert "never interpret any part as a day of the month" in rendered_expiration.lower()
-    assert "even if the transcription gives it an ordinal suffix" in rendered_expiration.lower()
+    assert "strip any ordinal suffix" in rendered_expiration.lower()
+    assert "never call `decline_card_capture` for it" in rendered_expiration.lower()
+
+    update_expiration_tool = next(
+        tool for tool in expiration_task.tools if tool.id == "update_expiration_date"
+    )
+    description = update_expiration_tool.info.description or ""
+    assert "always interpreted as a year and never as a day" in description.lower()

--- a/tests/test_credit_card_workflows.py
+++ b/tests/test_credit_card_workflows.py
@@ -1,0 +1,207 @@
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from livekit.agents.beta.workflows.credit_card import (
+    GetCardNumberResult,
+    GetCardNumberTask,
+    GetExpirationDateTask,
+    GetSecurityCodeTask,
+)
+from livekit.agents.llm.chat_context import Instructions
+from livekit.agents.llm.tool_context import ToolError
+
+pytestmark = pytest.mark.unit
+
+
+def _run_context(modality: str = "audio") -> Any:
+    return SimpleNamespace(
+        speech_handle=SimpleNamespace(input_details=SimpleNamespace(modality=modality))
+    )
+
+
+@pytest.mark.asyncio
+async def test_card_number_incremental_suffix_correction_and_finish() -> None:
+    task = GetCardNumberTask(require_confirmation=False)
+    ctx = _run_context()
+
+    first_output = await task._append_card_number_impl(ctx, "4242")
+    await task._append_card_number_impl(ctx, "4243")
+    await task._append_card_number_impl(ctx, "2", replace_last=1)
+    await task._append_card_number_impl(ctx, "4242")
+
+    with patch.object(task, "complete") as complete:
+        await task._append_card_number_impl(ctx, "4242", finish=True)
+
+    assert "4242" not in (first_output or "")
+    result = complete.call_args.args[0]
+    assert result == GetCardNumberResult(issuer="Visa", card_number="4242424242424242")
+
+
+@pytest.mark.asyncio
+async def test_card_number_invalid_updates_do_not_mutate_buffer() -> None:
+    task = GetCardNumberTask(require_confirmation=False)
+    ctx = _run_context()
+    await task._append_card_number_impl(ctx, "4242")
+
+    with pytest.raises(ToolError, match="negative"):
+        await task._append_card_number_impl(ctx, "1", replace_last=-1)
+    assert task._card_number_buffer == "4242"
+
+    with pytest.raises(ToolError, match="replace_last"):
+        await task._append_card_number_impl(ctx, "1", replace_last=5)
+    assert task._card_number_buffer == "4242"
+
+    with pytest.raises(ToolError, match="too long"):
+        await task._append_card_number_impl(ctx, "1" * 16)
+    assert task._card_number_buffer == "4242"
+
+    with pytest.raises(ToolError, match="No card-number digits"):
+        await task._append_card_number_impl(ctx, "not digits")
+    assert task._card_number_buffer == "4242"
+
+
+@pytest.mark.asyncio
+async def test_card_number_equal_confirmation_auto_submits() -> None:
+    task = GetCardNumberTask(require_confirmation=True)
+    ctx = _run_context()
+
+    transition = await task._append_card_number_impl(ctx, "4242424242424242", finish=True)
+    assert transition is not None and "repeat" in transition
+    assert task._card_number_buffer == ""
+
+    await task._append_card_number_impl(ctx, "42424242")
+    with patch.object(task, "complete") as complete:
+        await task._append_card_number_impl(ctx, "42424242")
+
+    result = complete.call_args.args[0]
+    assert result == GetCardNumberResult(issuer="Visa", card_number="4242424242424242")
+
+
+@pytest.mark.asyncio
+async def test_card_number_valid_mismatch_becomes_corrected_original() -> None:
+    task = GetCardNumberTask(require_confirmation=True)
+    ctx = _run_context()
+    await task._append_card_number_impl(ctx, "4242424242424242", finish=True)
+
+    correction = await task._append_card_number_impl(ctx, "4000000000000002", finish=True)
+    assert correction is not None and "correction" in correction
+    assert task._card_number == "4000000000000002"
+    assert task._card_number_buffer == ""
+
+    with patch.object(task, "complete") as complete:
+        await task._append_card_number_impl(ctx, "4000000000000002")
+
+    result = complete.call_args.args[0]
+    assert result == GetCardNumberResult(issuer="Visa", card_number="4000000000000002")
+
+
+@pytest.mark.asyncio
+async def test_invalid_confirmation_is_discarded() -> None:
+    task = GetCardNumberTask(require_confirmation=True)
+    ctx = _run_context()
+    await task._append_card_number_impl(ctx, "4242424242424242", finish=True)
+
+    with pytest.raises(ToolError, match="failed validation"):
+        await task._append_card_number_impl(ctx, "4242424242424241", finish=True)
+
+    assert task._card_number == "4242424242424242"
+    assert task._card_number_buffer == ""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "card_number, issuer",
+    [
+        ("378282246310005", "American Express"),
+        ("5555555555554444", "Mastercard"),
+        ("4000000000000000006", "Visa"),
+    ],
+)
+async def test_card_number_conservative_auto_submit(card_number: str, issuer: str) -> None:
+    task = GetCardNumberTask(require_confirmation=False)
+
+    with patch.object(task, "complete") as complete:
+        await task._append_card_number_impl(_run_context(), card_number)
+
+    assert complete.call_args.args[0] == GetCardNumberResult(issuer=issuer, card_number=card_number)
+
+
+@pytest.mark.asyncio
+async def test_card_number_extendable_length_requires_submit() -> None:
+    task = GetCardNumberTask(require_confirmation=False)
+    ctx = _run_context()
+
+    await task._append_card_number_impl(ctx, "4242424242424242")
+    assert not task.done()
+
+    with patch.object(task, "complete") as complete:
+        await task._submit_card_number_impl(ctx)
+
+    assert complete.call_args.args[0] == GetCardNumberResult(
+        issuer="Visa", card_number="4242424242424242"
+    )
+
+
+@pytest.mark.asyncio
+async def test_card_number_parallel_calls_preserve_order() -> None:
+    task = GetCardNumberTask(require_confirmation=False)
+    ctx = _run_context()
+
+    with patch.object(task, "complete") as complete:
+        await asyncio.gather(
+            task._append_card_number_impl(ctx, "4242"),
+            task._append_card_number_impl(ctx, "4242"),
+            task._append_card_number_impl(ctx, "4242"),
+            task._append_card_number_impl(ctx, "4242", finish=True),
+        )
+
+    assert complete.call_args.args[0] == GetCardNumberResult(
+        issuer="Visa", card_number="4242424242424242"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sensitive_field_duplicate_updates_redirect_to_confirmation() -> None:
+    ctx = _run_context()
+
+    security_code_task = GetSecurityCodeTask(require_confirmation=True)
+    assert await security_code_task._update_security_code_impl(ctx, "123")
+    with pytest.raises(ToolError, match="confirm_security_code"):
+        await security_code_task._update_security_code_impl(ctx, "123")
+    assert await security_code_task._update_security_code_impl(ctx, "456")
+
+    expiration_task = GetExpirationDateTask(require_confirmation=True)
+    assert await expiration_task._update_expiration_date_impl(ctx, 4, 2099)
+    assert expiration_task._expiration_date == "04/99"
+    with pytest.raises(ToolError, match="confirm_expiration_date"):
+        await expiration_task._update_expiration_date_impl(ctx, 4, 99)
+    assert await expiration_task._update_expiration_date_impl(ctx, 5, 2099)
+
+    for invalid_year in (1999, 2100):
+        with pytest.raises(ToolError, match="last two digits or the full four-digit year"):
+            await expiration_task._update_expiration_date_impl(ctx, 5, invalid_year)
+
+
+def test_credit_card_instructions_prohibit_concrete_format_examples() -> None:
+    card_number_task = GetCardNumberTask()
+    tool_ids = {tool.id for tool in card_number_task.tools}
+    assert {"append_card_number", "submit_card_number"} <= tool_ids
+    assert {"update_card_number", "confirm_card_number"}.isdisjoint(tool_ids)
+
+    for task in (
+        card_number_task,
+        GetSecurityCodeTask(),
+        GetExpirationDateTask(),
+    ):
+        assert isinstance(task.instructions, Instructions)
+        rendered = task.instructions.render(modality="audio")
+        assert "never provide invented or example" in rendered.lower()
+
+    expiration = GetExpirationDateTask().instructions
+    assert isinstance(expiration, Instructions)
+    rendered_expiration = expiration.render(modality="audio")
+    assert "last two digits or in full four digits" in rendered_expiration

--- a/tests/test_credit_card_workflows.py
+++ b/tests/test_credit_card_workflows.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import date
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
@@ -175,15 +176,32 @@ async def test_sensitive_field_duplicate_updates_redirect_to_confirmation() -> N
     assert await security_code_task._update_security_code_impl(ctx, "456")
 
     expiration_task = GetExpirationDateTask(require_confirmation=True)
-    assert await expiration_task._update_expiration_date_impl(ctx, 4, 2099)
-    assert expiration_task._expiration_date == "04/99"
-    with pytest.raises(ToolError, match="confirm_expiration_date"):
-        await expiration_task._update_expiration_date_impl(ctx, 4, 99)
-    assert await expiration_task._update_expiration_date_impl(ctx, 5, 2099)
+    with patch.object(expiration_task, "_current_date", return_value=date(2026, 7, 21)):
+        assert await expiration_task._update_expiration_date_impl(ctx, 4, 2099)
+        assert expiration_task._expiration_date == "04/99"
+        with pytest.raises(ToolError, match="confirm_expiration_date"):
+            await expiration_task._update_expiration_date_impl(ctx, 4, 99)
+        assert await expiration_task._update_expiration_date_impl(ctx, 5, 2099)
 
-    for invalid_year in (1999, 2100):
-        with pytest.raises(ToolError, match="last two digits or the full four-digit year"):
-            await expiration_task._update_expiration_date_impl(ctx, 5, invalid_year)
+        for invalid_year in (1999, 2100):
+            with pytest.raises(ToolError, match="last two digits or the full four-digit year"):
+                await expiration_task._update_expiration_date_impl(ctx, 5, invalid_year)
+
+
+@pytest.mark.asyncio
+async def test_expiration_year_uses_the_current_century() -> None:
+    task = GetExpirationDateTask(require_confirmation=True)
+
+    with patch.object(task, "_current_date", return_value=date(3000, 1, 1)):
+        assert await task._update_expiration_date_impl(_run_context(), 4, 3000)
+        assert task._expiration_date == "04/00"
+
+        with pytest.raises(ToolError, match="confirm_expiration_date"):
+            await task._update_expiration_date_impl(_run_context(), 4, 0)
+
+        for invalid_year in (2999, 3100):
+            with pytest.raises(ToolError, match="last two digits or the full four-digit year"):
+                await task._update_expiration_date_impl(_run_context(), 4, invalid_year)
 
 
 def test_credit_card_instructions_prohibit_concrete_format_examples() -> None:

--- a/tests/test_credit_card_workflows.py
+++ b/tests/test_credit_card_workflows.py
@@ -212,6 +212,14 @@ def test_credit_card_instructions_prohibit_concrete_format_examples() -> None:
     assert {"update_card_number", "confirm_card_number"}.isdisjoint(tool_ids)
     assert not (tools_by_id["append_card_number"].info.flags & ToolFlag.IGNORE_ON_ENTER)
     assert not (tools_by_id["submit_card_number"].info.flags & ToolFlag.IGNORE_ON_ENTER)
+    for tool_id in ("append_card_number", "submit_card_number"):
+        description = tools_by_id[tool_id].info.description or ""
+        assert "confirmation" not in description.lower()
+
+    assert isinstance(card_number_task.instructions, Instructions)
+    rendered_card_number = card_number_task.instructions.render(modality="audio")
+    assert "during confirmation" not in rendered_card_number.lower()
+    assert "second complete reading" not in rendered_card_number.lower()
 
     explicit_ask_tools = {
         tool.id: tool for tool in GetCardNumberTask(require_explicit_ask=True).tools

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -111,3 +111,35 @@ async def test_get_dtmf_sip_event_with_confirmation() -> None:
             )
 
             assert result.final_output.user_input == "1 2 3 4 5 6 7 8 9 0"
+
+
+@pytest.mark.asyncio
+async def test_collect_card_number_incrementally_with_correction() -> None:
+    from livekit.agents.beta.workflows.credit_card import (
+        GetCardNumberResult,
+        GetCardNumberTask,
+    )
+
+    async with _llm_model() as llm, AgentSession(llm=llm) as sess:
+        await sess.start(GetCardNumberTask(require_confirmation=True))
+
+        for user_input in (
+            "The first group is 4 2 4 2, and I have more digits.",
+            "The next group is 4 2 4 3, and I have more digits.",
+            "Correction: replace the last digit with 2. I still have more digits.",
+            "The next group is 4 2 4 2, and I have one group left.",
+            "The final group is 4 2 4 2. That's the whole number.",
+        ):
+            result = await sess.run(user_input=user_input, input_modality="audio")
+            result.expect.contains_function_call(name="append_card_number")
+
+        result = await sess.run(
+            user_input="Repeating it for confirmation: 4 2 4 2 4 2 4 2 4 2 4 2 4 2 4 2.",
+            output_type=GetCardNumberResult,
+            input_modality="audio",
+        )
+
+        result.expect.contains_function_call(name="append_card_number")
+        assert result.final_output == GetCardNumberResult(
+            issuer="Visa", card_number="4242424242424242"
+        )

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -143,3 +143,26 @@ async def test_collect_card_number_incrementally_with_correction() -> None:
         assert result.final_output == GetCardNumberResult(
             issuer="Visa", card_number="4242424242424242"
         )
+
+
+@pytest.mark.asyncio
+async def test_collect_expiration_month_name_and_two_digit_year() -> None:
+    from livekit.agents.beta.workflows.credit_card import (
+        GetExpirationDateResult,
+        GetExpirationDateTask,
+    )
+
+    async with _llm_model() as llm, AgentSession(llm=llm) as sess:
+        await sess.start(GetExpirationDateTask(require_confirmation=False))
+
+        result = await sess.run(
+            user_input="July 32nd",
+            output_type=GetExpirationDateResult,
+            input_modality="audio",
+        )
+
+        result.expect.contains_function_call(
+            name="update_expiration_date",
+            arguments={"expiration_month": 7, "expiration_year": 32},
+        )
+        assert result.final_output == GetExpirationDateResult(date="07/32")

--- a/uv.lock
+++ b/uv.lock
@@ -133,21 +133,8 @@ typing = [
 ]
 
 [[package]]
-name = "aioboto3"
-version = "15.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiobotocore", extra = ["boto3"] },
-    { name = "aiofiles" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/01/92e9ab00f36e2899315f49eefcd5b4685fbb19016c7f19a9edf06da80bb0/aioboto3-15.5.0.tar.gz", hash = "sha256:ea8d8787d315594842fbfcf2c4dce3bac2ad61be275bc8584b2ce9a3402a6979", size = 255069, upload-time = "2025-10-30T13:37:16.122Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/3e/e8f5b665bca646d43b916763c901e00a07e40f7746c9128bdc912a089424/aioboto3-15.5.0-py3-none-any.whl", hash = "sha256:cc880c4d6a8481dd7e05da89f41c384dbd841454fc1998ae25ca9c39201437a6", size = 35913, upload-time = "2025-10-30T13:37:14.549Z" },
-]
-
-[[package]]
 name = "aiobotocore"
-version = "2.25.1"
+version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -158,14 +145,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/94/2e4ec48cf1abb89971cb2612d86f979a6240520f0a659b53a43116d344dc/aiobotocore-2.25.1.tar.gz", hash = "sha256:ea9be739bfd7ece8864f072ec99bb9ed5c7e78ebb2b0b15f29781fbe02daedbc", size = 120560, upload-time = "2025-10-28T22:33:21.787Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/a7/bc31b7046c610471f0630819ca5d2a57ac4efa8d47135cb53e43f2785390/aiobotocore-3.8.0.tar.gz", hash = "sha256:80a1eb64ea915f3af3c1518669975bae74a17b2f37c14eb0fa2f83b915974670", size = 131368, upload-time = "2026-07-17T03:10:30.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/2a/d275ec4ce5cd0096665043995a7d76f5d0524853c76a3d04656de49f8808/aiobotocore-2.25.1-py3-none-any.whl", hash = "sha256:eb6daebe3cbef5b39a0bb2a97cffbe9c7cb46b2fcc399ad141f369f3c2134b1f", size = 86039, upload-time = "2025-10-28T22:33:19.949Z" },
-]
-
-[package.optional-dependencies]
-boto3 = [
-    { name = "boto3" },
+    { url = "https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl", hash = "sha256:8bc605132cadfe844a3f334635a0a64fa5e360a4a206e915d99d53db5b6deeba", size = 91169, upload-time = "2026-07-17T03:10:28.771Z" },
 ]
 
 [[package]]
@@ -582,30 +564,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.40.61"
+version = "1.43.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/f9/6ef8feb52c3cce5ec3967a535a6114b57ac7949fd166b0f3090c2b06e4e5/boto3-1.40.61.tar.gz", hash = "sha256:d6c56277251adf6c2bdd25249feae625abe4966831676689ff23b4694dea5b12", size = 111535, upload-time = "2025-10-28T19:26:57.247Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/e7/976bf3dfe0aa5d7f31bec2f2cf57c79641620c910a39bc843a237aa9592d/boto3-1.43.46.tar.gz", hash = "sha256:66c0d943b049a46a492ec4ec2ebe73c930b1842c7137bee83aad6d93e95d4d96", size = 112654, upload-time = "2026-07-10T19:32:12.498Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/24/3bf865b07d15fea85b63504856e137029b6acbc73762496064219cdb265d/boto3-1.40.61-py3-none-any.whl", hash = "sha256:6b9c57b2a922b5d8c17766e29ed792586a818098efe84def27c8f582b33f898c", size = 139321, upload-time = "2025-10-28T19:26:55.007Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl", hash = "sha256:69453e2c1bcb9fd9806527ab99950cacfc2826cb0dce9a3a0414d19270c06c3c", size = 140031, upload-time = "2026-07-10T19:32:11.129Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.40.61"
+version = "1.43.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/a3/81d3a47c2dbfd76f185d3b894f2ad01a75096c006a2dd91f237dca182188/botocore-1.40.61.tar.gz", hash = "sha256:a2487ad69b090f9cccd64cf07c7021cd80ee9c0655ad974f87045b02f3ef52cd", size = 14393956, upload-time = "2025-10-28T19:26:46.108Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/f1/1917891851ac5ac09bb9f4862b8fc9252a009d7c24e8688bb67e4383d9e7/botocore-1.43.46.tar.gz", hash = "sha256:59f2e1ac3cdc66d191cae91c0804bc41847ce817dc8147cf43eaada8f76a5533", size = 15694635, upload-time = "2026-07-10T19:32:00.437Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/c5/f6ce561004db45f0b847c2cd9b19c67c6bf348a82018a48cb718be6b58b0/botocore-1.40.61-py3-none-any.whl", hash = "sha256:17ebae412692fd4824f99cde0f08d50126dc97954008e5ba2b522eb049238aa7", size = 14055973, upload-time = "2025-10-28T19:26:42.15Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f2/4bd8f2f419088feb3ce55f0ca91040ff902f402edfd197450b20a2e1d533/botocore-1.43.46-py3-none-any.whl", hash = "sha256:cb673891e623ae6e6a1bf24d94ef169504f3eb02584adb5d5bee2f6aae819b60", size = 15380350, upload-time = "2026-07-10T19:31:57.616Z" },
 ]
 
 [[package]]
@@ -2297,7 +2279,7 @@ requires-dist = [{ name = "livekit-agents", editable = "livekit-agents" }]
 name = "livekit-plugins-aws"
 source = { editable = "livekit-plugins/livekit-plugins-aws" }
 dependencies = [
-    { name = "aioboto3" },
+    { name = "aiobotocore" },
     { name = "aws-sdk-transcribe-streaming" },
     { name = "livekit-agents" },
 ]
@@ -2311,7 +2293,7 @@ realtime = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aioboto3", specifier = ">=14.1.0" },
+    { name = "aiobotocore", specifier = ">=3.0.0" },
     { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12' and extra == 'realtime'", specifier = ">=0.2.0" },
     { name = "aws-sdk-signers", marker = "python_full_version >= '3.12' and extra == 'realtime'", specifier = ">=0.0.3" },
     { name = "aws-sdk-transcribe-streaming", marker = "python_full_version >= '3.12'", specifier = ">=0.2.0" },
@@ -2548,7 +2530,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "livekit-agents", extras = ["codecs"], editable = "livekit-agents" },
-    { name = "websockets", specifier = ">=12.0,<16.0" },
+    { name = "websockets", specifier = ">=14.0,<16.0" },
 ]
 
 [[package]]
@@ -4951,14 +4933,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.14.0"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354, upload-time = "2026-07-10T19:32:04.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/f0/ae7ca09223a81a1d890b2557186ea015f6e0502e9b8cb8e1813f1d8cfa4e/s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456", size = 85712, upload-time = "2025-09-09T19:23:30.041Z" },
+    { url = "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl", hash = "sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de", size = 90072, upload-time = "2026-07-10T19:32:03.673Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Card-number groups were previously buffered in model context, so partial tool calls lost digits and polluted confirmation state. This moves accumulation and suffix correction into the task, reuses append/submit for confirmation, and makes expiration/security confirmation routing explicit.

**Known limitation:** tool choice remains automatic. Prompt guidance reduces but cannot eliminate a text-only model response leaving confirmation pending, so AGT-3140 remains open for deterministic recovery.

Fixes AGT-3139
Fixes AGT-3141
Related to AGT-3140
Supersedes #6447 and #6448