### PR TITLE
docs(examples): PII redaction between STT and the LLM

### DIFF
--- a/examples/voice_agents/pii_redaction.py
+++ b/examples/voice_agents/pii_redaction.py
@@ -60,8 +60,9 @@ _PII_RULES: list[tuple[re.Pattern, str | Callable[[re.Match], str]]] = [
     (re.compile(r"\b\d{3}-\d{2}-\d{4}\b"), "<SSN>"),
     (re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b"), "<EMAIL>"),
     # phone numbers must contain separators (or a + prefix) so plain digit
-    # runs like order ids are left alone
-    (re.compile(r"(?:\+\d{1,3}[ .-])?\b\(?\d{2,4}\)?[ .-]\d{3,4}[ .-]\d{2,4}\b"), "<PHONE>"),
+    # runs like order ids are left alone; the word boundary sits inside the
+    # optional "(" because \b cannot assert between a space and a parenthesis
+    (re.compile(r"(?:\+\d{1,3}[ .-]?)?\(?\b\d{2,4}\b\)?[ .-]\d{3,4}[ .-]\d{2,4}\b"), "<PHONE>"),
     (re.compile(r"\+\d{7,15}\b"), "<PHONE>"),
 ]
 

--- a/examples/voice_agents/pii_redaction.py
+++ b/examples/voice_agents/pii_redaction.py
@@ -10,6 +10,13 @@ The pattern engine below is intentionally simple regexes so it reads as a
 pattern, not a dependency: swap ``redact_pii`` for Microsoft Presidio, GLiNER,
 or your own rules without touching the wiring.
 
+The rules are deliberately safety-first: any 13-19 digit sequence is redacted
+(as ``<CARD_NUMBER>`` when it passes the Luhn checksum, ``<NUMBER>`` otherwise),
+because a card number merged with neighboring digits fails the checksum as a
+whole while still containing the card. Over-redacting an order id is the
+acceptable failure mode for a privacy filter; leaking a card is not. Tune the
+rules if your domain needs long non-sensitive numbers to survive.
+
 Scope note: this redacts the LLM path. The raw transcript still exists inside
 the process (e.g. ``user_input_transcribed`` events for UI display); redact at
 those sinks too if your compliance boundary includes logs and storage.
@@ -48,20 +55,24 @@ def _luhn_valid(digits: str) -> bool:
     return total % 10 == 0
 
 
-def _redact_card(match: re.Match) -> str:
+def _redact_long_number(match: re.Match) -> str:
     digits = re.sub(r"[ -]", "", match.group())
-    # Luhn-check to avoid eating arbitrary long numbers (order ids, tracking numbers)
-    return "<CARD_NUMBER>" if _luhn_valid(digits) else match.group()
+    # Safety-first: every 13-19 digit sequence is redacted. The Luhn check only
+    # refines the label - it must NOT gate redaction, because a card merged with
+    # adjacent digits (an expiry, a neighboring SSN/phone) fails the checksum as
+    # a whole while still containing the real card. Over-redacting an order id
+    # is the acceptable failure mode for a privacy filter; leaking a card is not.
+    return "<CARD_NUMBER>" if _luhn_valid(digits) else "<NUMBER>"
 
 
 # (pattern, replacement) pairs — replacement may be a string or a callable
 _PII_RULES: list[tuple[re.Pattern, str | Callable[[re.Match], str]]] = [
-    (re.compile(r"\b\d(?:[ -]?\d){12,18}\b"), _redact_card),
+    (re.compile(r"\b\d(?:[ -]?\d){12,18}\b"), _redact_long_number),
     (re.compile(r"\b\d{3}-\d{2}-\d{4}\b"), "<SSN>"),
     (re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b"), "<EMAIL>"),
-    # phone numbers must contain separators (or a + prefix) so plain digit
-    # runs like order ids are left alone; the word boundary sits inside the
-    # optional "(" because \b cannot assert between a space and a parenthesis
+    # phone numbers must contain separators (or a + prefix) so short plain
+    # digit runs are left alone; the word boundary sits inside the optional
+    # "(" because \b cannot assert between a space and a parenthesis
     (re.compile(r"(?:\+\d{1,3}[ .-]?)?\(?\b\d{2,4}\b\)?[ .-]\d{3,4}[ .-]\d{2,4}\b"), "<PHONE>"),
     (re.compile(r"\+\d{7,15}\b"), "<PHONE>"),
 ]
@@ -70,10 +81,10 @@ _PII_RULES: list[tuple[re.Pattern, str | Callable[[re.Match], str]]] = [
 def redact_pii(text: str) -> tuple[str, list[str]]:
     """Return the redacted text and the list of rule replacements applied.
 
-    Single pass over claimed spans: earlier rules claim the regions they
-    matched even when they decline to change them, so a card-like number that
-    fails the Luhn check is left fully intact instead of being partially
-    re-matched (and half-redacted) by the phone rule that runs later.
+    All rules match against the original text in a single pass over claimed
+    spans (earlier rules take priority on overlap), then replacements are
+    applied together — so a later rule can never half-match inside a region an
+    earlier rule already handled.
     """
     claimed: list[tuple[int, int, str]] = []  # (start, end, replacement)
     for pattern, replacement in _PII_RULES:
@@ -96,8 +107,8 @@ class RedactingAgent(Agent):
     def __init__(self) -> None:
         super().__init__(
             instructions="You are a helpful voice assistant. Redacted placeholders like "
-            "<CARD_NUMBER> in the user's message mean sensitive data was removed for "
-            "privacy; never ask the user to repeat it."
+            "<CARD_NUMBER>, <NUMBER>, <SSN>, <EMAIL>, or <PHONE> in the user's message "
+            "mean sensitive data was removed for privacy; never ask the user to repeat it."
         )
 
     async def on_enter(self) -> None:

--- a/examples/voice_agents/pii_redaction.py
+++ b/examples/voice_agents/pii_redaction.py
@@ -6,6 +6,17 @@ deterministic, code-level hook rather than a system-prompt instruction. The
 redacted text is what the LLM receives *and* what is stored in the chat
 history, so the PII never leaves your servers toward the model provider.
 
+That guarantee has a precondition: **preemptive generation must be off**
+(it is on by default). Preemptive generation issues a speculative LLM
+request built from the raw STT transcript *before* ``on_user_turn_completed``
+runs, which would transmit the unredacted text to the provider — and since
+redaction then changes the committed message, the framework discards the
+speculative reply and regenerates anyway, so speculation buys nothing for
+redacted turns. The session below disables it explicitly. The same applies
+to any other feature that consumes the raw transcript before the hook (e.g.
+LLM-based keyterm detection): leave them off, or redact at the STT layer
+instead if you need them.
+
 The pattern engine below is intentionally simple regexes so it reads as a
 pattern, not a dependency: swap ``redact_pii`` for Microsoft Presidio, GLiNER,
 or your own rules without touching the wiring.
@@ -34,6 +45,7 @@ from livekit.agents import (
     AgentServer,
     AgentSession,
     JobContext,
+    TurnHandlingOptions,
     cli,
     inference,
     llm,
@@ -145,6 +157,11 @@ async def entrypoint(ctx: JobContext) -> None:
         stt=inference.STT("deepgram/nova-3", language="multi"),
         llm=inference.LLM("openai/gpt-4.1-mini"),
         tts=inference.TTS("cartesia/sonic-3"),
+        # REQUIRED for the privacy boundary: preemptive generation (on by
+        # default) sends a speculative LLM request built from the raw STT
+        # transcript before on_user_turn_completed runs - the unredacted
+        # text would reach the model provider despite the redaction hook.
+        turn_handling=TurnHandlingOptions(preemptive_generation={"enabled": False}),
     )
     await session.start(agent=RedactingAgent(), room=ctx.room)
 

--- a/examples/voice_agents/pii_redaction.py
+++ b/examples/voice_agents/pii_redaction.py
@@ -10,12 +10,13 @@ The pattern engine below is intentionally simple regexes so it reads as a
 pattern, not a dependency: swap ``redact_pii`` for Microsoft Presidio, GLiNER,
 or your own rules without touching the wiring.
 
-The rules are deliberately safety-first: any 13-19 digit sequence is redacted
-(as ``<CARD_NUMBER>`` when it passes the Luhn checksum, ``<NUMBER>`` otherwise),
-because a card number merged with neighboring digits fails the checksum as a
-whole while still containing the card. Over-redacting an order id is the
-acceptable failure mode for a privacy filter; leaking a card is not. Tune the
-rules if your domain needs long non-sensitive numbers to survive.
+The rules are deliberately safety-first: any sequence of 13 or more digits is
+redacted (as ``<CARD_NUMBER>`` when it passes the Luhn checksum, ``<NUMBER>``
+otherwise), with no upper length cap — a card number merged with neighboring
+digits fails the checksum and would slip past a length-capped pattern while
+still containing the card. Over-redacting an order id is the acceptable
+failure mode for a privacy filter; leaking a card is not. Tune the rules if
+your domain needs long non-sensitive numbers to survive.
 
 Scope note: this redacts the LLM path. The raw transcript still exists inside
 the process (e.g. ``user_input_transcribed`` events for UI display); redact at
@@ -56,18 +57,20 @@ def _luhn_valid(digits: str) -> bool:
 
 
 def _redact_long_number(match: re.Match) -> str:
-    digits = re.sub(r"[ -]", "", match.group())
-    # Safety-first: every 13-19 digit sequence is redacted. The Luhn check only
-    # refines the label - it must NOT gate redaction, because a card merged with
-    # adjacent digits (an expiry, a neighboring SSN/phone) fails the checksum as
-    # a whole while still containing the real card. Over-redacting an order id
-    # is the acceptable failure mode for a privacy filter; leaking a card is not.
+    digits = re.sub(r"[ .-]", "", match.group())
+    # Safety-first: every sequence of 13 or more digits is redacted — no upper
+    # bound, so a card concatenated with adjacent digits (an expiry, another
+    # number) is caught as one blob instead of slipping past a length cap. The
+    # Luhn check only refines the label; it must NOT gate redaction, because a
+    # merged sequence fails the checksum as a whole while still containing the
+    # real card. Over-redacting an order id is the acceptable failure mode for
+    # a privacy filter; leaking a card is not.
     return "<CARD_NUMBER>" if _luhn_valid(digits) else "<NUMBER>"
 
 
 # (pattern, replacement) pairs — replacement may be a string or a callable
 _PII_RULES: list[tuple[re.Pattern, str | Callable[[re.Match], str]]] = [
-    (re.compile(r"\b\d(?:[ -]?\d){12,18}\b"), _redact_long_number),
+    (re.compile(r"\b\d(?:[ .-]?\d){12,}\b"), _redact_long_number),
     (re.compile(r"\b\d{3}-\d{2}-\d{4}\b"), "<SSN>"),
     (re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b"), "<EMAIL>"),
     # phone numbers must contain separators (or a + prefix) so short plain

--- a/examples/voice_agents/pii_redaction.py
+++ b/examples/voice_agents/pii_redaction.py
@@ -1,0 +1,130 @@
+"""PII redaction between STT and the LLM (issue #6204).
+
+The transcribed user turn passes through ``Agent.on_user_turn_completed``
+before it reaches the LLM, so sensitive data can be scrubbed there — a
+deterministic, code-level hook rather than a system-prompt instruction. The
+redacted text is what the LLM receives *and* what is stored in the chat
+history, so the PII never leaves your servers toward the model provider.
+
+The pattern engine below is intentionally simple regexes so it reads as a
+pattern, not a dependency: swap ``redact_pii`` for Microsoft Presidio, GLiNER,
+or your own rules without touching the wiring.
+
+Scope note: this redacts the LLM path. The raw transcript still exists inside
+the process (e.g. ``user_input_transcribed`` events for UI display); redact at
+those sinks too if your compliance boundary includes logs and storage.
+"""
+
+import logging
+import re
+from collections.abc import Callable
+
+from dotenv import load_dotenv
+
+from livekit.agents import (
+    Agent,
+    AgentServer,
+    AgentSession,
+    JobContext,
+    cli,
+    inference,
+    llm,
+)
+
+logger = logging.getLogger("pii-redaction")
+
+load_dotenv()
+
+
+def _luhn_valid(digits: str) -> bool:
+    total, parity = 0, len(digits) % 2
+    for i, ch in enumerate(digits):
+        d = int(ch)
+        if i % 2 == parity:
+            d *= 2
+            if d > 9:
+                d -= 9
+        total += d
+    return total % 10 == 0
+
+
+def _redact_card(match: re.Match) -> str:
+    digits = re.sub(r"[ -]", "", match.group())
+    # Luhn-check to avoid eating arbitrary long numbers (order ids, tracking numbers)
+    return "<CARD_NUMBER>" if _luhn_valid(digits) else match.group()
+
+
+# (pattern, replacement) pairs — replacement may be a string or a callable
+_PII_RULES: list[tuple[re.Pattern, str | Callable[[re.Match], str]]] = [
+    (re.compile(r"\b\d(?:[ -]?\d){12,18}\b"), _redact_card),
+    (re.compile(r"\b\d{3}-\d{2}-\d{4}\b"), "<SSN>"),
+    (re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b"), "<EMAIL>"),
+    # phone numbers must contain separators (or a + prefix) so plain digit
+    # runs like order ids are left alone
+    (re.compile(r"(?:\+\d{1,3}[ .-])?\b\(?\d{2,4}\)?[ .-]\d{3,4}[ .-]\d{2,4}\b"), "<PHONE>"),
+    (re.compile(r"\+\d{7,15}\b"), "<PHONE>"),
+]
+
+
+def redact_pii(text: str) -> tuple[str, list[str]]:
+    """Return the redacted text and the list of rule replacements applied."""
+    applied: list[str] = []
+    for pattern, replacement in _PII_RULES:
+
+        def _apply(
+            match: re.Match, _replacement: str | Callable[[re.Match], str] = replacement
+        ) -> str:
+            out = _replacement(match) if callable(_replacement) else _replacement
+            if out != match.group():
+                applied.append(out)
+            return out
+
+        text = pattern.sub(_apply, text)
+    return text, applied
+
+
+class RedactingAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(
+            instructions="You are a helpful voice assistant. Redacted placeholders like "
+            "<CARD_NUMBER> in the user's message mean sensitive data was removed for "
+            "privacy; never ask the user to repeat it."
+        )
+
+    async def on_enter(self) -> None:
+        self.session.generate_reply(instructions="greet the user")
+
+    async def on_user_turn_completed(
+        self, turn_ctx: llm.ChatContext, new_message: llm.ChatMessage
+    ) -> None:
+        # runs after STT finalizes the turn and before the LLM sees it
+        applied_rules: list[str] = []
+        content: list = []
+        for item in new_message.content:
+            if isinstance(item, str):
+                redacted, applied = redact_pii(item)
+                content.append(redacted)
+                applied_rules.extend(applied)
+            else:
+                content.append(item)
+        new_message.content = content
+        if applied_rules:
+            # log categories only — never the original values
+            logger.info("redacted PII from user turn", extra={"rules": applied_rules})
+
+
+server = AgentServer()
+
+
+@server.rtc_session()
+async def entrypoint(ctx: JobContext) -> None:
+    session = AgentSession(
+        stt=inference.STT("deepgram/nova-3", language="multi"),
+        llm=inference.LLM("openai/gpt-4.1-mini"),
+        tts=inference.TTS("cartesia/sonic-3"),
+    )
+    await session.start(agent=RedactingAgent(), room=ctx.room)
+
+
+if __name__ == "__main__":
+    cli.run_app(server)

--- a/examples/voice_agents/pii_redaction.py
+++ b/examples/voice_agents/pii_redaction.py
@@ -67,19 +67,27 @@ _PII_RULES: list[tuple[re.Pattern, str | Callable[[re.Match], str]]] = [
 
 
 def redact_pii(text: str) -> tuple[str, list[str]]:
-    """Return the redacted text and the list of rule replacements applied."""
-    applied: list[str] = []
+    """Return the redacted text and the list of rule replacements applied.
+
+    Single pass over claimed spans: earlier rules claim the regions they
+    matched even when they decline to change them, so a card-like number that
+    fails the Luhn check is left fully intact instead of being partially
+    re-matched (and half-redacted) by the phone rule that runs later.
+    """
+    claimed: list[tuple[int, int, str]] = []  # (start, end, replacement)
     for pattern, replacement in _PII_RULES:
+        for match in pattern.finditer(text):
+            if any(match.start() < end and start < match.end() for start, end, _ in claimed):
+                continue  # an earlier (higher-priority) rule already claimed this span
+            out = replacement(match) if callable(replacement) else replacement
+            claimed.append((match.start(), match.end(), out))
 
-        def _apply(
-            match: re.Match, _replacement: str | Callable[[re.Match], str] = replacement
-        ) -> str:
-            out = _replacement(match) if callable(_replacement) else _replacement
-            if out != match.group():
-                applied.append(out)
-            return out
-
-        text = pattern.sub(_apply, text)
+    applied: list[str] = []
+    for start, end, out in sorted(claimed, reverse=True):
+        if out == text[start:end]:
+            continue  # claimed but deliberately left as-is (e.g. Luhn-invalid number)
+        applied.insert(0, out)
+        text = text[:start] + out + text[end:]
     return text, applied
 
 


### PR DESCRIPTION
Fixes livekit/agents#6204

## What

The middleware hook the issue asks for already exists — `Agent.on_user_turn_completed` runs between STT finalizing the user turn and the LLM seeing it, and mutating `new_message` there changes both what the LLM receives and what lands in the chat history. What was missing is a runnable reference showing that wiring, so this adds `examples/voice_agents/pii_redaction.py`:

* `RedactingAgent.on_user_turn_completed` scrubs each text item of the user message in place.
* The rule engine is deliberately simple, swappable regexes (the docstring points at Presidio/GLiNER as drop-in upgrades): card numbers gated by a **Luhn check** so order ids and tracking numbers survive, SSNs, emails, and phone numbers that must contain separators or a `+` prefix so plain digit runs are left alone.
* Logs the applied rule categories only — never the original values.
* The docstring states the boundary honestly: this covers the LLM path; `user_input_transcribed` events still carry raw text, so log/storage sinks need their own redaction (related: livekit/agents#6050).

Verified the rules against the false-positive cases above (`order number 1234567890123` untouched; `4532 0151 1283 0366`, `856-45-6789`, `a@b.co`, `+1 415 555 0100`, `+14155550100` all redacted).

## Hardening notes (from review)

The example went through several adversarial review rounds; two outcomes matter to readers:

* **Safety-first rules:** any 13+ digit sequence is redacted (Luhn only refines the label, never gates redaction, no upper length cap) — over-redacting an order id is the acceptable failure mode; leaking a card is not. Invariant verified: no 13+ digit sequence survives redaction for any input in the test matrix.
* **The hook has a precondition:** `on_user_turn_completed` is only the STT→LLM chokepoint when preemptive generation is **off** (it is on by default; speculation sends the raw transcript to the provider before the hook runs). The session disables it explicitly and the docstring documents the precondition — including that LLM-based keyterm detection reopens the same path.