### PR TITLE
fix(livekit-agents): require livekit-protocol>=1.1.21 for MetricsRecordingHeader.simulated

### DIFF
--- a/livekit-agents/pyproject.toml
+++ b/livekit-agents/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "livekit==1.1.13",
     "livekit-api>=1.2.0,<2",
     "livekit-local-inference>=0.2.6",
-    "livekit-protocol>=1.1.19,<2",
+    "livekit-protocol>=1.1.21,<2",
     "livekit-blingfire~=1.1,<2",
     "protobuf>=3",
     "pyjwt>=2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2103,7 +2103,7 @@ requires-dist = [
     { name = "livekit-plugins-ultravox", marker = "extra == 'ultravox'", editable = "livekit-plugins/livekit-plugins-ultravox" },
     { name = "livekit-plugins-upliftai", marker = "extra == 'upliftai'", editable = "livekit-plugins/livekit-plugins-upliftai" },
     { name = "livekit-plugins-xai", marker = "extra == 'xai'", editable = "livekit-plugins/livekit-plugins-xai" },
-    { name = "livekit-protocol", specifier = ">=1.1.19,<2" },
+    { name = "livekit-protocol", specifier = ">=1.1.21,<2" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.24.0,<2" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "numpy", specifier = ">=1.26.0" },


### PR DESCRIPTION
## Why

livekit/agents#6497 added simulation/redaction telemetry tagging: `telemetry/traces.py` now builds `MetricsRecordingHeader(..., simulated=..., redaction_enabled=...)` in the session-report upload. But it left the dependency floor at `livekit-protocol>=1.1.19,<2`, and those proto fields were only added in **`livekit-protocol` 1.1.21** (proto side of livekit/protocol#1679; Go equivalent shipped in `v1.50.4`).

As a result, any install that resolves `livekit-protocol` to the floor (1.1.19 or 1.1.20 — non-locked installs, e.g. `pip install livekit-agents`) crashes on every session-report upload:

```
ValueError: Protocol message MetricsRecordingHeader has no "simulated" field
  at telemetry/traces.py in _upload_session_report
```

Because the upload fails, the recorded `chat_history` is never stored, which in turn makes the simulation summarizer 404-loop fetching it.

## What

- Bump the `livekit-protocol` floor to `>=1.1.21,<2` — the first release that defines `MetricsRecordingHeader.simulated` / `redaction_enabled` — so the declared dependency actually guarantees the fields #6497 writes.
- Re-lock (`uv lock`): the resolved version was already 1.1.21, so this is a one-line specifier update with no package churn.

## Verified

With `livekit-protocol==1.1.21` installed, a `lk agent simulate` run uploads the session report cleanly (`uploading session report` → `finished uploading`) and the exported run JSON retains full `function_call.arguments` and `function_call_output.output` (redaction is skipped for simulation sessions).