### PR TITLE
chore(krisp): adjust default noise_suppression_level

### DIFF
--- a/livekit-plugins/livekit-plugins-krisp/livekit/plugins/krisp/viva_filter.py
+++ b/livekit-plugins/livekit-plugins-krisp/livekit/plugins/krisp/viva_filter.py
@@ -206,14 +206,14 @@ class KrispVivaFilterFrameProcessor(rtc.FrameProcessor[rtc.AudioFrame]):
         mode: VivaMode = VivaMode.VOICE_ISOLATION,
         auth_provider: LiveKitCloudAuthProvider | KrispLicenseAuthProvider | None = None,
         model_path: str | None = None,
-        noise_suppression_level: int = 100,
+        noise_suppression_level: int = 75,
         frame_duration_ms: int | None = None,
         sample_rate: int | None = None,
     ) -> None:
         """Initialize the Krisp frame processor.
 
         Args:
-            noise_suppression_level: Noise suppression level (0-100, default: 100).
+            noise_suppression_level: Noise suppression level (0-100, default: 75).
             auth_provider: Authentication provider. Defaults to
                 :class:`LiveKitCloudAuthProvider` (LiveKit Cloud auth + bundled
                 model). Pass :class:`KrispLicenseAuthProvider` to use a Krisp

--- a/livekit-plugins/livekit-plugins-krisp/livekit/plugins/krisp/viva_filter.py
+++ b/livekit-plugins/livekit-plugins-krisp/livekit/plugins/krisp/viva_filter.py
@@ -337,7 +337,7 @@ class KrispVivaFilterFrameProcessor(rtc.FrameProcessor[rtc.AudioFrame]):
 def voice_isolation(
     *,
     auth_provider: LiveKitCloudAuthProvider | KrispLicenseAuthProvider | None = None,
-    noise_suppression_level: int = 100,
+    noise_suppression_level: int = 75,
 ) -> KrispVivaFilterFrameProcessor:
     """Create a Krisp VIVA voice isolation ``FrameProcessor``.
 
@@ -349,7 +349,7 @@ def voice_isolation(
     Args:
         auth_provider: Authentication provider. Defaults to
             :class:`LiveKitCloudAuthProvider` (LiveKit Cloud auth + bundled model).
-        noise_suppression_level: Noise suppression level (0-100, default: 100).
+        noise_suppression_level: Noise suppression level (0-100, default: 75).
     """
     return KrispVivaFilterFrameProcessor(
         mode=VivaMode.VOICE_ISOLATION,
@@ -361,7 +361,7 @@ def voice_isolation(
 def voice_isolation_telephony(
     *,
     auth_provider: LiveKitCloudAuthProvider | KrispLicenseAuthProvider | None = None,
-    noise_suppression_level: int = 100,
+    noise_suppression_level: int = 75,
 ) -> KrispVivaFilterFrameProcessor:
     """Create a Krisp VIVA voice isolation ``FrameProcessor`` tuned for telephony.
 
@@ -371,7 +371,7 @@ def voice_isolation_telephony(
     Args:
         auth_provider: Authentication provider. Defaults to
             :class:`LiveKitCloudAuthProvider` (LiveKit Cloud auth + bundled model).
-        noise_suppression_level: Noise suppression level (0-100, default: 100).
+        noise_suppression_level: Noise suppression level (0-100, default: 75).
     """
     return KrispVivaFilterFrameProcessor(
         mode=VivaMode.VOICE_ISOLATION_TELEPHONY,


### PR DESCRIPTION
The default noiseSuppressionLevel of 100 led to some speech being garbled in cases. Manual testing revealed 75 to be a good middleground as a default.

