### PR TITLE
fix(tts): give each fallback recovery path its own task slot

### DIFF
--- a/livekit-agents/livekit/agents/tts/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/tts/fallback_adapter.py
@@ -33,7 +33,11 @@ DEFAULT_FALLBACK_API_CONNECT_OPTIONS = APIConnectOptions(
 @dataclass
 class _TTSStatus:
     available: bool
-    recovering_task: asyncio.Task[None] | None
+    # One slot per recovery path, mirroring `_STTStatus`. A single shared slot let a probe in
+    # flight on one path suppress probing on the other, and let the second path to run drop the
+    # first path's task so `aclose()` could no longer cancel it.
+    recovering_synthesize_task: asyncio.Task[None] | None
+    recovering_stream_task: asyncio.Task[None] | None
     needs_resampling: bool
 
 
@@ -100,7 +104,12 @@ class FallbackAdapter(
                 logger.info(f"resampling {t.label} from {t.sample_rate}Hz to {sample_rate}Hz")
 
             self._status.append(
-                _TTSStatus(available=True, recovering_task=None, needs_resampling=needs_resampling)
+                _TTSStatus(
+                    available=True,
+                    recovering_synthesize_task=None,
+                    recovering_stream_task=None,
+                    needs_resampling=needs_resampling,
+                )
             )
 
             t.on("metrics_collected", self._on_metrics_collected)
@@ -132,8 +141,11 @@ class FallbackAdapter(
 
     async def aclose(self) -> None:
         for tts_status in self._status:
-            if tts_status.recovering_task is not None:
-                await aio.cancel_and_wait(tts_status.recovering_task)
+            if tts_status.recovering_synthesize_task is not None:
+                await aio.cancel_and_wait(tts_status.recovering_synthesize_task)
+
+            if tts_status.recovering_stream_task is not None:
+                await aio.cancel_and_wait(tts_status.recovering_stream_task)
 
         for t in self._tts_instances:
             t.off("metrics_collected", self._on_metrics_collected)
@@ -182,7 +194,8 @@ class FallbackChunkedStream(ChunkedStream):
         assert isinstance(self._tts, FallbackAdapter)
 
         tts_status = self._tts._status[self._tts._tts_instances.index(tts)]
-        if tts_status.recovering_task is None or tts_status.recovering_task.done():
+        recovering_task = tts_status.recovering_synthesize_task
+        if recovering_task is None or recovering_task.done():
 
             async def _recover_tts_task(tts: TTS) -> None:
                 try:
@@ -198,7 +211,7 @@ class FallbackChunkedStream(ChunkedStream):
                 except Exception:  # exceptions already logged inside _try_synthesize
                     return
 
-            tts_status.recovering_task = asyncio.create_task(_recover_tts_task(tts))
+            tts_status.recovering_synthesize_task = asyncio.create_task(_recover_tts_task(tts))
 
     async def _run(self, output_emitter: AudioEmitter) -> None:
         assert isinstance(self._tts, FallbackAdapter)
@@ -449,7 +462,8 @@ class FallbackSynthesizeStream(SynthesizeStream):
             return
 
         tts_status = self._tts._status[self._tts._tts_instances.index(tts)]
-        if tts_status.recovering_task is None or tts_status.recovering_task.done():
+        recovering_task = tts_status.recovering_stream_task
+        if recovering_task is None or recovering_task.done():
 
             async def _recover_tts_task(tts: TTS) -> None:
                 try:
@@ -481,4 +495,4 @@ class FallbackSynthesizeStream(SynthesizeStream):
                 except Exception:
                     return
 
-            tts_status.recovering_task = asyncio.create_task(_recover_tts_task(tts))
+            tts_status.recovering_stream_task = asyncio.create_task(_recover_tts_task(tts))

--- a/tests/test_tts_fallback.py
+++ b/tests/test_tts_fallback.py
@@ -10,10 +10,10 @@ from livekit import rtc
 from livekit.agents import APIConnectionError, APIConnectOptions, APIError, utils
 from livekit.agents.tts import TTS, AvailabilityChangedEvent, FallbackAdapter
 from livekit.agents.tts.tts import SynthesizedAudio, SynthesizeStream
-from livekit.agents.types import USERDATA_TTS_STARTED_TIME
+from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, USERDATA_TTS_STARTED_TIME
 from livekit.agents.utils.aio.channel import ChanEmpty
 
-from .fake_tts import FakeTTS
+from .fake_tts import FakeSynthesizeStream, FakeTTS
 
 pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
@@ -327,3 +327,82 @@ async def test_timeout():
     assert await asyncio.wait_for(fake2.stream_ch.recv(), 1.0)
 
     await fallback_adapter.aclose()
+
+
+class _GateTTS(FakeTTS):
+    """FakeTTS whose recovery probe (the second `stream()`) blocks until `gate` is set.
+
+    Blocking on an event rather than a timer keeps the probe pending for exactly as long as the
+    test needs, with nothing racing it to completion.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.gate = asyncio.Event()
+        self._stream_calls = 0
+
+    def stream(
+        self, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
+    ) -> FakeSynthesizeStream:
+        self._stream_calls += 1
+        if self._stream_calls == 1:
+            return super().stream(conn_options=conn_options)
+
+        gate = self.gate
+
+        class _Blocking(FakeSynthesizeStream):
+            async def _run(self, output_emitter) -> None:  # type: ignore[no-untyped-def]
+                await gate.wait()
+                await super()._run(output_emitter)
+
+        stream = _Blocking(tts=self, conn_options=conn_options)
+        self._stream_ch.send_nowait(stream)
+        return stream
+
+
+async def test_recovery_is_not_suppressed_across_paths() -> None:
+    """A recovery probe in flight on one path must not stop the other path from probing.
+
+    The two paths each keep their own recovery slot (as the STT adapter does). With a single
+    shared slot, the streamed probe below would sit in it and the chunked request would skip
+    recovery entirely, leaving the provider marked unavailable.
+    """
+    fake1 = _GateTTS(fake_exception=APIConnectionError("fake1 failed"), fake_exception_count=99)
+    fake2 = FakeTTS(fake_audio_duration=1.0)
+
+    fallback_adapter = FallbackAdapterTester([fake1, fake2], max_retry_per_tts=0)
+
+    # streamed request: fake1 fails only after tokens were pushed, so the streamed recovery
+    # actually starts, and then parks on the gate.
+    async with fallback_adapter.stream() as stream:
+        stream.push_text("hello test")
+        stream.end_input()
+
+        async for _ in stream:
+            pass
+
+    assert not fallback_adapter.availability_changed_ch(fake1).recv_nowait().available
+
+    assert await asyncio.wait_for(fake1.stream_ch.recv(), 1.0)  # the failing attempt
+    assert await asyncio.wait_for(fake1.stream_ch.recv(), 1.0)  # the recovery probe, now gated
+
+    # chunked request on the same adapter and provider: it must start its own probe rather than
+    # skip recovery because the streamed probe is still running.
+    async with fallback_adapter.synthesize("hello test") as chunked:
+        async for _ in chunked:
+            pass
+
+    assert await asyncio.wait_for(fake1.synthesize_ch.recv(), 1.0), (
+        "chunked path did not probe fake1 while the streamed probe was in flight"
+    )
+
+    status = fallback_adapter._status[0]
+    stream_task = status.recovering_stream_task
+    assert stream_task is not None and not stream_task.done()
+    assert status.recovering_synthesize_task is not None
+
+    # aclose() must cancel both slots, not just whichever one was written last
+    await fallback_adapter.aclose()
+    assert stream_task.done()
+
+    fake1.gate.set()


### PR DESCRIPTION
Fixes #6682.

### Problem

`_TTSStatus` carried a single `recovering_task` slot, but it was written by **both** of the TTS fallback adapter's recovery paths — `FallbackChunkedStream._try_recovery` and `FallbackSynthesizeStream._try_recovery`. Each guards on `if tts_status.recovering_task is None or tts_status.recovering_task.done()`, which gives two problems:

1. **Suppression.** While one path's probe is in flight, the other path's `_try_recovery` finds a non-done task in the shared slot and returns without probing. A provider that is healthy again stays marked unavailable.
2. **Lost cancellation.** When the second path does pass the guard it overwrites the slot, so `aclose()` — which only cancels what the slot currently references — can no longer cancel the dropped task.

`_STTStatus` already keeps `recovering_recognize_task` and `recovering_stream_task` as separate fields and cancels both in `aclose()`. The TTS adapter was the odd one out; this makes the two structurally identical.

### Change

Split the field into `recovering_synthesize_task` / `recovering_stream_task`, point each `_try_recovery` at its own slot, and cancel both in `aclose()`. Existing behaviour — at most one recovery probe per path per provider — is unchanged; only the cross-path interference goes away.

### Test

`test_recovery_is_not_suppressed_across_paths` drives the direction that actually isolates the slot: the **streamed** path leaves a probe in flight (gated on an `asyncio.Event` rather than a timer, so nothing can race it to completion), then a **chunked** request must still probe the same provider. The discriminating assertion is provider-level rather than field-level — did `fake1` receive a chunked `synthesize()` call — so it fails for the right reason at the parent commit:

```text
bbf163f  FAILED  assert await asyncio.wait_for(fake1.synthesize_ch.recv(), 1.0)
                 "chunked path did not probe fake1 while the streamed probe was in flight"
this PR  PASSED
```

It also asserts `aclose()` cancels the still-gated streamed probe after the chunked path has written its own slot, covering problem 2.

`tests/test_tts_fallback.py tests/test_stt_fallback.py tests/test_llm_fallback.py`: 15 passed at the parent commit, 16 with this change (the one added test). `ruff check` and `ruff format --check` clean.

One thing to flag: I originally reproduced this in the chunked → streamed direction, and that reproduction was **vacuous** — the streamed path bails at `if not retry_text: return` before it ever consults the slot, so the fix doesn't change that scenario. I've corrected the issue accordingly. Notably, **#6680 removes that guard**, which un-masks the second direction; so after #6680 lands the shared slot is reachable from both paths rather than one. The two changes remain independent (#6680 touches `retry_text`, this touches the slot) and don't conflict textually — happy to sequence them in whichever order you prefer, or to fold this in if you'd rather have one PR.

Branched off `bbf163f` deliberately rather than off my #6680 branch, so the two can be reviewed and landed independently.
