### PR TITLE
fix(tts): probe a skipped provider so the streamed path can recover it

### DIFF
--- a/livekit-agents/livekit/agents/tts/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/tts/fallback_adapter.py
@@ -29,6 +29,10 @@ DEFAULT_FALLBACK_API_CONNECT_OPTIONS = APIConnectOptions(
     max_retry=0, timeout=DEFAULT_API_CONNECT_OPTIONS.timeout
 )
 
+# synthesized by a recovery probe when no real text is available to replay; the audio is discarded,
+# only whether the request succeeds matters
+_RECOVERY_PROBE_TEXT = "."
+
 
 @dataclass
 class _TTSStatus:
@@ -444,9 +448,12 @@ class FallbackSynthesizeStream(SynthesizeStream):
     def _try_recovery(self, tts: TTS) -> None:
         assert isinstance(self._tts, FallbackAdapter)
 
-        retry_text = self._pushed_tokens.copy()
-        if not retry_text:
-            return
+        # A provider that is already unavailable is skipped by the loop in `_run`, which reaches
+        # here without awaiting, so `_forward_input_task` has not run yet and `_pushed_tokens` is
+        # still empty. Bailing out in that case means such a provider is never probed again and
+        # can never recover. A probe does not need the caller's real text, so fall back to a short
+        # placeholder, matching the other adapters, which all probe unconditionally.
+        retry_text = self._pushed_tokens.copy() or [_RECOVERY_PROBE_TEXT]
 
         tts_status = self._tts._status[self._tts._tts_instances.index(tts)]
         if tts_status.recovering_task is None or tts_status.recovering_task.done():

--- a/tests/test_tts_fallback.py
+++ b/tests/test_tts_fallback.py
@@ -243,6 +243,48 @@ async def test_tts_recover() -> None:
     await fallback_adapter.aclose()
 
 
+async def test_tts_stream_recover() -> None:
+    # the streamed counterpart of test_tts_recover: a provider that is already unavailable is
+    # skipped by the provider loop, which reaches _try_recovery without awaiting, so
+    # _forward_input_task has not filled _pushed_tokens yet. Bailing out on the empty list meant
+    # such a provider was never probed again and could never recover.
+    fake1 = FakeTTS(fake_exception=APIConnectionError("fake1 failed"))
+    fake2 = FakeTTS(fake_audio_duration=5.0)
+
+    fallback_adapter = FallbackAdapterTester([fake1, fake2])
+
+    async with fallback_adapter.stream() as stream:
+        stream.push_text("hello test")
+        stream.end_input()
+
+        async for _ in stream:
+            pass
+
+    assert fake1.stream_ch.recv_nowait()
+    assert not fallback_adapter.availability_changed_ch(fake1).recv_nowait().available
+
+    fake1.update_options(fake_exception=None, fake_audio_duration=5.0)
+
+    # let the recovery probe started by the request above settle, so the next one is not skipped
+    # merely because the single recovering_task slot is still occupied
+    await asyncio.sleep(1.0)
+
+    # fake1 is healthy again, but the adapter only learns that by probing it. This second request
+    # is served by fake2 and must still start a probe for the skipped fake1.
+    async with fallback_adapter.stream() as stream:
+        stream.push_text("hello test")
+        stream.end_input()
+
+        async for _ in stream:
+            pass
+
+    assert (
+        await asyncio.wait_for(fallback_adapter.availability_changed_ch(fake1).recv(), 5.0)
+    ).available, "fake1 should have recovered"
+
+    await fallback_adapter.aclose()
+
+
 async def test_audio_resampled() -> None:
     fake1 = FakeTTS(sample_rate=48000, fake_exception=APIConnectionError("fake1 failed"))
     fake2 = FakeTTS(fake_audio_duration=5.0, sample_rate=16000)


### PR DESCRIPTION
Fixes #6678.

### Problem

On `tts.FallbackAdapter`, a provider marked unavailable is never re-probed on the streamed path, so it can never recover. A single transient outage pins the adapter to its fallback provider for the life of the process, silently — the skipped recovery logs nothing.

`FallbackSynthesizeStream._run()` creates the task that fills `_pushed_tokens`, then loops over providers:

```python
input_task = asyncio.create_task(_forward_input_task())   # fills self._pushed_tokens

for i, tts in enumerate(self._fallback_adapter._tts_instances):
    tts_status = self._fallback_adapter._status[i]
    if tts_status.available or all_failed:
        ...                       # the only branch containing an await
    self._try_recovery(tts)
```

A provider that is **already** unavailable skips that branch, so nothing awaits between the `create_task` and the `_try_recovery(tts)` call. `_forward_input_task` has not been scheduled, `_pushed_tokens` is empty, and `_try_recovery`'s `if not retry_text: return` fires before it ever reaches the recovery-slot check.

### Fix

A recovery probe only needs to learn whether the provider answers; it does not need the caller's real text. So the empty case now probes with a short placeholder instead of bailing out.

This brings the method in line with its three siblings, all of which probe unconditionally and gate only on the recovery slot:

| method | line | probes unconditionally? |
| --- | --- | --- |
| `tts` `FallbackChunkedStream._try_recovery` | 181 | yes |
| `tts` `FallbackSynthesizeStream._try_recovery` | 444 | **no — fixed here** |
| `stt` `FallbackRecognizeStream._try_recovery` | 192 | yes |
| `stt` streamed `_try_recovery` | 423 | yes |

The `stt` streamed one is the closest precedent: it opens a fresh `stt.stream(...)` for the probe rather than replaying pushed input. Real pushed text is still preferred here when it is available, so the recovery request stays representative in the case that already worked.

### Verification

Measured on `bbf163f` with the reproduction from #6678 — a primary that fails once, then is healthy, driven identically through `stream()` and `synthesize()`:

```
before:  streamed: still unavailable after 4 healthy requests
         chunked:  recovered on request 2
after:   streamed: recovered on request 2
         chunked:  recovered on request 2
```

The chunked line is a control: same fakes, same timing, only the entry point differs. The reproduction also asserts that the provider really was marked unavailable and that the first probe has settled, so it fails loudly rather than passing vacuously if the setup drifts.

Instrumenting `_try_recovery` across three streamed requests pins the mechanism:

```
call 1: pushed_tokens=['first']  slot_before_done=None  started_probe=True
call 2: pushed_tokens=[]         slot_before_done=True  started_probe=False
call 3: pushed_tokens=[]         slot_before_done=True  started_probe=False
```

Call 1 is the request during which the provider was still available and failed mid-stream, after `_forward_input_task` had run. Calls 2 and 3 are the ones where it was already unavailable and got skipped. The slot is free in both (`slot_before_done=True`), so the slot check is not what blocks them.

- `test_tts_stream_recover` — the streamed counterpart of the existing chunked `test_tts_recover`, whose absence is why this survived. Confirmed failing on the unmodified tree (`fake1 should have recovered`) and passing with the fix.
- `tests/test_tts_fallback.py`, `tests/test_stt_fallback.py`, `tests/test_llm_fallback.py`: 16 passed.
- `ruff check` and `ruff format --check` clean on both changed files.
- `tests/test_tts.py` cannot be collected in my environment (`ModuleNotFoundError: No module named 'dotenv'`), unrelated to this change.

Environment: Python 3.12.10, Windows.

### Not included

Both `_try_recovery` implementations write to the single `_TTSStatus.recovering_task` slot, whereas `_STTStatus` deliberately keeps `recovering_recognize_task` and `recovering_stream_task` separate. With this fix in place, a chunked recovery in flight will make the streamed path's slot check bail, and vice versa. That is a real but distinct issue, only reachable once the above is fixed — noted in #6678, and I'm happy to add the second slot here or in a follow-up, whichever you prefer.
