### PR TITLE
fix: make AMD settle on endpointing backstop by default

### DIFF
--- a/livekit-agents/livekit/agents/voice/amd/classifier.py
+++ b/livekit-agents/livekit/agents/voice/amd/classifier.py
@@ -19,7 +19,7 @@ HUMAN_SILENCE_THRESHOLD = 0.5
 MACHINE_SILENCE_THRESHOLD = 1.5
 NO_SPEECH_THRESHOLD = 10.0
 TIMEOUT = 20.0
-MAX_ENDPOINTING_DELAY = 3.0  # fallback endpointing delay
+MAX_ENDPOINTING_DELAY = 3.0
 
 MAX_EXTENSIONS = 3
 MAX_EXTENSION_SECS = 10.0
@@ -141,6 +141,7 @@ class _AMDClassifier(EventEmitter[Literal["amd_prediction"]]):
         self._prompt = prompt
         self._speech_started_at: float | None = None
         self._speech_ended_at: float | None = None
+        self._speech_active = False
         self._listening = False
         self._closed = False
         self._silence_reached = False
@@ -150,9 +151,11 @@ class _AMDClassifier(EventEmitter[Literal["amd_prediction"]]):
         self._extension_count = 0
 
     def start_detection_timer(self) -> None:
-        """Arm the overall detection-timeout budget."""
-        if self._closed or self._detection_timeout_timer is not None:
+        """Arm or reset the overall detection-timeout budget."""
+        if self._closed or self._emitted:
             return
+        if self._detection_timeout_timer is not None:
+            self._detection_timeout_timer.cancel()
         self._detection_timeout_timer = asyncio.get_running_loop().call_later(
             self._timeout,
             functools.partial(
@@ -168,7 +171,7 @@ class _AMDClassifier(EventEmitter[Literal["amd_prediction"]]):
         Call once we expect audible speech to begin (e.g. after sip answer
         for outbound calls). Until this fires, all input methods are no-ops.
         """
-        if self._closed or self._listening:
+        if self._closed or self._emitted or self._listening:
             return
         self._listening = True
         if self._no_speech_timer is None:
@@ -195,6 +198,7 @@ class _AMDClassifier(EventEmitter[Literal["amd_prediction"]]):
             self._eot_timer = None
         if self._speech_started_at is None:
             self._speech_started_at = time.time()
+        self._speech_active = True
         self._silence_reached = False
         self._eot_reached = False
 
@@ -206,14 +210,8 @@ class _AMDClassifier(EventEmitter[Literal["amd_prediction"]]):
 
         self._speech_ended_at = time.time() - silence_duration
         speech_duration = self._speech_ended_at - self._speech_started_at
-
-        # arm the fallback eot timer in case the turn detector is too slow or fails
-        if self._eot_timer is not None:
-            self._eot_timer.cancel()
-        self._eot_timer = asyncio.get_running_loop().call_later(
-            max(0, self._max_endpointing_delay - silence_duration),
-            self._on_eot_reached,
-        )
+        self._speech_active = False
+        self._arm_eot_timer(delay=max(0, self._max_endpointing_delay - silence_duration))
 
         if speech_duration <= self._human_speech_threshold:
             if self._silence_timer is not None:
@@ -267,11 +265,11 @@ class _AMDClassifier(EventEmitter[Literal["amd_prediction"]]):
         lands last unblocks the wait). Humans only require the silence timer so
         we can respond quickly.
 
-        When the turn detector never calls this, the synthetic backstop timer
-        (``max_endpointing_delay``) sets the end-of-turn instead. This gate
-        matters most under ``wait_until_finished``: once speech has been heard
-        the detection timeout no longer forces a verdict, so the end-of-turn
-        (real or backstop) is what ultimately lets a machine verdict emit.
+        When the turn detector never calls this, the synthetic EOT timer
+        provides the backstop. This gate matters most under
+        ``wait_until_finished``: once speech has been heard the detection
+        timeout no longer forces a verdict, so the end-of-turn (real or
+        backstop) is what ultimately lets a machine verdict emit.
         """
         if self._closed:
             return
@@ -286,6 +284,17 @@ class _AMDClassifier(EventEmitter[Literal["amd_prediction"]]):
             self._eot_timer = None
         self._eot_reached = True
         self._try_emit_result()
+
+    def _arm_eot_timer(self, *, delay: float | None = None) -> None:
+        if self._closed or self._speech_active:
+            return
+        if self._eot_timer is not None:
+            self._eot_timer.cancel()
+        self._eot_reached = False
+        self._eot_timer = asyncio.get_running_loop().call_later(
+            self._max_endpointing_delay if delay is None else delay,
+            self._on_eot_reached,
+        )
 
     def _can_emit(self, verdict: AMDPredictionEvent) -> bool:
         """Release gate for a verdict (which verdict it is, is decided elsewhere).
@@ -385,6 +394,7 @@ class _AMDClassifier(EventEmitter[Literal["amd_prediction"]]):
         # ignore text from other sources (e.g. when both session and AMD have STT specified)
         if source != self._source:
             return
+        self._arm_eot_timer()
 
         if self._silence_timer is not None and self._silence_timer_trigger == "short_speech":
             self._silence_timer.cancel()

--- a/livekit-agents/livekit/agents/voice/amd/detector.py
+++ b/livekit-agents/livekit/agents/voice/amd/detector.py
@@ -72,6 +72,7 @@ class DetectionOptions(TypedDict, total=False):
     machine_silence_threshold: float
     no_speech_threshold: float
     timeout: float
+    max_endpointing_delay: float
     prompt: str
 
 
@@ -81,6 +82,7 @@ _DEFAULT_DETECTION_OPTIONS: DetectionOptions = {
     "machine_silence_threshold": MACHINE_SILENCE_THRESHOLD,
     "no_speech_threshold": NO_SPEECH_THRESHOLD,
     "timeout": TIMEOUT,
+    "max_endpointing_delay": MAX_ENDPOINTING_DELAY,
     "prompt": AMD_PROMPT,
 }
 
@@ -143,15 +145,20 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
             strings. Has no effect on classification behavior.
         detection_options: Optional overrides for timing thresholds and the AMD
             classification prompt (see :class:`DetectionOptions`). When
-            omitted, library defaults apply.
+            omitted, library defaults apply. ``max_endpointing_delay`` can be
+            set here to override the session activity's endpointing backstop
+            for AMD.
         wait_until_finished: If ``True``, once any speech has been heard the
             ``detection_timeout`` no longer forces emission — AMD will keep
-            waiting for the post-speech silence and a positive end-of-turn
-            from the session's turn detector before emitting. Useful for
-            outbound voicemail flows where leaving a message early would
-            overlap the greeting. ``no_speech_timeout`` (uncertain) still fires
-            normally (no audio at all means there is nothing to wait for).
-            Defaults to ``False``.
+            waiting for post-speech silence and either a session end-of-turn
+            signal or the session's max endpointing delay before emitting.
+            Useful for outbound voicemail flows where leaving a message early
+            would overlap the greeting. ``no_speech_timeout`` (uncertain)
+            still fires normally (no audio at all means there is nothing to
+            wait for). Continuous audio without a speech-end or end-of-turn can
+            therefore extend detection beyond ``timeout``; set this to
+            ``False`` when ``timeout`` should remain a hard cap after speech
+            starts. Defaults to ``True``.
     """
 
     _DEFAULT_LLM_MODEL: str = "google/gemini-3.1-flash-lite"
@@ -168,7 +175,7 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
         participant_identity: NotGivenOr[str] = NOT_GIVEN,
         suppress_compatibility_warning: bool = False,
         detection_options: NotGivenOr[DetectionOptions] = NOT_GIVEN,
-        wait_until_finished: bool = False,
+        wait_until_finished: bool = True,
     ) -> None:
         super().__init__()
 
@@ -199,11 +206,13 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
         self._closed = False
         self._span: trace.Span | None = None
 
-        self._opts: DetectionOptions = (
-            {**_DEFAULT_DETECTION_OPTIONS, **detection_options}
-            if is_given(detection_options)
-            else _DEFAULT_DETECTION_OPTIONS
+        self._provided_detection_options: DetectionOptions = (
+            detection_options if is_given(detection_options) else {}
         )
+        self._opts: DetectionOptions = {
+            **_DEFAULT_DETECTION_OPTIONS,
+            **self._provided_detection_options,
+        }
 
         if not self._suppress_compatibility_warning:
             if is_given(self._stt):
@@ -395,6 +404,10 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
                 self._classifier.start_detection_timer()
                 self._classifier.start_listening()
         else:
+            # Start the outer budget before waiting for a publication, so AMD
+            # can settle even if the participant never publishes audio.
+            if self._classifier:
+                self._classifier.start_detection_timer()
             room = session._room_io.room
             publication = await wait_for_track_publication(
                 room=room,
@@ -404,8 +417,8 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
             )
             if self._closed or not self._classifier:
                 return
-            # outer budget runs from track-up so AMD bails out even if the
-            # call never reaches the active state
+            # Reset the budget at track-up so normal AMD timing runs from the
+            # subscribed publication, matching the active audio source.
             self._classifier.start_detection_timer()
 
             if self._participant_identity:
@@ -576,9 +589,13 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
 
         if _llm:
             max_endpointing_delay = (
-                session._activity.max_endpointing_delay
-                if session._activity
-                else MAX_ENDPOINTING_DELAY
+                self._provided_detection_options["max_endpointing_delay"]
+                if "max_endpointing_delay" in self._provided_detection_options
+                else (
+                    session._activity.max_endpointing_delay
+                    if session._activity
+                    else self._opts["max_endpointing_delay"]
+                )
             )
             return _AMDClassifier(
                 _llm,

--- a/tests/test_amd_classifier.py
+++ b/tests/test_amd_classifier.py
@@ -9,15 +9,19 @@ from __future__ import annotations
 
 import asyncio
 import time
+from types import SimpleNamespace
 
 import pytest
 
 from livekit.agents.llm import FunctionToolCall
+from livekit.agents.types import NOT_GIVEN
+from livekit.agents.voice.amd import detector as amd_detector
 from livekit.agents.voice.amd.classifier import (
     AMDCategory,
     AMDPredictionEvent,
     _AMDClassifier,
 )
+from livekit.agents.voice.amd.detector import AMD
 
 from .fake_llm import FakeLLM, FakeLLMResponse
 
@@ -389,6 +393,46 @@ class TestAMDClassifier:
 
         await clf.close()
 
+    async def test_start_detection_timer_resets_existing_timer(self) -> None:
+        clf = _make_classifier(timeout=0.4)
+        clf.start_listening()
+        results: list[AMDPredictionEvent] = []
+        clf.on("amd_prediction", results.append)
+
+        clf.start_detection_timer()
+        first_timer = clf._detection_timeout_timer
+        assert first_timer is not None
+
+        await asyncio.sleep(0.25)
+        clf.start_detection_timer()
+        assert clf._detection_timeout_timer is not None
+        assert clf._detection_timeout_timer is not first_timer
+
+        await asyncio.sleep(0.25)
+        assert results == []
+
+        await asyncio.wait_for(clf._verdict_ready.wait(), timeout=1.0)
+        assert results[0].reason == "detection_timeout"
+
+        await clf.close()
+
+    async def test_settled_classifier_rejects_new_timers_and_listening(self) -> None:
+        clf = _make_classifier(no_speech_threshold=0.2)
+        clf.start_listening()
+
+        await asyncio.wait_for(clf._verdict_ready.wait(), timeout=1.0)
+        assert clf._emitted is True
+        assert clf._detection_timeout_timer is None
+        assert clf.listening is False
+
+        clf.start_detection_timer()
+        clf.start_listening()
+
+        assert clf._detection_timeout_timer is None
+        assert clf.listening is False
+
+        await clf.close()
+
     async def test_emit_cancels_timers(self) -> None:
         """Timers are cancelled at successful emission, not at verdict-set."""
         llm = FakeLLM(fake_responses=[_machine_vm_response("voicemail")])
@@ -459,8 +503,8 @@ class TestAMDClassifier:
 
         await clf.close()
 
-    async def test_eot_backstop_emits_machine_without_turn_detector(self) -> None:
-        """The synthetic end-of-turn backstop (max_endpointing_delay) lets a
+    async def test_max_endpointing_delay_emits_machine_without_turn_detector(self) -> None:
+        """The synthetic max-endpointing EOT lets a
         machine verdict emit even if on_end_of_turn() is never called."""
         llm = FakeLLM(fake_responses=[_machine_vm_response("voicemail")])
         clf = _make_classifier(
@@ -487,11 +531,26 @@ class TestAMDClassifier:
         assert clf._eot_reached is False
         assert results == []
 
-        # the eot backstop (0.4) fires without any on_end_of_turn() call → emit
+        # the max endpointing delay (0.4) fires without any on_end_of_turn() call → emit
         await asyncio.wait_for(clf._verdict_ready.wait(), timeout=1.0)
         assert clf._eot_reached is True
         assert len(results) == 1
         assert results[0].category == AMDCategory.MACHINE_VM
+
+        await clf.close()
+
+    async def test_max_endpointing_delay_accounts_for_elapsed_silence_on_eos(self) -> None:
+        clf = _make_classifier(human_speech_threshold=0.05, max_endpointing_delay=0.4)
+        clf.start_listening()
+
+        clf.on_user_speech_started()
+        await asyncio.sleep(0.1)
+        clf.on_user_speech_ended(silence_duration=0.25)
+
+        await asyncio.sleep(0.2)
+
+        assert clf._eot_reached is True
+        assert clf._eot_timer is None
 
         await clf.close()
 
@@ -528,7 +587,7 @@ class TestAMDClassifier:
         await clf.close()
 
     async def test_speech_restart_cancels_eot_backstop(self) -> None:
-        """on_user_speech_started cancels the eot backstop and resets the gate."""
+        """on_user_speech_started cancels the EOT timer and resets the gate."""
         clf = _make_classifier(human_speech_threshold=0.05, max_endpointing_delay=0.3)
         clf.start_listening()
 
@@ -547,3 +606,170 @@ class TestAMDClassifier:
         assert clf._eot_reached is False
 
         await clf.close()
+
+    async def test_max_endpointing_delay_starts_from_transcript_without_eos(self) -> None:
+        """A final transcript alone starts AMD's synthetic EOT timer."""
+        clf = _make_classifier(max_endpointing_delay=0.3)
+        clf.start_listening()
+
+        clf.push_text("voicemail greeting")
+        assert clf._eot_timer is not None
+
+        await asyncio.sleep(0.4)
+
+        assert clf._eot_reached is True
+        assert clf._eot_timer is None
+
+        await clf.close()
+
+    async def test_transcript_rearms_max_endpointing_delay_after_eos(self) -> None:
+        """A post-EOS transcript re-arms the synthetic EOT timer."""
+        clf = _make_classifier(human_speech_threshold=0.05, max_endpointing_delay=0.4)
+        clf.start_listening()
+
+        clf.on_user_speech_started()
+        await asyncio.sleep(0.1)
+        clf.on_user_speech_ended(silence_duration=0.0)
+        first_timer = clf._eot_timer
+        assert first_timer is not None
+
+        await asyncio.sleep(0.25)
+        clf.push_text("voicemail greeting")
+        assert clf._eot_timer is not None
+        assert clf._eot_timer is not first_timer
+
+        await asyncio.sleep(0.25)
+        assert clf._eot_reached is False
+
+        await asyncio.sleep(0.25)
+        assert clf._eot_reached is True
+
+        await clf.close()
+
+    def test_detection_option_max_endpointing_delay_overrides_activity(self) -> None:
+        llm = FakeLLM()
+        session = SimpleNamespace(
+            llm=llm,
+            _activity=SimpleNamespace(max_endpointing_delay=9.0),
+        )
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            detection_options={"max_endpointing_delay": 0.25},
+            suppress_compatibility_warning=True,
+        )
+
+        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
+
+        assert clf is not None
+        assert clf._max_endpointing_delay == 0.25
+
+    def test_detection_option_max_endpointing_delay_falls_back_to_activity(self) -> None:
+        llm = FakeLLM()
+        session = SimpleNamespace(
+            llm=llm,
+            _activity=SimpleNamespace(max_endpointing_delay=1.25),
+        )
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            suppress_compatibility_warning=True,
+        )
+
+        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
+
+        assert clf is not None
+        assert clf._max_endpointing_delay == 1.25
+
+    def test_detection_option_max_endpointing_delay_falls_back_to_default(self) -> None:
+        llm = FakeLLM()
+        session = SimpleNamespace(llm=llm, _activity=None)
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            suppress_compatibility_warning=True,
+        )
+
+        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
+
+        assert clf is not None
+        assert clf._max_endpointing_delay == detector._opts["max_endpointing_delay"]
+
+    def test_amd_defaults_to_wait_until_finished(self) -> None:
+        llm = FakeLLM()
+        session = SimpleNamespace(llm=llm, _activity=None)
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            suppress_compatibility_warning=True,
+        )
+
+        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
+
+        assert clf is not None
+        assert clf._wait_until_finished is True
+
+    def test_amd_wait_until_finished_can_be_disabled(self) -> None:
+        llm = FakeLLM()
+        session = SimpleNamespace(llm=llm, _activity=None)
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            wait_until_finished=False,
+            suppress_compatibility_warning=True,
+        )
+
+        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
+
+        assert clf is not None
+        assert clf._wait_until_finished is False
+
+    async def test_setup_resets_detection_timer_after_track_subscription(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = 0
+
+        class FakeClassifier:
+            listening = False
+
+            def start_detection_timer(self) -> None:
+                nonlocal calls
+                calls += 1
+
+            def start_listening(self) -> None:
+                self.listening = True
+
+        async def fake_wait_for_track_publication(**_: object) -> SimpleNamespace:
+            assert calls == 1
+            return SimpleNamespace(sid="track_sid")
+
+        monkeypatch.setattr(
+            amd_detector,
+            "wait_for_track_publication",
+            fake_wait_for_track_publication,
+        )
+
+        llm = FakeLLM()
+        publisher = SimpleNamespace(
+            kind=object(),
+            identity="callee",
+            track_publications={"track_sid": object()},
+        )
+        session = SimpleNamespace(
+            llm=llm,
+            _activity=None,
+            _room_io=SimpleNamespace(
+                room=SimpleNamespace(remote_participants={"callee": publisher})
+            ),
+        )
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            suppress_compatibility_warning=True,
+        )
+        detector._stt = NOT_GIVEN
+        detector._classifier = FakeClassifier()  # type: ignore[assignment]
+
+        await detector._setup(session)  # type: ignore[arg-type]
+
+        assert calls == 2


### PR DESCRIPTION
- Arm detection timeout before track subscription and reset it after that so it can be bounded in both cases: no publication or no answer.

- Add `max_endpointing_delay` for AMD to work with `wait_until_finished` to emit verdict when EOT is triggered. `wait_until_finished` is now `True` by default.

> [!WARNING]
> This is a behavior change for AMD default detection timeout behavior as longer continuous speech can extend beyond timeout value as it needs to wait for an EOS or EOT signal.