### PR TITLE
feat(voice): expose realtime provider request IDs

### DIFF
--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -278,6 +278,13 @@ class MetricsReport(TypedDict, total=False):
     Assistant `ChatMessage` only
     """
 
+    provider_request_ids: list[str]
+    """Provider-known request or response IDs associated with this turn.
+
+    Assistant `ChatMessage` only. These IDs can be used to correlate a turn with
+    provider-side logs.
+    """
+
     llm_metadata: MetricsMetadata
     tts_metadata: MetricsMetadata
     stt_metadata: MetricsMetadata

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3847,6 +3847,9 @@ class AgentActivity(RecognitionHooks):
         ) -> llm.ChatMessage:
             assistant_metrics: llm.MetricsReport = {}
 
+            if generation_ev.response_id:
+                assistant_metrics["provider_request_ids"] = [generation_ev.response_id]
+
             if stopped_speaking_at and started_speaking_at:
                 assistant_metrics["started_speaking_at"] = started_speaking_at
                 assistant_metrics["stopped_speaking_at"] = stopped_speaking_at

--- a/tests/test_realtime_message_metrics.py
+++ b/tests/test_realtime_message_metrics.py
@@ -1,0 +1,63 @@
+import asyncio
+
+import pytest
+
+from livekit import rtc
+from livekit.agents import Agent, AgentSession, llm, utils
+from livekit.agents.voice.events import ConversationItemAddedEvent
+
+from .fake_realtime import FakeRealtimeModel, fake_capabilities
+
+pytestmark = pytest.mark.unit
+
+
+async def test_realtime_response_id_is_available_on_assistant_message() -> None:
+    model = FakeRealtimeModel(capabilities=fake_capabilities(audio_output=False))
+    conversation_events: list[ConversationItemAddedEvent] = []
+
+    async with AgentSession(llm=model) as session:
+        session.on("conversation_item_added", conversation_events.append)
+        await session.start(Agent(instructions="test"))
+
+        speech_handle = session.generate_reply()
+        while not model.active_session._reply_futs:
+            await asyncio.sleep(0)
+
+        message_ch = utils.aio.Chan[llm.MessageGeneration]()
+        function_ch = utils.aio.Chan[llm.FunctionCall]()
+        text_ch = utils.aio.Chan[str]()
+        audio_ch = utils.aio.Chan[rtc.AudioFrame]()
+        modalities = asyncio.Future[list[str]]()
+        modalities.set_result(["text"])
+
+        message_ch.send_nowait(
+            llm.MessageGeneration(
+                message_id="message-id",
+                text_stream=text_ch,
+                audio_stream=audio_ch,
+                modalities=modalities,
+            )
+        )
+        message_ch.close()
+        function_ch.close()
+        text_ch.send_nowait("Hello")
+        text_ch.close()
+        audio_ch.close()
+
+        model.active_session._reply_futs[0].set_result(
+            llm.GenerationCreatedEvent(
+                message_stream=message_ch,
+                function_stream=function_ch,
+                user_initiated=True,
+                response_id="provider-response-id",
+            )
+        )
+        await speech_handle
+
+    assistant_messages = [
+        event.item
+        for event in conversation_events
+        if event.item.type == "message" and event.item.role == "assistant"
+    ]
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0].metrics["provider_request_ids"] == ["provider-response-id"]


### PR DESCRIPTION
## Summary

- expose provider-known request/response IDs on assistant `ChatMessage.metrics`
- propagate `GenerationCreatedEvent.response_id` for realtime responses
- add a hermetic regression test using the fake realtime model

## Context

xAI realtime already surfaces `response.id` internally as `GenerationCreatedEvent.response_id` and `RealtimeModelMetrics.request_id`, but the ID is dropped before the public, non-deprecated `ChatMessage.metrics` surface. This makes provider console/log correlation possible without subscribing to the deprecated `metrics_collected` event.

The field is named `provider_request_ids` to match the existing `lk.provider_request_ids` tracing convention. xAI does not currently surface a separate provider session/conversation ID, so this PR intentionally keeps the scope to the provider response ID.

## Testing

- `make check` (format, Ruff, strict mypy: 623 source files)
- `.venv/bin/pytest tests/test_realtime_message_metrics.py -q`
- `.venv/bin/pytest --unit --no-concurrent --ignore=tests/test_room.py` (1206 passed, 2 skipped)

The unchanged `tests/test_room.py` module requires a locally installed `livekit-server` binary on macOS; the official Ubuntu CI fixture starts it through Docker.

Closes #6333