### PR TITLE
fix(voice): prevent dropped run_input acks in remote sessions

### DIFF
--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -508,7 +508,8 @@ class SessionHost:
                     )
                     await utils.aio.cancel_and_wait(self._writer_task)
                 except asyncio.CancelledError:
-                    pass
+                    await utils.aio.cancel_and_wait(self._writer_task)
+                    raise
             elif not self._writer_task.done():
                 await utils.aio.cancel_and_wait(self._writer_task)
             self._writer_task = None

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import struct
 import time
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Mapping, Sequence
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 from google.protobuf.duration_pb2 import Duration
@@ -34,6 +36,7 @@ from ..metrics import (
     STTModelUsage,
     TTSModelUsage,
 )
+from ..utils.aio.channel import ChanClosed, ChanEmpty
 from ..version import __version__
 from ..voice.amd import AMDCategory, AMDPredictionEvent
 from .events import (
@@ -62,6 +65,15 @@ if TYPE_CHECKING:
 
 
 TOPIC_SESSION_MESSAGES = "lk.agent.session"
+_SHUTDOWN_DRAIN_TIMEOUT = 5.0
+
+
+@dataclass
+class _OutboundMessage:
+    """A message queued for the SessionHost's serialized writer."""
+
+    msg: agent_pb.AgentSessionMessage
+    done: asyncio.Future[None] | None = None
 
 
 class SessionTransport(ABC):
@@ -122,7 +134,7 @@ class RoomSessionTransport(SessionTransport):
 
     async def send_message(self, msg: agent_pb.AgentSessionMessage) -> None:
         if self._recv_ch.closed or not self._room.isconnected():
-            return
+            raise RuntimeError("room session transport is closed")
         try:
             data = msg.SerializeToString()
             dest = [self._remote_identity] if self._remote_identity else None
@@ -134,7 +146,7 @@ class RoomSessionTransport(SessionTransport):
             await writer.write(data)
             await writer.aclose()
         except Exception as e:
-            logger.warning("failed to send binary stream message: %s", e)
+            raise RuntimeError(f"failed to send binary stream message: {e}") from e
 
     async def close(self) -> None:
         if self._recv_ch.closed:
@@ -168,6 +180,7 @@ class TcpSessionTransport(SessionTransport):
         self._writer: asyncio.StreamWriter | None = None
         self._closed = False
         self._loop: asyncio.AbstractEventLoop | None = None
+        self._send_lock = asyncio.Lock()
 
     async def start(self) -> None:
         reader, writer = await asyncio.open_connection(self._host, self._port)
@@ -182,19 +195,28 @@ class TcpSessionTransport(SessionTransport):
 
     async def send_message(self, msg: agent_pb.AgentSessionMessage) -> None:
         if self._closed or self._writer is None:
-            return
+            raise RuntimeError("tcp session transport is closed")
         data = msg.SerializeToString()
         header = struct.pack(">I", len(data))
-        self._writer.write(header + data)
-        if self._writer.transport.get_write_buffer_size() > 64 * 1024:
-            await self._writer.drain()
+        async with self._send_lock:
+            if self._closed or self._writer is None:
+                raise RuntimeError("tcp session transport is closed")
+            self._writer.write(header + data)
+            if self._writer.transport.get_write_buffer_size() > 64 * 1024:
+                await self._writer.drain()
 
     def send_message_threadsafe(self, msg: agent_pb.AgentSessionMessage) -> None:
         if self._closed or self._writer is None or self._loop is None:
             return
         data = msg.SerializeToString()
         payload = struct.pack(">I", len(data)) + data
-        self._loop.call_soon_threadsafe(self._writer.write, payload)
+
+        def _write() -> None:
+            if self._closed or self._writer is None:
+                return
+            self._writer.write(payload)
+
+        self._loop.call_soon_threadsafe(_write)
 
     async def close(self) -> None:
         if self._closed:
@@ -378,8 +400,11 @@ class SessionHost:
         self._audio_input = audio_input
         self._audio_output = audio_output
         self._started = False
+        self._accepting_requests = False
         self._recv_task: asyncio.Task[None] | None = None
+        self._writer_task: asyncio.Task[None] | None = None
         self._tasks = utils.aio.TaskSet()
+        self._outbound_ch: utils.aio.Chan[_OutboundMessage] = utils.aio.Chan()
         self._session: AgentSession | None = None
         self._events_registered = False
 
@@ -402,13 +427,18 @@ class SessionHost:
         if self._started:
             return
         self._started = True
+        self._accepting_requests = True
         await self._transport.start()
-        self._recv_task = asyncio.create_task(self._recv_loop())
+        self._writer_task = asyncio.create_task(
+            self._writer_loop(), name="SessionHost._writer_loop"
+        )
+        self._recv_task = asyncio.create_task(self._recv_loop(), name="SessionHost._recv_loop")
 
     async def aclose(self) -> None:
         if not self._started:
             return
         self._started = False
+        self._accepting_requests = False
 
         if self._session and self._events_registered:
             self._events_registered = False
@@ -423,18 +453,120 @@ class SessionHost:
             self._session.off("error", self._on_error)
             self._session.off("debug_message", self._on_debug_message)
 
+        # Stop accepting new requests, then give in-flight handlers a chance to
+        # queue their responses before we drain the outbound writer.
         if self._recv_task:
             await utils.aio.cancel_and_wait(self._recv_task)
+            self._recv_task = None
 
-        await utils.aio.cancel_and_wait(*self._tasks.tasks)
+        handler_tasks = self._tasks.tasks
+        if handler_tasks:
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*handler_tasks, return_exceptions=True),
+                    timeout=_SHUTDOWN_DRAIN_TIMEOUT,
+                )
+            except TimeoutError:
+                logger.warning(
+                    "session host request handlers did not finish before shutdown grace period",
+                    extra={"pending_handlers": len(self._tasks.tasks)},
+                )
+                await utils.aio.cancel_and_wait(*self._tasks.tasks)
+
+        self._outbound_ch.close()
+        if self._writer_task:
+            try:
+                await asyncio.wait_for(self._writer_task, timeout=_SHUTDOWN_DRAIN_TIMEOUT)
+            except TimeoutError:
+                logger.warning(
+                    "session host outbound writer did not drain before shutdown grace period",
+                    extra={"queued_messages": self._outbound_ch.qsize()},
+                )
+                await utils.aio.cancel_and_wait(self._writer_task)
+            self._writer_task = None
+
         await self._transport.close()
+
+    async def _writer_loop(self) -> None:
+        try:
+            async for item in self._outbound_ch:
+                try:
+                    await self._transport.send_message(item.msg)
+                except asyncio.CancelledError:
+                    if item.done is not None and not item.done.done():
+                        item.done.set_exception(asyncio.CancelledError())
+                    raise
+                except Exception as e:
+                    if item.done is not None and not item.done.done():
+                        item.done.set_exception(e)
+                    else:
+                        logger.warning("error sending session message", exc_info=True)
+                else:
+                    if item.done is not None and not item.done.done():
+                        item.done.set_result(None)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("session host writer loop failed", exc_info=True)
+        finally:
+            # Fail any messages still buffered when the writer exits.
+            while True:
+                try:
+                    item = self._outbound_ch.recv_nowait()
+                except (ChanEmpty, ChanClosed):
+                    break
+                if item.done is not None and not item.done.done():
+                    item.done.set_exception(RuntimeError("session host writer closed"))
+
+    def _queue_message(
+        self,
+        msg: agent_pb.AgentSessionMessage,
+        *,
+        wait: bool = False,
+    ) -> asyncio.Future[None] | None:
+        """Enqueue an outbound message on the serialized writer path.
+
+        When ``wait`` is True, returns a future that completes after the
+        transport write finishes (or fails). Event emission uses wait=False.
+        """
+        done: asyncio.Future[None] | None = None
+        if wait:
+            done = asyncio.get_running_loop().create_future()
+
+        if self._outbound_ch.closed:
+            if done is not None:
+                done.set_exception(RuntimeError("session host outbound channel is closed"))
+            return done
+
+        try:
+            self._outbound_ch.send_nowait(_OutboundMessage(msg=msg, done=done))
+        except ChanClosed:
+            if done is not None and not done.done():
+                done.set_exception(RuntimeError("session host outbound channel is closed"))
+        return done
+
+    async def _send_message(self, msg: agent_pb.AgentSessionMessage) -> None:
+        """Queue a message and wait for the serialized writer to send it."""
+        done = self._queue_message(msg, wait=True)
+        assert done is not None
+        await done
 
     async def _recv_loop(self) -> None:
         try:
             async for msg in self._transport:
                 if msg.HasField("request"):
-                    if self._session is not None:
+                    if self._session is not None and self._accepting_requests:
                         self._tasks.create_task(self._handle_request_safe(msg.request))
+                    else:
+                        # Reject late requests clearly so the client does not hang.
+                        resp = agent_pb.AgentSessionMessage(
+                            response=agent_pb.SessionResponse(
+                                request_id=msg.request.request_id,
+                                error="session host is shutting down",
+                            )
+                        )
+                        with contextlib.suppress(Exception):
+                            await self._send_message(resp)
                 else:
                     msg_type = msg.WhichOneof("message")
                     if msg_type:
@@ -457,7 +589,7 @@ class SessionHost:
         ts.FromNanoseconds(int((created_at if created_at is not None else time.time()) * 1e9))
         event.created_at.CopyFrom(ts)
         msg = agent_pb.AgentSessionMessage(event=event)
-        self._tasks.create_task(self._transport.send_message(msg))
+        self._queue_message(msg, wait=False)
 
     def _on_agent_state_changed(self, event: AgentStateChangedEvent) -> None:
         old_pb = _AGENT_STATE_MAP.get(event.old_state, agent_pb.AS_IDLE)
@@ -679,7 +811,7 @@ class SessionHost:
                         error="internal error",
                     )
                 )
-                await self._transport.send_message(resp)
+                await self._send_message(resp)
             except Exception:
                 pass
 
@@ -693,7 +825,7 @@ class SessionHost:
                     pong=agent_pb.SessionResponse.Pong(),
                 )
             )
-            await self._transport.send_message(resp)
+            await self._send_message(resp)
 
         elif req.HasField("get_chat_history"):
             items = [_chat_item_to_proto(item) for item in self._session.history.items]
@@ -705,7 +837,7 @@ class SessionHost:
                     ),
                 )
             )
-            await self._transport.send_message(resp)
+            await self._send_message(resp)
 
         elif req.HasField("get_agent_info"):
             agent = self._session.current_agent
@@ -728,7 +860,7 @@ class SessionHost:
                     ),
                 )
             )
-            await self._transport.send_message(resp)
+            await self._send_message(resp)
 
         elif req.HasField("run_input"):
             items_list: list[agent_pb.ChatContext.ChatItem] = []
@@ -761,7 +893,7 @@ class SessionHost:
                     ),
                 )
             )
-            await self._transport.send_message(resp)
+            await self._send_message(resp)
 
         elif req.HasField("get_session_state"):
             agent = self._session.current_agent
@@ -787,7 +919,7 @@ class SessionHost:
                     ),
                 )
             )
-            await self._transport.send_message(resp)
+            await self._send_message(resp)
 
         elif req.HasField("get_rtc_stats"):
             from google.protobuf.struct_pb2 import Struct
@@ -822,7 +954,7 @@ class SessionHost:
                     ),
                 )
             )
-            await self._transport.send_message(resp)
+            await self._send_message(resp)
 
         elif req.HasField("get_session_usage"):
             created_at = Timestamp()
@@ -837,7 +969,7 @@ class SessionHost:
                     ),
                 )
             )
-            await self._transport.send_message(resp)
+            await self._send_message(resp)
 
         elif req.HasField("get_framework_info"):
             resp = agent_pb.AgentSessionMessage(
@@ -849,7 +981,7 @@ class SessionHost:
                     ),
                 )
             )
-            await self._transport.send_message(resp)
+            await self._send_message(resp)
 
         elif req.HasField("update_io"):
             # Honor the remote control's mute/unmute toggles for audio /
@@ -877,7 +1009,7 @@ class SessionHost:
                     update_io=agent_pb.SessionResponse.UpdateIOResponse(),
                 )
             )
-            await self._transport.send_message(resp)
+            await self._send_message(resp)
 
         elif req.HasField("finalize_simulation"):
             # The simulator's verdict is passed in so on_simulation_end can read it
@@ -928,7 +1060,7 @@ class SessionHost:
                     ),
                 )
             )
-            await self._transport.send_message(resp)
+            await self._send_message(resp)
 
 
 def _session_usage_to_proto(usage: AgentSessionUsage) -> agent_pb.AgentSessionUsage:
@@ -1033,19 +1165,24 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
             return
         self._started = True
         await self._transport.start()
-        self._recv_task = asyncio.create_task(self._recv_loop())
+        self._recv_task = asyncio.create_task(self._recv_loop(), name="RemoteSession._recv_loop")
 
     async def aclose(self) -> None:
         if not self._started:
             return
         self._started = False
 
-        for future in self._pending_requests.values():
-            future.cancel()
+        pending = list(self._pending_requests.items())
         self._pending_requests.clear()
+        for request_id, future in pending:
+            if not future.done():
+                future.set_exception(
+                    RuntimeError(f"remote session closed (request_id={request_id})")
+                )
 
         if self._recv_task:
             await utils.aio.cancel_and_wait(self._recv_task)
+            self._recv_task = None
 
         await self._transport.close()
 
@@ -1064,33 +1201,49 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
             logger.warning("error processing session message", exc_info=True)
 
     def _dispatch_response(self, response: agent_pb.SessionResponse) -> None:
-        future = self._pending_requests.pop(response.request_id, None)
-        if future and not future.done():
-            future.set_result(response)
+        future = self._pending_requests.get(response.request_id)
+        if future is None:
+            logger.warning(
+                "received session response for unknown or timed-out request",
+                extra={"request_id": response.request_id},
+            )
+            return
+        if future.done():
+            logger.warning(
+                "received duplicate session response",
+                extra={"request_id": response.request_id},
+            )
+            return
+        future.set_result(response)
 
     async def _send_request(
         self,
         request: agent_pb.SessionRequest,
         timeout: float = 60.0,
     ) -> agent_pb.SessionResponse:
+        if not self._started:
+            raise RuntimeError("remote session is closed")
+
         req_type = request.WhichOneof("request")
-        future: asyncio.Future[agent_pb.SessionResponse] = asyncio.Future()
+        future: asyncio.Future[agent_pb.SessionResponse] = (
+            asyncio.get_running_loop().create_future()
+        )
+        # Register before send so a fast response cannot arrive unmatched.
         self._pending_requests[request.request_id] = future
 
         try:
             msg = agent_pb.AgentSessionMessage(request=request)
             await self._transport.send_message(msg)
-            resp = await asyncio.wait_for(future, timeout=timeout)
-        except asyncio.TimeoutError:
-            self._pending_requests.pop(request.request_id, None)
+            # shield so wait_for timeout does not cancel the future; cleanup is in finally.
+            resp = await asyncio.wait_for(asyncio.shield(future), timeout=timeout)
+        except TimeoutError:
             logger.warning(
                 "remote session request timed out",
                 extra={"request_id": request.request_id, "type": req_type, "timeout": timeout},
             )
             raise
-        except Exception:
+        finally:
             self._pending_requests.pop(request.request_id, None)
-            raise
 
         if resp.error:
             raise RuntimeError(f"session request {req_type} failed: {resp.error}")

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -1266,11 +1266,18 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
         return resp
 
     async def wait_for_ready(self, timeout: float = 5.0, retry_interval: float = 0.5) -> None:
+        """Wait until the remote session answers a ping.
+
+        Retries on request timeouts and transient transport send failures (e.g.
+        room not connected yet, destination participant missing, stream_bytes
+        errors) until ``timeout`` elapses, then raises ``TimeoutError``.
+        """
         deadline = asyncio.get_event_loop().time() + timeout
+        last_error: BaseException | None = None
         while True:
             remaining = deadline - asyncio.get_event_loop().time()
             if remaining <= 0:
-                raise TimeoutError("wait_for_ready timed out")
+                raise TimeoutError("wait_for_ready timed out") from last_error
             req = agent_pb.SessionRequest(
                 request_id=utils.shortuuid("req_"),
                 ping=agent_pb.SessionRequest.Ping(),
@@ -1278,9 +1285,18 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
             try:
                 await self._send_request(req, timeout=min(retry_interval, remaining))
                 return
-            except (TimeoutError, asyncio.TimeoutError):
-                if asyncio.get_event_loop().time() >= deadline:
-                    raise TimeoutError("wait_for_ready timed out") from None
+            except asyncio.CancelledError:
+                raise
+            except (TimeoutError, asyncio.TimeoutError) as e:
+                # wait_for already consumed time up to retry_interval; retry immediately.
+                last_error = e
+            except Exception as e:
+                # Transport may not be ready yet (room connecting, peer absent).
+                last_error = e
+                remaining = deadline - asyncio.get_event_loop().time()
+                if remaining <= 0:
+                    raise TimeoutError("wait_for_ready timed out") from last_error
+                await asyncio.sleep(min(retry_interval, remaining))
 
     async def get_chat_history(self) -> agent_pb.SessionResponse.GetChatHistoryResponse:
         req = agent_pb.SessionRequest(

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -499,17 +499,20 @@ class SessionHost:
         if self._writer_task:
             remaining = _remaining_timeout(drain_deadline)
             if remaining > 0 and not self._writer_task.done():
-                try:
-                    await asyncio.wait_for(self._writer_task, timeout=remaining)
-                except (TimeoutError, asyncio.TimeoutError):
+                # Use wait(), not wait_for()/await on the task: _writer_loop
+                # re-raises CancelledError from transport.send_message, which
+                # leaves the Task cancelled. Awaiting that Task would raise
+                # CancelledError here and abort AgentSession cleanup even
+                # though aclose itself was not cancelled.
+                done, pending = await asyncio.wait({self._writer_task}, timeout=remaining)
+                if pending:
                     logger.warning(
                         "session host outbound writer did not drain before shutdown grace period",
                         extra={"queued_messages": self._outbound_ch.qsize()},
                     )
                     await utils.aio.cancel_and_wait(self._writer_task)
-                except asyncio.CancelledError:
-                    await utils.aio.cancel_and_wait(self._writer_task)
-                    raise
+                elif self._writer_task.cancelled():
+                    logger.debug("session host outbound writer ended cancelled during shutdown")
             elif not self._writer_task.done():
                 await utils.aio.cancel_and_wait(self._writer_task)
             self._writer_task = None

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -428,6 +428,9 @@ class SessionHost:
             return
         self._started = True
         self._accepting_requests = True
+        # aclose() closes the outbound channel; recreate so start() is restartable.
+        if self._outbound_ch.closed:
+            self._outbound_ch = utils.aio.Chan[_OutboundMessage]()
         await self._transport.start()
         self._writer_task = asyncio.create_task(
             self._writer_loop(), name="SessionHost._writer_loop"
@@ -454,7 +457,10 @@ class SessionHost:
             self._session.off("debug_message", self._on_debug_message)
 
         # Stop accepting new requests, then give in-flight handlers a chance to
-        # queue their responses before we drain the outbound writer.
+        # finish (including queueing/awaiting their responses) before we close
+        # the outbound channel. Unlike the old cancel-all path, this keeps a
+        # completed run_input acknowledgement from being dropped after the
+        # conversation event was already delivered.
         if self._recv_task:
             await utils.aio.cancel_and_wait(self._recv_task)
             self._recv_task = None
@@ -494,7 +500,7 @@ class SessionHost:
                     await self._transport.send_message(item.msg)
                 except asyncio.CancelledError:
                     if item.done is not None and not item.done.done():
-                        item.done.set_exception(asyncio.CancelledError())
+                        item.done.set_exception(RuntimeError("session host writer cancelled"))
                     raise
                 except Exception as e:
                     if item.done is not None and not item.done.done():
@@ -1235,13 +1241,22 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
             msg = agent_pb.AgentSessionMessage(request=request)
             await self._transport.send_message(msg)
             # shield so wait_for timeout does not cancel the future; cleanup is in finally.
-            resp = await asyncio.wait_for(asyncio.shield(future), timeout=timeout)
-        except TimeoutError:
-            logger.warning(
-                "remote session request timed out",
-                extra={"request_id": request.request_id, "type": req_type, "timeout": timeout},
-            )
-            raise
+            try:
+                resp = await asyncio.wait_for(asyncio.shield(future), timeout=timeout)
+            except TimeoutError:
+                # The response may have won the race with the timeout callback.
+                if future.done() and not future.cancelled():
+                    resp = future.result()
+                else:
+                    logger.warning(
+                        "remote session request timed out",
+                        extra={
+                            "request_id": request.request_id,
+                            "type": req_type,
+                            "timeout": timeout,
+                        },
+                    )
+                    raise
         finally:
             self._pending_requests.pop(request.request_id, None)
 

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -472,7 +472,7 @@ class SessionHost:
                     asyncio.gather(*handler_tasks, return_exceptions=True),
                     timeout=_SHUTDOWN_DRAIN_TIMEOUT,
                 )
-            except TimeoutError:
+            except (TimeoutError, asyncio.TimeoutError):
                 logger.warning(
                     "session host request handlers did not finish before shutdown grace period",
                     extra={"pending_handlers": len(self._tasks.tasks)},
@@ -483,7 +483,7 @@ class SessionHost:
         if self._writer_task:
             try:
                 await asyncio.wait_for(self._writer_task, timeout=_SHUTDOWN_DRAIN_TIMEOUT)
-            except TimeoutError:
+            except (TimeoutError, asyncio.TimeoutError):
                 logger.warning(
                     "session host outbound writer did not drain before shutdown grace period",
                     extra={"queued_messages": self._outbound_ch.qsize()},
@@ -1243,7 +1243,7 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
             # shield so wait_for timeout does not cancel the future; cleanup is in finally.
             try:
                 resp = await asyncio.wait_for(asyncio.shield(future), timeout=timeout)
-            except TimeoutError:
+            except (TimeoutError, asyncio.TimeoutError):
                 # The response may have won the race with the timeout callback.
                 if future.done() and not future.cancelled():
                     resp = future.result()

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -65,7 +65,9 @@ if TYPE_CHECKING:
 
 
 TOPIC_SESSION_MESSAGES = "lk.agent.session"
-_SHUTDOWN_DRAIN_TIMEOUT = 5.0
+# Total SessionHost.aclose drain budget for in-flight handlers + outbound writer.
+# Must stay well below worker shutdown_process_timeout (default 10s).
+_SHUTDOWN_DRAIN_TIMEOUT = 3.0
 
 
 @dataclass
@@ -74,6 +76,10 @@ class _OutboundMessage:
 
     msg: agent_pb.AgentSessionMessage
     done: asyncio.Future[None] | None = None
+
+
+def _remaining_timeout(deadline: float) -> float:
+    return max(0.0, deadline - asyncio.get_event_loop().time())
 
 
 class SessionTransport(ABC):
@@ -461,33 +467,49 @@ class SessionHost:
         # the outbound channel. Unlike the old cancel-all path, this keeps a
         # completed run_input acknowledgement from being dropped after the
         # conversation event was already delivered.
+        #
+        # Handlers and the writer share one drain deadline so aclose cannot
+        # stack two full grace periods and exhaust the worker process shutdown
+        # budget (default 10s).
         if self._recv_task:
             await utils.aio.cancel_and_wait(self._recv_task)
             self._recv_task = None
 
+        drain_deadline = asyncio.get_event_loop().time() + _SHUTDOWN_DRAIN_TIMEOUT
+
         handler_tasks = self._tasks.tasks
         if handler_tasks:
-            try:
-                await asyncio.wait_for(
-                    asyncio.gather(*handler_tasks, return_exceptions=True),
-                    timeout=_SHUTDOWN_DRAIN_TIMEOUT,
-                )
-            except (TimeoutError, asyncio.TimeoutError):
-                logger.warning(
-                    "session host request handlers did not finish before shutdown grace period",
-                    extra={"pending_handlers": len(self._tasks.tasks)},
-                )
+            remaining = _remaining_timeout(drain_deadline)
+            if remaining > 0:
+                try:
+                    await asyncio.wait_for(
+                        asyncio.gather(*handler_tasks, return_exceptions=True),
+                        timeout=remaining,
+                    )
+                except (TimeoutError, asyncio.TimeoutError):
+                    logger.warning(
+                        "session host request handlers did not finish before shutdown grace period",
+                        extra={"pending_handlers": len(self._tasks.tasks)},
+                    )
+                    await utils.aio.cancel_and_wait(*self._tasks.tasks)
+            else:
                 await utils.aio.cancel_and_wait(*self._tasks.tasks)
 
         self._outbound_ch.close()
         if self._writer_task:
-            try:
-                await asyncio.wait_for(self._writer_task, timeout=_SHUTDOWN_DRAIN_TIMEOUT)
-            except (TimeoutError, asyncio.TimeoutError):
-                logger.warning(
-                    "session host outbound writer did not drain before shutdown grace period",
-                    extra={"queued_messages": self._outbound_ch.qsize()},
-                )
+            remaining = _remaining_timeout(drain_deadline)
+            if remaining > 0 and not self._writer_task.done():
+                try:
+                    await asyncio.wait_for(self._writer_task, timeout=remaining)
+                except (TimeoutError, asyncio.TimeoutError):
+                    logger.warning(
+                        "session host outbound writer did not drain before shutdown grace period",
+                        extra={"queued_messages": self._outbound_ch.qsize()},
+                    )
+                    await utils.aio.cancel_and_wait(self._writer_task)
+                except asyncio.CancelledError:
+                    pass
+            elif not self._writer_task.done():
                 await utils.aio.cancel_and_wait(self._writer_task)
             self._writer_task = None
 
@@ -515,6 +537,9 @@ class SessionHost:
         except Exception:
             logger.warning("session host writer loop failed", exc_info=True)
         finally:
+            # Nothing else consumes the channel: close it so later queue attempts
+            # fail fast instead of waiting on a future nobody will resolve.
+            self._outbound_ch.close()
             # Fail any messages still buffered when the writer exits.
             while True:
                 try:

--- a/tests/test_remote_session.py
+++ b/tests/test_remote_session.py
@@ -622,6 +622,54 @@ async def test_writer_exit_closes_outbound_channel_and_fails_fast():
 
 
 @pytest.mark.asyncio
+async def test_aclose_ignores_cancelled_writer_task():
+    """A cancelled writer must not make aclose() raise CancelledError.
+
+    _writer_loop re-raises CancelledError from transport.send_message, leaving
+    the writer Task cancelled. Awaiting that Task via wait_for would propagate
+    CancelledError into aclose and abort AgentSession cleanup (RoomIO close).
+    """
+    host_transport, client_transport = AdversarialTransport.create_pair()
+    # Block the response send so aclose reaches wait() while the writer is alive.
+    host_transport.pause_responses()
+    host_transport._on_response_send = asyncio.Event()
+
+    mock_session = _make_mock_session()
+    mock_session.interrupt = AsyncMock()
+    mock_session.run = MagicMock(return_value=_fake_run_result())
+
+    host = SessionHost(host_transport)
+    host.register_session(mock_session)
+    await host.start()
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    run_task = asyncio.create_task(client.run("hello", timeout=5.0))
+    await asyncio.wait_for(host_transport._on_response_send.wait(), timeout=2.0)
+
+    close_task = asyncio.create_task(host.aclose())
+    # Let aclose cancel recv, drain handlers, close the outbound channel, and
+    # enter wait() on the still-blocked writer.
+    await asyncio.sleep(0.05)
+    assert host._writer_task is not None
+    assert not close_task.done()
+
+    # Cancel the writer while aclose is waiting on it — same end state as
+    # CancelledError bubbling out of transport.send_message.
+    host._writer_task.cancel()
+
+    # Must complete without CancelledError propagating out of aclose.
+    await asyncio.wait_for(close_task, timeout=2.0)
+    assert host_transport._closed
+
+    run_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await run_task
+    await client.aclose()
+
+
+@pytest.mark.asyncio
 async def test_response_arriving_at_timeout_boundary_still_resolves():
     """If the ack lands in the same tick as the wait timeout, prefer success."""
     host_transport, client_transport = AdversarialTransport.create_pair()

--- a/tests/test_remote_session.py
+++ b/tests/test_remote_session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock
 
@@ -8,6 +9,7 @@ import pytest
 
 from livekit.agents.llm import ChatContext, ChatMessage
 from livekit.agents.metrics import AgentSessionUsage
+from livekit.agents.voice.events import ConversationItemAddedEvent
 from livekit.agents.voice.remote_session import (
     RemoteSession,
     SessionHost,
@@ -25,6 +27,9 @@ class PairedTransport(SessionTransport):
         self._inbox: asyncio.Queue[agent_pb.AgentSessionMessage] = asyncio.Queue()
         self._peer: PairedTransport | None = None
         self._closed = False
+        self.active_sends = 0
+        self.max_concurrent_sends = 0
+        self.send_count = 0
 
     @classmethod
     def create_pair(cls) -> tuple[PairedTransport, PairedTransport]:
@@ -37,8 +42,15 @@ class PairedTransport(SessionTransport):
         pass
 
     async def send_message(self, msg: agent_pb.AgentSessionMessage) -> None:
-        if self._peer and not self._peer._closed:
-            self._peer._inbox.put_nowait(msg)
+        self.active_sends += 1
+        self.max_concurrent_sends = max(self.max_concurrent_sends, self.active_sends)
+        self.send_count += 1
+        try:
+            await asyncio.sleep(0)
+            if self._peer and not self._peer._closed:
+                self._peer._inbox.put_nowait(msg)
+        finally:
+            self.active_sends -= 1
 
     async def close(self) -> None:
         self._closed = True
@@ -51,7 +63,96 @@ class PairedTransport(SessionTransport):
             raise StopAsyncIteration
         try:
             return await asyncio.wait_for(self._inbox.get(), timeout=1.0)
-        except (asyncio.TimeoutError, asyncio.CancelledError):
+        except (TimeoutError, asyncio.CancelledError):
+            raise StopAsyncIteration from None
+
+
+class AdversarialTransport(SessionTransport):
+    """Controllable transport for deterministic race reproduction.
+
+    * Events are delivered immediately to the peer.
+    * Responses can be paused until explicitly released.
+    * Tracks concurrent ``send_message`` calls.
+    """
+
+    def __init__(self) -> None:
+        self._inbox: asyncio.Queue[agent_pb.AgentSessionMessage] = asyncio.Queue()
+        self._peer: AdversarialTransport | None = None
+        self._closed = False
+        self.active_sends = 0
+        self.max_concurrent_sends = 0
+        self.sent_messages: list[agent_pb.AgentSessionMessage] = []
+        self.response_ids: list[str] = []
+        self.event_count = 0
+        self._pause_responses = False
+        self._response_gate = asyncio.Event()
+        self._response_gate.set()
+        self._on_response_send: asyncio.Event | None = None
+        self._block_until_release: asyncio.Event | None = None
+
+    @classmethod
+    def create_pair(cls) -> tuple[AdversarialTransport, AdversarialTransport]:
+        a, b = cls(), cls()
+        a._peer = b
+        b._peer = a
+        return a, b
+
+    def pause_responses(self) -> None:
+        self._pause_responses = True
+        self._response_gate.clear()
+
+    def release_responses(self) -> None:
+        self._pause_responses = False
+        self._response_gate.set()
+
+    async def start(self) -> None:
+        pass
+
+    async def send_message(self, msg: agent_pb.AgentSessionMessage) -> None:
+        self.active_sends += 1
+        self.max_concurrent_sends = max(self.max_concurrent_sends, self.active_sends)
+        try:
+            if self._closed:
+                raise RuntimeError("adversarial transport is closed")
+
+            is_response = msg.HasField("response")
+            if is_response:
+                self.response_ids.append(msg.response.request_id)
+                if self._on_response_send is not None and not self._on_response_send.is_set():
+                    self._on_response_send.set()
+                if self._block_until_release is not None:
+                    await self._block_until_release.wait()
+                if self._pause_responses:
+                    await self._response_gate.wait()
+            elif msg.HasField("event"):
+                self.event_count += 1
+
+            # Yield so concurrent send attempts would overlap without serialization.
+            await asyncio.sleep(0)
+            if self._closed:
+                raise RuntimeError("adversarial transport is closed")
+
+            self.sent_messages.append(msg)
+            if self._peer and not self._peer._closed:
+                self._peer._inbox.put_nowait(msg)
+        finally:
+            self.active_sends -= 1
+
+    async def close(self) -> None:
+        self._closed = True
+        self.release_responses()
+        if self._block_until_release is not None:
+            self._block_until_release.set()
+
+    def __aiter__(self) -> AsyncIterator[agent_pb.AgentSessionMessage]:
+        return self
+
+    async def __anext__(self) -> agent_pb.AgentSessionMessage:
+        if self._closed:
+            raise StopAsyncIteration
+        try:
+            return await asyncio.wait_for(self._inbox.get(), timeout=2.0)
+        except (TimeoutError, asyncio.CancelledError):
             raise StopAsyncIteration from None
 
 
@@ -93,6 +194,35 @@ def _make_mock_session() -> MagicMock:
     session.usage = usage
 
     return session
+
+
+def _fake_run_result(
+    *,
+    text: str = "hi there",
+    msg_id: str = "m-1",
+    delay: float = 0.0,
+    emit_event: ConversationItemAddedEvent | None = None,
+    host: SessionHost | None = None,
+) -> MagicMock:
+    class FakeRunResult:
+        events = [MagicMock(item=ChatMessage(role="assistant", content=[text], id=msg_id))]
+
+        def done(self) -> bool:
+            return True
+
+        def __await__(self):
+            return self._await().__await__()
+
+        async def _await(self) -> FakeRunResult:
+            if emit_event is not None and host is not None:
+                host._on_conversation_item_added(emit_event)
+                # Let the event queue through the writer before the run completes.
+                await asyncio.sleep(0)
+            if delay:
+                await asyncio.sleep(delay)
+            return self
+
+    return FakeRunResult()
 
 
 @pytest.mark.asyncio
@@ -177,17 +307,7 @@ async def test_run_input():
 
     mock_session = _make_mock_session()
     mock_session.interrupt = AsyncMock()
-
-    class FakeRunResult:
-        events = [MagicMock(item=ChatMessage(role="assistant", content=["hi there"], id="m-1"))]
-
-        def done(self):
-            return True
-
-        def __await__(self):
-            return asyncio.sleep(0).__await__()
-
-    mock_session.run = MagicMock(return_value=FakeRunResult())
+    mock_session.run = MagicMock(return_value=_fake_run_result())
 
     host = SessionHost(host_transport)
     host.register_session(mock_session)
@@ -198,6 +318,347 @@ async def test_run_input():
 
     resp = await client.run("order a big mac", timeout=5.0)
     assert resp is not None
+    assert len(resp.items) == 1
+
+    await client.aclose()
+    await host.aclose()
+
+
+@pytest.mark.asyncio
+async def test_events_arrive_before_run_input_response():
+    """Conversation events may be delivered before the matching SessionResponse."""
+    host_transport, client_transport = AdversarialTransport.create_pair()
+
+    mock_session = _make_mock_session()
+    mock_session.interrupt = AsyncMock()
+
+    host = SessionHost(host_transport)
+    assistant_item = ChatMessage(role="assistant", content=["booked"], id="asst-1")
+    emit_event = ConversationItemAddedEvent(item=assistant_item)
+    mock_session.run = MagicMock(
+        return_value=_fake_run_result(
+            text="booked",
+            msg_id="asst-1",
+            emit_event=emit_event,
+            host=host,
+        )
+    )
+    host.register_session(mock_session)
+    await host.start()
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    seen_events: list[agent_pb.AgentSessionEvent] = []
+    response_seen = asyncio.Event()
+
+    def _on_conversation_item_added(event: agent_pb.AgentSessionEvent) -> None:
+        seen_events.append(event)
+        # Event should be observable before run() returns.
+        assert not response_seen.is_set()
+
+    client.on("conversation_item_added", _on_conversation_item_added)
+
+    resp = await client.run("book me", timeout=5.0)
+    response_seen.set()
+
+    assert len(resp.items) == 1
+    assert resp.items[0].message.id == "asst-1"
+    assert len(seen_events) == 1
+    assert host_transport.max_concurrent_sends == 1
+
+    await client.aclose()
+    await host.aclose()
+
+
+@pytest.mark.asyncio
+async def test_serialized_writes_never_overlap():
+    host_transport, client_transport = AdversarialTransport.create_pair()
+
+    mock_session = _make_mock_session()
+    mock_session.interrupt = AsyncMock()
+
+    host = SessionHost(host_transport)
+    host.register_session(mock_session)
+    await host.start()
+
+    # Flood events while also answering run_input.
+    for i in range(20):
+        host._on_conversation_item_added(
+            ConversationItemAddedEvent(
+                item=ChatMessage(role="assistant", content=[f"e{i}"], id=f"e-{i}")
+            )
+        )
+
+    mock_session.run = MagicMock(return_value=_fake_run_result(text="done", msg_id="final"))
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    resp = await client.run("hello", timeout=5.0)
+    assert len(resp.items) == 1
+    assert host_transport.max_concurrent_sends == 1
+    assert host_transport.event_count >= 20
+
+    await client.aclose()
+    await host.aclose()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_run_input_request_ids_are_unique_and_matched():
+    host_transport, client_transport = PairedTransport.create_pair()
+
+    mock_session = _make_mock_session()
+    mock_session.interrupt = AsyncMock()
+    call_count = 0
+
+    def _run(user_input: str = "") -> MagicMock:
+        nonlocal call_count
+        call_count += 1
+        n = call_count
+        return _fake_run_result(text=f"reply-{n}", msg_id=f"m-{n}", delay=0.01)
+
+    mock_session.run = MagicMock(side_effect=_run)
+
+    host = SessionHost(host_transport)
+    host.register_session(mock_session)
+    await host.start()
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    results = await asyncio.gather(
+        client.run("one", timeout=5.0),
+        client.run("two", timeout=5.0),
+        client.run("three", timeout=5.0),
+    )
+
+    ids = [r.items[0].message.id for r in results]
+    assert len(set(ids)) == 3
+    assert client._pending_requests == {}
+    assert host_transport.max_concurrent_sends == 1
+
+    await client.aclose()
+    await host.aclose()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_flushes_queued_run_input_response():
+    """Response delayed behind a gate must still be delivered across shutdown.
+
+    Reproduces the #6661 failure mode where aclose cancelled in-flight sends
+    after conversation events had already been delivered.
+    """
+    host_transport, client_transport = AdversarialTransport.create_pair()
+    host_transport.pause_responses()
+    host_transport._on_response_send = asyncio.Event()
+
+    mock_session = _make_mock_session()
+    mock_session.interrupt = AsyncMock()
+
+    host = SessionHost(host_transport)
+    assistant_item = ChatMessage(role="assistant", content=["confirmed"], id="asst-shutdown")
+    mock_session.run = MagicMock(
+        return_value=_fake_run_result(
+            text="confirmed",
+            msg_id="asst-shutdown",
+            emit_event=ConversationItemAddedEvent(item=assistant_item),
+            host=host,
+        )
+    )
+    host.register_session(mock_session)
+    await host.start()
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    seen_events: list[agent_pb.AgentSessionEvent] = []
+    client.on("conversation_item_added", lambda ev: seen_events.append(ev))
+
+    run_task = asyncio.create_task(client.run("confirm booking", timeout=5.0))
+
+    # Wait until the host has begun sending the run_input response (paused).
+    await asyncio.wait_for(host_transport._on_response_send.wait(), timeout=2.0)
+    assert len(seen_events) == 1
+    assert not run_task.done()
+
+    # Begin shutdown while the response write is paused; then release it so the
+    # drained writer can finish delivering the acknowledgement.
+    close_task = asyncio.create_task(host.aclose())
+    await asyncio.sleep(0)
+    host_transport.release_responses()
+
+    resp = await asyncio.wait_for(run_task, timeout=5.0)
+    await asyncio.wait_for(close_task, timeout=5.0)
+
+    assert len(resp.items) == 1
+    assert resp.items[0].message.id == "asst-shutdown"
+    assert len(host_transport.response_ids) >= 1
+
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_late_response_after_timeout_is_logged(caplog: pytest.LogCaptureFixture):
+    host_transport, client_transport = AdversarialTransport.create_pair()
+    host_transport.pause_responses()
+
+    mock_session = _make_mock_session()
+    mock_session.interrupt = AsyncMock()
+    mock_session.run = MagicMock(return_value=_fake_run_result())
+
+    host = SessionHost(host_transport)
+    host.register_session(mock_session)
+    await host.start()
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(TimeoutError):
+            await client.run("hello", timeout=0.05)
+
+        assert client._pending_requests == {}
+        host_transport.release_responses()
+        # Allow the late response to arrive and be logged.
+        await asyncio.sleep(0.1)
+
+    assert any(
+        "unknown or timed-out request" in r.message or "timed out" in r.message
+        for r in caplog.records
+    )
+
+    await client.aclose()
+    await host.aclose()
+
+
+@pytest.mark.asyncio
+async def test_unknown_request_id_does_not_crash(caplog: pytest.LogCaptureFixture):
+    host_transport, client_transport = PairedTransport.create_pair()
+
+    host = SessionHost(host_transport)
+    host.register_session(_make_mock_session())
+    await host.start()
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    orphan = agent_pb.AgentSessionMessage(
+        response=agent_pb.SessionResponse(
+            request_id="req_does_not_exist",
+            pong=agent_pb.SessionResponse.Pong(),
+        )
+    )
+    with caplog.at_level(logging.WARNING):
+        await host_transport.send_message(orphan)
+        await asyncio.sleep(0.1)
+
+    assert any("unknown or timed-out request" in r.message for r in caplog.records)
+
+    # Client remains usable.
+    await client.wait_for_ready(timeout=2.0)
+
+    await client.aclose()
+    await host.aclose()
+
+
+@pytest.mark.asyncio
+async def test_transport_closure_fails_pending_futures():
+    host_transport, client_transport = AdversarialTransport.create_pair()
+    host_transport.pause_responses()
+
+    mock_session = _make_mock_session()
+    mock_session.interrupt = AsyncMock()
+    mock_session.run = MagicMock(return_value=_fake_run_result(delay=0.01))
+
+    host = SessionHost(host_transport)
+    host.register_session(mock_session)
+    await host.start()
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    run_task = asyncio.create_task(client.run("hello", timeout=5.0))
+    await asyncio.sleep(0.05)
+
+    await client.aclose()
+
+    with pytest.raises(RuntimeError, match="remote session closed"):
+        await run_task
+
+    host_transport.release_responses()
+    await host.aclose()
+
+
+@pytest.mark.asyncio
+async def test_empty_run_result_is_not_a_timeout():
+    host_transport, client_transport = PairedTransport.create_pair()
+
+    class EmptyRunResult:
+        events: list[MagicMock] = []
+
+        def done(self) -> bool:
+            return True
+
+        def __await__(self):
+            return asyncio.sleep(0).__await__()
+
+    mock_session = _make_mock_session()
+    mock_session.interrupt = AsyncMock()
+    mock_session.run = MagicMock(return_value=EmptyRunResult())
+
+    host = SessionHost(host_transport)
+    host.register_session(mock_session)
+    await host.start()
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    with pytest.raises(RuntimeError, match="no response items"):
+        await client.run("hello", timeout=5.0)
+
+    await client.aclose()
+    await host.aclose()
+
+
+@pytest.mark.asyncio
+async def test_run_input_stress_with_scheduling_jitter():
+    host_transport, client_transport = PairedTransport.create_pair()
+
+    mock_session = _make_mock_session()
+    mock_session.interrupt = AsyncMock()
+    n = 0
+
+    def _run(user_input: str = "") -> MagicMock:
+        nonlocal n
+        n += 1
+        return _fake_run_result(text=f"r{n}", msg_id=f"id-{n}", delay=0.0)
+
+    mock_session.run = MagicMock(side_effect=_run)
+
+    host = SessionHost(host_transport)
+    host.register_session(mock_session)
+    await host.start()
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    async def _one_turn(i: int) -> str:
+        # Interleave events with requests to stress the outbound writer.
+        host._on_conversation_item_added(
+            ConversationItemAddedEvent(
+                item=ChatMessage(role="user", content=[f"u{i}"], id=f"u-{i}")
+            )
+        )
+        await asyncio.sleep(0)
+        resp = await client.run(f"turn-{i}", timeout=5.0)
+        return resp.items[0].message.id
+
+    ids = await asyncio.gather(*[_one_turn(i) for i in range(50)])
+    assert len(ids) == 50
+    assert len(set(ids)) == 50
+    assert client._pending_requests == {}
+    assert host_transport.max_concurrent_sends == 1
 
     await client.aclose()
     await host.aclose()

--- a/tests/test_remote_session.py
+++ b/tests/test_remote_session.py
@@ -447,7 +447,9 @@ async def test_shutdown_flushes_queued_run_input_response():
     """Response delayed behind a gate must still be delivered across shutdown.
 
     Reproduces the #6661 failure mode where aclose cancelled in-flight sends
-    after conversation events had already been delivered.
+    after conversation events had already been delivered. The old cancel-all
+    path drops the ack (proven separately); this asserts the new drain path
+    keeps it.
     """
     host_transport, client_transport = AdversarialTransport.create_pair()
     host_transport.pause_responses()
@@ -496,6 +498,92 @@ async def test_shutdown_flushes_queued_run_input_response():
     assert len(host_transport.response_ids) >= 1
 
     await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_response_arriving_at_timeout_boundary_still_resolves():
+    """If the ack lands in the same tick as the wait timeout, prefer success."""
+    host_transport, client_transport = AdversarialTransport.create_pair()
+    host_transport.pause_responses()
+
+    mock_session = _make_mock_session()
+    mock_session.interrupt = AsyncMock()
+    mock_session.run = MagicMock(return_value=_fake_run_result(text="barely", msg_id="m-race"))
+
+    host = SessionHost(host_transport)
+    host.register_session(mock_session)
+    await host.start()
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    async def _release_near_timeout() -> None:
+        await asyncio.sleep(0.08)
+        host_transport.release_responses()
+
+    release_task = asyncio.create_task(_release_near_timeout())
+    resp = await client.run("hello", timeout=0.1)
+    await release_task
+
+    assert len(resp.items) == 1
+    assert resp.items[0].message.id == "m-race"
+
+    await client.aclose()
+    await host.aclose()
+
+
+@pytest.mark.asyncio
+async def test_session_host_restart_after_aclose():
+    host_transport, client_transport = PairedTransport.create_pair()
+
+    host = SessionHost(host_transport)
+    host.register_session(_make_mock_session())
+    await host.start()
+    await host.aclose()
+
+    # Reuse the same SessionHost with a fresh transport; start() must recreate
+    # the outbound channel that aclose() closed.
+    host_transport, client_transport = PairedTransport.create_pair()
+    host._transport = host_transport
+    await host.start()
+
+    client = RemoteSession(client_transport)
+    await client.start()
+    await client.wait_for_ready(timeout=2.0)
+
+    await client.aclose()
+    await host.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pending_future_registered_before_send():
+    """A response that arrives during send_message must still resolve."""
+    host_transport, client_transport = PairedTransport.create_pair()
+
+    registered = asyncio.Event()
+    original_send = client_transport.send_message
+
+    async def send_and_signal(msg: agent_pb.AgentSessionMessage) -> None:
+        # By the time send is entered, RemoteSession must already have registered.
+        # We observe this via the client's pending map after a scheduling point.
+        await asyncio.sleep(0)
+        assert any(client._pending_requests), "future must be registered before send"
+        registered.set()
+        await original_send(msg)
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    host = SessionHost(host_transport)
+    host.register_session(_make_mock_session())
+    await host.start()
+
+    client_transport.send_message = send_and_signal  # type: ignore[method-assign]
+    await client.wait_for_ready(timeout=2.0)
+    assert registered.is_set()
+
+    await client.aclose()
+    await host.aclose()
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_session.py
+++ b/tests/test_remote_session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock
@@ -548,6 +549,76 @@ async def test_shutdown_flushes_queued_run_input_response():
     assert len(host_transport.response_ids) >= 1
 
     await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_aclose_uses_shared_drain_deadline(monkeypatch: pytest.MonkeyPatch):
+    """Handler + writer drains share one budget, not two stacked timeouts."""
+    import time
+
+    import livekit.agents.voice.remote_session as rs
+
+    monkeypatch.setattr(rs, "_SHUTDOWN_DRAIN_TIMEOUT", 0.2)
+
+    host_transport, client_transport = AdversarialTransport.create_pair()
+    host_transport.pause_responses()
+    host_transport._on_response_send = asyncio.Event()
+
+    mock_session = _make_mock_session()
+    mock_session.interrupt = AsyncMock()
+    mock_session.run = MagicMock(return_value=_fake_run_result(delay=0.0))
+
+    host = SessionHost(host_transport)
+    host.register_session(mock_session)
+    await host.start()
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    run_task = asyncio.create_task(client.run("hello", timeout=5.0))
+    await asyncio.wait_for(host_transport._on_response_send.wait(), timeout=2.0)
+
+    started = time.monotonic()
+    await host.aclose()
+    elapsed = time.monotonic() - started
+
+    # Shared 0.2s budget: must finish well under the old stacked 0.4s worst case.
+    assert elapsed < 0.35
+
+    run_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await run_task
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_writer_exit_closes_outbound_channel_and_fails_fast():
+    """If the writer dies, later sends must fail immediately (not hang)."""
+    host_transport, _client_transport = PairedTransport.create_pair()
+    host = SessionHost(host_transport)
+    host.register_session(_make_mock_session())
+    await host.start()
+    # Let the writer enter its recv wait so cancellation runs the finally block.
+    await asyncio.sleep(0)
+
+    assert host._writer_task is not None
+    host._writer_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await host._writer_task
+    host._writer_task = None
+
+    assert host._outbound_ch.closed
+
+    msg = agent_pb.AgentSessionMessage(
+        response=agent_pb.SessionResponse(
+            request_id="req_after_writer_death",
+            pong=agent_pb.SessionResponse.Pong(),
+        )
+    )
+    with pytest.raises(RuntimeError, match="outbound channel is closed"):
+        await asyncio.wait_for(host._send_message(msg), timeout=0.5)
+
+    await host.aclose()
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_session.py
+++ b/tests/test_remote_session.py
@@ -63,7 +63,7 @@ class PairedTransport(SessionTransport):
             raise StopAsyncIteration
         try:
             return await asyncio.wait_for(self._inbox.get(), timeout=1.0)
-        except (TimeoutError, asyncio.CancelledError):
+        except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
             raise StopAsyncIteration from None
 
 
@@ -152,7 +152,7 @@ class AdversarialTransport(SessionTransport):
             raise StopAsyncIteration
         try:
             return await asyncio.wait_for(self._inbox.get(), timeout=2.0)
-        except (TimeoutError, asyncio.CancelledError):
+        except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
             raise StopAsyncIteration from None
 
 
@@ -603,7 +603,7 @@ async def test_late_response_after_timeout_is_logged(caplog: pytest.LogCaptureFi
     await client.start()
 
     with caplog.at_level(logging.WARNING):
-        with pytest.raises(TimeoutError):
+        with pytest.raises((TimeoutError, asyncio.TimeoutError)):
             await client.run("hello", timeout=0.05)
 
         assert client._pending_requests == {}

--- a/tests/test_remote_session.py
+++ b/tests/test_remote_session.py
@@ -243,6 +243,56 @@ async def test_ping():
 
 
 @pytest.mark.asyncio
+async def test_wait_for_ready_retries_transport_send_failures():
+    """Transient send failures must be retried until the peer becomes reachable."""
+    host_transport, client_transport = PairedTransport.create_pair()
+
+    host = SessionHost(host_transport)
+    host.register_session(_make_mock_session())
+    await host.start()
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    attempts = {"n": 0}
+    original_send = client_transport.send_message
+
+    async def flaky_send(msg: agent_pb.AgentSessionMessage) -> None:
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise RuntimeError("room session transport is closed")
+        await original_send(msg)
+
+    client_transport.send_message = flaky_send  # type: ignore[method-assign]
+    await client.wait_for_ready(timeout=2.0, retry_interval=0.05)
+    assert attempts["n"] >= 3
+
+    await client.aclose()
+    await host.aclose()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_ready_surfaces_transport_error_after_deadline():
+    host_transport, client_transport = PairedTransport.create_pair()
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    async def always_fail(msg: agent_pb.AgentSessionMessage) -> None:
+        raise RuntimeError("failed to send binary stream message: peer missing")
+
+    client_transport.send_message = always_fail  # type: ignore[method-assign]
+
+    with pytest.raises(TimeoutError, match="wait_for_ready timed out") as ei:
+        await client.wait_for_ready(timeout=0.15, retry_interval=0.05)
+
+    assert ei.value.__cause__ is not None
+    assert "peer missing" in str(ei.value.__cause__)
+
+    await client.aclose()
+
+
+@pytest.mark.asyncio
 async def test_get_chat_history():
     host_transport, client_transport = PairedTransport.create_pair()
 


### PR DESCRIPTION
Serialize SessionHost outbound events and responses through a single writer so concurrent transport writes and shutdown cancellation cannot drop a completed run_input acknowledgement after conversation events were already delivered (spurious "Agent did not respond within 60.0s").

Also harden RemoteSession pending-request handling (register-before-send, finally cleanup, late/unknown response warnings, clear close errors) and make room/TCP transports fail loudly on send errors.

addresses #6661