### PR TITLE
Add beta post-call CRM/analytics telemetry collector (#6664)

### DIFF
--- a/examples/voice_agents/gtm_telemetry_agent.py
+++ b/examples/voice_agents/gtm_telemetry_agent.py
@@ -1,0 +1,105 @@
+import logging
+import os
+
+from dotenv import load_dotenv
+
+from livekit.agents import (
+    Agent,
+    AgentServer,
+    AgentSession,
+    JobContext,
+    RunContext,
+    cli,
+    inference,
+    room_io,
+)
+from livekit.agents.beta.gtm_telemetry import (
+    PostCallTelemetryCollector,
+    PostCallWebhookDispatcher,
+    WebhookConfig,
+    WebhookDeliveryError,
+)
+from livekit.agents.llm import function_tool
+
+logger = logging.getLogger("gtm-telemetry-agent")
+
+load_dotenv()
+
+# Beta feature: livekit.agents.beta.gtm_telemetry is opt-in and not covered by semver
+# stability guarantees. Nothing here runs unless you construct and attach a collector
+# yourself. collector.finalize() also works without a JobContext (e.g. `console` mode
+# or a bare script) — job_id/room_id/room_name/participant_identity are simply None.
+#
+# Transcripts and tool arguments/results may contain personal or confidential
+# information — review CollectorConfig before enabling this in production, and only
+# point the webhook at a destination you trust.
+
+
+class MyAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(
+            instructions="Your name is Kelly, a sales assistant built by LiveKit. "
+            "Keep responses concise and to the point. You will speak english to the "
+            "user over voice."
+        )
+
+    async def on_enter(self) -> None:
+        self.session.generate_reply(instructions="greet the user and introduce yourself")
+
+    @function_tool
+    async def lookup_pricing(self, context: RunContext, plan: str) -> str:
+        """Called when the user asks about pricing for a plan.
+
+        Args:
+            plan: The plan name the user is asking about.
+        """
+        return f"the {plan} plan is $49/month"
+
+
+server = AgentServer()
+
+
+@server.rtc_session()
+async def entrypoint(ctx: JobContext) -> None:
+    session: AgentSession = AgentSession(
+        stt=inference.STT("deepgram/nova-3", language="multi"),
+        llm=inference.LLM("openai/gpt-4.1-mini"),
+        tts=inference.TTS("cartesia/sonic-3", voice="9626c31c-bec5-4cca-baa8-f8ba9e84c8bc"),
+    )
+
+    collector = PostCallTelemetryCollector(
+        metadata={"campaign": "inbound-demo"},
+    )
+    collector.attach(session, job_ctx=ctx)
+
+    async def deliver_post_call_report() -> None:
+        report = collector.finalize()
+
+        webhook_url = os.environ.get("POST_CALL_WEBHOOK_URL")
+        webhook_secret = os.environ.get("POST_CALL_WEBHOOK_SECRET")
+        if not webhook_url or not webhook_secret:
+            logger.info("post-call webhook not configured, skipping delivery")
+            return
+
+        dispatcher = PostCallWebhookDispatcher(
+            WebhookConfig(url=webhook_url, secret=webhook_secret)
+        )
+        try:
+            await dispatcher.send(report)
+        except WebhookDeliveryError:
+            logger.exception("failed to deliver post-call report")
+        finally:
+            await dispatcher.aclose()
+
+    # shutdown callbacks are triggered when the session is over
+    ctx.add_shutdown_callback(deliver_post_call_report)
+
+    await session.start(
+        agent=MyAgent(),
+        room=ctx.room,
+        room_options=room_io.RoomOptions(),
+    )
+
+
+if __name__ == "__main__":
+    cli.run_app(server)

--- a/livekit-agents/livekit/agents/beta/gtm_telemetry/__init__.py
+++ b/livekit-agents/livekit/agents/beta/gtm_telemetry/__init__.py
@@ -1,0 +1,69 @@
+"""Post-call CRM & analytics telemetry: report collector, signed webhook delivery, and
+pure CRM payload adapters.
+
+Beta: this package's API and schema are not covered by semver stability guarantees and
+may change in a future release. Opt-in only — nothing here runs unless you construct
+and attach a :class:`PostCallTelemetryCollector` yourself.
+
+Transcripts and tool arguments/results may contain personal or confidential
+information. You control whether collection is enabled, what it includes
+(``CollectorConfig``), and whether/where it is delivered. Webhook destinations are
+trusted by this library without further validation — treat them accordingly. This
+module performs no automatic redaction; use ``PostCallTelemetryCollector(redact=...)``
+if you need one.
+
+Example::
+
+    from livekit.agents.beta.gtm_telemetry import (
+        PostCallTelemetryCollector,
+        PostCallWebhookDispatcher,
+        WebhookConfig,
+    )
+
+    collector = PostCallTelemetryCollector(metadata={"lead_id": "lead_123"})
+    collector.attach(session)
+
+    await session.start(...)
+
+    report = collector.finalize()
+
+    dispatcher = PostCallWebhookDispatcher(
+        WebhookConfig(url=os.environ["POST_CALL_WEBHOOK_URL"],
+                       secret=os.environ["POST_CALL_WEBHOOK_SECRET"])
+    )
+    try:
+        await dispatcher.send(report)
+    finally:
+        await dispatcher.aclose()
+"""
+
+from .adapters import build_hubspot_engagement, build_salesforce_task
+from .collector import PostCallTelemetryCollector
+from .models import (
+    CollectorConfig,
+    JsonValue,
+    MetricAggregate,
+    PostCallReport,
+    SessionMetricsSummary,
+    ToolExecutionRecord,
+    ToolProgressUpdate,
+    TranscriptTurn,
+)
+from .webhook import PostCallWebhookDispatcher, WebhookConfig, WebhookDeliveryError
+
+__all__ = [
+    "PostCallTelemetryCollector",
+    "CollectorConfig",
+    "PostCallReport",
+    "TranscriptTurn",
+    "ToolExecutionRecord",
+    "ToolProgressUpdate",
+    "SessionMetricsSummary",
+    "MetricAggregate",
+    "JsonValue",
+    "WebhookConfig",
+    "PostCallWebhookDispatcher",
+    "WebhookDeliveryError",
+    "build_hubspot_engagement",
+    "build_salesforce_task",
+]

--- a/livekit-agents/livekit/agents/beta/gtm_telemetry/adapters.py
+++ b/livekit-agents/livekit/agents/beta/gtm_telemetry/adapters.py
@@ -1,0 +1,144 @@
+"""Pure CRM payload builders.
+
+Beta: not covered by semver stability guarantees. External CRM API schemas change over
+time — these builders are a generic starting point, not full API coverage; consult the
+target CRM's current API docs before wiring a payload to a real portal.
+
+None of these functions perform network calls, require a CRM SDK, read environment
+variables, or mutate the input :class:`~.models.PostCallReport`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from .models import JsonValue, PostCallReport, to_json_safe
+
+
+def _format_transcript(report: PostCallReport, *, max_chars: int | None) -> tuple[str, bool, int]:
+    full_text = "\n".join(f"{turn.role}: {turn.text}" for turn in report.transcript if turn.text)
+    if max_chars is None or len(full_text) <= max_chars:
+        return full_text, False, 0
+    return full_text[:max_chars], True, len(full_text) - max_chars
+
+
+def _tool_summary(report: PostCallReport) -> str:
+    return ", ".join(
+        f"{record.name} ({'error' if record.is_error else record.status})"
+        for record in report.tool_executions
+    )
+
+
+def _copy_metadata(report: PostCallReport) -> dict[str, JsonValue]:
+    # to_json_safe rebuilds every nested container fresh, giving an independent copy
+    # that shares no mutable state with report.metadata
+    copied = to_json_safe(dict(report.metadata))
+    assert isinstance(copied, dict)
+    return copied
+
+
+def build_hubspot_engagement(
+    report: PostCallReport,
+    *,
+    owner_id: str | None = None,
+    contact_ids: Sequence[str] | None = None,
+    title: str | None = None,
+    transcript_max_chars: int | None = 10_000,
+) -> dict[str, JsonValue]:
+    """Build a JSON-safe payload shaped for a HubSpot call Engagement.
+
+    Args:
+        report: The report to summarize.
+        owner_id: Caller-supplied HubSpot owner id. Never fabricated.
+        contact_ids: Caller-supplied HubSpot contact ids to associate. Never fabricated.
+        title: Engagement title; defaults to a generic "Post-call report".
+        transcript_max_chars: Truncate the transcript body to this many characters. When
+            truncated, ``metadata.transcriptTruncated``/``transcriptOmittedChars`` in the
+            returned payload record that fact — content is never silently dropped
+            without a record of it. ``None`` disables truncation.
+    """
+    transcript, truncated, omitted_chars = _format_transcript(
+        report, max_chars=transcript_max_chars
+    )
+    metadata = _copy_metadata(report)
+
+    return {
+        "engagement": {
+            "type": "CALL",
+            "title": title or "Post-call report",
+            "timestamp": report.started_at,
+        },
+        "associations": {
+            "ownerId": owner_id,
+            "contactIds": list(contact_ids) if contact_ids else [],
+        },
+        "metadata": {
+            "durationMilliseconds": (
+                int(report.duration * 1000) if report.duration is not None else None
+            ),
+            "body": transcript,
+            "transcriptTruncated": truncated,
+            "transcriptOmittedChars": omitted_chars,
+            "toolSummary": _tool_summary(report),
+            "disposition": metadata.get("disposition"),
+        },
+        "source": {
+            "jobId": report.job_id,
+            "roomName": report.room_name,
+            "endReason": report.end_reason,
+            "reportId": report.report_id,
+        },
+        "customProperties": metadata,
+    }
+
+
+def build_salesforce_task(
+    report: PostCallReport,
+    *,
+    who_id: str | None = None,
+    what_id: str | None = None,
+    owner_id: str | None = None,
+    subject: str | None = None,
+    transcript_max_chars: int | None = 10_000,
+) -> dict[str, JsonValue]:
+    """Build a JSON-safe payload shaped for a Salesforce Task/Activity.
+
+    Args:
+        report: The report to summarize.
+        who_id: Caller-supplied Salesforce Contact/Lead id. Never fabricated.
+        what_id: Caller-supplied Salesforce related-object id. Never fabricated.
+        owner_id: Caller-supplied Salesforce owner (User) id. Never fabricated.
+        subject: Task subject; defaults to a generic "Post-call report".
+        transcript_max_chars: Truncate the description to this many characters. When
+            truncated, ``descriptionTruncated``/``descriptionOmittedChars`` in the
+            returned payload record that fact. ``None`` disables truncation.
+
+    Not tied to any specific Salesforce API version.
+    """
+    transcript, truncated, omitted_chars = _format_transcript(
+        report, max_chars=transcript_max_chars
+    )
+    metadata = _copy_metadata(report)
+
+    return {
+        "WhoId": who_id,
+        "WhatId": what_id,
+        "OwnerId": owner_id,
+        "Subject": subject or "Post-call report",
+        "Status": "Completed",
+        "Type": "Call",
+        "CallDurationInSeconds": report.duration,
+        "ActivityDate": report.started_at,
+        "Description": transcript,
+        "descriptionTruncated": truncated,
+        "descriptionOmittedChars": omitted_chars,
+        "toolSummary": _tool_summary(report),
+        "disposition": metadata.get("disposition"),
+        "source": {
+            "jobId": report.job_id,
+            "roomName": report.room_name,
+            "endReason": report.end_reason,
+            "reportId": report.report_id,
+        },
+        "customFields": metadata,
+    }

--- a/livekit-agents/livekit/agents/beta/gtm_telemetry/collector.py
+++ b/livekit-agents/livekit/agents/beta/gtm_telemetry/collector.py
@@ -72,6 +72,11 @@ class PostCallTelemetryCollector:
         self._session_ref: weakref.ReferenceType[AgentSession] | None = None
         self._job_ctx: NotGivenOr[JobContext | None] = NOT_GIVEN
         self._cached_report: PostCallReport | None = None
+        # session._started_at at the moment _cached_report was built — lets finalize()
+        # tell a genuinely new call on the SAME AgentSession instance (aclose() then
+        # start() again resets _started_at/_recorded_events) apart from a repeat query
+        # for the same call's report. See finalize() for how this is used.
+        self._cached_report_started_at: float | None = None
 
     @property
     def attached(self) -> bool:
@@ -106,6 +111,7 @@ class PostCallTelemetryCollector:
         self._session_ref = weakref.ref(session)
         self._job_ctx = job_ctx
         self._cached_report = None
+        self._cached_report_started_at = None
         # `.on()`, not `.once()`: EventEmitter.once() registers an internal wrapper
         # closure, not `self._on_close` itself, so a later `.off(event, self._on_close)`
         # in detach() would silently remove nothing and leave the listener firing after
@@ -133,15 +139,31 @@ class PostCallTelemetryCollector:
         (``report.ended is False``) on every call — never cached, since a report built
         mid-call would go stale the moment the call actually ends. Once the session has
         closed, the report is built once and cached; every subsequent call returns that
-        same, authoritative report.
+        same, authoritative report — *unless* the same ``AgentSession`` instance has
+        since been restarted (``aclose()`` then ``start()`` again on the same object,
+        which resets ``session._started_at``/``_recorded_events``), in which case the
+        stale cache is discarded and a fresh report is built for the new call.
 
         Performs no network I/O and never blocks on anything beyond reading in-memory
         session state.
         """
-        if self._cached_report is not None and self._cached_report.ended:
-            return self._cached_report
+        session = self._session_ref() if self._session_ref is not None else None
 
-        session = self._require_session()
+        if self._cached_report is not None and self._cached_report.ended:
+            # A `None` session (detached, or garbage-collected) can't prove the cache
+            # stale, so it's trusted as-is — matching detach()'s documented contract
+            # that the last report stays available. A live session must additionally
+            # match the _started_at captured when the cache was built; an id() compare
+            # on session._recorded_events would NOT work here — finalize() only ever
+            # holds a *copy* of that list, so the original is freed the instant a
+            # restart's start() reassigns it, and CPython's list free-list routinely
+            # hands the freed block straight back out to the next same-size (empty)
+            # list, making an id() match a false positive in exactly this scenario.
+            if session is None or session._started_at == self._cached_report_started_at:
+                return self._cached_report
+
+        if session is None:
+            session = self._require_session()
         # snapshot first: _recorded_events is a live, still-growing list while the
         # session runs, and start() swaps in a brand new list on each restart
         events_snapshot = list(session._recorded_events)
@@ -175,6 +197,7 @@ class PostCallTelemetryCollector:
 
         if report.ended:
             self._cached_report = report
+            self._cached_report_started_at = session._started_at
 
         return report
 

--- a/livekit-agents/livekit/agents/beta/gtm_telemetry/collector.py
+++ b/livekit-agents/livekit/agents/beta/gtm_telemetry/collector.py
@@ -1,0 +1,196 @@
+"""Collector that attaches to an ``AgentSession`` and builds a post-call report.
+
+Beta: not covered by semver stability guarantees.
+"""
+
+from __future__ import annotations
+
+import weakref
+from collections.abc import Callable
+from typing import Any
+
+from ...job import JobContext, get_job_context
+from ...log import logger
+from ...types import NOT_GIVEN, NotGivenOr
+from ...utils.misc import is_given
+from ...voice.agent_session import AgentSession
+from ...voice.events import CloseEvent
+from .models import CollectorConfig, PostCallReport
+
+
+class PostCallTelemetryCollector:
+    """Attaches to an ``AgentSession`` and builds a :class:`PostCallReport` on demand.
+
+    Beta: API not covered by semver stability guarantees.
+
+    Does not subscribe to any live per-turn/per-tool events. ``AgentSession`` already
+    buffers every event it emits (regardless of whether anything is listening) and
+    keeps the running chat history/usage, so :meth:`finalize` does a single
+    deterministic reduction over that already-buffered state instead of accumulating
+    incremental state via callbacks. This makes attach timing irrelevant to correctness
+    — attaching after the session has already started still produces a complete report
+    — and makes duplicate/out-of-order event delivery a non-issue.
+
+    Usage::
+
+        collector = PostCallTelemetryCollector(metadata={"lead_id": "lead_123"})
+        collector.attach(session)
+        await session.start(...)
+        ...
+        report = collector.finalize()
+
+    Works with or without a ``JobContext`` — ``job_id``/``room_id``/``room_name``/
+    ``participant_identity`` are simply ``None`` when unavailable.
+
+    Telemetry and business/CRM data may contain personal or confidential information.
+    Enable this collector deliberately, and treat any downstream webhook destination as
+    a trusted party.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: CollectorConfig | None = None,
+        metadata: dict[str, Any] | None = None,
+        redact: Callable[[PostCallReport], PostCallReport] | None = None,
+    ) -> None:
+        """
+        Args:
+            config: Controls which optional fields (system messages, tool arguments/
+                results) are included. Defaults to user+assistant transcript only, with
+                tool arguments/results included.
+            metadata: Business metadata copied into ``PostCallReport.metadata`` (e.g.
+                a CRM contact/lead id). Never place secrets here — it is serialized
+                verbatim into the report.
+            redact: Optional hook applied to the report immediately before it is cached/
+                returned, e.g. to strip PII from the transcript before delivery.
+        """
+        self._config = config or CollectorConfig()
+        self._metadata = dict(metadata) if metadata else {}
+        self._redact = redact
+
+        self._session_ref: weakref.ReferenceType[AgentSession] | None = None
+        self._job_ctx: NotGivenOr[JobContext | None] = NOT_GIVEN
+        self._cached_report: PostCallReport | None = None
+
+    @property
+    def attached(self) -> bool:
+        return self._session_ref is not None and self._session_ref() is not None
+
+    def attach(
+        self, session: AgentSession, *, job_ctx: NotGivenOr[JobContext | None] = NOT_GIVEN
+    ) -> None:
+        """Attach to ``session``. Safe to call before or after ``session.start()``.
+
+        Re-attaching to the same session is a no-op. Attaching while already attached to
+        a different, still-live session raises ``RuntimeError`` — call :meth:`detach`
+        first.
+
+        Args:
+            session: The session to observe.
+            job_ctx: Left as ``NOT_GIVEN`` (default), the job context is auto-detected
+                lazily at :meth:`finalize` time via ``get_job_context(required=False)``.
+                Pass an explicit ``JobContext`` to pin it, or ``None`` to force the
+                no-job-context path even when one is available (useful for tests).
+        """
+        current = self._session_ref() if self._session_ref is not None else None
+        if current is session:
+            return
+        if current is not None:
+            raise RuntimeError(
+                "PostCallTelemetryCollector is already attached to a different "
+                "AgentSession; call detach() first"
+            )
+
+        self._session_ref = weakref.ref(session)
+        self._job_ctx = job_ctx
+        session.once("close", self._on_close)
+
+    def detach(self) -> None:
+        """Stop observing the attached session, if any.
+
+        Does not clear any report already produced by :meth:`finalize` — it remains
+        available via a subsequent :meth:`finalize` call until a new session is
+        attached.
+        """
+        session = self._session_ref() if self._session_ref is not None else None
+        if session is not None:
+            session.off("close", self._on_close)
+        self._session_ref = None
+
+    def finalize(self) -> PostCallReport:
+        """Build (or return the cached) :class:`PostCallReport`.
+
+        Before the session has closed, this returns a fresh, honestly-partial snapshot
+        (``report.ended is False``) on every call — never cached, since a report built
+        mid-call would go stale the moment the call actually ends. Once the session has
+        closed, the report is built once and cached; every subsequent call returns that
+        same, authoritative report.
+
+        Performs no network I/O and never blocks on anything beyond reading in-memory
+        session state.
+        """
+        if self._cached_report is not None and self._cached_report.ended:
+            return self._cached_report
+
+        session = self._require_session()
+        # snapshot first: _recorded_events is a live, still-growing list while the
+        # session runs, and start() swaps in a brand new list on each restart
+        events_snapshot = list(session._recorded_events)
+
+        job_ctx = self._resolve_job_ctx()
+        job_id = room_id = room_name = participant_identity = None
+        if job_ctx is not None:
+            job_id = job_ctx.job.id
+            room_id = job_ctx.job.room.sid
+            room_name = job_ctx.job.room.name
+            try:
+                participant_identity = job_ctx.local_participant_identity
+            except Exception:  # noqa: BLE001 - best-effort field, never fatal
+                participant_identity = None
+
+        report = PostCallReport.from_session(
+            job_id=job_id,
+            room_id=room_id,
+            room_name=room_name,
+            participant_identity=participant_identity,
+            started_at=session._started_at,
+            events=events_snapshot,
+            chat_history=session.history.copy(),
+            model_usage=session.usage.model_usage,
+            config=self._config,
+            metadata=self._metadata,
+        )
+
+        if self._redact is not None:
+            report = self._redact(report)
+
+        if report.ended:
+            self._cached_report = report
+
+        return report
+
+    def _require_session(self) -> AgentSession:
+        if self._session_ref is None:
+            raise RuntimeError("PostCallTelemetryCollector.finalize() called before attach()")
+        session = self._session_ref()
+        if session is None:
+            raise RuntimeError(
+                "the AgentSession attached to this PostCallTelemetryCollector has been "
+                "garbage-collected"
+            )
+        return session
+
+    def _resolve_job_ctx(self) -> JobContext | None:
+        if is_given(self._job_ctx):
+            return self._job_ctx
+        return get_job_context(required=False)
+
+    def _on_close(self, ev: CloseEvent) -> None:
+        # Contained on purpose: a telemetry failure must never break session shutdown.
+        # utils.log_exceptions on AgentSession._aclose_impl re-raises after logging, so
+        # an uncaught error here would propagate into whatever awaits session.aclose().
+        try:
+            self.finalize()
+        except Exception:
+            logger.exception("PostCallTelemetryCollector failed to finalize on session close")

--- a/livekit-agents/livekit/agents/beta/gtm_telemetry/collector.py
+++ b/livekit-agents/livekit/agents/beta/gtm_telemetry/collector.py
@@ -84,7 +84,8 @@ class PostCallTelemetryCollector:
 
         Re-attaching to the same session is a no-op. Attaching while already attached to
         a different, still-live session raises ``RuntimeError`` — call :meth:`detach`
-        first.
+        first. Attaching to a new session always clears any report cached from a
+        previous session, so a reused collector never hands back a stale call's report.
 
         Args:
             session: The session to observe.
@@ -104,7 +105,14 @@ class PostCallTelemetryCollector:
 
         self._session_ref = weakref.ref(session)
         self._job_ctx = job_ctx
-        session.once("close", self._on_close)
+        self._cached_report = None
+        # `.on()`, not `.once()`: EventEmitter.once() registers an internal wrapper
+        # closure, not `self._on_close` itself, so a later `.off(event, self._on_close)`
+        # in detach() would silently remove nothing and leave the listener firing after
+        # detach. `.on()` stores the exact bound method, so `.off()` actually works.
+        # Firing more than once is harmless: finalize() is idempotent, and "close" is
+        # only ever emitted once per session in any case.
+        session.on("close", self._on_close)
 
     def detach(self) -> None:
         """Stop observing the attached session, if any.

--- a/livekit-agents/livekit/agents/beta/gtm_telemetry/models.py
+++ b/livekit-agents/livekit/agents/beta/gtm_telemetry/models.py
@@ -1,0 +1,451 @@
+"""Data models for the post-call telemetry report.
+
+Beta: this schema is not covered by semver stability guarantees and may change in a
+future release.
+"""
+
+from __future__ import annotations
+
+import base64
+import dataclasses
+import enum
+import json
+import math
+import time
+import uuid
+from typing import (  # noqa: UP035 - Dict/List/Union needed for the recursive alias below
+    Any,
+    Dict,
+    List,
+    Literal,
+    Union,
+)
+
+from pydantic import BaseModel, Field
+from typing_extensions import TypeAliasType
+
+from ...llm import ChatContext, ChatMessage, ChatRole, FunctionCall
+from ...metrics import ModelUsage
+from ...version import __version__
+from ...voice.events import (
+    AgentEvent,
+    CloseEvent,
+    FunctionToolsExecutedEvent,
+    ToolCallEnded,
+    ToolCallStarted,
+    ToolCallUpdated,
+    ToolExecutionUpdatedEvent,
+)
+
+# A plain recursive `TypeAlias` union causes pydantic's schema generator to recurse
+# infinitely; `TypeAliasType` (PEP 695 backport) is pydantic's documented way to define
+# a recursive JSON-safe-value type — it builds a ref-based schema instead of inlining.
+# mypy (2.3.0, checked in isolation without this repo's config too) cannot resolve the
+# self-reference through an explicit `TypeAliasType(...)` call — only through the native
+# `type X = ...` statement, which is Python 3.12+ only and unusable at this repo's
+# py310 floor — so this single-line definition is ignored; pydantic itself builds and
+# uses the schema correctly at runtime (see tests/test_gtm_telemetry_models.py).
+JsonValue = TypeAliasType("JsonValue", Union[Dict[str, "JsonValue"], List["JsonValue"], str, int, float, bool, None])  # type: ignore[misc]  # noqa: UP006, UP007 - Dict/List/Union needed, see above  # fmt: skip
+"""A JSON-safe value: the output of :func:`to_json_safe`."""
+
+_MAX_DEPTH = 20
+
+
+def to_json_safe(value: Any, *, _depth: int = 0, _seen: frozenset[int] = frozenset()) -> JsonValue:
+    """Recursively normalize an arbitrary value into JSON-safe primitives.
+
+    None/bool/int/str pass through unchanged. NaN/Infinity floats become sentinel
+    strings (JSON has no representation for them). bytes are base64-encoded. Enums use
+    their ``.value``. Dataclasses and pydantic models are recursed into field-by-field.
+    dict keys are coerced to ``str``. list/tuple become JSON arrays; set/frozenset
+    become a deterministically sorted JSON array. Exceptions become
+    ``{"type": ..., "message": ...}`` — never a traceback. Anything else falls back to
+    ``f"<unserializable:{type(value).__name__}>"`` — never ``repr()``/``str()`` of an
+    arbitrary object, since a default object repr can leak a memory address or a
+    private attribute. Guards against cycles (by ``id()``) and excessive depth.
+    """
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+
+    if isinstance(value, float):
+        if math.isnan(value):
+            return "<nan>"
+        if math.isinf(value):
+            return "<inf>" if value > 0 else "<-inf>"
+        return value
+
+    if _depth >= _MAX_DEPTH:
+        return "<max-depth-exceeded>"
+
+    if isinstance(value, (bytes, bytearray)):
+        return {"__bytes_b64__": base64.b64encode(bytes(value)).decode("ascii")}
+
+    if isinstance(value, enum.Enum):
+        return to_json_safe(value.value, _depth=_depth + 1, _seen=_seen)
+
+    if isinstance(value, BaseException):
+        return {"type": type(value).__name__, "message": str(value)}
+
+    if isinstance(value, BaseModel):
+        obj_id = id(value)
+        if obj_id in _seen:
+            return "<circular>"
+        return to_json_safe(
+            value.model_dump(mode="json"), _depth=_depth + 1, _seen=_seen | {obj_id}
+        )
+
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        obj_id = id(value)
+        if obj_id in _seen:
+            return "<circular>"
+        fields = {f.name: getattr(value, f.name) for f in dataclasses.fields(value)}
+        return to_json_safe(fields, _depth=_depth + 1, _seen=_seen | {obj_id})
+
+    if isinstance(value, dict):
+        obj_id = id(value)
+        if obj_id in _seen:
+            return "<circular>"
+        seen = _seen | {obj_id}
+        return {str(k): to_json_safe(v, _depth=_depth + 1, _seen=seen) for k, v in value.items()}
+
+    if isinstance(value, (list, tuple, set, frozenset)):
+        obj_id = id(value)
+        if obj_id in _seen:
+            return "<circular>"
+        seen = _seen | {obj_id}
+        items = [to_json_safe(v, _depth=_depth + 1, _seen=seen) for v in value]
+        if isinstance(value, (set, frozenset)):
+            # sets have no stable order; sort the normalized items for determinism
+            items.sort(key=lambda v: json.dumps(v, sort_keys=True, default=str))
+        return items
+
+    return f"<unserializable:{type(value).__name__}>"
+
+
+def _parse_json_ish(raw: str) -> JsonValue:
+    """Parse a JSON string when possible; otherwise keep the raw string as-is."""
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return raw
+    return to_json_safe(parsed)
+
+
+class MetricAggregate(BaseModel):
+    """A count/sum/min/max/mean aggregate over repeated latency samples."""
+
+    count: int
+    sum: float
+    min: float
+    max: float
+    mean: float
+
+
+class ToolProgressUpdate(BaseModel):
+    """A progress update emitted via ``ctx.update()`` while a tool call runs."""
+
+    message: str
+    created_at: float
+
+
+class ToolExecutionRecord(BaseModel):
+    """One logical record per function-call ``call_id``.
+
+    ``status`` mirrors ``ToolCallEnded.status`` (``"done"``/``"error"``/``"cancelled"``)
+    plus two bookend states: ``"started"`` (a start event was seen but no terminal event
+    yet) and ``"interrupted"`` (still ``"started"`` when the session ended — the call was
+    cut off before a terminal event arrived).
+
+    Note: this does not attempt to represent whether the *spoken reply* summarizing a
+    tool's result was itself interrupted or skipped (``ToolReplyUpdated`` in the
+    session's event stream) — that describes reply delivery, not the tool's own
+    execution outcome, so it is out of scope for this record.
+    """
+
+    call_id: str
+    name: str
+    arguments: JsonValue = None
+    result: JsonValue = None
+    status: Literal["started", "done", "error", "cancelled", "interrupted"] = "started"
+    is_error: bool = False
+    started_at: float | None = None
+    ended_at: float | None = None
+    error: str | None = None
+    """Error message when ``status == "error"``. Never a traceback."""
+    progress_updates: list[ToolProgressUpdate] = Field(default_factory=list)
+
+
+class TranscriptTurn(BaseModel):
+    """A single conversational turn extracted from the session's chat history."""
+
+    item_id: str
+    role: ChatRole
+    text: str
+    interrupted: bool
+    created_at: float
+
+
+class SessionMetricsSummary(BaseModel):
+    """A compact, post-call-analytics-oriented summary of session metrics."""
+
+    model_usage: list[ModelUsage] = Field(default_factory=list)
+    """Per-model/provider usage totals, from the session's ``ModelUsageCollector``."""
+    latency: dict[str, MetricAggregate] = Field(default_factory=dict)
+    """Aggregated per-turn latency samples pulled from ``ChatMessage.metrics``. Keys:
+    ``llm_node_ttft``, ``tts_node_ttfb``, ``end_of_turn_delay``, ``transcription_delay``.
+    A key is present only if at least one turn carried a sample for it."""
+    tool_call_count: int = 0
+    tool_error_count: int = 0
+
+
+class CollectorConfig(BaseModel):
+    """Configuration controlling what a :class:`PostCallTelemetryCollector` includes."""
+
+    include_system_messages: bool = False
+    """Include system/developer chat turns in the transcript (default: user+assistant only)."""
+    include_tool_arguments: bool = True
+    """Include parsed tool-call arguments in each :class:`ToolExecutionRecord`."""
+    include_tool_results: bool = True
+    """Include parsed tool-call results in each :class:`ToolExecutionRecord`."""
+
+
+class PostCallReport(BaseModel):
+    """A deterministic, JSON-serializable post-call report.
+
+    Beta: this schema is not covered by semver stability guarantees.
+    """
+
+    schema_version: str = "1"
+    report_id: str
+    """Generated fresh each time a report is built; stable within one report instance."""
+    job_id: str | None = None
+    room_id: str | None = None
+    room_name: str | None = None
+    participant_identity: str | None = None
+
+    started_at: float | None = None
+    ended: bool = False
+    """True once the session has fully closed. A report built while the session is
+    still running is a preliminary, honestly-partial snapshot (``ended=False``)."""
+    end_reason: (
+        Literal[
+            "error", "job_shutdown", "participant_disconnected", "user_initiated", "task_completed"
+        ]
+        | None
+    ) = None
+    duration: float | None = None
+    """Always >= 0. Computed from the session's own ``close`` event timestamp when
+    ``ended``, or "so far" from ``time.time()`` otherwise."""
+
+    transcript: list[TranscriptTurn] = Field(default_factory=list)
+    tool_executions: list[ToolExecutionRecord] = Field(default_factory=list)
+    metrics: SessionMetricsSummary = Field(default_factory=SessionMetricsSummary)
+
+    metadata: dict[str, JsonValue] = Field(default_factory=dict)
+    """User-supplied business metadata, normalized to JSON-safe values."""
+
+    report_created_at: float
+    sdk_version: str = __version__
+
+    @classmethod
+    def from_session(
+        cls,
+        *,
+        job_id: str | None,
+        room_id: str | None,
+        room_name: str | None,
+        participant_identity: str | None,
+        started_at: float | None,
+        events: list[AgentEvent],
+        chat_history: ChatContext,
+        model_usage: list[ModelUsage],
+        config: CollectorConfig,
+        metadata: dict[str, Any],
+    ) -> PostCallReport:
+        """Build a report from a single, already-captured snapshot of session state.
+
+        ``events`` should be a snapshot (e.g. ``list(session._recorded_events)``), not a
+        live reference, so this reduction sees a consistent, unchanging view.
+
+        ``ended`` is derived solely from whether a ``close`` event is present in
+        ``events`` — not from ``AgentSession._started`` — since a session that was
+        attached but never started also has ``_started is False``, which would
+        otherwise be indistinguishable from "ran and then closed".
+        """
+        close_event = _find_close_event(events)
+        ended = close_event is not None
+        end_reason = close_event.reason.value if close_event else None
+
+        now = time.time()
+        duration: float | None
+        if started_at is None:
+            duration = None
+        elif close_event is not None:
+            duration = max(0.0, close_event.created_at - started_at)
+        else:
+            duration = max(0.0, now - started_at)
+
+        tool_executions = _build_tool_executions(
+            events,
+            include_arguments=config.include_tool_arguments,
+            include_results=config.include_tool_results,
+        )
+
+        return cls(
+            report_id=uuid.uuid4().hex,
+            job_id=job_id,
+            room_id=room_id,
+            room_name=room_name,
+            participant_identity=participant_identity,
+            started_at=started_at,
+            ended=ended,
+            end_reason=end_reason,
+            duration=duration,
+            transcript=_build_transcript(
+                chat_history, include_system_messages=config.include_system_messages
+            ),
+            tool_executions=tool_executions,
+            metrics=_build_metrics_summary(chat_history, model_usage, tool_executions),
+            metadata={str(k): to_json_safe(v) for k, v in metadata.items()},
+            report_created_at=now,
+            sdk_version=__version__,
+        )
+
+
+def _find_close_event(events: list[AgentEvent]) -> CloseEvent | None:
+    for event in reversed(events):
+        if isinstance(event, CloseEvent):
+            return event
+    return None
+
+
+def _build_transcript(
+    chat_history: ChatContext, *, include_system_messages: bool
+) -> list[TranscriptTurn]:
+    allowed_roles: tuple[ChatRole, ...] = (
+        ("user", "assistant", "system", "developer")
+        if include_system_messages
+        else ("user", "assistant")
+    )
+    turns: list[TranscriptTurn] = []
+    for item in chat_history.items:
+        if not isinstance(item, ChatMessage) or item.role not in allowed_roles:
+            continue
+        turns.append(
+            TranscriptTurn(
+                item_id=item.id,
+                role=item.role,
+                text=item.text_content or "",
+                interrupted=item.interrupted,
+                created_at=item.created_at,
+            )
+        )
+    return turns
+
+
+def _build_tool_executions(
+    events: list[AgentEvent],
+    *,
+    include_arguments: bool,
+    include_results: bool,
+) -> list[ToolExecutionRecord]:
+    records: dict[str, ToolExecutionRecord] = {}
+    order: list[str] = []
+
+    def _get(call_id: str) -> ToolExecutionRecord:
+        if call_id not in records:
+            records[call_id] = ToolExecutionRecord(call_id=call_id, name="")
+            order.append(call_id)
+        return records[call_id]
+
+    def _set_arguments(record: ToolExecutionRecord, call: FunctionCall) -> None:
+        if include_arguments and record.arguments is None:
+            record.arguments = _parse_json_ish(call.arguments)
+
+    for event in events:
+        if isinstance(event, ToolExecutionUpdatedEvent):
+            update = event.update
+            if isinstance(update, ToolCallStarted):
+                record = _get(update.function_call.call_id)
+                record.name = update.function_call.name
+                record.started_at = update.function_call.created_at
+                _set_arguments(record, update.function_call)
+            elif isinstance(update, ToolCallUpdated):
+                record = _get(update.call_id)
+                record.progress_updates.append(
+                    ToolProgressUpdate(message=update.message, created_at=event.created_at)
+                )
+            elif isinstance(update, ToolCallEnded):
+                record = _get(update.call_id)
+                record.ended_at = event.created_at
+                if update.status == "error":
+                    record.status = "error"
+                    record.is_error = True
+                    record.error = update.message
+                else:
+                    record.status = update.status  # "done" or "cancelled"
+            # ToolReplyUpdated: deliberately not consumed here — see ToolExecutionRecord
+            # docstring for why.
+        elif isinstance(event, FunctionToolsExecutedEvent):
+            for call, output in event.zipped():
+                record = _get(call.call_id)
+                if not record.name:
+                    record.name = call.name
+                if record.started_at is None:
+                    record.started_at = call.created_at
+                _set_arguments(record, call)
+                if output is None:
+                    continue
+                if record.ended_at is None:
+                    record.ended_at = output.created_at
+                if include_results:
+                    record.result = _parse_json_ish(output.output)
+                if output.is_error:
+                    record.is_error = True
+                    if record.status == "started":
+                        record.status = "error"
+                    if record.error is None:
+                        record.error = output.output
+
+    for call_id in order:
+        record = records[call_id]
+        if record.status == "started":
+            record.status = "interrupted"
+
+    return [records[call_id] for call_id in order]
+
+
+def _build_metrics_summary(
+    chat_history: ChatContext,
+    model_usage: list[ModelUsage],
+    tool_executions: list[ToolExecutionRecord],
+) -> SessionMetricsSummary:
+    latency_keys = ("llm_node_ttft", "tts_node_ttfb", "end_of_turn_delay", "transcription_delay")
+    samples: dict[str, list[float]] = {key: [] for key in latency_keys}
+
+    for item in chat_history.items:
+        if not isinstance(item, ChatMessage):
+            continue
+        for key in latency_keys:
+            value = item.metrics.get(key)
+            if isinstance(value, (int, float)) and math.isfinite(value):
+                samples[key].append(float(value))
+
+    latency: dict[str, MetricAggregate] = {}
+    for key, values in samples.items():
+        if not values:
+            continue
+        latency[key] = MetricAggregate(
+            count=len(values),
+            sum=sum(values),
+            min=min(values),
+            max=max(values),
+            mean=sum(values) / len(values),
+        )
+
+    return SessionMetricsSummary(
+        model_usage=list(model_usage),
+        latency=latency,
+        tool_call_count=len(tool_executions),
+        tool_error_count=sum(1 for record in tool_executions if record.is_error),
+    )

--- a/livekit-agents/livekit/agents/beta/gtm_telemetry/webhook.py
+++ b/livekit-agents/livekit/agents/beta/gtm_telemetry/webhook.py
@@ -1,0 +1,195 @@
+"""Signed webhook delivery for post-call reports.
+
+Beta: not covered by semver stability guarantees.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+from collections.abc import Awaitable, Callable
+from urllib.parse import urlsplit
+
+import aiohttp
+from pydantic import BaseModel, Field, model_validator
+from typing_extensions import Self
+
+from ...utils import http_context
+from .models import PostCallReport
+
+_RESERVED_HEADERS = {"content-type", "x-livekit-signature"}
+_ALLOWED_SCHEMES = {"http", "https"}
+
+
+class WebhookConfig(BaseModel):
+    """Configuration for :class:`PostCallWebhookDispatcher`.
+
+    Signature format: ``X-LiveKit-Signature: v1=<hex_digest>``, an HMAC-SHA256 digest of
+    the exact JSON request body bytes, computed with ``secret``::
+
+        hmac.new(secret.encode(), body_bytes, hashlib.sha256).hexdigest()
+
+    The caller controls ``url`` — this library places no restriction beyond requiring an
+    ``http``/``https`` scheme and does not attempt SSRF protection beyond that; treat the
+    destination as trusted, and never place a secret in the URL itself.
+    """
+
+    url: str
+    secret: str
+    headers: dict[str, str] = Field(default_factory=dict)
+    """Extra headers to send. ``Content-Type`` and ``X-LiveKit-Signature`` are reserved
+    and cannot be overridden here."""
+    timeout: float = 10.0
+    max_retries: int = 2
+    """Retries after the initial attempt (default: 2, i.e. 3 attempts total)."""
+    retry_backoff: tuple[float, ...] = (0.5, 1.0)
+    """Delay, in seconds, before each retry attempt. The last value is reused if there
+    are more retries than entries."""
+
+    @model_validator(mode="after")
+    def _validate(self) -> Self:
+        parsed = urlsplit(self.url)
+        if parsed.scheme not in _ALLOWED_SCHEMES or not parsed.netloc:
+            raise ValueError(f"WebhookConfig.url must be an http(s) URL, got: {self.url!r}")
+        for name in self.headers:
+            if name.lower() in _RESERVED_HEADERS:
+                raise ValueError(f"WebhookConfig.headers cannot set the reserved header {name!r}")
+        return self
+
+
+class WebhookDeliveryError(Exception):
+    """Raised when webhook delivery fails after exhausting retries, or immediately on a
+    non-retryable (4xx) response. Never includes the secret or the full report body."""
+
+    def __init__(
+        self,
+        *,
+        attempts: int,
+        status: int | None,
+        response_summary: str | None,
+        cause: Exception | None,
+    ) -> None:
+        self.attempts = attempts
+        self.status = status
+        self.response_summary = response_summary
+        message = f"webhook delivery failed after {attempts} attempt(s)"
+        if status is not None:
+            message += f" (status={status})"
+        if cause is not None:
+            message += f": {cause}"
+        super().__init__(message)
+        if cause is not None:
+            self.__cause__ = cause
+
+
+class PostCallWebhookDispatcher:
+    """Delivers a :class:`PostCallReport` to a caller-configured webhook endpoint.
+
+    POSTs the report as ``application/json``, signed with HMAC-SHA256 over the exact
+    request body (see :class:`WebhookConfig`). Retries connection errors, timeouts, and
+    5xx responses using a fixed backoff schedule (default: 0.5s then 1.0s — 3 attempts
+    total). 4xx responses are never retried. Deliberately does not reuse
+    ``types.APIConnectOptions`` — its "immediate retry, then flat interval" schedule, and
+    lack of a 4xx/5xx distinction, don't match the schedule this dispatcher implements.
+
+    HTTP session resolution, in order: an injected ``http_session``; otherwise the
+    shared session from ``livekit.agents.utils.http_context`` when bound (the normal
+    case inside a job process); otherwise a private session is created and owned by
+    this dispatcher, closed by :meth:`aclose`. This lets the dispatcher work with or
+    without a ``JobContext`` — see ``utils.http_context.open()`` to bind the shared
+    session in scripts/tests run outside a job worker.
+    """
+
+    def __init__(
+        self,
+        config: WebhookConfig,
+        *,
+        http_session: aiohttp.ClientSession | None = None,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> None:
+        self._config = config
+        self._injected_session = http_session
+        self._owned_session: aiohttp.ClientSession | None = None
+        self._sleep = sleep
+
+    async def send(self, report: PostCallReport) -> None:
+        """POST ``report`` to the configured webhook.
+
+        Raises :class:`WebhookDeliveryError` immediately on a 4xx response, or once
+        retries are exhausted for connection errors/timeouts/5xx responses.
+        """
+        body = report.model_dump_json().encode("utf-8")
+        signature = hmac.new(self._config.secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+        headers = {
+            **self._config.headers,
+            "Content-Type": "application/json",
+            "X-LiveKit-Signature": f"v1={signature}",
+        }
+
+        session = self._resolve_session()
+        last_error: WebhookDeliveryError | None = None
+        max_attempts = self._config.max_retries + 1
+
+        for attempt in range(1, max_attempts + 1):
+            try:
+                async with session.post(
+                    self._config.url,
+                    data=body,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=self._config.timeout),
+                ) as resp:
+                    if resp.status < 400:
+                        return
+                    error = WebhookDeliveryError(
+                        attempts=attempt,
+                        status=resp.status,
+                        response_summary=await _safe_response_text(resp),
+                        cause=None,
+                    )
+                    if resp.status < 500:
+                        raise error
+                    last_error = error
+            except WebhookDeliveryError:
+                raise
+            except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                last_error = WebhookDeliveryError(
+                    attempts=attempt, status=None, response_summary=None, cause=exc
+                )
+
+            if attempt < max_attempts:
+                delay_idx = min(attempt - 1, len(self._config.retry_backoff) - 1)
+                await self._sleep(self._config.retry_backoff[delay_idx])
+
+        assert last_error is not None  # loop always sets it before falling through
+        raise last_error
+
+    async def aclose(self) -> None:
+        """Close the internally-owned HTTP session, if one was created.
+
+        A no-op when an ``http_session`` was injected, or when the shared
+        ``utils.http_context`` session was used (that session's lifecycle belongs to its
+        own context, not to this dispatcher).
+        """
+        if self._owned_session is not None and not self._owned_session.closed:
+            await self._owned_session.close()
+        self._owned_session = None
+
+    def _resolve_session(self) -> aiohttp.ClientSession:
+        if self._injected_session is not None:
+            return self._injected_session
+        try:
+            return http_context.http_session()
+        except RuntimeError:
+            pass
+        if self._owned_session is None or self._owned_session.closed:
+            self._owned_session = aiohttp.ClientSession()
+        return self._owned_session
+
+
+async def _safe_response_text(resp: aiohttp.ClientResponse) -> str | None:
+    try:
+        text = await resp.text()
+    except Exception:  # noqa: BLE001 - best-effort diagnostic only
+        return None
+    return text[:500]

--- a/tests/test_gtm_telemetry_adapters.py
+++ b/tests/test_gtm_telemetry_adapters.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+from livekit.agents.beta.gtm_telemetry.adapters import (
+    build_hubspot_engagement,
+    build_salesforce_task,
+)
+from livekit.agents.beta.gtm_telemetry.models import PostCallReport, TranscriptTurn
+
+pytestmark = pytest.mark.unit
+
+
+def _report(*, transcript_text: str | None = None) -> PostCallReport:
+    transcript = []
+    if transcript_text is not None:
+        transcript = [
+            TranscriptTurn(
+                item_id="item_1",
+                role="user",
+                text=transcript_text,
+                interrupted=False,
+                created_at=1.0,
+            )
+        ]
+    return PostCallReport(
+        report_id="r1",
+        report_created_at=0.0,
+        job_id="job-1",
+        room_name="room-1",
+        started_at=100.0,
+        ended=True,
+        end_reason="user_initiated",
+        duration=42.0,
+        transcript=transcript,
+        metadata={"disposition": "resolved"},
+    )
+
+
+# --- HubSpot ---------------------------------------------------------------------------
+
+
+def test_hubspot_engagement_shape_has_required_fields():
+    payload = build_hubspot_engagement(_report(), owner_id="owner_1", contact_ids=["c1", "c2"])
+    assert payload["engagement"]["type"] == "CALL"
+    assert payload["associations"]["ownerId"] == "owner_1"
+    assert payload["associations"]["contactIds"] == ["c1", "c2"]
+    assert payload["source"]["jobId"] == "job-1"
+
+
+def test_hubspot_engagement_transcript_truncated_with_metadata():
+    report = _report(transcript_text="x" * 100)
+    payload = build_hubspot_engagement(report, transcript_max_chars=10)
+    assert payload["metadata"]["transcriptTruncated"] is True
+    assert payload["metadata"]["transcriptOmittedChars"] > 0
+    assert len(payload["metadata"]["body"]) == 10
+
+
+def test_hubspot_engagement_no_truncation_when_under_limit():
+    report = _report(transcript_text="short")
+    payload = build_hubspot_engagement(report, transcript_max_chars=10_000)
+    assert payload["metadata"]["transcriptTruncated"] is False
+    assert payload["metadata"]["transcriptOmittedChars"] == 0
+
+
+def test_hubspot_engagement_no_network_or_env_access():
+    with patch("aiohttp.ClientSession") as mock_session, patch.dict(os.environ, {}, clear=False):
+        build_hubspot_engagement(_report())
+        mock_session.assert_not_called()
+
+
+def test_hubspot_engagement_does_not_mutate_input_report():
+    report = _report(transcript_text="hello")
+    original = copy.deepcopy(report.model_dump())
+    payload = build_hubspot_engagement(report, contact_ids=["c1"])
+    payload["associations"]["contactIds"].append("mutated")
+    payload["customProperties"]["disposition"] = "mutated"
+    assert report.model_dump() == original
+
+
+def test_hubspot_engagement_output_json_serializable():
+    payload = build_hubspot_engagement(_report(transcript_text="hi"), owner_id="o1")
+    json.dumps(payload)  # must not raise
+
+
+def test_hubspot_engagement_missing_optional_ids_default_sane():
+    payload = build_hubspot_engagement(_report())
+    assert payload["associations"]["ownerId"] is None
+    assert payload["associations"]["contactIds"] == []
+
+
+# --- Salesforce ---------------------------------------------------------------------------
+
+
+def test_salesforce_task_shape_has_required_fields():
+    payload = build_salesforce_task(_report(), who_id="who_1", what_id="what_1", owner_id="owner_1")
+    assert payload["WhoId"] == "who_1"
+    assert payload["WhatId"] == "what_1"
+    assert payload["OwnerId"] == "owner_1"
+    assert payload["Type"] == "Call"
+    assert payload["CallDurationInSeconds"] == 42.0
+
+
+def test_salesforce_task_transcript_truncated_with_metadata():
+    report = _report(transcript_text="y" * 100)
+    payload = build_salesforce_task(report, transcript_max_chars=10)
+    assert payload["descriptionTruncated"] is True
+    assert payload["descriptionOmittedChars"] > 0
+
+
+def test_salesforce_task_does_not_mutate_input_report():
+    report = _report(transcript_text="hello")
+    original = copy.deepcopy(report.model_dump())
+    payload = build_salesforce_task(report)
+    payload["customFields"]["disposition"] = "mutated"
+    assert report.model_dump() == original
+
+
+def test_salesforce_task_no_network_or_sdk_access():
+    with patch("aiohttp.ClientSession") as mock_session:
+        build_salesforce_task(_report())
+        mock_session.assert_not_called()
+
+
+def test_salesforce_task_output_json_serializable():
+    payload = build_salesforce_task(_report(transcript_text="hi"), who_id="w1")
+    json.dumps(payload)
+
+
+def test_salesforce_task_default_subject_when_not_provided():
+    payload = build_salesforce_task(_report())
+    assert payload["Subject"] == "Post-call report"
+
+
+def test_salesforce_task_never_fabricates_ids():
+    payload = build_salesforce_task(_report())
+    assert payload["WhoId"] is None
+    assert payload["WhatId"] is None
+    assert payload["OwnerId"] is None

--- a/tests/test_gtm_telemetry_collector.py
+++ b/tests/test_gtm_telemetry_collector.py
@@ -122,6 +122,49 @@ async def test_attach_to_new_session_clears_stale_cached_report():
     assert second_report.report_id != first_report.report_id
 
 
+@pytest.mark.asyncio
+async def test_finalize_after_restart_on_same_session_rebuilds_report():
+    # AgentSession supports being restarted on the same instance: aclose() sets
+    # _started=False, a later start() resets _recorded_events/_started_at. attach() is
+    # never re-called in this scenario (it's the same object), so nothing but finalize()
+    # itself can catch a stale cache here.
+    collector = PostCallTelemetryCollector()
+    sess = AgentSession(llm=FakeLLM())
+    collector.attach(sess)
+
+    await sess.start(_EchoAgent())
+    await sess.aclose()
+    report1 = collector.finalize()
+
+    await sess.start(_EchoAgent())
+    await sess.aclose()
+    report2 = collector.finalize()
+
+    assert report2 is not report1
+    assert report2.report_id != report1.report_id
+    assert report1.started_at != report2.started_at
+    assert report2.started_at == sess._started_at
+
+
+@pytest.mark.asyncio
+async def test_finalize_auto_caches_fresh_report_after_restart_close():
+    collector = PostCallTelemetryCollector()
+    sess = AgentSession(llm=FakeLLM())
+    collector.attach(sess)
+
+    await sess.start(_EchoAgent())
+    await sess.aclose()
+    report1 = collector.finalize()
+
+    await sess.start(_EchoAgent())
+    await sess.aclose()
+
+    cached = collector._cached_report
+    assert cached is not None
+    assert cached.report_id != report1.report_id
+    assert cached.started_at == sess._started_at
+
+
 def test_detach_before_attach_is_safe_noop():
     collector = PostCallTelemetryCollector()
     collector.detach()

--- a/tests/test_gtm_telemetry_collector.py
+++ b/tests/test_gtm_telemetry_collector.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import gc
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from livekit.agents import Agent, AgentSession, RunContext, function_tool
+from livekit.agents.beta.gtm_telemetry.collector import PostCallTelemetryCollector
+from livekit.agents.llm import FunctionToolCall
+
+from .fake_llm import FakeLLM, FakeLLMResponse
+
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
+
+_COLLECTOR_MOD = "livekit.agents.beta.gtm_telemetry.collector"
+
+
+class _EchoAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(instructions="echo agent")
+
+    @function_tool
+    async def lookup(self, ctx: RunContext) -> str:
+        """Look something up."""
+        return "42"
+
+    @function_tool
+    async def boom(self, ctx: RunContext) -> str:
+        """Always fails."""
+        raise ValueError("kaboom")
+
+
+def _mock_job_ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.job.id = "job-1"
+    ctx.job.room.sid = "room-sid-1"
+    ctx.job.room.name = "room-1"
+    ctx.local_participant_identity = "agent-identity"
+    return ctx
+
+
+# --- attach / detach lifecycle -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_attach_idempotent_same_session_is_noop():
+    collector = PostCallTelemetryCollector()
+    async with AgentSession(llm=FakeLLM()) as sess:
+        collector.attach(sess)
+        collector.attach(sess)
+        assert collector.attached
+
+
+@pytest.mark.asyncio
+async def test_attach_second_different_session_raises():
+    collector = PostCallTelemetryCollector()
+    async with AgentSession(llm=FakeLLM()) as sess1, AgentSession(llm=FakeLLM()) as sess2:
+        collector.attach(sess1)
+        with pytest.raises(RuntimeError):
+            collector.attach(sess2)
+
+
+@pytest.mark.asyncio
+async def test_attach_after_detach_allows_new_session():
+    collector = PostCallTelemetryCollector()
+    async with AgentSession(llm=FakeLLM()) as sess1, AgentSession(llm=FakeLLM()) as sess2:
+        collector.attach(sess1)
+        collector.detach()
+        collector.attach(sess2)
+        assert collector.attached
+
+
+@pytest.mark.asyncio
+async def test_detach_unregisters_close_listener():
+    collector = PostCallTelemetryCollector()
+    async with AgentSession(llm=FakeLLM()) as sess:
+        collector.attach(sess)
+        collector.detach()
+    # the session closed after detach; the auto-finalize-on-close listener must not
+    # have fired, so nothing should be cached
+    assert collector._cached_report is None
+
+
+def test_detach_before_attach_is_safe_noop():
+    collector = PostCallTelemetryCollector()
+    collector.detach()
+    assert not collector.attached
+
+
+def test_finalize_without_attach_raises():
+    collector = PostCallTelemetryCollector()
+    with pytest.raises(RuntimeError):
+        collector.finalize()
+
+
+@pytest.mark.asyncio
+async def test_finalize_after_session_garbage_collected_raises_clear_error():
+    collector = PostCallTelemetryCollector()
+    sess = AgentSession(llm=FakeLLM())
+    collector.attach(sess)
+    del sess
+    gc.collect()
+    with pytest.raises(RuntimeError):
+        collector.finalize()
+
+
+# --- finalize semantics: preliminary vs authoritative -------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_before_session_started_is_empty_and_not_ended():
+    collector = PostCallTelemetryCollector()
+    sess = AgentSession(llm=FakeLLM())
+    collector.attach(sess)
+    report = collector.finalize()
+    assert report.ended is False
+    assert report.transcript == []
+    assert report.tool_executions == []
+
+
+@pytest.mark.asyncio
+async def test_finalize_before_close_returns_snapshot_with_ended_false():
+    collector = PostCallTelemetryCollector()
+    async with AgentSession(llm=FakeLLM()) as sess:
+        collector.attach(sess)
+        await sess.start(_EchoAgent())
+        report = collector.finalize()
+        assert report.ended is False
+
+
+@pytest.mark.asyncio
+async def test_finalize_repeated_calls_before_close_are_not_cached():
+    collector = PostCallTelemetryCollector()
+    async with AgentSession(llm=FakeLLM()) as sess:
+        collector.attach(sess)
+        await sess.start(_EchoAgent())
+        report1 = collector.finalize()
+        report2 = collector.finalize()
+        assert report1 is not report2
+        assert report1.report_id != report2.report_id
+
+
+@pytest.mark.asyncio
+async def test_finalize_after_close_returns_cached_authoritative_report():
+    collector = PostCallTelemetryCollector()
+    sess = AgentSession(llm=FakeLLM())
+    collector.attach(sess)
+    await sess.start(_EchoAgent())
+    await sess.aclose()
+
+    report1 = collector.finalize()
+    report2 = collector.finalize()
+    assert report1.ended is True
+    assert report1 is report2
+
+
+@pytest.mark.asyncio
+async def test_attach_registers_close_listener_that_auto_finalizes():
+    collector = PostCallTelemetryCollector()
+    sess = AgentSession(llm=FakeLLM())
+    collector.attach(sess)
+    await sess.start(_EchoAgent())
+    await sess.aclose()
+
+    assert collector._cached_report is not None
+    assert collector._cached_report.ended is True
+
+
+@pytest.mark.asyncio
+async def test_finalize_does_not_perform_network_io():
+    collector = PostCallTelemetryCollector()
+    async with AgentSession(llm=FakeLLM()) as sess:
+        collector.attach(sess)
+        await sess.start(_EchoAgent())
+        with patch("aiohttp.ClientSession") as mock_session_cls:
+            collector.finalize()
+            mock_session_cls.assert_not_called()
+
+
+# --- job context resolution ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_with_job_context_populates_identity_fields():
+    collector = PostCallTelemetryCollector()
+    async with AgentSession(llm=FakeLLM()) as sess:
+        collector.attach(sess, job_ctx=_mock_job_ctx())
+        await sess.start(_EchoAgent())
+        report = collector.finalize()
+        assert report.job_id == "job-1"
+        assert report.room_id == "room-sid-1"
+        assert report.room_name == "room-1"
+        assert report.participant_identity == "agent-identity"
+
+
+@pytest.mark.asyncio
+async def test_finalize_without_job_context_leaves_identity_fields_none():
+    collector = PostCallTelemetryCollector()
+    async with AgentSession(llm=FakeLLM()) as sess:
+        collector.attach(sess, job_ctx=None)
+        await sess.start(_EchoAgent())
+        report = collector.finalize()
+        assert report.job_id is None
+        assert report.room_id is None
+        assert report.room_name is None
+
+
+@pytest.mark.asyncio
+async def test_finalize_auto_detects_job_context_when_not_given():
+    collector = PostCallTelemetryCollector()
+    async with AgentSession(llm=FakeLLM()) as sess:
+        collector.attach(sess)  # job_ctx left as NOT_GIVEN
+        await sess.start(_EchoAgent())
+        with patch(f"{_COLLECTOR_MOD}.get_job_context", return_value=_mock_job_ctx()) as mock_get:
+            report = collector.finalize()
+        mock_get.assert_called_once_with(required=False)
+        assert report.job_id == "job-1"
+
+
+@pytest.mark.asyncio
+async def test_finalize_participant_identity_lookup_failure_is_swallowed():
+    ctx = _mock_job_ctx()
+    type(ctx).local_participant_identity = property(
+        lambda self: (_ for _ in ()).throw(RuntimeError)
+    )
+    collector = PostCallTelemetryCollector()
+    async with AgentSession(llm=FakeLLM()) as sess:
+        collector.attach(sess, job_ctx=ctx)
+        await sess.start(_EchoAgent())
+        report = collector.finalize()
+        assert report.participant_identity is None
+        assert report.job_id == "job-1"  # other fields still populate
+
+
+# --- redact hook ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_redact_hook_applied_before_caching():
+    def _redact(report):
+        return report.model_copy(update={"metadata": {"redacted": True}})
+
+    collector = PostCallTelemetryCollector(metadata={"secret": "value"}, redact=_redact)
+    sess = AgentSession(llm=FakeLLM())
+    collector.attach(sess)
+    await sess.start(_EchoAgent())
+    await sess.aclose()
+
+    report = collector.finalize()
+    assert report.metadata == {"redacted": True}
+
+
+# --- integration: transcript + successful/failed tool calls -------------------------
+
+
+@pytest.mark.asyncio
+async def test_integration_full_session_produces_transcript_and_tool_executions():
+    llm = FakeLLM(
+        fake_responses=[
+            FakeLLMResponse(
+                input="please look something up",
+                content="",
+                ttft=0.05,
+                duration=0.05,
+                tool_calls=[FunctionToolCall(name="lookup", arguments="{}", call_id="call_1")],
+            ),
+            # after the tool runs, FakeLLM looks up the next response by the tool's
+            # own output string ("42", see fake_llm.py's _get_index_text)
+            FakeLLMResponse(input="42", content="the answer is 42", ttft=0.05, duration=0.05),
+        ]
+    )
+
+    collector = PostCallTelemetryCollector(metadata={"lead_id": "lead_123"})
+    sess = AgentSession(llm=llm)
+    collector.attach(sess, job_ctx=_mock_job_ctx())
+    await sess.start(_EchoAgent())
+
+    await sess.run(user_input="please look something up")
+    await sess.aclose()
+
+    report = collector.finalize()
+
+    assert report.ended is True
+    assert report.job_id == "job-1"
+    assert any(t.role == "user" and t.text == "please look something up" for t in report.transcript)
+    assert len(report.tool_executions) == 1
+    tool_record = report.tool_executions[0]
+    assert tool_record.name == "lookup"
+    assert tool_record.status == "done"
+    assert tool_record.is_error is False
+    assert report.metadata == {"lead_id": "lead_123"}

--- a/tests/test_gtm_telemetry_collector.py
+++ b/tests/test_gtm_telemetry_collector.py
@@ -82,6 +82,46 @@ async def test_detach_unregisters_close_listener():
     assert collector._cached_report is None
 
 
+@pytest.mark.asyncio
+async def test_detach_actually_removes_the_registered_close_handler():
+    # Direct regression test for the EventEmitter.once()-vs-.on() bug: .once() stores an
+    # internal wrapper closure, not the passed callback, so `session.off(event,
+    # self._on_close)` would silently remove nothing and _on_close would still fire
+    # after detach. The spy must be installed *before* attach() — patching afterwards
+    # wouldn't touch whatever object was actually captured by the event registration.
+    collector = PostCallTelemetryCollector()
+    sess = AgentSession(llm=FakeLLM())
+    with patch.object(collector, "_on_close") as spy:
+        collector.attach(sess)
+        collector.detach()
+        await sess.start(_EchoAgent())
+        await sess.aclose()
+        spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_attach_to_new_session_clears_stale_cached_report():
+    collector = PostCallTelemetryCollector(metadata={"call": "first"})
+    first_session = AgentSession(llm=FakeLLM())
+    collector.attach(first_session)
+    await first_session.start(_EchoAgent())
+    await first_session.aclose()
+
+    first_report = collector.finalize()
+    assert first_report.metadata == {"call": "first"}
+
+    collector.detach()
+    collector._metadata = {"call": "second"}
+    second_session = AgentSession(llm=FakeLLM())
+    collector.attach(second_session)
+    await second_session.start(_EchoAgent())
+    await second_session.aclose()
+
+    second_report = collector.finalize()
+    assert second_report.metadata == {"call": "second"}
+    assert second_report.report_id != first_report.report_id
+
+
 def test_detach_before_attach_is_safe_noop():
     collector = PostCallTelemetryCollector()
     collector.detach()

--- a/tests/test_gtm_telemetry_models.py
+++ b/tests/test_gtm_telemetry_models.py
@@ -1,0 +1,501 @@
+from __future__ import annotations
+
+import dataclasses
+from enum import Enum
+
+import pytest
+
+from livekit.agents.beta.gtm_telemetry.models import (
+    CollectorConfig,
+    PostCallReport,
+    to_json_safe,
+)
+from livekit.agents.llm import ChatContext, FunctionCall, FunctionCallOutput
+from livekit.agents.metrics import LLMModelUsage
+from livekit.agents.voice.events import (
+    AgentEvent,
+    CloseEvent,
+    CloseReason,
+    FunctionToolsExecutedEvent,
+    ToolCallEnded,
+    ToolCallStarted,
+    ToolCallUpdated,
+    ToolExecutionUpdatedEvent,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _report(
+    *,
+    events: list[AgentEvent] | None = None,
+    chat_history: ChatContext | None = None,
+    model_usage: list | None = None,
+    config: CollectorConfig | None = None,
+    metadata: dict | None = None,
+    started_at: float | None = 1_700_000_000.0,
+) -> PostCallReport:
+    return PostCallReport.from_session(
+        job_id="job_1",
+        room_id="room_sid_1",
+        room_name="my-room",
+        participant_identity="user_1",
+        started_at=started_at,
+        events=events or [],
+        chat_history=chat_history if chat_history is not None else ChatContext(),
+        model_usage=model_usage or [],
+        config=config or CollectorConfig(),
+        metadata=metadata or {},
+    )
+
+
+def _chat_ctx(*, include_system: bool = False) -> ChatContext:
+    ctx = ChatContext()
+    if include_system:
+        ctx.add_message(role="system", content="be nice", created_at=1.0)
+    ctx.add_message(role="user", content="hello", created_at=2.0)
+    ctx.add_message(role="assistant", content="hi there", interrupted=True, created_at=3.0)
+    return ctx
+
+
+# --- transcript -------------------------------------------------------------------
+
+
+def test_transcript_filters_by_role_default_user_assistant():
+    report = _report(chat_history=_chat_ctx(include_system=True))
+    assert [t.role for t in report.transcript] == ["user", "assistant"]
+
+
+def test_transcript_includes_system_when_opted_in():
+    report = _report(
+        chat_history=_chat_ctx(include_system=True),
+        config=CollectorConfig(include_system_messages=True),
+    )
+    assert "system" in [t.role for t in report.transcript]
+
+
+def test_transcript_preserves_interrupted_flag():
+    report = _report(chat_history=_chat_ctx())
+    assistant_turn = next(t for t in report.transcript if t.role == "assistant")
+    assert assistant_turn.interrupted is True
+
+
+def test_transcript_uses_text_content_strips_expr_markup():
+    ctx = ChatContext()
+    ctx.add_message(role="assistant", content="<expr>happy</expr>hello", created_at=1.0)
+    report = _report(chat_history=ctx)
+    assert "<expr>" not in report.transcript[0].text
+
+
+def test_transcript_empty_message_becomes_empty_string():
+    ctx = ChatContext()
+    ctx.add_message(role="user", content=[], created_at=1.0)
+    report = _report(chat_history=ctx)
+    assert report.transcript[0].text == ""
+
+
+def test_transcript_order_matches_chat_history_order():
+    ctx = _chat_ctx()
+    report = _report(chat_history=ctx)
+    assert [t.text for t in report.transcript] == ["hello", "hi there"]
+
+
+def test_transcript_ignores_function_call_items():
+    ctx = ChatContext()
+    ctx.add_message(role="user", content="hi", created_at=1.0)
+    ctx.insert(FunctionCall(call_id="c1", name="foo", arguments="{}", created_at=2.0))
+    report = _report(chat_history=ctx)
+    assert len(report.transcript) == 1
+
+
+# --- tool executions ----------------------------------------------------------------
+
+
+def _started(call_id: str, name: str = "lookup", arguments: str = "{}", at: float = 1.0):
+    return ToolExecutionUpdatedEvent(
+        update=ToolCallStarted(
+            function_call=FunctionCall(
+                call_id=call_id, name=name, arguments=arguments, created_at=at
+            )
+        ),
+        created_at=at,
+    )
+
+
+def _ended(call_id: str, status: str, message: str | None = None, at: float = 2.0):
+    return ToolExecutionUpdatedEvent(
+        update=ToolCallEnded(id=call_id, call_id=call_id, message=message, status=status),
+        created_at=at,
+    )
+
+
+def _progress(call_id: str, message: str, at: float = 1.5):
+    return ToolExecutionUpdatedEvent(
+        update=ToolCallUpdated(id=call_id, call_id=call_id, message=message),
+        created_at=at,
+    )
+
+
+def test_tool_execution_status_done():
+    report = _report(events=[_started("c1"), _ended("c1", "done")])
+    (record,) = report.tool_executions
+    assert record.status == "done"
+    assert record.is_error is False
+
+
+def test_tool_execution_status_error():
+    report = _report(events=[_started("c1"), _ended("c1", "error", message="boom")])
+    (record,) = report.tool_executions
+    assert record.status == "error"
+    assert record.is_error is True
+    assert record.error == "boom"
+
+
+def test_tool_execution_status_cancelled():
+    report = _report(events=[_started("c1"), _ended("c1", "cancelled")])
+    (record,) = report.tool_executions
+    assert record.status == "cancelled"
+    assert record.is_error is False
+
+
+def test_tool_execution_missing_terminal_event_becomes_interrupted():
+    report = _report(events=[_started("c1")])
+    (record,) = report.tool_executions
+    assert record.status == "interrupted"
+
+
+def test_tool_execution_missing_start_event_still_recorded():
+    report = _report(events=[_ended("c1", "done")])
+    (record,) = report.tool_executions
+    assert record.call_id == "c1"
+    assert record.status == "done"
+    assert record.started_at is None
+
+
+def test_tool_execution_out_of_order_events_still_reduce_correctly():
+    # ended arrives before started in the snapshot list
+    report = _report(events=[_ended("c1", "done"), _started("c1")])
+    (record,) = report.tool_executions
+    assert record.name == "lookup"
+    assert record.status == "done"
+
+
+def test_tool_execution_duplicate_started_event_does_not_duplicate_record():
+    report = _report(events=[_started("c1"), _started("c1"), _ended("c1", "done")])
+    assert len(report.tool_executions) == 1
+
+
+def test_tool_execution_progress_updates_ordered():
+    report = _report(
+        events=[
+            _started("c1"),
+            _progress("c1", "step 1", at=1.1),
+            _progress("c1", "step 2", at=1.2),
+            _ended("c1", "done"),
+        ]
+    )
+    (record,) = report.tool_executions
+    assert [u.message for u in record.progress_updates] == ["step 1", "step 2"]
+
+
+def test_tool_execution_same_name_different_call_ids_are_separate_records():
+    report = _report(
+        events=[_started("c1"), _ended("c1", "done"), _started("c2"), _ended("c2", "error")]
+    )
+    assert {r.call_id for r in report.tool_executions} == {"c1", "c2"}
+    assert len(report.tool_executions) == 2
+
+
+def test_tool_execution_arguments_parsed_as_json():
+    report = _report(events=[_started("c1", arguments='{"x": 1}'), _ended("c1", "done")])
+    (record,) = report.tool_executions
+    assert record.arguments == {"x": 1}
+
+
+def test_tool_execution_non_json_arguments_kept_as_raw_string():
+    report = _report(events=[_started("c1", arguments="not-json"), _ended("c1", "done")])
+    (record,) = report.tool_executions
+    assert record.arguments == "not-json"
+
+
+def test_tool_execution_arguments_omitted_when_disabled():
+    report = _report(
+        events=[_started("c1", arguments='{"x": 1}'), _ended("c1", "done")],
+        config=CollectorConfig(include_tool_arguments=False),
+    )
+    (record,) = report.tool_executions
+    assert record.arguments is None
+
+
+def test_tool_execution_enriched_with_result_from_function_tools_executed():
+    events = [
+        _started("c1"),
+        _ended("c1", "done"),
+        FunctionToolsExecutedEvent(
+            function_calls=[
+                FunctionCall(call_id="c1", name="lookup", arguments="{}", created_at=1.0)
+            ],
+            function_call_outputs=[
+                FunctionCallOutput(
+                    call_id="c1", output='{"weather": "sunny"}', is_error=False, created_at=2.0
+                )
+            ],
+        ),
+    ]
+    report = _report(events=events)
+    (record,) = report.tool_executions
+    assert record.result == {"weather": "sunny"}
+
+
+def test_tool_execution_result_omitted_when_disabled():
+    events = [
+        _started("c1"),
+        _ended("c1", "done"),
+        FunctionToolsExecutedEvent(
+            function_calls=[
+                FunctionCall(call_id="c1", name="lookup", arguments="{}", created_at=1.0)
+            ],
+            function_call_outputs=[
+                FunctionCallOutput(call_id="c1", output="ok", is_error=False, created_at=2.0)
+            ],
+        ),
+    ]
+    report = _report(events=events, config=CollectorConfig(include_tool_results=False))
+    (record,) = report.tool_executions
+    assert record.result is None
+
+
+def test_tool_execution_none_output_in_batch_event_is_tolerated():
+    events = [
+        _started("c1"),
+        _ended("c1", "done"),
+        FunctionToolsExecutedEvent(
+            function_calls=[
+                FunctionCall(call_id="c1", name="lookup", arguments="{}", created_at=1.0)
+            ],
+            function_call_outputs=[None],
+        ),
+    ]
+    report = _report(events=events)
+    (record,) = report.tool_executions
+    assert record.result is None
+    assert record.status == "done"
+
+
+def test_tool_execution_function_tools_executed_alone_infers_error_status():
+    # simulates the collector attaching after the start/end events were already missed
+    events = [
+        FunctionToolsExecutedEvent(
+            function_calls=[
+                FunctionCall(call_id="c1", name="lookup", arguments="{}", created_at=1.0)
+            ],
+            function_call_outputs=[
+                FunctionCallOutput(call_id="c1", output="failed", is_error=True, created_at=2.0)
+            ],
+        ),
+    ]
+    report = _report(events=events)
+    (record,) = report.tool_executions
+    assert record.is_error is True
+    assert record.status == "error"
+
+
+# --- metrics --------------------------------------------------------------------------
+
+
+def test_metrics_model_usage_passthrough():
+    usage = [LLMModelUsage(provider="openai", model="gpt-4o", input_tokens=10, output_tokens=5)]
+    report = _report(model_usage=usage)
+    assert report.metrics.model_usage == usage
+
+
+def test_metrics_no_latency_samples_means_empty_latency_dict():
+    report = _report(chat_history=ChatContext())
+    assert report.metrics.latency == {}
+
+
+def test_metrics_latency_aggregate_math():
+    ctx = ChatContext()
+    ctx.add_message(
+        role="assistant",
+        content="a",
+        created_at=1.0,
+        metrics={"llm_node_ttft": 0.1},
+    )
+    ctx.add_message(
+        role="assistant",
+        content="b",
+        created_at=2.0,
+        metrics={"llm_node_ttft": 0.3},
+    )
+    report = _report(chat_history=ctx)
+    agg = report.metrics.latency["llm_node_ttft"]
+    assert agg.count == 2
+    assert agg.min == pytest.approx(0.1)
+    assert agg.max == pytest.approx(0.3)
+    assert agg.sum == pytest.approx(0.4)
+    assert agg.mean == pytest.approx(0.2)
+
+
+def test_metrics_tool_call_and_error_counts():
+    report = _report(
+        events=[_started("c1"), _ended("c1", "done"), _started("c2"), _ended("c2", "error")]
+    )
+    assert report.metrics.tool_call_count == 2
+    assert report.metrics.tool_error_count == 1
+
+
+# --- end_reason / ended / duration -----------------------------------------------------
+
+
+def test_ended_and_end_reason_from_close_event():
+    close = CloseEvent(reason=CloseReason.USER_INITIATED, created_at=1_700_000_010.0)
+    report = _report(events=[close])
+    assert report.ended is True
+    assert report.end_reason == "user_initiated"
+
+
+def test_not_ended_without_close_event():
+    report = _report(events=[])
+    assert report.ended is False
+    assert report.end_reason is None
+
+
+def test_duration_from_close_event_created_at_when_ended():
+    close = CloseEvent(reason=CloseReason.TASK_COMPLETED, created_at=1_700_000_010.0)
+    report = _report(events=[close], started_at=1_700_000_000.0)
+    assert report.duration == pytest.approx(10.0)
+
+
+def test_duration_is_none_when_started_at_is_none():
+    report = _report(started_at=None)
+    assert report.duration is None
+
+
+def test_duration_clamped_nonnegative():
+    close = CloseEvent(reason=CloseReason.ERROR, created_at=100.0)
+    report = _report(events=[close], started_at=200.0)
+    assert report.duration == 0.0
+
+
+# --- to_json_safe -----------------------------------------------------------------------
+
+
+class _Color(Enum):
+    RED = "red"
+
+
+@dataclasses.dataclass
+class _Point:
+    x: int
+    y: int
+
+
+class _Unserializable:
+    def __repr__(self) -> str:
+        return f"<_Unserializable object at 0x{id(self):x}>"
+
+
+def test_to_json_safe_primitives_passthrough():
+    assert to_json_safe(None) is None
+    assert to_json_safe(True) is True
+    assert to_json_safe(1) == 1
+    assert to_json_safe("s") == "s"
+
+
+def test_to_json_safe_nan_and_infinity_become_sentinel_strings():
+    assert to_json_safe(float("nan")) == "<nan>"
+    assert to_json_safe(float("inf")) == "<inf>"
+    assert to_json_safe(float("-inf")) == "<-inf>"
+
+
+def test_to_json_safe_enum_uses_value():
+    assert to_json_safe(_Color.RED) == "red"
+
+
+def test_to_json_safe_dataclass_recursed():
+    assert to_json_safe(_Point(1, 2)) == {"x": 1, "y": 2}
+
+
+def test_to_json_safe_pydantic_model_recursed():
+    usage = LLMModelUsage(provider="openai", model="gpt-4o")
+    safe = to_json_safe(usage)
+    assert safe["provider"] == "openai"
+
+
+def test_to_json_safe_bytes_base64_encoded():
+    safe = to_json_safe(b"hello")
+    assert safe == {"__bytes_b64__": "aGVsbG8="}
+
+
+def test_to_json_safe_tuple_and_set_become_list():
+    assert to_json_safe((1, 2)) == [1, 2]
+    assert isinstance(to_json_safe({1, 2}), list)
+
+
+def test_to_json_safe_exception_becomes_type_and_message_never_traceback():
+    safe = to_json_safe(ValueError("bad value"))
+    assert safe == {"type": "ValueError", "message": "bad value"}
+
+
+def test_to_json_safe_unrecognized_object_never_uses_repr_or_memory_address():
+    safe = to_json_safe(_Unserializable())
+    assert isinstance(safe, str)
+    assert "0x" not in safe
+    assert safe == "<unserializable:_Unserializable>"
+
+
+def test_to_json_safe_circular_reference_detected():
+    d: dict = {}
+    d["self"] = d
+    assert to_json_safe(d) == {"self": "<circular>"}
+
+
+def test_to_json_safe_max_depth_guarded():
+    nested = None
+    for _ in range(50):
+        nested = [nested]
+    safe = to_json_safe(nested)
+    # must terminate and produce the sentinel somewhere in the structure
+    assert _contains(safe, "<max-depth-exceeded>")
+
+
+def _contains(value, needle) -> bool:
+    if value == needle:
+        return True
+    if isinstance(value, list):
+        return any(_contains(v, needle) for v in value)
+    if isinstance(value, dict):
+        return any(_contains(v, needle) for v in value.values())
+    return False
+
+
+# --- report-level ------------------------------------------------------------------------
+
+
+def test_report_metadata_is_normalized_copy_not_shared():
+    meta = {"lead_id": "123"}
+    report = _report(metadata=meta)
+    report.metadata["lead_id"] = "mutated"
+    assert meta["lead_id"] == "123"
+
+
+def test_report_json_roundtrip_is_deterministic():
+    report = _report(chat_history=_chat_ctx())
+    first = report.model_dump_json()
+    second = report.model_dump_json()
+    assert first == second
+
+
+def test_report_serializes_to_valid_json():
+    import json
+
+    report = _report(chat_history=_chat_ctx(), events=[_started("c1"), _ended("c1", "done")])
+    parsed = json.loads(report.model_dump_json())
+    assert parsed["schema_version"] == "1"
+    assert isinstance(parsed["started_at"], float)
+
+
+def test_report_id_is_stable_within_one_report():
+    report = _report()
+    assert report.report_id == report.model_copy().report_id

--- a/tests/test_gtm_telemetry_webhook.py
+++ b/tests/test_gtm_telemetry_webhook.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+import aiohttp
+import pytest
+
+from livekit.agents.beta.gtm_telemetry.models import PostCallReport
+from livekit.agents.beta.gtm_telemetry.webhook import (
+    PostCallWebhookDispatcher,
+    WebhookConfig,
+    WebhookDeliveryError,
+)
+from livekit.agents.utils import http_context
+
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
+
+
+def _report() -> PostCallReport:
+    return PostCallReport(
+        report_id="r1", report_created_at=0.0, metadata={"secret_leak_check": "x"}
+    )
+
+
+class _FakePostCM:
+    def __init__(self, result: object) -> None:
+        self._result = result
+
+    async def __aenter__(self):
+        if isinstance(self._result, BaseException):
+            raise self._result
+        return self._result
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+
+class _FakeResponse:
+    def __init__(self, status: int, text: str = "") -> None:
+        self.status = status
+        self._text = text
+
+    async def text(self) -> str:
+        return self._text
+
+
+class _FakeSession:
+    """A scripted aiohttp.ClientSession-shaped fake: each .post() call consumes the
+    next queued result (a _FakeResponse or an exception to raise) and records the call."""
+
+    def __init__(self, results: list[object]) -> None:
+        self._results = list(results)
+        self.calls: list[dict] = []
+        self.closed = False
+
+    def post(self, url: str, *, data: bytes, headers: dict, timeout: object) -> _FakePostCM:
+        self.calls.append({"url": url, "data": data, "headers": headers, "timeout": timeout})
+        return _FakePostCM(self._results.pop(0))
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+async def _fake_sleep(delays: list[float]):
+    async def _sleep(seconds: float) -> None:
+        delays.append(seconds)
+
+    return _sleep
+
+
+# --- WebhookConfig validation --------------------------------------------------------
+
+
+def test_webhook_url_scheme_http_https_accepted():
+    WebhookConfig(url="http://example.com/hook", secret="s")
+    WebhookConfig(url="https://example.com/hook", secret="s")
+
+
+def test_webhook_url_invalid_scheme_raises_at_construction():
+    with pytest.raises(ValueError):
+        WebhookConfig(url="ftp://example.com/hook", secret="s")
+
+
+def test_webhook_url_malformed_raises_at_construction():
+    with pytest.raises(ValueError):
+        WebhookConfig(url="not-a-url", secret="s")
+
+
+def test_webhook_reserved_header_override_raises_at_construction():
+    with pytest.raises(ValueError):
+        WebhookConfig(url="https://example.com", secret="s", headers={"Content-Type": "text/plain"})
+    with pytest.raises(ValueError):
+        WebhookConfig(
+            url="https://example.com", secret="s", headers={"X-LiveKit-Signature": "v1=x"}
+        )
+
+
+# --- signing --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_webhook_signature_format_is_v1_prefixed_hex_hmac_sha256():
+    session = _FakeSession([_FakeResponse(200)])
+    config = WebhookConfig(url="https://example.com/hook", secret="topsecret")
+    dispatcher = PostCallWebhookDispatcher(config, http_session=session)
+    report = _report()
+
+    await dispatcher.send(report)
+
+    sig_header = session.calls[0]["headers"]["X-LiveKit-Signature"]
+    assert sig_header.startswith("v1=")
+    digest = sig_header.removeprefix("v1=")
+    assert len(digest) == 64  # hex sha256
+    int(digest, 16)  # must be valid hex
+
+
+@pytest.mark.asyncio
+async def test_webhook_signature_computed_over_exact_sent_bytes():
+    session = _FakeSession([_FakeResponse(200)])
+    config = WebhookConfig(url="https://example.com/hook", secret="topsecret")
+    dispatcher = PostCallWebhookDispatcher(config, http_session=session)
+    report = _report()
+
+    await dispatcher.send(report)
+
+    sent_body = session.calls[0]["data"]
+    sig_header = session.calls[0]["headers"]["X-LiveKit-Signature"]
+    expected = hmac.new(b"topsecret", sent_body, hashlib.sha256).hexdigest()
+    assert sig_header == f"v1={expected}"
+
+
+@pytest.mark.asyncio
+async def test_webhook_content_type_header_set():
+    session = _FakeSession([_FakeResponse(200)])
+    dispatcher = PostCallWebhookDispatcher(
+        WebhookConfig(url="https://example.com/hook", secret="s"), http_session=session
+    )
+    await dispatcher.send(_report())
+    assert session.calls[0]["headers"]["Content-Type"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_webhook_custom_headers_included():
+    session = _FakeSession([_FakeResponse(200)])
+    config = WebhookConfig(url="https://example.com/hook", secret="s", headers={"X-Api-Key": "abc"})
+    dispatcher = PostCallWebhookDispatcher(config, http_session=session)
+    await dispatcher.send(_report())
+    assert session.calls[0]["headers"]["X-Api-Key"] == "abc"
+
+
+# --- success / retry behavior ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_webhook_success_first_attempt_no_retry():
+    session = _FakeSession([_FakeResponse(200)])
+    delays: list[float] = []
+    dispatcher = PostCallWebhookDispatcher(
+        WebhookConfig(url="https://example.com/hook", secret="s"),
+        http_session=session,
+        sleep=await _fake_sleep(delays),
+    )
+    await dispatcher.send(_report())
+    assert len(session.calls) == 1
+    assert delays == []
+
+
+@pytest.mark.asyncio
+async def test_webhook_5xx_retries_with_configured_backoff_then_succeeds():
+    session = _FakeSession([_FakeResponse(500), _FakeResponse(503), _FakeResponse(200)])
+    delays: list[float] = []
+    dispatcher = PostCallWebhookDispatcher(
+        WebhookConfig(url="https://example.com/hook", secret="s", max_retries=2),
+        http_session=session,
+        sleep=await _fake_sleep(delays),
+    )
+    await dispatcher.send(_report())
+    assert len(session.calls) == 3
+    assert delays == [0.5, 1.0]
+
+
+@pytest.mark.asyncio
+async def test_webhook_connection_error_retries():
+    session = _FakeSession([aiohttp.ClientConnectionError("boom"), _FakeResponse(200)])
+    delays: list[float] = []
+    dispatcher = PostCallWebhookDispatcher(
+        WebhookConfig(url="https://example.com/hook", secret="s"),
+        http_session=session,
+        sleep=await _fake_sleep(delays),
+    )
+    await dispatcher.send(_report())
+    assert len(session.calls) == 2
+    assert delays == [0.5]
+
+
+@pytest.mark.asyncio
+async def test_webhook_timeout_error_retries():
+    session = _FakeSession([TimeoutError("timed out"), _FakeResponse(200)])
+    dispatcher = PostCallWebhookDispatcher(
+        WebhookConfig(url="https://example.com/hook", secret="s"),
+        http_session=session,
+        sleep=await _fake_sleep([]),
+    )
+    await dispatcher.send(_report())
+    assert len(session.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_webhook_4xx_never_retries():
+    session = _FakeSession([_FakeResponse(404, text="not found")])
+    dispatcher = PostCallWebhookDispatcher(
+        WebhookConfig(url="https://example.com/hook", secret="s"),
+        http_session=session,
+        sleep=await _fake_sleep([]),
+    )
+    with pytest.raises(WebhookDeliveryError) as exc_info:
+        await dispatcher.send(_report())
+    assert len(session.calls) == 1
+    assert exc_info.value.attempts == 1
+    assert exc_info.value.status == 404
+
+
+@pytest.mark.asyncio
+async def test_webhook_401_never_retries():
+    session = _FakeSession([_FakeResponse(401)])
+    dispatcher = PostCallWebhookDispatcher(
+        WebhookConfig(url="https://example.com/hook", secret="s"),
+        http_session=session,
+        sleep=await _fake_sleep([]),
+    )
+    with pytest.raises(WebhookDeliveryError):
+        await dispatcher.send(_report())
+    assert len(session.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_webhook_exhausts_retries_raises_typed_error_with_attempt_count():
+    session = _FakeSession([_FakeResponse(500), _FakeResponse(500), _FakeResponse(500)])
+    dispatcher = PostCallWebhookDispatcher(
+        WebhookConfig(url="https://example.com/hook", secret="s", max_retries=2),
+        http_session=session,
+        sleep=await _fake_sleep([]),
+    )
+    with pytest.raises(WebhookDeliveryError) as exc_info:
+        await dispatcher.send(_report())
+    assert len(session.calls) == 3
+    assert exc_info.value.attempts == 3
+    assert exc_info.value.status == 500
+
+
+@pytest.mark.asyncio
+async def test_webhook_max_retries_zero_means_single_attempt():
+    session = _FakeSession([_FakeResponse(500)])
+    dispatcher = PostCallWebhookDispatcher(
+        WebhookConfig(url="https://example.com/hook", secret="s", max_retries=0),
+        http_session=session,
+        sleep=await _fake_sleep([]),
+    )
+    with pytest.raises(WebhookDeliveryError) as exc_info:
+        await dispatcher.send(_report())
+    assert len(session.calls) == 1
+    assert exc_info.value.attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_webhook_delivery_error_never_contains_secret_or_full_report():
+    session = _FakeSession([_FakeResponse(500)])
+    dispatcher = PostCallWebhookDispatcher(
+        WebhookConfig(url="https://example.com/hook", secret="super-secret-value", max_retries=0),
+        http_session=session,
+        sleep=await _fake_sleep([]),
+    )
+    with pytest.raises(WebhookDeliveryError) as exc_info:
+        await dispatcher.send(_report())
+    message = str(exc_info.value)
+    assert "super-secret-value" not in message
+    assert "secret_leak_check" not in message
+
+
+# --- session resolution -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_webhook_uses_injected_http_session_when_provided():
+    session = _FakeSession([_FakeResponse(200)])
+    dispatcher = PostCallWebhookDispatcher(
+        WebhookConfig(url="https://example.com/hook", secret="s"), http_session=session
+    )
+    await dispatcher.send(_report())
+    assert len(session.calls) == 1
+    await dispatcher.aclose()
+    assert session.closed is False  # injected session is not owned, so not closed
+
+
+@pytest.mark.asyncio
+async def test_webhook_falls_back_to_http_context_session_when_bound(monkeypatch):
+    session = _FakeSession([_FakeResponse(200)])
+    monkeypatch.setattr(http_context, "http_session", lambda: session)
+
+    dispatcher = PostCallWebhookDispatcher(
+        WebhookConfig(url="https://example.com/hook", secret="s")
+    )
+    await dispatcher.send(_report())
+
+    assert len(session.calls) == 1
+    # the http_context-bound session's lifecycle isn't owned by the dispatcher
+    await dispatcher.aclose()
+    assert session.closed is False
+
+
+@pytest.mark.asyncio
+async def test_webhook_creates_and_owns_private_session_when_neither_available(monkeypatch):
+    session = _FakeSession([_FakeResponse(200)])
+    monkeypatch.setattr(
+        "livekit.agents.beta.gtm_telemetry.webhook.aiohttp.ClientSession", lambda: session
+    )
+    dispatcher = PostCallWebhookDispatcher(
+        WebhookConfig(url="https://example.com/hook", secret="s")
+    )
+    await dispatcher.send(_report())
+    assert len(session.calls) == 1
+
+    await dispatcher.aclose()
+    assert session.closed is True


### PR DESCRIPTION
Adds livekit.agents.beta.gtm_telemetry: an opt-in collector that builds a deterministic PostCallReport (transcript, tool executions, metrics summary) from an AgentSession, a signed webhook dispatcher with bounded retries, and pure HubSpot/Salesforce payload adapters.

Reuses existing session internals (session.history, session.usage, session._recorded_events) instead of live event listeners, so attach() timing doesn't affect correctness and duplicate/out-of-order event delivery is a non-issue. Transcript and per-turn latency are sourced from ChatMessage/ChatMessage.metrics rather than the deprecated metrics_collected event.


