### PR TITLE
feat(telemetry): include agent_name as an OTLP resource attribute

### DIFF
--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -780,6 +780,7 @@ class JobContext:
         _setup_cloud_tracer(
             room_id=self.job.room.sid,
             job_id=self.job.id,
+            agent_name=self.job.agent_name,
             observability_url=obs_url,
             enable_traces=options["traces"],
             enable_logs=options["logs"],

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -236,6 +236,7 @@ def _setup_cloud_tracer(
     *,
     room_id: str,
     job_id: str,
+    agent_name: str = "",
     observability_url: str,
     enable_traces: bool = True,
     enable_logs: bool = True,
@@ -278,7 +279,15 @@ def _setup_cloud_tracer(
     if metadata:
         session_metadata.update(metadata)
 
-    resource = Resource.create({SERVICE_NAME: "livekit-agents", **base_metadata})
+    resource_attributes: dict[str, AttributeValue] = {
+        SERVICE_NAME: "livekit-agents",
+        **base_metadata,
+    }
+    if agent_name:
+        # identifies the agent for LiveKit Cloud agent insights (explicit dispatch
+        # only; the default dispatch has no agent name)
+        resource_attributes[trace_types.ATTR_AGENT_NAME] = agent_name
+    resource = Resource.create(resource_attributes)
 
     if enable_traces:
         # Check if a tracer provider is not set and set one up

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -275,19 +275,16 @@ def _setup_cloud_tracer(
     session = _AuthRefreshingSession(header_provider)
     otlp_compression = Compression.Gzip
     base_metadata: dict[str, AttributeValue] = {"room_id": room_id, "job_id": job_id}
+    if agent_name:
+        # identifies the agent for LiveKit Cloud agent insights (explicit dispatch
+        # only; the default dispatch has no agent name). Included in both the
+        # resource (traces) and the session metadata (spans + logs).
+        base_metadata[trace_types.ATTR_AGENT_NAME] = agent_name
     session_metadata = dict(base_metadata)
     if metadata:
         session_metadata.update(metadata)
 
-    resource_attributes: dict[str, AttributeValue] = {
-        SERVICE_NAME: "livekit-agents",
-        **base_metadata,
-    }
-    if agent_name:
-        # identifies the agent for LiveKit Cloud agent insights (explicit dispatch
-        # only; the default dispatch has no agent name)
-        resource_attributes[trace_types.ATTR_AGENT_NAME] = agent_name
-    resource = Resource.create(resource_attributes)
+    resource = Resource.create({SERVICE_NAME: "livekit-agents", **base_metadata})
 
     if enable_traces:
         # Check if a tracer provider is not set and set one up


### PR DESCRIPTION
Stamp lk.agent_name onto the telemetry resource when the job carries an agent name (explicit dispatch), so LiveKit Cloud agent insights can attribute per-agent metrics for self-hosted workers. Hosted agents also receive identity attrs via OTEL_RESOURCE_ATTRIBUTES; attributes passed to Resource.create() take precedence over the env var, and both sources derive the name from the same WorkerOptions value.

Confirmed working with session: https://cloud.livekit.io/projects/p_5zxtbufktnq/sessions/RM_NDwUfhhxaCGh