### PR TITLE
feat(llm): let an LLM declare chat() stateful

### DIFF
--- a/livekit-agents/livekit/agents/llm/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/fallback_adapter.py
@@ -230,6 +230,17 @@ class FallbackLLMStream(LLMStream):
         llm_status = self._fallback_adapter._status[
             self._fallback_adapter._llm_instances.index(llm)
         ]
+        if llm.stateful:
+            # a recovery probe runs a full chat() and throws every chunk away;
+            # for a stateful instance that commits the side effects of a real
+            # turn just to test availability. It is retried on real traffic
+            # instead (see _run), so it can still come back.
+            logger.debug(
+                "%s declares chat() stateful, skipping the recovery probe",
+                llm.label,
+            )
+            return
+
         if llm_status.recovering_task is None or llm_status.recovering_task.done():
 
             async def _recover_llm_task(llm: LLM) -> None:
@@ -257,7 +268,10 @@ class FallbackLLMStream(LLMStream):
 
         for i, llm in enumerate(self._fallback_adapter._llm_instances):
             llm_status = self._fallback_adapter._status[i]
-            if llm_status.available or all_failed:
+            # a stateful instance gets no background probe to mark it healthy
+            # again, so it is retried here instead - otherwise one failure
+            # would drop it (often the primary) for the rest of the process
+            if llm_status.available or all_failed or llm.stateful:
                 text_sent: str = ""
                 tool_calls_sent: list[str] = []
                 try:

--- a/livekit-agents/livekit/agents/llm/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/fallback_adapter.py
@@ -226,6 +226,18 @@ class FallbackLLMStream(LLMStream):
             )
             raise
 
+    def _mark_available(self, llm: LLM, llm_status: _LLMStatus) -> None:
+        """Report a healthy instance, announcing only an actual transition."""
+        if llm_status.available:
+            return
+
+        llm_status.available = True
+        logger.info(f"llm.FallbackAdapter, {llm.label} recovered")
+        self._fallback_adapter.emit(
+            "llm_availability_changed",
+            AvailabilityChangedEvent(llm=llm, available=True),
+        )
+
     def _try_recovery(self, llm: LLM) -> None:
         llm_status = self._fallback_adapter._status[
             self._fallback_adapter._llm_instances.index(llm)
@@ -248,12 +260,7 @@ class FallbackLLMStream(LLMStream):
                     async for _ in self._try_generate(llm=llm, check_recovery=True):
                         pass
 
-                    llm_status.available = True
-                    logger.info(f"llm.FallbackAdapter, {llm.label} recovered")
-                    self._fallback_adapter.emit(
-                        "llm_availability_changed",
-                        AvailabilityChangedEvent(llm=llm, available=True),
-                    )
+                    self._mark_available(llm, llm_status)
                 except Exception:
                     return
 
@@ -284,6 +291,10 @@ class FallbackLLMStream(LLMStream):
 
                         self._event_ch.send_nowait(result)
 
+                    # a completed request is proof of life. Stateful instances
+                    # get no background probe to clear the flag, and for the
+                    # rest this converges the status one request sooner
+                    self._mark_available(llm, llm_status)
                     return
                 except Exception:  # exceptions already logged inside _try_generate
                     if llm_status.available:

--- a/livekit-agents/livekit/agents/llm/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/fallback_adapter.py
@@ -88,6 +88,12 @@ class FallbackAdapter(
     def provider(self) -> str:
         return "livekit"
 
+    @property
+    def preemptive_generation_safe(self) -> bool:
+        # a speculative chat() may run on any wrapped instance, so speculation
+        # is only safe when every one of them declares it safe
+        return all(inst.preemptive_generation_safe for inst in self._llm_instances)
+
     def chat(
         self,
         *,

--- a/livekit-agents/livekit/agents/llm/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/fallback_adapter.py
@@ -89,10 +89,10 @@ class FallbackAdapter(
         return "livekit"
 
     @property
-    def preemptive_generation_safe(self) -> bool:
-        # a speculative chat() may run on any wrapped instance, so speculation
-        # is only safe when every one of them declares it safe
-        return all(inst.preemptive_generation_safe for inst in self._llm_instances)
+    def stateful(self) -> bool:
+        # a chat() may run on any wrapped instance, so the wrapper carries the
+        # state of the most constrained one
+        return any(inst.stateful for inst in self._llm_instances)
 
     def chat(
         self,

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -133,18 +133,21 @@ class LLM(
         return "unknown"
 
     @property
-    def preemptive_generation_safe(self) -> bool:
-        """Whether ``chat()`` may be invoked speculatively.
+    def stateful(self) -> bool:
+        """Whether ``chat()`` mutates state that outlives the call.
 
-        Preemptive generation calls the LLM before the user's turn is committed
-        and discards the result when the final context differs. That is only
-        safe when ``chat()`` has no side effects. Adapters that execute
-        application logic inside ``chat()`` — e.g. a LangGraph graph running
-        its own tools — should return ``False``; the session then skips
-        preemptive generation for them instead of mutating state on a run that
-        may be thrown away.
+        A stateless ``chat()`` is a pure request/response: discarding its
+        result leaves nothing behind. An implementation is stateful when a call
+        has effects that a discarded result does not undo — a LangGraph adapter
+        running the graph's own tools and checkpoints, or a provider that keeps
+        the conversation server-side.
+
+        The session avoids running a stateful ``chat()`` when the result may be
+        thrown away; today that means skipping preemptive generation, which
+        calls the LLM before the user's turn is committed and drops the run
+        when the final context differs.
         """
-        return True
+        return False
 
     @abstractmethod
     def chat(

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -132,6 +132,20 @@ class LLM(
         """
         return "unknown"
 
+    @property
+    def preemptive_generation_safe(self) -> bool:
+        """Whether ``chat()`` may be invoked speculatively.
+
+        Preemptive generation calls the LLM before the user's turn is committed
+        and discards the result when the final context differs. That is only
+        safe when ``chat()`` has no side effects. Adapters that execute
+        application logic inside ``chat()`` — e.g. a LangGraph graph running
+        its own tools — should return ``False``; the session then skips
+        preemptive generation for them instead of mutating state on a run that
+        may be thrown away.
+        """
+        return True
+
     @abstractmethod
     def chat(
         self,

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2151,6 +2151,15 @@ class AgentActivity(RecognitionHooks):
         ):
             return
 
+        if not self.llm.preemptive_generation_safe:
+            # e.g. a LangGraph adapter whose chat() runs graph nodes/tools:
+            # a discarded speculative run would still commit their side effects
+            logger.debug(
+                "preemptive generation skipped: %s declares chat() unsafe to run speculatively",
+                type(self.llm).__name__,
+            )
+            return
+
         self._cancel_preemptive_generation()
 
         if (

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2151,11 +2151,11 @@ class AgentActivity(RecognitionHooks):
         ):
             return
 
-        if not self.llm.preemptive_generation_safe:
+        if self.llm.stateful:
             # e.g. a LangGraph adapter whose chat() runs graph nodes/tools:
             # a discarded speculative run would still commit their side effects
             logger.debug(
-                "preemptive generation skipped: %s declares chat() unsafe to run speculatively",
+                "preemptive generation skipped: %s declares chat() stateful",
                 type(self.llm).__name__,
             )
             return

--- a/livekit-plugins/livekit-plugins-langchain/livekit/plugins/langchain/langgraph.py
+++ b/livekit-plugins/livekit-plugins-langchain/livekit/plugins/langchain/langgraph.py
@@ -44,7 +44,7 @@ class LLMAdapter(llm.LLM, Generic[ContextT]):
         context: ContextT | None = None,
         subgraphs: bool = False,
         stream_mode: StreamMode | list[StreamMode] = "messages",
-        preemptive_generation_safe: bool = False,
+        stateful: bool = True,
     ) -> None:
         """Adapt a LangGraph graph to the LiveKit LLM interface.
 
@@ -55,14 +55,13 @@ class LLMAdapter(llm.LLM, Generic[ContextT]):
             subgraphs: Whether to stream from subgraphs as well.
             stream_mode: LangGraph stream mode(s); only ``messages`` and
                 ``custom`` are supported.
-            preemptive_generation_safe: Whether the graph may be invoked
-                speculatively by preemptive generation. Unlike a plain LLM
-                call, a graph turn can execute tools and mutate state
-                (checkpoints, external systems) with no rollback when the
-                speculative run is discarded — so this defaults to ``False``,
-                which makes the session skip preemptive generation for this
-                adapter. Set to ``True`` only if every node in the graph is
-                side-effect-free or idempotent per turn.
+            stateful: Whether running the graph mutates state that outlives the
+                call. Unlike a plain LLM call, a graph turn can execute tools
+                and write checkpoints with no rollback if the result is
+                discarded, so this defaults to ``True`` and the session keeps
+                speculative runs (preemptive generation) away from it. Set to
+                ``False`` only if every node in the graph is side-effect-free
+                or idempotent per turn.
         """
         super().__init__()
         modes = {stream_mode} if isinstance(stream_mode, str) else set(stream_mode)
@@ -76,11 +75,11 @@ class LLMAdapter(llm.LLM, Generic[ContextT]):
         self._context = context
         self._subgraphs = subgraphs
         self._stream_mode = stream_mode
-        self._preemptive_generation_safe = preemptive_generation_safe
+        self._stateful = stateful
 
     @property
-    def preemptive_generation_safe(self) -> bool:
-        return self._preemptive_generation_safe
+    def stateful(self) -> bool:
+        return self._stateful
 
     @property
     def model(self) -> str:

--- a/livekit-plugins/livekit-plugins-langchain/livekit/plugins/langchain/langgraph.py
+++ b/livekit-plugins/livekit-plugins-langchain/livekit/plugins/langchain/langgraph.py
@@ -44,7 +44,26 @@ class LLMAdapter(llm.LLM, Generic[ContextT]):
         context: ContextT | None = None,
         subgraphs: bool = False,
         stream_mode: StreamMode | list[StreamMode] = "messages",
+        preemptive_generation_safe: bool = False,
     ) -> None:
+        """Adapt a LangGraph graph to the LiveKit LLM interface.
+
+        Args:
+            graph: The compiled LangGraph graph to run for each turn.
+            config: Optional RunnableConfig forwarded to ``graph.astream``.
+            context: Optional context forwarded to ``graph.astream``.
+            subgraphs: Whether to stream from subgraphs as well.
+            stream_mode: LangGraph stream mode(s); only ``messages`` and
+                ``custom`` are supported.
+            preemptive_generation_safe: Whether the graph may be invoked
+                speculatively by preemptive generation. Unlike a plain LLM
+                call, a graph turn can execute tools and mutate state
+                (checkpoints, external systems) with no rollback when the
+                speculative run is discarded — so this defaults to ``False``,
+                which makes the session skip preemptive generation for this
+                adapter. Set to ``True`` only if every node in the graph is
+                side-effect-free or idempotent per turn.
+        """
         super().__init__()
         modes = {stream_mode} if isinstance(stream_mode, str) else set(stream_mode)
         unsupported = modes - _SUPPORTED_MODES
@@ -57,6 +76,11 @@ class LLMAdapter(llm.LLM, Generic[ContextT]):
         self._context = context
         self._subgraphs = subgraphs
         self._stream_mode = stream_mode
+        self._preemptive_generation_safe = preemptive_generation_safe
+
+    @property
+    def preemptive_generation_safe(self) -> bool:
+        return self._preemptive_generation_safe
 
     @property
     def model(self) -> str:

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -1517,15 +1517,15 @@ async def test_preemptive_generation(preemptive_generation: dict, expected_laten
     assert agent_state_events[3].new_state == "listening"
 
 
-async def test_preemptive_generation_skipped_for_unsafe_llm(
+async def test_preemptive_generation_skipped_for_stateful_llm(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # an LLM that declares chat() unsafe to run speculatively (e.g. the
-    # LangGraph adapter, whose graph turns execute tools with side effects)
-    # must not be called preemptively: latency matches the disabled path
+    # an LLM that declares chat() stateful (e.g. the LangGraph adapter, whose
+    # graph turns execute tools with side effects) must not be called
+    # preemptively: latency matches the disabled path
     from .fake_llm import FakeLLM
 
-    monkeypatch.setattr(FakeLLM, "preemptive_generation_safe", property(lambda self: False))
+    monkeypatch.setattr(FakeLLM, "stateful", property(lambda self: True))
 
     speed = 1
     actions = FakeActions()

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -1517,6 +1517,48 @@ async def test_preemptive_generation(preemptive_generation: dict, expected_laten
     assert agent_state_events[3].new_state == "listening"
 
 
+async def test_preemptive_generation_skipped_for_unsafe_llm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # an LLM that declares chat() unsafe to run speculatively (e.g. the
+    # LangGraph adapter, whose graph turns execute tools with side effects)
+    # must not be called preemptively: latency matches the disabled path
+    from .fake_llm import FakeLLM
+
+    monkeypatch.setattr(FakeLLM, "preemptive_generation_safe", property(lambda self: False))
+
+    speed = 1
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.0, "Hello, how are you?", stt_delay=0.1)
+    actions.add_llm("I'm doing great, thank you!", ttft=0.1, duration=0.3)
+    actions.add_tts(3.0, ttfb=0.3)
+
+    session = create_session(
+        actions,
+        speed_factor=speed,
+        turn_handling={"preemptive_generation": {"preemptive_tts": True}},
+    )
+    agent = MyAgent()
+
+    agent_state_events: list[AgentStateChangedEvent] = []
+    user_state_events: list[UserStateChangedEvent] = []
+    session.on("agent_state_changed", agent_state_events.append)
+    session.on("user_state_changed", user_state_events.append)
+
+    await asyncio.wait_for(run_session(session, agent), timeout=SESSION_TIMEOUT)
+
+    t_user_stop_speaking = user_state_events[1].created_at
+    t_agent_start_speaking = agent_state_events[2].created_at
+    # 0.5 (endpointing) + 0.3 (llm) + 0.3 (tts ttfb) — the preemptive path
+    # would have been 0.7; the declaration must fully disable it
+    check_timestamp(
+        t_agent_start_speaking - t_user_stop_speaking,
+        t_target=1.1,
+        speed_factor=speed,
+        max_abs_diff=0.2,
+    )
+
+
 @pytest.mark.parametrize(
     "session_preemptive, agent_preemptive, expected_latency",
     [

--- a/tests/test_langchain_preemptive.py
+++ b/tests/test_langchain_preemptive.py
@@ -1,0 +1,33 @@
+"""Hermetic tests for the LangGraph adapter's preemptive-generation opt-out (#5924).
+
+A graph turn can execute tools and mutate state (checkpoints, external
+systems) with no rollback when a speculative run is discarded, so the adapter
+declares ``chat()`` unsafe to run preemptively by default.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from livekit.agents import llm
+from livekit.plugins.langchain import LLMAdapter
+
+pytestmark = pytest.mark.unit
+
+
+class TestPreemptiveGenerationSafe:
+    def test_base_llm_defaults_to_safe(self) -> None:
+        # plain LLM chat() calls are side-effect-free; speculation stays enabled
+        class _PlainLLM(llm.LLM):
+            def chat(self, **kwargs):  # type: ignore[override]
+                raise NotImplementedError
+
+        assert _PlainLLM().preemptive_generation_safe is True
+
+    def test_langgraph_adapter_defaults_to_unsafe(self) -> None:
+        adapter = LLMAdapter(MagicMock())
+        assert adapter.preemptive_generation_safe is False
+
+    def test_langgraph_adapter_can_opt_in(self) -> None:
+        adapter = LLMAdapter(MagicMock(), preemptive_generation_safe=True)
+        assert adapter.preemptive_generation_safe is True

--- a/tests/test_langchain_preemptive.py
+++ b/tests/test_langchain_preemptive.py
@@ -2,7 +2,7 @@
 
 A graph turn can execute tools and mutate state (checkpoints, external
 systems) with no rollback when a speculative run is discarded, so the adapter
-declares ``chat()`` unsafe to run preemptively by default.
+declares ``chat()`` stateful by default.
 """
 
 from unittest.mock import MagicMock
@@ -15,34 +15,34 @@ from livekit.plugins.langchain import LLMAdapter
 pytestmark = pytest.mark.unit
 
 
-class TestPreemptiveGenerationSafe:
-    def test_base_llm_defaults_to_safe(self) -> None:
+class TestStateful:
+    def test_base_llm_defaults_to_stateless(self) -> None:
         # plain LLM chat() calls are side-effect-free; speculation stays enabled
         class _PlainLLM(llm.LLM):
             def chat(self, **kwargs):  # type: ignore[override]
                 raise NotImplementedError
 
-        assert _PlainLLM().preemptive_generation_safe is True
+        assert _PlainLLM().stateful is False
 
-    def test_langgraph_adapter_defaults_to_unsafe(self) -> None:
+    def test_langgraph_adapter_defaults_to_stateful(self) -> None:
         adapter = LLMAdapter(MagicMock())
-        assert adapter.preemptive_generation_safe is False
+        assert adapter.stateful is True
 
-    def test_langgraph_adapter_can_opt_in(self) -> None:
-        adapter = LLMAdapter(MagicMock(), preemptive_generation_safe=True)
-        assert adapter.preemptive_generation_safe is True
+    def test_langgraph_adapter_can_opt_out(self) -> None:
+        adapter = LLMAdapter(MagicMock(), stateful=False)
+        assert adapter.stateful is False
 
     def test_fallback_adapter_propagates_declaration(self) -> None:
-        # a speculative chat() may run on any wrapped instance: the fallback
-        # wrapper is only safe when every wrapped LLM is safe
+        # a chat() may run on any wrapped instance, so the wrapper is stateful
+        # as soon as one of them is
         from livekit.agents.llm import FallbackAdapter
 
         class _PlainLLM(llm.LLM):
             def chat(self, **kwargs):  # type: ignore[override]
                 raise NotImplementedError
 
-        safe = _PlainLLM()
-        unsafe = LLMAdapter(MagicMock())
+        stateless = _PlainLLM()
+        stateful = LLMAdapter(MagicMock())
 
-        assert FallbackAdapter([safe, unsafe]).preemptive_generation_safe is False
-        assert FallbackAdapter([safe, _PlainLLM()]).preemptive_generation_safe is True
+        assert FallbackAdapter([stateless, stateful]).stateful is True
+        assert FallbackAdapter([stateless, _PlainLLM()]).stateful is False

--- a/tests/test_langchain_preemptive.py
+++ b/tests/test_langchain_preemptive.py
@@ -5,14 +5,47 @@ systems) with no rollback when a speculative run is discarded, so the adapter
 declares ``chat()`` stateful by default.
 """
 
+from __future__ import annotations
+
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
-from livekit.agents import llm
+from livekit.agents import APIConnectionError, llm
+from livekit.agents.llm import FallbackAdapter
+from livekit.agents.utils import aio
 from livekit.plugins.langchain import LLMAdapter
 
 pytestmark = pytest.mark.unit
+
+
+class _CountingLLM(llm.LLM):
+    """Fails every chat(), counting the calls; optionally declares itself stateful."""
+
+    def __init__(self, *, stateful: bool) -> None:
+        super().__init__()
+        self._stateful = stateful
+        self.calls = 0
+
+    @property
+    def stateful(self) -> bool:
+        return self._stateful
+
+    def chat(self, **kwargs: Any) -> llm.LLMStream:  # type: ignore[override]
+        self.calls += 1
+        return _FailingStream(
+            self,
+            chat_ctx=kwargs["chat_ctx"],
+            tools=kwargs.get("tools") or [],
+            # honour the adapter's options so the fake fails fast
+            conn_options=kwargs["conn_options"],
+        )
+
+
+class _FailingStream(llm.LLMStream):
+    async def _run(self) -> None:
+        raise APIConnectionError("unavailable")
 
 
 class TestStateful:
@@ -35,8 +68,6 @@ class TestStateful:
     def test_fallback_adapter_propagates_declaration(self) -> None:
         # a chat() may run on any wrapped instance, so the wrapper is stateful
         # as soon as one of them is
-        from livekit.agents.llm import FallbackAdapter
-
         class _PlainLLM(llm.LLM):
             def chat(self, **kwargs):  # type: ignore[override]
                 raise NotImplementedError
@@ -46,3 +77,60 @@ class TestStateful:
 
         assert FallbackAdapter([stateless, stateful]).stateful is True
         assert FallbackAdapter([stateless, _PlainLLM()]).stateful is False
+
+
+class TestFallbackRecoveryProbes:
+    """A recovery probe drains and discards a full chat(), so it must not run
+    against a stateful instance - that would commit a real turn's side effects
+    just to test availability."""
+
+    async def _drain(self, adapter: FallbackAdapter) -> None:
+        with pytest.raises(APIConnectionError):
+            async with adapter.chat(chat_ctx=llm.ChatContext.empty()) as stream:
+                async for _ in stream:
+                    pass
+
+    @staticmethod
+    async def _settle(adapter: FallbackAdapter) -> None:
+        """Await the background recovery probes the adapter may have started."""
+        for status in adapter._status:
+            if status.recovering_task is not None:
+                await aio.cancel_and_wait(status.recovering_task)
+
+    async def test_no_recovery_probe_for_a_stateful_instance(self) -> None:
+        stateful = _CountingLLM(stateful=True)
+        adapter = FallbackAdapter([stateful])
+        try:
+            await self._drain(adapter)
+
+            # the probe would be a second, discarded chat() on top of the request
+            assert stateful.calls == 1
+            assert adapter._status[0].recovering_task is None
+        finally:
+            await self._settle(adapter)
+
+    async def test_stateless_instance_is_still_probed(self) -> None:
+        stateless = _CountingLLM(stateful=False)
+        adapter = FallbackAdapter([stateless])
+        try:
+            await self._drain(adapter)
+
+            assert adapter._status[0].recovering_task is not None
+        finally:
+            await self._settle(adapter)
+
+    async def test_stateful_instance_is_retried_on_the_next_request(self) -> None:
+        # with no probe to bring it back, a failed stateful instance must stay
+        # reachable through real traffic instead of being dropped for good
+        stateful = _CountingLLM(stateful=True)
+        stateless = _CountingLLM(stateful=False)
+        adapter = FallbackAdapter([stateful, stateless])
+        try:
+            await self._drain(adapter)
+            assert adapter._status[0].available is False
+            first_round = stateful.calls
+
+            await self._drain(adapter)
+            assert stateful.calls == first_round + 1
+        finally:
+            await self._settle(adapter)

--- a/tests/test_langchain_preemptive.py
+++ b/tests/test_langchain_preemptive.py
@@ -31,3 +31,18 @@ class TestPreemptiveGenerationSafe:
     def test_langgraph_adapter_can_opt_in(self) -> None:
         adapter = LLMAdapter(MagicMock(), preemptive_generation_safe=True)
         assert adapter.preemptive_generation_safe is True
+
+    def test_fallback_adapter_propagates_declaration(self) -> None:
+        # a speculative chat() may run on any wrapped instance: the fallback
+        # wrapper is only safe when every wrapped LLM is safe
+        from livekit.agents.llm import FallbackAdapter
+
+        class _PlainLLM(llm.LLM):
+            def chat(self, **kwargs):  # type: ignore[override]
+                raise NotImplementedError
+
+        safe = _PlainLLM()
+        unsafe = LLMAdapter(MagicMock())
+
+        assert FallbackAdapter([safe, unsafe]).preemptive_generation_safe is False
+        assert FallbackAdapter([safe, _PlainLLM()]).preemptive_generation_safe is True

--- a/tests/test_langchain_preemptive.py
+++ b/tests/test_langchain_preemptive.py
@@ -21,11 +21,15 @@ pytestmark = pytest.mark.unit
 
 
 class _CountingLLM(llm.LLM):
-    """Fails every chat(), counting the calls; optionally declares itself stateful."""
+    """Counts chat() calls; fails the first ``failures`` of them.
 
-    def __init__(self, *, stateful: bool) -> None:
+    ``failures=None`` fails every call.
+    """
+
+    def __init__(self, *, stateful: bool, failures: int | None = None) -> None:
         super().__init__()
         self._stateful = stateful
+        self._failures = failures
         self.calls = 0
 
     @property
@@ -34,7 +38,9 @@ class _CountingLLM(llm.LLM):
 
     def chat(self, **kwargs: Any) -> llm.LLMStream:  # type: ignore[override]
         self.calls += 1
-        return _FailingStream(
+        failing = self._failures is None or self.calls <= self._failures
+        stream_cls = _FailingStream if failing else _EmptyStream
+        return stream_cls(
             self,
             chat_ctx=kwargs["chat_ctx"],
             tools=kwargs.get("tools") or [],
@@ -46,6 +52,11 @@ class _CountingLLM(llm.LLM):
 class _FailingStream(llm.LLMStream):
     async def _run(self) -> None:
         raise APIConnectionError("unavailable")
+
+
+class _EmptyStream(llm.LLMStream):
+    async def _run(self) -> None:
+        return
 
 
 class TestStateful:
@@ -90,6 +101,11 @@ class TestFallbackRecoveryProbes:
                 async for _ in stream:
                     pass
 
+    async def _consume(self, adapter: FallbackAdapter) -> None:
+        async with adapter.chat(chat_ctx=llm.ChatContext.empty()) as stream:
+            async for _ in stream:
+                pass
+
     @staticmethod
     async def _settle(adapter: FallbackAdapter) -> None:
         """Await the background recovery probes the adapter may have started."""
@@ -132,5 +148,25 @@ class TestFallbackRecoveryProbes:
 
             await self._drain(adapter)
             assert stateful.calls == first_round + 1
+        finally:
+            await self._settle(adapter)
+
+    async def test_a_successful_request_clears_the_unavailable_flag(self) -> None:
+        # nothing else can clear it for a stateful instance, and leaving it set
+        # would log "all LLMs are unavailable" on every later turn and never
+        # report the recovery
+        stateful = _CountingLLM(stateful=True, failures=1)
+        adapter = FallbackAdapter([stateful])
+        events: list[bool] = []
+        adapter.on("llm_availability_changed", lambda ev: events.append(ev.available))
+        try:
+            await self._drain(adapter)
+            assert adapter._status[0].available is False
+
+            await self._consume(adapter)
+
+            assert adapter._status[0].available is True
+            # one transition each way, no repeats
+            assert events == [False, True]
         finally:
             await self._settle(adapter)


### PR DESCRIPTION
Fixes #5924

## Problem

Preemptive generation invokes `chat()` before the user's turn is committed and discards the result when the final context differs. For a plain LLM that's free — but for the LangGraph adapter, one `chat()` call runs a **full graph turn, tools included**. A discarded speculative run still commits whatever side effects the graph performed (checkpoints, external systems), with no rollback — silently corrupting agent state. As the issue puts it, there is no seam to distinguish "generate this speculatively" from "commit this once the turn is confirmed," so any state-mutating graph is unsafe with preemptive generation enabled.

## Change

The narrowest seam that makes this safe-by-default (a full speculative/commit protocol would be a much bigger design; this doesn't preclude one later):

- `LLM.stateful` property, **default `False`** — behavior unchanged for every existing plugin. It describes `chat()` itself: does the call mutate state that outlives it? That covers an adapter running its own tools and a provider keeping the conversation server-side, both of which make a discarded result unsafe.
- `AgentActivity.on_preemptive_generation` skips speculation for a stateful LLM (debug log explains why the latency optimization is off).
- The LangGraph `LLMAdapter` declares itself **stateful**, with a `stateful=False` constructor flag for graphs that are genuinely side-effect-free or idempotent per turn (documented in the docstring).
- `FallbackAdapter` surfaces `stateful` from its wrapped instances and honours it itself: its background recovery probe drains and discards a full `chat()`, so it no longer probes stateful instances — they are retried on real traffic instead, and any completed request clears the unavailable flag (announcing only real transitions, which also removes a duplicate `available=True` event the old probe could emit).

## Tests

- End-to-end in the fake-session harness: with preemptive generation enabled but the LLM declaring itself stateful, turn latency matches the preemptive-*disabled* path (1.1s vs 0.7s) — speculation demonstrably never ran.
- Adapter-level: base LLM defaults stateless, LangGraph adapter defaults stateful, opt-out works, `FallbackAdapter` propagates.
- Fallback recovery: no probe (and no extra `chat()`) for a stateful instance, probe still runs for a stateless one, a failed stateful instance is retried on the next request, and a later success restores `available` with exactly one transition event each way.

`stateful` replaces the original `preemptive_generation_safe` per review — it names the property of the LLM rather than the feature consuming it. Kept as a plain property rather than starting an `LLMCapabilities` struct, since `LLM` has none today (unlike STT/TTS/VAD/Realtime) and introducing one would touch every plugin constructor; happy to do that separately.
