### PR TITLE
fix: scope the foreground idle hold to one activity

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -182,6 +182,11 @@ class AgentActivity(RecognitionHooks):
         self._user_silence_event: asyncio.Event = asyncio.Event()
         self._user_silence_event.set()
 
+        # `_wait_for_idle_and_hold` scopes on this activity; while > 0, others block
+        self._idle_holds: int = 0
+        self._idle_released: asyncio.Event = asyncio.Event()
+        self._idle_released.set()
+
         # for false interruption handling
         self._paused_speech: _PausedSpeechInfo | None = None
         self._false_interruption_timer: asyncio.TimerHandle | None = None
@@ -1723,9 +1728,9 @@ class AgentActivity(RecognitionHooks):
                 agent_active = wait_for_agent
                 user_active = wait_for_user
 
-            if self._session._idle_holds > 0 and not _IdleHoldContextVar.get():
+            if self._idle_holds > 0 and not _IdleHoldContextVar.get():
                 # another caller holds `_wait_for_idle_and_hold` — block until release
-                await self._session._idle_released.wait()
+                await self._idle_released.wait()
                 agent_active = wait_for_agent
                 user_active = wait_for_user
 

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -560,12 +560,6 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         self._user_turn_released: asyncio.Event = asyncio.Event()
         self._user_turn_released.set()
 
-        # count of active `_wait_for_idle_and_hold` scopes; while > 0, non-holder
-        # `wait_for_idle` callers block until release. holder bypasses via contextvar.
-        self._idle_holds: int = 0
-        self._idle_released: asyncio.Event = asyncio.Event()
-        self._idle_released.set()
-
         self._global_run_state: RunResult | None = None
         # TODO(theomonnom): need a better way to expose early assistant metrics
         self._early_assistant_metrics: MetricsReport | None = None
@@ -1492,20 +1486,24 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
     @asynccontextmanager
     async def _wait_for_idle_and_hold(self) -> AsyncIterator[AgentActivity]:
-        """Wait for idle, then block other ``wait_for_idle`` callers until exit."""
+        """Wait for idle, then block other ``wait_for_idle`` callers on that activity.
+
+        Per-activity, not per-session: work handed to another agent keeps its own floor,
+        or its replies would wait on the work that is waiting for them.
+        """
         from .agent_activity import _IdleHoldContextVar
 
         activity = await self.wait_for_idle()
-        self._idle_holds += 1
-        self._idle_released.clear()
+        activity._idle_holds += 1
+        activity._idle_released.clear()
         token = _IdleHoldContextVar.set(True)
         try:
             yield activity
         finally:
             _IdleHoldContextVar.reset(token)
-            self._idle_holds -= 1
-            if self._idle_holds == 0:
-                self._idle_released.set()
+            activity._idle_holds -= 1
+            if activity._idle_holds == 0:
+                activity._idle_released.set()
 
     async def _update_activity(
         self,

--- a/livekit-agents/livekit/agents/voice/events.py
+++ b/livekit-agents/livekit/agents/voice/events.py
@@ -157,6 +157,9 @@ class RunContext(Generic[Userdata_T]):
 
         On enter, drains this tool's pending deferred reply first so its speech
         plays before the floor is held — keeps chat order matching code order.
+
+        The floor is the current agent's — work handed to another agent keeps its own, so
+        a tool that agent calls still gets its reply.
         """
         await self._drain_pending_reply()
         async with self._session._wait_for_idle_and_hold() as activity:

--- a/tests/test_nested_agent_task.py
+++ b/tests/test_nested_agent_task.py
@@ -152,6 +152,88 @@ async def test_handoff_from_pre_run_speech():
         assert isinstance(sess.current_agent, EnterHandoffAgent)
 
 
+class LookupTask(AgentTask[None]):
+    """A task whose LLM calls an async tool — one that releases the turn mid-run."""
+
+    def __init__(self) -> None:
+        super().__init__(instructions="lookup task")
+
+    async def on_enter(self) -> None:
+        self.session.generate_reply(instructions="lookup_greeting")
+
+    @function_tool
+    async def slow_lookup(self, ctx: RunContext) -> str:
+        """Look something up, reporting progress before the result."""
+        await ctx.update("one moment")
+        return "found it"
+
+
+class ForegroundAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(instructions="root agent")
+
+    @function_tool
+    async def take_floor(self, ctx: RunContext) -> str:
+        """Holds the floor for an interactive task."""
+        async with ctx.foreground():
+            await LookupTask()
+        return "task completed"
+
+
+@pytest.mark.asyncio
+async def test_async_tool_reply_inside_a_foregrounded_task():
+    """A tool called by an AgentTask under ctx.foreground() must still get its deferred
+    reply: a session-wide hold makes the reply wait for the task and the task for the
+    reply."""
+    llm = FakeLLM(
+        fake_responses=[
+            # user says "go" -> the tool takes the floor and hands off to LookupTask
+            FakeLLMResponse(
+                input="go",
+                content="",
+                ttft=0,
+                duration=0,
+                tool_calls=[FunctionToolCall(name="take_floor", arguments="{}", call_id="call_1")],
+            ),
+            FakeLLMResponse(
+                input="lookup_greeting", content="what do you need?", ttft=0, duration=0
+            ),
+            # the task's own turn calls the async tool
+            FakeLLMResponse(
+                input="look it up",
+                content="",
+                ttft=0,
+                duration=0,
+                tool_calls=[FunctionToolCall(name="slow_lookup", arguments="{}", call_id="call_2")],
+            ),
+        ]
+    )
+
+    delivered = asyncio.Event()
+
+    async with AgentSession(llm=llm) as sess:
+
+        @sess.on("tool_execution_updated")
+        def _on_update(ev) -> None:
+            update = ev.update
+            if (
+                update.type == "tool_reply_updated"
+                and update.status == "scheduled"
+                and "call_2_final" in update.update_ids
+            ):
+                delivered.set()
+
+        await sess.start(ForegroundAgent())
+        sess.generate_reply(user_input="go")
+
+        while not isinstance(sess.current_agent, LookupTask):
+            await asyncio.sleep(0.05)
+
+        # the task's turn, arriving from outside the held floor as a real one does
+        sess.generate_reply(user_input="look it up")
+        await asyncio.wait_for(delivered.wait(), timeout=5.0)
+
+
 def _build_fake_llm() -> FakeLLM:
     return FakeLLM(
         fake_responses=[


### PR DESCRIPTION
`ctx.foreground()` took a session-wide idle hold, so it also blocked `wait_for_idle` on activities it had nothing to do with.

When the foregrounded work is an `AgentTask`, any async tool the task's model calls deadlocks: the tool's deferred reply waits for the floor to go quiet, the floor is only released when the task finishes, and the task only finishes once the model has reacted to that reply. 

The hold now lives on the activity that had the floor rather than on the session. A held parent activity still keeps sibling tool replies out for the whole block — its object survives pause/resume, so the protection is intact when the task returns — while the task's own activity delivers its replies as usual.