### PR TITLE
fix(voice): keep the run open while a tool holds the floor

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -960,7 +960,7 @@ class AgentTask(Agent, Generic[TaskResult_T]):
 
         # TODO(theomonnom): could the RunResult watcher & the blocked_tasks share the same logic?
         self.__inactive_ev.clear()
-        suspended_handles: list[SpeechHandle | asyncio.Task[Any]] = []
+        suspended_handles: list[SpeechHandle | asyncio.Future[Any]] = []
         pending_on_enter_task: asyncio.Task[None] | None = None
         try:
             # use wait_on_enter=False to avoid deadlock: on_enter may spawn nested
@@ -991,13 +991,14 @@ class AgentTask(Agent, Generic[TaskResult_T]):
 
             # now unwatch the parent speech handle and blocked tasks that belong to the
             # old activity — they can't complete while this AgentTask is running, and
-            # keeping them watched would block RunResult from completing.
+            # keeping them watched would block RunResult from completing. A foreground
+            # hold waiting on this task is in the same position, so its guard suspends too.
             if run_state and not run_state.done():
                 if speech_handle and run_state._unwatch_handle(speech_handle):
                     suspended_handles.append(speech_handle)
-                for task in blocked_tasks:
-                    if run_state._unwatch_handle(task):
-                        suspended_handles.append(task)
+                for blocked in [*blocked_tasks, *session._foreground_guards]:
+                    if run_state._unwatch_handle(blocked):
+                        suspended_handles.append(blocked)
                 if suspended_handles:
                     run_state._mark_done_if_needed(None)
         except Exception:

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -679,6 +679,8 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         self._idle_released.set()
 
         self._global_run_state: RunResult | None = None
+        # guards keeping an active run open across `_wait_for_idle_and_hold` scopes
+        self._foreground_guards: set[asyncio.Future[None]] = set()
         # TODO(theomonnom): need a better way to expose early assistant metrics
         self._early_assistant_metrics: MetricsReport | None = None
 
@@ -1605,20 +1607,39 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
     @asynccontextmanager
     async def _wait_for_idle_and_hold(self) -> AsyncIterator[AgentActivity]:
-        """Wait for idle, then block other ``wait_for_idle`` callers until exit."""
+        """Wait for idle, then block other ``wait_for_idle`` callers until exit.
+
+        An active run is guarded for the whole scope, since reaching idle is itself what
+        completes the run: without the guard, whatever the scope does next lands after
+        ``run()`` returned and goes unrecorded.
+        """
         from .agent_activity import _IdleHoldContextVar
 
-        activity = await self.wait_for_idle()
-        self._idle_holds += 1
-        self._idle_released.clear()
-        token = _IdleHoldContextVar.set(True)
+        # registered before the wait below, which is what lets the run complete
+        guard: asyncio.Future[None] | None = None
+        if (run_state := self._global_run_state) is not None and not run_state.done():
+            guard = asyncio.get_running_loop().create_future()
+            run_state._watch_handle(guard)
+            self._foreground_guards.add(guard)
+
         try:
-            yield activity
+            activity = await self.wait_for_idle()
+            self._idle_holds += 1
+            self._idle_released.clear()
+            token = _IdleHoldContextVar.set(True)
+            try:
+                yield activity
+            finally:
+                _IdleHoldContextVar.reset(token)
+                self._idle_holds -= 1
+                if self._idle_holds == 0:
+                    self._idle_released.set()
         finally:
-            _IdleHoldContextVar.reset(token)
-            self._idle_holds -= 1
-            if self._idle_holds == 0:
-                self._idle_released.set()
+            if guard is not None:
+                self._foreground_guards.discard(guard)
+                # the run re-checks from the done callback; releasing here rather than on
+                # the way out of the inner block covers a floor that never arrives
+                guard.set_result(None)
 
     async def _update_activity(
         self,

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1606,18 +1606,22 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 continue
 
     @asynccontextmanager
-    async def _wait_for_idle_and_hold(self) -> AsyncIterator[AgentActivity]:
+    async def _wait_for_idle_and_hold(
+        self, *, run_state: RunResult | None = None
+    ) -> AsyncIterator[AgentActivity]:
         """Wait for idle, then block other ``wait_for_idle`` callers until exit.
 
-        An active run is guarded for the whole scope, since reaching idle is itself what
-        completes the run: without the guard, whatever the scope does next lands after
-        ``run()`` returned and goes unrecorded.
+        ``run_state`` is the run that owns the turn of the caller. That run is guarded for
+        the whole scope, since reaching idle is itself what completes the run: without the
+        guard, whatever the scope does next lands after ``run()`` returned and goes
+        unrecorded. A caller whose turn already ended guards nothing, so background work
+        cannot hold a later run open.
         """
         from .agent_activity import _IdleHoldContextVar
 
         # registered before the wait below, which is what lets the run complete
         guard: asyncio.Future[None] | None = None
-        if (run_state := self._global_run_state) is not None and not run_state.done():
+        if run_state is not None and run_state is self._global_run_state and not run_state.done():
             guard = asyncio.get_running_loop().create_future()
             run_state._watch_handle(guard)
             self._foreground_guards.add(guard)

--- a/livekit-agents/livekit/agents/voice/events.py
+++ b/livekit-agents/livekit/agents/voice/events.py
@@ -65,6 +65,10 @@ class RunContext(Generic[Userdata_T]):
         self._executor: _ToolExecutor | None = None
         self._first_update_fut: asyncio.Future[Any] | None = None
 
+        # the run this call belongs to; background work that outlives it must not hold a
+        # later run open
+        self._run_state = session._global_run_state
+
     @property
     def session(self) -> AgentSession[Userdata_T]:
         return self._session
@@ -159,7 +163,7 @@ class RunContext(Generic[Userdata_T]):
         plays before the floor is held — keeps chat order matching code order.
         """
         await self._drain_pending_reply()
-        async with self._session._wait_for_idle_and_hold() as activity:
+        async with self._session._wait_for_idle_and_hold(run_state=self._run_state) as activity:
             yield activity
 
     async def update(

--- a/livekit-agents/livekit/agents/voice/run_result.py
+++ b/livekit-agents/livekit/agents/voice/run_result.py
@@ -104,7 +104,7 @@ class RunResult(Generic[Run_T]):
         output_options: NotGivenOr[RunOutputOptions | None] = NOT_GIVEN,
         session: AgentSession | None = None,
     ) -> None:
-        self._handles: set[SpeechHandle | asyncio.Task] = set()
+        self._handles: set[SpeechHandle | asyncio.Future[Any]] = set()
 
         if not is_given(output_options):
             output_options = RunOutputOptions()
@@ -215,7 +215,7 @@ class RunResult(Generic[Run_T]):
             index = self._find_insertion_index(created_at=event.item.created_at)
             self._recorded_items.insert(index, event)
 
-    def _watch_handle(self, handle: SpeechHandle | asyncio.Task) -> None:
+    def _watch_handle(self, handle: SpeechHandle | asyncio.Future[Any]) -> None:
         if self._done_fut.done():
             return
 
@@ -226,7 +226,7 @@ class RunResult(Generic[Run_T]):
 
         handle.add_done_callback(self._mark_done_if_needed)
 
-    def _unwatch_handle(self, handle: SpeechHandle | asyncio.Task) -> bool:
+    def _unwatch_handle(self, handle: SpeechHandle | asyncio.Future[Any]) -> bool:
         if handle not in self._handles:
             return False
 
@@ -237,7 +237,7 @@ class RunResult(Generic[Run_T]):
             handle._remove_item_added_callback(self._item_added)
         return True
 
-    def _mark_done_if_needed(self, handle: SpeechHandle | asyncio.Task | None) -> None:
+    def _mark_done_if_needed(self, handle: SpeechHandle | asyncio.Future[Any] | None) -> None:
         if isinstance(handle, SpeechHandle):
             self.__last_speech_handle = handle
 

--- a/tests/test_filler.py
+++ b/tests/test_filler.py
@@ -68,6 +68,7 @@ class _FakeSession:
         self._listeners: dict[str, list[Any]] = {}
         self._idle_event = asyncio.Event()
         self._idle_event.set()  # idle by default
+        self._global_run_state = None  # read by RunContext
 
     def on(self, event: str, callback: Any) -> Any:
         self._listeners.setdefault(event, []).append(callback)

--- a/tests/test_foreground_run_tracking.py
+++ b/tests/test_foreground_run_tracking.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from livekit.agents import Agent, AgentSession, AgentTask, RunContext, function_tool
+from livekit.agents.llm import FunctionToolCall
+
+from .fake_llm import FakeLLM, FakeLLMResponse
+
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
+
+
+class Forwarded(Agent):
+    """The agent handed to, speaking from on_enter after the handoff."""
+
+    def __init__(self) -> None:
+        super().__init__(instructions="forwarded agent")
+
+    async def on_enter(self) -> None:
+        await self.session.generate_reply(instructions="forwarded_greeting")
+
+
+class Router(Agent):
+    def __init__(self) -> None:
+        super().__init__(instructions="router agent")
+
+    @function_tool
+    async def forward(self, ctx: RunContext) -> None:
+        """Hand off to the forwarded agent while holding the floor."""
+        # the update goes non-blocking, so the handoff below runs after the turn ended
+        await ctx.update("")
+        forward_agent = Forwarded()
+        async with ctx.foreground():
+            ctx.session.update_agent(forward_agent)
+
+
+class BackgroundWorker(Agent):
+    """Answers early, then keeps working for far longer than a run should last."""
+
+    def __init__(self) -> None:
+        super().__init__(instructions="background worker")
+        self.cancelled = False
+
+    @function_tool
+    async def slow_job(self, ctx: RunContext) -> None:
+        """Report progress, then keep working in the background."""
+        await ctx.update("working on it")
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+
+
+class AskNameTask(AgentTask[None]):
+    """A task that needs a future user turn to complete."""
+
+    def __init__(self) -> None:
+        super().__init__(instructions="ask name task")
+
+    async def on_enter(self) -> None:
+        await self.session.generate_reply(instructions="ask_name")
+
+    @function_tool
+    async def record_name(self, ctx: RunContext, name: str) -> str:
+        """Called when the user provides their name."""
+        self.complete(None)
+        return "recorded"
+
+
+class Surveyor(Agent):
+    def __init__(self) -> None:
+        super().__init__(instructions="surveyor agent")
+
+    @function_tool
+    async def start_survey(self, ctx: RunContext) -> None:
+        """Called when the user is ready to start the survey."""
+        async with ctx.foreground():
+            await AskNameTask()
+
+
+def _router_llm() -> FakeLLM:
+    return FakeLLM(
+        fake_responses=[
+            FakeLLMResponse(
+                input="go",
+                content="",
+                ttft=0.1,
+                duration=0.1,
+                tool_calls=[FunctionToolCall(name="forward", arguments="{}", call_id="call_1")],
+            ),
+            FakeLLMResponse(
+                input="forwarded_greeting", content="here is a joke", ttft=0.1, duration=0.1
+            ),
+        ]
+    )
+
+
+async def test_handoff_inside_foreground_after_going_non_blocking() -> None:
+    """A tool that hands off inside ``ctx.foreground()`` must still have the new agent's
+    on_enter reply recorded on the same RunResult.
+
+    ``ctx.foreground()`` waits for the activity to go idle, and going idle is what
+    completes the run. Without a guard, the handoff and everything it triggers land
+    after ``run()`` returned, and under the test framework the session closes first.
+    """
+    async with AgentSession(llm=_router_llm()) as sess:
+        await sess.start(Router())
+
+        result = await asyncio.wait_for(sess.run(user_input="go"), timeout=5.0)
+
+        kinds = [type(e).__name__ for e in result.events]
+        assert "ChatMessageEvent" in kinds, (
+            f"the forwarded agent's reply never reached the run; got {kinds}"
+        )
+
+
+async def test_handoff_inside_foreground_event_sequence() -> None:
+    """The same case asserted positionally, the way the testing guide shows."""
+    async with AgentSession(llm=_router_llm()) as sess:
+        await sess.start(Router())
+
+        result = await asyncio.wait_for(sess.run(user_input="go"), timeout=5.0)
+
+        result.expect.next_event().is_function_call(name="forward")
+        result.expect.next_event().is_function_call_output()
+        result.expect.next_event().is_agent_handoff(new_agent_type=Forwarded)
+        result.expect.next_event().is_message(role="assistant")
+
+
+async def test_background_tool_does_not_hold_the_run_open() -> None:
+    """``ctx.update()`` is also how a tool answers early and keeps working. Those tools
+    never take the floor, so they must not delay the run at all."""
+    llm = FakeLLM(
+        fake_responses=[
+            FakeLLMResponse(
+                input="go",
+                content="",
+                ttft=0.1,
+                duration=0.1,
+                tool_calls=[FunctionToolCall(name="slow_job", arguments="{}", call_id="call_1")],
+            ),
+            FakeLLMResponse(input="", content="ok, working on it", ttft=0.1, duration=0.1),
+        ]
+    )
+    agent = BackgroundWorker()
+    async with AgentSession(llm=llm) as sess:
+        await sess.start(agent)
+
+        loop = asyncio.get_running_loop()
+        started_at = loop.time()
+        result = await asyncio.wait_for(sess.run(user_input="go"), timeout=60.0)
+        elapsed = loop.time() - started_at
+
+        assert "FunctionCallEvent" in [type(e).__name__ for e in result.events]
+        # the tool sleeps for an hour; the run comes back on the turn's own timing
+        assert elapsed < 1.0, f"the background tool held run() open for {elapsed:.2f}s"
+        assert not agent.cancelled
+
+
+async def test_guard_released_when_the_floor_never_arrives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``wait_for_idle`` raises when the activity closes under a handoff. The guard is
+    registered before that wait, so releasing it has to cover the failure path too."""
+    from livekit.agents.voice.agent_activity import ActivityClosedError
+
+    async def _raise(self: AgentSession) -> None:
+        raise ActivityClosedError("activity closed")
+
+    llm = FakeLLM(
+        fake_responses=[
+            FakeLLMResponse(
+                input="go",
+                content="",
+                ttft=0.1,
+                duration=0.1,
+                tool_calls=[FunctionToolCall(name="forward", arguments="{}", call_id="call_1")],
+            ),
+            FakeLLMResponse(input="", content="ok", ttft=0.1, duration=0.1),
+        ]
+    )
+    async with AgentSession(llm=llm) as sess:
+        await sess.start(Router())
+        monkeypatch.setattr(AgentSession, "wait_for_idle", _raise)
+
+        # the tool raises out of ctx.foreground(); the run still has to come back
+        await asyncio.wait_for(sess.run(user_input="go"), timeout=5.0)
+
+
+async def test_agent_task_inside_foreground_does_not_deadlock() -> None:
+    """A foregrounded AgentTask that needs another user turn must not stall the run:
+    ``run()`` has to return before that turn can arrive."""
+    llm = FakeLLM(
+        fake_responses=[
+            FakeLLMResponse(
+                input="ready",
+                content="",
+                ttft=0.1,
+                duration=0.1,
+                tool_calls=[
+                    FunctionToolCall(name="start_survey", arguments="{}", call_id="call_1")
+                ],
+            ),
+            FakeLLMResponse(input="ask_name", content="what is your name?", ttft=0.1, duration=0.1),
+            FakeLLMResponse(
+                input="Bob",
+                content="",
+                ttft=0.1,
+                duration=0.1,
+                tool_calls=[
+                    FunctionToolCall(
+                        name="record_name", arguments='{"name": "Bob"}', call_id="call_2"
+                    )
+                ],
+            ),
+        ]
+    )
+    async with AgentSession(llm=llm) as sess:
+        await sess.start(Surveyor())
+
+        await asyncio.wait_for(sess.run(user_input="ready"), timeout=5.0)
+
+        second_result = await asyncio.wait_for(sess.run(user_input="Bob"), timeout=5.0)
+        second_result.expect.contains_function_call(name="record_name")

--- a/tests/test_foreground_run_tracking.py
+++ b/tests/test_foreground_run_tracking.py
@@ -80,6 +80,18 @@ class Surveyor(Agent):
         async with ctx.foreground():
             await AskNameTask()
 
+    @function_tool
+    async def ask_over_speech(self, ctx: RunContext) -> None:
+        """Called when the user wants the survey read out first."""
+        async with ctx.foreground():
+            await self.session.generate_reply(instructions="ask_via_tool")
+
+    @function_tool
+    async def collect_name(self, ctx: RunContext) -> str:
+        """Called when the name is needed."""
+        await AskNameTask()
+        return "collected"
+
 
 def _router_llm() -> FakeLLM:
     return FakeLLM(
@@ -225,3 +237,40 @@ async def test_agent_task_inside_foreground_does_not_deadlock() -> None:
 
         second_result = await asyncio.wait_for(sess.run(user_input="Bob"), timeout=5.0)
         second_result.expect.contains_function_call(name="record_name")
+
+
+async def test_agent_task_under_a_foregrounded_reply_does_not_deadlock() -> None:
+    """The same circular wait one level deeper: the foreground scope holds a
+    ``generate_reply``, and a tool of that reply awaits the task.
+
+    Only the deadlock is asserted. Whether the task survives to the next turn is a
+    separate question, and it behaves the same way with or without the guard.
+    """
+    llm = FakeLLM(
+        fake_responses=[
+            FakeLLMResponse(
+                input="ready",
+                content="",
+                ttft=0.1,
+                duration=0.1,
+                tool_calls=[
+                    FunctionToolCall(name="ask_over_speech", arguments="{}", call_id="call_1")
+                ],
+            ),
+            FakeLLMResponse(
+                input="ask_via_tool",
+                content="",
+                ttft=0.1,
+                duration=0.1,
+                tool_calls=[
+                    FunctionToolCall(name="collect_name", arguments="{}", call_id="call_2")
+                ],
+            ),
+            FakeLLMResponse(input="ask_name", content="what is your name?", ttft=0.1, duration=0.1),
+            FakeLLMResponse(input="collected", content="all done", ttft=0.1, duration=0.1),
+        ]
+    )
+    async with AgentSession(llm=llm) as sess:
+        await sess.start(Surveyor())
+
+        await asyncio.wait_for(sess.run(user_input="ready"), timeout=5.0)

--- a/tests/test_foreground_run_tracking.py
+++ b/tests/test_foreground_run_tracking.py
@@ -54,6 +54,24 @@ class BackgroundWorker(Agent):
             raise
 
 
+class LateFloorWorker(Agent):
+    """Answers early, then asks for the floor long after its own run ended."""
+
+    HOLD = 5.0
+
+    def __init__(self) -> None:
+        super().__init__(instructions="late floor worker")
+        self.resume = asyncio.Event()
+
+    @function_tool
+    async def slow_job(self, ctx: RunContext) -> None:
+        """Report progress, then take the floor much later."""
+        await ctx.update("working on it")
+        await self.resume.wait()
+        async with ctx.foreground():
+            await asyncio.sleep(self.HOLD)
+
+
 class AskNameTask(AgentTask[None]):
     """A task that needs a future user turn to complete."""
 
@@ -200,6 +218,42 @@ async def test_guard_released_when_the_floor_never_arrives(
 
         # the tool raises out of ctx.foreground(); the run still has to come back
         await asyncio.wait_for(sess.run(user_input="go"), timeout=5.0)
+
+
+async def test_stale_foreground_scope_does_not_hold_a_later_run() -> None:
+    """A tool that takes the floor after its own run ended must not gate the next run.
+
+    The guard belongs to the run that owns the turn of the tool. A later run is a
+    different run, so it gets no guard and keeps its own timing.
+    """
+    llm = FakeLLM(
+        fake_responses=[
+            FakeLLMResponse(
+                input="go",
+                content="",
+                ttft=0.1,
+                duration=0.1,
+                tool_calls=[FunctionToolCall(name="slow_job", arguments="{}", call_id="call_1")],
+            ),
+            FakeLLMResponse(input="", content="ok, working on it", ttft=0.1, duration=0.1),
+            FakeLLMResponse(input="second", content="hello again", ttft=0.1, duration=0.1),
+        ]
+    )
+    agent = LateFloorWorker()
+    async with AgentSession(llm=llm) as sess:
+        await sess.start(agent)
+
+        await asyncio.wait_for(sess.run(user_input="go"), timeout=5.0)
+
+        second_run = sess.run(user_input="second")
+        agent.resume.set()  # the tool of the finished run now asks for the floor
+
+        loop = asyncio.get_running_loop()
+        started_at = loop.time()
+        await asyncio.wait_for(second_run, timeout=60.0)
+        elapsed = loop.time() - started_at
+
+        assert elapsed < agent.HOLD, f"the second run was held open for {elapsed:.2f}s"
 
 
 async def test_agent_task_inside_foreground_does_not_deadlock() -> None:


### PR DESCRIPTION
Fixes livekit/agents#6658

## The bug

Under `session.run()`, a tool that calls `update_agent()` inside `ctx.foreground()` records no handoff and nothing after it.

`ctx.foreground()` waits for the activity to become idle. The activity becomes idle only after the speech handle of the turn completes, and that same completion ends the `RunResult`. The run finishes while the tool still waits for the floor. `update_agent()` then finds a run that is already done, so `_watch_handle` does nothing.

## The fix

* `_wait_for_idle_and_hold` registers a guard on the active run before it waits for the floor, and releases it on exit. A run cannot complete while a tool waits for the floor or holds it.
* `AgentTask` suspends that guard with the blocked tasks it already suspends. Without this step, `await AgentTask()` inside `ctx.foreground()` deadlocks. The run waits for the guard, the guard waits for the task, and the task waits for a user turn. That turn only arrives after `run()` returns.
* `_watch_handle` and the methods next to it accept `asyncio.Future`. `asyncio.Task` is a subclass of `Future`, so every current caller stays valid.

## Scope

A tool that returns early with `ctx.update()` and then works in the background never takes the floor. It gets no guard, so the run keeps its own timing.

A tool that returns early, waits, and then takes the floor much later is still not recorded. Nothing holds the floor in that window, and the later work belongs to a new turn.