### PR TITLE
fix(exceptions): name the underlying cause when an LLM/TTS/STT connection fails

### DIFF
--- a/livekit-agents/livekit/agents/_exceptions.py
+++ b/livekit-agents/livekit/agents/_exceptions.py
@@ -112,6 +112,29 @@ class APIConnectionError(APIError):
     def __init__(self, message: str = "Connection error.", *, retryable: bool = True) -> None:
         super().__init__(message, body=None, retryable=retryable)
 
+    def __str__(self) -> str:
+        # `raise ... from e` sets __cause__ after __init__, so the chain is unreachable at
+        # construction and must be read here. The default message carries no detail, and
+        # providers wrap transport failures behind placeholder messages of their own, so the
+        # root of the chain is the only place the actual failure is named.
+        root = self.__cause__
+        for _ in range(10):
+            if root is None or root.__cause__ is None or root.__cause__ is root:
+                break
+            root = root.__cause__
+
+        if root is None:
+            return self.message
+
+        # a third-party __str__ may raise (e.g. aiohttp.ClientConnectorError on a partially
+        # initialized connection key); the type name alone still beats losing the message.
+        try:
+            detail = f"{type(root).__name__}: {root}"
+        except Exception:
+            detail = type(root).__name__
+
+        return f"{self.message} (caused by {detail})"
+
 
 class APITimeoutError(APIConnectionError):
     """Raised when an API request timed out."""

--- a/livekit-agents/livekit/agents/_exceptions.py
+++ b/livekit-agents/livekit/agents/_exceptions.py
@@ -117,11 +117,14 @@ class APIConnectionError(APIError):
         # construction and must be read here. The default message carries no detail, and
         # providers wrap transport failures behind placeholder messages of their own, so the
         # root of the chain is the only place the actual failure is named.
-        # a chain may cycle back on itself, so the walk is bounded by identity, not by depth.
+        # a chain may cycle back on itself, so the walk stops at the first repeated exception
+        # and after 10 distinct ones.
         root: BaseException | None = None
         seen = {id(self)}
         cause = self.__cause__
-        while cause is not None and id(cause) not in seen:
+        for _ in range(10):
+            if cause is None or id(cause) in seen:
+                break
             seen.add(id(cause))
             root = cause
             cause = cause.__cause__

--- a/livekit-agents/livekit/agents/_exceptions.py
+++ b/livekit-agents/livekit/agents/_exceptions.py
@@ -117,21 +117,29 @@ class APIConnectionError(APIError):
         # construction and must be read here. The default message carries no detail, and
         # providers wrap transport failures behind placeholder messages of their own, so the
         # root of the chain is the only place the actual failure is named.
-        root = self.__cause__
-        for _ in range(10):
-            if root is None or root.__cause__ is None or root.__cause__ is root:
-                break
-            root = root.__cause__
+        # a chain may cycle back on itself, so the walk is bounded by identity, not by depth.
+        root: BaseException | None = None
+        seen = {id(self)}
+        cause = self.__cause__
+        while cause is not None and id(cause) not in seen:
+            seen.add(id(cause))
+            root = cause
+            cause = cause.__cause__
 
         if root is None:
             return self.message
 
-        # a third-party __str__ may raise (e.g. aiohttp.ClientConnectorError on a partially
-        # initialized connection key); the type name alone still beats losing the message.
-        try:
-            detail = f"{type(root).__name__}: {root}"
-        except Exception:
-            detail = type(root).__name__
+        # naming our own type by .message keeps a cycle that ends on one out of __str__, which
+        # would otherwise re-enter here through the same chain.
+        if isinstance(root, APIConnectionError):
+            detail = f"{type(root).__name__}: {root.message}"
+        else:
+            # a third-party __str__ may raise (e.g. aiohttp.ClientConnectorError on a partially
+            # initialized connection key); the type name alone still beats losing the message.
+            try:
+                detail = f"{type(root).__name__}: {root}"
+            except Exception:
+                detail = type(root).__name__
 
         return f"{self.message} (caused by {detail})"
 

--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -495,12 +495,7 @@ class LLMStream(llm.LLMStream):
                 retryable=retryable,
             ) from None
         except Exception as e:
-            # openai raises APIConnectionError with a fixed placeholder message and the transport
-            # failure only on __cause__; both must be in the message to survive serialization.
-            message = f"{type(e).__name__}: {e}"
-            if e.__cause__ is not None:
-                message += f" (caused by {type(e.__cause__).__name__}: {e.__cause__})"
-            raise APIConnectionError(message, retryable=retryable) from e
+            raise APIConnectionError(retryable=retryable) from e
 
     def _parse_choice(
         self, id: str, choice: Choice, thinking_filter: llm_utils.ThinkingTokenFilter

--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -495,7 +495,12 @@ class LLMStream(llm.LLMStream):
                 retryable=retryable,
             ) from None
         except Exception as e:
-            raise APIConnectionError(retryable=retryable) from e
+            # openai raises APIConnectionError with a fixed placeholder message and the transport
+            # failure only on __cause__; both must be in the message to survive serialization.
+            message = f"{type(e).__name__}: {e}"
+            if e.__cause__ is not None:
+                message += f" (caused by {type(e.__cause__).__name__}: {e.__cause__})"
+            raise APIConnectionError(message, retryable=retryable) from e
 
     def _parse_choice(
         self, id: str, choice: Choice, thinking_filter: llm_utils.ThinkingTokenFilter

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,67 @@
+"""Test that APIConnectionError names the underlying failure when stringified,
+which is the only detail available to callers that serialize the error."""
+
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents import APIConnectionError, APITimeoutError
+
+pytestmark = pytest.mark.unit
+
+
+def _wrap(inner: BaseException, err: APIConnectionError | None = None) -> APIConnectionError:
+    """`raise ... from inner` sets __cause__ after construction; assign it the same way."""
+    err = err or APIConnectionError()
+    err.__cause__ = inner
+    return err
+
+
+def test_str_without_cause_is_the_message() -> None:
+    assert str(APIConnectionError()) == "Connection error."
+    assert str(APIConnectionError("failed to connect")) == "failed to connect"
+
+
+def test_str_names_the_cause() -> None:
+    err = _wrap(ValueError("payload is not completed"))
+    assert str(err) == "Connection error. (caused by ValueError: payload is not completed)"
+
+
+def test_str_reports_the_root_of_the_chain() -> None:
+    """Providers wrap transport failures behind a placeholder message of their own."""
+    root = OSError("peer closed connection")
+    middle = RuntimeError("Connection error.")
+    middle.__cause__ = root
+
+    assert "OSError: peer closed connection" in str(_wrap(middle))
+
+
+def test_str_survives_a_cause_whose_str_raises() -> None:
+    class Hostile(Exception):
+        def __str__(self) -> str:
+            raise RuntimeError("nope")
+
+    assert str(_wrap(Hostile())) == "Connection error. (caused by Hostile)"
+
+
+def test_str_terminates_on_a_cyclic_chain() -> None:
+    a, b = ValueError("a"), ValueError("b")
+    a.__cause__, b.__cause__ = b, a
+
+    assert "ValueError" in str(_wrap(a))
+
+
+def test_timeout_subclass_keeps_its_own_message() -> None:
+    err = _wrap(TimeoutError(), APITimeoutError())
+    assert str(err).startswith("Request timed out. (caused by TimeoutError")
+
+
+def test_raise_from_populates_the_message() -> None:
+    """The real statement used at every wrap site."""
+    with pytest.raises(APIConnectionError) as exc_info:
+        try:
+            raise OSError("connection reset by peer")
+        except OSError as e:
+            raise APIConnectionError(retryable=False) from e
+
+    assert str(exc_info.value) == "Connection error. (caused by OSError: connection reset by peer)"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -51,6 +51,31 @@ def test_str_terminates_on_a_cyclic_chain() -> None:
     assert "ValueError" in str(_wrap(a))
 
 
+def test_str_terminates_when_the_error_causes_itself() -> None:
+    err = APIConnectionError("failed to connect")
+    err.__cause__ = err
+
+    assert str(err) == "failed to connect"
+
+
+def test_str_terminates_on_a_cycle_between_two_connection_errors() -> None:
+    outer, inner = APIConnectionError("outer"), APIConnectionError("inner")
+    outer.__cause__, inner.__cause__ = inner, outer
+
+    assert str(outer) == "outer (caused by APIConnectionError: inner)"
+
+
+def test_str_reports_the_root_of_a_chain_deeper_than_ten() -> None:
+    """A depth bound would leave intermediate wrappers in the message."""
+    root: BaseException = OSError("peer closed connection")
+    for i in range(20):
+        wrapper = APIConnectionError(f"wrapped {i}")
+        wrapper.__cause__ = root
+        root = wrapper
+
+    assert str(_wrap(root)) == "Connection error. (caused by OSError: peer closed connection)"
+
+
 def test_timeout_subclass_keeps_its_own_message() -> None:
     err = _wrap(TimeoutError(), APITimeoutError())
     assert str(err).startswith("Request timed out. (caused by TimeoutError")

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -65,15 +65,15 @@ def test_str_terminates_on_a_cycle_between_two_connection_errors() -> None:
     assert str(outer) == "outer (caused by APIConnectionError: inner)"
 
 
-def test_str_reports_the_root_of_a_chain_deeper_than_ten() -> None:
-    """A depth bound would leave intermediate wrappers in the message."""
+def test_str_stops_after_ten_distinct_causes() -> None:
+    """The 10th is named on its own; nothing deeper is walked or nested into the message."""
     root: BaseException = OSError("peer closed connection")
     for i in range(20):
         wrapper = APIConnectionError(f"wrapped {i}")
         wrapper.__cause__ = root
         root = wrapper
 
-    assert str(_wrap(root)) == "Connection error. (caused by OSError: peer closed connection)"
+    assert str(_wrap(root)) == "Connection error. (caused by APIConnectionError: wrapped 10)"
 
 
 def test_timeout_subclass_keeps_its_own_message() -> None:


### PR DESCRIPTION
## Problem

When an LLM, TTS, or STT stream fails, the only thing that reaches the caller is the string `Connection error.` — no exception type, no transport detail, no way to tell a dead socket apart from a bug in our own chunk parsing.

This surfaced in an agent simulation, where a job failed with:

```
Agent error on turn 7: session request run_input failed: Connection error.
```

The agent had completed both of its tool calls for that turn and was streaming the final reply. The message was committed to chat history truncated mid-sentence ("...vegetarian risotto, as well"), the stream then raised, and everything about *why* was gone.

## Root cause

Two things compound:

1. Providers hide the real failure behind a placeholder message. `openai` raises its own `APIConnectionError` as `APIConnectionError(request=request) from err` (`_base_client`, openai 2.46.0), whose message is the hardcoded default `"Connection error."`; the transport failure is only reachable via `__cause__`.
2. Our plugins then wrap that with `raise APIConnectionError() from e` — no message at all.

`from e` preserves the cause for a local traceback, but any consumer that stringifies the error loses it. That includes the simulation transport, which sends `str(e)` over a process boundary:

https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/voice/remote_session.py#L746-L751

and every `logger.error(..., str(e))` / `extra={"error": str(e)}` call in `voice/agent_activity.py`, which is where TTS and STT failures surface.

## Why this is fixed centrally

The bare-wrap pattern appears at **64 call sites** across LLM, TTS, and STT:

```
$ grep -rnE "raise APIConnectionError\((retryable=[a-zA-Z_]+)?\) from " livekit-agents livekit-plugins | wc -l
64
```

Two constraints rule out fixing them individually:

- `raise ... from e` sets `__cause__` *after* `__init__` returns, so no constructor argument can see it. `__str__` is the only place the chain is readable.
- Passing `str(e)` at each site would not have worked anyway — per (1) above, that string is still literally `"Connection error."`. The chain has to be walked to its root.

So `APIConnectionError.__str__` walks to the root cause and names it. All 64 sites are fixed without touching any of them, and `APITimeoutError` inherits it. `APIStatusError` is untouched — it already carries real messages.

## Verification

Real exception shapes from each subsystem, all through the unmodified call sites:

| Subsystem | Before | After |
|---|---|---|
| LLM mid-stream drop (`inference/llm.py`, openai double-wrap) | `Connection error.` | `Connection error. (caused by RemoteProtocolError: peer closed connection without sending complete message body)` |
| TTS connector failure (`inference/tts.py`) | `Connection error.` | `Connection error. (caused by ClientConnectorError: Cannot connect to host localhost:17770 ssl:default [Connection refused])` |
| STT truncated payload (`deepgram/stt.py`) | `Connection error.` | `Connection error. (caused by ClientPayloadError: Response payload is not completed)` |
| a parser bug, not the network | `Connection error.` | `Connection error. (caused by AttributeError: 'NoneType' object has no attribute 'index')` |

The last row is the one that matters most: a bug in our own chunk parsing and a dead socket were previously indistinguishable.

Two edge cases are handled because both are reachable in practice:

- **A cause whose `__str__` raises.** `aiohttp.ClientConnectorError.__str__` raises `AttributeError` when its connection key is partially initialized. An exception whose `__str__` explodes would destroy every log line that touches it, so the format falls back to the type name alone.
- **A cyclic `__cause__` chain**, which would otherwise hang the walk.

`ruff format --check`, `ruff check`, and `mypy` are clean on the changed files. Full unit suite: 1731 passed, 4 skipped.

Note for reviewers: the shared venv resolves `livekit.agents` to the primary checkout, so these runs need `PYTHONPATH=$PWD/livekit-agents` to exercise the branch rather than `main`.

## Cross-SDK parity

agents-js already propagates the underlying message (`toError(error).message`) at `agents/src/inference/llm.ts`, so no JS change is needed for the LLM path. Its TTS/STT plugins were not audited for the same pattern; worth a separate look.
