### PR TITLE
(inference): type Cartesia turn-detection params in CartesiaOptions

### DIFF
--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -68,8 +68,15 @@ InworldModels = Literal["inworld/inworld-stt-1",]
 
 
 class CartesiaOptions(TypedDict, total=False):
-    min_volume: float  # default: not specified
-    max_silence_duration_secs: float  # default: not specified
+    min_volume: float  # ink-whisper only; default: not specified
+    max_silence_duration_secs: float  # ink-whisper only; default: not specified
+    # Turn-detection tuning for turn-detecting models (e.g. ink-2). The gateway
+    # validates these against Cartesia's documented ranges.
+    turn_start_threshold: float  # range 0.5-0.9, default 0.8
+    turn_eager_end_threshold: float  # range 0.3-0.6, default 0.4
+    turn_end_threshold: float  # range 0.05-0.5, default 0.2
+    turn_end_timeout_ms: int  # range 640-11200, default 5600
+    keyterm: str | list[str]  # up to 100 terms totaling 1200 characters
 
 
 class DeepgramOptions(TypedDict, total=False):


### PR DESCRIPTION
Companion to #6594 (which exposed these on the direct plugin): the Inference gateway **already accepts and validates** Cartesia's turn-detection tuning params via `extra_kwargs` — they're just missing from the `CartesiaOptions` TypedDict, so users can't discover them.

Verified live against the gateway today:
- `extra_kwargs={"turn_start_threshold": 0.6}` on `cartesia/ink-2` → session created and runs normally.
- `extra_kwargs={"turn_start_threshold": 2.0}` → session creation fails with `cartesiaturns: extra settings validation failed: turn_start_threshold must be <= 0.9, got 2` — i.e. the gateway's cartesia-turns adapter knows these params and enforces Cartesia's documented ranges.

This PR only adds the keys to the TypedDict (typing/discoverability — `extra_kwargs` already passes them through verbatim) and annotates the two existing keys as ink-whisper-only, per Cartesia's API reference. Ranges/defaults from https://docs.cartesia.ai/api-reference/stt/turns/websocket.

Verified with `ruff check` / `ruff format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)