### PR TITLE
fix(voice): place a realtime user turn where the turn began

### DIFF
--- a/livekit-agents/livekit/agents/llm/realtime.py
+++ b/livekit-agents/livekit/agents/llm/realtime.py
@@ -161,6 +161,13 @@ class InputTranscriptionCompleted:
     is_final: bool
     confidence: float | None = None
     """confidence score of the transcript (0.0 to 1.0), derived from model logprobs"""
+    turn_started_at: float | None = None
+    """When the turn this transcript belongs to began (``time.time()``).
+
+    A provider that withholds the final transcript until its reply has finished
+    generating should set this, so the user message can be placed on the session
+    timeline where the turn happened rather than where the transcript arrived.
+    """
 
 
 @dataclass

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1919,9 +1919,12 @@ class AgentActivity(RecognitionHooks):
             if self.stt is None and ev.transcript and (amd := self._session._amd) is not None:
                 amd._on_transcript(ev.transcript)
 
-            # TODO: for realtime models, the created_at field is off. it should be set to when the user started speaking.
-            # but we don't have that information here.
             msg = llm.ChatMessage(role="user", content=[ev.transcript], id=ev.item_id)
+            if ev.turn_started_at is not None:
+                # a provider may withhold the final transcript until its reply has finished
+                # generating, which would otherwise stamp the turn after the reply it prompted
+                msg.created_at = ev.turn_started_at
+                msg.metrics = {"started_speaking_at": ev.turn_started_at}
             self._agent._chat_ctx._upsert_item(msg)
             self._session._conversation_item_added(msg)
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -880,6 +880,11 @@ class RealtimeSession(
         # accumulates partial input-audio transcripts per (item_id, content_index)
         self._input_transcript_accumulators: dict[str, dict[int, str]] = {}
 
+        # when serverside VAD detected speech onset, per item_id. Correlating through the
+        # item keeps each turn paired with its own start; a single "last speech started"
+        # value cannot, because a late transcript would consume the next turn's value.
+        self._input_speech_started_at: dict[str, float] = {}
+
         self._current_generation: _ResponseGeneration | _DiscardedGeneration | None = None
         self._remote_chat_ctx = llm.remote_chat_context.RemoteChatContext()
 
@@ -928,6 +933,7 @@ class RealtimeSession(
             old_chat_ctx = self._remote_chat_ctx
             self._remote_chat_ctx = llm.remote_chat_context.RemoteChatContext()
             self._input_transcript_accumulators.clear()
+            self._input_speech_started_at.clear()
             events.extend(self._create_update_chat_ctx_events(chat_ctx))
 
             try:
@@ -1773,8 +1779,10 @@ class RealtimeSession(
             yield frame
 
     def _handle_input_audio_buffer_speech_started(
-        self, _: InputAudioBufferSpeechStartedEvent
+        self, event: InputAudioBufferSpeechStartedEvent
     ) -> None:
+        if event.item_id:
+            self._input_speech_started_at[event.item_id] = time.time()
         self.emit("input_speech_started", llm.InputSpeechStartedEvent())
 
     def _handle_input_audio_buffer_speech_stopped(
@@ -1898,6 +1906,7 @@ class RealtimeSession(
         assert event.item_id is not None, "item_id is None"
 
         self._input_transcript_accumulators.pop(event.item_id, None)
+        self._input_speech_started_at.pop(event.item_id, None)
 
         try:
             self._remote_chat_ctx.delete(event.item_id)
@@ -1958,6 +1967,7 @@ class RealtimeSession(
                 transcript=event.transcript,
                 is_final=True,
                 confidence=confidence,
+                turn_started_at=self._input_speech_started_at.pop(event.item_id, None),
             ),
         )
 
@@ -1971,12 +1981,16 @@ class RealtimeSession(
 
         # close any open partial stream so consumers waiting for is_final don't hang
         partial = self._clear_transcript_accumulator(event.item_id, event.content_index or 0)
+        turn_started_at = self._input_speech_started_at.pop(event.item_id, None)
         if partial is None:
             return
         self.emit(
             "input_audio_transcription_completed",
             llm.InputTranscriptionCompleted(
-                item_id=event.item_id, transcript=partial, is_final=True
+                item_id=event.item_id,
+                transcript=partial,
+                is_final=True,
+                turn_started_at=turn_started_at,
             ),
         )
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -877,13 +877,7 @@ class RealtimeSession(
         # response is cancelled by id and discarded when it finally arrives
         self._discarded_event_ids: set[str] = set()
 
-        # accumulates partial input-audio transcripts per (item_id, content_index)
-        self._input_transcript_accumulators: dict[str, dict[int, str]] = {}
-
-        # when serverside VAD detected speech onset, per item_id. Correlating through the
-        # item keeps each turn paired with its own start; a single "last speech started"
-        # value cannot, because a late transcript would consume the next turn's value.
-        self._input_speech_started_at: dict[str, float] = {}
+        self._reset_input_turn_state()
 
         self._current_generation: _ResponseGeneration | _DiscardedGeneration | None = None
         self._remote_chat_ctx = llm.remote_chat_context.RemoteChatContext()
@@ -900,6 +894,20 @@ class RealtimeSession(
     def send_event(self, event: RealtimeClientEvent | dict[str, Any]) -> None:
         with contextlib.suppress(utils.aio.channel.ChanClosed):
             self._msg_ch.send_nowait(event)
+
+    def _reset_input_turn_state(self) -> None:
+        """Per-turn input state, keyed by item_id and valid only within one connection.
+
+        Every field here must be discarded on reconnect: the server assigns new item ids,
+        so a stale entry can never be matched again.
+        """
+        # accumulates partial input-audio transcripts per (item_id, content_index)
+        self._input_transcript_accumulators: dict[str, dict[int, str]] = {}
+
+        # when serverside VAD detected speech onset, per item_id. Correlating through the
+        # item keeps each turn paired with its own start; a single "last speech started"
+        # value cannot, because a late transcript would consume the next turn's value.
+        self._input_speech_started_at: dict[str, float] = {}
 
     @utils.log_exceptions(logger=logger)
     async def _main_task(self) -> None:
@@ -932,8 +940,7 @@ class RealtimeSession(
             )
             old_chat_ctx = self._remote_chat_ctx
             self._remote_chat_ctx = llm.remote_chat_context.RemoteChatContext()
-            self._input_transcript_accumulators.clear()
-            self._input_speech_started_at.clear()
+            self._reset_input_turn_state()
             events.extend(self._create_update_chat_ctx_events(chat_ctx))
 
             try:

--- a/tests/test_realtime/test_xai_realtime_model.py
+++ b/tests/test_realtime/test_xai_realtime_model.py
@@ -14,7 +14,7 @@ def _make_session() -> tuple[RealtimeSession, list[llm.InputTranscriptionComplet
     # build a session instance without going through __init__ (no network/model needed)
     session = RealtimeSession.__new__(RealtimeSession)
     session._remote_chat_ctx = RemoteChatContext()  # type: ignore[attr-defined]
-    session._input_transcript_accumulators = {}  # type: ignore[attr-defined]
+    session._reset_input_turn_state()
 
     emitted: list[llm.InputTranscriptionCompleted] = []
     session.emit = lambda name, ev: emitted.append(ev)  # type: ignore[method-assign,assignment]

--- a/tests/test_realtime_message_metrics.py
+++ b/tests/test_realtime_message_metrics.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 
 import pytest
 
@@ -61,3 +62,69 @@ async def test_realtime_response_id_is_available_on_assistant_message() -> None:
     ]
     assert len(assistant_messages) == 1
     assert assistant_messages[0].metrics["provider_request_ids"] == ["provider-response-id"]
+
+
+async def _transcribed_user_messages(
+    *transcripts: llm.InputTranscriptionCompleted,
+) -> list[llm.ChatMessage]:
+    model = FakeRealtimeModel(capabilities=fake_capabilities(audio_output=False))
+    conversation_events: list[ConversationItemAddedEvent] = []
+
+    async with AgentSession(llm=model) as session:
+        session.on("conversation_item_added", conversation_events.append)
+        await session.start(Agent(instructions="test"))
+
+        for transcript in transcripts:
+            model.active_session.emit("input_audio_transcription_completed", transcript)
+        await asyncio.sleep(0)
+
+    return [
+        event.item
+        for event in conversation_events
+        if event.item.type == "message" and event.item.role == "user"
+    ]
+
+
+async def test_realtime_user_message_placed_where_the_turn_began() -> None:
+    # the provider withholds the transcript until its reply is done generating
+    turn_started_at = 1_000_000.0
+
+    messages = await _transcribed_user_messages(
+        llm.InputTranscriptionCompleted(
+            item_id="item_1",
+            transcript="what is my name?",
+            is_final=True,
+            turn_started_at=turn_started_at,
+        )
+    )
+
+    assert len(messages) == 1
+    assert messages[0].created_at == turn_started_at
+    assert messages[0].metrics["started_speaking_at"] == turn_started_at
+
+
+async def test_realtime_late_transcripts_keep_their_own_turn_start() -> None:
+    messages = await _transcribed_user_messages(
+        llm.InputTranscriptionCompleted(
+            item_id="item_1", transcript="first", is_final=True, turn_started_at=1_000_000.0
+        ),
+        llm.InputTranscriptionCompleted(
+            item_id="item_2", transcript="second", is_final=True, turn_started_at=1_005_000.0
+        ),
+    )
+
+    assert [msg.created_at for msg in messages] == [1_000_000.0, 1_005_000.0]
+
+
+async def test_realtime_user_message_falls_back_to_delivery_time() -> None:
+    before = time.time()
+
+    messages = await _transcribed_user_messages(
+        llm.InputTranscriptionCompleted(
+            item_id="item_1", transcript="text injected turn", is_final=True
+        )
+    )
+
+    assert len(messages) == 1
+    assert before <= messages[0].created_at <= time.time()
+    assert "started_speaking_at" not in messages[0].metrics


### PR DESCRIPTION
Port of livekit/agents-js#2165.

## Problem

A realtime user message is committed with neither a `created_at` nor any `metrics`, so it lands on the session timeline where the provider *delivered the transcript*. The realtime assistant message pins `created_at` to `started_speaking_at` (`agent_activity.py:3911`), so it lands where the agent was *heard*. Any provider that withholds the final transcript past its own first audio frame therefore stamps the question after the answer, and the Cloud transcript renders every reply ahead of the question it answered.

The `# TODO: for realtime models, the created_at field is off` in `_on_input_audio_transcription_completed` is exactly this.

## Fix

Let a provider report the turn start via `InputTranscriptionCompleted.turn_started_at`, and stamp the user message's `created_at` and `metrics["started_speaking_at"]` with it. The OpenAI plugin records serverside VAD speech onset per `item_id` and attaches it to that item's transcript; correlating through the item keeps each turn paired with its own start, which a session-level "last speech started" value cannot do — a late transcript would consume the following turn's value.

`_upsert_item` appends rather than inserting by `created_at`, so chat context ordering and the LLM prompt are unaffected.

## Testing

Live OpenAI realtime voice session. Before, the reply's `created_at` was 374 ms *earlier* than the question it answered — assistant `…15.766` vs user `…16.140`. After, on the same script, the user turn lands 2.54 s *ahead* of its reply: user `1785420303.370` -> assistant `1785420305.913`.

Three new tests in `tests/test_realtime_message_metrics.py`; the first two fail on `main` and pass here. `tests/test_realtime_*`, `test_openai_realtime_chat_ctx.py`, `test_plugin_openai_realtime_reasoning.py` and `test_agent_session.py`: 133 passing.

## Known limit

`turn_started_at` is opt-in per provider — a realtime plugin that does not set it keeps today's behaviour. Only the OpenAI plugin sets it here. Gemini Live is the provider where this hurts most (it delivers the final transcript 9-10 s late, so the question renders far below its answer); its counterpart needs `generation.create_time` wired into the two `InputTranscriptionCompleted` emit sites in `livekit-plugins-google`, which I could not verify without a Google API key.