### PR TITLE
fix(anthropic): disable vendor SDK retries by default

### DIFF
--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
@@ -76,6 +76,7 @@ class LLM(llm.LLM):
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
         caching: NotGivenOr[Literal["ephemeral"]] = NOT_GIVEN,
         timeout: NotGivenOr[httpx.Timeout] = NOT_GIVEN,
+        max_retries: NotGivenOr[int] = NOT_GIVEN,
         _strict_tool_schema: bool = True,
     ) -> None:
         """
@@ -89,6 +90,8 @@ class LLM(llm.LLM):
         base_url (str, optional): The base URL for the Anthropic API. Defaults to None.
         user (str, optional): The user for the Anthropic API. Defaults to None.
         client (anthropic.AsyncClient | None): The Anthropic client to use. Defaults to None.
+        max_retries (int, optional): Vendor client retries. Defaults to 0 because the framework
+            owns retries via ``conn_options``.
         timeout (httpx.Timeout | None): HTTP timeout configuration for the underlying httpx client.
             Defaults to ``httpx.Timeout(5.0, read=30.0)``, which keeps a tight connect timeout
             while allowing up to 30 s between streamed chunks — long enough for Claude's
@@ -124,6 +127,7 @@ class LLM(llm.LLM):
         self._client = client or anthropic.AsyncClient(
             api_key=anthropic_api_key,
             base_url=base_url if is_given(base_url) else None,
+            max_retries=max_retries if is_given(max_retries) else 0,
             http_client=httpx.AsyncClient(
                 timeout=timeout or httpx.Timeout(5.0, read=30.0),
                 follow_redirects=True,

--- a/tests/test_plugin_anthropic.py
+++ b/tests/test_plugin_anthropic.py
@@ -17,6 +17,13 @@ def _make_llm(**kwargs):
     return LLM(api_key="sk-ant-test", **kwargs)
 
 
+class TestSDKRetries:
+    def test_disabled_by_default(self) -> None:
+        """The framework owns retries, so Anthropic SDK retries must default to disabled."""
+        llm = _make_llm()
+        assert llm._client.max_retries == 0
+
+
 class TestHttpxTimeoutDefaults:
     def test_default_read_timeout_is_generous(self) -> None:
         """Default read timeout must accommodate adaptive-thinking pauses (≥30 s)."""


### PR DESCRIPTION
## Summary

Fixes #6603.

`livekit-plugins-anthropic` was building `anthropic.AsyncClient` without `max_retries`, so the SDK default of 2 internal retries stacked on top of framework `conn_options.max_retry`. That made wall-clock time exceed `conn_options.timeout` (especially with FallbackAdapter).

OpenAI plugin already defaults vendor client retries to 0. This PR matches that for Anthropic.

## Changes

- Pass `max_retries=0` by default when constructing `anthropic.AsyncClient` in the Anthropic LLM plugin.
- Optional `max_retries` constructor arg for callers who want a different vendor-client policy.
- Unit test that the default client has `max_retries == 0`.
- Custom `client=` injection is unchanged (caller owns that client).

## Verification

- `ruff format` / `ruff check` on touched files
- `pytest tests/test_plugin_anthropic.py` (8 passed)

## Backwards compatibility

Default behavior for the constructed client changes from SDK default (2) to 0 so retries are owned by the framework only. Callers who pass their own `client=` are unaffected. Callers who want SDK retries can pass `max_retries=...`.
