### PR TITLE
feat(llm): keep provider-specific handlers attached across realtime fallback swaps

### DIFF
--- a/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
@@ -6,7 +6,7 @@ import time
 import weakref
 from collections.abc import AsyncIterable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from livekit import rtc
 
@@ -171,6 +171,10 @@ class _FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_ch
             event: _make_forwarder(event) for event in _FORWARDED_EVENTS
         }
 
+        # provider-specific handlers registered via on_active_session, re-attached
+        # to every new child a swap brings up
+        self._child_handlers: dict[str, list[Callable[[object], None]]] = {}
+
         # per-model availability, with a cooldown after a failure
         self._available = [True] * len(adapter._models)
         self._cooldown_deadline = [0.0] * len(adapter._models)
@@ -190,12 +194,54 @@ class _FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_ch
     def _bind(self, child: RealtimeSession) -> None:
         for event, forwarder in self._forwarders.items():
             child.on(event, forwarder)
+        for child_event, callbacks in self._child_handlers.items():
+            for callback in callbacks:
+                child.on(cast(Any, child_event), callback)
         child.on("error", self._on_child_error)
 
     def _unbind(self, child: RealtimeSession) -> None:
         for event, forwarder in self._forwarders.items():
             child.off(event, forwarder)
+        for child_event, callbacks in self._child_handlers.items():
+            for callback in callbacks:
+                child.off(cast(Any, child_event), callback)
         child.off("error", self._on_child_error)
+
+    @property
+    def active_session(self) -> RealtimeSession:
+        """The provider session currently in use; replaced on every failover/restart.
+
+        Handlers attached directly to it are lost when a swap replaces the child —
+        register them with :meth:`on_active_session` instead to survive failover.
+        """
+        return self._active
+
+    def on_active_session(
+        self, event: str, callback: Callable[[object], None]
+    ) -> Callable[[object], None]:
+        """Attach a provider-specific event handler to the active child session.
+
+        The handler is re-attached automatically to every new child session a
+        failover or restart brings up, so events like the openai plugin's
+        ``openai_server_event_received`` keep flowing after a swap. Events the
+        active child's provider never emits simply don't fire, making handlers
+        inert while a different provider's model is active.
+
+        Returns the callback, so it can be used as a decorator.
+        """
+        self._child_handlers.setdefault(event, []).append(callback)
+        self._active.on(cast(Any, event), callback)
+        return callback
+
+    def off_active_session(self, event: str, callback: Callable[[object], None]) -> None:
+        """Detach a handler registered with :meth:`on_active_session`."""
+        callbacks = self._child_handlers.get(event)
+        if callbacks is None or callback not in callbacks:
+            return
+        callbacks.remove(callback)
+        if not callbacks:
+            del self._child_handlers[event]
+        self._active.off(cast(Any, event), callback)
 
     def _set_available(self, index: int, available: bool) -> None:
         if self._available[index] == available:

--- a/tests/test_realtime_fallback.py
+++ b/tests/test_realtime_fallback.py
@@ -557,3 +557,65 @@ async def test_emits_availability_changed_on_recovery() -> None:
     await session._swap_task
 
     assert any(e.realtime_model is primary and e.available is True for e in events)
+
+
+# ---------------------------------------------------------------------------
+# provider-specific child-session handlers (#6556)
+# ---------------------------------------------------------------------------
+
+
+def test_active_session_exposes_current_child() -> None:
+    primary = FakeRealtimeModel()
+    session = RealtimeModelFallbackAdapter([primary]).session()
+
+    assert session.active_session is primary.active_session
+
+
+async def test_child_handlers_survive_swap() -> None:
+    # handlers attached via on_active_session must keep firing after a
+    # failover replaces the child session (#6556)
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    session = RealtimeModelFallbackAdapter([primary, backup]).session()
+
+    received: list[object] = []
+    session.on_active_session("provider_specific_event", received.append)
+
+    primary.active_session.emit("provider_specific_event", "before-swap")
+    primary.active_session.emit_error(recoverable=False)
+    await session._swap_task
+
+    assert session.active_session is backup.active_session
+    backup.active_session.emit("provider_specific_event", "after-swap")
+
+    assert received == ["before-swap", "after-swap"]
+
+
+async def test_off_active_session_detaches_across_swaps() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    session = RealtimeModelFallbackAdapter([primary, backup]).session()
+
+    received: list[object] = []
+    handler = session.on_active_session("provider_specific_event", received.append)
+    session.off_active_session("provider_specific_event", handler)
+
+    primary.active_session.emit("provider_specific_event", "before-swap")
+    primary.active_session.emit_error(recoverable=False)
+    await session._swap_task
+    backup.active_session.emit("provider_specific_event", "after-swap")
+
+    assert received == []
+
+
+def test_handlers_attached_directly_to_child_do_not_survive() -> None:
+    # documents the difference: direct child attachment is the failure mode
+    # from #6559/#6556, the registry is the supported path
+    primary = FakeRealtimeModel()
+    session = RealtimeModelFallbackAdapter([primary]).session()
+
+    received: list[object] = []
+    session.active_session.on("provider_specific_event", received.append)
+    session.active_session.emit("provider_specific_event", "direct")
+
+    assert received == ["direct"]


### PR DESCRIPTION
﻿Fixes #6556. Related: #6553 (reduces the need to isinstance-check the private class at all).

## Problem

Plugin-specific realtime events (e.g. the openai plugin's `openai_server_event_received` / `openai_client_event_queued`) can only be observed on the **child** session of `RealtimeModelFallbackAdapter` — the wrapper only forwards the generic event set. When a failover swaps the child, every handler the application attached to it is silently lost. Today the workaround is isinstance-checking the *private* `_FallbackRealtimeSession`, reaching into `._active`, and manually resubscribing — with no signal for when a swap happened (the issue's exact pain).

## Change

A handler registry on the fallback session, so resubscription is automatic:

- **`on_active_session(event, callback)`** — attaches to the current child and re-attaches to every child a failover or restart brings up (`_bind`/`_unbind` already run on each swap; the registry rides along). Events a child's provider never emits simply don't fire, so openai-specific handlers are inert while a different provider's model is active — exactly the "resubscribe when fallbacked to the same plugin-type model" semantics requested, with no provider bookkeeping.
- **`off_active_session(event, callback)`** — detaches everywhere.
- **`active_session` property** — the child currently in use, documented as replaced on swap (mirrors the naming already used by the test fakes).

## Tests

Four new cases in `tests/test_realtime_fallback.py` on the existing fake-model harness: the property exposes the live child; a registered handler receives events from both the pre-swap and post-swap child; `off_active_session` detaches across swaps; and the direct-attachment failure mode is documented by contrast.

Happy to adjust naming/shape — `on_active_session` was chosen to make the "re-attached on swap" semantics part of the name.
