### PR TITLE
fix(tts): probe a skipped provider for recovery on the streamed path

### DIFF
--- a/livekit-agents/livekit/agents/tts/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/tts/fallback_adapter.py
@@ -96,6 +96,7 @@ class FallbackAdapter(
 
         self._tts_instances = tts
         self._max_retry_per_tts = max_retry_per_tts
+        self._closed = False
 
         self._status: list[_TTSStatus] = []
         for t in tts:
@@ -140,6 +141,12 @@ class FallbackAdapter(
         self.emit("metrics_collected", *args, **kwargs)
 
     async def aclose(self) -> None:
+        # set before the sweep: _try_recovery is synchronous, so a probe is
+        # either already in a slot (and cancelled below) or refused by this
+        # flag. A stream still in flight runs its finally after this returns,
+        # and must not start a probe that nothing is left to cancel
+        self._closed = True
+
         for tts_status in self._status:
             if tts_status.recovering_synthesize_task is not None:
                 await aio.cancel_and_wait(tts_status.recovering_synthesize_task)
@@ -192,6 +199,10 @@ class FallbackChunkedStream(ChunkedStream):
 
     def _try_recovery(self, tts: TTS) -> None:
         assert isinstance(self._tts, FallbackAdapter)
+
+        if self._tts._closed:
+            # nothing would cancel a probe started from here
+            return
 
         tts_status = self._tts._status[self._tts._tts_instances.index(tts)]
         recovering_task = tts_status.recovering_synthesize_task
@@ -465,6 +476,11 @@ class FallbackSynthesizeStream(SynthesizeStream):
 
     def _try_recovery(self, tts: TTS) -> None:
         assert isinstance(self._tts, FallbackAdapter)
+
+        if self._tts._closed:
+            # a stream still in flight when the adapter closed runs its finally
+            # after the sweep, and nothing would cancel a probe started here
+            return
 
         retry_text = self._pushed_tokens.copy()
         if not retry_text:

--- a/livekit-agents/livekit/agents/tts/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/tts/fallback_adapter.py
@@ -384,6 +384,12 @@ class FallbackSynthesizeStream(SynthesizeStream):
 
         input_task = asyncio.create_task(_forward_input_task())
 
+        # a probe needs text to synthesize, and _pushed_tokens is only filled
+        # once _forward_input_task has run: an instance that is skipped because
+        # it is already unavailable is reached before that happens, so the
+        # probes are started below, after the input has been consumed
+        pending_recovery: list[TTS] = []
+
         try:
             for i, tts in enumerate(self._fallback_adapter._tts_instances):
                 tts_status = self._fallback_adapter._status[i]
@@ -446,13 +452,16 @@ class FallbackSynthesizeStream(SynthesizeStream):
                             )
                             return
 
-                self._try_recovery(tts)
+                pending_recovery.append(tts)
 
             raise APIConnectionError(
                 f"all TTSs failed ({[tts.label for tts in self._fallback_adapter._tts_instances]}) after {time.time() - start_time} seconds"  # noqa: E501
             )
         finally:
             await utils.aio.cancel_and_wait(input_task)
+
+            for tts in pending_recovery:
+                self._try_recovery(tts)
 
     def _try_recovery(self, tts: TTS) -> None:
         assert isinstance(self._tts, FallbackAdapter)

--- a/tests/test_tts_fallback.py
+++ b/tests/test_tts_fallback.py
@@ -406,3 +406,34 @@ async def test_recovery_is_not_suppressed_across_paths() -> None:
     assert stream_task.done()
 
     fake1.gate.set()
+async def test_tts_recover_on_streamed_path() -> None:
+    # a provider marked unavailable is skipped on later streamed requests, so
+    # nothing has awaited by the time recovery is considered and the probe used
+    # to be dropped for want of text - leaving the process pinned to its
+    # fallback for good after one transient outage (#6678)
+    fake1 = FakeTTS(fake_exception=APIConnectionError("fake1 failed"))
+    fake2 = FakeTTS(fake_audio_duration=1.0)
+
+    fallback_adapter = FallbackAdapterTester([fake1, fake2])
+
+    async def _drive() -> None:
+        async with fallback_adapter.stream() as stream:
+            stream.push_text("hello test")
+            stream.end_input()
+            async for _ in stream:
+                pass
+
+    # first request: fake1 fails and is marked unavailable
+    await _drive()
+    assert not fallback_adapter.availability_changed_ch(fake1).recv_nowait().available
+
+    fake1.update_options(fake_exception=None, fake_audio_duration=1.0)
+
+    # second request: fake1 is skipped, and must still be probed
+    await _drive()
+
+    assert (
+        await asyncio.wait_for(fallback_adapter.availability_changed_ch(fake1).recv(), 5.0)
+    ).available, "fake1 should have recovered on the streamed path"
+
+    await fallback_adapter.aclose()

--- a/tests/test_tts_fallback.py
+++ b/tests/test_tts_fallback.py
@@ -406,6 +406,8 @@ async def test_recovery_is_not_suppressed_across_paths() -> None:
     assert stream_task.done()
 
     fake1.gate.set()
+
+
 async def test_tts_recover_on_streamed_path() -> None:
     # a provider marked unavailable is skipped on later streamed requests, so
     # nothing has awaited by the time recovery is considered and the probe used
@@ -437,3 +439,45 @@ async def test_tts_recover_on_streamed_path() -> None:
     ).available, "fake1 should have recovered on the streamed path"
 
     await fallback_adapter.aclose()
+
+
+async def test_no_recovery_probe_after_close() -> None:
+    # aclose() cancels the recovery slots once; a stream still in flight runs
+    # its finally afterwards, and a probe started there would have nothing left
+    # to cancel it - a live synthesis against a provider that was just closed
+    fake1 = FakeTTS(fake_exception=APIConnectionError("fake1 failed"))
+    fake2 = FakeTTS(fake_audio_duration=1.0)
+
+    fallback_adapter = FallbackAdapterTester([fake1, fake2])
+
+    # first request: fake1 fails and is marked unavailable
+    async with fallback_adapter.stream() as stream:
+        stream.push_text("hello test")
+        stream.end_input()
+        async for _ in stream:
+            pass
+
+    assert not fallback_adapter.availability_changed_ch(fake1).recv_nowait().available
+
+    # second request left mid-flight: _pushed_tokens is populated and fake1 has
+    # been skipped, so its probe is pending when the adapter closes
+    fake1.update_options(fake_timeout=30.0, fake_exception=None)
+    stream = fallback_adapter.stream()
+    stream.push_text("hello test")  # deliberately no end_input()
+
+    drain = asyncio.create_task(_drain_stream(stream))
+    await asyncio.sleep(0.5)
+
+    await fallback_adapter.aclose()
+    await utils.aio.cancel_and_wait(drain)
+    await stream.aclose()
+
+    for tts_status in fallback_adapter._status:
+        for task in (tts_status.recovering_synthesize_task, tts_status.recovering_stream_task):
+            assert task is None or task.done(), "a recovery probe outlived aclose()"
+
+
+async def _drain_stream(stream: SynthesizeStream) -> None:
+    with contextlib.suppress(Exception):
+        async for _ in stream:
+            pass


### PR DESCRIPTION
Fixes #6678.

## Problem

`FallbackSynthesizeStream._try_recovery` starts by copying `_pushed_tokens` and returns when it is empty. `_pushed_tokens` is filled by `_forward_input_task`, which is created just above the provider loop but has not run yet: for an instance skipped by `if tts_status.available or all_failed`, nothing between the `create_task` and the `_try_recovery(tts)` call awaits, so the probe is dropped for want of text.

The instance is only skipped when it is *already* unavailable, which is exactly when it needs probing — so once a provider fails, a process that only uses `stream()` never re-probes it and stays pinned to its fallback for the rest of its life. The chunked path is unaffected because it has the text up front, which is why the same provider recovers there on the very next request.

Thanks @LHMQ878 for the diagnosis — it was precisely right, down to the line.

## Fix

The probes are started after the input has been consumed, in the `finally` that already awaits `input_task`, so they have the text they need. Instances are collected during the loop instead of being probed inside it; the success path returns through the same `finally`, so a provider skipped ahead of the one that worked is still probed.

Moving the call into `finally` introduced a second problem, also found by @LHMQ878: `aclose()` cancels the recovery slots exactly once, and a `finally` also runs on cancellation — so a stream still in flight when the adapter closes could create a probe in a slot nothing was left to sweep, leaving a live synthesis against a provider that was just closed. `FallbackAdapter._closed` is set before the sweep and refused in `_try_recovery`; because `_try_recovery` is synchronous, a probe is either already in a slot (and cancelled by the sweep) or refused by the flag, with no window between. Both stream types carry the guard so they don't drift.

Ordering is otherwise unchanged: an instance that fails *during* a request already had text by the time it was probed, and now gets probed a moment later with the same text. The STT adapter calls `_try_recovery` from its loop body rather than a `finally`, so it has no equivalent post-close path and is untouched.

## Verification

- `test_tts_recover_on_streamed_path` drives two streamed requests: the first marks the primary unavailable, the second skips it and must still probe it. Times out waiting for the recovery event on `main`, passes with the fix.
- `test_no_recovery_probe_after_close` leaves a request mid-flight (no `end_input()`), closes the adapter, and asserts no slot holds a live task. Fails without the close guard.

`ruff format --check`, `ruff check`, `check_types.py` (mypy strict) and the full `pytest --unit` suite pass locally.


## Merge order

This overlaps #6683, which splits `_TTSStatus.recovering_task` into `recovering_synthesize_task` / `recovering_stream_task`. Whichever lands second needs a small rebase: `_closed` and the two guards are unaffected, but `aclose()` sweeps two slots instead of one, and `test_no_recovery_probe_after_close` checks both rather than one. Happy for #6683 to go first — I'll rebase.
