### PR TITLE
Fix stale OpenAI Responses WebSocket reuse

### DIFF
--- a/livekit-agents/livekit/agents/utils/connection_pool.py
+++ b/livekit-agents/livekit/agents/utils/connection_pool.py
@@ -25,6 +25,7 @@ class ConnectionPool(Generic[T]):
         mark_refreshed_on_get: bool = False,
         connect_cb: Callable[[float], Awaitable[T]] | None = None,
         close_cb: Callable[[T], Awaitable[None]] | None = None,
+        validate_cb: Callable[[T], bool] | None = None,
         connect_timeout: float = 10.0,
     ) -> None:
         """Initialize the connection wrapper.
@@ -34,11 +35,13 @@ class ConnectionPool(Generic[T]):
             mark_refreshed_on_get: If True, the session will be marked as fresh when get() is called. only used when max_session_duration is set.
             connect_cb: Optional async callback to create new connections
             close_cb: Optional async callback to close connections
+            validate_cb: Optional callback to check whether a connection can be reused
         """  # noqa: E501
         self._max_session_duration = max_session_duration
         self._mark_refreshed_on_get = mark_refreshed_on_get
         self._connect_cb = connect_cb
         self._close_cb = close_cb
+        self._validate_cb = validate_cb
         self._connections: dict[T, float] = {}  # conn -> connected_at timestamp
         self._available: set[T] = set()
         self._connect_timeout = connect_timeout
@@ -106,10 +109,12 @@ class ConnectionPool(Generic[T]):
             # try to reuse an available connection that hasn't expired
             while self._available:
                 conn = self._available.pop()
-                if (
+                is_valid = self._validate_cb is None or self._validate_cb(conn)
+                has_expired = not (
                     self._max_session_duration is None
                     or now - self._connections[conn] <= self._max_session_duration
-                ):
+                )
+                if is_valid and not has_expired:
                     if self._mark_refreshed_on_get:
                         self._connections[conn] = now
                     self.last_acquire_time = 0.0

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -73,6 +73,7 @@ class _ResponsesWebsocket:
         self._pool = utils.ConnectionPool[aiohttp.ClientWebSocketResponse](
             connect_cb=self._create_ws,
             close_cb=self._close_ws,
+            validate_cb=lambda ws: not ws.closed,
             max_session_duration=3600,
         )
 

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -10,6 +10,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurr
 class DummyConnection:
     def __init__(self, id):
         self.id = id
+        self.is_usable = True
 
     def __repr__(self):
         return f"DummyConnection({self.id})"
@@ -83,3 +84,21 @@ async def test_get_expired():
 
     conn2 = await pool.get(timeout=10.0)
     assert conn2 is not conn, "Expected a new connection to be returned."
+
+
+@pytest.mark.asyncio
+async def test_get_skips_connection_that_fails_validation():
+    dummy_connect = dummy_connect_factory()
+    pool = ConnectionPool(
+        max_session_duration=60,
+        connect_cb=dummy_connect,
+        validate_cb=lambda conn: conn.is_usable,
+    )
+
+    conn1 = await pool.get(timeout=10.0)
+    pool.put(conn1)
+    conn1.is_usable = False
+
+    conn2 = await pool.get(timeout=10.0)
+
+    assert conn2 is not conn1, "Expected an unusable connection not to be reused."

--- a/tests/test_plugin_openai_responses.py
+++ b/tests/test_plugin_openai_responses.py
@@ -22,15 +22,21 @@ class _RecordingWS:
     """Minimal aiohttp-websocket stand-in: records what was sent, then replays
     a single terminal frame so `generate_response` returns."""
 
-    def __init__(self, reply: dict) -> None:
+    def __init__(self, reply: dict, *, closed: bool = False) -> None:
         self.sent: str | None = None
         self._reply = reply
+        self.closed = closed
 
     async def send_str(self, data: str) -> None:
+        if self.closed:
+            raise ConnectionResetError("cannot write to closing transport")
         self.sent = data
 
     async def receive(self) -> _FakeWSMsg:
         return _FakeWSMsg(json.dumps(self._reply))
+
+    async def close(self) -> None:
+        self.closed = True
 
 
 class _FakePool:
@@ -56,7 +62,7 @@ class _FakePool:
 async def _capture_sent_payload(msg: dict) -> dict:
     """Run the real `_ResponsesWebsocket.generate_response` against a fake pool
     and return the JSON that was actually put on the wire."""
-    ws = _ResponsesWebsocket(api_key="test-key", timeout=1.0)
+    ws = _ResponsesWebsocket(api_key="test-key", timeout=1.0, model="gpt-4.1")
     rec = _RecordingWS({"type": "response.completed", "response": {"output": []}})
     ws._pool = _FakePool(rec)  # type: ignore[assignment]
     async for _ in ws.generate_response(msg):
@@ -84,6 +90,31 @@ async def test_reasoning_object_serialized_without_null_fields() -> None:
     assert sent["reasoning"] == {"effort": "none"}
     # No serialized request model may carry an explicit null-valued key.
     assert None not in sent["reasoning"].values()
+
+
+async def test_websocket_pool_replaces_closed_connection() -> None:
+    transport = _ResponsesWebsocket(api_key="test-key", timeout=1.0, model="gpt-4.1")
+    reply = {"type": "response.completed", "response": {"output": []}}
+    stale = _RecordingWS(reply)
+    healthy = _RecordingWS(reply)
+    connections = iter([stale, healthy])
+
+    async def connect(_timeout: float) -> _RecordingWS:
+        return next(connections)
+
+    transport._pool._connect_cb = connect  # type: ignore[assignment]
+    first = await transport._pool.get(timeout=1.0)
+    transport._pool.put(first)
+    stale.closed = True
+
+    try:
+        async for _ in transport.generate_response({"type": "response.create"}):
+            pass
+    finally:
+        await transport.aclose()
+
+    assert stale.sent is None
+    assert healthy.sent is not None
 
 
 def test_error_event_missing_sequence_number_parses_cleanly() -> None:


### PR DESCRIPTION
## Summary

- add an optional `validate_cb` to `ConnectionPool` so unavailable pooled connections can be discarded before reuse
- configure the OpenAI Responses WebSocket pool to reject connections whose `closed` state is already known
- add hermetic regression coverage for both the generic pool and the OpenAI Responses transport

Fixes #6513.

## Problem

Concurrent Responses API requests can grow the WebSocket pool to multiple connections. If one or more of those connections close while idle, a later request may reuse a known-closed socket and fail at `send_str()`. The outer LLM retry eventually recovers, but each stale connection can add a warning and retry backoff to a live voice turn.

This change removes connections that fail a cheap, synchronous validation before returning them from the pool. The OpenAI transport uses `not ws.closed` for that check. Existing retry behavior remains unchanged for races where a connection becomes unusable after validation or during the send itself.

## Testing

- `uv run pytest tests/test_connection_pool.py --unit -q` (5 passed)
- `uv run pytest tests/test_plugin_openai_responses.py --plugin openai -q` (3 passed)
- `make check` (format, lint, and strict mypy across 623 source files)

Additional local unit-suite validation completed 1,216 tests with 4 skipped. Nine `tests/test_room.py` cases could not set up because the local machine does not have the external `livekit-server` binary installed.
