### PR TITLE
fix(eot): report None detection_delay when client timestamp is unset

### DIFF
--- a/livekit-agents/livekit/agents/inference/eot/transports.py
+++ b/livekit-agents/livekit/agents/inference/eot/transports.py
@@ -207,13 +207,17 @@ class _CloudTransport:
                 request_sent_at_ms = inference_stats.latest_client_created_at.ToMilliseconds()
                 current_time = Timestamp()
                 current_time.GetCurrentTime()
-                detection_delay_ms = current_time.ToMilliseconds() - request_sent_at_ms
                 inference_duration_ms = inference_stats.server_e2e_latency.ToMilliseconds()
+                # Unset timestamps read as epoch 0; treat that as unknown instead
+                # of reporting a decades-long `now - 0` delay.
+                detection_delay: float | None = None
+                if request_sent_at_ms > 0:
+                    detection_delay = (current_time.ToMilliseconds() - request_sent_at_ms) / 1000.0
 
                 stream._resolve_prediction(
                     msg.request_id,
                     prediction.probability,
-                    detection_delay=detection_delay_ms / 1000.0,
+                    detection_delay=detection_delay,
                     inference_duration=inference_duration_ms / 1000.0,
                     backchannel_probability=prediction.backchannel_probability,
                 )
@@ -227,7 +231,7 @@ class _CloudTransport:
                             timestamp=time.time(),
                             total_duration=client_e2e_ms / 1000.0,
                             prediction_duration=inference_duration_ms / 1000.0,
-                            detection_delay=detection_delay_ms / 1000.0,
+                            detection_delay=detection_delay,
                             num_requests=1,
                             metadata=Metadata(
                                 model_name=detector.model,

--- a/livekit-agents/livekit/agents/metrics/base.py
+++ b/livekit-agents/livekit/agents/metrics/base.py
@@ -119,8 +119,9 @@ class EOTInferenceMetrics(_BaseMetrics):
     timestamp: float
     total_duration: float
     """Earliest audio creation time in an inference to response receive time."""
-    detection_delay: float
-    """Latest audio creation time in an inference to response receive time."""
+    detection_delay: float | None
+    """Latest audio creation time in an inference to response receive time.
+    ``None`` when the server did not report the client-side timestamp."""
     prediction_duration: float
     """Server side model inference time."""
     num_requests: int = 1

--- a/tests/test_turn_detection_cloud_stream.py
+++ b/tests/test_turn_detection_cloud_stream.py
@@ -13,9 +13,12 @@ deterministically. Covers:
 from __future__ import annotations
 
 import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
 
 from livekit import rtc
 from livekit.agents._exceptions import APIConnectionError
+from livekit.agents.metrics import EOTInferenceMetrics
+from livekit.protocol.agent_pb.agent_inference import ServerMessage
 
 from .fake_turn_detector_ws import (
     drain_send_queue,
@@ -100,5 +103,76 @@ class TestCloudStreamSendOrdering:
                 if m.WhichOneof("message") == "inference_start"
             ]
             assert start_ids == [first_id, second_id]
+        finally:
+            await stream.aclose()
+
+
+def _eot_prediction_message(
+    request_id: str, *, sent_ms: int | None, probability: float = 0.9
+) -> ServerMessage:
+    """A server ``eot_prediction`` frame. When ``sent_ms`` is None the
+    ``latest_client_created_at`` timestamp is left unset, exactly as the server
+    may send it (an unset proto Timestamp reads back as epoch 0)."""
+    msg = ServerMessage()
+    msg.request_id = request_id
+    prediction = msg.eot_prediction
+    prediction.probability = probability
+    if sent_ms is not None:
+        prediction.inference_stats.latest_client_created_at.FromMilliseconds(sent_ms)
+    return msg
+
+
+def _emitted_eot_metrics(stream: object) -> list[EOTInferenceMetrics]:
+    return [
+        call.args[1]
+        for call in stream._detector.emit.call_args_list  # type: ignore[attr-defined]
+        if call.args and call.args[0] == "metrics_collected"
+    ]
+
+
+class TestCloudStreamDetectionDelay:
+    """``detection_delay`` derivation from the server's client timestamp."""
+
+    async def test_unset_client_timestamp_yields_null_detection_delay(self) -> None:
+        """Regression: when the server omits ``latest_client_created_at`` the
+        timestamp reads back as epoch 0, so ``now - 0`` used to report a
+        detection_delay of decades. Both the resolved prediction and the emitted
+        metric must report ``None`` (unknown) instead of a garbage duration."""
+        stream, _fake_ws, transport = make_stream(connect_script=[None])
+        try:
+            fut = stream.predict()
+            transport._process_message(_eot_prediction_message(stream._request_id, sent_ms=None))
+
+            event = fut.result()
+            assert event.detection_delay is None
+
+            metrics = _emitted_eot_metrics(stream)
+            assert metrics
+            assert metrics[-1].detection_delay is None
+        finally:
+            await stream.aclose()
+
+    async def test_known_client_timestamp_reports_real_detection_delay(self) -> None:
+        """Control: with a real ``latest_client_created_at`` the delay is still a
+        small positive number, so the guard does not change the correct case."""
+        now = Timestamp()
+        now.GetCurrentTime()
+        stream, _fake_ws, transport = make_stream(connect_script=[None])
+        try:
+            fut = stream.predict()
+            transport._process_message(
+                _eot_prediction_message(stream._request_id, sent_ms=now.ToMilliseconds() - 50)
+            )
+
+            event = fut.result()
+            assert event.detection_delay is not None
+            assert 0.0 <= event.detection_delay < 60.0
+
+            metrics = _emitted_eot_metrics(stream)
+            assert metrics
+            # The event and metric should expose the same computed delay.
+            assert metrics[-1].detection_delay == event.detection_delay
+            assert metrics[-1].detection_delay is not None
+            assert 0.0 <= metrics[-1].detection_delay < 60.0
         finally:
             await stream.aclose()


### PR DESCRIPTION
When the server doesn't set `latest_client_created_at`, the protobuf timestamp reads back as epoch 0.
That made `detection_delay = now - 0`, so a missing timestamp could report a delay of roughly 56 years. 
The agent behavior is unaffected, but that bad value can leak into EOT metrics and latency traces.

Before:

    unset latest_client_created_at -> detection_delay ~= 56 years

After:

    unset latest_client_created_at -> detection_delay = None

The fix uses the same `request_sent_at_ms > 0` guard already used by `_warn_transport_latency`. `EOTInferenceMetrics.detection_delay` is now `float | None`, so metrics handlers should handle `None` for this unknown case.

Includes a regression test for the unset case and a normal-timestamp control.