### PR TITLE
feat(inference): let the gateway mint the avatar worker token

### DIFF
--- a/livekit-agents/livekit/agents/inference/avatar.py
+++ b/livekit-agents/livekit/agents/inference/avatar.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 
 import aiohttp
 
-from livekit import api, rtc
+from livekit import rtc
 
 from .._exceptions import (
     APIConnectionError,
@@ -18,7 +18,6 @@ from .._exceptions import (
 from ..job import get_job_context
 from ..log import logger
 from ..types import (
-    ATTRIBUTE_PUBLISH_ON_BEHALF,
     DEFAULT_API_CONNECT_OPTIONS,
     NOT_GIVEN,
     APIConnectOptions,
@@ -45,10 +44,6 @@ _DEFAULT_SAMPLE_RATE = 16000
 # accepts the connection but never responds can't hang start()/aclose()
 # indefinitely. Matches the BYOK lemonslice plugin's request timeout.
 _REQUEST_TIMEOUT = 60.0
-# lk.avatar_provider tags the avatar worker participant with its provider so
-# server-side (participant-lifetime) avatar-minutes metering can attribute the
-# worker's room time to the right SKU.
-_ATTRIBUTE_AVATAR_PROVIDER = "lk.avatar_provider"
 
 
 class LemonSliceOptions(TypedDict, total=False):
@@ -113,16 +108,20 @@ class AvatarSession(BaseAvatarSession):
         await avatar.start(session, room=ctx.room)
         await avatar.wait_for_join()
 
-    Credentials come from two independent sources:
+    Unlike the BYOK plugins, this does **not** mint the avatar worker's room
+    token. The gateway mints it, scoped to this room and identity and stamped
+    with ``lk.publish_on_behalf`` and ``lk.avatar_provider``; a token the client
+    signed could not be trusted to carry those. The room fields this class sends
+    (``room_name`` / ``avatar_identity`` / ``agent_identity``) are the inputs to
+    that mint, so all three are required.
 
-    - Gateway auth (``api_key`` / ``api_secret``): resolved from the arguments,
-      then ``LIVEKIT_INFERENCE_API_KEY`` / ``LIVEKIT_INFERENCE_API_SECRET``,
-      then ``LIVEKIT_API_KEY`` / ``LIVEKIT_API_SECRET``.
-    - The avatar worker's room token: minted locally from the room project's
-      credentials, resolved from ``start()`` arguments then ``LIVEKIT_URL`` /
-      ``LIVEKIT_API_KEY`` / ``LIVEKIT_API_SECRET``. These may differ from the
-      gateway credentials when ``LIVEKIT_INFERENCE_*`` points at a different
-      project.
+    Credentials are gateway auth only (``api_key`` / ``api_secret``): resolved
+    from the arguments, then ``LIVEKIT_INFERENCE_API_KEY`` /
+    ``LIVEKIT_INFERENCE_API_SECRET``, then ``LIVEKIT_API_KEY`` /
+    ``LIVEKIT_API_SECRET``. Because the gateway signs the worker token with the
+    key it authenticated, the project that serves inference must be the project
+    that owns the room — pointing ``LIVEKIT_INFERENCE_*`` at a different project
+    than the room is no longer supported.
     """
 
     def __init__(
@@ -241,8 +240,6 @@ class AvatarSession(BaseAvatarSession):
         room: rtc.Room,
         *,
         livekit_url: NotGivenOr[str] = NOT_GIVEN,
-        livekit_api_key: NotGivenOr[str] = NOT_GIVEN,
-        livekit_api_secret: NotGivenOr[str] = NOT_GIVEN,
     ) -> None:
         if self._session_id is not None or self._provider_session_id is not None:
             raise RuntimeError(
@@ -252,14 +249,12 @@ class AvatarSession(BaseAvatarSession):
 
         await super().start(agent_session, room)
 
+        # Only the URL is needed: the provider dials it with the token the
+        # gateway mints, so no room-project key/secret is resolved here.
         lk_url = livekit_url or (os.getenv("LIVEKIT_URL") or NOT_GIVEN)
-        lk_key = livekit_api_key or (os.getenv("LIVEKIT_API_KEY") or NOT_GIVEN)
-        lk_secret = livekit_api_secret or (os.getenv("LIVEKIT_API_SECRET") or NOT_GIVEN)
-        if not lk_url or not lk_key or not lk_secret:
+        if not lk_url:
             raise ValueError(
-                "livekit_url, livekit_api_key, and livekit_api_secret must be set "
-                "by arguments or the LIVEKIT_URL / LIVEKIT_API_KEY / LIVEKIT_API_SECRET "
-                "environment variables"
+                "livekit_url must be set by argument or the LIVEKIT_URL environment variable"
             )
 
         # Usable inside an agent job or standalone (scripts/tests). The base
@@ -278,28 +273,10 @@ class AvatarSession(BaseAvatarSession):
                 "connect the room before calling start()"
             )
 
-        # Mint the avatar worker's room token locally, identical to the BYOK
-        # plugins, plus an lk.avatar_provider attribute for server-side metering.
-        worker_token = (
-            api.AccessToken(api_key=lk_key, api_secret=lk_secret)
-            .with_kind("agent")
-            .with_identity(self._avatar_participant_identity)
-            .with_name(self._avatar_participant_name)
-            .with_grants(api.VideoGrants(room_join=True, room=room.name))
-            .with_attributes(
-                {
-                    ATTRIBUTE_PUBLISH_ON_BEHALF: local_participant_identity,
-                    _ATTRIBUTE_AVATAR_PROVIDER: self._provider,
-                }
-            )
-            .to_jwt()
-        )
-
         create_resp = await self._create_session(
             room_name=room.name,
             room_sid=room_sid,
             livekit_url=lk_url,
-            worker_token=worker_token,
             agent_identity=local_participant_identity,
         )
 
@@ -412,16 +389,19 @@ class AvatarSession(BaseAvatarSession):
         room_name: str,
         room_sid: str,
         livekit_url: str,
-        worker_token: str,
         agent_identity: str,
     ) -> dict[str, Any]:
+        # room_name / avatar_identity / agent_identity are the inputs the
+        # gateway mints the worker room token from, not just attribution: it
+        # scopes the roomJoin grant to room_name, joins as avatar_identity, and
+        # sets lk.publish_on_behalf to agent_identity.
         payload: dict[str, Any] = {
             "provider": self._provider,
             "livekit_url": livekit_url,
-            "livekit_token": worker_token,
             "room_name": room_name,
             "room_sid": room_sid,
             "avatar_identity": self._avatar_participant_identity,
+            "avatar_name": self._avatar_participant_name,
             "agent_identity": agent_identity,
         }
         if self._avatar_id:

--- a/tests/test_inference_avatar.py
+++ b/tests/test_inference_avatar.py
@@ -1,9 +1,10 @@
 """Unit tests for livekit.agents.inference.AvatarSession.
 
 Covers model-string parsing, credential resolution, the gateway create call
-(payload/headers/idempotency), error mapping, that the response sample rate
-drives the DataStream audio sink, the terminate_token contract, double-start
-guarding, and the standalone (no job context) room paths.
+(payload/headers/idempotency), that the worker room token is left to the
+gateway to mint, error mapping, that the response sample rate drives the
+DataStream audio sink, the terminate_token contract, double-start guarding, and
+the standalone (no job context) room paths.
 """
 
 from __future__ import annotations
@@ -12,7 +13,6 @@ import contextlib
 from typing import Any
 
 import aiohttp
-import jwt
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestServer
@@ -147,7 +147,6 @@ async def _call_create(av: AvatarSession) -> dict[str, Any]:
         room_name="my-room",
         room_sid="RM_123",
         livekit_url="wss://example.livekit.cloud",
-        worker_token="worker-token",
         agent_identity="agent-worker-1",
     )
 
@@ -180,9 +179,10 @@ async def test_create_session_success() -> None:
 
     body = captured["body"]
     assert body["provider"] == "lemonslice"
-    assert body["livekit_token"] == "worker-token"
     assert body["avatar_identity"] == "lemonslice-inference-avatar"
+    assert body["avatar_name"] == "lemonslice-inference-avatar"
     assert body["agent_identity"] == "agent-worker-1"
+    assert body["room_name"] == "my-room"
     assert body["room_sid"] == "RM_123"
     # Known LemonSliceOptions keys map onto the gateway's first-class fields.
     assert body["image_url"] == "https://example.com/face.png"
@@ -357,8 +357,6 @@ async def test_start_uses_response_sample_rate(monkeypatch: pytest.MonkeyPatch) 
             agent_session,  # type: ignore[arg-type]
             _FakeRoom(),  # type: ignore[arg-type]
             livekit_url="wss://example.livekit.cloud",
-            livekit_api_key="devkey",
-            livekit_api_secret="devsecret",
         )
 
     assert av.session_id == "AVS_1"
@@ -368,12 +366,13 @@ async def test_start_uses_response_sample_rate(monkeypatch: pytest.MonkeyPatch) 
     assert agent_session.output.sink.sample_rate == 24000
 
 
-async def test_start_mints_worker_token_with_expected_grants(
+async def test_start_sends_mint_inputs_and_no_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The minted avatar worker token must carry the room-join grant and the
-    lk.publish_on_behalf / lk.avatar_provider attributes the gateway and
-    server-side metering depend on."""
+    """The gateway mints the avatar worker's room token, so start() must send
+    the fields it mints from — and must not send a token of its own. A
+    client-signed token could not be trusted to carry lk.avatar_provider, which
+    server-side avatar-minutes metering keys on."""
     captured: dict[str, Any] = {}
 
     async def handler(request: web.Request) -> web.Response:
@@ -384,28 +383,36 @@ async def test_start_mints_worker_token_with_expected_grants(
     monkeypatch.setattr(avatar_mod, "DataStreamAudioOutput", _FakeSink)
 
     async with _gateway(handler) as (base_url, session):
-        av = _make_avatar(base_url=base_url, http_session=session)
+        av = _make_avatar(base_url=base_url, http_session=session, avatar_participant_name="Ada")
         agent_session = _FakeAgentSession()
         await av.start(
             agent_session,  # type: ignore[arg-type]
             _FakeRoom(),  # type: ignore[arg-type]
             livekit_url="wss://example.livekit.cloud",
-            livekit_api_key="devkey",
-            livekit_api_secret="devsecret",
         )
 
-    assert captured["body"]["room_sid"] == "RM_123"
-    assert captured["body"]["agent_identity"] == "agent-worker-1"
+    body = captured["body"]
+    assert "livekit_token" not in body, "the gateway mints the worker token, not the SDK"
+    # The mint inputs: roomJoin scope, worker identity/name, publish-on-behalf.
+    assert body["room_name"] == "my-room"
+    assert body["avatar_identity"] == "lemonslice-inference-avatar"
+    assert body["avatar_name"] == "Ada"
+    assert body["agent_identity"] == "agent-worker-1"
+    assert body["room_sid"] == "RM_123"
 
-    claims = jwt.decode(captured["body"]["livekit_token"], options={"verify_signature": False})
-    assert claims["kind"] == "agent"
-    assert claims["sub"] == "lemonslice-inference-avatar"
-    assert claims["video"]["roomJoin"] is True
-    assert claims["video"]["room"] == "my-room"
-    assert claims["attributes"] == {
-        "lk.publish_on_behalf": "agent-worker-1",
-        "lk.avatar_provider": "lemonslice",
-    }
+
+async def test_start_without_livekit_url_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LIVEKIT_URL is still required (the provider dials it); the room project's
+    key/secret are not, since the SDK no longer signs anything."""
+    monkeypatch.delenv("LIVEKIT_URL", raising=False)
+    monkeypatch.setattr(avatar_mod, "get_job_context", lambda *a, **k: _FakeJobCtx())
+
+    av = _make_avatar()
+    with pytest.raises(ValueError, match="livekit_url"):
+        await av.start(
+            _FakeAgentSession(),  # type: ignore[arg-type]
+            _FakeRoom(),  # type: ignore[arg-type]
+        )
 
 
 async def test_start_twice_raises(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -427,8 +434,6 @@ async def test_start_twice_raises(monkeypatch: pytest.MonkeyPatch) -> None:
             agent_session,  # type: ignore[arg-type]
             _FakeRoom(),  # type: ignore[arg-type]
             livekit_url="wss://example.livekit.cloud",
-            livekit_api_key="devkey",
-            livekit_api_secret="devsecret",
         )
 
         with pytest.raises(RuntimeError, match="only be called once"):
@@ -436,8 +441,6 @@ async def test_start_twice_raises(monkeypatch: pytest.MonkeyPatch) -> None:
                 agent_session,  # type: ignore[arg-type]
                 _FakeRoom(),  # type: ignore[arg-type]
                 livekit_url="wss://example.livekit.cloud",
-                livekit_api_key="devkey",
-                livekit_api_secret="devsecret",
             )
 
     assert calls["n"] == 1, "second start() must not call the gateway again"
@@ -474,8 +477,6 @@ async def test_start_ids_set_before_audio_rebind(monkeypatch: pytest.MonkeyPatch
                 _FakeBrokenAgentSession(),  # type: ignore[arg-type]
                 _FakeRoom(),  # type: ignore[arg-type]
                 livekit_url="wss://example.livekit.cloud",
-                livekit_api_key="devkey",
-                livekit_api_secret="devsecret",
             )
 
     assert av.provider_session_id == "ls_1"
@@ -529,8 +530,6 @@ async def test_start_standalone_connected_room(monkeypatch: pytest.MonkeyPatch) 
             _FakeAgentSession(),  # type: ignore[arg-type]
             _FakeConnectedRoom(),  # type: ignore[arg-type]
             livekit_url="wss://example.livekit.cloud",
-            livekit_api_key="devkey",
-            livekit_api_secret="devsecret",
         )
 
         # isconnected() == True also makes the base class eagerly spawn a
@@ -559,8 +558,6 @@ async def test_start_standalone_disconnected_room_raises(monkeypatch: pytest.Mon
             _FakeAgentSession(),  # type: ignore[arg-type]
             _FakeRoom(),  # type: ignore[arg-type]
             livekit_url="wss://example.livekit.cloud",
-            livekit_api_key="devkey",
-            livekit_api_secret="devsecret",
         )
 
 


### PR DESCRIPTION
## What

`inference.AvatarSession` minted the avatar worker's room token locally and posted it to the gateway as `livekit_token`. The gateway now mints that token itself — **livekit/agent-gateway#1095** — so this PR stops minting client-side and sends the fields the gateway mints *from*.

**These two PRs must land together.** Against gateway #1095, a create that sends `livekit_token` and omits `agent_identity` is a 400. No live impact either way: the gateway endpoint is gated by the default-off `avatar_lemonslice` flag, so no project can be provisioning avatars today.

## Why

Billing integrity. Server-side avatar-minutes metering keys on the `lk.avatar_provider` participant attribute — and that attribute was being set by *this* code, in a token *we* signed. You cannot reconcile revenue against a value the customer's process controls. Same for `room_name` / `room_sid` / `avatar_identity`: self-reported body fields with nothing tying them to the token actually used.

Moving the mint server-side makes all of it gateway-authored. The gateway signs with the key it just authenticated the request on, so it grants nothing the caller could not already mint for itself.

## The change

```diff
-        worker_token = (
-            api.AccessToken(api_key=lk_key, api_secret=lk_secret)
-            .with_kind("agent")
-            .with_identity(self._avatar_participant_identity)
-            .with_grants(api.VideoGrants(room_join=True, room=room.name))
-            .with_attributes({...})
-            .to_jwt()
-        )
```

The gateway reproduces exactly that grant set: `kind=agent`, the identity, `roomJoin` scoped to the one room, publish/subscribe left implicit, plus `lk.publish_on_behalf` and `lk.avatar_provider`.

Payload changes: `livekit_token` removed; `avatar_name` added so a custom `avatar_participant_name` still reaches the minted token. `room_name` / `avatar_identity` / `agent_identity` were already sent and are now load-bearing mint inputs rather than attribution.

## ⚠️ Breaking change (in a released API)

`AvatarSession.start()` no longer accepts **`livekit_api_key`** / **`livekit_api_secret`**. `AvatarSession` shipped in **livekit-agents 1.6.7**, so this is a break to a published surface, not an unreleased one.

```diff
 await avatar.start(
     session,
     room=ctx.room,
     livekit_url="wss://...",
-    livekit_api_key="...",
-    livekit_api_secret="...",
 )
```

Nothing signs a token client-side any more, so only `livekit_url` remains — the provider still needs a URL to dial. Passing the removed arguments raises `TypeError` at the call site.

**Dropping them rather than ignoring them is deliberate.** The gateway signs with the *inference* project's key, so a room owned by a different project than `LIVEKIT_INFERENCE_*` points at is no longer supported. That configuration used to work (we minted for the room project; the gateway just forwarded it). Silently ignoring the old arguments would turn it into an unexplained join failure minutes later; a `TypeError` says what happened, where it happened.

## Testing

`uv run pytest tests/test_inference_avatar.py --unit` — 30 passed. `ruff format` / `ruff check` clean; `mypy -p livekit.agents` clean (205 files).

- Replaced `test_start_mints_worker_token_with_expected_grants` with `test_start_sends_mint_inputs_and_no_token`: asserts `livekit_token` is **absent** from the payload and that all four mint inputs (`room_name`, `avatar_identity`, `avatar_name`, `agent_identity`) are present, with a custom participant name flowing through as `avatar_name`.
- Added `test_start_without_livekit_url_raises` — the URL is still required; the room project's key/secret are not.
- Dropped the removed kwargs from the seven `start()` call sites; removed the now-unused `jwt` import.

## Note for the reviewer (out of scope here)

`examples/avatar/inference_agent.py` calls `inference.AvatarSession("lemonslice", image_url=..., prompt=...)`, but those go inside `extra_kwargs` (`LemonSliceOptions`) — the example raises `TypeError` on the constructor. It's pre-existing (example and class landed together in #6492, so it was never run) and unrelated to this change, so I left it alone rather than widening the diff. Worth a separate one-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
