### PR TITLE
feat(voice): support preemptive generation for realtime models

### DIFF
--- a/livekit-agents/livekit/agents/llm/realtime.py
+++ b/livekit-agents/livekit/agents/llm/realtime.py
@@ -241,6 +241,17 @@ class RealtimeSession(ABC, rtc.EventEmitter[EventTypes | TEvent], Generic[TEvent
         tools: NotGivenOr[list[Tool]] = NOT_GIVEN,
     ) -> asyncio.Future[GenerationCreatedEvent]: ...  # can raise RealtimeError on Timeout
 
+    @property
+    def has_active_generation(self) -> bool:
+        """Whether a server-side response is currently being generated for this session.
+
+        Plugins whose backing API enforces a single active response per session (e.g. OpenAI
+        Realtime rejects ``response.create`` with ``conversation_already_has_active_response``
+        while one is in flight) should override this so the framework can serialize response
+        creation. The default assumes no such constraint.
+        """
+        return False
+
     # commit the input audio buffer to the server
     @abstractmethod
     def commit_audio(self) -> None: ...

--- a/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
@@ -187,6 +187,10 @@ class _FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_ch
         self._active = adapter._models[0].session()
         self._bind(self._active)
 
+    @property
+    def has_active_generation(self) -> bool:
+        return self._active.has_active_generation
+
     def _bind(self, child: RealtimeSession) -> None:
         for event, forwarder in self._forwarders.items():
             child.on(event, forwarder)

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -102,6 +102,12 @@ if TYPE_CHECKING:
 
 
 _AgentActivityContextVar = contextvars.ContextVar["AgentActivity"]("agents_activity")
+
+# Upper bound on how long a preemptive realtime generation may stay parked awaiting the turn's
+# resolution. Sized to outlast the slowest legitimate end-of-turn (endpointing max_delay plus
+# transcript timeouts); expiry rolls the speculation back and the turn falls back to a normal
+# generation at end-of-turn.
+PREEMPTIVE_GENERATION_TTL = 10.0
 _SpeechHandleContextVar = contextvars.ContextVar["SpeechHandle"]("agents_speech_handle")
 _IdleHoldContextVar = contextvars.ContextVar[bool]("agents_idle_hold", default=False)
 
@@ -198,6 +204,20 @@ class AgentActivity(RecognitionHooks):
         self._speech_tasks: list[asyncio.Task[Any]] = []
 
         self._preemptive_generation: _PreemptiveGeneration | None = None
+        # resolves when the current realtime preemptive generation no longer holds any server
+        # state: set when the speculation starts, resolved on adoption or once its rollback has
+        # cancelled the response and restored the chat context. Later reply tasks (including a
+        # superseding speculation) wait on it so they never run against a dirty session.
+        self._realtime_preemptive_cleanup: asyncio.Future[None] | None = None
+        # remote items created by the in-flight speculation (the pushed user message ack and the
+        # speculative response), held back from the local history until the speculation resolves:
+        # replayed on adoption, deleted server-side on rollback
+        self._realtime_preemptive_remote_items: list[llm.RemoteItemAddedEvent] = []
+        # ids of user messages pushed by in-flight speculations. Kept separately from
+        # _preemptive_generation (whose lifetime ends at adoption/invalidation, before the
+        # rollback completes) so a late server ack for the pushed message is still recognized
+        # as speculation-owned by _on_remote_item_added.
+        self._realtime_preemptive_user_item_ids: set[str] = set()
         self._preemptive_generation_count: int = 0
         self._authorization_allowed = asyncio.Event()
         self._authorization_allowed.set()
@@ -1084,6 +1104,9 @@ class AgentActivity(RecognitionHooks):
         await self._session._keyterm_detector.aclose()
 
         self._scheduling_paused = True
+        # a parked preemptive speech task would never be authorized while scheduling is paused;
+        # cancel it (its rollback wakes and finishes the task) or the pause would wait forever
+        self._cancel_preemptive_generation()
         if blocked_tasks:
             self._add_drain_blocked_tasks(blocked_tasks)
         self._wake_up_scheduling_task()
@@ -1338,6 +1361,10 @@ class AgentActivity(RecognitionHooks):
             )
             allow_interruptions = NOT_GIVEN
 
+        if isinstance(self.llm, llm.RealtimeModel):
+            # an explicit say() supersedes any pending speculation (see _generate_reply)
+            self._cancel_preemptive_generation()
+
         handle = SpeechHandle.create(
             allow_interruptions=allow_interruptions
             if is_given(allow_interruptions)
@@ -1395,6 +1422,7 @@ class AgentActivity(RecognitionHooks):
         tools: NotGivenOr[list[str]] = NOT_GIVEN,
         allow_interruptions: NotGivenOr[bool] = NOT_GIVEN,
         schedule_speech: bool = True,
+        preemptive: bool = False,
         input_details: InputDetails = DEFAULT_INPUT_DETAILS,
     ) -> SpeechHandle:
         if (
@@ -1410,6 +1438,12 @@ class AgentActivity(RecognitionHooks):
 
         if self.llm is None:
             raise RuntimeError("trying to generate reply without an LLM model")
+
+        if not preemptive and isinstance(self.llm, llm.RealtimeModel):
+            # an explicit generation supersedes any pending speculation: cancel it so this reply
+            # doesn't collide with the speculative response (single-active-response APIs) or
+            # wait out the cleanup timeout on a speculation nothing else would resolve
+            self._cancel_preemptive_generation()
 
         task = asyncio.current_task()
         if not is_given(tool_choice) and task is not None:
@@ -1451,13 +1485,13 @@ class AgentActivity(RecognitionHooks):
             self._create_speech_task(
                 self._realtime_reply_task(
                     speech_handle=handle,
-                    # TODO(theomonnom): support llm.ChatMessage for the realtime model
-                    user_input=user_message.raw_text_content if user_message else None,
+                    user_message=user_message if user_message else None,
                     instructions=self._render_realtime_instructions(instructions)
                     if instructions
                     else None,
                     tools=resolved_tools if is_given(resolved_tools) else None,
                     model_settings=ModelSettings(tool_choice=tool_choice),
+                    preemptive=preemptive,
                 ),
                 speech_handle=handle,
                 name="AgentActivity.realtime_reply",
@@ -1544,6 +1578,9 @@ class AgentActivity(RecognitionHooks):
         return future
 
     def clear_user_turn(self) -> None:
+        # the cleared turn's end-of-turn will never arrive; drop any speculation on it
+        self._cancel_preemptive_generation()
+
         if self._audio_recognition:
             self._audio_recognition._clear_user_turn()
 
@@ -1554,6 +1591,10 @@ class AgentActivity(RecognitionHooks):
         self, *, transcript_timeout: float, stt_flush_duration: float, skip_reply: bool = False
     ) -> asyncio.Future[str]:
         if self._rt_session is not None:
+            # the committed turn is handled here; a pending speculation is doomed (the flushed
+            # end-of-turn arrives with skip_reply), so cancel it now rather than letting the
+            # reply below race its rollback
+            self._cancel_preemptive_generation()
             # commit audio buffer and conditionally trigger response generation
             self._rt_session.commit_audio()
             if not skip_reply:
@@ -1757,6 +1798,22 @@ class AgentActivity(RecognitionHooks):
         )
 
     def _on_remote_item_added(self, ev: llm.RemoteItemAddedEvent) -> None:
+        if (cleanup := self._realtime_preemptive_cleanup) is not None and not cleanup.done():
+            # a speculative (preemptive) generation is in flight: its items (the eagerly pushed
+            # user message and the speculative response output) must not reach the local history
+            # yet -- they would mutate the chat context mid-turn and invalidate the preemptive
+            # match. They are replayed on adoption and deleted server-side on rollback. Items
+            # NOT created by the speculation (e.g. the committed turn audio acked during a
+            # rollback, which the fallback generation replies to) apply normally.
+            is_other_user_item = (
+                ev.item.type == "message"
+                and ev.item.role == "user"
+                and ev.item.id not in self._realtime_preemptive_user_item_ids
+            )
+            if not is_other_user_item:
+                self._realtime_preemptive_remote_items.append(ev)
+                return
+
         # add the remote item to the local chat context as a placeholder
         local_chat_ctx = self._agent._chat_ctx
         if local_chat_ctx.get_by_id(ev.item.id) is not None:
@@ -2140,6 +2197,31 @@ class AgentActivity(RecognitionHooks):
             self._cancel_speech_pause(old_task=self._cancel_speech_pause_task)
         )
 
+    def _can_preemptively_generate(self) -> bool:
+        """Whether a preemptive generation may start right now for the current LLM."""
+        if isinstance(self.llm, llm.LLM):
+            return True
+
+        if isinstance(self.llm, llm.RealtimeModel):
+            caps = self.llm.capabilities
+            # the speculative reply is generated from the eager text transcript, so the session
+            # must accept context edits and must not run server-side turn detection (it would
+            # generate its own replies). Text-only output keeps the turn's input modality
+            # consistent: adopted turns reply to the pushed transcript, never to committed
+            # audio, so a model that also speaks from its own audio context is excluded.
+            if caps.turn_detection or not caps.mutable_chat_context or caps.audio_output:
+                return False
+            if self._rt_session is None:
+                return False
+            # most realtime APIs allow a single active response per session: don't start a
+            # speculative response while one is still in flight (e.g. the opening greeting the
+            # user talked over); the normal interrupt -> generate path handles this turn instead
+            if self._rt_session.has_active_generation:
+                return False
+            return True
+
+        return False
+
     def on_preemptive_generation(self, info: _PreemptiveGenerationInfo) -> None:
         preemptive_opts = self.preemptive_generation_opts
         if (
@@ -2147,7 +2229,7 @@ class AgentActivity(RecognitionHooks):
             or self._scheduling_paused
             or self._new_turns_blocked
             or (self._current_speech is not None and not self._current_speech.interrupted)
-            or not isinstance(self.llm, llm.LLM)
+            or not self._can_preemptively_generate()
         ):
             return
 
@@ -2176,6 +2258,7 @@ class AgentActivity(RecognitionHooks):
             user_message=user_message,
             chat_ctx=chat_ctx,
             schedule_speech=False,
+            preemptive=True,
             input_details=InputDetails(modality="audio"),
         )
 
@@ -2310,110 +2393,164 @@ class AgentActivity(RecognitionHooks):
         if user_message is not None:
             user_message.metrics = metrics_report
 
+        audio_commit_deferred = False
         if isinstance(self.llm, llm.RealtimeModel):
             if self.llm.capabilities.turn_detection:
                 return
 
             if self._rt_session is not None:
                 if info.skip_reply:
+                    if self._preemptive_generation is not None:
+                        # drop the pending speculation (e.g. commit_user_turn() forces
+                        # skip_reply for realtime): cancelling wakes the parked reply task,
+                        # whose rollback clears the speculative server state and resolves the
+                        # cleanup future so later replies aren't blocked on it
+                        self._cancel_preemptive_generation()
                     if info.new_transcript != "":
                         # only add user message to chat context if reply should be skipped
                         self._agent._chat_ctx.items.append(user_message)
                         self._session._conversation_item_added(user_message)
                     return
-                self._rt_session.commit_audio()
+                if self._preemptive_generation is None:
+                    self._rt_session.commit_audio()
+                else:
+                    # the audio commit is deferred until the preemptive generation is resolved:
+                    # the buffer is cleared if the speculative reply (generated from the pushed
+                    # transcript) is adopted, or committed before the fallback generation if
+                    # the speculation is invalidated. The finally below resolves the deferral
+                    # on every early exit (StopResponse, errors, pause) so the buffered audio
+                    # can never leak into a later turn's commit.
+                    audio_commit_deferred = True
 
-        if info.skip_reply:
-            if info.new_transcript != "":
-                self._agent._chat_ctx.items.append(user_message)
-                self._session._conversation_item_added(user_message)
-            return
+        try:
+            if info.skip_reply:
+                if info.new_transcript != "":
+                    self._agent._chat_ctx.items.append(user_message)
+                    self._session._conversation_item_added(user_message)
+                return
 
-        if (current_speech := self._current_speech) is not None:
-            if not current_speech.allow_interruptions:
+            if (current_speech := self._current_speech) is not None:
+                if not current_speech.allow_interruptions:
+                    logger.warning(
+                        "skipping reply to user input, current speech generation cannot be interrupted",  # noqa: E501
+                        extra={"user_input": info.new_transcript},
+                    )
+                    return
+                await self._cancel_speech_pause(self._cancel_speech_pause_task)
+
+                await current_speech.interrupt()
+
+                if self._rt_session is not None and self._preemptive_generation is None:
+                    # don't cancel the in-flight speculative response (the active response is
+                    # the speculation, not the interrupted speech); if the speculation is
+                    # invalidated below, its rollback interrupts it instead
+                    self._rt_session.interrupt()
+
+            if self._scheduling_paused or self._new_turns_blocked:
                 logger.warning(
-                    "skipping reply to user input, current speech generation cannot be interrupted",
+                    "skipping on_user_turn_completed, speech scheduling is paused",
                     extra={"user_input": info.new_transcript},
                 )
+                if self._session._closing:
+                    self._agent._chat_ctx.items.append(user_message)
+                    self._session._conversation_item_added(user_message)
                 return
-            await self._cancel_speech_pause(self._cancel_speech_pause_task)
 
-            await current_speech.interrupt()
-
-            if self._rt_session is not None:
-                self._rt_session.interrupt()
-
-        if self._scheduling_paused or self._new_turns_blocked:
-            logger.warning(
-                "skipping on_user_turn_completed, speech scheduling is paused",
-                extra={"user_input": info.new_transcript},
-            )
-            if self._session._closing:
-                self._agent._chat_ctx.items.append(user_message)
-                self._session._conversation_item_added(user_message)
-            return
-
-        # create a temporary mutable chat context to pass to on_user_turn_completed
-        # the user can edit it for the current generation, but changes will not be kept inside the
-        # Agent.chat_ctx
-        temp_mutable_chat_ctx = self._agent.chat_ctx.copy()
-        start_time = time.perf_counter()
-        try:
-            await self._agent.on_user_turn_completed(
-                temp_mutable_chat_ctx, new_message=user_message
-            )
-        except StopResponse:
-            return  # ignore this turn
-        except Exception:
-            logger.exception("error occurred during on_user_turn_completed")
-            return
-
-        on_user_turn_completed_delay = time.perf_counter() - start_time
-        metrics_report["on_user_turn_completed_delay"] = on_user_turn_completed_delay
-
-        if isinstance(self.llm, llm.RealtimeModel):
-            # ignore stt transcription for realtime model
-            user_message = None  # type: ignore
-        elif self.llm is None:
-            return  # skip response if no llm is set
-
-        if self._scheduling_paused or self._new_turns_blocked:
-            logger.warning(
-                "skipping reply to user input, speech scheduling is paused",
-                extra={"user_input": info.new_transcript},
-            )
-            if user_message and self._session._closing:
-                self._agent._chat_ctx.items.append(user_message)
-                self._session._conversation_item_added(user_message)
-            return
-
-        speech_handle: SpeechHandle | None = None
-        if preemptive := self._preemptive_generation:
-            # make sure the on_user_turn_completed didn't change some request parameters
-            # otherwise invalidate the preemptive generation
-            if (
-                preemptive.info.new_transcript == user_message.raw_text_content
-                and preemptive.chat_ctx.is_equivalent(temp_mutable_chat_ctx)
-                and preemptive.tools == self.tools
-                and preemptive.tool_choice == self._tool_choice
-            ):
-                speech_handle = preemptive.speech_handle
-
-                # preemptive generation is using another ChatMessage created outside of the on_end_of_turn callback,
-                # inject the metrics here.
-                preemptive.user_message.metrics = metrics_report
-                self._schedule_speech(speech_handle, priority=SpeechHandle.SPEECH_PRIORITY_NORMAL)
-                logger.debug(
-                    "using preemptive generation",
-                    extra={"preemptive_lead_time": time.time() - preemptive.created_at},
+            # create a temporary mutable chat context to pass to on_user_turn_completed
+            # the user can edit it for the current generation, but changes will not be kept inside
+            # the Agent.chat_ctx
+            temp_mutable_chat_ctx = self._agent.chat_ctx.copy()
+            start_time = time.perf_counter()
+            try:
+                await self._agent.on_user_turn_completed(
+                    temp_mutable_chat_ctx, new_message=user_message
                 )
-            else:
+            except StopResponse:
+                return  # ignore this turn
+            except Exception:
+                logger.exception("error occurred during on_user_turn_completed")
+                return
+
+            on_user_turn_completed_delay = time.perf_counter() - start_time
+            metrics_report["on_user_turn_completed_delay"] = on_user_turn_completed_delay
+
+            # capture the (possibly user-edited) transcript for the preemptive match below,
+            # before the realtime branch drops its reference to the message
+            adoption_transcript = user_message.raw_text_content
+            if isinstance(self.llm, llm.RealtimeModel):
+                # ignore stt transcription for realtime model
+                user_message = None  # type: ignore
+            elif self.llm is None:
+                return  # skip response if no llm is set
+
+            if self._scheduling_paused or self._new_turns_blocked:
                 logger.warning(
-                    "preemptive generation enabled but chat context or tools have changed after `on_user_turn_completed`",  # noqa: E501
+                    "skipping reply to user input, speech scheduling is paused",
+                    extra={"user_input": info.new_transcript},
                 )
-                preemptive.speech_handle._cancel()
+                if user_message and self._session._closing:
+                    self._agent._chat_ctx.items.append(user_message)
+                    self._session._conversation_item_added(user_message)
+                return
 
-            self._preemptive_generation = None
+            speech_handle: SpeechHandle | None = None
+            if preemptive := self._preemptive_generation:
+                # make sure the on_user_turn_completed didn't change some request parameters
+                # otherwise invalidate the preemptive generation
+                if (
+                    preemptive.info.new_transcript == adoption_transcript
+                    and preemptive.chat_ctx.is_equivalent(temp_mutable_chat_ctx)
+                    and preemptive.tools == self.tools
+                    and preemptive.tool_choice == self._tool_choice
+                    # the speculative generation may have already failed (e.g. the realtime
+                    # generate_reply was rejected); fall back to a normal generation instead of
+                    # scheduling a dead speech
+                    and not preemptive.speech_handle.done()
+                ):
+                    speech_handle = preemptive.speech_handle
+
+                    # preemptive generation is using another ChatMessage created outside of the on_end_of_turn callback,  # noqa: E501
+                    # inject the metrics here.
+                    preemptive.user_message.metrics = metrics_report
+                    if audio_commit_deferred:
+                        assert self._rt_session is not None
+                        # the speculative reply was generated from the pushed transcript; drop
+                        # the buffered turn audio so it can't leak into the next turn's commit
+                        self._rt_session.clear_audio()
+                        audio_commit_deferred = False
+                    self._schedule_speech(
+                        speech_handle, priority=SpeechHandle.SPEECH_PRIORITY_NORMAL
+                    )
+                    logger.debug(
+                        "using preemptive generation",
+                        extra={"preemptive_lead_time": time.time() - preemptive.created_at},
+                    )
+                else:
+                    if preemptive.speech_handle.done():
+                        logger.warning(
+                            "preemptive generation failed before the turn was confirmed; falling back to a normal generation",  # noqa: E501
+                        )
+                    else:
+                        logger.warning(
+                            "preemptive generation enabled but the transcript, chat context or tools have changed after `on_user_turn_completed`",  # noqa: E501
+                        )
+                    preemptive.speech_handle._cancel()
+                    if audio_commit_deferred:
+                        assert self._rt_session is not None
+                        # commit the real turn audio for the fallback generation below
+                        self._rt_session.commit_audio()
+                        audio_commit_deferred = False
+
+                self._preemptive_generation = None
+        finally:
+            if audio_commit_deferred:
+                # early exit while the speculation was still pending (StopResponse, errors,
+                # pause, or an external cancel that already cleared the record): drop the stale
+                # speculation (its reply task rolls back the server state) and commit the turn
+                # audio, matching the non-preemptive behavior above
+                self._cancel_preemptive_generation()
+                if self._rt_session is not None:
+                    self._rt_session.commit_audio()
 
         if speech_handle is None:
             # Ensure the new message is passed to generate_reply
@@ -3477,20 +3614,8 @@ class AgentActivity(RecognitionHooks):
                     speech_handle, SpeechHandle.SPEECH_PRIORITY_NORMAL, force=True
                 )
 
-    @utils.log_exceptions(logger=logger)
-    async def _realtime_reply_task(
-        self,
-        *,
-        speech_handle: SpeechHandle,
-        model_settings: ModelSettings,
-        tools: list[llm.Tool | llm.Toolset] | None = None,
-        user_input: str | None = None,
-        instructions: str | None = None,
-        tool_reply: bool = False,
-        text: str | AsyncIterable[str] | None = None,
-    ) -> None:
-        assert self._rt_session is not None, "rt_session is not available"
-        # realtime_reply_task is called only when there's text input, native audio input is handled by _realtime_generation_task
+    async def _wait_for_speech_authorization(self, speech_handle: SpeechHandle) -> bool:
+        """Wait until the speech is authorized to play out; False if it was interrupted first."""
         authorization_tasks: list[asyncio.Future[Any]] = [
             asyncio.ensure_future(speech_handle._wait_for_authorization()),
             asyncio.ensure_future(self._authorization_allowed.wait()),
@@ -3500,9 +3625,131 @@ class AgentActivity(RecognitionHooks):
         await speech_handle.wait_if_not_interrupted(authorization_tasks)
         if speech_handle.interrupted:
             await utils.aio.cancel_and_wait(*authorization_tasks)
-            return
+            return False
+        return True
+
+    async def _wait_for_active_response_cleared(self, timeout: float = 3.0) -> None:
+        """Wait for the server to release the active response.
+
+        ``RealtimeSession.interrupt()`` (and cancelling a pending ``generate_reply``) only
+        *requests* the cancellation; on single-active-response APIs the response stays active
+        until the server acks it, and creating a new response before that is rejected (e.g.
+        OpenAI's ``conversation_already_has_active_response``). No-op for plugins that don't
+        report ``has_active_generation``.
+        """
+        assert self._rt_session is not None, "rt_session is not available"
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while self._rt_session.has_active_generation:
+            if loop.time() >= deadline:
+                logger.warning(
+                    "timed out waiting for the active realtime response to clear",
+                    extra={"timeout": timeout},
+                )
+                return
+            await asyncio.sleep(0.01)
+
+    async def _wait_for_realtime_session_idle(self, timeout: float = 3.0) -> None:
+        """Wait until the realtime session is safe to generate on.
+
+        Waits for a pending preemptive generation to be adopted or fully rolled back (see
+        ``_rollback_preemptive_realtime_generation``), then for the server to release the
+        active response. Must not be used by the rollback itself: the cleanup future is the
+        rollback's own completion signal.
+        """
+        if (cleanup := self._realtime_preemptive_cleanup) is not None and not cleanup.done():
+            try:
+                await asyncio.wait_for(asyncio.shield(cleanup), timeout=timeout)
+            except asyncio.TimeoutError:
+                logger.warning("timed out waiting for the preemptive generation cleanup")
+
+        await self._wait_for_active_response_cleared(timeout)
+
+    @utils.log_exceptions(logger=logger)
+    async def _rollback_preemptive_realtime_generation(
+        self,
+        cleanup_fut: asyncio.Future[None],
+        generate_reply_fut: asyncio.Future[llm.GenerationCreatedEvent] | None,
+        user_message_id: str | None,
+    ) -> None:
+        """Cancel a speculative realtime response and remove its items from the server context.
+
+        The rollback must leave the session as if the speculation never happened, without
+        disturbing anything else that reached the session in the meantime (e.g. the committed
+        turn audio for the fallback generation): only the items the speculation created -- the
+        eagerly pushed user message and the speculative response items (tracked in
+        ``_realtime_preemptive_remote_items``) -- are removed. The cancelled response is awaited
+        so the follow-up generation doesn't collide with it. Resolving ``cleanup_fut`` (in all
+        cases) is what unblocks the follow-up generation.
+        """
+        original_user_message_id = user_message_id
+        try:
+            assert self._rt_session is not None, "rt_session is not available"
+            if generate_reply_fut is not None:
+                if not generate_reply_fut.done():
+                    # cancel the pending generation; the plugin emits response.cancel
+                    generate_reply_fut.cancel()
+                elif not generate_reply_fut.cancelled() and generate_reply_fut.exception() is None:
+                    # the response was already created; cancel it server-side
+                    self._rt_session.interrupt()
+
+            await self._wait_for_active_response_cleared()
+
+            # two passes: acks for the speculation's items can still arrive while the first
+            # removal round-trips (e.g. the cancelled response's item created just before the
+            # cancel took effect)
+            for _ in range(2):
+                remove_ids = {ev.item.id for ev in self._realtime_preemptive_remote_items}
+                self._realtime_preemptive_remote_items.clear()
+                if user_message_id is not None:
+                    remove_ids.add(user_message_id)
+                if not remove_ids:
+                    break
+                restore_ctx = self._rt_session.chat_ctx.copy()
+                restore_ctx.items = [i for i in restore_ctx.items if i.id not in remove_ids]
+                try:
+                    await self._rt_session.update_chat_ctx(restore_ctx)
+                except Exception:
+                    logger.warning(
+                        "failed to remove the speculative items after the preemptive rollback",
+                        exc_info=True,
+                    )
+                    break
+                user_message_id = None
+                if not self._realtime_preemptive_remote_items:
+                    break
+        finally:
+            if original_user_message_id is not None:
+                self._realtime_preemptive_user_item_ids.discard(original_user_message_id)
+            if not cleanup_fut.done():
+                cleanup_fut.set_result(None)
+
+    @utils.log_exceptions(logger=logger)
+    async def _realtime_reply_task(
+        self,
+        *,
+        speech_handle: SpeechHandle,
+        model_settings: ModelSettings,
+        tools: list[llm.Tool | llm.Toolset] | None = None,
+        user_message: llm.ChatMessage | None = None,
+        instructions: str | None = None,
+        tool_reply: bool = False,
+        text: str | AsyncIterable[str] | None = None,
+        preemptive: bool = False,
+    ) -> None:
+        assert self._rt_session is not None, "rt_session is not available"
+        # realtime_reply_task is called only when there's text input, native audio input is handled by _realtime_generation_task
+        if not preemptive:
+            # a preemptive (speculative) reply starts generating before the user turn is
+            # confirmed: the authorization gate moves after rt_session.generate_reply so the
+            # server streams the response eagerly, while playout stays gated on authorization
+            if not await self._wait_for_speech_authorization(speech_handle):
+                return
 
         if text is not None:
+            # don't create a response while a speculation rollback or another response is
+            # still clearing (single-active-response APIs)
+            await self._wait_for_realtime_session_idle()
             try:
                 generation_ev = await self._rt_session.say(text)
             except llm.RealtimeError as e:
@@ -3517,96 +3764,248 @@ class AgentActivity(RecognitionHooks):
             )
             return
 
-        if user_input is not None:
-            chat_ctx = self._rt_session.chat_ctx.copy()
-            msg = chat_ctx.add_message(role="user", content=user_input)
-            try:
-                await self._rt_session.update_chat_ctx(chat_ctx)
-            except llm.RealtimeError as e:
-                # the push is best-effort (the items were sent; only the ack timed out),
-                # so still generate the reply rather than dropping the whole turn
-                logger.warning(
-                    "failed to update the chat context before generating the reply",
-                    extra={"error": str(e)},
-                )
-            except Exception as e:
-                logger.exception("failed to update the chat context before generating the reply")
-                speech_handle._mark_done(error=e)
-                return
-            self._agent._chat_ctx._upsert_item(msg)
-            self._session._conversation_item_added(msg)
+        pending_user_message: llm.ChatMessage | None = None
+        generate_reply_fut: asyncio.Future[llm.GenerationCreatedEvent] | None = None
+        prev_cleanup: asyncio.Future[None] | None = None
+        cleanup_fut: asyncio.Future[None] | None = None
+        # True while this task owns speculative server state (a pushed user item and/or a
+        # speculative response) that must be rolled back on any exit other than adoption
+        speculation_active = False
 
-        # inside on_enter, hide flagged tools even when no tools= was passed (fall back to self.tools)
-        turn_tools: NotGivenOr[list[llm.Tool]] = NOT_GIVEN
-        tool_ctx = llm.ToolContext(tools if tools is not None else self.tools)
-        on_enter_ignored = self._on_enter_ignored_tools(tool_ctx)
-        if tools is not None or on_enter_ignored:
-            tool_ctx._exclude(on_enter_ignored)
-            turn_tools = tool_ctx.flatten()
+        if preemptive:
+            # Publish this speculation's cleanup future *before* touching the session and chain
+            # behind the previous one: a superseding speculation must never push until the
+            # superseded one has fully rolled back, and every follow-up reply task waits on
+            # this future (resolved on adoption, or by the rollback when interrupted).
+            prev_cleanup = self._realtime_preemptive_cleanup
+            cleanup_fut = asyncio.get_running_loop().create_future()
+            self._realtime_preemptive_cleanup = cleanup_fut
+            speculation_active = True
 
-        ori_tool_choice: NotGivenOr[llm.ToolChoice | None] = NOT_GIVEN
-        ori_tools: NotGivenOr[list[llm.Tool]] = NOT_GIVEN
+        def _schedule_rollback() -> asyncio.Task[Any]:
+            # run the rollback as its own tracked task (not linked to speech_handle, so the
+            # interruption watchdog can't cancel it); resolving cleanup_fut is what unblocks
+            # the follow-up generation for the confirmed turn
+            assert cleanup_fut is not None
+            return self._create_speech_task(
+                self._rollback_preemptive_realtime_generation(
+                    cleanup_fut,
+                    generate_reply_fut,
+                    user_message.id if user_message is not None else None,
+                ),
+                name="AgentActivity.preemptive_rollback",
+            )
+
         try:
-            if not (
-                per_response_tool_choice
-                := self._rt_session.realtime_model.capabilities.per_response_tool_choice
-            ):
-                # update the tool and tool choice at the session level if they are specified
-                if (
-                    is_given(model_settings.tool_choice)
-                    and model_settings.tool_choice != self._tool_choice
-                ):
-                    ori_tool_choice = self._tool_choice
-                    self._rt_session.update_options(tool_choice=model_settings.tool_choice)
+            # never generate on a session with a pending speculation or an active response
+            if preemptive:
+                # (_wait_for_realtime_session_idle would wait on our own cleanup future here)
+                if prev_cleanup is not None and not prev_cleanup.done():
+                    try:
+                        await asyncio.wait_for(asyncio.shield(prev_cleanup), timeout=3.0)
+                    except asyncio.TimeoutError:
+                        logger.warning("timed out waiting for the previous preemptive cleanup")
+                await self._wait_for_active_response_cleared()
 
-                if is_given(turn_tools):
-                    ori_tools = self._rt_session.tools.flatten()
-                    await self._rt_session.update_tools(turn_tools)
+                if speech_handle.interrupted:
+                    # superseded or cancelled while waiting: nothing was pushed yet, so the
+                    # rollback only needs to resolve the cleanup future
+                    speculation_active = False
+                    await asyncio.shield(_schedule_rollback())
+                    return
 
-            generate_reply_fut = self._rt_session.generate_reply(
-                instructions=instructions or NOT_GIVEN,
-                tool_choice=(model_settings.tool_choice if per_response_tool_choice else NOT_GIVEN),
-                tools=(turn_tools if per_response_tool_choice else NOT_GIVEN),
-            )
-            await speech_handle.wait_if_not_interrupted([generate_reply_fut])
-            if speech_handle.interrupted:
-                # cancel the pending generation; the plugin emits response.cancel
-                if not generate_reply_fut.done():
-                    generate_reply_fut.cancel()
-                return
+                # items created by this speculation are held back from the local history until
+                # adoption (see _on_remote_item_added); start from a clean slate
+                self._realtime_preemptive_remote_items.clear()
 
-            try:
-                generation_ev = await generate_reply_fut
-            except llm.RealtimeError as e:
-                logger.error(
-                    "failed to generate a reply%s: %s",
-                    " after tool execution" if tool_reply else "",
-                    str(e),
+                # A speculation is only resolved by a subsequent event (end of turn, supersession,
+                # interruption, ...). If the user vanishes mid-utterance no such event ever
+                # arrives, so bound the parked state: cancelling wakes the task and its rollback
+                # resolves the cleanup future that later replies wait on.
+                assert cleanup_fut is not None
+
+                def _speculation_ttl() -> None:
+                    assert cleanup_fut is not None
+                    if not cleanup_fut.done() and not speech_handle.done():
+                        logger.warning(
+                            "preemptive generation expired before the turn resolved; rolling back"
+                        )
+                        speech_handle._cancel()
+
+                ttl_handle = asyncio.get_running_loop().call_later(
+                    PREEMPTIVE_GENERATION_TTL, _speculation_ttl
                 )
-                speech_handle._mark_done(error=e)
-                self._session._update_agent_state("listening")
-                return
+                cleanup_fut.add_done_callback(lambda _: ttl_handle.cancel())
+            else:
+                await self._wait_for_realtime_session_idle()
 
-            # _realtime_generation_task will clear the authorization
-            await self._realtime_generation_task(
-                speech_handle=speech_handle,
-                generation_ev=generation_ev,
-                model_settings=model_settings,
-                instructions=instructions,
-            )
-        finally:
-            # reset tool_choice and tools
-            if is_given(ori_tool_choice):
+            if user_message is not None:
+                if preemptive:
+                    self._realtime_preemptive_user_item_ids.add(user_message.id)
+                chat_ctx = self._rt_session.chat_ctx.copy()
+                chat_ctx.insert(user_message)
                 try:
-                    self._rt_session.update_options(tool_choice=ori_tool_choice)
-                except Exception:
-                    logger.exception("failed to reset tool_choice")
+                    await self._rt_session.update_chat_ctx(chat_ctx)
+                except llm.RealtimeError as e:
+                    # the push is best-effort (the items were sent; only the ack timed out),
+                    # so still generate the reply rather than dropping the whole turn
+                    logger.warning(
+                        "failed to update the chat context before generating the reply",
+                        extra={"error": str(e)},
+                    )
+                except Exception as e:
+                    logger.exception(
+                        "failed to update the chat context before generating the reply"
+                    )
+                    speech_handle._mark_done(error=e)
+                    if speculation_active:
+                        # the item may have reached the server; restore before the fallback
+                        speculation_active = False
+                        _schedule_rollback()
+                    return
+                if preemptive:
+                    # the turn isn't confirmed yet: defer the local history commit and the
+                    # conversation_item_added event until this speech is adopted (authorized)
+                    pending_user_message = user_message
+                else:
+                    self._agent._chat_ctx._upsert_item(user_message)
+                    self._session._conversation_item_added(user_message)
 
-            if is_given(ori_tools):
+            # inside on_enter, hide flagged tools even when no tools= was passed (fall back to self.tools)
+            turn_tools: NotGivenOr[list[llm.Tool]] = NOT_GIVEN
+            tool_ctx = llm.ToolContext(tools if tools is not None else self.tools)
+            on_enter_ignored = self._on_enter_ignored_tools(tool_ctx)
+            if tools is not None or on_enter_ignored:
+                tool_ctx._exclude(on_enter_ignored)
+                turn_tools = tool_ctx.flatten()
+
+            ori_tool_choice: NotGivenOr[llm.ToolChoice | None] = NOT_GIVEN
+            ori_tools: NotGivenOr[list[llm.Tool]] = NOT_GIVEN
+            try:
+                if not (
+                    per_response_tool_choice
+                    := self._rt_session.realtime_model.capabilities.per_response_tool_choice
+                ):
+                    # update the tool and tool choice at the session level if they are specified
+                    if (
+                        is_given(model_settings.tool_choice)
+                        and model_settings.tool_choice != self._tool_choice
+                    ):
+                        ori_tool_choice = self._tool_choice
+                        self._rt_session.update_options(tool_choice=model_settings.tool_choice)
+
+                    if is_given(turn_tools):
+                        ori_tools = self._rt_session.tools.flatten()
+                        await self._rt_session.update_tools(turn_tools)
+
+                generate_reply_fut = self._rt_session.generate_reply(
+                    instructions=instructions or NOT_GIVEN,
+                    tool_choice=(
+                        model_settings.tool_choice if per_response_tool_choice else NOT_GIVEN
+                    ),
+                    tools=(turn_tools if per_response_tool_choice else NOT_GIVEN),
+                )
+
+                if preemptive:
+                    # a speculative generation that fails before adoption must be observed here:
+                    # this task is parked below waiting for authorization and can't see it.
+                    # _cancel() wakes the wait (running the rollback) and _mark_done() records
+                    # the error and makes the adoption check in _user_turn_completed_task fall
+                    # back to a normal generation instead of scheduling a dead speech.
+                    def _fail_speculation_early(f: asyncio.Future[Any]) -> None:
+                        assert cleanup_fut is not None
+                        if cleanup_fut.done() or speech_handle.scheduled:
+                            # already adopted (scheduling is decided synchronously with the
+                            # adoption check, before the cleanup future resolves) or rolled
+                            # back: failures follow the normal post-generation error handling
+                            return
+                        if not f.cancelled() and (exc := f.exception()) is not None:
+                            logger.warning(
+                                "speculative realtime generation failed before adoption",
+                                extra={"error": str(exc)},
+                            )
+                            speech_handle._cancel()
+                            speech_handle._mark_done(error=exc)
+
+                    generate_reply_fut.add_done_callback(_fail_speculation_early)
+
+                    # the speculative response is now generating server-side (this is the head
+                    # start); hold playout and the history commit until the user turn is
+                    # confirmed and this speech is scheduled (see _user_turn_completed_task)
+                    if not await self._wait_for_speech_authorization(speech_handle):
+                        # invalidated or superseded: undo the speculation before the follow-up
+                        # (non-speculative) generation for the confirmed turn runs; shield so
+                        # the rollback completes even if this task is cancelled while waiting
+                        speculation_active = False
+                        await asyncio.shield(_schedule_rollback())
+                        return
+
+                    # adopted: the speculation no longer needs a rollback; unblock any reply
+                    # task waiting on the cleanup future
+                    speculation_active = False
+                    assert cleanup_fut is not None
+                    if not cleanup_fut.done():
+                        cleanup_fut.set_result(None)
+
+                    if pending_user_message is not None:
+                        # the turn is confirmed: commit the user message to the local history
+                        self._agent._chat_ctx._upsert_item(pending_user_message)
+                        self._session._conversation_item_added(pending_user_message)
+                        self._realtime_preemptive_user_item_ids.discard(pending_user_message.id)
+
+                    # replay the remote items held back during the speculation (the response
+                    # placeholders); the cleanup future is resolved, so they apply normally
+                    held_back = self._realtime_preemptive_remote_items[:]
+                    self._realtime_preemptive_remote_items.clear()
+                    for held_ev in held_back:
+                        self._on_remote_item_added(held_ev)
+
+                await speech_handle.wait_if_not_interrupted([generate_reply_fut])
+                if speech_handle.interrupted:
+                    # cancel the pending generation; the plugin emits response.cancel
+                    if not generate_reply_fut.done():
+                        generate_reply_fut.cancel()
+                    return
+
                 try:
-                    await self._rt_session.update_tools(ori_tools)
-                except Exception:
-                    logger.exception("failed to reset tools")
+                    generation_ev = await generate_reply_fut
+                except llm.RealtimeError as e:
+                    logger.error(
+                        "failed to generate a reply%s: %s",
+                        " after tool execution" if tool_reply else "",
+                        str(e),
+                    )
+                    speech_handle._mark_done(error=e)
+                    self._session._update_agent_state("listening")
+                    return
+
+                # _realtime_generation_task will clear the authorization
+                await self._realtime_generation_task(
+                    speech_handle=speech_handle,
+                    generation_ev=generation_ev,
+                    model_settings=model_settings,
+                    instructions=instructions,
+                )
+            finally:
+                # reset tool_choice and tools
+                if is_given(ori_tool_choice):
+                    try:
+                        self._rt_session.update_options(tool_choice=ori_tool_choice)
+                    except Exception:
+                        logger.exception("failed to reset tool_choice")
+
+                if is_given(ori_tools):
+                    try:
+                        await self._rt_session.update_tools(ori_tools)
+                    except Exception:
+                        logger.exception("failed to reset tools")
+        except BaseException:
+            if speculation_active:
+                # any unwind (task cancellation, unexpected error) while speculative server
+                # state exists must still roll it back and resolve the cleanup future
+                speculation_active = False
+                _schedule_rollback()
+            raise
 
     @utils.log_exceptions(logger=logger)
     async def _realtime_generation_task(

--- a/livekit-agents/livekit/agents/voice/turn.py
+++ b/livekit-agents/livekit/agents/voice/turn.py
@@ -199,7 +199,12 @@ _INTERRUPTION_DEFAULTS: InterruptionOptions = {
 
 
 class PreemptiveGenerationOptions(TypedDict, total=False):
-    """Configuration for preemptive generation."""
+    """Configuration for preemptive generation.
+
+    Applies to ``llm.LLM`` pipelines and to ``llm.RealtimeModel`` sessions without
+    server-side turn detection (the reply starts generating on the eager transcript;
+    playout stays gated until the turn is confirmed).
+    """
 
     enabled: bool
     """Whether preemptive generation is enabled. Defaults to ``True``."""

--- a/tests/fake_realtime.py
+++ b/tests/fake_realtime.py
@@ -9,11 +9,13 @@ from livekit import rtc
 from livekit.agents import NOT_GIVEN, NotGivenOr
 from livekit.agents.llm import (
     ChatContext,
+    ChatItem,
     GenerationCreatedEvent,
     RealtimeCapabilities,
     RealtimeModel,
     RealtimeModelError,
     RealtimeSession,
+    RemoteItemAddedEvent,
 )
 from livekit.agents.llm.tool_context import Tool, ToolChoice, ToolContext
 
@@ -47,9 +49,12 @@ class FakeRealtimeSession(RealtimeSession):
         self.closed = False
         self.interrupted = False
         self.committed = False
+        self.committed_at: float | None = None
         self.audio_cleared = False
+        self.audio_cleared_at: float | None = None
         self.pushed_audio: list[rtc.AudioFrame] = []
         self.generate_reply_calls = 0
+        self.active_generation = False
         self.updated_instructions: str | None = None
         self.tool_choice: NotGivenOr[ToolChoice | None] = NOT_GIVEN
         self.say_calls: list[str | AsyncIterable[str]] = []
@@ -76,7 +81,25 @@ class FakeRealtimeSession(RealtimeSession):
     async def update_chat_ctx(self, chat_ctx: ChatContext) -> None:
         if self.update_error is not None:
             raise self.update_error
+        old_ids = {i.id for i in self._chat_ctx.items}
         self._chat_ctx = chat_ctx
+        # mirror the real plugins: the server acks newly created items, which the framework
+        # mirrors into the local history via remote_item_added
+        prev_id: str | None = None
+        for item in chat_ctx.items:
+            if item.id not in old_ids:
+                self.emit(
+                    "remote_item_added",
+                    RemoteItemAddedEvent(previous_item_id=prev_id, item=item),
+                )
+            prev_id = item.id
+
+    def emit_remote_item(self, item: ChatItem, *, previous_item_id: str | None = None) -> None:
+        """Test helper: simulate a server-initiated item (e.g. a response output item)."""
+        self._chat_ctx.items.append(item)
+        self.emit(
+            "remote_item_added", RemoteItemAddedEvent(previous_item_id=previous_item_id, item=item)
+        )
 
     async def update_tools(self, tools: list[Tool]) -> None:
         self._tools = ToolContext(tools)
@@ -102,11 +125,17 @@ class FakeRealtimeSession(RealtimeSession):
         self._reply_futs.append(fut)
         return fut
 
+    @property
+    def has_active_generation(self) -> bool:
+        return self.active_generation
+
     def commit_audio(self) -> None:
         self.committed = True
+        self.committed_at = time.time()
 
     def clear_audio(self) -> None:
         self.audio_cleared = True
+        self.audio_cleared_at = time.time()
 
     def interrupt(self) -> None:
         self.interrupted = True

--- a/tests/test_realtime_preemptive.py
+++ b/tests/test_realtime_preemptive.py
@@ -1,0 +1,860 @@
+"""
+Tests for preemptive (speculative) generation with RealtimeModel pipelines.
+
+A text-mode RealtimeModel (no server-side turn detection) driven by a client EOT signal starts
+generating on the eager transcript, before the user turn is confirmed:
+
+* the reply task issues ``rt_session.generate_reply`` *before* the authorization gate (the head
+  start), while the local history commit and playout stay gated on authorization
+* if the confirmed turn still matches, the in-flight generation is adopted (scheduled)
+* otherwise it is rolled back: the response is cancelled, the server-side chat context restored,
+  and the fallback generation waits for the rollback so it can't collide with the cancelled
+  response (single-active-response APIs)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import MethodType, SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from livekit.agents import Agent, AgentSession, llm, utils
+from livekit.agents.llm import ChatMessage, FunctionCall, GenerationCreatedEvent, MessageGeneration
+from livekit.agents.voice import ModelSettings
+from livekit.agents.voice.agent_activity import AgentActivity
+from livekit.agents.voice.audio_recognition import _PreemptiveGenerationInfo
+from livekit.agents.voice.speech_handle import SpeechHandle
+
+from .fake_realtime import FakeRealtimeModel, FakeRealtimeSession, fake_capabilities
+
+pytestmark = pytest.mark.unit
+
+
+def _text_realtime_model() -> FakeRealtimeModel:
+    return FakeRealtimeModel(
+        capabilities=fake_capabilities(turn_detection=False, audio_output=False)
+    )
+
+
+class _FakeActivity(SimpleNamespace):
+    """The attribute surface the preemptive realtime paths touch, around a FakeRealtimeSession."""
+
+    def __init__(self, rt_session: FakeRealtimeSession) -> None:
+        authorization_allowed = asyncio.Event()
+        authorization_allowed.set()
+        user_silence = asyncio.Event()
+        user_silence.set()
+        generation_calls: list[dict[str, Any]] = []
+        conversation_items: list[llm.ChatMessage] = []
+
+        async def _realtime_generation_task(**kwargs: Any) -> None:
+            generation_calls.append(kwargs)
+
+        super().__init__(
+            _rt_session=rt_session,
+            _authorization_allowed=authorization_allowed,
+            _user_silence_event=user_silence,
+            tools=[],
+            _on_enter_ignored_tools=lambda tool_ctx: [],
+            _tool_choice=None,
+            _agent=SimpleNamespace(_chat_ctx=llm.ChatContext.empty()),
+            _session=SimpleNamespace(
+                _conversation_item_added=conversation_items.append,
+                _update_agent_state=lambda state: None,
+            ),
+            _realtime_generation_task=_realtime_generation_task,
+            generation_calls=generation_calls,
+            conversation_items=conversation_items,
+            _realtime_preemptive_cleanup=None,
+            _realtime_preemptive_remote_items=[],
+            _realtime_preemptive_user_item_ids=set(),
+        )
+        # bind the real helpers so the reply task exercises the actual gating logic
+        for name in (
+            "_wait_for_speech_authorization",
+            "_wait_for_realtime_session_idle",
+            "_wait_for_active_response_cleared",
+            "_rollback_preemptive_realtime_generation",
+            "_on_remote_item_added",
+        ):
+            setattr(self, name, MethodType(getattr(AgentActivity, name), self))
+        # route the fake session's server acks through the real mirroring handler
+        rt_session.on("remote_item_added", self._on_remote_item_added)
+        self._create_speech_task = lambda coro, speech_handle=None, name=None: asyncio.create_task(
+            coro, name=name
+        )
+
+
+def _run_preemptive_reply(
+    activity: _FakeActivity, speech_handle: SpeechHandle, *, content: str = "hello"
+) -> asyncio.Task[None]:
+    coro = AgentActivity._realtime_reply_task(
+        cast(AgentActivity, activity),
+        speech_handle=speech_handle,
+        model_settings=ModelSettings(),
+        user_message=ChatMessage(role="user", content=[content]),
+        preemptive=True,
+    )
+    return asyncio.create_task(coro)
+
+
+async def _wait_for_reply_fut(rt_session: FakeRealtimeSession) -> asyncio.Future:
+    while not rt_session._reply_futs:
+        await asyncio.sleep(0)
+    return rt_session._reply_futs[-1]
+
+
+def _fake_generation_ev() -> GenerationCreatedEvent:
+    message_ch = utils.aio.Chan[MessageGeneration]()
+    function_ch = utils.aio.Chan[FunctionCall]()
+    message_ch.close()
+    function_ch.close()
+    return GenerationCreatedEvent(
+        message_stream=message_ch, function_stream=function_ch, user_initiated=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# _realtime_reply_task, preemptive=True
+# ---------------------------------------------------------------------------
+
+
+async def test_preemptive_generates_before_authorization() -> None:
+    # the whole point of the preemptive path: the response is requested while the speech is
+    # NOT authorized, and nothing is committed to the local history yet
+    rt_session = _text_realtime_model().session()
+    activity = _FakeActivity(rt_session)
+    handle = SpeechHandle.create()
+
+    task = _run_preemptive_reply(activity, handle)
+    await _wait_for_reply_fut(rt_session)
+
+    assert rt_session.generate_reply_calls == 1
+    assert not handle._authorize_event.is_set()  # generation started without authorization
+    # the user message was pushed to the server context...
+    assert any(item.type == "message" and item.role == "user" for item in rt_session.chat_ctx.items)
+    # ...but not committed locally, and no conversation event was emitted
+    assert not activity._agent._chat_ctx.items
+    assert activity.conversation_items == []
+    assert activity.generation_calls == []
+
+    handle._cancel()
+    await task
+
+
+async def test_preemptive_adoption_commits_and_drives_generation() -> None:
+    # once authorized (the confirmed turn matched), the user message is committed and the
+    # buffered generation is handed to the native realtime generation task
+    rt_session = _text_realtime_model().session()
+    activity = _FakeActivity(rt_session)
+    handle = SpeechHandle.create()
+
+    task = _run_preemptive_reply(activity, handle)
+    fut = await _wait_for_reply_fut(rt_session)
+    fut.set_result(_fake_generation_ev())
+
+    handle._authorize_generation()
+    await task
+
+    assert rt_session.generate_reply_calls == 1
+    assert len(activity.generation_calls) == 1
+    # local history commit happened exactly once, at adoption time
+    user_items = [
+        item
+        for item in activity._agent._chat_ctx.items
+        if item.type == "message" and item.role == "user"
+    ]
+    assert len(user_items) == 1
+    assert activity.conversation_items == user_items
+    assert not handle.done()
+
+
+async def test_preemptive_rollback_cancels_and_restores() -> None:
+    # interrupted before authorization (superseded or invalidated): the pending generation is
+    # cancelled, the server context restored, and nothing leaks into the local history
+    import time
+
+    rt_session = _text_realtime_model().session()
+    activity = _FakeActivity(rt_session)
+    handle = SpeechHandle.create()
+
+    task = _run_preemptive_reply(activity, handle)
+    fut = await _wait_for_reply_fut(rt_session)
+
+    t0 = time.monotonic()
+    handle._cancel()
+    await task
+
+    # regression: the rollback must never wait on its own cleanup future (it used to burn a
+    # full 3s timeout on every rollback)
+    assert time.monotonic() - t0 < 1.0
+
+    assert fut.cancelled()  # the pending generation was cancelled
+    # the speculative user message was removed from the server context
+    assert not [
+        item for item in rt_session.chat_ctx.items if item.type == "message" and item.role == "user"
+    ]
+    assert not activity._agent._chat_ctx.items
+    assert activity.conversation_items == []
+    assert activity.generation_calls == []
+    # the cleanup future resolved so follow-up reply tasks can proceed
+    assert activity._realtime_preemptive_cleanup is not None
+    assert activity._realtime_preemptive_cleanup.done()
+
+
+async def test_preemptive_rollback_interrupts_created_response() -> None:
+    # if the speculative response was already created server-side, rollback must cancel it via
+    # interrupt() and wait for the server to release it before completing
+    rt_session = _text_realtime_model().session()
+    activity = _FakeActivity(rt_session)
+    handle = SpeechHandle.create()
+
+    task = _run_preemptive_reply(activity, handle)
+    fut = await _wait_for_reply_fut(rt_session)
+    fut.set_result(_fake_generation_ev())
+    rt_session.active_generation = True  # the response is streaming server-side
+
+    handle._cancel()
+    await asyncio.sleep(0.05)  # rollback is waiting for the response to clear
+    assert rt_session.interrupted
+    assert activity._realtime_preemptive_cleanup is not None
+    assert not activity._realtime_preemptive_cleanup.done()
+
+    rt_session.active_generation = False  # server acks the cancellation
+    await task
+    assert activity._realtime_preemptive_cleanup.done()
+
+
+async def test_preemptive_supersession_serializes_cleanup() -> None:
+    # a superseding speculation (the user paused, then kept talking) must wait for the previous
+    # rollback to fully restore the server context before snapshotting and pushing its own
+    # message -- otherwise the late restore deletes the new turn's message from the server
+    rt_session = _text_realtime_model().session()
+    activity = _FakeActivity(rt_session)
+
+    handle1 = SpeechHandle.create()
+    task1 = _run_preemptive_reply(activity, handle1, content="one")
+    await _wait_for_reply_fut(rt_session)
+
+    # supersede: cancel #1 and immediately start #2 (mirrors on_preemptive_generation)
+    handle1._cancel()
+    handle2 = SpeechHandle.create()
+    task2 = _run_preemptive_reply(activity, handle2, content="two")
+
+    # #2's generation must appear (after #1's rollback), then adopt it
+    while len(rt_session._reply_futs) < 2:
+        await asyncio.sleep(0)
+    rt_session._reply_futs[-1].set_result(_fake_generation_ev())
+    handle2._authorize_generation()
+    await task1
+    await task2
+
+    # the server context contains exactly the adopted turn's message: #1's rollback neither
+    # left its own message behind nor deleted #2's
+    user_texts = [
+        item.text_content
+        for item in rt_session.chat_ctx.items
+        if item.type == "message" and item.role == "user"
+    ]
+    assert user_texts == ["two"]
+    assert rt_session.generate_reply_calls == 2
+
+
+async def test_preemptive_generation_failure_falls_back() -> None:
+    # a speculative generate_reply rejected before adoption must mark the handle done (with the
+    # error) and wake the parked reply task so it rolls back -- the adoption check then falls
+    # back to a normal generation instead of scheduling a dead speech
+    rt_session = _text_realtime_model().session()
+    activity = _FakeActivity(rt_session)
+    handle = SpeechHandle.create()
+
+    task = _run_preemptive_reply(activity, handle)
+    fut = await _wait_for_reply_fut(rt_session)
+
+    fut.set_exception(llm.RealtimeError("conversation_already_has_active_response"))
+    await task  # the failure wakes the parked task, which rolls back
+
+    assert handle.done()
+    assert isinstance(handle.exception(), llm.RealtimeError)
+    # rollback restored the server context (the failed response was never created, so no
+    # interrupt was needed)
+    assert not [i for i in rt_session.chat_ctx.items if i.type == "message" and i.role == "user"]
+    assert not rt_session.interrupted
+    assert activity._realtime_preemptive_cleanup is not None
+    assert activity._realtime_preemptive_cleanup.done()
+
+
+async def test_reply_task_waits_for_speculation_cleanup() -> None:
+    # a non-preemptive reply (e.g. the fallback for the confirmed turn) must not generate while
+    # a speculation rollback is still cleaning up the session
+    rt_session = _text_realtime_model().session()
+    activity = _FakeActivity(rt_session)
+    cleanup_fut: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    activity._realtime_preemptive_cleanup = cleanup_fut
+
+    handle = SpeechHandle.create()
+    handle._authorize_generation()
+    task = asyncio.create_task(
+        AgentActivity._realtime_reply_task(
+            cast(AgentActivity, activity),
+            speech_handle=handle,
+            model_settings=ModelSettings(),
+            user_message=ChatMessage(role="user", content=["hello"]),
+        )
+    )
+
+    await asyncio.sleep(0.05)
+    assert rt_session.generate_reply_calls == 0  # still waiting on the cleanup
+
+    cleanup_fut.set_result(None)
+    fut = await _wait_for_reply_fut(rt_session)
+    fut.set_result(_fake_generation_ev())
+    await task
+    assert rt_session.generate_reply_calls == 1
+
+
+async def test_reply_task_waits_for_active_response_to_clear() -> None:
+    # single-active-response serialization: generation is deferred until the server releases
+    # the previous (e.g. just-interrupted) response
+    rt_session = _text_realtime_model().session()
+    rt_session.active_generation = True
+    activity = _FakeActivity(rt_session)
+
+    handle = SpeechHandle.create()
+    handle._authorize_generation()
+    task = asyncio.create_task(
+        AgentActivity._realtime_reply_task(
+            cast(AgentActivity, activity),
+            speech_handle=handle,
+            model_settings=ModelSettings(),
+            user_message=ChatMessage(role="user", content=["hello"]),
+        )
+    )
+
+    await asyncio.sleep(0.05)
+    assert rt_session.generate_reply_calls == 0
+
+    rt_session.active_generation = False
+    fut = await _wait_for_reply_fut(rt_session)
+    fut.set_result(_fake_generation_ev())
+    await task
+    assert rt_session.generate_reply_calls == 1
+
+
+async def test_mirror_hold_buffers_and_replays_on_adoption() -> None:
+    # server acks for the speculation's items (the pushed user message, the response output)
+    # must not reach the local history mid-speculation -- they'd mutate the chat context and
+    # invalidate the preemptive match; on adoption they're replayed with id-dedup
+    rt_session = _text_realtime_model().session()
+    activity = _FakeActivity(rt_session)
+    handle = SpeechHandle.create()
+
+    task = _run_preemptive_reply(activity, handle)
+    fut = await _wait_for_reply_fut(rt_session)  # the push has been acked by now
+    rt_session.emit_remote_item(ChatMessage(role="assistant", content=["spec reply"]))
+
+    # nothing reached the local history while the speculation is unresolved
+    assert activity._agent._chat_ctx.items == []
+    assert len(activity._realtime_preemptive_remote_items) == 2  # user ack + response item
+
+    fut.set_result(_fake_generation_ev())
+    handle._authorize_generation()
+    await task
+
+    roles = [i.role for i in activity._agent._chat_ctx.items if i.type == "message"]
+    assert roles == ["user", "assistant"]  # exactly one of each: replay dedupes by id
+    assert activity._realtime_preemptive_remote_items == []
+    assert activity._realtime_preemptive_user_item_ids == set()
+
+
+async def test_mirror_hold_rollback_removes_buffered_items() -> None:
+    # on rollback, the held items are removed server-side and never reach the local history
+    rt_session = _text_realtime_model().session()
+    activity = _FakeActivity(rt_session)
+    handle = SpeechHandle.create()
+
+    task = _run_preemptive_reply(activity, handle)
+    await _wait_for_reply_fut(rt_session)
+    rt_session.emit_remote_item(ChatMessage(role="assistant", content=["spec reply"]))
+
+    handle._cancel()
+    await task
+
+    assert activity._agent._chat_ctx.items == []
+    assert rt_session.chat_ctx.items == []  # user push and response item both removed
+    assert activity._realtime_preemptive_remote_items == []
+    assert activity._realtime_preemptive_user_item_ids == set()
+
+
+async def test_mirror_hold_passes_unrelated_user_items() -> None:
+    # user items not owned by the speculation (e.g. the committed turn audio) apply normally
+    rt_session = _text_realtime_model().session()
+    activity = _FakeActivity(rt_session)
+    handle = SpeechHandle.create()
+
+    task = _run_preemptive_reply(activity, handle)
+    await _wait_for_reply_fut(rt_session)
+    rt_session.emit_remote_item(ChatMessage(role="user", content=["committed audio turn"]))
+
+    local_users = [
+        i.text_content
+        for i in activity._agent._chat_ctx.items
+        if i.type == "message" and i.role == "user"
+    ]
+    assert local_users == ["committed audio turn"]
+
+    handle._cancel()
+    await task
+    # the rollback must not have removed the unrelated user item from the server context
+    assert [
+        i.text_content
+        for i in rt_session.chat_ctx.items
+        if i.type == "message" and i.role == "user"
+    ] == ["committed audio turn"]
+
+
+async def test_mirror_applies_normally_without_speculation() -> None:
+    rt_session = _text_realtime_model().session()
+    activity = _FakeActivity(rt_session)
+
+    rt_session.emit_remote_item(ChatMessage(role="assistant", content=["hi"]))
+
+    assert [i.role for i in activity._agent._chat_ctx.items] == ["assistant"]
+    assert activity._realtime_preemptive_remote_items == []
+
+
+async def test_speculation_ttl_rolls_back_stranded_speculation(monkeypatch) -> None:
+    # a speculation is only resolved by a subsequent event; if none ever arrives (the user
+    # vanished mid-utterance), the TTL cancels it so the cleanup future can't tax every later
+    # reply with its wait timeout
+    from livekit.agents.voice import agent_activity as activity_mod
+
+    monkeypatch.setattr(activity_mod, "PREEMPTIVE_GENERATION_TTL", 0.2)
+
+    rt_session = _text_realtime_model().session()
+    activity = _FakeActivity(rt_session)
+    handle = SpeechHandle.create()
+
+    task = _run_preemptive_reply(activity, handle)
+    fut = await _wait_for_reply_fut(rt_session)
+
+    # no adoption, no cancellation: the TTL must resolve it
+    await asyncio.wait_for(task, timeout=2.0)
+
+    assert fut.cancelled()
+    assert activity._realtime_preemptive_cleanup is not None
+    assert activity._realtime_preemptive_cleanup.done()
+    assert not [i for i in rt_session.chat_ctx.items if i.type == "message" and i.role == "user"]
+
+
+# ---------------------------------------------------------------------------
+# on_preemptive_generation eligibility
+# ---------------------------------------------------------------------------
+
+
+class _FakePreemptiveActivity(SimpleNamespace):
+    """The attribute surface on_preemptive_generation touches."""
+
+    def __init__(self, llm_obj: Any, rt_session: FakeRealtimeSession | None) -> None:
+        generate_reply_calls: list[dict[str, Any]] = []
+
+        def _generate_reply(**kwargs: Any) -> SpeechHandle:
+            generate_reply_calls.append(kwargs)
+            return SpeechHandle.create()
+
+        super().__init__(
+            llm=llm_obj,
+            _rt_session=rt_session,
+            preemptive_generation_opts={
+                "enabled": True,
+                "max_speech_duration": 10.0,
+                "max_retries": 3,
+            },
+            _scheduling_paused=False,
+            _new_turns_blocked=False,
+            _current_speech=None,
+            _preemptive_generation=None,
+            _preemptive_generation_count=0,
+            _agent=SimpleNamespace(chat_ctx=llm.ChatContext.empty()),
+            tools=[],
+            _tool_choice=None,
+            _generate_reply=_generate_reply,
+            generate_reply_calls=generate_reply_calls,
+            _cancel_preemptive_generation=lambda: None,
+        )
+        self._can_preemptively_generate = MethodType(AgentActivity._can_preemptively_generate, self)
+        self.on_preemptive_generation = MethodType(AgentActivity.on_preemptive_generation, self)
+
+
+def _preemptive_info(transcript: str = "hello") -> _PreemptiveGenerationInfo:
+    return _PreemptiveGenerationInfo(
+        new_transcript=transcript, transcript_confidence=1.0, started_speaking_at=None
+    )
+
+
+async def test_on_preemptive_generation_starts_for_text_realtime() -> None:
+    model = _text_realtime_model()
+    rt_session = model.session()
+    activity = _FakePreemptiveActivity(model, rt_session)
+
+    activity.on_preemptive_generation(_preemptive_info())
+
+    assert len(activity.generate_reply_calls) == 1
+    call = activity.generate_reply_calls[0]
+    assert call["schedule_speech"] is False
+    assert call["preemptive"] is True
+    assert activity._preemptive_generation is not None
+
+
+async def test_on_preemptive_generation_skips_server_turn_detection() -> None:
+    model = FakeRealtimeModel(capabilities=fake_capabilities(turn_detection=True))
+    rt_session = model.session()
+    activity = _FakePreemptiveActivity(model, rt_session)
+
+    activity.on_preemptive_generation(_preemptive_info())
+
+    assert activity.generate_reply_calls == []
+    assert activity._preemptive_generation is None
+
+
+async def test_on_preemptive_generation_skips_active_response() -> None:
+    # the realtime API allows a single active response: never speculate while one is in flight
+    # (e.g. the opening greeting the user talked over)
+    model = _text_realtime_model()
+    rt_session = model.session()
+    rt_session.active_generation = True
+    activity = _FakePreemptiveActivity(model, rt_session)
+
+    activity.on_preemptive_generation(_preemptive_info())
+
+    assert activity.generate_reply_calls == []
+    assert activity._preemptive_generation is None
+
+
+async def test_on_preemptive_generation_requires_rt_session() -> None:
+    model = _text_realtime_model()
+    activity = _FakePreemptiveActivity(model, None)
+
+    activity.on_preemptive_generation(_preemptive_info())
+
+    assert activity.generate_reply_calls == []
+    assert activity._preemptive_generation is None
+
+
+# ---------------------------------------------------------------------------
+# full AgentSession integration
+# ---------------------------------------------------------------------------
+
+
+def _make_realtime_agent_session() -> tuple[AgentSession, FakeRealtimeModel]:
+    from .fake_io import FakeAudioInput, FakeAudioOutput, FakeTextOutput
+    from .fake_stt import FakeSTT, FakeUserSpeech
+    from .fake_tts import FakeTTS, FakeTTSResponse
+    from .fake_vad import FakeVAD
+
+    speeches = [
+        FakeUserSpeech(start_time=0.5, end_time=1.5, transcript="hello there", stt_delay=0.1)
+    ]
+    model = _text_realtime_model()
+    session = AgentSession(
+        llm=model,
+        stt=FakeSTT(fake_user_speeches=speeches),
+        vad=FakeVAD(
+            fake_user_speeches=speeches, min_silence_duration=0.5, min_speech_duration=0.05
+        ),
+        tts=FakeTTS(
+            fake_responses=[
+                FakeTTSResponse(audio_duration=1.0, input="Hi!", ttfb=0.1, duration=0.2),
+                FakeTTSResponse(audio_duration=1.0, input="Hi!", ttfb=0.1, duration=0.2),
+            ]
+        ),
+        turn_handling={
+            "turn_detection": "vad",
+            "endpointing": {"min_delay": 0.5, "max_delay": 6.0},
+            "interruption": {"min_duration": 0.5, "false_interruption_timeout": 2.0},
+        },
+        aec_warmup_duration=None,
+    )
+    session.input.audio = FakeAudioInput()
+    session.output.audio = FakeAudioOutput()
+    session.output.transcription = FakeTextOutput()
+    return session, model
+
+
+def _streamed_generation(text: str) -> GenerationCreatedEvent:
+    message_ch = utils.aio.Chan[MessageGeneration]()
+    function_ch = utils.aio.Chan[FunctionCall]()
+    text_ch = utils.aio.Chan[str]()
+    audio_ch = utils.aio.Chan["Any"]()
+    modalities_fut: asyncio.Future = asyncio.get_event_loop().create_future()
+    modalities_fut.set_result(["text"])
+    message_ch.send_nowait(
+        MessageGeneration(
+            message_id=utils.shortuuid("item_"),
+            text_stream=text_ch,
+            audio_stream=audio_ch,
+            modalities=modalities_fut,
+        )
+    )
+    text_ch.send_nowait(text)
+    text_ch.close()
+    audio_ch.close()
+    message_ch.close()
+    function_ch.close()
+    return GenerationCreatedEvent(
+        message_stream=message_ch, function_stream=function_ch, user_initiated=True
+    )
+
+
+async def _run_realtime_session(
+    session: AgentSession,
+    model: FakeRealtimeModel,
+    agent: Agent,
+    reply_times: list[float],
+) -> None:
+    """Run the session while resolving every generate_reply with a scripted generation."""
+    import time as time_mod
+
+    from .fake_io import FakeAudioInput
+    from .fake_stt import FakeSTT
+
+    await session.start(agent)
+
+    rt_session = model.active_session
+    resolved: set[asyncio.Future] = set()
+
+    async def _reply_watcher() -> None:
+        while True:
+            for fut in rt_session._reply_futs:
+                if fut not in resolved:
+                    resolved.add(fut)
+                    reply_times.append(time_mod.time())
+
+                    def _resolve(f: asyncio.Future = fut) -> None:
+                        if not f.done():
+                            f.set_result(_streamed_generation("Hi!"))
+
+                    # small delay to mimic the server's response.created latency
+                    asyncio.get_event_loop().call_later(0.15, _resolve)
+            await asyncio.sleep(0.01)
+
+    watcher = asyncio.create_task(_reply_watcher())
+    try:
+        stt = session.stt
+        audio_input = session.input.audio
+        assert isinstance(stt, FakeSTT)
+        assert isinstance(audio_input, FakeAudioInput)
+        audio_input.push(0.1)
+        await stt.fake_user_speeches_done
+        await asyncio.sleep(4.0)
+    finally:
+        watcher.cancel()
+        await asyncio.gather(watcher, return_exceptions=True)
+        import contextlib
+
+        with contextlib.suppress(RuntimeError):
+            await session.drain()
+        await session.aclose()
+
+
+async def test_realtime_preemptive_adoption_e2e() -> None:
+    # full turn: the speculative generation starts on the transcript (before end of turn) and,
+    # since nothing changes, it is adopted -- exactly one generate_reply for the whole turn
+
+    session, model = _make_realtime_agent_session()
+
+    reply_times: list[float] = []
+    agent = Agent(instructions="You are a helpful assistant.")
+    await _run_realtime_session(session, model, agent, reply_times)
+
+    rt_session = model.active_session
+    assert rt_session.generate_reply_calls == 1  # speculation adopted; no second generation
+
+    # the speculative generation was requested before the turn was committed: the speculation
+    # starts at the final transcript (~speech end + stt delay) while the turn commits at
+    # end-of-turn (~speech end + VAD silence + endpointing delay), marked by clear_audio()
+    assert len(reply_times) == 1
+    assert rt_session.audio_cleared_at is not None
+    assert reply_times[0] < rt_session.audio_cleared_at
+
+    # the user turn was committed exactly once, and the assistant reply made it to the history
+    history = agent.chat_ctx.items
+    user_msgs = [i for i in history if i.type == "message" and i.role == "user"]
+    assistant_msgs = [i for i in history if i.type == "message" and i.role == "assistant"]
+    assert len(user_msgs) == 1
+    assert user_msgs[0].text_content == "hello there"
+    assert len(assistant_msgs) == 1
+    assert assistant_msgs[0].text_content == "Hi!"
+
+    # adopted: the buffered turn audio was dropped, not committed (the reply came from the
+    # pushed transcript)
+    assert rt_session.audio_cleared
+    assert not rt_session.committed
+
+
+async def test_realtime_preemptive_invalidation_falls_back_e2e() -> None:
+    # on_user_turn_completed edits the transcript, invalidating the speculation: the speculative
+    # response is rolled back and a normal generation follows (two generate_reply calls total)
+
+    session, model = _make_realtime_agent_session()
+
+    class EditingAgent(Agent):
+        async def on_user_turn_completed(self, turn_ctx: llm.ChatContext, new_message) -> None:
+            new_message.content = ["hello there, edited"]
+
+    reply_times: list[float] = []
+    agent = EditingAgent(instructions="You are a helpful assistant.")
+    await _run_realtime_session(session, model, agent, reply_times)
+
+    rt_session = model.active_session
+    # speculation + fallback
+    assert rt_session.generate_reply_calls == 2
+    # invalidated: the real turn audio was committed for the fallback generation
+    assert rt_session.committed
+    # the rolled-back speculative user message was removed from the server context (the realtime
+    # fallback generates from the committed audio, so no user text message remains)
+    stale_user_msgs = [
+        i for i in rt_session.chat_ctx.items if i.type == "message" and i.role == "user"
+    ]
+    assert stale_user_msgs == []
+    # the fallback reply still made it to the history
+    assistant_msgs = [
+        i for i in agent.chat_ctx.items if i.type == "message" and i.role == "assistant"
+    ]
+    assert len(assistant_msgs) == 1
+
+
+async def test_realtime_preemptive_skip_reply_cancels_speculation_e2e() -> None:
+    # commit_user_turn() forces skip_reply for realtime sessions: a pending speculation must be
+    # cancelled and rolled back. Previously the realtime skip_reply branch returned early and
+    # left the speculative reply task parked forever -- the cleanup future never resolved
+    # (blocking every later reply on its timeout) and the speculative response kept the
+    # single-active-response slot occupied.
+    import contextlib
+
+    from livekit.agents.voice.audio_recognition import _EndOfTurnInfo, _EndOfTurnMetrics
+
+    from .fake_io import FakeAudioInput
+
+    session, model = _make_realtime_agent_session()
+    agent = Agent(instructions="Answer in one short sentence.")
+    await session.start(agent)
+
+    audio_input = session.input.audio
+    assert isinstance(audio_input, FakeAudioInput)
+    audio_input.push(0.1)  # kick off the scripted fake STT/VAD timeline
+
+    rt_session = model.active_session
+    loop = asyncio.get_event_loop()
+
+    # wait for the speculation to start (preemptive fires on the scripted final transcript)
+    deadline = loop.time() + 5.0
+    while not rt_session._reply_futs:
+        assert loop.time() < deadline, "speculation never started"
+        await asyncio.sleep(0.01)
+    spec_fut = rt_session._reply_futs[0]
+
+    activity = session._activity
+    assert activity is not None
+    assert activity._preemptive_generation is not None
+
+    # the skip_reply end-of-turn (what commit_user_turn produces for realtime)
+    info = _EndOfTurnInfo(
+        skip_reply=True,
+        new_transcript="hello there",
+        transcript_confidence=1.0,
+        metrics=_EndOfTurnMetrics(None, None, None, None),
+    )
+    assert activity.on_end_of_turn(info) is True
+
+    cleanup = activity._realtime_preemptive_cleanup
+    assert cleanup is not None
+    # the cancelled speculation's rollback must resolve the cleanup future promptly
+    await asyncio.wait_for(asyncio.shield(cleanup), timeout=2.0)
+
+    assert activity._preemptive_generation is None
+    assert spec_fut.cancelled()
+    # the rollback removed the speculative user message from the server context
+    assert not [i for i in rt_session.chat_ctx.items if i.type == "message" and i.role == "user"]
+
+    # resolve any follow-up generation (the natural VAD end-of-turn) so teardown is clean
+    await asyncio.sleep(1.0)
+    for fut in rt_session._reply_futs:
+        if not fut.done():
+            fut.set_result(_fake_generation_ev())
+    with contextlib.suppress(Exception):
+        await asyncio.wait_for(session.aclose(), timeout=10.0)
+
+
+async def test_realtime_preemptive_pause_cancels_parked_speculation_e2e() -> None:
+    # pause() (the AgentTask handoff path) must cancel a parked speculation like drain() does;
+    # previously it waited forever on the never-authorized speculative speech task, hanging the
+    # handoff (and any session close queued behind it)
+    import contextlib
+
+    from .fake_io import FakeAudioInput
+
+    session, model = _make_realtime_agent_session()
+    agent = Agent(instructions="Answer in one short sentence.")
+    await session.start(agent)
+
+    audio_input = session.input.audio
+    assert isinstance(audio_input, FakeAudioInput)
+    audio_input.push(0.1)
+
+    rt_session = model.active_session
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + 5.0
+    while not rt_session._reply_futs:
+        assert loop.time() < deadline, "speculation never started"
+        await asyncio.sleep(0.01)
+
+    activity = session._activity
+    assert activity is not None
+    assert activity._preemptive_generation is not None
+
+    reusable = await asyncio.wait_for(activity.pause(blocked_tasks=[]), timeout=5.0)
+
+    assert activity._preemptive_generation is None
+    cleanup = activity._realtime_preemptive_cleanup
+    assert cleanup is not None and cleanup.done()
+
+    # restore the activity so the session can tear down normally, resolving any follow-up
+    # generation (the natural end-of-turn) so drain doesn't wait on it
+    await activity.resume(reuse_resources=reusable)
+    await asyncio.sleep(1.0)
+    for fut in rt_session._reply_futs:
+        if not fut.done():
+            fut.set_result(_fake_generation_ev())
+    with contextlib.suppress(Exception):
+        await asyncio.wait_for(session.aclose(), timeout=10.0)
+
+
+async def test_realtime_preemptive_stop_response_commits_audio_e2e() -> None:
+    # StopResponse from on_user_turn_completed ignores the turn while a speculation is pending:
+    # the deferred audio commit must still resolve (commit, matching the non-preemptive
+    # behavior) so the buffered audio can't leak into a later turn's commit, and the stale
+    # speculation is dropped and rolled back
+    from livekit.agents.llm import StopResponse
+
+    session, model = _make_realtime_agent_session()
+
+    class StoppingAgent(Agent):
+        async def on_user_turn_completed(self, turn_ctx: llm.ChatContext, new_message) -> None:
+            raise StopResponse()
+
+    reply_times: list[float] = []
+    agent = StoppingAgent(instructions="You are a helpful assistant.")
+    await _run_realtime_session(session, model, agent, reply_times)
+
+    rt_session = model.active_session
+    # only the speculative generation ran; the ignored turn produced no fallback
+    assert rt_session.generate_reply_calls == 1
+    # the deferred audio commit resolved
+    assert rt_session.committed
+    # the speculation was rolled back: no user text message left in the server context
+    assert not [i for i in rt_session.chat_ctx.items if i.type == "message" and i.role == "user"]
+    # and no assistant reply was produced
+    assert not [i for i in agent.chat_ctx.items if i.type == "message" and i.role == "assistant"]

--- a/tests/test_realtime_reply_chat_ctx.py
+++ b/tests/test_realtime_reply_chat_ctx.py
@@ -11,7 +11,7 @@ error (observable via SpeechHandle.exception()) without crashing the turn task.
 from __future__ import annotations
 
 import asyncio
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -53,15 +53,37 @@ class _FakeActivity(SimpleNamespace):
             ),
             _realtime_generation_task=_realtime_generation_task,
             generation_calls=generation_calls,
+            _realtime_preemptive_cleanup=None,
+            _realtime_preemptive_remote_items=[],
+            _realtime_preemptive_user_item_ids=set(),
+        )
+        # bind the real gating helpers so the reply task exercises the actual logic
+        self._wait_for_speech_authorization = MethodType(
+            AgentActivity._wait_for_speech_authorization, self
+        )
+        self._wait_for_realtime_session_idle = MethodType(
+            AgentActivity._wait_for_realtime_session_idle, self
+        )
+        self._wait_for_active_response_cleared = MethodType(
+            AgentActivity._wait_for_active_response_cleared, self
+        )
+        self._rollback_preemptive_realtime_generation = MethodType(
+            AgentActivity._rollback_preemptive_realtime_generation, self
+        )
+        self._create_speech_task = lambda coro, speech_handle=None, name=None: asyncio.create_task(
+            coro, name=name
         )
 
 
-def _run_reply_task(activity: _FakeActivity, speech_handle: SpeechHandle) -> asyncio.Task[None]:
+def _run_reply_task(
+    activity: _FakeActivity, speech_handle: SpeechHandle, *, preemptive: bool = False
+) -> asyncio.Task[None]:
     coro = AgentActivity._realtime_reply_task(
         cast(AgentActivity, activity),
         speech_handle=speech_handle,
         model_settings=ModelSettings(),
-        user_input="hello",
+        user_message=llm.ChatMessage(role="user", content=["hello"]),
+        preemptive=preemptive,
     )
     return asyncio.create_task(coro)
 


### PR DESCRIPTION
## Motivation

Preemptive generation (starting the reply on the eager transcript, before the turn is confirmed) currently only fires for cascaded `llm.LLM` pipelines — `on_preemptive_generation` early-returns for any `RealtimeModel`. Pipelines that pair a text-mode realtime model with an STT that emits eager end-of-turn transcripts (e.g. Cartesia Ink-2's `PREFLIGHT_TRANSCRIPT`) can't get the same head start, even though everything downstream of the guard (the `_PreemptiveGeneration` fingerprint/adoption lifecycle, and `_realtime_generation_task`'s authorization-gated playout) already supports it.

The reason a naive guard-lift isn't enough: `_realtime_reply_task` waits for authorization *before* issuing `rt_session.generate_reply`, so an unscheduled preemptive speech would only start generating at adoption time — no head start. And unlike cascaded speculation (a stateless local task), a realtime speculation mutates remote state: a pushed conversation item and, on single-active-response APIs, the session's one response slot — so it needs a real rollback story.

## What this PR does

- **Eligibility**: `on_preemptive_generation` now accepts realtime models via `_can_preemptively_generate()`: requires `mutable_chat_context`, no server-side turn detection, text-only output (the speculative reply is generated from the pushed transcript, keeping the turn's input modality consistent), a live `rt_session`, and no active response.
- **Eager generation**: `_realtime_reply_task` gains a `preemptive` mode that pushes the transcript into the session context and issues `generate_reply()` *before* the authorization gate; playout and the local history commit stay gated on authorization (adoption). On adoption, the existing fingerprint match in `_user_turn_completed_task` schedules the held speech and the already-streaming generation plays through the native `_realtime_generation_task` path.
- **Exit-path-total rollback**: the speculation publishes a cleanup future before touching the session (chained behind any previous speculation's cleanup), and every exit other than adoption cancels the speculative response, waits for the server to release it, and restores the pre-speculation chat context. Follow-up generations wait on the cleanup future so they can never run against a dirty session. A speculative `generate_reply` that fails before adoption wakes the parked task and marks the handle done, so adoption falls back to a normal generation.
- **`RealtimeSession.has_active_generation`** (new ABC property, default `False`; the OpenAI plugin already implements it, and the realtime fallback adapter proxies it): lets the framework serialize response creation. Realtime replies — including tool replies and post-barge-in generations — now wait for a cancelled response to clear before creating the next one, avoiding `conversation_already_has_active_response` rejections.
- **Turn-commit fixes in `_user_turn_completed_task`**: the final transcript is captured for the preemptive match before the realtime branch nulls `user_message` (previously this path would have crashed reading `user_message.raw_text_content`); `commit_audio()` is deferred while a speculation is pending (`clear_audio()` on adoption, `commit_audio()` on invalidation or any early exit such as `StopResponse`, via a try/finally so buffered audio can never leak into a later turn's commit); the barge-in cleanup no longer interrupts the in-flight speculative response, and a turn arriving with `skip_reply` (e.g. `commit_user_turn()`) cancels the pending speculation instead of stranding it.
- `_realtime_reply_task` now receives the user message as `llm.ChatMessage` (resolving the existing TODO), so metrics injected at adoption land on the committed message.

## Testing

- 22 new tests in `tests/test_realtime_preemptive.py`: eager-generate-before-authorization, adoption commit + native generation, rollback of pending and already-created responses (with a duration regression bound), supersession serialization, pre-adoption generation failure fallback, follow-up serialization, eligibility gating, the remote-item mirroring hold-back (buffered + replayed on adoption, removed on rollback, pass-through for unrelated items), the speculation TTL, and five full-`AgentSession` e2e tests (adoption with a verified head start, invalidation via an `on_user_turn_completed` edit, `StopResponse` with the deferred audio commit resolved, `skip_reply`/`commit_user_turn` cancelling a pending speculation, and `pause()` completing with a parked speculation). `FakeRealtimeSession` now emits `remote_item_added` acks so the mirroring machinery is covered by the fakes.
- Existing suites green: `test_agent_session.py` (incl. cascaded preemptive latency tests), `test_realtime_reply_chat_ctx.py` (updated for the `ChatMessage` signature), `test_realtime_fallback.py`, `test_realtime_message_metrics.py`, `test_realtime_adaptive_interruption.py`, `test_session_host.py`, `test_remote_session.py` — 168 tests total. `ruff` and `mypy` clean on the changed files.

## Notes / possible follow-ups

- The bounded poll in `_wait_for_active_response_cleared` could become an awaitable on the `RealtimeSession` ABC if you'd prefer event-based signaling; the poll was chosen because it's self-healing across session reconnects (no waiter lifecycle to manage in every plugin).
- Audio-output realtime models are excluded from speculation for now (input-modality consistency); could be relaxed later.
- The adoption guard now also skips a preemptive speech handle that already failed (`speech_handle.done()`), which for cascaded pipelines means a failed preemptive inference falls back to a normal generation instead of scheduling a dead speech — intentional, previously the turn went silent.
- An optional normalized transcript match (case/punctuation-insensitive) would increase adoption rates for eager-EOT STTs whose preflight and final transcripts differ only in punctuation; kept exact-match here to preserve existing semantics.

Made with [Cursor](https://cursor.com)

## Live verification (real providers)

Verified end-to-end with **Cartesia Ink-2** (via LiveKit Inference, `turn_detection="stt"`) + **OpenAI Realtime `gpt-realtime-1.5`** (text-only) on a room-less `AgentSession`, streaming synthesized user speech at real-time pace:

- **Head start**: the speculative `generate_reply` launches on Ink-2's eager transcript ~0.10-0.14s after the user stops speaking (sometimes before), while the turn only commits at ~0.59s — a consistent **~460-490ms head start** across runs, all adopted (single generation per turn, `clear_audio`, correct reply, identical local/server history).
- **Baseline (preemptive disabled)**: `generate_reply` launches within 1ms *after* the turn commit, as expected.
- **End-to-end**: agent speech started a median **~0.52s sooner** after end-of-user-speech with preemptive generation enabled (0.74s vs 1.26s median across runs; TTS held constant).
- **Rollback**: forcing invalidation via an `on_user_turn_completed` edit produced the full rollback + fallback live: speculative response cancelled, its items removed server-side, the committed turn audio preserved, and the fallback generation answered the original question correctly.
- **Barge-in + speculation**: a mid-utterance pause produced two consecutive turns where the second speculation launched while the first reply was being interrupted — no `conversation_already_has_active_response` collisions (the serialization path).

Live testing also caught two integration issues the fake-based tests couldn't, now fixed in this PR: the plugin's `remote_item_added` mirroring placed speculative items into the local history mid-turn (invalidating the preemptive match on every real turn), so mirroring of speculation-owned items is held back until adoption; and the rollback now removes exactly the speculation's items from the live context instead of restoring a snapshot, so concurrent state (e.g. the committed turn audio) survives.



**Note on supersession coverage**: supersession (a second eager transcript superseding an in-flight speculation) could not be triggered against real providers — Ink-2's eager and final end-of-turn signals arrive ~0.5s apart, and `_can_preemptively_generate()` intentionally declines to re-speculate while the previous speculative response is still active (the stale speculation is then invalidated by the fingerprint at turn end: safe, just no head start). The rollback-chaining behavior is covered at the unit level (`test_preemptive_supersession_serializes_cleanup`).
