### PR TITLE
fix(voice): reset tool call created_at at execution start in realtime replies

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3918,7 +3918,12 @@ class AgentActivity(RecognitionHooks):
             )
         )
 
+        # messages in RunResult are ordered by the `created_at` field
         def _tool_execution_started_cb(fnc_call: llm.FunctionCall) -> None:
+            # function call is created during the realtime generation, before the assistant
+            # message it belongs to is placed at `started_speaking_at`
+            # reset the `created_at` to the start time of the tool execution
+            fnc_call.created_at = time.time()
             speech_handle._item_added([fnc_call])
             self._agent._chat_ctx._upsert_item(fnc_call)
             self._session._tool_items_added([fnc_call])

--- a/tests/test_realtime_tool_call_created_at.py
+++ b/tests/test_realtime_tool_call_created_at.py
@@ -1,0 +1,73 @@
+import asyncio
+import time
+
+import pytest
+
+from livekit import rtc
+from livekit.agents import Agent, AgentSession, function_tool, llm, utils
+
+from .fake_realtime import FakeRealtimeModel, fake_capabilities
+
+pytestmark = pytest.mark.unit
+
+
+async def test_realtime_tool_call_created_at_is_stamped_at_execution_start() -> None:
+    executed = asyncio.Event()
+
+    class ToolAgent(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="test")
+
+        @function_tool
+        async def lookup(self) -> str:
+            executed.set()
+            return "ok"
+
+    model = FakeRealtimeModel(capabilities=fake_capabilities(audio_output=False))
+
+    async with AgentSession(llm=model) as session:
+        await session.start(ToolAgent())
+
+        session.generate_reply()
+        while not model.active_session._reply_futs:
+            await asyncio.sleep(0)
+
+        message_ch = utils.aio.Chan[llm.MessageGeneration]()
+        function_ch = utils.aio.Chan[llm.FunctionCall]()
+        text_ch = utils.aio.Chan[str]()
+        audio_ch = utils.aio.Chan[rtc.AudioFrame]()
+        modalities = asyncio.Future[list[str]]()
+        modalities.set_result(["text"])
+
+        message_ch.send_nowait(
+            llm.MessageGeneration(
+                message_id="message-id",
+                text_stream=text_ch,
+                audio_stream=audio_ch,
+                modalities=modalities,
+            )
+        )
+        message_ch.close()
+        text_ch.send_nowait("Let me look that up.")
+        text_ch.close()
+        audio_ch.close()
+
+        # a call the model emitted well before this generation was authorized to speak
+        fnc_call = llm.FunctionCall(
+            call_id="call_1", name="lookup", arguments="{}", created_at=time.time() - 60
+        )
+        function_ch.send_nowait(fnc_call)
+        function_ch.close()
+
+        authorized_at = time.time()
+        model.active_session._reply_futs[0].set_result(
+            llm.GenerationCreatedEvent(
+                message_stream=message_ch,
+                function_stream=function_ch,
+                user_initiated=True,
+            )
+        )
+
+        await asyncio.wait_for(executed.wait(), timeout=5)
+
+    assert fnc_call.created_at >= authorized_at


### PR DESCRIPTION
`_pipeline_reply_task_impl` resets `fnc_call.created_at` when execution starts (agent_activity.py:3266); the realtime callback did not. The realtime assistant message is placed at `started_speaking_at`, and a realtime model starts emitting audio before the tool call arrives in the function stream, so the unreset call sorted ahead of the message that requested it — in chat context, in RunResult, and in the uploaded transcript.

Test drives a realtime generation whose function stream carries a call created 60s earlier and asserts the stamp lands at execution time; it fails without the change. Unit suite: 1607 passing (`tests/test_convert_html_docs.py` fails collection on main already, unrelated).

Counterpart to livekit/agents-js#2171.