### PR TITLE
fix(inference): report Ink-2 speech onset when the provider detects it

### DIFF
--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -931,6 +931,8 @@ class SpeechStream(stt.SpeechStream):
                 msg_type = data.get("type")
                 if msg_type == "session.created":
                     pass
+                elif msg_type == "start_of_speech":
+                    self._process_start_of_speech()
                 elif msg_type == "interim_transcript":
                     self._process_transcript(data, is_final=False)
                 elif msg_type == "preflight_transcript":
@@ -1077,17 +1079,26 @@ class SpeechStream(stt.SpeechStream):
         )
         self._event_ch.send_nowait(event)
 
+    def _process_start_of_speech(self) -> None:
+        """Onset reported by a provider that detects it server-side (e.g. Cartesia Ink-2).
+
+        Without this the first transcript has to stand in for onset, which lands about
+        800ms late because it waits for a word to be decoded.
+        """
+        if self._speaking:
+            return
+        self._speaking = True
+        self._event_ch.send_nowait(stt.SpeechEvent(type=stt.SpeechEventType.START_OF_SPEECH))
+
     def _process_transcript(self, data: dict, is_final: bool) -> None:
         request_id = data.get("request_id", self._request_id)
         text = data.get("transcript", "")
 
         if not text and not is_final:
             return
-        # We'll have a more accurate way of detecting when speech started when we have VAD
-        if not self._speaking:
-            self._speaking = True
-            start_event = stt.SpeechEvent(type=stt.SpeechEventType.START_OF_SPEECH)
-            self._event_ch.send_nowait(start_event)
+        # fallback onset for providers that send no start_of_speech; a transcript is the
+        # earliest evidence of speech we have, so it is late by a word-decode
+        self._process_start_of_speech()
 
         speech_data = self._build_speech_data(data)
 

--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -1096,8 +1096,6 @@ class SpeechStream(stt.SpeechStream):
 
         if not text and not is_final:
             return
-        # fallback onset for providers that send no start_of_speech; a transcript is the
-        # earliest evidence of speech we have, so it is late by a word-decode
         self._process_start_of_speech()
 
         speech_data = self._build_speech_data(data)

--- a/tests/test_inference_stt_start_of_speech.py
+++ b/tests/test_inference_stt_start_of_speech.py
@@ -1,0 +1,114 @@
+"""`inference.STT` must report speech onset when the provider detects it server-side.
+
+Cartesia Ink-2 signals onset with `turn.start`, which the gateway sends on as
+`start_of_speech`. That used to arrive as an `interim_transcript` with an empty string,
+which `_process_transcript` drops, so onset fell back to the first transcript carrying
+words — around 800ms late against the same audio through the Cartesia plugin.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from livekit.agents.inference.stt import SpeechStream as InferenceSpeechStream
+from livekit.agents.stt import SpeechEventType
+from livekit.agents.utils.aio.channel import Chan, ChanEmpty
+
+pytestmark = [pytest.mark.unit]
+
+
+def _stream() -> InferenceSpeechStream:
+    stream = InferenceSpeechStream.__new__(InferenceSpeechStream)
+    stream._event_ch = Chan()  # type: ignore[assignment]
+    stream._speaking = False
+    stream._request_id = "req-1"
+    stream._speech_duration = 0.0
+    stream._start_time_offset = 0.0
+    stream._pending_extra = None
+    stream._opts = SimpleNamespace(language="en")
+    return stream
+
+
+def _drain(stream: InferenceSpeechStream) -> list[SpeechEventType]:
+    out = []
+    while True:
+        try:
+            out.append(stream._event_ch.recv_nowait().type)
+        except ChanEmpty:
+            return out
+
+
+def test_start_of_speech_message_reports_onset_immediately() -> None:
+    """The onset event must not wait for a transcript."""
+    stream = _stream()
+
+    stream._process_start_of_speech()
+
+    assert _drain(stream) == [SpeechEventType.START_OF_SPEECH]
+    assert stream._speaking is True
+
+
+def test_onset_is_not_reported_twice() -> None:
+    """A later transcript must not re-announce onset the provider already gave us."""
+    stream = _stream()
+
+    stream._process_start_of_speech()
+    assert _drain(stream) == [SpeechEventType.START_OF_SPEECH]
+
+    stream._process_transcript({"transcript": "are you"}, is_final=False)
+
+    # only the interim, no second onset
+    assert _drain(stream) == [SpeechEventType.INTERIM_TRANSCRIPT]
+
+
+def test_duplicate_start_of_speech_is_ignored() -> None:
+    stream = _stream()
+
+    stream._process_start_of_speech()
+    stream._process_start_of_speech()
+
+    assert _drain(stream) == [SpeechEventType.START_OF_SPEECH]
+
+
+def test_providers_without_onset_still_fall_back_to_the_first_transcript() -> None:
+    """Models that send no onset event keep today's behaviour."""
+    stream = _stream()
+
+    stream._process_transcript({"transcript": "are you"}, is_final=False)
+
+    assert _drain(stream) == [
+        SpeechEventType.START_OF_SPEECH,
+        SpeechEventType.INTERIM_TRANSCRIPT,
+    ]
+
+
+def test_empty_interim_alone_never_reports_onset() -> None:
+    """The shape the gateway sends today: an empty interim carries no onset.
+
+    This is the bug. The gateway must send `start_of_speech` instead; the SDK cannot
+    infer onset from an empty transcript without firing for providers that emit empty
+    interims for unrelated reasons.
+    """
+    stream = _stream()
+
+    stream._process_transcript({"transcript": ""}, is_final=False)
+
+    assert _drain(stream) == []
+    assert stream._speaking is False
+
+
+def test_onset_resets_after_the_turn_ends() -> None:
+    """A second turn on the same stream must report its own onset."""
+    stream = _stream()
+
+    stream._process_start_of_speech()
+    stream._process_transcript(
+        {"transcript": "are you open on sunday", "start": 0.0, "duration": 1.0},
+        is_final=True,
+    )
+    assert stream._speaking is False
+
+    stream._process_start_of_speech()
+    assert SpeechEventType.START_OF_SPEECH in _drain(stream)


### PR DESCRIPTION
Companion to livekit/agent-gateway#1134, which makes the gateway send the message; this one handles it.

Independent of, and complementary to, #6629: that PR stops `inference.STT` claiming word alignment for Ink-2 (which was falsely enabling adaptive interruption and disabling the fast VAD path). Together the three PRs cover both causes of the slow Ink-2 barge-in. No file overlap — the hunks are in different regions of `stt.py`.

## The bug

Customers reported that Ink-2 barge-in through LiveKit Inference is "consistently over 1 sec late versus Silero VAD", while the same model via `cartesia.STT` is fine. That reproduces, but the delay is in **speech onset**, not end-of-turn.

Cartesia's Turns API emits `turn.start` about 130ms after speech begins. The gateway forwarded it as an `interim_transcript` whose transcript is the empty string, since `turn.start` carries no text. `_process_transcript` drops exactly that:

```python
if not text and not is_final:
    return
```

So the onset signal vanished, and `START_OF_SPEECH` was instead synthesized from the first interim that carried words — roughly a second in, once a word had been decoded. Interruption keys off onset, so barge-in inherited the full delay. `cartesia.STT` bypasses this translation and maps `turn.start` straight to `START_OF_SPEECH`, which is why the plugin looked fine and inference didn't.

## The fix

Handle a `start_of_speech` message and report onset from it. The transcript-based path stays as a fallback for providers that send no onset event, so their behaviour is unchanged.

Fixing this SDK-side alone isn't possible: inferring onset from an empty interim would fire for any provider that emits empty interims for unrelated reasons, which is why the gateway needs to name the event explicitly.

## Measurements

Same 5-turn fixture, real Cartesia, locally built gateway, pre-fix binary vs both halves of the fix. Numbers are ms after Silero VAD's onset:

| turn | before | after | `cartesia.STT` | first interim (old onset point) |
|---|---|---|---|---|
| 1 | 1014 | 363 | 271 | 957 |
| 2 | 954 | 134 | 156 | 919 |
| 3 | 810 | 157 | 153 | 778 |
| 4 | 1004 | 162 | 117 | 959 |
| 5 | 1100 | 260 | 264 | 1059 |

Median onset: **1004ms to 162ms**, within 6ms of the plugin instead of ~880ms behind. Three of five turns previously exceeded a second, matching the report.

Unchanged, as expected for an onset-only fix: `end_of_speech` lateness (368ms vs the plugin's 363ms) and preemptive-generation reuse (5/5 turns).

## Rollout

The two halves are independent. The gateway side can land first: this dispatch is an `if`/`elif` chain with no `else`, so an SDK without this change ignores `start_of_speech` silently and keeps today's behaviour, having already discarded the empty interim it replaces.

## Test plan

- [x] `tests/test_inference_stt_start_of_speech.py` — 6 tests: onset without waiting for a transcript, no duplicate onset, the fallback for providers with no onset event, that an empty interim alone never reports onset, and that onset resets across turns
- [x] End-to-end against real Cartesia through a locally built gateway (table above)
