### PR TITLE
fix(livekit-agents): forward prewarm to the primary LLM in the fallback adapter

### DIFF
--- a/livekit-agents/livekit/agents/llm/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/fallback_adapter.py
@@ -108,6 +108,19 @@ class FallbackAdapter(
             extra_kwargs=extra_kwargs,
         )
 
+    def prewarm(self, *, loop: asyncio.AbstractEventLoop | None = None) -> None:
+        """Pre-warm the primary LLM.
+
+        Only the first instance is prewarmed; the remaining instances are not expected to
+        serve traffic unless the primary fails.
+
+        Args:
+            loop: Event loop to schedule the prewarm request on. Defaults to the
+                running event loop.
+        """
+        if self._llm_instances:
+            self._llm_instances[0].prewarm(loop=loop)
+
     async def aclose(self) -> None:
         for llm_instance in self._llm_instances:
             llm_instance.off("metrics_collected", self._on_metrics_collected)

--- a/tests/test_llm_fallback.py
+++ b/tests/test_llm_fallback.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from livekit.agents.llm import FallbackAdapter
+
+from .fake_llm import FakeLLM
+
+pytestmark = [pytest.mark.unit]
+
+
+class PrewarmableLLM(FakeLLM):
+    """FakeLLM that opts into prewarming by overriding ``_prewarm_impl``."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.prewarmed = asyncio.Event()
+
+    async def _prewarm_impl(self) -> None:
+        self.prewarmed.set()
+
+
+async def test_prewarm_forwarded_to_primary_llm() -> None:
+    primary = PrewarmableLLM()
+    fallback = PrewarmableLLM()
+
+    fallback_adapter = FallbackAdapter([primary, fallback])
+    try:
+        fallback_adapter.prewarm()
+
+        await asyncio.wait_for(primary.prewarmed.wait(), timeout=5)
+        assert not fallback.prewarmed.is_set(), (
+            "expected only the primary LLM to be prewarmed, the fallbacks should stay cold"
+        )
+    finally:
+        await fallback_adapter.aclose()
+        await primary.aclose()
+        await fallback.aclose()
+
+
+async def test_prewarm_forwards_event_loop() -> None:
+    primary = PrewarmableLLM()
+
+    fallback_adapter = FallbackAdapter([primary])
+    try:
+        loop = asyncio.get_running_loop()
+        fallback_adapter.prewarm(loop=loop)
+
+        assert primary._prewarm_task is not None, "expected the primary LLM to be prewarmed"
+        assert primary._prewarm_task.get_loop() is loop, (
+            "expected the prewarm task to be scheduled on the provided event loop"
+        )
+        await asyncio.wait_for(primary.prewarmed.wait(), timeout=5)
+    finally:
+        await fallback_adapter.aclose()
+        await primary.aclose()

--- a/tests/test_llm_fallback.py
+++ b/tests/test_llm_fallback.py
@@ -22,6 +22,17 @@ class PrewarmableLLM(FakeLLM):
         self.prewarmed.set()
 
 
+class RecordingLLM(FakeLLM):
+    """FakeLLM that records the event loop it was asked to prewarm on."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.prewarm_loop: asyncio.AbstractEventLoop | None = None
+
+    def prewarm(self, *, loop: asyncio.AbstractEventLoop | None = None) -> None:
+        self.prewarm_loop = loop
+
+
 async def test_prewarm_forwarded_to_primary_llm() -> None:
     primary = PrewarmableLLM()
     fallback = PrewarmableLLM()
@@ -41,18 +52,18 @@ async def test_prewarm_forwarded_to_primary_llm() -> None:
 
 
 async def test_prewarm_forwards_event_loop() -> None:
-    primary = PrewarmableLLM()
+    primary = RecordingLLM()
 
     fallback_adapter = FallbackAdapter([primary])
+    # a loop distinct from the running one, so the assertion fails if `loop` is dropped
+    # and the wrapped LLM falls back to the running loop
+    supplied_loop = asyncio.new_event_loop()
     try:
-        loop = asyncio.get_running_loop()
-        fallback_adapter.prewarm(loop=loop)
+        fallback_adapter.prewarm(loop=supplied_loop)
 
-        assert primary._prewarm_task is not None, "expected the primary LLM to be prewarmed"
-        assert primary._prewarm_task.get_loop() is loop, (
-            "expected the prewarm task to be scheduled on the provided event loop"
+        assert primary.prewarm_loop is supplied_loop, (
+            "expected the provided event loop to be forwarded to the primary LLM"
         )
-        await asyncio.wait_for(primary.prewarmed.wait(), timeout=5)
     finally:
+        supplied_loop.close()
         await fallback_adapter.aclose()
-        await primary.aclose()


### PR DESCRIPTION
Fixes livekit/agents#6572.

### Problem

`LLM.prewarm()` short-circuits unless the concrete class overrides `_prewarm_impl` (`livekit-agents/livekit/agents/llm/llm.py:162-163`). `llm.FallbackAdapter` doesn't override it, so every `prewarm()` call it receives — from `AgentSession.__init__` (`voice/agent_session.py:490`) and from `AgentActivity` (`voice/agent_activity.py:636,721`) — returns immediately without ever reaching the wrapped instances. Providers that do implement prewarming are therefore never warmed when used behind the adapter, so the first reply pays the full DNS + TLS setup cost.

`tts.FallbackAdapter` already handles this correctly (`tts/fallback_adapter.py:126-128`); the LLM adapter is the gap.

`stt.FallbackAdapter` has the same gap — happy to cover it in this PR or a follow-up, whichever you prefer.

### Fix

Override `prewarm()` to delegate to the first instance, mirroring the TTS adapter. Only the primary is prewarmed: the remaining instances are not expected to serve traffic unless it fails, and warming them would open connections to providers that may never be used.

The `loop` argument is forwarded, which is the one place this differs from the TTS version — `LLM.prewarm()` accepts `loop` (the TTS and STT variants don't) and `AgentSession` passes the session loop explicitly, so dropping it would schedule the prewarm task on the wrong loop.

### Tests

New `tests/test_llm_fallback.py`:

* `test_prewarm_forwarded_to_primary_llm` — the primary's `_prewarm_impl` runs and the fallback instance stays cold.
* `test_prewarm_forwards_event_loop` — the prewarm task is scheduled on the loop supplied by the caller.

Both fail on `main` and pass with this change. `ruff check`, `ruff format --check` and `mypy --strict` are clean on the touched files, and `test_llm_fallback.py`, `test_tts_fallback.py` and `test_stt_fallback.py` pass together (15 passed).