### PR TITLE
feat(ipc): allow configuring job entrypoint shutdown grace period (#6512)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ This code snippet is abbreviated. For the full example, see [multi_agent.py](exa
 
 ```python
 ...
+
+
 class IntroAgent(Agent):
     def __init__(self) -> None:
         super().__init__(
@@ -210,6 +212,8 @@ async def entrypoint(ctx: JobContext):
         agent=IntroAgent(),
         room=ctx.room,
     )
+
+
 ...
 ```
 
@@ -223,9 +227,7 @@ async def test_no_availability() -> None:
     llm = google.LLM()
     async with AgentSession(llm=llm) as sess:
         await sess.start(MyAgent())
-        result = await sess.run(
-            user_input="Hello, I need to place an order."
-        )
+        result = await sess.run(user_input="Hello, I need to place an order.")
         result.expect.skip_next_event_if(type="message", role="assistant")
         result.expect.next_event().is_function_call(name="start_order")
         result.expect.next_event().is_function_call_output()
@@ -234,7 +236,6 @@ async def test_no_availability() -> None:
             .is_message(role="assistant")
             .judge(llm, intent="assistant should be asking the user what they would like")
         )
-
 ```
 
 ## Examples

--- a/livekit-agents/README.md
+++ b/livekit-agents/README.md
@@ -13,23 +13,17 @@ from livekit.plugins import openai
 
 load_dotenv()
 
+
 async def entrypoint(ctx: agents.JobContext):
     await ctx.connect()
 
-    session = AgentSession(
-        llm=openai.realtime.RealtimeModel(
-            voice="coral"
-        )
-    )
+    session = AgentSession(llm=openai.realtime.RealtimeModel(voice="coral"))
 
     await session.start(
-        room=ctx.room,
-        agent=Agent(instructions="You are a helpful voice AI assistant.")
+        room=ctx.room, agent=Agent(instructions="You are a helpful voice AI assistant.")
     )
 
-    await session.generate_reply(
-        instructions="Greet the user and offer your assistance."
-    )
+    await session.generate_reply(instructions="Greet the user and offer your assistance.")
 
 
 if __name__ == "__main__":

--- a/livekit-agents/livekit/agents/ipc/job_proc_executor.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_executor.py
@@ -30,6 +30,7 @@ class ProcJobExecutor(SupervisedProc):
         inference_executor: InferenceExecutor | None,
         initialize_timeout: float,
         close_timeout: float,
+        entrypoint_shutdown_timeout: float = 15.0,
         session_end_timeout: float,
         memory_warn_mb: float,
         memory_limit_mb: float,
@@ -60,6 +61,7 @@ class ProcJobExecutor(SupervisedProc):
         self._job_entrypoint_fnc = job_entrypoint_fnc
         self._session_end_fnc = session_end_fnc
         self._simulation_end_fnc = simulation_end_fnc
+        self._entrypoint_shutdown_timeout = entrypoint_shutdown_timeout
         self._session_end_timeout = session_end_timeout
         self._inference_executor = inference_executor
         self._inference_tasks: set[asyncio.Task[None]] = set()
@@ -106,6 +108,7 @@ class ProcJobExecutor(SupervisedProc):
             job_entrypoint_fnc=self._job_entrypoint_fnc,
             session_end_fnc=self._session_end_fnc,
             simulation_end_fnc=self._simulation_end_fnc,
+            entrypoint_shutdown_timeout=self._entrypoint_shutdown_timeout,
             session_end_timeout=self._session_end_timeout,
             log_cch=log_cch,
             mp_cch=cch,

--- a/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
@@ -62,6 +62,7 @@ class ProcStartArgs:
     mp_cch: socket.socket
     log_cch: socket.socket
     logger_levels: dict[str, int]
+    entrypoint_shutdown_timeout: float = 15.0
     simulation_end_fnc: Callable[[Any], Any] | None = None
 
 
@@ -84,6 +85,7 @@ def proc_main(args: ProcStartArgs) -> None:
         args.job_entrypoint_fnc,
         args.session_end_fnc,
         session_end_timeout=args.session_end_timeout,
+        entrypoint_shutdown_timeout=args.entrypoint_shutdown_timeout,
         executor_type=JobExecutorType.PROCESS,
         user_arguments=args.user_arguments,
         simulation_end_fnc=args.simulation_end_fnc,
@@ -192,6 +194,7 @@ class _JobProc:
         session_end_fnc: Callable[[JobContext], Awaitable[None]] | None,
         *,
         session_end_timeout: float,
+        entrypoint_shutdown_timeout: float = 15.0,
         executor_type: JobExecutorType,
         user_arguments: Any | None = None,
         simulation_end_fnc: Callable[[Any], Any] | None = None,
@@ -203,6 +206,7 @@ class _JobProc:
         self._session_end_fnc = session_end_fnc
         self._simulation_end_fnc = simulation_end_fnc
         self._session_end_timeout = session_end_timeout
+        self._entrypoint_shutdown_timeout = entrypoint_shutdown_timeout
         self._job_task: asyncio.Task[None] | None = None
 
         # used to warn users if both connect and shutdown are not called inside the job_entry
@@ -379,7 +383,9 @@ class _JobProc:
         # wait for the entrypoint to finish, cancel if it takes too long
         if not job_entry_task.done():
             try:
-                await asyncio.wait_for(asyncio.shield(job_entry_task), timeout=15)
+                await asyncio.wait_for(
+                    asyncio.shield(job_entry_task), timeout=self._entrypoint_shutdown_timeout
+                )
             except asyncio.TimeoutError:
                 logger.warning("entrypoint did not exit in time, cancelling")
                 await aio.cancel_and_wait(job_entry_task)
@@ -453,6 +459,7 @@ class ThreadStartArgs:
     join_fnc: Callable[[], None]
     mp_cch: socket.socket
     user_arguments: Any | None
+    entrypoint_shutdown_timeout: float = 15.0
     simulation_end_fnc: Callable[[Any], Any] | None = None
 
 
@@ -468,6 +475,7 @@ def thread_main(
             args.job_entrypoint_fnc,
             args.session_end_fnc,
             session_end_timeout=args.session_end_timeout,
+            entrypoint_shutdown_timeout=args.entrypoint_shutdown_timeout,
             executor_type=JobExecutorType.THREAD,
             user_arguments=args.user_arguments,
             simulation_end_fnc=args.simulation_end_fnc,

--- a/livekit-agents/livekit/agents/ipc/job_thread_executor.py
+++ b/livekit-agents/livekit/agents/ipc/job_thread_executor.py
@@ -26,6 +26,7 @@ class _ProcOpts:
     simulation_end_fnc: Callable[[Any], Any] | None
     initialize_timeout: float
     close_timeout: float
+    entrypoint_shutdown_timeout: float
     session_end_timeout: float
     ping_interval: float
     high_ping_threshold: float
@@ -43,6 +44,7 @@ class ThreadJobExecutor:
         inference_executor: InferenceExecutor | None,
         initialize_timeout: float,
         close_timeout: float,
+        entrypoint_shutdown_timeout: float = 15.0,
         session_end_timeout: float,
         ping_interval: float,
         high_ping_threshold: float,
@@ -57,6 +59,7 @@ class ThreadJobExecutor:
             simulation_end_fnc=simulation_end_fnc,
             initialize_timeout=initialize_timeout,
             close_timeout=close_timeout,
+            entrypoint_shutdown_timeout=entrypoint_shutdown_timeout,
             session_end_timeout=session_end_timeout,
             ping_interval=ping_interval,
             high_ping_threshold=high_ping_threshold,
@@ -137,6 +140,7 @@ class ThreadJobExecutor:
                     job_entrypoint_fnc=self._opts.job_entrypoint_fnc,
                     session_end_fnc=self._opts.session_end_fnc,
                     simulation_end_fnc=self._opts.simulation_end_fnc,
+                    entrypoint_shutdown_timeout=self._opts.entrypoint_shutdown_timeout,
                     session_end_timeout=self._opts.session_end_timeout,
                     user_arguments=self._user_args,
                     join_fnc=_on_join,

--- a/livekit-agents/livekit/agents/ipc/proc_pool.py
+++ b/livekit-agents/livekit/agents/ipc/proc_pool.py
@@ -36,6 +36,7 @@ class ProcPool(utils.EventEmitter[EventTypes]):
         num_idle_processes: int,
         initialize_timeout: float,
         close_timeout: float,
+        entrypoint_shutdown_timeout: float = 15.0,
         session_end_timeout: float,
         inference_executor: inference_executor.InferenceExecutor | None,
         job_executor_type: JobExecutorType,
@@ -53,6 +54,7 @@ class ProcPool(utils.EventEmitter[EventTypes]):
         self._session_end_fnc = session_end_fnc
         self._simulation_end_fnc = simulation_end_fnc
         self._close_timeout = close_timeout
+        self._entrypoint_shutdown_timeout = entrypoint_shutdown_timeout
         self._session_end_timeout = session_end_timeout
         self._inf_executor = inference_executor
         self._initialize_timeout = initialize_timeout
@@ -209,6 +211,7 @@ class ProcPool(utils.EventEmitter[EventTypes]):
                 simulation_end_fnc=self._simulation_end_fnc,
                 initialize_timeout=self._initialize_timeout,
                 close_timeout=self._close_timeout,
+                entrypoint_shutdown_timeout=self._entrypoint_shutdown_timeout,
                 session_end_timeout=self._session_end_timeout,
                 inference_executor=self._inf_executor,
                 ping_interval=2.5,
@@ -224,6 +227,7 @@ class ProcPool(utils.EventEmitter[EventTypes]):
                 simulation_end_fnc=self._simulation_end_fnc,
                 initialize_timeout=self._initialize_timeout,
                 close_timeout=self._close_timeout,
+                entrypoint_shutdown_timeout=self._entrypoint_shutdown_timeout,
                 session_end_timeout=self._session_end_timeout,
                 inference_executor=self._inf_executor,
                 mp_ctx=self._mp_ctx,

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -210,6 +210,8 @@ class ServerOptions:
     """Number of idle processes to keep warm."""
     shutdown_process_timeout: float = 10.0
     """Maximum amount of time to wait for a job to shut down gracefully"""
+    entrypoint_shutdown_timeout: float = 15.0
+    """Maximum amount of time to wait for entrypoint task to exit after shutdown signal (default: 15.0)."""
     session_end_timeout: float = 300.0
     """Maximum amount of time to wait for on_session_end to complete (default: 5 minutes)."""
     initialize_process_timeout: float = 10.0
@@ -310,6 +312,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
         drain_timeout: int = DRAIN_TIMEOUT,
         num_idle_processes: int | ServerEnvOption[int] = _default_num_idle_processes,
         shutdown_process_timeout: float = 10.0,
+        entrypoint_shutdown_timeout: float = 15.0,
         session_end_timeout: float = 300.0,
         initialize_process_timeout: float = 10.0,
         permissions: WorkerPermissions = _default_permissions,
@@ -346,6 +349,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
         self._drain_timeout = drain_timeout
         self._num_idle_processes = num_idle_processes
         self._shutdown_process_timeout = shutdown_process_timeout
+        self._entrypoint_shutdown_timeout = entrypoint_shutdown_timeout
         self._session_end_timeout = session_end_timeout
         self._initialize_process_timeout = initialize_process_timeout
         self._permissions = permissions
@@ -421,6 +425,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
             drain_timeout=options.drain_timeout,
             num_idle_processes=options.num_idle_processes,
             shutdown_process_timeout=options.shutdown_process_timeout,
+            entrypoint_shutdown_timeout=options.entrypoint_shutdown_timeout,
             session_end_timeout=options.session_end_timeout,
             initialize_process_timeout=options.initialize_process_timeout,
             permissions=options.permissions,
@@ -628,6 +633,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                 mp_ctx=self._mp_ctx,
                 initialize_timeout=self._initialize_process_timeout,
                 close_timeout=self._shutdown_process_timeout,
+                entrypoint_shutdown_timeout=self._entrypoint_shutdown_timeout,
                 session_end_timeout=self._session_end_timeout,
                 memory_warn_mb=self._job_memory_warn_mb,
                 memory_limit_mb=self._job_memory_limit_mb,

--- a/livekit-plugins/livekit-plugins-aws/README.md
+++ b/livekit-plugins/livekit-plugins-aws/README.md
@@ -18,10 +18,7 @@ If you need the previous behavior, explicitly specify Nova Sonic 1.0:
 ```python
 model = aws.realtime.RealtimeModel.with_nova_sonic_1()
 # or
-model = aws.realtime.RealtimeModel(
-    model="amazon.nova-sonic-v1:0",
-    modalities="audio"
-)
+model = aws.realtime.RealtimeModel(model="amazon.nova-sonic-v1:0", modalities="audio")
 ```
 
 ## Installation
@@ -243,9 +240,7 @@ The `generate_reply()` method accepts two parameters with different behaviors:
 
 **`instructions`** - System-level commands (recommended):
 ```python
-await session.generate_reply(
-    instructions="Greet the user warmly and ask how you can help"
-)
+await session.generate_reply(instructions="Greet the user warmly and ask how you can help")
 ```
 - Sent as a system prompt/command to the model
 - Triggers immediate generation
@@ -254,9 +249,7 @@ await session.generate_reply(
 
 **`user_input`** - Simulated user messages:
 ```python
-await session.generate_reply(
-    user_input="Hello, I need help with my account"
-)
+await session.generate_reply(user_input="Hello, I need help with my account")
 ```
 - Sent as interactive USER role content
 - Added to Nova's conversation context
@@ -294,32 +287,32 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+
 class Assistant(Agent):
     def __init__(self):
         super().__init__(
             instructions="You are a helpful voice assistant powered by Amazon Nova 2 Sonic."
         )
-    
+
     async def on_enter(self):
-        await self.session.generate_reply(
-            instructions="Greet the user and offer assistance"
-        )
+        await self.session.generate_reply(instructions="Greet the user and offer assistance")
+
 
 server = agents.AgentServer()
+
 
 @server.rtc_session()
 async def entrypoint(ctx: agents.JobContext):
     await ctx.connect()
-    
+
     session = AgentSession(
         llm=aws.realtime.RealtimeModel.with_nova_sonic_2(
-            voice="matthew",
-            turn_detection="MEDIUM",
-            tool_choice="auto"
+            voice="matthew", turn_detection="MEDIUM", tool_choice="auto"
         )
     )
-    
+
     await session.start(room=ctx.room, agent=Assistant())
+
 
 if __name__ == "__main__":
     agents.cli.run_app(server)
@@ -334,9 +327,9 @@ from livekit.agents import inference
 from livekit.plugins import aws
 
 session = AgentSession(
-    stt=aws.STT(),                    # Amazon Transcribe
-    llm=aws.LLM(),                    # Nova 2 Lite (default)
-    tts=aws.TTS(),                    # Amazon Polly
+    stt=aws.STT(),  # Amazon Transcribe
+    llm=aws.LLM(),  # Nova 2 Lite (default)
+    tts=aws.TTS(),  # Amazon Polly
     vad=inference.VAD(),
 )
 ```

--- a/livekit-plugins/livekit-plugins-baseten/README.md
+++ b/livekit-plugins/livekit-plugins-baseten/README.md
@@ -112,8 +112,7 @@ async def entrypoint(ctx: agents.JobContext):
         tts=baseten.TTS(
             api_key=BASETEN_API_KEY,
             model_endpoint=(
-                f"https://model-{orpheus_model_id}"
-                ".api.baseten.co/environments/production/predict"
+                f"https://model-{orpheus_model_id}.api.baseten.co/environments/production/predict"
             ),
         ),
         vad=inference.VAD(),
@@ -128,9 +127,7 @@ async def entrypoint(ctx: agents.JobContext):
         ),
     )
 
-    await session.generate_reply(
-        instructions="Greet the user and offer your assistance."
-    )
+    await session.generate_reply(instructions="Greet the user and offer your assistance.")
 
 
 if __name__ == "__main__":

--- a/livekit-plugins/livekit-plugins-cambai/README.md
+++ b/livekit-plugins/livekit-plugins-cambai/README.md
@@ -33,6 +33,7 @@ Or obtain it from [Camb.ai Studio](https://studio.camb.ai/public/onboarding).
 import asyncio
 from livekit.plugins.cambai import TTS
 
+
 async def main():
     # Initialize TTS (uses CAMB_API_KEY env var)
     tts = TTS()
@@ -45,6 +46,7 @@ async def main():
     with open("output.wav", "wb") as f:
         f.write(audio_frame.to_wav_bytes())
 
+
 asyncio.run(main())
 ```
 
@@ -54,10 +56,12 @@ asyncio.run(main())
 import asyncio
 from livekit.plugins.cambai import list_voices
 
+
 async def main():
     voices = await list_voices()
     for voice in voices:
         print(f"{voice['name']} ({voice['id']}): {voice['gender']}, {voice['language']}")
+
 
 asyncio.run(main())
 ```
@@ -99,6 +103,7 @@ tts = TTS(
 ```python
 from livekit import agents
 from livekit.plugins.cambai import TTS
+
 
 async def entrypoint(ctx: agents.JobContext):
     # Connect to room

--- a/livekit-plugins/livekit-plugins-gladia/README.md
+++ b/livekit-plugins/livekit-plugins-gladia/README.md
@@ -96,7 +96,7 @@ agent = Agent(
         api_key="your-api-key-here",
         languages=["en"],
         translation_enabled=True,
-        translation_target_languages=["es"]
+        translation_target_languages=["es"],
     )
 )
 

--- a/livekit-plugins/livekit-plugins-gnani/README.md
+++ b/livekit-plugins/livekit-plugins-gnani/README.md
@@ -192,12 +192,12 @@ Frames must be sent at **real-time cadence**. See **[STT Realtime — PCM Specif
 from livekit.plugins.gnani import STT
 
 stt = STT(
-    language="en-IN",              # Default: "en-IN"
-    sample_rate=16000,             # Default: 16000 (also: 8000, 44100, 48000)
-    format="verbatim",             # Default: "verbatim" (also: "transcribe" for ITN)
-    itn_native_numerals=False,     # Default: False
-    use_streaming=True,            # Default: True (WebSocket); False = REST + VAD
-    api_key=None,                  # Default: None (reads GNANI_API_KEY env var)
+    language="en-IN",  # Default: "en-IN"
+    sample_rate=16000,  # Default: 16000 (also: 8000, 44100, 48000)
+    format="verbatim",  # Default: "verbatim" (also: "transcribe" for ITN)
+    itn_native_numerals=False,  # Default: False
+    use_streaming=True,  # Default: True (WebSocket); False = REST + VAD
+    api_key=None,  # Default: None (reads GNANI_API_KEY env var)
     base_url="https://api.vachana.ai",
 )
 ```
@@ -208,16 +208,16 @@ stt = STT(
 from livekit.plugins.gnani import TTS
 
 tts = TTS(
-    voice="Pranav",                # Default: "Pranav" (timbre-v2.0: Kaveri, Shubhra, Deepak)
-    model="timbre-v2.0",           # Default: "timbre-v2.0" (also: "timbre-v2.5" with 42 voices)
-    language=None,                 # timbre-v2.5 only — e.g. "hi-IN", "en-IN"
-    sample_rate=16000,             # Default: 16000 (also: 8000, 22050, 44100)
-    encoding="linear_pcm",         # Default: "linear_pcm" (also: "oggopus")
-    container="wav",               # Default: "wav" (also: "raw", "mp3", "ogg")
-    num_channels=1,                # Default: 1
-    bitrate=None,                  # Default: None (also: "96k", "128k", "192k")
-    synthesize_method="rest",      # Default: "rest" (also: "sse", "websocket")
-    api_key=None,                  # Default: None (reads GNANI_API_KEY env var)
+    voice="Pranav",  # Default: "Pranav" (timbre-v2.0: Kaveri, Shubhra, Deepak)
+    model="timbre-v2.0",  # Default: "timbre-v2.0" (also: "timbre-v2.5" with 42 voices)
+    language=None,  # timbre-v2.5 only — e.g. "hi-IN", "en-IN"
+    sample_rate=16000,  # Default: 16000 (also: 8000, 22050, 44100)
+    encoding="linear_pcm",  # Default: "linear_pcm" (also: "oggopus")
+    container="wav",  # Default: "wav" (also: "raw", "mp3", "ogg")
+    num_channels=1,  # Default: 1
+    bitrate=None,  # Default: None (also: "96k", "128k", "192k")
+    synthesize_method="rest",  # Default: "rest" (also: "sse", "websocket")
+    api_key=None,  # Default: None (reads GNANI_API_KEY env var)
     base_url="https://api.vachana.ai",
 )
 ```

--- a/livekit-plugins/livekit-plugins-inworld/README.md
+++ b/livekit-plugins/livekit-plugins-inworld/README.md
@@ -32,15 +32,15 @@ Or with options:
 from livekit.plugins import inworld
 
 tts = inworld.TTS(
-    voice="Hades",                 # voice ID (default or custom cloned voice)
-    model="inworld-tts-1",         # or "inworld-tts-1-max"
-    encoding="OGG_OPUS",           # LINEAR16, MP3, OGG_OPUS, ALAW, MULAW, FLAC
-    sample_rate=48000,             # 8000-48000 Hz
-    bit_rate=64000,                # bits per second (for compressed formats)
-    speaking_rate=1.0,             # 0.5-1.5
-    temperature=1.1,               # 0-2
-    timestamp_type="WORD",         # WORD, CHARACTER, or TIMESTAMP_TYPE_UNSPECIFIED
-    text_normalization="OFF",      # ON, OFF, or APPLY_TEXT_NORMALIZATION_UNSPECIFIED
+    voice="Hades",  # voice ID (default or custom cloned voice)
+    model="inworld-tts-1",  # or "inworld-tts-1-max"
+    encoding="OGG_OPUS",  # LINEAR16, MP3, OGG_OPUS, ALAW, MULAW, FLAC
+    sample_rate=48000,  # 8000-48000 Hz
+    bit_rate=64000,  # bits per second (for compressed formats)
+    speaking_rate=1.0,  # 0.5-1.5
+    temperature=1.1,  # 0-2
+    timestamp_type="WORD",  # WORD, CHARACTER, or TIMESTAMP_TYPE_UNSPECIFIED
+    text_normalization="OFF",  # ON, OFF, or APPLY_TEXT_NORMALIZATION_UNSPECIFIED
 )
 ```
 
@@ -55,8 +55,8 @@ from livekit.plugins import inworld
 tts = inworld.TTS(
     voice="Hades",
     model="inworld-tts-1",
-    buffer_char_threshold=100,     # chars before triggering synthesis (default: 100)
-    max_buffer_delay_ms=3000,      # max buffer time in ms (default: 3000)
+    buffer_char_threshold=100,  # chars before triggering synthesis (default: 100)
+    max_buffer_delay_ms=3000,  # max buffer time in ms (default: 3000)
 )
 
 # Create a stream for real-time synthesis
@@ -82,8 +82,8 @@ Use Inworld STT for streaming speech-to-text. Multiple models are supported.
 from livekit.plugins import inworld
 
 session = AgentSession(
-   stt=inworld.STT()
-   # ... llm, tts, etc.
+    stt=inworld.STT()
+    # ... llm, tts, etc.
 )
 ```
 
@@ -93,11 +93,11 @@ With a specific model and voice profile detection:
 from livekit.plugins import inworld
 
 session = AgentSession(
-   stt=inworld.STT(
-       model="inworld/inworld-stt-1",
-       enable_voice_profile=True,
-   )
-   # ... llm, tts, etc.
+    stt=inworld.STT(
+        model="inworld/inworld-stt-1",
+        enable_voice_profile=True,
+    )
+    # ... llm, tts, etc.
 )
 ```
 
@@ -199,8 +199,8 @@ if __name__ == "__main__":
 from livekit.plugins import inworld
 
 session = AgentSession(
-   tts=inworld.TTS(voice="Hades"),
-   stt=inworld.STT(),
-   # ... llm, etc.
+    tts=inworld.TTS(voice="Hades"),
+    stt=inworld.STT(),
+    # ... llm, etc.
 )
 ```

--- a/livekit-plugins/livekit-plugins-krisp/README.md
+++ b/livekit-plugins/livekit-plugins-krisp/README.md
@@ -30,6 +30,7 @@ using the room JWT the agent framework hands to the `FrameProcessor` automatical
 from livekit.agents import AgentSession, Agent, JobContext, inference, room_io
 from livekit.plugins import krisp, openai
 
+
 @server.rtc_session()
 async def entrypoint(ctx: JobContext):
     # Default: LiveKit Cloud auth + bundled model. No keys or model files.
@@ -79,9 +80,9 @@ Both factory functions return a `KrispVivaFilterFrameProcessor`. Adjust it while
 session is running:
 
 ```python
-noise_cancellation.enabled = False              # pass audio through unmodified
+noise_cancellation.enabled = False  # pass audio through unmodified
 noise_cancellation.noise_suppression_level = 50  # adjust 0-100 on the fly
-noise_cancellation.close()                       # free resources when done
+noise_cancellation.close()  # free resources when done
 ```
 
 
@@ -119,7 +120,7 @@ from livekit.plugins import krisp
 
 noise_cancellation = krisp.voice_isolation(
     auth_provider=krisp.auth.krisp_license(
-        license_key="...",                    # or KRISP_VIVA_SDK_LICENSE_KEY
+        license_key="...",  # or KRISP_VIVA_SDK_LICENSE_KEY
         model_path="/path/to/noise_model.kef",  # or KRISP_VIVA_FILTER_MODEL_PATH
     ),
     noise_suppression_level=75,

--- a/livekit-plugins/livekit-plugins-langchain/README.md
+++ b/livekit-plugins/livekit-plugins-langchain/README.md
@@ -21,6 +21,7 @@ from livekit.plugins import langchain
 
 ...
 
+
 def entrypoint(ctx: JobContext):
     graph = StateGraph(...).compile()
 

--- a/livekit-plugins/livekit-plugins-mistralai/README.md
+++ b/livekit-plugins/livekit-plugins-mistralai/README.md
@@ -34,10 +34,7 @@ from livekit.plugins import mistralai
 stt = mistralai.STT()
 
 # With context biasing
-stt = mistralai.STT(
-    model="voxtral-mini-latest",
-    context_bias=["LiveKit", "Voxtral", "Mistral"]
-)
+stt = mistralai.STT(model="voxtral-mini-latest", context_bias=["LiveKit", "Voxtral", "Mistral"])
 ```
 
 #### Realtime streaming transcription
@@ -71,6 +68,7 @@ tts = mistralai.TTS(voice="en_paul_neutral")
 
 # Using zero-shot voice cloning
 import base64
+
 ref_audio_b64 = base64.b64encode(open("sample.mp3", "rb").read()).decode()
 tts = mistralai.TTS(ref_audio=ref_audio_b64)
 ```
@@ -101,7 +99,7 @@ agent = Agent(
         mistralai.tools.WebSearch(),
         mistralai.tools.CodeInterpreter(),
         mistralai.tools.DocumentLibrary(library_ids=["<your-library-id>"]),
-        mistralai.tools.Connector(connector_id="<your_connector_id>")
-    ]
+        mistralai.tools.Connector(connector_id="<your_connector_id>"),
+    ],
 )
 ```

--- a/livekit-plugins/livekit-plugins-resemble/README.md
+++ b/livekit-plugins/livekit-plugins-resemble/README.md
@@ -24,6 +24,7 @@ Additionally, you'll need the voice UUID from your Resemble AI account.
 import asyncio
 from livekit.plugins.resemble import TTS
 
+
 async def run_tts_example():
     # Use TTS with async context manager for automatic resource cleanup
     async with TTS(
@@ -36,23 +37,22 @@ async def run_tts_example():
     ) as tts:
         # One-off synthesis (uses REST API)
         audio_stream = tts.synthesize("Hello, world!")
-        
+
         # Process chunks as they arrive
         async for chunk in audio_stream:
             # Audio data is in the 'frame.data' attribute of SynthesizedAudio objects
             audio_data = chunk.frame.data
             print(f"Received chunk: {len(audio_data)} bytes")
-        
+
         # Alternative: collect all audio at once into a single AudioFrame
         audio_stream = tts.synthesize("Another example sentence.")
         audio_frame = await audio_stream.collect()
         print(f"Collected complete audio: {len(audio_frame.data)} bytes")
-        
+
         # Real-time streaming synthesis (uses WebSocket API)
         # Only available for Business plan users in Resemble AI
         stream = tts.stream()
         await stream.synthesize_text("Hello, world!")
-        
 
 
 # Run the example
@@ -67,10 +67,11 @@ If you prefer to manage resources manually, make sure to properly clean up:
 import asyncio
 from livekit.plugins.resemble import TTS
 
+
 async def run_tts_example():
     # Initialize TTS with your credentials
     tts = TTS(
-        api_key="your_api_key", 
+        api_key="your_api_key",
         voice_uuid="your_voice_uuid",
     )
 
@@ -83,6 +84,7 @@ async def run_tts_example():
     finally:
         # Always clean up resources when done
         await tts.aclose()
+
 
 # Run the example
 asyncio.run(run_tts_example())

--- a/livekit-plugins/livekit-plugins-runway/README.md
+++ b/livekit-plugins/livekit-plugins-runway/README.md
@@ -16,6 +16,7 @@ pip install livekit-plugins-runway
 from livekit.agents import AgentSession, Agent, RoomOutputOptions
 from livekit.plugins import runway
 
+
 async def entrypoint(ctx):
     session = AgentSession()
 

--- a/livekit-plugins/livekit-plugins-ultravox/README.md
+++ b/livekit-plugins/livekit-plugins-ultravox/README.md
@@ -33,9 +33,10 @@ import asyncio
 from livekit.agents import Agent, AgentSession, JobContext, WorkerOptions, cli, inference
 from livekit.plugins.ultravox.realtime import RealtimeModel
 
+
 async def entrypoint(ctx: JobContext):
     await ctx.connect()
-    
+
     session: AgentSession[None] = AgentSession(
         allow_interruptions=True,
         vad=inference.VAD(),
@@ -44,13 +45,14 @@ async def entrypoint(ctx: JobContext):
             voice="Mark",
         ),
     )
-    
+
     await session.start(
         agent=Agent(
             instructions="You are a helpful voice assistant.",
         ),
         room=ctx.room,
     )
+
 
 if __name__ == "__main__":
     cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))
@@ -59,28 +61,39 @@ if __name__ == "__main__":
 ### Voice Assistant with Tools
 
 ```python
-from livekit.agents import function_tool, Agent, AgentSession, JobContext, WorkerOptions, cli, inference
+from livekit.agents import (
+    function_tool,
+    Agent,
+    AgentSession,
+    JobContext,
+    WorkerOptions,
+    cli,
+    inference,
+)
 from livekit.plugins.ultravox.realtime import RealtimeModel
+
 
 @function_tool
 async def get_weather(location: str) -> str:
     """Get weather information for a location."""
     return f"The weather in {location} is sunny and 72°F"
 
+
 @function_tool
 async def book_appointment(date: str, time: str) -> str:
     """Book an appointment."""
     return f"Appointment booked for {date} at {time}"
 
+
 async def entrypoint(ctx: JobContext):
     await ctx.connect()
-    
+
     session: AgentSession[None] = AgentSession(
         allow_interruptions=True,
         vad=inference.VAD(),
         llm=RealtimeModel(model_id="fixie-ai/ultravox"),
     )
-    
+
     await session.start(
         agent=Agent(
             instructions="You are a helpful assistant with access to weather and scheduling tools.",
@@ -88,6 +101,7 @@ async def entrypoint(ctx: JobContext):
         ),
         room=ctx.room,
     )
+
 
 if __name__ == "__main__":
     cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))

--- a/tests/test_entrypoint_shutdown_timeout.py
+++ b/tests/test_entrypoint_shutdown_timeout.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from livekit.agents.ipc.job_proc_lazy_main import _JobProc, _ShutdownInfo
+from livekit.agents.ipc.proto import InitializeRequest
+from livekit.agents.job import JobContext, JobExecutorType
+from livekit.agents.worker import AgentServer, ServerOptions
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_server_options_entrypoint_shutdown_timeout() -> None:
+    opts = ServerOptions(
+        entrypoint_fnc=lambda ctx: None,  # type: ignore
+        entrypoint_shutdown_timeout=2.5,
+    )
+    server = AgentServer.from_server_options(opts)
+    assert server._entrypoint_shutdown_timeout == 2.5
+
+
+@pytest.mark.asyncio
+async def test_job_proc_entrypoint_shutdown_timeout_cancels() -> None:
+    entrypoint_cancelled = False
+
+    async def slow_entrypoint(ctx: JobContext) -> None:
+        nonlocal entrypoint_cancelled
+        try:
+            await asyncio.sleep(100.0)
+        except asyncio.CancelledError:
+            entrypoint_cancelled = True
+            raise
+
+    job_proc = _JobProc(
+        initialize_process_fnc=lambda proc: None,
+        job_entrypoint_fnc=slow_entrypoint,
+        session_end_fnc=None,
+        session_end_timeout=5.0,
+        entrypoint_shutdown_timeout=0.1,
+        executor_type=JobExecutorType.THREAD,
+    )
+
+    fake_client = AsyncMock()
+    job_proc.initialize(InitializeRequest(), fake_client)  # type: ignore
+
+    class FakeRunningJob:
+        fake_job = True
+
+        class Job:
+            id = "test_job"
+            agent_name = "test_agent"
+
+            class Room:
+                name = "test_room"
+
+            room = Room()
+
+        job = Job()
+
+    class FakeStartReq:
+        running_job = FakeRunningJob()
+
+    job_proc._exit_proc_flag = asyncio.Event()
+    job_proc._shutdown_fut = asyncio.Future[_ShutdownInfo]()
+
+    # Start job task
+    job_proc._start_job(FakeStartReq())  # type: ignore
+    assert job_proc._job_task is not None
+
+    # Simulate shutdown signal
+    job_proc._shutdown_fut.set_result(_ShutdownInfo(user_initiated=False, reason="test shutdown"))
+
+    # Wait for the job task to complete (it should finish in ~0.1s due to entrypoint_shutdown_timeout)
+    start_time = asyncio.get_running_loop().time()
+    await job_proc._job_task
+    elapsed = asyncio.get_running_loop().time() - start_time
+
+    assert elapsed < 2.0, f"Expected entrypoint cancellation in ~0.1s, took {elapsed:.2f}s"
+    assert entrypoint_cancelled is True


### PR DESCRIPTION
Fixes #6512

## Summary

When a worker process shuts down, `_JobProc` currently waits for the job entrypoint task for a hard-coded 15 seconds before cancelling it. Some applications need shutdown to terminate an active call immediately (e.g. `entrypoint_shutdown_timeout=0.0`) rather than allow voice playout or entrypoint tasks to drain for the full 15-second grace period.

This PR adds an `entrypoint_shutdown_timeout: float = 15.0` parameter to `ServerOptions` and `AgentServer`, passing it down through `ProcPool`, `ProcJobExecutor`, `ThreadJobExecutor`, `ProcStartArgs`, `ThreadStartArgs`, to `_JobProc`.

## Changes Made

- **worker.py**: Added `entrypoint_shutdown_timeout` to `ServerOptions` and `AgentServer.__init__`, passed down in `from_server_options` and `run()`.
- **proc_pool.py**: Added `entrypoint_shutdown_timeout` to `ProcPool.__init__`, passed down to job executors.
- **job_proc_executor.py**: Passed `entrypoint_shutdown_timeout` through process startup args.
- **job_thread_executor.py**: Passed `entrypoint_shutdown_timeout` through thread startup args.
- **job_proc_lazy_main.py**: Replaced hardcoded `timeout=15` in `_JobProc._run_job_task()` with `self._entrypoint_shutdown_timeout`.
- **tests/test_entrypoint_shutdown_timeout.py**: Added unit tests covering option propagation and fast entrypoint cancellation.

## Test Plan

- [x] Ran unit tests: `python -m pytest tests/test_entrypoint_shutdown_timeout.py --unit` (2 passed)
- [x] Ran `ruff check` & `ruff format`
