### PR TITLE
fix(inference): keep a stream retryable until it emits generation

### DIFF
--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -465,11 +465,16 @@ class LLMStream(llm.LLMStream):
                     for choice in chunk.choices:
                         chat_chunk = self._parse_choice(chunk.id, choice, thinking_filter)
                         if chat_chunk is not None:
-                            retryable = False
+                            # only generation makes a retry duplicate what the caller
+                            # already saw; provider metadata (a gateway deployment
+                            # stamp, a thought signature) is not output
+                            if chat_chunk.delta and (
+                                chat_chunk.delta.content or chat_chunk.delta.tool_calls
+                            ):
+                                retryable = False
                             self._event_ch.send_nowait(chat_chunk)
 
                     if chunk.usage is not None:
-                        retryable = False
                         tokens_details = chunk.usage.prompt_tokens_details
                         cached_tokens = tokens_details.cached_tokens if tokens_details else 0
                         usage_chunk = llm.ChatChunk(

--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -465,7 +465,7 @@ class LLMStream(llm.LLMStream):
                     for choice in chunk.choices:
                         chat_chunk = self._parse_choice(chunk.id, choice, thinking_filter)
                         if chat_chunk is not None:
-                            if chat_chunk.carries_generation():
+                            if chat_chunk.has_response():
                                 retryable = False
                             self._event_ch.send_nowait(chat_chunk)
 

--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -491,6 +491,10 @@ class LLMStream(llm.LLMStream):
 
         except openai.APITimeoutError:
             raise APITimeoutError(retryable=retryable) from None
+        except httpx.TimeoutException as e:
+            # Only the request call runs inside the openai client's error mapping, so a
+            # timeout waiting on the stream body arrives as the raw httpx exception.
+            raise APITimeoutError(retryable=retryable) from e
         except openai.APIStatusError as e:
             raise APIStatusError(
                 e.message,

--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -465,12 +465,7 @@ class LLMStream(llm.LLMStream):
                     for choice in chunk.choices:
                         chat_chunk = self._parse_choice(chunk.id, choice, thinking_filter)
                         if chat_chunk is not None:
-                            # only generation makes a retry duplicate what the caller
-                            # already saw; provider metadata (a gateway deployment
-                            # stamp, a thought signature) is not output
-                            if chat_chunk.delta and (
-                                chat_chunk.delta.content or chat_chunk.delta.tool_calls
-                            ):
+                            if chat_chunk.carries_generation():
                                 retryable = False
                             self._event_ch.send_nowait(chat_chunk)
 

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -81,7 +81,7 @@ class ChatChunk(BaseModel):
     delta: ChoiceDelta | None = None
     usage: CompletionUsage | None = None
 
-    def carries_generation(self) -> bool:
+    def has_response(self) -> bool:
         """Whether this chunk delivered generation the caller can see.
 
         Token counts and provider metadata (a gateway deployment stamp, a thought
@@ -346,7 +346,7 @@ class LLMStream(ABC):
                 self._provider_request_ids.append(request_id)
             # measured against generation, not the first chunk: a retry that follows a
             # contentless chunk would otherwise latch the clock on the failed attempt
-            if ttft == -1.0 and ev.carries_generation():
+            if ttft == -1.0 and ev.has_response():
                 ttft = time.perf_counter() - start_time
                 completion_start_time = datetime.now(timezone.utc).isoformat()
 

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -337,12 +337,16 @@ class LLMStream(ABC):
         response_content = ""
         tool_calls: list[FunctionToolCall] = []
         completion_start_time: str | None = None
+        received_chunk = False
 
         async for ev in event_aiter:
+            received_chunk = True
             request_id = ev.id
             if request_id and request_id not in self._provider_request_ids:
                 self._provider_request_ids.append(request_id)
-            if ttft == -1.0:
+            # measured against generation, not the first chunk: a retry that follows a
+            # contentless chunk would otherwise latch the clock on the failed attempt
+            if ttft == -1.0 and ev.carries_generation():
                 ttft = time.perf_counter() - start_time
                 completion_start_time = datetime.now(timezone.utc).isoformat()
 
@@ -357,8 +361,9 @@ class LLMStream(ABC):
 
         duration = time.perf_counter() - start_time
 
-        # if generation is aborted before any tokens are received, it doesn't make sense to report -1 ttft
-        if self._current_attempt_has_error or ttft < 0:
+        # a request that never yielded a chunk has nothing to report; one that yielded
+        # only metadata still carries token counts, and reports ttft as -1
+        if self._current_attempt_has_error or not received_chunk:
             return
 
         metrics = LLMMetrics(

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -81,6 +81,15 @@ class ChatChunk(BaseModel):
     delta: ChoiceDelta | None = None
     usage: CompletionUsage | None = None
 
+    def carries_generation(self) -> bool:
+        """Whether this chunk delivered generation the caller can see.
+
+        Token counts and provider metadata (a gateway deployment stamp, a thought
+        signature) reach the caller without being output: they neither start the
+        clock on time-to-first-token nor give a retry anything to duplicate.
+        """
+        return bool(self.delta and (self.delta.content or self.delta.tool_calls))
+
 
 class LLMError(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/livekit-agents/livekit/agents/metrics/base.py
+++ b/livekit-agents/livekit/agents/metrics/base.py
@@ -24,6 +24,7 @@ class LLMMetrics(_BaseMetrics):
     timestamp: float
     duration: float
     ttft: float
+    """Time to first generated token in seconds. -1 if the response generated none."""
     cancelled: bool
     completion_tokens: int
     prompt_tokens: int

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -243,7 +243,7 @@ async def _llm_inference_task(
                 if not chunk.delta:
                     continue
 
-                generated = chunk.carries_generation()
+                generated = chunk.has_response()
 
                 if chunk.delta.tool_calls:
                     for tool in chunk.delta.tool_calls:

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -231,18 +231,19 @@ async def _llm_inference_task(
     # forward llm stream to output channels
     try:
         async for chunk in llm_node:
-            if data.ttft is None:
-                data.ttft = time.perf_counter() - start_time
-
             # extract text content from either str or ChatChunk
             content: str | None = None
+            generated = False
 
             if isinstance(chunk, str):
                 content = chunk
+                generated = bool(chunk)
 
             elif isinstance(chunk, ChatChunk):
                 if not chunk.delta:
                     continue
+
+                generated = chunk.carries_generation()
 
                 if chunk.delta.tool_calls:
                     for tool in chunk.delta.tool_calls:
@@ -279,6 +280,9 @@ async def _llm_inference_task(
                     f"LLM node returned an unexpected type: {type(chunk)}",
                 )
                 content = None
+
+            if generated and data.ttft is None:
+                data.ttft = time.perf_counter() - start_time
 
             # route text content to output channels
             if content:

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -484,8 +484,9 @@ class LLMStream(llm.LLMStream):
                 }
                 async for raw_event in self._llm._ws.generate_response(payload):
                     parsed_ev = self._parse_ws_event(raw_event)
-                    self._process_event(parsed_ev)
-                    retryable = False
+                    chunk = self._process_event(parsed_ev)
+                    if chunk is not None and chunk.carries_generation():
+                        retryable = False
 
                 if not self._response_completed:
                     raise APIConnectionError(retryable=True)
@@ -512,8 +513,9 @@ class LLMStream(llm.LLMStream):
 
                 async with stream:
                     async for event in stream:
-                        self._process_event(event)
-                        retryable = False
+                        chunk = self._process_event(event)
+                        if chunk is not None and chunk.carries_generation():
+                            retryable = False
 
             except openai.APITimeoutError:
                 raise APITimeoutError(retryable=retryable)  # noqa: B904
@@ -567,9 +569,10 @@ class LLMStream(llm.LLMStream):
             return ResponseFailedEvent.model_validate(event)
         return None
 
-    def _process_event(self, event: ResponseStreamEvent | None) -> None:
+    def _process_event(self, event: ResponseStreamEvent | None) -> llm.ChatChunk | None:
+        """Handle one stream event, returning the chunk it sent to the caller, if any."""
         if event is None:
-            return
+            return None
         chunk = None
         if isinstance(event, ResponseErrorEvent):
             self._handle_error(event)
@@ -585,6 +588,7 @@ class LLMStream(llm.LLMStream):
             self._handle_response_failed(event)
         if chunk is not None:
             self._event_ch.send_nowait(chunk)
+        return chunk
 
     def _handle_error(self, event: ResponseErrorEvent) -> None:
         error_code = -1

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -485,7 +485,7 @@ class LLMStream(llm.LLMStream):
                 async for raw_event in self._llm._ws.generate_response(payload):
                     parsed_ev = self._parse_ws_event(raw_event)
                     chunk = self._process_event(parsed_ev)
-                    if chunk is not None and chunk.carries_generation():
+                    if chunk is not None and chunk.has_response():
                         retryable = False
 
                 if not self._response_completed:
@@ -514,7 +514,7 @@ class LLMStream(llm.LLMStream):
                 async with stream:
                     async for event in stream:
                         chunk = self._process_event(event)
-                        if chunk is not None and chunk.carries_generation():
+                        if chunk is not None and chunk.has_response():
                             retryable = False
 
             except openai.APITimeoutError:

--- a/tests/test_inference_llm_retry.py
+++ b/tests/test_inference_llm_retry.py
@@ -1,0 +1,116 @@
+"""Retry eligibility of a failed inference LLM stream.
+
+A stream that dies having emitted nothing the caller can see must be retried:
+provider metadata (a gateway deployment stamp, a thought signature) and token
+counts are not generation.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+import httpx
+import openai
+import pytest
+
+from livekit.agents import APIConnectOptions, llm
+from livekit.agents.inference import LLM
+
+pytestmark = pytest.mark.unit
+
+
+def _sse(payload: dict) -> bytes:
+    return f"data: {json.dumps(payload)}\n\n".encode()
+
+
+def _chunk(delta: dict) -> bytes:
+    return _sse(
+        {
+            "id": "chatcmpl-1",
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": "google/gemma-4-31b-it",
+            "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+        }
+    )
+
+
+# The gateway stamps its deployment and billing tier onto the leading delta, which
+# carries no content of its own.
+_METADATA_ONLY = _chunk(
+    {
+        "role": "assistant",
+        "extra_content": {
+            "livekit": {"inference_deployment": "d", "inference_tier_billed": "standard"}
+        },
+    }
+)
+_TEXT = _chunk({"role": "assistant", "content": "hello"})
+
+
+class _StallingStream(httpx.AsyncByteStream):
+    """Yields the given SSE bytes, then stalls out like a provider going quiet."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+        raise httpx.ReadTimeout("stalled mid-stream")
+
+
+def _llm_over(chunks: list[bytes]) -> tuple[LLM, list[httpx.Request]]:
+    attempts: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts.append(request)
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=_StallingStream(chunks),
+        )
+
+    # Long enough to keep PyJWT's short-key warning out of the suite output.
+    fake_secret = "f" * 32
+    llm_model = LLM(model="google/gemma-4-31b-it", api_key=fake_secret, api_secret=fake_secret)
+    llm_model._client = openai.AsyncClient(
+        api_key=fake_secret,
+        base_url="http://inference.test/v1",
+        max_retries=0,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    return llm_model, attempts
+
+
+async def _run(chunks: list[bytes], *, max_retry: int) -> tuple[Exception, list[httpx.Request]]:
+    llm_model, attempts = _llm_over(chunks)
+    chat_ctx = llm.ChatContext.empty()
+    chat_ctx.add_message(role="user", content="hi")
+
+    with pytest.raises(Exception) as exc_info:  # noqa: PT011
+        async with llm_model.chat(
+            chat_ctx=chat_ctx,
+            conn_options=APIConnectOptions(max_retry=max_retry, retry_interval=0.0, timeout=5.0),
+        ) as stream:
+            async for _ in stream:
+                pass
+
+    return exc_info.value, attempts
+
+
+@pytest.mark.asyncio
+async def test_metadata_only_chunk_stays_retryable() -> None:
+    error, attempts = await _run([_METADATA_ONLY], max_retry=2)
+
+    assert len(attempts) == 3, "a stall after metadata alone must exhaust the retries"
+    assert "after 3 attempts" in str(error)
+
+
+@pytest.mark.asyncio
+async def test_generated_text_is_not_retried() -> None:
+    error, attempts = await _run([_METADATA_ONLY, _TEXT], max_retry=2)
+
+    assert len(attempts) == 1, "text already sent to the caller must not be regenerated"
+    assert "after" not in str(error)

--- a/tests/test_inference_llm_retry.py
+++ b/tests/test_inference_llm_retry.py
@@ -1,14 +1,15 @@
-"""Retry eligibility of a failed inference LLM stream.
+"""Retry eligibility, and reported latency, of a failed inference LLM stream.
 
 A stream that dies having emitted nothing the caller can see must be retried:
 provider metadata (a gateway deployment stamp, a thought signature) and token
-counts are not generation.
+counts are not generation. The same line divides the latency the caller actually
+waited from the moment a contentless chunk happened to arrive.
 """
 
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import httpx
 import openai
@@ -16,6 +17,7 @@ import pytest
 
 from livekit.agents import APIConnectOptions, APITimeoutError, llm
 from livekit.agents.inference import LLM
+from livekit.agents.metrics import LLMMetrics
 
 pytestmark = pytest.mark.unit
 
@@ -47,6 +49,36 @@ _METADATA_ONLY = _chunk(
     }
 )
 _TEXT = _chunk({"role": "assistant", "content": "hello"})
+_TOOL_NAME = _chunk(
+    {
+        "role": "assistant",
+        "tool_calls": [
+            {"index": 0, "id": "call_1", "type": "function", "function": {"name": "lookup"}}
+        ],
+    }
+)
+_TOOL_ARGS = _chunk(
+    {"role": "assistant", "tool_calls": [{"index": 0, "function": {"arguments": '{"q":"x"}'}}]}
+)
+_TOOL_DONE = _sse(
+    {
+        "id": "chatcmpl-1",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "google/gemma-4-31b-it",
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+    }
+)
+_USAGE = _sse(
+    {
+        "id": "chatcmpl-1",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "google/gemma-4-31b-it",
+        "choices": [],
+        "usage": {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18},
+    }
+)
 
 
 class _StallingStream(httpx.AsyncByteStream):
@@ -61,15 +93,30 @@ class _StallingStream(httpx.AsyncByteStream):
         raise httpx.ReadTimeout("stalled mid-stream")
 
 
-def _llm_over(chunks: list[bytes]) -> tuple[LLM, list[httpx.Request]]:
+class _CompletedStream(httpx.AsyncByteStream):
+    """Yields the given SSE bytes, then ends the stream cleanly."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+        yield b"data: [DONE]\n\n"
+
+
+def _llm_for(
+    responder: Callable[[int], httpx.AsyncByteStream],
+) -> tuple[LLM, list[httpx.Request], list[LLMMetrics]]:
     attempts: list[httpx.Request] = []
+    metrics: list[LLMMetrics] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         attempts.append(request)
         return httpx.Response(
             200,
             headers={"content-type": "text/event-stream"},
-            stream=_StallingStream(chunks),
+            stream=responder(len(attempts)),
         )
 
     # Long enough to keep PyJWT's short-key warning out of the suite output.
@@ -81,23 +128,41 @@ def _llm_over(chunks: list[bytes]) -> tuple[LLM, list[httpx.Request]]:
         max_retries=0,
         http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
     )
-    return llm_model, attempts
+    llm_model.on("metrics_collected", metrics.append)
+    return llm_model, attempts, metrics
+
+
+def _drain(llm_model: LLM, *, max_retry: int):
+    chat_ctx = llm.ChatContext.empty()
+    chat_ctx.add_message(role="user", content="hi")
+    return llm_model.chat(
+        chat_ctx=chat_ctx,
+        conn_options=APIConnectOptions(max_retry=max_retry, retry_interval=0.0, timeout=5.0),
+    )
 
 
 async def _run(chunks: list[bytes], *, max_retry: int) -> tuple[Exception, list[httpx.Request]]:
-    llm_model, attempts = _llm_over(chunks)
-    chat_ctx = llm.ChatContext.empty()
-    chat_ctx.add_message(role="user", content="hi")
+    llm_model, attempts, _ = _llm_for(lambda _: _StallingStream(chunks))
 
     with pytest.raises(Exception) as exc_info:  # noqa: PT011
-        async with llm_model.chat(
-            chat_ctx=chat_ctx,
-            conn_options=APIConnectOptions(max_retry=max_retry, retry_interval=0.0, timeout=5.0),
-        ) as stream:
+        async with _drain(llm_model, max_retry=max_retry) as stream:
             async for _ in stream:
                 pass
 
     return exc_info.value, attempts
+
+
+async def _run_to_completion(
+    responder: Callable[[int], httpx.AsyncByteStream], *, max_retry: int
+) -> tuple[list[LLMMetrics], list[httpx.Request]]:
+    llm_model, attempts, metrics = _llm_for(responder)
+
+    # aclose() awaits the metrics monitor, so metrics are settled once the block exits
+    async with _drain(llm_model, max_retry=max_retry) as stream:
+        async for _ in stream:
+            pass
+
+    return metrics, attempts
 
 
 @pytest.mark.asyncio
@@ -117,8 +182,55 @@ async def test_generated_text_is_not_retried() -> None:
 
 
 @pytest.mark.asyncio
+async def test_completed_tool_call_is_not_retried() -> None:
+    error, attempts = await _run([_METADATA_ONLY, _TOOL_NAME, _TOOL_ARGS, _TOOL_DONE], max_retry=2)
+
+    assert len(attempts) == 1, "a tool call already sent to the caller must not be re-issued"
+    assert "after" not in str(error)
+
+
+@pytest.mark.asyncio
+async def test_partial_tool_arguments_stay_retryable() -> None:
+    _, attempts = await _run([_METADATA_ONLY, _TOOL_NAME, _TOOL_ARGS], max_retry=2)
+
+    assert len(attempts) == 3, "arguments still streaming have reached nobody"
+
+
+@pytest.mark.asyncio
 async def test_stream_read_timeout_is_a_timeout_error() -> None:
     error, _ = await _run([_TEXT], max_retry=0)
 
     assert isinstance(error, APITimeoutError), "a stalled stream body is a timeout, not a connect"
     assert "timed out" in str(error).lower()
+
+
+@pytest.mark.asyncio
+async def test_ttft_spans_the_retry() -> None:
+    """The clock runs until generation, not until the failed attempt's metadata."""
+
+    def responder(attempt: int) -> httpx.AsyncByteStream:
+        if attempt == 1:
+            return _StallingStream([_METADATA_ONLY])
+        return _CompletedStream([_METADATA_ONLY, _TEXT, _USAGE])
+
+    metrics, attempts = await _run_to_completion(responder, max_retry=2)
+
+    assert len(attempts) == 2
+    assert len(metrics) == 1
+    # the first retry always waits APIConnectOptions._interval_for_retry(0) == 0.1s
+    assert metrics[0].ttft > 0.09, "ttft latched on the failed attempt's metadata chunk"
+    assert metrics[0].ttft <= metrics[0].duration
+
+
+@pytest.mark.asyncio
+async def test_token_counts_survive_a_response_that_generates_nothing() -> None:
+    """Metadata and usage but no output: ttft is unmeasurable, the tokens still are."""
+    metrics, attempts = await _run_to_completion(
+        lambda _: _CompletedStream([_METADATA_ONLY, _USAGE]), max_retry=2
+    )
+
+    assert len(attempts) == 1
+    assert len(metrics) == 1
+    assert metrics[0].ttft == -1
+    assert metrics[0].completion_tokens == 7
+    assert metrics[0].total_tokens == 18

--- a/tests/test_inference_llm_retry.py
+++ b/tests/test_inference_llm_retry.py
@@ -14,7 +14,7 @@ import httpx
 import openai
 import pytest
 
-from livekit.agents import APIConnectOptions, llm
+from livekit.agents import APIConnectOptions, APITimeoutError, llm
 from livekit.agents.inference import LLM
 
 pytestmark = pytest.mark.unit
@@ -114,3 +114,11 @@ async def test_generated_text_is_not_retried() -> None:
 
     assert len(attempts) == 1, "text already sent to the caller must not be regenerated"
     assert "after" not in str(error)
+
+
+@pytest.mark.asyncio
+async def test_stream_read_timeout_is_a_timeout_error() -> None:
+    error, _ = await _run([_TEXT], max_retry=0)
+
+    assert isinstance(error, APITimeoutError), "a stalled stream body is a timeout, not a connect"
+    assert "timed out" in str(error).lower()

--- a/tests/test_plugin_openai_responses.py
+++ b/tests/test_plugin_openai_responses.py
@@ -197,3 +197,86 @@ async def test_create_ws_enables_heartbeat() -> None:
     assert await transport._create_ws(timeout=1.0) is fake_ws
     _, kwargs = session.ws_connect.call_args
     assert kwargs["heartbeat"] == _WS_HEARTBEAT
+
+
+_RESPONSE_CREATED = {
+    "type": "response.created",
+    "sequence_number": 0,
+    "response": {
+        "id": "resp_1",
+        "created_at": 0,
+        "model": "gpt-4.1",
+        "object": "response",
+        "output": [],
+        "parallel_tool_calls": False,
+        "tool_choice": "auto",
+        "tools": [],
+    },
+}
+_TEXT_DELTA = {
+    "type": "response.output_text.delta",
+    "sequence_number": 1,
+    "content_index": 0,
+    "delta": "hello",
+    "item_id": "msg_1",
+    "output_index": 0,
+    "logprobs": [],
+}
+
+
+class _StallingResponsesWS:
+    """Replays raw response frames, then dies the way a socket going quiet does."""
+
+    # read by LLM.provider
+    _base_url = "https://api.openai.com/v1"
+
+    def __init__(self, frames: list[dict]) -> None:
+        self._frames = frames
+        self.attempts = 0
+
+    def generate_response(self, payload: dict):  # noqa: ANN201
+        self.attempts += 1
+        frames = self._frames
+
+        async def _replay():  # noqa: ANN202
+            for frame in frames:
+                yield frame
+            raise ConnectionResetError("stalled mid-stream")
+
+        return _replay()
+
+    async def aclose(self) -> None:
+        pass
+
+
+async def _attempts_until_stall(frames: list[dict], *, max_retry: int) -> int:
+    from livekit.agents import APIConnectOptions, llm as agents_llm
+    from livekit.plugins.openai.responses.llm import LLM as ResponsesLLM
+
+    llm_model = ResponsesLLM(model="gpt-4.1", api_key="test-key")
+    ws = _StallingResponsesWS(frames)
+    llm_model._ws = ws  # type: ignore[assignment]
+
+    chat_ctx = agents_llm.ChatContext.empty()
+    chat_ctx.add_message(role="user", content="hi")
+
+    with pytest.raises(Exception):  # noqa: PT011, B017
+        async with llm_model.chat(
+            chat_ctx=chat_ctx,
+            conn_options=APIConnectOptions(max_retry=max_retry, retry_interval=0.0, timeout=5.0),
+        ) as stream:
+            async for _ in stream:
+                pass
+
+    return ws.attempts
+
+
+async def test_response_created_alone_stays_retryable() -> None:
+    """`response.created` opens every stream and carries no output, so a stall
+    right after it has surfaced nothing a retry could duplicate."""
+    assert await _attempts_until_stall([_RESPONSE_CREATED], max_retry=2) == 3
+
+
+async def test_generated_text_is_not_retried() -> None:
+    """Text already delivered must not be regenerated."""
+    assert await _attempts_until_stall([_RESPONSE_CREATED, _TEXT_DELTA], max_retry=2) == 1


### PR DESCRIPTION
## What

`retryable` was cleared by any chunk reaching the caller, including chunks that carry no output — a usage block, or provider metadata such as the inference gateway's deployment/tier stamp or a Gemini thought signature.

The gateway stamps `extra_content.livekit` onto every delta it forwards, including the leading contentless one, and `_parse_choice` returns a real `ChatChunk` for a delta whose only payload is `extra_content`. So **every streamed response through the gateway went unretryable from its first chunk.** Only failures landing before that first chunk could still recover.

The consequence, from a simulation run: a mid-stream stall past the inter-chunk timeout failed the turn outright, with `partial=''` — nothing generated, nothing a retry could have duplicated, and the caller had heard nothing. Two other turns in the same run stalled identically but *before* their first chunk, retried, and recovered silently (their TTFTs decompose exactly as `10.0s timeout + 0.1s first-retry interval + a fast second attempt`, against a p50 of 0.44s).

## Change

`retryable` is now cleared on text or a tool call — the output a retry would actually repeat. Two commits:

1. The `retryable` guard itself. Also drops the `retryable = False` on the usage chunk: token counts aren't output either. In practice that line rarely mattered (with `include_usage`, usage arrives last, after content has already cleared the flag), but it's the same defect.
2. A `httpx.TimeoutException` clause. Only the request call runs inside the openai client's error mapping, so a timeout waiting on the *stream body* arrived as a raw httpx exception, fell through to the catch-all, and was reported as `APIConnectionError` — which is what made the original failure read as a connection problem. `APITimeoutError` subclasses `APIConnectionError`, so no behavior changes; errors are just named correctly.

## Tests

`tests/test_inference_llm_retry.py` — hermetic, via a mock transport that yields SSE chunks then stalls. The metadata chunk in the fixtures is the literal `extra_content.livekit` payload observed in production.

- a stall after metadata alone exhausts its retries (3 attempts at `max_retry=2`)
- a stall after real text does not retry (1 attempt)
- a stalled stream body surfaces as `APITimeoutError`

Each confirmed failing without its corresponding fix. Full `--unit` suite: 1737 passed.

## Related

A gateway-side stopgap and a TypeScript port are going up alongside this; I'll cross-link them here once they exist.