### PR TITLE
feat: expose cache_creation_tokens in LLM metrics

### DIFF
--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -362,6 +362,7 @@ class LLMStream(ABC):
             completion_tokens=usage.completion_tokens if usage else 0,
             prompt_tokens=usage.prompt_tokens if usage else 0,
             prompt_cached_tokens=usage.prompt_cached_tokens if usage else 0,
+            cache_creation_tokens=usage.cache_creation_tokens if usage else 0,
             total_tokens=usage.total_tokens if usage else 0,
             tokens_per_second=usage.completion_tokens / duration if usage else 0.0,
             metadata=Metadata(

--- a/livekit-agents/livekit/agents/metrics/base.py
+++ b/livekit-agents/livekit/agents/metrics/base.py
@@ -28,6 +28,11 @@ class LLMMetrics(_BaseMetrics):
     completion_tokens: int
     prompt_tokens: int
     prompt_cached_tokens: int
+    cache_creation_tokens: int = 0
+    """The number of tokens used to write to the prompt cache (e.g. Anthropic cache writes).
+
+    Not all providers report this. ``prompt_cached_tokens`` covers cache reads.
+    """
     total_tokens: int
     tokens_per_second: float
     speech_id: str | None = None

--- a/livekit-agents/livekit/agents/metrics/usage.py
+++ b/livekit-agents/livekit/agents/metrics/usage.py
@@ -37,6 +37,8 @@ class LLMModelUsage(_BaseModelUsage):
     """Total input tokens."""
     input_cached_tokens: int = 0
     """Input tokens served from cache."""
+    input_cache_creation_tokens: int = 0
+    """Input tokens used to write to the prompt cache (e.g. Anthropic cache writes)."""
     input_audio_tokens: int = 0
     """Input audio tokens (for multimodal models)."""
     input_cached_audio_tokens: int = 0
@@ -201,6 +203,7 @@ class ModelUsageCollector:
             usage = self._get_llm_usage(provider, model)
             usage.input_tokens += metrics.prompt_tokens
             usage.input_cached_tokens += metrics.prompt_cached_tokens
+            usage.input_cache_creation_tokens += metrics.cache_creation_tokens
             usage.output_tokens += metrics.completion_tokens
 
         elif isinstance(metrics, RealtimeModelMetrics):

--- a/livekit-agents/livekit/agents/metrics/utils.py
+++ b/livekit-agents/livekit/agents/metrics/utils.py
@@ -34,6 +34,7 @@ def log_metrics(metrics: AgentMetrics, *, logger: logging.Logger | None = None) 
                 "ttft": round(metrics.ttft, 2),
                 "prompt_tokens": metrics.prompt_tokens,
                 "prompt_cached_tokens": metrics.prompt_cached_tokens,
+                "cache_creation_tokens": metrics.cache_creation_tokens,
                 "completion_tokens": metrics.completion_tokens,
                 "tokens_per_second": round(metrics.tokens_per_second, 2),
             },

--- a/tests/test_metrics_usage.py
+++ b/tests/test_metrics_usage.py
@@ -11,22 +11,22 @@ pytestmark = pytest.mark.unit
 
 
 def _llm_metrics(**overrides: object) -> LLMMetrics:
-    base: dict[str, object] = dict(
-        label="test.LLM",
-        request_id="req-1",
-        timestamp=0.0,
-        duration=1.0,
-        ttft=0.1,
-        cancelled=False,
-        completion_tokens=10,
-        prompt_tokens=100,
-        prompt_cached_tokens=20,
-        total_tokens=110,
-        tokens_per_second=10.0,
-        metadata=Metadata(model_provider="anthropic", model_name="claude-sonnet-4"),
-    )
+    base: dict[str, object] = {
+        "label": "test.LLM",
+        "request_id": "req-1",
+        "timestamp": 0.0,
+        "duration": 1.0,
+        "ttft": 0.1,
+        "cancelled": False,
+        "completion_tokens": 10,
+        "prompt_tokens": 100,
+        "prompt_cached_tokens": 20,
+        "total_tokens": 110,
+        "tokens_per_second": 10.0,
+        "metadata": Metadata(model_provider="anthropic", model_name="claude-sonnet-4"),
+    }
     base.update(overrides)
-    return LLMMetrics(**base)  # type: ignore[arg-type]
+    return LLMMetrics(**base)
 
 
 def test_llm_metrics_defaults_cache_creation_to_zero() -> None:

--- a/tests/test_metrics_usage.py
+++ b/tests/test_metrics_usage.py
@@ -1,0 +1,51 @@
+"""Unit tests for LLM usage aggregation, incl. prompt-cache creation tokens."""
+
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents.metrics import LLMMetrics, LLMModelUsage, ModelUsageCollector
+from livekit.agents.metrics.base import Metadata
+
+pytestmark = pytest.mark.unit
+
+
+def _llm_metrics(**overrides: object) -> LLMMetrics:
+    base: dict[str, object] = dict(
+        label="test.LLM",
+        request_id="req-1",
+        timestamp=0.0,
+        duration=1.0,
+        ttft=0.1,
+        cancelled=False,
+        completion_tokens=10,
+        prompt_tokens=100,
+        prompt_cached_tokens=20,
+        total_tokens=110,
+        tokens_per_second=10.0,
+        metadata=Metadata(model_provider="anthropic", model_name="claude-sonnet-4"),
+    )
+    base.update(overrides)
+    return LLMMetrics(**base)  # type: ignore[arg-type]
+
+
+def test_llm_metrics_defaults_cache_creation_to_zero() -> None:
+    m = _llm_metrics()
+    assert m.cache_creation_tokens == 0
+
+
+def test_llm_metrics_carries_cache_creation_tokens() -> None:
+    m = _llm_metrics(cache_creation_tokens=42)
+    assert m.cache_creation_tokens == 42
+
+
+def test_collector_aggregates_cache_creation_tokens() -> None:
+    collector = ModelUsageCollector()
+    collector.collect(_llm_metrics(cache_creation_tokens=42))
+    collector.collect(_llm_metrics(cache_creation_tokens=8))
+
+    usage = collector.flatten()
+    assert len(usage) == 1
+    llm_usage = usage[0]
+    assert isinstance(llm_usage, LLMModelUsage)
+    assert llm_usage.input_cache_creation_tokens == 50


### PR DESCRIPTION
## What

Surfaces prompt-cache **creation** (write) token counts through the metrics pipeline so downstream consumers can report on cache-creation usage.

- Adds `cache_creation_tokens` to `LLMMetrics` and wires it from the existing `CompletionUsage.cache_creation_tokens` at the metrics construction site.
- Adds `input_cache_creation_tokens` to the aggregate `LLMModelUsage` and accumulates it in `ModelUsageCollector.collect()`.
- Includes `cache_creation_tokens` in the `log_metrics` LLM log line.

## Why

Providers already populate `CompletionUsage.cache_creation_tokens` (Anthropic from `cache_creation_input_tokens`; AWS Bedrock as of #6663), but the value was **silently dropped** when `LLMMetrics` was constructed — `LLMMetrics` had no such field. So cache **reads** were observable (`prompt_cached_tokens`) while cache **writes** were not, on either the per-request `metrics_collected` signal or the aggregate `session_usage_updated` / `session.usage` signal. This surfaces already-collected-but-discarded data.

## Backward compatibility

All new fields default to `0`. No existing construction site or consumer changes behavior. The deprecated `UsageSummary` / `UsageCollector` is intentionally left untouched.

## Testing

- `tests/test_metrics_usage.py` (unit): defaults-to-zero, value pass-through on `LLMMetrics`, and additive aggregation into `LLMModelUsage` via `ModelUsageCollector`.
- `make check` passes (ruff format + lint + mypy strict).

## Notes

- Rebased on latest `main`. Provider-side emission of `cache_creation_tokens` on `CompletionUsage` is already handled upstream (Anthropic, and AWS Bedrock via #6663); this PR is the remaining piece that carries the value into `LLMMetrics` / `LLMModelUsage`.

## Known limitations (follow-ups, intentionally out of scope)

- `telemetry/otel_metrics.py` emits an OTel counter for `prompt_cached_tokens` but not yet for `cache_creation_tokens`.
- For remote/cloud sessions, `voice/remote_session.py` (`_session_usage_to_proto`) cannot forward `input_cache_creation_tokens` until the external `agent_pb` protobuf gains a corresponding field.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
