### PR TITLE
feat(telemetry): record tool definitions on the llm_node span

### DIFF
--- a/livekit-agents/livekit/agents/telemetry/trace_types.py
+++ b/livekit-agents/livekit/agents/telemetry/trace_types.py
@@ -31,6 +31,7 @@ ATTR_SPEECH_INTERRUPTED = "lk.interrupted"
 # llm node
 ATTR_CHAT_CTX = "lk.chat_ctx"
 ATTR_FUNCTION_TOOLS = "lk.function_tools"
+ATTR_FUNCTION_TOOL_DEFINITIONS = "lk.function_tool_definitions"
 ATTR_PROVIDER_TOOLS = "lk.provider_tools"
 ATTR_TOOL_SETS = "lk.tool_sets"
 ATTR_RESPONSE_TEXT = "lk.response.text"

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -169,13 +169,14 @@ def perform_llm_inference(
     return llm_task, data
 
 
-def _function_tool_definitions(tool_ctx: ToolContext) -> list[dict[str, Any]]:
+def _function_tool_definitions_json(tool_ctx: ToolContext) -> str:
     """Serialize tool definitions (name, description, parameters) for the llm span.
 
     Backends like Langfuse can then show what the LLM was actually offered on a
     turn; tool names alone can't explain a badly-worded description or a schema
-    mismatch. Telemetry must never break generation, so a tool whose schema
-    fails to build is recorded by name only.
+    mismatch. Telemetry must never break generation: a tool whose schema fails
+    to build is recorded by name only, non-JSON values are stringified, and if
+    serialization still fails the attribute degrades to the name list.
     """
     from ..llm.tool_context import is_function_tool, is_raw_function_tool
     from ..llm.utils import build_legacy_openai_schema
@@ -191,7 +192,10 @@ def _function_tool_definitions(tool_ctx: ToolContext) -> list[dict[str, Any]]:
                 definitions.append({"name": name})
         except Exception:
             definitions.append({"name": name})
-    return definitions
+    try:
+        return json.dumps(definitions, default=str)
+    except Exception:
+        return json.dumps([{"name": name} for name in tool_ctx.function_tools])
 
 
 @utils.log_exceptions(logger=logger)
@@ -222,9 +226,7 @@ async def _llm_inference_task(
             )
         ),
         trace_types.ATTR_FUNCTION_TOOLS: list(tool_ctx.function_tools.keys()),
-        trace_types.ATTR_FUNCTION_TOOL_DEFINITIONS: json.dumps(
-            _function_tool_definitions(tool_ctx)
-        ),
+        trace_types.ATTR_FUNCTION_TOOL_DEFINITIONS: _function_tool_definitions_json(tool_ctx),
         trace_types.ATTR_PROVIDER_TOOLS: [type(tool).__name__ for tool in tool_ctx.provider_tools],
         trace_types.ATTR_TOOL_SETS: [type(tool_set).__name__ for tool_set in tool_ctx.toolsets],
     }

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -169,6 +169,31 @@ def perform_llm_inference(
     return llm_task, data
 
 
+def _function_tool_definitions(tool_ctx: ToolContext) -> list[dict[str, Any]]:
+    """Serialize tool definitions (name, description, parameters) for the llm span.
+
+    Backends like Langfuse can then show what the LLM was actually offered on a
+    turn; tool names alone can't explain a badly-worded description or a schema
+    mismatch. Telemetry must never break generation, so a tool whose schema
+    fails to build is recorded by name only.
+    """
+    from ..llm.tool_context import is_function_tool, is_raw_function_tool
+    from ..llm.utils import build_legacy_openai_schema
+
+    definitions: list[dict[str, Any]] = []
+    for name, tool in tool_ctx.function_tools.items():
+        try:
+            if is_raw_function_tool(tool):
+                definitions.append({**tool.info.raw_schema, "name": tool.info.name})
+            elif is_function_tool(tool):
+                definitions.append(build_legacy_openai_schema(tool, internally_tagged=True))
+            else:
+                definitions.append({"name": name})
+        except Exception:
+            definitions.append({"name": name})
+    return definitions
+
+
 @utils.log_exceptions(logger=logger)
 @tracer.start_as_current_span("llm_node")
 async def _llm_inference_task(
@@ -197,6 +222,9 @@ async def _llm_inference_task(
             )
         ),
         trace_types.ATTR_FUNCTION_TOOLS: list(tool_ctx.function_tools.keys()),
+        trace_types.ATTR_FUNCTION_TOOL_DEFINITIONS: json.dumps(
+            _function_tool_definitions(tool_ctx)
+        ),
         trace_types.ATTR_PROVIDER_TOOLS: [type(tool).__name__ for tool in tool_ctx.provider_tools],
         trace_types.ATTR_TOOL_SETS: [type(tool_set).__name__ for tool_set in tool_ctx.toolsets],
     }

--- a/tests/test_llm_span_tool_definitions.py
+++ b/tests/test_llm_span_tool_definitions.py
@@ -14,10 +14,14 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 
 from livekit.agents.llm import ChatContext, ToolContext, function_tool
 from livekit.agents.telemetry import set_tracer_provider, trace_types
-from livekit.agents.voice.generation import _function_tool_definitions, perform_llm_inference
+from livekit.agents.voice.generation import _function_tool_definitions_json, perform_llm_inference
 from livekit.agents.voice.io import ModelSettings
 
 pytestmark = pytest.mark.unit
+
+
+def _definitions(tool_ctx: ToolContext) -> list[dict]:
+    return json.loads(_function_tool_definitions_json(tool_ctx))
 
 
 @function_tool
@@ -39,23 +43,40 @@ async def transfer_call(raw_arguments: dict) -> str:
 
 class TestFunctionToolDefinitions:
     def test_function_tool_definition_shape(self) -> None:
-        defs = _function_tool_definitions(ToolContext([get_weather]))
+        defs = _definitions(ToolContext([get_weather]))
         assert len(defs) == 1
         assert defs[0]["name"] == "get_weather"
         assert "weather" in defs[0]["description"].lower()
         assert defs[0]["parameters"]["properties"]["location"]["type"] == "string"
 
     def test_raw_tool_definition_shape(self) -> None:
-        defs = _function_tool_definitions(ToolContext([transfer_call]))
+        defs = _definitions(ToolContext([transfer_call]))
         assert len(defs) == 1
         assert defs[0]["name"] == "transfer_call"
         assert defs[0]["description"] == "Transfer the call to a human operator."
         assert "reason" in defs[0]["parameters"]["properties"]
 
-    def test_definitions_are_json_serializable(self) -> None:
-        defs = _function_tool_definitions(ToolContext([get_weather, transfer_call]))
-        parsed = json.loads(json.dumps(defs))
-        assert {d["name"] for d in parsed} == {"get_weather", "transfer_call"}
+    def test_multiple_tools(self) -> None:
+        defs = _definitions(ToolContext([get_weather, transfer_call]))
+        assert {d["name"] for d in defs} == {"get_weather", "transfer_call"}
+
+    def test_non_json_serializable_schema_never_raises(self) -> None:
+        # a raw schema carrying a non-JSON value must degrade (stringify),
+        # not abort the model turn (see the Devin finding on #6621)
+        @function_tool(
+            raw_schema={
+                "name": "weird_tool",
+                "description": "Has a non-serializable default.",
+                "parameters": {"type": "object", "properties": {}, "default": object()},
+            }
+        )
+        async def weird_tool(raw_arguments: dict) -> str:
+            return "ok"
+
+        defs = _definitions(ToolContext([weird_tool]))
+        assert defs[0]["name"] == "weird_tool"
+        # the non-serializable value was stringified rather than raising
+        assert isinstance(defs[0]["parameters"]["default"], str)
 
 
 class TestLLMSpanAttributes:

--- a/tests/test_llm_span_tool_definitions.py
+++ b/tests/test_llm_span_tool_definitions.py
@@ -1,0 +1,98 @@
+"""Hermetic tests: the llm_node span records full tool definitions (#6620).
+
+The span used to carry only tool *names* (``lk.function_tools``); descriptions
+and parameter schemas never reached OTel backends, so traces could not show
+what the LLM was actually offered on a turn.
+"""
+
+import json
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from livekit.agents.llm import ChatContext, ToolContext, function_tool
+from livekit.agents.telemetry import set_tracer_provider, trace_types
+from livekit.agents.voice.generation import _function_tool_definitions, perform_llm_inference
+from livekit.agents.voice.io import ModelSettings
+
+pytestmark = pytest.mark.unit
+
+
+@function_tool
+async def get_weather(location: str) -> str:
+    """Look up the current weather for a location."""
+    return "sunny"
+
+
+@function_tool(
+    raw_schema={
+        "name": "transfer_call",
+        "description": "Transfer the call to a human operator.",
+        "parameters": {"type": "object", "properties": {"reason": {"type": "string"}}},
+    }
+)
+async def transfer_call(raw_arguments: dict) -> str:
+    return "ok"
+
+
+class TestFunctionToolDefinitions:
+    def test_function_tool_definition_shape(self) -> None:
+        defs = _function_tool_definitions(ToolContext([get_weather]))
+        assert len(defs) == 1
+        assert defs[0]["name"] == "get_weather"
+        assert "weather" in defs[0]["description"].lower()
+        assert defs[0]["parameters"]["properties"]["location"]["type"] == "string"
+
+    def test_raw_tool_definition_shape(self) -> None:
+        defs = _function_tool_definitions(ToolContext([transfer_call]))
+        assert len(defs) == 1
+        assert defs[0]["name"] == "transfer_call"
+        assert defs[0]["description"] == "Transfer the call to a human operator."
+        assert "reason" in defs[0]["parameters"]["properties"]
+
+    def test_definitions_are_json_serializable(self) -> None:
+        defs = _function_tool_definitions(ToolContext([get_weather, transfer_call]))
+        parsed = json.loads(json.dumps(defs))
+        assert {d["name"] for d in parsed} == {"get_weather", "transfer_call"}
+
+
+class TestLLMSpanAttributes:
+    async def test_llm_node_span_carries_tool_definitions(self) -> None:
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        set_tracer_provider(provider)
+        try:
+
+            async def fake_node(chat_ctx, tools, model_settings):
+                async def gen():
+                    yield "hello"
+
+                return gen()
+
+            chat_ctx = ChatContext.empty()
+            chat_ctx.add_message(role="user", content="hi")
+
+            llm_task, data = perform_llm_inference(
+                node=fake_node,
+                chat_ctx=chat_ctx,
+                tool_ctx=ToolContext([get_weather]),
+                model_settings=ModelSettings(),
+            )
+            await llm_task
+
+            spans = exporter.get_finished_spans()
+            llm_span = next(s for s in spans if s.name == "llm_node")
+
+            # existing name-only attribute is unchanged
+            assert list(llm_span.attributes[trace_types.ATTR_FUNCTION_TOOLS]) == ["get_weather"]
+
+            defs = json.loads(llm_span.attributes[trace_types.ATTR_FUNCTION_TOOL_DEFINITIONS])
+            assert defs[0]["name"] == "get_weather"
+            assert "weather" in defs[0]["description"].lower()
+            assert defs[0]["parameters"]["properties"]["location"]["type"] == "string"
+        finally:
+            # restore an exporter-less provider so spans from other tests go nowhere
+            set_tracer_provider(TracerProvider())


### PR DESCRIPTION
﻿Fixes #6620

## Problem

The `llm_node` span records the full chat context (`lk.chat_ctx`) but only the **names** of function tools (`lk.function_tools`). Tool descriptions and parameter schemas never reach OTel backends (Langfuse, Jaeger, ...), so a trace cannot show what the LLM was actually offered on a turn — a badly-worded tool description or a schema mismatch is invisible when tracing back a conversation that went wrong. Reported by a user in the community Slack running Langfuse via `set_tracer_provider`.

## Change

Adds `lk.function_tool_definitions` to the `llm_node` span: a JSON attribute carrying each tool's name, description, and parameters schema — the same shape providers receive (`build_legacy_openai_schema(..., internally_tagged=True)` for function tools, `raw_schema` for raw tools).

- `lk.function_tools` (names) is unchanged, for backward compatibility with anything keying on it.
- Telemetry can never break generation: a tool whose schema fails to build is recorded by name only.

## Tests

New hermetic `tests/test_llm_span_tool_definitions.py` (unit-marked): definition shape for decorated and raw tools, JSON round-trip, and an end-to-end span assertion driving `perform_llm_inference` with a fake LLM node against an in-memory span exporter (the global tracer provider is restored afterwards).
