### PR TITLE
feat(sarvam): add realtime streaming STT

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/__init__.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/__init__.py
@@ -12,21 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Sarvam.ai plugin for LiveKit Agents
+"""Sarvam.ai plugin for LiveKit Agents.
 
-Support for speech-to-text, text-to-speech, and LLM with [Sarvam.ai](https://sarvam.ai/).
+Support for speech-to-text, text-to-speech, and LLM with Sarvam.ai.
 
-Sarvam.ai provides high-quality STT and TTS for Indian languages and OpenAI-compatible LLMs.
+Sarvam.ai provides high-quality STT and TTS for Indian languages and
+OpenAI-compatible LLMs.
 
 For API access, visit https://sarvam.ai/
 """
 
 from .llm import LLM, SarvamLLMModels
 from .stt import STT
+from .stt_streaming import StreamingSpeechStream, STTStreaming
 from .tts import TTS
 from .version import __version__
 
-__all__ = ["STT", "TTS", "LLM", "SarvamLLMModels", "__version__"]
+__all__ = [
+    "STT",
+    "STTStreaming",
+    "StreamingSpeechStream",
+    "TTS",
+    "LLM",
+    "SarvamLLMModels",
+    "__version__",
+]
 
 
 from livekit.agents import Plugin

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/__init__.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/__init__.py
@@ -22,14 +22,24 @@ OpenAI-compatible LLMs.
 For API access, visit https://sarvam.ai/
 """
 
+from livekit.agents import Plugin
+
 from .llm import LLM, SarvamLLMModels
+from .log import logger
 from .stt import STT
-from .stt_streaming import StreamingSpeechStream, STTStreaming
+from .stt_streaming import RealtimeSpeechStream, STTRealtime
 from .tts import TTS
 from .version import __version__
 
+# Deprecated compatibility aliases. Prefer `STTRealtime` and
+# `RealtimeSpeechStream`.
+STTStreaming = STTRealtime
+StreamingSpeechStream = RealtimeSpeechStream
+
 __all__ = [
     "STT",
+    "STTRealtime",
+    "RealtimeSpeechStream",
     "STTStreaming",
     "StreamingSpeechStream",
     "TTS",
@@ -37,11 +47,6 @@ __all__ = [
     "SarvamLLMModels",
     "__version__",
 ]
-
-
-from livekit.agents import Plugin
-
-from .log import logger
 
 
 class SarvamPlugin(Plugin):

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/_utils.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/_utils.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class PeriodicCollector(Generic[T]):
+    def __init__(
+        self,
+        callback: Callable[[T], None],
+        *,
+        duration: float,
+    ) -> None:
+        self._duration = duration
+        self._callback = callback
+        self._last_flush_time = time.monotonic()
+        self._total: T | None = None
+
+    def push(self, value: T) -> None:
+        if self._total is None:
+            self._total = value
+        else:
+            self._total += value  # type: ignore[operator]
+
+        if time.monotonic() - self._last_flush_time >= self._duration:
+            self.flush()
+
+    def flush(self) -> None:
+        if self._total is not None:
+            self._callback(self._total)
+            self._total = None
+        self._last_flush_time = time.monotonic()

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/_utils.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/_utils.py
@@ -8,18 +8,28 @@ T = TypeVar("T")
 
 
 class PeriodicCollector(Generic[T]):
+    """Accumulates pushed values and reports the total on a fixed interval."""
+
     def __init__(
         self,
         callback: Callable[[T], None],
         *,
         duration: float,
     ) -> None:
+        """Create a new periodic collector.
+
+        Args:
+            callback: Function to call with the accumulated value once
+                the duration expires.
+            duration: Time in seconds between callback invocations.
+        """
         self._duration = duration
         self._callback = callback
         self._last_flush_time = time.monotonic()
         self._total: T | None = None
 
     def push(self, value: T) -> None:
+        """Add a value, flushing once the duration has elapsed."""
         if self._total is None:
             self._total = value
         else:
@@ -29,6 +39,7 @@ class PeriodicCollector(Generic[T]):
             self.flush()
 
     def flush(self) -> None:
+        """Invoke the callback with the total, if anything is pending."""
         if self._total is not None:
             self._callback(self._total)
             self._total = None

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -438,6 +438,7 @@ class StreamingSpeechStream(stt.SpeechStream):
                     if reconnect_task not in done:
                         break
                     self._reconnect_event.clear()
+                    self._reset_connection_state()
                 finally:
                     await utils.aio.gracefully_cancel(*tasks, reconnect_task)
                     tasks_group.cancel()
@@ -462,6 +463,23 @@ class StreamingSpeechStream(stt.SpeechStream):
         if self._eos_fallback_task and not self._eos_fallback_task.done():
             self._eos_fallback_task.cancel()
         self._eos_fallback_task = None
+
+    def _reset_connection_state(self) -> None:
+        self._cancel_eos_fallback()
+        self._request_id = ""
+        self._session_id = ""
+        self._session_ended = False
+        self._manual_speech_started = False
+        self._pending_eos = False
+        self._pending_eos_time = None
+        self._pending_final_data = None
+        self._utterance_start_audio_pos = 0.0
+        self._utterance_speech_end_audio_pos = None
+        self._utterance_speech_end_wall = None
+        self._final_received_for_utterance = False
+        self._eos_emitted_for_utterance = False
+        self._audio_duration_collector.flush()
+        self._total_reported_audio_duration = 0.0
 
     def _reset_utterance_state(self) -> None:
         self._cancel_eos_fallback()

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -1,0 +1,870 @@
+# Copyright 2025 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import platform
+import time
+import weakref
+from dataclasses import dataclass
+from typing import Any, Literal
+from urllib.parse import urlencode
+
+import aiohttp
+
+from livekit import rtc
+from livekit.agents import (
+    DEFAULT_API_CONNECT_OPTIONS,
+    APIConnectionError,
+    APIConnectOptions,
+    APIStatusError,
+    APITimeoutError,
+    LanguageCode,
+    __version__ as livekit_version,
+    stt,
+    utils,
+)
+from livekit.agents.types import NOT_GIVEN, NotGivenOr
+from livekit.agents.utils import AudioBuffer
+from livekit.agents.utils.misc import is_given
+
+from ._utils import PeriodicCollector
+from .log import logger
+from .stt import _looks_like_error_text
+
+USER_AGENT = f"Livekit/{livekit_version} Python/{platform.python_version()}"
+
+SARVAM_STT_REALTIME_URL = "wss://api.sarvam.ai/speech-to-text-realtime/ws"
+REALTIME_MODEL = "saaras:v3-realtime"
+
+RealtimeStreamType = Literal["fast", "balanced", "simulated"]
+RealtimeEndpointing = Literal["vad", "manual"]
+RealtimeEncoding = Literal["linear16"]
+RealtimeMode = Literal["transcribe", "translate", "indic-en", "verbatim", "translit", "codemix"]
+
+SUPPORTED_SAMPLE_RATES = {8000, 16000}
+SUPPORTED_STREAM_TYPES = {"fast", "balanced", "simulated"}
+SUPPORTED_ENDPOINTING = {"vad", "manual"}
+SUPPORTED_ENCODINGS = {"linear16"}
+SUPPORTED_MODES = {"transcribe", "translate", "indic-en", "verbatim", "translit", "codemix"}
+STREAM_TYPE_CHUNK_MS = {"fast": 500, "balanced": 1000, "simulated": 1000}
+EOS_FALLBACK_TIMEOUT = 2.0
+
+SUPPORTED_LANGUAGES = {
+    "en-IN",
+    "hi-IN",
+    "bn-IN",
+    "kn-IN",
+    "ml-IN",
+    "mr-IN",
+    "or-IN",
+    "pa-IN",
+    "ta-IN",
+    "te-IN",
+    "gu-IN",
+    "as-IN",
+    "ur-IN",
+    "ne-IN",
+    "kok-IN",
+    "ks-IN",
+    "sd-IN",
+    "sa-IN",
+    "sat-IN",
+    "mni-IN",
+    "brx-IN",
+    "mai-IN",
+    "doi-IN",
+    "auto",
+}
+
+
+@dataclass
+class StreamingSTTOptions:
+    language: str
+    api_key: str
+    stream_type: RealtimeStreamType | str = "balanced"
+    mode: RealtimeMode | str = "transcribe"
+    endpointing: RealtimeEndpointing | str = "vad"
+    encoding: RealtimeEncoding | str = "linear16"
+    sample_rate: int = 16000
+    model: str = REALTIME_MODEL
+    base_url: str = SARVAM_STT_REALTIME_URL
+    vad_sot_threshold: float | None = None
+    vad_min_speech_ms: int | None = None
+    vad_min_silence_ms: int | None = None
+    vad_smoothing_alpha: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.model != REALTIME_MODEL:
+            raise ValueError(f"model must be {REALTIME_MODEL}")
+        if self.language not in SUPPORTED_LANGUAGES:
+            raise ValueError(f"language {self.language} is not supported")
+        if self.stream_type not in SUPPORTED_STREAM_TYPES:
+            raise ValueError(
+                f"stream_type must be one of {', '.join(sorted(SUPPORTED_STREAM_TYPES))}"
+            )
+        if self.language == "auto" and self.stream_type != "simulated":
+            raise ValueError("language auto is only supported when stream_type is simulated")
+        if self.mode not in SUPPORTED_MODES:
+            raise ValueError(f"mode must be one of {', '.join(sorted(SUPPORTED_MODES))}")
+        if self.endpointing not in SUPPORTED_ENDPOINTING:
+            raise ValueError(
+                f"endpointing must be one of {', '.join(sorted(SUPPORTED_ENDPOINTING))}"
+            )
+        if self.encoding not in SUPPORTED_ENCODINGS:
+            raise ValueError(f"encoding must be one of {', '.join(sorted(SUPPORTED_ENCODINGS))}")
+        if self.sample_rate not in SUPPORTED_SAMPLE_RATES:
+            raise ValueError(
+                f"sample_rate must be one of {', '.join(str(r) for r in SUPPORTED_SAMPLE_RATES)}"
+            )
+        if self.vad_sot_threshold is not None and not 0.0 <= self.vad_sot_threshold <= 1.0:
+            raise ValueError("vad_sot_threshold must be between 0.0 and 1.0")
+        if self.vad_smoothing_alpha is not None and not 0.0 < self.vad_smoothing_alpha <= 1.0:
+            raise ValueError("vad_smoothing_alpha must be greater than 0.0 and at most 1.0")
+        if self.vad_min_speech_ms is not None and self.vad_min_speech_ms < 0:
+            raise ValueError("vad_min_speech_ms must be greater than or equal to 0")
+        if self.vad_min_silence_ms is not None and self.vad_min_silence_ms < 0:
+            raise ValueError("vad_min_silence_ms must be greater than or equal to 0")
+
+
+def _build_realtime_ws_url(base_url: str, opts: StreamingSTTOptions) -> str:
+    params: dict[str, str] = {
+        "language-code": opts.language,
+        "stream-type": opts.stream_type,
+        "endpointing": opts.endpointing,
+        "encoding": opts.encoding,
+        "sample_rate": str(opts.sample_rate),
+        "model": opts.model,
+    }
+
+    if opts.stream_type == "simulated":
+        params["mode"] = opts.mode
+
+    if opts.endpointing == "vad":
+        if opts.vad_sot_threshold is not None:
+            params["vad_sot_threshold"] = str(opts.vad_sot_threshold)
+        if opts.vad_min_speech_ms is not None:
+            params["vad_min_speech_ms"] = str(opts.vad_min_speech_ms)
+        if opts.vad_min_silence_ms is not None:
+            params["vad_min_silence_ms"] = str(opts.vad_min_silence_ms)
+        if opts.vad_smoothing_alpha is not None:
+            params["vad_smoothing_alpha"] = str(opts.vad_smoothing_alpha)
+
+    return f"{base_url}?{urlencode(params)}"
+
+
+class STTStreaming(stt.STT):
+    def __init__(
+        self,
+        *,
+        language: str = "en-IN",
+        stream_type: RealtimeStreamType | str = "balanced",
+        mode: RealtimeMode | str = "transcribe",
+        endpointing: RealtimeEndpointing | str = "vad",
+        encoding: RealtimeEncoding | str = "linear16",
+        sample_rate: int = 16000,
+        api_key: str | None = None,
+        base_url: str = SARVAM_STT_REALTIME_URL,
+        http_session: aiohttp.ClientSession | None = None,
+        vad_sot_threshold: float | None = None,
+        vad_min_speech_ms: int | None = None,
+        vad_min_silence_ms: int | None = None,
+        vad_smoothing_alpha: float | None = None,
+    ) -> None:
+        super().__init__(
+            capabilities=stt.STTCapabilities(
+                streaming=True,
+                interim_results=True,
+                aligned_transcript=False,
+                offline_recognize=False,
+            )
+        )
+
+        api_key = api_key or os.environ.get("SARVAM_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "Sarvam API key is required. "
+                "Provide it directly or set SARVAM_API_KEY environment variable."
+            )
+
+        self._opts = StreamingSTTOptions(
+            language=language,
+            api_key=api_key,
+            stream_type=stream_type,
+            mode=mode,
+            endpointing=endpointing,
+            encoding=encoding,
+            sample_rate=sample_rate,
+            base_url=base_url,
+            vad_sot_threshold=vad_sot_threshold,
+            vad_min_speech_ms=vad_min_speech_ms,
+            vad_min_silence_ms=vad_min_silence_ms,
+            vad_smoothing_alpha=vad_smoothing_alpha,
+        )
+        self._session = http_session
+        self._owns_session = http_session is None
+        self._streams = weakref.WeakSet[StreamingSpeechStream]()
+
+    @property
+    def model(self) -> str:
+        return REALTIME_MODEL
+
+    @property
+    def provider(self) -> str:
+        return "Sarvam"
+
+    def _ensure_session(self) -> aiohttp.ClientSession:
+        if not self._session:
+            try:
+                self._session = utils.http_context.http_session()
+                self._owns_session = False
+            except RuntimeError:
+                self._session = aiohttp.ClientSession()
+                self._owns_session = True
+        return self._session
+
+    async def _recognize_impl(
+        self,
+        buffer: AudioBuffer,
+        *,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        conn_options: APIConnectOptions,
+    ) -> stt.SpeechEvent:
+        del buffer, language, conn_options
+        raise NotImplementedError("Sarvam realtime STT only supports streaming")
+
+    def update_options(
+        self,
+        *,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        stream_type: NotGivenOr[RealtimeStreamType | str] = NOT_GIVEN,
+        mode: NotGivenOr[RealtimeMode | str] = NOT_GIVEN,
+        endpointing: NotGivenOr[RealtimeEndpointing | str] = NOT_GIVEN,
+        sample_rate: NotGivenOr[int] = NOT_GIVEN,
+        vad_sot_threshold: NotGivenOr[float | None] = NOT_GIVEN,
+        vad_min_speech_ms: NotGivenOr[int | None] = NOT_GIVEN,
+        vad_min_silence_ms: NotGivenOr[int | None] = NOT_GIVEN,
+        vad_smoothing_alpha: NotGivenOr[float | None] = NOT_GIVEN,
+    ) -> None:
+        opts = StreamingSTTOptions(
+            language=language if is_given(language) else self._opts.language,
+            api_key=self._opts.api_key,
+            stream_type=stream_type if is_given(stream_type) else self._opts.stream_type,
+            mode=mode if is_given(mode) else self._opts.mode,
+            endpointing=endpointing if is_given(endpointing) else self._opts.endpointing,
+            encoding=self._opts.encoding,
+            sample_rate=sample_rate if is_given(sample_rate) else self._opts.sample_rate,
+            base_url=self._opts.base_url,
+            vad_sot_threshold=vad_sot_threshold
+            if is_given(vad_sot_threshold)
+            else self._opts.vad_sot_threshold,
+            vad_min_speech_ms=vad_min_speech_ms
+            if is_given(vad_min_speech_ms)
+            else self._opts.vad_min_speech_ms,
+            vad_min_silence_ms=vad_min_silence_ms
+            if is_given(vad_min_silence_ms)
+            else self._opts.vad_min_silence_ms,
+            vad_smoothing_alpha=vad_smoothing_alpha
+            if is_given(vad_smoothing_alpha)
+            else self._opts.vad_smoothing_alpha,
+        )
+        self._opts = opts
+        for stream in self._streams:
+            stream.update_options(opts)
+
+    def stream(
+        self,
+        *,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+    ) -> StreamingSpeechStream:
+        opts = StreamingSTTOptions(
+            language=language if is_given(language) else self._opts.language,
+            api_key=self._opts.api_key,
+            stream_type=self._opts.stream_type,
+            mode=self._opts.mode,
+            endpointing=self._opts.endpointing,
+            encoding=self._opts.encoding,
+            sample_rate=self._opts.sample_rate,
+            base_url=self._opts.base_url,
+            vad_sot_threshold=self._opts.vad_sot_threshold,
+            vad_min_speech_ms=self._opts.vad_min_speech_ms,
+            vad_min_silence_ms=self._opts.vad_min_silence_ms,
+            vad_smoothing_alpha=self._opts.vad_smoothing_alpha,
+        )
+        stream = StreamingSpeechStream(
+            stt=self,
+            opts=opts,
+            conn_options=conn_options,
+            http_session=self._ensure_session(),
+        )
+        self._streams.add(stream)
+        return stream
+
+    async def aclose(self) -> None:
+        for stream in list(self._streams):
+            await stream.aclose()
+        self._streams.clear()
+        if self._owns_session and self._session and not self._session.closed:
+            await self._session.close()
+
+
+class StreamingSpeechStream(stt.SpeechStream):
+    def __init__(
+        self,
+        *,
+        stt: STTStreaming,
+        opts: StreamingSTTOptions,
+        conn_options: APIConnectOptions,
+        http_session: aiohttp.ClientSession,
+    ) -> None:
+        super().__init__(stt=stt, conn_options=conn_options, sample_rate=opts.sample_rate)
+        self._opts = opts
+        self._session = http_session
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._request_id = ""
+        self._session_id = ""
+        self._session_ended = False
+        self._reconnect_event = asyncio.Event()
+        self._manual_speech_started = False
+        self._pending_eos = False
+        self._pending_eos_time: float | None = None
+        self._pending_final_data: dict[str, Any] | None = None
+        self._utterance_start_audio_pos = 0.0
+        self._utterance_speech_end_audio_pos: float | None = None
+        self._utterance_speech_end_wall: float | None = None
+        self._final_received_for_utterance = False
+        self._eos_emitted_for_utterance = False
+        self._eos_fallback_task: asyncio.Task[None] | None = None
+        self._stream_started_at = time.time()
+        self._audio_position = 0.0
+        self._total_reported_audio_duration = 0.0
+        self._audio_duration_collector = PeriodicCollector(
+            callback=self._on_audio_duration_report,
+            duration=5.0,
+        )
+        self._logger = logger
+
+    def update_options(self, opts: StreamingSTTOptions) -> None:
+        self._opts = opts
+        self._reconnect_event.set()
+
+    def _build_log_context(self) -> dict[str, Any]:
+        return {
+            "request_id": self._request_id,
+            "session_id": self._session_id,
+            "model": self._opts.model,
+            "language": self._opts.language,
+            "stream_type": self._opts.stream_type,
+            "endpointing": self._opts.endpointing,
+        }
+
+    @staticmethod
+    def _extract_request_id(data: dict[str, Any]) -> str | None:
+        request_id = data.get("request_id")
+        if request_id is None:
+            nested = data.get("data")
+            if isinstance(nested, dict):
+                request_id = nested.get("request_id")
+            metadata = data.get("metadata")
+            if request_id is None and isinstance(metadata, dict):
+                request_id = metadata.get("request_id")
+        if isinstance(request_id, str) and request_id:
+            return request_id
+        return None
+
+    @staticmethod
+    def _extract_session_id(data: dict[str, Any]) -> str | None:
+        session_id = data.get("session_id")
+        if isinstance(session_id, str) and session_id:
+            return session_id
+        return None
+
+    def _capture_server_ids(self, data: dict[str, Any]) -> None:
+        session_id = self._extract_session_id(data)
+        if session_id is not None:
+            self._session_id = session_id
+
+        if not self._request_id:
+            request_id = self._extract_request_id(data)
+            if request_id is not None:
+                self._request_id = request_id
+
+    async def aclose(self) -> None:
+        try:
+            self._cancel_eos_fallback()
+            if self._ws and not self._ws.closed:
+                await self._ws.close()
+        finally:
+            self._ws = None
+            await super().aclose()
+
+    async def _run(self) -> None:
+        ws: aiohttp.ClientWebSocketResponse | None = None
+        while True:
+            try:
+                ws = await self._connect_ws()
+                self._ws = ws
+                tasks = [
+                    asyncio.create_task(self._process_audio(ws)),
+                    asyncio.create_task(self._process_messages(ws)),
+                ]
+                reconnect_task = asyncio.create_task(self._reconnect_event.wait())
+                tasks_group = asyncio.gather(*tasks)
+
+                try:
+                    done, _ = await asyncio.wait(
+                        (tasks_group, reconnect_task),
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    for task in done:
+                        if task is not reconnect_task:
+                            task.result()
+
+                    if reconnect_task not in done:
+                        break
+                    self._reconnect_event.clear()
+                finally:
+                    await utils.aio.gracefully_cancel(*tasks, reconnect_task)
+                    tasks_group.cancel()
+                    tasks_group.exception()
+            except asyncio.TimeoutError as e:
+                raise APITimeoutError("Timed out connecting to Sarvam realtime STT") from e
+            except aiohttp.ClientResponseError as e:
+                raise APIStatusError(
+                    message=e.message,
+                    status_code=e.status,
+                    request_id=self._request_id or None,
+                    body=e.message,
+                ) from e
+            except aiohttp.ClientConnectorError as e:
+                raise APIConnectionError("failed to connect to Sarvam realtime STT") from e
+            finally:
+                if ws is not None:
+                    await ws.close()
+                self._ws = None
+
+    def _cancel_eos_fallback(self) -> None:
+        if self._eos_fallback_task and not self._eos_fallback_task.done():
+            self._eos_fallback_task.cancel()
+        self._eos_fallback_task = None
+
+    def _reset_utterance_state(self) -> None:
+        self._cancel_eos_fallback()
+        self._pending_eos = False
+        self._pending_eos_time = None
+        self._pending_final_data = None
+        self._utterance_start_audio_pos = self._audio_position
+        self._utterance_speech_end_audio_pos = None
+        self._utterance_speech_end_wall = None
+        self._final_received_for_utterance = False
+        self._eos_emitted_for_utterance = False
+
+    async def _safe_send_str(
+        self,
+        ws: Any,
+        payload: dict[str, Any],
+    ) -> None:
+        if ws.closed:
+            return
+
+        try:
+            await ws.send_str(json.dumps(payload))
+        except (aiohttp.ClientConnectionResetError, ConnectionError):
+            self._logger.debug(
+                "Sarvam realtime STT WebSocket closed before send completed",
+                extra={**self._build_log_context(), "payload": payload},
+            )
+
+    async def _connect_ws(self) -> aiohttp.ClientWebSocketResponse:
+        ws_url = _build_realtime_ws_url(self._opts.base_url, self._opts)
+        headers = {
+            "API-SUBSCRIPTION-KEY": self._opts.api_key,
+            "User-Agent": USER_AGENT,
+        }
+        self._logger.info(
+            "Connecting to Sarvam realtime STT WebSocket", extra=self._build_log_context()
+        )
+        try:
+            ws = await asyncio.wait_for(
+                self._session.ws_connect(ws_url, headers=headers, heartbeat=30.0),
+                self._conn_options.timeout,
+            )
+        except (aiohttp.ClientConnectorError, asyncio.TimeoutError):
+            raise
+        except aiohttp.ClientResponseError:
+            raise
+        except Exception as e:
+            raise APIConnectionError("failed to connect to Sarvam realtime STT") from e
+        self._logger.info(
+            "Sarvam realtime STT WebSocket connected", extra=self._build_log_context()
+        )
+        return ws
+
+    @utils.log_exceptions(logger=logger)
+    async def _process_audio(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        cap_ms = STREAM_TYPE_CHUNK_MS[self._opts.stream_type]
+        samples_per_channel = max(int(self._opts.sample_rate * cap_ms / 1000), 1)
+        audio_bstream = utils.audio.AudioByteStream(
+            sample_rate=self._opts.sample_rate,
+            num_channels=1,
+            samples_per_channel=samples_per_channel,
+        )
+
+        async for data in self._input_ch:
+            frames: list[rtc.AudioFrame] = []
+            if isinstance(data, rtc.AudioFrame):
+                frames.extend(audio_bstream.write(data.data.tobytes()))
+            elif isinstance(data, self._FlushSentinel):
+                frames.extend(audio_bstream.flush())
+
+            for frame in frames:
+                if self._opts.endpointing == "manual" and not self._manual_speech_started:
+                    await self._safe_send_str(ws, {"event": "speech_start"})
+                    self._manual_speech_started = True
+
+                self._audio_duration_collector.push(frame.duration)
+                self._audio_position += frame.duration
+                await ws.send_bytes(frame.data.tobytes())
+
+            if isinstance(data, self._FlushSentinel):
+                self._audio_duration_collector.flush()
+                if self._opts.endpointing == "manual" and self._manual_speech_started:
+                    await self._safe_send_str(ws, {"event": "speech_end"})
+                    self._manual_speech_started = False
+
+        self._audio_duration_collector.flush()
+        await self._safe_send_str(ws, {"event": "end"})
+
+    @utils.log_exceptions(logger=logger)
+    async def _process_messages(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        while True:
+            msg = await ws.receive()
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                try:
+                    await self._handle_message(json.loads(msg.data))
+                except json.JSONDecodeError as e:
+                    if _looks_like_error_text(msg.data):
+                        raise APIStatusError(
+                            message=f"Sarvam realtime STT non-JSON error message: {msg.data}",
+                            request_id=self._request_id or None,
+                            body={"raw_message": msg.data},
+                        ) from e
+                    self._logger.warning(
+                        "Invalid JSON received from Sarvam realtime STT",
+                        extra={**self._build_log_context(), "raw_data": msg.data},
+                    )
+                    continue
+            elif msg.type == aiohttp.WSMsgType.ERROR:
+                raise APIConnectionError(f"Sarvam realtime STT WebSocket error: {msg.data}")
+            elif msg.type in (
+                aiohttp.WSMsgType.CLOSED,
+                aiohttp.WSMsgType.CLOSE,
+                aiohttp.WSMsgType.CLOSING,
+            ):
+                close_code = ws.close_code if ws.close_code is not None else msg.data
+                close_reason = msg.extra
+                if self._session_ended and close_code in (1000, 1001, None):
+                    break
+                if close_code in (1000, 1001, None) and not _looks_like_error_text(close_reason):
+                    break
+                raise self._status_error_from_close(close_code, close_reason)
+            else:
+                self._logger.debug(
+                    "Unknown Sarvam realtime STT WebSocket message type",
+                    extra={**self._build_log_context(), "message_type": str(msg.type)},
+                )
+
+    def _status_error_from_close(self, close_code: object, close_reason: object) -> APIStatusError:
+        status_code = int(close_code) if isinstance(close_code, int) else -1
+        retryable = close_code == 1013
+        message = f"Sarvam realtime STT WebSocket closed unexpectedly: {close_reason}"
+        if close_code == 1003:
+            message = "Sarvam realtime STT authentication, quota, or rate limit error"
+        elif close_code == 1008:
+            message = "Sarvam realtime STT session timed out or exceeded the maximum duration"
+        elif close_code == 1013:
+            message = "Sarvam realtime STT backend temporarily unavailable"
+        elif close_code == 4000:
+            message = f"Sarvam realtime STT rejected the session: {close_reason}"
+
+        return APIStatusError(
+            message=message,
+            status_code=status_code,
+            request_id=self._request_id or None,
+            body={
+                "close_code": close_code,
+                "close_reason": close_reason,
+            },
+            retryable=retryable,
+        )
+
+    async def _handle_message(self, data: dict[str, Any]) -> None:
+        event = data.get("event")
+        self._capture_server_ids(data)
+        self._log_stt_event(event, data)
+        if event == "session.begin":
+            return
+        elif event == "vad.speech_start":
+            self._reset_utterance_state()
+            self._event_ch.send_nowait(
+                stt.SpeechEvent(
+                    type=stt.SpeechEventType.START_OF_SPEECH,
+                    request_id=self._request_id,
+                )
+            )
+        elif event == "vad.speech_end":
+            self._handle_speech_end()
+        elif event == "transcript.partial":
+            self._send_transcript_event(stt.SpeechEventType.INTERIM_TRANSCRIPT, data)
+        elif event == "transcript.final":
+            if self._opts.endpointing == "vad":
+                if self._is_valid_transcript(data):
+                    self._pending_final_data = data
+                    self._final_received_for_utterance = True
+                    self._try_commit_utterance()
+            elif self._send_transcript_event(stt.SpeechEventType.FINAL_TRANSCRIPT, data):
+                self._final_received_for_utterance = True
+        elif event == "session.end":
+            self._handle_session_end(data)
+        elif event == "error":
+            self._handle_error_event(data)
+        elif event == "pong":
+            return
+        else:
+            self._logger.debug(
+                "Unknown Sarvam realtime STT event",
+                extra={**self._build_log_context(), "event": event, "data": data},
+            )
+
+    def _log_stt_event(self, event: object, data: dict[str, Any]) -> None:
+        if event == "pong":
+            return
+
+        extra: dict[str, Any] = {
+            **self._build_log_context(),
+            "event": event,
+            "utterance_idx": data.get("utterance_idx"),
+            "raw_data": data,
+        }
+        if event in {"transcript.partial", "transcript.final"}:
+            text = data.get("text")
+            if isinstance(text, str):
+                extra["text"] = text[:200]
+                extra["text_length"] = len(text)
+            extra["language"] = data.get("language") or self._opts.language
+            extra["confidence"] = data.get("language_confidence", data.get("confidence"))
+        elif event == "vad.speech_start":
+            extra["audio_position"] = self._audio_position
+        elif event == "vad.speech_end":
+            extra["audio_position"] = self._audio_position
+        elif event == "session.begin":
+            pass
+        elif event == "session.end":
+            extra["audio_duration_s"] = data.get("audio_duration_s")
+        else:
+            return
+
+        self._logger.info(f"Sarvam realtime STT {event}", extra=extra)
+
+    def _is_valid_transcript(self, data: dict[str, Any]) -> bool:
+        text = data.get("text")
+        return isinstance(text, str) and bool(text)
+
+    def _handle_speech_end(self) -> None:
+        self._utterance_speech_end_audio_pos = self._audio_position
+        self._utterance_speech_end_wall = time.time()
+
+        if self._opts.endpointing != "vad":
+            self._emit_end_of_speech()
+            return
+
+        if self._eos_emitted_for_utterance:
+            return
+
+        if self._final_received_for_utterance:
+            self._try_commit_utterance()
+            return
+
+        self._pending_eos = True
+        self._pending_eos_time = self._utterance_speech_end_wall
+        if self._eos_fallback_task is None or self._eos_fallback_task.done():
+            self._eos_fallback_task = asyncio.create_task(self._emit_pending_eos_after_timeout())
+
+    async def _emit_pending_eos_after_timeout(
+        self,
+        timeout: float = EOS_FALLBACK_TIMEOUT,
+    ) -> None:
+        try:
+            if timeout > 0:
+                await asyncio.sleep(timeout)
+            if self._pending_eos and not self._eos_emitted_for_utterance:
+                self._emit_end_of_speech()
+        except asyncio.CancelledError:
+            raise
+
+    def _try_commit_utterance(self) -> None:
+        if (
+            self._pending_final_data is None
+            or self._utterance_speech_end_audio_pos is None
+            or self._eos_emitted_for_utterance
+        ):
+            return
+
+        committed_data = self._pending_final_data
+        if self._send_transcript_event(
+            stt.SpeechEventType.FINAL_TRANSCRIPT,
+            committed_data,
+        ):
+            self._logger.info(
+                "Sarvam realtime STT utterance committed",
+                extra={
+                    **self._build_log_context(),
+                    "end_time": self._utterance_speech_end_audio_pos,
+                    "speech_end_wall_time": self._utterance_speech_end_wall,
+                },
+            )
+            self._emit_end_of_speech()
+            self._pending_final_data = None
+
+    def _emit_end_of_speech(self) -> None:
+        current_task = asyncio.current_task()
+        fallback_task = self._eos_fallback_task
+        self._eos_fallback_task = None
+        if fallback_task and fallback_task is not current_task and not fallback_task.done():
+            fallback_task.cancel()
+
+        if self._eos_emitted_for_utterance:
+            return
+
+        alternatives: list[stt.SpeechData] = []
+        if self._utterance_speech_end_audio_pos is not None:
+            metadata: dict[str, Any] = {}
+            if self._utterance_speech_end_wall is not None:
+                metadata["speech_end_wall_time"] = self._utterance_speech_end_wall
+            if self._pending_final_data is not None:
+                utterance_idx = self._pending_final_data.get("utterance_idx")
+                if utterance_idx is not None:
+                    metadata["utterance_idx"] = utterance_idx
+            alternatives.append(
+                stt.SpeechData(
+                    language=LanguageCode(self._opts.language),
+                    text="",
+                    end_time=self._utterance_speech_end_audio_pos,
+                    metadata=metadata or None,
+                )
+            )
+
+        self._event_ch.send_nowait(
+            stt.SpeechEvent(
+                type=stt.SpeechEventType.END_OF_SPEECH,
+                request_id=self._request_id,
+                alternatives=alternatives,
+            )
+        )
+        self._pending_eos = False
+        self._pending_eos_time = None
+        self._eos_emitted_for_utterance = True
+
+    def _send_transcript_event(self, event_type: stt.SpeechEventType, data: dict[str, Any]) -> bool:
+        text = data.get("text")
+        if not isinstance(text, str) or not text:
+            return False
+
+        language = data.get("language") or self._opts.language
+        confidence = data.get("language_confidence")
+        if confidence is None:
+            confidence = data.get("confidence", 0.0)
+        if not isinstance(confidence, (int, float)) or isinstance(confidence, bool):
+            confidence = 0.0
+
+        metadata = {
+            key: data[key]
+            for key in ("utterance_idx", "language_confidence")
+            if key in data and data[key] is not None
+        }
+        if (
+            event_type == stt.SpeechEventType.FINAL_TRANSCRIPT
+            and self._utterance_speech_end_wall is not None
+        ):
+            metadata["speech_end_wall_time"] = self._utterance_speech_end_wall
+        end_time = 0.0
+        if (
+            event_type == stt.SpeechEventType.FINAL_TRANSCRIPT
+            and self._utterance_speech_end_audio_pos is not None
+        ):
+            end_time = self._utterance_speech_end_audio_pos
+        elif event_type == stt.SpeechEventType.FINAL_TRANSCRIPT and self._audio_position > 0:
+            end_time = self._audio_position
+
+        speech_data = stt.SpeechData(
+            language=LanguageCode(language),
+            text=text,
+            end_time=end_time,
+            confidence=float(confidence),
+            metadata=metadata or None,
+        )
+        self._event_ch.send_nowait(
+            stt.SpeechEvent(
+                type=event_type,
+                request_id=self._request_id,
+                alternatives=[speech_data],
+            )
+        )
+        return True
+
+    def _handle_session_end(self, data: dict[str, Any]) -> None:
+        self._capture_server_ids(data)
+        audio_duration = data.get("audio_duration_s")
+        if isinstance(audio_duration, (int, float)) and not isinstance(audio_duration, bool):
+            delta = max(float(audio_duration) - self._total_reported_audio_duration, 0.0)
+            if delta:
+                self._emit_usage(delta)
+        self._session_ended = True
+
+    def _handle_error_event(self, data: dict[str, Any]) -> None:
+        if not data.get("is_fatal", False):
+            self._logger.warning(
+                "Non-fatal Sarvam realtime STT error",
+                extra={**self._build_log_context(), "error": data},
+            )
+            return
+
+        code = data.get("code", "unknown")
+        status_code = data.get("status_code", -1)
+        if not isinstance(status_code, int):
+            status_code = -1
+        raise APIStatusError(
+            message=f"Sarvam realtime STT error: {data.get('message', code)}",
+            status_code=status_code,
+            request_id=self._request_id or None,
+            body=data,
+            retryable=code == "model_unavailable",
+        )
+
+    def _on_audio_duration_report(self, duration: float) -> None:
+        self._emit_usage(duration)
+
+    def _emit_usage(self, duration: float) -> None:
+        self._total_reported_audio_duration += duration
+        self._event_ch.send_nowait(
+            stt.SpeechEvent(
+                type=stt.SpeechEventType.RECOGNITION_USAGE,
+                request_id=self._request_id,
+                recognition_usage=stt.RecognitionUsage(audio_duration=duration),
+            )
+        )

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -638,6 +638,7 @@ class StreamingSpeechStream(stt.SpeechStream):
         if event == "session.begin":
             return
         elif event == "vad.speech_start":
+            self._emit_pending_eos_before_new_speech()
             self._reset_utterance_state()
             self._event_ch.send_nowait(
                 stt.SpeechEvent(
@@ -702,6 +703,10 @@ class StreamingSpeechStream(stt.SpeechStream):
     def _is_valid_transcript(self, data: dict[str, Any]) -> bool:
         text = data.get("text")
         return isinstance(text, str) and bool(text)
+
+    def _emit_pending_eos_before_new_speech(self) -> None:
+        if self._pending_eos and not self._eos_emitted_for_utterance:
+            self._emit_end_of_speech()
 
     def _handle_speech_end(self) -> None:
         self._utterance_speech_end_audio_pos = self._audio_position

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -67,7 +67,6 @@ SUPPORTED_MODES = {"transcribe", "translate", "verbatim", "translit", "codemix"}
 # not a send cadence, and the contract sets no client chunk size. Matches the
 # non-realtime Sarvam websocket plugin so audio reaches server VAD promptly.
 AUDIO_CHUNK_MS = 50
-EOS_FALLBACK_TIMEOUT = 2.0
 
 
 def _encode_pcm_for_wire(encoding: RealtimeEncoding | str, pcm: bytes) -> bytes:
@@ -528,18 +527,14 @@ class RealtimeSpeechStream(stt.SpeechStream):
         self._active_endpointing = opts.endpointing
         self._pending_endpointing: RealtimeEndpointing | str | None = None
         self._endpointing_update_acknowledged = False
-        self._reconnect_event = asyncio.Event()
         self._pending_config_update: dict[str, Any] | None = None
         self._manual_speech_started = False
-        self._pending_eos = False
-        self._pending_eos_time: float | None = None
         self._pending_final_data: dict[str, Any] | None = None
         self._utterance_start_audio_pos = 0.0
         self._utterance_speech_end_audio_pos: float | None = None
         self._utterance_speech_end_wall: float | None = None
         self._final_received_for_utterance = False
         self._eos_emitted_for_utterance = False
-        self._eos_fallback_task: asyncio.Task[None] | None = None
         self._stream_started_at = time.time()
         self._audio_position = 0.0
         self._local_audio_duration = 0.0
@@ -708,7 +703,6 @@ class RealtimeSpeechStream(stt.SpeechStream):
         deliver usage metrics.
         """
         try:
-            self._cancel_eos_fallback()
             if not self._event_ch.closed:
                 self._emit_local_usage_fallback()
                 # Give the metrics monitor a chance to consume the usage event before
@@ -721,88 +715,38 @@ class RealtimeSpeechStream(stt.SpeechStream):
             await super().aclose()
 
     async def _run(self) -> None:
+        # A single connection attempt: this endpoint bills per connection, so the
+        # stream never reconnects on its own (`stream()` also forces max_retry=0).
         ws: aiohttp.ClientWebSocketResponse | None = None
-        while True:
+        try:
+            ws = await self._connect_ws()
+            self._ws = ws
+            tasks = [
+                asyncio.create_task(self._process_audio(ws)),
+                asyncio.create_task(self._process_messages(ws)),
+            ]
             try:
-                ws = await self._connect_ws()
-                self._ws = ws
-                tasks = [
-                    asyncio.create_task(self._process_audio(ws)),
-                    asyncio.create_task(self._process_messages(ws)),
-                ]
-                reconnect_task = asyncio.create_task(self._reconnect_event.wait())
-                tasks_group = asyncio.gather(*tasks)
-
-                try:
-                    done, _ = await asyncio.wait(
-                        (tasks_group, reconnect_task),
-                        return_when=asyncio.FIRST_COMPLETED,
-                    )
-                    for task in done:
-                        if task is not reconnect_task:
-                            task.result()
-
-                    if reconnect_task not in done:
-                        break
-                    self._reconnect_event.clear()
-                    self._reset_connection_state()
-                finally:
-                    await utils.aio.gracefully_cancel(*tasks, reconnect_task)
-                    tasks_group.cancel()
-                    tasks_group.exception()
-            except asyncio.TimeoutError as e:
-                raise APITimeoutError("Timed out connecting to Sarvam realtime STT") from e
-            except aiohttp.ClientResponseError as e:
-                raise APIStatusError(
-                    message=e.message,
-                    status_code=e.status,
-                    request_id=self._request_id or None,
-                    body=e.message,
-                ) from e
-            except aiohttp.ClientConnectorError as e:
-                raise APIConnectionError("failed to connect to Sarvam realtime STT") from e
+                await asyncio.gather(*tasks)
             finally:
-                if ws is not None:
-                    await ws.close()
-                self._ws = None
-
-    def _cancel_eos_fallback(self) -> None:
-        if self._eos_fallback_task and not self._eos_fallback_task.done():
-            self._eos_fallback_task.cancel()
-        self._eos_fallback_task = None
-
-    def _reset_connection_state(self) -> None:
-        self._cancel_eos_fallback()
-        self._request_id = ""
-        self._session_id = ""
-        self._resolved_config = None
-        self._session_ended = False
-        self._utterance_idx = None
-        self._utterance_in_progress = False
-        self._active_endpointing = self._opts.endpointing
-        self._pending_endpointing = None
-        self._endpointing_update_acknowledged = False
-        self._pending_config_update = None
-        self._manual_speech_started = False
-        self._pending_eos = False
-        self._pending_eos_time = None
-        self._pending_final_data = None
-        self._utterance_start_audio_pos = 0.0
-        self._utterance_speech_end_audio_pos = None
-        self._utterance_speech_end_wall = None
-        self._final_received_for_utterance = False
-        self._eos_emitted_for_utterance = False
-        self._audio_duration_collector.flush()
-        self._emit_local_usage_fallback()
-        self._local_audio_duration = 0.0
-        self._total_reported_audio_duration = 0.0
-        self._server_audio_duration_reported = False
+                await utils.aio.gracefully_cancel(*tasks)
+        except asyncio.TimeoutError as e:
+            raise APITimeoutError("Timed out connecting to Sarvam realtime STT") from e
+        except aiohttp.ClientResponseError as e:
+            raise APIStatusError(
+                message=e.message,
+                status_code=e.status,
+                request_id=self._request_id or None,
+                body=e.message,
+            ) from e
+        except aiohttp.ClientConnectorError as e:
+            raise APIConnectionError("failed to connect to Sarvam realtime STT") from e
+        finally:
+            if ws is not None:
+                await ws.close()
+            self._ws = None
 
     def _reset_utterance_state(self) -> None:
-        self._cancel_eos_fallback()
         self._utterance_idx = None
-        self._pending_eos = False
-        self._pending_eos_time = None
         self._pending_final_data = None
         self._utterance_start_audio_pos = self._audio_position
         self._utterance_speech_end_audio_pos = None
@@ -1052,7 +996,6 @@ class RealtimeSpeechStream(stt.SpeechStream):
         if event == "session.begin":
             return
         elif event == "vad.speech_start":
-            self._emit_pending_eos_before_new_speech()
             self._reset_utterance_state()
             self._utterance_in_progress = True
             utterance_idx = data.get("utterance_idx")
@@ -1142,10 +1085,6 @@ class RealtimeSpeechStream(stt.SpeechStream):
         text = data.get("text")
         return isinstance(text, str) and bool(text)
 
-    def _emit_pending_eos_before_new_speech(self) -> None:
-        if self._pending_eos and not self._eos_emitted_for_utterance:
-            self._emit_end_of_speech()
-
     def _handle_speech_end(self) -> None:
         self._utterance_speech_end_audio_pos = self._audio_position
         self._utterance_speech_end_wall = time.time()
@@ -1157,23 +1096,9 @@ class RealtimeSpeechStream(stt.SpeechStream):
         if self._eos_emitted_for_utterance:
             return
 
-        self._pending_eos = True
-        self._pending_eos_time = self._utterance_speech_end_wall
         self._emit_end_of_speech()
         if self._final_received_for_utterance:
             self._try_commit_utterance()
-
-    async def _emit_pending_eos_after_timeout(
-        self,
-        timeout: float = EOS_FALLBACK_TIMEOUT,
-    ) -> None:
-        try:
-            if timeout > 0:
-                await asyncio.sleep(timeout)
-            if self._pending_eos and not self._eos_emitted_for_utterance:
-                self._emit_end_of_speech()
-        except asyncio.CancelledError:
-            raise
 
     def _try_commit_utterance(self) -> None:
         if self._pending_final_data is None or self._utterance_speech_end_audio_pos is None:
@@ -1211,20 +1136,12 @@ class RealtimeSpeechStream(stt.SpeechStream):
             if self._utterance_speech_end_wall is None:
                 self._utterance_speech_end_wall = time.time()
 
-        if not self._eos_emitted_for_utterance and (
-            self._pending_eos or self._pending_final_data is not None
-        ):
+        if not self._eos_emitted_for_utterance and self._pending_final_data is not None:
             self._emit_end_of_speech()
 
         self._try_commit_utterance()
 
     def _emit_end_of_speech(self) -> None:
-        current_task = asyncio.current_task()
-        fallback_task = self._eos_fallback_task
-        self._eos_fallback_task = None
-        if fallback_task and fallback_task is not current_task and not fallback_task.done():
-            fallback_task.cancel()
-
         if self._eos_emitted_for_utterance:
             return
 
@@ -1237,8 +1154,6 @@ class RealtimeSpeechStream(stt.SpeechStream):
                 request_id=self._request_id,
             )
         )
-        self._pending_eos = False
-        self._pending_eos_time = None
         self._eos_emitted_for_utterance = True
 
     def _send_transcript_event(self, event_type: stt.SpeechEventType, data: dict[str, Any]) -> bool:

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -158,8 +158,6 @@ class RealtimeSTTOptions:
     vad_min_speech_ms: int | None = None
     vad_min_silence_ms: int | None = None
     vad_prefix_padding_ms: int | None = None
-    lid_gate_seconds: float | None = None
-    lid_confidence_threshold: float | None = None
 
     def __post_init__(self) -> None:
         if self.model != REALTIME_MODEL:
@@ -190,13 +188,6 @@ class RealtimeSTTOptions:
             raise ValueError("vad_min_silence_ms must be greater than or equal to 0")
         if self.vad_prefix_padding_ms is not None and self.vad_prefix_padding_ms < 0:
             raise ValueError("vad_prefix_padding_ms must be greater than or equal to 0")
-        if self.lid_gate_seconds is not None and self.lid_gate_seconds < 0:
-            raise ValueError("lid_gate_seconds must be greater than or equal to 0")
-        if (
-            self.lid_confidence_threshold is not None
-            and not 0.0 <= self.lid_confidence_threshold <= 1.0
-        ):
-            raise ValueError("lid_confidence_threshold must be between 0.0 and 1.0")
 
 
 def _build_realtime_ws_url(base_url: str, opts: RealtimeSTTOptions) -> str:
@@ -213,10 +204,6 @@ def _build_realtime_ws_url(base_url: str, opts: RealtimeSTTOptions) -> str:
     params["return_timestamps"] = str(opts.return_timestamps).lower()
     if opts.prompt is not None:
         params["prompt"] = opts.prompt
-    if opts.lid_gate_seconds is not None:
-        params["lid_gate_seconds"] = str(opts.lid_gate_seconds)
-    if opts.lid_confidence_threshold is not None:
-        params["lid_confidence_threshold"] = str(opts.lid_confidence_threshold)
 
     if opts.endpointing == "vad":
         if opts.vad_sot_threshold is not None:
@@ -257,8 +244,6 @@ class STTRealtime(stt.STT):
         vad_min_speech_ms: int | None = None,
         vad_min_silence_ms: int | None = None,
         vad_prefix_padding_ms: int | None = None,
-        lid_gate_seconds: float | None = None,
-        lid_confidence_threshold: float | None = None,
     ) -> None:
         """Create a Sarvam realtime STT instance.
 
@@ -281,8 +266,6 @@ class STTRealtime(stt.STT):
             vad_min_silence_ms: End-of-turn silence in ms (``vad`` endpointing only).
             vad_prefix_padding_ms: Audio retained before speech onset in ms
                 (``vad`` endpointing only).
-            lid_gate_seconds: Utterance audio required before a detected language is promoted.
-            lid_confidence_threshold: Confidence required before a detected language is promoted.
 
         Raises:
             ValueError: If no API key is provided or found in the environment, or if an
@@ -319,8 +302,6 @@ class STTRealtime(stt.STT):
             vad_min_speech_ms=vad_min_speech_ms,
             vad_min_silence_ms=vad_min_silence_ms,
             vad_prefix_padding_ms=vad_prefix_padding_ms,
-            lid_gate_seconds=lid_gate_seconds,
-            lid_confidence_threshold=lid_confidence_threshold,
         )
         self._session = http_session
         self._owns_session = http_session is None
@@ -370,14 +351,12 @@ class STTRealtime(stt.STT):
         vad_min_speech_ms: NotGivenOr[int | None] = NOT_GIVEN,
         vad_min_silence_ms: NotGivenOr[int | None] = NOT_GIVEN,
         vad_prefix_padding_ms: NotGivenOr[int | None] = NOT_GIVEN,
-        lid_gate_seconds: NotGivenOr[float | None] = NOT_GIVEN,
-        lid_confidence_threshold: NotGivenOr[float | None] = NOT_GIVEN,
     ) -> None:
         """Update options for this instance and every stream it created.
 
         Options that Sarvam only accepts at connection time (``sample_rate``,
-        ``return_timestamps``, ``vad_prefix_padding_ms``, ``lid_gate_seconds``, and
-        ``lid_confidence_threshold``) take effect on newly created streams only.
+        ``return_timestamps``, and ``vad_prefix_padding_ms``) take effect on
+        newly created streams only.
         The remaining options are sent to active streams as an in-band
         ``config.update``, and the boundary-gated ones apply from the next
         utterance boundary.
@@ -394,8 +373,6 @@ class STTRealtime(stt.STT):
             vad_min_speech_ms: Minimum speech duration in ms (``vad`` endpointing only).
             vad_min_silence_ms: End-of-turn silence in ms (``vad`` endpointing only).
             vad_prefix_padding_ms: Audio retained before speech onset; new streams only.
-            lid_gate_seconds: Language-promotion audio gate; applies to new streams only.
-            lid_confidence_threshold: Language-promotion confidence; new streams only.
 
         Raises:
             ValueError: If an option falls outside the values the endpoint accepts.
@@ -425,12 +402,6 @@ class STTRealtime(stt.STT):
             vad_prefix_padding_ms=vad_prefix_padding_ms
             if is_given(vad_prefix_padding_ms)
             else self._opts.vad_prefix_padding_ms,
-            lid_gate_seconds=lid_gate_seconds
-            if is_given(lid_gate_seconds)
-            else self._opts.lid_gate_seconds,
-            lid_confidence_threshold=lid_confidence_threshold
-            if is_given(lid_confidence_threshold)
-            else self._opts.lid_confidence_threshold,
         )
         self._opts = opts
         # Forward the given fields only, so a stream created with a per-stream
@@ -448,8 +419,6 @@ class STTRealtime(stt.STT):
                 vad_min_speech_ms=vad_min_speech_ms,
                 vad_min_silence_ms=vad_min_silence_ms,
                 vad_prefix_padding_ms=vad_prefix_padding_ms,
-                lid_gate_seconds=lid_gate_seconds,
-                lid_confidence_threshold=lid_confidence_threshold,
             )
 
     def stream(
@@ -484,8 +453,6 @@ class STTRealtime(stt.STT):
             vad_min_speech_ms=self._opts.vad_min_speech_ms,
             vad_min_silence_ms=self._opts.vad_min_silence_ms,
             vad_prefix_padding_ms=self._opts.vad_prefix_padding_ms,
-            lid_gate_seconds=self._opts.lid_gate_seconds,
-            lid_confidence_threshold=self._opts.lid_confidence_threshold,
         )
         stream = RealtimeSpeechStream(
             stt=self,
@@ -546,6 +513,7 @@ class RealtimeSpeechStream(stt.SpeechStream):
         self._endpointing_update_sent = False
         self._pending_config_update: dict[str, Any] | None = None
         self._manual_speech_started = False
+        self._flush_observed = False
         self._pending_final_data: dict[str, Any] | None = None
         self._utterance_start_audio_pos = 0.0
         self._utterance_speech_end_audio_pos: float | None = None
@@ -582,8 +550,6 @@ class RealtimeSpeechStream(stt.SpeechStream):
         vad_min_speech_ms: NotGivenOr[int | None] = NOT_GIVEN,
         vad_min_silence_ms: NotGivenOr[int | None] = NOT_GIVEN,
         vad_prefix_padding_ms: NotGivenOr[int | None] = NOT_GIVEN,
-        lid_gate_seconds: NotGivenOr[float | None] = NOT_GIVEN,
-        lid_confidence_threshold: NotGivenOr[float | None] = NOT_GIVEN,
     ) -> None:
         """Apply an option change to this live connection.
 
@@ -606,8 +572,6 @@ class RealtimeSpeechStream(stt.SpeechStream):
             vad_min_speech_ms: Minimum speech duration in ms (``vad`` endpointing only).
             vad_min_silence_ms: End-of-turn silence in ms (``vad`` endpointing only).
             vad_prefix_padding_ms: Speech-onset padding; retained on a live stream.
-            lid_gate_seconds: Language-promotion audio gate; retained on a live stream.
-            lid_confidence_threshold: Language-promotion confidence; retained.
 
         Raises:
             ValueError: If an option falls outside the values the endpoint accepts.
@@ -636,10 +600,6 @@ class RealtimeSpeechStream(stt.SpeechStream):
             requested["vad_min_silence_ms"] = vad_min_silence_ms
         if is_given(vad_prefix_padding_ms):
             requested["vad_prefix_padding_ms"] = vad_prefix_padding_ms
-        if is_given(lid_gate_seconds):
-            requested["lid_gate_seconds"] = lid_gate_seconds
-        if is_given(lid_confidence_threshold):
-            requested["lid_confidence_threshold"] = lid_confidence_threshold
 
         if not requested:
             return
@@ -655,15 +615,6 @@ class RealtimeSpeechStream(stt.SpeechStream):
         if opts.vad_prefix_padding_ms != previous_opts.vad_prefix_padding_ms:
             connection_only_options.append("vad_prefix_padding_ms")
             opts = replace(opts, vad_prefix_padding_ms=previous_opts.vad_prefix_padding_ms)
-        if opts.lid_gate_seconds != previous_opts.lid_gate_seconds:
-            connection_only_options.append("lid_gate_seconds")
-            opts = replace(opts, lid_gate_seconds=previous_opts.lid_gate_seconds)
-        if opts.lid_confidence_threshold != previous_opts.lid_confidence_threshold:
-            connection_only_options.append("lid_confidence_threshold")
-            opts = replace(
-                opts,
-                lid_confidence_threshold=previous_opts.lid_confidence_threshold,
-            )
         if connection_only_options:
             self._logger.warning(
                 "Sarvam realtime STT connection-only option updates only apply to new streams",
@@ -675,6 +626,13 @@ class RealtimeSpeechStream(stt.SpeechStream):
 
         self._opts = opts
         if opts.endpointing != previous_opts.endpointing:
+            if opts.endpointing == "manual" and not self._flush_observed:
+                self._logger.warning(
+                    "Sarvam realtime STT switched to manual endpointing without an external VAD; "
+                    "turns will not be delimited unless the agent framework flushes the stream. "
+                    "Configure a VAD on the AgentSession to receive end-of-turn boundaries.",
+                    extra=self._build_log_context(),
+                )
             self._pending_endpointing = opts.endpointing
             self._endpointing_update_acknowledged = False
             self._endpointing_update_sent = False
@@ -992,7 +950,8 @@ class RealtimeSpeechStream(stt.SpeechStream):
             frames: list[rtc.AudioFrame] = []
             if isinstance(data, rtc.AudioFrame):
                 frames.extend(audio_bstream.write(data.data.tobytes()))
-            elif isinstance(data, self._FlushSentinel):
+            if isinstance(data, self._FlushSentinel):
+                self._flush_observed = True
                 frames.extend(audio_bstream.flush())
 
             for frame in frames:

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -108,7 +108,6 @@ class StreamingSTTOptions:
     vad_sot_threshold: float | None = None
     vad_min_speech_ms: int | None = None
     vad_min_silence_ms: int | None = None
-    vad_smoothing_alpha: float | None = None
 
     def __post_init__(self) -> None:
         if self.model != REALTIME_MODEL:
@@ -133,8 +132,6 @@ class StreamingSTTOptions:
             )
         if self.vad_sot_threshold is not None and not 0.0 <= self.vad_sot_threshold <= 1.0:
             raise ValueError("vad_sot_threshold must be between 0.0 and 1.0")
-        if self.vad_smoothing_alpha is not None and not 0.0 < self.vad_smoothing_alpha <= 1.0:
-            raise ValueError("vad_smoothing_alpha must be greater than 0.0 and at most 1.0")
         if self.vad_min_speech_ms is not None and self.vad_min_speech_ms < 0:
             raise ValueError("vad_min_speech_ms must be greater than or equal to 0")
         if self.vad_min_silence_ms is not None and self.vad_min_silence_ms < 0:
@@ -185,7 +182,6 @@ class STTStreaming(stt.STT):
         vad_sot_threshold: float | None = None,
         vad_min_speech_ms: int | None = None,
         vad_min_silence_ms: int | None = None,
-        vad_smoothing_alpha: float | None = None,
     ) -> None:
         super().__init__(
             capabilities=stt.STTCapabilities(
@@ -217,7 +213,6 @@ class STTStreaming(stt.STT):
             vad_sot_threshold=vad_sot_threshold,
             vad_min_speech_ms=vad_min_speech_ms,
             vad_min_silence_ms=vad_min_silence_ms,
-            vad_smoothing_alpha=vad_smoothing_alpha,
         )
         self._session = http_session
         self._owns_session = http_session is None
@@ -264,7 +259,6 @@ class STTStreaming(stt.STT):
         vad_sot_threshold: NotGivenOr[float | None] = NOT_GIVEN,
         vad_min_speech_ms: NotGivenOr[int | None] = NOT_GIVEN,
         vad_min_silence_ms: NotGivenOr[int | None] = NOT_GIVEN,
-        vad_smoothing_alpha: NotGivenOr[float | None] = NOT_GIVEN,
     ) -> None:
         opts = StreamingSTTOptions(
             language=language if is_given(language) else self._opts.language,
@@ -288,9 +282,6 @@ class STTStreaming(stt.STT):
             vad_min_silence_ms=vad_min_silence_ms
             if is_given(vad_min_silence_ms)
             else self._opts.vad_min_silence_ms,
-            vad_smoothing_alpha=vad_smoothing_alpha
-            if is_given(vad_smoothing_alpha)
-            else self._opts.vad_smoothing_alpha,
         )
         self._opts = opts
         for stream in self._streams:
@@ -316,7 +307,6 @@ class STTStreaming(stt.STT):
             vad_sot_threshold=self._opts.vad_sot_threshold,
             vad_min_speech_ms=self._opts.vad_min_speech_ms,
             vad_min_silence_ms=self._opts.vad_min_silence_ms,
-            vad_smoothing_alpha=self._opts.vad_smoothing_alpha,
         )
         stream = StreamingSpeechStream(
             stt=self,
@@ -935,7 +925,7 @@ class StreamingSpeechStream(stt.SpeechStream):
         if not isinstance(confidence, (int, float)) or isinstance(confidence, bool):
             confidence = 0.0
 
-        metadata = {
+        metadata: dict[str, Any] = {
             key: data[key]
             for key in ("utterance_idx", "language_confidence")
             if key in data and data[key] is not None

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -293,6 +293,7 @@ class STTStreaming(stt.STT):
         language: NotGivenOr[str] = NOT_GIVEN,
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
     ) -> StreamingSpeechStream:
+        conn_options = replace(conn_options, max_retry=0)
         opts = StreamingSTTOptions(
             language=language if is_given(language) else self._opts.language,
             api_key=self._opts.api_key,

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -62,7 +62,11 @@ SUPPORTED_STREAM_TYPES = {"fast", "balanced", "simulated"}
 SUPPORTED_ENDPOINTING = {"vad", "manual"}
 SUPPORTED_ENCODINGS = {"linear16", "linear32", "mulaw", "alaw"}
 SUPPORTED_MODES = {"transcribe", "translate", "verbatim", "translit", "codemix"}
-STREAM_TYPE_CHUNK_MS = {"fast": 500, "balanced": 1000, "simulated": 1000}
+# How much audio the client buffers before writing a frame. `stream_type` is a
+# server-side latency profile (how often the server flushes to produce a partial),
+# not a send cadence, and the contract sets no client chunk size. Matches the
+# non-realtime Sarvam websocket plugin so audio reaches server VAD promptly.
+AUDIO_CHUNK_MS = 50
 EOS_FALLBACK_TIMEOUT = 2.0
 
 
@@ -910,8 +914,7 @@ class RealtimeSpeechStream(stt.SpeechStream):
 
     @utils.log_exceptions(logger=logger)
     async def _process_audio(self, ws: aiohttp.ClientWebSocketResponse) -> None:
-        cap_ms = STREAM_TYPE_CHUNK_MS[self._opts.stream_type]
-        samples_per_channel = max(int(self._opts.sample_rate * cap_ms / 1000), 1)
+        samples_per_channel = max(int(self._opts.sample_rate * AUDIO_CHUNK_MS / 1000), 1)
         audio_bstream = utils.audio.AudioByteStream(
             sample_rate=self._opts.sample_rate,
             num_channels=1,

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -543,6 +543,7 @@ class RealtimeSpeechStream(stt.SpeechStream):
         self._active_endpointing = opts.endpointing
         self._pending_endpointing: RealtimeEndpointing | str | None = None
         self._endpointing_update_acknowledged = False
+        self._endpointing_update_sent = False
         self._pending_config_update: dict[str, Any] | None = None
         self._manual_speech_started = False
         self._pending_final_data: dict[str, Any] | None = None
@@ -676,6 +677,7 @@ class RealtimeSpeechStream(stt.SpeechStream):
         if opts.endpointing != previous_opts.endpointing:
             self._pending_endpointing = opts.endpointing
             self._endpointing_update_acknowledged = False
+            self._endpointing_update_sent = False
 
         update = self._config_update_payload(previous_opts, opts)
         if update is not None:
@@ -715,10 +717,32 @@ class RealtimeSpeechStream(stt.SpeechStream):
                 payload[key] = new_value
         return payload if len(payload) > 1 else None
 
-    def _handle_config_updated(self) -> None:
-        if self._pending_endpointing is not None:
-            self._endpointing_update_acknowledged = True
-            self._apply_pending_endpointing()
+    @staticmethod
+    def _ack_lists_endpointing(data: dict[str, Any]) -> bool | None:
+        """Whether a ``config.updated`` acknowledges an endpointing change.
+
+        The server echoes each applied key as ``"<key>=<value>"``, optionally
+        suffixed when the change is deferred to the next utterance boundary.
+        Returns ``None`` when ``applied`` is missing or not a list of strings, so
+        the caller can fall back instead of stalling on an unexpected shape.
+        """
+        applied = data.get("applied")
+        if not isinstance(applied, list) or not all(isinstance(e, str) for e in applied):
+            return None
+        return any(e.split("=", 1)[0].strip() == "endpointing" for e in applied)
+
+    def _handle_config_updated(self, data: dict[str, Any]) -> None:
+        if self._pending_endpointing is None:
+            return
+        if not self._endpointing_update_sent:
+            # This acknowledges an earlier update; ours is still queued locally and
+            # the server is still in the old mode.
+            return
+        if self._ack_lists_endpointing(data) is False:
+            return
+
+        self._endpointing_update_acknowledged = True
+        self._apply_pending_endpointing()
 
     def _apply_pending_endpointing(self) -> None:
         if (
@@ -729,6 +753,7 @@ class RealtimeSpeechStream(stt.SpeechStream):
             self._active_endpointing = self._pending_endpointing
             self._pending_endpointing = None
             self._endpointing_update_acknowledged = False
+            self._endpointing_update_sent = False
 
     def _complete_utterance(self) -> None:
         self._utterance_in_progress = False
@@ -863,9 +888,14 @@ class RealtimeSpeechStream(stt.SpeechStream):
         self,
         ws: Any,
         payload: dict[str, Any],
-    ) -> None:
+    ) -> bool:
+        """Send a JSON control message, tolerating a peer that already closed.
+
+        Returns:
+            Whether the payload reached the socket.
+        """
         if ws.closed:
-            return
+            return False
 
         try:
             await ws.send_str(json.dumps(payload))
@@ -874,6 +904,8 @@ class RealtimeSpeechStream(stt.SpeechStream):
                 "Sarvam realtime STT WebSocket closed before send completed",
                 extra={**self._build_log_context(), "payload": payload},
             )
+            return False
+        return True
 
     async def _safe_send_bytes(self, ws: Any, payload: bytes) -> None:
         if ws.closed:
@@ -890,8 +922,11 @@ class RealtimeSpeechStream(stt.SpeechStream):
     async def _send_pending_config_update(self, ws: Any) -> None:
         payload = self._pending_config_update
         self._pending_config_update = None
-        if payload is not None:
-            await self._safe_send_str(ws, payload)
+        if payload is None:
+            return
+        if await self._safe_send_str(ws, payload) and "endpointing" in payload:
+            # Only now can a config.updated acknowledgement refer to our change.
+            self._endpointing_update_sent = True
 
     async def _connect_ws(self) -> aiohttp.ClientWebSocketResponse:
         ws_url = _build_realtime_ws_url(self._opts.base_url, self._opts)
@@ -1104,7 +1139,7 @@ class RealtimeSpeechStream(stt.SpeechStream):
         elif event == "session.end":
             self._handle_session_end(data)
         elif event == "config.updated":
-            self._handle_config_updated()
+            self._handle_config_updated(data)
             return
         elif event == "error":
             self._handle_error_event(data)

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -103,6 +103,8 @@ class StreamingSTTOptions:
     sample_rate: int = 16000
     model: str = REALTIME_MODEL
     base_url: str = SARVAM_STT_REALTIME_URL
+    prompt: str | None = None
+    return_timestamps: bool = False
     vad_sot_threshold: float | None = None
     vad_min_speech_ms: int | None = None
     vad_min_silence_ms: int | None = None
@@ -117,8 +119,6 @@ class StreamingSTTOptions:
             raise ValueError(
                 f"stream_type must be one of {', '.join(sorted(SUPPORTED_STREAM_TYPES))}"
             )
-        if self.language == "auto" and self.stream_type != "simulated":
-            raise ValueError("language auto is only supported when stream_type is simulated")
         if self.mode not in SUPPORTED_MODES:
             raise ValueError(f"mode must be one of {', '.join(sorted(SUPPORTED_MODES))}")
         if self.endpointing not in SUPPORTED_ENDPOINTING:
@@ -143,26 +143,26 @@ class StreamingSTTOptions:
 
 def _build_realtime_ws_url(base_url: str, opts: StreamingSTTOptions) -> str:
     params: dict[str, str] = {
-        "language-code": opts.language,
-        "stream-type": opts.stream_type,
+        "language_code": opts.language,
+        "stream_type": opts.stream_type,
         "endpointing": opts.endpointing,
         "encoding": opts.encoding,
         "sample_rate": str(opts.sample_rate),
         "model": opts.model,
     }
 
-    if opts.stream_type == "simulated":
-        params["mode"] = opts.mode
+    params["mode"] = opts.mode
+    params["return_timestamps"] = str(opts.return_timestamps).lower()
+    if opts.prompt is not None:
+        params["prompt"] = opts.prompt
 
     if opts.endpointing == "vad":
         if opts.vad_sot_threshold is not None:
-            params["vad_sot_threshold"] = str(opts.vad_sot_threshold)
+            params["threshold"] = str(opts.vad_sot_threshold)
         if opts.vad_min_speech_ms is not None:
-            params["vad_min_speech_ms"] = str(opts.vad_min_speech_ms)
+            params["min_speech_duration_ms"] = str(opts.vad_min_speech_ms)
         if opts.vad_min_silence_ms is not None:
-            params["vad_min_silence_ms"] = str(opts.vad_min_silence_ms)
-        if opts.vad_smoothing_alpha is not None:
-            params["vad_smoothing_alpha"] = str(opts.vad_smoothing_alpha)
+            params["silence_duration_ms"] = str(opts.vad_min_silence_ms)
 
     return f"{base_url}?{urlencode(params)}"
 
@@ -177,6 +177,8 @@ class STTStreaming(stt.STT):
         endpointing: RealtimeEndpointing | str = "vad",
         encoding: RealtimeEncoding | str = "linear16",
         sample_rate: int = 16000,
+        prompt: str | None = None,
+        return_timestamps: bool = False,
         api_key: str | None = None,
         base_url: str = SARVAM_STT_REALTIME_URL,
         http_session: aiohttp.ClientSession | None = None,
@@ -210,6 +212,8 @@ class STTStreaming(stt.STT):
             encoding=encoding,
             sample_rate=sample_rate,
             base_url=base_url,
+            prompt=prompt,
+            return_timestamps=return_timestamps,
             vad_sot_threshold=vad_sot_threshold,
             vad_min_speech_ms=vad_min_speech_ms,
             vad_min_silence_ms=vad_min_silence_ms,
@@ -255,6 +259,8 @@ class STTStreaming(stt.STT):
         mode: NotGivenOr[RealtimeMode | str] = NOT_GIVEN,
         endpointing: NotGivenOr[RealtimeEndpointing | str] = NOT_GIVEN,
         sample_rate: NotGivenOr[int] = NOT_GIVEN,
+        prompt: NotGivenOr[str | None] = NOT_GIVEN,
+        return_timestamps: NotGivenOr[bool] = NOT_GIVEN,
         vad_sot_threshold: NotGivenOr[float | None] = NOT_GIVEN,
         vad_min_speech_ms: NotGivenOr[int | None] = NOT_GIVEN,
         vad_min_silence_ms: NotGivenOr[int | None] = NOT_GIVEN,
@@ -269,6 +275,10 @@ class STTStreaming(stt.STT):
             encoding=self._opts.encoding,
             sample_rate=sample_rate if is_given(sample_rate) else self._opts.sample_rate,
             base_url=self._opts.base_url,
+            prompt=prompt if is_given(prompt) else self._opts.prompt,
+            return_timestamps=return_timestamps
+            if is_given(return_timestamps)
+            else self._opts.return_timestamps,
             vad_sot_threshold=vad_sot_threshold
             if is_given(vad_sot_threshold)
             else self._opts.vad_sot_threshold,
@@ -301,6 +311,8 @@ class STTStreaming(stt.STT):
             encoding=self._opts.encoding,
             sample_rate=self._opts.sample_rate,
             base_url=self._opts.base_url,
+            prompt=self._opts.prompt,
+            return_timestamps=self._opts.return_timestamps,
             vad_sot_threshold=self._opts.vad_sot_threshold,
             vad_min_speech_ms=self._opts.vad_min_speech_ms,
             vad_min_silence_ms=self._opts.vad_min_silence_ms,
@@ -339,7 +351,9 @@ class StreamingSpeechStream(stt.SpeechStream):
         self._request_id = ""
         self._session_id = ""
         self._session_ended = False
+        self._utterance_idx: int | None = None
         self._reconnect_event = asyncio.Event()
+        self._pending_config_update: dict[str, Any] | None = None
         self._manual_speech_started = False
         self._pending_eos = False
         self._pending_eos_time: float | None = None
@@ -352,7 +366,9 @@ class StreamingSpeechStream(stt.SpeechStream):
         self._eos_fallback_task: asyncio.Task[None] | None = None
         self._stream_started_at = time.time()
         self._audio_position = 0.0
+        self._local_audio_duration = 0.0
         self._total_reported_audio_duration = 0.0
+        self._server_audio_duration_reported = False
         self._audio_duration_collector = PeriodicCollector(
             callback=self._on_audio_duration_report,
             duration=5.0,
@@ -360,8 +376,44 @@ class StreamingSpeechStream(stt.SpeechStream):
         self._logger = logger
 
     def update_options(self, opts: StreamingSTTOptions) -> None:
+        previous_opts = self._opts
         self._opts = opts
-        self._reconnect_event.set()
+        if opts.sample_rate != previous_opts.sample_rate:
+            self._reconnect_event.set()
+            return
+
+        update = self._config_update_payload(previous_opts, opts)
+        if update is not None:
+            self._pending_config_update = update
+
+    @staticmethod
+    def _config_update_payload(
+        previous: StreamingSTTOptions,
+        current: StreamingSTTOptions,
+    ) -> dict[str, Any] | None:
+        payload: dict[str, Any] = {"event": "config.update"}
+        values = (
+            ("language_code", previous.language, current.language),
+            ("stream_type", previous.stream_type, current.stream_type),
+            ("mode", previous.mode, current.mode),
+            ("prompt", previous.prompt, current.prompt),
+            ("endpointing", previous.endpointing, current.endpointing),
+            ("threshold", previous.vad_sot_threshold, current.vad_sot_threshold),
+            (
+                "min_speech_duration_ms",
+                previous.vad_min_speech_ms,
+                current.vad_min_speech_ms,
+            ),
+            (
+                "silence_duration_ms",
+                previous.vad_min_silence_ms,
+                current.vad_min_silence_ms,
+            ),
+        )
+        for key, old_value, new_value in values:
+            if old_value != new_value:
+                payload[key] = new_value
+        return payload if len(payload) > 1 else None
 
     def _build_log_context(self) -> dict[str, Any]:
         return {
@@ -371,6 +423,7 @@ class StreamingSpeechStream(stt.SpeechStream):
             "language": self._opts.language,
             "stream_type": self._opts.stream_type,
             "endpointing": self._opts.endpointing,
+            "utterance_idx": self._utterance_idx,
         }
 
     @staticmethod
@@ -469,6 +522,8 @@ class StreamingSpeechStream(stt.SpeechStream):
         self._request_id = ""
         self._session_id = ""
         self._session_ended = False
+        self._utterance_idx = None
+        self._pending_config_update = None
         self._manual_speech_started = False
         self._pending_eos = False
         self._pending_eos_time = None
@@ -479,10 +534,14 @@ class StreamingSpeechStream(stt.SpeechStream):
         self._final_received_for_utterance = False
         self._eos_emitted_for_utterance = False
         self._audio_duration_collector.flush()
+        self._emit_local_usage_fallback()
+        self._local_audio_duration = 0.0
         self._total_reported_audio_duration = 0.0
+        self._server_audio_duration_reported = False
 
     def _reset_utterance_state(self) -> None:
         self._cancel_eos_fallback()
+        self._utterance_idx = None
         self._pending_eos = False
         self._pending_eos_time = None
         self._pending_final_data = None
@@ -508,13 +567,19 @@ class StreamingSpeechStream(stt.SpeechStream):
                 extra={**self._build_log_context(), "payload": payload},
             )
 
+    async def _send_pending_config_update(self, ws: Any) -> None:
+        payload = self._pending_config_update
+        self._pending_config_update = None
+        if payload is not None:
+            await self._safe_send_str(ws, payload)
+
     async def _connect_ws(self) -> aiohttp.ClientWebSocketResponse:
         ws_url = _build_realtime_ws_url(self._opts.base_url, self._opts)
         headers = {
             "API-SUBSCRIPTION-KEY": self._opts.api_key,
             "User-Agent": USER_AGENT,
         }
-        self._logger.info(
+        self._logger.debug(
             "Connecting to Sarvam realtime STT WebSocket", extra=self._build_log_context()
         )
         try:
@@ -522,13 +587,33 @@ class StreamingSpeechStream(stt.SpeechStream):
                 self._session.ws_connect(ws_url, headers=headers, heartbeat=30.0),
                 self._conn_options.timeout,
             )
-        except (aiohttp.ClientConnectorError, asyncio.TimeoutError):
+        except (aiohttp.ClientConnectorError, asyncio.TimeoutError) as e:
+            self._logger.error(
+                "Failed to connect to Sarvam realtime STT WebSocket",
+                extra={**self._build_log_context(), "error": str(e), "url": ws_url},
+                exc_info=True,
+            )
             raise
-        except aiohttp.ClientResponseError:
+        except aiohttp.ClientResponseError as e:
+            self._logger.error(
+                "Sarvam realtime STT WebSocket handshake failed",
+                extra={
+                    **self._build_log_context(),
+                    "error": e.message,
+                    "status_code": e.status,
+                    "url": ws_url,
+                },
+                exc_info=True,
+            )
             raise
         except Exception as e:
+            self._logger.error(
+                "Unexpected Sarvam realtime STT WebSocket connection error",
+                extra={**self._build_log_context(), "error": str(e), "url": ws_url},
+                exc_info=True,
+            )
             raise APIConnectionError("failed to connect to Sarvam realtime STT") from e
-        self._logger.info(
+        self._logger.debug(
             "Sarvam realtime STT WebSocket connected", extra=self._build_log_context()
         )
         return ws
@@ -544,6 +629,7 @@ class StreamingSpeechStream(stt.SpeechStream):
         )
 
         async for data in self._input_ch:
+            await self._send_pending_config_update(ws)
             frames: list[rtc.AudioFrame] = []
             if isinstance(data, rtc.AudioFrame):
                 frames.extend(audio_bstream.write(data.data.tobytes()))
@@ -577,6 +663,10 @@ class StreamingSpeechStream(stt.SpeechStream):
                     await self._handle_message(json.loads(msg.data))
                 except json.JSONDecodeError as e:
                     if _looks_like_error_text(msg.data):
+                        self._logger.error(
+                            "Sarvam realtime STT non-JSON error message",
+                            extra={**self._build_log_context(), "raw_message": msg.data},
+                        )
                         raise APIStatusError(
                             message=f"Sarvam realtime STT non-JSON error message: {msg.data}",
                             request_id=self._request_id or None,
@@ -587,7 +677,13 @@ class StreamingSpeechStream(stt.SpeechStream):
                         extra={**self._build_log_context(), "raw_data": msg.data},
                     )
                     continue
+                if self._session_ended:
+                    break
             elif msg.type == aiohttp.WSMsgType.ERROR:
+                self._logger.error(
+                    "Sarvam realtime STT WebSocket error",
+                    extra={**self._build_log_context(), "raw_message": msg.data},
+                )
                 raise APIConnectionError(f"Sarvam realtime STT WebSocket error: {msg.data}")
             elif msg.type in (
                 aiohttp.WSMsgType.CLOSED,
@@ -597,9 +693,19 @@ class StreamingSpeechStream(stt.SpeechStream):
                 close_code = ws.close_code if ws.close_code is not None else msg.data
                 close_reason = msg.extra
                 if self._session_ended and close_code in (1000, 1001, None):
+                    self._emit_local_usage_fallback()
                     break
                 if close_code in (1000, 1001, None) and not _looks_like_error_text(close_reason):
+                    self._emit_local_usage_fallback()
                     break
+                self._logger.error(
+                    "Sarvam realtime STT WebSocket closed unexpectedly",
+                    extra={
+                        **self._build_log_context(),
+                        "close_code": close_code,
+                        "close_reason": close_reason,
+                    },
+                )
                 raise self._status_error_from_close(close_code, close_reason)
             else:
                 self._logger.debug(
@@ -640,6 +746,8 @@ class StreamingSpeechStream(stt.SpeechStream):
         elif event == "vad.speech_start":
             self._emit_pending_eos_before_new_speech()
             self._reset_utterance_state()
+            utterance_idx = data.get("utterance_idx")
+            self._utterance_idx = utterance_idx if isinstance(utterance_idx, int) else None
             self._event_ch.send_nowait(
                 stt.SpeechEvent(
                     type=stt.SpeechEventType.START_OF_SPEECH,
@@ -660,6 +768,8 @@ class StreamingSpeechStream(stt.SpeechStream):
                 self._final_received_for_utterance = True
         elif event == "session.end":
             self._handle_session_end(data)
+        elif event == "config.updated":
+            return
         elif event == "error":
             self._handle_error_event(data)
         elif event == "pong":
@@ -678,7 +788,6 @@ class StreamingSpeechStream(stt.SpeechStream):
             **self._build_log_context(),
             "event": event,
             "utterance_idx": data.get("utterance_idx"),
-            "raw_data": data,
         }
         if event in {"transcript.partial", "transcript.final"}:
             text = data.get("text")
@@ -695,10 +804,27 @@ class StreamingSpeechStream(stt.SpeechStream):
             pass
         elif event == "session.end":
             extra["audio_duration_s"] = data.get("audio_duration_s")
+        elif event == "config.updated":
+            extra["applied"] = data.get("applied")
+        elif event == "error":
+            extra["error_code"] = data.get("code")
+            extra["error_message"] = data.get("message")
+            extra["status_code"] = data.get("status_code")
         else:
             return
 
+        if event == "transcript.partial":
+            self._logger.debug(
+                "Sarvam realtime STT transcript.partial",
+                extra={**extra, "raw_data": data},
+            )
+            return
+
         self._logger.info(f"Sarvam realtime STT {event}", extra=extra)
+        self._logger.debug(
+            "Sarvam realtime STT raw event",
+            extra={**extra, "raw_data": data},
+        )
 
     def _is_valid_transcript(self, data: dict[str, Any]) -> bool:
         text = data.get("text")
@@ -719,14 +845,11 @@ class StreamingSpeechStream(stt.SpeechStream):
         if self._eos_emitted_for_utterance:
             return
 
-        if self._final_received_for_utterance:
-            self._try_commit_utterance()
-            return
-
         self._pending_eos = True
         self._pending_eos_time = self._utterance_speech_end_wall
-        if self._eos_fallback_task is None or self._eos_fallback_task.done():
-            self._eos_fallback_task = asyncio.create_task(self._emit_pending_eos_after_timeout())
+        self._emit_end_of_speech()
+        if self._final_received_for_utterance:
+            self._try_commit_utterance()
 
     async def _emit_pending_eos_after_timeout(
         self,
@@ -741,11 +864,7 @@ class StreamingSpeechStream(stt.SpeechStream):
             raise
 
     def _try_commit_utterance(self) -> None:
-        if (
-            self._pending_final_data is None
-            or self._utterance_speech_end_audio_pos is None
-            or self._eos_emitted_for_utterance
-        ):
+        if self._pending_final_data is None or self._utterance_speech_end_audio_pos is None:
             return
 
         committed_data = self._pending_final_data
@@ -753,7 +872,7 @@ class StreamingSpeechStream(stt.SpeechStream):
             stt.SpeechEventType.FINAL_TRANSCRIPT,
             committed_data,
         ):
-            self._logger.info(
+            self._logger.debug(
                 "Sarvam realtime STT utterance committed",
                 extra={
                     **self._build_log_context(),
@@ -761,7 +880,8 @@ class StreamingSpeechStream(stt.SpeechStream):
                     "speech_end_wall_time": self._utterance_speech_end_wall,
                 },
             )
-            self._emit_end_of_speech()
+            if not self._eos_emitted_for_utterance:
+                self._emit_end_of_speech()
             self._pending_final_data = None
 
     def _emit_end_of_speech(self) -> None:
@@ -826,17 +946,31 @@ class StreamingSpeechStream(stt.SpeechStream):
         ):
             metadata["speech_end_wall_time"] = self._utterance_speech_end_wall
         end_time = 0.0
+        start_time = 0.0
+        if event_type == stt.SpeechEventType.FINAL_TRANSCRIPT:
+            start_s = data.get("start_s")
+            end_s = data.get("end_s")
+            if isinstance(start_s, (int, float)) and not isinstance(start_s, bool):
+                start_time = max(float(start_s), 0.0)
+            if isinstance(end_s, (int, float)) and not isinstance(end_s, bool):
+                end_time = max(float(end_s), 0.0)
         if (
             event_type == stt.SpeechEventType.FINAL_TRANSCRIPT
             and self._utterance_speech_end_audio_pos is not None
+            and end_time == 0.0
         ):
             end_time = self._utterance_speech_end_audio_pos
-        elif event_type == stt.SpeechEventType.FINAL_TRANSCRIPT and self._audio_position > 0:
+        elif (
+            event_type == stt.SpeechEventType.FINAL_TRANSCRIPT
+            and self._audio_position > 0
+            and end_time == 0.0
+        ):
             end_time = self._audio_position
 
         speech_data = stt.SpeechData(
             language=LanguageCode(language),
             text=text,
+            start_time=start_time,
             end_time=end_time,
             confidence=float(confidence),
             metadata=metadata or None,
@@ -853,17 +987,28 @@ class StreamingSpeechStream(stt.SpeechStream):
     def _handle_session_end(self, data: dict[str, Any]) -> None:
         self._capture_server_ids(data)
         audio_duration = data.get("audio_duration_s")
-        if isinstance(audio_duration, (int, float)) and not isinstance(audio_duration, bool):
-            delta = max(float(audio_duration) - self._total_reported_audio_duration, 0.0)
-            if delta:
-                self._emit_usage(delta)
+        if (
+            isinstance(audio_duration, (int, float))
+            and not isinstance(audio_duration, bool)
+            and not self._server_audio_duration_reported
+        ):
+            server_audio_duration = max(float(audio_duration), 0.0)
+            if server_audio_duration:
+                self._emit_usage(server_audio_duration)
+            self._server_audio_duration_reported = True
         self._session_ended = True
 
     def _handle_error_event(self, data: dict[str, Any]) -> None:
         if not data.get("is_fatal", False):
             self._logger.warning(
                 "Non-fatal Sarvam realtime STT error",
-                extra={**self._build_log_context(), "error": data},
+                extra={
+                    **self._build_log_context(),
+                    "error_code": data.get("code"),
+                    "error_message": data.get("message"),
+                    "status_code": data.get("status_code"),
+                    "raw_message": data,
+                },
             )
             return
 
@@ -871,6 +1016,16 @@ class StreamingSpeechStream(stt.SpeechStream):
         status_code = data.get("status_code", -1)
         if not isinstance(status_code, int):
             status_code = -1
+        self._logger.error(
+            "Fatal Sarvam realtime STT error",
+            extra={
+                **self._build_log_context(),
+                "error_code": code,
+                "error_message": data.get("message", code),
+                "status_code": status_code,
+                "raw_message": data,
+            },
+        )
         raise APIStatusError(
             message=f"Sarvam realtime STT error: {data.get('message', code)}",
             status_code=status_code,
@@ -880,7 +1035,14 @@ class StreamingSpeechStream(stt.SpeechStream):
         )
 
     def _on_audio_duration_report(self, duration: float) -> None:
-        self._emit_usage(duration)
+        self._local_audio_duration += duration
+
+    def _emit_local_usage_fallback(self) -> None:
+        if self._server_audio_duration_reported:
+            return
+        delta = max(self._local_audio_duration - self._total_reported_audio_duration, 0.0)
+        if delta:
+            self._emit_usage(delta)
 
     def _emit_usage(self, duration: float) -> None:
         self._total_reported_audio_duration += duration

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -433,8 +433,24 @@ class STTRealtime(stt.STT):
             else self._opts.lid_confidence_threshold,
         )
         self._opts = opts
+        # Forward the given fields only, so a stream created with a per-stream
+        # override (e.g. `stream(language=...)`) keeps it through unrelated updates.
         for stream in self._streams:
-            stream.update_options(opts)
+            stream.update_options(
+                language=language,
+                stream_type=stream_type,
+                mode=mode,
+                endpointing=endpointing,
+                sample_rate=sample_rate,
+                prompt=prompt,
+                return_timestamps=return_timestamps,
+                vad_sot_threshold=vad_sot_threshold,
+                vad_min_speech_ms=vad_min_speech_ms,
+                vad_min_silence_ms=vad_min_silence_ms,
+                vad_prefix_padding_ms=vad_prefix_padding_ms,
+                lid_gate_seconds=lid_gate_seconds,
+                lid_confidence_threshold=lid_confidence_threshold,
+            )
 
     def stream(
         self,
@@ -551,18 +567,83 @@ class RealtimeSpeechStream(stt.SpeechStream):
         """Return the configuration resolved by Sarvam for this connection."""
         return dict(self._resolved_config) if self._resolved_config is not None else None
 
-    def update_options(self, opts: RealtimeSTTOptions) -> None:
+    def update_options(
+        self,
+        *,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        stream_type: NotGivenOr[RealtimeStreamType | str] = NOT_GIVEN,
+        mode: NotGivenOr[RealtimeMode | str] = NOT_GIVEN,
+        endpointing: NotGivenOr[RealtimeEndpointing | str] = NOT_GIVEN,
+        sample_rate: NotGivenOr[int] = NOT_GIVEN,
+        prompt: NotGivenOr[str | None] = NOT_GIVEN,
+        return_timestamps: NotGivenOr[bool] = NOT_GIVEN,
+        vad_sot_threshold: NotGivenOr[float | None] = NOT_GIVEN,
+        vad_min_speech_ms: NotGivenOr[int | None] = NOT_GIVEN,
+        vad_min_silence_ms: NotGivenOr[int | None] = NOT_GIVEN,
+        vad_prefix_padding_ms: NotGivenOr[int | None] = NOT_GIVEN,
+        lid_gate_seconds: NotGivenOr[float | None] = NOT_GIVEN,
+        lid_confidence_threshold: NotGivenOr[float | None] = NOT_GIVEN,
+    ) -> None:
         """Apply an option change to this live connection.
 
-        Connection-time options are retained at their current values and a warning is
-        logged, since changing them would desynchronize the already-negotiated session.
-        Every other change is queued as an in-band ``config.update`` sent before the
-        next audio frame.
+        Only the options explicitly passed here are changed, so per-stream overrides
+        such as a ``language`` given to :meth:`STTRealtime.stream` survive an unrelated
+        update. Connection-time options are retained at their current values and a
+        warning is logged, since changing them would desynchronize the
+        already-negotiated session. Every other change is queued as an in-band
+        ``config.update`` sent before the next audio frame.
 
         Args:
-            opts: The requested options for this stream.
+            language: BCP-47 language code, or ``auto`` for adaptive identification.
+            stream_type: Latency profile: ``fast``, ``balanced``, or ``simulated``.
+            mode: Task applied to finals.
+            endpointing: ``vad`` for server-side turn detection, or ``manual``.
+            sample_rate: Audio sample rate in Hz; retained on a live stream.
+            prompt: Context or terminology hint; ``None`` clears it.
+            return_timestamps: Segment-level timestamps; retained on a live stream.
+            vad_sot_threshold: VAD activation threshold (``vad`` endpointing only).
+            vad_min_speech_ms: Minimum speech duration in ms (``vad`` endpointing only).
+            vad_min_silence_ms: End-of-turn silence in ms (``vad`` endpointing only).
+            vad_prefix_padding_ms: Speech-onset padding; retained on a live stream.
+            lid_gate_seconds: Language-promotion audio gate; retained on a live stream.
+            lid_confidence_threshold: Language-promotion confidence; retained.
+
+        Raises:
+            ValueError: If an option falls outside the values the endpoint accepts.
         """
         previous_opts = self._opts
+        requested: dict[str, Any] = {}
+        if is_given(language):
+            requested["language"] = language
+        if is_given(stream_type):
+            requested["stream_type"] = stream_type
+        if is_given(mode):
+            requested["mode"] = mode
+        if is_given(endpointing):
+            requested["endpointing"] = endpointing
+        if is_given(sample_rate):
+            requested["sample_rate"] = sample_rate
+        if is_given(prompt):
+            requested["prompt"] = prompt
+        if is_given(return_timestamps):
+            requested["return_timestamps"] = return_timestamps
+        if is_given(vad_sot_threshold):
+            requested["vad_sot_threshold"] = vad_sot_threshold
+        if is_given(vad_min_speech_ms):
+            requested["vad_min_speech_ms"] = vad_min_speech_ms
+        if is_given(vad_min_silence_ms):
+            requested["vad_min_silence_ms"] = vad_min_silence_ms
+        if is_given(vad_prefix_padding_ms):
+            requested["vad_prefix_padding_ms"] = vad_prefix_padding_ms
+        if is_given(lid_gate_seconds):
+            requested["lid_gate_seconds"] = lid_gate_seconds
+        if is_given(lid_confidence_threshold):
+            requested["lid_confidence_threshold"] = lid_confidence_threshold
+
+        if not requested:
+            return
+
+        opts = replace(previous_opts, **requested)
         connection_only_options: list[str] = []
         if opts.sample_rate != previous_opts.sample_rate:
             connection_only_options.append("sample_rate")
@@ -897,7 +978,7 @@ class RealtimeSpeechStream(stt.SpeechStream):
                     self._manual_speech_started = False
                     self._end_manual_utterance()
 
-        self._audio_duration_collector.flush()
+        self._emit_local_usage_fallback()
         if not self._session_ended:
             await self._safe_send_str(ws, {"event": "end"})
 

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -20,7 +20,7 @@ import os
 import platform
 import time
 import weakref
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Literal
 from urllib.parse import urlencode
 
@@ -342,6 +342,10 @@ class StreamingSpeechStream(stt.SpeechStream):
         self._session_id = ""
         self._session_ended = False
         self._utterance_idx: int | None = None
+        self._utterance_in_progress = False
+        self._active_endpointing = opts.endpointing
+        self._pending_endpointing: RealtimeEndpointing | str | None = None
+        self._endpointing_update_acknowledged = False
         self._reconnect_event = asyncio.Event()
         self._pending_config_update: dict[str, Any] | None = None
         self._manual_speech_started = False
@@ -367,14 +371,33 @@ class StreamingSpeechStream(stt.SpeechStream):
 
     def update_options(self, opts: StreamingSTTOptions) -> None:
         previous_opts = self._opts
-        self._opts = opts
+        connection_only_options: list[str] = []
         if opts.sample_rate != previous_opts.sample_rate:
-            self._reconnect_event.set()
-            return
+            connection_only_options.append("sample_rate")
+            opts = replace(opts, sample_rate=previous_opts.sample_rate)
+        if opts.return_timestamps != previous_opts.return_timestamps:
+            connection_only_options.append("return_timestamps")
+            opts = replace(opts, return_timestamps=previous_opts.return_timestamps)
+        if connection_only_options:
+            self._logger.warning(
+                "Sarvam realtime STT connection-only option updates only apply to new streams",
+                extra={
+                    **self._build_log_context(),
+                    "options": connection_only_options,
+                },
+            )
+
+        self._opts = opts
+        if opts.endpointing != previous_opts.endpointing:
+            self._pending_endpointing = opts.endpointing
+            self._endpointing_update_acknowledged = False
 
         update = self._config_update_payload(previous_opts, opts)
         if update is not None:
-            self._pending_config_update = update
+            if self._pending_config_update is None:
+                self._pending_config_update = update
+            else:
+                self._pending_config_update.update(update)
 
     @staticmethod
     def _config_update_payload(
@@ -402,8 +425,29 @@ class StreamingSpeechStream(stt.SpeechStream):
         )
         for key, old_value, new_value in values:
             if old_value != new_value:
+                if key == "prompt" and new_value is None:
+                    new_value = ""
                 payload[key] = new_value
         return payload if len(payload) > 1 else None
+
+    def _handle_config_updated(self) -> None:
+        if self._pending_endpointing is not None:
+            self._endpointing_update_acknowledged = True
+            self._apply_pending_endpointing()
+
+    def _apply_pending_endpointing(self) -> None:
+        if (
+            self._pending_endpointing is not None
+            and self._endpointing_update_acknowledged
+            and not self._utterance_in_progress
+        ):
+            self._active_endpointing = self._pending_endpointing
+            self._pending_endpointing = None
+            self._endpointing_update_acknowledged = False
+
+    def _complete_utterance(self) -> None:
+        self._utterance_in_progress = False
+        self._apply_pending_endpointing()
 
     def _build_log_context(self) -> dict[str, Any]:
         return {
@@ -513,6 +557,10 @@ class StreamingSpeechStream(stt.SpeechStream):
         self._session_id = ""
         self._session_ended = False
         self._utterance_idx = None
+        self._utterance_in_progress = False
+        self._active_endpointing = self._opts.endpointing
+        self._pending_endpointing = None
+        self._endpointing_update_acknowledged = False
         self._pending_config_update = None
         self._manual_speech_started = False
         self._pending_eos = False
@@ -627,9 +675,10 @@ class StreamingSpeechStream(stt.SpeechStream):
                 frames.extend(audio_bstream.flush())
 
             for frame in frames:
-                if self._opts.endpointing == "manual" and not self._manual_speech_started:
+                if self._active_endpointing == "manual" and not self._manual_speech_started:
                     await self._safe_send_str(ws, {"event": "speech_start"})
                     self._manual_speech_started = True
+                    self._utterance_in_progress = True
 
                 self._audio_duration_collector.push(frame.duration)
                 self._audio_position += frame.duration
@@ -637,7 +686,7 @@ class StreamingSpeechStream(stt.SpeechStream):
 
             if isinstance(data, self._FlushSentinel):
                 self._audio_duration_collector.flush()
-                if self._opts.endpointing == "manual" and self._manual_speech_started:
+                if self._active_endpointing == "manual" and self._manual_speech_started:
                     await self._safe_send_str(ws, {"event": "speech_end"})
                     self._manual_speech_started = False
 
@@ -736,6 +785,7 @@ class StreamingSpeechStream(stt.SpeechStream):
         elif event == "vad.speech_start":
             self._emit_pending_eos_before_new_speech()
             self._reset_utterance_state()
+            self._utterance_in_progress = True
             utterance_idx = data.get("utterance_idx")
             self._utterance_idx = utterance_idx if isinstance(utterance_idx, int) else None
             self._event_ch.send_nowait(
@@ -749,16 +799,18 @@ class StreamingSpeechStream(stt.SpeechStream):
         elif event == "transcript.partial":
             self._send_transcript_event(stt.SpeechEventType.INTERIM_TRANSCRIPT, data)
         elif event == "transcript.final":
-            if self._opts.endpointing == "vad":
+            if self._active_endpointing == "vad":
                 if self._is_valid_transcript(data):
                     self._pending_final_data = data
                     self._final_received_for_utterance = True
                     self._try_commit_utterance()
             elif self._send_transcript_event(stt.SpeechEventType.FINAL_TRANSCRIPT, data):
                 self._final_received_for_utterance = True
+                self._complete_utterance()
         elif event == "session.end":
             self._handle_session_end(data)
         elif event == "config.updated":
+            self._handle_config_updated()
             return
         elif event == "error":
             self._handle_error_event(data)
@@ -828,7 +880,7 @@ class StreamingSpeechStream(stt.SpeechStream):
         self._utterance_speech_end_audio_pos = self._audio_position
         self._utterance_speech_end_wall = time.time()
 
-        if self._opts.endpointing != "vad":
+        if self._active_endpointing != "vad":
             self._emit_end_of_speech()
             return
 
@@ -873,6 +925,7 @@ class StreamingSpeechStream(stt.SpeechStream):
             if not self._eos_emitted_for_utterance:
                 self._emit_end_of_speech()
             self._pending_final_data = None
+            self._complete_utterance()
 
     def _emit_end_of_speech(self) -> None:
         current_task = asyncio.current_task()

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -1165,7 +1165,9 @@ class RealtimeSpeechStream(stt.SpeechStream):
 
     def _is_valid_transcript(self, data: dict[str, Any]) -> bool:
         text = data.get("text")
-        return isinstance(text, str) and bool(text)
+        # Whitespace carries no content, and emitting it would commit a user turn
+        # with no words.
+        return isinstance(text, str) and bool(text.strip())
 
     def _handle_speech_end(self) -> None:
         self._utterance_speech_end_audio_pos = self._audio_position
@@ -1173,14 +1175,16 @@ class RealtimeSpeechStream(stt.SpeechStream):
 
         if self._active_endpointing != "vad":
             self._emit_end_of_speech()
-            return
+        elif not self._eos_emitted_for_utterance:
+            self._emit_end_of_speech()
+            if self._final_received_for_utterance:
+                self._try_commit_utterance()
 
-        if self._eos_emitted_for_utterance:
-            return
-
-        self._emit_end_of_speech()
-        if self._final_received_for_utterance:
-            self._try_commit_utterance()
+        # The server's speech end is the utterance boundary, so the turn is over even
+        # when the final is empty or never arrives. Completing unconditionally is what
+        # lets a boundary-gated endpointing change promote; leaving the utterance open
+        # would strand the stream in the old mode with the server in the new one.
+        self._complete_utterance()
 
     def _try_commit_utterance(self) -> None:
         if self._pending_final_data is None or self._utterance_speech_end_audio_pos is None:
@@ -1240,7 +1244,7 @@ class RealtimeSpeechStream(stt.SpeechStream):
 
     def _send_transcript_event(self, event_type: stt.SpeechEventType, data: dict[str, Any]) -> bool:
         text = data.get("text")
-        if not isinstance(text, str) or not text:
+        if not isinstance(text, str) or not text.strip():
             return False
 
         language = data.get("language") or self._opts.language

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -99,7 +99,7 @@ def _encode_alaw(samples: np.ndarray) -> bytes:
     mantissa = (magnitude >> (exponent + 3)) & 0x0F
     encoded = np.where(magnitude < 256, magnitude >> 4, (exponent << 4) | mantissa)
     xor_mask = np.where(samples >= 0, 0xD5, 0x55)
-    return cast(bytes, (encoded ^ xor_mask).astype(np.uint8).tobytes())
+    return bytes((encoded ^ xor_mask).astype(np.uint8).tobytes())
 
 
 SUPPORTED_LANGUAGES = {

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -21,10 +21,11 @@ import platform
 import time
 import weakref
 from dataclasses import dataclass, replace
-from typing import Any, Literal
+from typing import Any, Literal, cast
 from urllib.parse import urlencode
 
 import aiohttp
+import numpy as np
 
 from livekit import rtc
 from livekit.agents import (
@@ -53,16 +54,53 @@ REALTIME_MODEL = "saaras:v3-realtime"
 
 RealtimeStreamType = Literal["fast", "balanced", "simulated"]
 RealtimeEndpointing = Literal["vad", "manual"]
-RealtimeEncoding = Literal["linear16"]
-RealtimeMode = Literal["transcribe", "translate", "indic-en", "verbatim", "translit", "codemix"]
+RealtimeEncoding = Literal["linear16", "linear32", "mulaw", "alaw"]
+RealtimeMode = Literal["transcribe", "translate", "verbatim", "translit", "codemix"]
 
 SUPPORTED_SAMPLE_RATES = {8000, 16000}
 SUPPORTED_STREAM_TYPES = {"fast", "balanced", "simulated"}
 SUPPORTED_ENDPOINTING = {"vad", "manual"}
-SUPPORTED_ENCODINGS = {"linear16"}
-SUPPORTED_MODES = {"transcribe", "translate", "indic-en", "verbatim", "translit", "codemix"}
+SUPPORTED_ENCODINGS = {"linear16", "linear32", "mulaw", "alaw"}
+SUPPORTED_MODES = {"transcribe", "translate", "verbatim", "translit", "codemix"}
 STREAM_TYPE_CHUNK_MS = {"fast": 500, "balanced": 1000, "simulated": 1000}
 EOS_FALLBACK_TIMEOUT = 2.0
+
+
+def _encode_pcm_for_wire(encoding: RealtimeEncoding | str, pcm: bytes) -> bytes:
+    """Encode little-endian signed 16-bit PCM for Sarvam's realtime wire format."""
+    if len(pcm) % 2:
+        raise ValueError("PCM data must contain whole 16-bit samples")
+    if encoding == "linear16":
+        return pcm
+
+    samples = np.frombuffer(pcm, dtype="<i2").astype(np.int32)
+    if encoding == "linear32":
+        return (samples.astype(np.int64) * (1 << 16)).astype("<i4").tobytes()
+    if encoding == "mulaw":
+        return _encode_mulaw(samples)
+    if encoding == "alaw":
+        return _encode_alaw(samples)
+    raise ValueError(f"Unsupported realtime encoding: {encoding}")
+
+
+def _encode_mulaw(samples: np.ndarray) -> bytes:
+    """Encode signed linear PCM samples as 8-bit ITU-T G.711 mu-law."""
+    magnitude = np.minimum(np.abs(samples), 32635) + 0x84
+    exponent = np.clip(np.floor(np.log2(magnitude)).astype(np.int32) - 7, 0, 7)
+    mantissa = (magnitude >> (exponent + 3)) & 0x0F
+    sign = np.where(samples < 0, 0x80, 0)
+    return cast(bytes, (~(sign | (exponent << 4) | mantissa) & 0xFF).astype(np.uint8).tobytes())
+
+
+def _encode_alaw(samples: np.ndarray) -> bytes:
+    """Encode signed linear PCM samples as 8-bit ITU-T G.711 A-law."""
+    magnitude = np.minimum(np.abs(samples), 32767)
+    exponent = np.clip(np.floor(np.log2(np.maximum(magnitude, 1))).astype(np.int32) - 7, 0, 7)
+    mantissa = (magnitude >> (exponent + 3)) & 0x0F
+    encoded = np.where(magnitude < 256, magnitude >> 4, (exponent << 4) | mantissa)
+    xor_mask = np.where(samples >= 0, 0xD5, 0x55)
+    return cast(bytes, (encoded ^ xor_mask).astype(np.uint8).tobytes())
+
 
 SUPPORTED_LANGUAGES = {
     "en-IN",
@@ -93,7 +131,7 @@ SUPPORTED_LANGUAGES = {
 
 
 @dataclass
-class StreamingSTTOptions:
+class RealtimeSTTOptions:
     language: str
     api_key: str
     stream_type: RealtimeStreamType | str = "balanced"
@@ -108,6 +146,9 @@ class StreamingSTTOptions:
     vad_sot_threshold: float | None = None
     vad_min_speech_ms: int | None = None
     vad_min_silence_ms: int | None = None
+    vad_prefix_padding_ms: int | None = None
+    lid_gate_seconds: float | None = None
+    lid_confidence_threshold: float | None = None
 
     def __post_init__(self) -> None:
         if self.model != REALTIME_MODEL:
@@ -136,9 +177,18 @@ class StreamingSTTOptions:
             raise ValueError("vad_min_speech_ms must be greater than or equal to 0")
         if self.vad_min_silence_ms is not None and self.vad_min_silence_ms < 0:
             raise ValueError("vad_min_silence_ms must be greater than or equal to 0")
+        if self.vad_prefix_padding_ms is not None and self.vad_prefix_padding_ms < 0:
+            raise ValueError("vad_prefix_padding_ms must be greater than or equal to 0")
+        if self.lid_gate_seconds is not None and self.lid_gate_seconds < 0:
+            raise ValueError("lid_gate_seconds must be greater than or equal to 0")
+        if (
+            self.lid_confidence_threshold is not None
+            and not 0.0 <= self.lid_confidence_threshold <= 1.0
+        ):
+            raise ValueError("lid_confidence_threshold must be between 0.0 and 1.0")
 
 
-def _build_realtime_ws_url(base_url: str, opts: StreamingSTTOptions) -> str:
+def _build_realtime_ws_url(base_url: str, opts: RealtimeSTTOptions) -> str:
     params: dict[str, str] = {
         "language_code": opts.language,
         "stream_type": opts.stream_type,
@@ -152,6 +202,10 @@ def _build_realtime_ws_url(base_url: str, opts: StreamingSTTOptions) -> str:
     params["return_timestamps"] = str(opts.return_timestamps).lower()
     if opts.prompt is not None:
         params["prompt"] = opts.prompt
+    if opts.lid_gate_seconds is not None:
+        params["lid_gate_seconds"] = str(opts.lid_gate_seconds)
+    if opts.lid_confidence_threshold is not None:
+        params["lid_confidence_threshold"] = str(opts.lid_confidence_threshold)
 
     if opts.endpointing == "vad":
         if opts.vad_sot_threshold is not None:
@@ -160,11 +214,13 @@ def _build_realtime_ws_url(base_url: str, opts: StreamingSTTOptions) -> str:
             params["min_speech_duration_ms"] = str(opts.vad_min_speech_ms)
         if opts.vad_min_silence_ms is not None:
             params["silence_duration_ms"] = str(opts.vad_min_silence_ms)
+        if opts.vad_prefix_padding_ms is not None:
+            params["prefix_padding_ms"] = str(opts.vad_prefix_padding_ms)
 
     return f"{base_url}?{urlencode(params)}"
 
 
-class STTStreaming(stt.STT):
+class STTRealtime(stt.STT):
     def __init__(
         self,
         *,
@@ -182,6 +238,9 @@ class STTStreaming(stt.STT):
         vad_sot_threshold: float | None = None,
         vad_min_speech_ms: int | None = None,
         vad_min_silence_ms: int | None = None,
+        vad_prefix_padding_ms: int | None = None,
+        lid_gate_seconds: float | None = None,
+        lid_confidence_threshold: float | None = None,
     ) -> None:
         super().__init__(
             capabilities=stt.STTCapabilities(
@@ -199,7 +258,7 @@ class STTStreaming(stt.STT):
                 "Provide it directly or set SARVAM_API_KEY environment variable."
             )
 
-        self._opts = StreamingSTTOptions(
+        self._opts = RealtimeSTTOptions(
             language=language,
             api_key=api_key,
             stream_type=stream_type,
@@ -213,10 +272,13 @@ class STTStreaming(stt.STT):
             vad_sot_threshold=vad_sot_threshold,
             vad_min_speech_ms=vad_min_speech_ms,
             vad_min_silence_ms=vad_min_silence_ms,
+            vad_prefix_padding_ms=vad_prefix_padding_ms,
+            lid_gate_seconds=lid_gate_seconds,
+            lid_confidence_threshold=lid_confidence_threshold,
         )
         self._session = http_session
         self._owns_session = http_session is None
-        self._streams = weakref.WeakSet[StreamingSpeechStream]()
+        self._streams = weakref.WeakSet[RealtimeSpeechStream]()
 
     @property
     def model(self) -> str:
@@ -259,8 +321,11 @@ class STTStreaming(stt.STT):
         vad_sot_threshold: NotGivenOr[float | None] = NOT_GIVEN,
         vad_min_speech_ms: NotGivenOr[int | None] = NOT_GIVEN,
         vad_min_silence_ms: NotGivenOr[int | None] = NOT_GIVEN,
+        vad_prefix_padding_ms: NotGivenOr[int | None] = NOT_GIVEN,
+        lid_gate_seconds: NotGivenOr[float | None] = NOT_GIVEN,
+        lid_confidence_threshold: NotGivenOr[float | None] = NOT_GIVEN,
     ) -> None:
-        opts = StreamingSTTOptions(
+        opts = RealtimeSTTOptions(
             language=language if is_given(language) else self._opts.language,
             api_key=self._opts.api_key,
             stream_type=stream_type if is_given(stream_type) else self._opts.stream_type,
@@ -282,6 +347,15 @@ class STTStreaming(stt.STT):
             vad_min_silence_ms=vad_min_silence_ms
             if is_given(vad_min_silence_ms)
             else self._opts.vad_min_silence_ms,
+            vad_prefix_padding_ms=vad_prefix_padding_ms
+            if is_given(vad_prefix_padding_ms)
+            else self._opts.vad_prefix_padding_ms,
+            lid_gate_seconds=lid_gate_seconds
+            if is_given(lid_gate_seconds)
+            else self._opts.lid_gate_seconds,
+            lid_confidence_threshold=lid_confidence_threshold
+            if is_given(lid_confidence_threshold)
+            else self._opts.lid_confidence_threshold,
         )
         self._opts = opts
         for stream in self._streams:
@@ -292,9 +366,9 @@ class STTStreaming(stt.STT):
         *,
         language: NotGivenOr[str] = NOT_GIVEN,
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
-    ) -> StreamingSpeechStream:
+    ) -> RealtimeSpeechStream:
         conn_options = replace(conn_options, max_retry=0)
-        opts = StreamingSTTOptions(
+        opts = RealtimeSTTOptions(
             language=language if is_given(language) else self._opts.language,
             api_key=self._opts.api_key,
             stream_type=self._opts.stream_type,
@@ -308,8 +382,11 @@ class STTStreaming(stt.STT):
             vad_sot_threshold=self._opts.vad_sot_threshold,
             vad_min_speech_ms=self._opts.vad_min_speech_ms,
             vad_min_silence_ms=self._opts.vad_min_silence_ms,
+            vad_prefix_padding_ms=self._opts.vad_prefix_padding_ms,
+            lid_gate_seconds=self._opts.lid_gate_seconds,
+            lid_confidence_threshold=self._opts.lid_confidence_threshold,
         )
-        stream = StreamingSpeechStream(
+        stream = RealtimeSpeechStream(
             stt=self,
             opts=opts,
             conn_options=conn_options,
@@ -326,12 +403,12 @@ class STTStreaming(stt.STT):
             await self._session.close()
 
 
-class StreamingSpeechStream(stt.SpeechStream):
+class RealtimeSpeechStream(stt.SpeechStream):
     def __init__(
         self,
         *,
-        stt: STTStreaming,
-        opts: StreamingSTTOptions,
+        stt: STTRealtime,
+        opts: RealtimeSTTOptions,
         conn_options: APIConnectOptions,
         http_session: aiohttp.ClientSession,
     ) -> None:
@@ -341,6 +418,7 @@ class StreamingSpeechStream(stt.SpeechStream):
         self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._request_id = ""
         self._session_id = ""
+        self._resolved_config: dict[str, Any] | None = None
         self._session_ended = False
         self._utterance_idx: int | None = None
         self._utterance_in_progress = False
@@ -370,7 +448,12 @@ class StreamingSpeechStream(stt.SpeechStream):
         )
         self._logger = logger
 
-    def update_options(self, opts: StreamingSTTOptions) -> None:
+    @property
+    def resolved_config(self) -> dict[str, Any] | None:
+        """Return the configuration resolved by Sarvam for this connection."""
+        return dict(self._resolved_config) if self._resolved_config is not None else None
+
+    def update_options(self, opts: RealtimeSTTOptions) -> None:
         previous_opts = self._opts
         connection_only_options: list[str] = []
         if opts.sample_rate != previous_opts.sample_rate:
@@ -379,6 +462,18 @@ class StreamingSpeechStream(stt.SpeechStream):
         if opts.return_timestamps != previous_opts.return_timestamps:
             connection_only_options.append("return_timestamps")
             opts = replace(opts, return_timestamps=previous_opts.return_timestamps)
+        if opts.vad_prefix_padding_ms != previous_opts.vad_prefix_padding_ms:
+            connection_only_options.append("vad_prefix_padding_ms")
+            opts = replace(opts, vad_prefix_padding_ms=previous_opts.vad_prefix_padding_ms)
+        if opts.lid_gate_seconds != previous_opts.lid_gate_seconds:
+            connection_only_options.append("lid_gate_seconds")
+            opts = replace(opts, lid_gate_seconds=previous_opts.lid_gate_seconds)
+        if opts.lid_confidence_threshold != previous_opts.lid_confidence_threshold:
+            connection_only_options.append("lid_confidence_threshold")
+            opts = replace(
+                opts,
+                lid_confidence_threshold=previous_opts.lid_confidence_threshold,
+            )
         if connection_only_options:
             self._logger.warning(
                 "Sarvam realtime STT connection-only option updates only apply to new streams",
@@ -402,8 +497,8 @@ class StreamingSpeechStream(stt.SpeechStream):
 
     @staticmethod
     def _config_update_payload(
-        previous: StreamingSTTOptions,
-        current: StreamingSTTOptions,
+        previous: RealtimeSTTOptions,
+        current: RealtimeSTTOptions,
     ) -> dict[str, Any] | None:
         payload: dict[str, Any] = {"event": "config.update"}
         values = (
@@ -556,6 +651,7 @@ class StreamingSpeechStream(stt.SpeechStream):
         self._cancel_eos_fallback()
         self._request_id = ""
         self._session_id = ""
+        self._resolved_config = None
         self._session_ended = False
         self._utterance_idx = None
         self._utterance_in_progress = False
@@ -683,7 +779,7 @@ class StreamingSpeechStream(stt.SpeechStream):
 
                 self._audio_duration_collector.push(frame.duration)
                 self._audio_position += frame.duration
-                await ws.send_bytes(frame.data.tobytes())
+                await ws.send_bytes(_encode_pcm_for_wire(self._opts.encoding, frame.data.tobytes()))
 
             if isinstance(data, self._FlushSentinel):
                 self._audio_duration_collector.flush()
@@ -780,6 +876,9 @@ class StreamingSpeechStream(stt.SpeechStream):
     async def _handle_message(self, data: dict[str, Any]) -> None:
         event = data.get("event")
         self._capture_server_ids(data)
+        if event == "session.begin":
+            config = data.get("config")
+            self._resolved_config = dict(config) if isinstance(config, dict) else None
         self._log_stt_event(event, data)
         if event == "session.begin":
             return
@@ -1099,3 +1198,9 @@ class StreamingSpeechStream(stt.SpeechStream):
                 recognition_usage=stt.RecognitionUsage(audio_duration=duration),
             )
         )
+
+
+# Deprecated compatibility aliases. Prefer the endpoint-specific realtime names above.
+STTStreaming = STTRealtime
+StreamingSpeechStream = RealtimeSpeechStream
+StreamingSTTOptions = RealtimeSTTOptions

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -221,6 +221,13 @@ def _build_realtime_ws_url(base_url: str, opts: RealtimeSTTOptions) -> str:
 
 
 class STTRealtime(stt.STT):
+    """Speech-to-text using Sarvam's realtime WebSocket endpoint (``saaras:v3-realtime``).
+
+    This endpoint streams interim and final transcripts over a single
+    WebSocket connection and supports either server-side VAD or
+    client-driven (manual) turn boundaries.
+    """
+
     def __init__(
         self,
         *,
@@ -242,6 +249,34 @@ class STTRealtime(stt.STT):
         lid_gate_seconds: float | None = None,
         lid_confidence_threshold: float | None = None,
     ) -> None:
+        """Create a Sarvam realtime STT instance.
+
+        Args:
+            language: BCP-47 language code, or ``auto`` for adaptive language identification.
+            stream_type: Latency profile: ``fast``, ``balanced``, or ``simulated``.
+            mode: Task applied to finals: ``transcribe``, ``translate``, ``verbatim``,
+                ``translit``, or ``codemix``.
+            endpointing: ``vad`` for server-side turn detection, or ``manual`` when the
+                caller delimits turns by flushing the stream.
+            encoding: Wire encoding: ``linear16``, ``linear32``, ``mulaw``, or ``alaw``.
+            sample_rate: Audio sample rate in Hz; ``8000`` or ``16000``.
+            prompt: Optional context or terminology hint used to bias decoding.
+            return_timestamps: Whether finals should carry segment-level start and end times.
+            api_key: Sarvam API key. Falls back to the ``SARVAM_API_KEY`` environment variable.
+            base_url: WebSocket URL of the realtime endpoint.
+            http_session: Optional aiohttp session to reuse for the connection.
+            vad_sot_threshold: VAD activation threshold (``vad`` endpointing only).
+            vad_min_speech_ms: Minimum speech duration in ms (``vad`` endpointing only).
+            vad_min_silence_ms: End-of-turn silence in ms (``vad`` endpointing only).
+            vad_prefix_padding_ms: Audio retained before speech onset in ms
+                (``vad`` endpointing only).
+            lid_gate_seconds: Utterance audio required before a detected language is promoted.
+            lid_confidence_threshold: Confidence required before a detected language is promoted.
+
+        Raises:
+            ValueError: If no API key is provided or found in the environment, or if an
+                option falls outside the values the endpoint accepts.
+        """
         super().__init__(
             capabilities=stt.STTCapabilities(
                 streaming=True,
@@ -282,10 +317,12 @@ class STTRealtime(stt.STT):
 
     @property
     def model(self) -> str:
+        """Name of the Sarvam realtime model backing this instance."""
         return REALTIME_MODEL
 
     @property
     def provider(self) -> str:
+        """Name of the speech-to-text provider."""
         return "Sarvam"
 
     def _ensure_session(self) -> aiohttp.ClientSession:
@@ -325,6 +362,33 @@ class STTRealtime(stt.STT):
         lid_gate_seconds: NotGivenOr[float | None] = NOT_GIVEN,
         lid_confidence_threshold: NotGivenOr[float | None] = NOT_GIVEN,
     ) -> None:
+        """Update options for this instance and every stream it created.
+
+        Options that Sarvam only accepts at connection time (``sample_rate``,
+        ``return_timestamps``, ``vad_prefix_padding_ms``, ``lid_gate_seconds``, and
+        ``lid_confidence_threshold``) take effect on newly created streams only.
+        The remaining options are sent to active streams as an in-band
+        ``config.update``, and the boundary-gated ones apply from the next
+        utterance boundary.
+
+        Args:
+            language: BCP-47 language code, or ``auto`` for adaptive language identification.
+            stream_type: Latency profile: ``fast``, ``balanced``, or ``simulated``.
+            mode: Task applied to finals.
+            endpointing: ``vad`` for server-side turn detection, or ``manual``.
+            sample_rate: Audio sample rate in Hz; applies to new streams only.
+            prompt: Context or terminology hint; ``None`` clears it.
+            return_timestamps: Segment-level timestamps; applies to new streams only.
+            vad_sot_threshold: VAD activation threshold (``vad`` endpointing only).
+            vad_min_speech_ms: Minimum speech duration in ms (``vad`` endpointing only).
+            vad_min_silence_ms: End-of-turn silence in ms (``vad`` endpointing only).
+            vad_prefix_padding_ms: Audio retained before speech onset; new streams only.
+            lid_gate_seconds: Language-promotion audio gate; applies to new streams only.
+            lid_confidence_threshold: Language-promotion confidence; new streams only.
+
+        Raises:
+            ValueError: If an option falls outside the values the endpoint accepts.
+        """
         opts = RealtimeSTTOptions(
             language=language if is_given(language) else self._opts.language,
             api_key=self._opts.api_key,
@@ -367,6 +431,16 @@ class STTRealtime(stt.STT):
         language: NotGivenOr[str] = NOT_GIVEN,
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
     ) -> RealtimeSpeechStream:
+        """Create a new realtime speech stream.
+
+        Args:
+            language: Overrides the instance language for this stream only.
+            conn_options: Connection options. ``max_retry`` is forced to ``0`` because this
+                endpoint bills per connection and must not silently reconnect.
+
+        Returns:
+            A stream that accepts audio frames and yields speech events.
+        """
         conn_options = replace(conn_options, max_retry=0)
         opts = RealtimeSTTOptions(
             language=language if is_given(language) else self._opts.language,
@@ -396,6 +470,7 @@ class STTRealtime(stt.STT):
         return stream
 
     async def aclose(self) -> None:
+        """Close every stream created by this instance and any owned HTTP session."""
         for stream in list(self._streams):
             await stream.aclose()
         self._streams.clear()
@@ -404,6 +479,14 @@ class STTRealtime(stt.STT):
 
 
 class RealtimeSpeechStream(stt.SpeechStream):
+    """A single WebSocket session against Sarvam's realtime STT endpoint.
+
+    Audio pushed into the stream is forwarded in the configured wire encoding, and
+    the events Sarvam returns are translated into LiveKit speech events. Audio
+    duration is reported incrementally while the session runs and reconciled
+    against the server's authoritative total when the session ends.
+    """
+
     def __init__(
         self,
         *,
@@ -412,6 +495,14 @@ class RealtimeSpeechStream(stt.SpeechStream):
         conn_options: APIConnectOptions,
         http_session: aiohttp.ClientSession,
     ) -> None:
+        """Create a realtime speech stream.
+
+        Args:
+            stt: The parent instance that created this stream.
+            opts: Resolved options for this connection.
+            conn_options: Connection options for this stream.
+            http_session: aiohttp session used to open the WebSocket.
+        """
         super().__init__(stt=stt, conn_options=conn_options, sample_rate=opts.sample_rate)
         self._opts = opts
         self._session = http_session
@@ -454,6 +545,16 @@ class RealtimeSpeechStream(stt.SpeechStream):
         return dict(self._resolved_config) if self._resolved_config is not None else None
 
     def update_options(self, opts: RealtimeSTTOptions) -> None:
+        """Apply an option change to this live connection.
+
+        Connection-time options are retained at their current values and a warning is
+        logged, since changing them would desynchronize the already-negotiated session.
+        Every other change is queued as an in-band ``config.update`` sent before the
+        next audio frame.
+
+        Args:
+            opts: The requested options for this stream.
+        """
         previous_opts = self._opts
         connection_only_options: list[str] = []
         if opts.sample_rate != previous_opts.sample_rate:
@@ -588,8 +689,19 @@ class RealtimeSpeechStream(stt.SpeechStream):
                 self._request_id = request_id
 
     async def aclose(self) -> None:
+        """Close the connection, reporting any audio duration not yet billed.
+
+        Agents normally end a stream here rather than waiting for ``session.end``, so
+        the pending duration is flushed before the base class cancels the tasks that
+        deliver usage metrics.
+        """
         try:
             self._cancel_eos_fallback()
+            if not self._event_ch.closed:
+                self._emit_local_usage_fallback()
+                # Give the metrics monitor a chance to consume the usage event before
+                # super().aclose() cancels it.
+                await asyncio.sleep(0)
             if self._ws and not self._ws.closed:
                 await self._ws.close()
         finally:
@@ -686,6 +798,29 @@ class RealtimeSpeechStream(stt.SpeechStream):
         self._final_received_for_utterance = False
         self._eos_emitted_for_utterance = False
 
+    def _begin_manual_utterance(self) -> None:
+        """Open a client-delimited turn.
+
+        Sarvam emits no ``vad.speech_start`` under manual endpointing, so the client
+        boundary is what starts an utterance. Resetting here keeps the per-utterance
+        flags and timings from leaking across turns, including after an ``endpointing``
+        switch from ``vad`` to ``manual``.
+        """
+        self._reset_utterance_state()
+        self._utterance_in_progress = True
+        self._event_ch.send_nowait(
+            stt.SpeechEvent(
+                type=stt.SpeechEventType.START_OF_SPEECH,
+                request_id=self._request_id,
+            )
+        )
+
+    def _end_manual_utterance(self) -> None:
+        """Close a client-delimited turn and anchor its speech-end position."""
+        self._utterance_speech_end_audio_pos = self._audio_position
+        self._utterance_speech_end_wall = time.time()
+        self._emit_end_of_speech()
+
     async def _safe_send_str(
         self,
         ws: Any,
@@ -775,7 +910,7 @@ class RealtimeSpeechStream(stt.SpeechStream):
                 if self._active_endpointing == "manual" and not self._manual_speech_started:
                     await self._safe_send_str(ws, {"event": "speech_start"})
                     self._manual_speech_started = True
-                    self._utterance_in_progress = True
+                    self._begin_manual_utterance()
 
                 self._audio_duration_collector.push(frame.duration)
                 self._audio_position += frame.duration
@@ -786,6 +921,7 @@ class RealtimeSpeechStream(stt.SpeechStream):
                 if self._active_endpointing == "manual" and self._manual_speech_started:
                     await self._safe_send_str(ws, {"event": "speech_end"})
                     self._manual_speech_started = False
+                    self._end_manual_utterance()
 
         self._audio_duration_collector.flush()
         await self._safe_send_str(ws, {"event": "end"})
@@ -829,9 +965,11 @@ class RealtimeSpeechStream(stt.SpeechStream):
                 close_code = ws.close_code if ws.close_code is not None else msg.data
                 close_reason = msg.extra
                 if self._session_ended and close_code in (1000, 1001, None):
+                    self._flush_terminal_utterance()
                     self._emit_local_usage_fallback()
                     break
                 if close_code in (1000, 1001, None) and not _looks_like_error_text(close_reason):
+                    self._flush_terminal_utterance()
                     self._emit_local_usage_fallback()
                     break
                 self._logger.error(
@@ -932,9 +1070,10 @@ class RealtimeSpeechStream(stt.SpeechStream):
             "utterance_idx": data.get("utterance_idx"),
         }
         if event in {"transcript.partial", "transcript.final"}:
+            # Recognized speech is personal data, so only its length is safe for the
+            # INFO record; the text itself stays in the opt-in DEBUG raw payload.
             text = data.get("text")
             if isinstance(text, str):
-                extra["text"] = text[:200]
                 extra["text_length"] = len(text)
             extra["language"] = data.get("language") or self._opts.language
             extra["confidence"] = data.get("language_confidence", data.get("confidence"))
@@ -1026,6 +1165,27 @@ class RealtimeSpeechStream(stt.SpeechStream):
                 self._emit_end_of_speech()
             self._pending_final_data = None
             self._complete_utterance()
+
+    def _flush_terminal_utterance(self) -> None:
+        """Commit a buffered final transcript when the session ends mid-utterance.
+
+        In VAD endpointing a ``transcript.final`` is held until ``vad.speech_end``
+        supplies the speech-end position. When the input audio ends mid-utterance
+        the server finalizes and closes without that event, so the speech-end
+        position is anchored to the audio consumed so far instead of dropping the
+        transcript. Safe to call more than once per session.
+        """
+        if self._pending_final_data is not None and self._utterance_speech_end_audio_pos is None:
+            self._utterance_speech_end_audio_pos = self._audio_position
+            if self._utterance_speech_end_wall is None:
+                self._utterance_speech_end_wall = time.time()
+
+        if not self._eos_emitted_for_utterance and (
+            self._pending_eos or self._pending_final_data is not None
+        ):
+            self._emit_end_of_speech()
+
+        self._try_commit_utterance()
 
     def _emit_end_of_speech(self) -> None:
         current_task = asyncio.current_task()
@@ -1129,15 +1289,20 @@ class RealtimeSpeechStream(stt.SpeechStream):
 
     def _handle_session_end(self, data: dict[str, Any]) -> None:
         self._capture_server_ids(data)
+        self._flush_terminal_utterance()
         audio_duration = data.get("audio_duration_s")
         if (
             isinstance(audio_duration, (int, float))
             and not isinstance(audio_duration, bool)
             and not self._server_audio_duration_reported
         ):
+            # Report whatever audio is still buffered locally, then top up to Sarvam's
+            # authoritative total so the session bills exactly once for it.
+            self._audio_duration_collector.flush()
             server_audio_duration = max(float(audio_duration), 0.0)
-            if server_audio_duration:
-                self._emit_usage(server_audio_duration)
+            delta = max(server_audio_duration - self._total_reported_audio_duration, 0.0)
+            if delta:
+                self._emit_usage(delta)
             self._server_audio_duration_reported = True
         else:
             self._emit_local_usage_fallback()
@@ -1181,13 +1346,12 @@ class RealtimeSpeechStream(stt.SpeechStream):
 
     def _on_audio_duration_report(self, duration: float) -> None:
         self._local_audio_duration += duration
+        self._emit_usage(duration)
 
     def _emit_local_usage_fallback(self) -> None:
         if self._server_audio_duration_reported:
             return
-        delta = max(self._local_audio_duration - self._total_reported_audio_duration, 0.0)
-        if delta:
-            self._emit_usage(delta)
+        self._audio_duration_collector.flush()
 
     def _emit_usage(self, duration: float) -> None:
         self._total_reported_audio_duration += duration

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -857,6 +857,7 @@ class RealtimeSpeechStream(stt.SpeechStream):
         self._utterance_speech_end_audio_pos = self._audio_position
         self._utterance_speech_end_wall = time.time()
         self._emit_end_of_speech()
+        self._complete_utterance()
 
     async def _safe_send_str(
         self,
@@ -1243,11 +1244,14 @@ class RealtimeSpeechStream(stt.SpeechStream):
             return False
 
         language = data.get("language") or self._opts.language
-        confidence = data.get("language_confidence")
-        if confidence is None:
-            confidence = data.get("confidence", 0.0)
+        # Recognition confidence only: `language_confidence` is a language-identification
+        # score and stays in metadata. The endpoint sends no per-segment confidence
+        # today, and an absent value falls back to 1.0 (as `_extract_confidence` in
+        # stt.py does) so it isn't averaged downstream as "no confidence".
+        # bool is a subclass of int, so exclude it explicitly.
+        confidence = data.get("confidence")
         if not isinstance(confidence, (int, float)) or isinstance(confidence, bool):
-            confidence = 0.0
+            confidence = 1.0
 
         metadata: dict[str, Any] = {
             key: data[key]

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -845,6 +845,18 @@ class RealtimeSpeechStream(stt.SpeechStream):
                 extra={**self._build_log_context(), "payload": payload},
             )
 
+    async def _safe_send_bytes(self, ws: Any, payload: bytes) -> None:
+        if ws.closed:
+            return
+
+        try:
+            await ws.send_bytes(payload)
+        except (aiohttp.ClientConnectionResetError, ConnectionError):
+            self._logger.debug(
+                "Sarvam realtime STT WebSocket closed before audio send completed",
+                extra={**self._build_log_context(), "payload_bytes": len(payload)},
+            )
+
     async def _send_pending_config_update(self, ws: Any) -> None:
         payload = self._pending_config_update
         self._pending_config_update = None
@@ -907,6 +919,11 @@ class RealtimeSpeechStream(stt.SpeechStream):
         )
 
         async for data in self._input_ch:
+            # The server is done reading, so stop the pump instead of writing into a
+            # socket whose reset would fail the whole stream (max_retry is forced to 0).
+            if self._session_ended or ws.closed:
+                break
+
             await self._send_pending_config_update(ws)
             frames: list[rtc.AudioFrame] = []
             if isinstance(data, rtc.AudioFrame):
@@ -922,7 +939,9 @@ class RealtimeSpeechStream(stt.SpeechStream):
 
                 self._audio_duration_collector.push(frame.duration)
                 self._audio_position += frame.duration
-                await ws.send_bytes(_encode_pcm_for_wire(self._opts.encoding, frame.data.tobytes()))
+                await self._safe_send_bytes(
+                    ws, _encode_pcm_for_wire(self._opts.encoding, frame.data.tobytes())
+                )
 
             if isinstance(data, self._FlushSentinel):
                 self._audio_duration_collector.flush()
@@ -932,7 +951,8 @@ class RealtimeSpeechStream(stt.SpeechStream):
                     self._end_manual_utterance()
 
         self._audio_duration_collector.flush()
-        await self._safe_send_str(ws, {"event": "end"})
+        if not self._session_ended:
+            await self._safe_send_str(ws, {"event": "end"})
 
     @utils.log_exceptions(logger=logger)
     async def _process_messages(self, ws: aiohttp.ClientWebSocketResponse) -> None:

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -1040,6 +1040,8 @@ class StreamingSpeechStream(stt.SpeechStream):
             if server_audio_duration:
                 self._emit_usage(server_audio_duration)
             self._server_audio_duration_reported = True
+        else:
+            self._emit_local_usage_fallback()
         self._session_ended = True
 
     def _handle_error_event(self, data: dict[str, Any]) -> None:

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -132,6 +132,14 @@ SUPPORTED_LANGUAGES = {
 
 @dataclass
 class RealtimeSTTOptions:
+    """Resolved options for a single Sarvam realtime STT connection.
+
+    Values are validated against the realtime contract in ``__post_init__``, which
+    raises ``ValueError`` for anything the endpoint would reject. Some fields are
+    negotiated at connection time and cannot change on a live stream; see
+    :meth:`RealtimeSpeechStream.update_options`.
+    """
+
     language: str
     api_key: str
     stream_type: RealtimeStreamType | str = "balanced"
@@ -1197,29 +1205,13 @@ class RealtimeSpeechStream(stt.SpeechStream):
         if self._eos_emitted_for_utterance:
             return
 
-        alternatives: list[stt.SpeechData] = []
-        if self._utterance_speech_end_audio_pos is not None:
-            metadata: dict[str, Any] = {}
-            if self._utterance_speech_end_wall is not None:
-                metadata["speech_end_wall_time"] = self._utterance_speech_end_wall
-            if self._pending_final_data is not None:
-                utterance_idx = self._pending_final_data.get("utterance_idx")
-                if utterance_idx is not None:
-                    metadata["utterance_idx"] = utterance_idx
-            alternatives.append(
-                stt.SpeechData(
-                    language=LanguageCode(self._opts.language),
-                    text="",
-                    end_time=self._utterance_speech_end_audio_pos,
-                    metadata=metadata or None,
-                )
-            )
-
+        # Emitted without alternatives so the agent pipeline treats it as a sentinel
+        # it can hold and release with a concrete transcript. The speech-end timing
+        # travels on the FINAL_TRANSCRIPT event instead.
         self._event_ch.send_nowait(
             stt.SpeechEvent(
                 type=stt.SpeechEventType.END_OF_SPEECH,
                 request_id=self._request_id,
-                alternatives=alternatives,
             )
         )
         self._pending_eos = False

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -49,8 +49,15 @@ def _make_stream(
     stream._final_received_for_utterance = False
     stream._eos_emitted_for_utterance = False
     stream._eos_fallback_task = None
+    stream._manual_speech_started = False
     stream._stream_started_at = stt_streaming.time.time()
     stream._audio_position = 0.0
+    stream._audio_duration_collector = stt_streaming.PeriodicCollector(
+        callback=stt_streaming.StreamingSpeechStream._on_audio_duration_report.__get__(
+            stream, stt_streaming.StreamingSpeechStream
+        ),
+        duration=5.0,
+    )
     return stream
 
 
@@ -514,6 +521,115 @@ async def test_streaming_error_handling_distinguishes_fatal_and_non_fatal() -> N
     assert excinfo.value.status_code == 503
     assert excinfo.value.body["code"] == "model_unavailable"
     assert excinfo.value.retryable is True
+
+
+def test_reset_connection_state_clears_session_and_utterance_fields() -> None:
+    class _FakeFallbackTask:
+        def __init__(self) -> None:
+            self.cancelled = False
+
+        def done(self) -> bool:
+            return False
+
+        def cancel(self) -> None:
+            self.cancelled = True
+
+    stream = _make_stream()
+    stream._request_id = "req_old"
+    stream._session_id = "sess_old"
+    stream._session_ended = True
+    stream._manual_speech_started = True
+    stream._pending_eos = True
+    stream._pending_eos_time = 1.0
+    stream._pending_final_data = {"text": "hello"}
+    stream._utterance_start_audio_pos = 3.0
+    stream._utterance_speech_end_audio_pos = 4.0
+    stream._utterance_speech_end_wall = 5.0
+    stream._final_received_for_utterance = True
+    stream._eos_emitted_for_utterance = True
+    stream._total_reported_audio_duration = 50.0
+    fallback_task = _FakeFallbackTask()
+    stream._eos_fallback_task = fallback_task
+
+    stream._reset_connection_state()
+
+    assert fallback_task.cancelled is True
+
+    assert stream._request_id == ""
+    assert stream._session_id == ""
+    assert stream._session_ended is False
+    assert stream._manual_speech_started is False
+    assert stream._pending_eos is False
+    assert stream._pending_eos_time is None
+    assert stream._pending_final_data is None
+    assert stream._utterance_start_audio_pos == 0.0
+    assert stream._utterance_speech_end_audio_pos is None
+    assert stream._utterance_speech_end_wall is None
+    assert stream._final_received_for_utterance is False
+    assert stream._eos_emitted_for_utterance is False
+    assert stream._total_reported_audio_duration == 0.0
+    assert stream._eos_fallback_task is None
+
+
+@pytest.mark.asyncio
+async def test_session_end_delta_after_connection_reset() -> None:
+    stream = _make_stream()
+    stream._total_reported_audio_duration = 50.0
+
+    stream._reset_connection_state()
+
+    await stream._handle_message(
+        {
+            "event": "session.end",
+            "session_id": "sess_new",
+            "audio_duration_s": 12.0,
+        }
+    )
+
+    usage_events = [
+        event
+        for event in stream._event_ch.events
+        if event.type == stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE
+    ]
+    assert len(usage_events) == 1
+    assert usage_events[0].recognition_usage.audio_duration == 12.0
+
+
+@pytest.mark.asyncio
+async def test_collector_flush_before_reset_emits_pending_usage() -> None:
+    stream = _make_stream()
+    stream._audio_duration_collector.push(2.5)
+
+    stream._reset_connection_state()
+
+    usage_events = [
+        event
+        for event in stream._event_ch.events
+        if event.type == stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE
+    ]
+    assert len(usage_events) == 1
+    assert usage_events[0].recognition_usage.audio_duration == 2.5
+    assert stream._total_reported_audio_duration == 0.0
+
+
+@pytest.mark.asyncio
+async def test_reset_connection_state_allows_new_request_id_capture() -> None:
+    stream = _make_stream()
+    stream._request_id = "req_old"
+    stream._session_id = "sess_old"
+
+    stream._reset_connection_state()
+
+    await stream._handle_message(
+        {
+            "event": "session.begin",
+            "session_id": "sess_new",
+            "request_id": "req_new",
+        }
+    )
+
+    assert stream._request_id == "req_new"
+    assert stream._session_id == "sess_new"
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -1,0 +1,539 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from livekit.agents import APIStatusError
+from livekit.plugins.sarvam import stt_streaming
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeEventChannel:
+    def __init__(self) -> None:
+        self.events = []
+
+    def send_nowait(self, event: object) -> None:
+        self.events.append(event)
+
+
+def _make_stream(
+    *,
+    endpointing: str = "vad",
+) -> stt_streaming.StreamingSpeechStream:
+    stream = object.__new__(stt_streaming.StreamingSpeechStream)
+    stream._event_ch = _FakeEventChannel()
+    stream._request_id = ""
+    stream._session_id = ""
+    stream._session_ended = False
+    stream._total_reported_audio_duration = 0.0
+    stream._opts = stt_streaming.StreamingSTTOptions(
+        language="hi-IN",
+        api_key="sk_test",
+        endpointing=endpointing,
+    )
+    stream._logger = stt_streaming.logger.getChild("StreamingSpeechStream")
+    stream._build_log_context = stt_streaming.StreamingSpeechStream._build_log_context.__get__(
+        stream, stt_streaming.StreamingSpeechStream
+    )
+    stream._pending_eos = False
+    stream._pending_eos_time = None
+    stream._pending_final_data = None
+    stream._utterance_start_audio_pos = 0.0
+    stream._utterance_speech_end_audio_pos = None
+    stream._utterance_speech_end_wall = None
+    stream._final_received_for_utterance = False
+    stream._eos_emitted_for_utterance = False
+    stream._eos_fallback_task = None
+    stream._stream_started_at = stt_streaming.time.time()
+    stream._audio_position = 0.0
+    return stream
+
+
+def _parse_ws_url(url: str) -> dict[str, str]:
+    parsed = urlparse(url)
+    qs = parse_qs(parsed.query)
+    return {key: value[0] for key, value in qs.items()}
+
+
+def test_realtime_ws_url_includes_core_and_vad_params() -> None:
+    opts = stt_streaming.StreamingSTTOptions(
+        language="hi-IN",
+        api_key="sk_test",
+        stream_type="fast",
+        endpointing="vad",
+        sample_rate=16000,
+        vad_sot_threshold=0.4,
+        vad_min_speech_ms=300,
+        vad_min_silence_ms=800,
+        vad_smoothing_alpha=0.5,
+    )
+
+    url = stt_streaming._build_realtime_ws_url(stt_streaming.SARVAM_STT_REALTIME_URL, opts)
+
+    assert url.startswith(stt_streaming.SARVAM_STT_REALTIME_URL)
+    assert _parse_ws_url(url) == {
+        "language-code": "hi-IN",
+        "stream-type": "fast",
+        "endpointing": "vad",
+        "encoding": "linear16",
+        "sample_rate": "16000",
+        "model": "saaras:v3-realtime",
+        "vad_sot_threshold": "0.4",
+        "vad_min_speech_ms": "300",
+        "vad_min_silence_ms": "800",
+        "vad_smoothing_alpha": "0.5",
+    }
+
+
+def test_realtime_ws_url_omits_vad_params_for_manual_endpointing() -> None:
+    opts = stt_streaming.StreamingSTTOptions(
+        language="en-IN",
+        api_key="sk_test",
+        endpointing="manual",
+        vad_sot_threshold=0.4,
+        vad_min_speech_ms=300,
+    )
+
+    url = stt_streaming._build_realtime_ws_url(stt_streaming.SARVAM_STT_REALTIME_URL, opts)
+
+    params = _parse_ws_url(url)
+    assert params["endpointing"] == "manual"
+    assert "vad_sot_threshold" not in params
+    assert "vad_min_speech_ms" not in params
+
+
+def test_streaming_options_validate_realtime_contract() -> None:
+    with pytest.raises(ValueError, match="language auto is only supported"):
+        stt_streaming.StreamingSTTOptions(language="auto", api_key="sk_test", stream_type="fast")
+
+    with pytest.raises(ValueError, match="sample_rate must be one of"):
+        stt_streaming.StreamingSTTOptions(language="hi-IN", api_key="sk_test", sample_rate=44100)
+
+    with pytest.raises(ValueError, match="language od-IN is not supported"):
+        stt_streaming.StreamingSTTOptions(language="od-IN", api_key="sk_test")
+
+
+def test_simulated_streaming_allows_auto_language_and_mode() -> None:
+    opts = stt_streaming.StreamingSTTOptions(
+        language="auto",
+        api_key="sk_test",
+        stream_type="simulated",
+        mode="translate",
+    )
+
+    params = _parse_ws_url(
+        stt_streaming._build_realtime_ws_url(stt_streaming.SARVAM_STT_REALTIME_URL, opts)
+    )
+
+    assert params["language-code"] == "auto"
+    assert params["stream-type"] == "simulated"
+    assert params["mode"] == "translate"
+
+
+@pytest.mark.asyncio
+async def test_streaming_event_mapping_emits_speech_and_transcript_events() -> None:
+    stream = _make_stream()
+    stream._audio_position = 1.25
+
+    await stream._handle_message(
+        {
+            "event": "session.begin",
+            "session_id": "sess_123",
+            "request_id": "20260608_31c9dc1d-3435-4e76-ae51-05de31025a68",
+        }
+    )
+    await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
+    await stream._handle_message(
+        {
+            "event": "transcript.partial",
+            "utterance_idx": 0,
+            "text": "नमस्ते",
+            "confidence": 0.91,
+        }
+    )
+    await stream._handle_message(
+        {
+            "event": "transcript.final",
+            "utterance_idx": 0,
+            "text": "नमस्ते आप कैसे हैं",
+            "language": "hi-IN",
+            "language_confidence": 0.99,
+        }
+    )
+
+    assert [event.type for event in stream._event_ch.events] == [
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.INTERIM_TRANSCRIPT,
+    ]
+
+    stream._audio_position = 1.75
+    await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
+
+    event_types = [event.type for event in stream._event_ch.events]
+    assert event_types == [
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.INTERIM_TRANSCRIPT,
+        stt_streaming.stt.SpeechEventType.FINAL_TRANSCRIPT,
+        stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
+    ]
+    final_event = stream._event_ch.events[2]
+    assert stream._session_id == "sess_123"
+    assert stream._request_id == "20260608_31c9dc1d-3435-4e76-ae51-05de31025a68"
+    assert final_event.request_id == "20260608_31c9dc1d-3435-4e76-ae51-05de31025a68"
+    assert final_event.alternatives[0].text == "नमस्ते आप कैसे हैं"
+    assert final_event.alternatives[0].language == "hi-IN"
+    assert final_event.alternatives[0].confidence == 0.99
+    assert final_event.alternatives[0].end_time == 1.75
+
+    eos_event = stream._event_ch.events[3]
+    assert eos_event.alternatives[0].end_time == 1.75
+    assert eos_event.alternatives[0].metadata["utterance_idx"] == 0
+
+
+@pytest.mark.asyncio
+async def test_streaming_session_begin_captures_server_request_id() -> None:
+    stream = _make_stream()
+
+    await stream._handle_message(
+        {
+            "event": "session.begin",
+            "session_id": "sess_4594d4503cd4",
+            "request_id": "20260608_31c9dc1d-3435-4e76-ae51-05de31025a68",
+        }
+    )
+
+    assert stream._session_id == "sess_4594d4503cd4"
+    assert stream._request_id == "20260608_31c9dc1d-3435-4e76-ae51-05de31025a68"
+
+
+@pytest.mark.asyncio
+async def test_streaming_request_id_stores_raw_value_without_format_assumptions() -> None:
+    stream = _make_stream()
+
+    await stream._handle_message(
+        {
+            "event": "session.begin",
+            "session_id": "sess_xyz",
+            "request_id": "srv_custom-id_v9",
+        }
+    )
+
+    assert stream._session_id == "sess_xyz"
+    assert stream._request_id == "srv_custom-id_v9"
+
+
+@pytest.mark.asyncio
+async def test_streaming_session_begin_without_request_id_leaves_request_id_empty() -> None:
+    stream = _make_stream()
+
+    await stream._handle_message({"event": "session.begin", "session_id": "sess_only"})
+
+    assert stream._session_id == "sess_only"
+    assert stream._request_id == ""
+
+
+@pytest.mark.asyncio
+async def test_streaming_defers_end_of_speech_until_final_transcript() -> None:
+    stream = _make_stream()
+
+    await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
+    await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
+
+    assert [event.type for event in stream._event_ch.events] == [
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+    ]
+
+    await stream._handle_message(
+        {
+            "event": "transcript.final",
+            "utterance_idx": 0,
+            "text": "नमस्ते आप कैसे हैं",
+            "language": "hi-IN",
+            "language_confidence": 0.99,
+        }
+    )
+
+    assert [event.type for event in stream._event_ch.events] == [
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.FINAL_TRANSCRIPT,
+        stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_streaming_final_after_speech_end_includes_audio_end_time() -> None:
+    stream = _make_stream()
+    stream._audio_position = 1.25
+
+    await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
+    stream._audio_position = 1.75
+    await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
+    await stream._handle_message(
+        {
+            "event": "transcript.final",
+            "utterance_idx": 0,
+            "text": "नमस्ते आप कैसे हैं",
+            "language": "hi-IN",
+            "language_confidence": 0.99,
+        }
+    )
+
+    final_event = stream._event_ch.events[1]
+    eos_event = stream._event_ch.events[2]
+    assert final_event.alternatives[0].end_time == 1.75
+    assert eos_event.alternatives[0].end_time == 1.75
+    assert final_event.alternatives[0].metadata["speech_end_wall_time"] > 0
+
+
+@pytest.mark.asyncio
+async def test_streaming_final_transcript_waits_for_speech_end_for_end_time() -> None:
+    stream = _make_stream()
+    stream._audio_position = 1.25
+
+    await stream._handle_message(
+        {
+            "event": "transcript.final",
+            "utterance_idx": 0,
+            "text": "नमस्ते आप कैसे हैं",
+            "language": "hi-IN",
+            "language_confidence": 0.99,
+        }
+    )
+
+    assert stream._event_ch.events == []
+
+    stream._audio_position = 2.0
+    await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
+
+    final_event = stream._event_ch.events[0]
+    eos_event = stream._event_ch.events[1]
+    assert final_event.alternatives[0].end_time == 2.0
+    assert eos_event.alternatives[0].end_time == 2.0
+
+
+@pytest.mark.asyncio
+async def test_streaming_final_transcript_uses_current_audio_position_without_vad() -> None:
+    stream = _make_stream(endpointing="manual")
+    stream._audio_position = 1.25
+
+    await stream._handle_message(
+        {
+            "event": "transcript.final",
+            "utterance_idx": 0,
+            "text": "नमस्ते आप कैसे हैं",
+            "language": "hi-IN",
+            "language_confidence": 0.99,
+        }
+    )
+
+    final_event = stream._event_ch.events[0]
+    assert final_event.alternatives[0].end_time == 1.25
+
+
+@pytest.mark.asyncio
+async def test_streaming_logs_include_server_request_id_after_session_begin(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    stream = _make_stream()
+
+    with caplog.at_level(logging.INFO, logger=stt_streaming.logger.name):
+        await stream._handle_message(
+            {
+                "event": "session.begin",
+                "session_id": "sess_4594d4503cd4",
+                "request_id": "srv_custom-id_v9",
+            }
+        )
+        await stream._handle_message(
+            {
+                "event": "transcript.partial",
+                "utterance_idx": 0,
+                "text": "नमस्ते",
+                "confidence": 0.91,
+            }
+        )
+
+    partial_records = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "Sarvam realtime STT transcript.partial"
+    ]
+    assert len(partial_records) == 1
+    assert partial_records[0].request_id == "srv_custom-id_v9"
+    assert partial_records[0].session_id == "sess_4594d4503cd4"
+
+
+@pytest.mark.asyncio
+async def test_streaming_logs_partial_and_final_transcripts(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    stream = _make_stream()
+    stream._audio_position = 1.0
+
+    with caplog.at_level(logging.INFO, logger=stt_streaming.logger.name):
+        await stream._handle_message(
+            {
+                "event": "transcript.partial",
+                "utterance_idx": 0,
+                "text": "नमस्ते",
+                "confidence": 0.91,
+            }
+        )
+        await stream._handle_message(
+            {
+                "event": "transcript.final",
+                "utterance_idx": 0,
+                "text": "नमस्ते आप कैसे हैं",
+                "language": "hi-IN",
+                "language_confidence": 0.99,
+            }
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert "Sarvam realtime STT transcript.partial" in messages
+    assert "Sarvam realtime STT transcript.final" in messages
+
+
+@pytest.mark.asyncio
+async def test_streaming_emits_pending_end_of_speech_when_final_never_arrives() -> None:
+    stream = _make_stream()
+
+    await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
+    await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
+    await stream._emit_pending_eos_after_timeout(0)
+
+    assert [event.type for event in stream._event_ch.events] == [
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_streaming_safe_send_str_ignores_closed_transport() -> None:
+    stream = _make_stream()
+    calls = []
+
+    closed_ws = SimpleNamespace(closed=True, send_str=lambda payload: calls.append(payload))
+    await stream._safe_send_str(closed_ws, {"event": "end"})
+
+    assert calls == []
+
+    async def _raise_reset(payload: str) -> None:
+        raise stt_streaming.aiohttp.ClientConnectionResetError("Cannot write to closing transport")
+
+    closing_ws = SimpleNamespace(closed=False, send_str=_raise_reset)
+    await stream._safe_send_str(closing_ws, {"event": "end"})
+
+
+@pytest.mark.asyncio
+async def test_streaming_usage_metrics_emit_periodic_and_session_end_deltas() -> None:
+    stream = _make_stream()
+    stream._request_id = "sess_123"
+
+    stream._on_audio_duration_report(1.5)
+    await stream._handle_message(
+        {
+            "event": "session.end",
+            "session_id": "sess_123",
+            "audio_duration_s": 2.25,
+        }
+    )
+
+    usage_events = [
+        event
+        for event in stream._event_ch.events
+        if event.type == stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE
+    ]
+    assert [event.recognition_usage.audio_duration for event in usage_events] == [1.5, 0.75]
+    assert all(event.request_id == "sess_123" for event in usage_events)
+    assert stream._session_ended is True
+
+
+@pytest.mark.asyncio
+async def test_streaming_usage_event_is_converted_to_livekit_stt_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _idle_run(self: object) -> None:
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(stt_streaming.StreamingSpeechStream, "_run", _idle_run)
+    stt_impl = stt_streaming.STTStreaming(api_key="sk_test")
+    metrics = []
+    stt_impl.on("metrics_collected", metrics.append)
+    stream = stt_impl.stream()
+
+    stream._event_ch.send_nowait(
+        stt_streaming.stt.SpeechEvent(
+            type=stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE,
+            request_id="sess_123",
+            recognition_usage=stt_streaming.stt.RecognitionUsage(audio_duration=3.0),
+        )
+    )
+    await asyncio.sleep(0)
+    await stream.aclose()
+    await stt_impl.aclose()
+
+    assert len(metrics) == 1
+    assert metrics[0].request_id == "sess_123"
+    assert metrics[0].audio_duration == 3.0
+    assert metrics[0].streamed is True
+    assert metrics[0].metadata.model_name == "saaras:v3-realtime"
+    assert metrics[0].metadata.model_provider == "Sarvam"
+
+
+@pytest.mark.asyncio
+async def test_streaming_error_handling_distinguishes_fatal_and_non_fatal() -> None:
+    stream = _make_stream()
+    stream._request_id = "sess_123"
+
+    await stream._handle_message(
+        {
+            "event": "error",
+            "code": "chunk_too_large",
+            "message": "chunk too large",
+            "is_fatal": False,
+        }
+    )
+
+    with pytest.raises(APIStatusError) as excinfo:
+        await stream._handle_message(
+            {
+                "event": "error",
+                "code": "model_unavailable",
+                "message": "backend saturated",
+                "is_fatal": True,
+                "status_code": 503,
+            }
+        )
+
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.body["code"] == "model_unavailable"
+    assert excinfo.value.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_streaming_process_messages_raises_on_realtime_rejection_close() -> None:
+    stream = _make_stream()
+
+    ws = SimpleNamespace(
+        receive=lambda: asyncio.sleep(
+            0,
+            result=SimpleNamespace(
+                type=stt_streaming.aiohttp.WSMsgType.CLOSE,
+                data=4000,
+                extra="beta access denied",
+            ),
+        ),
+        close_code=4000,
+    )
+
+    with pytest.raises(APIStatusError) as excinfo:
+        await stream._process_messages(ws)
+
+    assert excinfo.value.status_code == 4000
+    assert "beta access denied" in excinfo.value.message

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -421,6 +421,30 @@ async def test_streaming_emits_pending_end_of_speech_when_final_never_arrives() 
 
 
 @pytest.mark.asyncio
+async def test_new_speech_start_emits_pending_end_of_speech_for_previous_utterance() -> None:
+    stream = _make_stream()
+    stream._audio_position = 1.0
+
+    await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
+    stream._audio_position = 1.5
+    await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
+    stream._audio_position = 2.0
+    await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 1})
+
+    assert [event.type for event in stream._event_ch.events] == [
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+    ]
+    eos_event = stream._event_ch.events[1]
+    assert eos_event.alternatives[0].end_time == 1.5
+    assert eos_event.alternatives[0].metadata["speech_end_wall_time"] > 0
+    assert stream._pending_eos is False
+    assert stream._eos_emitted_for_utterance is False
+    assert stream._utterance_start_audio_pos == 2.0
+
+
+@pytest.mark.asyncio
 async def test_streaming_safe_send_str_ignores_closed_transport() -> None:
     stream = _make_stream()
     calls = []

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -84,6 +84,8 @@ def test_realtime_stt_exports_and_legacy_aliases() -> None:
     assert sarvam.RealtimeSpeechStream is stt_streaming.RealtimeSpeechStream
     assert sarvam.STTStreaming is sarvam.STTRealtime
     assert sarvam.StreamingSpeechStream is sarvam.RealtimeSpeechStream
+    assert "STTStreaming" in sarvam.__all__
+    assert "StreamingSpeechStream" in sarvam.__all__
     assert stt_streaming.StreamingSTTOptions is stt_streaming.RealtimeSTTOptions
 
 

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -13,7 +13,7 @@ from livekit.agents import APIStatusError
 from livekit.plugins import sarvam
 from livekit.plugins.sarvam import stt_streaming, tts
 
-pytestmark = pytest.mark.unit
+pytestmark = pytest.mark.plugin("sarvam")
 
 
 class _FakeEventChannel:

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -32,6 +32,11 @@ def _make_stream(
     stream._session_id = ""
     stream._session_ended = False
     stream._utterance_idx = None
+    stream._utterance_in_progress = False
+    stream._active_endpointing = endpointing
+    stream._pending_endpointing = None
+    stream._endpointing_update_acknowledged = False
+    stream._pending_config_update = None
     stream._total_reported_audio_duration = 0.0
     stream._local_audio_duration = 0.0
     stream._server_audio_duration_reported = False
@@ -218,6 +223,104 @@ def test_streaming_option_update_uses_in_band_contract_config_message() -> None:
         "threshold": 0.6,
     }
     assert stream._reconnect_event.set_called is False
+
+
+def test_active_stream_keeps_connection_only_options_on_update(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    stream = _make_stream()
+    stream._pending_config_update = None
+    stream._reconnect_event = SimpleNamespace(set_called=False)
+    stream._reconnect_event.set = lambda: setattr(stream._reconnect_event, "set_called", True)
+    updated_options = stt_streaming.StreamingSTTOptions(
+        language="hi-IN",
+        api_key="sk_test",
+        sample_rate=8000,
+        return_timestamps=True,
+        prompt="LiveKit",
+    )
+
+    with caplog.at_level(logging.WARNING, logger=stt_streaming.logger.name):
+        stream.update_options(updated_options)
+
+    assert stream._opts.sample_rate == 16000
+    assert stream._opts.return_timestamps is False
+    assert stream._pending_config_update == {
+        "event": "config.update",
+        "prompt": "LiveKit",
+    }
+    assert stream._reconnect_event.set_called is False
+    assert "only apply to new streams" in caplog.text
+
+
+def test_streaming_option_updates_merge_before_the_next_audio_frame() -> None:
+    stream = _make_stream()
+    stream._pending_config_update = None
+    stream.update_options(
+        stt_streaming.StreamingSTTOptions(
+            language="hi-IN",
+            api_key="sk_test",
+            prompt="LiveKit",
+        )
+    )
+    stream.update_options(
+        stt_streaming.StreamingSTTOptions(
+            language="hi-IN",
+            api_key="sk_test",
+            prompt="LiveKit",
+            mode="translate",
+        )
+    )
+
+    assert stream._pending_config_update == {
+        "event": "config.update",
+        "prompt": "LiveKit",
+        "mode": "translate",
+    }
+
+
+def test_streaming_option_update_clears_prompt_with_empty_string() -> None:
+    previous = stt_streaming.StreamingSTTOptions(
+        language="hi-IN",
+        api_key="sk_test",
+        prompt="LiveKit",
+    )
+    current = stt_streaming.StreamingSTTOptions(
+        language="hi-IN",
+        api_key="sk_test",
+        prompt=None,
+    )
+
+    assert stt_streaming.StreamingSpeechStream._config_update_payload(previous, current) == {
+        "event": "config.update",
+        "prompt": "",
+    }
+
+
+def test_active_stream_defers_endpointing_until_config_acknowledgement() -> None:
+    stream = _make_stream()
+    stream._active_endpointing = "vad"
+    stream._utterance_in_progress = True
+    stream._pending_endpointing = None
+    stream._endpointing_update_acknowledged = False
+    stream._pending_config_update = None
+    stream.update_options(
+        stt_streaming.StreamingSTTOptions(
+            language="hi-IN",
+            api_key="sk_test",
+            endpointing="manual",
+        )
+    )
+
+    assert stream._active_endpointing == "vad"
+    assert stream._pending_endpointing == "manual"
+
+    stream._handle_config_updated()
+    assert stream._active_endpointing == "vad"
+
+    stream._utterance_in_progress = False
+    stream._apply_pending_endpointing()
+    assert stream._active_endpointing == "manual"
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -70,6 +70,19 @@ def _make_stream(
     return stream
 
 
+async def _flush_pending_config_update(
+    stream: stt_streaming.RealtimeSpeechStream,
+) -> list[dict[str, object]]:
+    """Send the queued config update the way the audio pump does."""
+    sent: list[dict[str, object]] = []
+    ws = SimpleNamespace(
+        closed=False,
+        send_str=lambda payload: asyncio.sleep(0, result=sent.append(json.loads(payload))),
+    )
+    await stream._send_pending_config_update(ws)
+    return sent
+
+
 def _parse_ws_url(url: str) -> dict[str, str]:
     parsed = urlparse(url)
     qs = parse_qs(parsed.query)
@@ -480,7 +493,8 @@ def test_stream_update_options_without_arguments_is_a_no_op() -> None:
     assert stream._opts.language == "hi-IN"
 
 
-def test_active_stream_defers_endpointing_until_config_acknowledgement() -> None:
+@pytest.mark.asyncio
+async def test_active_stream_defers_endpointing_until_config_acknowledgement() -> None:
     stream = _make_stream()
     stream._active_endpointing = "vad"
     stream._utterance_in_progress = True
@@ -492,11 +506,103 @@ def test_active_stream_defers_endpointing_until_config_acknowledgement() -> None
     assert stream._active_endpointing == "vad"
     assert stream._pending_endpointing == "manual"
 
-    stream._handle_config_updated()
+    assert await _flush_pending_config_update(stream) == [
+        {"event": "config.update", "endpointing": "manual"}
+    ]
+    stream._handle_config_updated({"applied": ["endpointing=manual"]})
     assert stream._active_endpointing == "vad"
 
     stream._utterance_in_progress = False
     stream._apply_pending_endpointing()
+    assert stream._active_endpointing == "manual"
+
+
+@pytest.mark.asyncio
+async def test_endpointing_ignores_ack_for_an_update_not_yet_sent() -> None:
+    """An earlier update's acknowledgement must not promote a still-queued switch.
+
+    The payload is only flushed on the next audio frame, so a ``config.updated`` for a
+    previous change can arrive first. Promoting on it would put the client in manual
+    mode, sending client-delimited boundaries, while the server is still in ``vad``.
+    """
+    stream = _make_stream()
+    # An earlier prompt update that has already been sent and is awaiting its ack.
+    stream.update_options(prompt="LiveKit")
+    await _flush_pending_config_update(stream)
+    # The endpointing switch is queued but not yet on the wire.
+    stream.update_options(endpointing="manual")
+    assert stream._pending_config_update == {
+        "event": "config.update",
+        "endpointing": "manual",
+    }
+
+    await stream._handle_message({"event": "config.updated", "applied": ["prompt=LiveKit"]})
+
+    assert stream._active_endpointing == "vad"
+    assert stream._pending_endpointing == "manual"
+    assert stream._endpointing_update_acknowledged is False
+
+    # Once it is actually sent and acknowledged, the switch promotes.
+    await _flush_pending_config_update(stream)
+    await stream._handle_message({"event": "config.updated", "applied": ["endpointing=manual"]})
+    assert stream._active_endpointing == "manual"
+
+
+@pytest.mark.asyncio
+async def test_endpointing_ignores_ack_that_does_not_list_endpointing() -> None:
+    """Acks are per message, so a later unrelated ack can arrive after ours is sent."""
+    stream = _make_stream()
+    stream.update_options(endpointing="manual")
+    await _flush_pending_config_update(stream)
+
+    await stream._handle_message({"event": "config.updated", "applied": ["mode=translate"]})
+
+    assert stream._active_endpointing == "vad"
+    assert stream._pending_endpointing == "manual"
+
+    # A multi-key ack that does include endpointing is accepted.
+    await stream._handle_message(
+        {"event": "config.updated", "applied": ["mode=translate", "endpointing=manual"]}
+    )
+    assert stream._active_endpointing == "manual"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "applied",
+    [None, "endpointing=manual", [42]],
+    ids=["missing", "not_a_list", "non_string_entries"],
+)
+async def test_endpointing_falls_back_when_applied_list_is_unusable(
+    applied: object,
+) -> None:
+    """An unexpected `applied` shape must not stall the switch forever."""
+    stream = _make_stream()
+    stream.update_options(endpointing="manual")
+    await _flush_pending_config_update(stream)
+
+    payload: dict[str, object] = {"event": "config.updated"}
+    if applied is not None:
+        payload["applied"] = applied
+    await stream._handle_message(payload)
+
+    assert stream._active_endpointing == "manual"
+
+
+@pytest.mark.asyncio
+async def test_deferred_endpointing_ack_is_accepted() -> None:
+    """The server suffixes the entry when it defers to the next utterance boundary."""
+    stream = _make_stream()
+    stream.update_options(endpointing="manual")
+    await _flush_pending_config_update(stream)
+
+    await stream._handle_message(
+        {
+            "event": "config.updated",
+            "applied": ["endpointing=manual (pending: applies next boundary)"],
+        }
+    )
+
     assert stream._active_endpointing == "manual"
 
 
@@ -522,7 +628,8 @@ async def test_speech_end_promotes_pending_endpointing_without_a_valid_final(
     stream = _make_stream()
     stream.update_options(endpointing="manual")
     await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
-    await stream._handle_message({"event": "config.updated", "applied": ["endpointing"]})
+    await _flush_pending_config_update(stream)
+    await stream._handle_message({"event": "config.updated", "applied": ["endpointing=manual"]})
 
     assert stream._utterance_in_progress is True
     assert stream._active_endpointing == "vad"
@@ -560,7 +667,8 @@ async def test_repeated_speech_end_still_completes_the_utterance() -> None:
     stream = _make_stream()
     stream.update_options(endpointing="manual")
     await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
-    await stream._handle_message({"event": "config.updated", "applied": ["endpointing"]})
+    await _flush_pending_config_update(stream)
+    await stream._handle_message({"event": "config.updated", "applied": ["endpointing=manual"]})
     await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
     # A duplicate speech end takes the already-emitted branch; it must not reopen or
     # strand the utterance.

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -59,6 +59,7 @@ def _make_stream(
     stream._final_received_for_utterance = False
     stream._eos_emitted_for_utterance = False
     stream._manual_speech_started = False
+    stream._flush_observed = False
     stream._stream_started_at = stt_streaming.time.time()
     stream._audio_position = 0.0
     stream._audio_duration_collector = stt_streaming.PeriodicCollector(
@@ -198,13 +199,11 @@ def test_realtime_ws_url_includes_prompt_and_timestamp_controls() -> None:
     assert params["return_timestamps"] == "true"
 
 
-def test_realtime_ws_url_includes_connection_only_vad_and_lid_controls() -> None:
+def test_realtime_ws_url_includes_connection_only_vad_controls() -> None:
     opts = stt_streaming.RealtimeSTTOptions(
         language="auto",
         api_key="sk_test",
         vad_prefix_padding_ms=320,
-        lid_gate_seconds=2.5,
-        lid_confidence_threshold=0.85,
     )
 
     params = _parse_ws_url(
@@ -212,8 +211,6 @@ def test_realtime_ws_url_includes_connection_only_vad_and_lid_controls() -> None
     )
 
     assert params["prefix_padding_ms"] == "320"
-    assert params["lid_gate_seconds"] == "2.5"
-    assert params["lid_confidence_threshold"] == "0.85"
 
 
 def test_realtime_ws_url_omits_prefix_padding_for_manual_endpointing() -> None:
@@ -243,20 +240,6 @@ def test_streaming_options_validate_realtime_contract() -> None:
             language="hi-IN",
             api_key="sk_test",
             vad_prefix_padding_ms=-1,
-        )
-
-    with pytest.raises(ValueError, match="lid_gate_seconds"):
-        stt_streaming.RealtimeSTTOptions(
-            language="auto",
-            api_key="sk_test",
-            lid_gate_seconds=-1,
-        )
-
-    with pytest.raises(ValueError, match="lid_confidence_threshold"):
-        stt_streaming.RealtimeSTTOptions(
-            language="auto",
-            api_key="sk_test",
-            lid_confidence_threshold=1.1,
         )
 
     with pytest.raises(ValueError, match="mode must be one of"):

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
@@ -30,7 +31,11 @@ def _make_stream(
     stream._request_id = ""
     stream._session_id = ""
     stream._session_ended = False
+    stream._utterance_idx = None
     stream._total_reported_audio_duration = 0.0
+    stream._local_audio_duration = 0.0
+    stream._server_audio_duration_reported = False
+    stream._conn_options = stt_streaming.DEFAULT_API_CONNECT_OPTIONS
     stream._opts = stt_streaming.StreamingSTTOptions(
         language="hi-IN",
         api_key="sk_test",
@@ -84,16 +89,17 @@ def test_realtime_ws_url_includes_core_and_vad_params() -> None:
 
     assert url.startswith(stt_streaming.SARVAM_STT_REALTIME_URL)
     assert _parse_ws_url(url) == {
-        "language-code": "hi-IN",
-        "stream-type": "fast",
+        "language_code": "hi-IN",
+        "stream_type": "fast",
         "endpointing": "vad",
         "encoding": "linear16",
         "sample_rate": "16000",
         "model": "saaras:v3-realtime",
-        "vad_sot_threshold": "0.4",
-        "vad_min_speech_ms": "300",
-        "vad_min_silence_ms": "800",
-        "vad_smoothing_alpha": "0.5",
+        "mode": "transcribe",
+        "return_timestamps": "false",
+        "threshold": "0.4",
+        "min_speech_duration_ms": "300",
+        "silence_duration_ms": "800",
     }
 
 
@@ -110,19 +116,49 @@ def test_realtime_ws_url_omits_vad_params_for_manual_endpointing() -> None:
 
     params = _parse_ws_url(url)
     assert params["endpointing"] == "manual"
-    assert "vad_sot_threshold" not in params
-    assert "vad_min_speech_ms" not in params
+    assert "threshold" not in params
+    assert "min_speech_duration_ms" not in params
+
+
+def test_realtime_ws_url_includes_prompt_and_timestamp_controls() -> None:
+    opts = stt_streaming.StreamingSTTOptions(
+        language="en-IN",
+        api_key="sk_test",
+        prompt="LiveKit terminology",
+        return_timestamps=True,
+    )
+
+    params = _parse_ws_url(
+        stt_streaming._build_realtime_ws_url(stt_streaming.SARVAM_STT_REALTIME_URL, opts)
+    )
+
+    assert params["prompt"] == "LiveKit terminology"
+    assert params["return_timestamps"] == "true"
 
 
 def test_streaming_options_validate_realtime_contract() -> None:
-    with pytest.raises(ValueError, match="language auto is only supported"):
-        stt_streaming.StreamingSTTOptions(language="auto", api_key="sk_test", stream_type="fast")
-
     with pytest.raises(ValueError, match="sample_rate must be one of"):
         stt_streaming.StreamingSTTOptions(language="hi-IN", api_key="sk_test", sample_rate=44100)
 
     with pytest.raises(ValueError, match="language od-IN is not supported"):
         stt_streaming.StreamingSTTOptions(language="od-IN", api_key="sk_test")
+
+
+@pytest.mark.parametrize("endpointing", ["vad", "manual"])
+def test_auto_language_is_valid_for_all_contract_endpointing_modes(endpointing: str) -> None:
+    opts = stt_streaming.StreamingSTTOptions(
+        language="auto",
+        api_key="sk_test",
+        stream_type="fast",
+        endpointing=endpointing,
+    )
+
+    params = _parse_ws_url(
+        stt_streaming._build_realtime_ws_url(stt_streaming.SARVAM_STT_REALTIME_URL, opts)
+    )
+
+    assert params["language_code"] == "auto"
+    assert params["endpointing"] == endpointing
 
 
 def test_simulated_streaming_allows_auto_language_and_mode() -> None:
@@ -137,9 +173,43 @@ def test_simulated_streaming_allows_auto_language_and_mode() -> None:
         stt_streaming._build_realtime_ws_url(stt_streaming.SARVAM_STT_REALTIME_URL, opts)
     )
 
-    assert params["language-code"] == "auto"
-    assert params["stream-type"] == "simulated"
+    assert params["language_code"] == "auto"
+    assert params["stream_type"] == "simulated"
     assert params["mode"] == "translate"
+
+
+def test_streaming_option_update_uses_in_band_contract_config_message() -> None:
+    class _ReconnectEvent:
+        def __init__(self) -> None:
+            self.set_called = False
+
+        def set(self) -> None:
+            self.set_called = True
+
+    stream = _make_stream()
+    stream._ws = None
+    stream._reconnect_event = _ReconnectEvent()
+    updated_options = stt_streaming.StreamingSTTOptions(
+        language="en-IN",
+        api_key="sk_test",
+        stream_type="fast",
+        mode="translate",
+        endpointing="vad",
+        prompt="LiveKit",
+        vad_sot_threshold=0.6,
+    )
+
+    stream.update_options(updated_options)
+
+    assert stream._pending_config_update == {
+        "event": "config.update",
+        "language_code": "en-IN",
+        "stream_type": "fast",
+        "mode": "translate",
+        "prompt": "LiveKit",
+        "threshold": 0.6,
+    }
+    assert stream._reconnect_event.set_called is False
 
 
 @pytest.mark.asyncio
@@ -185,10 +255,10 @@ async def test_streaming_event_mapping_emits_speech_and_transcript_events() -> N
     assert event_types == [
         stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
         stt_streaming.stt.SpeechEventType.INTERIM_TRANSCRIPT,
-        stt_streaming.stt.SpeechEventType.FINAL_TRANSCRIPT,
         stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.FINAL_TRANSCRIPT,
     ]
-    final_event = stream._event_ch.events[2]
+    final_event = stream._event_ch.events[3]
     assert stream._session_id == "sess_123"
     assert stream._request_id == "20260608_31c9dc1d-3435-4e76-ae51-05de31025a68"
     assert final_event.request_id == "20260608_31c9dc1d-3435-4e76-ae51-05de31025a68"
@@ -197,9 +267,10 @@ async def test_streaming_event_mapping_emits_speech_and_transcript_events() -> N
     assert final_event.alternatives[0].confidence == 0.99
     assert final_event.alternatives[0].end_time == 1.75
 
-    eos_event = stream._event_ch.events[3]
+    eos_event = stream._event_ch.events[2]
     assert eos_event.alternatives[0].end_time == 1.75
-    assert eos_event.alternatives[0].metadata["utterance_idx"] == 0
+    assert eos_event.alternatives[0].metadata is not None
+    assert eos_event.alternatives[0].metadata["speech_end_wall_time"] > 0
 
 
 @pytest.mark.asyncio
@@ -209,12 +280,11 @@ async def test_streaming_session_begin_captures_server_request_id() -> None:
     await stream._handle_message(
         {
             "event": "session.begin",
-            "session_id": "sess_4594d4503cd4",
             "request_id": "20260608_31c9dc1d-3435-4e76-ae51-05de31025a68",
         }
     )
 
-    assert stream._session_id == "sess_4594d4503cd4"
+    assert stream._session_id == ""
     assert stream._request_id == "20260608_31c9dc1d-3435-4e76-ae51-05de31025a68"
 
 
@@ -225,12 +295,11 @@ async def test_streaming_request_id_stores_raw_value_without_format_assumptions(
     await stream._handle_message(
         {
             "event": "session.begin",
-            "session_id": "sess_xyz",
             "request_id": "srv_custom-id_v9",
         }
     )
 
-    assert stream._session_id == "sess_xyz"
+    assert stream._session_id == ""
     assert stream._request_id == "srv_custom-id_v9"
 
 
@@ -238,14 +307,14 @@ async def test_streaming_request_id_stores_raw_value_without_format_assumptions(
 async def test_streaming_session_begin_without_request_id_leaves_request_id_empty() -> None:
     stream = _make_stream()
 
-    await stream._handle_message({"event": "session.begin", "session_id": "sess_only"})
+    await stream._handle_message({"event": "session.begin"})
 
-    assert stream._session_id == "sess_only"
+    assert stream._session_id == ""
     assert stream._request_id == ""
 
 
 @pytest.mark.asyncio
-async def test_streaming_defers_end_of_speech_until_final_transcript() -> None:
+async def test_streaming_emits_end_of_speech_before_final_transcript() -> None:
     stream = _make_stream()
 
     await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
@@ -253,6 +322,7 @@ async def test_streaming_defers_end_of_speech_until_final_transcript() -> None:
 
     assert [event.type for event in stream._event_ch.events] == [
         stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
     ]
 
     await stream._handle_message(
@@ -267,8 +337,8 @@ async def test_streaming_defers_end_of_speech_until_final_transcript() -> None:
 
     assert [event.type for event in stream._event_ch.events] == [
         stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
-        stt_streaming.stt.SpeechEventType.FINAL_TRANSCRIPT,
         stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.FINAL_TRANSCRIPT,
     ]
 
 
@@ -290,8 +360,8 @@ async def test_streaming_final_after_speech_end_includes_audio_end_time() -> Non
         }
     )
 
-    final_event = stream._event_ch.events[1]
-    eos_event = stream._event_ch.events[2]
+    eos_event = stream._event_ch.events[1]
+    final_event = stream._event_ch.events[2]
     assert final_event.alternatives[0].end_time == 1.75
     assert eos_event.alternatives[0].end_time == 1.75
     assert final_event.alternatives[0].metadata["speech_end_wall_time"] > 0
@@ -317,8 +387,8 @@ async def test_streaming_final_transcript_waits_for_speech_end_for_end_time() ->
     stream._audio_position = 2.0
     await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
 
-    final_event = stream._event_ch.events[0]
-    eos_event = stream._event_ch.events[1]
+    eos_event = stream._event_ch.events[0]
+    final_event = stream._event_ch.events[1]
     assert final_event.alternatives[0].end_time == 2.0
     assert eos_event.alternatives[0].end_time == 2.0
 
@@ -343,12 +413,33 @@ async def test_streaming_final_transcript_uses_current_audio_position_without_va
 
 
 @pytest.mark.asyncio
+async def test_streaming_final_transcript_uses_contract_timestamps_when_present() -> None:
+    stream = _make_stream(endpointing="manual")
+
+    await stream._handle_message(
+        {
+            "event": "transcript.final",
+            "utterance_idx": 0,
+            "text": "hello",
+            "language": "en-IN",
+            "language_confidence": 0.99,
+            "start_s": 0.7,
+            "end_s": 1.2,
+        }
+    )
+
+    final_event = stream._event_ch.events[0]
+    assert final_event.alternatives[0].start_time == 0.7
+    assert final_event.alternatives[0].end_time == 1.2
+
+
+@pytest.mark.asyncio
 async def test_streaming_logs_include_server_request_id_after_session_begin(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     stream = _make_stream()
 
-    with caplog.at_level(logging.INFO, logger=stt_streaming.logger.name):
+    with caplog.at_level(logging.DEBUG, logger=stt_streaming.logger.name):
         await stream._handle_message(
             {
                 "event": "session.begin",
@@ -373,6 +464,7 @@ async def test_streaming_logs_include_server_request_id_after_session_begin(
     assert len(partial_records) == 1
     assert partial_records[0].request_id == "srv_custom-id_v9"
     assert partial_records[0].session_id == "sess_4594d4503cd4"
+    assert partial_records[0].raw_data["text"] == "नमस्ते"
 
 
 @pytest.mark.asyncio
@@ -382,7 +474,7 @@ async def test_streaming_logs_partial_and_final_transcripts(
     stream = _make_stream()
     stream._audio_position = 1.0
 
-    with caplog.at_level(logging.INFO, logger=stt_streaming.logger.name):
+    with caplog.at_level(logging.DEBUG, logger=stt_streaming.logger.name):
         await stream._handle_message(
             {
                 "event": "transcript.partial",
@@ -404,6 +496,44 @@ async def test_streaming_logs_partial_and_final_transcripts(
     messages = [record.getMessage() for record in caplog.records]
     assert "Sarvam realtime STT transcript.partial" in messages
     assert "Sarvam realtime STT transcript.final" in messages
+
+
+@pytest.mark.asyncio
+async def test_streaming_info_logs_essential_data_without_raw_payload(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    stream = _make_stream(endpointing="manual")
+    final_payload = {
+        "event": "transcript.final",
+        "utterance_idx": 0,
+        "text": "hello",
+        "language": "en-IN",
+        "language_confidence": 0.99,
+    }
+
+    with caplog.at_level(logging.INFO, logger=stt_streaming.logger.name):
+        await stream._handle_message(final_payload)
+
+    info_records = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "Sarvam realtime STT transcript.final"
+    ]
+    assert len(info_records) == 1
+    assert info_records[0].text == "hello"
+    assert not hasattr(info_records[0], "raw_data")
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger=stt_streaming.logger.name):
+        await stream._handle_message(final_payload)
+
+    debug_records = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "Sarvam realtime STT raw event"
+    ]
+    assert len(debug_records) == 1
+    assert debug_records[0].raw_data == final_payload
 
 
 @pytest.mark.asyncio
@@ -462,7 +592,7 @@ async def test_streaming_safe_send_str_ignores_closed_transport() -> None:
 
 
 @pytest.mark.asyncio
-async def test_streaming_usage_metrics_emit_periodic_and_session_end_deltas() -> None:
+async def test_streaming_usage_metrics_emit_server_authoritative_session_end() -> None:
     stream = _make_stream()
     stream._request_id = "sess_123"
 
@@ -480,9 +610,54 @@ async def test_streaming_usage_metrics_emit_periodic_and_session_end_deltas() ->
         for event in stream._event_ch.events
         if event.type == stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE
     ]
-    assert [event.recognition_usage.audio_duration for event in usage_events] == [1.5, 0.75]
+    assert [event.recognition_usage.audio_duration for event in usage_events] == [2.25]
     assert all(event.request_id == "sess_123" for event in usage_events)
     assert stream._session_ended is True
+    assert stream._server_audio_duration_reported is True
+
+
+@pytest.mark.asyncio
+async def test_streaming_usage_accepts_server_duration_smaller_than_local_estimate() -> None:
+    stream = _make_stream()
+
+    stream._on_audio_duration_report(5.0)
+    await stream._handle_message(
+        {
+            "event": "session.end",
+            "session_id": "sess_123",
+            "audio_duration_s": 2.25,
+        }
+    )
+    await stream._handle_message(
+        {
+            "event": "session.end",
+            "session_id": "sess_123",
+            "audio_duration_s": 2.25,
+        }
+    )
+
+    usage_events = [
+        event
+        for event in stream._event_ch.events
+        if event.type == stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE
+    ]
+    assert [event.recognition_usage.audio_duration for event in usage_events] == [2.25]
+
+
+@pytest.mark.asyncio
+async def test_streaming_usage_falls_back_to_local_duration_on_clean_close() -> None:
+    stream = _make_stream()
+
+    stream._on_audio_duration_report(1.5)
+    stream._emit_local_usage_fallback()
+    stream._emit_local_usage_fallback()
+
+    usage_events = [
+        event
+        for event in stream._event_ch.events
+        if event.type == stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE
+    ]
+    assert [event.recognition_usage.audio_duration for event in usage_events] == [1.5]
 
 
 @pytest.mark.asyncio
@@ -547,6 +722,51 @@ async def test_streaming_error_handling_distinguishes_fatal_and_non_fatal() -> N
     assert excinfo.value.retryable is True
 
 
+@pytest.mark.asyncio
+async def test_streaming_error_logs_include_raw_sarvam_payload(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    stream = _make_stream()
+    stream._request_id = "req_123"
+    raw_error = {
+        "event": "error",
+        "code": "invalid_subscription_key",
+        "message": "Invalid subscription key",
+        "is_fatal": True,
+        "status_code": 1003,
+    }
+
+    with caplog.at_level(logging.DEBUG, logger=stt_streaming.logger.name):
+        with pytest.raises(APIStatusError):
+            await stream._handle_message(raw_error)
+
+    info_records = [
+        record for record in caplog.records if record.getMessage() == "Sarvam realtime STT error"
+    ]
+    assert len(info_records) == 1
+    assert info_records[0].error_code == "invalid_subscription_key"
+    assert info_records[0].status_code == 1003
+    assert not hasattr(info_records[0], "raw_data")
+
+    raw_records = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "Sarvam realtime STT raw event"
+    ]
+    assert len(raw_records) == 1
+    assert raw_records[0].raw_data == raw_error
+
+    error_records = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "Fatal Sarvam realtime STT error"
+    ]
+    assert len(error_records) == 1
+    assert error_records[0].request_id == "req_123"
+    assert error_records[0].error_code == "invalid_subscription_key"
+    assert error_records[0].raw_message == raw_error
+
+
 def test_reset_connection_state_clears_session_and_utterance_fields() -> None:
     class _FakeFallbackTask:
         def __init__(self) -> None:
@@ -562,6 +782,7 @@ def test_reset_connection_state_clears_session_and_utterance_fields() -> None:
     stream._request_id = "req_old"
     stream._session_id = "sess_old"
     stream._session_ended = True
+    stream._utterance_idx = 7
     stream._manual_speech_started = True
     stream._pending_eos = True
     stream._pending_eos_time = 1.0
@@ -571,7 +792,9 @@ def test_reset_connection_state_clears_session_and_utterance_fields() -> None:
     stream._utterance_speech_end_wall = 5.0
     stream._final_received_for_utterance = True
     stream._eos_emitted_for_utterance = True
+    stream._local_audio_duration = 10.0
     stream._total_reported_audio_duration = 50.0
+    stream._server_audio_duration_reported = True
     fallback_task = _FakeFallbackTask()
     stream._eos_fallback_task = fallback_task
 
@@ -582,6 +805,7 @@ def test_reset_connection_state_clears_session_and_utterance_fields() -> None:
     assert stream._request_id == ""
     assert stream._session_id == ""
     assert stream._session_ended is False
+    assert stream._utterance_idx is None
     assert stream._manual_speech_started is False
     assert stream._pending_eos is False
     assert stream._pending_eos_time is None
@@ -591,7 +815,9 @@ def test_reset_connection_state_clears_session_and_utterance_fields() -> None:
     assert stream._utterance_speech_end_wall is None
     assert stream._final_received_for_utterance is False
     assert stream._eos_emitted_for_utterance is False
+    assert stream._local_audio_duration == 0.0
     assert stream._total_reported_audio_duration == 0.0
+    assert stream._server_audio_duration_reported is False
     assert stream._eos_fallback_task is None
 
 
@@ -677,3 +903,103 @@ async def test_streaming_process_messages_raises_on_realtime_rejection_close() -
 
     assert excinfo.value.status_code == 4000
     assert "beta access denied" in excinfo.value.message
+
+
+@pytest.mark.asyncio
+async def test_streaming_process_messages_stops_after_session_end() -> None:
+    stream = _make_stream()
+
+    class _SessionEndWS:
+        close_code = None
+
+        def __init__(self) -> None:
+            self.receive_count = 0
+
+        async def receive(self) -> SimpleNamespace:
+            self.receive_count += 1
+            if self.receive_count > 1:
+                raise AssertionError("process_messages should stop after session.end")
+            return SimpleNamespace(
+                type=stt_streaming.aiohttp.WSMsgType.TEXT,
+                data=json.dumps(
+                    {
+                        "event": "session.end",
+                        "request_id": "req_123",
+                        "audio_duration_s": 1.25,
+                    }
+                ),
+            )
+
+    ws = _SessionEndWS()
+
+    await stream._process_messages(ws)
+
+    assert ws.receive_count == 1
+    usage_events = [
+        event
+        for event in stream._event_ch.events
+        if event.type == stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE
+    ]
+    assert [event.recognition_usage.audio_duration for event in usage_events] == [1.25]
+
+
+@pytest.mark.asyncio
+async def test_streaming_process_messages_logs_realtime_rejection_close(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    stream = _make_stream()
+    ws = SimpleNamespace(
+        receive=lambda: asyncio.sleep(
+            0,
+            result=SimpleNamespace(
+                type=stt_streaming.aiohttp.WSMsgType.CLOSE,
+                data=4000,
+                extra="beta access denied",
+            ),
+        ),
+        close_code=4000,
+    )
+
+    with caplog.at_level(logging.ERROR, logger=stt_streaming.logger.name):
+        with pytest.raises(APIStatusError):
+            await stream._process_messages(ws)
+
+    close_records = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "Sarvam realtime STT WebSocket closed unexpectedly"
+    ]
+    assert len(close_records) == 1
+    assert close_records[0].close_code == 4000
+    assert close_records[0].close_reason == "beta access denied"
+
+
+@pytest.mark.asyncio
+async def test_streaming_connect_logs_handshake_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    stream = _make_stream()
+    response_error = stt_streaming.aiohttp.ClientResponseError(
+        request_info=None,
+        history=(),
+        status=403,
+        message="Forbidden",
+    )
+
+    async def _raise_response_error(*args: object, **kwargs: object) -> None:
+        raise response_error
+
+    stream._session = SimpleNamespace(ws_connect=_raise_response_error)
+
+    with caplog.at_level(logging.ERROR, logger=stt_streaming.logger.name):
+        with pytest.raises(stt_streaming.aiohttp.ClientResponseError):
+            await stream._connect_ws()
+
+    records = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "Sarvam realtime STT WebSocket handshake failed"
+    ]
+    assert len(records) == 1
+    assert records[0].status_code == 403
+    assert "API-SUBSCRIPTION-KEY" not in records[0].url

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -52,15 +52,12 @@ def _make_stream(
     stream._build_log_context = stt_streaming.RealtimeSpeechStream._build_log_context.__get__(
         stream, stt_streaming.RealtimeSpeechStream
     )
-    stream._pending_eos = False
-    stream._pending_eos_time = None
     stream._pending_final_data = None
     stream._utterance_start_audio_pos = 0.0
     stream._utterance_speech_end_audio_pos = None
     stream._utterance_speech_end_wall = None
     stream._final_received_for_utterance = False
     stream._eos_emitted_for_utterance = False
-    stream._eos_fallback_task = None
     stream._manual_speech_started = False
     stream._stream_started_at = stt_streaming.time.time()
     stream._audio_position = 0.0
@@ -362,16 +359,8 @@ def test_simulated_streaming_allows_auto_language_and_mode() -> None:
 
 
 def test_streaming_option_update_uses_in_band_contract_config_message() -> None:
-    class _ReconnectEvent:
-        def __init__(self) -> None:
-            self.set_called = False
-
-        def set(self) -> None:
-            self.set_called = True
-
     stream = _make_stream()
     stream._ws = None
-    stream._reconnect_event = _ReconnectEvent()
     updated_options = stt_streaming.RealtimeSTTOptions(
         language="en-IN",
         api_key="sk_test",
@@ -392,7 +381,6 @@ def test_streaming_option_update_uses_in_band_contract_config_message() -> None:
         "prompt": "LiveKit",
         "threshold": 0.6,
     }
-    assert stream._reconnect_event.set_called is False
 
 
 def test_active_stream_keeps_connection_only_options_on_update(
@@ -400,8 +388,6 @@ def test_active_stream_keeps_connection_only_options_on_update(
 ) -> None:
     stream = _make_stream()
     stream._pending_config_update = None
-    stream._reconnect_event = SimpleNamespace(set_called=False)
-    stream._reconnect_event.set = lambda: setattr(stream._reconnect_event, "set_called", True)
     updated_options = stt_streaming.RealtimeSTTOptions(
         language="hi-IN",
         api_key="sk_test",
@@ -419,7 +405,6 @@ def test_active_stream_keeps_connection_only_options_on_update(
         "event": "config.update",
         "prompt": "LiveKit",
     }
-    assert stream._reconnect_event.set_called is False
     assert "only apply to new streams" in caplog.text
 
 
@@ -820,17 +805,18 @@ async def test_streaming_info_logs_essential_data_without_raw_payload(
 
 
 @pytest.mark.asyncio
-async def test_streaming_emits_pending_end_of_speech_when_final_never_arrives() -> None:
+async def test_streaming_emits_end_of_speech_when_final_never_arrives() -> None:
+    """Speech end is reported immediately, without waiting on a final transcript."""
     stream = _make_stream()
 
     await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
     await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
-    await stream._emit_pending_eos_after_timeout(0)
 
     assert [event.type for event in stream._event_ch.events] == [
         stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
         stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
     ]
+    assert stream._eos_emitted_for_utterance is True
 
 
 @pytest.mark.asyncio
@@ -851,7 +837,6 @@ async def test_new_speech_start_emits_pending_end_of_speech_for_previous_utteran
     ]
     eos_event = stream._event_ch.events[1]
     assert eos_event.alternatives == []
-    assert stream._pending_eos is False
     assert stream._eos_emitted_for_utterance is False
     assert stream._utterance_start_audio_pos == 2.0
 
@@ -1070,121 +1055,6 @@ async def test_streaming_error_logs_include_raw_sarvam_payload(
     assert error_records[0].request_id == "req_123"
     assert error_records[0].error_code == "invalid_subscription_key"
     assert error_records[0].raw_message == raw_error
-
-
-def test_reset_connection_state_clears_session_and_utterance_fields() -> None:
-    class _FakeFallbackTask:
-        def __init__(self) -> None:
-            self.cancelled = False
-
-        def done(self) -> bool:
-            return False
-
-        def cancel(self) -> None:
-            self.cancelled = True
-
-    stream = _make_stream()
-    stream._request_id = "req_old"
-    stream._session_id = "sess_old"
-    stream._session_ended = True
-    stream._utterance_idx = 7
-    stream._manual_speech_started = True
-    stream._pending_eos = True
-    stream._pending_eos_time = 1.0
-    stream._pending_final_data = {"text": "hello"}
-    stream._utterance_start_audio_pos = 3.0
-    stream._utterance_speech_end_audio_pos = 4.0
-    stream._utterance_speech_end_wall = 5.0
-    stream._final_received_for_utterance = True
-    stream._eos_emitted_for_utterance = True
-    stream._local_audio_duration = 10.0
-    stream._total_reported_audio_duration = 50.0
-    stream._server_audio_duration_reported = True
-    fallback_task = _FakeFallbackTask()
-    stream._eos_fallback_task = fallback_task
-
-    stream._reset_connection_state()
-
-    assert fallback_task.cancelled is True
-
-    assert stream._request_id == ""
-    assert stream._session_id == ""
-    assert stream._session_ended is False
-    assert stream._utterance_idx is None
-    assert stream._manual_speech_started is False
-    assert stream._pending_eos is False
-    assert stream._pending_eos_time is None
-    assert stream._pending_final_data is None
-    assert stream._utterance_start_audio_pos == 0.0
-    assert stream._utterance_speech_end_audio_pos is None
-    assert stream._utterance_speech_end_wall is None
-    assert stream._final_received_for_utterance is False
-    assert stream._eos_emitted_for_utterance is False
-    assert stream._local_audio_duration == 0.0
-    assert stream._total_reported_audio_duration == 0.0
-    assert stream._server_audio_duration_reported is False
-    assert stream._eos_fallback_task is None
-
-
-@pytest.mark.asyncio
-async def test_session_end_delta_after_connection_reset() -> None:
-    stream = _make_stream()
-    stream._total_reported_audio_duration = 50.0
-
-    stream._reset_connection_state()
-
-    await stream._handle_message(
-        {
-            "event": "session.end",
-            "session_id": "sess_new",
-            "audio_duration_s": 12.0,
-        }
-    )
-
-    usage_events = [
-        event
-        for event in stream._event_ch.events
-        if event.type == stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE
-    ]
-    assert len(usage_events) == 1
-    assert usage_events[0].recognition_usage.audio_duration == 12.0
-
-
-@pytest.mark.asyncio
-async def test_collector_flush_before_reset_emits_pending_usage() -> None:
-    stream = _make_stream()
-    stream._audio_duration_collector.push(2.5)
-
-    stream._reset_connection_state()
-
-    usage_events = [
-        event
-        for event in stream._event_ch.events
-        if event.type == stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE
-    ]
-    assert len(usage_events) == 1
-    assert usage_events[0].recognition_usage.audio_duration == 2.5
-    assert stream._total_reported_audio_duration == 0.0
-
-
-@pytest.mark.asyncio
-async def test_reset_connection_state_allows_new_request_id_capture() -> None:
-    stream = _make_stream()
-    stream._request_id = "req_old"
-    stream._session_id = "sess_old"
-
-    stream._reset_connection_state()
-
-    await stream._handle_message(
-        {
-            "event": "session.begin",
-            "session_id": "sess_new",
-            "request_id": "req_new",
-        }
-    )
-
-    assert stream._request_id == "req_new"
-    assert stream._session_id == "sess_new"
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -549,9 +549,8 @@ async def test_streaming_event_mapping_emits_speech_and_transcript_events() -> N
     assert final_event.alternatives[0].end_time == 1.75
 
     eos_event = stream._event_ch.events[2]
-    assert eos_event.alternatives[0].end_time == 1.75
-    assert eos_event.alternatives[0].metadata is not None
-    assert eos_event.alternatives[0].metadata["speech_end_wall_time"] > 0
+    assert eos_event.alternatives == []
+    assert final_event.alternatives[0].metadata["speech_end_wall_time"] > 0
 
 
 @pytest.mark.asyncio
@@ -644,7 +643,7 @@ async def test_streaming_final_after_speech_end_includes_audio_end_time() -> Non
     eos_event = stream._event_ch.events[1]
     final_event = stream._event_ch.events[2]
     assert final_event.alternatives[0].end_time == 1.75
-    assert eos_event.alternatives[0].end_time == 1.75
+    assert eos_event.alternatives == []
     assert final_event.alternatives[0].metadata["speech_end_wall_time"] > 0
 
 
@@ -671,7 +670,7 @@ async def test_streaming_final_transcript_waits_for_speech_end_for_end_time() ->
     eos_event = stream._event_ch.events[0]
     final_event = stream._event_ch.events[1]
     assert final_event.alternatives[0].end_time == 2.0
-    assert eos_event.alternatives[0].end_time == 2.0
+    assert eos_event.alternatives == []
 
 
 @pytest.mark.asyncio
@@ -851,8 +850,7 @@ async def test_new_speech_start_emits_pending_end_of_speech_for_previous_utteran
         stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
     ]
     eos_event = stream._event_ch.events[1]
-    assert eos_event.alternatives[0].end_time == 1.5
-    assert eos_event.alternatives[0].metadata["speech_end_wall_time"] > 0
+    assert eos_event.alternatives == []
     assert stream._pending_eos is False
     assert stream._eos_emitted_for_utterance is False
     assert stream._utterance_start_audio_pos == 2.0
@@ -1551,12 +1549,16 @@ async def test_manual_endpointing_emits_boundary_events_and_resets_each_turn() -
         stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE,
         stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
     ]
+    # A second end-of-speech only appears because the turn reset cleared
+    # _eos_emitted_for_utterance; without it _emit_end_of_speech returns early.
     first_eos, second_eos = (
         stream._event_ch.events[2],
         stream._event_ch.events[5],
     )
-    assert first_eos.alternatives[0].end_time == 0.5
-    assert second_eos.alternatives[0].end_time == 1.0
+    assert first_eos.alternatives == []
+    assert second_eos.alternatives == []
+    # The speech-end position is re-anchored to the second turn.
+    assert stream._utterance_speech_end_audio_pos == 1.0
 
 
 @pytest.mark.asyncio
@@ -1587,3 +1589,30 @@ async def test_manual_final_uses_current_turn_timings_after_first_turn() -> None
     final_event = stream._event_ch.events[2]
     assert final_event.alternatives[0].end_time == 6.0
     assert final_event.alternatives[0].metadata["speech_end_wall_time"] > 100.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpointing", ["vad", "manual"])
+async def test_end_of_speech_is_emitted_as_a_bare_pipeline_sentinel(endpointing: str) -> None:
+    """END_OF_SPEECH must carry no alternatives.
+
+    livekit-agents treats an event without alternatives as a sentinel it holds until a
+    concrete transcript releases it (``_should_hold_stt_event``) and always flushes from
+    (``_flush_held_transcripts``). An alternative with ``start_time == 0`` would bypass
+    the hold check and be timestamp-compared like a transcript instead.
+    """
+    stream = _make_stream(endpointing=endpointing)
+    stream._audio_position = 2.0
+    stream._utterance_speech_end_audio_pos = 2.0
+    stream._utterance_speech_end_wall = stt_streaming.time.time()
+
+    stream._emit_end_of_speech()
+
+    eos_events = [
+        event
+        for event in stream._event_ch.events
+        if event.type == stt_streaming.stt.SpeechEventType.END_OF_SPEECH
+    ]
+    assert len(eos_events) == 1
+    assert eos_events[0].alternatives == []
+    assert eos_events[0].request_id == stream._request_id

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -6,10 +6,12 @@ import logging
 from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
 
+import numpy as np
 import pytest
 
 from livekit.agents import APIStatusError
-from livekit.plugins.sarvam import stt_streaming
+from livekit.plugins import sarvam
+from livekit.plugins.sarvam import stt_streaming, tts
 
 pytestmark = pytest.mark.unit
 
@@ -25,8 +27,8 @@ class _FakeEventChannel:
 def _make_stream(
     *,
     endpointing: str = "vad",
-) -> stt_streaming.StreamingSpeechStream:
-    stream = object.__new__(stt_streaming.StreamingSpeechStream)
+) -> stt_streaming.RealtimeSpeechStream:
+    stream = object.__new__(stt_streaming.RealtimeSpeechStream)
     stream._event_ch = _FakeEventChannel()
     stream._request_id = ""
     stream._session_id = ""
@@ -41,14 +43,14 @@ def _make_stream(
     stream._local_audio_duration = 0.0
     stream._server_audio_duration_reported = False
     stream._conn_options = stt_streaming.DEFAULT_API_CONNECT_OPTIONS
-    stream._opts = stt_streaming.StreamingSTTOptions(
+    stream._opts = stt_streaming.RealtimeSTTOptions(
         language="hi-IN",
         api_key="sk_test",
         endpointing=endpointing,
     )
-    stream._logger = stt_streaming.logger.getChild("StreamingSpeechStream")
-    stream._build_log_context = stt_streaming.StreamingSpeechStream._build_log_context.__get__(
-        stream, stt_streaming.StreamingSpeechStream
+    stream._logger = stt_streaming.logger.getChild("RealtimeSpeechStream")
+    stream._build_log_context = stt_streaming.RealtimeSpeechStream._build_log_context.__get__(
+        stream, stt_streaming.RealtimeSpeechStream
     )
     stream._pending_eos = False
     stream._pending_eos_time = None
@@ -63,8 +65,8 @@ def _make_stream(
     stream._stream_started_at = stt_streaming.time.time()
     stream._audio_position = 0.0
     stream._audio_duration_collector = stt_streaming.PeriodicCollector(
-        callback=stt_streaming.StreamingSpeechStream._on_audio_duration_report.__get__(
-            stream, stt_streaming.StreamingSpeechStream
+        callback=stt_streaming.RealtimeSpeechStream._on_audio_duration_report.__get__(
+            stream, stt_streaming.RealtimeSpeechStream
         ),
         duration=5.0,
     )
@@ -75,6 +77,14 @@ def _parse_ws_url(url: str) -> dict[str, str]:
     parsed = urlparse(url)
     qs = parse_qs(parsed.query)
     return {key: value[0] for key, value in qs.items()}
+
+
+def test_realtime_stt_exports_and_legacy_aliases() -> None:
+    assert sarvam.STTRealtime is stt_streaming.STTRealtime
+    assert sarvam.RealtimeSpeechStream is stt_streaming.RealtimeSpeechStream
+    assert sarvam.STTStreaming is sarvam.STTRealtime
+    assert sarvam.StreamingSpeechStream is sarvam.RealtimeSpeechStream
+    assert stt_streaming.StreamingSTTOptions is stt_streaming.RealtimeSTTOptions
 
 
 def test_streaming_disables_connection_retries(
@@ -88,10 +98,10 @@ def test_streaming_disables_connection_retries(
 
     monkeypatch.setattr(
         stt_streaming,
-        "StreamingSpeechStream",
+        "RealtimeSpeechStream",
         _CapturedStream,
     )
-    stt = stt_streaming.STTStreaming(
+    stt = stt_streaming.STTRealtime(
         api_key="sk_test",
         http_session=object(),  # type: ignore[arg-type]
     )
@@ -114,7 +124,7 @@ def test_streaming_disables_connection_retries(
 
 
 def test_realtime_ws_url_includes_core_and_vad_params() -> None:
-    opts = stt_streaming.StreamingSTTOptions(
+    opts = stt_streaming.RealtimeSTTOptions(
         language="hi-IN",
         api_key="sk_test",
         stream_type="fast",
@@ -144,7 +154,7 @@ def test_realtime_ws_url_includes_core_and_vad_params() -> None:
 
 
 def test_realtime_ws_url_omits_vad_params_for_manual_endpointing() -> None:
-    opts = stt_streaming.StreamingSTTOptions(
+    opts = stt_streaming.RealtimeSTTOptions(
         language="en-IN",
         api_key="sk_test",
         endpointing="manual",
@@ -161,7 +171,7 @@ def test_realtime_ws_url_omits_vad_params_for_manual_endpointing() -> None:
 
 
 def test_realtime_ws_url_includes_prompt_and_timestamp_controls() -> None:
-    opts = stt_streaming.StreamingSTTOptions(
+    opts = stt_streaming.RealtimeSTTOptions(
         language="en-IN",
         api_key="sk_test",
         prompt="LiveKit terminology",
@@ -176,26 +186,148 @@ def test_realtime_ws_url_includes_prompt_and_timestamp_controls() -> None:
     assert params["return_timestamps"] == "true"
 
 
+def test_realtime_ws_url_includes_connection_only_vad_and_lid_controls() -> None:
+    opts = stt_streaming.RealtimeSTTOptions(
+        language="auto",
+        api_key="sk_test",
+        vad_prefix_padding_ms=320,
+        lid_gate_seconds=2.5,
+        lid_confidence_threshold=0.85,
+    )
+
+    params = _parse_ws_url(
+        stt_streaming._build_realtime_ws_url(stt_streaming.SARVAM_STT_REALTIME_URL, opts)
+    )
+
+    assert params["prefix_padding_ms"] == "320"
+    assert params["lid_gate_seconds"] == "2.5"
+    assert params["lid_confidence_threshold"] == "0.85"
+
+
+def test_realtime_ws_url_omits_prefix_padding_for_manual_endpointing() -> None:
+    opts = stt_streaming.RealtimeSTTOptions(
+        language="en-IN",
+        api_key="sk_test",
+        endpointing="manual",
+        vad_prefix_padding_ms=320,
+    )
+
+    params = _parse_ws_url(
+        stt_streaming._build_realtime_ws_url(stt_streaming.SARVAM_STT_REALTIME_URL, opts)
+    )
+
+    assert "prefix_padding_ms" not in params
+
+
 def test_streaming_options_validate_realtime_contract() -> None:
     with pytest.raises(ValueError, match="sample_rate must be one of"):
-        stt_streaming.StreamingSTTOptions(language="hi-IN", api_key="sk_test", sample_rate=44100)
+        stt_streaming.RealtimeSTTOptions(language="hi-IN", api_key="sk_test", sample_rate=44100)
 
     with pytest.raises(ValueError, match="language od-IN is not supported"):
-        stt_streaming.StreamingSTTOptions(language="od-IN", api_key="sk_test")
+        stt_streaming.RealtimeSTTOptions(language="od-IN", api_key="sk_test")
+
+    with pytest.raises(ValueError, match="vad_prefix_padding_ms"):
+        stt_streaming.RealtimeSTTOptions(
+            language="hi-IN",
+            api_key="sk_test",
+            vad_prefix_padding_ms=-1,
+        )
+
+    with pytest.raises(ValueError, match="lid_gate_seconds"):
+        stt_streaming.RealtimeSTTOptions(
+            language="auto",
+            api_key="sk_test",
+            lid_gate_seconds=-1,
+        )
+
+    with pytest.raises(ValueError, match="lid_confidence_threshold"):
+        stt_streaming.RealtimeSTTOptions(
+            language="auto",
+            api_key="sk_test",
+            lid_confidence_threshold=1.1,
+        )
+
+    with pytest.raises(ValueError, match="mode must be one of"):
+        stt_streaming.RealtimeSTTOptions(
+            language="hi-IN",
+            api_key="sk_test",
+            mode="indic-en",
+        )
 
 
 def test_streaming_options_reject_server_tuned_vad_smoothing() -> None:
     with pytest.raises(TypeError, match="vad_smoothing_alpha"):
-        stt_streaming.StreamingSTTOptions(
+        stt_streaming.RealtimeSTTOptions(
             language="hi-IN",
             api_key="sk_test",
             vad_smoothing_alpha=0.5,
         )
 
 
+@pytest.mark.parametrize("encoding", ["linear16", "linear32", "mulaw", "alaw"])
+def test_streaming_options_accept_all_contract_encodings(encoding: str) -> None:
+    opts = stt_streaming.RealtimeSTTOptions(
+        language="hi-IN",
+        api_key="sk_test",
+        encoding=encoding,
+    )
+
+    assert opts.encoding == encoding
+
+
+@pytest.mark.parametrize("encoding", ["mulaw", "alaw"])
+def test_realtime_pcm_telephony_encoders_round_trip(encoding: str) -> None:
+    pcm = np.array([-30000, -1000, 0, 1000, 30000], dtype="<i2").tobytes()
+
+    encoded = stt_streaming._encode_pcm_for_wire(encoding, pcm)
+    decoded = np.frombuffer(tts._decode_telephony(encoding, encoded), dtype="<i2")
+
+    assert len(encoded) == 5
+    assert np.max(np.abs(decoded.astype(np.int32) - np.frombuffer(pcm, dtype="<i2"))) < 1500
+
+
+def test_realtime_pcm_linear32_encoder_preserves_full_scale() -> None:
+    pcm = np.array([-32768, -1, 0, 1, 32767], dtype="<i2").tobytes()
+
+    encoded = stt_streaming._encode_pcm_for_wire("linear32", pcm)
+
+    assert np.frombuffer(encoded, dtype="<i4").tolist() == [
+        -2147483648,
+        -65536,
+        0,
+        65536,
+        2147418112,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_session_begin_records_resolved_config() -> None:
+    stream = _make_stream()
+    resolved_config = {
+        "encoding": "mulaw",
+        "sample_rate": 8000,
+        "prefix_padding_ms": 320,
+    }
+
+    await stream._handle_message(
+        {
+            "event": "session.begin",
+            "request_id": "req_123",
+            "config": resolved_config,
+        }
+    )
+    resolved_config["sample_rate"] = 16000
+
+    assert stream.resolved_config == {
+        "encoding": "mulaw",
+        "sample_rate": 8000,
+        "prefix_padding_ms": 320,
+    }
+
+
 @pytest.mark.parametrize("endpointing", ["vad", "manual"])
 def test_auto_language_is_valid_for_all_contract_endpointing_modes(endpointing: str) -> None:
-    opts = stt_streaming.StreamingSTTOptions(
+    opts = stt_streaming.RealtimeSTTOptions(
         language="auto",
         api_key="sk_test",
         stream_type="fast",
@@ -211,7 +343,7 @@ def test_auto_language_is_valid_for_all_contract_endpointing_modes(endpointing: 
 
 
 def test_simulated_streaming_allows_auto_language_and_mode() -> None:
-    opts = stt_streaming.StreamingSTTOptions(
+    opts = stt_streaming.RealtimeSTTOptions(
         language="auto",
         api_key="sk_test",
         stream_type="simulated",
@@ -238,7 +370,7 @@ def test_streaming_option_update_uses_in_band_contract_config_message() -> None:
     stream = _make_stream()
     stream._ws = None
     stream._reconnect_event = _ReconnectEvent()
-    updated_options = stt_streaming.StreamingSTTOptions(
+    updated_options = stt_streaming.RealtimeSTTOptions(
         language="en-IN",
         api_key="sk_test",
         stream_type="fast",
@@ -268,7 +400,7 @@ def test_active_stream_keeps_connection_only_options_on_update(
     stream._pending_config_update = None
     stream._reconnect_event = SimpleNamespace(set_called=False)
     stream._reconnect_event.set = lambda: setattr(stream._reconnect_event, "set_called", True)
-    updated_options = stt_streaming.StreamingSTTOptions(
+    updated_options = stt_streaming.RealtimeSTTOptions(
         language="hi-IN",
         api_key="sk_test",
         sample_rate=8000,
@@ -293,14 +425,14 @@ def test_streaming_option_updates_merge_before_the_next_audio_frame() -> None:
     stream = _make_stream()
     stream._pending_config_update = None
     stream.update_options(
-        stt_streaming.StreamingSTTOptions(
+        stt_streaming.RealtimeSTTOptions(
             language="hi-IN",
             api_key="sk_test",
             prompt="LiveKit",
         )
     )
     stream.update_options(
-        stt_streaming.StreamingSTTOptions(
+        stt_streaming.RealtimeSTTOptions(
             language="hi-IN",
             api_key="sk_test",
             prompt="LiveKit",
@@ -316,18 +448,18 @@ def test_streaming_option_updates_merge_before_the_next_audio_frame() -> None:
 
 
 def test_streaming_option_update_clears_prompt_with_empty_string() -> None:
-    previous = stt_streaming.StreamingSTTOptions(
+    previous = stt_streaming.RealtimeSTTOptions(
         language="hi-IN",
         api_key="sk_test",
         prompt="LiveKit",
     )
-    current = stt_streaming.StreamingSTTOptions(
+    current = stt_streaming.RealtimeSTTOptions(
         language="hi-IN",
         api_key="sk_test",
         prompt=None,
     )
 
-    assert stt_streaming.StreamingSpeechStream._config_update_payload(previous, current) == {
+    assert stt_streaming.RealtimeSpeechStream._config_update_payload(previous, current) == {
         "event": "config.update",
         "prompt": "",
     }
@@ -341,7 +473,7 @@ def test_active_stream_defers_endpointing_until_config_acknowledgement() -> None
     stream._endpointing_update_acknowledged = False
     stream._pending_config_update = None
     stream.update_options(
-        stt_streaming.StreamingSTTOptions(
+        stt_streaming.RealtimeSTTOptions(
             language="hi-IN",
             api_key="sk_test",
             endpointing="manual",
@@ -833,8 +965,8 @@ async def test_streaming_usage_event_is_converted_to_livekit_stt_metrics(
     async def _idle_run(self: object) -> None:
         await asyncio.Event().wait()
 
-    monkeypatch.setattr(stt_streaming.StreamingSpeechStream, "_run", _idle_run)
-    stt_impl = stt_streaming.STTStreaming(api_key="sk_test")
+    monkeypatch.setattr(stt_streaming.RealtimeSpeechStream, "_run", _idle_run)
+    stt_impl = stt_streaming.STTRealtime(api_key="sk_test")
     metrics = []
     stt_impl.on("metrics_collected", metrics.append)
     stream = stt_impl.stream()

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -552,12 +552,54 @@ async def test_streaming_event_mapping_emits_speech_and_transcript_events() -> N
     assert final_event.request_id == "20260608_31c9dc1d-3435-4e76-ae51-05de31025a68"
     assert final_event.alternatives[0].text == "नमस्ते आप कैसे हैं"
     assert final_event.alternatives[0].language == "hi-IN"
-    assert final_event.alternatives[0].confidence == 0.99
+    # The endpoint sends no recognition confidence, so it falls back to 1.0 and the
+    # language-identification score stays in metadata.
+    assert final_event.alternatives[0].confidence == 1.0
+    assert final_event.alternatives[0].metadata["language_confidence"] == 0.99
     assert final_event.alternatives[0].end_time == 1.75
 
     eos_event = stream._event_ch.events[2]
     assert eos_event.alternatives == []
     assert final_event.alternatives[0].metadata["speech_end_wall_time"] > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload_confidence", "expected"),
+    [
+        ({"confidence": 0.42}, 0.42),
+        ({}, 1.0),
+        ({"confidence": None}, 1.0),
+        ({"confidence": "high"}, 1.0),
+        # bool is a subclass of int; False must not read as zero confidence.
+        ({"confidence": False}, 1.0),
+    ],
+)
+async def test_transcript_confidence_uses_recognition_score_with_absent_fallback(
+    payload_confidence: dict[str, object],
+    expected: float,
+) -> None:
+    """`language_confidence` is a language-ID score and must not stand in for it.
+
+    An absent value falls back to 1.0 rather than 0.0, matching `_extract_confidence`
+    in stt.py, so livekit-agents' confidence averaging is not dragged toward zero.
+    """
+    stream = _make_stream(endpointing="manual")
+
+    await stream._handle_message(
+        {
+            "event": "transcript.final",
+            "utterance_idx": 0,
+            "text": "नमस्ते",
+            "language": "hi-IN",
+            "language_confidence": 0.2,
+            **payload_confidence,
+        }
+    )
+
+    final_event = stream._event_ch.events[0]
+    assert final_event.alternatives[0].confidence == expected
+    assert final_event.alternatives[0].metadata["language_confidence"] == 0.2
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -1564,7 +1564,7 @@ async def test_manual_endpointing_emits_boundary_events_and_resets_each_turn() -
     assert first_eos.alternatives == []
     assert second_eos.alternatives == []
     # The speech-end position is re-anchored to the second turn.
-    assert stream._utterance_speech_end_audio_pos == 1.0
+    assert stream._utterance_speech_end_audio_pos == pytest.approx(1.0)
 
 
 @pytest.mark.asyncio
@@ -1716,3 +1716,45 @@ async def test_process_audio_survives_reset_race_on_peer_close() -> None:
     await stream._process_audio(ws)
 
     assert [json.loads(payload)["event"] for payload in sent] == ["end"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream_type", ["fast", "balanced"])
+async def test_process_audio_forwards_small_frames_regardless_of_stream_type(
+    stream_type: str,
+) -> None:
+    """Audio must reach the server in small frames.
+
+    ``stream_type`` is the server's flush profile, not a client send cadence, so
+    buffering 500-1000 ms locally would delay server VAD boundaries and partials by
+    that much.
+    """
+    stream = _make_stream()
+    stream._opts = stt_streaming.replace(stream._opts, stream_type=stream_type)
+    sent: list[bytes] = []
+
+    ws = SimpleNamespace(
+        closed=False,
+        send_str=lambda payload: asyncio.sleep(0),
+        send_bytes=lambda payload: asyncio.sleep(0, result=sent.append(payload)),
+    )
+    # One second of 16 kHz mono audio.
+    frame = stt_streaming.rtc.AudioFrame(
+        data=bytes(32000),
+        sample_rate=16000,
+        num_channels=1,
+        samples_per_channel=16000,
+    )
+
+    async def _input() -> object:
+        yield frame
+
+    stream._input_ch = _input()
+    stream._FlushSentinel = stt_streaming.stt.RecognizeStream._FlushSentinel
+
+    await stream._process_audio(ws)
+
+    expected_bytes = int(16000 * stt_streaming.AUDIO_CHUNK_MS / 1000) * 2
+    assert stt_streaming.AUDIO_CHUNK_MS <= 100
+    assert len(sent) == 1000 // stt_streaming.AUDIO_CHUNK_MS
+    assert {len(payload) for payload in sent} == {expected_bytes}

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -82,7 +82,6 @@ def test_realtime_ws_url_includes_core_and_vad_params() -> None:
         vad_sot_threshold=0.4,
         vad_min_speech_ms=300,
         vad_min_silence_ms=800,
-        vad_smoothing_alpha=0.5,
     )
 
     url = stt_streaming._build_realtime_ws_url(stt_streaming.SARVAM_STT_REALTIME_URL, opts)
@@ -142,6 +141,15 @@ def test_streaming_options_validate_realtime_contract() -> None:
 
     with pytest.raises(ValueError, match="language od-IN is not supported"):
         stt_streaming.StreamingSTTOptions(language="od-IN", api_key="sk_test")
+
+
+def test_streaming_options_reject_server_tuned_vad_smoothing() -> None:
+    with pytest.raises(TypeError, match="vad_smoothing_alpha"):
+        stt_streaming.StreamingSTTOptions(
+            language="hi-IN",
+            api_key="sk_test",
+            vad_smoothing_alpha=0.5,
+        )
 
 
 @pytest.mark.parametrize("endpointing", ["vad", "manual"])

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -77,6 +77,42 @@ def _parse_ws_url(url: str) -> dict[str, str]:
     return {key: value[0] for key, value in qs.items()}
 
 
+def test_streaming_disables_connection_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _CapturedStream:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        stt_streaming,
+        "StreamingSpeechStream",
+        _CapturedStream,
+    )
+    stt = stt_streaming.STTStreaming(
+        api_key="sk_test",
+        http_session=object(),  # type: ignore[arg-type]
+    )
+    conn_options = stt_streaming.APIConnectOptions(
+        max_retry=3,
+        retry_interval=1.5,
+        timeout=12.0,
+    )
+
+    stt.stream(conn_options=conn_options)
+
+    stream_conn_options = captured["conn_options"]
+    assert isinstance(
+        stream_conn_options,
+        stt_streaming.APIConnectOptions,
+    )
+    assert stream_conn_options.max_retry == 0
+    assert stream_conn_options.retry_interval == 1.5
+    assert stream_conn_options.timeout == 12.0
+
+
 def test_realtime_ws_url_includes_core_and_vad_params() -> None:
     opts = stt_streaming.StreamingSTTOptions(
         language="hi-IN",

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -361,17 +361,15 @@ def test_simulated_streaming_allows_auto_language_and_mode() -> None:
 def test_streaming_option_update_uses_in_band_contract_config_message() -> None:
     stream = _make_stream()
     stream._ws = None
-    updated_options = stt_streaming.RealtimeSTTOptions(
+
+    stream.update_options(
         language="en-IN",
-        api_key="sk_test",
         stream_type="fast",
         mode="translate",
         endpointing="vad",
         prompt="LiveKit",
         vad_sot_threshold=0.6,
     )
-
-    stream.update_options(updated_options)
 
     assert stream._pending_config_update == {
         "event": "config.update",
@@ -388,16 +386,13 @@ def test_active_stream_keeps_connection_only_options_on_update(
 ) -> None:
     stream = _make_stream()
     stream._pending_config_update = None
-    updated_options = stt_streaming.RealtimeSTTOptions(
-        language="hi-IN",
-        api_key="sk_test",
-        sample_rate=8000,
-        return_timestamps=True,
-        prompt="LiveKit",
-    )
 
     with caplog.at_level(logging.WARNING, logger=stt_streaming.logger.name):
-        stream.update_options(updated_options)
+        stream.update_options(
+            sample_rate=8000,
+            return_timestamps=True,
+            prompt="LiveKit",
+        )
 
     assert stream._opts.sample_rate == 16000
     assert stream._opts.return_timestamps is False
@@ -411,21 +406,8 @@ def test_active_stream_keeps_connection_only_options_on_update(
 def test_streaming_option_updates_merge_before_the_next_audio_frame() -> None:
     stream = _make_stream()
     stream._pending_config_update = None
-    stream.update_options(
-        stt_streaming.RealtimeSTTOptions(
-            language="hi-IN",
-            api_key="sk_test",
-            prompt="LiveKit",
-        )
-    )
-    stream.update_options(
-        stt_streaming.RealtimeSTTOptions(
-            language="hi-IN",
-            api_key="sk_test",
-            prompt="LiveKit",
-            mode="translate",
-        )
-    )
+    stream.update_options(prompt="LiveKit")
+    stream.update_options(prompt="LiveKit", mode="translate")
 
     assert stream._pending_config_update == {
         "event": "config.update",
@@ -452,6 +434,52 @@ def test_streaming_option_update_clears_prompt_with_empty_string() -> None:
     }
 
 
+@pytest.mark.asyncio
+async def test_instance_update_preserves_per_stream_language_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unrelated instance-level update must not clobber a per-stream override.
+
+    ``stream(language=...)`` is a per-stream override, so pushing the instance
+    defaults wholesale would silently reset it and queue a server-side language
+    change the caller never asked for.
+    """
+
+    async def _idle_run(self: object) -> None:
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(stt_streaming.RealtimeSpeechStream, "_run", _idle_run)
+
+    stt_impl = stt_streaming.STTRealtime(
+        api_key="sk_test",
+        language="hi-IN",
+        http_session=object(),  # type: ignore[arg-type]
+    )
+    stream = stt_impl.stream(language="ta-IN")
+
+    stt_impl.update_options(prompt="LiveKit")
+
+    assert stream._opts.language == "ta-IN"
+    assert stt_impl._opts.language == "hi-IN"
+    assert stream._pending_config_update == {
+        "event": "config.update",
+        "prompt": "LiveKit",
+    }
+
+    await stream.aclose()
+    await stt_impl.aclose()
+
+
+def test_stream_update_options_without_arguments_is_a_no_op() -> None:
+    stream = _make_stream()
+    stream._pending_config_update = None
+
+    stream.update_options()
+
+    assert stream._pending_config_update is None
+    assert stream._opts.language == "hi-IN"
+
+
 def test_active_stream_defers_endpointing_until_config_acknowledgement() -> None:
     stream = _make_stream()
     stream._active_endpointing = "vad"
@@ -459,13 +487,7 @@ def test_active_stream_defers_endpointing_until_config_acknowledgement() -> None
     stream._pending_endpointing = None
     stream._endpointing_update_acknowledged = False
     stream._pending_config_update = None
-    stream.update_options(
-        stt_streaming.RealtimeSTTOptions(
-            language="hi-IN",
-            api_key="sk_test",
-            endpointing="manual",
-        )
-    )
+    stream.update_options(endpointing="manual")
 
     assert stream._active_endpointing == "vad"
     assert stream._pending_endpointing == "manual"

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -801,7 +801,9 @@ async def test_streaming_info_logs_essential_data_without_raw_payload(
         if record.getMessage() == "Sarvam realtime STT transcript.final"
     ]
     assert len(info_records) == 1
-    assert info_records[0].text == "hello"
+    assert not hasattr(info_records[0], "text")
+    assert info_records[0].text_length == len("hello")
+    assert info_records[0].language == "en-IN"
     assert not hasattr(info_records[0], "raw_data")
 
     caplog.clear()
@@ -815,6 +817,7 @@ async def test_streaming_info_logs_essential_data_without_raw_payload(
     ]
     assert len(debug_records) == 1
     assert debug_records[0].raw_data == final_payload
+    assert debug_records[0].raw_data["text"] == "hello"
 
 
 @pytest.mark.asyncio
@@ -891,7 +894,9 @@ async def test_streaming_usage_metrics_emit_server_authoritative_session_end() -
         for event in stream._event_ch.events
         if event.type == stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE
     ]
-    assert [event.recognition_usage.audio_duration for event in usage_events] == [2.25]
+    # The 1.5s already billed incrementally is topped up to the server total of 2.25s.
+    assert [event.recognition_usage.audio_duration for event in usage_events] == [1.5, 0.75]
+    assert sum(event.recognition_usage.audio_duration for event in usage_events) == 2.25
     assert all(event.request_id == "sess_123" for event in usage_events)
     assert stream._session_ended is True
     assert stream._server_audio_duration_reported is True
@@ -941,7 +946,9 @@ async def test_streaming_usage_accepts_server_duration_smaller_than_local_estima
         for event in stream._event_ch.events
         if event.type == stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE
     ]
-    assert [event.recognition_usage.audio_duration for event in usage_events] == [2.25]
+    # 5.0s was already billed incrementally, so a smaller server total adds nothing
+    # rather than double counting or emitting a negative delta.
+    assert [event.recognition_usage.audio_duration for event in usage_events] == [5.0]
 
 
 @pytest.mark.asyncio
@@ -1303,3 +1310,280 @@ async def test_streaming_connect_logs_handshake_failure(
     assert len(records) == 1
     assert records[0].status_code == 403
     assert "API-SUBSCRIPTION-KEY" not in records[0].url
+
+
+@pytest.mark.asyncio
+async def test_session_end_commits_final_buffered_without_speech_end() -> None:
+    stream = _make_stream()
+    stream._audio_position = 3.5
+
+    await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
+    await stream._handle_message(
+        {
+            "event": "transcript.final",
+            "utterance_idx": 0,
+            "text": "नमस्ते आप कैसे हैं",
+            "language": "hi-IN",
+            "language_confidence": 0.99,
+        }
+    )
+
+    assert [event.type for event in stream._event_ch.events] == [
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+    ]
+
+    await stream._handle_message(
+        {
+            "event": "session.end",
+            "request_id": "req_123",
+            "audio_duration_s": 3.5,
+        }
+    )
+
+    assert [event.type for event in stream._event_ch.events] == [
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.FINAL_TRANSCRIPT,
+        stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE,
+    ]
+    final_event = stream._event_ch.events[2]
+    assert final_event.alternatives[0].text == "नमस्ते आप कैसे हैं"
+    assert final_event.alternatives[0].end_time == 3.5
+    assert stream._pending_final_data is None
+
+
+@pytest.mark.asyncio
+async def test_clean_close_commits_final_buffered_without_speech_end() -> None:
+    stream = _make_stream()
+    stream._audio_position = 2.0
+    ws = SimpleNamespace(
+        receive=lambda: asyncio.sleep(
+            0,
+            result=SimpleNamespace(
+                type=stt_streaming.aiohttp.WSMsgType.CLOSE,
+                data=1000,
+                extra=None,
+            ),
+        ),
+        close_code=1000,
+    )
+
+    await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
+    await stream._handle_message(
+        {
+            "event": "transcript.final",
+            "utterance_idx": 0,
+            "text": "hello",
+            "language": "en-IN",
+            "language_confidence": 0.99,
+        }
+    )
+
+    await stream._process_messages(ws)
+
+    assert [event.type for event in stream._event_ch.events] == [
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.FINAL_TRANSCRIPT,
+    ]
+    assert stream._event_ch.events[2].alternatives[0].end_time == 2.0
+
+
+@pytest.mark.asyncio
+async def test_terminal_flush_is_idempotent_across_session_end_and_close() -> None:
+    stream = _make_stream()
+    stream._audio_position = 1.0
+
+    await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
+    await stream._handle_message(
+        {
+            "event": "transcript.final",
+            "utterance_idx": 0,
+            "text": "hello",
+            "language": "en-IN",
+        }
+    )
+    await stream._handle_message({"event": "session.end", "request_id": "req_123"})
+    stream._flush_terminal_utterance()
+
+    finals = [
+        event
+        for event in stream._event_ch.events
+        if event.type == stt_streaming.stt.SpeechEventType.FINAL_TRANSCRIPT
+    ]
+    eos_events = [
+        event
+        for event in stream._event_ch.events
+        if event.type == stt_streaming.stt.SpeechEventType.END_OF_SPEECH
+    ]
+    assert len(finals) == 1
+    assert len(eos_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_audio_duration_collector_emits_usage_incrementally() -> None:
+    stream = _make_stream()
+
+    stream._on_audio_duration_report(5.0)
+    stream._on_audio_duration_report(5.0)
+
+    usage_events = [
+        event
+        for event in stream._event_ch.events
+        if event.type == stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE
+    ]
+    assert [event.recognition_usage.audio_duration for event in usage_events] == [5.0, 5.0]
+    assert stream._total_reported_audio_duration == 10.0
+    assert stream._local_audio_duration == 10.0
+
+
+@pytest.mark.asyncio
+async def test_session_end_tops_up_pending_collector_audio_to_server_total() -> None:
+    stream = _make_stream()
+    stream._audio_duration_collector.push(1.0)
+
+    await stream._handle_message(
+        {
+            "event": "session.end",
+            "request_id": "req_123",
+            "audio_duration_s": 2.5,
+        }
+    )
+
+    usage_events = [
+        event
+        for event in stream._event_ch.events
+        if event.type == stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE
+    ]
+    assert [event.recognition_usage.audio_duration for event in usage_events] == [1.0, 1.5]
+    assert stream._total_reported_audio_duration == 2.5
+
+
+@pytest.mark.asyncio
+async def test_aclose_flushes_pending_audio_duration_into_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _idle_run(self: object) -> None:
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(stt_streaming.RealtimeSpeechStream, "_run", _idle_run)
+
+    stt_impl = stt_streaming.STTRealtime(api_key="sk_test", http_session=object())  # type: ignore[arg-type]
+    metrics = []
+    stt_impl.on("metrics_collected", metrics.append)
+    stream = stt_impl.stream()
+    stream._request_id = "req_123"
+    stream._audio_duration_collector.push(1.75)
+
+    await stream.aclose()
+    await stt_impl.aclose()
+
+    assert [metric.audio_duration for metric in metrics] == [1.75]
+    assert metrics[0].request_id == "req_123"
+
+
+@pytest.mark.asyncio
+async def test_aclose_skips_usage_flush_when_stream_already_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _failing_run(self: object) -> None:
+        raise APIStatusError("boom", status_code=1006)
+
+    monkeypatch.setattr(stt_streaming.RealtimeSpeechStream, "_run", _failing_run)
+
+    stt_impl = stt_streaming.STTRealtime(api_key="sk_test", http_session=object())  # type: ignore[arg-type]
+    stream = stt_impl.stream()
+    stream._audio_duration_collector.push(1.0)
+
+    with pytest.raises(APIStatusError):
+        async for _ in stream:
+            pass
+
+    # The event channel closes with the failed run, so the flush must not raise.
+    await stream.aclose()
+    await stt_impl.aclose()
+
+
+@pytest.mark.asyncio
+async def test_manual_endpointing_emits_boundary_events_and_resets_each_turn() -> None:
+    stream = _make_stream(endpointing="manual")
+    sent: list[dict[str, object]] = []
+    ws = SimpleNamespace(
+        closed=False,
+        send_str=lambda payload: asyncio.sleep(0, result=sent.append(json.loads(payload))),
+        send_bytes=lambda payload: asyncio.sleep(0),
+    )
+    frame = stt_streaming.rtc.AudioFrame(
+        data=bytes(16000),
+        sample_rate=16000,
+        num_channels=1,
+        samples_per_channel=8000,
+    )
+
+    async def _input() -> object:
+        yield frame
+        yield stream._FlushSentinel()
+        yield frame
+        yield stream._FlushSentinel()
+
+    stream._input_ch = _input()
+    stream._FlushSentinel = stt_streaming.stt.RecognizeStream._FlushSentinel
+
+    async def _run_turns() -> None:
+        await stream._process_audio(ws)
+
+    await _run_turns()
+
+    assert [payload["event"] for payload in sent] == [
+        "speech_start",
+        "speech_end",
+        "speech_start",
+        "speech_end",
+        "end",
+    ]
+    # The collector is flushed before the turn boundary is sent, so usage lands
+    # between the speech events of each turn.
+    assert [event.type for event in stream._event_ch.events] == [
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE,
+        stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE,
+        stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
+    ]
+    first_eos, second_eos = (
+        stream._event_ch.events[2],
+        stream._event_ch.events[5],
+    )
+    assert first_eos.alternatives[0].end_time == 0.5
+    assert second_eos.alternatives[0].end_time == 1.0
+
+
+@pytest.mark.asyncio
+async def test_manual_final_uses_current_turn_timings_after_first_turn() -> None:
+    stream = _make_stream(endpointing="manual")
+    stream._audio_position = 4.0
+    stream._utterance_speech_end_audio_pos = 1.0
+    stream._utterance_speech_end_wall = 100.0
+    stream._eos_emitted_for_utterance = True
+
+    stream._begin_manual_utterance()
+    stream._audio_position = 6.0
+    stream._end_manual_utterance()
+    await stream._handle_message(
+        {
+            "event": "transcript.final",
+            "utterance_idx": 1,
+            "text": "second turn",
+            "language": "en-IN",
+        }
+    )
+
+    assert [event.type for event in stream._event_ch.events] == [
+        stt_streaming.stt.SpeechEventType.START_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.END_OF_SPEECH,
+        stt_streaming.stt.SpeechEventType.FINAL_TRANSCRIPT,
+    ]
+    final_event = stream._event_ch.events[2]
+    assert final_event.alternatives[0].end_time == 6.0
+    assert final_event.alternatives[0].metadata["speech_end_wall_time"] > 100.0

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -764,6 +764,25 @@ async def test_streaming_usage_metrics_emit_server_authoritative_session_end() -
 
 
 @pytest.mark.asyncio
+async def test_streaming_session_end_falls_back_to_local_duration_without_server_usage() -> None:
+    stream = _make_stream()
+    stream._request_id = "req_123"
+    stream._on_audio_duration_report(1.5)
+
+    await stream._handle_message({"event": "session.end", "request_id": "req_123"})
+    await stream._handle_message({"event": "session.end", "request_id": "req_123"})
+
+    usage_events = [
+        event
+        for event in stream._event_ch.events
+        if event.type == stt_streaming.stt.SpeechEventType.RECOGNITION_USAGE
+    ]
+    assert [event.recognition_usage.audio_duration for event in usage_events] == [1.5]
+    assert stream._server_audio_duration_reported is False
+    assert stream._session_ended is True
+
+
+@pytest.mark.asyncio
 async def test_streaming_usage_accepts_server_duration_smaller_than_local_estimate() -> None:
     stream = _make_stream()
 

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -1466,7 +1466,10 @@ async def test_aclose_flushes_pending_audio_duration_into_metrics(
 
     monkeypatch.setattr(stt_streaming.RealtimeSpeechStream, "_run", _idle_run)
 
-    stt_impl = stt_streaming.STTRealtime(api_key="sk_test", http_session=object())  # type: ignore[arg-type]
+    stt_impl = stt_streaming.STTRealtime(
+        api_key="sk_test",
+        http_session=object(),  # type: ignore[arg-type]
+    )
     metrics = []
     stt_impl.on("metrics_collected", metrics.append)
     stream = stt_impl.stream()
@@ -1489,7 +1492,10 @@ async def test_aclose_skips_usage_flush_when_stream_already_failed(
 
     monkeypatch.setattr(stt_streaming.RealtimeSpeechStream, "_run", _failing_run)
 
-    stt_impl = stt_streaming.STTRealtime(api_key="sk_test", http_session=object())  # type: ignore[arg-type]
+    stt_impl = stt_streaming.STTRealtime(
+        api_key="sk_test",
+        http_session=object(),  # type: ignore[arg-type]
+    )
     stream = stt_impl.stream()
     stream._audio_duration_collector.push(1.0)
 
@@ -1616,3 +1622,97 @@ async def test_end_of_speech_is_emitted_as_a_bare_pipeline_sentinel(endpointing:
     assert len(eos_events) == 1
     assert eos_events[0].alternatives == []
     assert eos_events[0].request_id == stream._request_id
+
+
+@pytest.mark.asyncio
+async def test_streaming_safe_send_bytes_ignores_closed_transport() -> None:
+    stream = _make_stream()
+    calls = []
+
+    closed_ws = SimpleNamespace(closed=True, send_bytes=lambda payload: calls.append(payload))
+    await stream._safe_send_bytes(closed_ws, b"\x00\x01")
+
+    assert calls == []
+
+    async def _raise_reset(payload: bytes) -> None:
+        raise stt_streaming.aiohttp.ClientConnectionResetError("Cannot write to closing transport")
+
+    closing_ws = SimpleNamespace(closed=False, send_bytes=_raise_reset)
+    await stream._safe_send_bytes(closing_ws, b"\x00\x01")
+
+
+@pytest.mark.asyncio
+async def test_process_audio_stops_pumping_after_session_end() -> None:
+    """The audio pump must end cleanly once the server has closed the session.
+
+    ``_run`` gathers the audio and message pumps, so an exception here would fail the
+    whole stream rather than letting it finish.
+    """
+    stream = _make_stream()
+    stream._session_ended = True
+    sent: list[object] = []
+
+    async def _raise_reset(payload: object) -> None:
+        raise stt_streaming.aiohttp.ClientConnectionResetError("Cannot write to closing transport")
+
+    ws = SimpleNamespace(
+        closed=False,
+        send_str=lambda payload: asyncio.sleep(0, result=sent.append(payload)),
+        send_bytes=_raise_reset,
+    )
+    frame = stt_streaming.rtc.AudioFrame(
+        data=bytes(16000),
+        sample_rate=16000,
+        num_channels=1,
+        samples_per_channel=8000,
+    )
+
+    async def _input() -> object:
+        yield frame
+        yield frame
+
+    stream._input_ch = _input()
+    stream._FlushSentinel = stt_streaming.stt.RecognizeStream._FlushSentinel
+
+    await stream._process_audio(ws)
+
+    # No audio was written and no redundant "end" was sent for an ended session.
+    assert sent == []
+    assert stream._audio_position == 0.0
+
+
+@pytest.mark.asyncio
+async def test_process_audio_survives_reset_race_on_peer_close() -> None:
+    """A reset raised mid-send must not fail the stream.
+
+    The peer can close between the loop's closed check and the write, so the audio
+    send has to tolerate a reset the same way the JSON control sends do.
+    """
+    stream = _make_stream()
+    sent: list[str] = []
+
+    async def _raise_reset(payload: object) -> None:
+        raise stt_streaming.aiohttp.ClientConnectionResetError("Cannot write to closing transport")
+
+    ws = SimpleNamespace(
+        closed=False,
+        send_str=lambda payload: asyncio.sleep(0, result=sent.append(payload)),
+        send_bytes=_raise_reset,
+    )
+    frame = stt_streaming.rtc.AudioFrame(
+        data=bytes(16000),
+        sample_rate=16000,
+        num_channels=1,
+        samples_per_channel=8000,
+    )
+
+    async def _input() -> object:
+        yield frame
+        yield frame
+
+    stream._input_ch = _input()
+    stream._FlushSentinel = stt_streaming.stt.RecognizeStream._FlushSentinel
+
+    await stream._process_audio(ws)
+
+    assert [json.loads(payload)["event"] for payload in sent] == ["end"]

--- a/tests/test_plugin_sarvam_stt_streaming.py
+++ b/tests/test_plugin_sarvam_stt_streaming.py
@@ -501,6 +501,82 @@ def test_active_stream_defers_endpointing_until_config_acknowledgement() -> None
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "final_payload",
+    [
+        None,
+        {"event": "transcript.final", "utterance_idx": 0, "text": ""},
+        {"event": "transcript.final", "utterance_idx": 0, "text": "   "},
+    ],
+    ids=["no_final", "empty_final", "whitespace_final"],
+)
+async def test_speech_end_promotes_pending_endpointing_without_a_valid_final(
+    final_payload: dict[str, object] | None,
+) -> None:
+    """A turn with no usable final must still count as an utterance boundary.
+
+    Otherwise `_utterance_in_progress` stays set, `_apply_pending_endpointing` refuses
+    to promote, and the stream is stranded in ``vad`` while the server has already
+    acknowledged the switch to ``manual`` and stopped sending ``vad.*`` events.
+    """
+    stream = _make_stream()
+    stream.update_options(endpointing="manual")
+    await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
+    await stream._handle_message({"event": "config.updated", "applied": ["endpointing"]})
+
+    assert stream._utterance_in_progress is True
+    assert stream._active_endpointing == "vad"
+
+    if final_payload is not None:
+        await stream._handle_message(final_payload)
+    await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
+
+    assert stream._utterance_in_progress is False
+    assert stream._active_endpointing == "manual"
+    assert stream._pending_endpointing is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpointing", ["vad", "manual"])
+@pytest.mark.parametrize("text", ["", "   ", "\n\t"])
+async def test_blank_final_transcript_is_not_emitted(endpointing: str, text: str) -> None:
+    """A blank final has no words, so committing it would trigger a reply on nothing."""
+    stream = _make_stream(endpointing=endpointing)
+    stream._audio_position = 1.0
+
+    await stream._handle_message({"event": "transcript.final", "utterance_idx": 0, "text": text})
+
+    finals = [
+        event
+        for event in stream._event_ch.events
+        if event.type == stt_streaming.stt.SpeechEventType.FINAL_TRANSCRIPT
+    ]
+    assert finals == []
+    assert stream._pending_final_data is None
+
+
+@pytest.mark.asyncio
+async def test_repeated_speech_end_still_completes_the_utterance() -> None:
+    stream = _make_stream()
+    stream.update_options(endpointing="manual")
+    await stream._handle_message({"event": "vad.speech_start", "utterance_idx": 0})
+    await stream._handle_message({"event": "config.updated", "applied": ["endpointing"]})
+    await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
+    # A duplicate speech end takes the already-emitted branch; it must not reopen or
+    # strand the utterance.
+    stream._utterance_in_progress = True
+    await stream._handle_message({"event": "vad.speech_end", "utterance_idx": 0})
+
+    assert stream._utterance_in_progress is False
+    eos_events = [
+        event
+        for event in stream._event_ch.events
+        if event.type == stt_streaming.stt.SpeechEventType.END_OF_SPEECH
+    ]
+    assert len(eos_events) == 1
+
+
+@pytest.mark.asyncio
 async def test_streaming_event_mapping_emits_speech_and_transcript_events() -> None:
     stream = _make_stream()
     stream._audio_position = 1.25


### PR DESCRIPTION
Summary:

- Add Sarvam saaras:v3-realtime streaming STT support aligned with the realtime API contract.
- Map session, VAD, partial/final transcript, config-update, and error events into LiveKit STT events.
- Use Sarvam’s session.end.audio_duration_s as the authoritative STT usage value, including intentionally sent silent audio.
- Support contract query/config options, in-band updates, transcript timestamps, and structured observability without exposing raw payloads at INFO level.