### PR TITLE
fix(stt): send the turn commit when a flush yields no buffered audio

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -628,10 +628,10 @@ class SpeechStream(stt.SpeechStream):
                         self._audio_duration_collector.push(frame.duration)
                         await ws.send_bytes(frame.data.tobytes())
 
-                        if has_ended:
-                            self._audio_duration_collector.flush()
-                            await ws.send_str(SpeechStream._FINALIZE_MSG)
-                            has_ended = False
+                    if has_ended:
+                        self._audio_duration_collector.flush()
+                        await ws.send_str(SpeechStream._FINALIZE_MSG)
+                        has_ended = False
 
                 # tell deepgram we are done sending audio/inputs
                 closing_ws = True

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -450,9 +450,9 @@ class SpeechStreamv2(stt.SpeechStream):
                         self._audio_duration_collector.push(frame.duration)
                         await ws.send_bytes(frame.data.tobytes())
 
-                        if has_ended:
-                            self._audio_duration_collector.flush()
-                            has_ended = False
+                    if has_ended:
+                        self._audio_duration_collector.flush()
+                        has_ended = False
 
                 # tell deepgram we are done sending audio/inputs
                 closing_ws = True

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
@@ -457,9 +457,19 @@ class SpeechStream(stt.SpeechStream):
                             )
                         )
 
-                        if has_ended:
-                            self._audio_duration_collector.flush()
-                            has_ended = False
+                    if has_ended:
+                        self._audio_duration_collector.flush()
+                        await ws.send_str(
+                            json.dumps(
+                                {
+                                    "message_type": "input_audio_chunk",
+                                    "audio_base_64": "",
+                                    "commit": True,
+                                    "sample_rate": self._opts.sample_rate,
+                                }
+                            )
+                        )
+                        has_ended = False
 
                 closing_ws = True
             except (aiohttp.ClientError, ConnectionError) as e:

--- a/tests/test_plugin_deepgram_stt.py
+++ b/tests/test_plugin_deepgram_stt.py
@@ -154,3 +154,105 @@ async def test_flux_configure_noop_when_disconnected():
     await stream._reconfigure_atask
 
     assert stream._opts.keyterm == ["LiveKit"]
+
+
+class _LiveWS:
+    """Records what the send loop writes. receive() parks so recv_task stays alive."""
+
+    def __init__(self) -> None:
+        # a single ordered log, so "Finalize came after the audio" is assertable
+        self.wire: list[str] = []
+        self._closed = asyncio.Event()
+
+    async def send_str(self, data: str) -> None:
+        self.wire.append(json.loads(data)["type"])
+
+    async def send_bytes(self, data: bytes) -> None:
+        self.wire.append("audio")
+
+    async def receive(self):
+        await self._closed.wait()
+        raise AssertionError("the test should never let recv_task resume")
+
+    async def close(self) -> None:
+        self._closed.set()
+
+    def sent(self) -> list[str]:
+        """The wire log without the periodic KeepAlive noise."""
+        return [msg for msg in self.wire if msg != "KeepAlive"]
+
+
+def _live_stream(ws: _LiveWS):
+    """A real SpeechStream running its real _run loop against a fake socket."""
+    import dataclasses
+    from typing import Any, cast
+
+    from livekit.agents import DEFAULT_API_CONNECT_OPTIONS
+    from livekit.plugins.deepgram.stt import STT, SpeechStream
+
+    instance = STT(api_key="test-key", language="en-US", sample_rate=16000)
+    stream = SpeechStream(
+        stt=instance,
+        opts=dataclasses.replace(instance._opts, sample_rate=16000),
+        conn_options=DEFAULT_API_CONNECT_OPTIONS,
+        api_key="test-key",
+        http_session=cast(Any, SimpleNamespace(closed=False)),
+        base_url="wss://api.deepgram.com/v1/listen",
+    )
+
+    async def _fake_connect() -> Any:
+        return ws
+
+    # patched before the _run task gets its first tick, so no real socket is opened
+    stream._connect_ws = _fake_connect
+    return stream
+
+
+def _frame(ms: int, sample_rate: int = 16000):
+    from livekit import rtc
+
+    samples = sample_rate * ms // 1000
+    return rtc.AudioFrame(
+        data=b"\x00\x00" * samples,
+        sample_rate=sample_rate,
+        num_channels=1,
+        samples_per_channel=samples,
+    )
+
+
+async def _wait_until(predicate, *, timeout: float = 5.0) -> None:
+    import time
+
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        assert time.monotonic() < deadline, "timed out waiting for the stream to send"
+        await asyncio.sleep(0.01)
+
+
+async def test_flush_finalizes_the_turn_when_no_audio_is_left_to_send():
+    # 50ms is exactly one repack chunk, so AudioByteStream.flush() returns no frames.
+    # Finalize must still go out, otherwise the turn waits on Deepgram's own endpointing
+    # and has_ended leaks into the next utterance.
+    ws = _LiveWS()
+    stream = _live_stream(ws)
+    try:
+        stream.push_frame(_frame(50))
+        await _wait_until(lambda: ws.sent() == ["audio"])
+
+        stream.flush()
+        await _wait_until(lambda: ws.sent() == ["audio", "Finalize"])
+    finally:
+        await stream.aclose()
+
+
+async def test_flush_finalizes_after_the_buffered_audio():
+    # a partial chunk is still pending: it has to reach the server before Finalize,
+    # otherwise the tail of the turn is transcribed against the next one
+    ws = _LiveWS()
+    stream = _live_stream(ws)
+    try:
+        stream.push_frame(_frame(30))
+        stream.flush()
+        await _wait_until(lambda: ws.sent() == ["audio", "Finalize"])
+    finally:
+        await stream.aclose()

--- a/tests/test_plugin_elevenlabs_stt.py
+++ b/tests/test_plugin_elevenlabs_stt.py
@@ -2,10 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
+import dataclasses
+import json
+import time
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any, cast
+
 import pytest
 from multidict import CIMultiDict
 
-from livekit.agents import stt
+from livekit import rtc
+from livekit.agents import DEFAULT_API_CONNECT_OPTIONS, stt
 from livekit.agents.types import NOT_GIVEN
 from livekit.plugins.elevenlabs import stt as elevenlabs_stt
 from livekit.plugins.elevenlabs._utils import trace_id_from_headers
@@ -177,6 +186,96 @@ async def test_connect_ws_includes_enable_logging(enable_logging: bool, expected
     await stream._connect_ws()
 
     assert f"enable_logging={expected}" in captured["url"]
+
+
+class _FakeWS:
+    """Records outgoing messages. receive() parks so recv_task stays alive."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        self._closed = asyncio.Event()
+
+    async def send_str(self, data: str) -> None:
+        self.sent.append(json.loads(data))
+
+    async def receive(self) -> Any:
+        await self._closed.wait()
+        raise AssertionError("the test should never let recv_task resume")
+
+    async def close(self) -> None:
+        self._closed.set()
+
+
+def _live_stream(ws: _FakeWS) -> elevenlabs_stt.SpeechStream:
+    """A real SpeechStream running its real _run loop against a fake socket."""
+    instance = elevenlabs_stt.STT(api_key="test-key", model="scribe_v2_realtime")
+    opts = dataclasses.replace(instance._opts, sample_rate=16000)
+    stream = elevenlabs_stt.SpeechStream(
+        stt=instance,
+        opts=opts,
+        conn_options=DEFAULT_API_CONNECT_OPTIONS,
+        language=None,
+        http_session=cast(Any, SimpleNamespace(closed=False)),
+    )
+
+    async def _fake_connect() -> Any:
+        return ws
+
+    # patched before the _run task gets its first tick, so no real socket is opened
+    stream._connect_ws = _fake_connect  # type: ignore[method-assign]
+    return stream
+
+
+def _frame(ms: int, sample_rate: int = 16000) -> rtc.AudioFrame:
+    samples = sample_rate * ms // 1000
+    return rtc.AudioFrame(
+        data=b"\x00\x00" * samples,
+        sample_rate=sample_rate,
+        num_channels=1,
+        samples_per_channel=samples,
+    )
+
+
+async def _wait_until(predicate: Callable[[], bool], *, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        assert time.monotonic() < deadline, "timed out waiting for the stream to send"
+        await asyncio.sleep(0.01)
+
+
+async def test_flush_commits_the_turn_when_no_audio_is_left_to_send() -> None:
+    # 50ms is exactly one repack chunk, so AudioByteStream.flush() returns no frames.
+    # The commit must still go out: Scribe v2 does not finalize a turn without one, and
+    # gating it on the per-frame loop dropped it here (roughly 1 flush in 5).
+    ws = _FakeWS()
+    stream = _live_stream(ws)
+    try:
+        stream.push_frame(_frame(50))
+        await _wait_until(lambda: len(ws.sent) == 1)
+
+        stream.flush()
+        await _wait_until(lambda: len(ws.sent) == 2)
+
+        assert [msg["commit"] for msg in ws.sent] == [False, True]
+        assert ws.sent[-1]["audio_base_64"] == ""
+    finally:
+        await stream.aclose()
+
+
+async def test_flush_commits_after_the_buffered_audio() -> None:
+    # a partial chunk is still pending: it has to reach the server before the commit,
+    # otherwise the tail of the turn is transcribed against the next one
+    ws = _FakeWS()
+    stream = _live_stream(ws)
+    try:
+        stream.push_frame(_frame(30))
+        stream.flush()
+        await _wait_until(lambda: len(ws.sent) == 2)
+
+        assert [msg["commit"] for msg in ws.sent] == [False, True]
+        assert ws.sent[0]["audio_base_64"] != ""
+    finally:
+        await stream.aclose()
 
 
 def test_trace_id_from_headers() -> None:


### PR DESCRIPTION
`AudioByteStream.flush()` returns `[]` when its buffer happens to be empty, roughly 1 in 5 flushes with 10ms input frames repacked into 50ms chunks. Any finalize gated on `for frame in frames:` is then skipped, and `has_ended` leaks into the next utterance so the message fires mid-way through the following turn.

**elevenlabs:** Scribe v2 realtime never finalized at all without a `commit`, so send an empty `commit: true` chunk, hoisted out of the frame loop.
**deepgram:** hoist `Finalize` out of the frame loop (`stt_v2` gets the same dedent for its metrics flush).

**Tests:** both plugins get coverage that drives the real `SpeechStream._run` loop against a fake socket, asserting the commit lands after a flush with an empty repack buffer (the regression) and after the leftover audio when a partial chunk is pending (ordering). Both fail with the fix reverted.

**Scope:** the default `stt_node` only calls `push_frame`, and the pipeline commits a turn by pushing silence, so nothing flushes a streaming STT stream in a normal `AgentSession`. Verified by patching `RecognizeStream.flush`/`end_input` across the unit suite: 0 calls from the voice pipeline. This hardens direct `stt.stream()` + `flush()` use; it does not on its own fix AGT-2264.

Gladia has the same shape and is deliberately left alone: `stop_recording` is session-terminating there (see `gladia/stt.py:388`), so making it fire reliably per turn would be worse than the current miss.

Related to AGT-2264 (#4087)

🤖 Generated with [Claude Code](https://claude.com/claude-code)