### PR TITLE
fix(livekit-agents): propagate prewarm through the STT fallback and stream adapters

### DIFF
--- a/livekit-agents/livekit/agents/stt/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/stt/fallback_adapter.py
@@ -280,6 +280,15 @@ class FallbackAdapter(
     ) -> RecognizeStream:
         return FallbackRecognizeStream(stt=self, language=language, conn_options=conn_options)
 
+    def prewarm(self) -> None:
+        """Pre-warm the primary STT.
+
+        Only the first instance is prewarmed; the remaining instances are not expected to
+        serve traffic unless the primary fails.
+        """
+        if self._stt_instances:
+            self._stt_instances[0].prewarm()
+
     async def aclose(self) -> None:
         for stt_status in self._status:
             if stt_status.recovering_recognize_task is not None:

--- a/livekit-agents/livekit/agents/stt/stream_adapter.py
+++ b/livekit-agents/livekit/agents/stt/stream_adapter.py
@@ -78,6 +78,9 @@ class StreamAdapter(STT):
             conn_options=conn_options,
         )
 
+    def prewarm(self) -> None:
+        self._stt.prewarm()
+
     def _on_metrics_collected(self, *args: Any, **kwargs: Any) -> None:
         self.emit("metrics_collected", *args, **kwargs)
 

--- a/tests/test_stt_prewarm.py
+++ b/tests/test_stt_prewarm.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents.stt import FallbackAdapter, StreamAdapter, STTCapabilities
+
+from .fake_stt import FakeSTT
+from .fake_vad import FakeVAD
+
+pytestmark = [pytest.mark.unit]
+
+
+class PrewarmableSTT(FakeSTT):
+    """FakeSTT that records prewarm calls, optionally without streaming support."""
+
+    def __init__(self, *, streaming: bool = True) -> None:
+        super().__init__()
+        self._capabilities = STTCapabilities(streaming=streaming, interim_results=False)
+        self.prewarm_count = 0
+
+    def prewarm(self) -> None:
+        self.prewarm_count += 1
+
+
+async def test_fallback_adapter_prewarms_primary_stt() -> None:
+    primary = PrewarmableSTT()
+    fallback = PrewarmableSTT()
+
+    fallback_adapter = FallbackAdapter([primary, fallback])
+    try:
+        fallback_adapter.prewarm()
+
+        assert primary.prewarm_count == 1, "expected the primary STT to be prewarmed"
+        assert fallback.prewarm_count == 0, (
+            "expected only the primary STT to be prewarmed, the fallbacks should stay cold"
+        )
+    finally:
+        await fallback_adapter.aclose()
+
+
+async def test_stream_adapter_forwards_prewarm() -> None:
+    wrapped = PrewarmableSTT(streaming=False)
+
+    stream_adapter = StreamAdapter(stt=wrapped, vad=FakeVAD())
+    try:
+        stream_adapter.prewarm()
+
+        assert wrapped.prewarm_count == 1, (
+            "expected StreamAdapter to forward prewarm to the wrapped STT"
+        )
+    finally:
+        await stream_adapter.aclose()
+
+
+async def test_prewarm_reaches_non_streaming_primary() -> None:
+    # a non-streaming STT is transparently wrapped in a StreamAdapter by the fallback
+    # adapter, so prewarm has to survive both hops to reach the provider
+    primary = PrewarmableSTT(streaming=False)
+    fallback = PrewarmableSTT()
+
+    fallback_adapter = FallbackAdapter([primary, fallback], vad=FakeVAD())
+    try:
+        fallback_adapter.prewarm()
+
+        assert primary.prewarm_count == 1, (
+            "expected prewarm to reach the primary STT through the wrapping StreamAdapter"
+        )
+        assert fallback.prewarm_count == 0
+    finally:
+        await fallback_adapter.aclose()


### PR DESCRIPTION
Follow-up to #6582, where I flagged the same gap on the STT side and offered to cover it separately.

### Problem

Both `stt.FallbackAdapter` and `stt.StreamAdapter` inherit the no-op `STT.prewarm()` and neither forwards it, so the prewarm issued by `AgentActivity` (`voice/agent_activity.py:608,724`) never reaches the wrapped instances. Providers that implement prewarming — currently the mistralai realtime STT, which warms its connection pool — are therefore never warmed behind either adapter.

The TTS equivalents already forward it (`tts/fallback_adapter.py:126-128`, `tts/stream_adapter.py:68-69`), so this brings the STT path in line.

### Why both hops

They interact rather than being two independent nits. `FallbackAdapter` transparently wraps non-streaming STTs in a `StreamAdapter` (`stt/fallback_adapter.py:74-76`), so on that path prewarm has to survive the adapter *and* the wrapper to reach the provider — fixing only `FallbackAdapter` leaves it swallowed one level down. `test_prewarm_reaches_non_streaming_primary` covers exactly that chain and still fails with only the `FallbackAdapter` half applied.

As in #6582, only the primary instance is prewarmed: the remaining instances are not expected to serve traffic unless it fails.

### Tests

New `tests/test_stt_prewarm.py`:

- `test_fallback_adapter_prewarms_primary_stt` — primary warmed, fallbacks stay cold.
- `test_stream_adapter_forwards_prewarm` — `StreamAdapter` forwards to the wrapped STT.
- `test_prewarm_reaches_non_streaming_primary` — prewarm survives both hops when the primary is non-streaming and gets auto-wrapped.

All three fail on `main`. With only the `FallbackAdapter` fix, the third still fails, which is what motivates touching `StreamAdapter` too. `ruff check`, `ruff format --check` and `mypy --strict` are clean on the touched files, and `test_stt_prewarm.py`, `test_stt_fallback.py`, `test_stt_base.py` and `test_tts_fallback.py` pass together (20 passed).
