### PR TITLE
fix(llm): handle TypedDict required and optional fields in response format

### DIFF
--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -256,7 +256,54 @@ ResponseFormatT = TypeVar("ResponseFormatT", default=None)
 
 
 def is_typed_dict(cls: type | Any) -> bool:
-    return isinstance(cls, type) and issubclass(cls, dict) and hasattr(cls, "__annotations__")
+    if not isinstance(cls, type):
+        return False
+    from typing_extensions import is_typeddict
+
+    return is_typeddict(cls) or (issubclass(cls, dict) and hasattr(cls, "__annotations__"))
+
+
+def _clean_type_annotation(ann: Any) -> Any:
+    if ann is None:
+        return ann
+    origin = get_origin(ann)
+    if origin is not None and (
+        getattr(origin, "__name__", "") in ("Required", "NotRequired")
+        or str(origin).endswith(("Required", "NotRequired"))
+    ):
+        args = get_args(ann)
+        if args:
+            return _clean_type_annotation(args[0])
+    if getattr(ann, "__name__", "") in ("Required", "NotRequired") or str(ann).endswith(
+        ("Required", "NotRequired")
+    ):
+        args = get_args(ann)
+        if args:
+            return _clean_type_annotation(args[0])
+    return ann
+
+
+def _is_typed_dict_field_required(cls: type, key: str, raw_ann: Any) -> bool:
+    ann_str = str(raw_ann)
+    if "NotRequired" in ann_str:
+        return False
+    if "Required" in ann_str:
+        return True
+    opt_keys = getattr(cls, "__optional_keys__", None)
+    if opt_keys is not None and key in opt_keys:
+        return False
+    req_keys = getattr(cls, "__required_keys__", None)
+    if req_keys is not None:
+        return key in req_keys
+    return getattr(cls, "__total__", True)
+
+
+def _get_typed_dict_hints(cls: type) -> dict[str, Any]:
+    try:
+        raw_hints = get_type_hints(cls)
+    except Exception:
+        raw_hints = getattr(cls, "__annotations__", {})
+    return {k: _clean_type_annotation(v) for k, v in raw_hints.items()}
 
 
 # mostly from https://github.com/openai/openai-python/blob/main/src/openai/lib/_parsing/_completions.py
@@ -277,10 +324,14 @@ def to_response_format_param(
 
     # add support for TypedDict
     if is_typed_dict(response_format):
-        response_format = create_model(
-            response_format.__name__,
-            **{k: (v, ...) for k, v in response_format.__annotations__.items()},  # type: ignore
-        )
+        hints = _get_typed_dict_hints(response_format)
+        raw_annotations = getattr(response_format, "__annotations__", {})
+        fields: dict[str, Any] = {}
+        for k, v in hints.items():
+            is_req = _is_typed_dict_field_required(response_format, k, raw_annotations.get(k, v))
+            fields[k] = (v, ... if is_req else None)
+
+        response_format = create_model(response_format.__name__, **fields)
     json_schema_type: type[BaseModel] | TypeAdapter[Any] | None = None
     if inspect.isclass(response_format) and issubclass(response_format, BaseModel):
         name = response_format.__name__

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TypedDict
+
 import pytest
 from openai.types.chat.chat_completion_chunk import (
     Choice,
@@ -7,6 +9,7 @@ from openai.types.chat.chat_completion_chunk import (
     ChoiceDeltaToolCall,
     ChoiceDeltaToolCallFunction,
 )
+from typing_extensions import NotRequired, Required
 
 from livekit.agents.inference.llm import LLMStream
 from livekit.agents.llm.utils import ThinkingTokenFilter, strip_thinking_tokens
@@ -140,3 +143,31 @@ def test_strips_reasoning_from_text_alongside_tool_call() -> None:
     assert chunk is not None
     assert chunk.delta is not None
     assert chunk.delta.content == "Let me check that.\n\n"
+
+
+class UserProfile(TypedDict):
+    name: Required[str]
+    age: NotRequired[int]
+
+
+class OptionalProfile(TypedDict, total=False):
+    bio: str
+
+
+def test_to_response_format_param_typed_dict() -> None:
+    from livekit.agents.llm.utils import to_openai_response_format, to_response_format_param
+
+    name, model_cls = to_response_format_param(UserProfile)
+    assert name == "UserProfile"
+    schema = model_cls.model_json_schema()
+    assert "name" in schema.get("required", [])
+    assert "age" not in schema.get("required", [])
+
+    name_opt, opt_cls = to_response_format_param(OptionalProfile)
+    assert name_opt == "OptionalProfile"
+    opt_schema = opt_cls.model_json_schema()
+    assert "bio" not in opt_schema.get("required", [])
+
+    openai_format = to_openai_response_format(UserProfile)
+    assert openai_format["type"] == "json_schema"
+    assert openai_format["json_schema"]["name"] == "UserProfile"


### PR DESCRIPTION
### Summary

Fixes a bug in `to_response_format_param` where passing a `TypedDict` containing `Required[...]` or `NotRequired[...]` qualifiers (or stringified type annotations under `from __future__ import annotations`) raises `PydanticUserError` or `PydanticForbiddenQualifier` when converted to a Pydantic `BaseModel`.

Additionally, fixes an issue where all `TypedDict` fields were previously set as required (`...`) regardless of `NotRequired` annotations or `total=False`.

### Changes

1. **Unwrap Type Qualifiers**: Implemented `_get_typed_dict_hints` and `_clean_type_annotation` to safely unwrap `Required` and `NotRequired` qualifiers and evaluate type annotations.
2. **Field Requirement Resolution**: Added `_is_typed_dict_field_required` to check `__required_keys__`, `__optional_keys__`, `__total__`, and annotation markers (`NotRequired`/`Required`) so optional fields are properly initialized with `default=None`.
3. **Unit Tests**: Added `test_to_response_format_param_typed_dict` to `tests/test_llm_utils.py` verifying response format parameter generation and OpenAI response format conversion for `TypedDict`.

### Verification

- `uv run pytest tests/test_llm_utils.py` passes (14/14 tests).
- `make lint` (`ruff check`) passes with zero issues.
- `make type-check` (`mypy`) passes across 625 source files with zero issues.