### PR TITLE
docs(openai): note base_url for OpenAI-compatible multi-model gateways

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/README.md
+++ b/livekit-plugins/livekit-plugins-openai/README.md
@@ -4,6 +4,8 @@ Support for OpenAI Realtime API, Responses API, LLM, TTS, and STT APIs.
 
 Also includes support for a large number of OpenAI-compatible APIs including [Azure OpenAI](https://docs.livekit.io/agents/integrations/llm/azure-openai/), [Cerebras](https://docs.livekit.io/agents/integrations/cerebras/), [Fireworks](https://docs.livekit.io/agents/integrations/llm/fireworks/), [Perplexity](https://docs.livekit.io/agents/integrations/llm/perplexity/), [Telnyx](https://docs.livekit.io/agents/integrations/llm/telnyx/), [xAI](https://docs.livekit.io/agents/integrations/llm/xai/), [Ollama](https://docs.livekit.io/agents/integrations/llm/ollama/), [DeepSeek](https://docs.livekit.io/agents/integrations/llm/deepseek/), and [SambaNova](https://docs.livekit.io/agents/integrations/llm/sambanova/).
 
+You can also point the OpenAI plugin at any OpenAI-compatible multi-model gateway via `base_url` — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.
+
 See [https://docs.livekit.io/agents/integrations/openai/](https://docs.livekit.io/agents/integrations/openai/) for more information.
 
 ## Installation


### PR DESCRIPTION
## Summary

The OpenAI plugin README already lists many OpenAI-compatible APIs.

This PR notes that the same `base_url` pattern also works with OpenAI-compatible multi-model gateways, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] Plugin README renders
- [ ] Listed integrations unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>