### PR TITLE
fix(inference): tolerate null token counts in streamed usage

### DIFF
--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -454,10 +454,10 @@ class LLMStream(llm.LLMStream):
                         usage_chunk = llm.ChatChunk(
                             id=chunk.id,
                             usage=llm.CompletionUsage(
-                                completion_tokens=chunk.usage.completion_tokens,
-                                prompt_tokens=chunk.usage.prompt_tokens,
+                                completion_tokens=chunk.usage.completion_tokens or 0,
+                                prompt_tokens=chunk.usage.prompt_tokens or 0,
                                 prompt_cached_tokens=cached_tokens or 0,
-                                total_tokens=chunk.usage.total_tokens,
+                                total_tokens=chunk.usage.total_tokens or 0,
                                 service_tier=getattr(chunk, "service_tier", None),
                             ),
                         )

--- a/tests/test_inference_llm_usage.py
+++ b/tests/test_inference_llm_usage.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from livekit.agents.inference.llm import LLMStream
+from livekit.agents.llm import ChatContext
+from livekit.agents.types import APIConnectOptions
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeOpenAIStream:
+    """Stands in for the openai streaming response: async context manager + async iterator."""
+
+    def __init__(self, chunks: list[SimpleNamespace]) -> None:
+        self._chunks = chunks
+
+    async def __aenter__(self) -> _FakeOpenAIStream:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+def _usage_chunk(
+    *,
+    completion_tokens: int | None,
+    prompt_tokens: int | None,
+    total_tokens: int | None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id="chunk-id",
+        choices=[],
+        usage=SimpleNamespace(
+            completion_tokens=completion_tokens,
+            prompt_tokens=prompt_tokens,
+            total_tokens=total_tokens,
+            prompt_tokens_details=None,
+        ),
+    )
+
+
+def _make_stream(chunk: SimpleNamespace) -> LLMStream:
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=_FakeOpenAIStream([chunk]))
+
+    llm_v = MagicMock()
+    llm_v._label = "test-llm"
+    llm_v.model = "gpt-4o-mini"
+    llm_v.provider = "openai"
+
+    return LLMStream(
+        llm_v,
+        model="gpt-4o-mini",
+        strict_tool_schema=False,
+        client=client,
+        chat_ctx=ChatContext.empty(),
+        tools=[],
+        conn_options=APIConnectOptions(max_retry=0, timeout=5.0),
+        extra_kwargs={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_null_completion_tokens_does_not_crash_stream() -> None:
+    """A provider that omits completion_tokens must not kill the session."""
+    stream = _make_stream(_usage_chunk(completion_tokens=None, prompt_tokens=7, total_tokens=7))
+
+    chunks = [chunk async for chunk in stream]
+
+    usages = [chunk.usage for chunk in chunks if chunk.usage is not None]
+    assert len(usages) == 1
+    assert usages[0].completion_tokens == 0
+    assert usages[0].prompt_tokens == 7
+    assert usages[0].total_tokens == 7
+
+
+@pytest.mark.asyncio
+async def test_null_prompt_and_total_tokens_are_coerced() -> None:
+    stream = _make_stream(_usage_chunk(completion_tokens=5, prompt_tokens=None, total_tokens=None))
+
+    chunks = [chunk async for chunk in stream]
+
+    usages = [chunk.usage for chunk in chunks if chunk.usage is not None]
+    assert len(usages) == 1
+    assert usages[0].completion_tokens == 5
+    assert usages[0].prompt_tokens == 0
+    assert usages[0].total_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_complete_usage_is_passed_through() -> None:
+    stream = _make_stream(_usage_chunk(completion_tokens=11, prompt_tokens=13, total_tokens=24))
+
+    chunks = [chunk async for chunk in stream]
+
+    usages = [chunk.usage for chunk in chunks if chunk.usage is not None]
+    assert len(usages) == 1
+    assert usages[0].completion_tokens == 11
+    assert usages[0].prompt_tokens == 13
+    assert usages[0].total_tokens == 24


### PR DESCRIPTION
Fixes #6595

## What breaks

On the OpenAI-compatible path (`livekit.agents.inference.llm.LLMStream`), a provider can send a final streaming chunk where `usage` is present but individual counts are `null`. We only guard on `if chunk.usage is not None:`, then pass the fields straight into `CompletionUsage`, where `completion_tokens`, `prompt_tokens` and `total_tokens` are all required `int`.

The pydantic `ValidationError` gets caught by the generic `except Exception` at the bottom of `_run` and re-raised as `APIConnectionError(retryable=False)`. Because it's non-retryable it surfaces as an unrecoverable `llm_error` and terminates the `AgentSession`, so a malformed usage payload drops a live call.

The reporter hits this behind a proxy in front of a custom model that occasionally omits `completion_tokens`.

## Fix

Coerce the three counts with `or 0`. That's what `prompt_cached_tokens` on the adjacent line already does, so this keeps the block internally consistent rather than introducing a new pattern. Complete payloads are unaffected.

Same shape as #5404, which fixed the other half of this (usage present but not reached).

## Tests

`tests/test_inference_llm_usage.py` drives `LLMStream` with a fake OpenAI stream, so it needs no network or credentials:

- a chunk with `completion_tokens=None` yields usage with `0` and does not raise
- a chunk with `prompt_tokens`/`total_tokens` null is coerced the same way
- a fully-populated chunk passes through untouched

The first two fail on `main` with `APIConnectionError` and pass with the change.

Full unit gate: 1175 passed, 4 skipped. `make type-check`, `make lint` and `make format-check` are clean. The 9 errors in the pytest summary are a pre-existing OTLP metrics-exporter teardown issue that reproduces identically on a clean checkout.
