### PR TITLE
Allow local VAD inference to use a dedicated executor

### DIFF
--- a/livekit-agents/livekit/agents/inference/vad.py
+++ b/livekit-agents/livekit/agents/inference/vad.py
@@ -54,7 +54,8 @@ class VAD(vad.VAD):
 
     The native model singleton is loaded once at module import (via the
     pybind11 ``.so`` constructor); each stream allocates its own per-instance
-    LSTM/context state.
+    LSTM/context state. Pass ``executor`` to isolate inference from the event
+    loop's default executor; the caller remains responsible for shutting it down.
     """
 
     def __init__(

--- a/livekit-agents/livekit/agents/inference/vad.py
+++ b/livekit-agents/livekit/agents/inference/vad.py
@@ -18,7 +18,7 @@ import asyncio
 import time
 import weakref
 from dataclasses import dataclass, replace
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
@@ -29,6 +29,9 @@ from .. import utils, vad
 from ..log import logger
 from ..types import NOT_GIVEN, NotGivenOr
 from ..utils import is_given
+
+if TYPE_CHECKING:
+    from concurrent.futures import Executor
 
 SLOW_INFERENCE_THRESHOLD = 0.2  # late by 200ms
 _MODEL_SAMPLE_RATE = 16000
@@ -64,6 +67,7 @@ class VAD(vad.VAD):
         max_buffered_speech: float = 60.0,
         activation_threshold: float = 0.5,
         deactivation_threshold: NotGivenOr[float] = NOT_GIVEN,
+        executor: Executor | None = None,
     ) -> None:
         super().__init__(capabilities=vad.VADCapabilities(update_interval=0.032))
         if model != "silero":
@@ -71,6 +75,7 @@ class VAD(vad.VAD):
         if is_given(deactivation_threshold) and deactivation_threshold <= 0:
             raise ValueError("deactivation_threshold must be greater than 0")
         self._model = model
+        self._executor = executor
         self._opts = _VADOptions(
             min_speech_duration=min_speech_duration,
             min_silence_duration=min_silence_duration,
@@ -97,7 +102,7 @@ class VAD(vad.VAD):
         # max_buffered_speech before mutating it. Sharing the dataclass would
         # let VAD.update_options() mutate the stream's view first, and the
         # stream would never observe an increase.
-        stream = _VADStream(self, replace(self._opts))
+        stream = _VADStream(self, replace(self._opts), executor=self._executor)
         self._streams.add(stream)
         return stream
 
@@ -140,9 +145,10 @@ class VAD(vad.VAD):
 
 
 class _VADStream(vad.VADStream):
-    def __init__(self, parent: VAD, opts: _VADOptions) -> None:
+    def __init__(self, parent: VAD, opts: _VADOptions, *, executor: Executor | None) -> None:
         super().__init__(parent)
         self._opts = opts
+        self._executor = executor
         self._native_vad = _NativeVAD()
 
         self._input_sample_rate = 0
@@ -313,7 +319,9 @@ class _VADStream(vad.VADStream):
                 )
 
                 # run the inference
-                p = await asyncio.to_thread(self._native_vad.predict, inference_window)
+                p = await asyncio.get_running_loop().run_in_executor(
+                    self._executor, self._native_vad.predict, inference_window
+                )
 
                 window_duration = VAD_WINDOW_SAMPLES / _MODEL_SAMPLE_RATE
 

--- a/tests/test_vad.py
+++ b/tests/test_vad.py
@@ -1,4 +1,6 @@
 import asyncio
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any
 
 import pytest
 
@@ -18,6 +20,16 @@ VAD = InferenceVAD(
     min_speech_duration=0.5,
     min_silence_duration=0.75,
 )
+
+
+class _RecordingExecutor(ThreadPoolExecutor):
+    def __init__(self) -> None:
+        super().__init__(max_workers=1)
+        self.submissions = 0
+
+    def submit(self, fn: Any, /, *args: Any, **kwargs: Any) -> Future[Any]:
+        self.submissions += 1
+        return super().submit(fn, *args, **kwargs)
 
 
 @pytest.mark.parametrize("sample_rate", SAMPLE_RATES)
@@ -64,6 +76,22 @@ async def test_chunks_vad(sample_rate) -> None:
 
     with open(f"test_vad.{sample_rate}.inference_frames.wav", "wb") as f:
         f.write(utils.make_wav_file(inference_frames))
+
+
+async def test_vad_uses_configured_executor() -> None:
+    frames, *_ = await utils.make_test_speech(chunk_duration_ms=10, sample_rate=16000)
+    executor = _RecordingExecutor()
+    stream = InferenceVAD(model="silero", executor=executor).stream()
+    try:
+        for frame in frames:
+            stream.push_frame(frame)
+        stream.end_input()
+        _ = [event async for event in stream]
+    finally:
+        await stream.aclose()
+        executor.shutdown()
+
+    assert executor.submissions > 0
 
 
 async def _drain_speech_segment(


### PR DESCRIPTION
## Summary

Add an optional caller-owned executor to the local inference VAD. When supplied, native prediction runs there instead of the event loop default executor. Existing behavior remains unchanged when omitted.

## Why

Applications embedding AgentSession alongside other blocking workloads may heavily use the default executor. VAD inference then waits behind unrelated work and can fall behind realtime audio. A caller-provided executor gives latency-sensitive inference an isolated queue without changing VAD internals or global event-loop configuration.

## Validation

- make check
- uv run pytest --plugin silero tests/test_vad.py