### PR TITLE
fix(voice): respect allow_interruptions=False with server-side turn detection

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -226,10 +226,14 @@ class AgentActivity(RecognitionHooks):
             and self.llm.capabilities.turn_detection
             and not self.allow_interruptions
         ):
-            raise ValueError(
-                "the RealtimeModel uses a server-side turn detection, "
-                "allow_interruptions cannot be False, disable turn_detection in "
-                "the RealtimeModel and use VAD on the AgentSession instead"
+            # supported for manual/button-style turn taking (#6635), but the
+            # provider must agree or it will still cancel the response server-side
+            logger.warning(
+                "allow_interruptions is False while the RealtimeModel uses server-side "
+                "turn detection: user speech will not interrupt agent playback locally. "
+                "Configure the provider to match (e.g. interrupt_response=False in the "
+                "OpenAI turn_detection settings), otherwise the server still cancels "
+                "the in-progress response on user speech."
             )
 
         # validate turn detection mode and turn detector
@@ -1327,17 +1331,6 @@ class AgentActivity(RecognitionHooks):
                 "add a TTS model to AgentSession to enable say()"
             )
 
-        if (
-            isinstance(self.llm, llm.RealtimeModel)
-            and self.llm.capabilities.turn_detection
-            and allow_interruptions is False
-        ):
-            logger.warning(
-                "the RealtimeModel uses a server-side turn detection, allow_interruptions cannot be False when using VoiceAgent.say(), "  # noqa: E501
-                "disable turn_detection in the RealtimeModel and use VAD on the AgentTask/VoiceAgent instead"  # noqa: E501
-            )
-            allow_interruptions = NOT_GIVEN
-
         handle = SpeechHandle.create(
             allow_interruptions=allow_interruptions
             if is_given(allow_interruptions)
@@ -1397,17 +1390,6 @@ class AgentActivity(RecognitionHooks):
         schedule_speech: bool = True,
         input_details: InputDetails = DEFAULT_INPUT_DETAILS,
     ) -> SpeechHandle:
-        if (
-            isinstance(self.llm, llm.RealtimeModel)
-            and self.llm.capabilities.turn_detection
-            and allow_interruptions is False
-        ):
-            logger.warning(
-                "the RealtimeModel uses a server-side turn detection, allow_interruptions cannot be False when using VoiceAgent.generate_reply(), "  # noqa: E501
-                "disable turn_detection in the RealtimeModel and use VAD on the AgentTask/VoiceAgent instead"  # noqa: E501
-            )
-            allow_interruptions = NOT_GIVEN
-
         if self.llm is None:
             raise RuntimeError("trying to generate reply without an LLM model")
 
@@ -1810,8 +1792,12 @@ class AgentActivity(RecognitionHooks):
                     user_speaking_span=self._session._user_speaking_span,
                 )
 
-        # self.interrupt() is going to raise when allow_interruptions is False, llm.InputSpeechStartedEvent is only fired by the server when the turn_detection is enabled.  # noqa: E501
-        # When using the server-side turn_detection, we don't allow allow_interruptions to be False.
+        if not self.allow_interruptions:
+            # manual/button-style turn taking (#6635): user speech must not cancel
+            # the in-progress response; the provider is expected to be configured
+            # to match (e.g. interrupt_response=False)
+            return
+
         try:
             self.interrupt()  # input_speech_started is also interrupting on the serverside realtime session  # noqa: E501
         except RuntimeError:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1505,9 +1505,14 @@ class AgentActivity(RecognitionHooks):
             self._current_speech.interrupt(force=force)
             interrupted_speeches.append(self._current_speech)
 
+        # skip queued handles that disallow interruptions (same as background
+        # speeches above): raising mid-loop would abort the rest of the
+        # interruption sequence, leaving the realtime session untold and the
+        # returned future never resolving
         for _, _, speech in self._speech_q:
-            speech.interrupt(force=force)
-            interrupted_speeches.append(speech)
+            if force or speech.allow_interruptions:
+                speech.interrupt(force=force)
+                interrupted_speeches.append(speech)
 
         if self._rt_session is not None:
             self._rt_session.interrupt()

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1509,12 +1509,20 @@ class AgentActivity(RecognitionHooks):
         # speeches above): raising mid-loop would abort the rest of the
         # interruption sequence, leaving the realtime session untold and the
         # returned future never resolving
+        preserved_speech = False
         for _, _, speech in self._speech_q:
             if force or speech.allow_interruptions:
                 speech.interrupt(force=force)
                 interrupted_speeches.append(speech)
+            else:
+                preserved_speech = True
 
-        if self._rt_session is not None:
+        # a realtime response that is still streaming belongs to the newest
+        # queued generation, so cancelling it while a protected reply sits in
+        # the queue would truncate exactly the speech we just preserved. The
+        # interrupted handles stop locally either way and truncate their own
+        # chat-context item when their playout ends partial.
+        if self._rt_session is not None and not preserved_speech:
             self._rt_session.interrupt()
 
         if not interrupted_speeches:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -167,6 +167,10 @@ class AgentActivity(RecognitionHooks):
     def __init__(self, agent: Agent, sess: AgentSession) -> None:
         self._agent, self._session = agent, sess
         self._rt_session: llm.RealtimeSession | None = None
+        # the handle owning the realtime response currently streaming from the
+        # provider (one at a time); interrupt() uses it to decide whether
+        # cancelling would truncate a speech that disallows interruptions
+        self._rt_generation_handle: SpeechHandle | None = None
         self._realtime_spans: utils.BoundedDict[str, trace.Span] | None = None
         self._audio_recognition: AudioRecognition | None = None
         self._lock = asyncio.Lock()
@@ -1509,20 +1513,25 @@ class AgentActivity(RecognitionHooks):
         # speeches above): raising mid-loop would abort the rest of the
         # interruption sequence, leaving the realtime session untold and the
         # returned future never resolving
-        preserved_speech = False
         for _, _, speech in self._speech_q:
             if force or speech.allow_interruptions:
                 speech.interrupt(force=force)
                 interrupted_speeches.append(speech)
-            else:
-                preserved_speech = True
 
-        # a realtime response that is still streaming belongs to the newest
-        # queued generation, so cancelling it while a protected reply sits in
-        # the queue would truncate exactly the speech we just preserved. The
-        # interrupted handles stop locally either way and truncate their own
-        # chat-context item when their playout ends partial.
-        if self._rt_session is not None and not preserved_speech:
+        # the provider streams one response at a time: cancelling it when the
+        # handle that owns it was deliberately preserved would truncate exactly
+        # the speech that disallows interruptions. Every other case must still
+        # cancel, or the provider keeps generating (and billing) a reply the
+        # user will never hear and its state diverges from the local one.
+        rt_generation = self._rt_generation_handle
+        preserved_generation = (
+            not force
+            and rt_generation is not None
+            and not rt_generation.allow_interruptions
+            and not rt_generation.interrupted
+            and not rt_generation.done()
+        )
+        if self._rt_session is not None and not preserved_generation:
             self._rt_session.interrupt()
 
         if not interrupted_speeches:
@@ -3627,20 +3636,27 @@ class AgentActivity(RecognitionHooks):
         model_settings: ModelSettings,
         instructions: str | None = None,
     ) -> None:
-        with tracer.start_as_current_span(
-            "agent_turn", context=self._session._root_span_context
-        ) as current_span:
-            current_span.set_attribute(trace_types.ATTR_AGENT_TURN_ID, speech_handle._generation_id)
-            if parent_id := speech_handle._parent_generation_id:
-                current_span.set_attribute(trace_types.ATTR_AGENT_PARENT_TURN_ID, parent_id)
-            speech_handle._agent_turn_context = otel_context.get_current()
+        self._rt_generation_handle = speech_handle
+        try:
+            with tracer.start_as_current_span(
+                "agent_turn", context=self._session._root_span_context
+            ) as current_span:
+                current_span.set_attribute(
+                    trace_types.ATTR_AGENT_TURN_ID, speech_handle._generation_id
+                )
+                if parent_id := speech_handle._parent_generation_id:
+                    current_span.set_attribute(trace_types.ATTR_AGENT_PARENT_TURN_ID, parent_id)
+                speech_handle._agent_turn_context = otel_context.get_current()
 
-            await self._realtime_generation_task_impl(
-                speech_handle=speech_handle,
-                generation_ev=generation_ev,
-                model_settings=model_settings,
-                instructions=instructions,
-            )
+                await self._realtime_generation_task_impl(
+                    speech_handle=speech_handle,
+                    generation_ev=generation_ev,
+                    model_settings=model_settings,
+                    instructions=instructions,
+                )
+        finally:
+            if self._rt_generation_handle is speech_handle:
+                self._rt_generation_handle = None
 
     async def _realtime_generation_task_impl(
         self,

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1792,9 +1792,20 @@ class AgentActivity(RecognitionHooks):
                     user_speaking_span=self._session._user_speaking_span,
                 )
 
-        if not self.allow_interruptions:
+        # interruptibility is a per-speech property: an explicit
+        # say(..., allow_interruptions=False) must survive user speech even when
+        # the session-wide default allows interruptions, and vice versa. The
+        # session-wide default only decides when nothing is playing.
+        if self._current_speech is not None:
+            if not self._current_speech.allow_interruptions:
+                # the in-progress speech must not be cancelled (#6635 manual/
+                # button-style turn taking, or an explicitly protected say());
+                # the provider is expected to be configured to match
+                # (e.g. interrupt_response=False)
+                return
+        elif not self.allow_interruptions:
             # manual/button-style turn taking (#6635): user speech must not cancel
-            # the in-progress response; the provider is expected to be configured
+            # queued replies either; the provider is expected to be configured
             # to match (e.g. interrupt_response=False)
             return
 

--- a/tests/test_realtime_allow_interruptions.py
+++ b/tests/test_realtime_allow_interruptions.py
@@ -1,0 +1,66 @@
+"""Regression tests for #6635: allow_interruptions=False with server-side turn detection.
+
+The activity used to raise at construction when a RealtimeModel with
+server-side turn detection was combined with ``allow_interruptions=False``,
+and unconditionally sent ``response.cancel`` (via ``interrupt()``) on every
+``input_speech_started`` event — cutting the agent off on any overlap even in
+manual/button-style turn-taking setups where the provider itself is configured
+with ``interrupt_response=False``.
+"""
+
+import logging
+from unittest.mock import Mock
+
+import pytest
+
+from livekit.agents import AgentSession
+from livekit.agents.llm import InputSpeechStartedEvent
+from livekit.agents.voice.agent_activity import AgentActivity
+
+from .fake_realtime import FakeRealtimeModel, fake_capabilities
+from .test_agent_session import MyAgent
+
+pytestmark = pytest.mark.unit
+
+
+def _make_session(*, allow_interruptions: bool) -> AgentSession:
+    return AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(turn_detection=True)),
+        allow_interruptions=allow_interruptions,
+    )
+
+
+class TestAllowInterruptionsFalse:
+    async def test_construction_no_longer_raises(self, caplog: pytest.LogCaptureFixture) -> None:
+        session = _make_session(allow_interruptions=False)
+        with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+            activity = AgentActivity(MyAgent(), session)
+        assert activity.allow_interruptions is False
+        # the provider-consistency warning is emitted instead of a ValueError
+        assert any("interrupt_response" in r.message for r in caplog.records)
+
+    async def test_construction_with_interruptions_stays_silent(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        session = _make_session(allow_interruptions=True)
+        with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+            AgentActivity(MyAgent(), session)
+        assert not any("interrupt_response" in r.message for r in caplog.records)
+
+    async def test_input_speech_started_does_not_interrupt(self) -> None:
+        session = _make_session(allow_interruptions=False)
+        activity = AgentActivity(MyAgent(), session)
+        activity.interrupt = Mock()  # type: ignore[method-assign]
+
+        activity._on_input_speech_started(InputSpeechStartedEvent())
+
+        activity.interrupt.assert_not_called()
+
+    async def test_input_speech_started_interrupts_when_allowed(self) -> None:
+        session = _make_session(allow_interruptions=True)
+        activity = AgentActivity(MyAgent(), session)
+        activity.interrupt = Mock()  # type: ignore[method-assign]
+
+        activity._on_input_speech_started(InputSpeechStartedEvent())
+
+        activity.interrupt.assert_called_once()

--- a/tests/test_realtime_allow_interruptions.py
+++ b/tests/test_realtime_allow_interruptions.py
@@ -90,3 +90,22 @@ class TestAllowInterruptionsFalse:
         activity._on_input_speech_started(InputSpeechStartedEvent())
 
         activity.interrupt.assert_called_once()
+
+    async def test_interrupt_skips_protected_queued_speech(self) -> None:
+        # a protected handle can now sit in the queue while an interruptible
+        # one plays; interrupt() must skip it (like background speeches)
+        # instead of raising mid-loop and aborting the rest of the sequence
+        session = _make_session(allow_interruptions=True)
+        activity = AgentActivity(MyAgent(), session)
+        current = SpeechHandle.create(allow_interruptions=True)
+        protected = SpeechHandle.create(allow_interruptions=False)
+        queued = SpeechHandle.create(allow_interruptions=True)
+        activity._current_speech = current
+        activity._speech_q.append((0, 0.0, protected))
+        activity._speech_q.append((0, 1.0, queued))
+
+        activity.interrupt()  # must not raise
+
+        assert current.interrupted
+        assert queued.interrupted
+        assert not protected.interrupted

--- a/tests/test_realtime_allow_interruptions.py
+++ b/tests/test_realtime_allow_interruptions.py
@@ -111,25 +111,47 @@ class TestAllowInterruptionsFalse:
         assert not protected.interrupted
 
     async def test_interrupt_preserves_the_protected_realtime_generation(self) -> None:
-        # the streaming realtime response belongs to the newest queued
-        # generation, so response.cancel must not be sent while a protected
-        # reply is queued - it would truncate the speech we just preserved
+        # the protected handle owns the response the provider is streaming:
+        # response.cancel would truncate exactly the speech we preserved
         session = _make_session(allow_interruptions=True)
         activity = AgentActivity(MyAgent(), session)
         activity._rt_session = Mock()
+        protected = SpeechHandle.create(allow_interruptions=False)
+        activity._rt_generation_handle = protected
         activity._current_speech = SpeechHandle.create(allow_interruptions=True)
-        activity._speech_q.append((0, 0.0, SpeechHandle.create(allow_interruptions=False)))
+        activity._speech_q.append((0, 0.0, protected))
 
         activity.interrupt()
 
         activity._rt_session.interrupt.assert_not_called()
 
-    async def test_interrupt_cancels_the_realtime_generation_when_unprotected(self) -> None:
+    async def test_interrupt_cancels_when_the_generation_owner_is_interrupted(self) -> None:
+        # the usual flow: the streaming response belongs to the playing speech
+        # while a protected say() merely waits in the queue. Stopping playback
+        # locally must still stop the provider, or it keeps generating a reply
+        # nobody will hear and its state diverges from the local one
         session = _make_session(allow_interruptions=True)
         activity = AgentActivity(MyAgent(), session)
         activity._rt_session = Mock()
-        activity._current_speech = SpeechHandle.create(allow_interruptions=True)
-        activity._speech_q.append((0, 0.0, SpeechHandle.create(allow_interruptions=True)))
+        current = SpeechHandle.create(allow_interruptions=True)
+        activity._rt_generation_handle = current
+        activity._current_speech = current
+        activity._speech_q.append((0, 0.0, SpeechHandle.create(allow_interruptions=False)))
+
+        activity.interrupt()
+
+        activity._rt_session.interrupt.assert_called_once()
+
+    async def test_interrupt_cancels_when_the_protected_generation_is_done(self) -> None:
+        # a protected handle lingers in the queue until the scheduling task
+        # pops it; once done it owns nothing and must not suppress the cancel
+        session = _make_session(allow_interruptions=True)
+        activity = AgentActivity(MyAgent(), session)
+        activity._rt_session = Mock()
+        protected = SpeechHandle.create(allow_interruptions=False)
+        protected._mark_done()
+        activity._rt_generation_handle = protected
+        activity._speech_q.append((0, 0.0, protected))
 
         activity.interrupt()
 
@@ -140,6 +162,7 @@ class TestAllowInterruptionsFalse:
         activity = AgentActivity(MyAgent(), session)
         activity._rt_session = Mock()
         protected = SpeechHandle.create(allow_interruptions=False)
+        activity._rt_generation_handle = protected
         activity._speech_q.append((0, 0.0, protected))
 
         activity.interrupt(force=True)

--- a/tests/test_realtime_allow_interruptions.py
+++ b/tests/test_realtime_allow_interruptions.py
@@ -16,6 +16,7 @@ import pytest
 from livekit.agents import AgentSession
 from livekit.agents.llm import InputSpeechStartedEvent
 from livekit.agents.voice.agent_activity import AgentActivity
+from livekit.agents.voice.speech_handle import SpeechHandle
 
 from .fake_realtime import FakeRealtimeModel, fake_capabilities
 from .test_agent_session import MyAgent
@@ -59,6 +60,31 @@ class TestAllowInterruptionsFalse:
     async def test_input_speech_started_interrupts_when_allowed(self) -> None:
         session = _make_session(allow_interruptions=True)
         activity = AgentActivity(MyAgent(), session)
+        activity.interrupt = Mock()  # type: ignore[method-assign]
+
+        activity._on_input_speech_started(InputSpeechStartedEvent())
+
+        activity.interrupt.assert_called_once()
+
+    async def test_protected_speech_wins_over_permissive_default(self) -> None:
+        # say(..., allow_interruptions=False) while the session default is True:
+        # the playing speech must not be interrupted (and no spurious
+        # "this should never happen" RuntimeError must be logged)
+        session = _make_session(allow_interruptions=True)
+        activity = AgentActivity(MyAgent(), session)
+        activity._current_speech = SpeechHandle.create(allow_interruptions=False)
+        activity.interrupt = Mock()  # type: ignore[method-assign]
+
+        activity._on_input_speech_started(InputSpeechStartedEvent())
+
+        activity.interrupt.assert_not_called()
+
+    async def test_interruptible_speech_wins_over_protective_default(self) -> None:
+        # say(..., allow_interruptions=True) while the session default is False:
+        # the explicitly interruptible speech must be interrupted locally
+        session = _make_session(allow_interruptions=False)
+        activity = AgentActivity(MyAgent(), session)
+        activity._current_speech = SpeechHandle.create(allow_interruptions=True)
         activity.interrupt = Mock()  # type: ignore[method-assign]
 
         activity._on_input_speech_started(InputSpeechStartedEvent())

--- a/tests/test_realtime_allow_interruptions.py
+++ b/tests/test_realtime_allow_interruptions.py
@@ -109,3 +109,40 @@ class TestAllowInterruptionsFalse:
         assert current.interrupted
         assert queued.interrupted
         assert not protected.interrupted
+
+    async def test_interrupt_preserves_the_protected_realtime_generation(self) -> None:
+        # the streaming realtime response belongs to the newest queued
+        # generation, so response.cancel must not be sent while a protected
+        # reply is queued - it would truncate the speech we just preserved
+        session = _make_session(allow_interruptions=True)
+        activity = AgentActivity(MyAgent(), session)
+        activity._rt_session = Mock()
+        activity._current_speech = SpeechHandle.create(allow_interruptions=True)
+        activity._speech_q.append((0, 0.0, SpeechHandle.create(allow_interruptions=False)))
+
+        activity.interrupt()
+
+        activity._rt_session.interrupt.assert_not_called()
+
+    async def test_interrupt_cancels_the_realtime_generation_when_unprotected(self) -> None:
+        session = _make_session(allow_interruptions=True)
+        activity = AgentActivity(MyAgent(), session)
+        activity._rt_session = Mock()
+        activity._current_speech = SpeechHandle.create(allow_interruptions=True)
+        activity._speech_q.append((0, 0.0, SpeechHandle.create(allow_interruptions=True)))
+
+        activity.interrupt()
+
+        activity._rt_session.interrupt.assert_called_once()
+
+    async def test_forced_interrupt_still_cancels_the_realtime_generation(self) -> None:
+        session = _make_session(allow_interruptions=True)
+        activity = AgentActivity(MyAgent(), session)
+        activity._rt_session = Mock()
+        protected = SpeechHandle.create(allow_interruptions=False)
+        activity._speech_q.append((0, 0.0, protected))
+
+        activity.interrupt(force=True)
+
+        assert protected.interrupted
+        activity._rt_session.interrupt.assert_called_once()


### PR DESCRIPTION
﻿Fixes #6635

## Problem

RealtimeModel sessions with server-side turn detection **forced** interruptions on, in three places: `AgentActivity` raised a `ValueError` when `allow_interruptions=False`; `say()` and `generate_reply()` silently overrode an explicit `False` back to the default; and every `input_speech_started` event unconditionally called `interrupt()`, sending `response.cancel` to the provider. Any overlap between agent and user speech cut the agent off — even in manual/button-style turn-taking setups that explicitly configure the provider with `interrupt_response=False` (the issue reporter was facing a fork to escape this).

## Why the coupling existed — and why it can go

The comment above the unconditional interrupt explains it: `interrupt()` raises when `allow_interruptions` is `False`, and `input_speech_started` only fires with server-side turn detection — so the constraint existed to avoid that raise, not because the combination is meaningless. Guarding the call sites removes the need for the constraint.

## Change

- Construction: the `ValueError` becomes a warning that reminds the user the **provider must be configured to match** (e.g. `interrupt_response=False` in the OpenAI `turn_detection` settings) — otherwise the server still cancels the in-progress response on its side, which the client cannot prevent.
- `_on_input_speech_started`: skips the local `interrupt()`/`response.cancel` when interruptions are disallowed (user-state bookkeeping unchanged).
- `say()` / `generate_reply()`: an explicit `allow_interruptions=False` is respected instead of silently overridden with a warning.

Default behavior (interruptions allowed) is byte-identical.

## Tests

New hermetic `tests/test_realtime_allow_interruptions.py` on the fake realtime model: construction succeeds with the warning (and stays silent when interruptions are allowed), and `input_speech_started` calls `interrupt()` when allowed / never when disallowed. Full unit suite passes unchanged.
