### PR TITLE
fix: defer interim interruptions to local VAD

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2089,9 +2089,14 @@ class AgentActivity(RecognitionHooks):
             ),
         )
 
-        if ev.alternatives[0].text and self._turn_detection not in (
-            "manual",
-            "realtime_llm",
+        if (
+            self.vad is None
+            and ev.alternatives[0].text
+            and self._turn_detection
+            not in (
+                "manual",
+                "realtime_llm",
+            )
         ):
             self._interrupt_by_audio_activity()
 

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -125,6 +125,45 @@ def test_realtime_user_input_transcription_preserves_item_id() -> None:
     assert captured_events[0].item_id == "item_123"
 
 
+@pytest.mark.parametrize(
+    ("has_local_vad", "should_interrupt"),
+    [
+        (False, True),
+        (True, False),
+    ],
+)
+def test_interim_transcript_interrupts_only_without_local_vad(
+    has_local_vad: bool, should_interrupt: bool
+) -> None:
+    captured_events: list[UserInputTranscribedEvent] = []
+    activity = object.__new__(AgentActivity)
+    activity._agent = SimpleNamespace(llm=NOT_GIVEN, vad=NOT_GIVEN)
+    activity._session = SimpleNamespace(
+        _text_only=False,
+        llm=None,
+        vad=Mock(spec=vad.VAD) if has_local_vad else None,
+        _user_input_transcribed=captured_events.append,
+    )
+    activity._turn_detection = None
+    activity._paused_speech = None
+    activity._interrupt_by_audio_activity = Mock()
+
+    activity.on_interim_transcript(
+        SpeechEvent(
+            type=SpeechEventType.INTERIM_TRANSCRIPT,
+            alternatives=[SpeechData(text="hello", language=LanguageCode("en"))],
+        ),
+        speaking=None,
+    )
+
+    assert len(captured_events) == 1
+    assert captured_events[0].transcript == "hello"
+    if should_interrupt:
+        activity._interrupt_by_audio_activity.assert_called_once_with()
+    else:
+        activity._interrupt_by_audio_activity.assert_not_called()
+
+
 async def test_events_and_metrics() -> None:
     speed = 1
     actions = FakeActions()


### PR DESCRIPTION
Local VAD should own barge-in detection and apply the configured minimum speech duration. STT partials can be stale or punctuation-only, so treating both as interruption signals can stop valid agent playback.

Sessions without VAD retain interim-based interruption, and final transcripts remain a fallback.

Fixes AGT-3202