### PR TITLE
Add phrase_list_weight option to Azure STT plugin

### DIFF
--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/stt.py
@@ -59,6 +59,7 @@ class STTOptions:
     speech_endpoint: NotGivenOr[str] = NOT_GIVEN
     profanity: NotGivenOr[speechsdk.enums.ProfanityOption] = NOT_GIVEN
     phrase_list: NotGivenOr[list[str] | None] = NOT_GIVEN
+    phrase_list_weight: NotGivenOr[float] = NOT_GIVEN
     explicit_punctuation: bool = False
     true_text_post_processing: bool = False
 
@@ -81,6 +82,7 @@ class STT(stt.STT):
         profanity: NotGivenOr[speechsdk.enums.ProfanityOption] = NOT_GIVEN,
         speech_endpoint: NotGivenOr[str] = NOT_GIVEN,
         phrase_list: NotGivenOr[list[str] | None] = NOT_GIVEN,
+        phrase_list_weight: NotGivenOr[float] = NOT_GIVEN,
         explicit_punctuation: bool = False,
         true_text_post_processing: bool = False,
     ):
@@ -98,6 +100,9 @@ class STT(stt.STT):
         Args:
             phrase_list: List of words or phrases to boost recognition accuracy.
                         Azure will give higher priority to these phrases during recognition.
+            phrase_list_weight: Biasing weight for the phrase list, in the range [0.0, 2.0].
+                        Azure's default is 1.0; higher values bias more strongly toward the
+                        phrase list, and 0.0 disables it without removing the phrases.
             explicit_punctuation: Controls punctuation behavior. If True, enables explicit punctuation mode
                         where punctuation marks are added explicitly. If False (default), uses Azure's
                         default punctuation behavior.
@@ -157,6 +162,7 @@ class STT(stt.STT):
             profanity=profanity,
             speech_endpoint=speech_endpoint,
             phrase_list=phrase_list,
+            phrase_list_weight=phrase_list_weight,
             explicit_punctuation=explicit_punctuation,
             true_text_post_processing=true_text_post_processing,
         )
@@ -526,5 +532,7 @@ def _create_speech_recognizer(
         phrase_list_grammar = speechsdk.PhraseListGrammar.from_recognizer(speech_recognizer)
         for phrase in config.phrase_list:
             phrase_list_grammar.addPhrase(phrase)
+        if is_given(config.phrase_list_weight):
+            phrase_list_grammar.setWeight(config.phrase_list_weight)
 
     return speech_recognizer

--- a/tests/test_plugin_azure_stt.py
+++ b/tests/test_plugin_azure_stt.py
@@ -1,9 +1,11 @@
 import asyncio
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
-from livekit.agents import stt
+from livekit.agents import LanguageCode, stt
+from livekit.agents.types import NOT_GIVEN
 from livekit.plugins.azure import stt as azure_stt
 
 pytestmark = pytest.mark.plugin("azure")
@@ -88,3 +90,55 @@ def test_azure_canceled_without_error_is_ignored():
 
     assert not stream._session_stopped_event.is_set()
     assert stream._cancellation_error is None
+
+
+def _stt_options(**overrides):
+    defaults = {
+        "speech_key": "key",
+        "speech_region": "region",
+        "speech_host": NOT_GIVEN,
+        "speech_auth_token": NOT_GIVEN,
+        "sample_rate": 16000,
+        "num_channels": 1,
+        "segmentation_silence_timeout_ms": NOT_GIVEN,
+        "segmentation_max_time_ms": NOT_GIVEN,
+        "segmentation_strategy": NOT_GIVEN,
+        "language": [LanguageCode("en-US")],
+    }
+    defaults.update(overrides)
+    return azure_stt.STTOptions(**defaults)
+
+
+def _patch_recognizer_deps(monkeypatch, grammar):
+    monkeypatch.setattr(
+        azure_stt.speechsdk,
+        "PhraseListGrammar",
+        SimpleNamespace(from_recognizer=lambda recognizer: grammar),
+    )
+    monkeypatch.setattr(azure_stt.speechsdk, "SpeechConfig", lambda **kwargs: MagicMock())
+    monkeypatch.setattr(azure_stt.speechsdk.audio, "AudioConfig", lambda **kwargs: MagicMock())
+    monkeypatch.setattr(azure_stt.speechsdk, "SpeechRecognizer", lambda **kwargs: MagicMock())
+
+
+def test_azure_phrase_list_weight_applied_to_grammar(monkeypatch):
+    grammar = MagicMock()
+    _patch_recognizer_deps(monkeypatch, grammar)
+    config = _stt_options(phrase_list=["LiveKit", "WebRTC"], phrase_list_weight=1.8)
+
+    azure_stt._create_speech_recognizer(config=config, stream=MagicMock())
+
+    assert [call.args[0] for call in grammar.addPhrase.call_args_list] == [
+        "LiveKit",
+        "WebRTC",
+    ]
+    grammar.setWeight.assert_called_once_with(1.8)
+
+
+def test_azure_phrase_list_without_weight_leaves_grammar_default(monkeypatch):
+    grammar = MagicMock()
+    _patch_recognizer_deps(monkeypatch, grammar)
+    config = _stt_options(phrase_list=["LiveKit"])
+
+    azure_stt._create_speech_recognizer(config=config, stream=MagicMock())
+
+    grammar.setWeight.assert_not_called()


### PR DESCRIPTION
The Azure STT [PhraseListGrammar](https://learn.microsoft.com/en-us/python/api/azure-cognitiveservices-speech/azure.cognitiveservices.speech.phraselistgrammar?view=azure-python) class also exposes `setWeight(weight: float)` to bias recognition toward the phrase list (between 0.0 and 2.0, default 1.0), but the plugin never calls it, so there's no way to modify the default bias.

This adds a `phrase_list_weight` parameter to `STT`/`STTOptions`, analogous to the existing `phrase_list` parameter, that calls `setWeight()` when given.