### PR TITLE
Add first interim STT latency metric

### DIFF
--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -244,6 +244,12 @@ class MetricsReport(TypedDict, total=False):
     User `ChatMessage` only
     """
 
+    first_interim_status: Literal["received", "absent"]
+    """Terminal outcome for first-interim STT responsiveness.
+
+    User `ChatMessage` only
+    """
+
     end_of_turn_delay: float
     """Amount of time between the end of speech and the decision to end the user's turn
 

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -238,6 +238,12 @@ class MetricsReport(TypedDict, total=False):
     User `ChatMessage` only
     """
 
+    first_interim_delay: float
+    """Time from speech onset to the first interim transcript.
+
+    User `ChatMessage` only
+    """
+
     end_of_turn_delay: float
     """Amount of time between the end of speech and the decision to end the user's turn
 

--- a/livekit-agents/livekit/agents/metrics/base.py
+++ b/livekit-agents/livekit/agents/metrics/base.py
@@ -113,7 +113,6 @@ class EOUMetrics(_BaseMetrics):
     """Time taken to invoke the user's `Agent.on_user_turn_completed` callback."""
 
     speech_id: str | None = None
-    utterance_id: str | None = None
 
     metadata: Metadata | None = None
 

--- a/livekit-agents/livekit/agents/metrics/base.py
+++ b/livekit-agents/livekit/agents/metrics/base.py
@@ -103,6 +103,8 @@ class EOUMetrics(_BaseMetrics):
     """Time taken to obtain the transcript after the end of the user's speech.
     Set to 0.0 if the end of speech was not detected.
     """
+    first_interim_delay: float
+    """Time from speech onset to the first interim transcript, or 0.0 when unavailable."""
 
     on_user_turn_completed_delay: float
     """Time taken to invoke the user's `Agent.on_user_turn_completed` callback."""

--- a/livekit-agents/livekit/agents/metrics/base.py
+++ b/livekit-agents/livekit/agents/metrics/base.py
@@ -103,13 +103,17 @@ class EOUMetrics(_BaseMetrics):
     """Time taken to obtain the transcript after the end of the user's speech.
     Set to 0.0 if the end of speech was not detected.
     """
-    first_interim_delay: float
-    """Time from speech onset to the first interim transcript, or 0.0 when unavailable."""
+    first_interim_delay: float | None
+    """Time from speech onset to the first interim transcript, if one was received."""
+
+    first_interim_status: Literal["received", "absent"] | None = None
+    """Whether the utterance produced an interim transcript before its terminal turn event."""
 
     on_user_turn_completed_delay: float
     """Time taken to invoke the user's `Agent.on_user_turn_completed` callback."""
 
     speech_id: str | None = None
+    utterance_id: str | None = None
 
     metadata: Metadata | None = None
 

--- a/livekit-agents/livekit/agents/telemetry/otel_metrics.py
+++ b/livekit-agents/livekit/agents/telemetry/otel_metrics.py
@@ -45,6 +45,14 @@ _turn_first_interim_delay = _meter.create_histogram(
     unit="s",
     description="Time from speech onset to first interim transcript",
 )
+_turn_first_interim_received = _meter.create_counter(
+    "lk.agents.turn.first_interim_received",
+    description="Number of utterances that produced a first interim transcript",
+)
+_turn_first_interim_absent = _meter.create_counter(
+    "lk.agents.turn.first_interim_absent",
+    description="Number of completed utterances without an interim transcript",
+)
 _turn_end_of_turn_delay = _meter.create_histogram(
     "lk.agents.turn.end_of_turn_delay",
     unit="s",
@@ -127,6 +135,10 @@ def _record_turn_metrics(report: MetricsReport) -> None:
         _turn_transcription_delay.record(report["transcription_delay"], attributes=stt_attrs)
     if "first_interim_delay" in report:
         _turn_first_interim_delay.record(report["first_interim_delay"], attributes=stt_attrs)
+    if report.get("first_interim_status") == "received":
+        _turn_first_interim_received.add(1, attributes=stt_attrs)
+    elif report.get("first_interim_status") == "absent":
+        _turn_first_interim_absent.add(1, attributes=stt_attrs)
     if "end_of_turn_delay" in report:
         _turn_end_of_turn_delay.record(report["end_of_turn_delay"], attributes=stt_attrs)
     if "on_user_turn_completed_delay" in report:

--- a/livekit-agents/livekit/agents/telemetry/otel_metrics.py
+++ b/livekit-agents/livekit/agents/telemetry/otel_metrics.py
@@ -40,6 +40,11 @@ _turn_transcription_delay = _meter.create_histogram(
     unit="s",
     description="Time from end of speech to transcript available",
 )
+_turn_first_interim_delay = _meter.create_histogram(
+    "lk.agents.turn.first_interim_delay",
+    unit="s",
+    description="Time from speech onset to first interim transcript",
+)
 _turn_end_of_turn_delay = _meter.create_histogram(
     "lk.agents.turn.end_of_turn_delay",
     unit="s",
@@ -120,6 +125,8 @@ def _record_turn_metrics(report: MetricsReport) -> None:
         _turn_tts_ttfb.record(report["tts_node_ttfb"], attributes=tts_attrs)
     if "transcription_delay" in report:
         _turn_transcription_delay.record(report["transcription_delay"], attributes=stt_attrs)
+    if "first_interim_delay" in report:
+        _turn_first_interim_delay.record(report["first_interim_delay"], attributes=stt_attrs)
     if "end_of_turn_delay" in report:
         _turn_end_of_turn_delay.record(report["end_of_turn_delay"], attributes=stt_attrs)
     if "on_user_turn_completed_delay" in report:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2447,7 +2447,6 @@ class AgentActivity(RecognitionHooks):
             first_interim_status=info.metrics.first_interim_status,
             on_user_turn_completed_delay=on_user_turn_completed_delay,
             speech_id=speech_handle.id,
-            utterance_id=info.metrics.utterance_id,
             metadata=metadata,
         )
         self._session.emit("metrics_collected", MetricsCollectedEvent(metrics=eou_metrics))

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2443,6 +2443,7 @@ class AgentActivity(RecognitionHooks):
             timestamp=time.time(),
             end_of_utterance_delay=info.metrics.end_of_turn_delay or 0.0,
             transcription_delay=info.metrics.transcription_delay or 0.0,
+            first_interim_delay=info.metrics.first_interim_delay or 0.0,
             on_user_turn_completed_delay=on_user_turn_completed_delay,
             speech_id=speech_handle.id,
             metadata=metadata,
@@ -4309,6 +4310,9 @@ class AgentActivity(RecognitionHooks):
 
         if info.metrics.transcription_delay is not None:
             metrics_report["transcription_delay"] = info.metrics.transcription_delay
+
+        if info.metrics.first_interim_delay is not None:
+            metrics_report["first_interim_delay"] = info.metrics.first_interim_delay
 
         if info.metrics.end_of_turn_delay is not None:
             metrics_report["end_of_turn_delay"] = info.metrics.end_of_turn_delay

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2443,9 +2443,11 @@ class AgentActivity(RecognitionHooks):
             timestamp=time.time(),
             end_of_utterance_delay=info.metrics.end_of_turn_delay or 0.0,
             transcription_delay=info.metrics.transcription_delay or 0.0,
-            first_interim_delay=info.metrics.first_interim_delay or 0.0,
+            first_interim_delay=info.metrics.first_interim_delay,
+            first_interim_status=info.metrics.first_interim_status,
             on_user_turn_completed_delay=on_user_turn_completed_delay,
             speech_id=speech_handle.id,
+            utterance_id=info.metrics.utterance_id,
             metadata=metadata,
         )
         self._session.emit("metrics_collected", MetricsCollectedEvent(metrics=eou_metrics))
@@ -4313,6 +4315,9 @@ class AgentActivity(RecognitionHooks):
 
         if info.metrics.first_interim_delay is not None:
             metrics_report["first_interim_delay"] = info.metrics.first_interim_delay
+
+        if info.metrics.first_interim_status is not None:
+            metrics_report["first_interim_status"] = info.metrics.first_interim_status
 
         if info.metrics.end_of_turn_delay is not None:
             metrics_report["end_of_turn_delay"] = info.metrics.end_of_turn_delay

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -63,6 +63,7 @@ class _EndOfTurnMetrics:
     stopped_speaking_at: float | None
     transcription_delay: float | None
     end_of_turn_delay: float | None
+    first_interim_delay: float | None
 
 
 @dataclass
@@ -82,6 +83,7 @@ def _compute_end_of_turn_metrics(
     last_speaking_time: float | None,
     last_final_transcript_time: float | None,
     now: float,
+    first_interim_time: float | None = None,
 ) -> _EndOfTurnMetrics:
     """Compute the end-of-turn timing metrics from the captured turn anchors.
 
@@ -107,6 +109,7 @@ def _compute_end_of_turn_metrics(
             stopped_speaking_at=None,
             transcription_delay=None,
             end_of_turn_delay=None,
+            first_interim_delay=None,
         )
 
     return _EndOfTurnMetrics(
@@ -114,6 +117,11 @@ def _compute_end_of_turn_metrics(
         stopped_speaking_at=last_speaking_time,
         transcription_delay=max(last_final_transcript_time - last_speaking_time, 0),
         end_of_turn_delay=max(now - last_speaking_time, 0),
+        first_interim_delay=(
+            max(first_interim_time - speech_start_time, 0)
+            if first_interim_time is not None
+            else None
+        ),
     )
 
 
@@ -271,6 +279,7 @@ class AudioRecognition:
         self._last_final_transcript_time: float | None = None
         self._last_speaking_time: float | None = None
         self._speech_start_time: float | None = None
+        self._first_interim_time: float | None = None
 
         # used for manual commit_user_turn
         self._final_transcript_received = asyncio.Event()
@@ -979,6 +988,7 @@ class AudioRecognition:
         self._final_transcript_confidence = []
         self._last_final_transcript_time = None
         self._speech_start_time = None
+        self._first_interim_time = None
         self._last_speaking_time = None
         self._vad_speech_started = False
         self._user_turn_committed = False
@@ -1270,6 +1280,8 @@ class AudioRecognition:
                 )
 
         elif ev.type == stt.SpeechEventType.INTERIM_TRANSCRIPT:
+            if self._first_interim_time is None and self._speech_start_time is not None:
+                self._first_interim_time = time.time()
             self._hooks.on_interim_transcript(
                 ev,
                 speaking=self._speaking
@@ -1648,6 +1660,7 @@ class AudioRecognition:
                 speech_start_time=speech_start_time,
                 last_speaking_time=last_speaking_time,
                 last_final_transcript_time=last_final_transcript_time,
+                first_interim_time=self._first_interim_time,
                 now=time.time(),
             )
             committed = self._hooks.on_end_of_turn(
@@ -1697,6 +1710,7 @@ class AudioRecognition:
                 # only reset if there is no new speech
                 if self._last_speaking_time == last_speaking_time:
                     self._speech_start_time = None
+                    self._first_interim_time = None
                     self._vad_speech_started = False
                     self._last_speaking_time = None
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -65,7 +65,6 @@ class _EndOfTurnMetrics:
     end_of_turn_delay: float | None
     first_interim_delay: float | None = None
     first_interim_status: Literal["received", "absent"] | None = None
-    utterance_id: str | None = None
 
 
 @dataclass
@@ -86,7 +85,6 @@ def _compute_end_of_turn_metrics(
     last_final_transcript_time: float | None,
     now: float,
     first_interim_time: float | None = None,
-    utterance_id: str | None = None,
 ) -> _EndOfTurnMetrics:
     """Compute the end-of-turn timing metrics from the captured turn anchors.
 
@@ -114,7 +112,6 @@ def _compute_end_of_turn_metrics(
             end_of_turn_delay=None,
             first_interim_delay=None,
             first_interim_status=None,
-            utterance_id=utterance_id,
         )
 
     return _EndOfTurnMetrics(
@@ -128,7 +125,6 @@ def _compute_end_of_turn_metrics(
             else None
         ),
         first_interim_status="received" if first_interim_time is not None else "absent",
-        utterance_id=utterance_id,
     )
 
 
@@ -287,7 +283,6 @@ class AudioRecognition:
         self._last_speaking_time: float | None = None
         self._speech_start_time: float | None = None
         self._first_interim_time: float | None = None
-        self._utterance_id: str | None = None
 
         # used for manual commit_user_turn
         self._final_transcript_received = asyncio.Event()
@@ -997,7 +992,6 @@ class AudioRecognition:
         self._last_final_transcript_time = None
         self._speech_start_time = None
         self._first_interim_time = None
-        self._utterance_id = None
         self._last_speaking_time = None
         self._vad_speech_started = False
         self._user_turn_committed = False
@@ -1342,7 +1336,6 @@ class AudioRecognition:
             # otherwise fall back to message arrival time.
             if self._speech_start_time is None:
                 self._speech_start_time = ev.speech_start_time or time.time()
-                self._utterance_id = utils.shortuuid("utterance_")
 
             with trace.use_span(self._ensure_user_turn_span(start_time=self._speech_start_time)):
                 self._hooks.on_start_of_speech(None, speech_start_time=self._speech_start_time)
@@ -1359,7 +1352,6 @@ class AudioRecognition:
             speech_start_time = time.time() - ev.speech_duration - ev.inference_duration
             if not self._vad_speech_started:
                 self._speech_start_time = speech_start_time
-                self._utterance_id = utils.shortuuid("utterance_")
                 self._vad_speech_started = True
 
             with trace.use_span(self._ensure_user_turn_span(start_time=speech_start_time)):
@@ -1387,7 +1379,6 @@ class AudioRecognition:
 
                 if self._speech_start_time is None:
                     self._speech_start_time = time.time() - ev.raw_accumulated_speech
-                    self._utterance_id = utils.shortuuid("utterance_")
                 if self._speaking and self._turn_detector_prediction_fut is not None:
                     if self._turn_detector_stream is not None:
                         self._turn_detector_stream.cancel_inference()
@@ -1673,7 +1664,6 @@ class AudioRecognition:
                 last_speaking_time=last_speaking_time,
                 last_final_transcript_time=last_final_transcript_time,
                 first_interim_time=self._first_interim_time,
-                utterance_id=self._utterance_id,
                 now=time.time(),
             )
             committed = self._hooks.on_end_of_turn(
@@ -1724,7 +1714,6 @@ class AudioRecognition:
                 if self._last_speaking_time == last_speaking_time:
                     self._speech_start_time = None
                     self._first_interim_time = None
-                    self._utterance_id = None
                     self._vad_speech_started = False
                     self._last_speaking_time = None
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -63,7 +63,7 @@ class _EndOfTurnMetrics:
     stopped_speaking_at: float | None
     transcription_delay: float | None
     end_of_turn_delay: float | None
-    first_interim_delay: float | None
+    first_interim_delay: float | None = None
 
 
 @dataclass

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -64,6 +64,8 @@ class _EndOfTurnMetrics:
     transcription_delay: float | None
     end_of_turn_delay: float | None
     first_interim_delay: float | None = None
+    first_interim_status: Literal["received", "absent"] | None = None
+    utterance_id: str | None = None
 
 
 @dataclass
@@ -84,6 +86,7 @@ def _compute_end_of_turn_metrics(
     last_final_transcript_time: float | None,
     now: float,
     first_interim_time: float | None = None,
+    utterance_id: str | None = None,
 ) -> _EndOfTurnMetrics:
     """Compute the end-of-turn timing metrics from the captured turn anchors.
 
@@ -110,6 +113,8 @@ def _compute_end_of_turn_metrics(
             transcription_delay=None,
             end_of_turn_delay=None,
             first_interim_delay=None,
+            first_interim_status=None,
+            utterance_id=utterance_id,
         )
 
     return _EndOfTurnMetrics(
@@ -122,6 +127,8 @@ def _compute_end_of_turn_metrics(
             if first_interim_time is not None
             else None
         ),
+        first_interim_status="received" if first_interim_time is not None else "absent",
+        utterance_id=utterance_id,
     )
 
 
@@ -280,6 +287,7 @@ class AudioRecognition:
         self._last_speaking_time: float | None = None
         self._speech_start_time: float | None = None
         self._first_interim_time: float | None = None
+        self._utterance_id: str | None = None
 
         # used for manual commit_user_turn
         self._final_transcript_received = asyncio.Event()
@@ -989,6 +997,7 @@ class AudioRecognition:
         self._last_final_transcript_time = None
         self._speech_start_time = None
         self._first_interim_time = None
+        self._utterance_id = None
         self._last_speaking_time = None
         self._vad_speech_started = False
         self._user_turn_committed = False
@@ -1333,6 +1342,7 @@ class AudioRecognition:
             # otherwise fall back to message arrival time.
             if self._speech_start_time is None:
                 self._speech_start_time = ev.speech_start_time or time.time()
+                self._utterance_id = utils.shortuuid("utterance_")
 
             with trace.use_span(self._ensure_user_turn_span(start_time=self._speech_start_time)):
                 self._hooks.on_start_of_speech(None, speech_start_time=self._speech_start_time)
@@ -1349,6 +1359,7 @@ class AudioRecognition:
             speech_start_time = time.time() - ev.speech_duration - ev.inference_duration
             if not self._vad_speech_started:
                 self._speech_start_time = speech_start_time
+                self._utterance_id = utils.shortuuid("utterance_")
                 self._vad_speech_started = True
 
             with trace.use_span(self._ensure_user_turn_span(start_time=speech_start_time)):
@@ -1376,6 +1387,7 @@ class AudioRecognition:
 
                 if self._speech_start_time is None:
                     self._speech_start_time = time.time() - ev.raw_accumulated_speech
+                    self._utterance_id = utils.shortuuid("utterance_")
                 if self._speaking and self._turn_detector_prediction_fut is not None:
                     if self._turn_detector_stream is not None:
                         self._turn_detector_stream.cancel_inference()
@@ -1661,6 +1673,7 @@ class AudioRecognition:
                 last_speaking_time=last_speaking_time,
                 last_final_transcript_time=last_final_transcript_time,
                 first_interim_time=self._first_interim_time,
+                utterance_id=self._utterance_id,
                 now=time.time(),
             )
             committed = self._hooks.on_end_of_turn(
@@ -1711,6 +1724,7 @@ class AudioRecognition:
                 if self._last_speaking_time == last_speaking_time:
                     self._speech_start_time = None
                     self._first_interim_time = None
+                    self._utterance_id = None
                     self._vad_speech_started = False
                     self._last_speaking_time = None
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -1283,7 +1283,11 @@ class AudioRecognition:
                 )
 
         elif ev.type == stt.SpeechEventType.INTERIM_TRANSCRIPT:
-            if self._first_interim_time is None and self._speech_start_time is not None:
+            if (
+                self._first_interim_time is None
+                and self._speech_start_time is not None
+                and ev.alternatives[0].text
+            ):
                 self._first_interim_time = time.time()
             self._hooks.on_interim_transcript(
                 ev,

--- a/tests/test_stt_first_interim_metric.py
+++ b/tests/test_stt_first_interim_metric.py
@@ -1,8 +1,14 @@
 """Unit coverage for first-interim STT responsiveness metrics."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
-from livekit.agents.voice.audio_recognition import _compute_end_of_turn_metrics
+from livekit.agents.stt import SpeechData, SpeechEvent, SpeechEventType
+from livekit.agents.voice.audio_recognition import (
+    AudioRecognition,
+    _compute_end_of_turn_metrics,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -29,3 +35,31 @@ def test_first_interim_delay_is_unavailable_without_interim() -> None:
     )
     assert metrics.first_interim_delay is None
     assert metrics.first_interim_status == "absent"
+
+
+async def test_blank_interim_does_not_capture_first_interim_time() -> None:
+    recognition = AudioRecognition.__new__(AudioRecognition)
+    recognition._turn_detection_mode = "vad"
+    recognition._interruption_enabled = False
+    recognition._first_interim_time = None
+    recognition._speech_start_time = 10.0
+    recognition._hooks = MagicMock()
+    recognition._vad = None
+
+    blank_interim = SpeechEvent(
+        type=SpeechEventType.INTERIM_TRANSCRIPT,
+        alternatives=[SpeechData(language="", text="")],
+    )
+    with patch("livekit.agents.voice.audio_recognition.time.time", return_value=11.0):
+        await recognition._on_stt_event(blank_interim)
+
+    assert recognition._first_interim_time is None
+
+    populated_interim = SpeechEvent(
+        type=SpeechEventType.INTERIM_TRANSCRIPT,
+        alternatives=[SpeechData(language="", text="hello")],
+    )
+    with patch("livekit.agents.voice.audio_recognition.time.time", return_value=12.0):
+        await recognition._on_stt_event(populated_interim)
+
+    assert recognition._first_interim_time == 12.0

--- a/tests/test_stt_first_interim_metric.py
+++ b/tests/test_stt_first_interim_metric.py
@@ -16,6 +16,7 @@ def test_first_interim_delay_uses_speech_onset() -> None:
         now=15.0,
     )
     assert metrics.first_interim_delay == pytest.approx(0.25)
+    assert metrics.first_interim_status == "received"
 
 
 def test_first_interim_delay_is_unavailable_without_interim() -> None:
@@ -27,3 +28,4 @@ def test_first_interim_delay_is_unavailable_without_interim() -> None:
         now=15.0,
     )
     assert metrics.first_interim_delay is None
+    assert metrics.first_interim_status == "absent"

--- a/tests/test_stt_first_interim_metric.py
+++ b/tests/test_stt_first_interim_metric.py
@@ -1,0 +1,29 @@
+"""Unit coverage for first-interim STT responsiveness metrics."""
+
+import pytest
+
+from livekit.agents.voice.audio_recognition import _compute_end_of_turn_metrics
+
+pytestmark = pytest.mark.unit
+
+
+def test_first_interim_delay_uses_speech_onset() -> None:
+    metrics = _compute_end_of_turn_metrics(
+        speech_start_time=10.0,
+        last_speaking_time=14.0,
+        last_final_transcript_time=14.5,
+        first_interim_time=10.25,
+        now=15.0,
+    )
+    assert metrics.first_interim_delay == pytest.approx(0.25)
+
+
+def test_first_interim_delay_is_unavailable_without_interim() -> None:
+    metrics = _compute_end_of_turn_metrics(
+        speech_start_time=10.0,
+        last_speaking_time=14.0,
+        last_final_transcript_time=14.5,
+        first_interim_time=None,
+        now=15.0,
+    )
+    assert metrics.first_interim_delay is None


### PR DESCRIPTION
  closes #6533 — STT time-to-first-partial metric (https://github.com/livekit/agents/issues/6533)
  ## Summary

  Adds `first_interim_delay`: the elapsed time from VAD detecting speech onset to the first interim (partial) STT
  transcript for a user turn.

  The metric is:

  - captured once, on the first interim STT event for each turn
  - reset when the user turn is cleared or completed
  - exposed in `EOUMetrics`
  - included in the per-turn metrics report
  - recorded as the `lk.agents.turn.first_interim_delay` OpenTelemetry histogram

  A missing interim transcript is represented as unavailable in the turn report and `0.0` in the existing `EOUMetrics`
  event convention.

  ## Tests

  ```text
  pytest tests/test_end_of_turn_metrics.py tests/test_stt_first_interim_metric.py

  - verifies the delay is calculated from speech onset
  - verifies the metric is unavailable when no interim transcript arrives