### PR TITLE
fix(elevenlabs): close TTS websocket on job shutdown

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -34,6 +34,7 @@ from livekit.agents import (
     APIError,
     APIStatusError,
     APITimeoutError,
+    JobContext,
     LanguageCode,
     get_job_context,
     tokenize,
@@ -212,7 +213,7 @@ class TTS(tts.TTS):
 
         self.__current_connection: _Connection | None = None
         self._connection_lock = asyncio.Lock()
-        self._job_context_cb_registered = False
+        self._registered_job_ctx_ref: weakref.ReferenceType[JobContext] | None = None
 
     @property
     def model(self) -> str:
@@ -288,13 +289,15 @@ class TTS(tts.TTS):
             Tuple of (connection, acquire_time, connection_reused)
         """
         async with self._connection_lock:
-            if not self._job_context_cb_registered:
-                job_ctx = get_job_context(required=False)
-                if job_ctx is not None:
-                    # AgentSession closes active synthesis streams but does not own the TTS
-                    # model. Close our reusable WebSocket before the job-owned HTTP session.
-                    job_ctx.add_shutdown_callback(self.aclose)
-                    self._job_context_cb_registered = True
+            job_ctx = get_job_context(required=False)
+            registered_job_ctx = (
+                self._registered_job_ctx_ref() if self._registered_job_ctx_ref is not None else None
+            )
+            if job_ctx is not None and job_ctx is not registered_job_ctx:
+                # AgentSession closes active synthesis streams but does not own the TTS
+                # model. Close our reusable WebSocket before the job-owned HTTP session.
+                job_ctx.add_shutdown_callback(self.aclose)
+                self._registered_job_ctx_ref = weakref.ref(job_ctx)
 
             if (
                 self.__current_connection

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -35,6 +35,7 @@ from livekit.agents import (
     APIStatusError,
     APITimeoutError,
     LanguageCode,
+    get_job_context,
     tokenize,
     tts,
     utils,
@@ -211,6 +212,7 @@ class TTS(tts.TTS):
 
         self.__current_connection: _Connection | None = None
         self._connection_lock = asyncio.Lock()
+        self._job_context_cb_registered = False
 
     @property
     def model(self) -> str:
@@ -286,6 +288,14 @@ class TTS(tts.TTS):
             Tuple of (connection, acquire_time, connection_reused)
         """
         async with self._connection_lock:
+            if not self._job_context_cb_registered:
+                job_ctx = get_job_context(required=False)
+                if job_ctx is not None:
+                    # AgentSession closes active synthesis streams but does not own the TTS
+                    # model. Close our reusable WebSocket before the job-owned HTTP session.
+                    job_ctx.add_shutdown_callback(self.aclose)
+                    self._job_context_cb_registered = True
+
             if (
                 self.__current_connection
                 and self.__current_connection.is_current

--- a/tests/test_plugin_elevenlabs_tts.py
+++ b/tests/test_plugin_elevenlabs_tts.py
@@ -112,7 +112,7 @@ def test_auto_mode_respects_explicit_value_with_chunk_length_schedule() -> None:
 async def test_job_shutdown_gracefully_closes_websocket(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    close_code: asyncio.Future[int | None] = asyncio.get_running_loop().create_future()
+    close_codes: asyncio.Queue[int | None] = asyncio.Queue()
 
     async def websocket_handler(request: web.Request) -> web.WebSocketResponse:
         websocket = web.WebSocketResponse()
@@ -121,8 +121,7 @@ async def test_job_shutdown_gracefully_closes_websocket(
             async for _ in websocket:
                 pass
         finally:
-            if not close_code.done():
-                close_code.set_result(websocket.close_code)
+            close_codes.put_nowait(websocket.close_code)
         return websocket
 
     app = web.Application()
@@ -154,7 +153,17 @@ async def test_job_shutdown_gracefully_closes_websocket(
                 assert len(job_ctx.shutdown_callbacks) == 1
                 await job_ctx.shutdown_callbacks[0]()
 
-                assert await asyncio.wait_for(close_code, timeout=1) == 1000
+                assert await asyncio.wait_for(close_codes.get(), timeout=1) == 1000
+                assert not http_session.closed
+
+                job_ctx = _FakeJobContext()
+                await tts._current_connection()  # pyright: ignore[reportPrivateUsage]
+                await tts._current_connection()  # pyright: ignore[reportPrivateUsage]
+
+                assert len(job_ctx.shutdown_callbacks) == 1
+                await job_ctx.shutdown_callbacks[0]()
+
+                assert await asyncio.wait_for(close_codes.get(), timeout=1) == 1000
                 assert not http_session.closed
             finally:
                 await tts.aclose()

--- a/tests/test_plugin_elevenlabs_tts.py
+++ b/tests/test_plugin_elevenlabs_tts.py
@@ -3,14 +3,25 @@
 import asyncio
 import base64
 import json
+import socket
+from collections.abc import Awaitable, Callable
 from types import SimpleNamespace
 
 import aiohttp
 import pytest
+from aiohttp import web
 
 from livekit.plugins.elevenlabs import tts as elevenlabs_tts
 
 pytestmark = pytest.mark.plugin("elevenlabs")
+
+
+class _FakeJobContext:
+    def __init__(self) -> None:
+        self.shutdown_callbacks: list[Callable[[], Awaitable[None]]] = []
+
+    def add_shutdown_callback(self, callback: Callable[[], Awaitable[None]]) -> None:
+        self.shutdown_callbacks.append(callback)
 
 
 class _FakeWebSocket:
@@ -95,6 +106,60 @@ def test_auto_mode_respects_explicit_value_with_chunk_length_schedule() -> None:
         auto_mode=True,
     )
     assert tts._opts.auto_mode is True
+
+
+@pytest.mark.asyncio
+async def test_job_shutdown_gracefully_closes_websocket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    close_code: asyncio.Future[int | None] = asyncio.get_running_loop().create_future()
+
+    async def websocket_handler(request: web.Request) -> web.WebSocketResponse:
+        websocket = web.WebSocketResponse()
+        await websocket.prepare(request)
+        try:
+            async for _ in websocket:
+                pass
+        finally:
+            if not close_code.done():
+                close_code.set_result(websocket.close_code)
+        return websocket
+
+    app = web.Application()
+    app.router.add_get("/{path:.*}", websocket_handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+
+    server_socket = socket.socket()
+    server_socket.bind(("127.0.0.1", 0))
+    port = server_socket.getsockname()[1]
+    site = web.SockSite(runner, server_socket)
+    await site.start()
+
+    job_ctx = _FakeJobContext()
+    monkeypatch.setattr(elevenlabs_tts, "get_job_context", lambda *, required=False: job_ctx)
+
+    try:
+        async with aiohttp.ClientSession() as http_session:
+            tts = elevenlabs_tts.TTS(
+                api_key="test-key",
+                voice_id="test-voice",
+                base_url=f"http://127.0.0.1:{port}",
+                http_session=http_session,
+            )
+            try:
+                await tts._current_connection()  # pyright: ignore[reportPrivateUsage]
+                await tts._current_connection()  # pyright: ignore[reportPrivateUsage]
+
+                assert len(job_ctx.shutdown_callbacks) == 1
+                await job_ctx.shutdown_callbacks[0]()
+
+                assert await asyncio.wait_for(close_code, timeout=1) == 1000
+                assert not http_session.closed
+            finally:
+                await tts.aclose()
+    finally:
+        await runner.cleanup()
 
 
 def test_build_context_init_packet_includes_generation_config() -> None:


### PR DESCRIPTION
## Summary

- register the ElevenLabs TTS `aclose()` method as a job shutdown callback when its reusable multi-stream WebSocket is first acquired
- register only once even when the WebSocket connection is reused
- close ElevenLabs-owned streams and the WebSocket without closing the job-owned `aiohttp.ClientSession`

## Problem

The ElevenLabs multi-stream WebSocket is intentionally reused across synthesis requests. `AgentSession.aclose()` stops active synthesis streams, but it does not close the configured TTS model, and `FallbackAdapter.aclose()` does not cascade cleanup to its child providers.

At job teardown, the shared HTTP context can therefore close while the ElevenLabs WebSocket is still open. The remote endpoint observes an abnormal `1006` closure because it never receives a WebSocket Close frame, even when synthesis completed successfully.

## Why the job shutdown callback

The worker awaits `AgentSession.aclose()` before running job shutdown callbacks, then closes the shared HTTP context after those callbacks. Registering the concrete ElevenLabs model in that window:

1. lets active synthesis streams stop first
2. gracefully closes the reusable WebSocket
3. preserves ownership of the shared HTTP session
4. avoids closing provider connections during agent handoffs

This is deliberately narrower than closing TTS models from `AgentActivity`, as discussed in #3825, and avoids the shared-session ownership issue identified in #4745.

## Tests

The regression test uses the real ElevenLabs plugin against a local `aiohttp` WebSocket server and verifies that:

- job shutdown produces close code `1000`
- repeated connection acquisition registers only one callback
- the supplied/shared HTTP session remains open

Commands run:

- `uv run pytest --plugin elevenlabs tests/test_plugin_elevenlabs_tts.py -q`
- `make check`
