### PR TITLE
feat(voice): auto-disable realtime server-side turn detection

### DIFF
--- a/livekit-agents/livekit/agents/llm/realtime.py
+++ b/livekit-agents/livekit/agents/llm/realtime.py
@@ -70,6 +70,9 @@ class RealtimeCapabilities:
     """Whether the model can produce audio output directly"""
     manual_function_calls: bool
     """Whether function call items already in the chat context can be resumed"""
+    can_disable_turn_detection: bool = False
+    """Whether server-side turn detection can be disabled for a session so the client drives
+    turn-taking. Set by plugins that implement ``session(turn_detection_disabled=True)``."""
     mutable_chat_context: bool = False
     """Whether the chat context can be updated mid-session"""
     mutable_instructions: bool = False
@@ -113,7 +116,12 @@ class RealtimeModel:
         return self._label
 
     @abstractmethod
-    def session(self) -> RealtimeSession: ...
+    def session(self, *, turn_detection_disabled: bool = False) -> RealtimeSession:
+        """Create a new session, optionally with server-side turn detection disabled.
+
+        ``turn_detection_disabled`` is honored only by plugins reporting
+        ``can_disable_turn_detection``; the model itself is left unchanged and reusable."""
+        ...
 
     @abstractmethod
     async def aclose(self) -> None: ...

--- a/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
@@ -52,6 +52,7 @@ _SOFT_CAPABILITIES = (
     "mutable_tools",
     "per_response_tool_choice",
     "supports_say",
+    "can_disable_turn_detection",
 )
 
 # child events re-emitted on the wrapper
@@ -127,8 +128,8 @@ class RealtimeModelFallbackAdapter(
     def provider(self) -> str:
         return "livekit"
 
-    def session(self) -> _FallbackRealtimeSession:
-        sess = _FallbackRealtimeSession(self)
+    def session(self, *, turn_detection_disabled: bool = False) -> _FallbackRealtimeSession:
+        sess = _FallbackRealtimeSession(self, turn_detection_disabled=turn_detection_disabled)
         self._sessions.add(sess)
         return sess
 
@@ -150,9 +151,13 @@ class RealtimeModelFallbackAdapter(
 class _FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_changed"]]):
     """Bound once by AgentActivity; swaps the inner child session internally."""
 
-    def __init__(self, adapter: RealtimeModelFallbackAdapter) -> None:
+    def __init__(
+        self, adapter: RealtimeModelFallbackAdapter, *, turn_detection_disabled: bool = False
+    ) -> None:
         super().__init__(adapter)
         self._adapter = adapter
+        # applied to every underlying session, including those brought up on a swap
+        self._turn_detection_disabled = turn_detection_disabled
 
         # session state replayed onto a new child on swap
         self._instructions: NotGivenOr[str] = NOT_GIVEN
@@ -184,7 +189,9 @@ class _FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_ch
         self._swapping = False
 
         self._active_index = 0
-        self._active = adapter._models[0].session()
+        self._active = adapter._models[0].session(
+            turn_detection_disabled=self._turn_detection_disabled
+        )
         self._bind(self._active)
 
     def _bind(self, child: RealtimeSession) -> None:
@@ -287,7 +294,9 @@ class _FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_ch
             # return the error so the caller can try the next model
             async def _bring_up(index: int) -> Exception | None:
                 try:
-                    self._active = self._adapter._models[index].session()
+                    self._active = self._adapter._models[index].session(
+                        turn_detection_disabled=self._turn_detection_disabled
+                    )
                     self._active_index = index
                     self._bind(self._active)
                     await self._active._update_session(

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2294,7 +2294,7 @@ class AgentActivity(RecognitionHooks):
             self.stt is None
             and self._turn_detection != "manual"
             and isinstance(self.llm, llm.RealtimeModel)
-            and not self.llm.capabilities.turn_detection
+            and not self._rt_turn_detection_enabled
             and self._interruption_detection_enabled
             and (
                 # confirmed backchannel for this turn (survives the agent stopping)
@@ -4382,7 +4382,7 @@ class AgentActivity(RecognitionHooks):
         realtime_llm = self.llm if isinstance(self.llm, llm.RealtimeModel) else None
         if realtime_llm is not None:
             # realtime commits turns manually; barge-in withholds the commit, so no STT is needed
-            can_gatekeep = not realtime_llm.capabilities.turn_detection
+            can_gatekeep = not self._rt_turn_detection_enabled
         else:
             # the STT pipeline gatekeeps by holding and flushing transcripts
             can_gatekeep = (

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -855,6 +855,10 @@ class AgentActivity(RecognitionHooks):
                     self.llm.capabilities.mutable_tools
                     or llm.ToolContext(self.tools) == llm.ToolContext(new_activity.tools)
                 )
+                # only reuse if the new activity resolves server-side turn detection the same way
+                reusable = reusable and (
+                    self._rt_turn_detection_enabled == new_activity._rt_turn_detection_enabled
+                )
 
                 if reusable:
                     # detach: remove event listeners but don't close the session

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -221,11 +221,10 @@ class AgentActivity(RecognitionHooks):
         self._on_enter_task: asyncio.Task | None = None
         self._on_exit_task: asyncio.Task | None = None
 
-        if (
-            isinstance(self.llm, llm.RealtimeModel)
-            and self.llm.capabilities.turn_detection
-            and not self.allow_interruptions
-        ):
+        # session-scoped truth read by every server-side turn-detection check below
+        self._rt_turn_detection_enabled = self._resolve_rt_turn_detection_enabled()
+
+        if self._rt_turn_detection_enabled and not self.allow_interruptions:
             raise ValueError(
                 "the RealtimeModel uses a server-side turn detection, "
                 "allow_interruptions cannot be False, disable turn_detection in "
@@ -263,6 +262,55 @@ class AgentActivity(RecognitionHooks):
         # model to auto-generate a tool reply (auto_tool_reply_generation=True).
         self._pending_auto_tool_reply_fut: asyncio.Future[None] | None = None
 
+    def _resolve_rt_turn_detection_enabled(self) -> bool:
+        """Whether a realtime model's server-side turn detection is on for this session.
+
+        Off when the model can hand turn-taking to the client and the user configured
+        client-side turn-taking; otherwise the model's own setting stands.
+        """
+        if not isinstance(self.llm, llm.RealtimeModel):
+            return False
+
+        # a model that without turn_detection
+        # or can't hand turn-taking to the client keeps its own setting
+        if (
+            not (caps := self.llm.capabilities).turn_detection
+            or not caps.can_disable_turn_detection
+        ):
+            return caps.turn_detection
+
+        # resolve client-side turn detection (agent overrides session)
+        if is_given(self._agent.turn_detection):
+            client_td: TurnDetectionMode | None = self._agent.turn_detection
+            client_td_explicit = True
+        elif self._session._turn_detection_explicit:
+            client_td = self._session.turn_detection
+            client_td_explicit = True
+        else:
+            client_td = None
+            client_td_explicit = False
+
+        if client_td_explicit and client_td == "realtime_llm":
+            return True  # user wants the model to keep doing turn-taking
+        if client_td_explicit and client_td == "manual":
+            return False  # client commits turns manually, no VAD needed
+
+        # disable server-side turn detection if the user has a client-side turn detector or interruption detection
+        if self.vad is not None and (
+            (
+                client_td_explicit
+                and (isinstance(client_td, _StreamingTurnDetector) or client_td == "vad")
+            )
+            or is_given(self._agent.interruption_detection)
+            or is_given(self._session.interruption_detection)
+        ):
+            logger.info(
+                "client-side turn detection or interruption detection is enabled, "
+                "disabling realtime server-side turn detection."
+            )
+            return False
+        return True
+
     def _validate_turn_detection(
         self, turn_detection: TurnDetectionMode | None
     ) -> TurnDetectionMode | None:
@@ -275,7 +323,7 @@ class AgentActivity(RecognitionHooks):
                     )
                     return None
 
-                if isinstance(self.llm, llm.RealtimeModel) and self.llm.capabilities.turn_detection:
+                if self._rt_turn_detection_enabled:
                     logger.warning(
                         "turn_detection is a TurnDetector, but the LLM is a RealtimeModel "
                         "with server-side turn detection enabled, ignoring the turn_detection setting"
@@ -304,7 +352,7 @@ class AgentActivity(RecognitionHooks):
             mode = None
 
         if isinstance(llm_model, llm.RealtimeModel):
-            if mode == "realtime_llm" and not llm_model.capabilities.turn_detection:
+            if mode == "realtime_llm" and not self._rt_turn_detection_enabled:
                 logger.warning(
                     "turn_detection is set to 'realtime_llm', but the LLM is not a RealtimeModel "
                     "or the server-side turn detection is not supported/enabled, "
@@ -319,7 +367,7 @@ class AgentActivity(RecognitionHooks):
                 )
                 mode = None
 
-            elif mode and mode != "realtime_llm" and llm_model.capabilities.turn_detection:
+            elif mode and mode != "realtime_llm" and self._rt_turn_detection_enabled:
                 logger.warning(
                     f"turn_detection is set to '{mode}', but the LLM "
                     "is a RealtimeModel and server-side turn detection enabled, "
@@ -329,7 +377,7 @@ class AgentActivity(RecognitionHooks):
 
             # fallback to VAD if server side turn detection is disabled and user supplied VAD is available
             if (
-                not llm_model.capabilities.turn_detection
+                not self._rt_turn_detection_enabled
                 and vad_model is not None
                 and not self.using_default_vad
                 and mode is None
@@ -912,7 +960,13 @@ class AgentActivity(RecognitionHooks):
                 self._rt_session.interrupt()
                 self._rt_session.clear_audio()
             else:
-                self._rt_session = self.llm.session()
+                # disable only when we resolved it off AND the model can (guards a model whose
+                # turn detection is explicitly pinned off from a spurious disable)
+                turn_detection_disabled = (
+                    not self._rt_turn_detection_enabled
+                    and self.llm.capabilities.can_disable_turn_detection
+                )
+                self._rt_session = self.llm.session(turn_detection_disabled=turn_detection_disabled)
                 logger.debug("created new realtime session for activity, id=%s", self._rt_session)
 
             self._rt_session.on("generation_created", self._on_generation_created)
@@ -987,12 +1041,7 @@ class AgentActivity(RecognitionHooks):
         await self._resume_scheduling_task()
         # skip default vad when llm does not need it
         wired_vad = self.vad
-        if (
-            wired_vad is not None
-            and self.using_default_vad
-            and isinstance(self.llm, llm.RealtimeModel)
-            and self.llm.capabilities.turn_detection
-        ):
+        if wired_vad is not None and self.using_default_vad and self._rt_turn_detection_enabled:
             wired_vad = None
         self._audio_recognition = AudioRecognition(
             self._session,
@@ -1327,11 +1376,7 @@ class AgentActivity(RecognitionHooks):
                 "add a TTS model to AgentSession to enable say()"
             )
 
-        if (
-            isinstance(self.llm, llm.RealtimeModel)
-            and self.llm.capabilities.turn_detection
-            and allow_interruptions is False
-        ):
+        if self._rt_turn_detection_enabled and allow_interruptions is False:
             logger.warning(
                 "the RealtimeModel uses a server-side turn detection, allow_interruptions cannot be False when using VoiceAgent.say(), "  # noqa: E501
                 "disable turn_detection in the RealtimeModel and use VAD on the AgentTask/VoiceAgent instead"  # noqa: E501
@@ -1397,11 +1442,7 @@ class AgentActivity(RecognitionHooks):
         schedule_speech: bool = True,
         input_details: InputDetails = DEFAULT_INPUT_DETAILS,
     ) -> SpeechHandle:
-        if (
-            isinstance(self.llm, llm.RealtimeModel)
-            and self.llm.capabilities.turn_detection
-            and allow_interruptions is False
-        ):
+        if self._rt_turn_detection_enabled and allow_interruptions is False:
             logger.warning(
                 "the RealtimeModel uses a server-side turn detection, allow_interruptions cannot be False when using VoiceAgent.generate_reply(), "  # noqa: E501
                 "disable turn_detection in the RealtimeModel and use VAD on the AgentTask/VoiceAgent instead"  # noqa: E501
@@ -1907,7 +1948,7 @@ class AgentActivity(RecognitionHooks):
             # disable interruption from audio activity while aec warmup is active
             return
 
-        if isinstance(self.llm, llm.RealtimeModel) and self.llm.capabilities.turn_detection:
+        if self._rt_turn_detection_enabled:
             # ignore if realtime model has turn detection enabled
             return
 
@@ -2311,7 +2352,7 @@ class AgentActivity(RecognitionHooks):
             user_message.metrics = metrics_report
 
         if isinstance(self.llm, llm.RealtimeModel):
-            if self.llm.capabilities.turn_detection:
+            if self._rt_turn_detection_enabled:
                 return
 
             if self._rt_session is not None:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -223,6 +223,15 @@ class AgentActivity(RecognitionHooks):
 
         # session-scoped truth read by every server-side turn-detection check below
         self._rt_turn_detection_enabled = self._resolve_rt_turn_detection_enabled()
+        if (
+            isinstance(self.llm, llm.RealtimeModel)
+            and not self._rt_turn_detection_enabled
+            and self.llm.capabilities.turn_detection
+        ):
+            logger.info(
+                "client-side turn-taking is configured, disabling realtime server-side "
+                "turn detection."
+            )
 
         if self._rt_turn_detection_enabled and not self.allow_interruptions:
             raise ValueError(
@@ -304,10 +313,6 @@ class AgentActivity(RecognitionHooks):
             or is_given(self._agent.interruption_detection)
             or is_given(self._session.interruption_detection)
         ):
-            logger.info(
-                "client-side turn detection or interruption detection is enabled, "
-                "disabling realtime server-side turn detection."
-            )
             return False
         return True
 
@@ -592,6 +597,21 @@ class AgentActivity(RecognitionHooks):
             self._rt_session.update_options(tool_choice=self._tool_choice)
 
         if utils.is_given(turn_detection):
+            # a realtime model's server-side turn detection is resolved once at session start;
+            # runtime re-sync isn't supported yet, so warn when an explicit change would flip it.
+            if (
+                isinstance(self.llm, llm.RealtimeModel)
+                and self.llm.capabilities.can_disable_turn_detection
+                and turn_detection is not None
+                and self._resolve_rt_turn_detection_enabled() != self._rt_turn_detection_enabled
+            ):
+                logger.warning(
+                    "changing turn_detection at runtime does not update a realtime model's "
+                    "server-side turn detection (resolved at session start); it stays %s "
+                    "for this session.",
+                    "enabled" if self._rt_turn_detection_enabled else "disabled",
+                )
+
             turn_detection = self._validate_turn_detection(turn_detection)
 
             if (

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -329,10 +329,17 @@ class AgentActivity(RecognitionHooks):
                     return None
 
                 if self._rt_turn_detection_enabled:
-                    logger.warning(
-                        "turn_detection is a TurnDetector, but the LLM is a RealtimeModel "
-                        "with server-side turn detection enabled, ignoring the turn_detection setting"
-                    )
+                    # only warn when the user asked for a TurnDetector, the eager default is
+                    # silently superseded by the server-side turn detection
+                    if (
+                        is_given(self._agent.turn_detection)
+                        or self._session._turn_detection_explicit
+                    ):
+                        logger.warning(
+                            "turn_detection is a TurnDetector, but the LLM is a RealtimeModel "
+                            "with server-side turn detection enabled, "
+                            "ignoring the turn_detection setting"
+                        )
                     return None
 
             return turn_detection

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -490,6 +490,8 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         )
 
         self._turn_detection = raw_turn_detection
+        # whether the user passed turn_detection, vs the eager TurnDetector() default
+        self._turn_detection_explicit = "turn_detection" in turn_handling
         self._interruption_detection = interruption.get("mode", NOT_GIVEN)
         self._mcp_servers = mcp_servers or None
         if self._mcp_servers:

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1228,6 +1228,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         if is_given(turn_detection):
             self._turn_detection = turn_detection
+            self._turn_detection_explicit = turn_detection is not None
 
         if self._activity is not None:
             self._activity.update_options(

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -472,8 +472,9 @@ class RealtimeModel(llm.RealtimeModel):
     def provider(self) -> str:
         return "Amazon"
 
-    def session(self) -> RealtimeSession:
+    def session(self, *, turn_detection_disabled: bool = False) -> RealtimeSession:
         """Return a new RealtimeSession bound to this model instance."""
+        # disabling server-side turn detection is unsupported (can_disable_turn_detection=False)
         sess = RealtimeSession(self)
         self._sessions.add(sess)
         return sess

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -407,7 +407,9 @@ class RealtimeModel(llm.RealtimeModel):
         else:
             return "Gemini"
 
-    def session(self) -> RealtimeSession:
+    def session(self, *, turn_detection_disabled: bool = False) -> RealtimeSession:
+        # Gemini drives manual turns via activity_start/activity_end, not commit_audio/clear_audio,
+        # so the pipeline can't gatekeep turns yet; keep can_disable_turn_detection=False for now
         sess = RealtimeSession(self)
         self._sessions.add(sess)
         return sess

--- a/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/experimental/realtime/realtime_model.py
@@ -154,7 +154,8 @@ class RealtimeModel(llm.RealtimeModel):
             self._http_session = utils.http_context.http_session()
         return self._http_session
 
-    def session(self) -> RealtimeSession:
+    def session(self, *, turn_detection_disabled: bool = False) -> RealtimeSession:
+        # disabling server-side turn detection is unsupported (can_disable_turn_detection=False)
         sess = RealtimeSession(realtime_model=self)
         self._sessions.add(sess)
         return sess

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -457,6 +457,7 @@ class RealtimeModel(llm.RealtimeModel):
             capabilities=llm.RealtimeCapabilities(
                 message_truncation=True,
                 turn_detection=turn_detection is not None,
+                can_disable_turn_detection=not is_given(turn_detection),
                 user_transcription=input_audio_transcription is not None,
                 auto_tool_reply_generation=False,
                 audio_output="audio" in modalities,
@@ -767,8 +768,8 @@ class RealtimeModel(llm.RealtimeModel):
 
         return self._http_session
 
-    def session(self) -> RealtimeSession:
-        sess = RealtimeSession(self)
+    def session(self, *, turn_detection_disabled: bool = False) -> RealtimeSession:
+        sess = RealtimeSession(self, turn_detection_disabled=turn_detection_disabled)
         self._sessions.add(sess)
         return sess
 
@@ -841,11 +842,16 @@ class RealtimeSession(
     - openai_client_event_queued: expose the raw client events sent to the OpenAI Realtime API
     """
 
-    def __init__(self, realtime_model: RealtimeModel) -> None:
+    def __init__(
+        self, realtime_model: RealtimeModel, *, turn_detection_disabled: bool = False
+    ) -> None:
         super().__init__(realtime_model)
         self._realtime_model: RealtimeModel = realtime_model
         # per-session copy of opts so update_options can diff against session's own state
-        self._opts = replace(realtime_model._opts)
+        self._opts = replace(
+            realtime_model._opts,
+            turn_detection=None if turn_detection_disabled else realtime_model._opts.turn_detection,
+        )
         self._tools = llm.ToolContext.empty()
         self._msg_ch = utils.aio.Chan[RealtimeClientEvent | dict[str, Any]]()
         self._input_resampler: rtc.AudioResampler | None = None

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -672,10 +672,13 @@ class RealtimeModel(llm.RealtimeModel):
         if not is_given(input_audio_transcription):
             input_audio_transcription = AZURE_DEFAULT_INPUT_AUDIO_TRANSCRIPTION
 
+        # capture intent before applying the azure default, so the framework can still
+        # auto-disable server-side turn detection when the user didn't configure it
+        can_disable_turn_detection = not is_given(turn_detection)
         if not is_given(turn_detection):
             turn_detection = AZURE_DEFAULT_TURN_DETECTION
 
-        return RealtimeModel(
+        model = RealtimeModel(
             voice=voice,
             modalities=modalities,
             input_audio_transcription=input_audio_transcription,
@@ -692,6 +695,8 @@ class RealtimeModel(llm.RealtimeModel):
             base_url=base_url,
             max_session_duration=max_session_duration,
         )
+        model._capabilities.can_disable_turn_detection = can_disable_turn_detection
+        return model
 
     def update_options(
         self,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -747,7 +747,9 @@ class RealtimeModel(llm.RealtimeModel):
         for sess in self._sessions:
             sess.update_options(
                 voice=voice,
-                turn_detection=self._opts.turn_detection,
+                # only propagate when the caller set it, so a session that opted out of
+                # server-side turn detection isn't force-synced back on by an unrelated update
+                turn_detection=self._opts.turn_detection if is_given(turn_detection) else NOT_GIVEN,
                 tool_choice=tool_choice,
                 input_audio_transcription=self._opts.input_audio_transcription,
                 input_audio_noise_reduction=self._opts.input_audio_noise_reduction,

--- a/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
@@ -247,7 +247,8 @@ class RealtimeModel(llm.RealtimeModel):
     def provider(self) -> str:
         return "phonic"
 
-    def session(self) -> RealtimeSession:
+    def session(self, *, turn_detection_disabled: bool = False) -> RealtimeSession:
+        # disabling server-side turn detection is unsupported (can_disable_turn_detection=False)
         sess = RealtimeSession(self)
         self._sessions.add(sess)
         return sess

--- a/livekit-plugins/livekit-plugins-ultravox/livekit/plugins/ultravox/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-ultravox/livekit/plugins/ultravox/realtime/realtime_model.py
@@ -224,7 +224,7 @@ class RealtimeModel(llm.RealtimeModel):
             self._http_session = utils.http_context.http_session()
         return self._http_session
 
-    def session(self) -> RealtimeSession:
+    def session(self, *, turn_detection_disabled: bool = False) -> RealtimeSession:
         """Create a new Ultravox real-time session.
 
         Returns
@@ -232,6 +232,7 @@ class RealtimeModel(llm.RealtimeModel):
         RealtimeSession
             An instance of the Ultravox real-time session.
         """
+        # disabling server-side turn detection is unsupported (can_disable_turn_detection=False)
         sess = RealtimeSession(realtime_model=self)
         self._sessions.add(sess)
         return sess

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/realtime/realtime_model.py
@@ -86,9 +86,12 @@ class RealtimeModel(openai.realtime.RealtimeModel):
             conn_options=conn_options,
         )
         self._capabilities.per_response_tool_choice = False
+        # client turn-taking is not stable during testing, mark it as unsupported for now
+        self._capabilities.can_disable_turn_detection = False
         self._provider_label = "xAI Realtime API"
 
-    def session(self) -> "RealtimeSession":
+    def session(self, *, turn_detection_disabled: bool = False) -> "RealtimeSession":
+        # manual turn-taking is unsupported (can_disable_turn_detection=False)
         sess = RealtimeSession(self)
         self._sessions.add(sess)
         return sess

--- a/tests/fake_realtime.py
+++ b/tests/fake_realtime.py
@@ -40,8 +40,9 @@ def fake_capabilities(**overrides: bool) -> RealtimeCapabilities:
 class FakeRealtimeSession(RealtimeSession):
     """A hermetic RealtimeSession that records calls and can be scripted to fail."""
 
-    def __init__(self, model: FakeRealtimeModel) -> None:
+    def __init__(self, model: FakeRealtimeModel, *, turn_detection_disabled: bool = False) -> None:
         super().__init__(model)
+        self.turn_detection_disabled = turn_detection_disabled
         self._chat_ctx = ChatContext.empty()
         self._tools = ToolContext.empty()
         self.closed = False
@@ -171,8 +172,8 @@ class FakeRealtimeModel(RealtimeModel):
     def active_session(self) -> FakeRealtimeSession:
         return self.created_sessions[-1]
 
-    def session(self) -> FakeRealtimeSession:
-        sess = FakeRealtimeSession(self)
+    def session(self, *, turn_detection_disabled: bool = False) -> FakeRealtimeSession:
+        sess = FakeRealtimeSession(self, turn_detection_disabled=turn_detection_disabled)
         sess.update_error = self.bring_up_error
         self.created_sessions.append(sess)
         return sess

--- a/tests/test_realtime/test_openai_realtime_model.py
+++ b/tests/test_realtime/test_openai_realtime_model.py
@@ -41,6 +41,26 @@ def test_update_options_only_propagates_given_turn_detection() -> None:
     assert is_given(stub.calls[-1]["turn_detection"])
 
 
+def test_with_azure_preserves_can_disable_turn_detection() -> None:
+    # with_azure fills in a default turn_detection, but the framework must still be allowed to
+    # auto-disable server-side turn detection when the caller didn't configure it. An explicit
+    # value is respected. (PR #6495 review)
+    default_td = RealtimeModel.with_azure(
+        azure_deployment="dep", api_key="fake", base_url="https://example.com/openai"
+    )
+    assert default_td.capabilities.turn_detection is True
+    assert default_td.capabilities.can_disable_turn_detection is True
+
+    explicit_off = RealtimeModel.with_azure(
+        azure_deployment="dep",
+        api_key="fake",
+        base_url="https://example.com/openai",
+        turn_detection=None,
+    )
+    assert explicit_off.capabilities.turn_detection is False
+    assert explicit_off.capabilities.can_disable_turn_detection is False
+
+
 def test_update_chat_ctx_deletes_empty_remote_items() -> None:
     remote_ctx = RemoteChatContext()
     audio_item = llm.ChatMessage(id="audio_item", role="user", content=[])

--- a/tests/test_realtime/test_openai_realtime_model.py
+++ b/tests/test_realtime/test_openai_realtime_model.py
@@ -8,9 +8,37 @@ import pytest
 from livekit.agents import llm
 from livekit.agents._exceptions import APIError
 from livekit.agents.llm.remote_chat_context import RemoteChatContext
-from livekit.plugins.openai.realtime.realtime_model import RealtimeSession, _is_fatal_error
+from livekit.agents.utils import is_given
+from livekit.plugins.openai.realtime.realtime_model import (
+    RealtimeModel,
+    RealtimeSession,
+    _is_fatal_error,
+)
 
 pytestmark = pytest.mark.unit
+
+
+def test_update_options_only_propagates_given_turn_detection() -> None:
+    # RealtimeModel.update_options must not force-sync turn_detection to sessions when the
+    # caller didn't set it, else a session that opted out of server-side turn detection gets
+    # server VAD re-enabled by an unrelated change (e.g. voice). An explicit value still
+    # propagates, so callers can re-enable it. (PR #6495 review)
+    class _StubSession:
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
+
+        def update_options(self, **kw: object) -> None:
+            self.calls.append(kw)
+
+    model = RealtimeModel(api_key="fake")
+    stub = _StubSession()
+    model._sessions.add(cast(RealtimeSession, stub))
+
+    model.update_options(voice="verse")
+    assert not is_given(stub.calls[-1]["turn_detection"])
+
+    model.update_options(turn_detection=model._opts.turn_detection)
+    assert is_given(stub.calls[-1]["turn_detection"])
 
 
 def test_update_chat_ctx_deletes_empty_remote_items() -> None:

--- a/tests/test_realtime_auto_disable_turn_detection.py
+++ b/tests/test_realtime_auto_disable_turn_detection.py
@@ -197,3 +197,34 @@ def test_fallback_adapter_support_is_conservative_and() -> None:
     adapter = RealtimeModelFallbackAdapter([m1, m2])
 
     assert adapter.capabilities.can_disable_turn_detection is False
+
+
+# --------------------------------------------------------------------------- #
+# handoff: reuse a realtime session only when the new agent resolves server TD the same
+# --------------------------------------------------------------------------- #
+
+
+async def test_rt_session_reuse_respects_turn_detection_resolution() -> None:
+    model = FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True))
+
+    def _act(**handling: object) -> AgentActivity:
+        session = AgentSession(
+            llm=model,
+            vad=FakeVAD(fake_user_speeches=[]),
+            turn_handling=TurnHandlingOptions(**handling),  # type: ignore[typeddict-item]
+        )
+        return _activity(session)
+
+    server_on = _act()  # no client trigger -> server-side TD on
+    client_a = _act(turn_detection="vad")  # client vad -> server-side TD off
+    client_b = _act(turn_detection="vad")
+    assert server_on._rt_turn_detection_enabled is True
+    assert client_a._rt_turn_detection_enabled is False
+
+    # differing resolution -> refuse reuse, fall back to a fresh session
+    server_on._rt_session = model.session()
+    assert (await server_on._detach_reusable_resources(client_a)).rt_session is None
+
+    # same resolution -> reuse
+    client_a._rt_session = model.session()
+    assert (await client_a._detach_reusable_resources(client_b)).rt_session is not None

--- a/tests/test_realtime_auto_disable_turn_detection.py
+++ b/tests/test_realtime_auto_disable_turn_detection.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents import Agent, AgentSession, TurnHandlingOptions, inference
+from livekit.agents.llm import RealtimeModelFallbackAdapter
+from livekit.agents.voice.agent_activity import AgentActivity
+
+from .fake_llm import FakeLLM
+from .fake_realtime import FakeRealtimeModel, fake_capabilities
+from .fake_vad import FakeVAD
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _livekit_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    # inference.TurnDetector() and the adaptive detector read these; keep construction hermetic
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+
+def _activity(session: AgentSession) -> AgentActivity:
+    return AgentActivity(Agent(instructions="test"), session)
+
+
+# --------------------------------------------------------------------------- #
+# reconcile matrix: client config x model capabilities -> effective server-side TD
+# --------------------------------------------------------------------------- #
+
+
+def test_turn_detector_disables_server_side_td() -> None:
+    # explicit client-side EoT + a model that defaulted to (and can disable) server VAD
+    session = AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True)),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(turn_detection=inference.TurnDetector()),
+    )
+    activity = _activity(session)
+
+    assert activity._rt_turn_detection_enabled is False
+
+
+def test_vad_mode_disables_server_side_td() -> None:
+    session = AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True)),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(turn_detection="vad"),
+    )
+    activity = _activity(session)
+
+    assert activity._rt_turn_detection_enabled is False
+
+
+def test_adaptive_interruption_alone_disables_server_side_td() -> None:
+    # no explicit turn_detection, but adaptive interruption is the explicit trigger
+    session = AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True)),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(interruption={"mode": "adaptive"}),
+    )
+    activity = _activity(session)
+
+    assert activity._rt_turn_detection_enabled is False
+
+
+def test_manual_disables_server_side_td_without_vad() -> None:
+    # manual turn commit drives turns on the client and needs no VAD
+    session = AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True)),
+        vad=None,
+        turn_handling=TurnHandlingOptions(turn_detection="manual"),
+    )
+    activity = _activity(session)
+
+    assert activity._rt_turn_detection_enabled is False
+
+
+def test_vad_interruption_disables_server_side_td() -> None:
+    # any explicit interruption mode (not just adaptive) hands interruption to the client
+    session = AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True)),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(interruption={"mode": "vad"}),
+    )
+    activity = _activity(session)
+
+    assert activity._rt_turn_detection_enabled is False
+
+
+def test_stt_mode_keeps_server_side_td() -> None:
+    # "stt" turn detection is rejected for realtime models, so it never disables server-side TD
+    session = AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True)),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(turn_detection="stt"),
+    )
+    activity = _activity(session)
+
+    assert activity._rt_turn_detection_enabled is True
+
+
+def test_conflict_keeps_server_side_td() -> None:
+    # user pinned turn_detection on the model (can_disable=False) AND set client-side -> server wins
+    session = AgentSession(
+        llm=FakeRealtimeModel(
+            capabilities=fake_capabilities(turn_detection=True, can_disable_turn_detection=False)
+        ),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(turn_detection="vad"),
+    )
+    activity = _activity(session)
+
+    assert activity._rt_turn_detection_enabled is True
+
+
+def test_explicit_none_on_model_is_already_off() -> None:
+    # model turn_detection explicitly None: nothing to disable, ours is honored, no server TD
+    session = AgentSession(
+        llm=FakeRealtimeModel(
+            capabilities=fake_capabilities(turn_detection=False, can_disable_turn_detection=False)
+        ),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(turn_detection="vad"),
+    )
+    activity = _activity(session)
+
+    assert activity._rt_turn_detection_enabled is False
+
+
+def test_no_client_trigger_keeps_server_side_td() -> None:
+    # nothing client-side configured (NOT_GIVEN) -> server-side TD wins, unchanged
+    session = AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True)),
+        vad=FakeVAD(fake_user_speeches=[]),
+    )
+    activity = _activity(session)
+
+    assert activity._rt_turn_detection_enabled is True
+
+
+def test_realtime_llm_mode_is_not_a_trigger() -> None:
+    # turn_detection="realtime_llm" explicitly wants server-side turn-taking
+    session = AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True)),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(turn_detection="realtime_llm"),
+    )
+    activity = _activity(session)
+
+    assert activity._rt_turn_detection_enabled is True
+
+
+def test_no_vad_does_not_disable() -> None:
+    # with VAD explicitly off, we must not disable into a no-turn-detection state
+    session = AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True)),
+        vad=None,
+        turn_handling=TurnHandlingOptions(turn_detection="vad"),
+    )
+    activity = _activity(session)
+
+    assert activity._rt_turn_detection_enabled is True
+
+
+def test_non_realtime_llm_reports_no_server_side_td() -> None:
+    session = AgentSession(
+        llm=FakeLLM(),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(turn_detection="vad"),
+    )
+    activity = _activity(session)
+
+    assert activity._rt_turn_detection_enabled is False
+
+
+# --------------------------------------------------------------------------- #
+# fallback adapter: disable propagates to every underlying session; support is
+# the conservative AND across models
+# --------------------------------------------------------------------------- #
+
+
+def test_fallback_adapter_propagates_disable_to_underlying_session() -> None:
+    m1 = FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True))
+    m2 = FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True))
+    adapter = RealtimeModelFallbackAdapter([m1, m2])
+
+    assert adapter.capabilities.can_disable_turn_detection is True
+
+    adapter.session(turn_detection_disabled=True)
+    assert m1.created_sessions[-1].turn_detection_disabled is True
+
+
+def test_fallback_adapter_support_is_conservative_and() -> None:
+    m1 = FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True))
+    m2 = FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=False))
+    adapter = RealtimeModelFallbackAdapter([m1, m2])
+
+    assert adapter.capabilities.can_disable_turn_detection is False

--- a/tests/test_realtime_auto_disable_turn_detection.py
+++ b/tests/test_realtime_auto_disable_turn_detection.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from livekit.agents import Agent, AgentSession, TurnHandlingOptions, inference
 from livekit.agents.llm import RealtimeModelFallbackAdapter
 from livekit.agents.voice.agent_activity import AgentActivity
+from livekit.agents.voice.turn import TurnDetectionMode
 
 from .fake_llm import FakeLLM
 from .fake_realtime import FakeRealtimeModel, fake_capabilities
@@ -137,6 +140,98 @@ def test_no_client_trigger_keeps_server_side_td() -> None:
     activity = _activity(session)
 
     assert activity._rt_turn_detection_enabled is True
+
+
+def _rt_resync_warned(caplog: pytest.LogCaptureFixture) -> bool:
+    # match the flip warning specifically, not the generic _validate_turn_detection warnings
+    return any(
+        r.levelno == logging.WARNING and "resolved at session start" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def _change_turn_detection(
+    session: AgentSession, activity: AgentActivity, turn_detection: TurnDetectionMode | None
+) -> None:
+    # drive the real entry point: session.update_options updates the session-owned turn detection
+    # state, then notifies the activity (which re-resolves)
+    session._activity = activity
+    session.update_options(turn_detection=turn_detection)
+
+
+def test_update_options_warns_when_runtime_change_would_disable_server_td(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # server-side TD is on at start; switching to a client-side mode would turn it off, but the
+    # realtime session is resolved at session start and won't re-sync — warn (PR #6495)
+    session = AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True)),
+        vad=FakeVAD(fake_user_speeches=[]),
+    )
+    activity = _activity(session)
+    assert activity._rt_turn_detection_enabled is True
+
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        _change_turn_detection(session, activity, "manual")
+
+    assert _rt_resync_warned(caplog)
+
+
+def test_update_options_warns_when_runtime_change_would_enable_server_td(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # server-side TD is off at start (client-side VAD); switching to realtime_llm would turn it
+    # back on, which also won't re-sync at runtime — warn (PR #6495)
+    session = AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True)),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(turn_detection="vad"),
+    )
+    activity = _activity(session)
+    assert activity._rt_turn_detection_enabled is False
+
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        _change_turn_detection(session, activity, "realtime_llm")
+
+    assert _rt_resync_warned(caplog)
+
+
+def test_update_options_no_warn_when_reverting_to_automatic(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # reverting to None re-selects automatically rather than pinning an explicit client mode; even
+    # though automatic could re-enable server-side TD, we don't warn for it (PR #6495)
+    session = AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True)),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(turn_detection="vad"),
+    )
+    activity = _activity(session)
+    assert activity._rt_turn_detection_enabled is False
+
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        _change_turn_detection(session, activity, None)
+
+    assert not _rt_resync_warned(caplog)
+
+
+def test_update_options_no_warn_when_server_td_state_unchanged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # server-side TD is off at start; switching between two client-side modes keeps it off, so
+    # there's nothing to re-sync — no warning
+    session = AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True)),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(turn_detection="vad"),
+    )
+    activity = _activity(session)
+    assert activity._rt_turn_detection_enabled is False
+
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        _change_turn_detection(session, activity, "manual")
+
+    assert not _rt_resync_warned(caplog)
 
 
 def test_realtime_llm_mode_is_not_a_trigger() -> None:

--- a/tests/test_realtime_auto_disable_turn_detection.py
+++ b/tests/test_realtime_auto_disable_turn_detection.py
@@ -270,6 +270,66 @@ def test_non_realtime_llm_reports_no_server_side_td() -> None:
 
 
 # --------------------------------------------------------------------------- #
+# "ignoring the turn_detection setting": only when the user set one
+# --------------------------------------------------------------------------- #
+
+
+def _td_ignored_warned(caplog: pytest.LogCaptureFixture) -> bool:
+    return any(
+        r.levelno == logging.WARNING and "ignoring the turn_detection setting" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_default_turn_detector_is_superseded_silently(caplog: pytest.LogCaptureFixture) -> None:
+    # nothing configured client-side: the eager TurnDetector() default is not user intent
+    session = AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(can_disable_turn_detection=True)),
+        vad=FakeVAD(fake_user_speeches=[]),
+    )
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        activity = _activity(session)
+
+    assert activity._rt_turn_detection_enabled is True
+    assert activity._turn_detection is None
+    assert not _td_ignored_warned(caplog)
+
+
+def test_session_turn_detector_warns_when_model_keeps_server_td(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # can_disable=False: the user's TurnDetector really is dropped, so say so
+    session = AgentSession(
+        llm=FakeRealtimeModel(
+            capabilities=fake_capabilities(turn_detection=True, can_disable_turn_detection=False)
+        ),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(turn_detection=inference.TurnDetector()),
+    )
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        activity = _activity(session)
+
+    assert activity._turn_detection is None
+    assert _td_ignored_warned(caplog)
+
+
+def test_agent_turn_detector_warns_when_model_keeps_server_td(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # an agent-level override is user intent as well, even on a default session
+    session = AgentSession(
+        llm=FakeRealtimeModel(
+            capabilities=fake_capabilities(turn_detection=True, can_disable_turn_detection=False)
+        ),
+        vad=FakeVAD(fake_user_speeches=[]),
+    )
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        AgentActivity(Agent(instructions="test", turn_detection=inference.TurnDetector()), session)
+
+    assert _td_ignored_warned(caplog)
+
+
+# --------------------------------------------------------------------------- #
 # fallback adapter: disable propagates to every underlying session; support is
 # the conservative AND across models
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Auto-disables a realtime model's server-side turn detection for the session when the user configured client-side turn-taking (a TurnDetector, `vad`, `manual`, or an explicit interruption mode) and the model supports it, so client-side EoT/barge-in works without also passing `turn_detection=None` to the RealtimeModel.

Adds `RealtimeCapabilities.can_disable_turn_detection` (OpenAI sets it from the ctor `turn_detection` given-ness) and a `session(turn_detection_disabled=...)` seam applied on the initial `session.update` via the per-session opts copy, so the model is never mutated and stays reusable. `AgentActivity` resolves the effective state once (`_rt_turn_detection_enabled`) and routes every server-side turn-detection check through it.

Other realtime plugins accept-and-ignore the flag (`can_disable_turn_detection` stays False): xAI (client turn-taking not stable in testing) and Gemini/others (no `commit_audio`/`clear_audio`; turns are activity-signal based).

Stacked on `longc/realtime-barge-in`; this PR targets that branch, not main.