### PR TITLE
Feat/anam support ai disclosure

### DIFF
--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/api.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/api.py
@@ -125,7 +125,9 @@ class AnamAPI:
         if session_options is not None and session_options.show_ai_avatar_disclosure is not None:
             if "sessionOptions" not in payload:
                 payload["sessionOptions"] = {}
-            payload["sessionOptions"]["showAIAvatarDisclosure"] = session_options.show_ai_avatar_disclosure
+            payload["sessionOptions"]["showAIAvatarDisclosure"] = (
+                session_options.show_ai_avatar_disclosure
+            )
 
         headers = {
             "Authorization": f"Bearer {self._api_key}",  # Use API Key here

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/api.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/api.py
@@ -120,6 +120,7 @@ class AnamAPI:
             payload["sessionOptions"] = {
                 "videoWidth": session_options.video_width,
                 "videoHeight": session_options.video_height,
+                "showAIAvatarDisclosure": session_options.show_ai_avatar_disclosure,
             }
 
         headers = {

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/api.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/api.py
@@ -120,8 +120,12 @@ class AnamAPI:
             payload["sessionOptions"] = {
                 "videoWidth": session_options.video_width,
                 "videoHeight": session_options.video_height,
-                "showAIAvatarDisclosure": session_options.show_ai_avatar_disclosure,
             }
+
+        if session_options is not None and session_options.show_ai_avatar_disclosure is not None:
+            if "sessionOptions" not in payload:
+                payload["sessionOptions"] = {}
+            payload["sessionOptions"]["showAIAvatarDisclosure"] = session_options.show_ai_avatar_disclosure
 
         headers = {
             "Authorization": f"Bearer {self._api_key}",  # Use API Key here

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
@@ -56,7 +56,9 @@ class SessionOptions:
             validated by Anam; an unsupported pair is rejected with an HTTP 400
             rather than silently downgraded.
         video_height: Output video frame height in pixels. See ``video_width``.
+        show_ai_avatar_disclosure: Whether to show an AI avatar disclosure watermark, default off.
     """
 
     video_width: int | None = None
     video_height: int | None = None
+    show_ai_avatar_disclosure: bool | None = None

--- a/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
+++ b/livekit-plugins/livekit-plugins-anam/livekit/plugins/anam/types.py
@@ -56,7 +56,9 @@ class SessionOptions:
             validated by Anam; an unsupported pair is rejected with an HTTP 400
             rather than silently downgraded.
         video_height: Output video frame height in pixels. See ``video_width``.
-        show_ai_avatar_disclosure: Whether to show an AI avatar disclosure watermark, default off.
+        show_ai_avatar_disclosure: Anam's default is not to render an AI avatar
+            disclosure watermark. Set to ``True`` to have Anam disclose that the
+            video contains an AI avatar via a watermark.
     """
 
     video_width: int | None = None


### PR DESCRIPTION
What
Adds support for an optional burnt in watermark to disclose the AI avatar

Why
To help users support article 50 of the EU AI act they can optionally display a watermark on their AI avatar.

Design
Resilient to omitted/None values - falls back to Anam defaults (off)
Validated on the Anam side