### PR TITLE
feat(fishaudio): add normalize_loudness and generation-tuning TTS options

### DIFF
--- a/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/tts.py
+++ b/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/tts.py
@@ -58,6 +58,11 @@ class _TTSOptions:
     mp3_bitrate: MP3Bitrate
     opus_bitrate: OpusBitrate
     normalize: bool
+    normalize_loudness: NotGivenOr[bool]
+    max_new_tokens: NotGivenOr[int]
+    min_chunk_length: NotGivenOr[int]
+    condition_on_previous_chunks: NotGivenOr[bool]
+    early_stop_threshold: NotGivenOr[float]
 
     def get_http_url(self, path: str) -> str:
         return f"{self.base_url}{path}"
@@ -85,6 +90,11 @@ class TTS(tts.TTS):
         mp3_bitrate: MP3Bitrate = 64,
         opus_bitrate: OpusBitrate = 64000,
         normalize: bool = True,
+        normalize_loudness: NotGivenOr[bool] = NOT_GIVEN,
+        max_new_tokens: NotGivenOr[int] = NOT_GIVEN,
+        min_chunk_length: NotGivenOr[int] = NOT_GIVEN,
+        condition_on_previous_chunks: NotGivenOr[bool] = NOT_GIVEN,
+        early_stop_threshold: NotGivenOr[float] = NOT_GIVEN,
         tokenizer: NotGivenOr[tokenize.SentenceTokenizer] = NOT_GIVEN,
         http_session: aiohttp.ClientSession | None = None,
     ) -> None:
@@ -124,6 +134,18 @@ class TTS(tts.TTS):
                 Defaults to 64000.
             normalize (bool): Whether Fish normalizes the input text (numbers, dates,
                 abbreviations) before synthesis. Defaults to True.
+            normalize_loudness (NotGivenOr[bool]): Whether Fish normalizes the output
+                loudness for more consistent volume (Fish ``prosody.normalize_loudness``,
+                S2-Pro family). Unset uses Fish's server default (True).
+            max_new_tokens (NotGivenOr[int]): Maximum audio tokens Fish generates per
+                text chunk. Unset uses Fish's server default (1024).
+            min_chunk_length (NotGivenOr[int]): Minimum characters before Fish splits
+                text into a new chunk (0-100). Unset uses Fish's server default (50).
+            condition_on_previous_chunks (NotGivenOr[bool]): Whether Fish uses previous
+                audio as context for voice consistency across chunks. Unset uses Fish's
+                server default (True).
+            early_stop_threshold (NotGivenOr[float]): Early stopping threshold for batch
+                processing (0-1). Unset uses Fish's server default (1.0).
             tokenizer (tokenize.SentenceTokenizer): Sentence tokenizer used to detect
                 sentence boundaries. Defaults to ``tokenize.blingfire.SentenceTokenizer()``.
             http_session (aiohttp.ClientSession | None): Optional aiohttp session.
@@ -157,6 +179,12 @@ class TTS(tts.TTS):
             raise ValueError("temperature must be between 0 and 1")
         if not 0 <= top_p <= 1:
             raise ValueError("top_p must be between 0 and 1")
+        if is_given(max_new_tokens) and max_new_tokens < 0:
+            raise ValueError("max_new_tokens must be non-negative")
+        if is_given(min_chunk_length) and not 0 <= min_chunk_length <= 100:
+            raise ValueError("min_chunk_length must be between 0 and 100")
+        if is_given(early_stop_threshold) and not 0 <= early_stop_threshold <= 1:
+            raise ValueError("early_stop_threshold must be between 0 and 1")
 
         self._opts = _TTSOptions(
             model=model,
@@ -174,6 +202,11 @@ class TTS(tts.TTS):
             mp3_bitrate=mp3_bitrate,
             opus_bitrate=opus_bitrate,
             normalize=normalize,
+            normalize_loudness=normalize_loudness,
+            max_new_tokens=max_new_tokens,
+            min_chunk_length=min_chunk_length,
+            condition_on_previous_chunks=condition_on_previous_chunks,
+            early_stop_threshold=early_stop_threshold,
         )
 
         self._session = http_session
@@ -253,6 +286,11 @@ class TTS(tts.TTS):
         mp3_bitrate: NotGivenOr[MP3Bitrate] = NOT_GIVEN,
         opus_bitrate: NotGivenOr[OpusBitrate] = NOT_GIVEN,
         normalize: NotGivenOr[bool] = NOT_GIVEN,
+        normalize_loudness: NotGivenOr[bool] = NOT_GIVEN,
+        max_new_tokens: NotGivenOr[int] = NOT_GIVEN,
+        min_chunk_length: NotGivenOr[int] = NOT_GIVEN,
+        condition_on_previous_chunks: NotGivenOr[bool] = NOT_GIVEN,
+        early_stop_threshold: NotGivenOr[float] = NOT_GIVEN,
     ) -> None:
         if is_given(model) and model != self._opts.model:
             self._opts.model = model
@@ -287,6 +325,22 @@ class TTS(tts.TTS):
             self._opts.opus_bitrate = opus_bitrate
         if is_given(normalize):
             self._opts.normalize = normalize
+        if is_given(normalize_loudness):
+            self._opts.normalize_loudness = normalize_loudness
+        if is_given(max_new_tokens):
+            if max_new_tokens < 0:
+                raise ValueError("max_new_tokens must be non-negative")
+            self._opts.max_new_tokens = max_new_tokens
+        if is_given(min_chunk_length):
+            if not 0 <= min_chunk_length <= 100:
+                raise ValueError("min_chunk_length must be between 0 and 100")
+            self._opts.min_chunk_length = min_chunk_length
+        if is_given(condition_on_previous_chunks):
+            self._opts.condition_on_previous_chunks = condition_on_previous_chunks
+        if is_given(early_stop_threshold):
+            if not 0 <= early_stop_threshold <= 1:
+                raise ValueError("early_stop_threshold must be between 0 and 1")
+            self._opts.early_stop_threshold = early_stop_threshold
 
     def synthesize(
         self,
@@ -317,16 +371,18 @@ def _build_tts_request(opts: _TTSOptions, *, text: str = "") -> dict[str, Any]:
     # server doesn't fall back to its own (larger) defaults — in particular the
     # docs default of `chunk_length=300` produces large bursts that leave audible
     # gaps between Fish's chunk boundaries.
-    # `prosody` stays None unless the caller set speed/volume, so the default
-    # request is byte-for-byte unchanged.
-    prosody: dict[str, float] | None = None
-    if is_given(opts.speed) or is_given(opts.volume):
+    # `prosody` stays None unless the caller set speed/volume/normalize_loudness,
+    # so the default request is byte-for-byte unchanged.
+    prosody: dict[str, Any] | None = None
+    if is_given(opts.speed) or is_given(opts.volume) or is_given(opts.normalize_loudness):
         prosody = {}
         if is_given(opts.speed):
             prosody["speed"] = opts.speed
         if is_given(opts.volume):
             prosody["volume"] = opts.volume
-    return {
+        if is_given(opts.normalize_loudness):
+            prosody["normalize_loudness"] = opts.normalize_loudness
+    request: dict[str, Any] = {
         "text": text,
         "chunk_length": opts.chunk_length,
         "format": opts.output_format,
@@ -343,6 +399,17 @@ def _build_tts_request(opts: _TTSOptions, *, text: str = "") -> dict[str, Any]:
         "top_p": opts.top_p,
         "temperature": opts.temperature,
     }
+    # Generation-tuning fields have no plugin default: they are omitted unless
+    # set so Fish's server-side defaults stay in effect.
+    if is_given(opts.max_new_tokens):
+        request["max_new_tokens"] = opts.max_new_tokens
+    if is_given(opts.min_chunk_length):
+        request["min_chunk_length"] = opts.min_chunk_length
+    if is_given(opts.condition_on_previous_chunks):
+        request["condition_on_previous_chunks"] = opts.condition_on_previous_chunks
+    if is_given(opts.early_stop_threshold):
+        request["early_stop_threshold"] = opts.early_stop_threshold
+    return request
 
 
 class ChunkedStream(tts.ChunkedStream):

--- a/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/tts.py
+++ b/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/tts.py
@@ -135,8 +135,9 @@ class TTS(tts.TTS):
             normalize (bool): Whether Fish normalizes the input text (numbers, dates,
                 abbreviations) before synthesis. Defaults to True.
             normalize_loudness (NotGivenOr[bool]): Whether Fish normalizes the output
-                loudness for more consistent volume (Fish ``prosody.normalize_loudness``,
-                S2-Pro family). Unset uses Fish's server default (True).
+                loudness for more consistent volume (Fish ``prosody.normalize_loudness``).
+                S2-Pro family only: on the ``s1`` model the option is dropped with a
+                warning. Unset uses Fish's server default (True).
             max_new_tokens (NotGivenOr[int]): Maximum audio tokens Fish generates per
                 text chunk. Unset uses Fish's server default (1024).
             min_chunk_length (NotGivenOr[int]): Minimum characters before Fish splits
@@ -185,6 +186,9 @@ class TTS(tts.TTS):
             raise ValueError("min_chunk_length must be between 0 and 100")
         if is_given(early_stop_threshold) and not 0 <= early_stop_threshold <= 1:
             raise ValueError("early_stop_threshold must be between 0 and 1")
+        if is_given(normalize_loudness) and model == "s1":
+            logger.warning("normalize_loudness is not supported by the s1 model, dropping")
+            normalize_loudness = NOT_GIVEN
 
         self._opts = _TTSOptions(
             model=model,
@@ -299,6 +303,9 @@ class TTS(tts.TTS):
             # connections so the next stream reconnects with the new model. Other
             # options ride in the per-request body and need no reconnect.
             self._pool.invalidate()
+            if model == "s1" and is_given(self._opts.normalize_loudness):
+                logger.warning("normalize_loudness is not supported by the s1 model, dropping")
+                self._opts.normalize_loudness = NOT_GIVEN
         if is_given(voice_id):
             self._opts.voice_id = voice_id
         if is_given(latency_mode):
@@ -326,7 +333,10 @@ class TTS(tts.TTS):
         if is_given(normalize):
             self._opts.normalize = normalize
         if is_given(normalize_loudness):
-            self._opts.normalize_loudness = normalize_loudness
+            if self._opts.model == "s1":
+                logger.warning("normalize_loudness is not supported by the s1 model, dropping")
+            else:
+                self._opts.normalize_loudness = normalize_loudness
         if is_given(max_new_tokens):
             if max_new_tokens < 0:
                 raise ValueError("max_new_tokens must be non-negative")

--- a/tests/test_plugin_fishaudio_tts.py
+++ b/tests/test_plugin_fishaudio_tts.py
@@ -135,6 +135,96 @@ def test_temperature_and_top_p_validated():
         tts.update_options(top_p=-0.1)
 
 
+def test_normalize_loudness_sets_prosody():
+    """normalize_loudness rides inside prosody, alongside speed/volume."""
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    prosody = _build_tts_request(TTS_opts(normalize_loudness=False), text="hi")["prosody"]
+    assert prosody == {"normalize_loudness": False}
+
+
+def test_normalize_loudness_with_speed_and_volume():
+    """All three prosody fields are populated together."""
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    prosody = _build_tts_request(
+        TTS_opts(speed=1.2, volume=-3.0, normalize_loudness=True), text="hi"
+    )["prosody"]
+    assert prosody == {"speed": 1.2, "volume": -3.0, "normalize_loudness": True}
+
+
+def test_generation_tuning_omitted_by_default():
+    """Unset tuning params are absent from the request so Fish's defaults apply."""
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    request = _build_tts_request(TTS_opts(), text="hi")
+    assert "max_new_tokens" not in request
+    assert "min_chunk_length" not in request
+    assert "condition_on_previous_chunks" not in request
+    assert "early_stop_threshold" not in request
+
+
+def test_constructor_sets_generation_tuning_params():
+    """max_new_tokens/min_chunk_length/condition_on_previous_chunks/early_stop_threshold
+    flow onto the request."""
+    from livekit.plugins.fishaudio import TTS
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    tts = TTS(
+        api_key="test-key",
+        max_new_tokens=512,
+        min_chunk_length=25,
+        condition_on_previous_chunks=False,
+        early_stop_threshold=0.8,
+    )
+    request = _build_tts_request(tts._opts, text="hi")
+    assert request["max_new_tokens"] == 512
+    assert request["min_chunk_length"] == 25
+    assert request["condition_on_previous_chunks"] is False
+    assert request["early_stop_threshold"] == 0.8
+
+
+def test_update_options_sets_generation_tuning_params():
+    """update_options forwards the tuning params onto the request."""
+    from livekit.plugins.fishaudio import TTS
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    tts = TTS(api_key="test-key")
+    tts.update_options(
+        max_new_tokens=2048,
+        min_chunk_length=30,
+        condition_on_previous_chunks=False,
+        early_stop_threshold=0.5,
+        normalize_loudness=False,
+    )
+    request = _build_tts_request(tts._opts, text="hi")
+    assert request["max_new_tokens"] == 2048
+    assert request["min_chunk_length"] == 30
+    assert request["condition_on_previous_chunks"] is False
+    assert request["early_stop_threshold"] == 0.5
+    assert request["prosody"] == {"normalize_loudness": False}
+
+
+def test_generation_tuning_validated():
+    """Out-of-range tuning params raise, in the constructor and update_options."""
+    from livekit.plugins.fishaudio import TTS
+
+    with pytest.raises(ValueError):
+        TTS(api_key="test-key", max_new_tokens=-1)
+    with pytest.raises(ValueError):
+        TTS(api_key="test-key", min_chunk_length=150)
+    with pytest.raises(ValueError):
+        TTS(api_key="test-key", early_stop_threshold=1.5)
+
+    tts = TTS(api_key="test-key")
+    with pytest.raises(ValueError):
+        tts.update_options(max_new_tokens=-1)
+    with pytest.raises(ValueError):
+        tts.update_options(min_chunk_length=-5)
+    with pytest.raises(ValueError):
+        tts.update_options(early_stop_threshold=-0.1)
+
+
 def TTS_opts(**overrides):
     """Build a _TTSOptions with sensible test defaults, overriding as needed."""
     from livekit.plugins.fishaudio.tts import DEFAULT_BASE_URL, DEFAULT_MODEL, _TTSOptions
@@ -155,6 +245,11 @@ def TTS_opts(**overrides):
         "mp3_bitrate": 64,
         "opus_bitrate": 64000,
         "normalize": True,
+        "normalize_loudness": NOT_GIVEN,
+        "max_new_tokens": NOT_GIVEN,
+        "min_chunk_length": NOT_GIVEN,
+        "condition_on_previous_chunks": NOT_GIVEN,
+        "early_stop_threshold": NOT_GIVEN,
     }
     opts.update(overrides)
     return _TTSOptions(**opts)

--- a/tests/test_plugin_fishaudio_tts.py
+++ b/tests/test_plugin_fishaudio_tts.py
@@ -225,6 +225,48 @@ def test_generation_tuning_validated():
         tts.update_options(early_stop_threshold=-0.1)
 
 
+def test_normalize_loudness_dropped_on_s1_constructor():
+    """On the s1 model normalize_loudness is dropped (warn log), not sent."""
+    from livekit.plugins.fishaudio import TTS
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    tts = TTS(api_key="test-key", model="s1", normalize_loudness=True)
+    assert _build_tts_request(tts._opts, text="hi")["prosody"] is None
+
+
+def test_normalize_loudness_dropped_on_s1_update_options():
+    """update_options refuses normalize_loudness while the model is s1."""
+    from livekit.plugins.fishaudio import TTS
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    tts = TTS(api_key="test-key", model="s1")
+    tts.update_options(normalize_loudness=True)
+    assert _build_tts_request(tts._opts, text="hi")["prosody"] is None
+
+
+def test_normalize_loudness_dropped_on_model_switch_to_s1():
+    """Switching to s1 drops a previously set normalize_loudness."""
+    from livekit.plugins.fishaudio import TTS
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    tts = TTS(api_key="test-key", model="s2-pro", normalize_loudness=True)
+    assert _build_tts_request(tts._opts, text="hi")["prosody"] == {"normalize_loudness": True}
+
+    tts.update_options(model="s1")
+    assert _build_tts_request(tts._opts, text="hi")["prosody"] is None
+
+
+def test_normalize_loudness_kept_on_s2_pro_family():
+    """s2-pro and s2.1-pro keep normalize_loudness."""
+    from livekit.plugins.fishaudio import TTS
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    for model in ("s2-pro", "s2.1-pro"):
+        tts = TTS(api_key="test-key", model=model, normalize_loudness=False)
+        prosody = _build_tts_request(tts._opts, text="hi")["prosody"]
+        assert prosody == {"normalize_loudness": False}
+
+
 def TTS_opts(**overrides):
     """Build a _TTSOptions with sensible test defaults, overriding as needed."""
     from livekit.plugins.fishaudio.tts import DEFAULT_BASE_URL, DEFAULT_MODEL, _TTSOptions


### PR DESCRIPTION
## Summary

Exposes five Fish Audio TTS params the plugin did not forward, per the [Fish Audio TTS API](https://docs.fish.audio/api-reference/endpoint/openapi-v1/text-to-speech):

**Top-level request fields**
- `max_new_tokens` — max audio tokens generated per text chunk (Fish default 1024)
- `min_chunk_length` — minimum characters before splitting a chunk, 0–100 (Fish default 50)
- `condition_on_previous_chunks` — use previous audio as context for voice consistency (Fish default true)
- `early_stop_threshold` — early stopping threshold, 0–1 (Fish default 1.0)

**Prosody sub-object** (alongside the existing `speed`/`volume`)
- `normalize_loudness` — consistent output loudness (Fish default true). **S2-Pro family only:** dropped with a warning at set time (constructor, `update_options`, and on a model switch to `s1`) rather than sent for a model that cannot honor it

All five default to `NOT_GIVEN` and are omitted from the request unless set, so Fish's server-side defaults stay in effect and the default wire request is byte-for-byte unchanged. Values are validated in both the constructor and `update_options`. Follows the same pattern as #6456.

A sibling change adds the same params to the LiveKit inference gateway (livekit/agent-gateway#1066).

## Testing

Explicit unit tests in `tests/test_plugin_fishaudio_tts.py` cover prosody placement of `normalize_loudness`, omission-when-unset, constructor and `update_options` forwarding, and range validation. `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
