### PR TITLE
fix(voice): retain concrete language for turn detection

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
     from .agent_session import AgentSession
 
 MIN_LANGUAGE_DETECTION_LENGTH = 5
+_NON_SPECIFIC_LANGUAGE_CODES = frozenset({"auto", "multi"})
 # Mirrors turn_detector.base.MAX_HISTORY_TURNS for tracing
 _EOU_MAX_HISTORY_TURNS = 6
 # backoff before recreating the stt stream after an unrecoverable error
@@ -367,6 +368,13 @@ class AudioRecognition:
                     if self._turn_detector_stream is not None:
                         self._turn_detector_stream.cancel_inference()
                     self._turn_detector_prediction_fut = None
+
+    def _update_last_language(self, language: LanguageCode, transcript: str) -> None:
+        if not language or language.language in _NON_SPECIFIC_LANGUAGE_CODES:
+            return
+
+        if not self._last_language or len(transcript) > MIN_LANGUAGE_DETECTION_LENGTH:
+            self._last_language = language
 
     @property
     def _input_started_at(self) -> float | None:
@@ -1163,10 +1171,7 @@ class AudioRecognition:
             language = ev.alternatives[0].language
             confidence = ev.alternatives[0].confidence
 
-            if not self._last_language or (
-                language and len(transcript) > MIN_LANGUAGE_DETECTION_LENGTH
-            ):
-                self._last_language = language
+            self._update_last_language(language, transcript)
 
             self._final_transcript_received.set()
             if not transcript:
@@ -1236,10 +1241,7 @@ class AudioRecognition:
             language = ev.alternatives[0].language
             confidence = ev.alternatives[0].confidence
 
-            if not self._last_language or (
-                language and len(transcript) > MIN_LANGUAGE_DETECTION_LENGTH
-            ):
-                self._last_language = language
+            self._update_last_language(language, transcript)
 
             if not transcript:
                 return

--- a/tests/test_audio_recognition_turn_detection.py
+++ b/tests/test_audio_recognition_turn_detection.py
@@ -33,7 +33,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from livekit.agents import vad
+from livekit.agents import LanguageCode, vad
 from livekit.agents.utils import aio
 from livekit.agents.voice.audio_recognition import AudioRecognition
 from livekit.agents.voice.turn import (
@@ -124,6 +124,32 @@ def _make_chat_ctx_stub() -> MagicMock:
     ctx.add_message = MagicMock()
     ctx.items = []
     return ctx
+
+
+class TestLanguageTracking:
+    def test_non_specific_language_does_not_replace_concrete_language(self) -> None:
+        ar = AudioRecognition.__new__(AudioRecognition)
+        ar._last_language = LanguageCode("en")
+
+        ar._update_last_language(LanguageCode("multi"), "ambiguous phrase")
+
+        assert ar._last_language == LanguageCode("en")
+
+    def test_non_specific_language_does_not_initialize_language(self) -> None:
+        ar = AudioRecognition.__new__(AudioRecognition)
+        ar._last_language = None
+
+        ar._update_last_language(LanguageCode("multi"), "we")
+
+        assert ar._last_language is None
+
+    def test_concrete_language_still_updates_after_long_transcript(self) -> None:
+        ar = AudioRecognition.__new__(AudioRecognition)
+        ar._last_language = LanguageCode("en")
+
+        ar._update_last_language(LanguageCode("fr"), "bonjour")
+
+        assert ar._last_language == LanguageCode("fr")
 
 
 def _resolved_prediction(


### PR DESCRIPTION
Fixes #6530

## Summary
- keep `multi` and `auto` language-detection modes from replacing the last concrete language
- share the same language-tracking logic across final and preflight transcripts
- add regression coverage for ambiguous multilingual results and later concrete-language updates

## Root Cause
`AudioRecognition` stored every initial STT language value in `_last_language`. When a multilingual STT provider returned the mode value `multi` for an ambiguous utterance, the turn detector treated it as a concrete language code, could not find a matching threshold, and skipped end-of-turn prediction.

The STT event still retains the provider's original language value. Only the language tracked for language-specific turn-detection behavior ignores non-specific detection modes.

## Verification
- `uv run --no-sync pytest tests/test_audio_recognition_turn_detection.py::TestLanguageTracking --audio_eot -q` -> 3 passed
- `uv run --no-sync ruff check livekit-agents/livekit/agents/voice/audio_recognition.py tests/test_audio_recognition_turn_detection.py` -> passed
- `uv run --no-sync ruff format --check livekit-agents/livekit/agents/voice/audio_recognition.py tests/test_audio_recognition_turn_detection.py` -> passed
- `uv run --group typing mypy -p livekit.agents` -> passed (205 source files)
- `uv run --no-sync pytest --unit -q` -> 1142 passed, 4 skipped before the repository's concurrent-test runner stopped with 9 event-loop errors on Python 3.13

## Notes for Reviewers
- If no concrete language has been detected yet, `multi` leaves the tracked language unset and the existing endpointing fallback remains unchanged.
- No public API or STT event payload is changed.
