### PR TITLE
fix(google): release the genai client when the realtime session closes

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -858,6 +858,15 @@ class RealtimeSession(llm.RealtimeSession):
         if self._current_generation:
             self._mark_current_generation_done()
 
+        # release the genai http clients owned by this session. Without this
+        # they stay open until the garbage collector runs `AsyncClient.__del__`,
+        # which schedules `aclose()` on whatever event loop happens to be
+        # running at that moment.
+        try:
+            await self._client.aio.aclose()
+        except Exception:
+            logger.warning("failed to close the genai client", exc_info=True)
+
     @utils.log_exceptions(logger=logger)
     async def _main_task(self) -> None:
         max_retries = self._opts.conn_options.max_retry

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 import pytest
 from google.genai import types
@@ -14,15 +16,24 @@ pytestmark = pytest.mark.unit
 _PCM_FRAME = b"\x00\x01" * 240
 
 
-async def _make_session(monkeypatch: pytest.MonkeyPatch) -> RealtimeSession:
-    """A session whose background connect loop is stopped before it hits the network."""
+@asynccontextmanager
+async def _make_session(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[RealtimeSession]:
+    """A session whose background connect loop is stopped before it hits the network.
+
+    Closed on exit so the genai http clients are released here instead of by
+    ``AsyncClient.__del__``, which schedules ``aclose()`` on whatever event loop
+    is running when the collector happens to reach them.
+    """
     monkeypatch.setenv("GOOGLE_API_KEY", "fake-key")
     session = RealtimeModel().session()
     # cancel the connect loop before the event loop ever schedules it, so no
     # websocket connection is attempted
     session._msg_ch.close()
     await utils.aio.cancel_and_wait(session._main_atask)
-    return session
+    try:
+        yield session
+    finally:
+        await session.aclose()
 
 
 def _audio_content(**kwargs: object) -> types.LiveServerContent:
@@ -45,31 +56,31 @@ async def test_output_streams_close_on_generation_complete(
     generation_complete, while the generation stays open until turn_complete for input
     transcription and metrics.
     """
-    session = await _make_session(monkeypatch)
-    session._start_new_generation()
-    gen = session._current_generation
-    assert gen is not None
+    async with _make_session(monkeypatch) as session:
+        session._start_new_generation()
+        gen = session._current_generation
+        assert gen is not None
 
-    session._handle_server_content(
-        _audio_content(
-            output_transcription=types.Transcription(text="hello"),
-            generation_complete=True,
+        session._handle_server_content(
+            _audio_content(
+                output_transcription=types.Transcription(text="hello"),
+                generation_complete=True,
+            )
         )
-    )
 
-    # audio and text were consumed and both segments ended immediately
-    assert gen._first_token_timestamp is not None
-    assert gen.output_text == "hello"
-    assert gen.audio_ch.closed
-    assert gen.text_ch.closed
-    # but the generation is still open for trailing input transcription until turn_complete
-    assert not gen._done
-    assert not gen.message_ch.closed
+        # audio and text were consumed and both segments ended immediately
+        assert gen._first_token_timestamp is not None
+        assert gen.output_text == "hello"
+        assert gen.audio_ch.closed
+        assert gen.text_ch.closed
+        # but the generation is still open for trailing input transcription until turn_complete
+        assert not gen._done
+        assert not gen.message_ch.closed
 
-    session._handle_server_content(types.LiveServerContent(turn_complete=True))
+        session._handle_server_content(types.LiveServerContent(turn_complete=True))
 
-    assert gen._done
-    assert gen.message_ch.closed
+        assert gen._done
+        assert gen.message_ch.closed
 
 
 async def test_late_content_after_generation_complete_is_dropped(
@@ -77,21 +88,45 @@ async def test_late_content_after_generation_complete_is_dropped(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Stray audio/text after generation_complete is dropped (not pushed to a closed stream)."""
-    session = await _make_session(monkeypatch)
-    session._start_new_generation()
-    gen = session._current_generation
-    assert gen is not None
+    async with _make_session(monkeypatch) as session:
+        session._start_new_generation()
+        gen = session._current_generation
+        assert gen is not None
 
-    session._handle_server_content(_audio_content(generation_complete=True))
-    assert gen.audio_ch.closed and gen.text_ch.closed
+        session._handle_server_content(_audio_content(generation_complete=True))
+        assert gen.audio_ch.closed and gen.text_ch.closed
 
-    with caplog.at_level(logging.WARNING):
-        # must not raise ChanClosed, must not append to the transcript, and must warn
-        session._handle_server_content(
-            _audio_content(output_transcription=types.Transcription(text="late"))
-        )
+        with caplog.at_level(logging.WARNING):
+            # must not raise ChanClosed, must not append to the transcript, and must warn
+            session._handle_server_content(
+                _audio_content(output_transcription=types.Transcription(text="late"))
+            )
 
-    assert gen.audio_ch.closed and gen.text_ch.closed
-    assert gen.output_text == ""
-    assert not gen._done
-    assert any("after generation completed" in r.message for r in caplog.records)
+        assert gen.audio_ch.closed and gen.text_ch.closed
+        assert gen.output_text == ""
+        assert not gen._done
+        assert any("after generation completed" in r.message for r in caplog.records)
+
+
+async def test_session_close_releases_the_genai_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """aclose() must release the genai http clients.
+
+    Otherwise they live until the collector runs ``AsyncClient.__del__``, which
+    does ``asyncio.get_running_loop().create_task(self.aclose())`` - creating
+    pending tasks on whatever event loop is running at that moment.
+    """
+    closed = False
+
+    async with _make_session(monkeypatch) as session:
+        real_aclose = session._client.aio.aclose
+
+        async def _spy() -> None:
+            nonlocal closed
+            closed = True
+            await real_aclose()
+
+        monkeypatch.setattr(session._client.aio, "aclose", _spy)
+
+    assert closed


### PR DESCRIPTION
## Problem

`google.realtime.RealtimeSession` constructs its own `genai.Client` (`realtime_api.py:488`), but `aclose()` only tears down the websocket and the pending futures — the client is never closed. Its http clients therefore stay alive until the garbage collector reaches them, and both `google/genai/client.py:186` and `google/genai/_api_client.py:2234` implement `__del__` as:

```python
def __del__(self) -> None:
    try:
        asyncio.get_running_loop().create_task(self.aclose())
    except Exception:
        pass
```

So the close is scheduled as a task on whatever event loop happens to be running when the collector fires — not necessarily the loop the client was created on, and possibly during shutdown.

The visible symptom is in CI: the `unit-tests` job intermittently fails the `fail_on_leaked_tasks` check with pending `BaseApiClient.aclose` / `AsyncClient.aclose` / httpx `AsyncClient.aclose` tasks, attributed to whichever test happened to be finishing when the collector ran (I hit it on an unrelated AMD-only PR, #6639).

## Fix

`RealtimeSession.aclose()` now awaits `self._client.aio.aclose()` after the rest of its teardown, so the session releases what it allocated. Failures there are logged rather than raised, since aclose is a teardown path.

`tests/test_plugin_google_realtime.py` builds sessions through an async context manager that closes them, instead of leaving them to the collector — otherwise the tests keep leaking clients regardless of the plugin fix. Added a test asserting the close actually reaches the genai client.

## Verification

`ruff format --check`, `ruff check`, `check_types.py` (mypy strict) and the full `pytest --unit` suite all pass locally.
