### PR TITLE
fix(amd): start SIP detection timeout after answer

### DIFF
--- a/examples/telephony/amd.py
+++ b/examples/telephony/amd.py
@@ -57,7 +57,6 @@ async def entrypoint(ctx: JobContext):
             )
         )
 
-    # Register before dialing so failed calls also delete the room.
     ctx.add_shutdown_callback(hangup)
 
     phone_number = os.getenv("SIP_PHONE_NUMBER")

--- a/examples/telephony/amd.py
+++ b/examples/telephony/amd.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 
@@ -49,6 +50,16 @@ async def entrypoint(ctx: JobContext):
         room=ctx.room,
     )
 
+    async def hangup():
+        await ctx.api.room.delete_room(
+            api.DeleteRoomRequest(
+                room=ctx.room.name,
+            )
+        )
+
+    # Register before dialing so failed calls also delete the room.
+    ctx.add_shutdown_callback(hangup)
+
     phone_number = os.getenv("SIP_PHONE_NUMBER")
     participant_identity = os.getenv("SIP_PARTICIPANT_IDENTITY")
     outbound_trunk_id = os.getenv("SIP_OUTBOUND_TRUNK_ID")
@@ -69,16 +80,28 @@ async def entrypoint(ctx: JobContext):
         # start running amd before the SIP participant joins to avoid audio loss
         if phone_number and outbound_trunk_id and participant_identity:
             logger.info(f"creating SIP participant for {participant_identity}")
-            await ctx.api.sip.create_sip_participant(
-                api.CreateSIPParticipantRequest(
-                    room_name=ctx.room.name,
-                    sip_trunk_id=outbound_trunk_id,
-                    sip_call_to=phone_number,
-                    participant_identity=participant_identity,
-                    wait_until_answered=True,
+            # The API timeout must outlast the ring window; AMD's timeout starts after answer.
+            try:
+                await ctx.api.sip.create_sip_participant(
+                    api.CreateSIPParticipantRequest(
+                        room_name=ctx.room.name,
+                        sip_trunk_id=outbound_trunk_id,
+                        sip_call_to=phone_number,
+                        participant_identity=participant_identity,
+                        wait_until_answered=True,
+                    ),
+                    timeout=45,
                 )
-            )
-            participant = await ctx.wait_for_participant(identity=participant_identity)
+            except (api.SipCallError, asyncio.TimeoutError) as e:
+                logger.info(f"call was not answered: {e}")
+                ctx.shutdown("call not answered")
+                return
+            # The call may end just before wait_until_answered returns.
+            participant = ctx.room.remote_participants.get(participant_identity)
+            if participant is None:
+                logger.info("SIP participant missing, ending")
+                ctx.shutdown("participant missing")
+                return
             logger.info(
                 "participant joined",
                 extra={
@@ -126,15 +149,6 @@ async def entrypoint(ctx: JobContext):
             logger.info("mailbox unavailable, ending call", extra={"transcript": result.transcript})
 
             ctx.shutdown("mailbox unavailable")
-
-    async def hangup():
-        await ctx.api.room.delete_room(
-            api.DeleteRoomRequest(
-                room=ctx.room.name,
-            )
-        )
-
-    ctx.add_shutdown_callback(hangup)
 
 
 if __name__ == "__main__":

--- a/livekit-agents/livekit/agents/utils/participant.py
+++ b/livekit-agents/livekit/agents/utils/participant.py
@@ -245,6 +245,10 @@ async def wait_for_track_publication(
 
     When `include_local` is True, tracks published by the local participant are also considered;
     local publications resolve on publish and ignore ``wait_for_subscription``.
+
+    When ``identity`` is set, raises :class:`RuntimeError` if that participant
+    disconnects before a matching publication is found, so callers don't wait
+    on a participant that is gone.
     """
     if not room.isconnected():
         raise RuntimeError("room is not connected")
@@ -295,6 +299,14 @@ async def wait_for_track_publication(
         if (identity is None or local.identity == identity) and kind_match(publication.kind):
             fut.set_result(publication)
 
+    def _on_participant_disconnected(p: rtc.RemoteParticipant) -> None:
+        if p.identity == identity and not fut.done():
+            fut.set_exception(
+                RuntimeError(
+                    f"participant {identity!r} disconnected while waiting for track publication"
+                )
+            )
+
     def _on_connection_state_changed(state: int) -> None:
         if state == rtc.ConnectionState.CONN_DISCONNECTED and not fut.done():
             fut.set_exception(RuntimeError("room disconnected while waiting for track publication"))
@@ -305,6 +317,8 @@ async def wait_for_track_publication(
         room.on("track_published", _on_track_published)
     if include_local:
         room.on("local_track_published", _on_local_track_published)
+    if identity is not None:
+        room.on("participant_disconnected", _on_participant_disconnected)
 
     room.on("connection_state_changed", _on_connection_state_changed)
 
@@ -332,4 +346,6 @@ async def wait_for_track_publication(
             room.off("track_published", _on_track_published)
         if include_local:
             room.off("local_track_published", _on_local_track_published)
+        if identity is not None:
+            room.off("participant_disconnected", _on_participant_disconnected)
         room.off("connection_state_changed", _on_connection_state_changed)

--- a/livekit-agents/livekit/agents/voice/amd/classifier.py
+++ b/livekit-agents/livekit/agents/voice/amd/classifier.py
@@ -159,7 +159,7 @@ class _AMDClassifier(EventEmitter[Literal["amd_prediction"]]):
         self._detection_timeout_timer = asyncio.get_running_loop().call_later(
             self._timeout,
             functools.partial(
-                self._on_timeout,
+                self.settle,
                 category=AMDCategory.UNCERTAIN,
                 reason="detection_timeout",
             ),
@@ -178,7 +178,7 @@ class _AMDClassifier(EventEmitter[Literal["amd_prediction"]]):
             self._no_speech_timer = asyncio.get_running_loop().call_later(
                 self._no_speech_threshold,
                 functools.partial(
-                    self._on_timeout,
+                    self.settle,
                     category=AMDCategory.UNCERTAIN,
                     reason="no_speech_timeout",
                 ),
@@ -222,7 +222,7 @@ class _AMDClassifier(EventEmitter[Literal["amd_prediction"]]):
                 self._silence_timer = asyncio.get_running_loop().call_later(
                     max(0, self._human_silence_threshold - silence_duration),
                     functools.partial(
-                        self._on_timeout,
+                        self.settle,
                         category=AMDCategory.HUMAN,
                         reason="short_greeting",
                         speech_duration=speech_duration,
@@ -342,25 +342,16 @@ class _AMDClassifier(EventEmitter[Literal["amd_prediction"]]):
         self._try_emit_result()
 
     @log_exceptions(logger=logger)
-    def _on_timeout(
+    def settle(
         self,
         category: AMDCategory,
         reason: str,
         speech_duration: float | None = None,
     ) -> None:
-        """A timeout (detection budget, no-speech, short greeting) fired.
+        """Commit a fallback verdict and attempt emission.
 
-        Commit a fallback verdict if none exists, then try to emit. This only
-        decides *what* the verdict is; ``_can_emit`` decides *when* it is
-        released. End-of-turn is forced here only when there is nothing left to
-        wait for: no speech was heard, or we are not waiting for the greeting to
-        finish. When ``wait_until_finished`` is set and speech was heard, the
-        fallback is still committed but its release stays gated on end-of-turn
-        (the real signal or the backstop timer), so we don't cut the greeting
-        short with an ``uncertain`` result.
-
-        Not gated by ``_listening_guard``: detection_timeout must still fire
-        when the call never reaches listening (e.g. sip never answered).
+        This can run before listening begins. After speech, ``wait_until_finished``
+        keeps emission gated on end-of-turn so a fallback cannot cut the greeting short.
         """
         if self._closed:
             return

--- a/livekit-agents/livekit/agents/voice/amd/detector.py
+++ b/livekit-agents/livekit/agents/voice/amd/detector.py
@@ -64,6 +64,7 @@ EVALUATED_STT_MODELS: set[str] = {
 
 _SIP_CALL_STATUS_ATTR = "sip.callStatus"
 _SIP_CALL_STATUS_ACTIVE = "active"
+_TRACK_PUBLICATION_TIMEOUT = 5.0
 
 
 class DetectionOptions(TypedDict, total=False):
@@ -404,12 +405,18 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
         else:
             room = session._room_io.room
             try:
-                publication = await wait_for_track_publication(
-                    room=room,
-                    identity=self._participant_identity or None,
-                    kind=rtc.TrackKind.KIND_AUDIO,
-                    wait_for_subscription=True,
+                publication = await asyncio.wait_for(
+                    wait_for_track_publication(
+                        room=room,
+                        identity=self._participant_identity or None,
+                        kind=rtc.TrackKind.KIND_AUDIO,
+                        wait_for_subscription=True,
+                    ),
+                    timeout=_TRACK_PUBLICATION_TIMEOUT,
                 )
+            except asyncio.TimeoutError:
+                self._settle_participant_missing("timed out waiting for participant audio track")
+                return
             except RuntimeError as e:
                 self._settle_participant_missing(str(e))
                 return

--- a/livekit-agents/livekit/agents/voice/amd/detector.py
+++ b/livekit-agents/livekit/agents/voice/amd/detector.py
@@ -101,10 +101,10 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
     - ``machine-unavailable``: the mailbox is full or not set up; leaving a message is not possible.
     - ``uncertain``: the transcript is ambiguous and could not be classified.
 
-    AMD should be started before the SIP participant is created so no audio
-    is missed. The overall detection-timeout budget starts when the
-    participant's audio track is subscribed (so AMD cannot hang if the call
-    never connects).
+    Start AMD before creating the SIP participant so no audio is missed. Its
+    detection timeout begins only after listening starts; SIP settings bound
+    the pre-answer phase. If the call ends before audio arrives, AMD settles
+    immediately with an ``uncertain`` verdict (``reason="participant_missing"``).
 
     For SIP participants, the no-speech timer and
     audio/transcript processing are deferred until ``sip.callStatus ==
@@ -114,8 +114,7 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
     The recommended pattern is the async context manager::
 
         async with AMD(session, llm="openai/gpt-4.1-mini") as detector:
-            await ctx.api.sip.create_sip_participant(...)
-            await ctx.wait_for_participant(identity=participant_identity)
+            await ctx.api.sip.create_sip_participant(...)  # wait_until_answered=True
             result = await detector.execute()
 
     Args:
@@ -132,8 +131,9 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
         ivr_detection: If ``True`` (default), automatically start IVR
             navigation when a ``machine-ivr`` result is returned.
         participant_identity: If set, AMD listens only to this participant's
-            audio track. If omitted, the first remote audio track wins and
-            the publisher is resolved from the track sid.
+            audio track, and settles immediately if that participant
+            disconnects before publishing audio. If omitted, the first remote
+            audio track wins and the publisher is resolved from the track sid.
         stt: STT used for transcript generation. Accepts an :class:`STT`
             instance or an inference model string (e.g.
             ``"cartesia/ink-whisper"``). When omitted, AMD auto-selects:
@@ -400,26 +400,21 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
             logger.warning(
                 "session room_io unavailable, starting amd timers immediately as fallback"
             )
-            if self._classifier:
-                self._classifier.start_detection_timer()
-                self._classifier.start_listening()
+            self._start_listening()
         else:
-            # Start the outer budget before waiting for a publication, so AMD
-            # can settle even if the participant never publishes audio.
-            if self._classifier:
-                self._classifier.start_detection_timer()
             room = session._room_io.room
-            publication = await wait_for_track_publication(
-                room=room,
-                identity=self._participant_identity or None,
-                kind=rtc.TrackKind.KIND_AUDIO,
-                wait_for_subscription=True,
-            )
+            try:
+                publication = await wait_for_track_publication(
+                    room=room,
+                    identity=self._participant_identity or None,
+                    kind=rtc.TrackKind.KIND_AUDIO,
+                    wait_for_subscription=True,
+                )
+            except RuntimeError as e:
+                self._settle_participant_missing(str(e))
+                return
             if self._closed or not self._classifier:
                 return
-            # Reset the budget at track-up so normal AMD timing runs from the
-            # subscribed publication, matching the active audio source.
-            self._classifier.start_detection_timer()
 
             if self._participant_identity:
                 publisher = room.remote_participants.get(self._participant_identity)
@@ -452,8 +447,18 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
     def _start_listening(self) -> None:
         if self._closed or not self._classifier:
             return
+        self._classifier.start_detection_timer()
         self._classifier.start_listening()
-        logger.debug("call has been answered, AMD starts listening")
+        logger.debug("AMD starts listening")
+
+    def _settle_participant_missing(self, error: str) -> None:
+        if self._closed or not self._classifier:
+            return
+        logger.debug(
+            "AMD: call ended before detection could run, settling",
+            extra={"error": error},
+        )
+        self._classifier.settle(AMDCategory.UNCERTAIN, reason="participant_missing")
 
     async def _wait_for_sip_answer(self, room: rtc.Room, identity: str) -> None:
         try:
@@ -464,10 +469,8 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
                 value=_SIP_CALL_STATUS_ACTIVE,
             )
         except RuntimeError as e:
-            # SIP participant disconnected before going active, default to detection timeout
-            logger.debug(
-                "AMD: SIP answer wait failed; starting to listen", extra={"reason": str(e)}
-            )
+            self._settle_participant_missing(str(e))
+            return
 
         if not self._closed:
             self._start_listening()

--- a/livekit-agents/livekit/agents/voice/amd/detector.py
+++ b/livekit-agents/livekit/agents/voice/amd/detector.py
@@ -428,8 +428,7 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
                     None,
                 )
             if publisher is None:
-                # publisher gone start listening so the no-speech timer settles faster
-                self._start_listening()
+                self._settle_participant_missing("participant disappeared after track subscription")
                 return
 
             if publisher.kind == rtc.ParticipantKind.PARTICIPANT_KIND_SIP:

--- a/tests/test_amd_classifier.py
+++ b/tests/test_amd_classifier.py
@@ -818,6 +818,42 @@ class TestAMDClassifier:
         assert classifier.timer_calls == 0
         assert classifier.listening is False
 
+    async def test_setup_settles_when_track_publication_times_out(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        classifier = _RecordingClassifier()
+
+        async def fake_wait_for_track_publication(**_: object) -> SimpleNamespace:
+            await asyncio.Future[None]()
+            raise AssertionError("unreachable")
+
+        monkeypatch.setattr(
+            amd_detector,
+            "wait_for_track_publication",
+            fake_wait_for_track_publication,
+        )
+        monkeypatch.setattr(amd_detector, "_TRACK_PUBLICATION_TIMEOUT", 0.1)
+
+        llm = FakeLLM()
+        session = SimpleNamespace(
+            llm=llm,
+            _activity=None,
+            _room_io=SimpleNamespace(room=SimpleNamespace(remote_participants={})),
+        )
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            suppress_compatibility_warning=True,
+        )
+        detector._stt = NOT_GIVEN
+        detector._classifier = classifier  # type: ignore[assignment]
+
+        await detector._setup(session)  # type: ignore[arg-type]
+
+        assert classifier.settled == [(AMDCategory.UNCERTAIN, "participant_missing")]
+        assert classifier.timer_calls == 0
+        assert classifier.listening is False
+
     async def test_setup_settles_when_participant_disappears_after_track(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_amd_classifier.py
+++ b/tests/test_amd_classifier.py
@@ -818,6 +818,41 @@ class TestAMDClassifier:
         assert classifier.timer_calls == 0
         assert classifier.listening is False
 
+    async def test_setup_settles_when_participant_disappears_after_track(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        classifier = _RecordingClassifier()
+
+        async def fake_wait_for_track_publication(**_: object) -> SimpleNamespace:
+            return SimpleNamespace(sid="track_sid")
+
+        monkeypatch.setattr(
+            amd_detector,
+            "wait_for_track_publication",
+            fake_wait_for_track_publication,
+        )
+
+        llm = FakeLLM()
+        session = SimpleNamespace(
+            llm=llm,
+            _activity=None,
+            _room_io=SimpleNamespace(room=SimpleNamespace(remote_participants={})),
+        )
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            participant_identity="callee",
+            suppress_compatibility_warning=True,
+        )
+        detector._stt = NOT_GIVEN
+        detector._classifier = classifier  # type: ignore[assignment]
+
+        await detector._setup(session)  # type: ignore[arg-type]
+
+        assert classifier.settled == [(AMDCategory.UNCERTAIN, "participant_missing")]
+        assert classifier.timer_calls == 0
+        assert classifier.listening is False
+
     async def test_sip_answer_failure_settles(self, monkeypatch: pytest.MonkeyPatch) -> None:
         classifier = _RecordingClassifier()
 

--- a/tests/test_amd_classifier.py
+++ b/tests/test_amd_classifier.py
@@ -51,6 +51,22 @@ def _make_classifier(
     )
 
 
+class _RecordingClassifier:
+    def __init__(self) -> None:
+        self.timer_calls = 0
+        self.listening = False
+        self.settled: list[tuple[AMDCategory, str]] = []
+
+    def start_detection_timer(self) -> None:
+        self.timer_calls += 1
+
+    def start_listening(self) -> None:
+        self.listening = True
+
+    def settle(self, category: AMDCategory, reason: str) -> None:
+        self.settled.append((category, reason))
+
+
 def _machine_vm_response(transcript: str = "voicemail greeting") -> FakeLLMResponse:
     return FakeLLMResponse(
         input=transcript,
@@ -724,23 +740,15 @@ class TestAMDClassifier:
         assert clf is not None
         assert clf._wait_until_finished is False
 
-    async def test_setup_resets_detection_timer_after_track_subscription(
+    async def test_setup_arms_detection_timer_only_at_listening(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        calls = 0
-
-        class FakeClassifier:
-            listening = False
-
-            def start_detection_timer(self) -> None:
-                nonlocal calls
-                calls += 1
-
-            def start_listening(self) -> None:
-                self.listening = True
+        classifier = _RecordingClassifier()
 
         async def fake_wait_for_track_publication(**_: object) -> SimpleNamespace:
-            assert calls == 1
+            assert classifier.timer_calls == 0, (
+                "no detection timer must be armed while waiting for the track"
+            )
             return SimpleNamespace(sid="track_sid")
 
         monkeypatch.setattr(
@@ -768,8 +776,85 @@ class TestAMDClassifier:
             suppress_compatibility_warning=True,
         )
         detector._stt = NOT_GIVEN
-        detector._classifier = FakeClassifier()  # type: ignore[assignment]
+        detector._classifier = classifier  # type: ignore[assignment]
 
         await detector._setup(session)  # type: ignore[arg-type]
 
-        assert calls == 2
+        assert classifier.timer_calls == 1
+        assert classifier.listening is True
+        assert classifier.settled == []
+
+    async def test_setup_settles_when_participant_disconnects_before_track(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        classifier = _RecordingClassifier()
+
+        async def fake_wait_for_track_publication(**_: object) -> SimpleNamespace:
+            raise RuntimeError("participant 'callee' disconnected while waiting")
+
+        monkeypatch.setattr(
+            amd_detector,
+            "wait_for_track_publication",
+            fake_wait_for_track_publication,
+        )
+
+        llm = FakeLLM()
+        session = SimpleNamespace(
+            llm=llm,
+            _activity=None,
+            _room_io=SimpleNamespace(room=SimpleNamespace(remote_participants={})),
+        )
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            suppress_compatibility_warning=True,
+        )
+        detector._stt = NOT_GIVEN
+        detector._classifier = classifier  # type: ignore[assignment]
+
+        await detector._setup(session)  # type: ignore[arg-type]
+
+        assert classifier.settled == [(AMDCategory.UNCERTAIN, "participant_missing")]
+        assert classifier.timer_calls == 0
+        assert classifier.listening is False
+
+    async def test_sip_answer_failure_settles(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        classifier = _RecordingClassifier()
+
+        async def fake_wait_for_participant_attribute(*_: object, **__: object) -> None:
+            raise RuntimeError("participant 'callee' disconnected while waiting for sip.callStatus")
+
+        monkeypatch.setattr(
+            amd_detector,
+            "wait_for_participant_attribute",
+            fake_wait_for_participant_attribute,
+        )
+
+        llm = FakeLLM()
+        session = SimpleNamespace(llm=llm, _activity=None)
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            suppress_compatibility_warning=True,
+        )
+        detector._classifier = classifier  # type: ignore[assignment]
+
+        await detector._wait_for_sip_answer(SimpleNamespace(), "callee")  # type: ignore[arg-type]
+
+        assert classifier.settled == [(AMDCategory.UNCERTAIN, "participant_missing")]
+        assert classifier.timer_calls == 0
+        assert classifier.listening is False
+
+    async def test_settle_emits_uncertain_before_listening(self) -> None:
+        clf = _make_classifier()
+        results: list[AMDPredictionEvent] = []
+        clf.on("amd_prediction", results.append)
+
+        clf.settle(AMDCategory.UNCERTAIN, reason="participant_missing")
+
+        assert len(results) == 1
+        assert results[0].category == AMDCategory.UNCERTAIN
+        assert results[0].reason == "participant_missing"
+        assert clf._verdict_ready.is_set()
+
+        await clf.close()


### PR DESCRIPTION
Carrier early media can publish audio before answer, exhausting AMD’s detection budget during ringback and misclassifying late answers.

Start the budget only when listening begins, and settle immediately if the participant disappears before audio arrives. This builds on [#6386](<https://github.com/livekit/agents/issues/6386>) by @dexhunter, credited as a commit co-author.

Fixes livekit/agents#6187. Closes livekit/agents#6187.