### PR TITLE
feat: tag simulation and redaction telemetry

### DIFF
--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -43,7 +43,6 @@ from .telemetry.traces import _BufferingHandler, _setup_cloud_tracer, _shutdown_
 from .types import (
     ATTRIBUTE_REDACTION_ENABLED,
     ATTRIBUTE_SIMULATION_ENABLED,
-    ATTRIBUTE_SIMULATION_RUN_ID,
     ATTRIBUTE_SIMULATOR,
     ATTRIBUTE_SIMULATOR_DISPATCH,
     NotGivenOr,
@@ -833,9 +832,8 @@ class JobContext:
 
     def _otel_metadata(self, options: RecordingOptions | None = None) -> dict[str, Any] | None:
         metadata: dict[str, Any] = {}
-        if sim_ctx := self.simulation_context():
+        if self.simulation_context() is not None:
             metadata[ATTRIBUTE_SIMULATION_ENABLED] = True
-            metadata[ATTRIBUTE_SIMULATION_RUN_ID] = sim_ctx._dispatch.simulation_run_id
         if options and options.get("redaction", False):
             metadata[ATTRIBUTE_REDACTION_ENABLED] = True
         return metadata or None

--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -40,7 +40,12 @@ from .log import logger
 from .observability import Tagger
 from .telemetry import _upload_session_report, otel_metrics
 from .telemetry.traces import _BufferingHandler, _setup_cloud_tracer, _shutdown_telemetry
-from .types import ATTRIBUTE_SIMULATOR, ATTRIBUTE_SIMULATOR_DISPATCH, NotGivenOr
+from .types import (
+    ATTRIBUTE_SIMULATOR,
+    ATTRIBUTE_SIMULATOR_DISPATCH,
+    NotGivenOr,
+    recording_enabled,
+)
 from .utils import http_context, is_given, wait_for_participant
 from .utils.deprecation import deprecate_params
 from .utils.misc import is_cloud
@@ -296,7 +301,7 @@ class JobContext:
 
         has_evals = bool(self._tagger.evaluations or self._tagger.outcome)
         obs_url = _observability_url(self._info.url)
-        if (any(report.recording_options.values()) or has_evals) and obs_url:
+        if (recording_enabled(report.recording_options) or has_evals) and obs_url:
             try:
                 await _upload_session_report(
                     agent_name=self._info.job.agent_name,
@@ -304,6 +309,7 @@ class JobContext:
                     report=report,
                     tagger=self._tagger,
                     http_session=http_context.http_session(),
+                    metadata=self._otel_metadata(report.recording_options),
                 )
             except Exception:
                 logger.exception("failed to upload the session report to LiveKit Cloud")
@@ -775,6 +781,7 @@ class JobContext:
             observability_url=obs_url,
             enable_traces=options["traces"],
             enable_logs=options["logs"],
+            metadata=self._otel_metadata(options),
         )
         # init_recording is typically called during session.start(), at which point a bunch of
         # the logs would have already been emitted. we want to capture all of the logs as it
@@ -820,6 +827,15 @@ class JobContext:
 
     def token_claims(self) -> Claims:
         return api.TokenVerifier().verify(self._info.token, verify_signature=False)
+
+    def _otel_metadata(self, options: RecordingOptions | None = None) -> dict[str, Any] | None:
+        metadata: dict[str, Any] = {}
+        if sim_ctx := self.simulation_context():
+            metadata["lk.simulation.enabled"] = True
+            metadata["lk.simulation.run_id"] = sim_ctx._dispatch.simulation_run_id
+        if options and options.get("redaction", False):
+            metadata["lk.redaction.enabled"] = True
+        return metadata or None
 
 
 def _apply_auto_subscribe_opts(room: rtc.Room, auto_subscribe: AutoSubscribe) -> None:

--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -41,6 +41,9 @@ from .observability import Tagger
 from .telemetry import _upload_session_report, otel_metrics
 from .telemetry.traces import _BufferingHandler, _setup_cloud_tracer, _shutdown_telemetry
 from .types import (
+    ATTRIBUTE_REDACTION_ENABLED,
+    ATTRIBUTE_SIMULATION_ENABLED,
+    ATTRIBUTE_SIMULATION_RUN_ID,
     ATTRIBUTE_SIMULATOR,
     ATTRIBUTE_SIMULATOR_DISPATCH,
     NotGivenOr,
@@ -831,10 +834,10 @@ class JobContext:
     def _otel_metadata(self, options: RecordingOptions | None = None) -> dict[str, Any] | None:
         metadata: dict[str, Any] = {}
         if sim_ctx := self.simulation_context():
-            metadata["lk.simulation.enabled"] = True
-            metadata["lk.simulation.run_id"] = sim_ctx._dispatch.simulation_run_id
+            metadata[ATTRIBUTE_SIMULATION_ENABLED] = True
+            metadata[ATTRIBUTE_SIMULATION_RUN_ID] = sim_ctx._dispatch.simulation_run_id
         if options and options.get("redaction", False):
-            metadata["lk.redaction.enabled"] = True
+            metadata[ATTRIBUTE_REDACTION_ENABLED] = True
         return metadata or None
 
 

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -49,7 +49,11 @@ from livekit import api
 from livekit.protocol import agent_pb, metrics as proto_metrics
 
 from ..log import TRACE_LEVEL, logger
-from ..types import recording_enabled
+from ..types import (
+    ATTRIBUTE_REDACTION_ENABLED,
+    ATTRIBUTE_SIMULATION_ENABLED,
+    recording_enabled,
+)
 from . import trace_types
 
 if TYPE_CHECKING:
@@ -452,9 +456,6 @@ async def _upload_session_report(
     metadata: dict[str, AttributeValue] | None = None,
 ) -> None:
     metadata = metadata or {}
-    metadata_headers = {
-        k: str(v).lower() if isinstance(v, bool) else str(v) for k, v in metadata.items()
-    }
 
     def _get_logger(name: str) -> Any:
         return get_logger_provider().get_logger(
@@ -587,6 +588,8 @@ async def _upload_session_report(
     header_msg = proto_metrics.MetricsRecordingHeader(
         room_id=report.room_id,
         job_id=report.job_id,
+        simulated=bool(metadata.get(ATTRIBUTE_SIMULATION_ENABLED, False)),
+        redaction_enabled=bool(metadata.get(ATTRIBUTE_REDACTION_ENABLED, False)),
     )
     header_msg.start_time.FromMilliseconds(int((report.audio_recording_started_at or 0) * 1000))
     header_bytes = header_msg.SerializeToString()
@@ -610,7 +613,6 @@ async def _upload_session_report(
 
         part = mp.append(header_bytes)
         part.set_content_disposition("form-data", name="header", filename="header.binpb")
-        part.headers.update(metadata_headers)
         part.headers["Content-Type"] = "application/protobuf"
         part.headers["Content-Length"] = str(len(header_bytes))
 
@@ -619,14 +621,12 @@ async def _upload_session_report(
             part.set_content_disposition(
                 "form-data", name="chat_history", filename="chat_history.json"
             )
-            part.headers.update(metadata_headers)
             part.headers["Content-Type"] = "application/json"
             part.headers["Content-Length"] = str(len(chat_history_json))
 
         if audio_bytes:
             part = mp.append(audio_bytes)
             part.set_content_disposition("form-data", name="audio", filename="recording.ogg")
-            part.headers.update(metadata_headers)
             part.headers["Content-Type"] = "audio/ogg"
             part.headers["Content-Length"] = str(len(audio_bytes))
 

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -49,6 +49,7 @@ from livekit import api
 from livekit.protocol import agent_pb, metrics as proto_metrics
 
 from ..log import TRACE_LEVEL, logger
+from ..types import recording_enabled
 from . import trace_types
 
 if TYPE_CHECKING:
@@ -98,7 +99,7 @@ class _MetadataLogProcessor(LogRecordProcessor):
         if log_data.log_record.attributes:
             log_data.log_record.attributes.update(self._metadata)  # type: ignore
         else:
-            log_data.log_record.attributes = self._metadata
+            log_data.log_record.attributes = dict(self._metadata)
 
         if log_data.instrumentation_scope:
             log_data.log_record.attributes.update(  # type: ignore
@@ -161,6 +162,7 @@ def _setup_cloud_tracer(
     observability_url: str,
     enable_traces: bool = True,
     enable_logs: bool = True,
+    metadata: dict[str, AttributeValue] | None = None,
 ) -> None:
     token_ttl = timedelta(hours=6)
     refresh_margin = timedelta(minutes=5)
@@ -201,15 +203,12 @@ def _setup_cloud_tracer(
     header_provider = _AuthHeaderProvider()
     session = _AuthRefreshingSession(header_provider)
     otlp_compression = Compression.Gzip
-    metadata: dict[str, AttributeValue] = {"room_id": room_id, "job_id": job_id}
+    base_metadata: dict[str, AttributeValue] = {"room_id": room_id, "job_id": job_id}
+    session_metadata = dict(base_metadata)
+    if metadata:
+        session_metadata.update(metadata)
 
-    resource = Resource.create(
-        {
-            SERVICE_NAME: "livekit-agents",
-            "room_id": room_id,
-            "job_id": job_id,
-        }
-    )
+    resource = Resource.create({SERVICE_NAME: "livekit-agents", **base_metadata})
 
     if enable_traces:
         # Check if a tracer provider is not set and set one up
@@ -235,7 +234,7 @@ def _setup_cloud_tracer(
         )
 
         if isinstance(tracer_provider, trace_sdk.TracerProvider):
-            tracer_provider.add_span_processor(_MetadataSpanProcessor(metadata))
+            tracer_provider.add_span_processor(_MetadataSpanProcessor(session_metadata))
             tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
 
     # Always set up the logger provider — it's needed for session reports,
@@ -251,7 +250,7 @@ def _setup_cloud_tracer(
             compression=otlp_compression,
             session=session,
         )
-        logger_provider.add_log_record_processor(_MetadataLogProcessor(metadata))
+        logger_provider.add_log_record_processor(_MetadataLogProcessor(session_metadata))
         logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
 
         handler = _TraceLevelLoggingHandler(level=logging.NOTSET, logger_provider=logger_provider)
@@ -450,7 +449,13 @@ async def _upload_session_report(
     report: SessionReport,
     tagger: Tagger,
     http_session: aiohttp.ClientSession,
+    metadata: dict[str, AttributeValue] | None = None,
 ) -> None:
+    metadata = metadata or {}
+    metadata_headers = {
+        k: str(v).lower() if isinstance(v, bool) else str(v) for k, v in metadata.items()
+    }
+
     def _get_logger(name: str) -> Any:
         return get_logger_provider().get_logger(
             name=name,
@@ -458,6 +463,7 @@ async def _upload_session_report(
                 "room_id": report.room_id,
                 "job_id": report.job_id,
                 "room": report.room,
+                **metadata,
             },
         )
 
@@ -480,7 +486,7 @@ async def _upload_session_report(
     chat_logger = _get_logger("chat_history")
     recording_options = report.recording_options
 
-    if any(recording_options.values()):
+    if recording_enabled(recording_options):
         _log(
             chat_logger,
             body="session report",
@@ -604,6 +610,7 @@ async def _upload_session_report(
 
         part = mp.append(header_bytes)
         part.set_content_disposition("form-data", name="header", filename="header.binpb")
+        part.headers.update(metadata_headers)
         part.headers["Content-Type"] = "application/protobuf"
         part.headers["Content-Length"] = str(len(header_bytes))
 
@@ -612,12 +619,14 @@ async def _upload_session_report(
             part.set_content_disposition(
                 "form-data", name="chat_history", filename="chat_history.json"
             )
+            part.headers.update(metadata_headers)
             part.headers["Content-Type"] = "application/json"
             part.headers["Content-Length"] = str(len(chat_history_json))
 
         if audio_bytes:
             part = mp.append(audio_bytes)
             part.set_content_disposition("form-data", name="audio", filename="recording.ogg")
+            part.headers.update(metadata_headers)
             part.headers["Content-Type"] = "audio/ogg"
             part.headers["Content-Length"] = str(len(audio_bytes))
 

--- a/livekit-agents/livekit/agents/types.py
+++ b/livekit-agents/livekit/agents/types.py
@@ -52,6 +52,15 @@ delivered with the agent dispatch and read by
 ``JobContext.simulation_context()``.
 """
 
+ATTRIBUTE_SIMULATION_ENABLED = "lk.simulation.enabled"
+"""Telemetry metadata key marking the session as a simulation."""
+
+ATTRIBUTE_SIMULATION_RUN_ID = "lk.simulation.run_id"
+"""Telemetry metadata key carrying the simulation run id."""
+
+ATTRIBUTE_REDACTION_ENABLED = "lk.redaction.enabled"
+"""Telemetry metadata key requesting collector-side PII redaction for the session."""
+
 _RECORDING_OPTION_KEYS = ("audio", "traces", "logs", "transcript")
 
 

--- a/livekit-agents/livekit/agents/types.py
+++ b/livekit-agents/livekit/agents/types.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Literal, TypeAlias, TypeVar
 
@@ -50,6 +51,13 @@ The job attribute carrying the run's protojson ``SimulationDispatch``,
 delivered with the agent dispatch and read by
 ``JobContext.simulation_context()``.
 """
+
+_RECORDING_OPTION_KEYS = ("audio", "traces", "logs", "transcript")
+
+
+def recording_enabled(options: Mapping[str, object]) -> bool:
+    return any(options.get(key, False) for key in _RECORDING_OPTION_KEYS)
+
 
 TOPIC_CHAT = "lk.chat"
 TOPIC_TRANSCRIPTION = "lk.transcription"

--- a/livekit-agents/livekit/agents/types.py
+++ b/livekit-agents/livekit/agents/types.py
@@ -55,9 +55,6 @@ delivered with the agent dispatch and read by
 ATTRIBUTE_SIMULATION_ENABLED = "lk.simulation.enabled"
 """Telemetry metadata key marking the session as a simulation."""
 
-ATTRIBUTE_SIMULATION_RUN_ID = "lk.simulation.run_id"
-"""Telemetry metadata key carrying the simulation run id."""
-
 ATTRIBUTE_REDACTION_ENABLED = "lk.redaction.enabled"
 """Telemetry metadata key requesting collector-side PII redaction for the session."""
 

--- a/livekit-agents/livekit/agents/types.py
+++ b/livekit-agents/livekit/agents/types.py
@@ -56,7 +56,7 @@ ATTRIBUTE_SIMULATION_ENABLED = "lk.simulation.enabled"
 """Telemetry metadata key marking the session as a simulation."""
 
 ATTRIBUTE_REDACTION_ENABLED = "lk.redaction.enabled"
-"""Telemetry metadata key requesting collector-side PII redaction for the session."""
+"""Telemetry metadata key requesting PII redaction for the session."""
 
 _RECORDING_OPTION_KEYS = ("audio", "traces", "logs", "transcript")
 

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -107,7 +107,7 @@ class RecordingOptions(TypedDict, total=False):
     * ``record=True``  → all on (backward compatible)
     * ``record=False`` → all off (backward compatible)
     * ``record={"audio": True, "traces": False}`` → granular
-    * ``record={"redaction": True}`` → preview collector-side redaction
+    * ``record={"redaction": True}`` → enable redaction for the session
     """
 
     audio: bool

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -40,6 +40,7 @@ from ..types import (
     NOT_GIVEN,
     APIConnectOptions,
     NotGivenOr,
+    recording_enabled,
 )
 from ..utils.deprecation import deprecate_params
 from ..utils.misc import is_given
@@ -97,14 +98,16 @@ if TYPE_CHECKING:
 class RecordingOptions(TypedDict, total=False):
     """Granular control over which recording features are active.
 
-    All keys default to ``True`` when not specified, so ``{"logs": False}``
-    means "record everything except logs."
+    Recording keys default to ``True`` when not specified, so ``{"logs": False}``
+    means "record everything except logs." Redaction defaults to the project setting;
+    ``False`` is ignored when redaction is enabled globally for the project.
 
     Can be passed directly to :pymethod:`AgentSession.start(record=...)`:
 
     * ``record=True``  → all on (backward compatible)
     * ``record=False`` → all off (backward compatible)
     * ``record={"audio": True, "traces": False}`` → granular
+    * ``record={"redaction": True}`` → preview collector-side redaction
     """
 
     audio: bool
@@ -115,6 +118,8 @@ class RecordingOptions(TypedDict, total=False):
     """Export OpenTelemetry logs. Defaults to ``True``."""
     transcript: bool
     """Upload the conversation transcript (chat history). Defaults to ``True``."""
+    redaction: bool
+    """Request collector-side redaction preview. ``False`` does not disable project redaction."""
 
 
 _RECORDING_ALL_ON: RecordingOptions = {
@@ -122,12 +127,14 @@ _RECORDING_ALL_ON: RecordingOptions = {
     "traces": True,
     "logs": True,
     "transcript": True,
+    "redaction": False,
 }
 _RECORDING_ALL_OFF: RecordingOptions = {
     "audio": False,
     "traces": False,
     "logs": False,
     "transcript": False,
+    "redaction": False,
 }
 
 
@@ -761,7 +768,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                     job_ctx._primary_agent_session = self
                 else:
                     is_primary = False
-                    if any(self._recording_options.values()):
+                    if recording_enabled(self._recording_options):
                         if record_is_given:
                             raise RuntimeError(
                                 "Only one `AgentSession` can be the primary at a time. "

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -119,7 +119,7 @@ class RecordingOptions(TypedDict, total=False):
     transcript: bool
     """Upload the conversation transcript (chat history). Defaults to ``True``."""
     redaction: bool
-    """Request collector-side redaction preview. ``False`` does not disable project redaction."""
+    """Enable redaction. ``False`` does not disable project redaction."""
 
 
 _RECORDING_ALL_ON: RecordingOptions = {

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -406,7 +406,6 @@ async def test_upload_session_report_includes_simulation_metadata() -> None:
     report = _make_mock_report({"audio": False, "traces": True, "logs": False, "transcript": False})
     metadata = {
         "lk.simulation.enabled": True,
-        "lk.simulation.run_id": "run-1",
     }
 
     with _patch_upload_deps() as mock_logger:
@@ -414,7 +413,6 @@ async def test_upload_session_report_includes_simulation_metadata() -> None:
 
     attrs = mock_logger.provider.get_logger.call_args_list[0].kwargs["attributes"]
     assert attrs["lk.simulation.enabled"] is True
-    assert attrs["lk.simulation.run_id"] == "run-1"
     session_report_call = next(
         c for c in mock_logger.emit.call_args_list if c.kwargs.get("body") == "session report"
     )
@@ -435,7 +433,6 @@ async def test_upload_multipart_header_carries_simulation_redaction() -> None:
     report = _make_mock_report({"audio": False, "traces": False, "logs": False, "transcript": True})
     metadata = {
         "lk.simulation.enabled": True,
-        "lk.simulation.run_id": "run-1",
         "lk.redaction.enabled": True,
     }
     mock_http = _make_mock_http()
@@ -500,7 +497,7 @@ def test_setup_cloud_tracer_logger_provider_always_created() -> None:
             **_observability_endpoint_arg(_setup_cloud_tracer),
             enable_traces=False,
             enable_logs=False,
-            metadata={"lk.simulation.enabled": True, "lk.simulation.run_id": "run-1"},
+            metadata={"lk.simulation.enabled": True},
         )
 
     mock_slp.assert_called_once()

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -20,6 +20,7 @@ from livekit.agents.voice.agent_session import (
     RecordingOptions,
 )
 from livekit.agents.voice.recorder_io.recorder_io import _split_frame
+from livekit.protocol import metrics as proto_metrics
 
 from .fake_io import FakeAudioInput, FakeAudioOutput, FakeTextOutput
 from .fake_llm import FakeLLM
@@ -430,7 +431,7 @@ async def test_upload_session_report_includes_redaction_metadata() -> None:
     assert attrs["lk.redaction.enabled"] is True
 
 
-async def test_upload_multipart_includes_metadata_headers() -> None:
+async def test_upload_multipart_header_carries_simulation_redaction() -> None:
     report = _make_mock_report({"audio": False, "traces": False, "logs": False, "transcript": True})
     metadata = {
         "lk.simulation.enabled": True,
@@ -444,10 +445,9 @@ async def test_upload_multipart_includes_metadata_headers() -> None:
 
     mp_writer = mock_http.post.call_args.kwargs.get("data") or mock_http.post.call_args[1]["data"]
     parts = _get_multipart_parts(mp_writer)
-    assert parts["header"].headers["lk.simulation.enabled"] == "true"
-    assert parts["header"].headers["lk.simulation.run_id"] == "run-1"
-    assert parts["header"].headers["lk.redaction.enabled"] == "true"
-    assert parts["chat_history"].headers["lk.simulation.run_id"] == "run-1"
+    header = proto_metrics.MetricsRecordingHeader.FromString(parts["header"]._value)
+    assert header.simulated is True
+    assert header.redaction_enabled is True
 
 
 def test_job_context_otel_metadata_includes_redaction_option() -> None:

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -118,6 +118,9 @@ def _make_mock_tagger(
     mock = MagicMock()
     mock.evaluations = evaluations or []
     mock.outcome_reason = outcome_reason
+    mock.tags = set()
+    mock._tags = {}
+    mock.outcome = "pass" if outcome_reason else None
     return mock
 
 
@@ -148,7 +151,9 @@ def _patch_upload_deps() -> Iterator[MagicMock]:
         patch(f"{_TRACES_MOD}.get_logger_provider") as mock_glp,
         patch(f"{_TRACES_MOD}.api.AccessToken") as mock_at,
     ):
-        mock_glp.return_value.get_logger.return_value = mock_logger
+        provider = mock_glp.return_value
+        provider.get_logger.return_value = mock_logger
+        mock_logger.provider = provider
         mock_token = MagicMock()
         mock_token.with_observability_grants.return_value = mock_token
         mock_token.with_ttl.return_value = mock_token
@@ -162,6 +167,7 @@ async def _call_upload(
     *,
     tagger: MagicMock | None = None,
     http_session: MagicMock | None = None,
+    metadata: dict[str, Any] | None = None,
 ) -> None:
     """Call _upload_session_report with sensible defaults."""
     await _upload_session_report(
@@ -170,6 +176,7 @@ async def _call_upload(
         report=report,
         tagger=tagger or _make_mock_tagger(),
         http_session=http_session or _make_mock_http(),
+        metadata=metadata,
     )
 
 
@@ -184,6 +191,16 @@ def _get_multipart_part_names(mp_writer: aiohttp.MultipartWriter) -> list[str]:
     return names
 
 
+def _get_multipart_parts(mp_writer: aiohttp.MultipartWriter) -> dict[str, Any]:
+    parts = {}
+    for payload, _enc, _te in mp_writer._parts:
+        cd = payload.headers.get("Content-Disposition", "")
+        for name in ("header", "chat_history", "audio"):
+            if f'name="{name}"' in cd:
+                parts[name] = payload
+    return parts
+
+
 # ---------------------------------------------------------------------------
 # Group 1: RecordingOptions normalization (no JobContext)
 # ---------------------------------------------------------------------------
@@ -196,8 +213,25 @@ def _get_multipart_part_names(mp_writer: aiohttp.MultipartWriter) -> list[str]:
         pytest.param(False, _RECORDING_ALL_OFF, id="record=False"),
         pytest.param(
             {"audio": False},
-            {"audio": False, "traces": True, "logs": True, "transcript": True},
+            {
+                "audio": False,
+                "traces": True,
+                "logs": True,
+                "transcript": True,
+                "redaction": False,
+            },
             id="partial",
+        ),
+        pytest.param(
+            {"redaction": True},
+            {
+                "audio": True,
+                "traces": True,
+                "logs": True,
+                "transcript": True,
+                "redaction": True,
+            },
+            id="redaction",
         ),
     ],
 )
@@ -227,7 +261,13 @@ async def test_init_recording_called_with_options() -> None:
     """init_recording should be called with the correct RecordingOptions."""
     session = _create_simple_session()
     mock_ctx = _make_mock_job_ctx()
-    custom: RecordingOptions = {"audio": True, "traces": True, "logs": False, "transcript": True}
+    custom: RecordingOptions = {
+        "audio": True,
+        "traces": True,
+        "logs": False,
+        "transcript": True,
+        "redaction": True,
+    }
 
     with _patch_job_ctx(mock_ctx, patch_recorder=True):
         await session.start(SimpleAgent(), record=custom)
@@ -239,6 +279,7 @@ async def test_init_recording_called_with_options() -> None:
         "traces": True,
         "logs": False,
         "transcript": True,
+        "redaction": True,
     }
     await _cleanup(session)
 
@@ -290,7 +331,7 @@ async def test_init_recording_called_when_job_recording_disabled() -> None:
 async def test_upload_returns_early_when_none() -> None:
     """When all options are False, no HTTP request and no session report log should be made."""
     report = _make_mock_report(
-        {"audio": False, "traces": False, "logs": False, "transcript": False}
+        {"audio": False, "traces": False, "logs": False, "transcript": False, "redaction": True}
     )
     mock_http = MagicMock(spec=aiohttp.ClientSession)
     mock_http.post = MagicMock()
@@ -360,6 +401,78 @@ async def test_upload_evaluations_emitted_without_logs() -> None:
     assert bodies.count("outcome") == 1
 
 
+async def test_upload_session_report_includes_simulation_metadata() -> None:
+    report = _make_mock_report({"audio": False, "traces": True, "logs": False, "transcript": False})
+    metadata = {
+        "lk.simulation.enabled": True,
+        "lk.simulation.run_id": "run-1",
+    }
+
+    with _patch_upload_deps() as mock_logger:
+        await _call_upload(report, metadata=metadata)
+
+    attrs = mock_logger.provider.get_logger.call_args_list[0].kwargs["attributes"]
+    assert attrs["lk.simulation.enabled"] is True
+    assert attrs["lk.simulation.run_id"] == "run-1"
+    session_report_call = next(
+        c for c in mock_logger.emit.call_args_list if c.kwargs.get("body") == "session report"
+    )
+    assert "session.simulation" not in session_report_call.kwargs["attributes"]
+
+
+async def test_upload_session_report_includes_redaction_metadata() -> None:
+    report = _make_mock_report({"audio": False, "traces": True, "logs": False, "transcript": False})
+
+    with _patch_upload_deps() as mock_logger:
+        await _call_upload(report, metadata={"lk.redaction.enabled": True})
+
+    attrs = mock_logger.provider.get_logger.call_args_list[0].kwargs["attributes"]
+    assert attrs["lk.redaction.enabled"] is True
+
+
+async def test_upload_multipart_includes_metadata_headers() -> None:
+    report = _make_mock_report({"audio": False, "traces": False, "logs": False, "transcript": True})
+    metadata = {
+        "lk.simulation.enabled": True,
+        "lk.simulation.run_id": "run-1",
+        "lk.redaction.enabled": True,
+    }
+    mock_http = _make_mock_http()
+
+    with _patch_upload_deps():
+        await _call_upload(report, http_session=mock_http, metadata=metadata)
+
+    mp_writer = mock_http.post.call_args.kwargs.get("data") or mock_http.post.call_args[1]["data"]
+    parts = _get_multipart_parts(mp_writer)
+    assert parts["header"].headers["lk.simulation.enabled"] == "true"
+    assert parts["header"].headers["lk.simulation.run_id"] == "run-1"
+    assert parts["header"].headers["lk.redaction.enabled"] == "true"
+    assert parts["chat_history"].headers["lk.simulation.run_id"] == "run-1"
+
+
+def test_job_context_otel_metadata_includes_redaction_option() -> None:
+    from livekit.agents.job import JobContext
+
+    ctx = object.__new__(JobContext)
+    ctx.simulation_context = MagicMock(return_value=None)
+
+    assert ctx._otel_metadata({"redaction": True}) == {"lk.redaction.enabled": True}
+
+
+async def test_upload_session_report_omits_simulation_metadata_for_normal_session() -> None:
+    report = _make_mock_report({"audio": False, "traces": True, "logs": False, "transcript": False})
+
+    with _patch_upload_deps() as mock_logger:
+        await _call_upload(report)
+
+    attrs = mock_logger.provider.get_logger.call_args_list[0].kwargs["attributes"]
+    assert not any(k.startswith("lk.simulation.") for k in attrs)
+    session_report_call = next(
+        c for c in mock_logger.emit.call_args_list if c.kwargs.get("body") == "session report"
+    )
+    assert "session.simulation" not in session_report_call.kwargs["attributes"]
+
+
 def test_setup_cloud_tracer_logger_provider_always_created() -> None:
     """LoggerProvider should be set up even when enable_logs=False."""
     from livekit.agents.telemetry.traces import _setup_cloud_tracer
@@ -370,6 +483,7 @@ def test_setup_cloud_tracer_logger_provider_always_created() -> None:
         patch(f"{_TRACES_MOD}.set_logger_provider") as mock_slp,
         patch(f"{_TRACES_MOD}.OTLPLogExporter") as mock_exporter,
         patch(f"{_TRACES_MOD}.BatchLogRecordProcessor") as mock_blrp,
+        patch(f"{_TRACES_MOD}.Resource.create") as mock_resource_create,
         patch(f"{_TRACES_MOD}.logging"),
     ):
         mock_token = MagicMock()
@@ -386,9 +500,11 @@ def test_setup_cloud_tracer_logger_provider_always_created() -> None:
             **_observability_endpoint_arg(_setup_cloud_tracer),
             enable_traces=False,
             enable_logs=False,
+            metadata={"lk.simulation.enabled": True, "lk.simulation.run_id": "run-1"},
         )
 
     mock_slp.assert_called_once()
+    assert not any(k.startswith("lk.simulation.") for k in mock_resource_create.call_args.args[0])
     # OTLP exporter should NOT be created when enable_logs=False
     mock_exporter.assert_not_called()
     mock_blrp.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -133,21 +133,8 @@ typing = [
 ]
 
 [[package]]
-name = "aioboto3"
-version = "15.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiobotocore", extra = ["boto3"] },
-    { name = "aiofiles" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/01/92e9ab00f36e2899315f49eefcd5b4685fbb19016c7f19a9edf06da80bb0/aioboto3-15.5.0.tar.gz", hash = "sha256:ea8d8787d315594842fbfcf2c4dce3bac2ad61be275bc8584b2ce9a3402a6979", size = 255069, upload-time = "2025-10-30T13:37:16.122Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/3e/e8f5b665bca646d43b916763c901e00a07e40f7746c9128bdc912a089424/aioboto3-15.5.0-py3-none-any.whl", hash = "sha256:cc880c4d6a8481dd7e05da89f41c384dbd841454fc1998ae25ca9c39201437a6", size = 35913, upload-time = "2025-10-30T13:37:14.549Z" },
-]
-
-[[package]]
 name = "aiobotocore"
-version = "2.25.1"
+version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -158,14 +145,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/94/2e4ec48cf1abb89971cb2612d86f979a6240520f0a659b53a43116d344dc/aiobotocore-2.25.1.tar.gz", hash = "sha256:ea9be739bfd7ece8864f072ec99bb9ed5c7e78ebb2b0b15f29781fbe02daedbc", size = 120560, upload-time = "2025-10-28T22:33:21.787Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/a7/bc31b7046c610471f0630819ca5d2a57ac4efa8d47135cb53e43f2785390/aiobotocore-3.8.0.tar.gz", hash = "sha256:80a1eb64ea915f3af3c1518669975bae74a17b2f37c14eb0fa2f83b915974670", size = 131368, upload-time = "2026-07-17T03:10:30.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/2a/d275ec4ce5cd0096665043995a7d76f5d0524853c76a3d04656de49f8808/aiobotocore-2.25.1-py3-none-any.whl", hash = "sha256:eb6daebe3cbef5b39a0bb2a97cffbe9c7cb46b2fcc399ad141f369f3c2134b1f", size = 86039, upload-time = "2025-10-28T22:33:19.949Z" },
-]
-
-[package.optional-dependencies]
-boto3 = [
-    { name = "boto3" },
+    { url = "https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl", hash = "sha256:8bc605132cadfe844a3f334635a0a64fa5e360a4a206e915d99d53db5b6deeba", size = 91169, upload-time = "2026-07-17T03:10:28.771Z" },
 ]
 
 [[package]]
@@ -582,30 +564,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.40.61"
+version = "1.43.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/f9/6ef8feb52c3cce5ec3967a535a6114b57ac7949fd166b0f3090c2b06e4e5/boto3-1.40.61.tar.gz", hash = "sha256:d6c56277251adf6c2bdd25249feae625abe4966831676689ff23b4694dea5b12", size = 111535, upload-time = "2025-10-28T19:26:57.247Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/e7/976bf3dfe0aa5d7f31bec2f2cf57c79641620c910a39bc843a237aa9592d/boto3-1.43.46.tar.gz", hash = "sha256:66c0d943b049a46a492ec4ec2ebe73c930b1842c7137bee83aad6d93e95d4d96", size = 112654, upload-time = "2026-07-10T19:32:12.498Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/24/3bf865b07d15fea85b63504856e137029b6acbc73762496064219cdb265d/boto3-1.40.61-py3-none-any.whl", hash = "sha256:6b9c57b2a922b5d8c17766e29ed792586a818098efe84def27c8f582b33f898c", size = 139321, upload-time = "2025-10-28T19:26:55.007Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl", hash = "sha256:69453e2c1bcb9fd9806527ab99950cacfc2826cb0dce9a3a0414d19270c06c3c", size = 140031, upload-time = "2026-07-10T19:32:11.129Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.40.61"
+version = "1.43.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/a3/81d3a47c2dbfd76f185d3b894f2ad01a75096c006a2dd91f237dca182188/botocore-1.40.61.tar.gz", hash = "sha256:a2487ad69b090f9cccd64cf07c7021cd80ee9c0655ad974f87045b02f3ef52cd", size = 14393956, upload-time = "2025-10-28T19:26:46.108Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/f1/1917891851ac5ac09bb9f4862b8fc9252a009d7c24e8688bb67e4383d9e7/botocore-1.43.46.tar.gz", hash = "sha256:59f2e1ac3cdc66d191cae91c0804bc41847ce817dc8147cf43eaada8f76a5533", size = 15694635, upload-time = "2026-07-10T19:32:00.437Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/c5/f6ce561004db45f0b847c2cd9b19c67c6bf348a82018a48cb718be6b58b0/botocore-1.40.61-py3-none-any.whl", hash = "sha256:17ebae412692fd4824f99cde0f08d50126dc97954008e5ba2b522eb049238aa7", size = 14055973, upload-time = "2025-10-28T19:26:42.15Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f2/4bd8f2f419088feb3ce55f0ca91040ff902f402edfd197450b20a2e1d533/botocore-1.43.46-py3-none-any.whl", hash = "sha256:cb673891e623ae6e6a1bf24d94ef169504f3eb02584adb5d5bee2f6aae819b60", size = 15380350, upload-time = "2026-07-10T19:31:57.616Z" },
 ]
 
 [[package]]
@@ -2297,7 +2279,7 @@ requires-dist = [{ name = "livekit-agents", editable = "livekit-agents" }]
 name = "livekit-plugins-aws"
 source = { editable = "livekit-plugins/livekit-plugins-aws" }
 dependencies = [
-    { name = "aioboto3" },
+    { name = "aiobotocore" },
     { name = "aws-sdk-transcribe-streaming" },
     { name = "livekit-agents" },
 ]
@@ -2311,7 +2293,7 @@ realtime = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aioboto3", specifier = ">=14.1.0" },
+    { name = "aiobotocore", specifier = ">=3.0.0" },
     { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12' and extra == 'realtime'", specifier = ">=0.2.0" },
     { name = "aws-sdk-signers", marker = "python_full_version >= '3.12' and extra == 'realtime'", specifier = ">=0.0.3" },
     { name = "aws-sdk-transcribe-streaming", marker = "python_full_version >= '3.12'", specifier = ">=0.2.0" },
@@ -2548,7 +2530,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "livekit-agents", extras = ["codecs"], editable = "livekit-agents" },
-    { name = "websockets", specifier = ">=12.0,<16.0" },
+    { name = "websockets", specifier = ">=14.0,<16.0" },
 ]
 
 [[package]]
@@ -3193,15 +3175,15 @@ requires-dist = [{ name = "livekit-agents", extras = ["openai"], editable = "liv
 
 [[package]]
 name = "livekit-protocol"
-version = "1.1.19"
+version = "1.1.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
     { name = "types-protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/85/10aee7d87cf716ab06075836590616cb91d453251dac683cae73fe4b7122/livekit_protocol-1.1.19.tar.gz", hash = "sha256:81709e8bc47cdaf0cc5ba937bd9ec24a095e4978c58fb3d5e69b9888b9930be4", size = 118325, upload-time = "2026-07-08T17:21:10.707Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/ae/9d60fe37d85623e68a2e36ae31d18c671949db67d2a13a6438410d930466/livekit_protocol-1.1.21.tar.gz", hash = "sha256:8bb1ac1aba5d37d0af43e9d56d129a5d16295cbd91518b00fd157e258f20a6ef", size = 122363, upload-time = "2026-07-21T18:28:26.372Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/20/98150dc45b9e92ab81a8eba74cdf544015b9291c4281252e2e76a7338462/livekit_protocol-1.1.19-py3-none-any.whl", hash = "sha256:fe5a8411c6cb886e55b2564d729f275af5d77ec191dd2ca95ffac3db16979a8a", size = 145513, upload-time = "2026-07-08T17:21:09.303Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/ec10b1cdf912235c2b07898be6ba2535e50f23e8980bb719f29decbd8034/livekit_protocol-1.1.21-py3-none-any.whl", hash = "sha256:ce0bb763327c91349ee8831843c4f8bd72132c4d06ac572171f2ae5c0217211d", size = 149245, upload-time = "2026-07-21T18:28:24.985Z" },
 ]
 
 [[package]]
@@ -4951,14 +4933,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.14.0"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354, upload-time = "2026-07-10T19:32:04.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/f0/ae7ca09223a81a1d890b2557186ea015f6e0502e9b8cb8e1813f1d8cfa4e/s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456", size = 85712, upload-time = "2025-09-09T19:23:30.041Z" },
+    { url = "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl", hash = "sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de", size = 90072, upload-time = "2026-07-10T19:32:03.673Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Simulated sessions and redaction previews need lightweight collector signals without scenario metadata or metrics attrs. 

**Passing simulation metadata to collector**
This adds only `lk.simulation.enabled` and opt-in `lk.redaction.enabled` to **trace/log metadata**, session-report logger metadata, and recording multipart part headers. 

**Force redaction with client side opt-in**
`record={"redaction": True}` to enable redaction for a session if the project setting is unset. `record=True` stays unchanged: without `record={"redaction": True}`, redaction is left to the project setting, and `False` is ignored when redaction is enabled globally for the project.

Safe to merge before redaction release as this is a client side addition, no-op for collector endpoints today.