### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ if __name__ == "__main__":
     cli.run_app(server)
 ```
 
+> **Note:** The OpenAI plugin also works with OpenAI-compatible multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1` (set `base_url` if the plugin supports it).
+
 You'll need the following environment variables for this example:
 
 - LIVEKIT_URL


### PR DESCRIPTION
## Summary

The README already shows the OpenAI plugin for LLM.

This PR adds a one-line note that the same OpenAI plugin pattern works with OpenAI-compatible multi-model gateways when you are not self-hosting, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] README renders
- [ ] Existing examples unchanged
- [ ] Note is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>