### PR TITLE
feat(inference): add inference.AvatarSession (avatar provisioning via the gateway)

### DIFF
--- a/examples/avatar/README.md
+++ b/examples/avatar/README.md
@@ -7,6 +7,14 @@ all change without dropping the call.
 
 Try it in the [LiveKit Playground](https://agents.livekit.io/?example=avatar).
 
+> **Inference variant:** [`inference_agent.py`](./inference_agent.py) is a
+> minimal version that provisions the avatar through **LiveKit Inference**
+> instead of the BYOK plugin — the agent needs only `LIVEKIT_API_KEY` /
+> `LIVEKIT_API_SECRET` (no `LEMONSLICE_API_KEY`); the gateway creates the
+> provider session with LiveKit's wholesale key. Requires the
+> `avatar_lemonslice` feature flag on your project. Run with
+> `python inference_agent.py dev` and set `LEMONSLICE_IMAGE_URL`.
+
 ## What's in here
 
 - **9 personas** to choose from — each has its own face, voice, system

--- a/examples/avatar/inference_agent.py
+++ b/examples/avatar/inference_agent.py
@@ -1,0 +1,69 @@
+"""Avatar agent provisioned through LiveKit Inference (no provider key).
+
+Unlike agent.py (which uses the BYOK lemonslice plugin with a LEMONSLICE_API_KEY),
+this starts the avatar with inference.AvatarSession: the agent authenticates only
+with LIVEKIT_API_KEY / LIVEKIT_API_SECRET, and the Inference gateway creates the
+LemonSlice session using LiveKit's wholesale key. Media and lip-sync still flow
+in-room over DataStream, exactly as the BYOK path does.
+
+Requires the `avatar_lemonslice` feature flag to be enabled for your project on
+the Inference gateway.
+
+Run:
+    python inference_agent.py dev
+"""
+
+import logging
+import os
+
+from dotenv import load_dotenv
+
+from livekit.agents import (
+    Agent,
+    AgentServer,
+    AgentSession,
+    JobContext,
+    cli,
+    inference,
+)
+
+logger = logging.getLogger("inference-avatar-example")
+logger.setLevel(logging.INFO)
+
+load_dotenv()
+
+
+server = AgentServer()
+
+
+@server.rtc_session()
+async def entrypoint(ctx: JobContext) -> None:
+    session = AgentSession(
+        stt=inference.STT("deepgram/nova-3"),
+        llm=inference.LLM("google/gemini-2.5-flash"),
+        tts=inference.TTS("cartesia/sonic-3"),
+    )
+
+    # Avatar provisioning goes through LiveKit Inference: only LIVEKIT_API_KEY /
+    # LIVEKIT_API_SECRET are needed (no provider key). The gateway creates the
+    # LemonSlice session with LiveKit's wholesale key; media stays in-room.
+    #
+    # Pass a catalog agent id instead of an image with
+    # inference.AvatarSession("lemonslice/<agent_id>", ...).
+    avatar_image_url = os.getenv("LEMONSLICE_IMAGE_URL")
+    if not avatar_image_url:
+        raise ValueError("LEMONSLICE_IMAGE_URL must be set")
+    avatar = inference.AvatarSession(
+        "lemonslice",
+        image_url=avatar_image_url,
+        prompt="Be expressive in your movements and use your hands while talking.",
+    )
+    await avatar.start(session, room=ctx.room)
+    await avatar.wait_for_join()
+
+    await session.start(agent=Agent(instructions="Talk to me!"), room=ctx.room)
+    session.generate_reply(instructions="say hello to the user")
+
+
+if __name__ == "__main__":
+    cli.run_app(server)

--- a/livekit-agents/livekit/agents/inference/__init__.py
+++ b/livekit-agents/livekit/agents/inference/__init__.py
@@ -13,7 +13,7 @@ from .tts import TTS, TTSModels
 from .vad import VAD, VADModels
 
 if TYPE_CHECKING:
-    from .avatar import AvatarSession
+    from .avatar import AvatarSession, LemonSliceOptions
 
 
 # AvatarSession subclasses voice.avatar.AvatarSession. Because this package is
@@ -22,10 +22,10 @@ if TYPE_CHECKING:
 # it lazily on first attribute access, by which point voice is fully
 # initialized. See PEP 562.
 def __getattr__(name: str) -> Any:
-    if name == "AvatarSession":
-        from .avatar import AvatarSession
+    if name in ("AvatarSession", "LemonSliceOptions"):
+        from . import avatar
 
-        return AvatarSession
+        return getattr(avatar, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -35,6 +35,7 @@ __all__ = [
     "LLM",
     "VAD",
     "AvatarSession",
+    "LemonSliceOptions",
     "LLMStream",
     "STTModels",
     "TTSModels",

--- a/livekit-agents/livekit/agents/inference/__init__.py
+++ b/livekit-agents/livekit/agents/inference/__init__.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING, Any
+
 from .eot import TurnDetector, TurnDetectorModels, TurnDetectorVersions
 from .interruption import (
     AdaptiveInterruptionDetector,
@@ -10,11 +12,29 @@ from .stt import STT, STTModels
 from .tts import TTS, TTSModels
 from .vad import VAD, VADModels
 
+if TYPE_CHECKING:
+    from .avatar import AvatarSession
+
+
+# AvatarSession subclasses voice.avatar.AvatarSession. Because this package is
+# imported *during* voice package initialization (voice.agent imports
+# inference), importing .avatar eagerly here would form a circular import. Load
+# it lazily on first attribute access, by which point voice is fully
+# initialized. See PEP 562.
+def __getattr__(name: str) -> Any:
+    if name == "AvatarSession":
+        from .avatar import AvatarSession
+
+        return AvatarSession
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
     "STT",
     "TTS",
     "LLM",
     "VAD",
+    "AvatarSession",
     "LLMStream",
     "STTModels",
     "TTSModels",

--- a/livekit-agents/livekit/agents/inference/avatar.py
+++ b/livekit-agents/livekit/agents/inference/avatar.py
@@ -37,9 +37,14 @@ if TYPE_CHECKING:
     from ..voice import AgentSession
 
 # Fallback audio sample rate when the gateway response omits one. The gateway
-# is authoritative (it returns the per-provider rate) so this is only a floor
-# for older gateways.
+# is authoritative (it returns the per-provider rate) so this is only a
+# fallback for older gateways.
 _DEFAULT_SAMPLE_RATE = 16000
+# Total request timeout for gateway calls. sock_connect (conn_options.timeout)
+# bounds the TCP connect; this bounds the whole request so a gateway that
+# accepts the connection but never responds can't hang start()/aclose()
+# indefinitely. Matches the BYOK lemonslice plugin's request timeout.
+_REQUEST_TIMEOUT = 60.0
 # lk.avatar_provider tags the avatar worker participant with its provider so
 # server-side (participant-lifetime) avatar-minutes metering can attribute the
 # worker's room time to the right SKU. See the inference-avatar plan.
@@ -174,6 +179,9 @@ class AvatarSession(BaseAvatarSession):
 
         self._session_id: str | None = None
         self._provider_session_id: str | None = None
+        # HMAC issued by the gateway alongside provider_session_id; required by
+        # /avatar/sessions/terminate to prove this project owns the session.
+        self._terminate_token: str | None = None
 
     @property
     def avatar_identity(self) -> str:
@@ -202,6 +210,12 @@ class AvatarSession(BaseAvatarSession):
         livekit_api_key: NotGivenOr[str] = NOT_GIVEN,
         livekit_api_secret: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
+        if self._session_id is not None or self._provider_session_id is not None:
+            raise RuntimeError(
+                "AvatarSession.start() may only be called once per instance; "
+                "create a new AvatarSession to start another avatar"
+            )
+
         await super().start(agent_session, room)
 
         lk_url = livekit_url or (os.getenv("LIVEKIT_URL") or NOT_GIVEN)
@@ -221,7 +235,7 @@ class AvatarSession(BaseAvatarSession):
         if job_ctx is not None:
             local_participant_identity = job_ctx.local_participant_identity
             room_sid = job_ctx.job.room.sid or await room.sid
-        elif room.local_participant is not None:
+        elif room.isconnected():
             local_participant_identity = room.local_participant.identity
             room_sid = await room.sid
         else:
@@ -257,7 +271,22 @@ class AvatarSession(BaseAvatarSession):
 
         self._session_id = create_resp.get("session_id")
         self._provider_session_id = create_resp.get("provider_session_id")
+        self._terminate_token = create_resp.get("terminate_token")
         sample_rate = create_resp.get("sample_rate") or _DEFAULT_SAMPLE_RATE
+
+        if self._provider_session_id and not self._terminate_token:
+            # aclose() cannot terminate without this; the provider session will
+            # run to its own idle timeout instead of being stopped explicitly.
+            logger.warning(
+                "avatar gateway create response had no terminate_token; this "
+                "session cannot be explicitly terminated and will bill until "
+                "its provider idle timeout",
+                extra={
+                    "provider": self._provider,
+                    "session_id": self._session_id,
+                    "provider_session_id": self._provider_session_id,
+                },
+            )
 
         # Rebind the audio tail to the avatar worker using the gateway-reported
         # sample rate. Done after the create response (unlike BYOK, which
@@ -289,22 +318,40 @@ class AvatarSession(BaseAvatarSession):
     async def aclose(self) -> None:
         # Terminate the provider session through the gateway so it stops billing
         # immediately instead of lingering until its idle timeout. Best-effort:
-        # a failure must not block participant cleanup in the base class.
+        # a failure must not block participant cleanup in the base class, so
+        # base cleanup runs in `finally` even if terminate raises or is
+        # cancelled (e.g. job-shutdown deadline). The ids are cleared only on
+        # a confirmed terminate so a second aclose() call can still retry.
         provider_session_id = self._provider_session_id
-        self._provider_session_id = None
-        if provider_session_id:
-            try:
-                await self._terminate_session(provider_session_id)
-            except Exception:
-                logger.warning(
-                    "failed to terminate inference avatar session",
+        terminate_token = self._terminate_token
+        try:
+            if provider_session_id and terminate_token:
+                try:
+                    await self._terminate_session(provider_session_id, terminate_token)
+                except Exception:
+                    logger.warning(
+                        "failed to terminate inference avatar session; it will "
+                        "keep billing until its provider idle timeout unless "
+                        "aclose() is called again",
+                        extra={
+                            "provider": self._provider,
+                            "provider_session_id": provider_session_id,
+                        },
+                        exc_info=True,
+                    )
+                else:
+                    self._provider_session_id = None
+                    self._terminate_token = None
+            elif provider_session_id:
+                logger.debug(
+                    "no terminate_token for this avatar session; skipping explicit terminate",
                     extra={
                         "provider": self._provider,
                         "provider_session_id": provider_session_id,
                     },
-                    exc_info=True,
                 )
-        await super().aclose()
+        finally:
+            await super().aclose()
 
     async def _create_session(
         self,
@@ -360,7 +407,7 @@ class AvatarSession(BaseAvatarSession):
                         headers=headers,
                         json=payload,
                         timeout=aiohttp.ClientTimeout(
-                            total=None,
+                            total=_REQUEST_TIMEOUT,
                             sock_connect=self._conn_options.timeout,
                         ),
                     ) as response:
@@ -372,13 +419,20 @@ class AvatarSession(BaseAvatarSession):
                                 body=text,
                             )
                         return await response.json()  # type: ignore[no-any-return]
-                except asyncio.TimeoutError as e:
-                    last_exc = APITimeoutError()
-                    logger.warning("avatar gateway request timed out", extra={"attempt": i})
-                    _ = e
+                except asyncio.TimeoutError:
+                    last_exc = APITimeoutError(
+                        f"avatar gateway create timed out after attempt {i + 1}"
+                    )
+                    logger.warning(
+                        "avatar gateway request timed out",
+                        extra={"provider": self._provider, "attempt": i},
+                    )
                 except aiohttp.ClientError as e:
                     last_exc = APIConnectionError(str(e))
-                    logger.warning("failed to call avatar gateway", extra={"error": str(e)})
+                    logger.warning(
+                        "failed to call avatar gateway",
+                        extra={"provider": self._provider, "error": str(e)},
+                    )
                 except APIError as e:
                     last_exc = e
                     if not e.retryable:
@@ -398,7 +452,7 @@ class AvatarSession(BaseAvatarSession):
             if self._http_session is None:
                 await session.close()
 
-    async def _terminate_session(self, provider_session_id: str) -> None:
+    async def _terminate_session(self, provider_session_id: str, terminate_token: str) -> None:
         url = f"{self._base_url.rstrip('/')}/avatar/sessions/terminate"
         headers = {
             **get_inference_headers(),
@@ -406,7 +460,11 @@ class AvatarSession(BaseAvatarSession):
             HEADER_INFERENCE_PROVIDER: self._provider,
             "Content-Type": "application/json",
         }
-        payload = {"provider": self._provider, "provider_session_id": provider_session_id}
+        payload = {
+            "provider": self._provider,
+            "provider_session_id": provider_session_id,
+            "terminate_token": terminate_token,
+        }
 
         session = self._http_session or aiohttp.ClientSession()
         try:
@@ -414,7 +472,9 @@ class AvatarSession(BaseAvatarSession):
                 url,
                 headers=headers,
                 json=payload,
-                timeout=aiohttp.ClientTimeout(total=None, sock_connect=self._conn_options.timeout),
+                timeout=aiohttp.ClientTimeout(
+                    total=_REQUEST_TIMEOUT, sock_connect=self._conn_options.timeout
+                ),
             ) as response:
                 if not response.ok:
                     text = await response.text()

--- a/livekit-agents/livekit/agents/inference/avatar.py
+++ b/livekit-agents/livekit/agents/inference/avatar.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+from livekit import api, rtc
+
+from .._exceptions import (
+    APIConnectionError,
+    APIError,
+    APITimeoutError,
+    create_api_error_from_http,
+)
+from ..job import get_job_context
+from ..log import logger
+from ..types import (
+    ATTRIBUTE_PUBLISH_ON_BEHALF,
+    DEFAULT_API_CONNECT_OPTIONS,
+    NOT_GIVEN,
+    APIConnectOptions,
+    NotGivenOr,
+)
+from ..utils import is_given
+from ..voice.avatar import AvatarSession as BaseAvatarSession, DataStreamAudioOutput
+from ._utils import (
+    HEADER_INFERENCE_PROVIDER,
+    create_access_token,
+    get_default_inference_url,
+    get_inference_headers,
+)
+
+if TYPE_CHECKING:
+    from ..voice import AgentSession
+
+# Fallback audio sample rate when the gateway response omits one. The gateway
+# is authoritative (it returns the per-provider rate) so this is only a floor
+# for older gateways.
+_DEFAULT_SAMPLE_RATE = 16000
+# lk.avatar_provider tags the avatar worker participant with its provider so
+# server-side (participant-lifetime) avatar-minutes metering can attribute the
+# worker's room time to the right SKU. See the inference-avatar plan.
+_ATTRIBUTE_AVATAR_PROVIDER = "lk.avatar_provider"
+
+
+def _parse_avatar_model(model: str) -> tuple[str, str | None]:
+    """Parse an avatar model string into (provider, avatar_id).
+
+    ``"lemonslice"`` -> ``("lemonslice", None)``; ``"lemonslice/agent_abc"`` ->
+    ``("lemonslice", "agent_abc")``. The id (when present) is a provider catalog
+    id forwarded to the gateway as ``avatar_id``.
+    """
+    provider, _, avatar_id = model.partition("/")
+    provider = provider.strip()
+    if not provider:
+        raise ValueError(
+            f"invalid avatar model string: {model!r} (expected 'provider' or 'provider/<id>')"
+        )
+    avatar_id = avatar_id.strip()
+    return provider, (avatar_id or None)
+
+
+class AvatarSession(BaseAvatarSession):
+    """An avatar session provisioned through LiveKit Inference.
+
+    Unlike the BYOK avatar plugins (which call the avatar provider directly with
+    a customer API key), this calls the LiveKit Inference gateway with LiveKit
+    credentials; the gateway creates the provider session with LiveKit's
+    wholesale key. Media and RPC still flow in-room over DataStream, exactly as
+    the BYOK plugins do.
+
+    Example::
+
+        avatar = inference.AvatarSession("lemonslice", image_url="https://...", prompt="...")
+        await avatar.start(session, room=ctx.room)
+        await avatar.wait_for_join()
+
+    Credentials come from two independent sources:
+
+    - Gateway auth (``api_key`` / ``api_secret``): resolved from the arguments,
+      then ``LIVEKIT_INFERENCE_API_KEY`` / ``LIVEKIT_INFERENCE_API_SECRET``,
+      then ``LIVEKIT_API_KEY`` / ``LIVEKIT_API_SECRET``.
+    - The avatar worker's room token: minted locally from the room project's
+      credentials, resolved from ``start()`` arguments then ``LIVEKIT_URL`` /
+      ``LIVEKIT_API_KEY`` / ``LIVEKIT_API_SECRET``. These may differ from the
+      gateway credentials when ``LIVEKIT_INFERENCE_*`` points at a different
+      project.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        image_url: NotGivenOr[str] = NOT_GIVEN,
+        prompt: NotGivenOr[str] = NOT_GIVEN,
+        idle_prompt: NotGivenOr[str] = NOT_GIVEN,
+        idle_timeout: NotGivenOr[int] = NOT_GIVEN,
+        avatar_participant_identity: NotGivenOr[str] = NOT_GIVEN,
+        avatar_participant_name: NotGivenOr[str] = NOT_GIVEN,
+        extra_kwargs: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
+        base_url: NotGivenOr[str] = NOT_GIVEN,
+        api_key: NotGivenOr[str] = NOT_GIVEN,
+        api_secret: NotGivenOr[str] = NOT_GIVEN,
+        http_session: aiohttp.ClientSession | None = None,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+    ) -> None:
+        """
+        Args:
+            model: ``"<provider>"`` or ``"<provider>/<avatar_id>"``
+                (e.g. ``"lemonslice"`` or ``"lemonslice/agent_abc"``).
+            image_url: Appearance source for image-sourced avatars (LemonSlice).
+                Mutually exclusive with a catalog id in the model string.
+            prompt: Speaking prompt (mapped to the provider's agent_prompt).
+            idle_prompt: Idle prompt (mapped to the provider's agent_idle_prompt).
+            idle_timeout: Provider idle timeout in seconds; the gateway clamps it
+                to the provider's configured bounds.
+            avatar_participant_identity: Room identity for the avatar worker.
+                Defaults to ``"<provider>-avatar-agent"``.
+            avatar_participant_name: Display name for the avatar worker.
+            extra_kwargs: Provider-specific extras forwarded verbatim (subject to
+                the gateway's per-provider allowlist).
+            base_url: Inference gateway base URL. Defaults to the environment's
+                gateway (see ``get_default_inference_url``).
+            api_key: Gateway API key (see the class docstring for resolution).
+            api_secret: Gateway API secret (see the class docstring).
+            http_session: Optional aiohttp session; one is created per call if
+                omitted.
+            conn_options: Retry/timeout options for the create call.
+        """
+        super().__init__()
+
+        self._provider, self._avatar_id = _parse_avatar_model(model)
+        self._image_url = image_url
+        self._prompt = prompt
+        self._idle_prompt = idle_prompt
+        self._idle_timeout = idle_timeout
+        self._extra_kwargs = extra_kwargs
+        self._conn_options = conn_options
+        self._http_session = http_session
+
+        self._base_url = base_url if is_given(base_url) else get_default_inference_url()
+        self._api_key = (
+            api_key
+            if is_given(api_key)
+            else os.getenv("LIVEKIT_INFERENCE_API_KEY", os.getenv("LIVEKIT_API_KEY", ""))
+        )
+        if not self._api_key:
+            raise ValueError(
+                "api_key is required, either as argument or set LIVEKIT_API_KEY environment variable"
+            )
+        self._api_secret = (
+            api_secret
+            if is_given(api_secret)
+            else os.getenv("LIVEKIT_INFERENCE_API_SECRET", os.getenv("LIVEKIT_API_SECRET", ""))
+        )
+        if not self._api_secret:
+            raise ValueError(
+                "api_secret is required, either as argument or set LIVEKIT_API_SECRET environment variable"
+            )
+
+        self._avatar_participant_identity = (
+            avatar_participant_identity
+            if is_given(avatar_participant_identity)
+            else f"{self._provider}-avatar-agent"
+        )
+        self._avatar_participant_name = (
+            avatar_participant_name
+            if is_given(avatar_participant_name)
+            else self._avatar_participant_identity
+        )
+
+        self._session_id: str | None = None
+        self._provider_session_id: str | None = None
+
+    @property
+    def avatar_identity(self) -> str:
+        return self._avatar_participant_identity
+
+    @property
+    def provider(self) -> str:
+        return self._provider
+
+    @property
+    def session_id(self) -> str | None:
+        """The gateway-generated avatar session id (available after start())."""
+        return self._session_id
+
+    @property
+    def provider_session_id(self) -> str | None:
+        """The provider's own session id (available after start())."""
+        return self._provider_session_id
+
+    async def start(  # type: ignore[override]
+        self,
+        agent_session: AgentSession,
+        room: rtc.Room,
+        *,
+        livekit_url: NotGivenOr[str] = NOT_GIVEN,
+        livekit_api_key: NotGivenOr[str] = NOT_GIVEN,
+        livekit_api_secret: NotGivenOr[str] = NOT_GIVEN,
+    ) -> None:
+        await super().start(agent_session, room)
+
+        lk_url = livekit_url or (os.getenv("LIVEKIT_URL") or NOT_GIVEN)
+        lk_key = livekit_api_key or (os.getenv("LIVEKIT_API_KEY") or NOT_GIVEN)
+        lk_secret = livekit_api_secret or (os.getenv("LIVEKIT_API_SECRET") or NOT_GIVEN)
+        if not lk_url or not lk_key or not lk_secret:
+            raise ValueError(
+                "livekit_url, livekit_api_key, and livekit_api_secret must be set "
+                "by arguments or the LIVEKIT_URL / LIVEKIT_API_KEY / LIVEKIT_API_SECRET "
+                "environment variables"
+            )
+
+        # Usable inside an agent job or standalone (scripts/tests). The base
+        # class already tolerates a missing job context; derive the same values
+        # from the connected room when there is none.
+        job_ctx = get_job_context(required=False)
+        if job_ctx is not None:
+            local_participant_identity = job_ctx.local_participant_identity
+            room_sid = job_ctx.job.room.sid or await room.sid
+        elif room.local_participant is not None:
+            local_participant_identity = room.local_participant.identity
+            room_sid = await room.sid
+        else:
+            raise RuntimeError(
+                "AvatarSession.start() needs a connected room or an agent job context; "
+                "connect the room before calling start()"
+            )
+
+        # Mint the avatar worker's room token locally, identical to the BYOK
+        # plugins, plus an lk.avatar_provider attribute for server-side metering.
+        worker_token = (
+            api.AccessToken(api_key=lk_key, api_secret=lk_secret)
+            .with_kind("agent")
+            .with_identity(self._avatar_participant_identity)
+            .with_name(self._avatar_participant_name)
+            .with_grants(api.VideoGrants(room_join=True, room=room.name))
+            .with_attributes(
+                {
+                    ATTRIBUTE_PUBLISH_ON_BEHALF: local_participant_identity,
+                    _ATTRIBUTE_AVATAR_PROVIDER: self._provider,
+                }
+            )
+            .to_jwt()
+        )
+
+        create_resp = await self._create_session(
+            room_name=room.name,
+            room_sid=room_sid,
+            livekit_url=lk_url,
+            worker_token=worker_token,
+            agent_identity=local_participant_identity,
+        )
+
+        self._session_id = create_resp.get("session_id")
+        self._provider_session_id = create_resp.get("provider_session_id")
+        sample_rate = create_resp.get("sample_rate") or _DEFAULT_SAMPLE_RATE
+
+        # Rebind the audio tail to the avatar worker using the gateway-reported
+        # sample rate. Done after the create response (unlike BYOK, which
+        # hardcodes the rate and rebinds first): in the canonical flow
+        # avatar.start() runs before session.start(), so no audio has flowed yet
+        # and nothing is lost. wait_remote_track buffers until the video track
+        # appears; replace_audio_tail keeps the TranscriptSynchronizer /
+        # RecorderAudioOutput chain intact.
+        agent_session.output.replace_audio_tail(
+            DataStreamAudioOutput(
+                room=room,
+                destination_identity=self._avatar_participant_identity,
+                sample_rate=sample_rate,
+                wait_remote_track=rtc.TrackKind.KIND_VIDEO,
+                clear_buffer_timeout=None,
+                wait_playback_start=True,
+            ),
+        )
+
+        logger.debug(
+            "inference avatar session created",
+            extra={
+                "provider": self._provider,
+                "session_id": self._session_id,
+                "provider_session_id": self._provider_session_id,
+            },
+        )
+
+    async def aclose(self) -> None:
+        # Terminate the provider session through the gateway so it stops billing
+        # immediately instead of lingering until its idle timeout. Best-effort:
+        # a failure must not block participant cleanup in the base class.
+        provider_session_id = self._provider_session_id
+        self._provider_session_id = None
+        if provider_session_id:
+            try:
+                await self._terminate_session(provider_session_id)
+            except Exception:
+                logger.warning(
+                    "failed to terminate inference avatar session",
+                    extra={
+                        "provider": self._provider,
+                        "provider_session_id": provider_session_id,
+                    },
+                    exc_info=True,
+                )
+        await super().aclose()
+
+    async def _create_session(
+        self,
+        *,
+        room_name: str,
+        room_sid: str,
+        livekit_url: str,
+        worker_token: str,
+        agent_identity: str,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "provider": self._provider,
+            "livekit_url": livekit_url,
+            "livekit_token": worker_token,
+            "room_name": room_name,
+            "room_sid": room_sid,
+            "avatar_identity": self._avatar_participant_identity,
+            "agent_identity": agent_identity,
+        }
+        if self._avatar_id:
+            payload["avatar_id"] = self._avatar_id
+        if is_given(self._image_url):
+            payload["image_url"] = self._image_url
+        if is_given(self._prompt):
+            payload["prompt"] = self._prompt
+        if is_given(self._idle_prompt):
+            payload["idle_prompt"] = self._idle_prompt
+        if is_given(self._idle_timeout):
+            payload["idle_timeout_s"] = self._idle_timeout
+        if is_given(self._extra_kwargs):
+            payload["extra_kwargs"] = self._extra_kwargs
+
+        # One idempotency key per start(), stable across retries, so a retried
+        # create replays the first result on the gateway instead of paying for a
+        # second provider session.
+        idempotency_key = uuid.uuid4().hex
+        url = f"{self._base_url.rstrip('/')}/avatar/sessions"
+
+        session = self._http_session or aiohttp.ClientSession()
+        try:
+            last_exc: Exception | None = None
+            for i in range(self._conn_options.max_retry + 1):
+                headers = {
+                    **get_inference_headers(),
+                    "Authorization": f"Bearer {create_access_token(self._api_key, self._api_secret)}",
+                    HEADER_INFERENCE_PROVIDER: self._provider,
+                    "Idempotency-Key": idempotency_key,
+                    "Content-Type": "application/json",
+                }
+                try:
+                    async with session.post(
+                        url,
+                        headers=headers,
+                        json=payload,
+                        timeout=aiohttp.ClientTimeout(
+                            total=None,
+                            sock_connect=self._conn_options.timeout,
+                        ),
+                    ) as response:
+                        if not response.ok:
+                            text = await response.text()
+                            raise create_api_error_from_http(
+                                f"avatar gateway returned an error: {text}",
+                                status=response.status,
+                                body=text,
+                            )
+                        return await response.json()  # type: ignore[no-any-return]
+                except asyncio.TimeoutError as e:
+                    last_exc = APITimeoutError()
+                    logger.warning("avatar gateway request timed out", extra={"attempt": i})
+                    _ = e
+                except aiohttp.ClientError as e:
+                    last_exc = APIConnectionError(str(e))
+                    logger.warning("failed to call avatar gateway", extra={"error": str(e)})
+                except APIError as e:
+                    last_exc = e
+                    if not e.retryable:
+                        raise
+                    logger.warning(
+                        "avatar gateway returned a retryable error",
+                        extra={"error": str(e)},
+                    )
+
+                if i < self._conn_options.max_retry:
+                    await asyncio.sleep(self._conn_options._interval_for_retry(i))
+
+            if last_exc is not None:
+                raise last_exc
+            raise APIConnectionError("failed to create avatar session after all retries")
+        finally:
+            if self._http_session is None:
+                await session.close()
+
+    async def _terminate_session(self, provider_session_id: str) -> None:
+        url = f"{self._base_url.rstrip('/')}/avatar/sessions/terminate"
+        headers = {
+            **get_inference_headers(),
+            "Authorization": f"Bearer {create_access_token(self._api_key, self._api_secret)}",
+            HEADER_INFERENCE_PROVIDER: self._provider,
+            "Content-Type": "application/json",
+        }
+        payload = {"provider": self._provider, "provider_session_id": provider_session_id}
+
+        session = self._http_session or aiohttp.ClientSession()
+        try:
+            async with session.post(
+                url,
+                headers=headers,
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=None, sock_connect=self._conn_options.timeout),
+            ) as response:
+                if not response.ok:
+                    text = await response.text()
+                    raise create_api_error_from_http(
+                        f"avatar gateway returned an error: {text}",
+                        status=response.status,
+                        body=text,
+                    )
+        finally:
+            if self._http_session is None:
+                await session.close()

--- a/livekit-agents/livekit/agents/inference/avatar.py
+++ b/livekit-agents/livekit/agents/inference/avatar.py
@@ -193,7 +193,7 @@ class AvatarSession(BaseAvatarSession):
         """The provider's own session id (available after start())."""
         return self._provider_session_id
 
-    async def start(  # type: ignore[override]
+    async def start(
         self,
         agent_session: AgentSession,
         room: rtc.Room,

--- a/livekit-agents/livekit/agents/inference/avatar.py
+++ b/livekit-agents/livekit/agents/inference/avatar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 import uuid
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import aiohttp
 
@@ -51,6 +51,31 @@ _REQUEST_TIMEOUT = 60.0
 _ATTRIBUTE_AVATAR_PROVIDER = "lk.avatar_provider"
 
 
+class LemonSliceOptions(TypedDict, total=False):
+    """Provider-specific options for a LemonSlice inference avatar.
+
+    Mirrors the per-provider option dicts in :mod:`inference.stt` /
+    :mod:`inference.tts` (e.g. ``CartesiaOptions``); passed via ``extra_kwargs``.
+    All keys are optional.
+    """
+
+    image_url: str  # appearance source; mutually exclusive with a model-string agent id
+    prompt: str  # speaking prompt (mapped to the provider's agent_prompt)
+    idle_prompt: str  # idle prompt (mapped to the provider's agent_idle_prompt)
+    idle_timeout: int  # provider idle timeout in seconds; the gateway clamps it
+
+
+# Maps LemonSliceOptions keys onto the gateway avatar-request's first-class
+# fields. Keys not listed here are forwarded verbatim under ``extra_kwargs``
+# (subject to the gateway's per-provider allowlist).
+_OPTION_TO_PAYLOAD_FIELD = {
+    "image_url": "image_url",
+    "prompt": "prompt",
+    "idle_prompt": "idle_prompt",
+    "idle_timeout": "idle_timeout_s",
+}
+
+
 def _parse_avatar_model(model: str) -> tuple[str, str | None]:
     """Parse an avatar model string into (provider, avatar_id).
 
@@ -81,7 +106,10 @@ class AvatarSession(BaseAvatarSession):
 
     Example::
 
-        avatar = inference.AvatarSession("lemonslice", image_url="https://...", prompt="...")
+        avatar = inference.AvatarSession(
+            "lemonslice",
+            extra_kwargs=LemonSliceOptions(image_url="https://...", prompt="..."),
+        )
         await avatar.start(session, room=ctx.room)
         await avatar.wait_for_join()
 
@@ -101,13 +129,9 @@ class AvatarSession(BaseAvatarSession):
         self,
         model: str,
         *,
-        image_url: NotGivenOr[str] = NOT_GIVEN,
-        prompt: NotGivenOr[str] = NOT_GIVEN,
-        idle_prompt: NotGivenOr[str] = NOT_GIVEN,
-        idle_timeout: NotGivenOr[int] = NOT_GIVEN,
         avatar_participant_identity: NotGivenOr[str] = NOT_GIVEN,
         avatar_participant_name: NotGivenOr[str] = NOT_GIVEN,
-        extra_kwargs: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
+        extra_kwargs: NotGivenOr[LemonSliceOptions | dict[str, Any]] = NOT_GIVEN,
         base_url: NotGivenOr[str] = NOT_GIVEN,
         api_key: NotGivenOr[str] = NOT_GIVEN,
         api_secret: NotGivenOr[str] = NOT_GIVEN,
@@ -121,19 +145,18 @@ class AvatarSession(BaseAvatarSession):
                 LemonSlice the ``<avatar_id>`` is the agent id (the gateway maps
                 it onto LemonSlice's ``agent_id``); pass a pre-built agent as
                 ``"lemonslice/<agent_id>"``.
-            image_url: Appearance source for image-sourced avatars (LemonSlice).
-                Mutually exclusive with a catalog id in the model string; passing
-                both raises here (and the gateway rejects the combination too).
-            prompt: Speaking prompt (mapped to the provider's agent_prompt).
-            idle_prompt: Idle prompt (mapped to the provider's agent_idle_prompt).
-            idle_timeout: Provider idle timeout in seconds; the gateway clamps it
-                to the provider's configured bounds.
             avatar_participant_identity: Room identity for the avatar worker.
                 Defaults to ``"<provider>-inference-avatar"`` (the ``inference``
                 marker distinguishes it from the BYOK plugins' worker identity).
             avatar_participant_name: Display name for the avatar worker.
-            extra_kwargs: Provider-specific extras forwarded verbatim (subject to
-                the gateway's per-provider allowlist).
+            extra_kwargs: Provider-specific options. For LemonSlice use
+                :class:`LemonSliceOptions` (``image_url`` / ``prompt`` /
+                ``idle_prompt`` / ``idle_timeout``); known keys map onto the
+                gateway's first-class request fields and anything else is
+                forwarded verbatim, subject to the gateway's per-provider
+                allowlist. ``image_url`` is mutually exclusive with a catalog id
+                in the model string — passing both raises here (and the gateway
+                rejects the combination too).
             base_url: Inference gateway base URL. Defaults to the environment's
                 gateway (see ``get_default_inference_url``).
             api_key: Gateway API key (see the class docstring for resolution).
@@ -145,19 +168,15 @@ class AvatarSession(BaseAvatarSession):
         super().__init__()
 
         self._provider, self._avatar_id = _parse_avatar_model(model)
-        if self._avatar_id and is_given(image_url):
+        # Copy so a later mutation of the caller's dict can't change what we send.
+        self._extra_kwargs: dict[str, Any] = dict(extra_kwargs) if is_given(extra_kwargs) else {}
+        if self._avatar_id and "image_url" in self._extra_kwargs:
             # The gateway (e.g. the LemonSlice adapter) rejects both; fail fast
             # here so the caller doesn't spend a round trip to learn that.
             raise ValueError(
                 "pass either a catalog id in the model string "
                 f"('{self._provider}/<avatar_id>') or image_url, not both"
             )
-        self._image_url = image_url
-        self._prompt = prompt
-        self._idle_prompt = idle_prompt
-        self._idle_timeout = idle_timeout
-        # Copy so a later mutation of the caller's dict can't change what we send.
-        self._extra_kwargs = dict(extra_kwargs) if is_given(extra_kwargs) else extra_kwargs
         self._conn_options = conn_options
         self._http_session = http_session
 
@@ -407,16 +426,17 @@ class AvatarSession(BaseAvatarSession):
         }
         if self._avatar_id:
             payload["avatar_id"] = self._avatar_id
-        if is_given(self._image_url):
-            payload["image_url"] = self._image_url
-        if is_given(self._prompt):
-            payload["prompt"] = self._prompt
-        if is_given(self._idle_prompt):
-            payload["idle_prompt"] = self._idle_prompt
-        if is_given(self._idle_timeout):
-            payload["idle_timeout_s"] = self._idle_timeout
-        if is_given(self._extra_kwargs):
-            payload["extra_kwargs"] = self._extra_kwargs
+        # Map known LemonSlice options onto the gateway's first-class request
+        # fields; forward anything else via extra_kwargs (gateway allowlist).
+        extra: dict[str, Any] = {}
+        for key, value in self._extra_kwargs.items():
+            payload_field = _OPTION_TO_PAYLOAD_FIELD.get(key)
+            if payload_field is not None:
+                payload[payload_field] = value
+            else:
+                extra[key] = value
+        if extra:
+            payload["extra_kwargs"] = extra
 
         # One idempotency key per start(), stable across retries, so a retried
         # create replays the first result on the gateway instead of paying for a

--- a/livekit-agents/livekit/agents/inference/avatar.py
+++ b/livekit-agents/livekit/agents/inference/avatar.py
@@ -47,7 +47,7 @@ _DEFAULT_SAMPLE_RATE = 16000
 _REQUEST_TIMEOUT = 60.0
 # lk.avatar_provider tags the avatar worker participant with its provider so
 # server-side (participant-lifetime) avatar-minutes metering can attribute the
-# worker's room time to the right SKU. See the inference-avatar plan.
+# worker's room time to the right SKU.
 _ATTRIBUTE_AVATAR_PROVIDER = "lk.avatar_provider"
 
 
@@ -56,7 +56,9 @@ def _parse_avatar_model(model: str) -> tuple[str, str | None]:
 
     ``"lemonslice"`` -> ``("lemonslice", None)``; ``"lemonslice/agent_abc"`` ->
     ``("lemonslice", "agent_abc")``. The id (when present) is a provider catalog
-    id forwarded to the gateway as ``avatar_id``.
+    id forwarded to the gateway as ``avatar_id``. For LemonSlice this is the
+    agent id: the gateway maps ``avatar_id`` onto LemonSlice's ``agent_id``, so
+    ``"lemonslice/<agent_id>"`` selects a pre-built LemonSlice agent.
     """
     provider, _, avatar_id = model.partition("/")
     provider = provider.strip()
@@ -115,15 +117,20 @@ class AvatarSession(BaseAvatarSession):
         """
         Args:
             model: ``"<provider>"`` or ``"<provider>/<avatar_id>"``
-                (e.g. ``"lemonslice"`` or ``"lemonslice/agent_abc"``).
+                (e.g. ``"lemonslice"`` or ``"lemonslice/agent_abc"``). For
+                LemonSlice the ``<avatar_id>`` is the agent id (the gateway maps
+                it onto LemonSlice's ``agent_id``); pass a pre-built agent as
+                ``"lemonslice/<agent_id>"``.
             image_url: Appearance source for image-sourced avatars (LemonSlice).
-                Mutually exclusive with a catalog id in the model string.
+                Mutually exclusive with a catalog id in the model string; passing
+                both raises here (and the gateway rejects the combination too).
             prompt: Speaking prompt (mapped to the provider's agent_prompt).
             idle_prompt: Idle prompt (mapped to the provider's agent_idle_prompt).
             idle_timeout: Provider idle timeout in seconds; the gateway clamps it
                 to the provider's configured bounds.
             avatar_participant_identity: Room identity for the avatar worker.
-                Defaults to ``"<provider>-avatar-agent"``.
+                Defaults to ``"<provider>-inference-avatar"`` (the ``inference``
+                marker distinguishes it from the BYOK plugins' worker identity).
             avatar_participant_name: Display name for the avatar worker.
             extra_kwargs: Provider-specific extras forwarded verbatim (subject to
                 the gateway's per-provider allowlist).
@@ -138,11 +145,19 @@ class AvatarSession(BaseAvatarSession):
         super().__init__()
 
         self._provider, self._avatar_id = _parse_avatar_model(model)
+        if self._avatar_id and is_given(image_url):
+            # The gateway (e.g. the LemonSlice adapter) rejects both; fail fast
+            # here so the caller doesn't spend a round trip to learn that.
+            raise ValueError(
+                "pass either a catalog id in the model string "
+                f"('{self._provider}/<avatar_id>') or image_url, not both"
+            )
         self._image_url = image_url
         self._prompt = prompt
         self._idle_prompt = idle_prompt
         self._idle_timeout = idle_timeout
-        self._extra_kwargs = extra_kwargs
+        # Copy so a later mutation of the caller's dict can't change what we send.
+        self._extra_kwargs = dict(extra_kwargs) if is_given(extra_kwargs) else extra_kwargs
         self._conn_options = conn_options
         self._http_session = http_session
 
@@ -169,7 +184,7 @@ class AvatarSession(BaseAvatarSession):
         self._avatar_participant_identity = (
             avatar_participant_identity
             if is_given(avatar_participant_identity)
-            else f"{self._provider}-avatar-agent"
+            else f"{self._provider}-inference-avatar"
         )
         self._avatar_participant_name = (
             avatar_participant_name
@@ -274,7 +289,16 @@ class AvatarSession(BaseAvatarSession):
         self._terminate_token = create_resp.get("terminate_token")
         sample_rate = create_resp.get("sample_rate") or _DEFAULT_SAMPLE_RATE
 
-        if self._provider_session_id and not self._terminate_token:
+        if not self._provider_session_id:
+            # Without it aclose() has nothing to terminate; the provider session
+            # runs to its own idle timeout instead of being stopped explicitly.
+            logger.warning(
+                "avatar gateway create response had no provider_session_id; this "
+                "session cannot be explicitly terminated and will bill until its "
+                "provider idle timeout",
+                extra={"provider": self._provider, "session_id": self._session_id},
+            )
+        elif not self._terminate_token:
             # aclose() cannot terminate without this; the provider session will
             # run to its own idle timeout instead of being stopped explicitly.
             logger.warning(
@@ -289,8 +313,8 @@ class AvatarSession(BaseAvatarSession):
             )
 
         # Rebind the audio tail to the avatar worker using the gateway-reported
-        # sample rate. Done after the create response (unlike BYOK, which
-        # hardcodes the rate and rebinds first): in the canonical flow
+        # sample rate. Done after the create response (the lemonslice BYOK plugin
+        # instead hardcodes the rate and rebinds first): in the canonical flow
         # avatar.start() runs before session.start(), so no audio has flowed yet
         # and nothing is lost. wait_remote_track buffers until the video track
         # appears; replace_audio_tail keeps the TranscriptSynchronizer /
@@ -353,6 +377,16 @@ class AvatarSession(BaseAvatarSession):
         finally:
             await super().aclose()
 
+    def _auth_headers(self) -> dict[str, str]:
+        # Minted fresh on each call: callers inside the create retry loop re-mint
+        # per attempt rather than reusing a token that may expire between tries.
+        return {
+            **get_inference_headers(),
+            "Authorization": f"Bearer {create_access_token(self._api_key, self._api_secret)}",
+            HEADER_INFERENCE_PROVIDER: self._provider,
+            "Content-Type": "application/json",
+        }
+
     async def _create_session(
         self,
         *,
@@ -394,13 +428,7 @@ class AvatarSession(BaseAvatarSession):
         try:
             last_exc: Exception | None = None
             for i in range(self._conn_options.max_retry + 1):
-                headers = {
-                    **get_inference_headers(),
-                    "Authorization": f"Bearer {create_access_token(self._api_key, self._api_secret)}",
-                    HEADER_INFERENCE_PROVIDER: self._provider,
-                    "Idempotency-Key": idempotency_key,
-                    "Content-Type": "application/json",
-                }
+                headers = {**self._auth_headers(), "Idempotency-Key": idempotency_key}
                 try:
                     async with session.post(
                         url,
@@ -439,7 +467,7 @@ class AvatarSession(BaseAvatarSession):
                         raise
                     logger.warning(
                         "avatar gateway returned a retryable error",
-                        extra={"error": str(e)},
+                        extra={"provider": self._provider, "error": str(e)},
                     )
 
                 if i < self._conn_options.max_retry:
@@ -454,12 +482,7 @@ class AvatarSession(BaseAvatarSession):
 
     async def _terminate_session(self, provider_session_id: str, terminate_token: str) -> None:
         url = f"{self._base_url.rstrip('/')}/avatar/sessions/terminate"
-        headers = {
-            **get_inference_headers(),
-            "Authorization": f"Bearer {create_access_token(self._api_key, self._api_secret)}",
-            HEADER_INFERENCE_PROVIDER: self._provider,
-            "Content-Type": "application/json",
-        }
+        headers = self._auth_headers()
         payload = {
             "provider": self._provider,
             "provider_session_id": provider_session_id,

--- a/tests/test_inference_avatar.py
+++ b/tests/test_inference_avatar.py
@@ -92,14 +92,38 @@ class TestConstructorValidation:
         # A catalog id in the model string and an image_url are mutually
         # exclusive (the gateway rejects both); the constructor fails fast.
         with pytest.raises(ValueError, match="not both"):
-            _make_avatar(model="lemonslice/agent_abc", image_url="https://x/y.png")
+            _make_avatar(
+                model="lemonslice/agent_abc", extra_kwargs={"image_url": "https://x/y.png"}
+            )
 
     def test_extra_kwargs_is_copied(self) -> None:
         # A later mutation of the caller's dict must not change what we send.
-        extra: dict[str, Any] = {"foo": 1}
+        extra: dict[str, Any] = {"prompt": "hi"}
         av = _make_avatar(extra_kwargs=extra)
-        extra["foo"] = 999
-        assert av._extra_kwargs == {"foo": 1}
+        extra["prompt"] = "changed"
+        assert av._extra_kwargs == {"prompt": "hi"}
+
+
+async def test_extra_kwargs_splits_known_and_unknown_keys() -> None:
+    """Known LemonSliceOptions keys map onto first-class gateway fields; any
+    other key is forwarded verbatim under extra_kwargs (gateway allowlist)."""
+    captured: dict[str, Any] = {}
+
+    async def handler(request: web.Request) -> web.Response:
+        captured["body"] = await request.json()
+        return web.json_response({"session_id": "AVS_1"})
+
+    async with _gateway(handler) as (base_url, session):
+        av = _make_avatar(
+            base_url=base_url,
+            http_session=session,
+            extra_kwargs={"idle_prompt": "look attentive", "some_future_knob": True},
+        )
+        await _call_create(av)
+
+    body = captured["body"]
+    assert body["idle_prompt"] == "look attentive"  # known -> first-class field
+    assert body["extra_kwargs"] == {"some_future_knob": True}  # unknown -> passthrough
 
 
 @contextlib.asynccontextmanager
@@ -143,9 +167,11 @@ async def test_create_session_success() -> None:
             model="lemonslice",
             base_url=base_url,
             http_session=session,
-            image_url="https://example.com/face.png",
-            prompt="be expressive",
-            idle_timeout=300,
+            extra_kwargs={
+                "image_url": "https://example.com/face.png",
+                "prompt": "be expressive",
+                "idle_timeout": 300,
+            },
         )
         resp = await _call_create(av)
 
@@ -158,9 +184,11 @@ async def test_create_session_success() -> None:
     assert body["avatar_identity"] == "lemonslice-inference-avatar"
     assert body["agent_identity"] == "agent-worker-1"
     assert body["room_sid"] == "RM_123"
+    # Known LemonSliceOptions keys map onto the gateway's first-class fields.
     assert body["image_url"] == "https://example.com/face.png"
     assert body["prompt"] == "be expressive"
     assert body["idle_timeout_s"] == 300
+    assert "extra_kwargs" not in body
 
     headers = captured["headers"]
     assert headers["Authorization"].startswith("Bearer ")
@@ -322,7 +350,7 @@ async def test_start_uses_response_sample_rate(monkeypatch: pytest.MonkeyPatch) 
         av = _make_avatar(
             base_url=base_url,
             http_session=session,
-            image_url="https://example.com/face.png",
+            extra_kwargs={"image_url": "https://example.com/face.png"},
         )
         agent_session = _FakeAgentSession()
         await av.start(

--- a/tests/test_inference_avatar.py
+++ b/tests/test_inference_avatar.py
@@ -1,0 +1,351 @@
+"""Unit tests for livekit.agents.inference.AvatarSession.
+
+Covers model-string parsing, credential resolution, the gateway create call
+(payload/headers/idempotency), error mapping, and that the response sample rate
+drives the DataStream audio sink.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any
+
+import aiohttp
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+from livekit.agents import APIStatusError
+from livekit.agents.inference import avatar as avatar_mod
+from livekit.agents.inference._utils import HEADER_INFERENCE_PROVIDER
+from livekit.agents.inference.avatar import AvatarSession, _parse_avatar_model
+from livekit.agents.types import APIConnectOptions
+
+pytestmark = pytest.mark.unit
+
+
+def _make_avatar(**kwargs: Any) -> AvatarSession:
+    defaults: dict[str, Any] = {
+        "model": "lemonslice",
+        "api_key": "test-key",
+        "api_secret": "test-secret",
+        "base_url": "https://example.livekit.cloud/v1",
+    }
+    defaults.update(kwargs)
+    return AvatarSession(**defaults)
+
+
+class TestParseAvatarModel:
+    @pytest.mark.parametrize(
+        "model,provider,avatar_id",
+        [
+            ("lemonslice", "lemonslice", None),
+            ("lemonslice/agent_abc", "lemonslice", "agent_abc"),
+            ("lemonslice/", "lemonslice", None),
+            ("bey/face_1", "bey", "face_1"),
+        ],
+    )
+    def test_valid(self, model: str, provider: str, avatar_id: str | None) -> None:
+        assert _parse_avatar_model(model) == (provider, avatar_id)
+
+    @pytest.mark.parametrize("model", ["", "/foo", "  "])
+    def test_invalid_provider_raises(self, model: str) -> None:
+        with pytest.raises(ValueError):
+            _parse_avatar_model(model)
+
+
+class TestCredentials:
+    def test_defaults_and_identity(self) -> None:
+        av = _make_avatar()
+        assert av.provider == "lemonslice"
+        assert av.avatar_identity == "lemonslice-avatar-agent"
+
+    def test_env_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("LIVEKIT_INFERENCE_API_KEY", raising=False)
+        monkeypatch.delenv("LIVEKIT_INFERENCE_API_SECRET", raising=False)
+        monkeypatch.setenv("LIVEKIT_API_KEY", "env-key")
+        monkeypatch.setenv("LIVEKIT_API_SECRET", "env-secret")
+        av = AvatarSession("lemonslice", base_url="https://x/v1")
+        assert av._api_key == "env-key"
+        assert av._api_secret == "env-secret"
+
+    def test_missing_key_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in (
+            "LIVEKIT_INFERENCE_API_KEY",
+            "LIVEKIT_API_KEY",
+            "LIVEKIT_INFERENCE_API_SECRET",
+            "LIVEKIT_API_SECRET",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        with pytest.raises(ValueError):
+            AvatarSession("lemonslice", base_url="https://x/v1")
+
+    def test_custom_identity(self) -> None:
+        av = _make_avatar(avatar_participant_identity="custom-id")
+        assert av.avatar_identity == "custom-id"
+
+
+@contextlib.asynccontextmanager
+async def _gateway(handler):  # type: ignore[no-untyped-def]
+    """Start an aiohttp test server exposing POST /v1/avatar/sessions."""
+    app = web.Application()
+    app.router.add_post("/v1/avatar/sessions", handler)
+    server = TestServer(app)
+    await server.start_server()
+    session = aiohttp.ClientSession()
+    try:
+        base_url = str(server.make_url("/v1"))
+        yield base_url, session
+    finally:
+        await session.close()
+        await server.close()
+
+
+async def _call_create(av: AvatarSession) -> dict[str, Any]:
+    return await av._create_session(
+        room_name="my-room",
+        room_sid="RM_123",
+        livekit_url="wss://example.livekit.cloud",
+        worker_token="worker-token",
+        agent_identity="agent-worker-1",
+    )
+
+
+async def test_create_session_success() -> None:
+    captured: dict[str, Any] = {}
+
+    async def handler(request: web.Request) -> web.Response:
+        captured["headers"] = dict(request.headers)
+        captured["body"] = await request.json()
+        return web.json_response(
+            {"session_id": "AVS_1", "provider_session_id": "ls_abc", "sample_rate": 16000}
+        )
+
+    async with _gateway(handler) as (base_url, session):
+        av = _make_avatar(
+            model="lemonslice",
+            base_url=base_url,
+            http_session=session,
+            image_url="https://example.com/face.png",
+            prompt="be expressive",
+            idle_timeout=300,
+        )
+        resp = await _call_create(av)
+
+    assert resp["session_id"] == "AVS_1"
+    assert resp["provider_session_id"] == "ls_abc"
+
+    body = captured["body"]
+    assert body["provider"] == "lemonslice"
+    assert body["livekit_token"] == "worker-token"
+    assert body["avatar_identity"] == "lemonslice-avatar-agent"
+    assert body["agent_identity"] == "agent-worker-1"
+    assert body["room_sid"] == "RM_123"
+    assert body["image_url"] == "https://example.com/face.png"
+    assert body["prompt"] == "be expressive"
+    assert body["idle_timeout_s"] == 300
+
+    headers = captured["headers"]
+    assert headers["Authorization"].startswith("Bearer ")
+    assert headers[HEADER_INFERENCE_PROVIDER] == "lemonslice"
+    assert headers["Idempotency-Key"]
+
+
+async def test_avatar_id_from_model_string() -> None:
+    captured: dict[str, Any] = {}
+
+    async def handler(request: web.Request) -> web.Response:
+        captured["body"] = await request.json()
+        return web.json_response({"session_id": "AVS_1"})
+
+    async with _gateway(handler) as (base_url, session):
+        av = _make_avatar(model="lemonslice/agent_abc", base_url=base_url, http_session=session)
+        await _call_create(av)
+
+    assert captured["body"]["avatar_id"] == "agent_abc"
+    assert "image_url" not in captured["body"]
+
+
+async def test_idempotency_key_stable_across_retries() -> None:
+    keys: list[str] = []
+
+    async def handler(request: web.Request) -> web.Response:
+        keys.append(request.headers["Idempotency-Key"])
+        if len(keys) < 3:
+            return web.json_response({"error": "unavailable"}, status=503)
+        return web.json_response({"session_id": "AVS_1"})
+
+    async with _gateway(handler) as (base_url, session):
+        av = _make_avatar(
+            base_url=base_url,
+            http_session=session,
+            conn_options=APIConnectOptions(max_retry=3, retry_interval=0.0, timeout=5.0),
+        )
+        resp = await _call_create(av)
+
+    assert resp["session_id"] == "AVS_1"
+    assert len(keys) == 3
+    assert len(set(keys)) == 1, "idempotency key must be stable across retries"
+
+
+async def test_non_retryable_error_not_retried() -> None:
+    calls = {"n": 0}
+
+    async def handler(request: web.Request) -> web.Response:
+        calls["n"] += 1
+        return web.json_response({"error": "not enabled"}, status=403)
+
+    async with _gateway(handler) as (base_url, session):
+        av = _make_avatar(
+            base_url=base_url,
+            http_session=session,
+            conn_options=APIConnectOptions(max_retry=3, retry_interval=0.0, timeout=5.0),
+        )
+        with pytest.raises(APIStatusError) as exc:
+            await _call_create(av)
+
+    assert exc.value.status_code == 403
+    assert calls["n"] == 1, "a 403 is non-retryable and must not be retried"
+
+
+async def test_server_error_retried_then_raised() -> None:
+    calls = {"n": 0}
+
+    async def handler(request: web.Request) -> web.Response:
+        calls["n"] += 1
+        return web.json_response({"error": "boom"}, status=502)
+
+    async with _gateway(handler) as (base_url, session):
+        av = _make_avatar(
+            base_url=base_url,
+            http_session=session,
+            conn_options=APIConnectOptions(max_retry=2, retry_interval=0.0, timeout=5.0),
+        )
+        with pytest.raises(APIStatusError) as exc:
+            await _call_create(av)
+
+    assert exc.value.status_code == 502
+    assert calls["n"] == 3, "502 is retryable: initial try + 2 retries"
+
+
+class _FakeSink:
+    def __init__(self, **kwargs: Any) -> None:
+        self.sample_rate = kwargs.get("sample_rate")
+
+
+class _FakeOutput:
+    def __init__(self) -> None:
+        self.sink: Any = None
+
+    def replace_audio_tail(self, sink: Any) -> None:
+        self.sink = sink
+
+
+class _FakeAgentSession:
+    def __init__(self) -> None:
+        self.output = _FakeOutput()
+
+    def on(self, *_a: Any, **_k: Any) -> None:
+        pass
+
+    def emit(self, *_a: Any, **_k: Any) -> None:
+        pass
+
+
+class _FakeRoom:
+    name = "my-room"
+
+    def isconnected(self) -> bool:
+        # False so the base class registers a connection callback instead of
+        # launching the participant-join wait task (which would hang offline).
+        return False
+
+    def on(self, *_a: Any, **_k: Any) -> None:
+        pass
+
+    def off(self, *_a: Any, **_k: Any) -> None:
+        pass
+
+
+class _FakeJobRoom:
+    sid = "RM_123"
+
+
+class _FakeJob:
+    room = _FakeJobRoom()
+
+
+class _FakeJobCtx:
+    local_participant_identity = "agent-worker-1"
+    job = _FakeJob()
+
+    def add_shutdown_callback(self, *_a: Any, **_k: Any) -> None:
+        pass
+
+
+async def test_start_uses_response_sample_rate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The DataStream sink is created with the gateway-reported sample rate,
+    not a hardcoded per-provider constant."""
+
+    async def handler(request: web.Request) -> web.Response:
+        return web.json_response(
+            {"session_id": "AVS_1", "provider_session_id": "ls_1", "sample_rate": 24000}
+        )
+
+    monkeypatch.setattr(avatar_mod, "get_job_context", lambda *a, **k: _FakeJobCtx())
+    monkeypatch.setattr(avatar_mod, "DataStreamAudioOutput", _FakeSink)
+
+    async with _gateway(handler) as (base_url, session):
+        av = _make_avatar(
+            base_url=base_url,
+            http_session=session,
+            image_url="https://example.com/face.png",
+        )
+        agent_session = _FakeAgentSession()
+        await av.start(
+            agent_session,  # type: ignore[arg-type]
+            _FakeRoom(),  # type: ignore[arg-type]
+            livekit_url="wss://example.livekit.cloud",
+            livekit_api_key="devkey",
+            livekit_api_secret="devsecret",
+        )
+
+    assert av.session_id == "AVS_1"
+    assert av.provider_session_id == "ls_1"
+    assert isinstance(agent_session.output.sink, _FakeSink)
+    assert agent_session.output.sink.sample_rate == 24000
+
+
+async def test_aclose_terminates_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """aclose() calls the gateway terminate endpoint so the provider session
+    stops billing instead of lingering until idle timeout."""
+    terminate_bodies: list[dict[str, Any]] = []
+
+    async def handler(request: web.Request) -> web.Response:
+        terminate_bodies.append(await request.json())
+        return web.json_response({"terminated": True})
+
+    app = web.Application()
+    app.router.add_post("/v1/avatar/sessions/terminate", handler)
+    server = TestServer(app)
+    await server.start_server()
+    session = aiohttp.ClientSession()
+    try:
+        av = _make_avatar(base_url=str(server.make_url("/v1")), http_session=session)
+        av._provider_session_id = "ls_abc"
+        # No room/agent were started; base aclose() no-ops on cleanup.
+        await av.aclose()
+    finally:
+        await session.close()
+        await server.close()
+
+    assert len(terminate_bodies) == 1
+    assert terminate_bodies[0] == {"provider": "lemonslice", "provider_session_id": "ls_abc"}
+    # provider session id cleared so a second aclose() does not re-terminate.
+    assert av.provider_session_id is None
+
+
+async def test_aclose_without_session_is_noop() -> None:
+    av = _make_avatar()
+    # No provider session created; aclose() must not raise.
+    await av.aclose()

--- a/tests/test_inference_avatar.py
+++ b/tests/test_inference_avatar.py
@@ -60,7 +60,7 @@ class TestCredentials:
     def test_defaults_and_identity(self) -> None:
         av = _make_avatar()
         assert av.provider == "lemonslice"
-        assert av.avatar_identity == "lemonslice-avatar-agent"
+        assert av.avatar_identity == "lemonslice-inference-avatar"
 
     def test_env_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("LIVEKIT_INFERENCE_API_KEY", raising=False)
@@ -85,6 +85,21 @@ class TestCredentials:
     def test_custom_identity(self) -> None:
         av = _make_avatar(avatar_participant_identity="custom-id")
         assert av.avatar_identity == "custom-id"
+
+
+class TestConstructorValidation:
+    def test_image_url_and_model_id_conflict_raises(self) -> None:
+        # A catalog id in the model string and an image_url are mutually
+        # exclusive (the gateway rejects both); the constructor fails fast.
+        with pytest.raises(ValueError, match="not both"):
+            _make_avatar(model="lemonslice/agent_abc", image_url="https://x/y.png")
+
+    def test_extra_kwargs_is_copied(self) -> None:
+        # A later mutation of the caller's dict must not change what we send.
+        extra: dict[str, Any] = {"foo": 1}
+        av = _make_avatar(extra_kwargs=extra)
+        extra["foo"] = 999
+        assert av._extra_kwargs == {"foo": 1}
 
 
 @contextlib.asynccontextmanager
@@ -140,7 +155,7 @@ async def test_create_session_success() -> None:
     body = captured["body"]
     assert body["provider"] == "lemonslice"
     assert body["livekit_token"] == "worker-token"
-    assert body["avatar_identity"] == "lemonslice-avatar-agent"
+    assert body["avatar_identity"] == "lemonslice-inference-avatar"
     assert body["agent_identity"] == "agent-worker-1"
     assert body["room_sid"] == "RM_123"
     assert body["image_url"] == "https://example.com/face.png"
@@ -356,7 +371,7 @@ async def test_start_mints_worker_token_with_expected_grants(
 
     claims = jwt.decode(captured["body"]["livekit_token"], options={"verify_signature": False})
     assert claims["kind"] == "agent"
-    assert claims["sub"] == "lemonslice-avatar-agent"
+    assert claims["sub"] == "lemonslice-inference-avatar"
     assert claims["video"]["roomJoin"] is True
     assert claims["video"]["room"] == "my-room"
     assert claims["attributes"] == {

--- a/tests/test_inference_avatar.py
+++ b/tests/test_inference_avatar.py
@@ -1,8 +1,9 @@
 """Unit tests for livekit.agents.inference.AvatarSession.
 
 Covers model-string parsing, credential resolution, the gateway create call
-(payload/headers/idempotency), error mapping, and that the response sample rate
-drives the DataStream audio sink.
+(payload/headers/idempotency), error mapping, that the response sample rate
+drives the DataStream audio sink, the terminate_token contract, double-start
+guarding, and the standalone (no job context) room paths.
 """
 
 from __future__ import annotations
@@ -11,6 +12,7 @@ import contextlib
 from typing import Any
 
 import aiohttp
+import jwt
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestServer
@@ -86,10 +88,10 @@ class TestCredentials:
 
 
 @contextlib.asynccontextmanager
-async def _gateway(handler):  # type: ignore[no-untyped-def]
-    """Start an aiohttp test server exposing POST /v1/avatar/sessions."""
+async def _gateway(handler, path: str = "/v1/avatar/sessions"):  # type: ignore[no-untyped-def]
+    """Start an aiohttp test server exposing POST `path`."""
     app = web.Application()
-    app.router.add_post("/v1/avatar/sessions", handler)
+    app.router.add_post(path, handler)
     server = TestServer(app)
     await server.start_server()
     session = aiohttp.ClientSession()
@@ -285,11 +287,17 @@ class _FakeJobCtx:
 
 async def test_start_uses_response_sample_rate(monkeypatch: pytest.MonkeyPatch) -> None:
     """The DataStream sink is created with the gateway-reported sample rate,
-    not a hardcoded per-provider constant."""
+    not a hardcoded per-provider constant, and terminate_token is captured
+    from the create response for later use by aclose()."""
 
     async def handler(request: web.Request) -> web.Response:
         return web.json_response(
-            {"session_id": "AVS_1", "provider_session_id": "ls_1", "sample_rate": 24000}
+            {
+                "session_id": "AVS_1",
+                "provider_session_id": "ls_1",
+                "terminate_token": "tt_1",
+                "sample_rate": 24000,
+            }
         )
 
     monkeypatch.setattr(avatar_mod, "get_job_context", lambda *a, **k: _FakeJobCtx())
@@ -312,37 +320,283 @@ async def test_start_uses_response_sample_rate(monkeypatch: pytest.MonkeyPatch) 
 
     assert av.session_id == "AVS_1"
     assert av.provider_session_id == "ls_1"
+    assert av._terminate_token == "tt_1"
     assert isinstance(agent_session.output.sink, _FakeSink)
     assert agent_session.output.sink.sample_rate == 24000
 
 
-async def test_aclose_terminates_session(monkeypatch: pytest.MonkeyPatch) -> None:
-    """aclose() calls the gateway terminate endpoint so the provider session
-    stops billing instead of lingering until idle timeout."""
+async def test_start_mints_worker_token_with_expected_grants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The minted avatar worker token must carry the room-join grant and the
+    lk.publish_on_behalf / lk.avatar_provider attributes the gateway and
+    server-side metering depend on."""
+    captured: dict[str, Any] = {}
+
+    async def handler(request: web.Request) -> web.Response:
+        captured["body"] = await request.json()
+        return web.json_response({"session_id": "AVS_1", "provider_session_id": "ls_1"})
+
+    monkeypatch.setattr(avatar_mod, "get_job_context", lambda *a, **k: _FakeJobCtx())
+    monkeypatch.setattr(avatar_mod, "DataStreamAudioOutput", _FakeSink)
+
+    async with _gateway(handler) as (base_url, session):
+        av = _make_avatar(base_url=base_url, http_session=session)
+        agent_session = _FakeAgentSession()
+        await av.start(
+            agent_session,  # type: ignore[arg-type]
+            _FakeRoom(),  # type: ignore[arg-type]
+            livekit_url="wss://example.livekit.cloud",
+            livekit_api_key="devkey",
+            livekit_api_secret="devsecret",
+        )
+
+    assert captured["body"]["room_sid"] == "RM_123"
+    assert captured["body"]["agent_identity"] == "agent-worker-1"
+
+    claims = jwt.decode(captured["body"]["livekit_token"], options={"verify_signature": False})
+    assert claims["kind"] == "agent"
+    assert claims["sub"] == "lemonslice-avatar-agent"
+    assert claims["video"]["roomJoin"] is True
+    assert claims["video"]["room"] == "my-room"
+    assert claims["attributes"] == {
+        "lk.publish_on_behalf": "agent-worker-1",
+        "lk.avatar_provider": "lemonslice",
+    }
+
+
+async def test_start_twice_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A second start() must not create a second paid provider session or lose
+    the first session's terminate handle."""
+    calls = {"n": 0}
+
+    async def handler(request: web.Request) -> web.Response:
+        calls["n"] += 1
+        return web.json_response({"session_id": "AVS_1", "provider_session_id": "ls_1"})
+
+    monkeypatch.setattr(avatar_mod, "get_job_context", lambda *a, **k: _FakeJobCtx())
+    monkeypatch.setattr(avatar_mod, "DataStreamAudioOutput", _FakeSink)
+
+    async with _gateway(handler) as (base_url, session):
+        av = _make_avatar(base_url=base_url, http_session=session)
+        agent_session = _FakeAgentSession()
+        await av.start(
+            agent_session,  # type: ignore[arg-type]
+            _FakeRoom(),  # type: ignore[arg-type]
+            livekit_url="wss://example.livekit.cloud",
+            livekit_api_key="devkey",
+            livekit_api_secret="devsecret",
+        )
+
+        with pytest.raises(RuntimeError, match="only be called once"):
+            await av.start(
+                agent_session,  # type: ignore[arg-type]
+                _FakeRoom(),  # type: ignore[arg-type]
+                livekit_url="wss://example.livekit.cloud",
+                livekit_api_key="devkey",
+                livekit_api_secret="devsecret",
+            )
+
+    assert calls["n"] == 1, "second start() must not call the gateway again"
+    assert av.provider_session_id == "ls_1", "the first session's terminate handle must survive"
+
+
+class _FakeBrokenOutput:
+    def replace_audio_tail(self, sink: Any) -> None:
+        raise RuntimeError("boom")
+
+
+class _FakeBrokenAgentSession(_FakeAgentSession):
+    def __init__(self) -> None:
+        super().__init__()
+        self.output = _FakeBrokenOutput()  # type: ignore[assignment]
+
+
+async def test_start_ids_set_before_audio_rebind(monkeypatch: pytest.MonkeyPatch) -> None:
+    """session_id/provider_session_id/terminate_token must be recorded before
+    the audio-output rebind, so a failure in the rebind still leaves a
+    terminable (billable) session rather than an orphaned one."""
+
+    async def handler(request: web.Request) -> web.Response:
+        return web.json_response(
+            {"session_id": "AVS_1", "provider_session_id": "ls_1", "terminate_token": "tt_1"}
+        )
+
+    monkeypatch.setattr(avatar_mod, "get_job_context", lambda *a, **k: _FakeJobCtx())
+
+    async with _gateway(handler) as (base_url, session):
+        av = _make_avatar(base_url=base_url, http_session=session)
+        with pytest.raises(RuntimeError, match="boom"):
+            await av.start(
+                _FakeBrokenAgentSession(),  # type: ignore[arg-type]
+                _FakeRoom(),  # type: ignore[arg-type]
+                livekit_url="wss://example.livekit.cloud",
+                livekit_api_key="devkey",
+                livekit_api_secret="devsecret",
+            )
+
+    assert av.provider_session_id == "ls_1"
+    assert av._terminate_token == "tt_1"
+
+
+class _FakeLocalParticipant:
+    identity = "standalone-agent"
+
+
+class _FakeConnectedRoom:
+    name = "my-room"
+
+    def isconnected(self) -> bool:
+        return True
+
+    @property
+    def local_participant(self) -> Any:
+        return _FakeLocalParticipant()
+
+    @property
+    def sid(self) -> Any:
+        async def _get() -> str:
+            return "RM_789"
+
+        return _get()
+
+    def on(self, *_a: Any, **_k: Any) -> None:
+        pass
+
+    def off(self, *_a: Any, **_k: Any) -> None:
+        pass
+
+
+async def test_start_standalone_connected_room(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without a job context, a connected room's local_participant/sid drive
+    start() (guarded by isconnected(), not a bare local_participant access,
+    which raises on a real rtc.Room instead of returning None)."""
+    captured: dict[str, Any] = {}
+
+    async def handler(request: web.Request) -> web.Response:
+        captured["body"] = await request.json()
+        return web.json_response({"session_id": "AVS_1", "provider_session_id": "ls_1"})
+
+    monkeypatch.setattr(avatar_mod, "get_job_context", lambda *a, **k: None)
+    monkeypatch.setattr(avatar_mod, "DataStreamAudioOutput", _FakeSink)
+
+    async with _gateway(handler) as (base_url, session):
+        av = _make_avatar(base_url=base_url, http_session=session)
+        await av.start(
+            _FakeAgentSession(),  # type: ignore[arg-type]
+            _FakeConnectedRoom(),  # type: ignore[arg-type]
+            livekit_url="wss://example.livekit.cloud",
+            livekit_api_key="devkey",
+            livekit_api_secret="devsecret",
+        )
+
+        # isconnected() == True also makes the base class eagerly spawn a
+        # join-wait task; this fake doesn't implement remote_participants
+        # (out of scope for this test), so retrieve/discard its exception
+        # rather than leaving it unretrieved at garbage-collection time.
+        join_task = av._wait_avatar_join_task
+        if join_task is not None:
+            join_task.cancel()
+            with contextlib.suppress(BaseException):
+                await join_task
+
+    assert captured["body"]["agent_identity"] == "standalone-agent"
+    assert captured["body"]["room_sid"] == "RM_789"
+
+
+async def test_start_standalone_disconnected_room_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without a job context and a disconnected room, start() must raise the
+    documented, actionable RuntimeError rather than an opaque error from the
+    rtc layer (Room.local_participant raises rather than returning None)."""
+    monkeypatch.setattr(avatar_mod, "get_job_context", lambda *a, **k: None)
+
+    av = _make_avatar()
+    with pytest.raises(RuntimeError, match="needs a connected room"):
+        await av.start(
+            _FakeAgentSession(),  # type: ignore[arg-type]
+            _FakeRoom(),  # type: ignore[arg-type]
+            livekit_url="wss://example.livekit.cloud",
+            livekit_api_key="devkey",
+            livekit_api_secret="devsecret",
+        )
+
+
+async def test_aclose_terminates_session() -> None:
+    """aclose() calls the gateway terminate endpoint (with the terminate_token
+    the gateway requires) so the provider session stops billing instead of
+    lingering until idle timeout."""
     terminate_bodies: list[dict[str, Any]] = []
 
     async def handler(request: web.Request) -> web.Response:
         terminate_bodies.append(await request.json())
         return web.json_response({"terminated": True})
 
-    app = web.Application()
-    app.router.add_post("/v1/avatar/sessions/terminate", handler)
-    server = TestServer(app)
-    await server.start_server()
-    session = aiohttp.ClientSession()
-    try:
-        av = _make_avatar(base_url=str(server.make_url("/v1")), http_session=session)
+    async with _gateway(handler, path="/v1/avatar/sessions/terminate") as (base_url, session):
+        av = _make_avatar(base_url=base_url, http_session=session)
         av._provider_session_id = "ls_abc"
+        av._terminate_token = "tt_abc"
         # No room/agent were started; base aclose() no-ops on cleanup.
         await av.aclose()
-    finally:
-        await session.close()
-        await server.close()
 
     assert len(terminate_bodies) == 1
-    assert terminate_bodies[0] == {"provider": "lemonslice", "provider_session_id": "ls_abc"}
-    # provider session id cleared so a second aclose() does not re-terminate.
+    assert terminate_bodies[0] == {
+        "provider": "lemonslice",
+        "provider_session_id": "ls_abc",
+        "terminate_token": "tt_abc",
+    }
+    # cleared on a confirmed terminate, so a second aclose() does not re-terminate.
     assert av.provider_session_id is None
+    assert av._terminate_token is None
+
+
+async def test_aclose_skips_terminate_without_token() -> None:
+    """If the create response never returned a terminate_token, aclose() must
+    not call the gateway at all (it would just 400) — it logs and moves on."""
+    calls = {"n": 0}
+
+    async def handler(request: web.Request) -> web.Response:
+        calls["n"] += 1
+        return web.json_response({"terminated": True})
+
+    async with _gateway(handler, path="/v1/avatar/sessions/terminate") as (base_url, session):
+        av = _make_avatar(base_url=base_url, http_session=session)
+        av._provider_session_id = "ls_abc"
+        # av._terminate_token left None, as if the gateway never returned one.
+        await av.aclose()  # must not raise
+
+    assert calls["n"] == 0, "terminate must not be attempted without a terminate_token"
+
+
+async def test_aclose_terminate_failure_keeps_ids_and_runs_base_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed terminate must not raise, must leave the ids in place so a
+    subsequent aclose() call can retry, and must not block the base class's
+    own cleanup."""
+    from livekit.agents.voice.avatar import AvatarSession as BaseAvatarSession
+
+    base_aclose_calls = {"n": 0}
+    orig_base_aclose = BaseAvatarSession.aclose
+
+    async def spy_base_aclose(self: Any) -> None:
+        base_aclose_calls["n"] += 1
+        await orig_base_aclose(self)
+
+    monkeypatch.setattr(BaseAvatarSession, "aclose", spy_base_aclose)
+
+    async def handler(request: web.Request) -> web.Response:
+        return web.json_response({"error": "boom"}, status=500)
+
+    async with _gateway(handler, path="/v1/avatar/sessions/terminate") as (base_url, session):
+        av = _make_avatar(base_url=base_url, http_session=session)
+        av._provider_session_id = "ls_abc"
+        av._terminate_token = "tt_abc"
+
+        await av.aclose()  # must not raise
+
+    assert base_aclose_calls["n"] == 1
+    assert av.provider_session_id == "ls_abc", "must survive a failed terminate for a retry"
+    assert av._terminate_token == "tt_abc"
 
 
 async def test_aclose_without_session_is_noop() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -133,21 +133,8 @@ typing = [
 ]
 
 [[package]]
-name = "aioboto3"
-version = "15.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiobotocore", extra = ["boto3"] },
-    { name = "aiofiles" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/01/92e9ab00f36e2899315f49eefcd5b4685fbb19016c7f19a9edf06da80bb0/aioboto3-15.5.0.tar.gz", hash = "sha256:ea8d8787d315594842fbfcf2c4dce3bac2ad61be275bc8584b2ce9a3402a6979", size = 255069, upload-time = "2025-10-30T13:37:16.122Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/3e/e8f5b665bca646d43b916763c901e00a07e40f7746c9128bdc912a089424/aioboto3-15.5.0-py3-none-any.whl", hash = "sha256:cc880c4d6a8481dd7e05da89f41c384dbd841454fc1998ae25ca9c39201437a6", size = 35913, upload-time = "2025-10-30T13:37:14.549Z" },
-]
-
-[[package]]
 name = "aiobotocore"
-version = "2.25.1"
+version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -158,14 +145,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/94/2e4ec48cf1abb89971cb2612d86f979a6240520f0a659b53a43116d344dc/aiobotocore-2.25.1.tar.gz", hash = "sha256:ea9be739bfd7ece8864f072ec99bb9ed5c7e78ebb2b0b15f29781fbe02daedbc", size = 120560, upload-time = "2025-10-28T22:33:21.787Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/a7/bc31b7046c610471f0630819ca5d2a57ac4efa8d47135cb53e43f2785390/aiobotocore-3.8.0.tar.gz", hash = "sha256:80a1eb64ea915f3af3c1518669975bae74a17b2f37c14eb0fa2f83b915974670", size = 131368, upload-time = "2026-07-17T03:10:30.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/2a/d275ec4ce5cd0096665043995a7d76f5d0524853c76a3d04656de49f8808/aiobotocore-2.25.1-py3-none-any.whl", hash = "sha256:eb6daebe3cbef5b39a0bb2a97cffbe9c7cb46b2fcc399ad141f369f3c2134b1f", size = 86039, upload-time = "2025-10-28T22:33:19.949Z" },
-]
-
-[package.optional-dependencies]
-boto3 = [
-    { name = "boto3" },
+    { url = "https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl", hash = "sha256:8bc605132cadfe844a3f334635a0a64fa5e360a4a206e915d99d53db5b6deeba", size = 91169, upload-time = "2026-07-17T03:10:28.771Z" },
 ]
 
 [[package]]
@@ -582,30 +564,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.40.61"
+version = "1.43.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/f9/6ef8feb52c3cce5ec3967a535a6114b57ac7949fd166b0f3090c2b06e4e5/boto3-1.40.61.tar.gz", hash = "sha256:d6c56277251adf6c2bdd25249feae625abe4966831676689ff23b4694dea5b12", size = 111535, upload-time = "2025-10-28T19:26:57.247Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/e7/976bf3dfe0aa5d7f31bec2f2cf57c79641620c910a39bc843a237aa9592d/boto3-1.43.46.tar.gz", hash = "sha256:66c0d943b049a46a492ec4ec2ebe73c930b1842c7137bee83aad6d93e95d4d96", size = 112654, upload-time = "2026-07-10T19:32:12.498Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/24/3bf865b07d15fea85b63504856e137029b6acbc73762496064219cdb265d/boto3-1.40.61-py3-none-any.whl", hash = "sha256:6b9c57b2a922b5d8c17766e29ed792586a818098efe84def27c8f582b33f898c", size = 139321, upload-time = "2025-10-28T19:26:55.007Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl", hash = "sha256:69453e2c1bcb9fd9806527ab99950cacfc2826cb0dce9a3a0414d19270c06c3c", size = 140031, upload-time = "2026-07-10T19:32:11.129Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.40.61"
+version = "1.43.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/a3/81d3a47c2dbfd76f185d3b894f2ad01a75096c006a2dd91f237dca182188/botocore-1.40.61.tar.gz", hash = "sha256:a2487ad69b090f9cccd64cf07c7021cd80ee9c0655ad974f87045b02f3ef52cd", size = 14393956, upload-time = "2025-10-28T19:26:46.108Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/f1/1917891851ac5ac09bb9f4862b8fc9252a009d7c24e8688bb67e4383d9e7/botocore-1.43.46.tar.gz", hash = "sha256:59f2e1ac3cdc66d191cae91c0804bc41847ce817dc8147cf43eaada8f76a5533", size = 15694635, upload-time = "2026-07-10T19:32:00.437Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/c5/f6ce561004db45f0b847c2cd9b19c67c6bf348a82018a48cb718be6b58b0/botocore-1.40.61-py3-none-any.whl", hash = "sha256:17ebae412692fd4824f99cde0f08d50126dc97954008e5ba2b522eb049238aa7", size = 14055973, upload-time = "2025-10-28T19:26:42.15Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f2/4bd8f2f419088feb3ce55f0ca91040ff902f402edfd197450b20a2e1d533/botocore-1.43.46-py3-none-any.whl", hash = "sha256:cb673891e623ae6e6a1bf24d94ef169504f3eb02584adb5d5bee2f6aae819b60", size = 15380350, upload-time = "2026-07-10T19:31:57.616Z" },
 ]
 
 [[package]]
@@ -2297,7 +2279,7 @@ requires-dist = [{ name = "livekit-agents", editable = "livekit-agents" }]
 name = "livekit-plugins-aws"
 source = { editable = "livekit-plugins/livekit-plugins-aws" }
 dependencies = [
-    { name = "aioboto3" },
+    { name = "aiobotocore" },
     { name = "aws-sdk-transcribe-streaming" },
     { name = "livekit-agents" },
 ]
@@ -2311,7 +2293,7 @@ realtime = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aioboto3", specifier = ">=14.1.0" },
+    { name = "aiobotocore", specifier = ">=3.0.0" },
     { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12' and extra == 'realtime'", specifier = ">=0.2.0" },
     { name = "aws-sdk-signers", marker = "python_full_version >= '3.12' and extra == 'realtime'", specifier = ">=0.0.3" },
     { name = "aws-sdk-transcribe-streaming", marker = "python_full_version >= '3.12'", specifier = ">=0.2.0" },
@@ -2548,7 +2530,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "livekit-agents", extras = ["codecs"], editable = "livekit-agents" },
-    { name = "websockets", specifier = ">=12.0,<16.0" },
+    { name = "websockets", specifier = ">=14.0,<16.0" },
 ]
 
 [[package]]
@@ -4951,14 +4933,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.14.0"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354, upload-time = "2026-07-10T19:32:04.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/f0/ae7ca09223a81a1d890b2557186ea015f6e0502e9b8cb8e1813f1d8cfa4e/s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456", size = 85712, upload-time = "2025-09-09T19:23:30.041Z" },
+    { url = "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl", hash = "sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de", size = 90072, upload-time = "2026-07-10T19:32:03.673Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -133,8 +133,21 @@ typing = [
 ]
 
 [[package]]
+name = "aioboto3"
+version = "15.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiobotocore", extra = ["boto3"] },
+    { name = "aiofiles" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/01/92e9ab00f36e2899315f49eefcd5b4685fbb19016c7f19a9edf06da80bb0/aioboto3-15.5.0.tar.gz", hash = "sha256:ea8d8787d315594842fbfcf2c4dce3bac2ad61be275bc8584b2ce9a3402a6979", size = 255069, upload-time = "2025-10-30T13:37:16.122Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/3e/e8f5b665bca646d43b916763c901e00a07e40f7746c9128bdc912a089424/aioboto3-15.5.0-py3-none-any.whl", hash = "sha256:cc880c4d6a8481dd7e05da89f41c384dbd841454fc1998ae25ca9c39201437a6", size = 35913, upload-time = "2025-10-30T13:37:14.549Z" },
+]
+
+[[package]]
 name = "aiobotocore"
-version = "3.8.0"
+version = "2.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -145,9 +158,14 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/a7/bc31b7046c610471f0630819ca5d2a57ac4efa8d47135cb53e43f2785390/aiobotocore-3.8.0.tar.gz", hash = "sha256:80a1eb64ea915f3af3c1518669975bae74a17b2f37c14eb0fa2f83b915974670", size = 131368, upload-time = "2026-07-17T03:10:30.258Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/94/2e4ec48cf1abb89971cb2612d86f979a6240520f0a659b53a43116d344dc/aiobotocore-2.25.1.tar.gz", hash = "sha256:ea9be739bfd7ece8864f072ec99bb9ed5c7e78ebb2b0b15f29781fbe02daedbc", size = 120560, upload-time = "2025-10-28T22:33:21.787Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl", hash = "sha256:8bc605132cadfe844a3f334635a0a64fa5e360a4a206e915d99d53db5b6deeba", size = 91169, upload-time = "2026-07-17T03:10:28.771Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/d275ec4ce5cd0096665043995a7d76f5d0524853c76a3d04656de49f8808/aiobotocore-2.25.1-py3-none-any.whl", hash = "sha256:eb6daebe3cbef5b39a0bb2a97cffbe9c7cb46b2fcc399ad141f369f3c2134b1f", size = 86039, upload-time = "2025-10-28T22:33:19.949Z" },
+]
+
+[package.optional-dependencies]
+boto3 = [
+    { name = "boto3" },
 ]
 
 [[package]]
@@ -564,30 +582,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.46"
+version = "1.40.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/e7/976bf3dfe0aa5d7f31bec2f2cf57c79641620c910a39bc843a237aa9592d/boto3-1.43.46.tar.gz", hash = "sha256:66c0d943b049a46a492ec4ec2ebe73c930b1842c7137bee83aad6d93e95d4d96", size = 112654, upload-time = "2026-07-10T19:32:12.498Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/f9/6ef8feb52c3cce5ec3967a535a6114b57ac7949fd166b0f3090c2b06e4e5/boto3-1.40.61.tar.gz", hash = "sha256:d6c56277251adf6c2bdd25249feae625abe4966831676689ff23b4694dea5b12", size = 111535, upload-time = "2025-10-28T19:26:57.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl", hash = "sha256:69453e2c1bcb9fd9806527ab99950cacfc2826cb0dce9a3a0414d19270c06c3c", size = 140031, upload-time = "2026-07-10T19:32:11.129Z" },
+    { url = "https://files.pythonhosted.org/packages/61/24/3bf865b07d15fea85b63504856e137029b6acbc73762496064219cdb265d/boto3-1.40.61-py3-none-any.whl", hash = "sha256:6b9c57b2a922b5d8c17766e29ed792586a818098efe84def27c8f582b33f898c", size = 139321, upload-time = "2025-10-28T19:26:55.007Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.46"
+version = "1.40.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/f1/1917891851ac5ac09bb9f4862b8fc9252a009d7c24e8688bb67e4383d9e7/botocore-1.43.46.tar.gz", hash = "sha256:59f2e1ac3cdc66d191cae91c0804bc41847ce817dc8147cf43eaada8f76a5533", size = 15694635, upload-time = "2026-07-10T19:32:00.437Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/a3/81d3a47c2dbfd76f185d3b894f2ad01a75096c006a2dd91f237dca182188/botocore-1.40.61.tar.gz", hash = "sha256:a2487ad69b090f9cccd64cf07c7021cd80ee9c0655ad974f87045b02f3ef52cd", size = 14393956, upload-time = "2025-10-28T19:26:46.108Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/f2/4bd8f2f419088feb3ce55f0ca91040ff902f402edfd197450b20a2e1d533/botocore-1.43.46-py3-none-any.whl", hash = "sha256:cb673891e623ae6e6a1bf24d94ef169504f3eb02584adb5d5bee2f6aae819b60", size = 15380350, upload-time = "2026-07-10T19:31:57.616Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c5/f6ce561004db45f0b847c2cd9b19c67c6bf348a82018a48cb718be6b58b0/botocore-1.40.61-py3-none-any.whl", hash = "sha256:17ebae412692fd4824f99cde0f08d50126dc97954008e5ba2b522eb049238aa7", size = 14055973, upload-time = "2025-10-28T19:26:42.15Z" },
 ]
 
 [[package]]
@@ -2279,7 +2297,7 @@ requires-dist = [{ name = "livekit-agents", editable = "livekit-agents" }]
 name = "livekit-plugins-aws"
 source = { editable = "livekit-plugins/livekit-plugins-aws" }
 dependencies = [
-    { name = "aiobotocore" },
+    { name = "aioboto3" },
     { name = "aws-sdk-transcribe-streaming" },
     { name = "livekit-agents" },
 ]
@@ -2293,7 +2311,7 @@ realtime = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiobotocore", specifier = ">=3.0.0" },
+    { name = "aioboto3", specifier = ">=14.1.0" },
     { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12' and extra == 'realtime'", specifier = ">=0.2.0" },
     { name = "aws-sdk-signers", marker = "python_full_version >= '3.12' and extra == 'realtime'", specifier = ">=0.0.3" },
     { name = "aws-sdk-transcribe-streaming", marker = "python_full_version >= '3.12'", specifier = ">=0.2.0" },
@@ -2530,7 +2548,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "livekit-agents", extras = ["codecs"], editable = "livekit-agents" },
-    { name = "websockets", specifier = ">=14.0,<16.0" },
+    { name = "websockets", specifier = ">=12.0,<16.0" },
 ]
 
 [[package]]
@@ -4933,14 +4951,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.19.1"
+version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354, upload-time = "2026-07-10T19:32:04.849Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl", hash = "sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de", size = 90072, upload-time = "2026-07-10T19:32:03.673Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f0/ae7ca09223a81a1d890b2557186ea015f6e0502e9b8cb8e1813f1d8cfa4e/s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456", size = 85712, upload-time = "2025-09-09T19:23:30.041Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Adds `livekit.agents.inference.AvatarSession` — a thin subclass of `voice.avatar.AvatarSession` that provisions an avatar provider session through the **LiveKit Inference gateway** (`POST /v1/avatar/sessions`) instead of a BYOK provider key.

```python
from livekit.agents import AgentSession, inference

avatar = inference.AvatarSession("lemonslice", image_url="https://…", prompt="…")
await avatar.start(session, room=ctx.room)
await avatar.wait_for_join()
```

## Why
BYOK avatar plugins require a customer provider key and bill LiveKit nothing for the avatar. Routing provisioning through Inference gives a **single-key** experience (`LIVEKIT_API_KEY` / `LIVEKIT_API_SECRET` only) and lets LiveKit meter avatar usage — matching `inference.STT/LLM/TTS`. BYOK plugins stay as-is; this is an additive path.

## How
- The agent mints the avatar worker's room token **locally** (identical to the BYOK plugins — `kind=agent`, `room_join`, `lk.publish_on_behalf`, plus an `lk.avatar_provider` attribute for future metering) and sends a normalized payload to the gateway; the gateway calls the provider with LiveKit's wholesale key. Media/lip-sync still flow in-room over `DataStreamAudioOutput` — unchanged from BYOK.
- Model string `"lemonslice"` or `"lemonslice/<agent_id>"`; `image_url` / `prompt` / `idle_prompt` first-class; `extra_kwargs` for provider-specific fields.
- **Idempotency-Key** per `start()` (stable across retries) so a retried create replays on the gateway instead of creating a second paid session.
- **`aclose()`** terminates the provider session via the gateway (`/v1/avatar/sessions/terminate`) so it stops billing on shutdown rather than lingering to the idle timeout.
- Uses the gateway-reported **`sample_rate`** for `DataStreamAudioOutput` (no per-provider hardcoding). Works inside an agent job or standalone (derives identity/room-sid from the connected room when there's no job context).
- Lazy PEP 562 export in `inference/__init__.py` to avoid a circular import during voice-package init.

## Files
- `livekit-agents/livekit/agents/inference/avatar.py` (new)
- `livekit-agents/livekit/agents/inference/__init__.py` — lazy `AvatarSession` export
- `examples/avatar/inference_agent.py` (new) + a note in `examples/avatar/README.md`
- `tests/test_inference_avatar.py` (new)

## Testing
`pytest tests/test_inference_avatar.py` — 19 passing: model-string parsing, credential resolution/env fallbacks, create payload/headers (incl. stable Idempotency-Key), retry/error mapping (403 non-retryable, 502 retried), response `sample_rate` → `DataStreamAudioOutput`, and `aclose()` terminate (+ no-op when no session). `ruff` clean.

## Dependencies / rollout
- Requires the gateway endpoints from **livekit/agent-gateway#1034** and the `avatar_lemonslice` feature flag enabled for the project (staging first). Until then, `start()` returns a `403 not_enabled`.
- E2E coverage: **livekit/e2e#1255** (`agents/avatar/` suite), which activates once this ships and the flag is on.

Refs: LKINF-386

🤖 Generated with [Claude Code](https://claude.com/claude-code)