### PR TITLE
Support adaptive interruption for realtime models

### DIFF
--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -136,6 +136,13 @@ class OverlappingSpeechEvent(BaseModel):
     is_interruption: bool = False
     """Whether interruption is detected."""
 
+    agent_ended: bool = False
+    """True when the overlap ended because the agent finished speaking rather than the user.
+
+    The user may still be talking, so ``is_interruption`` (always ``False`` here) is inconclusive
+    and must not be treated as a confirmed backchannel verdict.
+    """
+
     total_duration: float = 0.0
     """RTT (Round Trip Time) time taken to perform the inference, in seconds."""
 
@@ -180,6 +187,7 @@ class OverlappingSpeechEvent(BaseModel):
         is_interruption: bool,
         started_at: float | None = None,
         ended_at: float | None = None,
+        agent_ended: bool = False,
     ) -> OverlappingSpeechEvent:
         """Initialize the event from a cache entry.
 
@@ -188,6 +196,7 @@ class OverlappingSpeechEvent(BaseModel):
             is_interruption: Whether the interruption is detected.
             started_at: The timestamp when the overlap speech started.
             ended_at: The timestamp when the overlap speech ended.
+            agent_ended: Whether the overlap ended because the agent finished speaking.
 
         Returns:
             The initialized event.
@@ -196,6 +205,7 @@ class OverlappingSpeechEvent(BaseModel):
             type="overlapping_speech",
             detected_at=ended_at or time.time(),
             is_interruption=is_interruption,
+            agent_ended=agent_ended,
             overlap_started_at=started_at,
             speech_input=entry.speech_input,
             probabilities=entry.probabilities,
@@ -232,8 +242,9 @@ class _OverlapSpeechStartedSentinel:
 
 
 class _OverlapSpeechEndedSentinel:
-    def __init__(self, ended_at: float) -> None:
+    def __init__(self, ended_at: float, agent_ended: bool = False) -> None:
         self._ended_at = ended_at
+        self._agent_ended = agent_ended
 
 
 class _FlushSentinel:
@@ -623,6 +634,7 @@ class InterruptionStreamBase(ABC):
                             is_interruption=False,
                             started_at=self._overlap_started_at,
                             ended_at=input_frame._ended_at,
+                            agent_ended=input_frame._agent_ended,
                         )
                         ev.num_requests = await self._num_requests.get_and_reset()
                         self.send(ev)

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -245,6 +245,9 @@ class AgentActivity(RecognitionHooks):
         )
         self._interruption_detection_enabled: bool = self._interruption_detector is not None
         self._interruption_detected: bool = False
+        # backchannel verdict for the turn's overlap; unlike _interruption_detected it
+        # survives the agent stopping, so a late-ending backchannel is still dropped
+        self._backchannel_detected: bool = False
 
         # this allows taking over audio interruption temporarily until interruption is detected
         # by default it is true unless turn_detection is manual or realtime_llm
@@ -1798,10 +1801,18 @@ class AgentActivity(RecognitionHooks):
         self._session._on_error(error)
 
     def _on_overlap_speech_ended(self, ev: inference.OverlappingSpeechEvent) -> None:
-        if ev.is_interruption:
-            self._interruption_detected = True
-        else:
-            self._interruption_detected = False
+        self._interruption_detected = ev.is_interruption
+        self._backchannel_detected = not ev.is_interruption
+
+        # clear rt_session's audio buffer when backchannel if the server-side turn detection is disabled
+        if (
+            not ev.is_interruption
+            and isinstance(self.llm, llm.RealtimeModel)
+            and not self.llm.capabilities.turn_detection
+            and self._rt_session
+        ):
+            self._rt_session.clear_audio()
+
         self._session.emit("overlapping_speech", ev)
 
     def _on_input_speech_started(self, _: llm.InputSpeechStartedEvent) -> None:
@@ -1985,6 +1996,7 @@ class AgentActivity(RecognitionHooks):
         self._user_silence_event.clear()
         self._stt_eos_received = False
         self._interruption_detected = False
+        self._backchannel_detected = False
 
         if self._false_interruption_timer:
             # cancel the timer when user starts speaking but leave the paused state unchanged
@@ -2224,6 +2236,7 @@ class AgentActivity(RecognitionHooks):
             # TODO(theomonnom): should we "forward" this new turn to the next agent/activity?
             return True
 
+        # avoid interruption if the new_transcript is too short
         if (
             self.stt is not None
             and self._turn_detection != "manual"
@@ -2235,7 +2248,28 @@ class AgentActivity(RecognitionHooks):
             < self._session.options.interruption["min_words"]
         ):
             self._cancel_preemptive_generation()
-            # avoid interruption if the new_transcript is too short
+            return False
+
+        # avoid interruption if backchannel is detected with realtime model
+        if (
+            self.stt is None
+            and self._turn_detection != "manual"
+            and isinstance(self.llm, llm.RealtimeModel)
+            and not self.llm.capabilities.turn_detection
+            and self._interruption_detection_enabled
+            and (
+                # confirmed backchannel (survives the agent stopping)
+                self._backchannel_detected
+                # or agent still speaking with nothing flagged yet
+                or (
+                    not self._interruption_detected
+                    and self._current_speech is not None
+                    and not self._current_speech.interrupted
+                )
+            )
+        ):
+            self._cancel_preemptive_generation()
+            # no transcript to gatekeep for realtime barge-in — drop the backchannel turn
             return False
 
         old_task = self._user_turn_completed_atask

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -4303,13 +4303,22 @@ class AgentActivity(RecognitionHooks):
         return self._session._using_default_vad
 
     def _resolve_interruption_detection(self) -> inference.AdaptiveInterruptionDetector | None:
-        if not (
-            self.stt is not None
-            and self.stt.capabilities.aligned_transcript
-            and self.stt.capabilities.streaming
-            and self.vad is not None
-            and self._turn_detection not in ("manual", "realtime_llm")
-            and not isinstance(self.llm, llm.RealtimeModel)
+        realtime_llm = self.llm if isinstance(self.llm, llm.RealtimeModel) else None
+        if realtime_llm is not None:
+            # realtime commits turns manually; barge-in withholds the commit, so no STT is needed
+            can_gatekeep = not realtime_llm.capabilities.turn_detection
+        else:
+            # the STT pipeline gatekeeps by holding and flushing transcripts
+            can_gatekeep = (
+                self.stt is not None
+                and self.stt.capabilities.aligned_transcript
+                and self.stt.capabilities.streaming
+            )
+
+        if (
+            not can_gatekeep
+            or self.vad is None
+            or self._turn_detection in ("manual", "realtime_llm")
         ):
             if (
                 is_given(self._agent.interruption_detection)

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -245,9 +245,6 @@ class AgentActivity(RecognitionHooks):
         )
         self._interruption_detection_enabled: bool = self._interruption_detector is not None
         self._interruption_detected: bool = False
-        # backchannel verdict for the turn's overlap; unlike _interruption_detected it
-        # survives the agent stopping, so a late-ending backchannel is still dropped
-        self._backchannel_detected: bool = False
 
         # this allows taking over audio interruption temporarily until interruption is detected
         # by default it is true unless turn_detection is manual or realtime_llm
@@ -1802,17 +1799,6 @@ class AgentActivity(RecognitionHooks):
 
     def _on_overlap_speech_ended(self, ev: inference.OverlappingSpeechEvent) -> None:
         self._interruption_detected = ev.is_interruption
-        self._backchannel_detected = not ev.is_interruption
-
-        # clear rt_session's audio buffer when backchannel if the server-side turn detection is disabled
-        if (
-            not ev.is_interruption
-            and isinstance(self.llm, llm.RealtimeModel)
-            and not self.llm.capabilities.turn_detection
-            and self._rt_session
-        ):
-            self._rt_session.clear_audio()
-
         self._session.emit("overlapping_speech", ev)
 
     def _on_input_speech_started(self, _: llm.InputSpeechStartedEvent) -> None:
@@ -1996,7 +1982,6 @@ class AgentActivity(RecognitionHooks):
         self._user_silence_event.clear()
         self._stt_eos_received = False
         self._interruption_detected = False
-        self._backchannel_detected = False
 
         if self._false_interruption_timer:
             # cancel the timer when user starts speaking but leave the paused state unchanged
@@ -2258,8 +2243,8 @@ class AgentActivity(RecognitionHooks):
             and not self.llm.capabilities.turn_detection
             and self._interruption_detection_enabled
             and (
-                # confirmed backchannel (survives the agent stopping)
-                self._backchannel_detected
+                # confirmed backchannel for this turn (survives the agent stopping)
+                info.backchannel_over_agent
                 # or agent still speaking with nothing flagged yet
                 or (
                     not self._interruption_detected
@@ -2270,6 +2255,9 @@ class AgentActivity(RecognitionHooks):
         ):
             self._cancel_preemptive_generation()
             # no transcript to gatekeep for realtime barge-in — drop the backchannel turn
+            # and clear the buffered audio so it can't leak into the next committed turn
+            if self._rt_session is not None:
+                self._rt_session.clear_audio()
             return False
 
         old_task = self._user_turn_completed_atask

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2054,6 +2054,15 @@ class AgentActivity(RecognitionHooks):
         else:
             self._user_silence_event.set()
 
+    def on_backchannel_confirmed(self) -> None:
+        # clear the buffered backchannel audio so it can't prefix the next committed turn
+        if (
+            self._interruption_detection_enabled
+            and self._rt_session is not None
+            and self._turn_detection not in ("manual", "realtime_llm")
+        ):
+            self._rt_session.clear_audio()
+
     def on_interruption(self, ev: inference.OverlappingSpeechEvent) -> None:
         # restore interruption by audio activity and then immediately interrupt
         self._restore_interruption_by_audio_activity()

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -478,7 +478,7 @@ class AudioRecognition:
         if self._agent_speaking:
             # no interruption is detected, end the inference (idempotent)
             if not is_given(self._ignore_user_transcript_until):
-                self._on_end_of_overlap_speech(ended_at=time.time())
+                self._on_end_of_overlap_speech(ended_at=time.time(), agent_ended=True)
 
             end_cooldown: float = (
                 self._backchannel_boundary[1] if self._backchannel_boundary else 0.0
@@ -550,8 +550,14 @@ class AudioRecognition:
         self,
         ended_at: float,
         user_speaking_span: trace.Span | None = None,
+        agent_ended: bool = False,
     ) -> None:
-        """End interruption inference when agent is speaking and overlap speech ends."""
+        """End interruption inference when agent is speaking and overlap speech ends.
+
+        agent_ended is True when the overlap is force-ended because the agent finished
+        speaking (the user may still be talking), in which case the synthesized verdict
+        is inconclusive and must not be treated as a confirmed backchannel.
+        """
         if not self._adaptive_interruption_active or not self._agent_speaking:
             return
 
@@ -567,7 +573,7 @@ class AudioRecognition:
                 user_speaking_span.set_attribute(trace_types.ATTR_IS_INTERRUPTION, "false")
 
         self._interruption_ch.send_nowait(  # type: ignore[union-attr]
-            _OverlapSpeechEndedSentinel(ended_at=ended_at or time.time())
+            _OverlapSpeechEndedSentinel(ended_at=ended_at or time.time(), agent_ended=agent_ended)
         )
 
     @property
@@ -1395,7 +1401,7 @@ class AudioRecognition:
 
         # only honor the verdict while this turn's overlap is unresolved so a late verdict
         # can't leak into the next turn; an interruption supersedes a prior backchannel
-        if self._overlap_in_current_turn:
+        if self._overlap_in_current_turn and not ev.agent_ended:
             self._turn_backchannel_over_agent = not ev.is_interruption
 
         if ev.is_interruption:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -133,6 +133,7 @@ class _UserTurnTracker:
 
 class RecognitionHooks(Protocol):
     def on_interruption(self, ev: inference.OverlappingSpeechEvent) -> None: ...
+    def on_backchannel_confirmed(self) -> None: ...
     def on_start_of_speech(self, ev: vad.VADEvent | None, speech_start_time: float) -> None: ...
     def on_vad_inference_done(self, ev: vad.VADEvent) -> None: ...
     def on_end_of_speech(self, ev: vad.VADEvent | None) -> None: ...
@@ -1403,6 +1404,9 @@ class AudioRecognition:
         # can't leak into the next turn; an interruption supersedes a prior backchannel
         if self._overlap_in_current_turn and not ev.agent_ended:
             self._turn_backchannel_over_agent = not ev.is_interruption
+            # clear the backchannel audio, but only between segments — else we'd clip a real turn
+            if not ev.is_interruption and not self._speaking:
+                self._hooks.on_backchannel_confirmed()
 
         if ev.is_interruption:
             self._hooks.on_interruption(ev)

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -72,6 +72,8 @@ class _EndOfTurnInfo:
     new_transcript: str
     transcript_confidence: float
     metrics: _EndOfTurnMetrics
+    backchannel_over_agent: bool = False
+    """The turn's speech overlapped agent speech and was classified a backchannel by adaptive interruption."""
 
 
 def _compute_end_of_turn_metrics(
@@ -293,6 +295,9 @@ class AudioRecognition:
         self._interruption_enabled: bool = interruption_detection is not None and vad is not None
         self._agent_speaking: bool = False
         self._agent_speech_started_at: float | None = None
+        # turn-scoped backchannel-over-agent verdict from adaptive interruption, consumed and reset at end of turn
+        self._overlap_in_current_turn: bool = False
+        self._turn_backchannel_over_agent: bool = False
 
         _backchannel_boundary: float | tuple[float, float] | None = (
             session.options.interruption.get("backchannel_boundary")
@@ -511,6 +516,8 @@ class AudioRecognition:
         )
         if not self._adaptive_interruption_active or not self._agent_speaking:
             return
+        # overlap over agent speech started this turn; gates verdict acceptance below
+        self._overlap_in_current_turn = True
         self._interruption_ch.send_nowait(  # type: ignore[union-attr]
             _OverlapSpeechStartedSentinel(
                 speech_duration=speech_duration,
@@ -1381,6 +1388,11 @@ class AudioRecognition:
             )
             return
 
+        # only honor the verdict while this turn's overlap is unresolved so a late verdict
+        # can't leak into the next turn; an interruption supersedes a prior backchannel
+        if self._overlap_in_current_turn:
+            self._turn_backchannel_over_agent = not ev.is_interruption
+
         if ev.is_interruption:
             self._hooks.on_interruption(ev)
 
@@ -1629,6 +1641,7 @@ class AudioRecognition:
                     new_transcript=self._audio_transcript,
                     transcript_confidence=confidence_avg,
                     metrics=metrics,
+                    backchannel_over_agent=self._turn_backchannel_over_agent,
                 )
             )
             if committed:
@@ -1677,6 +1690,9 @@ class AudioRecognition:
                     self._turn_detector_prediction_fut = None
                     self._turn_detector_flushed = True
 
+            # reset turn-scoped barge-in state once per logical turn (commit or drop)
+            self._turn_backchannel_over_agent = False
+            self._overlap_in_current_turn = False
             self._user_turn_committed = False
 
         if self._end_of_turn_task is not None:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -514,6 +514,11 @@ class AudioRecognition:
         self._endpointing.on_start_of_speech(
             started_at=started_at, overlapping=self._agent_speaking
         )
+        if not self._agent_speaking:
+            # non-overlapping speech drops a stale backchannel verdict
+            self._turn_backchannel_over_agent = False
+            self._overlap_in_current_turn = False
+
         if not self._adaptive_interruption_active or not self._agent_speaking:
             return
         # overlap over agent speech started this turn; gates verdict acceptance below

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -514,9 +514,9 @@ class AudioRecognition:
         self._endpointing.on_start_of_speech(
             started_at=started_at, overlapping=self._agent_speaking
         )
+        # every speech onset clears the prior backchannel verdict; an overlap re-derives it below
+        self._turn_backchannel_over_agent = False
         if not self._agent_speaking:
-            # non-overlapping speech drops a stale backchannel verdict
-            self._turn_backchannel_over_agent = False
             self._overlap_in_current_turn = False
 
         if not self._adaptive_interruption_active or not self._agent_speaking:

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -1777,6 +1777,9 @@ class _TestRecognitionHooks:
     def on_interruption(self, ev: inference.OverlappingSpeechEvent) -> None:
         self.interruptions.append(ev)
 
+    def on_backchannel_confirmed(self) -> None:
+        pass
+
     def on_start_of_speech(self, ev: object, speech_start_time: float) -> None:
         pass
 

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents import Agent, AgentSession, TurnHandlingOptions
+from livekit.agents.voice.agent_activity import AgentActivity
+
+from .fake_llm import FakeLLM
+from .fake_realtime import FakeRealtimeModel, fake_capabilities
+from .fake_vad import FakeVAD
+
+pytestmark = pytest.mark.unit
+
+
+def _make_activity(session: AgentSession) -> AgentActivity:
+    return AgentActivity(Agent(instructions="test"), session)
+
+
+async def test_adaptive_interruption_enabled_for_realtime_without_stt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # a realtime model with server-side turn detection off transcribes internally and
+    # commits turns manually, so barge-in gatekeeps by withholding commit rather than
+    # holding STT transcripts — no separate STT is required
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    session = AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(turn_detection=False)),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(
+            turn_detection="vad",
+            interruption={"mode": "adaptive"},
+        ),
+    )
+
+    activity = _make_activity(session)
+
+    assert activity._interruption_detection_enabled is True
+    assert activity._interruption_detector is not None
+
+
+async def test_adaptive_interruption_still_requires_stt_for_non_realtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # the STT pipeline path is unchanged: without an aligned streaming STT there is
+    # nothing to gatekeep, so adaptive interruption stays disabled
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    session = AgentSession(
+        llm=FakeLLM(fake_responses=[]),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(
+            turn_detection="vad",
+            interruption={"mode": "adaptive"},
+        ),
+    )
+
+    activity = _make_activity(session)
+
+    assert activity._interruption_detection_enabled is False
+    assert activity._interruption_detector is None
+
+
+async def test_adaptive_interruption_disabled_for_realtime_with_server_turn_detection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # server-side turn detection creates turns automatically, so client-side barge-in
+    # cannot take over — it stays disabled even for a realtime model
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    session = AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(turn_detection=True)),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(interruption={"mode": "adaptive"}),
+    )
+
+    activity = _make_activity(session)
+
+    assert activity._interruption_detection_enabled is False
+    assert activity._interruption_detector is None

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -19,7 +19,9 @@ def _make_activity(session: AgentSession) -> AgentActivity:
     return AgentActivity(Agent(instructions="test"), session)
 
 
-def _end_of_turn_info(transcript: str = "") -> _EndOfTurnInfo:
+def _end_of_turn_info(
+    transcript: str = "", *, backchannel_over_agent: bool = False
+) -> _EndOfTurnInfo:
     return _EndOfTurnInfo(
         skip_reply=False,
         new_transcript=transcript,
@@ -30,6 +32,7 @@ def _end_of_turn_info(transcript: str = "") -> _EndOfTurnInfo:
             transcription_delay=None,
             end_of_turn_delay=None,
         ),
+        backchannel_over_agent=backchannel_over_agent,
     )
 
 
@@ -119,9 +122,9 @@ async def test_backchannel_does_not_commit_while_agent_speaking(
     current_speech.interrupted = False
     activity._current_speech = current_speech
     activity._interruption_detected = False
-    activity._backchannel_detected = False  # verdict pending, agent still speaking
 
-    assert activity.on_end_of_turn(_end_of_turn_info()) is False
+    # verdict pending, agent still speaking — dropped via the live-speech branch
+    assert activity.on_end_of_turn(_end_of_turn_info(backchannel_over_agent=False)) is False
 
 
 async def test_backchannel_dropped_after_agent_finishes_speaking(
@@ -137,6 +140,6 @@ async def test_backchannel_dropped_after_agent_finishes_speaking(
 
     activity._current_speech = None  # agent has finished speaking
     activity._interruption_detected = False
-    activity._backchannel_detected = True
 
-    assert activity.on_end_of_turn(_end_of_turn_info()) is False
+    # backchannel verdict for this turn survives the agent stopping
+    assert activity.on_end_of_turn(_end_of_turn_info(backchannel_over_agent=True)) is False

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -15,6 +16,7 @@ from livekit.agents.voice.audio_recognition import (
 
 from .fake_llm import FakeLLM
 from .fake_realtime import FakeRealtimeModel, fake_capabilities
+from .fake_stt import FakeSTT
 from .fake_vad import FakeVAD
 
 pytestmark = pytest.mark.unit
@@ -151,11 +153,55 @@ async def test_backchannel_dropped_after_agent_finishes_speaking(
     assert activity.on_end_of_turn(_end_of_turn_info(backchannel_over_agent=True)) is False
 
 
-def _recognition_for_overlap() -> AudioRecognition:
+async def test_backchannel_confirmed_clears_rt_audio_even_with_stt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # a realtime session buffers input even with an STT attached, so the clear isn't stt-gated
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    session = AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(turn_detection=False)),
+        stt=FakeSTT(),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(
+            turn_detection="vad",
+            interruption={"mode": "adaptive"},
+        ),
+    )
+    activity = _make_activity(session)
+    assert activity.stt is not None
+    activity._rt_session = MagicMock()
+
+    activity.on_backchannel_confirmed()
+
+    activity._rt_session.clear_audio.assert_called_once()
+
+
+async def test_backchannel_confirmed_noop_when_barge_in_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # a late event after barge-in was disabled must not clear the buffer
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    activity = _make_activity(_realtime_barge_in_session())
+    activity._interruption_detection_enabled = False
+    activity._rt_session = MagicMock()
+
+    activity.on_backchannel_confirmed()
+
+    activity._rt_session.clear_audio.assert_not_called()
+
+
+def _recognition_for_overlap(*, speaking: bool = False) -> AudioRecognition:
     ar = AudioRecognition.__new__(AudioRecognition)
     ar._backchannel_boundary_timer = None
     ar._overlap_in_current_turn = True
     ar._turn_backchannel_over_agent = False
+    ar._user_silence_ev = asyncio.Event()
+    if not speaking:
+        ar._user_silence_ev.set()  # silent (between segments) unless told otherwise
     ar._hooks = MagicMock()
     return ar
 
@@ -171,12 +217,28 @@ async def test_user_ended_overlap_latches_backchannel() -> None:
     assert ar._turn_backchannel_over_agent is True
 
 
+async def test_confirmed_backchannel_between_segments_clears_audio() -> None:
+    # confirmed between segments (user silent) — cleared so it can't prefix the next turn
+    ar = _recognition_for_overlap(speaking=False)
+    await ar._on_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=False))
+    ar._hooks.on_backchannel_confirmed.assert_called_once()
+
+
+async def test_confirmed_backchannel_while_speaking_defers_clear() -> None:
+    # user already mid next-segment — latch the verdict but defer the clear (else we'd clip it)
+    ar = _recognition_for_overlap(speaking=True)
+    await ar._on_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=False))
+    assert ar._turn_backchannel_over_agent is True
+    ar._hooks.on_backchannel_confirmed.assert_not_called()
+
+
 async def test_agent_ended_overlap_is_not_a_backchannel() -> None:
     # the overlap ended because the agent finished, not the user — the user may still be
     # mid-turn, so this inconclusive verdict must not mark the turn a backchannel
     ar = _recognition_for_overlap()
     await ar._on_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=True))
     assert ar._turn_backchannel_over_agent is False
+    ar._hooks.on_backchannel_confirmed.assert_not_called()
 
 
 async def test_agent_ended_overlap_preserves_prior_backchannel() -> None:
@@ -195,3 +257,4 @@ async def test_interruption_clears_backchannel() -> None:
     await ar._on_overlap_speech_event(_overlap_event(is_interruption=True, agent_ended=False))
     assert ar._turn_backchannel_over_agent is False
     ar._hooks.on_interruption.assert_called_once()
+    ar._hooks.on_backchannel_confirmed.assert_not_called()

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from livekit.agents import Agent, AgentSession, TurnHandlingOptions
 from livekit.agents.voice.agent_activity import AgentActivity
+from livekit.agents.voice.audio_recognition import _EndOfTurnInfo, _EndOfTurnMetrics
 
 from .fake_llm import FakeLLM
 from .fake_realtime import FakeRealtimeModel, fake_capabilities
@@ -16,6 +19,31 @@ def _make_activity(session: AgentSession) -> AgentActivity:
     return AgentActivity(Agent(instructions="test"), session)
 
 
+def _end_of_turn_info(transcript: str = "") -> _EndOfTurnInfo:
+    return _EndOfTurnInfo(
+        skip_reply=False,
+        new_transcript=transcript,
+        transcript_confidence=0.0,
+        metrics=_EndOfTurnMetrics(
+            started_speaking_at=None,
+            stopped_speaking_at=None,
+            transcription_delay=None,
+            end_of_turn_delay=None,
+        ),
+    )
+
+
+def _realtime_barge_in_session() -> AgentSession:
+    return AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(turn_detection=False)),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(
+            turn_detection="vad",
+            interruption={"mode": "adaptive"},
+        ),
+    )
+
+
 async def test_adaptive_interruption_enabled_for_realtime_without_stt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -25,16 +53,7 @@ async def test_adaptive_interruption_enabled_for_realtime_without_stt(
     monkeypatch.setenv("LIVEKIT_API_KEY", "k")
     monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
 
-    session = AgentSession(
-        llm=FakeRealtimeModel(capabilities=fake_capabilities(turn_detection=False)),
-        vad=FakeVAD(fake_user_speeches=[]),
-        turn_handling=TurnHandlingOptions(
-            turn_detection="vad",
-            interruption={"mode": "adaptive"},
-        ),
-    )
-
-    activity = _make_activity(session)
+    activity = _make_activity(_realtime_barge_in_session())
 
     assert activity._interruption_detection_enabled is True
     assert activity._interruption_detector is not None
@@ -81,3 +100,43 @@ async def test_adaptive_interruption_disabled_for_realtime_with_server_turn_dete
 
     assert activity._interruption_detection_enabled is False
     assert activity._interruption_detector is None
+
+
+async def test_backchannel_does_not_commit_while_agent_speaking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # the turn overlapped agent speech and no interruption was flagged, so it's a
+    # backchannel and must not commit a user turn
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    activity = _make_activity(_realtime_barge_in_session())
+    activity._scheduling_paused = False  # simulate a running session
+    assert activity._interruption_detection_enabled is True
+
+    current_speech = MagicMock()
+    current_speech.done.return_value = False
+    current_speech.interrupted = False
+    activity._current_speech = current_speech
+    activity._interruption_detected = False
+    activity._backchannel_detected = False  # verdict pending, agent still speaking
+
+    assert activity.on_end_of_turn(_end_of_turn_info()) is False
+
+
+async def test_backchannel_dropped_after_agent_finishes_speaking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # same backchannel, but the agent finished before the user stopped — the backchannel
+    # verdict survives, so the turn is still dropped with no live speech to key off
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    activity = _make_activity(_realtime_barge_in_session())
+    activity._scheduling_paused = False  # simulate a running session
+
+    activity._current_speech = None  # agent has finished speaking
+    activity._interruption_detected = False
+    activity._backchannel_detected = True
+
+    assert activity.on_end_of_turn(_end_of_turn_info()) is False

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -5,8 +5,13 @@ from unittest.mock import MagicMock
 import pytest
 
 from livekit.agents import Agent, AgentSession, TurnHandlingOptions
+from livekit.agents.inference import OverlappingSpeechEvent
 from livekit.agents.voice.agent_activity import AgentActivity
-from livekit.agents.voice.audio_recognition import _EndOfTurnInfo, _EndOfTurnMetrics
+from livekit.agents.voice.audio_recognition import (
+    AudioRecognition,
+    _EndOfTurnInfo,
+    _EndOfTurnMetrics,
+)
 
 from .fake_llm import FakeLLM
 from .fake_realtime import FakeRealtimeModel, fake_capabilities
@@ -130,8 +135,9 @@ async def test_backchannel_does_not_commit_while_agent_speaking(
 async def test_backchannel_dropped_after_agent_finishes_speaking(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # same backchannel, but the agent finished before the user stopped — the backchannel
-    # verdict survives, so the turn is still dropped with no live speech to key off
+    # the user finished the backchannel first (verdict latched), then the agent finished —
+    # the backchannel verdict survives to end of turn, so the turn is still dropped with no
+    # live speech to key off
     monkeypatch.setenv("LIVEKIT_API_KEY", "k")
     monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
 
@@ -143,3 +149,49 @@ async def test_backchannel_dropped_after_agent_finishes_speaking(
 
     # backchannel verdict for this turn survives the agent stopping
     assert activity.on_end_of_turn(_end_of_turn_info(backchannel_over_agent=True)) is False
+
+
+def _recognition_for_overlap() -> AudioRecognition:
+    ar = AudioRecognition.__new__(AudioRecognition)
+    ar._backchannel_boundary_timer = None
+    ar._overlap_in_current_turn = True
+    ar._turn_backchannel_over_agent = False
+    ar._hooks = MagicMock()
+    return ar
+
+
+def _overlap_event(*, is_interruption: bool, agent_ended: bool) -> OverlappingSpeechEvent:
+    return OverlappingSpeechEvent(is_interruption=is_interruption, agent_ended=agent_ended)
+
+
+async def test_user_ended_overlap_latches_backchannel() -> None:
+    # the user's overlap ended on its own with no interruption flagged — a real backchannel
+    ar = _recognition_for_overlap()
+    await ar._on_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=False))
+    assert ar._turn_backchannel_over_agent is True
+
+
+async def test_agent_ended_overlap_is_not_a_backchannel() -> None:
+    # the overlap ended because the agent finished, not the user — the user may still be
+    # mid-turn, so this inconclusive verdict must not mark the turn a backchannel
+    ar = _recognition_for_overlap()
+    await ar._on_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=True))
+    assert ar._turn_backchannel_over_agent is False
+
+
+async def test_agent_ended_overlap_preserves_prior_backchannel() -> None:
+    # a real backchannel was already latched this turn; the later agent-ended overlap is a
+    # no-op and must not clear it
+    ar = _recognition_for_overlap()
+    ar._turn_backchannel_over_agent = True
+    await ar._on_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=True))
+    assert ar._turn_backchannel_over_agent is True
+
+
+async def test_interruption_clears_backchannel() -> None:
+    # a confirmed interruption supersedes any prior backchannel verdict for the turn
+    ar = _recognition_for_overlap()
+    ar._turn_backchannel_over_agent = True
+    await ar._on_overlap_speech_event(_overlap_event(is_interruption=True, agent_ended=False))
+    assert ar._turn_backchannel_over_agent is False
+    ar._hooks.on_interruption.assert_called_once()


### PR DESCRIPTION
Enables client-side adaptive interruption (barge-in) for OpenAI-compatible realtime models when the model's own server-side turn detection is disabled — so a backchannel ("uh-huh") while the agent is speaking doesn't trigger a spurious reply, without requiring a separate STT.

**The gate.** With no STT there's no transcript to gatekeep, so the audio recognition layer tracks a turn-scoped signal — whether the turn's speech overlapped agent speech and was classified a backchannel — and surfaces it on the end-of-turn info. When set, the user turn is dropped and the buffered input audio is cleared, so no reply is generated.

**Difference from the STT gate.** The STT path is timestamp-windowed: it drops the backchannel portion of a turn and re-emits the rest. Realtime is all-or-nothing — `clear_audio()` wipes the whole input buffer and the model buffers the turn as one unit, so there's no per-timestamp split. It's correct for the dominant cases (pure backchannel, real interruption) and drops only on a confirmed backchannel; a slow verdict after the agent has stopped falls back to committing rather than silently dropping a possible real barge-in.

**STT + realtime.** If you want the finer-grained STT gate, pass an STT alongside the realtime model — the realtime drop path is skipped when an STT is present and transcript-based backchanneling takes over.
