### PR TITLE
feat(xai): support session-managed STT keyterms

### DIFF
--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/stt.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/stt.py
@@ -81,15 +81,17 @@ def _merge_keyterms(user_keyterms: list[str], session_keyterms: list[str]) -> li
             _MAX_KEYTERM_LENGTH,
         )
 
-    remaining = _MAX_KEYTERMS - len(user_keyterms)
-    if len(valid_session_keyterms) > remaining:
+    # session keyterms arrive oldest-first, so the tail holds the freshest detections
+    overflow = len(valid_session_keyterms) - (_MAX_KEYTERMS - len(user_keyterms))
+    if overflow > 0:
         logger.warning(
-            "ignored %d xAI session keyterms beyond the %d-term limit",
-            len(valid_session_keyterms) - remaining,
+            "dropped the %d oldest xAI session keyterms beyond the %d-term limit",
+            overflow,
             _MAX_KEYTERMS,
         )
+        valid_session_keyterms = valid_session_keyterms[overflow:]
 
-    return [*user_keyterms, *valid_session_keyterms[:remaining]]
+    return [*user_keyterms, *valid_session_keyterms]
 
 
 @dataclass

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/stt.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/stt.py
@@ -627,6 +627,7 @@ class SpeechStream(stt.RecognizeStream):
             if self._speaking:
                 self._speaking = False
                 self._event_ch.send_nowait(stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH))
+                self._on_end_of_speech()
 
         elif msg_type == "error":
             logger.error("xAI STT error: %s", data.get("message", "unknown error"))

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/stt.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/stt.py
@@ -49,6 +49,47 @@ from .types import STTLanguages
 SAMPLE_RATE = 16000
 XAI_WEBSOCKET_URL = "wss://api.x.ai/v1/stt"
 XAI_REST_URL = "https://api.x.ai/v1/stt"
+_MAX_KEYTERMS = 100
+_MAX_KEYTERM_LENGTH = 50
+
+
+def _validate_user_keyterms(keyterms: list[str]) -> list[str]:
+    unique = list(dict.fromkeys(keyterms))
+    if len(unique) > _MAX_KEYTERMS:
+        raise ValueError(f"xAI supports at most {_MAX_KEYTERMS} keyterms")
+
+    if any(len(term) > _MAX_KEYTERM_LENGTH for term in unique):
+        raise ValueError(f"xAI keyterms must contain at most {_MAX_KEYTERM_LENGTH} characters each")
+    return unique
+
+
+def _merge_keyterms(user_keyterms: list[str], session_keyterms: list[str]) -> list[str]:
+    seen = set(user_keyterms)
+    valid_session_keyterms: list[str] = []
+    invalid_count = 0
+    for term in session_keyterms:
+        if len(term) > _MAX_KEYTERM_LENGTH:
+            invalid_count += 1
+        elif term not in seen:
+            seen.add(term)
+            valid_session_keyterms.append(term)
+
+    if invalid_count:
+        logger.warning(
+            "ignored %d xAI session keyterms longer than %d characters",
+            invalid_count,
+            _MAX_KEYTERM_LENGTH,
+        )
+
+    remaining = _MAX_KEYTERMS - len(user_keyterms)
+    if len(valid_session_keyterms) > remaining:
+        logger.warning(
+            "ignored %d xAI session keyterms beyond the %d-term limit",
+            len(valid_session_keyterms) - remaining,
+            _MAX_KEYTERMS,
+        )
+
+    return [*user_keyterms, *valid_session_keyterms[:remaining]]
 
 
 @dataclass
@@ -96,7 +137,8 @@ class STT(stt.STT):
             http_session: Optional aiohttp ClientSession to use for requests.
 
         Raises:
-            ValueError: If no API key is provided or found in environment variables.
+            ValueError: If no API key is available, more than 100 user keyterms are provided,
+                or any user keyterm exceeds 50 characters.
 
         Note:
             The api_key must be set either through the constructor argument or by setting
@@ -109,6 +151,7 @@ class STT(stt.STT):
                 interim_results=enable_interim_results,
                 diarization=enable_diarization,
                 aligned_transcript="word",
+                keyterms=True,
             )
         )
 
@@ -117,6 +160,7 @@ class STT(stt.STT):
             raise ValueError("xAI API key is required")
         self._api_key = xai_api_key
 
+        user_keyterms = _validate_user_keyterms(keyterm) if is_given(keyterm) else []
         self._opts = STTOptions(
             enable_interim_results=enable_interim_results,
             sample_rate=sample_rate,
@@ -126,8 +170,12 @@ class STT(stt.STT):
             vad_threshold=vad_threshold,
             smart_turn=smart_turn,
             smart_turn_timeout=smart_turn_timeout,
-            keyterm=keyterm,
+            keyterm=user_keyterms,
         )
+        # User keyterms remain separate from framework-managed session keyterms so either
+        # source can be updated without discarding the other.
+        self._user_keyterms = user_keyterms
+        self._session_keyterms: list[str] = []
         self._session = http_session
         self._streams = weakref.WeakSet[SpeechStream]()
 
@@ -244,6 +292,8 @@ class STT(stt.STT):
             self._opts.smart_turn_timeout = smart_turn_timeout
 
         if is_given(keyterm):
+            self._user_keyterms = _validate_user_keyterms(keyterm)
+            keyterm = _merge_keyterms(self._user_keyterms, self._session_keyterms)
             self._opts.keyterm = keyterm
 
         for stream in self._streams:
@@ -258,6 +308,23 @@ class STT(stt.STT):
                 smart_turn_timeout=smart_turn_timeout,
                 keyterm=keyterm,
             )
+
+    def _update_session_keyterms(self, keyterms: list[str]) -> None:
+        if keyterms == self._session_keyterms:
+            return
+
+        self._session_keyterms = list(keyterms)
+        merged = _merge_keyterms(self._user_keyterms, self._session_keyterms)
+        if merged == self._opts.keyterm:
+            return
+
+        self._opts.keyterm = merged
+        for stream in self._streams:
+            if stream._speaking:
+                # Reconnecting mid-utterance would discard audio/transcript state.
+                stream._pending_keyterm = merged
+            else:
+                stream.update_options(keyterm=merged)
 
 
 class SpeechStream(stt.RecognizeStream):
@@ -284,6 +351,8 @@ class SpeechStream(stt.RecognizeStream):
         self._request_id = str(uuid.uuid4())
         self._reconnect_event = asyncio.Event()
         self._server_ready = asyncio.Event()
+        # Session keyterms received during speech are applied when the utterance ends.
+        self._pending_keyterm: list[str] | None = None
 
     def update_options(
         self,
@@ -323,9 +392,15 @@ class SpeechStream(stt.RecognizeStream):
             self._opts.smart_turn_timeout = smart_turn_timeout
 
         if is_given(keyterm):
-            self._opts.keyterm = keyterm
+            self._opts.keyterm = list(keyterm)
+            self._pending_keyterm = None
 
         self._reconnect_event.set()
+
+    def _on_end_of_speech(self) -> None:
+        if self._pending_keyterm is not None:
+            self.update_options(keyterm=self._pending_keyterm)
+            self._pending_keyterm = None
 
     async def _run(self) -> None:
         closing_ws = False
@@ -517,6 +592,7 @@ class SpeechStream(stt.RecognizeStream):
                     self._event_ch.send_nowait(
                         stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH)
                     )
+                    self._on_end_of_speech()
             else:
                 if self._opts.enable_interim_results:
                     self._event_ch.send_nowait(

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/stt.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/stt.py
@@ -269,6 +269,13 @@ class STT(stt.STT):
         smart_turn_timeout: NotGivenOr[int] = NOT_GIVEN,
         keyterm: NotGivenOr[list[str]] = NOT_GIVEN,
     ) -> None:
+        # keyterms are validated before anything is mutated so a rejected list
+        # cannot leave the options partially updated
+        if is_given(keyterm):
+            self._user_keyterms = _validate_user_keyterms(keyterm)
+            keyterm = _merge_keyterms(self._user_keyterms, self._session_keyterms)
+            self._opts.keyterm = keyterm
+
         if is_given(interim_results):
             self._opts.enable_interim_results = interim_results
 
@@ -292,11 +299,6 @@ class STT(stt.STT):
 
         if is_given(smart_turn_timeout):
             self._opts.smart_turn_timeout = smart_turn_timeout
-
-        if is_given(keyterm):
-            self._user_keyterms = _validate_user_keyterms(keyterm)
-            keyterm = _merge_keyterms(self._user_keyterms, self._session_keyterms)
-            self._opts.keyterm = keyterm
 
         for stream in self._streams:
             stream.update_options(

--- a/tests/test_plugin_xai_stt.py
+++ b/tests/test_plugin_xai_stt.py
@@ -124,6 +124,8 @@ def test_session_keyterms_respect_provider_limits(caplog: pytest.LogCaptureFixtu
 
     assert len(instance._opts.keyterm) == 100
     assert instance._opts.keyterm[0] == "user"
-    assert instance._opts.keyterm[-1] == "session-98"
+    # the two oldest session terms are evicted, the newest survive
+    assert instance._opts.keyterm[1] == "session-2"
+    assert instance._opts.keyterm[-1] == "session-100"
     assert "longer than 50 characters" in caplog.text
     assert "beyond the 100-term limit" in caplog.text

--- a/tests/test_plugin_xai_stt.py
+++ b/tests/test_plugin_xai_stt.py
@@ -10,16 +10,29 @@ from livekit.agents.utils import is_given
 pytestmark = pytest.mark.plugin("xai")
 
 
+class _FakeEventCh:
+    def send_nowait(self, event: Any) -> None:
+        pass
+
+
 class _FakeStream:
     def __init__(self, *, speaking: bool = False) -> None:
         self._speaking = speaking
         self._pending_keyterm: list[str] | None = None
         self.updated_keyterms: list[list[str]] = []
+        self._event_ch = _FakeEventCh()
+        self._emitted_chunk_final = False
+        self._request_id = "test-request"
 
     def update_options(self, *, keyterm: Any = NOT_GIVEN, **_: Any) -> None:
         if is_given(keyterm):
             self.updated_keyterms.append(list(keyterm))
         self._pending_keyterm = None
+
+    def _on_end_of_speech(self) -> None:
+        from livekit.plugins.xai.stt import SpeechStream
+
+        SpeechStream._on_end_of_speech(cast(Any, self))
 
 
 def _add_fake_stream(instance: Any, *, speaking: bool = False) -> _FakeStream:
@@ -55,21 +68,40 @@ def test_merges_user_and_session_keyterms() -> None:
     assert stream.updated_keyterms[-1] == ["Agents"]
 
 
-def test_defers_session_keyterm_reconnect_while_speaking() -> None:
+# every message that ends an utterance must flush the deferred keyterms
+@pytest.mark.parametrize(
+    "end_of_speech_event",
+    [
+        {
+            "type": "transcript.partial",
+            "text": "hello",
+            "is_final": True,
+            "speech_final": True,
+            "words": [],
+            "language": "en",
+        },
+        {"type": "transcript.done", "text": "", "words": [], "language": "en"},
+    ],
+)
+def test_defers_session_keyterm_reconnect_while_speaking(
+    end_of_speech_event: dict[str, Any],
+) -> None:
     from livekit.plugins.xai import STT
     from livekit.plugins.xai.stt import SpeechStream
 
     instance = STT(api_key="test-key", keyterm=["LiveKit"])
     stream = _add_fake_stream(instance, speaking=True)
+    stream._opts = instance._opts  # type: ignore[attr-defined]
 
     instance._update_session_keyterms(["Krisp"])
 
     assert stream.updated_keyterms == []
     assert stream._pending_keyterm == ["LiveKit", "Krisp"]
 
-    SpeechStream._on_end_of_speech(cast(Any, stream))
+    SpeechStream._process_stream_event(cast(Any, stream), end_of_speech_event)
     assert stream.updated_keyterms == [["LiveKit", "Krisp"]]
     assert stream._pending_keyterm is None
+    assert stream._speaking is False
 
 
 def test_validates_user_keyterm_limits() -> None:

--- a/tests/test_plugin_xai_stt.py
+++ b/tests/test_plugin_xai_stt.py
@@ -114,6 +114,19 @@ def test_validates_user_keyterm_limits() -> None:
         STT(api_key="test-key", keyterm=["x" * 51])
 
 
+def test_rejected_keyterms_leave_other_options_untouched() -> None:
+    from livekit.plugins.xai import STT
+
+    instance = STT(api_key="test-key", language="en")
+    stream = _add_fake_stream(instance)
+
+    with pytest.raises(ValueError, match="at most 50 characters"):
+        instance.update_options(language="fr", keyterm=["x" * 51])
+
+    assert instance._opts.language == "en"
+    assert stream.updated_keyterms == []
+
+
 def test_session_keyterms_respect_provider_limits(caplog: pytest.LogCaptureFixture) -> None:
     from livekit.plugins.xai import STT
 

--- a/tests/test_plugin_xai_stt.py
+++ b/tests/test_plugin_xai_stt.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from livekit.agents.types import NOT_GIVEN
+from livekit.agents.utils import is_given
+
+pytestmark = pytest.mark.plugin("xai")
+
+
+class _FakeStream:
+    def __init__(self, *, speaking: bool = False) -> None:
+        self._speaking = speaking
+        self._pending_keyterm: list[str] | None = None
+        self.updated_keyterms: list[list[str]] = []
+
+    def update_options(self, *, keyterm: Any = NOT_GIVEN, **_: Any) -> None:
+        if is_given(keyterm):
+            self.updated_keyterms.append(list(keyterm))
+        self._pending_keyterm = None
+
+
+def _add_fake_stream(instance: Any, *, speaking: bool = False) -> _FakeStream:
+    stream = _FakeStream(speaking=speaking)
+    instance._streams.add(cast(Any, stream))
+    return stream
+
+
+def test_reports_keyterm_capability() -> None:
+    from livekit.plugins.xai import STT
+
+    instance = STT(api_key="test-key")
+    assert instance.capabilities.keyterms is True
+
+
+def test_merges_user_and_session_keyterms() -> None:
+    from livekit.plugins.xai import STT
+
+    instance = STT(api_key="test-key", keyterm=["LiveKit", "shared"])
+    stream = _add_fake_stream(instance)
+
+    instance._update_session_keyterms(["shared", "Krisp"])
+
+    assert instance._opts.keyterm == ["LiveKit", "shared", "Krisp"]
+    assert stream.updated_keyterms == [["LiveKit", "shared", "Krisp"]]
+
+    instance.update_options(keyterm=["Agents"])
+    assert instance._opts.keyterm == ["Agents", "shared", "Krisp"]
+    assert stream.updated_keyterms[-1] == ["Agents", "shared", "Krisp"]
+
+    instance._update_session_keyterms([])
+    assert instance._opts.keyterm == ["Agents"]
+    assert stream.updated_keyterms[-1] == ["Agents"]
+
+
+def test_defers_session_keyterm_reconnect_while_speaking() -> None:
+    from livekit.plugins.xai import STT
+    from livekit.plugins.xai.stt import SpeechStream
+
+    instance = STT(api_key="test-key", keyterm=["LiveKit"])
+    stream = _add_fake_stream(instance, speaking=True)
+
+    instance._update_session_keyterms(["Krisp"])
+
+    assert stream.updated_keyterms == []
+    assert stream._pending_keyterm == ["LiveKit", "Krisp"]
+
+    SpeechStream._on_end_of_speech(cast(Any, stream))
+    assert stream.updated_keyterms == [["LiveKit", "Krisp"]]
+    assert stream._pending_keyterm is None
+
+
+def test_validates_user_keyterm_limits() -> None:
+    from livekit.plugins.xai import STT
+
+    with pytest.raises(ValueError, match="at most 100 keyterms"):
+        STT(api_key="test-key", keyterm=[f"term-{i}" for i in range(101)])
+
+    with pytest.raises(ValueError, match="at most 50 characters"):
+        STT(api_key="test-key", keyterm=["x" * 51])
+
+
+def test_session_keyterms_respect_provider_limits(caplog: pytest.LogCaptureFixture) -> None:
+    from livekit.plugins.xai import STT
+
+    instance = STT(api_key="test-key", keyterm=["user"])
+    session_keyterms = ["x" * 51, *[f"session-{i}" for i in range(101)]]
+
+    instance._update_session_keyterms(session_keyterms)
+
+    assert len(instance._opts.keyterm) == 100
+    assert instance._opts.keyterm[0] == "user"
+    assert instance._opts.keyterm[-1] == "session-98"
+    assert "longer than 50 characters" in caplog.text
+    assert "beyond the 100-term limit" in caplog.text


### PR DESCRIPTION
## Summary

- advertise xAI STT keyterm support to the AgentSession context pipeline
- merge explicit user keyterms with framework-managed terms without losing either source
- enforce xAI limits of 100 terms and 50 characters, prioritizing explicit user terms
- defer session-keyterm reconnects until the active utterance ends

Follow-up to #6587, which exposed the raw xAI `keyterm` WebSocket option.

## Validation

- `pytest --plugin xai` (6 passed)
- `ruff format --check` and `ruff check` on changed files
- repository-wide strict mypy check (625 source files)