### PR TITLE
fix(voice): skip committing late STT finals after a turn flush (#6504)

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -1431,6 +1431,22 @@ class AudioRecognition:
             speech_start_time: float | None = None,
         ) -> None:
             endpointing_delay = self._endpointing.min_delay
+
+            # A late STT final transcript can arrive after the turn detector was
+            # already flushed for a committed turn. There is no prediction in flight,
+            # so continuing would commit a second turn with a null end_of_turn_probability
+            # and split one utterance into two turns (issue #6504). Genuinely skip here
+            # — as the log message states — leaving the transcript to fold into the next
+            # turn instead of shipping a fragment that bypassed turn detection.
+            if (
+                trigger == "stt"
+                and self._turn_detector_flushed
+                and self._turn_detector_prediction_fut is None
+                and isinstance(turn_detector, _StreamingTurnDetectorStream)
+            ):
+                self._on_missing_eot_prediction()
+                return
+
             user_turn_span = self._ensure_user_turn_span()
 
             end_of_turn_probability: float | None = None

--- a/tests/test_audio_recognition_turn_detection.py
+++ b/tests/test_audio_recognition_turn_detection.py
@@ -540,10 +540,14 @@ class TestPredictionFutureLifecycle:
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
         """A late stt final after the turn was flushed must not start an
-        inference request; it warns once, then logs at debug level."""
+        inference request and must not commit a second turn (issue #6504):
+        committing here would ship a turn with a null ``end_of_turn_probability``
+        and split one utterance into two. It warns once, then logs at debug level,
+        and leaves the transcript untouched so it folds into the next turn."""
         caplog.set_level(logging.WARNING, logger="livekit.agents")
         ar = _make_full_recognition_for_eou()
         ar._turn_detector_flushed = True
+        ar._audio_transcript = "date needed now"
         chat_ctx = _make_chat_ctx_stub()
 
         for _ in range(2):
@@ -553,7 +557,13 @@ class TestPredictionFutureLifecycle:
 
         assert ar._turn_detector_stream.predict.call_count == 0
         ar._hooks.on_eot_prediction.assert_not_called()
-        flush_warnings = [r for r in caplog.records if "already flushed" in r.getMessage()]
+        # the late transcript is genuinely skipped, never committed with a null prediction
+        ar._hooks.on_end_of_turn.assert_not_called()
+        # transcript is preserved so it merges into the next turn instead of being lost
+        assert ar._audio_transcript == "date needed now"
+        flush_warnings = [
+            r for r in caplog.records if "after turn has been committed" in r.getMessage()
+        ]
         assert len(flush_warnings) == 1
 
     async def test_predict_timeout_signals_fallback_and_drops_future(self) -> None:


### PR DESCRIPTION
A late STT final transcript could arrive after VAD had already committed and flushed the turn. With no prediction future left in flight, the eou bounce logged "skipping eot prediction" but then fell through and committed a second turn with a null end_of_turn_probability, splitting one utterance into two conversation items where the second bypassed turn detection.

Genuinely short-circuit that case: when a streaming detector has been flushed and there is no prediction in flight, skip the commit instead of shipping a null-probability turn. The transcript is left intact so the trailing words fold into the next turn rather than being lost.

Fixes livekit/agents#6504