### PR TITLE
feat(cli): deprecate console and dev modes in favor of `lk agent`

### DIFF
--- a/livekit-agents/livekit/agents/cli/_legacy.py
+++ b/livekit-agents/livekit/agents/cli/_legacy.py
@@ -1527,7 +1527,8 @@ def _run_console(
 
     c.print(
         "console mode is deprecated and will be removed in a future release. "
-        "Use [bold]lk agent console[/bold] instead.",
+        "Use [bold]lk agent console[/bold] instead: "
+        "https://docs.livekit.io/reference/developer-tools/livekit-cli/#setup",
         tag="Deprecated",
         tag_style=Style.parse("black on yellow"),
     )
@@ -1661,7 +1662,8 @@ def _build_cli(server: AgentServer) -> typer.Typer:
         """
         Run a [bold]LiveKit Agents[/bold] in [yellow]console[/yellow] mode.
 
-        [red]Deprecated[/red]: use [bold]lk agent console[/bold] instead.
+        [red]Deprecated[/red]: use [bold]lk agent console[/bold] instead
+        (https://docs.livekit.io/reference/developer-tools/livekit-cli/#setup).
         """
         if list_devices:
             _print_audio_devices()

--- a/livekit-agents/livekit/agents/cli/_legacy.py
+++ b/livekit-agents/livekit/agents/cli/_legacy.py
@@ -1525,6 +1525,13 @@ def _run_console(
     _configure_logger(c, log_level)
     c.print("Starting console mode 🚀", tag="Agents")
 
+    c.print(
+        "console mode is deprecated and will be removed in a future release. "
+        "Use [bold]lk agent console[/bold] instead.",
+        tag="Deprecated",
+        tag_style=Style.parse("black on yellow"),
+    )
+
     if c.record:
         c.print(
             f"Session recording will be saved to {c.session_directory}",
@@ -1653,6 +1660,8 @@ def _build_cli(server: AgentServer) -> typer.Typer:
     ) -> None:
         """
         Run a [bold]LiveKit Agents[/bold] in [yellow]console[/yellow] mode.
+
+        [red]Deprecated[/red]: use [bold]lk agent console[/bold] instead.
         """
         if list_devices:
             _print_audio_devices()

--- a/livekit-agents/livekit/agents/cli/_legacy.py
+++ b/livekit-agents/livekit/agents/cli/_legacy.py
@@ -1778,6 +1778,18 @@ def _build_cli(server: AgentServer) -> typer.Typer:
             ),
         ] = None,
     ) -> None:
+        """
+        Run a [bold]LiveKit Agents[/bold] in [yellow]development[/yellow] mode.
+
+        [red]Deprecated[/red]: use [bold]lk agent dev[/bold] instead
+        (https://docs.livekit.io/reference/developer-tools/livekit-cli/#setup).
+        """
+        logger.warning(
+            "dev mode is deprecated and will be removed in a future release; "
+            "use `lk agent dev` instead "
+            "(https://docs.livekit.io/reference/developer-tools/livekit-cli/#setup)"
+        )
+
         if reload:
             logger.warning(
                 "in-process auto-reload has been removed from the Python CLI; "


### PR DESCRIPTION
Console and dev modes are being removed from the Python framework. This adds the deprecation notices first, pointing users at `lk agent console` / `lk agent dev` and the [CLI setup docs](https://docs.livekit.io/reference/developer-tools/livekit-cli/#setup).

Surfaces, all in the legacy rich CLI:

- Console startup notice, using the existing tagged-print pattern (same mechanism as the `Recording` notice), so it shows in both audio and text mode:

```
    Agents   Starting console mode 🚀
 Deprecated  console mode is deprecated and will be removed in a future release.
             Use lk agent console instead: https://docs.livekit.io/reference/developer-tools/livekit-cli/#setup
```

- `dev` logs a deprecation warning at startup (alongside the existing auto-reload warning).
- `console --help` and `dev --help` both read `Deprecated: use lk agent <cmd> instead`.

`run_app` already emits a generic `DeprecationWarning` for the whole legacy Python CLI, so no second command-specific `warnings.warn` here — this fills the gap in per-command migration guidance.

The TCP console in `cli.py` is untouched; that is the path `lk agent console` drives, not the one being deprecated.