### PR TITLE
fix(google): preserve non-blocking realtime generation

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -1443,6 +1443,12 @@ class RealtimeSession(llm.RealtimeSession):
                     arguments=arguments,
                 )
             )
+
+        # NON_BLOCKING calls may be followed by more output in the same turn.
+        # Keep the generation open until Gemini sends its completion events.
+        if self._opts.tool_behavior == types.Behavior.NON_BLOCKING:
+            return
+
         self._mark_current_generation_done()
 
     def _handle_tool_call_cancellation(

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -14,10 +14,17 @@ pytestmark = pytest.mark.unit
 _PCM_FRAME = b"\x00\x01" * 240
 
 
-async def _make_session(monkeypatch: pytest.MonkeyPatch) -> RealtimeSession:
+async def _make_session(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    tool_behavior: types.Behavior | None = None,
+) -> RealtimeSession:
     """A session whose background connect loop is stopped before it hits the network."""
     monkeypatch.setenv("GOOGLE_API_KEY", "fake-key")
-    session = RealtimeModel().session()
+    model = (
+        RealtimeModel(tool_behavior=tool_behavior) if tool_behavior is not None else RealtimeModel()
+    )
+    session = model.session()
     # cancel the connect loop before the event loop ever schedules it, so no
     # websocket connection is attempted
     session._msg_ch.close()
@@ -95,3 +102,70 @@ async def test_late_content_after_generation_complete_is_dropped(
     assert gen.output_text == ""
     assert not gen._done
     assert any("after generation completed" in r.message for r in caplog.records)
+
+
+async def test_blocking_tool_call_finalizes_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = await _make_session(monkeypatch)
+    session._start_new_generation()
+    gen = session._current_generation
+    assert gen is not None
+
+    session._handle_tool_calls(
+        types.LiveServerToolCall(
+            function_calls=[types.FunctionCall(id="call-1", name="get_weather", args={})]
+        )
+    )
+
+    function_call = gen.function_ch.recv_nowait()
+    assert function_call.call_id == "call-1"
+    assert function_call.name == "get_weather"
+    assert gen._done
+    assert gen.message_ch.closed
+    assert gen.audio_ch.closed
+    assert gen.text_ch.closed
+
+
+async def test_non_blocking_tool_call_keeps_generation_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = await _make_session(
+        monkeypatch,
+        tool_behavior=types.Behavior.NON_BLOCKING,
+    )
+    session._start_new_generation()
+    gen = session._current_generation
+    assert gen is not None
+
+    session._handle_tool_calls(
+        types.LiveServerToolCall(
+            function_calls=[types.FunctionCall(id="call-1", name="get_weather", args={})]
+        )
+    )
+
+    function_call = gen.function_ch.recv_nowait()
+    assert function_call.call_id == "call-1"
+    assert function_call.name == "get_weather"
+    assert not gen._done
+    assert not gen.message_ch.closed
+    assert not gen.audio_ch.closed
+    assert not gen.text_ch.closed
+
+    session._handle_server_content(
+        _audio_content(
+            output_transcription=types.Transcription(text="still speaking"),
+            generation_complete=True,
+        )
+    )
+
+    assert gen.output_text == "still speaking"
+    assert gen.audio_ch.qsize() == 1
+    assert gen.audio_ch.closed
+    assert gen.text_ch.closed
+    assert not gen._done
+
+    session._handle_server_content(types.LiveServerContent(turn_complete=True))
+
+    assert gen._done
+    assert gen.message_ch.closed


### PR DESCRIPTION
## Summary

- keep Gemini realtime output streams open when a `NON_BLOCKING` function call arrives
- continue using the existing immediate finalization behavior for blocking function calls
- add regression coverage for both blocking and non-blocking tool behavior

## Why

Gemini 2.5 asynchronous function calling allows the model to continue the active conversation while a non-blocking tool executes. The Google realtime plugin currently calls `_mark_current_generation_done()` for every tool call, which closes the audio and text streams before trailing output in the same turn can be delivered.

This change only defers finalization for declarations configured with `Behavior.NON_BLOCKING`. The generation still closes on Gemini's existing `generation_complete` and `turn_complete` events. Blocking calls retain the current behavior.

This is intentionally narrower than #6285, which addresses blocking/tool-terminated turns such as Gemini 3.1 with an audio-drain timeout.

Related: #5742

## Tests

- `uv run --python 3.12 pytest tests/test_plugin_google_realtime.py --unit -q`
- `uv run --python 3.12 ruff check livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py tests/test_plugin_google_realtime.py`
- `uv run --python 3.12 ruff format --check livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py tests/test_plugin_google_realtime.py`
- `uv run --python 3.12 mypy --untyped-calls-exclude=smithy_aws_core -p livekit.plugins.google`

Full repository type checking is currently blocked locally by a missing `boto3` stub in the AWS experimental plugin.
