### PR TITLE
fix(openai): discard stale pooled Responses WebSocket connections

### DIFF
--- a/livekit-agents/livekit/agents/utils/connection_pool.py
+++ b/livekit-agents/livekit/agents/utils/connection_pool.py
@@ -25,6 +25,7 @@ class ConnectionPool(Generic[T]):
         mark_refreshed_on_get: bool = False,
         connect_cb: Callable[[float], Awaitable[T]] | None = None,
         close_cb: Callable[[T], Awaitable[None]] | None = None,
+        validate_cb: Callable[[T], bool] | None = None,
         connect_timeout: float = 10.0,
     ) -> None:
         """Initialize the connection wrapper.
@@ -34,11 +35,16 @@ class ConnectionPool(Generic[T]):
             mark_refreshed_on_get: If True, the session will be marked as fresh when get() is called. only used when max_session_duration is set.
             connect_cb: Optional async callback to create new connections
             close_cb: Optional async callback to close connections
+            validate_cb: Optional callback to check whether an available pooled connection is
+                still usable before it is returned by get(). Return False to discard a
+                connection (e.g. a websocket that was closed remotely while idle) so it does
+                not surface as a caller-visible send failure.
         """  # noqa: E501
         self._max_session_duration = max_session_duration
         self._mark_refreshed_on_get = mark_refreshed_on_get
         self._connect_cb = connect_cb
         self._close_cb = close_cb
+        self._validate_cb = validate_cb
         self._connections: dict[T, float] = {}  # conn -> connected_at timestamp
         self._available: set[T] = set()
         self._connect_timeout = connect_timeout
@@ -103,20 +109,26 @@ class ConnectionPool(Generic[T]):
             await self._drain_to_close()
             now = time.time()
 
-            # try to reuse an available connection that hasn't expired
+            # try to reuse an available connection that hasn't expired and is still usable
             while self._available:
                 conn = self._available.pop()
                 if (
-                    self._max_session_duration is None
-                    or now - self._connections[conn] <= self._max_session_duration
+                    self._max_session_duration is not None
+                    and now - self._connections[conn] > self._max_session_duration
                 ):
-                    if self._mark_refreshed_on_get:
-                        self._connections[conn] = now
-                    self.last_acquire_time = 0.0
-                    self.last_connection_reused = True
-                    return conn
-                # connection expired; mark it for resetting.
-                self.remove(conn)
+                    # connection expired; mark it for resetting.
+                    self.remove(conn)
+                    continue
+                if self._validate_cb is not None and not self._validate_cb(conn):
+                    # connection is no longer usable (e.g. remotely closed while idle);
+                    # discard it instead of handing a stale connection to the caller.
+                    self.remove(conn)
+                    continue
+                if self._mark_refreshed_on_get:
+                    self._connections[conn] = now
+                self.last_acquire_time = 0.0
+                self.last_connection_reused = True
+                return conn
 
             t0 = time.perf_counter()
             conn = await self._connect(timeout)

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -73,6 +73,11 @@ class _ResponsesWebsocket:
         self._pool = utils.ConnectionPool[aiohttp.ClientWebSocketResponse](
             connect_cb=self._create_ws,
             close_cb=self._close_ws,
+            # A Responses socket that was closed while idle (by OpenAI, a NAT
+            # gateway, VPN, or proxy) must be discarded before it is handed
+            # back, otherwise generate_response() burns an outer LLM retry per
+            # stale connection on send_str().
+            validate_cb=lambda ws: not ws.closed,
             max_session_duration=3600,
         )
 

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -83,3 +83,73 @@ async def test_get_expired():
 
     conn2 = await pool.get(timeout=10.0)
     assert conn2 is not conn, "Expected a new connection to be returned."
+
+
+@pytest.mark.asyncio
+async def test_get_discards_invalid_connection():
+    # Regression for livekit/agents#6513: a pooled websocket that was closed
+    # while idle must be discarded by get() instead of being handed back to the
+    # caller (which would burn an outer LLM retry on send).
+    dummy_connect = dummy_connect_factory()
+    pool = ConnectionPool(
+        max_session_duration=60,
+        connect_cb=dummy_connect,
+        validate_cb=lambda c: not c.closed,
+    )
+
+    stale1 = DummyConnection("stale-1")
+    stale1.closed = True
+    stale2 = DummyConnection("stale-2")
+    stale2.closed = True
+    healthy = DummyConnection("healthy")
+    healthy.closed = False
+
+    for conn in (stale1, stale2, healthy):
+        pool._connections[conn] = time.time()
+        pool._available.add(conn)
+
+    acquired = await pool.get(timeout=10.0)
+    assert acquired is healthy, (
+        "Expected get() to skip stale connections and return the healthy one."
+    )
+    assert acquired.closed is False
+    assert pool.last_connection_reused is True
+
+
+@pytest.mark.asyncio
+async def test_get_creates_new_when_all_invalid():
+    # When every pooled connection fails validation, get() must fall back to
+    # creating a fresh connection rather than returning a stale one.
+    dummy_connect = dummy_connect_factory()
+    pool = ConnectionPool(
+        max_session_duration=60,
+        connect_cb=dummy_connect,
+        validate_cb=lambda c: not c.closed,
+    )
+
+    stale = DummyConnection("stale")
+    stale.closed = True
+    pool._connections[stale] = time.time()
+    pool._available.add(stale)
+
+    acquired = await pool.get(timeout=10.0)
+    assert acquired is not stale, (
+        "Expected a fresh connection when all pooled connections are invalid."
+    )
+    assert pool.last_connection_reused is False
+    assert stale not in pool._connections
+
+
+@pytest.mark.asyncio
+async def test_get_reuses_when_no_validate_cb():
+    # Without a validate_cb the pool must keep its previous behavior and reuse
+    # available connections regardless of any connection-local state.
+    dummy_connect = dummy_connect_factory()
+    pool = ConnectionPool(max_session_duration=60, connect_cb=dummy_connect)
+
+    conn = await pool.get(timeout=10.0)
+    conn.closed = True  # attribute the pool must ignore when no validate_cb is set
+    pool.put(conn)
+
+    conn2 = await pool.get(timeout=10.0)
+    assert conn2 is conn, "Expected reuse to be unaffected when no validate_cb is provided."


### PR DESCRIPTION
## Summary

Fixes #6513.

The OpenAI Responses WebSocket transport (`openai.responses.LLM(use_websocket=True)`) pools connections through `ConnectionPool`. `ConnectionPool.get()` only validated `max_session_duration` before returning an available connection — it never checked whether the connection was still open.

After concurrent requests grow the pool (a single Responses socket handles one in-flight response, so parallel work creates multiple sockets) and those sockets sit idle, a peer / NAT gateway / VPN / proxy can close them. `_ResponsesWebsocket.generate_response()` then acquires a dead socket and fails at `ws.send_str()`:

```
failed to send request over WebSocket, retrying in 0.1s
failed to send request over WebSocket, retrying in 2.0s
```

Each stale pooled connection burns one outer LLM retry attempt (and its backoff) before a healthy connection is reached, adding noticeable latency to a live voice turn.

## Change

- Add an optional `validate_cb: Callable[[T], bool] | None` to `ConnectionPool`. It is invoked before a pooled connection is handed out; connections that fail validation are removed/closed and `get()` keeps searching (or creates a fresh connection).
- Wire the Responses pool with `validate_cb=lambda ws: not ws.closed`, so a socket that was closed while idle is discarded before it reaches the caller instead of surfacing a send failure and retry.
- The existing retry behavior is preserved for connections that become unusable *during* the actual send (a live race), which validation cannot catch.

This follows the minimal approach suggested in the issue.

## Tests

`tests/test_connection_pool.py`:
- `test_get_discards_invalid_connection` — a healthy connection is returned even when stale (closed) connections are present in the pool.
- `test_get_creates_new_when_all_invalid` — when every pooled connection fails validation, `get()` discards them and creates a fresh connection.
- `test_get_reuses_when_no_validate_cb` — behavior is unchanged when no `validate_cb` is configured.

```
$ python -m pytest tests/test_connection_pool.py -q
7 passed
```

`ruff format --check` and `ruff check` pass on the changed files; `mypy` clean on `connection_pool.py`.