### PR TITLE
bithuman: fail closed on Python versions the SDK has no build for

### DIFF
--- a/livekit-plugins/livekit-plugins-bithuman/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-bithuman/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Agent Framework plugin for services from BitHuman Avatar Rendering"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.10.0"
+requires-python = ">=3.11"
 authors = [{ name = "LiveKit", email = "support@livekit.io" }]
 keywords = ["voice", "ai", "realtime", "audio", "video", "livekit", "webrtc"]
 classifiers = [
@@ -18,14 +18,18 @@ classifiers = [
     "Topic :: Multimedia :: Video",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
 ]
 
-# bithuman builds only for Python 3.11 through 3.13
+# bithuman builds only for Python 3.11 through 3.13. requires-python holds the lower
+# bound; the upper bound has to be a marker here, since the virtual workspace root
+# intersects requires-python over all members and would cap the whole workspace.
 dependencies = [
     "livekit-agents>=1.6.7",
-    "bithuman>=0.5.25,<3; python_version >= '3.11' and python_version < '3.14'",
+    "bithuman>=0.5.25,<3; python_version < '3.14'",
 ]
 
 [project.urls]

--- a/livekit-plugins/livekit-plugins-bithuman/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-bithuman/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Agent Framework plugin for services from BitHuman Avatar Rendering"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.11"
+requires-python = ">=3.10.0"
 authors = [{ name = "LiveKit", email = "support@livekit.io" }]
 keywords = ["voice", "ai", "realtime", "audio", "video", "livekit", "webrtc"]
 classifiers = [
@@ -18,18 +18,20 @@ classifiers = [
     "Topic :: Multimedia :: Video",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
 ]
 
-# bithuman builds only for Python 3.11 through 3.13. requires-python holds the lower
-# bound; the upper bound has to be a marker here, since the virtual workspace root
-# intersects requires-python over all members and would cap the whole workspace.
+# bithuman builds only for Python 3.11 through 3.13. Both marker bounds are
+# load-bearing while the floor stays at 0.5.25: 2.3.10 ships cp310 and cp314
+# wheels and declares no upper bound, so either bound dropped lets an install
+# outside 3.11-3.13 backtrack onto it instead of resolving bithuman away.
 dependencies = [
     "livekit-agents>=1.6.7",
-    "bithuman>=0.5.25,<3; python_version < '3.14'",
+    "bithuman>=0.5.25,<3; python_version >= '3.11' and python_version < '3.14'",
 ]
 
 [project.urls]

--- a/livekit-plugins/livekit-plugins-bithuman/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-bithuman/pyproject.toml
@@ -25,10 +25,11 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 
-# bithuman builds only for Python 3.11 through 3.13. Both marker bounds are
-# load-bearing while the floor stays at 0.5.25: 2.3.10 ships cp310 and cp314
-# wheels and declares no upper bound, so either bound dropped lets an install
-# outside 3.11-3.13 backtrack onto it instead of resolving bithuman away.
+# bithuman 2.x builds only for Python 3.11 through 3.13, so the marker keeps
+# 3.10 and 3.14 from resolving it at all rather than backtracking onto 2.3.10,
+# which ships cp310 and cp314 wheels and declares no upper bound. The floor
+# stays wide so platforms 2.x dropped (Windows, x86_64 macOS, macOS < 14) can
+# still resolve the 1.x line, which satisfies everything avatar.py calls.
 dependencies = [
     "livekit-agents>=1.6.7",
     "bithuman>=0.5.25,<3; python_version >= '3.11' and python_version < '3.14'",


### PR DESCRIPTION
Rescoped: #6561 landed the marker on the plugin's own dependency while this was open, so the root `override-dependencies` approach here is redundant. Rebased onto main; what's left is the metadata fix.

`requires-python` was `>=3.10` and the classifiers claimed 3.10 only, while `bithuman` 2.6+ requires `>=3.11,<3.14`. The wide dep range (`>=0.5.25,<3`) let a 3.10 install backtrack to `bithuman==2.3.10` (which ships cp310 wheels) and succeed against a stale SDK rather than being refused, so the floor moves into `requires-python` and the classifiers list the versions that actually work.

The `<3.14` bound stays a marker: the virtual workspace root intersects `requires-python` over all members, so an upper bound here would cap the whole workspace.

Verified: the built wheel reports `Requires-Python: >=3.11` and `Requires-Dist: bithuman<3,>=0.5.25; python_version < '3.14'`; `uv sync --python 3.14 --all-extras --dev` resolves with `bithuman` absent and the plugin still installed; `--python 3.13` installs `bithuman==2.7.0`; `uv lock` is a no-op.

Not addressed: there are no Windows or macOS-x86_64 `bithuman` wheels, so installs fail there on every Python version. The `>=0.5.25` floor is also stale — it is what makes deep backtracks possible — but raising it is a user-facing compat change and belongs in its own PR.
