### PR TITLE
fix(deepgram): use punctuated_word for word-level transcripts

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -882,9 +882,11 @@ def _word_text(word: dict, *, punctuate: bool) -> str:
     honours `punctuate`, so the word list follows the same option to stay consistent with
     the text it belongs to. Falls back to `word` if the key is missing.
     """
-    if punctuate:
-        return word.get("punctuated_word") or word.get("word", "")
-    return word.get("word", "")
+    raw: str = word.get("word", "")
+    if not punctuate:
+        return raw
+    punctuated: str = word.get("punctuated_word") or raw
+    return punctuated
 
 
 def live_transcription_to_speech_data(

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -872,6 +872,17 @@ class SpeechStream(stt.SpeechStream):
             logger.warning("received unexpected message from deepgram %s", data)
 
 
+def _word_text(word: dict) -> str:
+    """Prefer Deepgram's punctuated form so words match SpeechData.text.
+
+    Deepgram returns both `word` (lowercase, unpunctuated) and, when `punctuate` is
+    enabled, `punctuated_word`. `SpeechData.text` comes from `alt["transcript"]`, which is
+    punctuated, so using `word` left the word list disagreeing with the text it belongs to.
+    Falls back to `word` when punctuation is disabled or the key is absent.
+    """
+    return word.get("punctuated_word") or word.get("word", "")
+
+
 def live_transcription_to_speech_data(
     language: str, data: dict, *, is_final: bool, start_time_offset: float
 ) -> list[stt.SpeechData]:
@@ -895,7 +906,7 @@ def live_transcription_to_speech_data(
             speaker_id=f"S{speaker}" if speaker is not None else None,
             words=[
                 TimedString(
-                    text=word.get("word", ""),
+                    text=_word_text(word),
                     start_time=word.get("start", 0) + start_time_offset,
                     end_time=word.get("end", 0) + start_time_offset,
                     start_time_offset=start_time_offset,
@@ -936,7 +947,7 @@ def prerecorded_transcription_to_speech_event(
                 text=alt["transcript"],
                 words=[
                     TimedString(
-                        text=word.get("word", ""),
+                        text=_word_text(word),
                         start_time=word.get("start", 0),
                         end_time=word.get("end", 0),
                     )

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -285,6 +285,7 @@ class STT(stt.STT):
                 return prerecorded_transcription_to_speech_event(
                     config.language,
                     await res.json(),
+                    punctuate=config.punctuate,
                 )
 
         except asyncio.TimeoutError as e:
@@ -826,6 +827,7 @@ class SpeechStream(stt.SpeechStream):
                 data,
                 is_final=is_final_transcript,
                 start_time_offset=self.start_time_offset,
+                punctuate=self._opts.punctuate,
             )
             # If, for some reason, we didn't get a SpeechStarted event but we got
             # a transcript with text, we should start speaking. It's rare but has
@@ -872,19 +874,26 @@ class SpeechStream(stt.SpeechStream):
             logger.warning("received unexpected message from deepgram %s", data)
 
 
-def _word_text(word: dict) -> str:
-    """Prefer Deepgram's punctuated form so words match SpeechData.text.
+def _word_text(word: dict, *, punctuate: bool) -> str:
+    """Return the word form matching what the caller asked Deepgram for.
 
-    Deepgram returns both `word` (lowercase, unpunctuated) and, when `punctuate` is
-    enabled, `punctuated_word`. `SpeechData.text` comes from `alt["transcript"]`, which is
-    punctuated, so using `word` left the word list disagreeing with the text it belongs to.
-    Falls back to `word` when punctuation is disabled or the key is absent.
+    Deepgram returns `word` (lowercase, unpunctuated) and, when `punctuate` is enabled,
+    `punctuated_word` alongside it. `SpeechData.text` comes from `alt["transcript"]`, which
+    honours `punctuate`, so the word list follows the same option to stay consistent with
+    the text it belongs to. Falls back to `word` if the key is missing.
     """
-    return word.get("punctuated_word") or word.get("word", "")
+    if punctuate:
+        return word.get("punctuated_word") or word.get("word", "")
+    return word.get("word", "")
 
 
 def live_transcription_to_speech_data(
-    language: str, data: dict, *, is_final: bool, start_time_offset: float
+    language: str,
+    data: dict,
+    *,
+    is_final: bool,
+    start_time_offset: float,
+    punctuate: bool = True,
 ) -> list[stt.SpeechData]:
     dg_alts = data["channel"]["alternatives"]
 
@@ -906,7 +915,7 @@ def live_transcription_to_speech_data(
             speaker_id=f"S{speaker}" if speaker is not None else None,
             words=[
                 TimedString(
-                    text=_word_text(word),
+                    text=_word_text(word, punctuate=punctuate),
                     start_time=word.get("start", 0) + start_time_offset,
                     end_time=word.get("end", 0) + start_time_offset,
                     start_time_offset=start_time_offset,
@@ -925,6 +934,8 @@ def live_transcription_to_speech_data(
 def prerecorded_transcription_to_speech_event(
     language: str | None,  # language should be None when 'detect_language' is enabled
     data: dict,
+    *,
+    punctuate: bool = True,
 ) -> stt.SpeechEvent:
     # We only support one channel for now
     request_id = data["metadata"]["request_id"]
@@ -947,7 +958,7 @@ def prerecorded_transcription_to_speech_event(
                 text=alt["transcript"],
                 words=[
                     TimedString(
-                        text=_word_text(word),
+                        text=_word_text(word, punctuate=punctuate),
                         start_time=word.get("start", 0),
                         end_time=word.get("end", 0),
                     )

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -285,7 +285,7 @@ class STT(stt.STT):
                 return prerecorded_transcription_to_speech_event(
                     config.language,
                     await res.json(),
-                    punctuate=config.punctuate,
+                    use_punctuated_word=config.punctuate or config.smart_format,
                 )
 
         except asyncio.TimeoutError as e:
@@ -827,7 +827,7 @@ class SpeechStream(stt.SpeechStream):
                 data,
                 is_final=is_final_transcript,
                 start_time_offset=self.start_time_offset,
-                punctuate=self._opts.punctuate,
+                use_punctuated_word=self._opts.punctuate or self._opts.smart_format,
             )
             # If, for some reason, we didn't get a SpeechStarted event but we got
             # a transcript with text, we should start speaking. It's rare but has
@@ -874,16 +874,20 @@ class SpeechStream(stt.SpeechStream):
             logger.warning("received unexpected message from deepgram %s", data)
 
 
-def _word_text(word: dict, *, punctuate: bool) -> str:
-    """Return the word form matching what the caller asked Deepgram for.
+def _word_text(word: dict, *, use_punctuated_word: bool) -> str:
+    """Return the word form matching the transcript the caller asked Deepgram for.
 
-    Deepgram returns `word` (lowercase, unpunctuated) and, when `punctuate` is enabled,
-    `punctuated_word` alongside it. `SpeechData.text` comes from `alt["transcript"]`, which
-    honours `punctuate`, so the word list follows the same option to stay consistent with
-    the text it belongs to. Falls back to `word` if the key is missing.
+    Deepgram returns `word` (lowercase, unpunctuated) and, when the request formats the
+    transcript, `punctuated_word` alongside it. `SpeechData.text` comes from
+    `alt["transcript"]`, so the word list follows the same formatting to stay consistent
+    with the text it belongs to.
+
+    Both `punctuate` and `smart_format` produce a formatted transcript, so callers pass
+    `punctuate or smart_format` rather than either alone. Falls back to `word` if the key
+    is missing, which is what Deepgram sends when neither option is set.
     """
     raw: str = word.get("word", "")
-    if not punctuate:
+    if not use_punctuated_word:
         return raw
     punctuated: str = word.get("punctuated_word") or raw
     return punctuated
@@ -895,7 +899,7 @@ def live_transcription_to_speech_data(
     *,
     is_final: bool,
     start_time_offset: float,
-    punctuate: bool = True,
+    use_punctuated_word: bool = True,
 ) -> list[stt.SpeechData]:
     dg_alts = data["channel"]["alternatives"]
 
@@ -917,7 +921,7 @@ def live_transcription_to_speech_data(
             speaker_id=f"S{speaker}" if speaker is not None else None,
             words=[
                 TimedString(
-                    text=_word_text(word, punctuate=punctuate),
+                    text=_word_text(word, use_punctuated_word=use_punctuated_word),
                     start_time=word.get("start", 0) + start_time_offset,
                     end_time=word.get("end", 0) + start_time_offset,
                     start_time_offset=start_time_offset,
@@ -937,7 +941,7 @@ def prerecorded_transcription_to_speech_event(
     language: str | None,  # language should be None when 'detect_language' is enabled
     data: dict,
     *,
-    punctuate: bool = True,
+    use_punctuated_word: bool = True,
 ) -> stt.SpeechEvent:
     # We only support one channel for now
     request_id = data["metadata"]["request_id"]
@@ -960,7 +964,7 @@ def prerecorded_transcription_to_speech_event(
                 text=alt["transcript"],
                 words=[
                     TimedString(
-                        text=_word_text(word, punctuate=punctuate),
+                        text=_word_text(word, use_punctuated_word=use_punctuated_word),
                         start_time=word.get("start", 0),
                         end_time=word.get("end", 0),
                     )


### PR DESCRIPTION
## Summary

`SpeechData.text` and `SpeechData.words` are built from different Deepgram fields, so the two disagree on the same object.

`text` comes from the transcript, which honours the `punctuate` option. The word list was built from the raw per-word field, which is lowercase and unpunctuated regardless of any option:

```python
text=alt["transcript"],                    # honours `punctuate`
...
words=[
    TimedString(
        text=word.get("word", ""),         # never punctuated
```

Deepgram returns `punctuated_word` alongside `word`, in the very dict that comprehension iterates:

```
keys : ['confidence', 'end', 'punctuated_word', 'start', 'word']
word            : hello my name is alex
punctuated_word : Hello. My name is Alex.
```

Field selection across the four cases:

```python
_word_text({"word": "alex", "punctuated_word": "Alex."}, punctuate=True)   # -> "Alex."
_word_text({"word": "alex"},                             punctuate=True)   # -> "alex"
_word_text({"word": "alex", "punctuated_word": ""},      punctuate=True)   # -> "alex"
_word_text({"word": "alex", "punctuated_word": "Alex."}, punctuate=False)  # -> "alex"
```
