### PR TITLE
fix(livekit-agents): cancel in-flight recovery in the LLM fallback adapter's aclose

### DIFF
--- a/livekit-agents/livekit/agents/llm/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/fallback_adapter.py
@@ -10,6 +10,7 @@ from typing import Any, ClassVar, Literal
 from .._exceptions import APIConnectionError, APIError
 from ..log import logger
 from ..types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, APIConnectOptions, NotGivenOr
+from ..utils import aio
 from .chat_context import ChatContext
 from .llm import LLM, ChatChunk, LLMStream
 from .tool_context import Tool, ToolChoice
@@ -122,6 +123,13 @@ class FallbackAdapter(
             self._llm_instances[0].prewarm(loop=loop)
 
     async def aclose(self) -> None:
+        # a recovery attempt outlives the stream that started it, so cancel it here rather
+        # than leaving an in-flight request that can still flip availability and emit on a
+        # closed adapter (the STT and TTS fallback adapters do the same)
+        for llm_status in self._status:
+            if llm_status.recovering_task is not None:
+                await aio.cancel_and_wait(llm_status.recovering_task)
+
         for llm_instance in self._llm_instances:
             llm_instance.off("metrics_collected", self._on_metrics_collected)
 

--- a/tests/test_llm_fallback.py
+++ b/tests/test_llm_fallback.py
@@ -1,12 +1,27 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 import pytest
 
-from livekit.agents.llm import FallbackAdapter
+from livekit.agents import APIConnectionError
+from livekit.agents.llm import (
+    LLM,
+    ChatContext,
+    FallbackAdapter,
+    LLMStream,
+    Tool,
+    ToolChoice,
+)
+from livekit.agents.types import (
+    DEFAULT_API_CONNECT_OPTIONS,
+    NOT_GIVEN,
+    APIConnectOptions,
+    NotGivenOr,
+)
 
-from .fake_llm import FakeLLM
+from .fake_llm import FakeLLM, FakeLLMResponse
 
 pytestmark = [pytest.mark.unit]
 
@@ -31,6 +46,99 @@ class RecordingLLM(FakeLLM):
 
     def prewarm(self, *, loop: asyncio.AbstractEventLoop | None = None) -> None:
         self.prewarm_loop = loop
+
+
+class FlakyLLM(LLM):
+    """Fails the first request, then blocks on the recovery attempt until released.
+
+    Modelled on a provider outage: the adapter falls back to the next LLM and kicks off a
+    background recovery request against this one, which is still in flight at ``aclose``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.requests = 0
+        self.recovery_started = asyncio.Event()
+        self.release_recovery = asyncio.Event()
+        self.recovery_completed = False
+
+    def chat(
+        self,
+        *,
+        chat_ctx: ChatContext,
+        tools: list[Tool] | None = None,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+        parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
+        tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
+        extra_kwargs: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
+    ) -> LLMStream:
+        self.requests += 1
+        return FlakyLLMStream(self, chat_ctx=chat_ctx, tools=tools or [], conn_options=conn_options)
+
+
+class FlakyLLMStream(LLMStream):
+    def __init__(
+        self,
+        llm: FlakyLLM,
+        *,
+        chat_ctx: ChatContext,
+        tools: list[Tool],
+        conn_options: APIConnectOptions,
+    ) -> None:
+        super().__init__(llm, chat_ctx=chat_ctx, tools=tools, conn_options=conn_options)
+        self._flaky_llm = llm
+
+    async def _run(self) -> None:
+        if self._flaky_llm.requests == 1:
+            raise APIConnectionError("primary is down")
+
+        self._flaky_llm.recovery_started.set()
+        await self._flaky_llm.release_recovery.wait()
+        self._flaky_llm.recovery_completed = True
+
+
+async def test_aclose_cancels_in_flight_recovery() -> None:
+    primary = FlakyLLM()
+    fallback = FakeLLM(
+        fake_responses=[FakeLLMResponse(input="hello", content="hi", ttft=0.0, duration=0.0)]
+    )
+
+    fallback_adapter = FallbackAdapter([primary, fallback])
+    availability: list[bool] = []
+    fallback_adapter.on("llm_availability_changed", lambda ev: availability.append(ev.available))
+
+    chat_ctx = ChatContext.empty()
+    chat_ctx.add_message(role="user", content="hello")
+
+    try:
+        async with fallback_adapter.chat(chat_ctx=chat_ctx) as stream:
+            async for _ in stream:
+                pass
+
+        await asyncio.wait_for(primary.recovery_started.wait(), timeout=5)
+        recovering_task = fallback_adapter._status[0].recovering_task
+        assert recovering_task is not None and not recovering_task.done()
+
+        await fallback_adapter.aclose()
+
+        assert recovering_task.done(), (
+            "expected aclose to cancel the in-flight recovery request, "
+            "it outlives the stream that started it"
+        )
+
+        # releasing it must not resurrect the attempt: a cancelled recovery can no longer
+        # flip availability or emit on an adapter the caller has already closed
+        primary.release_recovery.set()
+        await asyncio.sleep(0)
+
+        assert not primary.recovery_completed
+        assert availability == [False]
+        assert not fallback_adapter._status[0].available
+    finally:
+        primary.release_recovery.set()
+        await fallback_adapter.aclose()
+        await primary.aclose()
+        await fallback.aclose()
 
 
 async def test_prewarm_forwarded_to_primary_llm() -> None:


### PR DESCRIPTION
## Summary

`llm.FallbackAdapter`'s recovery task outlives `aclose()`.

When a provider fails, `FallbackLLMStream._try_recovery` starts a background task that re-issues the request against it to see whether it has come back. The task is stored on `_LLMStatus.recovering_task`, but `FallbackAdapter.aclose()` only detached the metrics handlers:

```python
async def aclose(self) -> None:
    for llm_instance in self._llm_instances:
        llm_instance.off("metrics_collected", self._on_metrics_collected)
```

The two sibling adapters already cancel theirs, which is what makes this look like an oversight rather than a deliberate difference:

| adapter | cancels recovery in `aclose` |
|---|---|
| `stt.FallbackAdapter` (`stt/fallback_adapter.py:292`) | yes — both `recovering_recognize_task` and `recovering_stream_task` |
| `tts.FallbackAdapter` (`tts/fallback_adapter.py:133`) | yes |
| `llm.FallbackAdapter` | no |

## Measured on `bbf163f`

A primary that raises `APIConnectionError` on its first request and then blocks on the recovery request, so the attempt is still in flight when the adapter is closed:

| | before | after |
|---|---|---|
| recovery task pending after `await adapter.aclose()` | **yes** | no |
| recovery request runs to completion once released | **yes** | no |
| `_status[0].available` flipped back to `True` post-`aclose` | **yes** | no |
| `llm_availability_changed` emitted on the closed adapter | **yes** | no |
| tasks left on the loop after closing the adapter *and* every provider | **3** | 0 |

That last row is the practical one. Closing the adapter and then each LLM — the ordinary teardown order — still left `FallbackLLMStream._try_recovery.<locals>._recover_llm_task` pending, along with the `LLMStream` main and metrics tasks it owns. So a real provider request stays open past shutdown, and the task keeps the chat context it was constructed with alive. It also means a `_status` mutation and an event can land after the caller has stopped listening.

## Change

Cancel the recovery tasks in `aclose()`, the same way the STT and TTS adapters do:

```python
async def aclose(self) -> None:
    # a recovery attempt outlives the stream that started it, so cancel it here rather
    # than leaving an in-flight request that can still flip availability and emit on a
    # closed adapter (the STT and TTS fallback adapters do the same)
    for llm_status in self._status:
        if llm_status.recovering_task is not None:
            await aio.cancel_and_wait(llm_status.recovering_task)

    for llm_instance in self._llm_instances:
        llm_instance.off("metrics_collected", self._on_metrics_collected)
```

## Test

`test_aclose_cancels_in_flight_recovery` in `tests/test_llm_fallback.py`, confirmed **red on the unmodified tree** before being kept (`AssertionError: expected aclose to cancel the in-flight recovery request, it outlives the stream that started it`).

It drives the real adapter: the primary fails, the fallback answers, the recovery attempt blocks, then `aclose()` is called. Beyond asserting the task is done it also releases the blocked request afterwards and asserts the attempt did **not** resurrect — no `available` flip, no extra `llm_availability_changed`. Cancelling the task alone would satisfy a `done()` assertion even if the underlying request completed anyway, so the post-release assertions are what pin the actual behaviour.

## Verification

- `ruff check` and `ruff format --check` on both changed files — clean.
- `mypy` (repo config, `strict`) on `livekit.agents.llm` — 1 diagnostic, identical with and without this change (a pre-existing `import-untyped` for `livekit.plugins.google.utils`, from that plugin not being installed in my environment).
- `uv run pytest --unit`: I could not install the full workspace on this machine — `bithuman` 2.7.0 publishes no Windows wheel, so `uv sync --all-extras --dev` fails outright. I ran the suite against an editable `livekit-agents` instead, which leaves 15 modules erroring on absent plugin packages. Captured the sorted `FAILED`/`ERROR` set with the change stashed and unstashed: **byte-identical** (15 collection errors + 4 failures in `test_ivr_activity.py` and `test_tokenizer_xml_markup.py`, all pre-existing and unrelated), 1567 passed both ways. `tests/test_llm_fallback.py` is green: 3 passed.

I did not touch `CHANGELOG.md` or any package manifest, per CONTRIBUTING.
