### PR TITLE
fix: account for STT fallback transcript alignment

### DIFF
--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -365,6 +365,20 @@ def _normalize_fallback(
     return [_make_fallback(fallback)]
 
 
+def _aligned_transcript_for_models(
+    model: NotGivenOr[STTModels | str],
+    fallback: NotGivenOr[list[FallbackModel]],
+) -> Literal["word", False]:
+    models = [model]
+    if is_given(fallback):
+        models.extend(item["model"] for item in fallback)
+    return (
+        "word"
+        if all(_aligned_transcript_for_model(candidate) == "word" for candidate in models)
+        else False
+    )
+
+
 STTModels = (
     DeepgramModels
     | DeepgramFluxModels
@@ -613,13 +627,17 @@ class STT(stt.STT):
 
         vad = _resolve_vad_for_model(model, vad if is_given(vad) else None)
 
+        fallback_models: NotGivenOr[list[FallbackModel]] = NOT_GIVEN
+        if is_given(fallback):
+            fallback_models = _normalize_fallback(fallback)
+
         # chat_context follows the model's native support; the session decides whether to forward
         super().__init__(
             capabilities=stt.STTCapabilities(
                 streaming=True,
                 interim_results=True,
                 diarization=diarization_enabled,
-                aligned_transcript=_aligned_transcript_for_model(model),
+                aligned_transcript=_aligned_transcript_for_models(model, fallback_models),
                 offline_recognize=False,
                 keyterms=_keyterms_extra_for_model(model) is not None,
                 chat_context=_supports_agent_context_carryover(model),
@@ -647,9 +665,6 @@ class STT(stt.STT):
             raise ValueError(
                 "api_secret is required, either as argument or set LIVEKIT_API_SECRET environmental variable"
             )
-        fallback_models: NotGivenOr[list[FallbackModel]] = NOT_GIVEN
-        if is_given(fallback):
-            fallback_models = _normalize_fallback(fallback)
 
         self._opts = STTOptions(
             model=model,
@@ -745,7 +760,9 @@ class STT(stt.STT):
                 self._capabilities,
                 keyterms=_keyterms_extra_for_model(self._opts.model) is not None,
                 chat_context=_supports_agent_context_carryover(self._opts.model),
-                aligned_transcript=_aligned_transcript_for_model(self._opts.model),
+                aligned_transcript=_aligned_transcript_for_models(
+                    self._opts.model, self._opts.fallback
+                ),
             )
         if is_given(language):
             self._opts.language = LanguageCode(language)

--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -393,7 +393,7 @@ class STTOptions:
     api_key: str
     api_secret: str
     extra_kwargs: dict[str, Any]
-    fallback: NotGivenOr[list[FallbackModel]]
+    fallback: list[FallbackModel]
     conn_options: NotGivenOr[APIConnectOptions]
 
 
@@ -613,14 +613,10 @@ class STT(stt.STT):
 
         vad = _resolve_vad_for_model(model, vad if is_given(vad) else None)
 
-        fallback_models: NotGivenOr[list[FallbackModel]] = NOT_GIVEN
-        if is_given(fallback):
-            fallback_models = _normalize_fallback(fallback)
-        models = [model]
-        if is_given(fallback_models):
-            models.extend(item["model"] for item in fallback_models)
+        fallback_models = _normalize_fallback(fallback) if is_given(fallback) else []
+        all_models = [model, *(item["model"] for item in fallback_models)]
         aligned_transcript: Literal["word", False] = (
-            "word" if all(_aligned_transcript_for_model(item) for item in models) else False
+            "word" if all(_aligned_transcript_for_model(item) for item in all_models) else False
         )
 
         # chat_context follows the model's native support; the session decides whether to forward
@@ -748,15 +744,18 @@ class STT(stt.STT):
 
             self._opts.model = model
             self._vad = _resolve_vad_for_model(model, self._vad)
-            models = [self._opts.model]
-            if is_given(self._opts.fallback):
-                models.extend(item["model"] for item in self._opts.fallback)
+            all_models = [
+                self._opts.model,
+                *(item["model"] for item in self._opts.fallback),
+            ]
             self._capabilities = replace(
                 self._capabilities,
                 keyterms=_keyterms_extra_for_model(self._opts.model) is not None,
                 chat_context=_supports_agent_context_carryover(self._opts.model),
                 aligned_transcript=(
-                    "word" if all(_aligned_transcript_for_model(item) for item in models) else False
+                    "word"
+                    if all(_aligned_transcript_for_model(item) for item in all_models)
+                    else False
                 ),
             )
         if is_given(language):

--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -365,20 +365,6 @@ def _normalize_fallback(
     return [_make_fallback(fallback)]
 
 
-def _aligned_transcript_for_models(
-    model: NotGivenOr[STTModels | str],
-    fallback: NotGivenOr[list[FallbackModel]],
-) -> Literal["word", False]:
-    models = [model]
-    if is_given(fallback):
-        models.extend(item["model"] for item in fallback)
-    return (
-        "word"
-        if all(_aligned_transcript_for_model(candidate) == "word" for candidate in models)
-        else False
-    )
-
-
 STTModels = (
     DeepgramModels
     | DeepgramFluxModels
@@ -630,6 +616,12 @@ class STT(stt.STT):
         fallback_models: NotGivenOr[list[FallbackModel]] = NOT_GIVEN
         if is_given(fallback):
             fallback_models = _normalize_fallback(fallback)
+        models = [model]
+        if is_given(fallback_models):
+            models.extend(item["model"] for item in fallback_models)
+        aligned_transcript: Literal["word", False] = (
+            "word" if all(_aligned_transcript_for_model(item) for item in models) else False
+        )
 
         # chat_context follows the model's native support; the session decides whether to forward
         super().__init__(
@@ -637,7 +629,7 @@ class STT(stt.STT):
                 streaming=True,
                 interim_results=True,
                 diarization=diarization_enabled,
-                aligned_transcript=_aligned_transcript_for_models(model, fallback_models),
+                aligned_transcript=aligned_transcript,
                 offline_recognize=False,
                 keyterms=_keyterms_extra_for_model(model) is not None,
                 chat_context=_supports_agent_context_carryover(model),
@@ -756,12 +748,15 @@ class STT(stt.STT):
 
             self._opts.model = model
             self._vad = _resolve_vad_for_model(model, self._vad)
+            models = [self._opts.model]
+            if is_given(self._opts.fallback):
+                models.extend(item["model"] for item in self._opts.fallback)
             self._capabilities = replace(
                 self._capabilities,
                 keyterms=_keyterms_extra_for_model(self._opts.model) is not None,
                 chat_context=_supports_agent_context_carryover(self._opts.model),
-                aligned_transcript=_aligned_transcript_for_models(
-                    self._opts.model, self._opts.fallback
+                aligned_transcript=(
+                    "word" if all(_aligned_transcript_for_model(item) for item in models) else False
                 ),
             )
         if is_given(language):

--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -393,7 +393,7 @@ class STTOptions:
     api_key: str
     api_secret: str
     extra_kwargs: dict[str, Any]
-    fallback: list[FallbackModel]
+    fallback: NotGivenOr[list[FallbackModel]]
     conn_options: NotGivenOr[APIConnectOptions]
 
 
@@ -613,8 +613,12 @@ class STT(stt.STT):
 
         vad = _resolve_vad_for_model(model, vad if is_given(vad) else None)
 
-        fallback_models = _normalize_fallback(fallback) if is_given(fallback) else []
-        all_models = [model, *(item["model"] for item in fallback_models)]
+        models: NotGivenOr[list[FallbackModel]] = (
+            _normalize_fallback(fallback) if is_given(fallback) else NOT_GIVEN
+        )
+        all_models = [model]
+        if is_given(models):
+            all_models.extend(item["model"] for item in models)
         aligned_transcript: Literal["word", False] = (
             "word" if all(_aligned_transcript_for_model(item) for item in all_models) else False
         )
@@ -663,7 +667,7 @@ class STT(stt.STT):
             api_key=lk_api_key,
             api_secret=lk_api_secret,
             extra_kwargs=dict(extra_kwargs) if is_given(extra_kwargs) else {},
-            fallback=fallback_models,
+            fallback=models,
             conn_options=conn_options if is_given(conn_options) else DEFAULT_API_CONNECT_OPTIONS,
         )
 
@@ -744,10 +748,9 @@ class STT(stt.STT):
 
             self._opts.model = model
             self._vad = _resolve_vad_for_model(model, self._vad)
-            all_models = [
-                self._opts.model,
-                *(item["model"] for item in self._opts.fallback),
-            ]
+            all_models = [self._opts.model]
+            if is_given(self._opts.fallback):
+                all_models.extend(item["model"] for item in self._opts.fallback)
             self._capabilities = replace(
                 self._capabilities,
                 keyterms=_keyterms_extra_for_model(self._opts.model) is not None,

--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -613,14 +613,14 @@ class STT(stt.STT):
 
         vad = _resolve_vad_for_model(model, vad if is_given(vad) else None)
 
-        models: NotGivenOr[list[FallbackModel]] = (
-            _normalize_fallback(fallback) if is_given(fallback) else NOT_GIVEN
-        )
-        all_models = [model]
-        if is_given(models):
-            all_models.extend(item["model"] for item in models)
+        fallback_models: NotGivenOr[list[FallbackModel]] = NOT_GIVEN
+        if is_given(fallback):
+            fallback_models = _normalize_fallback(fallback)
+        models = [model]
+        if is_given(fallback_models):
+            models.extend(item["model"] for item in fallback_models)
         aligned_transcript: Literal["word", False] = (
-            "word" if all(_aligned_transcript_for_model(item) for item in all_models) else False
+            "word" if all(_aligned_transcript_for_model(item) for item in models) else False
         )
 
         # chat_context follows the model's native support; the session decides whether to forward
@@ -667,7 +667,7 @@ class STT(stt.STT):
             api_key=lk_api_key,
             api_secret=lk_api_secret,
             extra_kwargs=dict(extra_kwargs) if is_given(extra_kwargs) else {},
-            fallback=models,
+            fallback=fallback_models,
             conn_options=conn_options if is_given(conn_options) else DEFAULT_API_CONNECT_OPTIONS,
         )
 
@@ -748,17 +748,15 @@ class STT(stt.STT):
 
             self._opts.model = model
             self._vad = _resolve_vad_for_model(model, self._vad)
-            all_models = [self._opts.model]
+            models = [self._opts.model]
             if is_given(self._opts.fallback):
-                all_models.extend(item["model"] for item in self._opts.fallback)
+                models.extend(item["model"] for item in self._opts.fallback)
             self._capabilities = replace(
                 self._capabilities,
                 keyterms=_keyterms_extra_for_model(self._opts.model) is not None,
                 chat_context=_supports_agent_context_carryover(self._opts.model),
                 aligned_transcript=(
-                    "word"
-                    if all(_aligned_transcript_for_model(item) for item in all_models)
-                    else False
+                    "word" if all(_aligned_transcript_for_model(item) for item in models) else False
                 ),
             )
         if is_given(language):

--- a/tests/test_inference_stt_aligned_transcript_claim.py
+++ b/tests/test_inference_stt_aligned_transcript_claim.py
@@ -102,6 +102,29 @@ def test_unknown_models_do_not_claim_alignment(_fake_credentials: None) -> None:
     assert stt_impl.capabilities.aligned_transcript is False
 
 
+@pytest.mark.parametrize(
+    ("fallback", "expected"),
+    [
+        pytest.param("cartesia/ink-whisper", "word", id="aligned-fallback"),
+        pytest.param("cartesia/ink-2", False, id="unaligned-fallback"),
+        pytest.param("new-provider/new-turn-model", False, id="unknown-fallback"),
+    ],
+)
+def test_fallback_models_constrain_alignment_claim(
+    fallback: str, expected: object, _fake_credentials: None
+) -> None:
+    stt_impl = inference.STT(model="deepgram/nova-3", fallback=fallback)
+    assert stt_impl.capabilities.aligned_transcript == expected
+
+
+def test_alignment_update_still_accounts_for_fallback(_fake_credentials: None) -> None:
+    stt_impl = inference.STT(model="cartesia/ink-2", fallback="new-provider/new-turn-model")
+
+    stt_impl.update_options(model="deepgram/nova-3")
+
+    assert stt_impl.capabilities.aligned_transcript is False
+
+
 def test_gateway_ink2_payload_carries_no_word_alignment() -> None:
     """The advertised word alignment is not in the data the gateway sends."""
     stream = InferenceSpeechStream.__new__(InferenceSpeechStream)

--- a/tests/test_inference_stt_fallback.py
+++ b/tests/test_inference_stt_fallback.py
@@ -175,9 +175,9 @@ class TestSTTConstructorFallbackAndConnectOptions:
     """Tests for STT constructor focusing on fallback and connect_options args."""
 
     def test_fallback_not_given(self):
-        """When fallback is not provided, _opts.fallback is empty."""
+        """When fallback is not provided, _opts.fallback is NOT_GIVEN."""
         stt = _make_stt()
-        assert stt._opts.fallback == []
+        assert stt._opts.fallback is NOT_GIVEN
 
     def test_fallback_single_string(self):
         """Single string fallback is normalized to list of FallbackModel."""

--- a/tests/test_inference_stt_fallback.py
+++ b/tests/test_inference_stt_fallback.py
@@ -175,9 +175,9 @@ class TestSTTConstructorFallbackAndConnectOptions:
     """Tests for STT constructor focusing on fallback and connect_options args."""
 
     def test_fallback_not_given(self):
-        """When fallback is not provided, _opts.fallback is NOT_GIVEN."""
+        """When fallback is not provided, _opts.fallback is empty."""
         stt = _make_stt()
-        assert stt._opts.fallback is NOT_GIVEN
+        assert stt._opts.fallback == []
 
     def test_fallback_single_string(self):
         """Single string fallback is normalized to list of FallbackModel."""


### PR DESCRIPTION
Inference STT can switch server-side to a fallback whose transcripts do not carry word timings. Only claim word alignment when the primary and every fallback support it, keeping adaptive interruption from relying on unavailable timing data.

Fixes AGT-3210