### PR TITLE
fix(ipc): treat closed inference process as dead in is_alive

### DIFF
--- a/livekit-agents/livekit/agents/ipc/inference_proc_executor.py
+++ b/livekit-agents/livekit/agents/ipc/inference_proc_executor.py
@@ -110,4 +110,7 @@ class InferenceProcExecutor(SupervisedProc):
         return extra
 
     def is_alive(self) -> bool:
-        return self._proc.is_alive()
+        try:
+            return self._proc.is_alive()
+        except ValueError:  # process object is closed
+            return False


### PR DESCRIPTION
health_check was raising ValueError after _proc.close(), returning 500 instead of 503. Mirror the guard already used in _send_kill_signal (#4500).

Fixes #6672