### PR TITLE
fix(soniox): report RECOGNITION_USAGE on every frame

### DIFF
--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
@@ -534,9 +534,6 @@ class SpeechStream(stt.SpeechStream):
                         if token["is_final"]:
                             if is_end_token(token):
                                 send_endpoint_transcript()
-                                self._report_processed_audio_duration(
-                                    total_audio_proc_ms,
-                                )
                             else:
                                 final.update(token)
                         else:
@@ -602,7 +599,10 @@ class SpeechStream(stt.SpeechStream):
                     # 3) on error or finish, flush any remaining final tokens.
                     if content.get("finished") or has_error:
                         send_endpoint_transcript()
-                        self._report_processed_audio_duration(total_audio_proc_ms)
+
+                    # 4) report processed audio for every frame; gating on
+                    #    endpoint/finish frames dropped whatever never reached one.
+                    self._report_processed_audio_duration(total_audio_proc_ms)
 
                     if has_error:
                         err_code = content.get("error_code")

--- a/tests/test_plugin_soniox_stt.py
+++ b/tests/test_plugin_soniox_stt.py
@@ -568,3 +568,91 @@ async def test_final_transcript_no_translation_code_switched_populates_source_ru
     assert sd.target_texts is None
     assert sd.source_texts is not None
     assert "".join(sd.source_texts) == sd.text
+
+
+# --- RECOGNITION_USAGE reporting cadence -----------------------------------
+
+
+async def test_recognition_usage_reported_for_silent_frames():
+    """Frames that carry no tokens still report the audio Soniox processed.
+
+    The regression case: a silent speaker produces no endpoint token, and a
+    cancelled stream never reads the `finished` frame, so gating on those two
+    reported nothing at all.
+    """
+    stream = _make_stream(translation=None)
+
+    events = await _drive_recv(
+        stream,
+        [{"tokens": [], "total_audio_proc_ms": 3000}],
+        expect_events=1,
+    )
+
+    assert [e.type for e in events] == [SpeechEventType.RECOGNITION_USAGE]
+    assert events[0].recognition_usage is not None
+    assert events[0].recognition_usage.audio_duration == pytest.approx(3.0)
+
+
+async def test_recognition_usage_reported_without_endpoint_token():
+    """Interim-only frames report usage too, ordered after the transcript events."""
+    stream = _make_stream(translation=None)
+
+    events = await _drive_recv(
+        stream,
+        [{"tokens": [_nonfinal_token("hola", "es")], "total_audio_proc_ms": 2500}],
+        expect_events=3,
+    )
+
+    assert [e.type for e in events] == [
+        SpeechEventType.START_OF_SPEECH,
+        SpeechEventType.INTERIM_TRANSCRIPT,
+        SpeechEventType.RECOGNITION_USAGE,
+    ]
+    assert events[-1].recognition_usage is not None
+    assert events[-1].recognition_usage.audio_duration == pytest.approx(2.5)
+
+
+async def test_recognition_usage_reports_delta_and_skips_unchanged_totals():
+    """Usage is the delta against what was already reported, so the running
+    total stays monotonic and an unchanged total emits nothing."""
+    stream = _make_stream(translation=None)
+
+    events = await _drive_recv(
+        stream,
+        [
+            {"tokens": [], "total_audio_proc_ms": 3000},
+            # Same total: already accounted for, so no event.
+            {"tokens": [], "total_audio_proc_ms": 3000},
+            {"tokens": [], "total_audio_proc_ms": 5000},
+        ],
+        expect_events=2,
+    )
+
+    assert [e.type for e in events] == [SpeechEventType.RECOGNITION_USAGE] * 2
+    durations = [e.recognition_usage.audio_duration for e in events if e.recognition_usage]
+    assert durations == pytest.approx([3.0, 2.0])
+    assert sum(durations) == pytest.approx(5.0)
+
+
+async def test_recognition_usage_still_reported_on_endpoint_frame():
+    """The endpoint path keeps reporting usage, after the transcript events."""
+    stream = _make_stream(translation=None)
+
+    events = await _drive_recv(
+        stream,
+        [
+            {
+                "tokens": [_final_token("Hello world.", "en"), END_TOKEN_FINAL],
+                "total_audio_proc_ms": 1500,
+            }
+        ],
+        expect_events=3,
+    )
+
+    assert [e.type for e in events] == [
+        SpeechEventType.FINAL_TRANSCRIPT,
+        SpeechEventType.END_OF_SPEECH,
+        SpeechEventType.RECOGNITION_USAGE,
+    ]
+    assert events[-1].recognition_usage is not None
+    assert events[-1].recognition_usage.audio_duration == pytest.approx(1.5)


### PR DESCRIPTION
Partly fixes #6584 

### What

`livekit-plugins-soniox` reported `RECOGNITION_USAGE` only when an `<end>` endpoint token arrived, or on a `finished`/error frame. Soniox documents `total_audio_proc_ms` as *"audio processed into final + non-final tokens"* — so it advances on interim frames too, and `_recv_messages_task` already reads it into a local on every frame. Any progress not coinciding with one of those two triggers was discarded.

This moves the call to once per frame.

### Why it matters

1. Every stream loses its tail — whatever advanced after the last `<end>` token is never reported.
2. The `finished` backstop is skipped when the stream is cancelled — the normal teardown path when a telephony participant disconnects — so in production it rarely fires.
3. A stream that never reaches an endpoint reports **nothing at all** — not a zero-duration `STTModelUsage`, an absent one.

This is a partial regression against #4034, which asked for *periodic* reporting. #4332 correctly switched to Soniox's provider-side `total_audio_proc_ms` instead of client-side frame counting, but tied the cadence to endpoint detection.

### Scope

This fixes the reporting *cadence*. It does not change what `total_audio_proc_ms` measures, and both of Soniox's counters are defined in terms of tokens — so if the server emits no frames during pure silence, a stream producing no tokens may still report nothing. The docs don't specify the non-speech cadence; I've raised that as an open question in #6584 rather than guess at it here, since closing it may need a client-side estimate and that's a separate design call.

### Why this is safe

`_report_processed_audio_duration` already does the work that makes per-frame calls correct:

```python
to_report_ms = total_audio_proc_ms - self._reported_duration_ms
if to_report_ms <= 0:
    return
```

- **Idempotent and monotonic** — reports the delta, so repeated frames with an unchanged total emit nothing.
- **No new state**, and `_reported_duration_ms` is still reset per connection in `_connect_ws`, so reconnects stay correct.
- **Degrades safely** on frames that omit the field: `.get(..., 0)` → negative delta → no-op.
- **Ordering preserved** — placed after the frame's transcript events (so the existing transcript-then-usage order on endpoint frames is unchanged) and before an error frame raises, so error frames still report before propagating.

Net diff is one *fewer* call site.

### Proof

Four tests added to the existing fake-WebSocket harness in `tests/test_plugin_soniox_stt.py`:

| Test | On `main` |
|---|---|
| `test_recognition_usage_reported_without_endpoint_token` | **fails** (times out — no usage event) |
| `test_recognition_usage_reported_for_silent_frames` | **fails** (times out) |
| `test_recognition_usage_reports_delta_and_skips_unchanged_totals` | **fails** (times out) |
| `test_recognition_usage_still_reported_on_endpoint_frame` | passes — regression guard for the existing endpoint path |
