### PR TITLE
fix(transcription): strip `***bold italic***` markdown emphasis

### DIFF
--- a/livekit-agents/livekit/agents/voice/transcription/filters.py
+++ b/livekit-agents/livekit/agents/voice/transcription/filters.py
@@ -15,11 +15,16 @@ INLINE_PATTERNS = [
     (re.compile(r"!\[([^\]]*)\]\([^)]*\)"), r"\1"),
     # links: keep text part [text](url) -> text
     (re.compile(r"\[([^\]]*)\]\([^)]*\)"), r"\1"),
+    # bold italic: remove asterisks from ***text*** (must run before the **/*
+    # patterns, which cannot match across the extra delimiter)
+    (re.compile(r"(?<![\w*])\*\*\*(?!\s)([^*\n]+?)(?<!\s)\*\*\*(?![\w*])"), r"\1"),
     # bold: remove asterisks from **text** (word/asterisk boundaries, so
     # punctuation like ``**bold**!`` still matches)
     (re.compile(r"(?<![\w*])\*\*(?!\s)([^*\n]+?)(?<!\s)\*\*(?![\w*])"), r"\1"),
     # italic: remove asterisks from *text* (word/asterisk boundaries)
     (re.compile(r"(?<![\w*])\*(?!\s|\*)([^*\n]+?)(?<!\s)\*(?![\w*])"), r"\1"),
+    # bold italic with underscores: remove underscores from ___text___
+    (re.compile(r"(?<!\w)___([^_]+?)___(?!\w)"), r"\1"),
     # bold with underscores: remove underscores from __text__ (word boundaries)
     (re.compile(r"(?<!\w)__([^_]+?)__(?!\w)"), r"\1"),
     # italic with underscores: remove underscores from _text_ (word boundaries)

--- a/tests/test_transcription_filter.py
+++ b/tests/test_transcription_filter.py
@@ -216,6 +216,37 @@ async def test_punctuation_boundary_no_false_positives(text: str, chunk_size: in
     assert result == text
 
 
+# --- combined bold + italic ---
+#
+# ``***text***`` and ``___text___`` were left untouched: the bold pattern
+# stops at the extra delimiter and the italic pattern rejects a ``*`` right
+# after the opening one, so the delimiters leaked through to TTS.
+
+BOLD_ITALIC_CASES = [
+    # (input, expected)
+    ("This is ***very important*** text.", "This is very important text."),
+    ("Call ***now***!", "Call now!"),
+    ("___Totally___ critical.", "Totally critical."),
+    ("Use ***both*** and **bold** and *italic*.", "Use both and bold and italic."),
+]
+
+
+@pytest.mark.parametrize("text,expected", BOLD_ITALIC_CASES)
+@pytest.mark.parametrize("chunk_size", [1, 2, 3, 7, 50])
+async def test_bold_italic(text: str, expected: str, chunk_size: int):
+    """Triple-delimiter emphasis is stripped like the single and double forms."""
+
+    async def stream():
+        for i in range(0, len(text), chunk_size):
+            yield text[i : i + chunk_size]
+
+    result = ""
+    async for chunk in filter_markdown(stream()):
+        result += chunk
+
+    assert result == expected
+
+
 # Emoji test data
 EMOJI_INPUT = """Hello! 😀 Welcome to our app! 🎉
 


### PR DESCRIPTION
### Problem

`filter_markdown` strips markdown before text reaches TTS, but it only covers `*italic*` and `**bold**`. The combined `***text***` / `___text___` form is left untouched, so the delimiters leak through and get spoken.

```python
"This is ***very important*** text."  ->  "This is ***very important*** text."
"___Totally___ critical."             ->  "___Totally___ critical."
"Use ***both*** and **bold**"         ->  "Use ***both*** and bold"
```

Neither existing pattern can match it:

- **bold** — the body is `[^*\n]+?`, which stops at the third asterisk
- **italic** — the `(?!\s|\*)` guard rejects a `*` immediately after the opening delimiter

Same for the underscore variants. LLMs emit `***…***` fairly often for emphasis, so this shows up in practice.

### Fix

Add a triple-delimiter pattern ahead of each existing pair. The word/asterisk boundary assertions (`(?<![\w*])` / `(?![\w*])`) are carried over unchanged from the existing patterns.

### Tests

Added `test_bold_italic`, covering the four cases above across chunk sizes `1, 2, 3, 7, 50` so the streaming path is exercised too. All fail before the change, pass after.

Existing coverage is unaffected — the full `MARKDOWN_INPUT` document test, the punctuation-boundary cases, and the no-false-positive cases (`2 * 3 = 6`, `Use *.py files`, `x**2 + y**2 = z**2`, `__dunder_method__`) all still pass.

`ruff check` and `ruff format` are clean.
