### PR TITLE
fix(cartesia): learn word-timestamp support from the response

### DIFF
--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -313,20 +313,21 @@ class TTS(tts.TTS):
         # the transcript can only be read from the TTS alignment when they arrive
         self._capabilities.aligned_transcript = enabled
 
-    def _word_timestamps_unavailable(self) -> None:
+    def _word_timestamps_unavailable(self, *, model: str, language: str | None) -> None:
         """Stop asking for word timestamps this model/language never returns.
 
         Which combinations support them is the provider's business and changes
         over time, so it is learned from the responses rather than declared
-        here: a synthesis that produced audio but no timestamps settles it. The
-        result is remembered per combination, so switching model or language
-        starts over rather than staying degraded for the session.
+        here: a synthesis of real words that produced audio but no timestamps
+        settles it. The result is remembered per combination, so switching
+        model or language starts over rather than staying degraded for the
+        session. The combination is the one the finished request was sent with,
+        which is not necessarily the one set now.
         """
-        combination = self._word_timestamps_combination()
-        if not self._opts.word_timestamps or combination in self._no_word_timestamps:
+        combination = (model, language)
+        if not self._word_timestamps_requested or combination in self._no_word_timestamps:
             return
 
-        model, language = combination
         logger.warning(
             "Cartesia returned no word timestamps for model %s (language %s); not requesting "
             "them for this combination. "
@@ -433,6 +434,9 @@ class SynthesizeStream(tts.SynthesizeStream):
         )
         input_sent_event = asyncio.Event()
         sent_tokens = deque[str]()
+        # punctuation or an emoji still yields audio but never a timestamp, so
+        # only a synthesis of real words can tell us anything about support
+        sent_words = False
 
         sent_tokenizer_stream = self._tts._sentence_tokenizer.stream()
         flush_on_chunk = isinstance(self._tts._sentence_tokenizer, tokenize.SentenceTokenizer)
@@ -448,11 +452,13 @@ class SynthesizeStream(tts.SynthesizeStream):
             base_pkt = _to_cartesia_options(self._opts, streaming=True)
             if flush_on_chunk is True:
                 base_pkt["max_buffer_delay_ms"] = 0
+            nonlocal sent_words
             async for ev in sent_tokenizer_stream:
                 token_pkt = base_pkt.copy()
                 token_pkt["context_id"] = cartesia_context_id
                 token_pkt["transcript"] = ev.token + " "
                 sent_tokens.append(ev.token + " ")
+                sent_words = sent_words or any(char.isalnum() for char in ev.token)
                 token_pkt["continue"] = True
                 self._mark_started()
                 await ws.send_str(json.dumps(token_pkt))
@@ -515,8 +521,18 @@ class SynthesizeStream(tts.SynthesizeStream):
                     b64data = base64.b64decode(data["data"])
                     output_emitter.push(b64data)
                 elif data.get("done"):
-                    if self._opts.word_timestamps and received_audio and not received_timestamps:
-                        self._tts._word_timestamps_unavailable()
+                    if (
+                        self._opts.word_timestamps
+                        and sent_words
+                        and received_audio
+                        and not received_timestamps
+                    ):
+                        # keyed on what this request was sent with: update_options
+                        # may have moved the instance on since then
+                        self._tts._word_timestamps_unavailable(
+                            model=self._opts.model,
+                            language=self._opts.language.language if self._opts.language else None,
+                        )
 
                     if sent_tokenizer_stream.closed:
                         # close only if the input stream is closed

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -83,6 +83,16 @@ class _TTSOptions:
         return f"{self.base_url.replace('http', 'ws', 1)}{path}"
 
 
+def _supports_word_timestamps(model: str, language: str | None) -> bool:
+    """Whether the model/language combination can return word timestamps.
+
+    https://docs.cartesia.ai/api-reference/tts/compare-tts-endpoints
+    """
+    if "preview" in model:
+        return True
+    return language is None or LanguageCode(language).language in {"en", "de", "es", "fr"}
+
+
 class TTS(tts.TTS):
     def __init__(
         self,
@@ -126,6 +136,14 @@ class TTS(tts.TTS):
             text_pacing (tts.SentenceStreamPacer | bool, optional): Stream pacer for the TTS. Set to True to use the default pacer, False to disable.
             base_url (str, optional): The base URL for the Cartesia API. Defaults to "https://api.cartesia.ai".
         """  # noqa: E501
+
+        if word_timestamps and not _supports_word_timestamps(model, language):
+            # https://docs.cartesia.ai/api-reference/tts/compare-tts-endpoints
+            logger.warning(
+                "word_timestamps disabled: it is only supported for languages en, de, es, and fr"
+                " with `sonic` models, or all languages with `preview` models"
+            )
+            word_timestamps = False
 
         super().__init__(
             capabilities=tts.TTSCapabilities(
@@ -180,23 +198,6 @@ class TTS(tts.TTS):
             self._stream_pacer = tts.SentenceStreamPacer()
         elif isinstance(text_pacing, tts.SentenceStreamPacer):
             self._stream_pacer = text_pacing
-
-        if word_timestamps:
-            if "preview" not in self._opts.model and (
-                self._opts.language is not None
-                and self._opts.language.language
-                not in {
-                    "en",
-                    "de",
-                    "es",
-                    "fr",
-                }
-            ):
-                # https://docs.cartesia.ai/api-reference/tts/compare-tts-endpoints
-                logger.warning(
-                    "word_timestamps is only supported for languages en, de, es, and fr with `sonic` models"
-                    " or all languages with `preview` models"
-                )
 
     class Markup(tts.TTS.Markup):
         # markup delegation lives in the base class, keyed on _provider_key()

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -83,16 +83,6 @@ class _TTSOptions:
         return f"{self.base_url.replace('http', 'ws', 1)}{path}"
 
 
-def _supports_word_timestamps(model: str, language: str | None) -> bool:
-    """Whether the model/language combination can return word timestamps.
-
-    https://docs.cartesia.ai/api-reference/tts/compare-tts-endpoints
-    """
-    if "preview" in model:
-        return True
-    return language is None or LanguageCode(language).language in {"en", "de", "es", "fr"}
-
-
 class TTS(tts.TTS):
     def __init__(
         self,
@@ -136,14 +126,6 @@ class TTS(tts.TTS):
             text_pacing (tts.SentenceStreamPacer | bool, optional): Stream pacer for the TTS. Set to True to use the default pacer, False to disable.
             base_url (str, optional): The base URL for the Cartesia API. Defaults to "https://api.cartesia.ai".
         """  # noqa: E501
-
-        if word_timestamps and not _supports_word_timestamps(model, language):
-            # https://docs.cartesia.ai/api-reference/tts/compare-tts-endpoints
-            logger.warning(
-                "word_timestamps disabled: it is only supported for languages en, de, es, and fr"
-                " with `sonic` models, or all languages with `preview` models"
-            )
-            word_timestamps = False
 
         super().__init__(
             capabilities=tts.TTSCapabilities(
@@ -310,6 +292,26 @@ class TTS(tts.TTS):
         self._streams.clear()
         await self._pool.aclose()
 
+    def _word_timestamps_unavailable(self) -> None:
+        """Stop asking for word timestamps this model/language never returns.
+
+        Which combinations support them is the provider's business and changes
+        over time, so it is learned from the responses rather than declared
+        here: a synthesis that produced audio but no timestamps settles it.
+        """
+        if not self._opts.word_timestamps:
+            return
+
+        logger.warning(
+            "Cartesia returned no word timestamps for model %s (language %s); disabling them "
+            "for this session. See https://docs.cartesia.ai/api-reference/tts/compare-tts-endpoints",
+            self._opts.model,
+            self._opts.language.language if self._opts.language else "unset",
+        )
+        self._opts.word_timestamps = False
+        # the transcript can no longer be read from the TTS alignment
+        self._capabilities.aligned_transcript = False
+
     def _check_generation_config(self) -> None:
         if _is_sonic_3(self._opts.model):
             if self._opts.speed:
@@ -452,6 +454,10 @@ class SynthesizeStream(tts.SynthesizeStream):
             current_segment_id: str | None = None
             await input_sent_event.wait()
             skip_aligning = False
+            # timestamps are only reported for some model/language combinations;
+            # audio without any is how we learn this one is not among them
+            received_audio = False
+            received_timestamps = False
             while True:
                 msg = await ws.receive(timeout=self._conn_options.timeout)
                 if msg.type in (
@@ -480,14 +486,19 @@ class SynthesizeStream(tts.SynthesizeStream):
                     current_segment_id = segment_id
                     output_emitter.start_segment(segment_id=segment_id)
                 if data.get("data"):
+                    received_audio = True
                     b64data = base64.b64decode(data["data"])
                     output_emitter.push(b64data)
                 elif data.get("done"):
+                    if self._opts.word_timestamps and received_audio and not received_timestamps:
+                        self._tts._word_timestamps_unavailable()
+
                     if sent_tokenizer_stream.closed:
                         # close only if the input stream is closed
                         output_emitter.end_input()
                         break
                 elif word_timestamps := data.get("word_timestamps"):
+                    received_timestamps = True
                     # assuming Cartesia echos the sent text in the original format and order.
                     for word, start, end in zip(
                         word_timestamps["words"],

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -172,6 +172,9 @@ class TTS(tts.TTS):
             mark_refreshed_on_get=True,
         )
         self._streams = weakref.WeakSet[SynthesizeStream]()
+        # what the caller asked for, kept apart from what the responses taught us
+        self._word_timestamps_requested = word_timestamps
+        self._no_word_timestamps: set[tuple[str, str | None]] = set()
         self._sentence_tokenizer = (
             tokenizer if is_given(tokenizer) else tokenize.blingfire.SentenceTokenizer()
         )
@@ -270,6 +273,11 @@ class TTS(tts.TTS):
         if is_given(api_version):
             self._opts.api_version = api_version
 
+        if is_given(model) or is_given(language):
+            # whether timestamps arrive is a property of the combination, so a
+            # negative result learned for the previous one says nothing here
+            self._sync_word_timestamps()
+
         if speed or emotion or volume or pronunciation_dict_id:
             self._check_generation_config()
 
@@ -292,25 +300,42 @@ class TTS(tts.TTS):
         self._streams.clear()
         await self._pool.aclose()
 
+    def _word_timestamps_combination(self) -> tuple[str, str | None]:
+        return self._opts.model, self._opts.language.language if self._opts.language else None
+
+    def _sync_word_timestamps(self) -> None:
+        """Request word timestamps unless this combination is known not to send them."""
+        enabled = (
+            self._word_timestamps_requested
+            and self._word_timestamps_combination() not in self._no_word_timestamps
+        )
+        self._opts.word_timestamps = enabled
+        # the transcript can only be read from the TTS alignment when they arrive
+        self._capabilities.aligned_transcript = enabled
+
     def _word_timestamps_unavailable(self) -> None:
         """Stop asking for word timestamps this model/language never returns.
 
         Which combinations support them is the provider's business and changes
         over time, so it is learned from the responses rather than declared
-        here: a synthesis that produced audio but no timestamps settles it.
+        here: a synthesis that produced audio but no timestamps settles it. The
+        result is remembered per combination, so switching model or language
+        starts over rather than staying degraded for the session.
         """
-        if not self._opts.word_timestamps:
+        combination = self._word_timestamps_combination()
+        if not self._opts.word_timestamps or combination in self._no_word_timestamps:
             return
 
+        model, language = combination
         logger.warning(
-            "Cartesia returned no word timestamps for model %s (language %s); disabling them "
-            "for this session. See https://docs.cartesia.ai/api-reference/tts/compare-tts-endpoints",
-            self._opts.model,
-            self._opts.language.language if self._opts.language else "unset",
+            "Cartesia returned no word timestamps for model %s (language %s); not requesting "
+            "them for this combination. "
+            "See https://docs.cartesia.ai/api-reference/tts/compare-tts-endpoints",
+            model,
+            language or "unset",
         )
-        self._opts.word_timestamps = False
-        # the transcript can no longer be read from the TTS alignment
-        self._capabilities.aligned_transcript = False
+        self._no_word_timestamps.add(combination)
+        self._sync_word_timestamps()
 
     def _check_generation_config(self) -> None:
         if _is_sonic_3(self._opts.model):

--- a/tests/test_cartesia_tts_capabilities.py
+++ b/tests/test_cartesia_tts_capabilities.py
@@ -41,7 +41,7 @@ class TestLearningFromTheResponse:
         t = TTS(api_key="test-key", language="hi")
 
         with caplog.at_level(logging.WARNING, logger="livekit.plugins.cartesia"):
-            t._word_timestamps_unavailable()
+            t._word_timestamps_unavailable(model=t._opts.model, language="hi")
 
         # downstream must stop reading the transcript from the TTS alignment
         assert t.capabilities.aligned_transcript is False
@@ -55,7 +55,7 @@ class TestLearningFromTheResponse:
         t = TTS(api_key="test-key", model="sonic-3", language="hi")
 
         with caplog.at_level(logging.WARNING, logger="livekit.plugins.cartesia"):
-            t._word_timestamps_unavailable()
+            t._word_timestamps_unavailable(model=t._opts.model, language="hi")
 
         record = next(r for r in caplog.records if "no word timestamps" in r.message)
         assert "sonic-3" in record.getMessage()
@@ -65,8 +65,8 @@ class TestLearningFromTheResponse:
         t = TTS(api_key="test-key", language="hi")
 
         with caplog.at_level(logging.WARNING, logger="livekit.plugins.cartesia"):
-            t._word_timestamps_unavailable()
-            t._word_timestamps_unavailable()
+            t._word_timestamps_unavailable(model=t._opts.model, language="hi")
+            t._word_timestamps_unavailable(model=t._opts.model, language="hi")
 
         assert len([r for r in caplog.records if "no word timestamps" in r.message]) == 1
 
@@ -74,9 +74,25 @@ class TestLearningFromTheResponse:
         t = TTS(api_key="test-key", language="en", word_timestamps=False)
 
         with caplog.at_level(logging.WARNING, logger="livekit.plugins.cartesia"):
-            t._word_timestamps_unavailable()
+            t._word_timestamps_unavailable(model=t._opts.model, language="en")
 
         assert not caplog.records
+
+    def test_learns_about_the_combination_the_request_used(self) -> None:
+        # a request is sent with a snapshot of the options; update_options may
+        # have moved the instance on before the response comes back, and the
+        # result belongs to the combination that was actually used
+        t = TTS(api_key="test-key", model="sonic-3", language="hi")
+        t.update_options(language="en")
+
+        t._word_timestamps_unavailable(model="sonic-3", language="hi")
+
+        # the combination in use now was never the one that came back empty
+        assert t.capabilities.aligned_transcript is True
+        assert t._opts.word_timestamps is True
+        # and going back to it applies what was learned
+        t.update_options(language="hi")
+        assert t.capabilities.aligned_transcript is False
 
 
 class TestLearnedPerCombination:
@@ -85,7 +101,7 @@ class TestLearnedPerCombination:
 
     def test_changing_language_re_enables(self) -> None:
         t = TTS(api_key="test-key", language="hi")
-        t._word_timestamps_unavailable()
+        t._word_timestamps_unavailable(model=t._opts.model, language="hi")
         assert t.capabilities.aligned_transcript is False
 
         t.update_options(language="en")
@@ -95,7 +111,7 @@ class TestLearnedPerCombination:
 
     def test_changing_model_re_enables(self) -> None:
         t = TTS(api_key="test-key", model="sonic-3", language="hi")
-        t._word_timestamps_unavailable()
+        t._word_timestamps_unavailable(model=t._opts.model, language="hi")
 
         t.update_options(model="sonic-preview")
 
@@ -103,7 +119,7 @@ class TestLearnedPerCombination:
 
     def test_switching_back_keeps_what_was_learned(self, caplog: pytest.LogCaptureFixture) -> None:
         t = TTS(api_key="test-key", language="hi")
-        t._word_timestamps_unavailable()
+        t._word_timestamps_unavailable(model=t._opts.model, language="hi")
         t.update_options(language="en")
 
         caplog.clear()
@@ -124,7 +140,7 @@ class TestLearnedPerCombination:
 
     def test_unrelated_updates_leave_it_alone(self) -> None:
         t = TTS(api_key="test-key", language="hi")
-        t._word_timestamps_unavailable()
+        t._word_timestamps_unavailable(model=t._opts.model, language="hi")
 
         t.update_options(voice="some-voice")
 

--- a/tests/test_cartesia_tts_capabilities.py
+++ b/tests/test_cartesia_tts_capabilities.py
@@ -1,0 +1,64 @@
+"""Hermetic tests for cartesia's aligned_transcript capability narrowing (#6493).
+
+``word_timestamps=True`` (the default) used to set
+``capabilities.aligned_transcript=True`` unconditionally, even for
+model/language combinations Cartesia documents as unable to return timing
+data — the plugin warned about the combination but left the capability set,
+so every turn downstream selected the TTS-aligned transcript path and logged
+"no agent transcript was returned from tts".
+"""
+
+import logging
+
+import pytest
+
+from livekit.plugins.cartesia import TTS
+from livekit.plugins.cartesia.tts import _supports_word_timestamps
+
+pytestmark = pytest.mark.unit
+
+
+class TestSupportsWordTimestamps:
+    def test_supported_languages_on_sonic(self) -> None:
+        for lang in ("en", "de", "es", "fr"):
+            assert _supports_word_timestamps("sonic-3", lang) is True
+
+    def test_unsupported_language_on_sonic(self) -> None:
+        assert _supports_word_timestamps("sonic-3", "hi") is False
+        assert _supports_word_timestamps("sonic-3", "tr") is False
+
+    def test_preview_models_support_all_languages(self) -> None:
+        assert _supports_word_timestamps("sonic-preview", "hi") is True
+
+    def test_language_variants_normalize(self) -> None:
+        # locale-tagged languages narrow to their base language code
+        assert _supports_word_timestamps("sonic-3", "en-US") is True
+
+    def test_no_language_is_supported(self) -> None:
+        assert _supports_word_timestamps("sonic-3", None) is True
+
+
+class TestCapabilityNarrowing:
+    def test_capability_set_for_supported_combo(self) -> None:
+        t = TTS(api_key="test-key", language="en")
+        assert t.capabilities.aligned_transcript is True
+
+    def test_capability_cleared_for_unsupported_combo(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING, logger="livekit.plugins.cartesia"):
+            t = TTS(api_key="test-key", language="hi")
+        assert t.capabilities.aligned_transcript is False
+        # the request must not ask for timestamps the combo can't deliver
+        assert t._opts.word_timestamps is False
+        assert any("word_timestamps disabled" in r.message for r in caplog.records)
+
+    def test_capability_kept_for_preview_model_any_language(self) -> None:
+        t = TTS(api_key="test-key", model="sonic-preview", language="hi")
+        assert t.capabilities.aligned_transcript is True
+
+    def test_explicit_opt_out_unchanged(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="livekit.plugins.cartesia"):
+            t = TTS(api_key="test-key", language="hi", word_timestamps=False)
+        assert t.capabilities.aligned_transcript is False
+        assert not any("word_timestamps disabled" in r.message for r in caplog.records)

--- a/tests/test_cartesia_tts_capabilities.py
+++ b/tests/test_cartesia_tts_capabilities.py
@@ -1,11 +1,13 @@
-"""Hermetic tests for cartesia's aligned_transcript capability narrowing (#6493).
+"""Hermetic tests for cartesia's aligned_transcript capability (#6493).
 
-``word_timestamps=True`` (the default) used to set
-``capabilities.aligned_transcript=True`` unconditionally, even for
-model/language combinations Cartesia documents as unable to return timing
-data — the plugin warned about the combination but left the capability set,
-so every turn downstream selected the TTS-aligned transcript path and logged
-"no agent transcript was returned from tts".
+``word_timestamps=True`` (the default) sets ``capabilities.aligned_transcript``
+at construction, but only some model/language combinations actually return
+timing data. The capability used to stay set for the ones that don't, so every
+turn downstream selected the TTS-aligned transcript path and logged "no agent
+transcript was returned from tts".
+
+Which combinations are supported is the provider's business and changes over
+time, so it is learned from the responses instead of being declared here.
 """
 
 import logging
@@ -13,52 +15,65 @@ import logging
 import pytest
 
 from livekit.plugins.cartesia import TTS
-from livekit.plugins.cartesia.tts import _supports_word_timestamps
 
 pytestmark = pytest.mark.unit
 
 
-class TestSupportsWordTimestamps:
-    def test_supported_languages_on_sonic(self) -> None:
-        for lang in ("en", "de", "es", "fr"):
-            assert _supports_word_timestamps("sonic-3", lang) is True
+class TestConstructionDoesNotPrejudge:
+    """No model/language is refused up front - a stale table here would block
+    combinations the provider has since added support for."""
 
-    def test_unsupported_language_on_sonic(self) -> None:
-        assert _supports_word_timestamps("sonic-3", "hi") is False
-        assert _supports_word_timestamps("sonic-3", "tr") is False
+    def test_capability_set_for_any_language(self) -> None:
+        for language in ("en", "hi", "tr", None):
+            t = TTS(api_key="test-key", language=language)
+            assert t.capabilities.aligned_transcript is True
+            assert t._opts.word_timestamps is True
 
-    def test_preview_models_support_all_languages(self) -> None:
-        assert _supports_word_timestamps("sonic-preview", "hi") is True
-
-    def test_language_variants_normalize(self) -> None:
-        # locale-tagged languages narrow to their base language code
-        assert _supports_word_timestamps("sonic-3", "en-US") is True
-
-    def test_no_language_is_supported(self) -> None:
-        assert _supports_word_timestamps("sonic-3", None) is True
+    def test_capability_follows_an_explicit_opt_out(self) -> None:
+        t = TTS(api_key="test-key", language="en", word_timestamps=False)
+        assert t.capabilities.aligned_transcript is False
 
 
-class TestCapabilityNarrowing:
-    def test_capability_set_for_supported_combo(self) -> None:
-        t = TTS(api_key="test-key", language="en")
-        assert t.capabilities.aligned_transcript is True
-
-    def test_capability_cleared_for_unsupported_combo(
+class TestLearningFromTheResponse:
+    def test_clears_the_capability_and_stops_requesting(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
+        t = TTS(api_key="test-key", language="hi")
+
         with caplog.at_level(logging.WARNING, logger="livekit.plugins.cartesia"):
-            t = TTS(api_key="test-key", language="hi")
+            t._word_timestamps_unavailable()
+
+        # downstream must stop reading the transcript from the TTS alignment
         assert t.capabilities.aligned_transcript is False
-        # the request must not ask for timestamps the combo can't deliver
+        # and the next request must not ask for what never arrives
         assert t._opts.word_timestamps is False
-        assert any("word_timestamps disabled" in r.message for r in caplog.records)
+        assert any("no word timestamps" in r.message for r in caplog.records)
 
-    def test_capability_kept_for_preview_model_any_language(self) -> None:
-        t = TTS(api_key="test-key", model="sonic-preview", language="hi")
-        assert t.capabilities.aligned_transcript is True
+    def test_reports_the_combination_it_learned_about(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        t = TTS(api_key="test-key", model="sonic-3", language="hi")
 
-    def test_explicit_opt_out_unchanged(self, caplog: pytest.LogCaptureFixture) -> None:
         with caplog.at_level(logging.WARNING, logger="livekit.plugins.cartesia"):
-            t = TTS(api_key="test-key", language="hi", word_timestamps=False)
-        assert t.capabilities.aligned_transcript is False
-        assert not any("word_timestamps disabled" in r.message for r in caplog.records)
+            t._word_timestamps_unavailable()
+
+        record = next(r for r in caplog.records if "no word timestamps" in r.message)
+        assert "sonic-3" in record.getMessage()
+        assert "hi" in record.getMessage()
+
+    def test_warns_once(self, caplog: pytest.LogCaptureFixture) -> None:
+        t = TTS(api_key="test-key", language="hi")
+
+        with caplog.at_level(logging.WARNING, logger="livekit.plugins.cartesia"):
+            t._word_timestamps_unavailable()
+            t._word_timestamps_unavailable()
+
+        assert len([r for r in caplog.records if "no word timestamps" in r.message]) == 1
+
+    def test_is_a_no_op_when_never_requested(self, caplog: pytest.LogCaptureFixture) -> None:
+        t = TTS(api_key="test-key", language="en", word_timestamps=False)
+
+        with caplog.at_level(logging.WARNING, logger="livekit.plugins.cartesia"):
+            t._word_timestamps_unavailable()
+
+        assert not caplog.records

--- a/tests/test_cartesia_tts_capabilities.py
+++ b/tests/test_cartesia_tts_capabilities.py
@@ -77,3 +77,55 @@ class TestLearningFromTheResponse:
             t._word_timestamps_unavailable()
 
         assert not caplog.records
+
+
+class TestLearnedPerCombination:
+    """What the responses taught us is about one model/language pair, so it
+    must not outlive a switch to another one."""
+
+    def test_changing_language_re_enables(self) -> None:
+        t = TTS(api_key="test-key", language="hi")
+        t._word_timestamps_unavailable()
+        assert t.capabilities.aligned_transcript is False
+
+        t.update_options(language="en")
+
+        assert t.capabilities.aligned_transcript is True
+        assert t._opts.word_timestamps is True
+
+    def test_changing_model_re_enables(self) -> None:
+        t = TTS(api_key="test-key", model="sonic-3", language="hi")
+        t._word_timestamps_unavailable()
+
+        t.update_options(model="sonic-preview")
+
+        assert t.capabilities.aligned_transcript is True
+
+    def test_switching_back_keeps_what_was_learned(self, caplog: pytest.LogCaptureFixture) -> None:
+        t = TTS(api_key="test-key", language="hi")
+        t._word_timestamps_unavailable()
+        t.update_options(language="en")
+
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="livekit.plugins.cartesia"):
+            t.update_options(language="hi")
+
+        # no second round-trip needed to rediscover it, and no second warning
+        assert t.capabilities.aligned_transcript is False
+        assert not [r for r in caplog.records if "no word timestamps" in r.message]
+
+    def test_an_explicit_opt_out_survives_an_update(self) -> None:
+        t = TTS(api_key="test-key", language="hi", word_timestamps=False)
+
+        t.update_options(language="en")
+
+        assert t.capabilities.aligned_transcript is False
+        assert t._opts.word_timestamps is False
+
+    def test_unrelated_updates_leave_it_alone(self) -> None:
+        t = TTS(api_key="test-key", language="hi")
+        t._word_timestamps_unavailable()
+
+        t.update_options(voice="some-voice")
+
+        assert t.capabilities.aligned_transcript is False


### PR DESCRIPTION
Addresses the Cartesia half of #6493.

## Problem

`word_timestamps=True` (the default) sets `capabilities.aligned_transcript=True` at construction, but only some model/language combinations actually return timing data. For the others the capability stayed set, so every turn the framework selected the TTS-aligned transcript path, got nothing, and logged:

```
`use_tts_aligned_transcript` is enabled but no agent transcript was returned from tts
```

The plugin already knew something was off — it warned about the combination — but the warning didn't change what the capability claimed.

## Change

The plugin learns which combinations work from the responses rather than declaring it:

- Cartesia simply omits `word_timestamps` for combinations that can't produce them, so a synthesis that pushed audio but never sent a timestamp payload settles it.
- When that happens the plugin clears `capabilities.aligned_transcript` and stops setting `add_timestamps` on later requests, so the framework stops selecting the aligned path and the warning stops repeating.
- The hardcoded language/model list is removed, including the pre-existing warn-only one. Nothing is refused up front, so a language or model Cartesia adds support for works immediately with no release here.

The trade-off is that the first synthesis on an unsupported combination still takes the aligned path once, before the plugin has seen a response to learn from.

## Not covered here

This is the plugin's half only. `perform_tts_inference` resolves `timed_texts_fut` to the channel as soon as the node is streaming, before any timed word has arrived (`generation.py:375-379`), and `agent_activity.py` commits `text_source` on that truthiness — so any provider whose alignment silently doesn't arrive reaches the same warning. #6493 reports ElevenLabs hitting it too. Happy to follow up centrally if that's wanted.

## Verification

`tests/test_cartesia_tts_capabilities.py` covers construction not prejudging any language, an explicit `word_timestamps=False` still clearing the capability, and the learning step clearing both the capability and the request flag, naming the model/language it learned about, warning once, and staying a no-op when timestamps were never requested.

`ruff format --check`, `ruff check`, `check_types.py` (mypy strict) and the full `pytest --unit` suite pass locally.
