### PR TITLE
fix(livekit-agents): forward the STT hooks through MultiSpeakerAdapter

### DIFF
--- a/livekit-agents/livekit/agents/stt/multi_speaker_adapter.py
+++ b/livekit-agents/livekit/agents/stt/multi_speaker_adapter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -14,6 +15,9 @@ from ..log import logger
 from ..types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, APIConnectOptions, NotGivenOr
 from ..utils.audio import AudioByteStream
 from .stt import STT, RecognizeStream, SpeechData, SpeechEvent, SpeechEventType
+
+if TYPE_CHECKING:
+    from ..voice.events import ConversationItemAddedEvent
 
 
 class MultiSpeakerAdapter(STT):
@@ -55,6 +59,35 @@ class MultiSpeakerAdapter(STT):
         self._opt = primary_detection_options or PrimarySpeakerDetectionOptions()
         self._primary_format = primary_format
         self._background_format = background_format
+
+        self._stt.on("metrics_collected", self._on_metrics_collected)
+
+    @property
+    def wrapped_stt(self) -> STT:
+        return self._stt
+
+    @property
+    def model(self) -> str:
+        return self._stt.model
+
+    @property
+    def provider(self) -> str:
+        return self._stt.provider
+
+    def _update_session_keyterms(self, keyterms: list[str]) -> None:
+        self._stt._update_session_keyterms(keyterms)
+
+    def _push_conversation_item(self, item: ConversationItemAddedEvent) -> None:
+        self._stt._push_conversation_item(item)
+
+    def prewarm(self) -> None:
+        self._stt.prewarm()
+
+    def _on_metrics_collected(self, *args: Any, **kwargs: Any) -> None:
+        self.emit("metrics_collected", *args, **kwargs)
+
+    async def aclose(self) -> None:
+        self._stt.off("metrics_collected", self._on_metrics_collected)
 
     async def _recognize_impl(
         self,

--- a/livekit-agents/livekit/agents/stt/multi_speaker_adapter.py
+++ b/livekit-agents/livekit/agents/stt/multi_speaker_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from collections.abc import AsyncIterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -61,6 +62,10 @@ class MultiSpeakerAdapter(STT):
         self._background_format = background_format
 
         self._stt.on("metrics_collected", self._on_metrics_collected)
+        # the wrapped STT's metrics are the accurate ones (its own label, model/provider and
+        # provider-reported usage), so they are re-emitted here and this adapter does not add a
+        # second measurement for the same audio -- same split as the stream and fallback adapters
+        self._recognize_metrics_needed = False
 
     @property
     def wrapped_stt(self) -> STT:
@@ -129,6 +134,12 @@ class MultiSpeakerAdapterWrapper(RecognizeStream):
             primary_format=stt._primary_format,
             background_format=stt._background_format,
         )
+
+    async def _metrics_monitor_task(self, event_aiter: AsyncIterable[SpeechEvent]) -> None:
+        # the wrapped stream already reports usage for this audio and the adapter re-emits it,
+        # so measuring the forwarded events here would count every recognition twice
+        async for _ in event_aiter:
+            pass
 
     async def _run(self) -> None:
         async def _forward_input(stream: RecognizeStream) -> None:

--- a/livekit-agents/livekit/agents/stt/multi_speaker_adapter.py
+++ b/livekit-agents/livekit/agents/stt/multi_speaker_adapter.py
@@ -137,9 +137,12 @@ class MultiSpeakerAdapterWrapper(RecognizeStream):
 
     async def _metrics_monitor_task(self, event_aiter: AsyncIterable[SpeechEvent]) -> None:
         # the wrapped stream already reports usage for this audio and the adapter re-emits it,
-        # so measuring the forwarded events here would count every recognition twice
-        async for _ in event_aiter:
-            pass
+        # so measuring the forwarded events here would count every recognition twice. the
+        # retry-count reset still has to happen, otherwise hiccups spread over a long call
+        # accumulate instead of being forgiven by a successful transcript.
+        async for ev in event_aiter:
+            if ev.type == SpeechEventType.FINAL_TRANSCRIPT:
+                self._num_retries = 0
 
     async def _run(self) -> None:
         async def _forward_input(stream: RecognizeStream) -> None:

--- a/tests/test_multi_speaker_adapter.py
+++ b/tests/test_multi_speaker_adapter.py
@@ -8,11 +8,14 @@ to reach the wrapped STT, otherwise the capability the adapter advertises is a n
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from typing import Any
 
 import pytest
 
 from livekit import rtc
+from livekit.agents import APIConnectionError, utils
 from livekit.agents.llm import ChatContext, ChatMessage
 from livekit.agents.metrics import STTMetrics
 from livekit.agents.stt import (
@@ -114,6 +117,37 @@ class _RecordingStream(RecognizeStream):
                 recognition_usage=RecognitionUsage(audio_duration=1.0),
             )
         )
+
+
+class _HiccupSTT(_RecordingSTT):
+    """Its stream delivers a good transcript and then drops the connection, every attempt.
+
+    ``max_retry=0`` on the inner stream mirrors a plugin that has already spent its own retry
+    budget, so each hiccup propagates to the adapter's wrapper.
+    """
+
+    def stream(
+        self,
+        *,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        conn_options: APIConnectOptions = _CONN,
+    ) -> RecognizeStream:
+        return _HiccupStream(
+            stt=self, conn_options=APIConnectOptions(max_retry=0, retry_interval=0.0, timeout=5.0)
+        )
+
+
+class _HiccupStream(RecognizeStream):
+    async def _run(self) -> None:
+        self._event_ch.send_nowait(
+            SpeechEvent(
+                type=SpeechEventType.FINAL_TRANSCRIPT,
+                request_id="req-1",
+                alternatives=[SpeechData(language="en", text="hello", speaker_id="A")],
+            )
+        )
+        await asyncio.sleep(0)
+        raise APIConnectionError("brief connection hiccup")
 
 
 class _FakeSession(rtc.EventEmitter[Any]):
@@ -237,3 +271,39 @@ async def test_stream_reports_usage_once() -> None:
     assert len(received) == 1, f"one usage report, {len(received)} metrics events"
     assert received[0].label == wrapped.label
     assert received[0].audio_duration == 1.0
+
+
+async def test_successful_transcript_forgives_earlier_hiccups() -> None:
+    """Suppressing the adapter's own metrics must not drop the retry-count reset.
+
+    ``RecognizeStream._main_task`` gives up once ``_num_retries`` exceeds ``max_retry``, and
+    the base metrics monitor resets it on every final transcript. Without that reset,
+    unrelated brief failures accumulate over a long call until recognition dies for good.
+    """
+    inner = _HiccupSTT()
+    adapter = MultiSpeakerAdapter(stt=inner)
+    conn = APIConnectOptions(max_retry=3, retry_interval=0.0, timeout=5.0)
+    stream = adapter.stream(conn_options=conn)
+
+    transcripts: list[str] = []
+    fatal: list[BaseException] = []
+
+    async def _read() -> None:
+        try:
+            async for ev in stream:
+                if ev.type == SpeechEventType.FINAL_TRANSCRIPT and ev.alternatives[0].text:
+                    transcripts.append(ev.alternatives[0].text)
+        except Exception as e:  # noqa: BLE001 - recorded, asserted on below
+            fatal.append(e)
+
+    task = asyncio.create_task(_read())
+    stream.push_frame(_silence())
+    while len(transcripts) < 5 and not fatal:
+        await asyncio.sleep(0)
+
+    assert not fatal, f"recognition died after {len(transcripts)} good transcripts: {fatal}"
+    assert stream._num_retries == 0
+
+    await utils.aio.cancel_and_wait(task)
+    with contextlib.suppress(Exception):
+        await stream.aclose()

--- a/tests/test_multi_speaker_adapter.py
+++ b/tests/test_multi_speaker_adapter.py
@@ -1,0 +1,174 @@
+"""MultiSpeakerAdapter delegation contract.
+
+The adapter wraps another STT and inherits its ``capabilities`` wholesale, so the framework
+treats it as if it were the wrapped recognizer: it pushes keyterms and conversation items to
+it, prewarms it, and reads ``model``/``provider`` off it for metrics. Every one of those has
+to reach the wrapped STT, otherwise the capability the adapter advertises is a no-op.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from livekit import rtc
+from livekit.agents.llm import ChatContext, ChatMessage
+from livekit.agents.metrics import STTMetrics
+from livekit.agents.stt import (
+    STT,
+    MultiSpeakerAdapter,
+    RecognizeStream,
+    SpeechEvent,
+    SpeechEventType,
+    STTCapabilities,
+)
+from livekit.agents.types import NOT_GIVEN, APIConnectOptions, NotGivenOr
+from livekit.agents.utils import AudioBuffer
+from livekit.agents.voice.events import ConversationItemAddedEvent
+from livekit.agents.voice.keyterm_detection import KeytermDetector
+
+pytestmark = pytest.mark.unit
+
+
+class _RecordingSTT(STT):
+    """Diarization-capable STT that records every framework hook it receives.
+
+    ``diarization`` is required by MultiSpeakerAdapter; ``keyterms`` and ``chat_context``
+    are both offered by shipped diarization plugins (deepgram, assemblyai).
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            capabilities=STTCapabilities(
+                streaming=True,
+                interim_results=True,
+                diarization=True,
+                keyterms=True,
+                chat_context=True,
+            )
+        )
+        self.pushed_keyterms: list[list[str]] = []
+        self.chat_items: list[ChatMessage] = []
+        self.prewarmed = False
+
+    @property
+    def model(self) -> str:
+        return "recording-model-v1"
+
+    @property
+    def provider(self) -> str:
+        return "recording-provider"
+
+    def _update_session_keyterms(self, keyterms: list[str]) -> None:
+        self.pushed_keyterms.append(list(keyterms))
+
+    def _push_conversation_item(self, ev: ConversationItemAddedEvent) -> None:
+        if isinstance(ev.item, ChatMessage):
+            self.chat_items.append(ev.item)
+
+    def prewarm(self) -> None:
+        self.prewarmed = True
+
+    async def _recognize_impl(
+        self,
+        buffer: AudioBuffer,
+        *,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        conn_options: APIConnectOptions = ...,  # type: ignore[assignment]
+    ) -> SpeechEvent:
+        return SpeechEvent(type=SpeechEventType.FINAL_TRANSCRIPT)
+
+    def stream(
+        self,
+        *,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        conn_options: APIConnectOptions = ...,  # type: ignore[assignment]
+    ) -> RecognizeStream:
+        raise NotImplementedError
+
+
+class _FakeSession(rtc.EventEmitter[Any]):
+    pass
+
+
+def _adapter() -> tuple[MultiSpeakerAdapter, _RecordingSTT]:
+    wrapped = _RecordingSTT()
+    return MultiSpeakerAdapter(stt=wrapped), wrapped
+
+
+def _metrics(label: str) -> STTMetrics:
+    return STTMetrics(
+        request_id="r1",
+        timestamp=0.0,
+        duration=0.0,
+        label=label,
+        audio_duration=1.0,
+        streamed=True,
+    )
+
+
+def test_wrapped_stt_exposed() -> None:
+    adapter, wrapped = _adapter()
+    assert adapter.wrapped_stt is wrapped
+
+
+def test_keyterms_reach_the_wrapped_stt() -> None:
+    adapter, wrapped = _adapter()
+    # the adapter advertises keyterms=True (inherited), so the base warn-and-skip never runs:
+    # a dropped push here is silent
+    assert adapter.capabilities.keyterms
+
+    adapter._update_session_keyterms(["LiveKit", "WebRTC"])
+    assert wrapped.pushed_keyterms == [["LiveKit", "WebRTC"]]
+
+
+async def test_keyterm_detector_reaches_the_wrapped_stt() -> None:
+    """The real framework path: AgentActivity binds the detector to the session's STT."""
+    adapter, wrapped = _adapter()
+    detector = KeytermDetector(static_keyterms=["Acme"])
+
+    detector.start(_FakeSession(), stt=adapter)  # type: ignore[arg-type]
+    assert wrapped.pushed_keyterms == [["Acme"]]
+
+    detector.set_static_keyterms(["Acme", "Cartesia"])  # mid-call update
+    assert wrapped.pushed_keyterms[-1] == ["Acme", "Cartesia"]
+
+    await detector.aclose()
+
+
+def test_conversation_items_reach_the_wrapped_stt() -> None:
+    adapter, wrapped = _adapter()
+    assert adapter.capabilities.chat_context
+
+    chat_ctx = ChatContext.empty()
+    item = chat_ctx.add_message(role="assistant", content="your room is booked")
+    adapter._push_conversation_item(ConversationItemAddedEvent(item=item))
+
+    assert [i.text_content for i in wrapped.chat_items] == ["your room is booked"]
+
+
+def test_prewarm_reaches_the_wrapped_stt() -> None:
+    adapter, wrapped = _adapter()
+    adapter.prewarm()
+    assert wrapped.prewarmed
+
+
+def test_model_and_provider_come_from_the_wrapped_stt() -> None:
+    adapter, wrapped = _adapter()
+    # "unknown" is the STT base default; reporting it would mislabel telemetry
+    assert (adapter.model, adapter.provider) == ("recording-model-v1", "recording-provider")
+
+
+async def test_metrics_are_forwarded_and_detached_on_aclose() -> None:
+    adapter, wrapped = _adapter()
+    received: list[STTMetrics] = []
+    adapter.on("metrics_collected", received.append)
+
+    metrics = _metrics(wrapped.label)
+    wrapped.emit("metrics_collected", metrics)
+    assert received == [metrics]
+
+    await adapter.aclose()  # detaches, so a later emit is dropped
+    wrapped.emit("metrics_collected", metrics)
+    assert received == [metrics]

--- a/tests/test_multi_speaker_adapter.py
+++ b/tests/test_multi_speaker_adapter.py
@@ -19,16 +19,20 @@ from livekit.agents.stt import (
     STT,
     MultiSpeakerAdapter,
     RecognizeStream,
+    SpeechData,
     SpeechEvent,
     SpeechEventType,
     STTCapabilities,
 )
+from livekit.agents.stt.stt import RecognitionUsage
 from livekit.agents.types import NOT_GIVEN, APIConnectOptions, NotGivenOr
 from livekit.agents.utils import AudioBuffer
 from livekit.agents.voice.events import ConversationItemAddedEvent
 from livekit.agents.voice.keyterm_detection import KeytermDetector
 
 pytestmark = pytest.mark.unit
+
+_CONN = APIConnectOptions(max_retry=0, timeout=5.0)
 
 
 class _RecordingSTT(STT):
@@ -75,17 +79,41 @@ class _RecordingSTT(STT):
         buffer: AudioBuffer,
         *,
         language: NotGivenOr[str] = NOT_GIVEN,
-        conn_options: APIConnectOptions = ...,  # type: ignore[assignment]
+        conn_options: APIConnectOptions = _CONN,
     ) -> SpeechEvent:
-        return SpeechEvent(type=SpeechEventType.FINAL_TRANSCRIPT)
+        return SpeechEvent(
+            type=SpeechEventType.FINAL_TRANSCRIPT,
+            request_id="req-1",
+            alternatives=[SpeechData(language="en", text="hello")],
+        )
 
     def stream(
         self,
         *,
         language: NotGivenOr[str] = NOT_GIVEN,
-        conn_options: APIConnectOptions = ...,  # type: ignore[assignment]
+        conn_options: APIConnectOptions = _CONN,
     ) -> RecognizeStream:
-        raise NotImplementedError
+        return _RecordingStream(stt=self, conn_options=conn_options)
+
+
+class _RecordingStream(RecognizeStream):
+    """Emits one transcript plus the provider's usage report, as a real plugin stream does."""
+
+    async def _run(self) -> None:
+        self._event_ch.send_nowait(
+            SpeechEvent(
+                type=SpeechEventType.FINAL_TRANSCRIPT,
+                request_id="req-1",
+                alternatives=[SpeechData(language="en", text="hello", speaker_id="A")],
+            )
+        )
+        self._event_ch.send_nowait(
+            SpeechEvent(
+                type=SpeechEventType.RECOGNITION_USAGE,
+                request_id="req-1",
+                recognition_usage=RecognitionUsage(audio_duration=1.0),
+            )
+        )
 
 
 class _FakeSession(rtc.EventEmitter[Any]):
@@ -95,6 +123,12 @@ class _FakeSession(rtc.EventEmitter[Any]):
 def _adapter() -> tuple[MultiSpeakerAdapter, _RecordingSTT]:
     wrapped = _RecordingSTT()
     return MultiSpeakerAdapter(stt=wrapped), wrapped
+
+
+def _silence() -> rtc.AudioFrame:
+    return rtc.AudioFrame(
+        data=b"\x00\x00" * 160, sample_rate=16000, num_channels=1, samples_per_channel=160
+    )
 
 
 def _metrics(label: str) -> STTMetrics:
@@ -172,3 +206,34 @@ async def test_metrics_are_forwarded_and_detached_on_aclose() -> None:
     await adapter.aclose()  # detaches, so a later emit is dropped
     wrapped.emit("metrics_collected", metrics)
     assert received == [metrics]
+
+
+async def test_recognize_reports_usage_once() -> None:
+    """Re-emitting the wrapped STT's metrics must not add a second measurement."""
+    adapter, wrapped = _adapter()
+    received: list[STTMetrics] = []
+    adapter.on("metrics_collected", received.append)
+
+    await adapter.recognize([_silence()], conn_options=_CONN)
+
+    assert len(received) == 1, f"one recognition, {len(received)} metrics events"
+    # the wrapped STT's own measurement is the accurate one: it carries its label, and its
+    # model/provider rather than the adapter's
+    assert received[0].label == wrapped.label
+
+
+async def test_stream_reports_usage_once() -> None:
+    adapter, wrapped = _adapter()
+    received: list[STTMetrics] = []
+    adapter.on("metrics_collected", received.append)
+
+    stream = adapter.stream(conn_options=_CONN)
+    stream.push_frame(_silence())
+    stream.end_input()
+    async for _ in stream:
+        pass
+    await stream.aclose()
+
+    assert len(received) == 1, f"one usage report, {len(received)} metrics events"
+    assert received[0].label == wrapped.label
+    assert received[0].audio_duration == 1.0


### PR DESCRIPTION
## Summary

`stt.MultiSpeakerAdapter` advertises the wrapped STT's capabilities but forwards none of the framework hooks those capabilities gate.

`__init__` passes the wrapped recognizer's capabilities through unchanged:

```python
super().__init__(capabilities=stt.capabilities)
self._stt = stt
```

So when the wrapped STT sets `keyterms=True` / `chat_context=True` — both shipped diarization plugins do (`deepgram`, `assemblyai`) — the adapter claims them too. The framework then pushes keyterms and conversation items at the adapter, prewarms it, and reads `model`/`provider` off it for metrics. `MultiSpeakerAdapter` defined none of those, so all of it landed on the `STT` base class and went nowhere.

The drop is **silent** precisely because the capability is advertised: the base `_update_session_keyterms` / `_push_conversation_item` warn-and-skip paths only fire when the capability is `False`.

`stt/stream_adapter.py` — the other STT wrapper in the same package — forwards all seven, which is what makes this look like an oversight rather than a deliberate difference:

| forwarded to the wrapped STT | `StreamAdapter` | `MultiSpeakerAdapter` |
|---|---|---|
| `wrapped_stt` (`stream_adapter.py:38`) | yes | no |
| `model` / `provider` (`:42`, `:46`) | yes | no |
| `_update_session_keyterms` (`:50`) | yes | no |
| `_push_conversation_item` (`:53`) | yes | no |
| `prewarm` (`:81`) | yes | no |
| `metrics_collected` re-emit (`:36`, `:84`) | yes | no |
| `aclose` detach (`:87`) | yes | no |

## Measured on `bbf163f`

A diarization-capable recording STT that also supports keyterms and chat context, through the adapter vs. called directly:

| | `MultiSpeakerAdapter` | wrapped STT directly |
|---|---|---|
| `capabilities.keyterms` | True | True |
| `capabilities.chat_context` | True | True |
| keyterms the recognizer received | **`None`** | `['livekit', 'webrtc']` |
| conversation items the recognizer received | **0** | 1 |
| recognizer prewarmed | **False** | True |
| `model` | **`'unknown'`** | `'recording-model-v1'` |
| `provider` | **`'unknown'`** | `'recording-provider'` |
| metrics reaching a listener on the adapter | **0** | 1 |

And through the real framework path rather than a direct hook call — `KeytermDetector`, which `AgentActivity` binds to the session's STT:

```
detector = KeytermDetector(static_keyterms=["LiveKit", "WebRTC", "Deepgram"])
detector.start(session, stt=adapter)

  wrapped recognizer keyterms = None
  expected                    = ['LiveKit', 'WebRTC', 'Deepgram']

detector.set_static_keyterms([..., "Cartesia"])   # mid-call update
  wrapped recognizer keyterms = None
```

So enabling `MultiSpeakerAdapter` on a Deepgram or AssemblyAI STT silently turns off keyterm boosting and context carryover for that session, and mislabels the STT in metrics as `unknown`/`unknown`.

## Change

Forward the same seven members `StreamAdapter` does, in the same shape.

Two deliberate details, both copied from the siblings rather than invented here:

- **`aclose` only detaches the metrics handler** and does not close the wrapped STT — matching `StreamAdapter.aclose` and `stt.FallbackAdapter.aclose`. The caller constructed the inner STT and owns its lifecycle.
- **Forwarding the inner metrics means suppressing the adapter'''s own**, or the same audio gets measured twice. `StreamAdapterWrapper` makes `_metrics_monitor_task` a no-op (`stream_adapter.py:107`) and `stt.FallbackAdapter` sets `_recognize_metrics_needed = False` (`fallback_adapter.py:111`); this does both. Measured 2 events per recognition on both the `recognize()` and `stream()` paths with the forwarding alone, 1 with the suppression. The kept event is the wrapped plugin'''s, which carries its label and its real `model`/`provider` metadata.
- **The metrics override still has to reset the retry counter.** A *bare* no-op monitor — the shape the siblings use — also drops the `_num_retries = 0` the base does on each final transcript, and `_main_task` gives up once that exceeds `max_retry`. Measured with an inner stream that transcribes then drops the connection every attempt (`max_retry=3`): with the bare no-op, four good transcripts still left `_num_retries` at 3 and the stream died with `failed to recognize speech after 3 attempts`; with the reset kept, recognition continued. `StreamAdapterWrapper` is safe with a bare no-op only because it builds itself with `max_retry=0` (`stream_adapter.py:16`, `:101`) so the counter is never consulted; `MultiSpeakerAdapterWrapper` passes the caller'''s `conn_options` through, so its budget is live. I verified StreamAdapter does not accumulate under the same pattern.

## Test

`tests/test_multi_speaker_adapter.py` (new module, `pytestmark = pytest.mark.unit`), 10 tests — one per forwarded member, one that drives the real `KeytermDetector` end to end instead of calling the hook directly, two that pin the metrics count on each path, and one that pins the retry-counter reset.

The 7 delegation tests confirmed **red on the unmodified tree** before being kept:

```
FAILED test_wrapped_stt_exposed - AttributeError: 'MultiSpeakerAdapter' object has no attribute 'wrapped_stt'
FAILED test_keyterms_reach_the_wrapped_stt - assert [] == [['LiveKit', 'WebRTC']]
FAILED test_keyterm_detector_reaches_the_wrapped_stt - assert [] == [['Acme']]
FAILED test_conversation_items_reach_the_wrapped_stt - assert [] == ['your room is booked']
FAILED test_prewarm_reaches_the_wrapped_stt - assert False
FAILED test_model_and_provider_come_from_the_wrapped_stt - assert ('unknown', 'unknown') == ('recording-model-v1', 'recording-provider')
FAILED test_metrics_are_forwarded_and_detached_on_aclose - assert [] == [STTMetrics(...)]
```

The 2 metrics tests were confirmed red at the intermediate state (forwarding without suppression): `AssertionError: one usage report, 2 metrics events`. The retry test was confirmed red with a bare no-op monitor: `AssertionError: recognition died after 4 good transcripts`.

`MultiSpeakerAdapter` itself had no coverage before this — `tests/test_multi_speaker_primary_speaker.py` exercises the private `_PrimarySpeakerDetector` only, never the adapter.

## Verification

- `ruff check` and `ruff format --check` on both files — clean.
- `mypy` (repo config, strict) on `livekit.agents.stt` — `Success: no issues found in 5 source files`.
- `pytest --unit`: I could not install the full workspace on this machine — `bithuman` 2.7.0 publishes no Windows wheel, so `uv sync --all-extras --dev` fails outright. I ran the suite against an editable `livekit-agents` instead, which leaves 16 modules erroring on absent plugin packages. Captured the sorted `FAILED`/`ERROR` set with the change (and the new test file) removed and restored: **identical**, 20 entries both ways (16 collection errors + 4 pre-existing failures in `test_ivr_activity.py` and `test_tokenizer_xml_markup.py`, unrelated). Passing count 1557 → 1567, i.e. exactly the 10 new tests.

I did not touch `CHANGELOG.md` or any package manifest, per CONTRIBUTING.
