### PR TITLE
feat(telemetry): include recording options in session reports

### DIFF
--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -303,7 +303,7 @@ class JobContext:
 
         has_evals = bool(self._tagger.evaluations or self._tagger.outcome)
         obs_url = _observability_url(self._info.url)
-        if (recording_enabled(report.recording_options) or has_evals) and obs_url:
+        if (recording_enabled(report.options.recording_options) or has_evals) and obs_url:
             try:
                 await _upload_session_report(
                     agent_name=self._info.job.agent_name,
@@ -311,7 +311,7 @@ class JobContext:
                     report=report,
                     tagger=self._tagger,
                     http_session=http_context.http_session(),
-                    metadata=self._otel_metadata(report.recording_options),
+                    metadata=self._otel_metadata(report.options.recording_options),
                 )
             except Exception:
                 logger.exception("failed to upload the session report to LiveKit Cloud")
@@ -379,7 +379,6 @@ class JobContext:
             )
 
         sr = SessionReport(
-            recording_options=session._recording_options,
             job_id=self.job.id,
             room_id=self.job.room.sid,
             room=self.job.room.name,

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -559,7 +559,7 @@ async def _upload_session_report(
         )
 
     chat_logger = _get_logger("chat_history")
-    recording_options = report.recording_options
+    recording_options = report.options.recording_options
 
     if recording_enabled(recording_options):
         _log(

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -198,6 +198,7 @@ class AgentSessionOptions:
     ivr_detection: bool
     aec_warmup_duration: float | None
     session_close_transcript_timeout: float
+    recording_options: RecordingOptions
 
     @property
     def endpointing(self) -> EndpointingOptions:
@@ -461,6 +462,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             ),
             aec_warmup_duration=aec_warmup_duration,
             session_close_transcript_timeout=session_close_transcript_timeout,
+            recording_options=_RECORDING_ALL_OFF.copy(),
         )
         # expressive mode is not publicly exposed; the pipeline stays disabled
         self._expressive: bool | ExpressiveOptions = False
@@ -578,7 +580,6 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         self._session_ctx_token: Token[otel_context.Context] | None = None
 
         self._recorded_events: list[AgentEvent] = []
-        self._recording_options: RecordingOptions = _RECORDING_ALL_OFF.copy()
         self._started_at: float | None = None
         self._usage_collector = ModelUsageCollector()
 
@@ -762,9 +763,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 # defer to server-side setting for recording
                 record = job_ctx.job.enable_recording if job_ctx else False
 
-            self._recording_options = _resolve_recording_options(record)  # type: ignore[arg-type]
+            self._opts.recording_options = _resolve_recording_options(record)  # type: ignore[arg-type]
             if self._text_only:
-                self._recording_options["audio"] = False
+                self._opts.recording_options["audio"] = False
 
             is_primary = True
             if job_ctx:
@@ -773,7 +774,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                     job_ctx._primary_agent_session = self
                 else:
                     is_primary = False
-                    if recording_enabled(self._recording_options):
+                    if recording_enabled(self._opts.recording_options):
                         if record_is_given:
                             raise RuntimeError(
                                 "Only one `AgentSession` can be the primary at a time. "
@@ -782,9 +783,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                             )
                         else:
                             # auto-disable recording for non-primary sessions when record is not given
-                            self._recording_options = _resolve_recording_options(False)
+                            self._opts.recording_options = _resolve_recording_options(False)
 
-                job_ctx.init_recording(self._recording_options)
+                job_ctx.init_recording(self._opts.recording_options)
 
             # Under a text simulation the simulated user interacts over text
             # streams only: disable audio I/O here, and STT/TTS/VAD via
@@ -883,7 +884,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             if job_ctx:
                 # these aren't relevant during eval mode, as they require job context and/or room_io
                 if self.input.audio and self.output.audio:
-                    if self._recording_options["audio"] or (c.enabled and c.record):
+                    if self._opts.recording_options["audio"] or (c.enabled and c.record):
                         self._recorder_io = RecorderIO(agent_session=self)
                         self.input.audio = self._recorder_io.record_input(self.input.audio)
                         self.output.audio = self._recorder_io.record_output(self.output.audio)

--- a/livekit-agents/livekit/agents/voice/report.py
+++ b/livekit-agents/livekit/agents/voice/report.py
@@ -7,13 +7,12 @@ from pathlib import Path
 from ..llm import ChatContext
 from ..metrics import ModelUsage
 from ..version import __version__
-from .agent_session import AgentSessionOptions, RecordingOptions
+from .agent_session import AgentSessionOptions
 from .events import AgentEvent
 
 
 @dataclass
 class SessionReport:
-    recording_options: RecordingOptions
     job_id: str
     room_id: str
     room: str
@@ -64,6 +63,7 @@ class SessionReport:
                 "user_away_timeout": self.options.user_away_timeout,
                 "min_consecutive_speech_delay": self.options.min_consecutive_speech_delay,
                 "preemptive_generation": dict(self.options.preemptive_generation),
+                "recording_options": dict(self.options.recording_options),
             },
             "chat_history": self.chat_history.to_dict(exclude_timestamp=False),
             "timestamp": self.timestamp,

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -97,7 +97,6 @@ def _patch_job_ctx(mock_ctx: MagicMock, *, patch_recorder: bool = False) -> Iter
 def _make_mock_report(recording_options: RecordingOptions | None = None) -> MagicMock:
     """Create a minimal mock SessionReport for upload tests."""
     report = MagicMock()
-    report.recording_options = recording_options or _RECORDING_ALL_ON.copy()
     report.job_id = "job-1"
     report.room_id = "room-1"
     report.room = "test-room"
@@ -110,6 +109,7 @@ def _make_mock_report(recording_options: RecordingOptions | None = None) -> Magi
     report.started_at = 1000.0
     report.timestamp = 1010.0
     report.options = MagicMock()
+    report.options.recording_options = recording_options or _RECORDING_ALL_ON.copy()
     return report
 
 
@@ -241,7 +241,7 @@ async def test_record_normalization(
 ) -> None:
     session = _create_simple_session()
     await session.start(SimpleAgent(), record=record)
-    assert session._recording_options == expected
+    assert session.options.recording_options == expected
     await _cleanup(session)
 
 
@@ -249,7 +249,7 @@ async def test_record_not_given_without_job_ctx() -> None:
     """When record is omitted and no JobContext is available, all options should be False."""
     session = _create_simple_session()
     await session.start(SimpleAgent())
-    assert session._recording_options == _RECORDING_ALL_OFF
+    assert session.options.recording_options == _RECORDING_ALL_OFF
     await _cleanup(session)
 
 
@@ -320,7 +320,7 @@ async def test_init_recording_called_when_job_recording_disabled() -> None:
         await session.start(SimpleAgent())
 
     mock_ctx.init_recording.assert_called_once()
-    assert session._recording_options == _RECORDING_ALL_OFF
+    assert session.options.recording_options == _RECORDING_ALL_OFF
     await _cleanup(session)
 
 
@@ -372,6 +372,35 @@ async def test_upload_session_report_sent_without_transcript() -> None:
     bodies = [c.kwargs.get("body") for c in mock_logger.emit.call_args_list]
     assert "session report" in bodies
     assert "chat item" not in bodies
+
+
+def test_session_report_constructor_includes_recording_options_in_options() -> None:
+    from livekit.agents.voice.report import SessionReport
+
+    recording_options: RecordingOptions = {
+        "audio": False,
+        "traces": True,
+        "logs": False,
+        "transcript": False,
+        "redaction": True,
+    }
+    session = _create_simple_session()
+    session.options.recording_options = recording_options
+    report = SessionReport(
+        job_id="job-1",
+        room_id="room-1",
+        room="test-room",
+        options=session.options,
+        events=[],
+        chat_history=session.history,
+    )
+
+    assert report.options.recording_options == recording_options
+    serialized_recording_options = report.to_dict()["options"]["recording_options"]
+    assert serialized_recording_options == recording_options
+
+    serialized_recording_options["audio"] = True
+    assert report.options.recording_options["audio"] is False
 
 
 async def test_upload_audio_only_no_file() -> None:


### PR DESCRIPTION
Observability could not distinguish disabled audio capture from a failed recording upload.

Record the resolved client-side recording configuration in session options so Cloud can determine whether audio should exist. 

> [!WARNING]
>  breaking change to SessionReport but it should be fine since it is used only for LK Cloud internally.

Fixes AGT-3176.