### PR TITLE
fix(scripts): type-check for linux on every host OS, matching CI

### DIFF
--- a/scripts/check_types.py
+++ b/scripts/check_types.py
@@ -98,6 +98,15 @@ def main() -> None:
         *uv_run_args,
         "mypy",
         "--untyped-calls-exclude=smithy_aws_core",
+        # Analyze for linux regardless of the host OS, matching the CI gate.
+        # Host-platform analysis breaks on Windows: the unix branch of
+        # cli/readchar.py resolves against the empty win32 termios stub
+        # (20 attr-defined errors) and the win32 branches demand stubs the
+        # typing group intentionally doesn't carry (types-colorama,
+        # types-pywin32, ...). User-supplied args come later, so an explicit
+        # --platform still overrides this default.
+        "--platform",
+        "linux",
         *pkg_args,
         *mypy_args,
     ]


### PR DESCRIPTION
﻿Fixes #6622

## Problem

`make type-check` / `python scripts/check_types.py` is unusable for contributors on Windows: mypy analyzes platform-conditional code for the *host* platform, so the unix branch of `cli/readchar.py` resolves against the empty win32 `termios` stub (20 `attr-defined` errors that don't exist in CI), and the win32 branches demand stub packages the `typing` group intentionally doesn't carry (`types-colorama`, `types-pywin32`, `types-jsonschema`, `types-nanoid`) — with the script instructing the contributor to `uv add` them, which would dirty the lockfile with Windows-only entries.

## Change

Pass `--platform linux` to mypy by default in `scripts/check_types.py`:

- CI is byte-identical — the gate already runs on Ubuntu.
- Windows/macOS contributors get exactly the CI result. Verified on Windows 11 / Python 3.12: cold-cache run passes with zero extra stubs ("Success: no issues found in 625 source files"); without the flag, the 20 termios errors + missing-stub failure reproduce.
- User-supplied mypy args are appended after the default, so an explicit `--platform` still overrides.
