### PR TITLE
fix(fallback): prewarm all instances in LLM/STT/TTS FallbackAdapters; fix soniox RECOGNITION_USAGE under-reporting

### DIFF
--- a/livekit-agents/livekit/agents/llm/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/fallback_adapter.py
@@ -88,6 +88,16 @@ class FallbackAdapter(
     def provider(self) -> str:
         return "livekit"
 
+    def prewarm(self, *, loop: asyncio.AbstractEventLoop | None = None) -> None:
+        """Pre-warm connections for all contained LLM instances.
+
+        Every LLM in the fallback chain is warmed so that a fallback provider has
+        an already-established connection (DNS resolved, TLS handshaked) and does
+        not add latency precisely when the primary has just failed.
+        """
+        for llm_instance in self._llm_instances:
+            llm_instance.prewarm(loop=loop)
+
     def chat(
         self,
         *,

--- a/livekit-agents/livekit/agents/stt/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/stt/fallback_adapter.py
@@ -118,6 +118,16 @@ class FallbackAdapter(
     def provider(self) -> str:
         return "livekit"
 
+    def prewarm(self) -> None:
+        """Pre-warm connections for all contained STT instances.
+
+        Every STT in the fallback chain is warmed so that a fallback provider has
+        an already-established connection (DNS resolved, TLS handshaked) and does
+        not add latency precisely when the primary has just failed.
+        """
+        for stt_instance in self._stt_instances:
+            stt_instance.prewarm()
+
     def _update_session_keyterms(self, keyterms: list[str]) -> None:
         # forward to every underlying STT; unsupported ones warn-and-skip internally
         for stt_instance in self._stt_instances:

--- a/livekit-agents/livekit/agents/tts/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/tts/fallback_adapter.py
@@ -124,8 +124,14 @@ class FallbackAdapter(
         return FallbackSynthesizeStream(tts=self, conn_options=conn_options)
 
     def prewarm(self) -> None:
-        if self._tts_instances:
-            self._tts_instances[0].prewarm()
+        """Pre-warm connections for all contained TTS instances.
+
+        Every TTS in the fallback chain is warmed so that a fallback provider has
+        an already-established connection (DNS resolved, TLS handshaked) and does
+        not add latency precisely when the primary has just failed.
+        """
+        for tts_instance in self._tts_instances:
+            tts_instance.prewarm()
 
     def _on_metrics_collected(self, *args: Any, **kwargs: Any) -> None:
         self.emit("metrics_collected", *args, **kwargs)

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
@@ -534,9 +534,6 @@ class SpeechStream(stt.SpeechStream):
                         if token["is_final"]:
                             if is_end_token(token):
                                 send_endpoint_transcript()
-                                self._report_processed_audio_duration(
-                                    total_audio_proc_ms,
-                                )
                             else:
                                 final.update(token)
                         else:
@@ -602,7 +599,13 @@ class SpeechStream(stt.SpeechStream):
                     # 3) on error or finish, flush any remaining final tokens.
                     if content.get("finished") or has_error:
                         send_endpoint_transcript()
-                        self._report_processed_audio_duration(total_audio_proc_ms)
+
+                    # Report processed audio duration on every message. The helper tracks
+                    # `_reported_duration_ms` and only emits a RECOGNITION_USAGE event for
+                    # the delta since the last report, so calling this unconditionally is
+                    # safe and ensures usage is never under-reported when the stream ends
+                    # without a clean endpoint token (e.g. disconnection or error).
+                    self._report_processed_audio_duration(total_audio_proc_ms)
 
                     if has_error:
                         err_code = content.get("error_code")


### PR DESCRIPTION
## Summary

This PR fixes two independent bugs found in the fallback adapters and Soniox plugin.

---

### Bug 1 — `RECOGNITION_USAGE` under-reporting in `livekit-plugins-soniox` (fixes #6584)

**Root cause:** `_report_processed_audio_duration()` was only called on endpoint
tokens (`<end>` / `<fin>`) and on `finished`/`has_error` messages. Every
interim-only message silently advanced `total_audio_proc_ms` without emitting
a `RECOGNITION_USAGE` event, causing heavy under-reporting of STT usage.

**Fix:** Call `_report_processed_audio_duration(total_audio_proc_ms)` unconditionally
at the end of every message. The helper's `_reported_duration_ms` delta tracking
already prevents double-counting.

---

### Bug 2 — `FallbackAdapter.prewarm()` does not warm fallback providers

All three fallback adapters had the same bug: when a primary provider fails,
the fallback's connection is **cold** (no DNS, no TLS), adding latency exactly
when it matters most.

| Adapter | Before | After |
|---------|--------|-------|
| `tts.FallbackAdapter` | Only prewarmed `_tts_instances[0]` | Prewarms all instances |
| `stt.FallbackAdapter` | No `prewarm()` at all | Prewarms all instances |
| `llm.FallbackAdapter` | No `prewarm()` at all | Prewarms all instances |

---

## Files Changed
- `livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py`
- `livekit-agents/livekit/agents/tts/fallback_adapter.py`
- `livekit-agents/livekit/agents/stt/fallback_adapter.py`
- `livekit-agents/livekit/agents/llm/fallback_adapter.py`

## Checklist
- [x] `ruff check` — All checks passed
- [x] `ruff format --check` — All files already formatted
