### PR TITLE
fix(llm): never give a const field the null default sentinel

### DIFF
--- a/livekit-agents/livekit/agents/llm/_strict.py
+++ b/livekit-agents/livekit/agents/llm/_strict.py
@@ -239,13 +239,19 @@ def _add_null_sentinel(json_schema: dict[str, Any]) -> None:
     constraints.
 
     Appending ``"null"`` to a bare ``type`` only works when the schema has a direct type
-    and no value constraints. Literals (``const``/``enum``), unions (``anyOf``), and
-    ``$ref``-ed models need a full null branch instead, otherwise the wire schema either
-    contradicts itself or never advertises the sentinel at all.
+    and no value constraints. Enums, unions (``anyOf``), and ``$ref``-ed models need a full
+    null branch instead, otherwise the wire schema either contradicts itself or never
+    advertises the sentinel at all. A ``const`` gets no sentinel at all.
     """
     typ = json_schema.get("type")
     if typ == "null" or (is_list(typ) and "null" in typ):
         return  # already nullable via type
+
+    # A const has exactly one legal value, so a null branch adds nothing and contradicts it.
+    # It must also stay non-nullable: with `discriminator` stripped, the const a variant pins
+    # on its tag field is all that resolves a discriminated union.
+    if "const" in json_schema:
+        return
 
     for union_key in ("anyOf", "oneOf"):
         variants = json_schema.get(union_key)
@@ -254,15 +260,15 @@ def _add_null_sentinel(json_schema: dict[str, Any]) -> None:
                 variants.append({"type": "null"})
             return
 
-    has_value_constraint = "const" in json_schema or "enum" in json_schema
-    if isinstance(typ, str) and not has_value_constraint:
+    has_enum = "enum" in json_schema
+    if isinstance(typ, str) and not has_enum:
         json_schema["type"] = [typ, "null"]
         return
-    if is_list(typ) and not has_value_constraint:
+    if is_list(typ) and not has_enum:
         json_schema["type"] = [*typ, "null"]
         return
 
-    # const / enum / $ref / allOf: wrap so null is a valid instance without violating
+    # enum / $ref / allOf: wrap so null is a valid instance without violating
     # the original constraints. An empty schema already accepts null — leave it.
     inner = dict(json_schema)
     if not inner:

--- a/livekit-agents/livekit/agents/llm/_strict.py
+++ b/livekit-agents/livekit/agents/llm/_strict.py
@@ -239,13 +239,21 @@ def _add_null_sentinel(json_schema: dict[str, Any]) -> None:
     constraints.
 
     Appending ``"null"`` to a bare ``type`` only works when the schema has a direct type
-    and no value constraints. Literals (``const``/``enum``), unions (``anyOf``), and
-    ``$ref``-ed models need a full null branch instead, otherwise the wire schema either
-    contradicts itself or never advertises the sentinel at all.
+    and no value constraints. Enums, unions (``anyOf``), and ``$ref``-ed models need a full
+    null branch instead, otherwise the wire schema either contradicts itself or never
+    advertises the sentinel at all. A ``const`` gets no sentinel at all.
     """
     typ = json_schema.get("type")
     if typ == "null" or (is_list(typ) and "null" in typ):
         return  # already nullable via type
+
+    # A const field has exactly one legal value, so the model can always produce it and a
+    # null branch would contradict the const. It also has to stay non-nullable: the const
+    # a discriminated union's tag field carries is the only thing that resolves the variant
+    # once the unsupported `discriminator` keyword is stripped, and a nulled tag makes
+    # variants that differ only in their tag collide.
+    if "const" in json_schema:
+        return
 
     for union_key in ("anyOf", "oneOf"):
         variants = json_schema.get(union_key)
@@ -254,15 +262,15 @@ def _add_null_sentinel(json_schema: dict[str, Any]) -> None:
                 variants.append({"type": "null"})
             return
 
-    has_value_constraint = "const" in json_schema or "enum" in json_schema
-    if isinstance(typ, str) and not has_value_constraint:
+    has_enum = "enum" in json_schema
+    if isinstance(typ, str) and not has_enum:
         json_schema["type"] = [typ, "null"]
         return
-    if is_list(typ) and not has_value_constraint:
+    if is_list(typ) and not has_enum:
         json_schema["type"] = [*typ, "null"]
         return
 
-    # const / enum / $ref / allOf: wrap so null is a valid instance without violating
+    # enum / $ref / allOf: wrap so null is a valid instance without violating
     # the original constraints. An empty schema already accepts null — leave it.
     inner = dict(json_schema)
     if not inner:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -739,6 +739,10 @@ class _DefaultedFieldsModel(BaseModel):
     child: _SentinelChildModel = _SentinelChildModel()
 
 
+class _DefaultedConstModel(BaseModel):
+    tag: Literal["only"] = "only"
+
+
 class TestNullSentinelForDefaults:
     """Tool schemas advertise null for defaulted fields — the tool-args pipeline
     resolves the sentinel in _prepare_function_arguments. Without the flag,
@@ -750,6 +754,14 @@ class TestNullSentinelForDefaults:
             prop = schema["properties"][field]
             assert _json_schema_allows_null(prop, root=schema), f"{field}: {prop}"
             assert "default" not in prop
+
+    def test_const_field_gets_no_sentinel(self):
+        # a const has one legal value, which the model can always produce; a null branch
+        # would contradict it and lose the only information the field carries
+        schema = to_strict_json_schema(_DefaultedConstModel, null_sentinel_for_defaults=True)
+        prop = schema["properties"]["tag"]
+        assert prop == {"const": "only", "type": "string"}
+        assert not _json_schema_allows_null(prop, root=schema)
 
     def test_no_flag_keeps_defaulted_fields_required_and_non_nullable(self):
         schema = to_strict_json_schema(_DefaultedFieldsModel)
@@ -817,6 +829,17 @@ class _NestedDiscriminatedUnionModel(BaseModel):
     items: list[Annotated[_CarModel | _BikeModel, Field(discriminator="vehicle")]]
 
 
+# tags carrying a default, i.e. how discriminated unions are usually written
+class _DefaultedTagCelsius(BaseModel):
+    unit: Literal["celsius"] = "celsius"
+    value: float
+
+
+class _DefaultedTagFahrenheit(BaseModel):
+    unit: Literal["fahrenheit"] = "fahrenheit"
+    value: float
+
+
 def _has_one_of(schema: object) -> bool:
     """Recursively check if any dict in the schema tree contains 'oneOf'."""
     if isinstance(schema, dict):
@@ -865,6 +888,36 @@ class TestDiscriminatedUnionSchema:
         assert '"oneOf"' not in schema_str, (
             f"strict openai schema should not contain oneOf: {json.dumps(schema, indent=2)}"
         )
+
+    def test_defaulted_tag_stays_pinned_and_resolves_to_its_variant(self):
+        """`discriminator` is unsupported by strict mode, so the per-variant tag const is
+        all that resolves the variant. A nulled tag makes variants that differ only in
+        their tag collide, and the first one silently wins."""
+
+        @function_tool
+        async def set_thermostat(
+            temp: Annotated[
+                _DefaultedTagCelsius | _DefaultedTagFahrenheit, Field(discriminator="unit")
+            ],
+        ) -> str:
+            """Set the thermostat."""
+            return str(temp)
+
+        schema = build_strict_openai_schema(set_thermostat)["function"]["parameters"]
+        for name, tag in (
+            ("_DefaultedTagCelsius", "celsius"),
+            ("_DefaultedTagFahrenheit", "fahrenheit"),
+        ):
+            unit = schema["$defs"][name]["properties"]["unit"]
+            assert unit == {"const": tag, "type": "string"}
+            assert not _json_schema_allows_null(unit, root=schema)
+            assert "unit" in schema["$defs"][name]["required"]
+
+        args, _ = prepare_function_arguments(
+            fnc=set_thermostat,
+            json_arguments=json.dumps({"temp": {"unit": "fahrenheit", "value": 70.0}}),
+        )
+        assert isinstance(args[0], _DefaultedTagFahrenheit)
 
 
 class _OpenEnumModel(BaseModel):


### PR DESCRIPTION
## Summary

A defaulted field gets a null branch in strict schemas so the model can decline a value, which `_prepare_function_arguments` swaps back for the Python default. A `const` field has exactly one legal value, so nulling it gains nothing and the emitted schema contradicts itself:

```json
{"const": "celsius", "type": ["string", "null"]}
```

It also loses information. Strict mode has no `discriminator` keyword, so the `const` each variant of a discriminated union pins on its tag is the only thing that resolves the variant on the way back in. Tags are normally written with a default (`unit: Literal["celsius"] = "celsius"`), so they were taking the sentinel — and a returned null leaves variants that differ only in their tag indistinguishable:

```python
{"temp": {"unit": None, "value": 70.0}}  ->  Celsius(unit='celsius', value=70.0)
```

The model said Fahrenheit; the tool got Celsius. Covers callable discriminators (`Discriminator(fn)` + `Tag(...)`) too, which emit no `discriminator` keyword to key off.

## Testing

- `pytest tests/test_tools.py` (105 passed), plus `-k "strict or schema or tool"` across `tests/` (211 passed)
- tag emitted as `{"const": ..., "type": "string"}`, required and non-nullable, and the named variant round-trips, for: bare arg, optional-only arg, list element, nested model field, `str`-Enum-valued tag, callable discriminator, and `to_openai_response_format`
- live tool call accepted with the correct tag returned by `openai/gpt-4.1-mini` and `google/gemini-2.5-flash` via the inference gateway