### PR TITLE
fix(llm): tolerate list-shaped streaming delta content in strip_thinking_tokens

### DIFF
--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -628,9 +628,37 @@ def _partial_marker_length(content: str, markers: tuple[str, ...]) -> int:
     )
 
 
+def _flatten_delta_content(content: Any) -> str | None:
+    """Flatten list-shaped streaming delta content to its concatenated text.
+
+    The OpenAI-compatible ecosystem allows ``delta.content`` to be a list of
+    typed content parts (``[{"type": "text", "text": ...}]``) instead of a
+    plain string — Mistral emits this shape on some streamed chunks — and the
+    openai SDK constructs stream models without validation, so the list
+    reaches us as-is when the plugin points at such a provider (#6323).
+    """
+    if content is None or isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+                continue
+            text = part.get("text") if isinstance(part, dict) else getattr(part, "text", None)
+            if isinstance(text, str):
+                parts.append(text)
+        return "".join(parts)
+    logger.warning(
+        "unexpected streaming delta content type %s; dropping the chunk", type(content).__name__
+    )
+    return None
+
+
 def strip_thinking_tokens(
-    content: str | None, state: ThinkingTokenFilter, *, final: bool = False
+    content: str | list[Any] | None, state: ThinkingTokenFilter, *, final: bool = False
 ) -> str | None:
+    content = _flatten_delta_content(content)
     if content is not None:
         state._buffer += content
 

--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -648,7 +648,9 @@ def _flatten_delta_content(content: Any) -> str | None:
             text = part.get("text") if isinstance(part, dict) else getattr(part, "text", None)
             if isinstance(text, str):
                 parts.append(text)
-        return "".join(parts)
+        # no text part at all carries no content, unlike a part that carries an
+        # empty string - that one is kept, like a plain "" delta
+        return "".join(parts) if parts else None
     logger.warning(
         "unexpected streaming delta content type %s; dropping the chunk", type(content).__name__
     )

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -155,6 +155,23 @@ def test_list_parts_without_text_are_ignored() -> None:
     assert content == "hi"
 
 
+def test_list_without_any_text_part_carries_no_content() -> None:
+    # nothing textual arrived, so report "no content" rather than an empty
+    # string the provider never sent
+    state = ThinkingTokenFilter()
+    assert strip_thinking_tokens([], state) is None
+    assert (
+        strip_thinking_tokens([{"type": "image_url", "image_url": {"url": "https://x"}}], state)
+        is None
+    )
+
+
+def test_an_empty_text_part_is_kept_as_empty_content() -> None:
+    # the provider did send text, it is just empty - same as a plain "" delta
+    state = ThinkingTokenFilter()
+    assert strip_thinking_tokens([{"type": "text", "text": ""}], state) == ""
+
+
 def test_object_parts_with_text_attribute_are_flattened() -> None:
     class _Part:
         text = "typed part"

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -113,6 +113,56 @@ def test_drops_unclosed_reasoning_at_end_of_stream() -> None:
     )
 
 
+def test_flattens_list_shaped_delta_content() -> None:
+    # OpenAI-compatible providers (e.g. Mistral) can emit delta.content as a
+    # list of typed content parts instead of a string; this used to crash the
+    # session with AttributeError/TypeError (#6323)
+    state = ThinkingTokenFilter()
+    assert strip_thinking_tokens([{"type": "text", "text": "Hallo"}], state) == "Hallo"
+
+
+def test_flattens_multiple_and_string_parts() -> None:
+    state = ThinkingTokenFilter()
+    content = strip_thinking_tokens(
+        [{"type": "text", "text": "Hello "}, "from ", {"type": "text", "text": "LiveKit"}],
+        state,
+    )
+    assert content == "Hello from LiveKit"
+
+
+def test_strips_thinking_tokens_inside_list_parts() -> None:
+    state = ThinkingTokenFilter()
+    visible = []
+    for chunk in (
+        [{"type": "text", "text": "<think>private "}],
+        [{"type": "text", "text": "reasoning</think>answer"}],
+    ):
+        content = strip_thinking_tokens(chunk, state)
+        if content is not None:
+            visible.append(content)
+    content = strip_thinking_tokens(None, state, final=True)
+    if content is not None:
+        visible.append(content)
+    assert "".join(visible) == "answer"
+
+
+def test_list_parts_without_text_are_ignored() -> None:
+    state = ThinkingTokenFilter()
+    content = strip_thinking_tokens(
+        [{"type": "image_url", "image_url": {"url": "https://x"}}, {"type": "text", "text": "hi"}],
+        state,
+    )
+    assert content == "hi"
+
+
+def test_object_parts_with_text_attribute_are_flattened() -> None:
+    class _Part:
+        text = "typed part"
+
+    state = ThinkingTokenFilter()
+    assert strip_thinking_tokens([_Part()], state) == "typed part"
+
+
 def test_strips_reasoning_from_text_alongside_tool_call() -> None:
     stream = LLMStream.__new__(LLMStream)
     stream._tool_call_id = None


### PR DESCRIPTION
Fixes livekit/agents#6323

## Problem

`strip_thinking_tokens` assumes `delta.content` is `str | None`. The OpenAI-compatible ecosystem allows it to be a **list of typed content parts** (`[{"type": "text", "text": ...}]`) — Mistral emits this shape on some streamed chunks — and the openai SDK constructs stream models without validation (`construct()`), so when `openai.LLM` points at such a provider via `base_url`, the raw list reaches the filter and crashes the session. Wrapped as a retryable `APIConnectionError` mid-stream, a `FallbackAdapter` then silently fails the whole session over to its fallback leg — a hard-to-diagnose degradation.

Re: the open question on the issue about the source of the claim ("the OpenAI streaming spec only documents string"): correct for OpenAI's own service — the authority here is **Mistral's** chat-completions API, whose assistant/delta message `content` is typed `string | ContentChunk[]` in their reference and SDK. Since the plugin explicitly supports OpenAI-*compatible* providers through `base_url`, and the SDK's unvalidated stream models pass whatever the provider sends, the list shape is reachable in practice (that's how the original reporter hit it in production). Answered in more detail on the issue thread.

## Change

Flatten list-shaped content to its concatenated text parts before the tag scan — dict parts (`{"text": ...}`), plain strings, and typed objects with a `.text` attribute. Unknown content types are dropped with a warning instead of crashing. String/None behavior is byte-identical.

## Tests

Five new cases in `tests/test_llm_utils.py`: the issue's exact repro (`[{"type": "text", "text": "Hallo"}]`), mixed part lists, thinking-tag stripping across list-shaped chunks, non-text parts ignored, and typed objects with `.text`.

## Relationship to [#6324](<https://github.com/livekit/agents/issues/6324>)

This supersedes the stalled [#6324](<https://github.com/livekit/agents/issues/6324>) (same diagnosis, by @KSerProject — credit where due): that PR has had merge conflicts and an unsigned CLA for four weeks. Happy to close this one if the original author returns.