### PR TITLE
fix(voice): avoid dropping turns and resuming early while a speech is paused

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -4333,6 +4333,13 @@ class AgentActivity(RecognitionHooks):
         if not self._paused_speech:
             return
 
+        # the pause withheld end-of-agent-speech for a resume; this ends the agent turn instead.
+        # the audio stopped when it was paused, so there is no playout left to wait for
+        if self._audio_recognition:
+            self._audio_recognition._on_end_of_agent_speech(
+                ignore_user_transcript_until=time.time()
+            )
+
         if (
             interrupt
             and not self._paused_speech.handle.interrupted
@@ -4345,12 +4352,6 @@ class AgentActivity(RecognitionHooks):
             if self._paused_speech.handle._generations:
                 await self._paused_speech.handle._wait_for_generation()
         self._paused_speech = None
-
-        # the pause withheld end-of-agent-speech for a resume; this ends the agent turn instead
-        if self._audio_recognition:
-            self._audio_recognition._on_end_of_agent_speech(
-                ignore_user_transcript_until=time.time()
-            )
 
         if (
             self._session.options.interruption["resume_false_interruption"]

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2319,24 +2319,18 @@ class AgentActivity(RecognitionHooks):
             self._cancel_preemptive_generation()
             return False
 
-        # avoid interruption if backchannel is detected with realtime model
+        # avoid interruption if backchannel is detected with realtime model. only a confirmed
+        # verdict suppresses a turn: an unjudged overlap is committed, since interrupting the
+        # agent is recoverable where silently discarding what the user said is not
         if (
             self.stt is None
             and self._turn_detection != "manual"
             and isinstance(self.llm, llm.RealtimeModel)
             and not self._rt_turn_detection_enabled
             and self._interruption_detection_enabled
-            and (
-                # confirmed backchannel for this turn (survives the agent stopping)
-                info.backchannel_over_agent
-                # or agent still speaking with nothing flagged yet
-                or (
-                    not self._interruption_detected
-                    and self._current_speech is not None
-                    and not self._current_speech.interrupted
-                )
-            )
+            and info.backchannel_over_agent
         ):
+            logger.debug("skipping user input, realtime backchannel detected")
             self._cancel_preemptive_generation()
             # no transcript to gatekeep for realtime barge-in — drop the backchannel turn
             # and clear the buffered audio so it can't leak into the next committed turn

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -4333,9 +4333,9 @@ class AgentActivity(RecognitionHooks):
         if not self._paused_speech:
             return
 
-        # the pause withheld end-of-agent-speech for a resume; this ends the agent turn instead.
-        # the audio stopped when it was paused, so there is no playout left to wait for
-        if self._audio_recognition:
+        # the pause withheld end-of-agent-speech for a resume; interrupting ends the turn
+        # instead. the audio stopped when it was paused, so no playout is left to wait for
+        if interrupt and self._audio_recognition:
             self._audio_recognition._on_end_of_agent_speech(
                 ignore_user_transcript_until=time.time()
             )

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -4345,7 +4345,7 @@ class AgentActivity(RecognitionHooks):
                 await self._paused_speech.handle._wait_for_generation()
         self._paused_speech = None
 
-        # the pause withheld end-of-agent-speech for a possible resume; there is none now
+        # the pause withheld end-of-agent-speech for a resume; this ends the agent turn instead
         if self._audio_recognition:
             self._audio_recognition._on_end_of_agent_speech(
                 ignore_user_transcript_until=time.time()

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2344,9 +2344,9 @@ class AgentActivity(RecognitionHooks):
                 self._rt_session.clear_audio()
             return False
 
-        # the reply task now owns the paused speech and interrupts it, so the resume must not
-        # fire in the window before `_cancel_speech_pause` gets there
-        self._cancel_false_interruption_timer()
+        # the reply task interrupts the paused speech, so the resume must not beat it there
+        if not info.skip_reply:  # a skipped reply returns early and needs the resume armed
+            self._cancel_false_interruption_timer()
 
         old_task = self._user_turn_completed_atask
         self._user_turn_completed_atask = self._create_speech_task(

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -4306,9 +4306,8 @@ class AgentActivity(RecognitionHooks):
         def _on_timeout() -> None:
             self._false_interruption_timer = None
 
-            # an open turn decision owns the paused speech: it either commits and interrupts it,
-            # or drops it — only then is the interruption known to be false. the elapsed timeout
-            # counts as part of that wait, so the resume follows the decision immediately.
+            # an open turn decision owns the paused speech: it either commits and interrupts it
+            # or drops it, and only then is the interruption known to be false
             eot_task = (
                 self._audio_recognition._end_of_turn_task if self._audio_recognition else None
             )

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -185,6 +185,8 @@ class AgentActivity(RecognitionHooks):
         # for false interruption handling
         self._paused_speech: _PausedSpeechInfo | None = None
         self._false_interruption_timer: asyncio.TimerHandle | None = None
+        # the timeout elapsed while a turn decision was still open; the resume waits on it
+        self._false_interruption_pending: bool = False
         self._cancel_speech_pause_task: asyncio.Task[None] | None = None
 
         self._stt_eos_received: bool = False
@@ -621,11 +623,8 @@ class AgentActivity(RecognitionHooks):
 
             turn_detection = self._validate_turn_detection(turn_detection)
 
-            if (
-                self._turn_detection == "manual" or turn_detection == "manual"
-            ) and self._false_interruption_timer is not None:
-                self._false_interruption_timer.cancel()
-                self._false_interruption_timer = None
+            if self._turn_detection == "manual" or turn_detection == "manual":
+                self._cancel_false_interruption_timer()
 
             self._turn_detection = turn_detection
             self._default_interruption_by_audio_activity_enabled = self._turn_detection not in (
@@ -1702,9 +1701,7 @@ class AgentActivity(RecognitionHooks):
                 if self._paused_speech and self._paused_speech.handle is self._current_speech:
                     # clear paused speech after generation done
                     self._paused_speech = None
-                    if self._false_interruption_timer is not None:
-                        self._false_interruption_timer.cancel()
-                        self._false_interruption_timer = None
+                    self._cancel_false_interruption_timer()
                     if (audio_output := self._session.output.audio) and audio_output.can_pause:
                         audio_output.resume()
                 self._current_speech = None
@@ -2007,9 +2004,7 @@ class AgentActivity(RecognitionHooks):
             and self._current_speech.allow_interruptions
         ):
             # reset the false interruption timer
-            if self._false_interruption_timer:
-                self._false_interruption_timer.cancel()
-                self._false_interruption_timer = None
+            self._cancel_false_interruption_timer()
 
             # only interrupt if not already interrupting
             if (
@@ -2059,10 +2054,8 @@ class AgentActivity(RecognitionHooks):
         self._stt_eos_received = False
         self._interruption_detected = False
 
-        if self._false_interruption_timer:
-            # cancel the timer when user starts speaking but leave the paused state unchanged
-            self._false_interruption_timer.cancel()
-            self._false_interruption_timer = None
+        # cancel the timer when user starts speaking but leave the paused state unchanged
+        self._cancel_false_interruption_timer()
 
         if (
             self._session.agent_state != "speaking"
@@ -2350,6 +2343,10 @@ class AgentActivity(RecognitionHooks):
             if self._rt_session is not None:
                 self._rt_session.clear_audio()
             return False
+
+        # the reply task now owns the paused speech and interrupts it, so the resume must not
+        # fire in the window before `_cancel_speech_pause` gets there
+        self._cancel_false_interruption_timer()
 
         old_task = self._user_turn_completed_atask
         self._user_turn_completed_atask = self._create_speech_task(
@@ -4246,9 +4243,14 @@ class AgentActivity(RecognitionHooks):
             and self._session.output.audio.can_pause
         )
 
-    def _start_false_interruption_timer(self, timeout: float) -> None:
+    def _cancel_false_interruption_timer(self) -> None:
         if self._false_interruption_timer is not None:
             self._false_interruption_timer.cancel()
+            self._false_interruption_timer = None
+        self._false_interruption_pending = False
+
+    def _start_false_interruption_timer(self, timeout: float) -> None:
+        self._cancel_false_interruption_timer()
 
         def _on_false_interruption() -> None:
             if self._paused_speech is None or (
@@ -4286,9 +4288,38 @@ class AgentActivity(RecognitionHooks):
             self._paused_speech = None
             self._false_interruption_timer = None
 
-        self._false_interruption_timer = self._session._loop.call_later(
-            timeout, _on_false_interruption
-        )
+        def _on_turn_settled(settled: asyncio.Task[None]) -> None:
+            if not self._false_interruption_pending:
+                return  # the turn committed, or the pause was resolved another way
+
+            # a newer decision superseded this one (e.g. an stt final re-armed the bounce)
+            eot_task = (
+                self._audio_recognition._end_of_turn_task if self._audio_recognition else None
+            )
+            if eot_task is not None and eot_task is not settled and not eot_task.done():
+                eot_task.add_done_callback(_on_turn_settled)
+                return
+
+            self._false_interruption_pending = False
+            _on_false_interruption()
+
+        def _on_timeout() -> None:
+            self._false_interruption_timer = None
+
+            # an open turn decision owns the paused speech: it either commits and interrupts it,
+            # or drops it — only then is the interruption known to be false. the elapsed timeout
+            # counts as part of that wait, so the resume follows the decision immediately.
+            eot_task = (
+                self._audio_recognition._end_of_turn_task if self._audio_recognition else None
+            )
+            if eot_task is not None and not eot_task.done():
+                self._false_interruption_pending = True
+                eot_task.add_done_callback(_on_turn_settled)
+                return
+
+            _on_false_interruption()
+
+        self._false_interruption_timer = self._session._loop.call_later(timeout, _on_timeout)
 
     async def _cancel_speech_pause(
         self, old_task: asyncio.Task[None] | None = None, *, interrupt: bool = True
@@ -4302,9 +4333,7 @@ class AgentActivity(RecognitionHooks):
                 # the paused speech had no active generation (race condition).
                 logger.debug("previous _cancel_speech_pause task failed, ignoring")
 
-        if self._false_interruption_timer is not None:
-            self._false_interruption_timer.cancel()
-            self._false_interruption_timer = None
+        self._cancel_false_interruption_timer()
 
         if not self._paused_speech:
             return

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -4292,15 +4292,17 @@ class AgentActivity(RecognitionHooks):
             if not self._false_interruption_pending:
                 return  # the turn committed, or the pause was resolved another way
 
+            recognition = self._audio_recognition
+            eot_task = recognition._end_of_turn_task if recognition else None
             # a newer decision superseded this one (e.g. an stt final re-armed the bounce)
-            eot_task = (
-                self._audio_recognition._end_of_turn_task if self._audio_recognition else None
-            )
             if eot_task is not None and eot_task is not settled and not eot_task.done():
                 eot_task.add_done_callback(_on_turn_settled)
                 return
 
             self._false_interruption_pending = False
+            if settled.cancelled() or (recognition is not None and recognition._closing.is_set()):
+                return  # torn down instead of decided; closing releases the pause itself
+
             _on_false_interruption()
 
         def _on_timeout() -> None:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2337,8 +2337,9 @@ class AgentActivity(RecognitionHooks):
                 self._rt_session.clear_audio()
             return False
 
-        # the reply task interrupts the paused speech, so the resume must not beat it there
-        if not info.skip_reply:  # a skipped reply returns early and needs the resume armed
+        # a replying turn interrupts the paused speech, so cancel the resume that would race it —
+        # but the reply task returns before that in these two cases, so leave the resume armed
+        if not info.skip_reply and not self._rt_turn_detection_enabled:
             self._cancel_false_interruption_timer()
 
         old_task = self._user_turn_completed_atask

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2030,7 +2030,8 @@ class AgentActivity(RecognitionHooks):
                 self._session._update_agent_state("listening")
                 if self._audio_recognition:
                     self._audio_recognition._on_end_of_agent_speech(
-                        ignore_user_transcript_until=ignore_user_transcript_until or time.time()
+                        ignore_user_transcript_until=ignore_user_transcript_until or time.time(),
+                        paused=True,
                     )
                 if self.interruption_enabled:
                     self._restore_interruption_by_audio_activity()
@@ -2147,7 +2148,8 @@ class AgentActivity(RecognitionHooks):
         # flush held transcripts again if possible
         if self._audio_recognition:
             self._audio_recognition._on_end_of_agent_speech(
-                ignore_user_transcript_until=ev.overlap_started_at or ev.detected_at
+                ignore_user_transcript_until=ev.overlap_started_at or ev.detected_at,
+                paused=self._paused_speech is not None,
             )
 
     def on_interim_transcript(self, ev: stt.SpeechEvent, *, speaking: bool | None) -> None:
@@ -4268,7 +4270,9 @@ class AgentActivity(RecognitionHooks):
                     otel_context=self._paused_speech.handle._agent_turn_context,
                 )
                 if self._audio_recognition and self._paused_speech.agent_state == "speaking":
-                    self._audio_recognition._on_start_of_agent_speech(started_at=time.time())
+                    self._audio_recognition._on_start_of_agent_speech(
+                        started_at=time.time(), resumed=True
+                    )
                 if self.interruption_enabled:
                     self._disable_vad_interruption_soon()
                 audio_output.resume()

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2319,9 +2319,8 @@ class AgentActivity(RecognitionHooks):
             self._cancel_preemptive_generation()
             return False
 
-        # avoid interruption if backchannel is detected with realtime model. only a confirmed
-        # verdict suppresses a turn: an unjudged overlap is committed, since interrupting the
-        # agent is recoverable where silently discarding what the user said is not
+        # avoid interruption if backchannel is detected with realtime model. an unjudged overlap
+        # commits: interrupting the agent is recoverable, discarding a real user turn is not
         if (
             self.stt is None
             and self._turn_detection != "manual"
@@ -4345,6 +4344,12 @@ class AgentActivity(RecognitionHooks):
             if self._paused_speech.handle._generations:
                 await self._paused_speech.handle._wait_for_generation()
         self._paused_speech = None
+
+        # the pause withheld end-of-agent-speech for a possible resume; there is none now
+        if self._audio_recognition:
+            self._audio_recognition._on_end_of_agent_speech(
+                ignore_user_transcript_until=time.time()
+            )
 
         if (
             self._session.options.interruption["resume_false_interruption"]

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -300,6 +300,8 @@ class AudioRecognition:
         # turn-scoped backchannel-over-agent verdict from adaptive interruption, consumed and reset at end of turn
         self._overlap_in_current_turn: bool = False
         self._turn_backchannel_over_agent: bool = False
+        # an overlap is open right now, awaiting a verdict; several can occur within one turn
+        self._overlap_open: bool = False
 
         _backchannel_boundary: float | tuple[float, float] | None = (
             session.options.interruption.get("backchannel_boundary")
@@ -517,6 +519,9 @@ class AudioRecognition:
             task.add_done_callback(lambda _: self._tasks.discard(task))
             self._tasks.add(task)
 
+        if not paused:
+            # the sentinel sent above resets the detector stream, dropping any open overlap
+            self._overlap_open = False
         self._agent_speaking = False
 
     def _on_start_of_speech(
@@ -537,6 +542,7 @@ class AudioRecognition:
             return
         # overlap over agent speech started this turn; gates verdict acceptance below
         self._overlap_in_current_turn = True
+        self._overlap_open = True
         self._interruption_ch.send_nowait(  # type: ignore[union-attr]
             _OverlapSpeechStartedSentinel(
                 speech_duration=speech_duration,
@@ -572,11 +578,11 @@ class AudioRecognition:
         speaking (the user may still be talking), in which case the synthesized verdict
         is inconclusive and must not be treated as a confirmed backchannel.
         """
-        # an open overlap outlives a paused agent speech, so it can still be closed here
-        if not self._adaptive_interruption_active or not (
-            self._agent_speaking or self._overlap_in_current_turn
-        ):
+        # the overlap ends once, on the first of: a verdict, the user stopping, the agent
+        # stopping, or a teardown — so a call can arrive with it already closed
+        if not self._adaptive_interruption_active or not self._overlap_open:
             return
+        self._overlap_open = False
 
         # Only set is_interruption=false if not already set (avoid overwriting true from interruption detection)
         if user_speaking_span and user_speaking_span.is_recording():
@@ -925,6 +931,7 @@ class AudioRecognition:
         self, interruption_detection: inference.AdaptiveInterruptionDetector | None
     ) -> None:
         self._interruption_detection = interruption_detection
+        self._overlap_open = False  # the stream it belonged to is gone either way
         if interruption_detection is not None:
             self._interruption_ch = aio.Chan[inference.InterruptionDataFrameType]()
             self._interruption_atask = asyncio.create_task(
@@ -1404,6 +1411,9 @@ class AudioRecognition:
                 self._session.amd._on_user_speech_ended(ev.silence_duration)
 
     async def _on_overlap_speech_event(self, ev: inference.OverlappingSpeechEvent) -> None:
+        # every verdict is terminal for its overlap, including one the cooldown then ignores
+        self._overlap_open = False
+
         if self._backchannel_boundary_active and not ev.is_interruption:
             logger.trace(
                 "ignoring backchannel event during backchannel boundary cooldown, falling back to vad"

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -469,8 +469,7 @@ class AudioRecognition:
                 start_cooldown, self._on_backchannel_boundary_done
             )
 
-        # a resume re-enters the agent turn the overlap is being judged against; restarting
-        # the detector would discard that overlap along with the verdict it owes us
+        # a resume re-enters the same agent turn; restarting would discard the open overlap
         if self._adaptive_interruption_active and not resumed:
             self._interruption_ch.send_nowait(_AgentSpeechStartedSentinel())  # type: ignore[union-attr]
 
@@ -486,8 +485,7 @@ class AudioRecognition:
             self._agent_speaking = False
             return
 
-        # pausing is provisional — the overlap verdict is what decides whether it becomes an
-        # interruption, so keep the inference running until the user's speech actually ends
+        # a pause is provisional: keep the inference running until the overlap has a verdict
         if not paused:
             self._interruption_ch.send_nowait(_AgentSpeechEndedSentinel())  # type: ignore[union-attr]
 
@@ -574,8 +572,7 @@ class AudioRecognition:
         speaking (the user may still be talking), in which case the synthesized verdict
         is inconclusive and must not be treated as a confirmed backchannel.
         """
-        # an overlap opened this turn outlives a paused agent speech, so it can still be
-        # closed (and its verdict emitted) after the audio output went silent
+        # an open overlap outlives a paused agent speech, so it can still be closed here
         if not self._adaptive_interruption_active or not (
             self._agent_speaking or self._overlap_in_current_turn
         ):

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -455,7 +455,7 @@ class AudioRecognition:
 
     # endregion
 
-    def _on_start_of_agent_speech(self, started_at: float) -> None:
+    def _on_start_of_agent_speech(self, started_at: float, *, resumed: bool = False) -> None:
         self._agent_speaking = True
         self._agent_speech_started_at = started_at
         self._endpointing.on_start_of_agent_speech(started_at=started_at)
@@ -469,10 +469,14 @@ class AudioRecognition:
                 start_cooldown, self._on_backchannel_boundary_done
             )
 
-        if self._adaptive_interruption_active:
+        # a resume re-enters the agent turn the overlap is being judged against; restarting
+        # the detector would discard that overlap along with the verdict it owes us
+        if self._adaptive_interruption_active and not resumed:
             self._interruption_ch.send_nowait(_AgentSpeechStartedSentinel())  # type: ignore[union-attr]
 
-    def _on_end_of_agent_speech(self, *, ignore_user_transcript_until: float) -> None:
+    def _on_end_of_agent_speech(
+        self, *, ignore_user_transcript_until: float, paused: bool = False
+    ) -> None:
         self._cancel_backchannel_boundary()
 
         if self._agent_speaking:
@@ -482,11 +486,14 @@ class AudioRecognition:
             self._agent_speaking = False
             return
 
-        self._interruption_ch.send_nowait(_AgentSpeechEndedSentinel())  # type: ignore[union-attr]
+        # pausing is provisional — the overlap verdict is what decides whether it becomes an
+        # interruption, so keep the inference running until the user's speech actually ends
+        if not paused:
+            self._interruption_ch.send_nowait(_AgentSpeechEndedSentinel())  # type: ignore[union-attr]
 
         if self._agent_speaking:
             # no interruption is detected, end the inference (idempotent)
-            if not is_given(self._ignore_user_transcript_until):
+            if not paused and not is_given(self._ignore_user_transcript_until):
                 self._on_end_of_overlap_speech(ended_at=time.time(), agent_ended=True)
 
             end_cooldown: float = (
@@ -567,7 +574,11 @@ class AudioRecognition:
         speaking (the user may still be talking), in which case the synthesized verdict
         is inconclusive and must not be treated as a confirmed backchannel.
         """
-        if not self._adaptive_interruption_active or not self._agent_speaking:
+        # an overlap opened this turn outlives a paused agent speech, so it can still be
+        # closed (and its verdict emitted) after the audio output went silent
+        if not self._adaptive_interruption_active or not (
+            self._agent_speaking or self._overlap_in_current_turn
+        ):
             return
 
         # Only set is_interruption=false if not already set (avoid overwriting true from interruption detection)

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -1,10 +1,8 @@
 """The false-interruption resume must follow the end-of-turn decision, never race it.
 
-Both deadlines are armed from the same VAD ``END_OF_SPEECH``: the resume timer counts
-``false_interruption_timeout`` from the event, while the turn commits at
-``last_speaking_time + endpointing_delay`` — measured from before the VAD silence window.
-When the turn detector reads the pause as mid-utterance the delay becomes ``max_delay``,
-which lands after the resume timer, so the agent used to resume and get cut off again.
+Both are armed from the same VAD ``END_OF_SPEECH``, but the turn commits at
+``last_speaking_time + endpointing_delay`` — measured from before the VAD silence window —
+so a ``max_delay`` decision lands after the resume timer.
 """
 
 from __future__ import annotations

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -17,7 +17,11 @@ import pytest
 
 from livekit.agents import Agent, AgentSession, TurnHandlingOptions
 from livekit.agents.voice.agent_activity import AgentActivity, _PausedSpeechInfo
-from livekit.agents.voice.audio_recognition import AudioRecognition
+from livekit.agents.voice.audio_recognition import (
+    AudioRecognition,
+    _EndOfTurnInfo,
+    _EndOfTurnMetrics,
+)
 from livekit.agents.voice.turn import (
     TurnDetectionEvent,
     _StreamingTurnDetector,
@@ -122,6 +126,12 @@ def _paused_activity(session: AgentSession) -> tuple[AgentActivity, MagicMock]:
     return activity, handle
 
 
+def _swallow_task(coro: object, **kwargs: object) -> MagicMock:
+    """Stand in for _create_speech_task: the reply pipeline isn't under test here."""
+    coro.close()  # type: ignore[attr-defined]
+    return MagicMock()
+
+
 def _session() -> AgentSession:
     return AgentSession(
         llm=FakeRealtimeModel(capabilities=fake_capabilities(turn_detection=False)),
@@ -167,12 +177,7 @@ async def test_committed_turn_suppresses_the_resume(monkeypatch: pytest.MonkeyPa
     activity, _ = _paused_activity(session)
     # a confirmed interruption: on_end_of_turn commits and the reply task interrupts the pause
     activity._interruption_detected = True
-
-    def _swallow(coro: object, **kwargs: object) -> MagicMock:
-        coro.close()  # type: ignore[attr-defined]
-        return MagicMock()
-
-    activity._create_speech_task = _swallow  # type: ignore[method-assign, assignment]
+    activity._create_speech_task = _swallow_task  # type: ignore[method-assign, assignment]
 
     events: list[str] = []
     session.on("agent_false_interruption", lambda _: events.append("resume"))
@@ -189,6 +194,42 @@ async def test_committed_turn_suppresses_the_resume(monkeypatch: pytest.MonkeyPa
     assert events == []
     assert activity._false_interruption_pending is False
     assert activity._paused_speech is not None  # left for _cancel_speech_pause to interrupt
+
+
+async def test_skipped_reply_keeps_the_resume_armed(monkeypatch: pytest.MonkeyPatch) -> None:
+    # a skipped reply (AMD verdict, or commit_user_turn on a realtime session) returns before
+    # _cancel_speech_pause, so the resume is the only thing that can un-pause the speech
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    session = _session()
+    activity, _ = _paused_activity(session)
+    activity._interruption_detected = True
+    activity._create_speech_task = _swallow_task  # type: ignore[method-assign, assignment]
+
+    events: list[str] = []
+    session.on("agent_false_interruption", lambda _: events.append("resume"))
+
+    activity.on_end_of_speech(None)
+    info = _EndOfTurnInfo(
+        skip_reply=True,
+        new_transcript="",
+        transcript_confidence=0.0,
+        metrics=_EndOfTurnMetrics(
+            started_speaking_at=None,
+            stopped_speaking_at=None,
+            transcription_delay=None,
+            end_of_turn_delay=None,
+        ),
+        backchannel_over_agent=False,
+    )
+    assert activity.on_end_of_turn(info) is True
+
+    await asyncio.sleep(FALSE_INTERRUPTION_TIMEOUT + 0.2)
+    await session.aclose()
+
+    assert events == ["resume"]
+    assert activity._paused_speech is None
 
 
 async def test_resume_is_immediate_when_no_turn_decision_is_open(

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -132,6 +132,21 @@ def _paused_activity(session: AgentSession) -> tuple[AgentActivity, MagicMock]:
     return activity, handle
 
 
+def _eot_info(*, skip_reply: bool = False) -> _EndOfTurnInfo:
+    return _EndOfTurnInfo(
+        skip_reply=skip_reply,
+        new_transcript="",
+        transcript_confidence=0.0,
+        metrics=_EndOfTurnMetrics(
+            started_speaking_at=None,
+            stopped_speaking_at=None,
+            transcription_delay=None,
+            end_of_turn_delay=None,
+        ),
+        backchannel_over_agent=False,
+    )
+
+
 def _swallow_task(coro: object, **kwargs: object) -> MagicMock:
     """Stand in for _create_speech_task: the reply pipeline isn't under test here."""
     coro.close()  # type: ignore[attr-defined]
@@ -248,19 +263,33 @@ async def test_skipped_reply_keeps_the_resume_armed(monkeypatch: pytest.MonkeyPa
     session.on("agent_false_interruption", lambda _: events.append("resume"))
 
     activity.on_end_of_speech(None)
-    info = _EndOfTurnInfo(
-        skip_reply=True,
-        new_transcript="",
-        transcript_confidence=0.0,
-        metrics=_EndOfTurnMetrics(
-            started_speaking_at=None,
-            stopped_speaking_at=None,
-            transcription_delay=None,
-            end_of_turn_delay=None,
-        ),
-        backchannel_over_agent=False,
-    )
-    assert activity.on_end_of_turn(info) is True
+    assert activity.on_end_of_turn(_eot_info(skip_reply=True)) is True
+
+    await asyncio.sleep(FALSE_INTERRUPTION_TIMEOUT + 0.2)
+    await session.aclose()
+
+    assert events == ["resume"]
+    assert activity._paused_speech is None
+
+
+async def test_server_side_turn_detection_keeps_the_resume_armed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # the reply task returns before _cancel_speech_pause when the server owns turn taking, so
+    # only the resume can release the pre-pause taken while the agent was still generating
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    session = _session()
+    activity, _ = _paused_activity(session)
+    activity._rt_turn_detection_enabled = True
+    activity._create_speech_task = _swallow_task  # type: ignore[method-assign, assignment]
+
+    events: list[str] = []
+    session.on("agent_false_interruption", lambda _: events.append("resume"))
+
+    activity.on_end_of_speech(None)
+    assert activity.on_end_of_turn(_eot_info()) is True
 
     await asyncio.sleep(FALSE_INTERRUPTION_TIMEOUT + 0.2)
     await session.aclose()

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -163,6 +163,8 @@ async def test_resume_waits_for_a_dropped_turn(monkeypatch: pytest.MonkeyPatch) 
     t0 = time.time()
     activity.on_end_of_speech(None)
     activity._audio_recognition = _recognition(activity, last_speaking_time=t0 - VAD_MIN_SILENCE)
+    # a confirmed backchannel is what makes the turn drop rather than commit
+    activity._audio_recognition._turn_backchannel_over_agent = True
     activity._audio_recognition._run_eou_detection(MagicMock(), trigger="vad")
 
     await asyncio.sleep(MAX_DELAY + 0.3)

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -269,6 +269,23 @@ async def test_skipped_reply_keeps_the_resume_armed(monkeypatch: pytest.MonkeyPa
     assert activity._paused_speech is None
 
 
+async def test_interrupting_the_pause_ends_the_agent_turn(monkeypatch: pytest.MonkeyPatch) -> None:
+    # the pipeline paths that report it are gated on a speaking state the pause already left
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    session = _session()
+    activity, handle = _paused_activity(session)
+    handle._generations = []
+    activity._audio_recognition = MagicMock()
+
+    await activity._cancel_speech_pause()
+    await session.aclose()
+
+    handle.interrupt.assert_called_once()
+    activity._audio_recognition._on_end_of_agent_speech.assert_called_once()
+
+
 async def test_resume_is_immediate_when_no_turn_decision_is_open(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -1,0 +1,214 @@
+"""The false-interruption resume must follow the end-of-turn decision, never race it.
+
+Both deadlines are armed from the same VAD ``END_OF_SPEECH``: the resume timer counts
+``false_interruption_timeout`` from the event, while the turn commits at
+``last_speaking_time + endpointing_delay`` — measured from before the VAD silence window.
+When the turn detector reads the pause as mid-utterance the delay becomes ``max_delay``,
+which lands after the resume timer, so the agent used to resume and get cut off again.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from livekit.agents import Agent, AgentSession, TurnHandlingOptions
+from livekit.agents.voice.agent_activity import AgentActivity, _PausedSpeechInfo
+from livekit.agents.voice.audio_recognition import AudioRecognition
+from livekit.agents.voice.turn import (
+    TurnDetectionEvent,
+    _StreamingTurnDetector,
+    _StreamingTurnDetectorStream,
+)
+
+from .fake_io import FakeAudioOutput
+from .fake_realtime import FakeRealtimeModel, fake_capabilities
+from .fake_vad import FakeVAD
+
+pytestmark = pytest.mark.unit
+
+# scaled-down shipped defaults, keeping max_delay - vad_min_silence > timeout
+VAD_MIN_SILENCE = 0.05
+FALSE_INTERRUPTION_TIMEOUT = 0.3
+MAX_DELAY = 0.5
+
+
+def _recognition(hooks: AgentActivity, last_speaking_time: float) -> AudioRecognition:
+    """AudioRecognition wired to drive one real eou bounce against ``hooks``."""
+    ar = AudioRecognition.__new__(AudioRecognition)
+    ar._session = MagicMock()
+    ar._hooks = hooks
+    ar._stt = None  # realtime model, no STT
+    ar._audio_transcript = ""
+    ar._turn_detection_mode = None
+    ar._turn_detector = MagicMock(spec=_StreamingTurnDetector)
+
+    stream_mock = MagicMock(spec=_StreamingTurnDetectorStream)
+    stream_mock.supports_language = AsyncMock(return_value=True)
+    stream_mock.unlikely_threshold = AsyncMock(return_value=0.5)
+    stream_mock.backchannel_threshold = AsyncMock(return_value=None)
+    stream_mock.flush = MagicMock()
+    stream_mock.cancel_inference = MagicMock()
+    stream_mock.prediction_timeout = 0.5
+    ar._turn_detector_stream = stream_mock
+
+    # the detector already answered: mid-utterance, so the bounce waits out max_delay
+    fut: asyncio.Future[TurnDetectionEvent] = asyncio.Future()
+    fut.set_result(
+        TurnDetectionEvent(
+            type="eot_prediction",
+            end_of_turn_probability=0.1,
+            last_speaking_time=last_speaking_time,
+        )
+    )
+    ar._turn_detector_prediction_fut = fut
+    ar._turn_detector_flushed = False
+    ar._turn_detector_late_prediction_warned = False
+    ar._agent_speaking = False
+    ar._interruption_enabled = False
+    ar._interruption_ch = None
+    ar._vad_base_turn_detection = True
+    ar._backchannel_boundary = None
+    ar._backchannel_boundary_timer = None
+    ar._backchannel_boundary_callback = None
+
+    endpointing = MagicMock()
+    endpointing.min_delay = 0.05
+    endpointing.max_delay = MAX_DELAY
+    ar._endpointing = endpointing
+
+    ar._ensure_user_turn_span = MagicMock(  # type: ignore[method-assign]
+        return_value=MagicMock(is_recording=MagicMock(return_value=False))
+    )
+    ar._user_turn_span = None
+    ar._user_turn_start = None
+    ar._user_silence_ev = asyncio.Event()
+    ar._speaking = False
+    ar._final_transcript_confidence = []
+    ar._stt_request_ids = []
+    ar._last_speaking_time = last_speaking_time
+    ar._last_final_transcript_time = None
+    ar._speech_start_time = None
+    ar._vad_speech_started = False
+    ar._end_of_turn_task = None
+    ar._user_turn_committed = False
+    ar._vad = None
+    ar._last_language = None
+    ar._last_emitted_prediction = None
+    ar._turn_backchannel_over_agent = False
+    ar._overlap_in_current_turn = False
+    ar._turn_tracker = MagicMock()
+    ar._closing = asyncio.Event()
+    return ar
+
+
+def _paused_activity(session: AgentSession) -> tuple[AgentActivity, MagicMock]:
+    activity = AgentActivity(Agent(instructions="test"), session)
+    activity._scheduling_paused = False
+    session.output.audio = FakeAudioOutput(can_pause=True)
+
+    handle = MagicMock()
+    handle.done.return_value = False
+    handle.interrupted = False
+    handle.allow_interruptions = True
+    handle._agent_turn_context = None
+    activity._current_speech = handle
+    activity._paused_speech = _PausedSpeechInfo(
+        handle=handle, agent_state="speaking", timeout=FALSE_INTERRUPTION_TIMEOUT
+    )
+    return activity, handle
+
+
+def _session() -> AgentSession:
+    return AgentSession(
+        llm=FakeRealtimeModel(capabilities=fake_capabilities(turn_detection=False)),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(
+            turn_detection="vad",
+            interruption={"mode": "adaptive"},
+        ),
+    )
+
+
+async def test_resume_waits_for_a_dropped_turn(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    session = _session()
+    activity, _ = _paused_activity(session)
+
+    events: list[tuple[str, float]] = []
+    session.on("agent_false_interruption", lambda _: events.append(("resume", time.time())))
+
+    # t0: VAD END_OF_SPEECH — the resume timer is armed, then the bounce is scheduled
+    t0 = time.time()
+    activity.on_end_of_speech(None)
+    activity._audio_recognition = _recognition(activity, last_speaking_time=t0 - VAD_MIN_SILENCE)
+    activity._audio_recognition._run_eou_detection(MagicMock(), trigger="vad")
+
+    await asyncio.sleep(MAX_DELAY + 0.3)
+    await session.aclose()
+
+    assert [name for name, _ in events] == ["resume"]
+    resumed_at = events[0][1] - t0
+    # the turn is dropped at max_delay - vad silence; resuming any earlier is the race
+    assert resumed_at == pytest.approx(MAX_DELAY - VAD_MIN_SILENCE, abs=0.1)
+    assert activity._paused_speech is None
+
+
+async def test_committed_turn_suppresses_the_resume(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    session = _session()
+    activity, _ = _paused_activity(session)
+    # a confirmed interruption: on_end_of_turn commits and the reply task interrupts the pause
+    activity._interruption_detected = True
+
+    def _swallow(coro: object, **kwargs: object) -> MagicMock:
+        coro.close()  # type: ignore[attr-defined]
+        return MagicMock()
+
+    activity._create_speech_task = _swallow  # type: ignore[method-assign, assignment]
+
+    events: list[str] = []
+    session.on("agent_false_interruption", lambda _: events.append("resume"))
+
+    activity.on_end_of_speech(None)
+    activity._audio_recognition = _recognition(
+        activity, last_speaking_time=time.time() - VAD_MIN_SILENCE
+    )
+    activity._audio_recognition._run_eou_detection(MagicMock(), trigger="vad")
+
+    await asyncio.sleep(MAX_DELAY + 0.3)
+    await session.aclose()
+
+    assert events == []
+    assert activity._false_interruption_pending is False
+    assert activity._paused_speech is not None  # left for _cancel_speech_pause to interrupt
+
+
+async def test_resume_is_immediate_when_no_turn_decision_is_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # VAD-only noise on an stt pipeline never starts a bounce, so the timeout still rules
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    session = _session()
+    activity, _ = _paused_activity(session)
+
+    events: list[tuple[str, float]] = []
+    session.on("agent_false_interruption", lambda _: events.append(("resume", time.time())))
+
+    t0 = time.time()
+    activity.on_end_of_speech(None)
+
+    await asyncio.sleep(FALSE_INTERRUPTION_TIMEOUT + 0.2)
+    await session.aclose()
+
+    assert [name for name, _ in events] == ["resume"]
+    assert events[0][1] - t0 == pytest.approx(FALSE_INTERRUPTION_TIMEOUT, abs=0.1)

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -315,6 +315,24 @@ async def test_interrupting_the_pause_ends_the_agent_turn(monkeypatch: pytest.Mo
     activity._audio_recognition._on_end_of_agent_speech.assert_called_once()
 
 
+async def test_handing_over_a_paused_speech_does_not_end_the_agent_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # a handoff keeps the speech for the next activity, and the recognition is closed by then
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    session = _session()
+    activity, handle = _paused_activity(session)
+    activity._audio_recognition = MagicMock()
+
+    await activity._cancel_speech_pause(interrupt=False)
+    await session.aclose()
+
+    handle.interrupt.assert_not_called()
+    activity._audio_recognition._on_end_of_agent_speech.assert_not_called()
+
+
 async def test_resume_is_immediate_when_no_turn_decision_is_open(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -54,6 +54,7 @@ def _recognition(hooks: AgentActivity, last_speaking_time: float) -> AudioRecogn
     stream_mock.backchannel_threshold = AsyncMock(return_value=None)
     stream_mock.flush = MagicMock()
     stream_mock.cancel_inference = MagicMock()
+    stream_mock.aclose = AsyncMock()
     stream_mock.prediction_timeout = 0.5
     ar._turn_detector_stream = stream_mock
 
@@ -104,6 +105,13 @@ def _recognition(hooks: AgentActivity, last_speaking_time: float) -> AudioRecogn
     ar._overlap_in_current_turn = False
     ar._turn_tracker = MagicMock()
     ar._closing = asyncio.Event()
+    # only touched by _aclose
+    ar._commit_user_turn_atask = None
+    ar._stt_pipeline = None
+    ar._stt_consumer_atask = None
+    ar._vad_atask = None
+    ar._interruption_atask = None
+    ar._tasks = set()
     return ar
 
 
@@ -192,6 +200,35 @@ async def test_committed_turn_suppresses_the_resume(monkeypatch: pytest.MonkeyPa
     assert events == []
     assert activity._false_interruption_pending is False
     assert activity._paused_speech is not None  # left for _cancel_speech_pause to interrupt
+
+
+async def test_teardown_does_not_resume_a_deferred_pause(monkeypatch: pytest.MonkeyPatch) -> None:
+    # closing settles the open decision without deciding anything; the close path releases the
+    # pause itself, so the resume must not fire mid-teardown
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    session = _session()
+    activity, _ = _paused_activity(session)
+
+    events: list[str] = []
+    session.on("agent_false_interruption", lambda _: events.append("resume"))
+
+    activity.on_end_of_speech(None)
+    activity._audio_recognition = _recognition(
+        activity, last_speaking_time=time.time() - VAD_MIN_SILENCE
+    )
+    activity._audio_recognition._run_eou_detection(MagicMock(), trigger="vad")
+
+    # let the timeout elapse while the decision is still open
+    await asyncio.sleep(FALSE_INTERRUPTION_TIMEOUT + 0.05)
+    assert activity._false_interruption_pending is True
+
+    await activity._audio_recognition._aclose()
+    await asyncio.sleep(0.2)
+    await session.aclose()
+
+    assert events == []
 
 
 async def test_skipped_reply_keeps_the_resume_armed(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -113,26 +113,45 @@ async def test_adaptive_interruption_disabled_for_realtime_with_server_turn_dete
     assert activity._interruption_detector is None
 
 
-async def test_backchannel_does_not_commit_while_agent_speaking(
+async def test_unjudged_overlap_over_a_paused_speech_commits(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # the turn overlapped agent speech and no interruption was flagged, so it's a
-    # backchannel and must not commit a user turn
+    # a pause silences the agent and ends the overlap, so no verdict is coming: the turn must
+    # commit rather than be discarded on the assumption that one might still arrive
     monkeypatch.setenv("LIVEKIT_API_KEY", "k")
     monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
 
     activity = _make_activity(_realtime_barge_in_session())
     activity._scheduling_paused = False  # simulate a running session
     assert activity._interruption_detection_enabled is True
+    activity._create_speech_task = _swallow_task  # type: ignore[method-assign, assignment]
 
     current_speech = MagicMock()
     current_speech.done.return_value = False
     current_speech.interrupted = False
     activity._current_speech = current_speech
     activity._interruption_detected = False
+    activity._update_paused_speech(current_speech, timeout=2.0)
 
-    # verdict pending, agent still speaking — dropped via the live-speech branch
-    assert activity.on_end_of_turn(_end_of_turn_info(backchannel_over_agent=False)) is False
+    assert activity.on_end_of_turn(_end_of_turn_info(backchannel_over_agent=False)) is True
+
+
+async def test_confirmed_backchannel_drops_while_agent_speaking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # the detector's verdict is the only thing that suppresses a turn
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    activity = _make_activity(_realtime_barge_in_session())
+    activity._scheduling_paused = False
+
+    current_speech = MagicMock()
+    current_speech.done.return_value = False
+    current_speech.interrupted = False
+    activity._current_speech = current_speech
+
+    assert activity.on_end_of_turn(_end_of_turn_info(backchannel_over_agent=True)) is False
 
 
 async def test_backchannel_dropped_after_agent_finishes_speaking(
@@ -205,6 +224,12 @@ def _recognition_for_overlap(*, speaking: bool = False) -> AudioRecognition:
         ar._user_silence_ev.set()  # silent (between segments) unless told otherwise
     ar._hooks = MagicMock()
     return ar
+
+
+def _swallow_task(coro: object, **kwargs: object) -> MagicMock:
+    """Stand in for _create_speech_task: the reply pipeline isn't under test here."""
+    coro.close()  # type: ignore[attr-defined]
+    return MagicMock()
 
 
 def _overlap_event(*, is_interruption: bool, agent_ended: bool) -> OverlappingSpeechEvent:

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from unittest.mock import MagicMock
 
 import pytest
 
-from livekit.agents import Agent, AgentSession, TurnHandlingOptions
+from livekit.agents import NOT_GIVEN, Agent, AgentSession, TurnHandlingOptions
 from livekit.agents.inference import OverlappingSpeechEvent
 from livekit.agents.voice.agent_activity import AgentActivity
 from livekit.agents.voice.audio_recognition import (
@@ -258,3 +259,92 @@ async def test_interruption_clears_backchannel() -> None:
     assert ar._turn_backchannel_over_agent is False
     ar._hooks.on_interruption.assert_called_once()
     ar._hooks.on_backchannel_confirmed.assert_not_called()
+
+
+class _RecordingChan:
+    """Stands in for the interruption channel, capturing the sentinels sent to it."""
+
+    def __init__(self) -> None:
+        self.sent: list[object] = []
+        self.closed = False
+
+    def send_nowait(self, item: object) -> None:
+        self.sent.append(item)
+
+
+def _recognition_with_interruption_ch() -> tuple[AudioRecognition, _RecordingChan]:
+    ar = AudioRecognition.__new__(AudioRecognition)
+    ch = _RecordingChan()
+    ar._interruption_enabled = True
+    ar._interruption_ch = ch  # type: ignore[assignment]
+    ar._agent_speaking = False
+    ar._agent_speech_started_at = None
+    ar._endpointing = MagicMock()
+    ar._backchannel_boundary = None
+    ar._backchannel_boundary_timer = None
+    ar._backchannel_boundary_callback = None
+    ar._ignore_user_transcript_until = NOT_GIVEN
+    ar._overlap_in_current_turn = False
+    ar._turn_backchannel_over_agent = False
+    ar._transcript_buffer = []
+    ar._tasks = set()
+    ar._user_silence_ev = asyncio.Event()
+    ar._user_silence_ev.set()
+    ar._hooks = MagicMock()
+    return ar, ch
+
+
+def _sentinel_names(ch: _RecordingChan) -> list[str]:
+    return [type(item).__name__ for item in ch.sent]
+
+
+async def test_pause_keeps_overlap_inference_alive() -> None:
+    # pausing is provisional: the verdict for this overlap is what decides whether the
+    # pause becomes an interruption, so the inference must survive it
+    ar, ch = _recognition_with_interruption_ch()
+    ar._on_start_of_agent_speech(started_at=time.time())
+    ar._on_start_of_speech(started_at=time.time())
+    ch.sent.clear()
+
+    ar._on_end_of_agent_speech(ignore_user_transcript_until=time.time(), paused=True)
+
+    assert _sentinel_names(ch) == []
+
+
+async def test_pause_still_lets_the_user_close_the_overlap() -> None:
+    # the user finishing their utterance during the pause is what produces the verdict
+    ar, ch = _recognition_with_interruption_ch()
+    ar._on_start_of_agent_speech(started_at=time.time())
+    ar._on_start_of_speech(started_at=time.time())
+    ar._on_end_of_agent_speech(ignore_user_transcript_until=time.time(), paused=True)
+    ch.sent.clear()
+
+    ar._on_end_of_speech(ended_at=time.time())
+
+    assert _sentinel_names(ch) == ["_OverlapSpeechEndedSentinel"]
+    assert ch.sent[0]._agent_ended is False  # type: ignore[attr-defined]
+
+
+async def test_resume_does_not_restart_the_detector() -> None:
+    # a resume re-enters the same agent turn; restarting would reset the open overlap
+    ar, ch = _recognition_with_interruption_ch()
+    ar._on_start_of_agent_speech(started_at=time.time())
+    ar._on_start_of_speech(started_at=time.time())
+    ar._on_end_of_agent_speech(ignore_user_transcript_until=time.time(), paused=True)
+    ch.sent.clear()
+
+    ar._on_start_of_agent_speech(started_at=time.time(), resumed=True)
+
+    assert _sentinel_names(ch) == []
+
+
+async def test_real_end_of_agent_speech_still_tears_down() -> None:
+    # the agent turn genuinely ending must stop the inference
+    ar, ch = _recognition_with_interruption_ch()
+    ar._on_start_of_agent_speech(started_at=time.time())
+    ar._on_start_of_speech(started_at=time.time())
+    ch.sent.clear()
+
+    ar._on_end_of_agent_speech(ignore_user_transcript_until=time.time())
+
+    assert "_AgentSpeechEndedSentinel" in _sentinel_names(ch)

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -310,6 +310,7 @@ def _recognition_with_interruption_ch() -> tuple[AudioRecognition, _RecordingCha
     ar._backchannel_boundary_callback = None
     ar._ignore_user_transcript_until = NOT_GIVEN
     ar._overlap_in_current_turn = False
+    ar._overlap_open = False
     ar._turn_backchannel_over_agent = False
     ar._transcript_buffer = []
     ar._tasks = set()
@@ -359,6 +360,19 @@ async def test_resume_does_not_restart_the_detector() -> None:
     ch.sent.clear()
 
     ar._on_start_of_agent_speech(started_at=time.time(), resumed=True)
+
+    assert _sentinel_names(ch) == []
+
+
+async def test_a_resolved_overlap_is_not_closed_again() -> None:
+    # a turn can hold several overlaps, so closing keys off the open one rather than the turn
+    ar, ch = _recognition_with_interruption_ch()
+    ar._on_start_of_agent_speech(started_at=time.time())
+    ar._on_start_of_speech(started_at=time.time())
+    await ar._on_overlap_speech_event(_overlap_event(is_interruption=True, agent_ended=False))
+    ch.sent.clear()
+
+    ar._on_end_of_speech(ended_at=time.time())
 
     assert _sentinel_names(ch) == []
 

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -363,6 +363,19 @@ async def test_resume_does_not_restart_the_detector() -> None:
     assert _sentinel_names(ch) == []
 
 
+async def test_interrupting_a_paused_speech_tears_down() -> None:
+    # the pause withheld the teardown for a possible resume; an interrupt ends the turn instead
+    ar, ch = _recognition_with_interruption_ch()
+    ar._on_start_of_agent_speech(started_at=time.time())
+    ar._on_start_of_speech(started_at=time.time())
+    ar._on_end_of_agent_speech(ignore_user_transcript_until=time.time(), paused=True)
+    ch.sent.clear()
+
+    ar._on_end_of_agent_speech(ignore_user_transcript_until=time.time())
+
+    assert _sentinel_names(ch) == ["_AgentSpeechEndedSentinel"]
+
+
 async def test_real_end_of_agent_speech_still_tears_down() -> None:
     # the agent turn genuinely ending must stop the inference
     ar, ch = _recognition_with_interruption_ch()


### PR DESCRIPTION
Three fixes around a paused agent speech: the turn gate, the overlap the barge-in verdict comes from, and the resume timer.

### Turns silently dropped (realtime without STT)

**a. The gate treated a paused speech as still deciding.** `on_end_of_turn` dropped a turn whenever the agent had a live, uninterrupted speech and no interruption had been flagged, on the assumption that a verdict might still arrive. Once the speech is paused that assumption is permanently false — pausing silences the agent and ends the overlap, so no verdict is coming — and the user was ignored for a whole turn while the agent resumed mid-sentence.

Only a confirmed verdict suppresses a turn now. An unjudged overlap commits, so a barge-in verdict that lands late can interrupt the agent on what may have been a backchannel — an unwanted interruption is audible, so the user hears the agent stop and carries on, while a discarded turn is invisible and leaves them repeating themselves to an agent that never registered them.

**b. Pausing tore down the overlap that verdict comes from.** Pausing signalled end-of-agent-speech to the adaptive detector, which reset its stream and closed the overlap window. The verdict is emitted when the user's speech ends, so with the window gone none ever arrived: no late detection could land, and every paused backchannel would interrupt the agent.

A pause no longer ends the detector's overlap and a resume no longer restarts its stream. The user's speech ending closes it instead, which emits the verdict and stops inference.

### Resume racing the turn decision

The resume timer counts `false_interruption_timeout` from the VAD `END_OF_SPEECH` event, while the turn commits at `last_speaking_time + endpointing_delay` — measured from before the VAD silence window. When the detector reads the pause as mid-utterance that delay becomes `max_delay`, so with the shipped defaults the resume lands 0.25s before the commit and the agent is cut off right after resuming.

An open turn decision now owns the paused speech: the timer defers to it and resumes only once the turn is dropped, while a committed turn cancels the resume synchronously from `on_end_of_turn`. The elapsed timeout counts toward that wait, so a resume with no decision pending keeps its current latency.
