### PR TITLE
fix(aws): strip temperature and retry when Bedrock rejects it

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 from aiobotocore.session import AioSession  # type: ignore
 from botocore.config import Config  # type: ignore
+from botocore.exceptions import ClientError  # type: ignore
 
 from livekit.agents import APIConnectionError, APIStatusError, llm
 from livekit.agents.llm import ChatContext, FunctionToolCall, ToolChoice
@@ -119,6 +120,9 @@ class LLM(llm.LLM):
             cache_system=cache_system,
             cache_tools=cache_tools,
         )
+        # set once Bedrock rejects the temperature parameter for this model
+        # (newer models discontinue it); later requests then omit it entirely
+        self._temperature_rejected = False
 
     @property
     def model(self) -> str:
@@ -197,7 +201,7 @@ class LLM(llm.LLM):
         if is_given(self._opts.max_output_tokens):
             inference_config["maxTokens"] = self._opts.max_output_tokens
         temperature = temperature if is_given(temperature) else self._opts.temperature
-        if is_given(temperature):
+        if is_given(temperature) and not self._temperature_rejected:
             inference_config["temperature"] = temperature
         if is_given(self._opts.top_p):
             inference_config["topP"] = self._opts.top_p
@@ -260,10 +264,49 @@ class LLMStream(llm.LLMStream):
                         self._event_ch.send_nowait(chat_chunk)
 
         except Exception as e:
+            if self._maybe_strip_rejected_temperature(e):
+                # the request was modified so an immediate retry can succeed
+                raise APIStatusError(
+                    f"aws bedrock llm: model rejected the temperature parameter: {e}",
+                    status_code=400,
+                    retryable=True,
+                ) from e
             raise APIConnectionError(
                 f"aws bedrock llm: error generating content: {e}",
                 retryable=retryable,
             ) from e
+
+    def _maybe_strip_rejected_temperature(self, e: Exception) -> bool:
+        """Drop ``temperature`` from the request when Bedrock rejected it.
+
+        Bedrock has discontinued the temperature parameter for some newer models
+        and fails the whole request with a ValidationException when it is sent.
+        The stream's request options are mutated so the framework's retry runs
+        without the parameter, and the parent LLM stops sending it altogether.
+        """
+        inference_config = self._opts.get("inferenceConfig")
+        if (
+            not isinstance(e, ClientError)
+            or not inference_config
+            or "temperature" not in inference_config
+        ):
+            return False
+        error = e.response.get("Error", {})
+        if error.get("Code") != "ValidationException":
+            return False
+        message = error.get("Message", "")
+        if "temperature" not in message.lower():
+            return False
+
+        del inference_config["temperature"]
+        self._llm._temperature_rejected = True
+        logger.warning(
+            "aws bedrock llm: model %s rejected the temperature parameter; retrying without "
+            "it and omitting it for subsequent requests (%s)",
+            self._opts.get("modelId"),
+            message,
+        )
+        return True
 
     def _parse_chunk(self, request_id: str, chunk: dict) -> llm.ChatChunk | None:
         if "contentBlockStart" in chunk:

--- a/tests/test_aws_bedrock_temperature.py
+++ b/tests/test_aws_bedrock_temperature.py
@@ -1,0 +1,117 @@
+"""Hermetic tests for Bedrock temperature-rejection handling (#6581).
+
+Bedrock has discontinued the ``temperature`` inference parameter for some newer
+models and fails the whole request with a ValidationException when it is sent.
+The plugin should strip the parameter and retry instead of failing every
+request identically.
+"""
+
+import pytest
+from botocore.exceptions import ClientError
+
+from livekit.agents import APIConnectOptions
+from livekit.agents.llm import ChatContext
+from livekit.plugins.aws import llm as aws_llm
+
+pytestmark = pytest.mark.unit
+
+CONN_OPTIONS = APIConnectOptions(max_retry=0, retry_interval=0.0, timeout=1.0)
+
+
+def _make_llm(**kwargs) -> aws_llm.LLM:
+    return aws_llm.LLM(
+        model="anthropic.claude-test-v1:0",
+        api_key="test-key",
+        api_secret="test-secret",
+        **kwargs,
+    )
+
+
+def _validation_error(message: str) -> ClientError:
+    return ClientError(
+        error_response={"Error": {"Code": "ValidationException", "Message": message}},
+        operation_name="ConverseStream",
+    )
+
+
+def _make_chat_ctx() -> ChatContext:
+    chat_ctx = ChatContext.empty()
+    chat_ctx.add_message(role="user", content="hello")
+    return chat_ctx
+
+
+@pytest.fixture
+def no_run(monkeypatch: pytest.MonkeyPatch):
+    """Prevent LLMStream._run from performing any I/O."""
+
+    async def _noop(self) -> None:
+        return None
+
+    monkeypatch.setattr(aws_llm.LLMStream, "_run", _noop)
+
+
+class TestStripRejectedTemperature:
+    async def test_strips_and_flags_on_temperature_validation_error(self, no_run) -> None:
+        llm_instance = _make_llm(temperature=0.5)
+        stream = llm_instance.chat(chat_ctx=_make_chat_ctx(), conn_options=CONN_OPTIONS)
+        try:
+            assert stream._opts["inferenceConfig"]["temperature"] == 0.5
+
+            err = _validation_error(
+                "This model doesn't support the temperature inference parameter."
+            )
+            assert stream._maybe_strip_rejected_temperature(err) is True
+            assert "temperature" not in stream._opts["inferenceConfig"]
+            assert llm_instance._temperature_rejected is True
+        finally:
+            await stream.aclose()
+
+    async def test_ignores_unrelated_validation_error(self, no_run) -> None:
+        llm_instance = _make_llm(temperature=0.5)
+        stream = llm_instance.chat(chat_ctx=_make_chat_ctx(), conn_options=CONN_OPTIONS)
+        try:
+            err = _validation_error("The provided model identifier is invalid.")
+            assert stream._maybe_strip_rejected_temperature(err) is False
+            assert stream._opts["inferenceConfig"]["temperature"] == 0.5
+            assert llm_instance._temperature_rejected is False
+        finally:
+            await stream.aclose()
+
+    async def test_ignores_when_temperature_not_sent(self, no_run) -> None:
+        llm_instance = _make_llm()
+        stream = llm_instance.chat(chat_ctx=_make_chat_ctx(), conn_options=CONN_OPTIONS)
+        try:
+            err = _validation_error(
+                "This model doesn't support the temperature inference parameter."
+            )
+            assert stream._maybe_strip_rejected_temperature(err) is False
+        finally:
+            await stream.aclose()
+
+    async def test_ignores_non_client_error(self, no_run) -> None:
+        llm_instance = _make_llm(temperature=0.5)
+        stream = llm_instance.chat(chat_ctx=_make_chat_ctx(), conn_options=CONN_OPTIONS)
+        try:
+            assert stream._maybe_strip_rejected_temperature(RuntimeError("temperature")) is False
+            assert stream._opts["inferenceConfig"]["temperature"] == 0.5
+        finally:
+            await stream.aclose()
+
+
+class TestSubsequentRequestsOmitTemperature:
+    async def test_chat_omits_temperature_after_rejection(self, no_run) -> None:
+        llm_instance = _make_llm(temperature=0.5)
+        llm_instance._temperature_rejected = True
+        stream = llm_instance.chat(chat_ctx=_make_chat_ctx(), conn_options=CONN_OPTIONS)
+        try:
+            assert "temperature" not in stream._opts["inferenceConfig"]
+        finally:
+            await stream.aclose()
+
+    async def test_chat_includes_temperature_by_default(self, no_run) -> None:
+        llm_instance = _make_llm(temperature=0.5)
+        stream = llm_instance.chat(chat_ctx=_make_chat_ctx(), conn_options=CONN_OPTIONS)
+        try:
+            assert stream._opts["inferenceConfig"]["temperature"] == 0.5
+        finally:
+            await stream.aclose()


### PR DESCRIPTION
﻿Fixes #6581

## Problem

Bedrock has discontinued the `temperature` inference parameter for some newer models; sending it fails the whole `ConverseStream` request with a `ValidationException`. The plugin wrapped that as a retryable `APIConnectionError` and retried with **identical** parameters — every attempt failing the same way, so sessions configured with a `temperature` simply cannot use those models.

## Change

The exact set of rejecting models is a moving target (and differs per region), so instead of maintaining a model list, the stream now reacts to the provider's own signal:

- On a `ValidationException` whose message names `temperature` while the request carried one, the parameter is stripped from the request options and the error is re-raised as retryable — the framework's existing retry immediately re-runs the request without it.
- The rejection is remembered on the `LLM` instance (`_temperature_rejected`), so every subsequent `chat()` omits `temperature` outright — the fallback costs one extra round-trip once per LLM instance, not per turn.
- A warning is logged once with the model id and the provider message. Validation errors about anything else, and models that accept `temperature`, behave exactly as before.

## Tests

New hermetic `tests/test_aws_bedrock_temperature.py` (unit-marked, `_run` stubbed, no network): strip-and-flag on a matching ValidationException, no action on unrelated validation errors / when temperature was not sent / on non-ClientError exceptions, and `chat()` omitting the parameter after a rejection.
