### PR TITLE
fix(voice): stop the interrupt walk at a queued speech that disallows interruptions

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1506,66 +1506,48 @@ class AgentActivity(RecognitionHooks):
 
         return interrupted_speeches
 
-    def _playout_ordered_speeches(self) -> list[SpeechHandle]:
-        """The playing speech followed by the queued ones, in playout order.
-
-        ``_speech_q`` is a heap, so its list order is not the order the
-        speeches will be popped in.
-        """
-        speeches = [self._current_speech] if self._current_speech is not None else []
-        speeches.extend(
-            speech for _, _, speech in sorted(self._speech_q, key=lambda item: (item[0], item[1]))
-        )
-        return speeches
-
     def interrupt(self, *, force: bool = False) -> asyncio.Future[None]:
         """Interrupt the current speech generation and any queued speeches.
 
-        The playing speech and the queued ones are interrupted in playout
-        order, stopping at the first speech that disallows interruptions:
-        everything behind it still plays, so interrupting past it would leave
-        a gap in the conversation. ``force`` interrupts them regardless.
+        A queued speech that disallows interruptions keeps playing, along with the ones
+        behind it, unless ``force`` is set.
 
         Returns:
             An asyncio.Future that completes when the interruption is fully processed
             and chat context has been updated
+
+        Raises:
+            RuntimeError: If the speech currently playing disallows interruptions and
+                ``force`` is False.
         """
-        # independent of the playing speech, so always cancelled
         self._cancel_preemptive_generation()
 
         future = asyncio.Future[None]()
 
         interrupted_speeches = self._interrupt_background_speeches(force=force)
 
-        kept_next_speech = False
-        stopped_a_live_speech = False
-        for speech in self._playout_ordered_speeches():
-            # a done or already interrupted handle lingers in the queue (and
-            # _current_speech) until the scheduling task drops it, but it is
-            # never going to play
-            stale = speech.done() or speech.interrupted
+        if self._current_speech is not None:
+            self._current_speech.interrupt(force=force)
+            interrupted_speeches.append(self._current_speech)
 
-            if not force and not speech.allow_interruptions:
-                if stale:
-                    # it cannot leave a gap behind it, so keep walking
-                    continue
+        if self._rt_session is not None:
+            self._rt_session.interrupt()
 
-                # SpeechHandle.interrupt() would raise here, and the speeches
-                # behind this one are going to play, so stop the walk instead
-                kept_next_speech = not stopped_a_live_speech
+        # _speech_q is a heap, so its list order is not the order it pops in
+        for _, _, speech in sorted(self._speech_q, key=lambda item: (item[0], item[1])):
+            try:
+                speech.interrupt(force=force)
+            except RuntimeError:
+                # the speeches behind this one are going to play, so stopping
+                # here keeps the conversation contiguous
+                logger.warning(
+                    "a queued speech does not allow interruptions and will play after the "
+                    "interruption, use interrupt(force=True) to interrupt it as well",
+                    extra={"speech_id": speech.id},
+                )
                 break
 
-            speech.interrupt(force=force)
             interrupted_speeches.append(speech)
-            if not stale:
-                stopped_a_live_speech = True
-
-        # a realtime response still streaming belongs to the first speech that
-        # is actually going to play - the playing one, or the head of the queue
-        # while it waits to be promoted - so cancelling it while that speech is
-        # kept would truncate it. Anything else must still stop the provider.
-        if self._rt_session is not None and not kept_next_speech:
-            self._rt_session.interrupt()
 
         if not interrupted_speeches:
             future.set_result(None)

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1506,53 +1506,50 @@ class AgentActivity(RecognitionHooks):
 
         return interrupted_speeches
 
+    def _playout_ordered_speeches(self) -> list[SpeechHandle]:
+        """The playing speech followed by the queued ones, in playout order.
+
+        ``_speech_q`` is a heap, so its list order is not the order the
+        speeches will be popped in.
+        """
+        speeches = [self._current_speech] if self._current_speech is not None else []
+        speeches.extend(
+            speech for _, _, speech in sorted(self._speech_q, key=lambda item: (item[0], item[1]))
+        )
+        return speeches
+
     def interrupt(self, *, force: bool = False) -> asyncio.Future[None]:
         """Interrupt the current speech generation and any queued speeches.
 
-        Speeches that disallow interruptions are left running unless ``force``
-        is set; the playing one is reported instead of being skipped silently.
+        The playing speech and the queued ones are interrupted in playout
+        order, stopping at the first speech that disallows interruptions:
+        everything behind it still plays, so interrupting past it would leave
+        a gap in the conversation. ``force`` interrupts them regardless.
 
         Returns:
             An asyncio.Future that completes when the interruption is fully processed
             and chat context has been updated
-
-        Raises:
-            RuntimeError: If the playing speech disallows interruptions and
-                ``force`` is False. Nothing is interrupted in that case.
         """
-        # checked up-front: SpeechHandle.interrupt() raises for a protected
-        # handle, and letting that happen mid-sequence would leave the
-        # background speeches interrupted, the queue untouched, the realtime
-        # session untold and the returned future unresolved
-        if (
-            not force
-            and self._current_speech is not None
-            and not self._current_speech.allow_interruptions
-        ):
-            raise RuntimeError(
-                "the current speech does not allow interruptions, "
-                "use interrupt(force=True) to interrupt it anyway"
-            )
-
+        # independent of the playing speech, so always cancelled
         self._cancel_preemptive_generation()
 
         future = asyncio.Future[None]()
 
         interrupted_speeches = self._interrupt_background_speeches(force=force)
 
-        if self._current_speech is not None:
-            self._current_speech.interrupt(force=force)
-            interrupted_speeches.append(self._current_speech)
+        current_speech = self._current_speech
+        for speech in self._playout_ordered_speeches():
+            if not force and not speech.allow_interruptions:
+                # SpeechHandle.interrupt() would raise here, and the speeches
+                # behind this one are going to play, so stop the walk instead
+                break
 
-        # skip queued handles that disallow interruptions, like the background
-        # speeches above: raising mid-loop would leave the remaining queue
-        # playing, the realtime session untold and the future unresolved
-        for _, _, speech in self._speech_q:
-            if force or speech.allow_interruptions:
-                speech.interrupt(force=force)
-                interrupted_speeches.append(speech)
+            speech.interrupt(force=force)
+            interrupted_speeches.append(speech)
 
-        if self._rt_session is not None:
+        # a realtime response still streaming belongs to the playing speech;
+        # cancelling it while that speech survives would truncate it
+        if self._rt_session is not None and (current_speech is None or current_speech.interrupted):
             self._rt_session.interrupt()
 
         if not interrupted_speeches:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1537,19 +1537,22 @@ class AgentActivity(RecognitionHooks):
 
         interrupted_speeches = self._interrupt_background_speeches(force=force)
 
-        current_speech = self._current_speech
-        for speech in self._playout_ordered_speeches():
+        kept_next_speech = False
+        for index, speech in enumerate(self._playout_ordered_speeches()):
             if not force and not speech.allow_interruptions:
                 # SpeechHandle.interrupt() would raise here, and the speeches
                 # behind this one are going to play, so stop the walk instead
+                kept_next_speech = index == 0
                 break
 
             speech.interrupt(force=force)
             interrupted_speeches.append(speech)
 
-        # a realtime response still streaming belongs to the playing speech;
-        # cancelling it while that speech survives would truncate it
-        if self._rt_session is not None and (current_speech is None or current_speech.interrupted):
+        # a realtime response still streaming belongs to whatever speaks next -
+        # the playing one, or the head of the queue while it waits to be
+        # promoted - so cancelling it while that speech is kept would truncate
+        # it. Anything else must still stop the provider from generating.
+        if self._rt_session is not None and not kept_next_speech:
             self._rt_session.interrupt()
 
         if not interrupted_speeches:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1509,10 +1509,31 @@ class AgentActivity(RecognitionHooks):
     def interrupt(self, *, force: bool = False) -> asyncio.Future[None]:
         """Interrupt the current speech generation and any queued speeches.
 
+        Speeches that disallow interruptions are left running unless ``force``
+        is set; the playing one is reported instead of being skipped silently.
+
         Returns:
             An asyncio.Future that completes when the interruption is fully processed
             and chat context has been updated
+
+        Raises:
+            RuntimeError: If the playing speech disallows interruptions and
+                ``force`` is False. Nothing is interrupted in that case.
         """
+        # checked up-front: SpeechHandle.interrupt() raises for a protected
+        # handle, and letting that happen mid-sequence would leave the
+        # background speeches interrupted, the queue untouched, the realtime
+        # session untold and the returned future unresolved
+        if (
+            not force
+            and self._current_speech is not None
+            and not self._current_speech.allow_interruptions
+        ):
+            raise RuntimeError(
+                "the current speech does not allow interruptions, "
+                "use interrupt(force=True) to interrupt it anyway"
+            )
+
         self._cancel_preemptive_generation()
 
         future = asyncio.Future[None]()
@@ -1523,9 +1544,13 @@ class AgentActivity(RecognitionHooks):
             self._current_speech.interrupt(force=force)
             interrupted_speeches.append(self._current_speech)
 
+        # skip queued handles that disallow interruptions, like the background
+        # speeches above: raising mid-loop would leave the remaining queue
+        # playing, the realtime session untold and the future unresolved
         for _, _, speech in self._speech_q:
-            speech.interrupt(force=force)
-            interrupted_speeches.append(speech)
+            if force or speech.allow_interruptions:
+                speech.interrupt(force=force)
+                interrupted_speeches.append(speech)
 
         if self._rt_session is not None:
             self._rt_session.interrupt()

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1538,20 +1538,32 @@ class AgentActivity(RecognitionHooks):
         interrupted_speeches = self._interrupt_background_speeches(force=force)
 
         kept_next_speech = False
-        for index, speech in enumerate(self._playout_ordered_speeches()):
+        stopped_a_live_speech = False
+        for speech in self._playout_ordered_speeches():
+            # a done or already interrupted handle lingers in the queue (and
+            # _current_speech) until the scheduling task drops it, but it is
+            # never going to play
+            stale = speech.done() or speech.interrupted
+
             if not force and not speech.allow_interruptions:
+                if stale:
+                    # it cannot leave a gap behind it, so keep walking
+                    continue
+
                 # SpeechHandle.interrupt() would raise here, and the speeches
                 # behind this one are going to play, so stop the walk instead
-                kept_next_speech = index == 0
+                kept_next_speech = not stopped_a_live_speech
                 break
 
             speech.interrupt(force=force)
             interrupted_speeches.append(speech)
+            if not stale:
+                stopped_a_live_speech = True
 
-        # a realtime response still streaming belongs to whatever speaks next -
-        # the playing one, or the head of the queue while it waits to be
-        # promoted - so cancelling it while that speech is kept would truncate
-        # it. Anything else must still stop the provider from generating.
+        # a realtime response still streaming belongs to the first speech that
+        # is actually going to play - the playing one, or the head of the queue
+        # while it waits to be promoted - so cancelling it while that speech is
+        # kept would truncate it. Anything else must still stop the provider.
         if self._rt_session is not None and not kept_next_speech:
             self._rt_session.interrupt()
 

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1368,17 +1368,17 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
     def interrupt(self, *, force: bool = False) -> asyncio.Future[None]:
         """Interrupt the current speech generation.
 
-        Speeches created with ``allow_interruptions=False`` keep playing unless
-        ``force`` is set.
+        The playing speech and the queued ones are interrupted in playout
+        order, stopping at the first one created with
+        ``allow_interruptions=False`` — it and everything behind it keep
+        playing. ``force`` interrupts them regardless.
 
         Returns:
             An asyncio.Future that completes when the interruption is fully processed
             and chat context has been updated.
 
         Raises:
-            RuntimeError: If the session isn't running, or if the playing speech
-                disallows interruptions and ``force`` is False (nothing is
-                interrupted in that case).
+            RuntimeError: If the session isn't running.
         """
         if self._activity is None:
             raise RuntimeError("AgentSession isn't running")

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1368,9 +1368,17 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
     def interrupt(self, *, force: bool = False) -> asyncio.Future[None]:
         """Interrupt the current speech generation.
 
+        Speeches created with ``allow_interruptions=False`` keep playing unless
+        ``force`` is set.
+
         Returns:
             An asyncio.Future that completes when the interruption is fully processed
             and chat context has been updated.
+
+        Raises:
+            RuntimeError: If the session isn't running, or if the playing speech
+                disallows interruptions and ``force`` is False (nothing is
+                interrupted in that case).
         """
         if self._activity is None:
             raise RuntimeError("AgentSession isn't running")

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1368,17 +1368,16 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
     def interrupt(self, *, force: bool = False) -> asyncio.Future[None]:
         """Interrupt the current speech generation.
 
-        The playing speech and the queued ones are interrupted in playout
-        order, stopping at the first one created with
-        ``allow_interruptions=False`` — it and everything behind it keep
-        playing. ``force`` interrupts them regardless.
+        A queued speech created with ``allow_interruptions=False`` keeps playing,
+        along with the ones behind it, unless ``force`` is set.
 
         Returns:
             An asyncio.Future that completes when the interruption is fully processed
             and chat context has been updated.
 
         Raises:
-            RuntimeError: If the session isn't running.
+            RuntimeError: If the session isn't running, or if the speech currently
+                playing disallows interruptions and ``force`` is False.
         """
         if self._activity is None:
             raise RuntimeError("AgentSession isn't running")

--- a/tests/test_interrupt_protected_speech.py
+++ b/tests/test_interrupt_protected_speech.py
@@ -1,14 +1,16 @@
-"""``AgentActivity.interrupt()`` must not half-apply an interruption.
+"""``AgentActivity.interrupt()`` walks the playout order and stops at the first
+speech that disallows interruptions.
 
-``SpeechHandle.interrupt()`` raises when the handle disallows interruptions.
-That raise used to escape from the middle of ``interrupt()``: the preemptive
-generation was already cancelled and the background speeches already
-interrupted, while the queue kept playing, the realtime session was never told
-and the returned future never resolved. Background speeches were filtered but
-queued ones were not, so a queued ``say(allow_interruptions=False)`` aborted the
-sequence too.
+``SpeechHandle.interrupt()`` raises for such a handle, and that raise used to
+escape from the middle of ``interrupt()``: the queued speeches were left
+playing, the realtime session was never told to stop generating, and the
+returned future never resolved. Interrupting *past* a protected speech is
+wrong too — the speeches behind it still play, so skipping one in the middle
+would leave a gap in the conversation.
 """
 
+import heapq
+import time
 from unittest.mock import Mock
 
 import pytest
@@ -26,68 +28,137 @@ def _make_activity() -> AgentActivity:
     return AgentActivity(MyAgent(), create_session(FakeActions()))
 
 
-class TestInterruptProtectedSpeech:
-    async def test_protected_current_speech_leaves_everything_untouched(self) -> None:
+def _enqueue(activity: AgentActivity, speech: SpeechHandle, *, priority: int = 0) -> None:
+    """Queue a speech the way _schedule_speech does (a heap, not a list)."""
+    heapq.heappush(activity._speech_q, (-priority, time.perf_counter_ns(), speech))
+
+
+class TestInterruptWalk:
+    async def test_protected_current_speech_stops_the_walk(self) -> None:
         activity = _make_activity()
         activity._rt_session = Mock()
+        activity._preemptive_generation = Mock()
         background = SpeechHandle.create(allow_interruptions=True)
         queued = SpeechHandle.create(allow_interruptions=True)
-        activity._current_speech = SpeechHandle.create(allow_interruptions=False)
-        activity._background_speeches.add(background)
-        activity._speech_q.append((0, 0.0, queued))
-
-        try:
-            with pytest.raises(RuntimeError, match="force=True"):
-                activity.interrupt()
-
-            assert not background.interrupted
-            assert not queued.interrupted
-            activity._rt_session.interrupt.assert_not_called()
-        finally:
-            await _close_test_session(activity._session)
-
-    async def test_protected_queued_speech_is_skipped(self) -> None:
-        activity = _make_activity()
-        activity._rt_session = Mock()
-        current = SpeechHandle.create(allow_interruptions=True)
-        protected = SpeechHandle.create(allow_interruptions=False)
-        queued = SpeechHandle.create(allow_interruptions=True)
+        current = SpeechHandle.create(allow_interruptions=False)
         activity._current_speech = current
-        activity._speech_q.append((0, 0.0, protected))
-        activity._speech_q.append((0, 1.0, queued))
+        activity._background_speeches.add(background)
+        _enqueue(activity, queued)
 
         try:
             activity.interrupt()  # must not raise
 
+            # the protected speech keeps playing, and so does everything queued
+            # behind it
+            assert not current.interrupted
+            assert not queued.interrupted
+            # the streaming realtime response belongs to the speech we kept
+            activity._rt_session.interrupt.assert_not_called()
+            # neither of these depends on the playing speech
+            assert background.interrupted
+            assert activity._preemptive_generation is None
+        finally:
+            await _close_test_session(activity._session)
+
+    async def test_walk_stops_at_the_first_protected_queued_speech(self) -> None:
+        activity = _make_activity()
+        activity._rt_session = Mock()
+        current = SpeechHandle.create(allow_interruptions=True)
+        first = SpeechHandle.create(allow_interruptions=True)
+        protected = SpeechHandle.create(allow_interruptions=False)
+        behind = SpeechHandle.create(allow_interruptions=True)
+        activity._current_speech = current
+        for speech in (first, protected, behind):
+            _enqueue(activity, speech)
+
+        try:
+            activity.interrupt()
+
             assert current.interrupted
-            assert queued.interrupted
+            assert first.interrupted
             assert not protected.interrupted
-            # the rest of the sequence still runs
+            # no hole: what plays after the protected speech is untouched
+            assert not behind.interrupted
+            # the playing speech was interrupted, so the server must stop too
             activity._rt_session.interrupt.assert_called_once()
         finally:
             await _close_test_session(activity._session)
 
-    async def test_force_interrupts_protected_speeches(self) -> None:
+    async def test_a_protected_head_is_not_skipped_over(self) -> None:
+        # [protected, interruptible, protected]: interrupting only the middle
+        # one would play the first and third with a gap between them
         activity = _make_activity()
+        activity._rt_session = Mock()
+        head = SpeechHandle.create(allow_interruptions=False)
+        middle = SpeechHandle.create(allow_interruptions=True)
+        tail = SpeechHandle.create(allow_interruptions=False)
+        for speech in (head, middle, tail):
+            _enqueue(activity, speech)
+
+        try:
+            activity.interrupt()
+
+            assert not head.interrupted
+            assert not middle.interrupted
+            assert not tail.interrupted
+        finally:
+            await _close_test_session(activity._session)
+
+    async def test_the_walk_follows_playout_order_not_heap_order(self) -> None:
+        # a higher-priority speech is queued last but plays first; the heap's
+        # list order does not reflect that, the walk must
+        activity = _make_activity()
+        activity._rt_session = Mock()
+        low = SpeechHandle.create(allow_interruptions=True)
+        urgent_protected = SpeechHandle.create(allow_interruptions=False)
+        _enqueue(activity, low, priority=SpeechHandle.SPEECH_PRIORITY_NORMAL)
+        _enqueue(activity, urgent_protected, priority=SpeechHandle.SPEECH_PRIORITY_HIGH)
+
+        try:
+            assert activity._playout_ordered_speeches() == [urgent_protected, low]
+
+            activity.interrupt()
+
+            # the protected speech plays first, so the walk stops immediately
+            assert not urgent_protected.interrupted
+            assert not low.interrupted
+        finally:
+            await _close_test_session(activity._session)
+
+    async def test_realtime_is_cancelled_when_nothing_is_playing(self) -> None:
+        activity = _make_activity()
+        activity._rt_session = Mock()
+
+        try:
+            activity.interrupt()
+
+            activity._rt_session.interrupt.assert_called_once()
+        finally:
+            await _close_test_session(activity._session)
+
+    async def test_force_interrupts_the_whole_chain(self) -> None:
+        activity = _make_activity()
+        activity._rt_session = Mock()
         current = SpeechHandle.create(allow_interruptions=False)
         queued = SpeechHandle.create(allow_interruptions=False)
         activity._current_speech = current
-        activity._speech_q.append((0, 0.0, queued))
+        _enqueue(activity, queued)
 
         try:
             activity.interrupt(force=True)
 
             assert current.interrupted
             assert queued.interrupted
+            activity._rt_session.interrupt.assert_called_once()
         finally:
             await _close_test_session(activity._session)
 
-    async def test_interruptible_speeches_are_unaffected(self) -> None:
+    async def test_interruptible_chain_is_unaffected(self) -> None:
         activity = _make_activity()
         current = SpeechHandle.create(allow_interruptions=True)
         queued = SpeechHandle.create(allow_interruptions=True)
         activity._current_speech = current
-        activity._speech_q.append((0, 0.0, queued))
+        _enqueue(activity, queued)
 
         try:
             activity.interrupt()

--- a/tests/test_interrupt_protected_speech.py
+++ b/tests/test_interrupt_protected_speech.py
@@ -1,15 +1,14 @@
-"""``AgentActivity.interrupt()`` walks the playout order and stops at the first
-speech that disallows interruptions.
+"""``AgentActivity.interrupt()`` and queued speeches that disallow interruptions.
 
-``SpeechHandle.interrupt()`` raises for such a handle, and that raise used to
-escape from the middle of ``interrupt()``: the queued speeches were left
-playing, the realtime session was never told to stop generating, and the
-returned future never resolved. Interrupting *past* a protected speech is
-wrong too — the speeches behind it still play, so skipping one in the middle
-would leave a gap in the conversation.
+``SpeechHandle.interrupt()`` raises for such a handle, and the queue loop used
+to let that raise escape: the remaining queued speeches were left playing and
+the returned future never resolved. Interrupting *past* the protected speech
+would be wrong too — the ones behind it still play, so skipping one in the
+middle would leave a gap in the conversation.
 """
 
 import heapq
+import logging
 import time
 from unittest.mock import Mock
 
@@ -33,34 +32,10 @@ def _enqueue(activity: AgentActivity, speech: SpeechHandle, *, priority: int = 0
     heapq.heappush(activity._speech_q, (-priority, time.perf_counter_ns(), speech))
 
 
-class TestInterruptWalk:
-    async def test_protected_current_speech_stops_the_walk(self) -> None:
-        activity = _make_activity()
-        activity._rt_session = Mock()
-        activity._preemptive_generation = Mock()
-        background = SpeechHandle.create(allow_interruptions=True)
-        queued = SpeechHandle.create(allow_interruptions=True)
-        current = SpeechHandle.create(allow_interruptions=False)
-        activity._current_speech = current
-        activity._background_speeches.add(background)
-        _enqueue(activity, queued)
-
-        try:
-            activity.interrupt()  # must not raise
-
-            # the protected speech keeps playing, and so does everything queued
-            # behind it
-            assert not current.interrupted
-            assert not queued.interrupted
-            # the streaming realtime response belongs to the speech we kept
-            activity._rt_session.interrupt.assert_not_called()
-            # neither of these depends on the playing speech
-            assert background.interrupted
-            assert activity._preemptive_generation is None
-        finally:
-            await _close_test_session(activity._session)
-
-    async def test_walk_stops_at_the_first_protected_queued_speech(self) -> None:
+class TestInterruptQueuedSpeeches:
+    async def test_queue_stops_at_the_protected_speech(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         activity = _make_activity()
         activity._rt_session = Mock()
         current = SpeechHandle.create(allow_interruptions=True)
@@ -72,19 +47,21 @@ class TestInterruptWalk:
             _enqueue(activity, speech)
 
         try:
-            activity.interrupt()
+            with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+                activity.interrupt()  # must not raise
 
             assert current.interrupted
             assert first.interrupted
             assert not protected.interrupted
             # no hole: what plays after the protected speech is untouched
             assert not behind.interrupted
-            # the playing speech was interrupted, so the server must stop too
+            # the rest of the sequence still ran
             activity._rt_session.interrupt.assert_called_once()
+            assert any("force=True" in record.message for record in caplog.records)
         finally:
             await _close_test_session(activity._session)
 
-    async def test_a_protected_head_is_not_skipped_over(self) -> None:
+    async def test_a_protected_head_shields_the_whole_queue(self) -> None:
         # [protected, interruptible, protected]: interrupting only the middle
         # one would play the first and third with a gap between them
         activity = _make_activity()
@@ -101,89 +78,10 @@ class TestInterruptWalk:
             assert not head.interrupted
             assert not middle.interrupted
             assert not tail.interrupted
-            # a realtime handle sits in the queue before the scheduling task
-            # promotes it, so the streaming response belongs to this kept head
-            activity._rt_session.interrupt.assert_not_called()
         finally:
             await _close_test_session(activity._session)
 
-    async def test_a_finished_protected_speech_does_not_block_the_walk(self) -> None:
-        # a done handle lingers in _current_speech until the scheduling task
-        # drops it; it will never play, so it cannot leave a gap and must not
-        # shield the speeches behind it
-        activity = _make_activity()
-        activity._rt_session = Mock()
-        finished = SpeechHandle.create(allow_interruptions=False)
-        finished._mark_done()
-        queued = SpeechHandle.create(allow_interruptions=True)
-        activity._current_speech = finished
-        _enqueue(activity, queued)
-
-        try:
-            activity.interrupt()
-
-            assert queued.interrupted
-            activity._rt_session.interrupt.assert_called_once()
-        finally:
-            await _close_test_session(activity._session)
-
-    async def test_a_force_interrupted_queue_entry_does_not_block_the_walk(self) -> None:
-        # interrupt(force=True) leaves handles in _speech_q until the
-        # scheduling task pops and skips them
-        activity = _make_activity()
-        activity._rt_session = Mock()
-        cancelled = SpeechHandle.create(allow_interruptions=False)
-        cancelled.interrupt(force=True)
-        behind = SpeechHandle.create(allow_interruptions=True)
-        for speech in (cancelled, behind):
-            _enqueue(activity, speech)
-
-        try:
-            activity.interrupt()
-
-            assert behind.interrupted
-            activity._rt_session.interrupt.assert_called_once()
-        finally:
-            await _close_test_session(activity._session)
-
-    async def test_a_live_protected_speech_behind_a_stale_one_is_still_kept(self) -> None:
-        # walking past the stale handle must not make the live protected one
-        # look like something we interrupted: the streaming response is its own
-        activity = _make_activity()
-        activity._rt_session = Mock()
-        stale = SpeechHandle.create(allow_interruptions=False)
-        stale._mark_done()
-        live = SpeechHandle.create(allow_interruptions=False)
-        activity._current_speech = stale
-        _enqueue(activity, live)
-
-        try:
-            activity.interrupt()
-
-            assert not live.interrupted
-            activity._rt_session.interrupt.assert_not_called()
-        finally:
-            await _close_test_session(activity._session)
-
-    async def test_realtime_is_cancelled_when_the_playing_speech_is_done(self) -> None:
-        # SpeechHandle._cancel() is a no-op once the handle is done, so
-        # `interrupted` stays False while the scheduling task has not cleared
-        # _current_speech yet - nothing was protected, the provider must stop
-        activity = _make_activity()
-        activity._rt_session = Mock()
-        current = SpeechHandle.create(allow_interruptions=True)
-        current._mark_done()
-        activity._current_speech = current
-
-        try:
-            activity.interrupt()
-
-            assert not current.interrupted
-            activity._rt_session.interrupt.assert_called_once()
-        finally:
-            await _close_test_session(activity._session)
-
-    async def test_the_walk_follows_playout_order_not_heap_order(self) -> None:
+    async def test_the_queue_is_walked_in_playout_order_not_heap_order(self) -> None:
         # a higher-priority speech is queued last but plays first; the heap's
         # list order does not reflect that, the walk must
         activity = _make_activity()
@@ -194,8 +92,6 @@ class TestInterruptWalk:
         _enqueue(activity, urgent_protected, priority=SpeechHandle.SPEECH_PRIORITY_HIGH)
 
         try:
-            assert activity._playout_ordered_speeches() == [urgent_protected, low]
-
             activity.interrupt()
 
             # the protected speech plays first, so the walk stops immediately
@@ -204,14 +100,14 @@ class TestInterruptWalk:
         finally:
             await _close_test_session(activity._session)
 
-    async def test_realtime_is_cancelled_when_nothing_is_playing(self) -> None:
+    async def test_a_protected_playing_speech_still_raises(self) -> None:
+        # unchanged behaviour: SpeechHandle.interrupt() is explicit about it
         activity = _make_activity()
-        activity._rt_session = Mock()
+        activity._current_speech = SpeechHandle.create(allow_interruptions=False)
 
         try:
-            activity.interrupt()
-
-            activity._rt_session.interrupt.assert_called_once()
+            with pytest.raises(RuntimeError):
+                activity.interrupt()
         finally:
             await _close_test_session(activity._session)
 
@@ -220,20 +116,24 @@ class TestInterruptWalk:
         activity._rt_session = Mock()
         current = SpeechHandle.create(allow_interruptions=False)
         queued = SpeechHandle.create(allow_interruptions=False)
+        behind = SpeechHandle.create(allow_interruptions=True)
         activity._current_speech = current
-        _enqueue(activity, queued)
+        for speech in (queued, behind):
+            _enqueue(activity, speech)
 
         try:
             activity.interrupt(force=True)
 
             assert current.interrupted
             assert queued.interrupted
+            assert behind.interrupted
             activity._rt_session.interrupt.assert_called_once()
         finally:
             await _close_test_session(activity._session)
 
     async def test_interruptible_chain_is_unaffected(self) -> None:
         activity = _make_activity()
+        activity._rt_session = Mock()
         current = SpeechHandle.create(allow_interruptions=True)
         queued = SpeechHandle.create(allow_interruptions=True)
         activity._current_speech = current
@@ -244,5 +144,6 @@ class TestInterruptWalk:
 
             assert current.interrupted
             assert queued.interrupted
+            activity._rt_session.interrupt.assert_called_once()
         finally:
             await _close_test_session(activity._session)

--- a/tests/test_interrupt_protected_speech.py
+++ b/tests/test_interrupt_protected_speech.py
@@ -107,6 +107,64 @@ class TestInterruptWalk:
         finally:
             await _close_test_session(activity._session)
 
+    async def test_a_finished_protected_speech_does_not_block_the_walk(self) -> None:
+        # a done handle lingers in _current_speech until the scheduling task
+        # drops it; it will never play, so it cannot leave a gap and must not
+        # shield the speeches behind it
+        activity = _make_activity()
+        activity._rt_session = Mock()
+        finished = SpeechHandle.create(allow_interruptions=False)
+        finished._mark_done()
+        queued = SpeechHandle.create(allow_interruptions=True)
+        activity._current_speech = finished
+        _enqueue(activity, queued)
+
+        try:
+            activity.interrupt()
+
+            assert queued.interrupted
+            activity._rt_session.interrupt.assert_called_once()
+        finally:
+            await _close_test_session(activity._session)
+
+    async def test_a_force_interrupted_queue_entry_does_not_block_the_walk(self) -> None:
+        # interrupt(force=True) leaves handles in _speech_q until the
+        # scheduling task pops and skips them
+        activity = _make_activity()
+        activity._rt_session = Mock()
+        cancelled = SpeechHandle.create(allow_interruptions=False)
+        cancelled.interrupt(force=True)
+        behind = SpeechHandle.create(allow_interruptions=True)
+        for speech in (cancelled, behind):
+            _enqueue(activity, speech)
+
+        try:
+            activity.interrupt()
+
+            assert behind.interrupted
+            activity._rt_session.interrupt.assert_called_once()
+        finally:
+            await _close_test_session(activity._session)
+
+    async def test_a_live_protected_speech_behind_a_stale_one_is_still_kept(self) -> None:
+        # walking past the stale handle must not make the live protected one
+        # look like something we interrupted: the streaming response is its own
+        activity = _make_activity()
+        activity._rt_session = Mock()
+        stale = SpeechHandle.create(allow_interruptions=False)
+        stale._mark_done()
+        live = SpeechHandle.create(allow_interruptions=False)
+        activity._current_speech = stale
+        _enqueue(activity, live)
+
+        try:
+            activity.interrupt()
+
+            assert not live.interrupted
+            activity._rt_session.interrupt.assert_not_called()
+        finally:
+            await _close_test_session(activity._session)
+
     async def test_realtime_is_cancelled_when_the_playing_speech_is_done(self) -> None:
         # SpeechHandle._cancel() is a no-op once the handle is done, so
         # `interrupted` stays False while the scheduling task has not cleared

--- a/tests/test_interrupt_protected_speech.py
+++ b/tests/test_interrupt_protected_speech.py
@@ -1,0 +1,98 @@
+"""``AgentActivity.interrupt()`` must not half-apply an interruption.
+
+``SpeechHandle.interrupt()`` raises when the handle disallows interruptions.
+That raise used to escape from the middle of ``interrupt()``: the preemptive
+generation was already cancelled and the background speeches already
+interrupted, while the queue kept playing, the realtime session was never told
+and the returned future never resolved. Background speeches were filtered but
+queued ones were not, so a queued ``say(allow_interruptions=False)`` aborted the
+sequence too.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from livekit.agents.voice.agent_activity import AgentActivity
+from livekit.agents.voice.speech_handle import SpeechHandle
+
+from .fake_session import FakeActions, create_session
+from .test_agent_session import MyAgent, _close_test_session
+
+pytestmark = pytest.mark.unit
+
+
+def _make_activity() -> AgentActivity:
+    return AgentActivity(MyAgent(), create_session(FakeActions()))
+
+
+class TestInterruptProtectedSpeech:
+    async def test_protected_current_speech_leaves_everything_untouched(self) -> None:
+        activity = _make_activity()
+        activity._rt_session = Mock()
+        background = SpeechHandle.create(allow_interruptions=True)
+        queued = SpeechHandle.create(allow_interruptions=True)
+        activity._current_speech = SpeechHandle.create(allow_interruptions=False)
+        activity._background_speeches.add(background)
+        activity._speech_q.append((0, 0.0, queued))
+
+        try:
+            with pytest.raises(RuntimeError, match="force=True"):
+                activity.interrupt()
+
+            assert not background.interrupted
+            assert not queued.interrupted
+            activity._rt_session.interrupt.assert_not_called()
+        finally:
+            await _close_test_session(activity._session)
+
+    async def test_protected_queued_speech_is_skipped(self) -> None:
+        activity = _make_activity()
+        activity._rt_session = Mock()
+        current = SpeechHandle.create(allow_interruptions=True)
+        protected = SpeechHandle.create(allow_interruptions=False)
+        queued = SpeechHandle.create(allow_interruptions=True)
+        activity._current_speech = current
+        activity._speech_q.append((0, 0.0, protected))
+        activity._speech_q.append((0, 1.0, queued))
+
+        try:
+            activity.interrupt()  # must not raise
+
+            assert current.interrupted
+            assert queued.interrupted
+            assert not protected.interrupted
+            # the rest of the sequence still runs
+            activity._rt_session.interrupt.assert_called_once()
+        finally:
+            await _close_test_session(activity._session)
+
+    async def test_force_interrupts_protected_speeches(self) -> None:
+        activity = _make_activity()
+        current = SpeechHandle.create(allow_interruptions=False)
+        queued = SpeechHandle.create(allow_interruptions=False)
+        activity._current_speech = current
+        activity._speech_q.append((0, 0.0, queued))
+
+        try:
+            activity.interrupt(force=True)
+
+            assert current.interrupted
+            assert queued.interrupted
+        finally:
+            await _close_test_session(activity._session)
+
+    async def test_interruptible_speeches_are_unaffected(self) -> None:
+        activity = _make_activity()
+        current = SpeechHandle.create(allow_interruptions=True)
+        queued = SpeechHandle.create(allow_interruptions=True)
+        activity._current_speech = current
+        activity._speech_q.append((0, 0.0, queued))
+
+        try:
+            activity.interrupt()
+
+            assert current.interrupted
+            assert queued.interrupted
+        finally:
+            await _close_test_session(activity._session)

--- a/tests/test_interrupt_protected_speech.py
+++ b/tests/test_interrupt_protected_speech.py
@@ -101,6 +101,27 @@ class TestInterruptWalk:
             assert not head.interrupted
             assert not middle.interrupted
             assert not tail.interrupted
+            # a realtime handle sits in the queue before the scheduling task
+            # promotes it, so the streaming response belongs to this kept head
+            activity._rt_session.interrupt.assert_not_called()
+        finally:
+            await _close_test_session(activity._session)
+
+    async def test_realtime_is_cancelled_when_the_playing_speech_is_done(self) -> None:
+        # SpeechHandle._cancel() is a no-op once the handle is done, so
+        # `interrupted` stays False while the scheduling task has not cleared
+        # _current_speech yet - nothing was protected, the provider must stop
+        activity = _make_activity()
+        activity._rt_session = Mock()
+        current = SpeechHandle.create(allow_interruptions=True)
+        current._mark_done()
+        activity._current_speech = current
+
+        try:
+            activity.interrupt()
+
+            assert not current.interrupted
+            activity._rt_session.interrupt.assert_called_once()
         finally:
             await _close_test_session(activity._session)
 


### PR DESCRIPTION
A bug in `AgentActivity.interrupt()`, independent of how #6635 gets fixed — found while working on #6638, which was closed in favour of #6642. It isn't realtime-specific.

## Problem

`SpeechHandle.interrupt()` raises `RuntimeError` when the handle disallows interruptions, and the queue loop calls it on every queued speech without handling that. With an interruptible speech playing and a protected one queued behind it, the raise escapes from the middle of `interrupt()`: the remaining queued speeches are never interrupted and the returned future never resolves.

Reachable today without a realtime model: `session.say("...", allow_interruptions=False)` queued behind another speech, then any `session.interrupt()` from user code.

## Fix

The queue walk stops at the first speech that disallows interruptions, logging a warning that names the handle and points at `force=True`. Everything behind it is going to play, so interrupting past it would leave a gap in the conversation — skipping per handle would drop the middle speech of `[protected, interruptible, protected]` and play the other two.

The queue is walked sorted by `(priority, sequence)`, since `_speech_q` is a heap and its list order is not the order it pops in.

Behaviour that is deliberately unchanged: the preemptive generation and the background speeches are cancelled as before, `rt_session.interrupt()` is still called unconditionally (nothing maps the streaming realtime response to a `SpeechHandle`, so there is no sound way to decide it belongs to a speech that was kept), a protected speech that is currently *playing* still raises, and `force=True` interrupts the whole chain.

## Verification

`tests/test_interrupt_protected_speech.py` covers stopping mid-queue with the speeches behind untouched and the warning emitted, the `[protected, interruptible, protected]` no-hole case, a priority-ordered case where heap order differs from pop order, the playing-protected speech still raising, `force=True`, and the ordinary all-interruptible path.

`ruff format --check`, `ruff check`, `check_types.py` (mypy strict) and the full `pytest --unit` suite pass locally.
