### PR TITLE
voice: strip markdown emphasis in CJK text

### DIFF
--- a/livekit-agents/livekit/agents/voice/transcription/filters.py
+++ b/livekit-agents/livekit/agents/voice/transcription/filters.py
@@ -1,6 +1,38 @@
 import re
 from collections.abc import AsyncIterable
 
+# Scripts written without spaces between words. An emphasis delimiter in such a
+# script necessarily sits flush against a word character, so a neighbour from
+# one of these ranges is still a valid emphasis boundary.
+_CONTINUOUS_SCRIPTS = (
+    r"\u0e00-\u0e7f"  # thai
+    r"\u3040-\u30ff"  # hiragana, katakana
+    r"\u3400-\u4dbf"  # cjk unified ideographs extension a
+    r"\u4e00-\u9fff"  # cjk unified ideographs
+    r"\uf900-\ufaff"  # cjk compatibility ideographs
+    r"\uff66-\uff9d"  # halfwidth katakana
+)
+# a word character that would make emphasis intra-word; the negated class
+# subtracts the continuous scripts from ``\w``
+_INTRAWORD = rf"[^\W{_CONTINUOUS_SCRIPTS}]"
+
+# emphasis *text*, **text**, ***text***: the closing run has to match the
+# opening one. Asterisks are also arithmetic, exponents and globs, so each side
+# needs a boundary that is neither intra-word nor another asterisk.
+_ASTERISK_EMPHASIS = re.compile(
+    rf"(?<!{_INTRAWORD})(?<!\*)"  # opening boundary
+    r"(\*{1,3})(?!\s)"  # opening delimiter run
+    r"([^*\n]+?)"  # body
+    r"(?<!\s)\1"  # closing run, same width
+    rf"(?!{_INTRAWORD})(?!\*)"  # closing boundary
+)
+# the same for underscores. CommonMark has no intra-word underscore emphasis,
+# so the boundary here stays the full word class -- that is what keeps
+# ``snake_case`` and ``__dunder__`` intact, in every script.
+_UNDERSCORE_EMPHASIS = re.compile(r"(?<!\w)(_{1,3})([^_]+?)\1(?!\w)")
+
+# Anchored at the start of a line only, so they are safe to apply to a prefix
+# of a line that is still being streamed.
 LINE_PATTERNS = [
     # headers: remove # and following spaces
     (re.compile(r"^#{1,6}\s+", re.MULTILINE), ""),
@@ -10,31 +42,49 @@ LINE_PATTERNS = [
     (re.compile(r"^\s*>\s+", re.MULTILINE), ""),
 ]
 
+# These match a whole line, so they may only be applied once the line is known
+# to be complete -- a prefix of ``____ and so on`` is not a horizontal rule.
+FULL_LINE_PATTERNS = [
+    # horizontal rules: --- / *** / ___ carry no spoken content
+    (re.compile(r"^[ \t]*(?:-{3,}|\*{3,}|_{3,})[ \t]*$", re.MULTILINE), ""),
+]
+
 INLINE_PATTERNS = [
     # images: keep alt text ![alt](url) -> alt
     (re.compile(r"!\[([^\]]*)\]\([^)]*\)"), r"\1"),
     # links: keep text part [text](url) -> text
     (re.compile(r"\[([^\]]*)\]\([^)]*\)"), r"\1"),
-    # bold: remove asterisks from **text** (word/asterisk boundaries, so
-    # punctuation like ``**bold**!`` still matches)
-    (re.compile(r"(?<![\w*])\*\*(?!\s)([^*\n]+?)(?<!\s)\*\*(?![\w*])"), r"\1"),
-    # italic: remove asterisks from *text* (word/asterisk boundaries)
-    (re.compile(r"(?<![\w*])\*(?!\s|\*)([^*\n]+?)(?<!\s)\*(?![\w*])"), r"\1"),
-    # bold with underscores: remove underscores from __text__ (word boundaries)
-    (re.compile(r"(?<!\w)__([^_]+?)__(?!\w)"), r"\1"),
-    # italic with underscores: remove underscores from _text_ (word boundaries)
-    (re.compile(r"(?<!\w)_([^_]+?)_(?!\w)"), r"\1"),
+    # emphasis: remove the delimiters, keep the body. Runs before the code and
+    # strikethrough patterns, which would otherwise consume the body and strand
+    # the delimiters around it (``**~~text~~**``).
+    (_ASTERISK_EMPHASIS, r"\2"),
+    (_UNDERSCORE_EMPHASIS, r"\2"),
+    # nesting is order-dependent -- ``**_text_**`` needs the asterisks off
+    # first, ``_**text**_`` the underscores -- so the asterisks get a second
+    # look once the underscores are gone
+    (_ASTERISK_EMPHASIS, r"\2"),
     # code blocks: remove ``` from ```text```
     (re.compile(r"`{3,4}[\S]*"), ""),
     # inline code: remove ` from `text`
     (re.compile(r"`([^`]+?)`"), r"\1"),
-    # strikethrough: remove ~~text~~ (no spaces next to tildes)
-    (re.compile(r"~~(?!\s)([^~]*?)(?<!\s)~~"), ""),
+    # strikethrough: drop ~~text~~ entirely, struck text is not spoken
+    (re.compile(r"~~(?!\s)[^~]*?(?<!\s)~~"), ""),
 ]
 INLINE_SPLIT_TOKENS = " ,.?!;，。？！；"
 
+# text without one of these cannot match any inline pattern
+INLINE_MARKERS = re.compile(r"[*_`~\[]")
+
 COMPLETE_LINKS_PATTERN = re.compile(r"\[[^\]]*\]\([^)]*\)")  # links [text](url)
 COMPLETE_IMAGES_PATTERN = re.compile(r"!\[[^\]]*\]\([^)]*\)")  # images ![text](url)
+
+
+def _unbalanced(buffer: str, delimiter: str) -> bool:
+    """Whether a delimiter's occurrences cannot pair up yet."""
+    doubles = buffer.count(delimiter * 2)
+    if doubles % 2 == 1:
+        return True
+    return (buffer.count(delimiter) - doubles * 2) % 2 == 1
 
 
 async def filter_markdown(text: AsyncIterable[str]) -> AsyncIterable[str]:
@@ -48,48 +98,33 @@ async def filter_markdown(text: AsyncIterable[str]) -> AsyncIterable[str]:
         if buffer.endswith(("#", "-", "+", "*", ">", "!", "`", "~", " ")):
             return True
 
-        # check for incomplete bold (**text** or *text*)
-        double_asterisks = buffer.count("**")
-        if double_asterisks % 2 == 1:
+        # emphasis delimiters that cannot pair up yet
+        if _unbalanced(buffer, "*") or _unbalanced(buffer, "_"):
             return True
 
-        single_asterisks = buffer.count("*") - (double_asterisks * 2)
-        if single_asterisks % 2 == 1:
+        # incomplete code (`text`) or strikethrough (~~text~~)
+        if buffer.count("`") % 2 == 1 or buffer.count("~~") % 2 == 1:
             return True
 
-        # check for incomplete underscores (__text__ or _text_)
-        double_underscores = buffer.count("__")
-        if double_underscores % 2 == 1:
-            return True
-        single_underscores = buffer.count("_") - (double_underscores * 2)
-        if single_underscores % 2 == 1:
-            return True
-
-        # check for incomplete code (`text`)
-        backticks = buffer.count("`")
-        if backticks % 2 == 1:
-            return True
-
-        # check for incomplete strikethrough (~~text~~)
-        double_tildes = buffer.count("~~")
-        if double_tildes % 2 == 1:
-            return True
-
-        # check for incomplete links [text](url) or images ![text](url)
+        # incomplete links [text](url) or images ![text](url)
         open_brackets = buffer.count("[")
         complete_links = len(COMPLETE_LINKS_PATTERN.findall(buffer))
         complete_images = len(COMPLETE_IMAGES_PATTERN.findall(buffer))
 
-        remaining_brackets = open_brackets - complete_links - complete_images
-        if remaining_brackets > 0:
-            return True
+        return open_brackets - complete_links - complete_images > 0
 
-        return False
-
-    def process_complete_text(text: str, is_newline: bool = False) -> str:
+    def process_complete_text(text: str, *, is_newline: bool, is_line_end: bool) -> str:
         if is_newline:
             for pattern, replacement in LINE_PATTERNS:
                 text = pattern.sub(replacement, text)
+
+            if is_line_end:
+                for pattern, replacement in FULL_LINE_PATTERNS:
+                    text = pattern.sub(replacement, text)
+
+        # most spoken text carries no inline markup at all
+        if not INLINE_MARKERS.search(text):
+            return text
 
         for pattern, replacement in INLINE_PATTERNS:
             text = pattern.sub(replacement, text)
@@ -108,29 +143,29 @@ async def filter_markdown(text: AsyncIterable[str]) -> AsyncIterable[str]:
 
             for i, line in enumerate(lines[:-1]):
                 is_newline = buffer_is_newline if i == 0 else True
-                processed_line = process_complete_text(line, is_newline=is_newline)
+                processed_line = process_complete_text(
+                    line, is_newline=is_newline, is_line_end=True
+                )
                 yield processed_line + "\n"
 
             buffer_is_newline = True
             continue
 
         # split at the position after the split token
-        last_split_pos = 0
-        for token in INLINE_SPLIT_TOKENS:
-            last_split_pos = max(last_split_pos, buffer.rfind(token, last_split_pos))
-            if last_split_pos >= len(buffer) - 1:
-                break
+        last_split_pos = max(map(buffer.rfind, INLINE_SPLIT_TOKENS))
 
         if last_split_pos >= 1:
             processable = buffer[:last_split_pos]  # exclude the split token
             rest = buffer[last_split_pos:]
             if not has_incomplete_pattern(processable):
-                yield process_complete_text(processable, is_newline=buffer_is_newline)
+                yield process_complete_text(
+                    processable, is_newline=buffer_is_newline, is_line_end=False
+                )
                 buffer = rest
                 buffer_is_newline = False
 
     if buffer:
-        yield process_complete_text(buffer, is_newline=buffer_is_newline)
+        yield process_complete_text(buffer, is_newline=buffer_is_newline, is_line_end=True)
 
 
 # Unicode block ranges from: https://unicode.org/Public/UNIDATA/Blocks.txt

--- a/livekit-agents/livekit/agents/voice/transcription/filters.py
+++ b/livekit-agents/livekit/agents/voice/transcription/filters.py
@@ -1,20 +1,22 @@
 import re
 from collections.abc import AsyncIterable
 
-# Scripts written without spaces between words. An emphasis delimiter in such a
-# script necessarily sits flush against a word character, so a neighbour from
-# one of these ranges is still a valid emphasis boundary.
-_CONTINUOUS_SCRIPTS = (
+# Scripts that put an emphasis delimiter flush against a word character: CJK,
+# kana and Thai take no spaces at all, Korean attaches particles to the closing
+# run. A neighbour from one of these ranges is still a valid boundary.
+_FLUSH_EMPHASIS_SCRIPTS = (
     r"\u0e00-\u0e7f"  # thai
+    r"\u1100-\u11ff"  # hangul jamo
     r"\u3040-\u30ff"  # hiragana, katakana
+    r"\u3130-\u318f"  # hangul compatibility jamo
     r"\u3400-\u4dbf"  # cjk unified ideographs extension a
     r"\u4e00-\u9fff"  # cjk unified ideographs
+    r"\uac00-\ud7af"  # hangul syllables
     r"\uf900-\ufaff"  # cjk compatibility ideographs
     r"\uff66-\uff9d"  # halfwidth katakana
 )
-# a word character that would make emphasis intra-word; the negated class
-# subtracts the continuous scripts from ``\w``
-_INTRAWORD = rf"[^\W{_CONTINUOUS_SCRIPTS}]"
+# a word character that would make emphasis intra-word: ``\w`` less those scripts
+_INTRAWORD = rf"[^\W{_FLUSH_EMPHASIS_SCRIPTS}]"
 
 # emphasis *text*, **text**, ***text***: the closing run has to match the
 # opening one. Asterisks are also arithmetic, exponents and globs, so each side
@@ -29,7 +31,7 @@ _ASTERISK_EMPHASIS = re.compile(
 # the same for underscores. CommonMark has no intra-word underscore emphasis,
 # so the boundary here stays the full word class -- that is what keeps
 # ``snake_case`` and ``__dunder__`` intact, in every script.
-_UNDERSCORE_EMPHASIS = re.compile(r"(?<!\w)(_{1,3})([^_]+?)\1(?!\w)")
+_UNDERSCORE_EMPHASIS = re.compile(r"(?<!\w)(_{1,3})(?!\s)([^_\n]+?)(?<!\s)\1(?!\w)")
 
 # Anchored at the start of a line only, so they are safe to apply to a prefix
 # of a line that is still being streamed.
@@ -43,10 +45,18 @@ LINE_PATTERNS = [
 ]
 
 # These match a whole line, so they may only be applied once the line is known
-# to be complete -- a prefix of ``____ and so on`` is not a horizontal rule.
+# to be complete -- a prefix of ``____ and so on`` is not a horizontal rule. They
+# run before LINE_PATTERNS, which would read ``* * *`` as a list item.
 FULL_LINE_PATTERNS = [
-    # horizontal rules: --- / *** / ___ carry no spoken content
-    (re.compile(r"^[ \t]*(?:-{3,}|\*{3,}|_{3,})[ \t]*$", re.MULTILINE), ""),
+    # horizontal rules carry no spoken content. per CommonMark the markers may be
+    # spaced apart, and a fourth column of indent makes the line code
+    (
+        re.compile(
+            r"^ {0,3}(?:(?:-[ \t]*){3,}|(?:\*[ \t]*){3,}|(?:_[ \t]*){3,})$",
+            re.MULTILINE,
+        ),
+        "",
+    ),
 ]
 
 INLINE_PATTERNS = [
@@ -95,7 +105,7 @@ async def filter_markdown(text: AsyncIterable[str]) -> AsyncIterable[str]:
     def has_incomplete_pattern(buffer: str) -> bool:
         """Check if buffer might contain incomplete markdown patterns that need more text."""
 
-        if buffer.endswith(("#", "-", "+", "*", ">", "!", "`", "~", " ")):
+        if buffer.endswith(("#", "-", "+", "*", "_", ">", "!", "`", "~", " ")):
             return True
 
         # emphasis delimiters that cannot pair up yet
@@ -115,12 +125,12 @@ async def filter_markdown(text: AsyncIterable[str]) -> AsyncIterable[str]:
 
     def process_complete_text(text: str, *, is_newline: bool, is_line_end: bool) -> str:
         if is_newline:
-            for pattern, replacement in LINE_PATTERNS:
-                text = pattern.sub(replacement, text)
-
             if is_line_end:
                 for pattern, replacement in FULL_LINE_PATTERNS:
                     text = pattern.sub(replacement, text)
+
+            for pattern, replacement in LINE_PATTERNS:
+                text = pattern.sub(replacement, text)
 
         # most spoken text carries no inline markup at all
         if not INLINE_MARKERS.search(text):

--- a/tests/test_transcription_filter.py
+++ b/tests/test_transcription_filter.py
@@ -5,6 +5,27 @@ from livekit.agents.voice.transcription.text_transforms import _apply_text_trans
 
 pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
+
+async def _stream_text(text: str, chunk_size: int):
+    for i in range(0, len(text), chunk_size):
+        yield text[i : i + chunk_size]
+
+
+async def _collect(stream) -> str:
+    result = ""
+    async for chunk in stream:
+        result += chunk
+    return result
+
+
+async def _collect_chunks(stream) -> list[str]:
+    return [chunk async for chunk in stream]
+
+
+async def _filtered(text: str, chunk_size: int) -> str:
+    return await _collect(filter_markdown(_stream_text(text, chunk_size)))
+
+
 MARKDOWN_INPUT = """# Mathematics and Markdown Guide
 
 Hi there~~ How are you?  # the ~~ shouldn't be removed.
@@ -111,58 +132,30 @@ This is a sentence. 这是一个中文句子。これは日本語の文章です
 
 @pytest.mark.parametrize("chunk_size", [1, 2, 3, 5, 7, 11, 50])
 async def test_markdown_filter(chunk_size: int):
-    """Comprehensive test with mixed markdown, math operations, and regular text."""
-
-    print("=== COMPREHENSIVE MARKDOWN FILTER TEST ===")
-    print(f"Input length: {len(MARKDOWN_INPUT)} characters")
-    print(f"Expected length: {len(MARKDOWN_EXPECTED_OUTPUT)} characters")
-
-    print(f"\n--- Testing with chunk_size={chunk_size} ---")
-
-    # Stream the input with specified chunk size
-    async def stream_text():
-        for i in range(0, len(MARKDOWN_INPUT), chunk_size):
-            yield MARKDOWN_INPUT[i : i + chunk_size]
-
-    # Process through the filter
-    result = ""
-    async for chunk in filter_markdown(stream_text()):
-        result += chunk
-
-    # Compare results
-    if result.strip() == MARKDOWN_EXPECTED_OUTPUT.strip():
-        print("✓ PASS")
-    else:
-        print("✗ FAIL")
-        print(f"Expected first 100 chars: {repr(MARKDOWN_EXPECTED_OUTPUT[:100])}")
-        print(f"Got first 100 chars:      {repr(result[:100])}")
-
-        # Show differences
-        expected_lines = MARKDOWN_EXPECTED_OUTPUT.strip().split("\n")
-        result_lines = result.strip().split("\n")
-
-        print("\nLine-by-line differences:")
-        for i, (exp, got) in enumerate(zip(expected_lines, result_lines, strict=False)):
-            if exp != got:
-                print(f"Line {i + 1}:")
-                print(f"  Expected: {repr(exp)}")
-                print(f"  Got:      {repr(got)}")
-    assert result == MARKDOWN_EXPECTED_OUTPUT.strip()
-
-    print("\n=== TEST COMPLETE ===")
+    """Mixed markdown, math and prose survive the streaming filter intact."""
+    assert await _filtered(MARKDOWN_INPUT, chunk_size) == MARKDOWN_EXPECTED_OUTPUT.strip()
 
 
-# --- emphasis adjacent to punctuation ---
+# --- emphasis that must be stripped ---
 #
-# Regression tests for the case where ``**bold**`` / ``*italic*`` delimiters
-# are immediately followed (or preceded) by a punctuation character rather
-# than whitespace. Previously the patterns used ``(?<!\S)`` / ``(?!\S)``
-# boundaries which rejected punctuation as a valid boundary, causing
-# ``Hi **Frankie**!`` to leak through untouched to TTS.
+# One table per direction. This one covers every emphasis form the filter is
+# expected to remove: the three delimiter widths, boundaries made of
+# punctuation rather than whitespace, and scripts written without spaces,
+# where the delimiter necessarily sits flush against a word character.
 
-
-PUNCTUATION_BOUNDARY_CASES = [
+EMPHASIS_CASES = [
     # (input, expected)
+    # single and double, whitespace boundaries
+    ("He said *hello* again.", "He said hello again."),
+    ("This is **bold** text.", "This is bold text."),
+    ("_underscore italic_ here.", "underscore italic here."),
+    ("__underscore bold__ here.", "underscore bold here."),
+    # triple: bold italic
+    ("This is ***very important*** text.", "This is very important text."),
+    ("Call ***now***!", "Call now!"),
+    ("___Totally___ critical.", "Totally critical."),
+    ("Use ***both*** and **bold** and *italic*.", "Use both and bold and italic."),
+    # punctuation rather than whitespace on the boundary
     ("Hi **Frankie**!", "Hi Frankie!"),
     ("See **Dr. Smith**.", "See Dr. Smith."),
     ("Scheduled for **Monday**, at 9am.", "Scheduled for Monday, at 9am."),
@@ -171,49 +164,102 @@ PUNCTUATION_BOUNDARY_CASES = [
     ("Options: **a**, **b**, or **c**?", "Options: a, b, or c?"),
     ("He said *hello*!", "He said hello!"),
     ("It was *amazing*, really.", "It was amazing, really."),
+    ("Hi ***Frankie***!", "Hi Frankie!"),
+    ("Press (***1***) to confirm.", "Press (1) to confirm."),
+    # nested delimiters, stripped by successive passes
+    ("**_mixed_** here.", "mixed here."),
+    ("_**mixed**_ here.", "mixed here."),
+    # scripts written without spaces
+    ("这是**很重要**的文本。", "这是很重要的文本。"),
+    ("这是***非常重要***的文本。", "这是非常重要的文本。"),
+    ("这是*重要*的文本。", "这是重要的文本。"),
+    ("テスト**強調**です。", "テスト強調です。"),
+    ("**中文**开头。", "中文开头。"),
 ]
 
 
-@pytest.mark.parametrize("text,expected", PUNCTUATION_BOUNDARY_CASES)
+@pytest.mark.parametrize("text,expected", EMPHASIS_CASES)
 @pytest.mark.parametrize("chunk_size", [1, 2, 3, 7, 50])
-async def test_punctuation_boundary(text: str, expected: str, chunk_size: int):
-    """Emphasis delimiters followed by punctuation are correctly stripped."""
-
-    async def stream():
-        for i in range(0, len(text), chunk_size):
-            yield text[i : i + chunk_size]
-
-    result = ""
-    async for chunk in filter_markdown(stream()):
-        result += chunk
-
-    assert result == expected
+async def test_emphasis_stripped(text: str, expected: str, chunk_size: int):
+    assert await _filtered(text, chunk_size) == expected
 
 
-# Must NOT mutate: the punctuation-boundary fix must still preserve
-# contexts where ``*`` is used for arithmetic, globs, or in-word.
-PUNCTUATION_BOUNDARY_PRESERVE_CASES = [
+# --- text that must survive untouched ---
+#
+# Asterisks and underscores carry meaning outside markdown: arithmetic, globs,
+# exponentiation and identifiers. Delimiter runs that cannot pair up are left
+# alone rather than half-stripped.
+
+PRESERVE_CASES = [
+    # arithmetic, globs, exponentiation
     "2 * 3 = 6",
     "Use *.py files",
     "x**2 + y**2 = z**2",
     "a ** b evaluated right-to-left",
+    "cost = a *** b",
+    # identifiers: underscores never emphasise intra-word
+    "__dunder_method__ stays",
+    "a___b and MAX___VALUE",
+    "snake___case___name",
+    "call some_function_name here",
+    # CommonMark forbids intra-word underscore emphasis, so CJK keeps its
+    # underscores even though CJK asterisk emphasis is stripped
+    "テスト__強調__です。",
+    "变量__name__的值",
+    # runs that cannot pair up
+    "****quad****",
+    "____quad____",
+    "**bold***italic*",
+    "*italic***bold**",
+    # a run of asterisks is only a rule on a line of its own
+    "see ***** here",
+    # unterminated at end of stream
+    "unterminated ***open",
+    "unterminated ___open",
 ]
 
 
-@pytest.mark.parametrize("text", PUNCTUATION_BOUNDARY_PRESERVE_CASES)
+@pytest.mark.parametrize("text", PRESERVE_CASES)
+@pytest.mark.parametrize("chunk_size", [1, 3, 7, 50])
+async def test_non_markdown_preserved(text: str, chunk_size: int):
+    assert await _filtered(text, chunk_size) == text
+
+
+# --- horizontal rules ---
+#
+# A rule carries no spoken content, so the whole line goes. Dashes that are
+# part of a sentence must survive.
+
+HORIZONTAL_RULE_CASES = [
+    ("before\n---\nafter", "before\n\nafter"),
+    ("before\n***\nafter", "before\n\nafter"),
+    ("before\n___\nafter", "before\n\nafter"),
+    ("before\n-----\nafter", "before\n\nafter"),
+    ("before\n  ---  \nafter", "before\n\nafter"),
+    ("*****", ""),
+    # not rules
+    ("wait --- what?", "wait --- what?"),
+    ("a -- b", "a -- b"),
+]
+
+
+@pytest.mark.parametrize("text,expected", HORIZONTAL_RULE_CASES)
 @pytest.mark.parametrize("chunk_size", [1, 3, 50])
-async def test_punctuation_boundary_no_false_positives(text: str, chunk_size: int):
-    """Non-markdown asterisk contexts are preserved."""
+async def test_horizontal_rule(text: str, expected: str, chunk_size: int):
+    assert await _filtered(text, chunk_size) == expected
 
-    async def stream():
-        for i in range(0, len(text), chunk_size):
-            yield text[i : i + chunk_size]
 
-    result = ""
-    async for chunk in filter_markdown(stream()):
-        result += chunk
+# --- streaming invariant ---
 
-    assert result == text
+
+@pytest.mark.parametrize(
+    "text",
+    [t for t, _ in EMPHASIS_CASES] + PRESERVE_CASES + [t for t, _ in HORIZONTAL_RULE_CASES],
+)
+async def test_output_independent_of_chunking(text: str):
+    """Buffering must not change the result: every chunk size yields one output."""
+    outputs = {await _filtered(text, size) for size in (1, 2, 3, 5, 7, 11, 50, 1000)}
+    assert len(outputs) == 1, f"chunk-size dependent output: {outputs}"
 
 
 # Emoji test data
@@ -268,64 +314,11 @@ End of emoji test. """  # noqa: W291
 
 @pytest.mark.parametrize("chunk_size", [1, 5, 10, 30])
 async def test_emoji_filter(chunk_size: int):
-    """Test emoji filtering with various chunk sizes."""
-
-    print("=== EMOJI FILTER TEST ===")
-    print(f"Input length: {len(EMOJI_INPUT)} characters")
-    print(f"Expected length: {len(EMOJI_EXPECTED_OUTPUT)} characters")
-
-    print(f"\n--- Testing with chunk_size={chunk_size} ---")
-
-    # Stream the input with specified chunk size
-    async def stream_text():
-        for i in range(0, len(EMOJI_INPUT), chunk_size):
-            yield EMOJI_INPUT[i : i + chunk_size]
-
-    # Process through the filter
-    result = ""
-    async for chunk in filter_emoji(stream_text()):
-        result += chunk
-
-    # Compare results
-    if result == EMOJI_EXPECTED_OUTPUT:
-        print("✓ PASS")
-    else:
-        print("✗ FAIL")
-        print(f"Expected first 100 chars: {repr(EMOJI_EXPECTED_OUTPUT[:100])}")
-        print(f"Got first 100 chars:      {repr(result[:100])}")
-
-        # Show differences
-        expected_lines = EMOJI_EXPECTED_OUTPUT.split("\n")
-        result_lines = result.split("\n")
-
-        print("\nLine-by-line differences:")
-        for i, (exp, got) in enumerate(zip(expected_lines, result_lines, strict=False)):
-            if exp != got:
-                print(f"Line {i + 1}:")
-                print(f"  Expected: {repr(exp)}")
-                print(f"  Got:      {repr(got)}")
+    result = await _collect(filter_emoji(_stream_text(EMOJI_INPUT, chunk_size)))
     assert result == EMOJI_EXPECTED_OUTPUT
-
-    print("\n=== EMOJI TEST COMPLETE ===")
 
 
 # --- text_transforms.replace tests ---
-
-
-async def _stream_text(text: str, chunk_size: int):
-    for i in range(0, len(text), chunk_size):
-        yield text[i : i + chunk_size]
-
-
-async def _collect(stream) -> str:
-    result = ""
-    async for chunk in stream:
-        result += chunk
-    return result
-
-
-async def _collect_chunks(stream) -> list[str]:
-    return [chunk async for chunk in stream]
 
 
 @pytest.mark.parametrize("chunk_size", [1, 2, 5, 11, 50])

--- a/tests/test_transcription_filter.py
+++ b/tests/test_transcription_filter.py
@@ -139,9 +139,8 @@ async def test_markdown_filter(chunk_size: int):
 # --- emphasis that must be stripped ---
 #
 # One table per direction. This one covers every emphasis form the filter is
-# expected to remove: the three delimiter widths, boundaries made of
-# punctuation rather than whitespace, and scripts written without spaces,
-# where the delimiter necessarily sits flush against a word character.
+# expected to remove: the three delimiter widths, boundaries made of punctuation
+# rather than whitespace, and delimiters flush against a word character.
 
 EMPHASIS_CASES = [
     # (input, expected)
@@ -175,6 +174,12 @@ EMPHASIS_CASES = [
     ("这是*重要*的文本。", "这是重要的文本。"),
     ("テスト**強調**です。", "テスト強調です。"),
     ("**中文**开头。", "中文开头。"),
+    ("นี่คือ**ข้อความ**สำคัญ", "นี่คือข้อความสำคัญ"),
+    # korean: spaced between words, but a particle follows the closing run
+    ("이것은 **중요**합니다.", "이것은 중요합니다."),
+    ("한국어**강조**입니다.", "한국어강조입니다."),
+    ("한국어***강조***입니다.", "한국어강조입니다."),
+    ("이것은 *중요*합니다.", "이것은 중요합니다."),
 ]
 
 
@@ -206,6 +211,7 @@ PRESERVE_CASES = [
     # underscores even though CJK asterisk emphasis is stripped
     "テスト__強調__です。",
     "变量__name__的值",
+    "한국어__강조__입니다.",
     # runs that cannot pair up
     "****quad****",
     "____quad____",
@@ -237,9 +243,17 @@ HORIZONTAL_RULE_CASES = [
     ("before\n-----\nafter", "before\n\nafter"),
     ("before\n  ---  \nafter", "before\n\nafter"),
     ("*****", ""),
+    # markers may be spaced apart, and a rule wins over a list item
+    ("before\n* * *\nafter", "before\n\nafter"),
+    ("before\n- - -\nafter", "before\n\nafter"),
+    ("before\n_ _ _\nafter", "before\n\nafter"),
+    ("before\n   - - - \nafter", "before\n\nafter"),
     # not rules
     ("wait --- what?", "wait --- what?"),
     ("a -- b", "a -- b"),
+    # a fourth column of indent makes the line code, not a rule
+    ("before\n    ---\nafter", "before\n    ---\nafter"),
+    ("before\n\t---\nafter", "before\n\t---\nafter"),
 ]
 
 


### PR DESCRIPTION
- Strip markdown emphasis where the delimiter sits flush against a word character — CJK, kana and Thai are written without spaces, and Korean attaches its particles directly after the closing run. `这是**很重要**的文本`, `テスト**強調**です` and `한국어**강조**입니다` all previously reached TTS with the asterisks spoken aloud. Underscores keep the full word boundary, so `snake_case` and `__dunder__` stay intact.
- Handle `***bold italic***`, collapsing the three delimiter widths into one pattern.
- Drop horizontal rules (`---` / `***` / `___`), which carry no spoken content. Following CommonMark, the markers may be spaced apart (`* * *`) and a fourth column of indent makes the line code rather than a rule. Rules are stripped before the line patterns, which would otherwise read a spaced rule's first marker as a list item.
- Require emphasis delimiters to hug their body on both sides, for underscores as well as asterisks, so `a _ b _ c` is left alone.
- Skip the inline pass for text containing no markup characters.
