### PR TITLE
fix: fallback adapters report the active instance's model/provider

### DIFF
--- a/livekit-agents/livekit/agents/llm/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/fallback_adapter.py
@@ -77,16 +77,21 @@ class FallbackAdapter(
             _LLMStatus(available=True, recovering_task=None) for _ in self._llm_instances
         ]
 
+        # the instance that most recently served a request; used to label metrics & traces
+        self._active_instance: LLM = self._llm_instances[0]
+
         for llm_instance in self._llm_instances:
             llm_instance.on("metrics_collected", self._on_metrics_collected)
 
     @property
     def model(self) -> str:
-        return "FallbackAdapter"
+        """The model of the instance that most recently served a request (the primary before any traffic)."""  # noqa: E501
+        return self._active_instance.model
 
     @property
     def provider(self) -> str:
-        return "livekit"
+        """The provider of the instance that most recently served a request (the primary before any traffic)."""  # noqa: E501
+        return self._active_instance.provider
 
     def chat(
         self,
@@ -194,6 +199,7 @@ class FallbackLLMStream(LLMStream):
                     if should_set_current:
                         should_set_current = False
                         self._current_stream = stream
+                        self._fallback_adapter._active_instance = llm
                     yield chunk
 
         except asyncio.TimeoutError:

--- a/livekit-agents/livekit/agents/llm/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/fallback_adapter.py
@@ -10,7 +10,7 @@ from typing import Any, ClassVar, Literal
 from .._exceptions import APIConnectionError, APIError
 from ..log import logger
 from ..types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, APIConnectOptions, NotGivenOr
-from .chat_context import ChatContext
+from .chat_context import ChatContext, MetricsMetadata
 from .llm import LLM, ChatChunk, LLMStream
 from .tool_context import Tool, ToolChoice
 
@@ -85,13 +85,16 @@ class FallbackAdapter(
 
     @property
     def model(self) -> str:
-        """The model of the instance that most recently served a request (the primary before any traffic)."""  # noqa: E501
-        return self._active_instance.model
+        return "FallbackAdapter"
 
     @property
     def provider(self) -> str:
-        """The provider of the instance that most recently served a request (the primary before any traffic)."""  # noqa: E501
-        return self._active_instance.provider
+        return "livekit"
+
+    @property
+    def metrics_metadata(self) -> MetricsMetadata:
+        """Metadata of the instance that most recently served a request (the primary before any traffic)."""  # noqa: E501
+        return self._active_instance.metrics_metadata
 
     def chat(
         self,

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -28,7 +28,7 @@ from ..types import (
     NotGivenOr,
 )
 from ..utils import aio
-from .chat_context import ChatContext, ChatRole
+from .chat_context import ChatContext, ChatRole, MetricsMetadata
 from .tool_context import Tool, ToolChoice
 
 
@@ -131,6 +131,11 @@ class LLM(
             Plugins should override this property to provide their provider information.
         """
         return "unknown"
+
+    @property
+    def metrics_metadata(self) -> MetricsMetadata:
+        """Metadata used to label turn metrics emitted for this LLM instance."""
+        return {"model_name": self.model, "model_provider": self.provider}
 
     @abstractmethod
     def chat(

--- a/livekit-agents/livekit/agents/llm/realtime.py
+++ b/livekit-agents/livekit/agents/llm/realtime.py
@@ -15,7 +15,7 @@ from livekit import rtc
 from ..log import logger
 from ..types import NOT_GIVEN, NotGivenOr
 from ..utils import is_given
-from .chat_context import ChatContext, ChatItem, FunctionCall
+from .chat_context import ChatContext, ChatItem, FunctionCall, MetricsMetadata
 from .tool_context import Tool, ToolChoice, ToolContext
 
 
@@ -106,6 +106,11 @@ class RealtimeModel:
     @property
     def provider(self) -> str:
         return "unknown"
+
+    @property
+    def metrics_metadata(self) -> MetricsMetadata:
+        """Metadata used to label turn metrics emitted for this realtime model."""
+        return {"model_name": self.model, "model_provider": self.provider}
 
     @property
     def capabilities(self) -> RealtimeCapabilities:

--- a/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
@@ -197,6 +197,8 @@ class _FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_ch
         self._active = adapter._models[0].session(
             turn_detection_disabled=self._turn_detection_disabled
         )
+        # a fresh session always starts on the primary, even after an earlier failover
+        adapter._active_instance = adapter._models[0]
         self._bind(self._active)
 
     def _bind(self, child: RealtimeSession) -> None:

--- a/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
@@ -13,7 +13,7 @@ from livekit import rtc
 from ..log import logger
 from ..types import NOT_GIVEN, NotGivenOr
 from ..utils import aio, is_given
-from .chat_context import ChatContext
+from .chat_context import ChatContext, MetricsMetadata
 from .realtime import (
     EventTypes,
     GenerationCreatedEvent,
@@ -125,13 +125,16 @@ class RealtimeModelFallbackAdapter(
 
     @property
     def model(self) -> str:
-        """The model name of the instance currently serving sessions (the primary until a swap)."""
-        return self._active_instance.model
+        return "RealtimeModelFallbackAdapter"
 
     @property
     def provider(self) -> str:
-        """The provider of the instance currently serving sessions (the primary until a swap)."""
-        return self._active_instance.provider
+        return "livekit"
+
+    @property
+    def metrics_metadata(self) -> MetricsMetadata:
+        """Metadata of the model currently serving sessions (the primary until a swap)."""
+        return self._active_instance.metrics_metadata
 
     def session(self, *, turn_detection_disabled: bool = False) -> _FallbackRealtimeSession:
         sess = _FallbackRealtimeSession(self, turn_detection_disabled=turn_detection_disabled)

--- a/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
@@ -120,13 +120,18 @@ class RealtimeModelFallbackAdapter(
         self._regenerate_on_swap = regenerate_on_swap
         self._sessions: weakref.WeakSet[_FallbackRealtimeSession] = weakref.WeakSet()
 
+        # the model currently serving sessions; used to label metrics & traces
+        self._active_instance: RealtimeModel = models[0]
+
     @property
     def model(self) -> str:
-        return "RealtimeModelFallbackAdapter"
+        """The model name of the instance currently serving sessions (the primary until a swap)."""
+        return self._active_instance.model
 
     @property
     def provider(self) -> str:
-        return "livekit"
+        """The provider of the instance currently serving sessions (the primary until a swap)."""
+        return self._active_instance.provider
 
     def session(self, *, turn_detection_disabled: bool = False) -> _FallbackRealtimeSession:
         sess = _FallbackRealtimeSession(self, turn_detection_disabled=turn_detection_disabled)
@@ -304,6 +309,7 @@ class _FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_ch
                     )
                     if is_given(self._tool_choice):
                         self._active.update_options(tool_choice=self._tool_choice)
+                    self._adapter._active_instance = self._adapter._models[index]
                     return None
                 except Exception as e:
                     logger.exception("failed to start realtime model on swap, trying next")

--- a/livekit-agents/livekit/agents/stt/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/stt/fallback_adapter.py
@@ -20,6 +20,7 @@ from ..vad import VAD
 from .stt import STT, RecognizeStream, SpeechEvent, SpeechEventType, STTCapabilities
 
 if TYPE_CHECKING:
+    from ..llm.chat_context import MetricsMetadata
     from ..voice.events import ConversationItemAddedEvent
 
 # don't retry when using the fallback adapter
@@ -115,13 +116,16 @@ class FallbackAdapter(
 
     @property
     def model(self) -> str:
-        """The model of the instance that most recently served a request (the primary before any traffic)."""  # noqa: E501
-        return self._active_instance.model
+        return "FallbackAdapter"
 
     @property
     def provider(self) -> str:
-        """The provider of the instance that most recently served a request (the primary before any traffic)."""  # noqa: E501
-        return self._active_instance.provider
+        return "livekit"
+
+    @property
+    def metrics_metadata(self) -> MetricsMetadata:
+        """Metadata of the instance that most recently served a request (the primary before any traffic)."""  # noqa: E501
+        return self._active_instance.metrics_metadata
 
     def _update_session_keyterms(self, keyterms: list[str]) -> None:
         # forward to every underlying STT; unsupported ones warn-and-skip internally

--- a/livekit-agents/livekit/agents/stt/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/stt/fallback_adapter.py
@@ -106,17 +106,22 @@ class FallbackAdapter(
             for _ in self._stt_instances
         ]
 
+        # the instance that most recently served a request; used to label metrics & traces
+        self._active_instance: STT = self._stt_instances[0]
+
         for stt_instance in self._stt_instances:
             stt_instance.on("metrics_collected", self._on_metrics_collected)
         self._recognize_metrics_needed = False  # don't emit metrics via fallback adapter
 
     @property
     def model(self) -> str:
-        return "FallbackAdapter"
+        """The model of the instance that most recently served a request (the primary before any traffic)."""  # noqa: E501
+        return self._active_instance.model
 
     @property
     def provider(self) -> str:
-        return "livekit"
+        """The provider of the instance that most recently served a request (the primary before any traffic)."""  # noqa: E501
+        return self._active_instance.provider
 
     def _update_session_keyterms(self, keyterms: list[str]) -> None:
         # forward to every underlying STT; unsupported ones warn-and-skip internally
@@ -242,13 +247,15 @@ class FallbackAdapter(
             stt_status = self._status[i]
             if stt_status.available or all_failed:
                 try:
-                    return await self._try_recognize(
+                    event = await self._try_recognize(
                         stt=stt,
                         buffer=buffer,
                         language=language,
                         conn_options=conn_options,
                         recovering=False,
                     )
+                    self._active_instance = stt
+                    return event
                 except Exception:  # exceptions already logged inside _try_recognize
                     if stt_status.available:
                         stt_status.available = False
@@ -375,8 +382,12 @@ class FallbackRecognizeStream(RecognizeStream):
                         forward_input_task = asyncio.create_task(_forward_input_task())
 
                     try:
+                        should_set_active = True
                         async with main_stream:
                             async for ev in main_stream:
+                                if should_set_active:
+                                    should_set_active = False
+                                    self._fallback_adapter._active_instance = stt
                                 self._event_ch.send_nowait(ev)
 
                     except asyncio.TimeoutError:

--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -29,6 +29,7 @@ from ..utils import AudioBuffer, aio, is_given
 from ..utils.audio import calculate_audio_duration
 
 if TYPE_CHECKING:
+    from ..llm.chat_context import MetricsMetadata
     from ..voice.events import ConversationItemAddedEvent
 
 
@@ -189,6 +190,11 @@ class STT(
             Plugins should override this property to provide their provider information.
         """
         return "unknown"
+
+    @property
+    def metrics_metadata(self) -> MetricsMetadata:
+        """Metadata used to label turn metrics emitted for this STT instance."""
+        return {"model_name": self.model, "model_provider": self.provider}
 
     @property
     def capabilities(self) -> STTCapabilities:

--- a/livekit-agents/livekit/agents/tts/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/tts/fallback_adapter.py
@@ -5,7 +5,7 @@ import dataclasses
 import time
 from collections.abc import AsyncGenerator, AsyncIterable
 from dataclasses import dataclass
-from typing import Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from livekit import rtc
 
@@ -23,6 +23,9 @@ from .tts import (
     SynthesizeStream,
     TTSCapabilities,
 )
+
+if TYPE_CHECKING:
+    from ..llm.chat_context import MetricsMetadata
 
 # don't retry when using the fallback adapter
 DEFAULT_FALLBACK_API_CONNECT_OPTIONS = APIConnectOptions(
@@ -110,13 +113,16 @@ class FallbackAdapter(
 
     @property
     def model(self) -> str:
-        """The model of the instance that most recently served a request (the primary before any traffic)."""  # noqa: E501
-        return self._active_instance.model
+        return "FallbackAdapter"
 
     @property
     def provider(self) -> str:
-        """The provider of the instance that most recently served a request (the primary before any traffic)."""  # noqa: E501
-        return self._active_instance.provider
+        return "livekit"
+
+    @property
+    def metrics_metadata(self) -> MetricsMetadata:
+        """Metadata of the instance that most recently served a request (the primary before any traffic)."""  # noqa: E501
+        return self._active_instance.metrics_metadata
 
     def synthesize(
         self, text: str, *, conn_options: APIConnectOptions = DEFAULT_FALLBACK_API_CONNECT_OPTIONS

--- a/livekit-agents/livekit/agents/tts/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/tts/fallback_adapter.py
@@ -93,6 +93,9 @@ class FallbackAdapter(
         self._tts_instances = tts
         self._max_retry_per_tts = max_retry_per_tts
 
+        # the instance that most recently served a request; used to label metrics & traces
+        self._active_instance: TTS = self._tts_instances[0]
+
         self._status: list[_TTSStatus] = []
         for t in tts:
             needs_resampling = sample_rate != t.sample_rate
@@ -107,11 +110,13 @@ class FallbackAdapter(
 
     @property
     def model(self) -> str:
-        return "FallbackAdapter"
+        """The model of the instance that most recently served a request (the primary before any traffic)."""  # noqa: E501
+        return self._active_instance.model
 
     @property
     def provider(self) -> str:
-        return "livekit"
+        """The provider of the instance that most recently served a request (the primary before any traffic)."""  # noqa: E501
+        return self._active_instance.provider
 
     def synthesize(
         self, text: str, *, conn_options: APIConnectOptions = DEFAULT_FALLBACK_API_CONNECT_OPTIONS
@@ -164,7 +169,11 @@ class FallbackChunkedStream(ChunkedStream):
                     retry_interval=self._conn_options.retry_interval,
                 ),
             ) as stream:
+                should_set_active = not recovering
                 async for audio in stream:
+                    if should_set_active:
+                        should_set_active = False
+                        self._fallback_adapter._active_instance = tts
                     yield audio
 
         except Exception as e:
@@ -317,8 +326,12 @@ class FallbackSynthesizeStream(SynthesizeStream):
 
         try:
             async with stream:
+                should_set_active = not recovering
                 async for audio in stream:
                     _capture_started_time()
+                    if should_set_active:
+                        should_set_active = False
+                        self._fallback_adapter._active_instance = tts
                     yield audio
         except Exception as e:
             if recovering:

--- a/livekit-agents/livekit/agents/tts/tts.py
+++ b/livekit-agents/livekit/agents/tts/tts.py
@@ -29,6 +29,7 @@ from ..types import (
 from ..utils import aio, audio, codecs, log_exceptions, shortuuid
 
 if TYPE_CHECKING:
+    from ..llm.chat_context import MetricsMetadata
     from ..voice.agent_session import SpeechSteeringOptions
     from ..voice.io import TimedString
 
@@ -203,6 +204,11 @@ class TTS(
             Plugins should override this property to provide their provider information.
         """
         return "unknown"
+
+    @property
+    def metrics_metadata(self) -> MetricsMetadata:
+        """Metadata used to label turn metrics emitted for this TTS instance."""
+        return {"model_name": self.model, "model_provider": self.provider}
 
     @property
     def capabilities(self) -> TTSCapabilities:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3377,15 +3377,9 @@ class AgentActivity(RecognitionHooks):
         assistant_metrics: llm.MetricsReport = {}
 
         if self.llm:
-            assistant_metrics["llm_metadata"] = {
-                "model_name": self.llm.model,
-                "model_provider": self.llm.provider,
-            }
+            assistant_metrics["llm_metadata"] = self.llm.metrics_metadata
         if self.tts:
-            assistant_metrics["tts_metadata"] = {
-                "model_name": self.tts.model,
-                "model_provider": self.tts.provider,
-            }
+            assistant_metrics["tts_metadata"] = self.tts.metrics_metadata
 
         if llm_gen_data.ttft is not None:
             assistant_metrics["llm_node_ttft"] = llm_gen_data.ttft
@@ -4454,10 +4448,7 @@ class AgentActivity(RecognitionHooks):
     def _init_metrics_from_end_of_turn(self, info: _EndOfTurnInfo) -> llm.MetricsReport:
         metrics_report: llm.MetricsReport = {}
         if self.stt:
-            metrics_report["stt_metadata"] = {
-                "model_name": self.stt.model,
-                "model_provider": self.stt.provider,
-            }
+            metrics_report["stt_metadata"] = self.stt.metrics_metadata
         if info.metrics.started_speaking_at is not None:
             metrics_report["started_speaking_at"] = info.metrics.started_speaking_at
 

--- a/tests/test_llm_fallback.py
+++ b/tests/test_llm_fallback.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 import pytest
 
-from livekit.agents.llm import FallbackAdapter
+from livekit.agents import APIConnectionError
+from livekit.agents.llm import ChatContext, FallbackAdapter, LLMStream, Tool
+from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, APIConnectOptions
 
-from .fake_llm import FakeLLM
+from .fake_llm import FakeLLM, FakeLLMResponse
 
 pytestmark = [pytest.mark.unit]
 
@@ -49,6 +52,71 @@ async def test_prewarm_forwarded_to_primary_llm() -> None:
         await fallback_adapter.aclose()
         await primary.aclose()
         await fallback.aclose()
+
+
+class _NamedLLM(FakeLLM):
+    """FakeLLM with a configurable model/provider so tests can tell instances apart."""
+
+    def __init__(self, *, model: str, provider: str, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._model_name = model
+        self._provider_name = provider
+
+    @property
+    def model(self) -> str:
+        return self._model_name
+
+    @property
+    def provider(self) -> str:
+        return self._provider_name
+
+
+class _FailingLLMStream(LLMStream):
+    async def _run(self) -> None:
+        raise APIConnectionError("failing llm")
+
+
+class _FailingLLM(_NamedLLM):
+    def chat(
+        self,
+        *,
+        chat_ctx: ChatContext,
+        tools: list[Tool] | None = None,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+        **kwargs: Any,
+    ) -> LLMStream:
+        return _FailingLLMStream(
+            self, chat_ctx=chat_ctx, tools=tools or [], conn_options=conn_options
+        )
+
+
+async def test_reports_active_instance_model_and_provider() -> None:
+    primary = _FailingLLM(model="primary-model", provider="primary")
+    fallback = _NamedLLM(
+        model="fallback-model",
+        provider="fallback",
+        fake_responses=[
+            FakeLLMResponse(input="hello", content="hi there", ttft=0.01, duration=0.02)
+        ],
+    )
+
+    fallback_adapter = FallbackAdapter([primary, fallback])
+    try:
+        # before any traffic, the primary is reported
+        assert fallback_adapter.model == "primary-model"
+        assert fallback_adapter.provider == "primary"
+
+        chat_ctx = ChatContext.empty()
+        chat_ctx.add_message(role="user", content="hello")
+        async with fallback_adapter.chat(chat_ctx=chat_ctx) as stream:
+            async for _ in stream:
+                pass
+
+        # the fallback served the request, so metrics must be labeled with it
+        assert fallback_adapter.model == "fallback-model"
+        assert fallback_adapter.provider == "fallback"
+    finally:
+        await fallback_adapter.aclose()
 
 
 async def test_prewarm_forwards_event_loop() -> None:

--- a/tests/test_llm_fallback.py
+++ b/tests/test_llm_fallback.py
@@ -103,8 +103,10 @@ async def test_reports_active_instance_model_and_provider() -> None:
     fallback_adapter = FallbackAdapter([primary, fallback])
     try:
         # before any traffic, the primary is reported
-        assert fallback_adapter.model == "primary-model"
-        assert fallback_adapter.provider == "primary"
+        assert fallback_adapter.metrics_metadata == {
+            "model_name": "primary-model",
+            "model_provider": "primary",
+        }
 
         chat_ctx = ChatContext.empty()
         chat_ctx.add_message(role="user", content="hello")
@@ -113,8 +115,12 @@ async def test_reports_active_instance_model_and_provider() -> None:
                 pass
 
         # the fallback served the request, so metrics must be labeled with it
-        assert fallback_adapter.model == "fallback-model"
-        assert fallback_adapter.provider == "fallback"
+        assert fallback_adapter.metrics_metadata == {
+            "model_name": "fallback-model",
+            "model_provider": "fallback",
+        }
+        # the adapter keeps its own stable identity for spans, logs, and error events
+        assert fallback_adapter.model == "FallbackAdapter"
     finally:
         await fallback_adapter.aclose()
 

--- a/tests/test_realtime_fallback.py
+++ b/tests/test_realtime_fallback.py
@@ -43,6 +43,41 @@ class _StubAgentSession:
         return object()
 
 
+class _NamedRealtimeModel(FakeRealtimeModel):
+    """FakeRealtimeModel with a configurable model/provider so tests can tell instances apart."""
+
+    def __init__(self, *, model: str, provider: str) -> None:
+        super().__init__()
+        self._model_name = model
+        self._provider_name = provider
+
+    @property
+    def model(self) -> str:
+        return self._model_name
+
+    @property
+    def provider(self) -> str:
+        return self._provider_name
+
+
+async def test_reports_active_model_and_provider() -> None:
+    primary = _NamedRealtimeModel(model="primary-model", provider="primary")
+    backup = _NamedRealtimeModel(model="backup-model", provider="backup")
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+
+    # before any swap, the primary is reported
+    assert adapter.model == "primary-model"
+    assert adapter.provider == "primary"
+
+    session = adapter.session()
+    primary.active_session.emit_error(recoverable=False)
+    await session._swap_task
+
+    # the backup now serves the session, so metrics must be labeled with it
+    assert adapter.model == "backup-model"
+    assert adapter.provider == "backup"
+
+
 def test_requires_at_least_one_model() -> None:
     with pytest.raises(ValueError):
         RealtimeModelFallbackAdapter([])

--- a/tests/test_realtime_fallback.py
+++ b/tests/test_realtime_fallback.py
@@ -66,16 +66,22 @@ async def test_reports_active_model_and_provider() -> None:
     adapter = RealtimeModelFallbackAdapter([primary, backup])
 
     # before any swap, the primary is reported
-    assert adapter.model == "primary-model"
-    assert adapter.provider == "primary"
+    assert adapter.metrics_metadata == {
+        "model_name": "primary-model",
+        "model_provider": "primary",
+    }
 
     session = adapter.session()
     primary.active_session.emit_error(recoverable=False)
     await session._swap_task
 
     # the backup now serves the session, so metrics must be labeled with it
-    assert adapter.model == "backup-model"
-    assert adapter.provider == "backup"
+    assert adapter.metrics_metadata == {
+        "model_name": "backup-model",
+        "model_provider": "backup",
+    }
+    # the adapter keeps its own stable identity for spans, logs, and error events
+    assert adapter.model == "RealtimeModelFallbackAdapter"
 
 
 async def test_new_session_resets_active_model_to_primary() -> None:
@@ -86,14 +92,16 @@ async def test_new_session_resets_active_model_to_primary() -> None:
     session = adapter.session()
     primary.active_session.emit_error(recoverable=False)
     await session._swap_task
-    assert adapter.model == "backup-model"
+    assert adapter.metrics_metadata["model_name"] == "backup-model"
 
     # a fresh session (e.g. a new agent activity) always starts on the primary,
     # so the label must follow it instead of sticking to the old failover target
     adapter.session()
 
-    assert adapter.model == "primary-model"
-    assert adapter.provider == "primary"
+    assert adapter.metrics_metadata == {
+        "model_name": "primary-model",
+        "model_provider": "primary",
+    }
 
 
 def test_requires_at_least_one_model() -> None:

--- a/tests/test_realtime_fallback.py
+++ b/tests/test_realtime_fallback.py
@@ -78,6 +78,24 @@ async def test_reports_active_model_and_provider() -> None:
     assert adapter.provider == "backup"
 
 
+async def test_new_session_resets_active_model_to_primary() -> None:
+    primary = _NamedRealtimeModel(model="primary-model", provider="primary")
+    backup = _NamedRealtimeModel(model="backup-model", provider="backup")
+    adapter = RealtimeModelFallbackAdapter([primary, backup])
+
+    session = adapter.session()
+    primary.active_session.emit_error(recoverable=False)
+    await session._swap_task
+    assert adapter.model == "backup-model"
+
+    # a fresh session (e.g. a new agent activity) always starts on the primary,
+    # so the label must follow it instead of sticking to the old failover target
+    adapter.session()
+
+    assert adapter.model == "primary-model"
+    assert adapter.provider == "primary"
+
+
 def test_requires_at_least_one_model() -> None:
     with pytest.raises(ValueError):
         RealtimeModelFallbackAdapter([])

--- a/tests/test_stt_fallback.py
+++ b/tests/test_stt_fallback.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 import pytest
 
@@ -53,6 +54,86 @@ class FallbackAdapterTester(FallbackAdapter):
         stt: STT,
     ) -> utils.aio.ChanReceiver[AvailabilityChangedEvent]:
         return self._availability_changed_ch[id(stt)]
+
+
+class _NamedSTT(FakeSTT):
+    """FakeSTT with a configurable model/provider so tests can tell instances apart."""
+
+    def __init__(self, *, model: str, provider: str, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._model_name = model
+        self._provider_name = provider
+
+    @property
+    def model(self) -> str:
+        return self._model_name
+
+    @property
+    def provider(self) -> str:
+        return self._provider_name
+
+
+async def test_reports_active_instance_model_and_provider() -> None:
+    fake1 = _NamedSTT(
+        model="primary-model",
+        provider="primary",
+        fake_exception=APIConnectionError("fake1 failed"),
+        fake_timeout=0.5,
+    )
+    fake2 = _NamedSTT(model="fallback-model", provider="fallback", fake_transcript="hello world")
+
+    fallback_adapter = FallbackAdapterTester([fake1, fake2])
+
+    # before any traffic, the primary is reported
+    assert fallback_adapter.model == "primary-model"
+    assert fallback_adapter.provider == "primary"
+
+    await fallback_adapter.recognize([])
+
+    # the fallback served the request, so metrics must be labeled with it
+    assert fallback_adapter.model == "fallback-model"
+    assert fallback_adapter.provider == "fallback"
+
+    assert not fallback_adapter.availability_changed_ch(fake1).recv_nowait().available
+
+    # a successful recovery probe must not relabel: its result is never surfaced
+    fake1.update_options(fake_exception=None, fake_transcript="probe")
+    assert (
+        await asyncio.wait_for(fallback_adapter.availability_changed_ch(fake1).recv(), 1.0)
+    ).available, "fake1 should have recovered"
+
+    assert fallback_adapter.model == "fallback-model"
+    assert fallback_adapter.provider == "fallback"
+
+    # once the recovered primary serves real traffic again, the label follows
+    await fallback_adapter.recognize([])
+
+    assert fallback_adapter.model == "primary-model"
+    assert fallback_adapter.provider == "primary"
+
+    await fallback_adapter.aclose()
+
+
+async def test_stream_reports_active_instance_model_and_provider() -> None:
+    fake1 = _NamedSTT(
+        model="primary-model",
+        provider="primary",
+        fake_exception=APIConnectionError("fake1 failed"),
+    )
+    fake2 = _NamedSTT(model="fallback-model", provider="fallback", fake_transcript="hello world")
+
+    fallback_adapter = FallbackAdapterTester([fake1, fake2])
+
+    async with fallback_adapter.stream() as stream:
+        stream.end_input()
+
+        async for _ in stream:
+            pass
+
+    assert fallback_adapter.model == "fallback-model"
+    assert fallback_adapter.provider == "fallback"
+
+    await fallback_adapter.aclose()
 
 
 async def test_stt_fallback() -> None:

--- a/tests/test_stt_fallback.py
+++ b/tests/test_stt_fallback.py
@@ -85,14 +85,18 @@ async def test_reports_active_instance_model_and_provider() -> None:
     fallback_adapter = FallbackAdapterTester([fake1, fake2])
 
     # before any traffic, the primary is reported
-    assert fallback_adapter.model == "primary-model"
-    assert fallback_adapter.provider == "primary"
+    assert fallback_adapter.metrics_metadata == {
+        "model_name": "primary-model",
+        "model_provider": "primary",
+    }
 
     await fallback_adapter.recognize([])
 
     # the fallback served the request, so metrics must be labeled with it
-    assert fallback_adapter.model == "fallback-model"
-    assert fallback_adapter.provider == "fallback"
+    assert fallback_adapter.metrics_metadata == {
+        "model_name": "fallback-model",
+        "model_provider": "fallback",
+    }
 
     assert not fallback_adapter.availability_changed_ch(fake1).recv_nowait().available
 
@@ -102,14 +106,18 @@ async def test_reports_active_instance_model_and_provider() -> None:
         await asyncio.wait_for(fallback_adapter.availability_changed_ch(fake1).recv(), 1.0)
     ).available, "fake1 should have recovered"
 
-    assert fallback_adapter.model == "fallback-model"
-    assert fallback_adapter.provider == "fallback"
+    assert fallback_adapter.metrics_metadata == {
+        "model_name": "fallback-model",
+        "model_provider": "fallback",
+    }
 
     # once the recovered primary serves real traffic again, the label follows
     await fallback_adapter.recognize([])
 
-    assert fallback_adapter.model == "primary-model"
-    assert fallback_adapter.provider == "primary"
+    assert fallback_adapter.metrics_metadata == {
+        "model_name": "primary-model",
+        "model_provider": "primary",
+    }
 
     await fallback_adapter.aclose()
 
@@ -130,8 +138,10 @@ async def test_stream_reports_active_instance_model_and_provider() -> None:
         async for _ in stream:
             pass
 
-    assert fallback_adapter.model == "fallback-model"
-    assert fallback_adapter.provider == "fallback"
+    assert fallback_adapter.metrics_metadata == {
+        "model_name": "fallback-model",
+        "model_provider": "fallback",
+    }
 
     await fallback_adapter.aclose()
 

--- a/tests/test_tts_fallback.py
+++ b/tests/test_tts_fallback.py
@@ -78,16 +78,20 @@ async def test_reports_active_instance_model_and_provider() -> None:
     fallback_adapter = FallbackAdapterTester([fake1, fake2])
 
     # before any traffic, the primary is reported
-    assert fallback_adapter.model == "primary-model"
-    assert fallback_adapter.provider == "primary"
+    assert fallback_adapter.metrics_metadata == {
+        "model_name": "primary-model",
+        "model_provider": "primary",
+    }
 
     async with fallback_adapter.synthesize("hello test") as stream:
         async for _ in stream:
             pass
 
     # the fallback served the request, so metrics must be labeled with it
-    assert fallback_adapter.model == "fallback-model"
-    assert fallback_adapter.provider == "fallback"
+    assert fallback_adapter.metrics_metadata == {
+        "model_name": "fallback-model",
+        "model_provider": "fallback",
+    }
 
     assert not fallback_adapter.availability_changed_ch(fake1).recv_nowait().available
 
@@ -97,16 +101,20 @@ async def test_reports_active_instance_model_and_provider() -> None:
         await asyncio.wait_for(fallback_adapter.availability_changed_ch(fake1).recv(), 1.0)
     ).available, "fake1 should have recovered"
 
-    assert fallback_adapter.model == "fallback-model"
-    assert fallback_adapter.provider == "fallback"
+    assert fallback_adapter.metrics_metadata == {
+        "model_name": "fallback-model",
+        "model_provider": "fallback",
+    }
 
     # once the recovered primary serves real traffic again, the label follows
     async with fallback_adapter.synthesize("hello again") as stream:
         async for _ in stream:
             pass
 
-    assert fallback_adapter.model == "primary-model"
-    assert fallback_adapter.provider == "primary"
+    assert fallback_adapter.metrics_metadata == {
+        "model_name": "primary-model",
+        "model_provider": "primary",
+    }
 
     await fallback_adapter.aclose()
 
@@ -128,8 +136,10 @@ async def test_stream_reports_active_instance_model_and_provider() -> None:
         async for _ in stream:
             pass
 
-    assert fallback_adapter.model == "fallback-model"
-    assert fallback_adapter.provider == "fallback"
+    assert fallback_adapter.metrics_metadata == {
+        "model_name": "fallback-model",
+        "model_provider": "fallback",
+    }
 
     await fallback_adapter.aclose()
 

--- a/tests/test_tts_fallback.py
+++ b/tests/test_tts_fallback.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import time
+from typing import Any
 
 import pytest
 
@@ -46,6 +47,91 @@ class FallbackAdapterTester(FallbackAdapter):
         tts: TTS,
     ) -> utils.aio.ChanReceiver[AvailabilityChangedEvent]:
         return self._availability_changed_ch[id(tts)]
+
+
+class _NamedTTS(FakeTTS):
+    """FakeTTS with a configurable model/provider so tests can tell instances apart."""
+
+    def __init__(self, *, model: str, provider: str, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._model_name = model
+        self._provider_name = provider
+
+    @property
+    def model(self) -> str:
+        return self._model_name
+
+    @property
+    def provider(self) -> str:
+        return self._provider_name
+
+
+async def test_reports_active_instance_model_and_provider() -> None:
+    fake1 = _NamedTTS(
+        model="primary-model",
+        provider="primary",
+        fake_exception=APIConnectionError("fake1 failed"),
+        fake_timeout=0.5,
+    )
+    fake2 = _NamedTTS(model="fallback-model", provider="fallback", fake_audio_duration=5.0)
+
+    fallback_adapter = FallbackAdapterTester([fake1, fake2])
+
+    # before any traffic, the primary is reported
+    assert fallback_adapter.model == "primary-model"
+    assert fallback_adapter.provider == "primary"
+
+    async with fallback_adapter.synthesize("hello test") as stream:
+        async for _ in stream:
+            pass
+
+    # the fallback served the request, so metrics must be labeled with it
+    assert fallback_adapter.model == "fallback-model"
+    assert fallback_adapter.provider == "fallback"
+
+    assert not fallback_adapter.availability_changed_ch(fake1).recv_nowait().available
+
+    # a successful recovery probe must not relabel: the caller never heard its audio
+    fake1.update_options(fake_exception=None, fake_audio_duration=1.0)
+    assert (
+        await asyncio.wait_for(fallback_adapter.availability_changed_ch(fake1).recv(), 1.0)
+    ).available, "fake1 should have recovered"
+
+    assert fallback_adapter.model == "fallback-model"
+    assert fallback_adapter.provider == "fallback"
+
+    # once the recovered primary serves real traffic again, the label follows
+    async with fallback_adapter.synthesize("hello again") as stream:
+        async for _ in stream:
+            pass
+
+    assert fallback_adapter.model == "primary-model"
+    assert fallback_adapter.provider == "primary"
+
+    await fallback_adapter.aclose()
+
+
+async def test_stream_reports_active_instance_model_and_provider() -> None:
+    fake1 = _NamedTTS(
+        model="primary-model",
+        provider="primary",
+        fake_exception=APIConnectionError("fake1 failed"),
+    )
+    fake2 = _NamedTTS(model="fallback-model", provider="fallback", fake_audio_duration=5.0)
+
+    fallback_adapter = FallbackAdapterTester([fake1, fake2])
+
+    async with fallback_adapter.stream() as stream:
+        stream.push_text("hello test")
+        stream.end_input()
+
+        async for _ in stream:
+            pass
+
+    assert fallback_adapter.model == "fallback-model"
+    assert fallback_adapter.provider == "fallback"
+
+    await fallback_adapter.aclose()
 
 
 async def test_tts_fallback() -> None:


### PR DESCRIPTION
## What

Adds a `metrics_metadata` property to the STT/TTS/LLM/RealtimeModel base classes (returns own `model`/`provider`), overridden by the fallback adapters to report the instance that most recently served a request. The three `lk.agents.turn.*` label sites in `agent_activity.py` now read it. Adapter `model`/`provider` stay `"FallbackAdapter"`/`"livekit"` for spans, logs, and error events.

## Why

Turn histograms labeled from the top-level component collapse into one `model_name="FallbackAdapter"` series with a fallback adapter — you can't tell your primary's ttfb from your fallback's. Discussed with the LiveKit team in slack; surfacing the actual provider was agreed on. Scoped to `metrics_metadata` per @longcw's review, keeping the adapter's own identity stable everywhere else.

Semantics: the primary before any traffic, the last instance to produce output after that. Recovery probes never relabel. Tests cover all four adapters, including probe-doesn't-relabel and fresh-session-resets-to-primary.

https://claude.ai/code/session_01AkHCx6Qfu5i2Z6h8Pa82gE
