### PR TITLE
(expressive mode): remove unconditional bracket stripping

### DIFF
--- a/livekit-agents/livekit/agents/inference/tts.py
+++ b/livekit-agents/livekit/agents/inference/tts.py
@@ -21,6 +21,7 @@ from .._exceptions import (
 )
 from ..language import LanguageCode
 from ..log import logger
+from ..tts._provider_format import drop_bracket_cues, minted_bracket_cues
 from ..types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, APIConnectOptions, NotGivenOr
 from ..utils import is_given
 from ._utils import create_access_token, get_default_inference_url, get_inference_headers
@@ -520,8 +521,8 @@ class TTS(tts.TTS):
                 return ""  # older inworld models don't support markup
             return provider
 
-        # llm_instructions / to_text / normalize / convert are inherited from the
-        # base Markup, keyed on _provider_key() above.
+        # llm_instructions / normalize / convert are inherited from the base Markup,
+        # keyed on _provider_key() above.
 
     @classmethod
     def from_model_string(cls, model: str) -> TTS:
@@ -681,6 +682,10 @@ class SynthesizeStream(tts.SynthesizeStream):
         # lazily in _run would race with the next turn/session mutating the shared
         # TTS instance.
         self._expressive = tts._expressive
+        # markup conversion mints native bracket cues for some providers; with aligned
+        # transcripts the provider hands that converted text back as the transcript, so
+        # the cues have to come back out again (see drop_bracket_cues)
+        self._minted_cues: list[str] = []
 
     async def _run(self, output_emitter: tts.AudioEmitter) -> None:
         request_id = utils.shortuuid()
@@ -715,7 +720,12 @@ class SynthesizeStream(tts.SynthesizeStream):
                 token_pkt = base_pkt.copy()
                 # re-normalize at sentence level: tags split across input chunks
                 # aren't caught by the per-chunk normalize in _input_task
-                converted = self._tts.markup.convert(self._tts.markup.normalize(ev.token))
+                normalized = self._tts.markup.normalize(ev.token)
+                converted = self._tts.markup.convert(normalized)
+                if self._expressive:
+                    # record what conversion minted, so the aligned transcript can drop
+                    # exactly those spans and leave the LLM's own brackets alone
+                    self._minted_cues.extend(minted_bracket_cues(normalized, converted))
                 token_pkt["transcript"] = converted + " "
                 generation_config: dict[str, Any] = {}
                 if self._opts.voice:
@@ -772,24 +782,23 @@ class SynthesizeStream(tts.SynthesizeStream):
                 elif data.get("type") == "output_alignment":
                     from ..voice.io import TimedString
 
+                    aligned: list[TimedString] = []
                     if words := data.get("words"):
-                        for word_info in words:
-                            output_emitter.push_timed_transcript(
-                                TimedString(
-                                    word_info["word"],
-                                    start_time=word_info["start"],
-                                    end_time=word_info["end"],
-                                )
-                            )
+                        aligned = [
+                            TimedString(w["word"], start_time=w["start"], end_time=w["end"])
+                            for w in words
+                        ]
                     elif chars := data.get("chars"):
-                        for char_info in chars:
-                            output_emitter.push_timed_transcript(
-                                TimedString(
-                                    char_info["char"],
-                                    start_time=char_info["start"],
-                                    end_time=char_info["end"],
-                                )
-                            )
+                        aligned = [
+                            TimedString(c["char"], start_time=c["start"], end_time=c["end"])
+                            for c in chars
+                        ]
+                    if aligned:
+                        # the provider aligned the *converted* text: drop the cues that
+                        # conversion minted before they become transcript text
+                        output_emitter.push_timed_transcript(
+                            drop_bracket_cues(aligned, self._minted_cues)
+                        )
                 elif data.get("type") == "done":
                     output_emitter.end_input()
                     break

--- a/livekit-agents/livekit/agents/inference/tts.py
+++ b/livekit-agents/livekit/agents/inference/tts.py
@@ -22,7 +22,13 @@ from .._exceptions import (
 from ..language import LanguageCode
 from ..log import logger
 from ..tts._provider_format import drop_bracket_cues
-from ..types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, APIConnectOptions, NotGivenOr
+from ..types import (
+    DEFAULT_API_CONNECT_OPTIONS,
+    NOT_GIVEN,
+    APIConnectOptions,
+    NotGivenOr,
+    TimedString,
+)
 from ..utils import is_given
 from ._utils import create_access_token, get_default_inference_url, get_inference_headers
 
@@ -682,6 +688,9 @@ class SynthesizeStream(tts.SynthesizeStream):
         # lazily in _run would race with the next turn/session mutating the shared
         # TTS instance.
         self._expressive = tts._expressive
+        # alignment arrives finer-grained than a cue, so drop_bracket_cues parks the tail
+        # of an unclosed span here between messages
+        self._held_tokens: list[TimedString] = []
 
     async def _run(self, output_emitter: tts.AudioEmitter) -> None:
         request_id = utils.shortuuid()
@@ -771,8 +780,6 @@ class SynthesizeStream(tts.SynthesizeStream):
                     b64data = base64.b64decode(data["audio"])
                     output_emitter.push(b64data)
                 elif data.get("type") == "output_alignment":
-                    from ..voice.io import TimedString
-
                     aligned: list[TimedString] = []
                     if words := data.get("words"):
                         aligned = [
@@ -788,9 +795,15 @@ class SynthesizeStream(tts.SynthesizeStream):
                         # the provider aligned the *converted* text, so under expressive it
                         # carries native cues that were never spoken
                         output_emitter.push_timed_transcript(
-                            drop_bracket_cues(aligned) if self._expressive else aligned
+                            drop_bracket_cues(aligned, self._held_tokens)
+                            if self._expressive
+                            else aligned
                         )
                 elif data.get("type") == "done":
+                    if self._held_tokens:  # release an unclosed span, cue unresolved
+                        output_emitter.push_timed_transcript(
+                            drop_bracket_cues([], self._held_tokens, final=True)
+                        )
                     output_emitter.end_input()
                     break
                 elif data.get("type") == "error":

--- a/livekit-agents/livekit/agents/inference/tts.py
+++ b/livekit-agents/livekit/agents/inference/tts.py
@@ -21,7 +21,7 @@ from .._exceptions import (
 )
 from ..language import LanguageCode
 from ..log import logger
-from ..tts._provider_format import drop_bracket_cues, minted_bracket_cues
+from ..tts._provider_format import drop_bracket_cues
 from ..types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, APIConnectOptions, NotGivenOr
 from ..utils import is_given
 from ._utils import create_access_token, get_default_inference_url, get_inference_headers
@@ -682,10 +682,6 @@ class SynthesizeStream(tts.SynthesizeStream):
         # lazily in _run would race with the next turn/session mutating the shared
         # TTS instance.
         self._expressive = tts._expressive
-        # markup conversion mints native bracket cues for some providers; with aligned
-        # transcripts the provider hands that converted text back as the transcript, so
-        # the cues have to come back out again (see drop_bracket_cues)
-        self._minted_cues: list[str] = []
 
     async def _run(self, output_emitter: tts.AudioEmitter) -> None:
         request_id = utils.shortuuid()
@@ -720,12 +716,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                 token_pkt = base_pkt.copy()
                 # re-normalize at sentence level: tags split across input chunks
                 # aren't caught by the per-chunk normalize in _input_task
-                normalized = self._tts.markup.normalize(ev.token)
-                converted = self._tts.markup.convert(normalized)
-                if self._expressive:
-                    # record what conversion minted, so the aligned transcript can drop
-                    # exactly those spans and leave the LLM's own brackets alone
-                    self._minted_cues.extend(minted_bracket_cues(normalized, converted))
+                converted = self._tts.markup.convert(self._tts.markup.normalize(ev.token))
                 token_pkt["transcript"] = converted + " "
                 generation_config: dict[str, Any] = {}
                 if self._opts.voice:
@@ -794,10 +785,10 @@ class SynthesizeStream(tts.SynthesizeStream):
                             for c in chars
                         ]
                     if aligned:
-                        # the provider aligned the *converted* text: drop the cues that
-                        # conversion minted before they become transcript text
+                        # the provider aligned the *converted* text, so under expressive it
+                        # carries native cues that were never spoken
                         output_emitter.push_timed_transcript(
-                            drop_bracket_cues(aligned, self._minted_cues)
+                            drop_bracket_cues(aligned) if self._expressive else aligned
                         )
                 elif data.get("type") == "done":
                     output_emitter.end_input()

--- a/livekit-agents/livekit/agents/tts/_provider_format.py
+++ b/livekit-agents/livekit/agents/tts/_provider_format.py
@@ -27,10 +27,9 @@ from .markup_utils import convert_expression_tags, extract_and_strip
 class ExpressiveTag(TypedDict):
     """An expressive markup tag stripped from a transcript, surfaced for the frontend.
 
-    ``type`` is the markup tag name (``"emotion"``, ``"expression"``, ``"sound"``, ...),
-    or ``""`` for square-bracket tags which carry no name. ``value`` is the spoken or
-    semantic payload (the ``value="..."`` attribute, the tag's inner text, or the bracket
-    content).
+    ``type`` is the markup tag name (``"emotion"``, ``"expression"``, ``"sound"``, ...) or
+    the expr marker type. ``value`` is the spoken or semantic payload (the ``value="..."``
+    attribute, the expr ``label``, or the tag's inner text).
     """
 
     type: str
@@ -761,63 +760,41 @@ def llm_instructions(provider: str) -> str | None:
     return _EXPR_LLM_INSTRUCTIONS.get(provider)
 
 
-# Per-provider markup spec: (xml tag names, whether square-bracket tags are used).
-_PROVIDER_MARKUP: dict[str, tuple[list[str], bool]] = {
-    "cartesia": (_CARTESIA_TAGS, False),
-    "inworld": (_INWORLD_TAGS, True),
-    # every tag the LLM is taught is XML (expr markers; native sounds/pauses become
-    # [..] only for the TTS in convert_markup), so the transcript has no brackets to strip
-    "xai": (_XAI_TAGS, False),
+# Per-provider native XML tag names. Membership also marks a provider as markup-capable
+# (see :func:`normalize_markup` / :func:`convert_markup`); the LLM only ever writes expr
+# markers, so these names exist to lower expr onto and to catch hallucinated natives.
+_PROVIDER_MARKUP: dict[str, list[str]] = {
+    "cartesia": _CARTESIA_TAGS,
+    "inworld": _INWORLD_TAGS,
+    "xai": _XAI_TAGS,
 }
-
-
-def split_markup(provider: str, text: str) -> tuple[str, list[ExpressiveTag]]:
-    """Strip provider markup and collect the stripped tags in a single pass.
-
-    Returns ``(clean_text, tags)`` — the user-visible transcript plus the expressive
-    tags that were removed (in document order), the single source of truth for both
-    :func:`strip_markup` and :func:`extract_markup`. ``([], text)`` for providers
-    without markup support.
-    """
-    spec = _PROVIDER_MARKUP.get(provider)
-    if spec is None:
-        return text, []
-    text, expr_tags = _split_expr(text)
-    xml_tags, brackets = spec
-    clean, raw_tags = extract_and_strip(text, xml_tags=xml_tags, brackets=brackets)
-    return clean, expr_tags + [{"type": tag, "value": value} for tag, value in raw_tags]
-
-
-def strip_markup(provider: str, text: str) -> str:
-    """Strip provider-specific markup tags from text, preserving content."""
-    return split_markup(provider, text)[0]
-
-
-def extract_markup(provider: str, text: str) -> list[ExpressiveTag]:
-    """Extract the markup tags that :func:`strip_markup` would remove, in order.
-
-    Lets the framework surface stripped expressive tags (e.g. as ``lk.transcription``
-    attributes for the frontend) instead of discarding them. Returns ``[]`` for
-    providers without markup support.
-    """
-    return split_markup(provider, text)[1]
-
 
 # Union of every provider's XML tag names — used by the transcript sinks to strip markup
 # without knowing which provider produced it (see :class:`TranscriptMarkupStripper`).
-_ALL_MARKUP_TAGS: list[str] = sorted({tag for tags, _ in _PROVIDER_MARKUP.values() for tag in tags})
+_ALL_MARKUP_TAGS: list[str] = sorted({tag for tags in _PROVIDER_MARKUP.values() for tag in tags})
 
 
 def split_all_markup(text: str) -> tuple[str, list[ExpressiveTag]]:
-    """Strip the union of every provider's expressive markup (provider-agnostic).
+    """Strip the union of every provider's expressive XML markup (provider-agnostic).
 
     The transcript sinks strip downstream, where the originating TTS/provider is no
-    longer in scope, so they remove every provider's tags (XML + square brackets) at
-    once. These tag shapes never appear in real spoken text — the LLM only emits them
-    as audio directives — so a universal strip is safe.
+    longer in scope, so they remove every provider's XML tags at once: expr markers
+    (all the LLM is ever taught) plus every native tag name, so a hallucinated native
+    tag is stripped rather than leaked.
+
+    Square-bracket spans are deliberately *not* stripped. A provider's native brackets
+    (Inworld ``[laughs]``, xAI ``[pause]``) are produced by ``convert_markup`` on the
+    audio path only, so they never reach a transcript — while ``[text](url)`` markdown
+    links and ``[Enter]``-style prose do, and a bracket strip mangles them.
     """
+    # every markup shape is angle-bracketed, so text without "<" cannot contain any. The
+    # sinks call this per streamed chunk and expressive is off by default, making this the
+    # overwhelmingly common case — skip the tag-union scan entirely
+    if "<" not in text:
+        return text, []
+
     text, expr_tags = _split_expr(text)
-    clean, raw_tags = extract_and_strip(text, xml_tags=_ALL_MARKUP_TAGS, brackets=True)
+    clean, raw_tags = extract_and_strip(text, xml_tags=_ALL_MARKUP_TAGS)
     return clean, expr_tags + [{"type": tag, "value": value} for tag, value in raw_tags]
 
 
@@ -829,8 +806,8 @@ def strip_all_markup(text: str) -> str:
 def strip_expr_markup(text: str) -> str:
     """Strip only the ``<expr/>`` dialect, leaving all other markup untouched.
 
-    Unlike :func:`strip_all_markup`, provider-native tags and square-bracket spans
-    survive.
+    Unlike :func:`strip_all_markup`, provider-native tags survive (both leave
+    square-bracket spans alone).
     """
     return _split_expr(text)[0]
 
@@ -854,11 +831,10 @@ class TranscriptMarkupStripper:
     """Stateful, provider-agnostic markup stripper for one transcript segment.
 
     Fed text chunk-by-chunk, it returns the user-visible text and accumulates the
-    stripped tags. A tag-shaped trailing fragment (a partial ``<...`` or ``[...``
-    arriving split across chunks) is held back until it closes, so a tag straddling a
-    chunk boundary is never emitted half-stripped. Shared by the transcript sinks (room
-    output + transcript synchronizer) so stripping and expression extraction stay
-    identical across them.
+    stripped tags. A tag-shaped trailing fragment (a partial ``<...`` arriving split
+    across chunks) is held back until it closes, so a tag straddling a chunk boundary is
+    never emitted half-stripped. Shared by the transcript sinks (room output + transcript
+    synchronizer) so stripping and expression extraction stay identical across them.
     """
 
     def __init__(self) -> None:
@@ -866,14 +842,15 @@ class TranscriptMarkupStripper:
         self._tags: list[ExpressiveTag] = []
 
     def _has_open_tag(self) -> bool:
-        # hold a tag-shaped trailing "<" (partial XML tag) so "3 < 5" isn't stalled, and
-        # any unclosed "[" (bracket tags have no such ambiguity)
+        # hold a tag-shaped trailing "<" (partial XML tag) so "3 < 5" isn't stalled. An
+        # unclosed "[" is not held: brackets aren't markup here, and stalling on one would
+        # delay every markdown link until its "]" arrives
         last_lt = self._buf.rfind("<")
         if last_lt > self._buf.rfind(">"):
             nxt = self._buf[last_lt + 1 : last_lt + 2]
             if not nxt or nxt == "/" or nxt.isalpha():
                 return True
-        return self._buf.rfind("[") > self._buf.rfind("]")
+        return False
 
     def push(self, text: str) -> str:
         """Feed a chunk; return the clean text ready to emit (may be empty)."""

--- a/livekit-agents/livekit/agents/tts/_provider_format.py
+++ b/livekit-agents/livekit/agents/tts/_provider_format.py
@@ -20,7 +20,7 @@ import re
 from typing import TYPE_CHECKING, TypedDict
 
 from ..llm.chat_context import Instructions
-from ..types import ATTRIBUTE_TRANSCRIPTION_EXPRESSION
+from ..types import ATTRIBUTE_TRANSCRIPTION_EXPRESSION, TimedString
 from .markup_utils import convert_expression_tags, extract_and_strip
 
 
@@ -782,10 +782,9 @@ def split_all_markup(text: str) -> tuple[str, list[ExpressiveTag]]:
     (all the LLM is ever taught) plus every native tag name, so a hallucinated native
     tag is stripped rather than leaked.
 
-    Square-bracket spans are deliberately *not* stripped. A provider's native brackets
-    (Inworld ``[laughs]``, xAI ``[pause]``) are produced by ``convert_markup`` on the
-    audio path only, so they never reach a transcript — while ``[text](url)`` markdown
-    links and ``[Enter]``-style prose do, and a bracket strip mangles them.
+    Square-bracket spans are *not* stripped: the LLM only writes expr, so brackets in its
+    output are prose (a ``[text](url)`` link) that a strip would mangle. Provider-native
+    brackets never arrive here — :func:`drop_bracket_cues` removes them at their source.
     """
     # every markup shape is angle-bracketed, so text without "<" cannot contain any. The
     # sinks call this per streamed chunk and expressive is off by default, making this the
@@ -879,6 +878,76 @@ class TranscriptMarkupStripper:
     def expression_attribute(self) -> dict[str, str] | None:
         """The ``lk.expression`` attribute for the tags stripped so far, if any."""
         return expression_attribute(self._tags)
+
+
+_BRACKET_SPAN_RE = re.compile(r"\[[^\]]*\]")
+
+
+def minted_bracket_cues(before: str, after: str) -> list[str]:
+    """The bracket spans :func:`convert_markup` added, e.g. ``[laugh]``, ``[long-pause]``.
+
+    Conversion only ever adds brackets, so a span in *after* beyond those in *before* is
+    markup; one the LLM wrote itself (a ``[text](url)`` link) is in both and not reported.
+    """
+    if "[" not in after:
+        return []
+
+    prose = _BRACKET_SPAN_RE.findall(before)
+    cues: list[str] = []
+    for span in _BRACKET_SPAN_RE.findall(after):
+        if span in prose:
+            prose.remove(span)  # the LLM's own span, passed through by conversion
+        else:
+            cues.append(span)
+    return cues
+
+
+def _retext(token: TimedString, text: str) -> TimedString:
+    """A copy of *token* carrying *text*, keeping the alignment metadata."""
+    return TimedString(
+        text,
+        start_time=token.start_time,
+        end_time=token.end_time,
+        confidence=token.confidence,
+        start_time_offset=token.start_time_offset,
+        speaker_id=token.speaker_id,
+    )
+
+
+def drop_bracket_cues(tokens: list[TimedString], cues: list[str]) -> list[TimedString]:
+    """Remove minted *cues* from one batch of TTS-aligned tokens, keeping their timings.
+
+    ``use_tts_aligned_transcript`` makes the provider's alignment of the *converted* text
+    the transcript, so the cues it carries would be published as words never spoken. Only
+    :func:`minted_bracket_cues` spans are dropped (each once), leaving the LLM's own
+    brackets alone; with expressive off nothing is recorded and this is a pass-through.
+
+    Matching runs over the batch's joined text, so a cue may straddle tokens. One split
+    across two alignment *messages* is missed and stays in the transcript.
+    """
+    if not cues:
+        return tokens
+
+    text = "".join(tokens)
+    if "[" not in text:
+        return tokens
+
+    dropped: set[int] = set()
+    for match in _BRACKET_SPAN_RE.finditer(text):
+        if (span := match.group()) in cues:
+            cues.remove(span)  # each mint accounts for one occurrence
+            dropped.update(range(*match.span()))
+    if not dropped:
+        return tokens
+
+    out: list[TimedString] = []
+    pos = 0
+    for token in tokens:
+        kept = "".join(c for i, c in enumerate(token, start=pos) if i not in dropped)
+        pos += len(token)
+        if kept:
+            out.append(token if kept == str(token) else _retext(token, kept))
+    return out
 
 
 _SELF_CLOSING_TAGS: dict[str, list[str]] = {

--- a/livekit-agents/livekit/agents/tts/_provider_format.py
+++ b/livekit-agents/livekit/agents/tts/_provider_format.py
@@ -881,6 +881,8 @@ class TranscriptMarkupStripper:
 
 
 _BRACKET_SPAN_RE = re.compile(r"\[[^\]]*\]")
+# cap on how long an unclosed "[" is held before it is released as plain text
+_MAX_HELD_CHARS = 256
 
 
 def _retext(token: TimedString, text: str) -> TimedString:
@@ -895,19 +897,23 @@ def _retext(token: TimedString, text: str) -> TimedString:
     )
 
 
-def drop_bracket_cues(tokens: list[TimedString]) -> list[TimedString]:
+def drop_bracket_cues(
+    tokens: list[TimedString], held: list[TimedString], *, final: bool = False
+) -> list[TimedString]:
     """Remove bracket cues from TTS-aligned tokens, keeping the survivors' timings.
 
     ``use_tts_aligned_transcript`` makes the provider's alignment of the text it was sent
-    the transcript, and that text is post-``convert_markup``, so it carries the native
-    ``[laugh]``/``[pause]`` cues as words the agent never spoke. Every bracket span goes:
-    the provider reads them all as cues, so none of them is ever audio, and markdown links
+    the transcript, and that text is post-``convert_markup``, so it carries native
+    ``[laugh]``/``[speak calmly]`` cues as words the agent never spoke. Every bracket span
+    goes: the provider reads them all as cues, so none is ever audio, and markdown links
     are already gone (``filter_markdown`` runs on TTS input by default).
 
-    Matching runs over the joined batch, so a cue may straddle tokens; one split across two
-    alignment *messages* is missed and stays in the transcript. A cue between two spaces
-    takes one of them with it, leaving a single separator rather than a double space.
+    Alignment arrives in messages finer-grained than a cue — often one word at a time — so
+    *held* carries the tail of an unclosed span across calls; pass the same list every time
+    and call once more with ``final=True`` at end of stream to release it.
     """
+    tokens = held + tokens
+    held.clear()
     text = "".join(tokens)
     if "[" not in text:
         return tokens
@@ -921,16 +927,26 @@ def drop_bracket_cues(tokens: list[TimedString]) -> list[TimedString]:
         elif start == 0 and end < len(text) and text[end] == " ":
             end += 1
         dropped.update(range(start, end))
-    if not dropped:
-        return tokens
+
+    # hold from an unclosed "[" so a cue straddling messages is still judged as a whole;
+    # past _MAX_HELD_CHARS give up, since a lone bracket must not stall the transcript
+    hold_from = len(text)
+    if not final and (open_at := text.rfind("[")) > text.rfind("]"):
+        if len(text) - open_at <= _MAX_HELD_CHARS:
+            hold_from = open_at
 
     out: list[TimedString] = []
     pos = 0
     for token in tokens:
-        kept = "".join(c for i, c in enumerate(token, start=pos) if i not in dropped)
+        emit = "".join(
+            c for i, c in enumerate(token, start=pos) if i < hold_from and i not in dropped
+        )
+        keep = "".join(c for i, c in enumerate(token, start=pos) if i >= hold_from)
         pos += len(token)
-        if kept:
-            out.append(token if kept == str(token) else _retext(token, kept))
+        if emit:
+            out.append(token if emit == str(token) else _retext(token, emit))
+        if keep:
+            held.append(token if keep == str(token) else _retext(token, keep))
     return out
 
 

--- a/livekit-agents/livekit/agents/tts/_provider_format.py
+++ b/livekit-agents/livekit/agents/tts/_provider_format.py
@@ -883,25 +883,6 @@ class TranscriptMarkupStripper:
 _BRACKET_SPAN_RE = re.compile(r"\[[^\]]*\]")
 
 
-def minted_bracket_cues(before: str, after: str) -> list[str]:
-    """The bracket spans :func:`convert_markup` added, e.g. ``[laugh]``, ``[long-pause]``.
-
-    Conversion only ever adds brackets, so a span in *after* beyond those in *before* is
-    markup; one the LLM wrote itself (a ``[text](url)`` link) is in both and not reported.
-    """
-    if "[" not in after:
-        return []
-
-    prose = _BRACKET_SPAN_RE.findall(before)
-    cues: list[str] = []
-    for span in _BRACKET_SPAN_RE.findall(after):
-        if span in prose:
-            prose.remove(span)  # the LLM's own span, passed through by conversion
-        else:
-            cues.append(span)
-    return cues
-
-
 def _retext(token: TimedString, text: str) -> TimedString:
     """A copy of *token* carrying *text*, keeping the alignment metadata."""
     return TimedString(
@@ -914,29 +895,32 @@ def _retext(token: TimedString, text: str) -> TimedString:
     )
 
 
-def drop_bracket_cues(tokens: list[TimedString], cues: list[str]) -> list[TimedString]:
-    """Remove minted *cues* from one batch of TTS-aligned tokens, keeping their timings.
+def drop_bracket_cues(tokens: list[TimedString]) -> list[TimedString]:
+    """Remove bracket cues from TTS-aligned tokens, keeping the survivors' timings.
 
-    ``use_tts_aligned_transcript`` makes the provider's alignment of the *converted* text
-    the transcript, so the cues it carries would be published as words never spoken. Only
-    :func:`minted_bracket_cues` spans are dropped (each once), leaving the LLM's own
-    brackets alone; with expressive off nothing is recorded and this is a pass-through.
+    ``use_tts_aligned_transcript`` makes the provider's alignment of the text it was sent
+    the transcript, and that text is post-``convert_markup``, so it carries the native
+    ``[laugh]``/``[pause]`` cues as words the agent never spoke. Every bracket span goes:
+    the provider reads them all as cues, so none of them is ever audio, and markdown links
+    are already gone (``filter_markdown`` runs on TTS input by default).
 
-    Matching runs over the batch's joined text, so a cue may straddle tokens. One split
-    across two alignment *messages* is missed and stays in the transcript.
+    Matching runs over the joined batch, so a cue may straddle tokens; one split across two
+    alignment *messages* is missed and stays in the transcript. A cue between two spaces
+    takes one of them with it, leaving a single separator rather than a double space.
     """
-    if not cues:
-        return tokens
-
     text = "".join(tokens)
     if "[" not in text:
         return tokens
 
     dropped: set[int] = set()
     for match in _BRACKET_SPAN_RE.finditer(text):
-        if (span := match.group()) in cues:
-            cues.remove(span)  # each mint accounts for one occurrence
-            dropped.update(range(*match.span()))
+        start, end = match.span()
+        # take one of the spaces the cue sat between, so it leaves a single separator
+        if start > 0 and text[start - 1] == " " and (end == len(text) or text[end] == " "):
+            start -= 1
+        elif start == 0 and end < len(text) and text[end] == " ":
+            end += 1
+        dropped.update(range(start, end))
     if not dropped:
         return tokens
 

--- a/livekit-agents/livekit/agents/tts/markup_utils.py
+++ b/livekit-agents/livekit/agents/tts/markup_utils.py
@@ -16,48 +16,44 @@ def convert_expression_tags(text: str) -> str:
 _VALUE_ATTR_RE = re.compile(r'\b[\w-]+\s*=\s*"([^"]*)"')
 
 
-def extract_and_strip(
-    text: str, *, xml_tags: list[str], brackets: bool
-) -> tuple[str, list[tuple[str, str]]]:
-    """Strip markup and collect the stripped tags in a single pass.
+def extract_and_strip(text: str, *, xml_tags: list[str]) -> tuple[str, list[tuple[str, str]]]:
+    """Strip XML markup tags and collect the stripped tags in a single pass.
 
     One regex scan both removes the markup and records each removed tag, so
     stripping and extraction can never disagree about what counts as a tag.
 
+    Only XML-shaped markup is recognized. Square-bracket spans are never markup
+    here: a provider's native brackets (Inworld ``[laughs]``, xAI ``[pause]``) are
+    produced on the audio path by ``convert_markup`` and never come back through a
+    strip, while ``[text](url)`` links and ``[Enter]``-style prose do.
+
     Returns ``(clean_text, tags)`` where ``tags`` is a list of ``(type, value)``
     pairs in order of appearance:
 
-    - ``type`` is the XML tag name, or ``""`` for square-bracket tags.
+    - ``type`` is the XML tag name.
     - ``value`` is a wrapping tag's inner text (``<spell>A7X9</spell>`` ->
       ``"A7X9"``), else its first quoted attribute value
-      (``<emotion value="happy"/>`` -> ``"happy"``), else the bracket content,
-      falling back to ``""``.
+      (``<emotion value="happy"/>`` -> ``"happy"``), falling back to ``""``.
 
     Wrapping tags keep their inner content in ``clean_text`` (only the delimiters
-    are removed); self-closing, lone, and bracket tags are removed entirely.
+    are removed); self-closing and lone tags are removed entirely.
 
     Args:
         text: The text containing markup.
         xml_tags: XML tag names to handle (e.g. ``["emotion", "sound"]``).
-        brackets: Whether to also handle square-bracket tags like ``[laughs]``.
     """
-    if not xml_tags and not brackets:
+    if not xml_tags:
         return text, []
 
-    alternatives: list[str] = []
-    if xml_tags:
-        tag_pattern = "|".join(re.escape(tag) for tag in xml_tags)
+    tag_pattern = "|".join(re.escape(tag) for tag in xml_tags)
+    pattern = re.compile(
         # <tag .../> or <tag ...> optionally followed by inner</tag>
-        alternatives.append(
-            rf"<(?P<tag>{tag_pattern})\b(?P<attrs>[^>]*?)\s*/?\s*>"
-            rf"(?:(?P<inner>.*?)</(?P=tag)\s*>)?"
-        )
+        rf"<(?P<tag>{tag_pattern})\b(?P<attrs>[^>]*?)\s*/?\s*>"
+        rf"(?:(?P<inner>.*?)</(?P=tag)\s*>)?"
         # lone closing tag: </tag>
-        alternatives.append(rf"</(?:{tag_pattern})\s*>")
-    if brackets:
-        alternatives.append(r"\[(?P<bracket>[^\]]+)\]")
-
-    pattern = re.compile("|".join(alternatives), re.DOTALL)
+        rf"|</(?:{tag_pattern})\s*>",
+        re.DOTALL,
+    )
     tags: list[tuple[str, str]] = []
 
     def _repl(m: re.Match[str]) -> str:
@@ -74,11 +70,6 @@ def extract_and_strip(
             # wrapping tags keep their inner content; self-closing/lone tags vanish
             return inner if inner is not None else ""
 
-        bracket = groups.get("bracket")
-        if bracket is not None:
-            tags.append(("", bracket.strip()))
-            return ""
-
         return ""  # lone closing tag
 
     # iterate to a fixed point so nested wrapping tags are fully removed: a single pass
@@ -91,24 +82,3 @@ def extract_and_strip(
         prev = clean
         clean = pattern.sub(_repl, clean)
     return clean, tags
-
-
-def strip_bracket_tags(text: str) -> str:
-    """Strip square bracket tags like ``[laughs]``, ``[whisper]`` from text."""
-    return extract_and_strip(text, xml_tags=[], brackets=True)[0]
-
-
-def strip_xml_tags(text: str, tags: list[str]) -> str:
-    """Strip specific XML-style tags from text, preserving their inner content.
-
-    Handles opening/closing tag pairs (``<tag ...>content</tag>``) and
-    self-closing tags (``<tag .../>``, ``<tag />``).
-
-    Args:
-        text: The text containing XML-style markup.
-        tags: List of tag names to strip (e.g. ``["emotion", "speed"]``).
-
-    Returns:
-        The text with the specified tags removed but their content preserved.
-    """
-    return extract_and_strip(text, xml_tags=tags, brackets=False)[0]

--- a/livekit-agents/livekit/agents/tts/markup_utils.py
+++ b/livekit-agents/livekit/agents/tts/markup_utils.py
@@ -22,10 +22,9 @@ def extract_and_strip(text: str, *, xml_tags: list[str]) -> tuple[str, list[tupl
     One regex scan both removes the markup and records each removed tag, so
     stripping and extraction can never disagree about what counts as a tag.
 
-    Only XML-shaped markup is recognized. Square-bracket spans are never markup
-    here: a provider's native brackets (Inworld ``[laughs]``, xAI ``[pause]``) are
-    produced on the audio path by ``convert_markup`` and never come back through a
-    strip, while ``[text](url)`` links and ``[Enter]``-style prose do.
+    Only XML-shaped markup is recognized. Square brackets are left alone: in LLM output
+    they are prose (``[text](url)`` links) that a strip would mangle, and provider-native
+    ones are removed at their source by ``_provider_format.drop_bracket_cues``.
 
     Returns ``(clean_text, tags)`` where ``tags`` is a list of ``(type, value)``
     pairs in order of appearance:

--- a/livekit-agents/livekit/agents/tts/tts.py
+++ b/livekit-agents/livekit/agents/tts/tts.py
@@ -5,7 +5,7 @@ import datetime
 import os
 import time
 from abc import ABC, abstractmethod
-from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator
+from collections.abc import AsyncIterable, AsyncIterator
 from dataclasses import dataclass
 from types import TracebackType
 from typing import TYPE_CHECKING, ClassVar, Generic, Literal, TypeVar
@@ -30,7 +30,6 @@ from ..utils import aio, audio, codecs, log_exceptions, shortuuid
 
 if TYPE_CHECKING:
     from ..voice.io import TimedString
-    from ._provider_format import ExpressiveTag
 
 lk_dump_tts = int(os.getenv("LK_DUMP_TTS", 0))
 
@@ -77,8 +76,11 @@ class TTS(
     class Markup:
         """Declares TTS markup capabilities for the expressive pipeline.
 
-        Plugins override this inner class to declare what markup tags the TTS supports
-        and how to convert marked-up text back to plain text.
+        Plugins override this inner class to declare which markup dialect the TTS speaks:
+        what the LLM is taught to write, and how those markers are normalized and lowered
+        to the provider's native syntax before synthesis. Stripping markup back out is not
+        here — the transcript sinks do it provider-agnostically (see
+        ``_provider_format.split_all_markup``).
         """
 
         def __init__(self, tts: TTS) -> None:
@@ -88,9 +90,9 @@ class TTS(
             """Key into the shared ``_provider_format`` markup tables, or "" for none.
 
             Plugins override this to opt into markup support; the default ("") means
-            no markup instructions, stripping, normalization, or conversion are applied.
-            The other markup methods delegate through this key, so a plugin only needs
-            to override ``_provider_key``.
+            no markup instructions, normalization, or conversion are applied. The other
+            markup methods delegate through this key, so a plugin only needs to override
+            ``_provider_key``.
             """
             return ""
 
@@ -103,63 +105,6 @@ class TTS(
             from ._provider_format import llm_instructions
 
             return llm_instructions(self._provider_key())
-
-        def _split(self, text: str) -> tuple[str, list[ExpressiveTag]]:
-            """Strip markup and collect the stripped tags in one pass."""
-            from ._provider_format import split_markup
-
-            return split_markup(self._provider_key(), text)
-
-        def to_text(self, text: str) -> str:
-            """Strip TTS-specific markup from *text*, returning plain text.
-
-            Used for transcripts streamed to the user and for chat history storage.
-            The TTS itself receives the original marked-up text.
-            """
-            return self._split(text)[0]
-
-        async def to_text_stream(
-            self, text_stream: AsyncIterable[str], *, tags_out: list[ExpressiveTag] | None = None
-        ) -> AsyncGenerator[str, None]:
-            """Strip TTS markup from a stream of text chunks.
-
-            Buffers partial XML tags across chunks so that each buffer is stripped as a
-            whole. When ``tags_out`` is given, the stripped tags are appended to it (in
-            document order) as a byproduct of the same pass — no second scan.
-            """
-            buf = ""
-            async for chunk in text_stream:
-                buf += chunk
-                # hold the buffer only for a *tag-shaped* trailing "<" (a partial tag
-                # arriving across chunks); a bare "<" as in "3 < 5" is plain text and
-                # must not stall the transcript until the next ">" or flush
-                last_open = buf.rfind("<")
-                if last_open > buf.rfind(">"):
-                    nxt = buf[last_open + 1 : last_open + 2]
-                    if not nxt or nxt == "/" or nxt.isalpha():
-                        continue
-                stripped, tags = self._split(buf)
-                buf = ""
-                if tags_out is not None:
-                    tags_out.extend(tags)
-                if stripped:
-                    yield stripped
-
-            if buf:
-                stripped, tags = self._split(buf)
-                if tags_out is not None:
-                    tags_out.extend(tags)
-                if stripped:
-                    yield stripped
-
-        def extract_tags(self, text: str) -> list[ExpressiveTag]:
-            """Extract the markup tags that :meth:`to_text` would strip, in order.
-
-            Lets the framework surface stripped expressive tags (e.g. as transcription
-            attributes for the frontend) instead of discarding them. Returns ``[]`` when
-            the provider declares no markup.
-            """
-            return self._split(text)[1]
 
         def normalize(self, text: str) -> str:
             """Fix common LLM markup mistakes (e.g. unclosed self-closing tags)."""

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -120,7 +120,8 @@ def _strip_assistant_markup(chat_ctx: ChatContext) -> None:
     for item in chat_ctx.items:
         if item.type != "message" or item.role != "assistant":
             continue
-        if not any(isinstance(c, str) and ("<" in c or "[" in c) for c in item.content):
+        # markup is XML-only here: strip_all_markup leaves square-bracket spans alone
+        if not any(isinstance(c, str) and "<" in c for c in item.content):
             continue
         item.content = [strip_all_markup(c) if isinstance(c, str) else c for c in item.content]
 

--- a/tests/test_expr_markup.py
+++ b/tests/test_expr_markup.py
@@ -19,7 +19,6 @@ from livekit.agents.tts._provider_format import (
     llm_instructions,
     normalize_markup,
     split_all_markup,
-    split_markup,
     strip_expr_markup,
 )
 
@@ -150,13 +149,12 @@ def test_convert_stray_expr_never_reaches_tts() -> None:
 
 
 # ---------------------------------------------------------------------------
-# transcript stripping (per-provider + provider-agnostic)
+# transcript stripping (provider-agnostic: the sinks strip without knowing the TTS)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("provider", ["xai", "inworld", "cartesia"])
-def test_split_markup_strips_expr(provider: str) -> None:
-    clean, tags = split_markup(provider, JOKE)
+def test_split_all_markup_strips_expr() -> None:
+    clean, tags = split_all_markup(JOKE)
     assert clean.strip() == "Why did the burger go to the gym?  Because it wanted better buns!"
     assert tags == [
         {"type": "expression", "value": "say playfully"},
@@ -165,12 +163,12 @@ def test_split_markup_strips_expr(provider: str) -> None:
     ]
 
 
-def test_split_markup_wrapping_keeps_inner_text() -> None:
+def test_split_all_markup_wrapping_keeps_inner_text() -> None:
     text = (
         'She said <expr type="prosody" label="whisper">keep it secret</expr> — '
         'code <expr type="spell">A7X9</expr>.'
     )
-    clean, tags = split_markup("xai", text)
+    clean, tags = split_all_markup(text)
     assert clean == "She said keep it secret — code A7X9."
     assert tags == [
         {"type": "prosody", "value": "whisper"},
@@ -179,19 +177,27 @@ def test_split_markup_wrapping_keeps_inner_text() -> None:
 
 
 def test_split_all_markup_mixed_expr_and_native() -> None:
-    text = '<expr type="expression" label="say playfully"/> Hello! <sound value="laugh"/> [sigh]'
+    text = '<expr type="expression" label="say playfully"/> Hello! <sound value="laugh"/>'
     clean, tags = split_all_markup(text)
     assert clean.strip() == "Hello!"
     assert {"type": "expression", "value": "say playfully"} in tags
     assert {"type": "sound", "value": "laugh"} in tags
-    assert {"type": "", "value": "sigh"} in tags
+
+
+def test_split_all_markup_keeps_square_brackets() -> None:
+    # bracket spans are a TTS-only native form (convert_markup emits them on the audio
+    # path), so the transcript strip must leave markdown links and prose brackets intact
+    text = 'Press [Enter], then read [the docs](https://docs.livekit.io). <sound value="sigh"/>'
+    clean, tags = split_all_markup(text)
+    assert clean == "Press [Enter], then read [the docs](https://docs.livekit.io). "
+    assert tags == [{"type": "sound", "value": "sigh"}]
 
 
 def test_expr_regex_does_not_match_native_expression_tag() -> None:
     # "<expr" is a prefix of "<expression" — the word boundary in the expr regexes
     # must keep the native Inworld tag on the generic strip path with its own type
     text = '<expression value="speak calmly"/> Hi <expr type="break" label="1s"/> there.'
-    clean, tags = split_markup("inworld", text)
+    clean, tags = split_all_markup(text)
     assert clean == " Hi  there."
     assert {"type": "expression", "value": "speak calmly"} in tags
     assert {"type": "break", "value": "1s"} in tags
@@ -217,7 +223,7 @@ def test_transcript_stripper_streaming_chunks() -> None:
 
 
 def test_expression_attribute_from_expr() -> None:
-    _, tags = split_markup("inworld", JOKE)
+    _, tags = split_all_markup(JOKE)
     attr = expression_attribute(tags)
     assert attr is not None
     assert '"say playfully"' in next(iter(attr.values()))

--- a/tests/test_expressive_toggle.py
+++ b/tests/test_expressive_toggle.py
@@ -21,7 +21,13 @@ pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurr
 SESSION_TIMEOUT = 60
 
 
-MARKED_UP = '<expression value="happy"/> Welcome back! [chuckling] Glad you called again.'
+# what an expressive turn actually leaves in history: the expr markers the LLM emitted,
+# plus (defensively) a hallucinated native tag. Square brackets are *not* markup here —
+# they reach history as prose or markdown links, so the scrub must leave them alone.
+MARKED_UP = (
+    '<expr type="expression" label="happy"/> Welcome back! <sound value="chuckle"/> '
+    "Glad you called again. Docs: [the guide](https://docs.livekit.io)."
+)
 
 
 def test_strip_assistant_markup() -> None:
@@ -38,10 +44,12 @@ def test_strip_assistant_markup() -> None:
         for item in ctx.items
         if item.type == "message" and item.role == "assistant"
     ]
-    assert "<expression" not in (assistant_texts[0] or "")
-    assert "[chuckling]" not in (assistant_texts[0] or "")
+    assert "<expr" not in (assistant_texts[0] or "")
+    assert "<sound" not in (assistant_texts[0] or "")
     assert "Welcome back!" in (assistant_texts[0] or "")
     assert "Glad you called again." in (assistant_texts[0] or "")
+    # markdown links survive: brackets are prose, not markup
+    assert "[the guide](https://docs.livekit.io)" in (assistant_texts[0] or "")
 
     # user content is never touched, tag-shaped or not
     user_text = next(
@@ -112,9 +120,10 @@ async def test_expressive_off_turn_scrubs_history() -> None:
     ]
     assert assistant_texts, "expected assistant messages in history"
     for text in assistant_texts:
-        assert "<expression" not in (text or "")
-        assert "[chuckling]" not in (text or "")
-    # the seeded message's visible text survives the scrub
+        assert "<expr" not in (text or "")
+        assert "<sound" not in (text or "")
+    # the seeded message's visible text survives the scrub, links included
     assert any("Welcome back!" in (t or "") for t in assistant_texts)
+    assert any("[the guide](https://docs.livekit.io)" in (t or "") for t in assistant_texts)
     # and the new reply went through normally
     assert any("I'm doing well" in (t or "") for t in assistant_texts)

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -12,7 +12,10 @@ from livekit.agents.voice.room_io._input import (
     _ParticipantAudioInputStream,
     _ParticipantInputStream,
 )
-from livekit.agents.voice.room_io._output import _ParticipantTranscriptionOutput
+from livekit.agents.voice.room_io._output import (
+    _ParticipantStreamTranscriptionOutput,
+    _ParticipantTranscriptionOutput,
+)
 from livekit.agents.voice.room_io.room_io import RoomIO
 from livekit.agents.voice.room_io.types import NoiseCancellationParams
 
@@ -112,6 +115,10 @@ class _NoopAudioInputStream(_ParticipantInputStream[rtc.AudioFrame]):
 class _FakeWriter:
     def __init__(self) -> None:
         self.close_calls = 0
+        self.chunks: list[str] = []
+
+    async def write(self, text: str) -> None:
+        self.chunks.append(text)
 
     async def aclose(self, attributes: dict[str, str] | None = None) -> None:
         self.close_calls += 1
@@ -180,6 +187,26 @@ async def test_transcription_output_aclose_unregisters_and_closes_resources() ->
     assert room.listener_count("local_track_published") == 0
     assert legacy_output._flush_task is not None and legacy_output._flush_task.done()
     assert writer.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_transcription_output_strips_markup_but_keeps_links() -> None:
+    room = _FakeRoom()
+    writer = _FakeWriter()
+    room.local_participant.stream_text = AsyncMock(return_value=writer)
+
+    output = _ParticipantStreamTranscriptionOutput(room=room, participant="agent")
+    await output.capture_text(
+        '<expr type="expression" label="happy"/>See [the docs](https://docs.livekit.io)'
+    )
+    output.flush()
+    assert output._flush_atask is not None
+    await output._flush_atask
+
+    published = "".join(writer.chunks)
+    # markup is removed; a markdown link is prose and must reach the user intact
+    assert "<expr" not in published
+    assert "[the docs](https://docs.livekit.io)" in published
 
 
 @pytest.mark.asyncio

--- a/tests/test_tokenizer_xml_markup.py
+++ b/tests/test_tokenizer_xml_markup.py
@@ -12,7 +12,7 @@ import pytest
 
 from livekit.agents.tokenize.blingfire import SentenceTokenizer
 from livekit.agents.tokenize.token_stream import _XML_TAG_RE
-from livekit.agents.tts.markup_utils import strip_xml_tags
+from livekit.agents.tts.markup_utils import extract_and_strip
 
 pytestmark = pytest.mark.unit
 
@@ -56,24 +56,40 @@ async def _stream_tokenize_tiktoken(tok: SentenceTokenizer, text: str) -> list[s
 
 
 # ===========================================================================
-# strip_xml_tags
+# extract_and_strip
 # ===========================================================================
 
 
-class TestStripXmlTags:
+def _strip(text: str, tags: list[str]) -> str:
+    return extract_and_strip(text, xml_tags=tags)[0]
+
+
+class TestExtractAndStrip:
     def test_self_closing(self) -> None:
-        assert strip_xml_tags('<emotion value="happy"/> Hello!', ["emotion"]) == " Hello!"
+        assert _strip('<emotion value="happy"/> Hello!', ["emotion"]) == " Hello!"
 
     def test_wrapping_preserves_content(self) -> None:
-        assert strip_xml_tags("<spell>A.B.C.</spell> confirmed", ["spell"]) == "A.B.C. confirmed"
+        assert _strip("<spell>A.B.C.</spell> confirmed", ["spell"]) == "A.B.C. confirmed"
 
     def test_preserves_unrelated_tags(self) -> None:
         text = '<emotion value="happy"/> <custom>keep</custom>'
-        assert strip_xml_tags(text, ["emotion"]) == " <custom>keep</custom>"
+        assert _strip(text, ["emotion"]) == " <custom>keep</custom>"
 
     def test_empty_tags_list(self) -> None:
         text = '<emotion value="happy"/> Hi'
-        assert strip_xml_tags(text, []) == text
+        assert _strip(text, []) == text
+
+    def test_square_brackets_are_never_markup(self) -> None:
+        # only XML is markup here — bracket spans reach transcripts as prose/markdown
+        text = 'Press [Enter] <emotion value="happy"/> to open [the docs](https://lk.io)'
+        assert _strip(text, ["emotion"]) == "Press [Enter]  to open [the docs](https://lk.io)"
+
+    def test_reports_stripped_tags(self) -> None:
+        clean, tags = extract_and_strip(
+            '<emotion value="happy"/>hi <spell>A7</spell>', xml_tags=["emotion", "spell"]
+        )
+        assert clean == "hi A7"
+        assert tags == [("emotion", "happy"), ("spell", "A7")]
 
 
 # ===========================================================================
@@ -98,11 +114,11 @@ class TestXaiDialect:
         assert '<expr type="sound" label="laugh"/>' in instr
         assert '<expr type="prosody" label="' in instr
 
-    def test_split_markup_strips_inline_keeps_wrapping_inner(self) -> None:
+    def test_strip_removes_inline_keeps_wrapping_inner(self) -> None:
         from livekit.agents.tts import _provider_format as pf
 
         raw = 'So I walked in and <break time="500ms"/> there it was. <sound value="laugh"/> <whisper>a secret</whisper> <emphasis>wow</emphasis>.'
-        clean, tags = pf.split_markup("xai", raw)
+        clean, tags = pf.split_all_markup(raw)
         # inline sounds/pauses removed entirely; wrapping tags keep their inner text
         assert "<break" not in clean and "<sound" not in clean and "laugh" not in clean
         assert "<whisper>" not in clean and "a secret" in clean and "wow" in clean
@@ -114,7 +130,7 @@ class TestXaiDialect:
         from livekit.agents.tts import _provider_format as pf
 
         raw = "<happy>Great to hear from you!</happy> <sad>I'm sorry about that.</sad>"
-        clean, tags = pf.split_markup("xai", raw)
+        clean, tags = pf.split_all_markup(raw)
         # emotion is the tag name; delimiters removed, spoken words preserved
         assert "<happy>" not in clean and "</sad>" not in clean
         assert "Great to hear from you!" in clean and "I'm sorry about that." in clean
@@ -130,7 +146,7 @@ class TestXaiDialect:
         for tag in pf._XAI_WRAPPING:
             assert tag in pf._XAI_EXPR_LLM_INSTRUCTIONS, f"{tag} not documented"
             assert tag in pf._XAI_TAGS
-            clean, _ = pf.split_markup("xai", f"<{tag}>hello there</{tag}>")
+            clean, _ = pf.split_all_markup(f"<{tag}>hello there</{tag}>")
             assert clean.strip() == "hello there", f"{tag} not stripped: {clean!r}"
 
     def test_emotion_tags_stripped_though_unprompted(self) -> None:
@@ -140,7 +156,7 @@ class TestXaiDialect:
         # stripped from the transcript rather than leaking to the user
         for tag in pf._XAI_EMOTIONS:
             assert tag in pf._XAI_TAGS
-            clean, _ = pf.split_markup("xai", f"<{tag}>hello there</{tag}>")
+            clean, _ = pf.split_all_markup(f"<{tag}>hello there</{tag}>")
             assert clean.strip() == "hello there", f"{tag} not stripped: {clean!r}"
 
     def test_documented_inline_tags_present(self) -> None:
@@ -175,7 +191,7 @@ class TestXaiDialect:
         # combining emotion + prosody means nesting; the transcript must come out clean
         # (no leaked inner markup) — this is what the fixed-point strip guarantees
         raw = '<excited><loud><higher-pitch>no way</higher-pitch></loud></excited> <sound value="laugh"/> okay'
-        clean, _ = pf.split_markup("xai", raw)
+        clean, _ = pf.split_all_markup(raw)
         assert "<" not in clean and ">" not in clean and "[" not in clean
         assert clean.strip() == "no way  okay".replace("  ", " ") or "no way" in clean
         assert "no way" in clean and "okay" in clean
@@ -426,82 +442,30 @@ class TestPlainTextAngleBrackets:
 
 
 # ===========================================================================
-# Markup.to_text_stream (transcript stripping)
-# ===========================================================================
-
-
-async def _achunks(items: list[str]):
-    for it in items:
-        yield it
-
-
-class TestToTextStreamBareLt:
-    """Regression: the transcript-strip path must not stall on a bare "<" either.
-
-    to_text_stream buffered on a naive `rfind("<") > rfind(">")` check, so a "<"
-    in prose (e.g. "3 < 5") froze every following transcript chunk of the segment
-    until a ">" arrived or the stream ended — the same stall fixed in the tokenizer.
-    """
-
-    def _markup(self):
-        from livekit.agents.tts.tts import TTS
-
-        class _DialectMarkup(TTS.Markup):
-            def _provider_key(self) -> str:
-                return "cartesia"
-
-        return _DialectMarkup(None)  # type: ignore[arg-type]  # _provider_key ignores tts
-
-    @pytest.mark.asyncio
-    async def test_bare_lt_does_not_hold_following_chunk(self) -> None:
-        out = [
-            c
-            async for c in self._markup().to_text_stream(_achunks(["The value 3 < 5 ", "is true."]))
-        ]
-        # fixed: the first chunk is emitted incrementally (>= 2 items); the buggy
-        # version held everything and emitted a single item at end-of-stream
-        assert len(out) >= 2
-        assert "3 < 5" in out[0]
-        assert "".join(out).replace(" ", "") == "Thevalue3<5istrue."
-
-    @pytest.mark.asyncio
-    async def test_partial_tag_still_buffered(self) -> None:
-        # a genuinely partial tag split across chunks must still be held and stripped
-        out = [
-            c
-            async for c in self._markup().to_text_stream(
-                _achunks(["Hi <emo", 'tion value="happy"/> there'])
-            )
-        ]
-        joined = "".join(out)
-        assert "<emotion" not in joined
-        assert "Hi" in joined and "there" in joined
-
-
-# ===========================================================================
 # Universal transcript stripping (provider-agnostic, used by the transcript sinks)
 # ===========================================================================
 
 
 class TestUniversalMarkupStrip:
     """The transcript sinks strip downstream without knowing the provider, so they remove
-    the union of every provider's tags. See split_all_markup / TranscriptMarkupStripper."""
+    the union of every provider's XML tags — but never square brackets, which reach the
+    transcript as markdown/prose. See split_all_markup / TranscriptMarkupStripper."""
 
     def test_split_all_markup_across_providers(self) -> None:
         from livekit.agents.tts._provider_format import split_all_markup
 
-        # Cartesia <emotion>, Inworld/xAI <expression>/<sound>, and bracket tags all strip
-        # regardless of which provider produced them
+        # Cartesia <emotion> and Inworld/xAI <expression>/<sound> all strip regardless of
+        # which provider produced them; a [bracket] span is left for the reader
         clean, tags = split_all_markup(
             '<emotion value="happy"/>Hi <expression value="warm"/>there '
             '<sound value="giggle"/>[pause] friend'
         )
-        assert clean == "Hi there  friend"
+        assert clean == "Hi there [pause] friend"
         types = [(t["type"], t["value"]) for t in tags]
         assert ("emotion", "happy") in types
         assert ("expression", "warm") in types
         assert ("sound", "giggle") in types
-        assert ("", "pause") in types
+        assert ("", "pause") not in types
 
     def test_expression_attribute_shape(self) -> None:
         from livekit.agents.tts._provider_format import expression_attribute, split_all_markup
@@ -510,8 +474,8 @@ class TestUniversalMarkupStrip:
         attr = expression_attribute(tags)
         assert attr == {"lk.expression": '{"value":"sad"}'}
 
-        # no expression/emotion tag -> no attribute (bracket sounds don't count)
-        _, tags = split_all_markup("[pause]hi")
+        # no expression/emotion tag -> no attribute
+        _, tags = split_all_markup('<break time="1s"/>hi')
         assert expression_attribute(tags) is None
 
     def test_streaming_stripper_holds_partial_tags(self) -> None:
@@ -526,6 +490,17 @@ class TestUniversalMarkupStrip:
         assert "<emotion" not in out
         assert out.replace(" ", "") == "Hithere"
         assert s.expression_attribute() == {"lk.expression": '{"value":"happy"}'}
+
+    def test_streaming_stripper_markdown_link_survives(self) -> None:
+        from livekit.agents.tts._provider_format import TranscriptMarkupStripper
+
+        s = TranscriptMarkupStripper()
+        # an unclosed "[" must not stall the chunk (brackets aren't markup), and the link
+        # must arrive intact rather than collapsed to its (url) tail
+        first = s.push("Read [the docs](https:")
+        assert first == "Read [the docs](https:"
+        rest = s.push("//docs.livekit.io) now.") + s.flush()
+        assert first + rest == "Read [the docs](https://docs.livekit.io) now."
 
     def test_streaming_stripper_bare_lt_not_stalled(self) -> None:
         from livekit.agents.tts._provider_format import TranscriptMarkupStripper


### PR DESCRIPTION
also removes brackets for tts aligned transcripts, for providers like inworld that include them in their timed transcripts