### PR TITLE
fix(aws): count cached tokens in Bedrock's prompt_tokens

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -287,18 +287,24 @@ class LLMStream(llm.LLMStream):
                 logger.warning(f"aws bedrock llm: unknown chunk type: {chunk}")
 
         elif "metadata" in chunk:
-            metadata = chunk["metadata"]
+            usage = chunk["metadata"]["usage"]
+            # Bedrock reports inputTokens net of the cache and puts the cached tokens in
+            # their own fields, so they have to be added back for prompt_tokens to mean what
+            # CompletionUsage says it means ("includes cached tokens"). This mirrors what the
+            # anthropic plugin already does for the same models served directly.
+            cache_read_tokens = usage.get("cacheReadInputTokens") or 0
+            cache_creation_tokens = usage.get("cacheWriteInputTokens") or 0
+            prompt_tokens = usage["inputTokens"] + cache_read_tokens + cache_creation_tokens
+            completion_tokens = usage["outputTokens"]
             return llm.ChatChunk(
                 id=request_id,
                 usage=llm.CompletionUsage(
-                    completion_tokens=metadata["usage"]["outputTokens"],
-                    prompt_tokens=metadata["usage"]["inputTokens"],
-                    total_tokens=metadata["usage"]["totalTokens"],
-                    prompt_cached_tokens=(
-                        metadata["usage"]["cacheReadInputTokens"]
-                        if "cacheReadInputTokens" in metadata["usage"]
-                        else 0
-                    ),
+                    completion_tokens=completion_tokens,
+                    prompt_tokens=prompt_tokens,
+                    total_tokens=prompt_tokens + completion_tokens,
+                    prompt_cached_tokens=cache_read_tokens,
+                    cache_creation_tokens=cache_creation_tokens,
+                    cache_read_tokens=cache_read_tokens,
                 ),
             )
         elif "contentBlockStop" in chunk:

--- a/livekit-plugins/livekit-plugins-aws/tests/test_llm_usage_cached_tokens.py
+++ b/livekit-plugins/livekit-plugins-aws/tests/test_llm_usage_cached_tokens.py
@@ -1,0 +1,93 @@
+"""Bedrock usage must satisfy the contract CompletionUsage states for itself.
+
+`CompletionUsage.prompt_tokens` is documented as "The number of input tokens used (includes
+cached tokens)", and `total_tokens` as "completion + prompt tokens". Bedrock reports
+`inputTokens` net of the cache and puts the cached tokens in `cacheReadInputTokens` and
+`cacheWriteInputTokens`, so assigning `inputTokens` straight through leaves every cached
+token out of `prompt_tokens` and makes `total_tokens` disagree with its own definition.
+
+The anthropic plugin already adds them back for the same models served directly:
+
+    prompt_token = self._input_tokens + self._cache_creation_tokens + self._cache_read_tokens
+
+This pins the Bedrock path to the same behaviour.
+"""
+
+from __future__ import annotations
+
+from livekit.plugins.aws.llm import LLMStream
+
+
+def _parse_metadata(usage: dict) -> object:
+    """Drive _parse_chunk's metadata branch without constructing a live stream."""
+    chunk = {"metadata": {"usage": usage}}
+    return LLMStream._parse_chunk(object.__new__(LLMStream), "req-1", chunk)
+
+
+class TestBedrockCachedTokens:
+    def test_cache_reads_are_included_in_prompt_tokens(self):
+        """2000 of the 2100 billed input tokens came from the cache."""
+        result = _parse_metadata(
+            {
+                "inputTokens": 100,
+                "outputTokens": 50,
+                "totalTokens": 2150,
+                "cacheReadInputTokens": 2000,
+            }
+        )
+        assert result.usage.prompt_tokens == 2100
+        assert result.usage.prompt_cached_tokens == 2000
+        assert result.usage.cache_read_tokens == 2000
+
+    def test_cache_writes_are_included_too(self):
+        """Writing the cache is billed, at a premium, and must not vanish."""
+        result = _parse_metadata(
+            {
+                "inputTokens": 100,
+                "outputTokens": 50,
+                "totalTokens": 1650,
+                "cacheWriteInputTokens": 1500,
+            }
+        )
+        assert result.usage.prompt_tokens == 1600
+        assert result.usage.cache_creation_tokens == 1500
+
+    def test_total_equals_prompt_plus_completion(self):
+        """total_tokens is documented as completion + prompt, so it must agree."""
+        result = _parse_metadata(
+            {
+                "inputTokens": 100,
+                "outputTokens": 50,
+                "totalTokens": 999999,  # deliberately inconsistent upstream value
+                "cacheReadInputTokens": 300,
+                "cacheWriteInputTokens": 200,
+            }
+        )
+        assert result.usage.prompt_tokens == 600
+        assert result.usage.total_tokens == 650
+        assert (
+            result.usage.total_tokens == result.usage.prompt_tokens + result.usage.completion_tokens
+        )
+
+    def test_uncached_request_is_unchanged(self):
+        """No cache in play means the previous arithmetic was already right."""
+        result = _parse_metadata({"inputTokens": 100, "outputTokens": 50, "totalTokens": 150})
+        assert result.usage.prompt_tokens == 100
+        assert result.usage.completion_tokens == 50
+        assert result.usage.total_tokens == 150
+        assert result.usage.prompt_cached_tokens == 0
+        assert result.usage.cache_creation_tokens == 0
+
+    def test_null_cache_fields_are_treated_as_zero(self):
+        """Bedrock may send the keys with null rather than omitting them."""
+        result = _parse_metadata(
+            {
+                "inputTokens": 100,
+                "outputTokens": 50,
+                "totalTokens": 150,
+                "cacheReadInputTokens": None,
+                "cacheWriteInputTokens": None,
+            }
+        )
+        assert result.usage.prompt_tokens == 100
+        assert result.usage.total_tokens == 150

--- a/livekit-plugins/livekit-plugins-aws/tests/test_llm_usage_cached_tokens.py
+++ b/livekit-plugins/livekit-plugins-aws/tests/test_llm_usage_cached_tokens.py
@@ -15,7 +15,11 @@ This pins the Bedrock path to the same behaviour.
 
 from __future__ import annotations
 
+import pytest
+
 from livekit.plugins.aws.llm import LLMStream
+
+pytestmark = pytest.mark.unit
 
 
 def _parse_metadata(usage: dict) -> object:


### PR DESCRIPTION
## The contract

`CompletionUsage` states what its own fields mean:

```python
prompt_tokens: int
"""The number of input tokens used (includes cached tokens)."""
...
total_tokens: int
"""The total number of tokens used (completion + prompt tokens)."""
```

The Bedrock path met neither.

```python
completion_tokens=metadata["usage"]["outputTokens"],
prompt_tokens=metadata["usage"]["inputTokens"],      # net of the cache
total_tokens=metadata["usage"]["totalTokens"],       # counts the cache
prompt_cached_tokens=metadata["usage"]["cacheReadInputTokens"] ...
```

Bedrock reports `inputTokens` net of the cache and puts the cached tokens in their own
`cacheReadInputTokens` and `cacheWriteInputTokens` fields. Assigning `inputTokens` straight
through therefore leaves every cached token out of `prompt_tokens`, while `total_tokens` is
taken from the provider and does count them. The two disagree inside the same object.

`cache_creation_tokens` and `cache_read_tokens` were also never populated, though Bedrock
supplies both.

## The anthropic plugin already does this

Same models, served directly rather than through Bedrock:

```python
# https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#tracking-cache-performance
prompt_token = self._input_tokens + self._cache_creation_tokens + self._cache_read_tokens
```

So the correct behaviour is settled in this repo; the Bedrock path just diverges from it.
This brings the two in line.

## Why it is not marginal

In a voice agent the system prompt and the conversation history are re-read from cache on
every turn, so cache reads come to dominate the input count within a few turns. A turn billed
for 2100 input tokens with 2000 of them cached reported 100. Nothing raises; `ModelUsageCollector`
just sums a number that is quietly low.

## Also a latent crash

The cache fields were read with `in` and passed through unchanged, so a `cacheReadInputTokens`
of `null` reached `prompt_cached_tokens`, which is a non-optional `int`. They are now coerced
to `0`.

## Tests

`livekit-plugins/livekit-plugins-aws/tests/test_llm_usage_cached_tokens.py`, five tests, four
of which fail on `main`:

```
FAILED test_cache_reads_are_included_in_prompt_tokens
FAILED test_cache_writes_are_included_too
FAILED test_total_equals_prompt_plus_completion
FAILED test_null_cache_fields_are_treated_as_zero
```

The fifth pins that an uncached request is completely unchanged.

`ruff format` and `ruff check` clean at line-length 100.

## Note

I found this coming from the same fix in Pipecat, where the AWS and Anthropic services had
the identical shape: https://github.com/pipecat-ai/pipecat/pull/5163. Happy to also align
`total_tokens` handling across the other plugins if you want that as a follow-up, but I kept
this to the one provider that diverges from your own anthropic implementation.
