### PR TITLE
fix(livekit-agents): keep plugin-specific realtime handlers across child swaps

### DIFF
--- a/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
@@ -6,7 +6,7 @@ import time
 import weakref
 from collections.abc import AsyncIterable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from livekit import rtc
 
@@ -65,6 +65,13 @@ _FORWARDED_EVENTS: tuple[EventTypes, ...] = (
     "metrics_collected",
     "remote_item_added",
 )
+
+# events the wrapper handles itself; anything else is plugin-specific and is
+# registered directly on the active child session
+_WRAPPER_EVENTS: frozenset[str] = frozenset(_FORWARDED_EVENTS) | {
+    "error",
+    "realtime_availability_changed",
+}
 
 
 def _merge_capabilities(models: list[RealtimeModel]) -> RealtimeCapabilities:
@@ -188,21 +195,84 @@ class _FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_ch
         # audio during a swap is dropped; replaying it would lag the model behind realtime
         self._swapping = False
 
+        # plugin-specific handlers registered on this wrapper, replayed onto every child
+        self._plugin_handlers: dict[str, set[Callable[..., Any]]] = {}
+
         self._active_index = 0
         self._active = adapter._models[0].session(
             turn_detection_disabled=self._turn_detection_disabled
         )
         self._bind(self._active)
 
+    def on(self, event: str, callback: Callable[..., Any] | None = None) -> Callable[..., Any]:
+        """Register a handler.
+
+        Events the wrapper forwards or emits itself are registered on the wrapper. Anything
+        else is treated as plugin-specific, registered on the active child session, and
+        re-registered automatically whenever the child is swapped.
+        """
+        if event in _WRAPPER_EVENTS:
+            return super().on(event, callback)  # type: ignore[arg-type]
+
+        if callback is None:
+
+            def _decorator(cb: Callable[..., Any]) -> Callable[..., Any]:
+                self.on(event, cb)
+                return cb
+
+            return _decorator
+
+        self._plugin_handlers.setdefault(event, set()).add(callback)
+        self._active.on(event, callback)  # type: ignore[arg-type]
+        return callback
+
+    def once(self, event: str, callback: Callable[..., Any] | None = None) -> Callable[..., Any]:
+        """Like ``on``, but fires at most once across child swaps."""
+        if event in _WRAPPER_EVENTS:
+            return super().once(event, callback)  # type: ignore[arg-type]
+
+        if callback is None:
+
+            def _decorator(cb: Callable[..., Any]) -> Callable[..., Any]:
+                self.once(event, cb)
+                return cb
+
+            return _decorator
+
+        def _fire_once(*args: Any, **kwargs: Any) -> None:
+            self.off(event, _fire_once)
+            callback(*args, **kwargs)
+
+        self.on(event, _fire_once)
+        return callback
+
+    def off(self, event: str, callback: Callable[..., Any]) -> None:
+        if event in _WRAPPER_EVENTS:
+            super().off(event, callback)  # type: ignore[arg-type]
+            return
+
+        handlers = self._plugin_handlers.get(event)
+        if handlers is not None:
+            handlers.discard(callback)
+            if not handlers:
+                del self._plugin_handlers[event]
+        self._active.off(event, callback)  # type: ignore[arg-type]
+
     def _bind(self, child: RealtimeSession) -> None:
         for event, forwarder in self._forwarders.items():
             child.on(event, forwarder)
         child.on("error", self._on_child_error)
+        for plugin_event, callbacks in self._plugin_handlers.items():
+            for callback in callbacks:
+                child.on(plugin_event, callback)  # type: ignore[arg-type]
 
     def _unbind(self, child: RealtimeSession) -> None:
         for event, forwarder in self._forwarders.items():
             child.off(event, forwarder)
         child.off("error", self._on_child_error)
+        for plugin_event, callbacks in self._plugin_handlers.items():
+            for callback in callbacks:
+                child.off(plugin_event, callback)  # type: ignore[arg-type]
 
     def _set_available(self, index: int, available: bool) -> None:
         if self._available[index] == available:

--- a/tests/test_realtime_fallback.py
+++ b/tests/test_realtime_fallback.py
@@ -557,3 +557,94 @@ async def test_emits_availability_changed_on_recovery() -> None:
     await session._swap_task
 
     assert any(e.realtime_model is primary and e.available is True for e in events)
+
+
+# --- plugin-specific event handlers -----------------------------------------
+# Providers emit their own events (openai_server_event_received, etc) that the
+# wrapper does not forward. Those handlers must survive a child swap.
+
+
+async def test_plugin_handler_survives_restart_same_model() -> None:
+    primary = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary])
+    session = adapter.session()
+
+    received: list[str] = []
+    session.on("openai_server_event_received", received.append)
+
+    await adapter.restart_session()
+    session._active.emit("openai_server_event_received", "after-restart")
+
+    assert received == ["after-restart"]
+
+
+async def test_plugin_handler_survives_switch_to_other_model() -> None:
+    primary = FakeRealtimeModel()
+    backup = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+    session = adapter.session()
+
+    received: list[str] = []
+    session.on("openai_server_event_received", received.append)
+
+    await adapter.restart_session(switch_model=True)
+    assert session._active is backup.active_session
+
+    session._active.emit("openai_server_event_received", "after-switch")
+    assert received == ["after-switch"]
+
+
+async def test_plugin_handler_reaches_current_child_before_any_swap() -> None:
+    primary = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary])
+    session = adapter.session()
+
+    received: list[str] = []
+    session.on("openai_server_event_received", received.append)
+
+    primary.active_session.emit("openai_server_event_received", "immediate")
+    assert received == ["immediate"]
+
+
+async def test_removed_plugin_handler_does_not_come_back_on_restart() -> None:
+    primary = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary])
+    session = adapter.session()
+
+    received: list[str] = []
+    session.on("openai_server_event_received", received.append)
+    session.off("openai_server_event_received", received.append)
+
+    await adapter.restart_session()
+    session._active.emit("openai_server_event_received", "should-not-arrive")
+
+    assert received == []
+
+
+async def test_plugin_once_fires_at_most_once_across_swap() -> None:
+    primary = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary])
+    session = adapter.session()
+
+    received: list[str] = []
+    session.once("openai_server_event_received", received.append)
+
+    primary.active_session.emit("openai_server_event_received", "first")
+    await adapter.restart_session()
+    session._active.emit("openai_server_event_received", "second")
+
+    assert received == ["first"]
+
+
+async def test_wrapper_events_still_registered_on_the_wrapper() -> None:
+    primary = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary])
+    session = adapter.session()
+
+    received: list[object] = []
+    session.on("input_speech_started", received.append)
+
+    primary.active_session.emit("input_speech_started", object())
+
+    assert len(received) == 1
+    assert "input_speech_started" not in session._plugin_handlers


### PR DESCRIPTION
Fixes #6559
Fixes #6556

Same root cause for both.

The fallback session only forwards the seven events in `_FORWARDED_EVENTS`. Provider events like `openai_server_event_received` aren't in that list, so they never reach the wrapper. People work around it by subscribing on `rt_session._active`, and those handlers get dropped when `_swap` replaces the child. That happens on `restart_session(switch_model=False)` and on a real fallback.

What I did: `on` / `off` / `once` on the wrapper now check the event name. Known events behave exactly as before. Anything else gets tracked and registered on the active child, and `_bind` / `_unbind` replay them onto every new child. So you subscribe on the session you already hold and `_active` stays internal.

Subscribing to an event the current child never emits is allowed, it just never fires. A fallback list can mix providers (openai to azure), so raising there felt wrong, but happy to change it if you'd rather.

Tests added to `tests/test_realtime_fallback.py`:

- handler survives `restart_session()` on the same model
- handler survives `restart_session(switch_model=True)` to another model
- handler reaches the current child before any swap
- handler stays gone after `off`
- `once` fires at most once across a swap
- known events still register on the wrapper, not as plugin handlers

Five of those six fail on main. ruff and `mypy --strict` are clean on the touched files, and the full `test_realtime_fallback.py` passes (42).
