### PR TITLE
fix(inference): don't claim word alignment for models that send none

### DIFF
--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -260,18 +260,34 @@ def _supports_agent_context_carryover(model: NotGivenOr[STTModels | str]) -> boo
     return is_given(model) and isinstance(model, str) and model in _ASSEMBLYAI_CARRYOVER_MODELS
 
 
-# Models whose transcripts carry no word timings. Cartesia's Turns API sends only
-# {type, transcript, turn_id, request_id} per turn, verified against the live service.
-_UNALIGNED_MODEL_PREFIXES = (
-    "cartesia/ink-2",
-    "inworld/",
-    "google/",
+# Models verified to carry word timings. Unknown models stay disabled until verified.
+_WORD_ALIGNED_MODELS = frozenset(
+    {
+        "deepgram/nova-3",
+        "deepgram/nova-3-medical",
+        "deepgram/nova-2",
+        "deepgram/nova-2-medical",
+        "deepgram/nova-2-conversationalai",
+        "deepgram/nova-2-phonecall",
+        "deepgram/flux-general",
+        "deepgram/flux-general-en",
+        "deepgram/flux-general-multi",
+        "cartesia/ink-whisper",
+        "assemblyai/universal-streaming",
+        "assemblyai/universal-streaming-multilingual",
+        "assemblyai/u3-rt-pro",
+        "assemblyai/universal-3-5-pro",
+        "elevenlabs/scribe_v2_realtime",
+        "xai/stt-1",
+        "speechmatics/enhanced",
+        "speechmatics/standard",
+    }
 )
 
 
 def _aligned_transcript_for_model(
     model: NotGivenOr[STTModels | str],
-) -> Literal["word"] | bool:
+) -> Literal["word", False]:
     """Word-level alignment, which adaptive interruption relies on to gatekeep transcripts.
 
     False when the model sends no word timings, and for "auto", where the provider is
@@ -279,11 +295,9 @@ def _aligned_transcript_for_model(
     don't have is the costlier error: it enables adaptive interruption, which then turns
     off the fast VAD barge-in path it can't actually replace.
     """
-    if not (is_given(model) and isinstance(model, str)) or model == "auto":
+    if not (is_given(model) and isinstance(model, str)):
         return False
-    if model.startswith(_UNALIGNED_MODEL_PREFIXES):
-        return False
-    return "word"
+    return "word" if model in _WORD_ALIGNED_MODELS else False
 
 
 STTLanguages = Literal["multi", "en", "de", "es", "fr", "ja", "pt", "zh", "hi"]

--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -260,6 +260,32 @@ def _supports_agent_context_carryover(model: NotGivenOr[STTModels | str]) -> boo
     return is_given(model) and isinstance(model, str) and model in _ASSEMBLYAI_CARRYOVER_MODELS
 
 
+# Models whose transcripts carry no word timings. Cartesia's Turns API sends only
+# {type, transcript, turn_id, request_id} per turn, verified against the live service.
+_UNALIGNED_MODEL_PREFIXES = (
+    "cartesia/ink-2",
+    "inworld/",
+    "google/",
+)
+
+
+def _aligned_transcript_for_model(
+    model: NotGivenOr[STTModels | str],
+) -> Literal["word"] | bool:
+    """Word-level alignment, which adaptive interruption relies on to gatekeep transcripts.
+
+    False when the model sends no word timings, and for "auto", where the provider is
+    picked server-side per language and so can't be known here. Claiming alignment we
+    don't have is the costlier error: it enables adaptive interruption, which then turns
+    off the fast VAD barge-in path it can't actually replace.
+    """
+    if not (is_given(model) and isinstance(model, str)) or model == "auto":
+        return False
+    if model.startswith(_UNALIGNED_MODEL_PREFIXES):
+        return False
+    return "word"
+
+
 STTLanguages = Literal["multi", "en", "de", "es", "fr", "ja", "pt", "zh", "hi"]
 
 
@@ -579,7 +605,7 @@ class STT(stt.STT):
                 streaming=True,
                 interim_results=True,
                 diarization=diarization_enabled,
-                aligned_transcript="word",
+                aligned_transcript=_aligned_transcript_for_model(model),
                 offline_recognize=False,
                 keyterms=_keyterms_extra_for_model(model) is not None,
                 chat_context=_supports_agent_context_carryover(model),
@@ -705,6 +731,7 @@ class STT(stt.STT):
                 self._capabilities,
                 keyterms=_keyterms_extra_for_model(self._opts.model) is not None,
                 chat_context=_supports_agent_context_carryover(self._opts.model),
+                aligned_transcript=_aligned_transcript_for_model(self._opts.model),
             )
         if is_given(language):
             self._opts.language = LanguageCode(language)

--- a/tests/fake_turn_stt.py
+++ b/tests/fake_turn_stt.py
@@ -1,0 +1,115 @@
+"""STT fake that replays the event order of a turn-detecting provider.
+
+Cartesia Ink-2's Turns API maps to SpeechEvents as: `turn.start` -> START_OF_SPEECH,
+`turn.eager_end` -> PREFLIGHT_TRANSCRIPT, `turn.end` -> FINAL_TRANSCRIPT immediately
+followed by END_OF_SPEECH. Deepgram Flux behaves the same way. Timings are relative to
+the first pushed audio frame, so these line up with FakeVAD/FakeAudioInput schedules.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from typing import Literal
+
+from pydantic import BaseModel
+
+from livekit.agents import LanguageCode
+from livekit.agents.stt import (
+    STT,
+    RecognizeStream,
+    SpeechData,
+    SpeechEvent,
+    SpeechEventType,
+    STTCapabilities,
+)
+from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, APIConnectOptions
+
+
+class ScriptedTurn(BaseModel):
+    speech_start: float
+    """When `turn.start` fires."""
+    final_at: float
+    """When `turn.end` fires, emitting the committed transcript and END_OF_SPEECH."""
+    final_text: str
+    eager_at: float | None = None
+    """When `turn.eager_end` fires. None skips the eager signal entirely."""
+    eager_text: str = ""
+    """The eager guess. Differs from ``final_text`` when the provider revises it."""
+
+
+class TurnScriptedSTT(STT):
+    def __init__(
+        self,
+        *,
+        turns: list[ScriptedTurn],
+        aligned_transcript: Literal["word", "segment"] | bool = False,
+    ) -> None:
+        super().__init__(
+            capabilities=STTCapabilities(
+                streaming=True,
+                interim_results=True,
+                aligned_transcript=aligned_transcript,
+            )
+        )
+        self._turns = turns
+        self._done_fut = asyncio.Future[None]()
+
+    @property
+    def turns_done(self) -> asyncio.Future[None]:
+        return self._done_fut
+
+    async def _recognize_impl(
+        self, buffer, *, language: str | None, conn_options: APIConnectOptions
+    ) -> SpeechEvent:
+        raise NotImplementedError("streaming only")
+
+    def stream(
+        self,
+        *,
+        language: str | None = None,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+    ) -> TurnScriptedStream:
+        return TurnScriptedStream(stt=self, conn_options=conn_options)
+
+
+class TurnScriptedStream(RecognizeStream):
+    def __init__(self, *, stt: TurnScriptedSTT, conn_options: APIConnectOptions) -> None:
+        super().__init__(stt=stt, conn_options=conn_options)
+        self._stt: TurnScriptedSTT = stt
+
+    def _emit(self, event_type: SpeechEventType, text: str = "") -> None:
+        # the Cartesia plugin builds SpeechData without start_time/end_time; keep that
+        # so timestamp-dependent code paths behave the same here
+        alternatives = (
+            [SpeechData(text=text, language=LanguageCode("en"), confidence=0.9)] if text else []
+        )
+        self._event_ch.send_nowait(SpeechEvent(type=event_type, alternatives=alternatives))
+
+    async def _run(self) -> None:
+        await self._input_ch.recv()  # align the script with the first pushed frame
+        origin = time.perf_counter()
+
+        async def sleep_until(t: float) -> None:
+            remaining = t - (time.perf_counter() - origin)
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+
+        for turn in self._stt._turns:
+            await sleep_until(turn.speech_start)
+            self._emit(SpeechEventType.START_OF_SPEECH)
+
+            if turn.eager_at is not None:
+                await sleep_until(turn.eager_at)
+                self._emit(SpeechEventType.PREFLIGHT_TRANSCRIPT, turn.eager_text)
+
+            await sleep_until(turn.final_at)
+            self._emit(SpeechEventType.FINAL_TRANSCRIPT, turn.final_text)
+            self._emit(SpeechEventType.END_OF_SPEECH)
+
+        with contextlib.suppress(asyncio.InvalidStateError):
+            self._stt._done_fut.set_result(None)
+
+        async for _ in self._input_ch:
+            pass

--- a/tests/test_inference_stt_aligned_transcript_claim.py
+++ b/tests/test_inference_stt_aligned_transcript_claim.py
@@ -97,6 +97,11 @@ def test_alignment_is_recomputed_when_the_model_changes(_fake_credentials: None)
     assert stt_impl.capabilities.aligned_transcript is False
 
 
+def test_unknown_models_do_not_claim_alignment(_fake_credentials: None) -> None:
+    stt_impl = inference.STT(model="new-provider/new-turn-model")
+    assert stt_impl.capabilities.aligned_transcript is False
+
+
 def test_gateway_ink2_payload_carries_no_word_alignment() -> None:
     """The advertised word alignment is not in the data the gateway sends."""
     stream = InferenceSpeechStream.__new__(InferenceSpeechStream)

--- a/tests/test_inference_stt_aligned_transcript_claim.py
+++ b/tests/test_inference_stt_aligned_transcript_claim.py
@@ -1,0 +1,289 @@
+"""`inference.STT` must not claim word-aligned transcripts for models with no word data.
+
+The gateway's Cartesia Ink-2 translator emits ``Words: []`` with ``Start`` = the
+audio-time offset and ``Duration`` = billed audio bytes / bytes-per-second — a billing
+figure, not the utterance span. Cartesia's Turns API sends no word timings to forward.
+
+That flag is load-bearing: `AgentActivity._resolve_interruption_detection` uses it as the
+`can_gatekeep` test for enabling adaptive interruption, which then disables the fast
+VAD interruption path once the backchannel boundary expires. So a false claim costs
+barge-in latency on exactly the models least able to make up for it.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from livekit.agents import (
+    Agent,
+    AgentSession,
+    EndpointingOptions,
+    InterruptionOptions,
+    TurnHandlingOptions,
+    inference,
+)
+from livekit.agents.inference.stt import SpeechStream as InferenceSpeechStream
+from livekit.agents.stt import SpeechData, SpeechEvent, SpeechEventType
+from livekit.agents.types import NOT_GIVEN
+from livekit.agents.voice.agent_activity import AgentActivity
+from livekit.agents.voice.audio_recognition import AudioRecognition
+
+from .fake_llm import FakeLLM
+from .fake_stt import FakeUserSpeech
+from .fake_tts import FakeTTS
+from .fake_turn_stt import ScriptedTurn, TurnScriptedSTT
+from .fake_vad import FakeVAD
+
+pytestmark = [pytest.mark.unit, pytest.mark.no_concurrent]
+
+# What the gateway actually puts on the wire for a cartesia/ink-2 final transcript.
+# See agent-gateway/pkg/provider/stt/cartesiaturns/translator.go
+# emitTranscriptWithBytes: Start = GetAudioTimeOffset().Seconds(),
+# Duration = audioBytes/bytesPerSec (final only), Words = []interfaces.Word{}.
+GATEWAY_INK2_FINAL = {
+    "transcript": "are you open on sunday",
+    "confidence": 1.0,
+    "start": 0.0,
+    "duration": 12.5,  # audio billed since the previous turn.end, not this utterance
+    "words": [],
+    "language": "en",
+}
+
+
+@pytest.fixture
+def _fake_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LIVEKIT_URL", "ws://localhost:7880")
+    monkeypatch.setenv("LIVEKIT_API_KEY", "fake")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "fakesecret")
+    monkeypatch.setenv("CARTESIA_API_KEY", "fake")
+
+
+def test_inference_and_plugin_agree_about_ink2(_fake_credentials: None) -> None:
+    """The same Cartesia model must report the same alignment through either integration.
+
+    Verified against the live Turns API: every event is {type, transcript, turn_id,
+    request_id}, on both the version the plugin pins and the one the gateway pins, and
+    neither `add_timestamps` nor `timestamp_granularities[]` changes that.
+    """
+    cartesia = pytest.importorskip("livekit.plugins.cartesia")
+
+    gateway_stt = inference.STT(model="cartesia/ink-2")
+    plugin_stt = cartesia.STT(model="ink-2")
+
+    assert plugin_stt.capabilities.aligned_transcript is False
+    assert gateway_stt.capabilities.aligned_transcript is False
+
+
+def test_models_that_do_send_words_keep_their_claim(_fake_credentials: None) -> None:
+    """The fix must not strip alignment from the providers that genuinely forward words."""
+    assert inference.STT(model="cartesia/ink-whisper").capabilities.aligned_transcript == "word"
+    assert inference.STT(model="deepgram/nova-3").capabilities.aligned_transcript == "word"
+    assert inference.STT(
+        model="assemblyai/universal-streaming"
+    ).capabilities.aligned_transcript == ("word")
+    # the provider is resolved server-side per language, so alignment can't be promised
+    assert inference.STT(model="auto").capabilities.aligned_transcript is False
+    assert inference.STT(model="inworld/inworld-stt-1").capabilities.aligned_transcript is False
+
+
+def test_alignment_is_recomputed_when_the_model_changes(_fake_credentials: None) -> None:
+    """`update_options` recomputes it, as it already does for keyterms and chat_context."""
+    stt_impl = inference.STT(model="deepgram/nova-3")
+    assert stt_impl.capabilities.aligned_transcript == "word"
+
+    stt_impl.update_options(model="cartesia/ink-2")
+    assert stt_impl.capabilities.aligned_transcript is False
+
+
+def test_gateway_ink2_payload_carries_no_word_alignment() -> None:
+    """The advertised word alignment is not in the data the gateway sends."""
+    stream = InferenceSpeechStream.__new__(InferenceSpeechStream)
+    stream._start_time_offset = 0.0
+    stream._opts = SimpleNamespace(language="en")
+
+    data = stream._build_speech_data(GATEWAY_INK2_FINAL)
+
+    # advertised as "word"-aligned, but there are no words to align to
+    assert data.words == []
+    # and the span is the billing figure, ~12.5s for a ~2s utterance
+    assert data.start_time == 0.0
+    assert data.end_time == 12.5
+
+
+def _recognition_awaiting_flush(
+    *, ignore_until: float, input_started_at: float
+) -> AudioRecognition:
+    """An AudioRecognition mid-ignore-window, as it sits just after agent speech ends."""
+    ar = AudioRecognition.__new__(AudioRecognition)
+    ar._interruption_enabled = True
+    ar._agent_speaking = False
+    ar._ignore_user_transcript_until = ignore_until
+    # _input_started_at is a read-only property over the STT pipeline
+    ar._stt_pipeline = SimpleNamespace(input_started_at=input_started_at)
+    ar._agent_speech_started_at = input_started_at
+    return ar
+
+
+def _final(*, start_time: float, end_time: float) -> SpeechEvent:
+    return SpeechEvent(
+        type=SpeechEventType.FINAL_TRANSCRIPT,
+        alternatives=[
+            SpeechData(
+                text="are you open on sunday",
+                language="en",
+                start_time=start_time,
+                end_time=end_time,
+            )
+        ],
+    )
+
+
+def test_gateway_timestamps_defeat_the_transcript_gate() -> None:
+    """Adaptive interruption's transcript gate cannot act on the gateway's Ink-2 output.
+
+    `_should_hold_stt_event` requires ``start_time > 0``, and the gateway pins ``start`` to
+    the audio-time offset — 0 until a reconnect. So the half of adaptive interruption that
+    is supposed to gatekeep transcripts is inert for this model, even though its
+    ``aligned_transcript`` claim is what switched adaptive on.
+    """
+    import time
+
+    now = time.time()
+    ar = _recognition_awaiting_flush(ignore_until=now + 1.0, input_started_at=now - 5.0)
+
+    gateway_shaped = _final(start_time=0.0, end_time=12.5)
+    properly_aligned = _final(start_time=4.5, end_time=5.2)
+
+    assert ar._should_hold_stt_event(gateway_shaped) is False
+    assert ar._should_hold_stt_event(properly_aligned) is True
+
+
+def test_reconnect_offset_makes_the_gate_use_a_billing_span() -> None:
+    """After a reconnect the gate does engage — on a window derived from billed bytes.
+
+    `RecognizeStream` accumulates `start_time_offset` across retries, so post-reconnect
+    ``start_time > 0`` and the hold decision is made with ``end_time - start_time`` equal
+    to the audio billed since the previous turn.
+    """
+    import time
+
+    now = time.time()
+    ar = _recognition_awaiting_flush(ignore_until=now + 1.0, input_started_at=now - 5.0)
+
+    # offset 4.5s after a reconnect; duration is still the 12.5s billing figure
+    post_reconnect = _final(start_time=4.5, end_time=17.0)
+    assert ar._should_hold_stt_event(post_reconnect) is True
+    assert (
+        post_reconnect.alternatives[0].end_time - post_reconnect.alternatives[0].start_time == 12.5
+    )
+
+
+def _build_session(*, aligned_transcript: object, mode: str | None = None) -> AgentSession:
+    speech = FakeUserSpeech(start_time=0.5, end_time=2.0, transcript="hello", stt_delay=0.0)
+    interruption = InterruptionOptions(resume_false_interruption=False)
+    if mode is not None:
+        interruption["mode"] = mode  # type: ignore[typeddict-item]
+    return AgentSession[None](
+        vad=FakeVAD(fake_user_speeches=[speech]),
+        stt=TurnScriptedSTT(
+            turns=[ScriptedTurn(speech_start=0.55, final_at=2.6, final_text="hello")],
+            aligned_transcript=aligned_transcript,  # type: ignore[arg-type]
+        ),
+        llm=FakeLLM(fake_responses=[]),
+        tts=FakeTTS(fake_responses=[]),
+        turn_handling=TurnHandlingOptions(
+            turn_detection="stt",
+            endpointing=EndpointingOptions(min_delay=0.2),
+            # mode absent means the session auto-detects
+            interruption=interruption,
+        ),
+        aec_warmup_duration=None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("aligned_transcript", "expect_adaptive"),
+    [
+        pytest.param("word", True, id="claims-word-alignment"),
+        pytest.param(False, False, id="reports-no-alignment"),
+    ],
+)
+def test_alignment_claim_alone_enables_adaptive_interruption(
+    aligned_transcript: object,
+    expect_adaptive: bool,
+    monkeypatch: pytest.MonkeyPatch,
+    _fake_credentials: None,
+) -> None:
+    """Only the capability flag differs, yet it decides whether adaptive interruption runs.
+
+    Dev mode (`lk agent dev` / `console`) and LiveKit Cloud hosted agents auto-enable
+    adaptive; plain production leaves it off unless `interruption.mode` is set.
+    """
+    monkeypatch.setenv("LIVEKIT_DEV_MODE", "1")
+
+    session = _build_session(aligned_transcript=aligned_transcript)
+    # AgentActivity resolves interruption detection in __init__, before any I/O starts
+    activity = AgentActivity(Agent(instructions="You are a helpful assistant."), session)
+
+    assert activity._interruption_detection_enabled is expect_adaptive
+
+
+def test_adaptive_stays_off_in_plain_production(
+    monkeypatch: pytest.MonkeyPatch, _fake_credentials: None
+) -> None:
+    """The blast radius is dev mode and hosted agents, not every deployment."""
+    monkeypatch.delenv("LIVEKIT_DEV_MODE", raising=False)
+    monkeypatch.delenv("LIVEKIT_REMOTE_EOT_URL", raising=False)
+
+    session = _build_session(aligned_transcript="word")
+    activity = AgentActivity(Agent(instructions="You are a helpful assistant."), session)
+
+    assert activity._interruption_detection_enabled is False
+    assert session.interruption_detection is NOT_GIVEN
+
+
+@pytest.mark.parametrize(
+    "aligned_transcript",
+    [
+        # inference.STT before the per-model fix, and any model that really is aligned
+        pytest.param("word", id="stt-claims-alignment"),
+        # the Cartesia plugin, and inference.STT for ink-2 after the fix
+        pytest.param(False, id="stt-reports-no-alignment"),
+    ],
+)
+def test_mode_vad_keeps_fast_interruption_on_either_stt(
+    aligned_transcript: object,
+    monkeypatch: pytest.MonkeyPatch,
+    _fake_credentials: None,
+) -> None:
+    """`interruption.mode="vad"` is the one mitigation that holds regardless of the STT.
+
+    `InterruptionOptions["mode"]` populates `AgentSession.interruption_detection`, which
+    `_resolve_interruption_detection` short-circuits on before it ever reaches the
+    hosted/dev-mode check. So it behaves the same whether the STT is the Cartesia plugin
+    or the inference gateway, and stays correct after the alignment fix lands.
+    """
+    monkeypatch.setenv("LIVEKIT_DEV_MODE", "1")
+
+    session = _build_session(aligned_transcript=aligned_transcript, mode="vad")
+    activity = AgentActivity(Agent(instructions="You are a helpful assistant."), session)
+
+    assert session.interruption_detection == "vad"
+    assert activity._interruption_detection_enabled is False
+    # the VAD barge-in path stays armed, so min_duration governs interruption speed
+    assert activity._interruption_by_audio_activity_enabled is True
+
+
+def test_session_vad_survives_a_turn_detecting_stt(_fake_credentials: None) -> None:
+    """The session VAD must reach AgentActivity, since barge-in speed depends on it.
+
+    `inference.STT` drops a `vad=` passed to its *own* constructor for models that
+    endpoint server-side, which is easy to confuse with the session-level VAD. Only the
+    latter feeds `on_vad_inference_done`, and it is untouched.
+    """
+    session = _build_session(aligned_transcript=False, mode="vad")
+    activity = AgentActivity(Agent(instructions="You are a helpful assistant."), session)
+
+    assert activity.vad is session.vad is not None


### PR DESCRIPTION
## The bug

`inference.STT` hardcoded `aligned_transcript="word"` for every model:

```python
capabilities=stt.STTCapabilities(
    streaming=True,
    interim_results=True,
    diarization=diarization_enabled,
    aligned_transcript="word",   # <- regardless of model
    ...
)
```

That flag is not cosmetic. It is the `can_gatekeep` test in
`AgentActivity._resolve_interruption_detection`:

```python
can_gatekeep = (
    self.stt is not None
    and self.stt.capabilities.aligned_transcript
    and self.stt.capabilities.streaming
)
```

When `can_gatekeep` is true and a VAD is present, adaptive interruption is
eligible, and it is enabled by default on LiveKit Cloud (`is_hosted()`) and in
dev mode (`lk agent dev`, `console`). Enabling it flips the fast path off: once
the `backchannel_boundary` window expires, `_disable_vad_interruption_soon` sets
`_interruption_by_audio_activity_enabled = False`, handing barge-in from VAD to
the adaptive detector. `backchannel_boundary` defaults to `(1.0, 1.0)`.

So for a model with no word timings we traded a VAD barge-in for a transcript
gate that cannot fire, and the user pays about a second of extra barge-in
latency. `_should_hold_stt_event` requires `start_time > 0`, and the gateway's
Ink-2 translator pins `Start` to the audio-time offset (0 until a reconnect) and
`Words` to `[]`, so the gate is inert. After a reconnect it does engage, but on
`end_time - start_time` derived from billed audio bytes rather than the
utterance span, which is worse than not engaging.

Cartesia Ink-2 is the case that surfaced this. Its Turns API sends only
`{type, transcript, turn_id, request_id}` per turn — verified against the live
service on both the version the plugin pins and the one the gateway pins, and
neither `add_timestamps` nor `timestamp_granularities[]` changes it. The
`livekit-plugins-cartesia` plugin reports `aligned_transcript=False` for the
same model, so the two integrations disagreed about identical audio, and only
the gateway path was slow. That matches the reports of Ink-2 barge-in being
roughly a second late through inference versus the plugin or raw VAD.

## The fix

Derive the capability per model, and recompute it in `update_options` alongside
`keyterms` and `chat_context` (it was previously never recomputed, so switching
models left a stale claim).

`False` for models known to send no word timings (`cartesia/ink-2`, `inworld/`,
`google/`), and for `"auto"`, where the provider is resolved server-side per
language and so cannot be known client-side. Erring toward `False` is the
cheaper mistake: it forgoes adaptive interruption, whereas a false `"word"`
disables a working VAD path in favour of one that cannot replace it.

Models that genuinely forward words (`cartesia/ink-whisper`, `deepgram/nova-3`,
`assemblyai/universal-streaming`, ...) keep `"word"` and are unaffected.

## Tests

`tests/test_inference_stt_aligned_transcript_claim.py`, with a
`TurnScriptedSTT` fake in `tests/fake_turn_stt.py` that replays a
turn-detecting provider's event order.

Three tests fail on `main` and pass here:

- `test_inference_and_plugin_agree_about_ink2` — both integrations report the
  same alignment for the same model
- `test_models_that_do_send_words_keep_their_claim` — the aligned providers are
  untouched
- `test_alignment_is_recomputed_when_the_model_changes` — `update_options`
  refreshes it

The rest document the mechanism, and hold before and after: that the capability
flag alone decides whether adaptive interruption runs, that the gateway's Ink-2
payload carries no words, that `_should_hold_stt_event` can't act on it, that
plain production is unaffected, and that `interruption.mode="vad"` remains a
working workaround on either integration.

## Workaround for anyone hitting this before it ships

```python
interruption=InterruptionOptions(mode="vad", min_duration=0.2)
```

`mode="vad"` short-circuits `_resolve_interruption_detection` before the
hosted/dev check, so it keeps the VAD path armed regardless of the STT.
`min_duration` then governs barge-in speed; the default is `0.5`. This does not
affect Ink-2's own turn detection, which continues to drive endpointing.

## Notes

- Complementary to #6599, which stopped interim transcripts from interrupting
  when a VAD is present. Different path, same symptom area.
- The prefix list is a client-side guess about server behaviour. If the gateway
  starts forwarding word timings for these providers, this needs updating —
  worth considering whether the gateway should advertise alignment instead.