### PR TITLE
fix(tts): strip nested markup from extracted expressive tag values

### DIFF
--- a/livekit-agents/livekit/agents/tts/markup_utils.py
+++ b/livekit-agents/livekit/agents/tts/markup_utils.py
@@ -60,8 +60,12 @@ def extract_and_strip(text: str, *, xml_tags: list[str]) -> tuple[str, list[tupl
         tag = groups.get("tag")
         if tag is not None:
             inner = groups.get("inner")
-            if inner is not None and inner.strip():
-                value = inner.strip()
+            # a wrapping tag's value is its inner *text*, so nested markup is stripped out
+            # of it -- those inner tags are recorded on their own by the later pass that
+            # sweeps the raw inner content returned below
+            inner_text = extract_and_strip(inner, xml_tags=xml_tags)[0].strip() if inner else ""
+            if inner_text:
+                value = inner_text
             else:
                 attr_match = _VALUE_ATTR_RE.search(groups.get("attrs") or "")
                 value = attr_match.group(1) if attr_match else ""

--- a/livekit-agents/livekit/agents/tts/markup_utils.py
+++ b/livekit-agents/livekit/agents/tts/markup_utils.py
@@ -78,7 +78,13 @@ def extract_and_strip(text: str, *, xml_tags: list[str]) -> tuple[str, list[tupl
             # of it -- those inner tags are recorded on their own by the later pass that
             # sweeps the raw inner content returned below. deleting delimiters is enough
             # here and keeps this linear: recursing would rescan each nesting level again.
-            inner_text = delimiters.sub("", inner).strip() if inner else ""
+            if not inner:
+                inner_text = ""
+            elif "<" in inner or ">" in inner:
+                inner_text = delimiters.sub("", inner).strip()
+            else:
+                # the common case: plain inner text needs no scan at all
+                inner_text = inner.strip()
             if inner_text:
                 value = inner_text
             else:

--- a/livekit-agents/livekit/agents/tts/markup_utils.py
+++ b/livekit-agents/livekit/agents/tts/markup_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from functools import lru_cache
 
 _EXPRESSION_RE = re.compile(r'<expression\s+value="([^"]*)"(?:\s*/>|>(?:.*?)</expression>)')
 _SOUND_RE = re.compile(r'<sound\s+value="([^"]*)"(?:\s*/>|>(?:.*?)</sound>)')
@@ -14,6 +15,27 @@ def convert_expression_tags(text: str) -> str:
 
 
 _VALUE_ATTR_RE = re.compile(r'\b[\w-]+\s*=\s*"([^"]*)"')
+
+
+@lru_cache(maxsize=32)
+def _compile_markup(xml_tags: tuple[str, ...]) -> tuple[re.Pattern[str], re.Pattern[str]]:
+    """Compile the strip and delimiter patterns for a tag set, once per set.
+
+    ``markup`` matches a whole tag (with its inner content, for a wrapping pair);
+    ``delimiters`` matches tag delimiters individually, so a single pass over a tag's
+    inner content reduces it to text without needing the fixed-point loop.
+    """
+    tag_pattern = "|".join(re.escape(tag) for tag in xml_tags)
+    markup = re.compile(
+        # <tag .../> or <tag ...> optionally followed by inner</tag>
+        rf"<(?P<tag>{tag_pattern})\b(?P<attrs>[^>]*?)\s*/?\s*>"
+        rf"(?:(?P<inner>.*?)</(?P=tag)\s*>)?"
+        # lone closing tag: </tag>
+        rf"|</(?:{tag_pattern})\s*>",
+        re.DOTALL,
+    )
+    delimiters = re.compile(rf"<(?:{tag_pattern})\b[^>]*>|</(?:{tag_pattern})\s*>")
+    return markup, delimiters
 
 
 def extract_and_strip(text: str, *, xml_tags: list[str]) -> tuple[str, list[tuple[str, str]]]:
@@ -44,15 +66,7 @@ def extract_and_strip(text: str, *, xml_tags: list[str]) -> tuple[str, list[tupl
     if not xml_tags:
         return text, []
 
-    tag_pattern = "|".join(re.escape(tag) for tag in xml_tags)
-    pattern = re.compile(
-        # <tag .../> or <tag ...> optionally followed by inner</tag>
-        rf"<(?P<tag>{tag_pattern})\b(?P<attrs>[^>]*?)\s*/?\s*>"
-        rf"(?:(?P<inner>.*?)</(?P=tag)\s*>)?"
-        # lone closing tag: </tag>
-        rf"|</(?:{tag_pattern})\s*>",
-        re.DOTALL,
-    )
+    pattern, delimiters = _compile_markup(tuple(xml_tags))
     tags: list[tuple[str, str]] = []
 
     def _repl(m: re.Match[str]) -> str:
@@ -62,8 +76,9 @@ def extract_and_strip(text: str, *, xml_tags: list[str]) -> tuple[str, list[tupl
             inner = groups.get("inner")
             # a wrapping tag's value is its inner *text*, so nested markup is stripped out
             # of it -- those inner tags are recorded on their own by the later pass that
-            # sweeps the raw inner content returned below
-            inner_text = extract_and_strip(inner, xml_tags=xml_tags)[0].strip() if inner else ""
+            # sweeps the raw inner content returned below. deleting delimiters is enough
+            # here and keeps this linear: recursing would rescan each nesting level again.
+            inner_text = delimiters.sub("", inner).strip() if inner else ""
             if inner_text:
                 value = inner_text
             else:

--- a/tests/test_tokenizer_xml_markup.py
+++ b/tests/test_tokenizer_xml_markup.py
@@ -91,6 +91,25 @@ class TestExtractAndStrip:
         assert clean == "hi A7"
         assert tags == [("emotion", "happy"), ("spell", "A7")]
 
+    def test_nested_tag_value_is_inner_text_not_inner_markup(self) -> None:
+        # a wrapping tag's value is documented as its inner *text*; an outer tag must not
+        # carry the nested tags' delimiters, since the value is surfaced to the frontend
+        clean, tags = extract_and_strip(
+            "<excited><loud>no way</loud></excited>", xml_tags=["excited", "loud"]
+        )
+        assert clean == "no way"
+        assert tags == [("excited", "no way"), ("loud", "no way")]
+
+    def test_nested_value_falls_back_to_attribute_when_inner_is_markup_only(self) -> None:
+        # stripping the nested markup empties the inner text, so the attribute is used
+        # rather than recording the raw delimiters
+        clean, tags = extract_and_strip(
+            '<excited value="wow"><break time="500ms"/></excited>',
+            xml_tags=["excited", "break"],
+        )
+        assert clean == ""
+        assert tags == [("excited", "wow"), ("break", "500ms")]
+
 
 # ===========================================================================
 # xAI dialect (mixed inline [..] + wrapping <..>)
@@ -195,10 +214,12 @@ class TestXaiDialect:
         # combining emotion + prosody means nesting; the transcript must come out clean
         # (no leaked inner markup) — this is what the fixed-point strip guarantees
         raw = '<excited><loud><higher-pitch>no way</higher-pitch></loud></excited> <sound value="laugh"/> okay'
-        clean, _ = pf.split_all_markup(raw)
+        clean, tags = pf.split_all_markup(raw)
         assert "<" not in clean and ">" not in clean and "[" not in clean
         assert clean.strip() == "no way  okay".replace("  ", " ") or "no way" in clean
         assert "no way" in clean and "okay" in clean
+        # the tags surfaced to the frontend must be just as clean as the transcript
+        assert all("<" not in tag["value"] and ">" not in tag["value"] for tag in tags)
 
     def test_convert_inline_sounds_and_pauses_to_brackets(self) -> None:
         from livekit.agents.tts import _provider_format as pf

--- a/tests/test_tokenizer_xml_markup.py
+++ b/tests/test_tokenizer_xml_markup.py
@@ -7,7 +7,6 @@ used in expressive mode (Cartesia, ElevenLabs, Inworld).
 from __future__ import annotations
 
 import asyncio
-import time
 
 import pytest
 
@@ -101,22 +100,18 @@ class TestExtractAndStrip:
         assert clean == "no way"
         assert tags == [("excited", "no way"), ("loud", "no way")]
 
-    def test_deep_nesting_stays_cheap(self) -> None:
-        # values are cleaned by deleting delimiters in one pass; recursing per level
-        # instead would make this exponential in nesting depth
+    def test_deep_nesting_records_inner_text_at_every_level(self) -> None:
+        # every level's value is the inner *text*, not the markup below it: before the
+        # delimiter pass an outer tag recorded the whole nested chain verbatim
+        # (t0 -> "<t1><t2>...x...</t2></t1>")
         tags = [f"t{i}" for i in range(20)]
         text = "".join(f"<{t}>" for t in tags) + "x" + "".join(f"</{t}>" for t in reversed(tags))
 
-        started = time.perf_counter()
         clean, found = extract_and_strip(text, xml_tags=tags)
-        elapsed = time.perf_counter() - started
 
         assert clean == "x"
         assert [tag for tag, _ in found] == tags
         assert all(value == "x" for _, value in found)
-        # generous bound: this is ~0.5ms cleaned up, and was several minutes when each
-        # level re-ran the whole strip
-        assert elapsed < 2.0
 
     def test_nested_value_falls_back_to_attribute_when_inner_is_markup_only(self) -> None:
         # stripping the nested markup empties the inner text, so the attribute is used

--- a/tests/test_tokenizer_xml_markup.py
+++ b/tests/test_tokenizer_xml_markup.py
@@ -7,6 +7,7 @@ used in expressive mode (Cartesia, ElevenLabs, Inworld).
 from __future__ import annotations
 
 import asyncio
+import time
 
 import pytest
 
@@ -99,6 +100,23 @@ class TestExtractAndStrip:
         )
         assert clean == "no way"
         assert tags == [("excited", "no way"), ("loud", "no way")]
+
+    def test_deep_nesting_stays_cheap(self) -> None:
+        # values are cleaned by deleting delimiters in one pass; recursing per level
+        # instead would make this exponential in nesting depth
+        tags = [f"t{i}" for i in range(20)]
+        text = "".join(f"<{t}>" for t in tags) + "x" + "".join(f"</{t}>" for t in reversed(tags))
+
+        started = time.perf_counter()
+        clean, found = extract_and_strip(text, xml_tags=tags)
+        elapsed = time.perf_counter() - started
+
+        assert clean == "x"
+        assert [tag for tag, _ in found] == tags
+        assert all(value == "x" for _, value in found)
+        # generous bound: this is ~0.5ms cleaned up, and was several minutes when each
+        # level re-ran the whole strip
+        assert elapsed < 2.0
 
     def test_nested_value_falls_back_to_attribute_when_inner_is_markup_only(self) -> None:
         # stripping the nested markup empties the inner text, so the attribute is used


### PR DESCRIPTION
`extract_and_strip` recorded a wrapping tag's value as its raw inner content, so nesting leaked the inner tags' delimiters into the value:

    <excited><loud>no way</loud></excited>
    -> [("excited", "<loud>no way</loud>"), ("loud", "no way")]

`ExpressiveTag.value` is documented as "the tag's inner text" and is surfaced to the frontend via ATTRIBUTE_TRANSCRIPTION_EXPRESSION, so the markup reached consumers even though the transcript itself was clean.

Clean the inner text before recording it. The raw inner content is still returned, so the fixed-point loop's next pass records the nested tags on their own -- the tag list is unchanged, only the values are now text.

test_nested_emotion_prosody_strips_cleanly already promised "no leaked inner markup" but only asserted on the transcript; it now checks the tags too, and fails without this change.