### PR TITLE
fix(openai): recover from stale pooled Responses WebSocket connections

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -180,6 +180,9 @@ class _ResponsesWebsocket:
                 last_exc = e
                 if not reused:
                     break  # a fresh connection failing to send is a real error, not staleness
+            except BaseException:
+                self._pool.remove(ws)  # cancellation: discard the socket, don't leak it
+                raise
         raise APIConnectionError("failed to send request over WebSocket") from last_exc
 
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -51,6 +51,11 @@ Verbosity = Literal["low", "medium", "high"]
 
 OPENAI_RESPONSES_WS_URL = "wss://api.openai.com/v1/responses"
 
+# ws ping interval; keeps idle pooled sockets warm and lets aiohttp detect dead peers
+_WS_HEARTBEAT = 30.0
+# max connections to try when a reused socket is stale, before the outer retry takes over
+_WS_SEND_MAX_ATTEMPTS = 6
+
 
 class _ResponsesWebsocket:
     def __init__(
@@ -87,6 +92,7 @@ class _ResponsesWebsocket:
                 self._ensure_http_session().ws_connect(
                     self._base_url,
                     headers={"Authorization": f"Bearer {self._api_key}"},
+                    heartbeat=_WS_HEARTBEAT,
                 ),
                 timeout,
             )
@@ -124,12 +130,9 @@ class _ResponsesWebsocket:
         except TypeError as e:
             raise APIConnectionError(f"failed to serialize request: {e}") from e
 
-        async with self._pool.connection(timeout=self._timeout) as ws:
-            try:
-                await ws.send_str(data)
-            except Exception as e:
-                raise APIConnectionError("failed to send request over WebSocket") from e
-
+        ws = await self._acquire_and_send(data)
+        completed = False
+        try:
             while True:
                 raw_msg = await ws.receive()
                 if raw_msg.type == aiohttp.WSMsgType.ERROR:
@@ -154,7 +157,30 @@ class _ResponsesWebsocket:
                 event = json.loads(raw_msg.data)
                 yield event
                 if event["type"] in ["response.completed", "response.failed", "error"]:
+                    completed = True
                     return
+        finally:
+            # only a cleanly completed exchange is safe to reuse; discard on any error
+            if completed:
+                self._pool.put(ws)
+            else:
+                self._pool.remove(ws)
+
+    async def _acquire_and_send(self, data: str) -> aiohttp.ClientWebSocketResponse:
+        # a socket closed while idle surfaces only as a send failure on reuse
+        last_exc: Exception | None = None
+        for _ in range(_WS_SEND_MAX_ATTEMPTS):
+            ws = await self._pool.get(timeout=self._timeout)
+            reused = self._pool.last_connection_reused
+            try:
+                await ws.send_str(data)
+                return ws
+            except Exception as e:
+                self._pool.remove(ws)  # discard the failed socket
+                last_exc = e
+                if not reused:
+                    break  # a fresh connection failing to send is a real error, not staleness
+        raise APIConnectionError("failed to send request over WebSocket") from last_exc
 
 
 @dataclass

--- a/tests/test_plugin_openai_responses.py
+++ b/tests/test_plugin_openai_responses.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 import json
+import time
+from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
 import pytest
 from openai.types import Reasoning
 
-from livekit.plugins.openai.responses.llm import LLMStream, _ResponsesWebsocket
+from livekit.agents import APIConnectionError
+from livekit.plugins.openai.responses.llm import (
+    _WS_HEARTBEAT,
+    LLMStream,
+    _ResponsesWebsocket,
+)
 
 pytestmark = pytest.mark.plugin("openai")
 
@@ -20,46 +27,50 @@ class _FakeWSMsg:
 
 class _RecordingWS:
     """Minimal aiohttp-websocket stand-in: records what was sent, then replays
-    a single terminal frame so `generate_response` returns."""
+    a single terminal frame so `generate_response` returns. When ``dead`` is set,
+    send_str fails the way a socket closed while idle does (and ws.closed stays
+    False, mirroring aiohttp)."""
 
-    def __init__(self, reply: dict) -> None:
+    def __init__(self, reply: dict, *, dead: bool = False) -> None:
         self.sent: str | None = None
         self._reply = reply
+        self._dead = dead
+        self.closed = False
 
     async def send_str(self, data: str) -> None:
+        if self._dead:
+            raise ConnectionResetError("Cannot write to closing transport")
         self.sent = data
 
     async def receive(self) -> _FakeWSMsg:
         return _FakeWSMsg(json.dumps(self._reply))
 
+    async def close(self) -> None:
+        self.closed = True
 
-class _FakePool:
-    def __init__(self, ws: _RecordingWS) -> None:
-        self._ws = ws
 
-    def connection(self, timeout: float | None = None):  # noqa: ANN201
-        ws = self._ws
+def _make_transport() -> _ResponsesWebsocket:
+    return _ResponsesWebsocket(api_key="test-key", timeout=1.0, model="gpt-4.1")
 
-        class _Ctx:
-            async def __aenter__(self):  # noqa: ANN202
-                return ws
 
-            async def __aexit__(self, *exc):  # noqa: ANN002, ANN202
-                return False
+def _use_connections(transport: _ResponsesWebsocket, *conns: _RecordingWS) -> None:
+    """Wire a connect callback that hands out ``conns`` in order (last one repeats)."""
+    remaining = list(conns)
 
-        return _Ctx()
+    async def _connect(_timeout: float) -> _RecordingWS:
+        return remaining.pop(0) if len(remaining) > 1 else remaining[0]
 
-    async def aclose(self) -> None:
-        return None
+    transport._pool._connect_cb = _connect  # type: ignore[assignment]
 
 
 async def _capture_sent_payload(msg: dict) -> dict:
-    """Run the real `_ResponsesWebsocket.generate_response` against a fake pool
-    and return the JSON that was actually put on the wire."""
-    ws = _ResponsesWebsocket(api_key="test-key", timeout=1.0)
+    """Run the real `_ResponsesWebsocket.generate_response` against a real
+    ConnectionPool whose connect callback yields a recording websocket, and
+    return the JSON that was actually put on the wire."""
+    transport = _make_transport()
     rec = _RecordingWS({"type": "response.completed", "response": {"output": []}})
-    ws._pool = _FakePool(rec)  # type: ignore[assignment]
-    async for _ in ws.generate_response(msg):
+    _use_connections(transport, rec)
+    async for _ in transport.generate_response(msg):
         pass
     assert rec.sent is not None
     return json.loads(rec.sent)
@@ -107,3 +118,60 @@ def test_error_event_missing_sequence_number_parses_cleanly() -> None:
     assert parsed.type == "error"
     assert parsed.message == frame["message"]
     assert parsed.param == "reasoning.mode"
+
+
+async def test_stale_reused_ws_is_discarded_and_request_succeeds() -> None:
+    """Regression for #6513: a pooled WebSocket that OpenAI (or an intermediary
+    such as a NAT/proxy) closed while idle only fails on send when reused —
+    aiohttp keeps ws.closed False until a read observes the close. The transport
+    must discard the stale connection and reconnect in place, instead of raising
+    a retryable error that costs a full outer LLM retry (with backoff) for every
+    stale socket."""
+    reply = {"type": "response.completed", "response": {"output": []}}
+    fresh = _RecordingWS(reply)
+
+    transport = _make_transport()
+    _use_connections(transport, fresh)
+
+    # two pooled connections dropped while idle: not expired, send fails, and
+    # ws.closed is still False (so a `not ws.closed` validation would not help).
+    stale = [_RecordingWS(reply, dead=True), _RecordingWS(reply, dead=True)]
+    for ws in stale:
+        transport._pool._connections[ws] = time.time()  # type: ignore[index]
+        transport._pool._available.add(ws)  # type: ignore[arg-type]
+
+    async for _ in transport.generate_response({"type": "response.create"}):
+        pass
+
+    assert all(s.sent is None for s in stale), "stale sockets must not carry the request"
+    assert fresh.sent is not None, "request must be sent on a fresh connection"
+    await transport.aclose()
+
+
+async def test_fresh_ws_send_failure_is_raised() -> None:
+    """A brand-new connection that fails to send is a genuine error and must be
+    surfaced, not silently retried the way a stale reused connection is."""
+    reply = {"type": "response.completed", "response": {"output": []}}
+    dead_fresh = _RecordingWS(reply, dead=True)
+
+    transport = _make_transport()
+    _use_connections(transport, dead_fresh)
+
+    with pytest.raises(APIConnectionError):
+        async for _ in transport.generate_response({"type": "response.create"}):
+            pass
+    await transport.aclose()
+
+
+async def test_create_ws_enables_heartbeat() -> None:
+    """Pooled Responses sockets set a ws heartbeat so idle connections stay warm
+    and dead peers are detected instead of surfacing only on the next send."""
+    transport = _make_transport()
+    fake_ws = object()
+    session = MagicMock()
+    session.ws_connect = AsyncMock(return_value=fake_ws)
+    transport._ensure_http_session = lambda: session  # type: ignore[method-assign]
+
+    assert await transport._create_ws(timeout=1.0) is fake_ws
+    _, kwargs = session.ws_connect.call_args
+    assert kwargs["heartbeat"] == _WS_HEARTBEAT

--- a/tests/test_plugin_openai_responses.py
+++ b/tests/test_plugin_openai_responses.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from unittest.mock import AsyncMock, MagicMock
@@ -160,6 +161,27 @@ async def test_fresh_ws_send_failure_is_raised() -> None:
     with pytest.raises(APIConnectionError):
         async for _ in transport.generate_response({"type": "response.create"}):
             pass
+    await transport.aclose()
+
+
+async def test_send_cancellation_discards_socket() -> None:
+    """A cancellation during send must discard the acquired socket, not leave it
+    orphaned in the pool (never reused, never closed until aclose)."""
+    ws = _RecordingWS({"type": "response.completed", "response": {"output": []}})
+
+    async def _cancel(_data: str) -> None:
+        raise asyncio.CancelledError
+
+    ws.send_str = _cancel  # type: ignore[method-assign]
+
+    transport = _make_transport()
+    _use_connections(transport, ws)
+
+    with pytest.raises(asyncio.CancelledError):
+        await transport._acquire_and_send("{}")
+
+    assert ws not in transport._pool._connections
+    assert ws not in transport._pool._available
     await transport.aclose()
 
 


### PR DESCRIPTION
Fixes livekit/agents#6513.

## Problem

The Responses WebSocket transport pools and reuses connections. A pooled socket closed while idle (by OpenAI or a NAT/proxy) is not reflected in `ws.closed` until a read observes it, so it fails on the next `send_str()` — burning a full outer LLM retry (with backoff) per stale socket, adding seconds of latency to a voice turn and eventually failing once enough accumulate.

## Fix

When a *reused* connection fails on send, discard it and try the next instead of raising a retryable error. A freshly created connection failing to send is still raised, and a connection returns to the pool only on clean completion. Also sets a WebSocket heartbeat so idle sockets stay warm and dead peers are detected.

## Alternatives considered

[#6514](<https://github.com/livekit/agents/issues/6514>) / [#6515](<https://github.com/livekit/agents/issues/6515>) add `validate_cb=lambda ws: not ws.closed`, but that is ineffective — aiohttp keeps `ws.closed` False on an idle drop, so the check hands a dead socket straight through (verified against aiohttp 3.14). Opened as a new PR since the mechanism differs: react on send vs. validate on acquire.