### PR TITLE
fix(cli): derive _ExitCli from SystemExit so loop callbacks cannot swallow it

### DIFF
--- a/livekit-agents/livekit/agents/cli/_legacy.py
+++ b/livekit-agents/livekit/agents/cli/_legacy.py
@@ -75,7 +75,9 @@ class _ToggleMode(Exception):
     pass
 
 
-class _ExitCli(BaseException):
+class _ExitCli(SystemExit):
+    # SystemExit so asyncio's Handle._run re-raises it instead of swallowing it
+    # when the signal-handler raise lands inside a loop callback (#5856).
     pass
 
 

--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -26,7 +26,13 @@ HANDLED_SIGNALS = (
 )
 
 
-class _ExitCli(BaseException):
+class _ExitCli(SystemExit):
+    # Derives from SystemExit, not BaseException: _handle_exit raises this from a
+    # signal handler, and the frame the raise lands in is whatever the event loop
+    # happened to be executing. If that frame is a loop callback, asyncio's
+    # Handle._run re-raises only SystemExit/KeyboardInterrupt and reports every
+    # other BaseException to the loop exception handler - swallowing the exit and
+    # leaving the loop running (#5856).
     pass
 
 

--- a/tests/test_exit_cli_propagation.py
+++ b/tests/test_exit_cli_propagation.py
@@ -55,3 +55,33 @@ class TestExitCliPropagation:
         except _ExitCli:
             caught = True
         assert caught
+
+    def test_propagates_out_of_a_task(self) -> None:
+        # #6724: SIGTERM landing while the main thread is inside a job-request task
+        # (a request_fnc doing blocking work) puts the raise in a coroutine, not a
+        # callback. Task.__step re-raises only SystemExit/KeyboardInterrupt out of the
+        # loop; any other BaseException is stored on the task ("Task exception was never
+        # retrieved") and the loop keeps running, so the worker never drains.
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def _job_request_task() -> None:
+                raise _ExitCli()
+
+            async def _main() -> None:
+                await asyncio.sleep(30)  # the worker's main task, still running
+
+            main_task = loop.create_task(_main())
+            loop.call_soon(lambda: loop.create_task(_job_request_task()))
+
+            swallowed: list[dict] = []
+            loop.set_exception_handler(lambda _loop, ctx: swallowed.append(ctx))
+            loop.call_later(0.5, loop.stop)  # safety stop for the broken case
+
+            with pytest.raises(_ExitCli):
+                loop.run_until_complete(main_task)
+
+            assert not swallowed, "exit was left on the task instead of reaching the loop"
+        finally:
+            main_task.cancel()
+            loop.close()

--- a/tests/test_exit_cli_propagation.py
+++ b/tests/test_exit_cli_propagation.py
@@ -1,0 +1,57 @@
+"""Regression tests for #5856: _ExitCli must escape asyncio's Handle._run.
+
+``_handle_exit`` raises ``_ExitCli`` synchronously from a signal handler; the
+frame that raise lands in is whatever the event loop happened to be executing.
+When that frame is a loop callback, CPython's ``Handle._run`` re-raises only
+``SystemExit``/``KeyboardInterrupt`` and reports every other ``BaseException``
+to the loop exception handler — logging it and leaving the loop running, so the
+CLI's drain/shutdown path is never reached.
+"""
+
+import asyncio
+
+import pytest
+
+from livekit.agents.cli import _legacy
+from livekit.agents.cli.cli import _ExitCli
+
+pytestmark = pytest.mark.unit
+
+
+class TestExitCliPropagation:
+    def test_is_systemexit(self) -> None:
+        # the only exception types Handle._run re-raises are SystemExit and
+        # KeyboardInterrupt; _ExitCli must be one of them to survive a raise
+        # that lands inside a loop callback
+        assert issubclass(_ExitCli, SystemExit)
+        assert issubclass(_legacy._ExitCli, SystemExit)
+
+    def test_propagates_out_of_a_loop_callback(self) -> None:
+        # simulates SIGTERM landing while the loop is mid-callback: the raise
+        # happens inside Handle._run. Before the fix the loop swallowed it and
+        # kept running until the 0.5s stop; now run_forever raises immediately.
+        loop = asyncio.new_event_loop()
+        try:
+
+            def _raise_exit() -> None:
+                raise _ExitCli()
+
+            swallowed: list[dict] = []
+            loop.set_exception_handler(lambda _loop, ctx: swallowed.append(ctx))
+            loop.call_soon(_raise_exit)
+            loop.call_later(0.5, loop.stop)  # safety stop for the broken case
+
+            with pytest.raises(_ExitCli):
+                loop.run_forever()
+
+            assert not swallowed, "exit was reported to the exception handler instead of raised"
+        finally:
+            loop.close()
+
+    def test_still_caught_by_except_exit_cli(self) -> None:
+        # _run_worker's `except _ExitCli:` handling must keep working
+        try:
+            raise _ExitCli()
+        except _ExitCli:
+            caught = True
+        assert caught


### PR DESCRIPTION
Fixes livekit/agents#5856

## Problem

`_handle_exit` raises `_ExitCli` synchronously from a signal handler, and the frame the raise lands in is whatever the event loop happened to be executing at that moment. When SIGTERM arrives while the loop is mid-callback, the raise happens inside asyncio's `Handle._run` — which re-raises only `SystemExit`/`KeyboardInterrupt` and reports every other `BaseException` to the loop exception handler. The exit is logged ("Exception in callback ... \_handle_exit") and the loop keeps running: the drain/shutdown path is never reached. [#5519](<https://github.com/livekit/agents/issues/5519>) (`Exception` → `BaseException`) closed the generic `except Exception:` swallow path; this closes the remaining callback-frame path identified in the issue.

## Change

`_ExitCli` now derives from `SystemExit` (in both `cli.py` and `_legacy.py`) — the exception class the loop machinery re-raises *by design*, which is exactly the semantic `_ExitCli` wants. Safety of the switch:

* `SystemExit` is still a `BaseException`, so every existing handler that caught `_ExitCli` continues to catch it; the `except _ExitCli:` sites are unchanged.
* There are no `except SystemExit` sites anywhere in `livekit-agents` that could change behavior (verified by search).

## Tests

New hermetic `tests/test_exit_cli_propagation.py` driving the exact failure: a raise from inside a loop callback must propagate out of `run_forever` rather than reach the loop exception handler. Verified red on the old class (the loop swallows the exit and runs until a safety stop) and green with the fix; also pins the subclass relationship for both CLI variants and that `except _ExitCli` still catches.

## Also fixes

* livekit/agents#6724 — SIGTERM ignored when `request_fnc` blocks. Same cause one boundary over: the raise lands in a coroutine, and `Task.__step` re-raises only `SystemExit`/`KeyboardInterrupt` too, so anything else is stored on the task and the loop keeps running. Covered by `test_propagates_out_of_a_task`.
* Under uvloop this stops being a race and becomes deterministic: signal delivery for `signal.signal()` handlers is routed through `Loop._invoke_signals` as a scheduled callback, so the raise *always* lands in `Handle._run` (`cbhandles.pyx`, same `(KeyboardInterrupt, SystemExit)` rule). A worker idle on I/O — the normal state at deploy time — never drains. Reported in-thread against a 3-worker production deployment.