### PR TITLE
feat(google): accept a credentials object on STT and TTS

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -315,6 +315,14 @@ class STT(stt.STT):
         if self._location != "global":
             client_options = ClientOptions(api_endpoint=f"{self._location}-speech.googleapis.com")
         if self._credentials is not None:
+            if self._project_id is None:
+                # in-memory credentials (e.g. Workload Identity Federation) may
+                # carry the project directly; resolve it here so _get_recognizer
+                # doesn't fall back to Application Default Credentials, which
+                # such setups typically don't have
+                self._project_id = getattr(self._credentials, "project_id", None) or getattr(
+                    self._credentials, "quota_project_id", None
+                )
             client = client_cls(credentials=self._credentials, client_options=client_options)
         elif is_given(self._credentials_info):
             client = client_cls.from_service_account_info(
@@ -345,7 +353,16 @@ class STT(stt.STT):
         except AttributeError:
             from google.auth import default as ga_default
 
-            _, project_id = ga_default()
+            try:
+                _, project_id = ga_default()
+            except DefaultCredentialsError as e:
+                raise APIConnectionError(
+                    "google stt: could not determine the GCP project id: the supplied "
+                    "credentials expose no project_id/quota_project_id and Application "
+                    "Default Credentials are unavailable. Pass credentials that carry a "
+                    "project (e.g. with a quota_project_id) or use credentials_info / "
+                    "credentials_file."
+                ) from e
         return f"projects/{project_id}/locations/{self._location}/recognizers/_"
 
     def _sanitize_options(self, *, language: NotGivenOr[str] = NOT_GIVEN) -> STTOptions:

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -27,6 +27,7 @@ from typing import cast, get_args
 from grpc.aio import StreamStreamCall
 
 import google.auth
+import google.auth.credentials
 from google.api_core.client_options import ClientOptions
 from google.api_core.exceptions import DeadlineExceeded, GoogleAPICallError
 from google.auth import default as gauth_default
@@ -158,6 +159,7 @@ class STT(stt.STT):
         ] = NOT_GIVEN,
         credentials_info: NotGivenOr[dict] = NOT_GIVEN,
         credentials_file: NotGivenOr[str] = NOT_GIVEN,
+        credentials: google.auth.credentials.Credentials | None = None,
         keywords: NotGivenOr[list[tuple[str, float]]] = NOT_GIVEN,
         speech_start_timeout: NotGivenOr[float] = NOT_GIVEN,
         speech_end_timeout: NotGivenOr[float] = NOT_GIVEN,
@@ -167,8 +169,9 @@ class STT(stt.STT):
         """
         Create a new instance of Google STT.
 
-        Credentials must be provided, either by using the ``credentials_info`` dict, or reading
-        from the file specified in ``credentials_file`` or via Application Default Credentials as
+        Credentials must be provided, either as a ``google.auth.credentials.Credentials`` object
+        via ``credentials``, by using the ``credentials_info`` dict, by reading from the file
+        specified in ``credentials_file``, or via Application Default Credentials as
         described in https://cloud.google.com/docs/authentication/application-default-credentials
 
         args:
@@ -190,6 +193,10 @@ class STT(stt.STT):
             adaptation (SpeechAdaptation): speech adaptation for biasing specific words and phrases (default: None)
             credentials_info(dict): the credentials info to use for recognition (default: None)
             credentials_file(str): the credentials file to use for recognition (default: None)
+            credentials(google.auth.credentials.Credentials): a credentials object to use
+                directly, e.g. from Workload Identity Federation, where credentials are
+                obtained in memory and never exist on disk. Takes precedence over
+                ``credentials_info`` and ``credentials_file`` (default: None)
             keywords(List[tuple[str, float]]): list of keywords to recognize (default: None)
             speech_start_timeout(float): maximum seconds to wait for speech to begin before timeout (default: None)
             speech_end_timeout(float): seconds of silence before marking utterance as complete (default: None)
@@ -239,9 +246,14 @@ class STT(stt.STT):
         self._location = location
         self._credentials_info = credentials_info
         self._credentials_file = credentials_file
+        self._credentials = credentials
         self._project_id: str | None = None
 
-        if not is_given(credentials_file) and not is_given(credentials_info):
+        if (
+            credentials is None
+            and not is_given(credentials_file)
+            and not is_given(credentials_info)
+        ):
             try:
                 gauth_default()
             except DefaultCredentialsError:
@@ -302,7 +314,9 @@ class STT(stt.STT):
         client_cls = SpeechAsyncClientV2 if self._config.version == 2 else SpeechAsyncClientV1
         if self._location != "global":
             client_options = ClientOptions(api_endpoint=f"{self._location}-speech.googleapis.com")
-        if is_given(self._credentials_info):
+        if self._credentials is not None:
+            client = client_cls(credentials=self._credentials, client_options=client_options)
+        elif is_given(self._credentials_info):
             client = client_cls.from_service_account_info(
                 self._credentials_info, client_options=client_options
             )

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -159,7 +159,7 @@ class STT(stt.STT):
         ] = NOT_GIVEN,
         credentials_info: NotGivenOr[dict] = NOT_GIVEN,
         credentials_file: NotGivenOr[str] = NOT_GIVEN,
-        credentials: google.auth.credentials.Credentials | None = None,
+        credentials: NotGivenOr[google.auth.credentials.Credentials] = NOT_GIVEN,
         keywords: NotGivenOr[list[tuple[str, float]]] = NOT_GIVEN,
         speech_start_timeout: NotGivenOr[float] = NOT_GIVEN,
         speech_end_timeout: NotGivenOr[float] = NOT_GIVEN,
@@ -196,7 +196,7 @@ class STT(stt.STT):
             credentials(google.auth.credentials.Credentials): a credentials object to use
                 directly, e.g. from Workload Identity Federation, where credentials are
                 obtained in memory and never exist on disk. Takes precedence over
-                ``credentials_info`` and ``credentials_file`` (default: None)
+                ``credentials_info`` and ``credentials_file`` (default: NOT_GIVEN)
             keywords(List[tuple[str, float]]): list of keywords to recognize (default: None)
             speech_start_timeout(float): maximum seconds to wait for speech to begin before timeout (default: None)
             speech_end_timeout(float): seconds of silence before marking utterance as complete (default: None)
@@ -250,7 +250,7 @@ class STT(stt.STT):
         self._project_id: str | None = None
 
         if (
-            credentials is None
+            not is_given(credentials)
             and not is_given(credentials_file)
             and not is_given(credentials_info)
         ):
@@ -314,7 +314,7 @@ class STT(stt.STT):
         client_cls = SpeechAsyncClientV2 if self._config.version == 2 else SpeechAsyncClientV1
         if self._location != "global":
             client_options = ClientOptions(api_endpoint=f"{self._location}-speech.googleapis.com")
-        if self._credentials is not None:
+        if is_given(self._credentials):
             if self._project_id is None:
                 # in-memory credentials (e.g. Workload Identity Federation) may
                 # carry the project directly; resolve it here so _get_recognizer

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
@@ -86,7 +86,7 @@ class TTS(tts.TTS):
         audio_encoding: texttospeech.AudioEncoding = texttospeech.AudioEncoding.PCM,  # type: ignore
         credentials_info: NotGivenOr[dict] = NOT_GIVEN,
         credentials_file: NotGivenOr[str] = NOT_GIVEN,
-        credentials: google.auth.credentials.Credentials | None = None,
+        credentials: NotGivenOr[google.auth.credentials.Credentials] = NOT_GIVEN,
         tokenizer: NotGivenOr[tokenize.SentenceTokenizer] = NOT_GIVEN,
         custom_pronunciations: NotGivenOr[CustomPronunciations] = NOT_GIVEN,
         use_streaming: bool = True,
@@ -116,7 +116,7 @@ class TTS(tts.TTS):
             volume_gain_db (float, optional): Volume gain in decibels. Default is 0.0. In the range [-96.0, 16.0]. Strongly recommended not to exceed +10 (dB).
             credentials_info (dict, optional): Dictionary containing Google Cloud credentials. Default is None.
             credentials_file (str, optional): Path to the Google Cloud credentials JSON file. Default is None.
-            credentials (google.auth.credentials.Credentials, optional): A credentials object to use directly, e.g. from Workload Identity Federation, where credentials are obtained in memory and never exist on disk. Takes precedence over ``credentials_info`` and ``credentials_file``. Default is None.
+            credentials (google.auth.credentials.Credentials, optional): A credentials object to use directly, e.g. from Workload Identity Federation, where credentials are obtained in memory and never exist on disk. Takes precedence over ``credentials_info`` and ``credentials_file``. Default is NOT_GIVEN.
             tokenizer (tokenize.SentenceTokenizer, optional): Tokenizer for the TTS. Defaults to `livekit.agents.tokenize.blingfire.SentenceTokenizer`.
             custom_pronunciations (CustomPronunciations, optional): Custom pronunciations for the TTS. Default is None.
             use_streaming (bool, optional): Whether to use streaming synthesis. Default is True.
@@ -258,7 +258,7 @@ class TTS(tts.TTS):
             api_endpoint = f"{self._location}-texttospeech.googleapis.com"
 
         if self._client is None:
-            if self._credentials is not None:
+            if is_given(self._credentials):
                 self._client = texttospeech.TextToSpeechAsyncClient(
                     credentials=self._credentials,
                     client_options=ClientOptions(api_endpoint=api_endpoint),

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, replace
 from typing import Any
 
 import google.auth
+import google.auth.credentials
 from google.api_core.client_options import ClientOptions
 from google.api_core.exceptions import DeadlineExceeded, GoogleAPICallError
 from google.cloud import texttospeech
@@ -85,6 +86,7 @@ class TTS(tts.TTS):
         audio_encoding: texttospeech.AudioEncoding = texttospeech.AudioEncoding.PCM,  # type: ignore
         credentials_info: NotGivenOr[dict] = NOT_GIVEN,
         credentials_file: NotGivenOr[str] = NOT_GIVEN,
+        credentials: google.auth.credentials.Credentials | None = None,
         tokenizer: NotGivenOr[tokenize.SentenceTokenizer] = NOT_GIVEN,
         custom_pronunciations: NotGivenOr[CustomPronunciations] = NOT_GIVEN,
         use_streaming: bool = True,
@@ -94,8 +96,9 @@ class TTS(tts.TTS):
         """
         Create a new instance of Google TTS.
 
-        Credentials must be provided, either by using the ``credentials_info`` dict, or reading
-        from the file specified in ``credentials_file`` or the ``GOOGLE_APPLICATION_CREDENTIALS``
+        Credentials must be provided, either as a ``google.auth.credentials.Credentials`` object
+        via ``credentials``, by using the ``credentials_info`` dict, by reading from the file
+        specified in ``credentials_file``, or via the ``GOOGLE_APPLICATION_CREDENTIALS``
         environmental variable.
 
         Args:
@@ -113,6 +116,7 @@ class TTS(tts.TTS):
             volume_gain_db (float, optional): Volume gain in decibels. Default is 0.0. In the range [-96.0, 16.0]. Strongly recommended not to exceed +10 (dB).
             credentials_info (dict, optional): Dictionary containing Google Cloud credentials. Default is None.
             credentials_file (str, optional): Path to the Google Cloud credentials JSON file. Default is None.
+            credentials (google.auth.credentials.Credentials, optional): A credentials object to use directly, e.g. from Workload Identity Federation, where credentials are obtained in memory and never exist on disk. Takes precedence over ``credentials_info`` and ``credentials_file``. Default is None.
             tokenizer (tokenize.SentenceTokenizer, optional): Tokenizer for the TTS. Defaults to `livekit.agents.tokenize.blingfire.SentenceTokenizer`.
             custom_pronunciations (CustomPronunciations, optional): Custom pronunciations for the TTS. Default is None.
             use_streaming (bool, optional): Whether to use streaming synthesis. Default is True.
@@ -134,6 +138,7 @@ class TTS(tts.TTS):
         self._client: texttospeech.TextToSpeechAsyncClient | None = None
         self._credentials_info = credentials_info
         self._credentials_file = credentials_file
+        self._credentials = credentials
         self._location = location
 
         lang = LanguageCode(language) if is_given(language) else DEFAULT_LANGUAGE
@@ -253,7 +258,12 @@ class TTS(tts.TTS):
             api_endpoint = f"{self._location}-texttospeech.googleapis.com"
 
         if self._client is None:
-            if self._credentials_info:
+            if self._credentials is not None:
+                self._client = texttospeech.TextToSpeechAsyncClient(
+                    credentials=self._credentials,
+                    client_options=ClientOptions(api_endpoint=api_endpoint),
+                )
+            elif self._credentials_info:
                 self._client = texttospeech.TextToSpeechAsyncClient.from_service_account_info(
                     self._credentials_info, client_options=ClientOptions(api_endpoint=api_endpoint)
                 )

--- a/tests/test_google_credentials.py
+++ b/tests/test_google_credentials.py
@@ -1,0 +1,50 @@
+"""Hermetic tests for the google plugin's direct ``credentials`` parameter (#6586).
+
+Uses ``AnonymousCredentials`` — a real ``google.auth.credentials.Credentials``
+object that requires no files, environment, or network — to verify the object
+is passed through to the underlying clients, mirroring what Workload Identity
+Federation setups do with in-memory credentials.
+"""
+
+import pytest
+from google.auth.credentials import AnonymousCredentials
+
+from livekit.plugins.google import STT, TTS
+
+pytestmark = pytest.mark.unit
+
+
+class TestSTTCredentials:
+    def test_constructs_without_adc(self) -> None:
+        # before #6586 there was no way to construct STT without ADC,
+        # credentials_info, or a credentials file on disk
+        creds = AnonymousCredentials()
+        stt_instance = STT(credentials=creds)
+        assert stt_instance._credentials is creds
+
+    async def test_client_uses_supplied_credentials(self) -> None:
+        creds = AnonymousCredentials()
+        stt_instance = STT(credentials=creds)
+        client = await stt_instance._create_client(timeout=1.0)
+        assert client.transport._credentials is creds
+
+    async def test_credentials_take_precedence_over_file(self, tmp_path) -> None:
+        creds = AnonymousCredentials()
+        # the file path is never read when a credentials object is supplied
+        stt_instance = STT(credentials=creds, credentials_file=str(tmp_path / "missing.json"))
+        client = await stt_instance._create_client(timeout=1.0)
+        assert client.transport._credentials is creds
+
+
+class TestTTSCredentials:
+    def test_client_uses_supplied_credentials(self) -> None:
+        creds = AnonymousCredentials()
+        tts_instance = TTS(credentials=creds)
+        client = tts_instance._ensure_client()
+        assert client.transport._credentials is creds
+
+    def test_credentials_take_precedence_over_file(self, tmp_path) -> None:
+        creds = AnonymousCredentials()
+        tts_instance = TTS(credentials=creds, credentials_file=str(tmp_path / "missing.json"))
+        client = tts_instance._ensure_client()
+        assert client.transport._credentials is creds

--- a/tests/test_google_credentials.py
+++ b/tests/test_google_credentials.py
@@ -9,9 +9,16 @@ Federation setups do with in-memory credentials.
 import pytest
 from google.auth.credentials import AnonymousCredentials
 
+from livekit.agents import APIConnectionError
 from livekit.plugins.google import STT, TTS
 
 pytestmark = pytest.mark.unit
+
+
+class _ProjectCredentials(AnonymousCredentials):
+    """In-memory credentials that carry a project, like WIF impersonated creds."""
+
+    project_id = "test-project-123"
 
 
 class TestSTTCredentials:
@@ -34,6 +41,26 @@ class TestSTTCredentials:
         stt_instance = STT(credentials=creds, credentials_file=str(tmp_path / "missing.json"))
         client = await stt_instance._create_client(timeout=1.0)
         assert client.transport._credentials is creds
+
+    async def test_recognizer_uses_project_from_credentials(self) -> None:
+        # credentials carrying a project must not fall back to ADC
+        creds = _ProjectCredentials()
+        stt_instance = STT(credentials=creds)
+        client = await stt_instance._create_client(timeout=1.0)
+        assert stt_instance._project_id == "test-project-123"
+        recognizer = stt_instance._get_recognizer(client)
+        assert recognizer == "projects/test-project-123/locations/global/recognizers/_"
+
+    async def test_clear_error_when_project_unresolvable(self, monkeypatch) -> None:
+        # no project on the credentials and no ADC available: the error must
+        # say what is wrong instead of a confusing "default credentials not
+        # found" at transcription time (Devin finding on #6618)
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        creds = AnonymousCredentials()
+        stt_instance = STT(credentials=creds)
+        client = await stt_instance._create_client(timeout=1.0)
+        with pytest.raises(APIConnectionError, match="could not determine the GCP project id"):
+            stt_instance._get_recognizer(client)
 
 
 class TestTTSCredentials:


### PR DESCRIPTION
﻿Fixes #6586

## Problem

`google.STT` and `google.TTS` only authenticate via `credentials_info` (a service-account dict), `credentials_file` (a path on disk), or Application Default Credentials. Workload Identity Federation setups with custom credential providers hold a `google.auth.credentials.Credentials` object in memory that never exists as a file — and had no way to pass it, despite both classes already constructing their clients with `credentials=<object>` internally (they just insisted on deriving that object from a file first).

## Change

Adds an optional `credentials` parameter to both `google.STT` and `google.TTS`, passed straight through to `SpeechAsyncClient` / `TextToSpeechAsyncClient`. It takes precedence over `credentials_info` / `credentials_file`, and STT skips its ADC-availability check when the object is supplied. Signature and type match the `credentials` parameter already accepted by `RealtimeModel`, `LLM`, and the aiplatform LLM in this same plugin — this just completes the parity, exactly as requested in the issue. Default is `None`, so existing callers are unaffected.

## Tests

New hermetic `tests/test_google_credentials.py` (unit-marked; uses `AnonymousCredentials`, no network/files/env): constructing STT without ADC now works with a credentials object, both clients receive the exact supplied object, and the object wins over a (nonexistent) `credentials_file`.
