### PR TITLE
feat(baseten): add Qwen3-ASR STT and Qwen3-TTS support, and language_options for Whisper STT

### DIFF
--- a/livekit-plugins/livekit-plugins-baseten/README.md
+++ b/livekit-plugins/livekit-plugins-baseten/README.md
@@ -177,7 +177,8 @@ session = AgentSession(
 ```
 
 Both accept `model_endpoint`, `model_id`, or `chain_id` (same precedence as
-`STT`) and read `BASETEN_API_KEY` from the environment.
+`STT`, falling back to `BASETEN_MODEL_ENDPOINT`) and read `BASETEN_API_KEY`
+from the environment.
 
 ### Qwen3 TTS voices
 

--- a/livekit-plugins/livekit-plugins-baseten/README.md
+++ b/livekit-plugins/livekit-plugins-baseten/README.md
@@ -67,6 +67,7 @@ stt = baseten.STT(
 | `model_id` | — | Baseten truss model ID; auto-constructs the endpoint URL |
 | `chain_id` | — | Baseten chain ID; auto-constructs the endpoint URL |
 | `language` | `"en"` | BCP-47 language code (use `"auto"` for auto-detection) |
+| `language_options` | `[]` | Restrict auto-detection to these codes, e.g. `["en", "de"]`. More reliable than `"auto"` on short telephony utterances. Requires Whisper runtime v0.5.0+ |
 | `encoding` | `"pcm_s16le"` | Audio encoding (`pcm_s16le` or `pcm_mulaw`) |
 | `sample_rate` | `16000` | Audio sample rate in Hz |
 | `enable_partial_transcripts` | `True` | Emit interim transcripts while the speaker is talking |

--- a/livekit-plugins/livekit-plugins-baseten/README.md
+++ b/livekit-plugins/livekit-plugins-baseten/README.md
@@ -153,33 +153,39 @@ tts = baseten.TTS(
 
 ## Qwen3 (STT + TTS)
 
-Baseten also hosts **Qwen3-ASR** and **Qwen3-TTS**, which speak different wire
-protocols from the Whisper/Orpheus trusses above. They have their own classes —
-`baseten.Qwen3STT` and `baseten.Qwen3TTS` — and are not drop-in swaps for
-`baseten.STT` / `baseten.TTS`.
-
-| | `STT` / `TTS` | `Qwen3STT` / `Qwen3TTS` |
-|---|---|---|
-| Models | Whisper Streaming, Orpheus | Qwen3-ASR Streaming, Qwen3-TTS |
-| STT audio | raw binary PCM | base64 `input_audio_buffer.append` |
-| STT results | `message_type` / `transcript` | `type: "transcription"` / `segments[].text` |
-| TTS transport | HTTP or WS with an `__END__` sentinel | `session.config` / `input.text` / `input.done` |
-| TTS voices | preset names (`tara`) | registered voice clones |
+Baseten also hosts **Qwen3-ASR** and **Qwen3-TTS**. They speak different wire
+protocols from the Whisper/Orpheus trusses, so select them with `model` — the
+same `baseten.STT` / `baseten.TTS` classes handle both.
 
 ```python
 from livekit.agents import AgentSession
 from livekit.plugins import baseten
 
 session = AgentSession(
-    stt=baseten.Qwen3STT(model_id="your-qwen3-asr-model-id"),
-    tts=baseten.Qwen3TTS(model_id="your-qwen3-tts-model-id", voice="your-voice"),
+    stt=baseten.STT(model="qwen3-asr", model_id="your-qwen3-asr-model-id"),
+    tts=baseten.TTS(model="qwen3-tts", model_id="your-qwen3-tts-model-id",
+                    voice="your-voice"),
     # llm=...
 )
 ```
 
-Both accept `model_endpoint`, `model_id`, or `chain_id` (same precedence as
-`STT`, falling back to `BASETEN_MODEL_ENDPOINT`) and read `BASETEN_API_KEY`
-from the environment.
+| | `model="whisper"` / `"orpheus"` (default) | `model="qwen3-asr"` / `"qwen3-tts"` |
+|---|---|---|
+| STT audio | raw binary PCM | base64 `input_audio_buffer.append` |
+| STT results | `message_type` / `transcript` | `type: "transcription"` / `segments[].text` |
+| TTS transport | HTTP, or WS with an `__END__` sentinel | `session.config` → `input.text` → `input.done` |
+| TTS voices | preset names (`tara`) | registered voice clones |
+
+Several defaults follow the selected model, matching each deployment's own:
+
+| Parameter | `whisper` / `orpheus` | `qwen3-asr` / `qwen3-tts` |
+|---|---|---|
+| `language` | `en` | `auto` (STT) / `Auto` (TTS) |
+| `partial_transcript_interval_s` | `1.0` | `0.5` |
+| `vad_min_silence_duration_ms` | `300` | `500` |
+| `vad_speech_pad_ms` | `30` | `100` |
+| `show_word_timestamps` | on | off (needs `STREAM_ALIGNER=mms` on the deployment) |
+| `voice` | `tara` | required — a registered clone |
 
 ### Qwen3 TTS voices
 
@@ -187,7 +193,7 @@ Qwen3-TTS Base ships **no built-in speakers** — there is no `tara` equivalent.
 Register a clone from 10–20s of clean speech, then pass its name as `voice`:
 
 ```python
-from livekit.plugins.baseten import register_voice, list_voices
+from livekit.plugins.baseten import list_voices, register_voice
 
 await register_voice(
     model_endpoint="wss://model-{model_id}.api.baseten.co/environments/production/websocket",
@@ -202,23 +208,15 @@ The server stores uploaded voices on the container's local disk, so a voice
 registered at runtime lives on **one replica** and is lost when that container
 restarts. For anything beyond single-replica testing, bake the reference audio
 into the deployment (`REQUIRED_VOICES`) so every replica starts with it, or pass
-`ref_audio`/`ref_text` to `Qwen3TTS` to clone inline on each session.
+`ref_audio`/`ref_text` to clone inline on each session.
 
-### Qwen3 configuration
+### Qwen3-only options
 
-| Parameter | Default | Description |
-|---|---|---|
-| `Qwen3STT.language` | `"auto"` | Qwen3-ASR canonical name (`"English"`, `"Cantonese"`). Forcing a language also sets the *output* language and can translate. |
-| `Qwen3STT.interim_results` | `True` | Emit revisable partials during a turn |
-| `Qwen3STT.partial_transcript_interval_s` | `0.5` | Cadence of partials |
-| `Qwen3STT.vad_*` | `0.5` / `500` / `100` | Server-side Silero VAD endpointing |
-| `Qwen3STT.word_timestamps` | `False` | Needs `STREAM_ALIGNER=mms` on the deployment |
-| `Qwen3TTS.voice` | required | Name of a registered voice clone |
-| `Qwen3TTS.task_type` | `"Base"` | `Base` (cloning), or `CustomVoice`/`VoiceDesign` deployments |
-| `Qwen3TTS.ref_audio` / `ref_text` | — | Clone inline instead of pre-registering |
-| `Qwen3TTS.word_timestamps` | `False` | Word-level aligned transcript |
-| `Qwen3TTS.extra_config` | `{}` | Merged into `session.config` for newer server fields |
-
+`task_type` (`Base` cloning, or `CustomVoice`/`VoiceDesign` deployments),
+`instructions`, `max_new_tokens`, `initial_codec_chunk_frames`,
+`x_vector_only_mode`, `ref_audio`/`ref_text`, and `extra_config` (merged into
+`session.config` for server fields newer than this plugin) apply to
+`model="qwen3-tts"` only.
 
 ## LLM (Large Language Model)
 

--- a/livekit-plugins/livekit-plugins-baseten/README.md
+++ b/livekit-plugins/livekit-plugins-baseten/README.md
@@ -150,6 +150,74 @@ tts = baseten.TTS(
 )
 ```
 
+## Qwen3 (STT + TTS)
+
+Baseten also hosts **Qwen3-ASR** and **Qwen3-TTS**, which speak different wire
+protocols from the Whisper/Orpheus trusses above. They have their own classes —
+`baseten.Qwen3STT` and `baseten.Qwen3TTS` — and are not drop-in swaps for
+`baseten.STT` / `baseten.TTS`.
+
+| | `STT` / `TTS` | `Qwen3STT` / `Qwen3TTS` |
+|---|---|---|
+| Models | Whisper Streaming, Orpheus | Qwen3-ASR Streaming, Qwen3-TTS |
+| STT audio | raw binary PCM | base64 `input_audio_buffer.append` |
+| STT results | `message_type` / `transcript` | `type: "transcription"` / `segments[].text` |
+| TTS transport | HTTP or WS with an `__END__` sentinel | `session.config` / `input.text` / `input.done` |
+| TTS voices | preset names (`tara`) | registered voice clones |
+
+```python
+from livekit.agents import AgentSession
+from livekit.plugins import baseten
+
+session = AgentSession(
+    stt=baseten.Qwen3STT(model_id="your-qwen3-asr-model-id"),
+    tts=baseten.Qwen3TTS(model_id="your-qwen3-tts-model-id", voice="your-voice"),
+    # llm=...
+)
+```
+
+Both accept `model_endpoint`, `model_id`, or `chain_id` (same precedence as
+`STT`) and read `BASETEN_API_KEY` from the environment.
+
+### Qwen3 TTS voices
+
+Qwen3-TTS Base ships **no built-in speakers** — there is no `tara` equivalent.
+Register a clone from 10–20s of clean speech, then pass its name as `voice`:
+
+```python
+from livekit.plugins.baseten import register_voice, list_voices
+
+await register_voice(
+    model_endpoint="wss://model-{model_id}.api.baseten.co/environments/production/websocket",
+    name="my_voice",
+    ref_audio_path="./reference.wav",
+    ref_text="Transcript of the reference audio.",
+)
+await list_voices(model_endpoint=...)  # {"voices": [...], "uploaded_voices": [...]}
+```
+
+The server stores uploaded voices on the container's local disk, so a voice
+registered at runtime lives on **one replica** and is lost when that container
+restarts. For anything beyond single-replica testing, bake the reference audio
+into the deployment (`REQUIRED_VOICES`) so every replica starts with it, or pass
+`ref_audio`/`ref_text` to `Qwen3TTS` to clone inline on each session.
+
+### Qwen3 configuration
+
+| Parameter | Default | Description |
+|---|---|---|
+| `Qwen3STT.language` | `"auto"` | Qwen3-ASR canonical name (`"English"`, `"Cantonese"`). Forcing a language also sets the *output* language and can translate. |
+| `Qwen3STT.interim_results` | `True` | Emit revisable partials during a turn |
+| `Qwen3STT.partial_transcript_interval_s` | `0.5` | Cadence of partials |
+| `Qwen3STT.vad_*` | `0.5` / `500` / `100` | Server-side Silero VAD endpointing |
+| `Qwen3STT.word_timestamps` | `False` | Needs `STREAM_ALIGNER=mms` on the deployment |
+| `Qwen3TTS.voice` | required | Name of a registered voice clone |
+| `Qwen3TTS.task_type` | `"Base"` | `Base` (cloning), or `CustomVoice`/`VoiceDesign` deployments |
+| `Qwen3TTS.ref_audio` / `ref_text` | — | Clone inline instead of pre-registering |
+| `Qwen3TTS.word_timestamps` | `False` | Word-level aligned transcript |
+| `Qwen3TTS.extra_config` | `{}` | Merged into `session.config` for newer server fields |
+
+
 ## LLM (Large Language Model)
 
 The LLM plugin wraps Baseten's OpenAI-compatible inference endpoint.

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/__init__.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/__init__.py
@@ -12,9 +12,8 @@
 
 from .llm import LLM
 from .log import logger
-from .models import LLMModels
-from .qwen3_stt import Qwen3SpeechStream, Qwen3STT
-from .qwen3_tts import Qwen3SynthesizeStream, Qwen3TTS, list_voices, register_voice
+from .models import LLMModels, STTModels, TTSModels
+from .qwen3_tts import list_voices, register_voice
 from .stt import STT, SpeechStream
 from .tts import TTS, SynthesizeStream
 from .version import __version__
@@ -26,13 +25,11 @@ __all__ = [
     "logger",
     "TTS",
     "SynthesizeStream",
-    "Qwen3TTS",
-    "Qwen3SynthesizeStream",
-    "Qwen3STT",
-    "Qwen3SpeechStream",
     "register_voice",
     "list_voices",
     "LLMModels",
+    "STTModels",
+    "TTSModels",
     "__version__",
 ]
 

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/__init__.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/__init__.py
@@ -13,6 +13,8 @@
 from .llm import LLM
 from .log import logger
 from .models import LLMModels
+from .qwen3_stt import Qwen3SpeechStream, Qwen3STT
+from .qwen3_tts import Qwen3SynthesizeStream, Qwen3TTS, list_voices, register_voice
 from .stt import STT, SpeechStream
 from .tts import TTS, SynthesizeStream
 from .version import __version__
@@ -24,6 +26,12 @@ __all__ = [
     "logger",
     "TTS",
     "SynthesizeStream",
+    "Qwen3TTS",
+    "Qwen3SynthesizeStream",
+    "Qwen3STT",
+    "Qwen3SpeechStream",
+    "register_voice",
+    "list_voices",
     "LLMModels",
     "__version__",
 ]

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/_endpoint.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/_endpoint.py
@@ -17,8 +17,12 @@
 from __future__ import annotations
 
 import os
+from urllib.parse import urlparse
+
+from .log import logger
 
 _TRUSS_URL_TEMPLATE = "wss://model-{model_id}.api.baseten.co/environments/production/websocket"
+_LOOPBACK = {"localhost", "127.0.0.1", "::1"}
 _CHAIN_URL_TEMPLATE = "wss://chain-{chain_id}.api.baseten.co/environments/production/websocket"
 
 
@@ -41,5 +45,14 @@ def resolve_endpoint(
         raise ValueError(
             f"This model is served over WebSocket only; got {endpoint!r}. Endpoints "
             "look like wss://model-<id>.api.baseten.co/environments/production/websocket"
+        )
+    if endpoint.startswith("ws://") and urlparse(endpoint).hostname not in _LOOPBACK:
+        # ws:// stays allowed for local proxies and tests, but the API key rides in
+        # an Authorization header and the audio is unencrypted, so plaintext to
+        # anything off-host is worth shouting about.
+        logger.warning(
+            "endpoint %r is plaintext ws://: the Baseten API key and all audio will be "
+            "sent unencrypted. Use wss:// for any non-local host.",
+            endpoint,
         )
     return endpoint

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/_endpoint.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/_endpoint.py
@@ -1,0 +1,45 @@
+# Copyright 2025 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared endpoint resolution for the Qwen3 WebSocket models."""
+
+from __future__ import annotations
+
+import os
+
+_TRUSS_URL_TEMPLATE = "wss://model-{model_id}.api.baseten.co/environments/production/websocket"
+_CHAIN_URL_TEMPLATE = "wss://chain-{chain_id}.api.baseten.co/environments/production/websocket"
+
+
+def resolve_endpoint(
+    model_endpoint: str | None, model_id: str | None, chain_id: str | None, env_var: str
+) -> str:
+    """Resolve a WebSocket endpoint, mirroring `STT`'s precedence rules."""
+    endpoint = model_endpoint
+    if not endpoint and model_id:
+        endpoint = _TRUSS_URL_TEMPLATE.format(model_id=model_id)
+    if not endpoint and chain_id:
+        endpoint = _CHAIN_URL_TEMPLATE.format(chain_id=chain_id)
+    endpoint = endpoint or os.environ.get(env_var)
+    if not endpoint:
+        raise ValueError(
+            f"An endpoint is required: pass model_endpoint, model_id, or chain_id, "
+            f"or set {env_var}."
+        )
+    if not endpoint.startswith(("wss://", "ws://")):
+        raise ValueError(
+            f"This model is served over WebSocket only; got {endpoint!r}. Endpoints "
+            "look like wss://model-<id>.api.baseten.co/environments/production/websocket"
+        )
+    return endpoint

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/_endpoint.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/_endpoint.py
@@ -22,8 +22,11 @@ from urllib.parse import urlparse
 from .log import logger
 
 _TRUSS_URL_TEMPLATE = "wss://model-{model_id}.api.baseten.co/environments/production/websocket"
-_LOOPBACK = {"localhost", "127.0.0.1", "::1"}
 _CHAIN_URL_TEMPLATE = "wss://chain-{chain_id}.api.baseten.co/environments/production/websocket"
+
+# Hosts exempt from the plaintext-ws:// warning below: local proxies and tests
+# legitimately use ws://127.0.0.1, and nothing leaves the machine there.
+_LOOPBACK = {"localhost", "127.0.0.1", "::1"}
 
 
 def resolve_endpoint(

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/models.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/models.py
@@ -9,3 +9,16 @@ LLMModels = Literal[
     "openai/gpt-oss-120b",
     "Qwen/Qwen3-235B-A22B-Instruct-2507",
 ]
+
+# Which wire protocol a deployment speaks. Baseten hosts several model families
+# behind the same WebSocket surface and they are not interchangeable, so the
+# plugin picks an implementation from this rather than sniffing the endpoint.
+STTModels = Literal[
+    "whisper",  # Streaming Whisper truss (raw PCM frames, message_type replies)
+    "qwen3-asr",  # Qwen3-ASR Streaming (OpenAI-realtime frames, transcription replies)
+]
+
+TTSModels = Literal[
+    "orpheus",  # Orpheus truss (HTTP prompt/voice, or WS + __END__ sentinel)
+    "qwen3-tts",  # Qwen3-TTS (session.config / input.text / input.done)
+]

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_stt.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_stt.py
@@ -420,9 +420,10 @@ class Qwen3SpeechStream(stt.SpeechStream):
             words = [
                 TimedString(
                     text=w.get("word", ""),
-                    start_time=float(w.get("start_time", 0.0)),
-                    end_time=float(w.get("end_time", 0.0)),
+                    start_time=float(w.get("start_time", 0.0)) + self.start_time_offset,
+                    end_time=float(w.get("end_time", 0.0)) + self.start_time_offset,
                     confidence=float(w.get("prob", 0.0)),
+                    start_time_offset=self.start_time_offset,
                 )
                 for s in segments
                 for w in (s.get("word_timestamps") or [])
@@ -431,8 +432,12 @@ class Qwen3SpeechStream(stt.SpeechStream):
         return stt.SpeechData(
             language=_language_code(event.get("language_code")),
             text=text,
-            start_time=float(segments[0].get("start_time", 0.0)) if segments else 0.0,
-            end_time=float(segments[-1].get("end_time", 0.0)) if segments else 0.0,
+            # Server times are socket-relative; the framework grows
+            # start_time_offset on every reconnect so consumers see one timeline.
+            start_time=(float(segments[0].get("start_time", 0.0)) if segments else 0.0)
+            + self.start_time_offset,
+            end_time=(float(segments[-1].get("end_time", 0.0)) if segments else 0.0)
+            + self.start_time_offset,
             confidence=1.0,
             words=words,
         )

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_stt.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_stt.py
@@ -111,6 +111,13 @@ class _STTOptions:
 
 
 class Qwen3STT(stt.STT):
+    """Streaming STT for a Baseten-hosted Qwen3-ASR deployment.
+
+    Not interchangeable with `STT`, which targets the streaming-Whisper truss and
+    speaks a different protocol. The server runs Silero VAD, so turns end on
+    their own; an explicit flush commits the buffered audio early.
+    """
+
     def __init__(
         self,
         *,
@@ -128,9 +135,33 @@ class Qwen3STT(stt.STT):
         word_timestamps: bool = False,
         http_session: aiohttp.ClientSession | None = None,
     ) -> None:
-        """`language` is a Qwen3-ASR canonical name ("English", "Cantonese") or
-        "auto". Forcing a language also sets the *output* language, so it can
-        translate — use it only to pin what is actually being spoken.
+        """
+        Args:
+            model_endpoint: Full ``wss://`` URL of the deployment. Takes priority
+                over ``model_id`` and ``chain_id``; falls back to
+                ``BASETEN_MODEL_ENDPOINT``.
+            model_id: Baseten truss model ID; builds the endpoint URL for you.
+            chain_id: Baseten chain ID; builds the endpoint URL for you.
+            api_key: Baseten API key, or ``BASETEN_API_KEY``.
+            language: A Qwen3-ASR canonical language name (``"English"``,
+                ``"Cantonese"``) or ``"auto"``. Forcing a language also sets the
+                *output* language and can translate, so use it only to pin what
+                is actually being spoken.
+            interim_results: Emit revisable partials during a turn. Partials are
+                replace-style: each re-states the whole current hypothesis.
+            partial_transcript_interval_s: Cadence of those partials.
+            final_transcript_max_duration_s: Longest turn before the server
+                forces a final.
+            vad_threshold: Server-side Silero VAD speech probability threshold.
+            vad_min_silence_duration_ms: Silence needed to end a turn.
+            vad_speech_pad_ms: Padding added around detected speech.
+            word_timestamps: Request word-level alignment on finals. Requires
+                ``STREAM_ALIGNER=mms`` and ``STREAM_ALIGNER_DEVICE=cuda`` on the
+                deployment; otherwise the server ignores it.
+            http_session: Optional aiohttp session to reuse.
+
+        Raises:
+            ValueError: If no API key or endpoint can be resolved.
         """
         super().__init__(
             capabilities=stt.STTCapabilities(
@@ -145,7 +176,7 @@ class Qwen3STT(stt.STT):
             raise ValueError("Pass `api_key` or set BASETEN_API_KEY.")
 
         model_endpoint = resolve_endpoint(
-            model_endpoint, model_id, chain_id, "BASETEN_STT_ENDPOINT"
+            model_endpoint, model_id, chain_id, "BASETEN_MODEL_ENDPOINT"
         )
 
         self._api_key = api_key
@@ -238,6 +269,8 @@ class Qwen3STT(stt.STT):
 
 
 class Qwen3SpeechStream(stt.SpeechStream):
+    """A single recognition session: audio frames in, speech events out."""
+
     def __init__(
         self, *, stt: Qwen3STT, opts: _STTOptions, conn_options: APIConnectOptions
     ) -> None:
@@ -273,26 +306,9 @@ class Qwen3SpeechStream(stt.SpeechStream):
                 num_channels=NUM_CHANNELS,
                 samples_per_channel=_SAMPLES_PER_CHUNK,
             )
-            try:
-                async for data in self._input_ch:
-                    if isinstance(data, self._FlushSentinel):
-                        frames = chunker.flush()
-                        commit = True
-                    else:
-                        frames = chunker.write(data.data.tobytes())
-                        commit = False
-                    for frame in frames:
-                        await ws.send_str(
-                            json.dumps(
-                                {
-                                    "type": "input_audio_buffer.append",
-                                    "audio": base64.b64encode(frame.data.tobytes()).decode(),
-                                }
-                            )
-                        )
-                    if commit:
-                        await ws.send_str(json.dumps({"type": "input_audio_buffer.commit"}))
-                for frame in chunker.flush():
+
+            async def append(frames: list[rtc.AudioFrame]) -> None:
+                for frame in frames:
                     await ws.send_str(
                         json.dumps(
                             {
@@ -301,7 +317,24 @@ class Qwen3SpeechStream(stt.SpeechStream):
                             }
                         )
                     )
-                await ws.send_str(json.dumps({"type": "input_audio_buffer.commit"}))
+
+            # `end_input()` pushes a flush sentinel *and then* closes the channel,
+            # so this has to remember whether the last thing it did was commit —
+            # otherwise the trailing commit below doubles it and the server
+            # answers an extra, empty turn.
+            committed = False
+            try:
+                async for data in self._input_ch:
+                    if isinstance(data, self._FlushSentinel):
+                        await append(chunker.flush())
+                        await ws.send_str(json.dumps({"type": "input_audio_buffer.commit"}))
+                        committed = True
+                    else:
+                        await append(chunker.write(data.data.tobytes()))
+                        committed = False
+                if not committed:
+                    await append(chunker.flush())
+                    await ws.send_str(json.dumps({"type": "input_audio_buffer.commit"}))
             finally:
                 input_ended.set()
 

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_stt.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_stt.py
@@ -370,7 +370,11 @@ class Qwen3SpeechStream(stt.SpeechStream):
                 text = " ".join(s.get("text", "") for s in segments).strip()
                 is_final = bool(event.get("is_final"))
 
-                if not speaking and (text or is_final):
+                # Only real words open a turn. An empty final (VAD closed on
+                # noise, recognizer returned nothing) would otherwise emit
+                # START/END_OF_SPEECH and, under turn_detection="stt", commit
+                # the user's turn so the agent answers silence.
+                if not speaking and text:
                     speaking = True
                     self._event_ch.send_nowait(
                         stt.SpeechEvent(type=stt.SpeechEventType.START_OF_SPEECH)

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_stt.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_stt.py
@@ -189,6 +189,7 @@ class _Qwen3Backend:
         language: NotGivenOr[str] = NOT_GIVEN,
         vad_threshold: NotGivenOr[float] = NOT_GIVEN,
         vad_min_silence_duration_ms: NotGivenOr[int] = NOT_GIVEN,
+        vad_speech_pad_ms: NotGivenOr[int] = NOT_GIVEN,
         partial_transcript_interval_s: NotGivenOr[float] = NOT_GIVEN,
     ) -> None:
         """Applies to streams opened after this call; the handshake is per-socket."""
@@ -198,6 +199,8 @@ class _Qwen3Backend:
             self._opts.vad_threshold = vad_threshold
         if is_given(vad_min_silence_duration_ms):
             self._opts.vad_min_silence_duration_ms = vad_min_silence_duration_ms
+        if is_given(vad_speech_pad_ms):
+            self._opts.vad_speech_pad_ms = vad_speech_pad_ms
         if is_given(partial_transcript_interval_s):
             self._opts.partial_transcript_interval_s = partial_transcript_interval_s
 

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_stt.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_stt.py
@@ -12,24 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""STT for Baseten's Qwen3-ASR streaming deployments.
+"""Qwen3-ASR protocol support for `STT` (``model="qwen3-asr"``).
 
-This is a separate class from `STT` because the two speak different wire
-protocols. `STT` targets the streaming-Whisper truss: it sends raw binary PCM
-and reads `message_type`/`transcript`. Qwen3-ASR takes base64 audio in
-OpenAI-realtime frames and replies with `type: "transcription"` /
-`segments[].text`.
+Qwen3-ASR takes base64 audio in OpenAI-realtime frames and replies with
+`type: "transcription"` / `segments[].text`, where the streaming-Whisper truss
+`STT` also serves sends raw binary PCM and reads `message_type`/`transcript`.
+Different protocol, so it gets its own backend and stream implementation here;
+`STT` picks between them.
 
 Protocol: a handshake frame, then
 `{"type": "input_audio_buffer.append", "audio": <base64 PCM16 16kHz mono>}`,
 ended by `{"type": "input_audio_buffer.commit"}`. The server runs Silero VAD, so
 turns also end on their own; each turn emits revisable partials
 (`is_final: false`, replace-style) then one final.
-
-    session = AgentSession(stt=Qwen3STT(
-        model_endpoint="wss://model-XXXXXXX.api.baseten.co/environments/production/websocket",
-        api_key=os.environ["BASETEN_API_KEY"],
-    ))
 
 Word timestamps need `STREAM_ALIGNER=mms` + `STREAM_ALIGNER_DEVICE=cuda` set on
 the deployment; without them the server ignores the request.
@@ -41,7 +36,6 @@ import asyncio
 import base64
 import json
 import os
-import weakref
 from dataclasses import dataclass, replace
 from typing import Any
 
@@ -54,7 +48,7 @@ from livekit.agents import (
     APIConnectOptions,
     APIStatusError,
     APITimeoutError,
-    stt,
+    stt as stt_module,
     utils,
 )
 from livekit.agents.language import LanguageCode
@@ -110,12 +104,11 @@ class _STTOptions:
         }
 
 
-class Qwen3STT(stt.STT):
-    """Streaming STT for a Baseten-hosted Qwen3-ASR deployment.
+class _Qwen3Backend:
+    """Connection settings for a Qwen3-ASR deployment, owned by `STT`.
 
-    Not interchangeable with `STT`, which targets the streaming-Whisper truss and
-    speaks a different protocol. The server runs Silero VAD, so turns end on
-    their own; an explicit flush commits the buffered audio early.
+    Not an `stt.STT` itself — `STT` selects this when ``model="qwen3-asr"`` and
+    keeps the public surface.
     """
 
     def __init__(
@@ -163,14 +156,6 @@ class Qwen3STT(stt.STT):
         Raises:
             ValueError: If no API key or endpoint can be resolved.
         """
-        super().__init__(
-            capabilities=stt.STTCapabilities(
-                streaming=True,
-                interim_results=interim_results,
-                aligned_transcript="word" if word_timestamps else False,
-                offline_recognize=True,
-            )
-        )
         api_key = api_key or os.environ.get("BASETEN_API_KEY")
         if not api_key:
             raise ValueError("Pass `api_key` or set BASETEN_API_KEY.")
@@ -182,7 +167,6 @@ class Qwen3STT(stt.STT):
         self._api_key = api_key
         self._model_endpoint = model_endpoint
         self._session = http_session
-        self._streams = weakref.WeakSet["Qwen3SpeechStream"]()
         self._opts = _STTOptions(
             audio_language=language,
             enable_partial_transcripts=interim_results,
@@ -193,14 +177,6 @@ class Qwen3STT(stt.STT):
             vad_speech_pad_ms=vad_speech_pad_ms,
             word_timestamps=word_timestamps,
         )
-
-    @property
-    def model(self) -> str:
-        return "qwen3-asr-1.7b-streaming"
-
-    @property
-    def provider(self) -> str:
-        return "Baseten"
 
     def _ensure_session(self) -> aiohttp.ClientSession:
         if not self._session:
@@ -225,28 +201,29 @@ class Qwen3STT(stt.STT):
         if is_given(partial_transcript_interval_s):
             self._opts.partial_transcript_interval_s = partial_transcript_interval_s
 
-    def stream(
+    def make_stream(
         self,
+        owner: stt_module.STT,
         *,
         language: NotGivenOr[str] = NOT_GIVEN,
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
     ) -> Qwen3SpeechStream:
+        """Build a recognition stream owned by the public `STT`."""
         opts = replace(self._opts)
         if is_given(language):
             opts.audio_language = language
-        stream = Qwen3SpeechStream(stt=self, opts=opts, conn_options=conn_options)
-        self._streams.add(stream)
-        return stream
+        return Qwen3SpeechStream(stt=owner, backend=self, opts=opts, conn_options=conn_options)
 
-    async def _recognize_impl(
+    async def recognize_via_stream(
         self,
+        owner: stt_module.STT,
         buffer: AudioBuffer,
         *,
         language: NotGivenOr[str] = NOT_GIVEN,
-        conn_options: APIConnectOptions,
-    ) -> stt.SpeechEvent:
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+    ) -> stt_module.SpeechEvent:
         """One-shot recognition, run over the same streaming session."""
-        stream = self.stream(language=language, conn_options=conn_options)
+        stream = self.make_stream(owner, language=language, conn_options=conn_options)
         stream.push_frame(rtc.combine_audio_frames(buffer))
         stream.end_input()
 
@@ -254,36 +231,41 @@ class Qwen3STT(stt.STT):
         code = ""
         try:
             async for ev in stream:
-                if ev.type is stt.SpeechEventType.FINAL_TRANSCRIPT and ev.alternatives:
+                if ev.type is stt_module.SpeechEventType.FINAL_TRANSCRIPT and ev.alternatives:
                     texts.append(ev.alternatives[0].text)
                     code = ev.alternatives[0].language or code
         finally:
             await stream.aclose()
 
-        return stt.SpeechEvent(
-            type=stt.SpeechEventType.FINAL_TRANSCRIPT,
+        return stt_module.SpeechEvent(
+            type=stt_module.SpeechEventType.FINAL_TRANSCRIPT,
             alternatives=[
-                stt.SpeechData(language=LanguageCode(code), text=" ".join(texts).strip())
+                stt_module.SpeechData(language=LanguageCode(code), text=" ".join(texts).strip())
             ],
         )
 
 
-class Qwen3SpeechStream(stt.SpeechStream):
+class Qwen3SpeechStream(stt_module.SpeechStream):
     """A single recognition session: audio frames in, speech events out."""
 
     def __init__(
-        self, *, stt: Qwen3STT, opts: _STTOptions, conn_options: APIConnectOptions
+        self,
+        *,
+        stt: stt_module.STT,
+        backend: _Qwen3Backend,
+        opts: _STTOptions,
+        conn_options: APIConnectOptions,
     ) -> None:
         super().__init__(stt=stt, conn_options=conn_options, sample_rate=SAMPLE_RATE)
-        self._stt_impl = stt
+        self._backend = backend
         self._opts = opts
 
     async def _run(self) -> None:
         try:
             ws = await asyncio.wait_for(
-                self._stt_impl._ensure_session().ws_connect(
-                    self._stt_impl._model_endpoint,
-                    headers={"Authorization": f"Api-Key {self._stt_impl._api_key}"},
+                self._backend._ensure_session().ws_connect(
+                    self._backend._model_endpoint,
+                    headers={"Authorization": f"Api-Key {self._backend._api_key}"},
                 ),
                 timeout=self._conn_options.timeout,
             )
@@ -377,15 +359,15 @@ class Qwen3SpeechStream(stt.SpeechStream):
                 if not speaking and text:
                     speaking = True
                     self._event_ch.send_nowait(
-                        stt.SpeechEvent(type=stt.SpeechEventType.START_OF_SPEECH)
+                        stt_module.SpeechEvent(type=stt_module.SpeechEventType.START_OF_SPEECH)
                     )
 
                 if text:
                     self._event_ch.send_nowait(
-                        stt.SpeechEvent(
-                            type=stt.SpeechEventType.FINAL_TRANSCRIPT
+                        stt_module.SpeechEvent(
+                            type=stt_module.SpeechEventType.FINAL_TRANSCRIPT
                             if is_final
-                            else stt.SpeechEventType.INTERIM_TRANSCRIPT,
+                            else stt_module.SpeechEventType.INTERIM_TRANSCRIPT,
                             alternatives=[self._speech_data(event, segments, text)],
                         )
                     )
@@ -393,7 +375,7 @@ class Qwen3SpeechStream(stt.SpeechStream):
                 if is_final:
                     if speaking:
                         self._event_ch.send_nowait(
-                            stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH)
+                            stt_module.SpeechEvent(type=stt_module.SpeechEventType.END_OF_SPEECH)
                         )
                         speaking = False
                     # Only the commit-triggered final ends the session; VAD
@@ -418,7 +400,7 @@ class Qwen3SpeechStream(stt.SpeechStream):
 
     def _speech_data(
         self, event: dict[str, Any], segments: list[dict[str, Any]], text: str
-    ) -> stt.SpeechData:
+    ) -> stt_module.SpeechData:
         words = None
         if self._opts.word_timestamps:
             words = [
@@ -433,7 +415,7 @@ class Qwen3SpeechStream(stt.SpeechStream):
                 for w in (s.get("word_timestamps") or [])
             ] or None
 
-        return stt.SpeechData(
+        return stt_module.SpeechData(
             language=_language_code(event.get("language_code")),
             text=text,
             # Server times are socket-relative; the framework grows

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_stt.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_stt.py
@@ -57,55 +57,27 @@ from livekit.agents import (
     stt,
     utils,
 )
-from livekit.agents.types import NOT_GIVEN, NotGivenOr
+from livekit.agents.language import LanguageCode
+from livekit.agents.types import NOT_GIVEN, NotGivenOr, TimedString
 from livekit.agents.utils import AudioBuffer, is_given
 
 from ._endpoint import resolve_endpoint
-from .log import logger
-
-try:
-    from livekit.agents.types import TimedString
-
-    _HAS_TIMED_STRING = True
-except ImportError:  # pragma: no cover
-    TimedString = None  # type: ignore[assignment]
-    _HAS_TIMED_STRING = False
-
 
 SAMPLE_RATE = 16000
 NUM_CHANNELS = 1
 _SAMPLES_PER_CHUNK = SAMPLE_RATE // 10  # 100 ms, matching the reference client
 
-# The server reports a Qwen3-ASR language *name*; LiveKit wants a code.
-# Unlisted names fall through lowercased.
-_LANGUAGE_CODES = {
-    "english": "en",
-    "chinese": "zh",
-    "cantonese": "yue",
-    "spanish": "es",
-    "french": "fr",
-    "german": "de",
-    "italian": "it",
-    "portuguese": "pt",
-    "russian": "ru",
-    "japanese": "ja",
-    "korean": "ko",
-    "arabic": "ar",
-    "hindi": "hi",
-    "turkish": "tr",
-    "vietnamese": "vi",
-    "indonesian": "id",
-    "dutch": "nl",
-    "polish": "pl",
-    "thai": "th",
-    "urdu": "ur",
-}
+# LanguageCode already maps most language *names* to codes ("English" -> "en");
+# these are the Qwen3-ASR languages it leaves untouched.
+_LANGUAGE_OVERRIDES = {"cantonese": "yue", "filipino": "fil"}
 
 
-def _language_code(name: str | None) -> str:
+def _language_code(name: str | None) -> LanguageCode:
+    """Normalize a Qwen3-ASR language name into a LanguageCode."""
     if not name:
-        return ""
-    return _LANGUAGE_CODES.get(name.strip().lower(), name.strip().lower())
+        return LanguageCode("")
+    key = name.strip().lower()
+    return LanguageCode(_LANGUAGE_OVERRIDES.get(key, key))
 
 
 @dataclass
@@ -175,9 +147,6 @@ class Qwen3STT(stt.STT):
         model_endpoint = resolve_endpoint(
             model_endpoint, model_id, chain_id, "BASETEN_STT_ENDPOINT"
         )
-        if word_timestamps and not _HAS_TIMED_STRING:
-            logger.warning("livekit-agents has no TimedString; disabling alignment")
-            word_timestamps = False
 
         self._api_key = api_key
         self._model_endpoint = model_endpoint
@@ -262,7 +231,9 @@ class Qwen3STT(stt.STT):
 
         return stt.SpeechEvent(
             type=stt.SpeechEventType.FINAL_TRANSCRIPT,
-            alternatives=[stt.SpeechData(language=code, text=" ".join(texts).strip())],
+            alternatives=[
+                stt.SpeechData(language=LanguageCode(code), text=" ".join(texts).strip())
+            ],
         )
 
 
@@ -412,9 +383,9 @@ class Qwen3SpeechStream(stt.SpeechStream):
         self, event: dict[str, Any], segments: list[dict[str, Any]], text: str
     ) -> stt.SpeechData:
         words = None
-        if self._opts.word_timestamps and _HAS_TIMED_STRING:
+        if self._opts.word_timestamps:
             words = [
-                TimedString(  # type: ignore[misc]
+                TimedString(
                     text=w.get("word", ""),
                     start_time=float(w.get("start_time", 0.0)),
                     end_time=float(w.get("end_time", 0.0)),

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_stt.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_stt.py
@@ -1,0 +1,434 @@
+# Copyright 2025 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""STT for Baseten's Qwen3-ASR streaming deployments.
+
+This is a separate class from `STT` because the two speak different wire
+protocols. `STT` targets the streaming-Whisper truss: it sends raw binary PCM
+and reads `message_type`/`transcript`. Qwen3-ASR takes base64 audio in
+OpenAI-realtime frames and replies with `type: "transcription"` /
+`segments[].text`.
+
+Protocol: a handshake frame, then
+`{"type": "input_audio_buffer.append", "audio": <base64 PCM16 16kHz mono>}`,
+ended by `{"type": "input_audio_buffer.commit"}`. The server runs Silero VAD, so
+turns also end on their own; each turn emits revisable partials
+(`is_final: false`, replace-style) then one final.
+
+    session = AgentSession(stt=Qwen3STT(
+        model_endpoint="wss://model-XXXXXXX.api.baseten.co/environments/production/websocket",
+        api_key=os.environ["BASETEN_API_KEY"],
+    ))
+
+Word timestamps need `STREAM_ALIGNER=mms` + `STREAM_ALIGNER_DEVICE=cuda` set on
+the deployment; without them the server ignores the request.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import weakref
+from dataclasses import dataclass, replace
+from typing import Any
+
+import aiohttp
+
+from livekit import rtc
+from livekit.agents import (
+    DEFAULT_API_CONNECT_OPTIONS,
+    APIConnectionError,
+    APIConnectOptions,
+    APIStatusError,
+    APITimeoutError,
+    stt,
+    utils,
+)
+from livekit.agents.types import NOT_GIVEN, NotGivenOr
+from livekit.agents.utils import AudioBuffer, is_given
+
+from ._endpoint import resolve_endpoint
+from .log import logger
+
+try:
+    from livekit.agents.types import TimedString
+
+    _HAS_TIMED_STRING = True
+except ImportError:  # pragma: no cover
+    TimedString = None  # type: ignore[assignment]
+    _HAS_TIMED_STRING = False
+
+
+SAMPLE_RATE = 16000
+NUM_CHANNELS = 1
+_SAMPLES_PER_CHUNK = SAMPLE_RATE // 10  # 100 ms, matching the reference client
+
+# The server reports a Qwen3-ASR language *name*; LiveKit wants a code.
+# Unlisted names fall through lowercased.
+_LANGUAGE_CODES = {
+    "english": "en",
+    "chinese": "zh",
+    "cantonese": "yue",
+    "spanish": "es",
+    "french": "fr",
+    "german": "de",
+    "italian": "it",
+    "portuguese": "pt",
+    "russian": "ru",
+    "japanese": "ja",
+    "korean": "ko",
+    "arabic": "ar",
+    "hindi": "hi",
+    "turkish": "tr",
+    "vietnamese": "vi",
+    "indonesian": "id",
+    "dutch": "nl",
+    "polish": "pl",
+    "thai": "th",
+    "urdu": "ur",
+}
+
+
+def _language_code(name: str | None) -> str:
+    if not name:
+        return ""
+    return _LANGUAGE_CODES.get(name.strip().lower(), name.strip().lower())
+
+
+@dataclass
+class _STTOptions:
+    audio_language: str
+    enable_partial_transcripts: bool
+    partial_transcript_interval_s: float
+    final_transcript_max_duration_s: float
+    vad_threshold: float
+    vad_min_silence_duration_ms: int
+    vad_speech_pad_ms: int
+    word_timestamps: bool
+
+    def handshake(self) -> dict[str, Any]:
+        return {
+            "whisper_params": {
+                "audio_language": self.audio_language,
+                "show_word_timestamps": self.word_timestamps,
+            },
+            "streaming_params": {
+                "enable_partial_transcripts": self.enable_partial_transcripts,
+                "partial_transcript_interval_s": self.partial_transcript_interval_s,
+                "final_transcript_max_duration_s": self.final_transcript_max_duration_s,
+            },
+            "streaming_vad_config": {
+                "threshold": self.vad_threshold,
+                "min_silence_duration_ms": self.vad_min_silence_duration_ms,
+                "speech_pad_ms": self.vad_speech_pad_ms,
+            },
+        }
+
+
+class Qwen3STT(stt.STT):
+    def __init__(
+        self,
+        *,
+        model_endpoint: str | None = None,
+        model_id: str | None = None,
+        chain_id: str | None = None,
+        api_key: str | None = None,
+        language: str = "auto",
+        interim_results: bool = True,
+        partial_transcript_interval_s: float = 0.5,
+        final_transcript_max_duration_s: float = 30,
+        vad_threshold: float = 0.5,
+        vad_min_silence_duration_ms: int = 500,
+        vad_speech_pad_ms: int = 100,
+        word_timestamps: bool = False,
+        http_session: aiohttp.ClientSession | None = None,
+    ) -> None:
+        """`language` is a Qwen3-ASR canonical name ("English", "Cantonese") or
+        "auto". Forcing a language also sets the *output* language, so it can
+        translate — use it only to pin what is actually being spoken.
+        """
+        super().__init__(
+            capabilities=stt.STTCapabilities(
+                streaming=True,
+                interim_results=interim_results,
+                aligned_transcript="word" if word_timestamps else False,
+                offline_recognize=True,
+            )
+        )
+        api_key = api_key or os.environ.get("BASETEN_API_KEY")
+        if not api_key:
+            raise ValueError("Pass `api_key` or set BASETEN_API_KEY.")
+
+        model_endpoint = resolve_endpoint(
+            model_endpoint, model_id, chain_id, "BASETEN_STT_ENDPOINT"
+        )
+        if word_timestamps and not _HAS_TIMED_STRING:
+            logger.warning("livekit-agents has no TimedString; disabling alignment")
+            word_timestamps = False
+
+        self._api_key = api_key
+        self._model_endpoint = model_endpoint
+        self._session = http_session
+        self._streams = weakref.WeakSet["Qwen3SpeechStream"]()
+        self._opts = _STTOptions(
+            audio_language=language,
+            enable_partial_transcripts=interim_results,
+            partial_transcript_interval_s=partial_transcript_interval_s,
+            final_transcript_max_duration_s=final_transcript_max_duration_s,
+            vad_threshold=vad_threshold,
+            vad_min_silence_duration_ms=vad_min_silence_duration_ms,
+            vad_speech_pad_ms=vad_speech_pad_ms,
+            word_timestamps=word_timestamps,
+        )
+
+    @property
+    def model(self) -> str:
+        return "qwen3-asr-1.7b-streaming"
+
+    @property
+    def provider(self) -> str:
+        return "Baseten"
+
+    def _ensure_session(self) -> aiohttp.ClientSession:
+        if not self._session:
+            self._session = utils.http_context.http_session()
+        return self._session
+
+    def update_options(
+        self,
+        *,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        vad_threshold: NotGivenOr[float] = NOT_GIVEN,
+        vad_min_silence_duration_ms: NotGivenOr[int] = NOT_GIVEN,
+        partial_transcript_interval_s: NotGivenOr[float] = NOT_GIVEN,
+    ) -> None:
+        """Applies to streams opened after this call; the handshake is per-socket."""
+        if is_given(language):
+            self._opts.audio_language = language
+        if is_given(vad_threshold):
+            self._opts.vad_threshold = vad_threshold
+        if is_given(vad_min_silence_duration_ms):
+            self._opts.vad_min_silence_duration_ms = vad_min_silence_duration_ms
+        if is_given(partial_transcript_interval_s):
+            self._opts.partial_transcript_interval_s = partial_transcript_interval_s
+
+    def stream(
+        self,
+        *,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+    ) -> Qwen3SpeechStream:
+        opts = replace(self._opts)
+        if is_given(language):
+            opts.audio_language = language
+        stream = Qwen3SpeechStream(stt=self, opts=opts, conn_options=conn_options)
+        self._streams.add(stream)
+        return stream
+
+    async def _recognize_impl(
+        self,
+        buffer: AudioBuffer,
+        *,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        conn_options: APIConnectOptions,
+    ) -> stt.SpeechEvent:
+        """One-shot recognition, run over the same streaming session."""
+        stream = self.stream(language=language, conn_options=conn_options)
+        stream.push_frame(rtc.combine_audio_frames(buffer))
+        stream.end_input()
+
+        texts: list[str] = []
+        code = ""
+        try:
+            async for ev in stream:
+                if ev.type is stt.SpeechEventType.FINAL_TRANSCRIPT and ev.alternatives:
+                    texts.append(ev.alternatives[0].text)
+                    code = ev.alternatives[0].language or code
+        finally:
+            await stream.aclose()
+
+        return stt.SpeechEvent(
+            type=stt.SpeechEventType.FINAL_TRANSCRIPT,
+            alternatives=[stt.SpeechData(language=code, text=" ".join(texts).strip())],
+        )
+
+
+class Qwen3SpeechStream(stt.SpeechStream):
+    def __init__(
+        self, *, stt: Qwen3STT, opts: _STTOptions, conn_options: APIConnectOptions
+    ) -> None:
+        super().__init__(stt=stt, conn_options=conn_options, sample_rate=SAMPLE_RATE)
+        self._stt_impl = stt
+        self._opts = opts
+
+    async def _run(self) -> None:
+        try:
+            ws = await asyncio.wait_for(
+                self._stt_impl._ensure_session().ws_connect(
+                    self._stt_impl._model_endpoint,
+                    headers={"Authorization": f"Api-Key {self._stt_impl._api_key}"},
+                ),
+                timeout=self._conn_options.timeout,
+            )
+        except asyncio.TimeoutError:
+            raise APITimeoutError() from None
+        except aiohttp.ClientResponseError as e:
+            raise APIStatusError(
+                message=e.message, status_code=e.status, request_id=None, body=None
+            ) from None
+        except Exception as e:
+            raise APIConnectionError() from e
+
+        input_ended = asyncio.Event()
+
+        async def _send() -> None:
+            # LiveKit resamples to SAMPLE_RATE for us; this only re-chunks into
+            # the ~100ms frames the server expects.
+            chunker = utils.audio.AudioByteStream(
+                sample_rate=SAMPLE_RATE,
+                num_channels=NUM_CHANNELS,
+                samples_per_channel=_SAMPLES_PER_CHUNK,
+            )
+            try:
+                async for data in self._input_ch:
+                    if isinstance(data, self._FlushSentinel):
+                        frames = chunker.flush()
+                        commit = True
+                    else:
+                        frames = chunker.write(data.data.tobytes())
+                        commit = False
+                    for frame in frames:
+                        await ws.send_str(
+                            json.dumps(
+                                {
+                                    "type": "input_audio_buffer.append",
+                                    "audio": base64.b64encode(frame.data.tobytes()).decode(),
+                                }
+                            )
+                        )
+                    if commit:
+                        await ws.send_str(json.dumps({"type": "input_audio_buffer.commit"}))
+                for frame in chunker.flush():
+                    await ws.send_str(
+                        json.dumps(
+                            {
+                                "type": "input_audio_buffer.append",
+                                "audio": base64.b64encode(frame.data.tobytes()).decode(),
+                            }
+                        )
+                    )
+                await ws.send_str(json.dumps({"type": "input_audio_buffer.commit"}))
+            finally:
+                input_ended.set()
+
+        async def _recv() -> None:
+            speaking = False
+            while True:
+                msg = await ws.receive()
+                if msg.type in (
+                    aiohttp.WSMsgType.CLOSE,
+                    aiohttp.WSMsgType.CLOSED,
+                    aiohttp.WSMsgType.CLOSING,
+                ):
+                    if input_ended.is_set():
+                        return
+                    raise APIConnectionError("Baseten closed the STT websocket")
+                if msg.type is aiohttp.WSMsgType.ERROR:
+                    raise APIConnectionError(f"websocket error: {ws.exception()}")
+                if msg.type is not aiohttp.WSMsgType.TEXT:
+                    continue
+
+                event = json.loads(msg.data)
+                if event.get("type") == "error":
+                    raise APIStatusError(
+                        message=str(event.get("message", "unknown STT error")),
+                        status_code=500,
+                        request_id=None,
+                        body=None,
+                    )
+                if event.get("type") != "transcription":
+                    continue
+
+                segments = event.get("segments") or []
+                text = " ".join(s.get("text", "") for s in segments).strip()
+                is_final = bool(event.get("is_final"))
+
+                if not speaking and (text or is_final):
+                    speaking = True
+                    self._event_ch.send_nowait(
+                        stt.SpeechEvent(type=stt.SpeechEventType.START_OF_SPEECH)
+                    )
+
+                if text:
+                    self._event_ch.send_nowait(
+                        stt.SpeechEvent(
+                            type=stt.SpeechEventType.FINAL_TRANSCRIPT
+                            if is_final
+                            else stt.SpeechEventType.INTERIM_TRANSCRIPT,
+                            alternatives=[self._speech_data(event, segments, text)],
+                        )
+                    )
+
+                if is_final:
+                    if speaking:
+                        self._event_ch.send_nowait(
+                            stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH)
+                        )
+                        speaking = False
+                    # Only the commit-triggered final ends the session; VAD
+                    # finals just close a turn and the stream keeps going.
+                    if event.get("is_end_of_audio_flush") and input_ended.is_set():
+                        return
+
+        try:
+            await ws.send_str(json.dumps(self._opts.handshake()))
+            send_task = asyncio.create_task(_send(), name="qwen3-stt-send")
+            recv_task = asyncio.create_task(_recv(), name="qwen3-stt-recv")
+            try:
+                await asyncio.gather(send_task, recv_task)
+            finally:
+                await utils.aio.gracefully_cancel(send_task, recv_task)
+        except (APIConnectionError, APIStatusError, APITimeoutError):
+            raise
+        except Exception as e:
+            raise APIConnectionError() from e
+        finally:
+            await ws.close()
+
+    def _speech_data(
+        self, event: dict[str, Any], segments: list[dict[str, Any]], text: str
+    ) -> stt.SpeechData:
+        words = None
+        if self._opts.word_timestamps and _HAS_TIMED_STRING:
+            words = [
+                TimedString(  # type: ignore[misc]
+                    text=w.get("word", ""),
+                    start_time=float(w.get("start_time", 0.0)),
+                    end_time=float(w.get("end_time", 0.0)),
+                    confidence=float(w.get("prob", 0.0)),
+                )
+                for s in segments
+                for w in (s.get("word_timestamps") or [])
+            ] or None
+
+        return stt.SpeechData(
+            language=_language_code(event.get("language_code")),
+            text=text,
+            start_time=float(segments[0].get("start_time", 0.0)) if segments else 0.0,
+            end_time=float(segments[-1].get("end_time", 0.0)) if segments else 0.0,
+            confidence=1.0,
+            words=words,
+        )

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
@@ -267,7 +267,10 @@ class Qwen3TTS(tts.TTS):
     def synthesize(
         self, text: str, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
     ) -> tts.ChunkedStream:
-        return Qwen3ChunkedStream(tts=self, input_text=text, conn_options=conn_options)
+        # The framework helper disables retries on the inner stream (this class
+        # already retries) and forwards timed transcripts; hand-rolling it did
+        # neither.
+        return self._synthesize_with_stream(text, conn_options=conn_options)
 
     async def aclose(self) -> None:
         self._closing = True
@@ -409,7 +412,14 @@ class Qwen3TTS(tts.TTS):
                     continue
                 self._warm = None
 
-            if not await self._empty_flush(warm.ws):
+            # While the flush is in flight this local is the only reference to
+            # the socket, so aclose() cancelling us here would leak it.
+            try:
+                alive = await self._empty_flush(warm.ws)
+            except asyncio.CancelledError:
+                await self._shutdown_ws(warm.ws, notify=False)
+                raise
+            if not alive:
                 await self._shutdown_ws(warm.ws, notify=False)
                 return
 
@@ -667,31 +677,6 @@ class Qwen3SynthesizeStream(tts.SynthesizeStream):
         ]
         if timed:
             output_emitter.push_timed_transcript(timed)
-
-
-class Qwen3ChunkedStream(tts.ChunkedStream):
-    """One-shot synthesis over the same streaming session."""
-
-    def __init__(self, *, tts: Qwen3TTS, input_text: str, conn_options: APIConnectOptions) -> None:
-        super().__init__(tts=tts, input_text=input_text, conn_options=conn_options)
-        self._tts: Qwen3TTS = tts
-
-    async def _run(self, output_emitter: tts.AudioEmitter) -> None:
-        stream = self._tts.stream(conn_options=self._conn_options)
-        stream.push_text(self._input_text)
-        stream.end_input()
-        output_emitter.initialize(
-            request_id=utils.shortuuid(),
-            sample_rate=SAMPLE_RATE,
-            num_channels=NUM_CHANNELS,
-            mime_type="audio/pcm",
-        )
-        try:
-            async for ev in stream:
-                output_emitter.push(ev.frame.data.tobytes())
-            output_emitter.flush()
-        finally:
-            await stream.aclose()
 
 
 async def _control(model_endpoint: str, api_key: str | None, message: dict) -> dict:

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
@@ -543,6 +543,12 @@ class Qwen3SynthesizeStream(tts.SynthesizeStream):
                         open_segment()
                     output_emitter.push(msg.data)
                     segment_bytes += len(msg.data)
+                    # Audio counts as progress. The server only sends
+                    # session.done once the whole utterance is synthesized, so
+                    # without this a turn longer than _SESSION_DONE_TIMEOUT is
+                    # aborted mid-sentence on a perfectly healthy socket — and
+                    # the framework won't retry once audio has been pushed.
+                    state.progress.set()
                     continue
                 if msg.type in (
                     aiohttp.WSMsgType.CLOSE,

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
@@ -1,0 +1,687 @@
+# Copyright 2025 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TTS for Baseten's Qwen3-TTS deployments.
+
+This is a separate class from `TTS` because the two speak different wire
+protocols. `TTS` targets the Orpheus truss (hence its `tara` default voice);
+Qwen3-TTS is: session.config -> input.text* -> input.done (a flush, not a
+close) -> audio.start / PCM / audio.done / session.done.
+
+Voices are clones, not presets: the Base checkpoint ships no built-in speakers.
+Register one first (see `register_voice`), or pass ref_audio/ref_text to clone
+inline. Note the server keeps uploaded voices on the container's local disk, so
+a runtime-registered voice is scoped to one replica and lost on restart — bake
+it into the truss via REQUIRED_VOICES for anything beyond single-replica tests.
+
+    session = AgentSession(tts=Qwen3TTS(
+        model_endpoint="wss://model-XXXXXXX.api.baseten.co/environments/production/websocket",
+        api_key=os.environ["BASETEN_API_KEY"],
+        voice="my_registered_voice",
+    ))
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import json
+import os
+import time
+import weakref
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+import aiohttp
+
+from livekit.agents import (
+    APIConnectionError,
+    APIConnectOptions,
+    APIStatusError,
+    APITimeoutError,
+    tts,
+    utils,
+)
+from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, NotGivenOr
+from livekit.agents.utils import is_given
+
+from ._endpoint import resolve_endpoint
+from .log import logger
+
+try:
+    from livekit.agents.types import TimedString
+
+    _HAS_TIMED_STRING = True
+except ImportError:  # pragma: no cover
+    TimedString = None  # type: ignore[assignment]
+    _HAS_TIMED_STRING = False
+
+
+SAMPLE_RATE = 24000
+NUM_CHANNELS = 1
+_BYTES_PER_SECOND = SAMPLE_RATE * NUM_CHANNELS * 2
+_WS_MAX_MSG_SIZE = 16 * 1024 * 1024
+
+# Server gives 10s for the first session.config, then 30s idle per message.
+# Ours sit below so we drop a stale socket instead of dying mid-turn.
+_UNCONFIGURED_TTL = 8.0
+_CONFIGURED_TTL = 25.0
+_KEEPALIVE_INTERVAL = 15.0
+_KEEPALIVE_TIMEOUT = 3.0
+_SESSION_DONE_TIMEOUT = 60.0
+
+
+@dataclass
+class _TTSOptions:
+    voice: str
+    task_type: str
+    language: str | None
+    speed: float
+    instructions: str | None
+    max_new_tokens: int | None
+    initial_codec_chunk_frames: int | None
+    x_vector_only_mode: bool | None
+    ref_audio: str | None
+    ref_text: str | None
+    word_timestamps: bool
+    extra_config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _WarmSocket:
+    ws: aiohttp.ClientWebSocketResponse
+    config: dict[str, Any] | None
+    last_activity: float
+
+
+@dataclass
+class _TurnState:
+    """Sender counts flushes issued, receiver counts the ones answered."""
+
+    flushes_sent: int = 0
+    flushes_done: int = 0
+    sender_finished: asyncio.Event = field(default_factory=asyncio.Event)
+    progress: asyncio.Event = field(default_factory=asyncio.Event)
+
+    @property
+    def settled(self) -> bool:
+        return self.sender_finished.is_set() and self.flushes_done >= self.flushes_sent
+
+
+class Qwen3TTS(tts.TTS):
+    def __init__(
+        self,
+        *,
+        model_endpoint: str | None = None,
+        model_id: str | None = None,
+        chain_id: str | None = None,
+        api_key: str | None = None,
+        voice: str,
+        task_type: str = "Base",
+        language: str | None = "Auto",
+        speed: float = 1.0,
+        instructions: str | None = None,
+        max_new_tokens: int | None = None,
+        initial_codec_chunk_frames: int | None = None,
+        x_vector_only_mode: bool | None = None,
+        ref_audio: str | None = None,
+        ref_text: str | None = None,
+        word_timestamps: bool = False,
+        extra_config: dict[str, Any] | None = None,
+        http_session: aiohttp.ClientSession | None = None,
+    ) -> None:
+        api_key = api_key or os.environ.get("BASETEN_API_KEY")
+        if not api_key:
+            raise ValueError("Pass `api_key` or set BASETEN_API_KEY.")
+
+        model_endpoint = resolve_endpoint(
+            model_endpoint, model_id, chain_id, "BASETEN_MODEL_ENDPOINT"
+        )
+        if not voice:
+            raise ValueError("`voice` is required: the Base checkpoint has no presets.")
+
+        if word_timestamps and not _HAS_TIMED_STRING:
+            logger.warning("livekit-agents has no TimedString; disabling alignment")
+            word_timestamps = False
+        if speed != 1.0:
+            logger.warning("progressive PCM requires speed=1.0; overriding %s", speed)
+            speed = 1.0
+
+        super().__init__(
+            capabilities=tts.TTSCapabilities(streaming=True, aligned_transcript=word_timestamps),
+            sample_rate=SAMPLE_RATE,
+            num_channels=NUM_CHANNELS,
+        )
+
+        self._api_key = api_key
+        self._model_endpoint = model_endpoint
+        self._session = http_session
+        self._streams = weakref.WeakSet["Qwen3SynthesizeStream"]()
+        self._opts = _TTSOptions(
+            voice=voice,
+            task_type=task_type,
+            language=language,
+            speed=speed,
+            instructions=instructions,
+            max_new_tokens=max_new_tokens,
+            initial_codec_chunk_frames=initial_codec_chunk_frames,
+            x_vector_only_mode=x_vector_only_mode,
+            ref_audio=ref_audio,
+            ref_text=ref_text,
+            word_timestamps=word_timestamps,
+            extra_config=dict(extra_config or {}),
+        )
+
+        self._ref_audio_b64: str | None = None
+        self._warm: _WarmSocket | None = None
+        self._warm_lock = asyncio.Lock()
+        self._keepalive_task: asyncio.Task[None] | None = None
+        self._closing = False
+
+    @property
+    def model(self) -> str:
+        return f"qwen3-tts-{self._opts.task_type.lower()}"
+
+    @property
+    def provider(self) -> str:
+        return "Baseten"
+
+    def update_options(
+        self,
+        *,
+        voice: NotGivenOr[str] = NOT_GIVEN,
+        language: NotGivenOr[str] = NOT_GIVEN,
+        instructions: NotGivenOr[str] = NOT_GIVEN,
+        max_new_tokens: NotGivenOr[int] = NOT_GIVEN,
+    ) -> None:
+        """Applies from the next turn: config is sticky for a socket's life."""
+        if is_given(voice):
+            self._opts.voice = voice
+        if is_given(language):
+            self._opts.language = language
+        if is_given(instructions):
+            self._opts.instructions = instructions
+        if is_given(max_new_tokens):
+            self._opts.max_new_tokens = max_new_tokens
+
+    def stream(
+        self, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
+    ) -> Qwen3SynthesizeStream:
+        stream = Qwen3SynthesizeStream(tts=self, conn_options=conn_options)
+        self._streams.add(stream)
+        return stream
+
+    def synthesize(
+        self, text: str, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
+    ) -> tts.ChunkedStream:
+        return Qwen3ChunkedStream(tts=self, input_text=text, conn_options=conn_options)
+
+    async def aclose(self) -> None:
+        self._closing = True
+        for stream in list(self._streams):
+            await stream.aclose()
+        self._streams.clear()
+        if self._keepalive_task and not self._keepalive_task.done():
+            self._keepalive_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._keepalive_task
+        async with self._warm_lock:
+            warm, self._warm = self._warm, None
+        if warm:
+            await self._shutdown_ws(warm.ws, notify=True)
+
+    def _load_ref_audio(self) -> str | None:
+        ref = self._opts.ref_audio
+        if not ref or ref.startswith(("http://", "https://")):
+            return ref
+        if self._ref_audio_b64 is None:
+            if not os.path.isfile(ref):
+                logger.error("ref_audio %r is neither a URL nor a file", ref)
+                self._opts.ref_audio = None
+                return None
+            with open(ref, "rb") as f:
+                self._ref_audio_b64 = base64.b64encode(f.read()).decode()
+        return self._ref_audio_b64
+
+    def _build_session_config(self) -> dict[str, Any]:
+        """Doubles as the identity of the config applied to a parked socket.
+
+        `split_granularity` is omitted on purpose: it is not in the streaming
+        schema, and an unrecognized field invalidates the whole config.
+        """
+        o = self._opts
+        config: dict[str, Any] = {
+            "task_type": o.task_type,
+            "response_format": "pcm",
+            "stream_audio": True,
+            "speed": o.speed,
+            "voice": o.voice,
+        }
+        optional = {
+            "language": o.language,
+            "instructions": o.instructions,
+            "max_new_tokens": o.max_new_tokens,
+            "initial_codec_chunk_frames": o.initial_codec_chunk_frames,
+            "x_vector_only_mode": o.x_vector_only_mode,
+        }
+        config.update({k: v for k, v in optional.items() if v is not None})
+
+        ref_audio = self._load_ref_audio()
+        if ref_audio:
+            config["ref_audio"] = ref_audio
+            if o.ref_text:
+                config["ref_text"] = o.ref_text
+        if o.word_timestamps:
+            # "sync" lands in audio.done, after that sentence's audio, so its
+            # offset is known exactly; "async" arrives arbitrarily interleaved.
+            config["timestamp_type"] = "word"
+            config["timestamp_transport_strategy"] = "sync"
+        config.update(o.extra_config)
+        return config
+
+    def _ensure_session(self) -> aiohttp.ClientSession:
+        if not self._session:
+            self._session = utils.http_context.http_session()
+        return self._session
+
+    async def _acquire(
+        self,
+    ) -> tuple[aiohttp.ClientWebSocketResponse, dict[str, Any] | None]:
+        """Reuse the parked socket if live, else dial. Returns its applied config."""
+        async with self._warm_lock:
+            warm, self._warm = self._warm, None
+
+        if warm:
+            ttl = _CONFIGURED_TTL if warm.config else _UNCONFIGURED_TTL
+            if not warm.ws.closed and (time.monotonic() - warm.last_activity) < ttl:
+                return warm.ws, warm.config
+            await self._shutdown_ws(warm.ws, notify=False)
+
+        ws = await self._ensure_session().ws_connect(
+            self._model_endpoint,
+            headers={"Authorization": f"Api-Key {self._api_key}"},
+            max_msg_size=_WS_MAX_MSG_SIZE,
+            compress=0,
+        )
+        return ws, None
+
+    async def _release(
+        self,
+        ws: aiohttp.ClientWebSocketResponse,
+        config: dict[str, Any] | None,
+        *,
+        discard: bool,
+    ) -> None:
+        """Park for the next turn, or discard.
+
+        Discard is for a socket abandoned mid-generation (barge-in, error):
+        closing it is what stops the server, and a polite session.close would
+        wait on audio nobody will hear.
+        """
+        if discard or self._closing or ws.closed:
+            await self._shutdown_ws(ws, notify=not discard)
+            return
+
+        async with self._warm_lock:
+            stale, self._warm = self._warm, _WarmSocket(ws, config, time.monotonic())
+        if stale and stale.ws is not ws:
+            await self._shutdown_ws(stale.ws, notify=True)
+
+        if not self._closing and (self._keepalive_task is None or self._keepalive_task.done()):
+            self._keepalive_task = asyncio.create_task(self._keepalive_loop())
+
+    async def _keepalive_loop(self) -> None:
+        """An empty input.done answers session.done and resets the idle timer.
+
+        A protocol ping would not: it proves the socket is alive, not the
+        session.
+        """
+        while not self._closing:
+            await asyncio.sleep(_KEEPALIVE_INTERVAL)
+            async with self._warm_lock:
+                warm = self._warm
+                if warm is None:
+                    return  # a turn took it; _release restarts us
+                if warm.ws.closed:
+                    self._warm = None
+                    return
+                if not warm.config:
+                    continue
+                if await self._empty_flush(warm.ws):
+                    warm.last_activity = time.monotonic()
+                else:
+                    self._warm = None
+                    await self._shutdown_ws(warm.ws, notify=False)
+                    return
+
+    async def _empty_flush(self, ws: aiohttp.ClientWebSocketResponse) -> bool:
+        try:
+            await ws.send_str(json.dumps({"type": "input.done"}))
+            deadline = time.monotonic() + _KEEPALIVE_TIMEOUT
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                msg = await ws.receive(timeout=remaining)
+                if msg.type is aiohttp.WSMsgType.BINARY:
+                    continue
+                if msg.type is not aiohttp.WSMsgType.TEXT:
+                    return False
+                event = json.loads(msg.data)
+                if event.get("type") == "session.done":
+                    return True
+                if event.get("type") == "error":
+                    logger.warning("keepalive rejected: %s", event.get("message"))
+                    return False
+        except Exception as e:  # noqa: BLE001
+            logger.debug("keepalive failed (%s); dropping socket", e)
+            return False
+
+    async def _shutdown_ws(self, ws: aiohttp.ClientWebSocketResponse, *, notify: bool) -> None:
+        with contextlib.suppress(Exception):
+            if notify and not ws.closed:
+                await ws.send_str(json.dumps({"type": "session.close"}))
+        with contextlib.suppress(Exception):
+            await ws.close()
+
+
+class Qwen3SynthesizeStream(tts.SynthesizeStream):
+    def __init__(self, *, tts: Qwen3TTS, conn_options: APIConnectOptions) -> None:
+        super().__init__(tts=tts, conn_options=conn_options)
+        self._tts: Qwen3TTS = tts
+        self._opts = replace(tts._opts)
+
+    async def _run(self, output_emitter: tts.AudioEmitter) -> None:
+        request_id = utils.shortuuid()
+        output_emitter.initialize(
+            request_id=request_id,
+            sample_rate=SAMPLE_RATE,
+            num_channels=NUM_CHANNELS,
+            mime_type="audio/pcm",
+            stream=True,
+        )
+
+        try:
+            ws, applied_config = await asyncio.wait_for(
+                self._tts._acquire(), timeout=self._conn_options.timeout
+            )
+        except asyncio.TimeoutError:
+            raise APITimeoutError() from None
+        except aiohttp.ClientResponseError as e:
+            raise APIStatusError(
+                message=e.message, status_code=e.status, request_id=None, body=None
+            ) from None
+        except Exception as e:
+            raise APIConnectionError() from e
+
+        config = self._tts._build_session_config()
+        state = _TurnState()
+        discard = True
+
+        async def _send() -> None:
+            buffered = False
+            try:
+                async for data in self._input_ch:
+                    if isinstance(data, self._FlushSentinel):
+                        if not buffered:
+                            continue
+                        await ws.send_str(json.dumps({"type": "input.done"}))
+                        state.flushes_sent += 1
+                        buffered = False
+                        continue
+                    self._mark_started()
+                    await ws.send_str(json.dumps({"type": "input.text", "text": data}))
+                    buffered = True
+                if buffered:
+                    await ws.send_str(json.dumps({"type": "input.done"}))
+                    state.flushes_sent += 1
+            finally:
+                state.sender_finished.set()
+                state.progress.set()
+
+        async def _recv() -> None:
+            # One segment per stream: livekit drops push_text() after a flush
+            # and raises if the emitter's segment count disagrees with its own.
+            # So a flush means "synthesize what's buffered", never "new
+            # segment", and the segment closes via end_input() below.
+            segment_open = False
+            segment_bytes = 0
+            sentence_offset = 0.0
+
+            def open_segment() -> None:
+                nonlocal segment_open
+                output_emitter.start_segment(segment_id=request_id)
+                segment_open = True
+
+            while True:
+                msg = await ws.receive()
+
+                if msg.type is aiohttp.WSMsgType.BINARY:
+                    if not segment_open:
+                        open_segment()
+                    output_emitter.push(msg.data)
+                    segment_bytes += len(msg.data)
+                    continue
+                if msg.type in (
+                    aiohttp.WSMsgType.CLOSE,
+                    aiohttp.WSMsgType.CLOSED,
+                    aiohttp.WSMsgType.CLOSING,
+                ):
+                    raise APIConnectionError("Baseten closed the TTS websocket")
+                if msg.type is aiohttp.WSMsgType.ERROR:
+                    raise APIConnectionError(f"websocket error: {ws.exception()}")
+                if msg.type is not aiohttp.WSMsgType.TEXT:
+                    continue
+
+                event = json.loads(msg.data)
+                etype = event.get("type")
+
+                if etype == "audio.start":
+                    rate = int(event.get("sample_rate", SAMPLE_RATE))
+                    if rate != SAMPLE_RATE:
+                        logger.warning(
+                            "server sample_rate=%d, expected %d; audio will be mistimed",
+                            rate,
+                            SAMPLE_RATE,
+                        )
+                    if not segment_open:
+                        open_segment()
+                    sentence_offset = segment_bytes / _BYTES_PER_SECOND
+
+                elif etype == "audio.done":
+                    if event.get("error"):
+                        logger.error(
+                            "synthesis failed for sentence %s",
+                            event.get("sentence_index"),
+                        )
+                    elif self._opts.word_timestamps:
+                        self._emit_timestamps(
+                            output_emitter, event.get("timestamp_info"), sentence_offset
+                        )
+
+                elif etype == "session.done":
+                    state.flushes_done += 1
+                    state.progress.set()
+                    if state.settled:
+                        return
+
+                elif etype == "error":
+                    raise APIStatusError(
+                        message=str(event.get("message", "unknown TTS error")),
+                        status_code=500,
+                        request_id=request_id,
+                        body=None,
+                    )
+
+        try:
+            if config != applied_config:
+                await ws.send_str(json.dumps({"type": "session.config", **config}))
+
+            send_task = asyncio.create_task(_send(), name="qwen3-tts-send")
+            recv_task = asyncio.create_task(_recv(), name="qwen3-tts-recv")
+            try:
+                await asyncio.gather(send_task, self._drain(recv_task, state))
+            finally:
+                await utils.aio.gracefully_cancel(send_task, recv_task)
+
+            output_emitter.end_input()
+            discard = False
+        except asyncio.TimeoutError:
+            raise APITimeoutError() from None
+        except aiohttp.ClientResponseError as e:
+            raise APIStatusError(
+                message=e.message, status_code=e.status, request_id=None, body=None
+            ) from None
+        except (APIConnectionError, APIStatusError, APITimeoutError):
+            raise
+        except Exception as e:
+            raise APIConnectionError() from e
+        finally:
+            await self._tts._release(ws, config, discard=discard)
+
+    async def _drain(self, recv_task: asyncio.Task[None], state: _TurnState) -> None:
+        """Unblock a receiver parked on ws.receive() with nothing left to read.
+
+        Happens when the sender's last chunk needed no extra flush, so the
+        final session.done already landed.
+        """
+        while True:
+            # Clear before testing so a session.done landing mid-check sets the
+            # flag again rather than being swallowed.
+            state.progress.clear()
+            if recv_task.done():
+                await recv_task
+                return
+            if state.settled:
+                return
+
+            waiter = asyncio.ensure_future(state.progress.wait())
+            try:
+                done, _ = await asyncio.wait(
+                    {recv_task, waiter},
+                    timeout=_SESSION_DONE_TIMEOUT,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+            finally:
+                if not waiter.done():
+                    waiter.cancel()
+            if not done:
+                raise APITimeoutError()
+
+    def _emit_timestamps(
+        self,
+        output_emitter: tts.AudioEmitter,
+        timestamp_info: dict[str, Any] | None,
+        offset: float,
+    ) -> None:
+        """Rebase one sentence's word times onto the segment timeline."""
+        if not timestamp_info or not _HAS_TIMED_STRING:
+            return
+        alignment = timestamp_info.get("word_alignment") or {}
+        timed = [
+            TimedString(  # type: ignore[misc]
+                text=f"{word} ",
+                start_time=offset + float(start),
+                end_time=offset + float(end),
+            )
+            # strict=False on purpose: a ragged alignment should cost timestamps,
+            # not drop the call mid-turn.
+            for word, start, end in zip(
+                alignment.get("words") or [],
+                alignment.get("word_start_times_seconds") or [],
+                alignment.get("word_end_times_seconds") or [],
+                strict=False,
+            )
+        ]
+        if timed:
+            output_emitter.push_timed_transcript(timed)
+
+
+class Qwen3ChunkedStream(tts.ChunkedStream):
+    """One-shot synthesis over the same streaming session."""
+
+    def __init__(self, *, tts: Qwen3TTS, input_text: str, conn_options: APIConnectOptions) -> None:
+        super().__init__(tts=tts, input_text=input_text, conn_options=conn_options)
+        self._tts: Qwen3TTS = tts
+
+    async def _run(self, output_emitter: tts.AudioEmitter) -> None:
+        stream = self._tts.stream(conn_options=self._conn_options)
+        stream.push_text(self._input_text)
+        stream.end_input()
+        output_emitter.initialize(
+            request_id=utils.shortuuid(),
+            sample_rate=SAMPLE_RATE,
+            num_channels=NUM_CHANNELS,
+            mime_type="audio/pcm",
+        )
+        try:
+            async for ev in stream:
+                output_emitter.push(ev.frame.data.tobytes())
+            output_emitter.flush()
+        finally:
+            await stream.aclose()
+
+
+async def _control(model_endpoint: str, api_key: str | None, message: dict) -> dict:
+    api_key = api_key or os.environ.get("BASETEN_API_KEY")
+    if not api_key:
+        raise ValueError("Pass `api_key` or set BASETEN_API_KEY.")
+    async with aiohttp.ClientSession() as session:
+        async with session.ws_connect(
+            model_endpoint,
+            headers={"Authorization": f"Api-Key {api_key}"},
+            max_msg_size=_WS_MAX_MSG_SIZE,
+        ) as ws:
+            await ws.send_str(json.dumps(message))
+            return json.loads((await ws.receive()).data)
+
+
+async def register_voice(
+    *,
+    model_endpoint: str,
+    name: str,
+    ref_audio_path: str,
+    ref_text: str | None = None,
+    api_key: str | None = None,
+    consent: str = "user_consent",
+) -> dict[str, Any]:
+    """Clone a voice from 10-20s of clean speech. Omitting ref_text is less faithful.
+
+    The clone lives on one replica's local disk and dies with the container.
+    """
+    with open(ref_audio_path, "rb") as f:
+        audio_b64 = base64.b64encode(f.read()).decode()
+    message: dict[str, Any] = {
+        "type": "voice.add",
+        "name": name,
+        "consent": consent,
+        "audio_data": audio_b64,
+        "audio_format": os.path.splitext(ref_audio_path)[1].lstrip(".").lower() or "wav",
+    }
+    if ref_text:
+        message["ref_text"] = ref_text
+
+    response = await _control(model_endpoint, api_key, message)
+    if response.get("type") == "error" or not response.get("success"):
+        raise RuntimeError(f"voice.add failed: {response.get('message') or response}")
+    return response.get("voice", response)
+
+
+async def list_voices(*, model_endpoint: str, api_key: str | None = None) -> dict[str, Any]:
+    """`voices` is built-ins (empty on Base); `uploaded_voices` is per-replica."""
+    response = await _control(model_endpoint, api_key, {"type": "voice.list"})
+    if response.get("type") == "error":
+        raise RuntimeError(f"voice.list failed: {response.get('message')}")
+    return response

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
@@ -690,7 +690,13 @@ async def _control(model_endpoint: str, api_key: str | None, message: dict) -> d
             max_msg_size=_WS_MAX_MSG_SIZE,
         ) as ws:
             await ws.send_str(json.dumps(message))
-            response: dict[str, Any] = json.loads((await ws.receive()).data)
+            msg = await ws.receive()
+            if msg.type is not aiohttp.WSMsgType.TEXT:
+                # .data is None on CLOSED, the close code on CLOSE, an exception
+                # on ERROR — json.loads would raise a bare TypeError and hide
+                # what actually went wrong.
+                raise RuntimeError(f"unexpected reply to {message.get('type')!r}: {msg.type.name}")
+            response: dict[str, Any] = json.loads(msg.data)
             return response
 
 

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
@@ -387,41 +387,44 @@ class Qwen3TTS(tts.TTS):
             self._keepalive_task = asyncio.create_task(self._keepalive_loop())
 
     async def _keepalive_loop(self) -> None:
-        """An empty input.done answers session.done and resets the idle timer.
+        """Keep the parked socket off the server's idle timeout.
 
-        A protocol ping would not: it proves the socket is alive, not the
-        session.
+        An empty ``input.done`` answers ``session.done`` with zero sentences.
+        Unlike a protocol ping that proves the *session* is alive, not merely
+        the TCP connection.
+
+        The loop only ever exits on shutdown. It deliberately does not return
+        when it finds nothing parked or when a flush fails: it releases
+        ``_warm_lock`` for the round trip, so a turn can park a fresh socket at
+        any point, and ``_release`` cannot schedule a keepalive for it while
+        this task is still running (not ``done()``). Returning early would
+        leave that socket to idle out.
         """
         while not self._closing:
             await asyncio.sleep(_KEEPALIVE_INTERVAL)
 
-            # Take the socket *out* of the slot before flushing. The lock is on
-            # the hot path for every turn, so holding it across the round trip
-            # would stall a reply that starts mid-keepalive by up to
-            # _KEEPALIVE_TIMEOUT. Removing it also keeps the invariant that a
-            # turn and the keepalive never touch the same socket: a turn
-            # arriving now finds an empty slot and dials its own.
             async with self._warm_lock:
                 warm = self._warm
-                if warm is None:
-                    return  # a turn took it; _release restarts us
+                if warm is None or not warm.config:
+                    continue  # nothing parked, or no session on it yet
                 if warm.ws.closed:
                     self._warm = None
-                    return
-                if not warm.config:
                     continue
+                # Take it out for the round trip so a turn starting now dials
+                # its own socket instead of blocking on the lock.
                 self._warm = None
 
-            # While the flush is in flight this local is the only reference to
-            # the socket, so aclose() cancelling us here would leak it.
             try:
                 alive = await self._empty_flush(warm.ws)
             except asyncio.CancelledError:
+                # This local is the only reference while the flush is in
+                # flight, so aclose() cancelling here would leak it.
                 await self._shutdown_ws(warm.ws, notify=False)
                 raise
+
             if not alive:
                 await self._shutdown_ws(warm.ws, notify=False)
-                return
+                continue
 
             warm.last_activity = time.monotonic()
             async with self._warm_lock:
@@ -429,11 +432,8 @@ class Qwen3TTS(tts.TTS):
                 if not surplus:
                     self._warm = warm
             if surplus:
-                # A turn started during the flush and parked its own socket on
-                # the way out, so ours is redundant. Drop it but keep looping:
-                # _release could not have scheduled a keepalive for that socket
-                # (this task was still running, so not `done()`), and returning
-                # here would leave it to idle out on the server.
+                # A turn parked its own socket while we were flushing; ours is
+                # redundant.
                 await self._shutdown_ws(warm.ws, notify=True)
 
     async def _empty_flush(self, ws: aiohttp.ClientWebSocketResponse) -> bool:

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
@@ -391,6 +391,13 @@ class Qwen3TTS(tts.TTS):
         """
         while not self._closing:
             await asyncio.sleep(_KEEPALIVE_INTERVAL)
+
+            # Take the socket *out* of the slot before flushing. The lock is on
+            # the hot path for every turn, so holding it across the round trip
+            # would stall a reply that starts mid-keepalive by up to
+            # _KEEPALIVE_TIMEOUT. Removing it also keeps the invariant that a
+            # turn and the keepalive never touch the same socket: a turn
+            # arriving now finds an empty slot and dials its own.
             async with self._warm_lock:
                 warm = self._warm
                 if warm is None:
@@ -400,12 +407,22 @@ class Qwen3TTS(tts.TTS):
                     return
                 if not warm.config:
                     continue
-                if await self._empty_flush(warm.ws):
-                    warm.last_activity = time.monotonic()
-                else:
-                    self._warm = None
-                    await self._shutdown_ws(warm.ws, notify=False)
-                    return
+                self._warm = None
+
+            if not await self._empty_flush(warm.ws):
+                await self._shutdown_ws(warm.ws, notify=False)
+                return
+
+            warm.last_activity = time.monotonic()
+            async with self._warm_lock:
+                surplus = self._warm is not None
+                if not surplus:
+                    self._warm = warm
+            if surplus:
+                # A turn started during the flush and parked its own socket on
+                # the way out, so ours is now redundant.
+                await self._shutdown_ws(warm.ws, notify=True)
+                return
 
     async def _empty_flush(self, ws: aiohttp.ClientWebSocketResponse) -> bool:
         try:

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
@@ -54,20 +54,16 @@ from livekit.agents import (
     tts,
     utils,
 )
-from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, NotGivenOr
+from livekit.agents.types import (
+    DEFAULT_API_CONNECT_OPTIONS,
+    NOT_GIVEN,
+    NotGivenOr,
+    TimedString,
+)
 from livekit.agents.utils import is_given
 
 from ._endpoint import resolve_endpoint
 from .log import logger
-
-try:
-    from livekit.agents.types import TimedString
-
-    _HAS_TIMED_STRING = True
-except ImportError:  # pragma: no cover
-    TimedString = None  # type: ignore[assignment]
-    _HAS_TIMED_STRING = False
-
 
 SAMPLE_RATE = 24000
 NUM_CHANNELS = 1
@@ -152,9 +148,6 @@ class Qwen3TTS(tts.TTS):
         if not voice:
             raise ValueError("`voice` is required: the Base checkpoint has no presets.")
 
-        if word_timestamps and not _HAS_TIMED_STRING:
-            logger.warning("livekit-agents has no TimedString; disabling alignment")
-            word_timestamps = False
         if speed != 1.0:
             logger.warning("progressive PCM requires speed=1.0; overriding %s", speed)
             speed = 1.0
@@ -587,11 +580,11 @@ class Qwen3SynthesizeStream(tts.SynthesizeStream):
         offset: float,
     ) -> None:
         """Rebase one sentence's word times onto the segment timeline."""
-        if not timestamp_info or not _HAS_TIMED_STRING:
+        if not timestamp_info:
             return
         alignment = timestamp_info.get("word_alignment") or {}
         timed = [
-            TimedString(  # type: ignore[misc]
+            TimedString(
                 text=f"{word} ",
                 start_time=offset + float(start),
                 end_time=offset + float(end),
@@ -645,7 +638,8 @@ async def _control(model_endpoint: str, api_key: str | None, message: dict) -> d
             max_msg_size=_WS_MAX_MSG_SIZE,
         ) as ws:
             await ws.send_str(json.dumps(message))
-            return json.loads((await ws.receive()).data)
+            response: dict[str, Any] = json.loads((await ws.receive()).data)
+            return response
 
 
 async def register_voice(
@@ -676,7 +670,8 @@ async def register_voice(
     response = await _control(model_endpoint, api_key, message)
     if response.get("type") == "error" or not response.get("success"):
         raise RuntimeError(f"voice.add failed: {response.get('message') or response}")
-    return response.get("voice", response)
+    voice: dict[str, Any] = response.get("voice", response)
+    return voice
 
 
 async def list_voices(*, model_endpoint: str, api_key: str | None = None) -> dict[str, Any]:

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
@@ -12,24 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""TTS for Baseten's Qwen3-TTS deployments.
+"""Qwen3-TTS protocol support for `TTS` (``model="qwen3-tts"``).
 
-This is a separate class from `TTS` because the two speak different wire
-protocols. `TTS` targets the Orpheus truss (hence its `tara` default voice);
 Qwen3-TTS is: session.config -> input.text* -> input.done (a flush, not a
-close) -> audio.start / PCM / audio.done / session.done.
+close) -> audio.start / PCM / audio.done / session.done. That is a different
+protocol from the Orpheus truss `TTS` also serves, so it gets its own backend
+and stream implementation here; `TTS` picks between them.
 
 Voices are clones, not presets: the Base checkpoint ships no built-in speakers.
 Register one first (see `register_voice`), or pass ref_audio/ref_text to clone
-inline. Note the server keeps uploaded voices on the container's local disk, so
-a runtime-registered voice is scoped to one replica and lost on restart — bake
-it into the truss via REQUIRED_VOICES for anything beyond single-replica tests.
-
-    session = AgentSession(tts=Qwen3TTS(
-        model_endpoint="wss://model-XXXXXXX.api.baseten.co/environments/production/websocket",
-        api_key=os.environ["BASETEN_API_KEY"],
-        voice="my_registered_voice",
-    ))
+inline. The server keeps uploaded voices on the container's local disk, so a
+runtime-registered voice is scoped to one replica and lost on restart — bake it
+into the truss via REQUIRED_VOICES for anything beyond single-replica tests.
 """
 
 from __future__ import annotations
@@ -40,7 +34,6 @@ import contextlib
 import json
 import os
 import time
-import weakref
 from dataclasses import dataclass, field, replace
 from typing import Any
 
@@ -51,11 +44,10 @@ from livekit.agents import (
     APIConnectOptions,
     APIStatusError,
     APITimeoutError,
-    tts,
+    tts as tts_module,
     utils,
 )
 from livekit.agents.types import (
-    DEFAULT_API_CONNECT_OPTIONS,
     NOT_GIVEN,
     NotGivenOr,
     TimedString,
@@ -116,13 +108,13 @@ class _TurnState:
         return self.sender_finished.is_set() and self.flushes_done >= self.flushes_sent
 
 
-class Qwen3TTS(tts.TTS):
-    """Streaming TTS for a Baseten-hosted Qwen3-TTS deployment.
+class _Qwen3Backend:
+    """Connection state for a Qwen3-TTS deployment, owned by `TTS`.
 
-    Not interchangeable with `TTS`, which targets the Orpheus truss and speaks a
-    different protocol. Keeps one WebSocket warm across turns, since the session
-    config is sticky and re-dialing would add a connect plus a config round trip
-    to every agent response.
+    Not a `tts.TTS` itself — `TTS` selects this when ``model="qwen3-tts"`` and
+    keeps the public surface. Holds one warm WebSocket across turns, since the
+    session config is sticky and re-dialing would add a connect plus a config
+    round trip to every agent response.
     """
 
     def __init__(
@@ -200,16 +192,9 @@ class Qwen3TTS(tts.TTS):
             logger.warning("progressive PCM requires speed=1.0; overriding %s", speed)
             speed = 1.0
 
-        super().__init__(
-            capabilities=tts.TTSCapabilities(streaming=True, aligned_transcript=word_timestamps),
-            sample_rate=SAMPLE_RATE,
-            num_channels=NUM_CHANNELS,
-        )
-
         self._api_key = api_key
         self._model_endpoint = model_endpoint
         self._session = http_session
-        self._streams = weakref.WeakSet["Qwen3SynthesizeStream"]()
         self._opts = _TTSOptions(
             voice=voice,
             task_type=task_type,
@@ -231,14 +216,6 @@ class Qwen3TTS(tts.TTS):
         self._keepalive_task: asyncio.Task[None] | None = None
         self._closing = False
 
-    @property
-    def model(self) -> str:
-        return f"qwen3-tts-{self._opts.task_type.lower()}"
-
-    @property
-    def provider(self) -> str:
-        return "Baseten"
-
     def update_options(
         self,
         *,
@@ -257,26 +234,8 @@ class Qwen3TTS(tts.TTS):
         if is_given(max_new_tokens):
             self._opts.max_new_tokens = max_new_tokens
 
-    def stream(
-        self, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
-    ) -> Qwen3SynthesizeStream:
-        stream = Qwen3SynthesizeStream(tts=self, conn_options=conn_options)
-        self._streams.add(stream)
-        return stream
-
-    def synthesize(
-        self, text: str, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
-    ) -> tts.ChunkedStream:
-        # The framework helper disables retries on the inner stream (this class
-        # already retries) and forwards timed transcripts; hand-rolling it did
-        # neither.
-        return self._synthesize_with_stream(text, conn_options=conn_options)
-
     async def aclose(self) -> None:
         self._closing = True
-        for stream in list(self._streams):
-            await stream.aclose()
-        self._streams.clear()
         if self._keepalive_task and not self._keepalive_task.done():
             self._keepalive_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -467,15 +426,21 @@ class Qwen3TTS(tts.TTS):
             await ws.close()
 
 
-class Qwen3SynthesizeStream(tts.SynthesizeStream):
+class Qwen3SynthesizeStream(tts_module.SynthesizeStream):
     """One agent turn: text in over the input channel, PCM out via the emitter."""
 
-    def __init__(self, *, tts: Qwen3TTS, conn_options: APIConnectOptions) -> None:
+    def __init__(
+        self,
+        *,
+        tts: tts_module.TTS,
+        backend: _Qwen3Backend,
+        conn_options: APIConnectOptions,
+    ) -> None:
         super().__init__(tts=tts, conn_options=conn_options)
-        self._tts: Qwen3TTS = tts
-        self._opts = replace(tts._opts)
+        self._backend = backend
+        self._opts = replace(backend._opts)
 
-    async def _run(self, output_emitter: tts.AudioEmitter) -> None:
+    async def _run(self, output_emitter: tts_module.AudioEmitter) -> None:
         request_id = utils.shortuuid()
         output_emitter.initialize(
             request_id=request_id,
@@ -487,7 +452,7 @@ class Qwen3SynthesizeStream(tts.SynthesizeStream):
 
         try:
             ws, applied_config = await asyncio.wait_for(
-                self._tts._acquire(), timeout=self._conn_options.timeout
+                self._backend._acquire(), timeout=self._conn_options.timeout
             )
         except asyncio.TimeoutError:
             raise APITimeoutError() from None
@@ -498,7 +463,7 @@ class Qwen3SynthesizeStream(tts.SynthesizeStream):
         except Exception as e:
             raise APIConnectionError() from e
 
-        config = self._tts._build_session_config()
+        config = self._backend._build_session_config()
         state = _TurnState()
         discard = True
 
@@ -627,7 +592,7 @@ class Qwen3SynthesizeStream(tts.SynthesizeStream):
         except Exception as e:
             raise APIConnectionError() from e
         finally:
-            await self._tts._release(ws, config, discard=discard)
+            await self._backend._release(ws, config, discard=discard)
 
     async def _drain(self, recv_task: asyncio.Task[None], state: _TurnState) -> None:
         """Unblock a receiver parked on ws.receive() with nothing left to read.
@@ -660,7 +625,7 @@ class Qwen3SynthesizeStream(tts.SynthesizeStream):
 
     def _emit_timestamps(
         self,
-        output_emitter: tts.AudioEmitter,
+        output_emitter: tts_module.AudioEmitter,
         timestamp_info: dict[str, Any] | None,
         offset: float,
     ) -> None:

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
@@ -117,6 +117,14 @@ class _TurnState:
 
 
 class Qwen3TTS(tts.TTS):
+    """Streaming TTS for a Baseten-hosted Qwen3-TTS deployment.
+
+    Not interchangeable with `TTS`, which targets the Orpheus truss and speaks a
+    different protocol. Keeps one WebSocket warm across turns, since the session
+    config is sticky and re-dialing would add a connect plus a config round trip
+    to every agent response.
+    """
+
     def __init__(
         self,
         *,
@@ -138,6 +146,46 @@ class Qwen3TTS(tts.TTS):
         extra_config: dict[str, Any] | None = None,
         http_session: aiohttp.ClientSession | None = None,
     ) -> None:
+        """
+        Args:
+            model_endpoint: Full ``wss://`` URL of the deployment. Takes priority
+                over ``model_id`` and ``chain_id``; falls back to
+                ``BASETEN_MODEL_ENDPOINT``.
+            model_id: Baseten truss model ID; builds the endpoint URL for you.
+            chain_id: Baseten chain ID; builds the endpoint URL for you.
+            api_key: Baseten API key, or ``BASETEN_API_KEY``.
+            voice: Name of a registered voice clone. Required — the Base
+                checkpoint ships no built-in speakers, so there is no sensible
+                default. See `register_voice`.
+            task_type: ``Base`` for the voice-cloning checkpoint. ``CustomVoice``
+                and ``VoiceDesign`` deployments use their own checkpoints and
+                expose preset speaker names.
+            language: Language hint; ``Auto`` lets the model decide.
+            speed: Playback rate. Forced to 1.0 — progressive PCM is only offered
+                at native speed and the server rejects anything else, which is
+                fatal on a socket that has no session yet.
+            instructions: Style prompt (``CustomVoice``/``VoiceDesign`` only).
+            max_new_tokens: Cap on generated audio tokens per sentence.
+            initial_codec_chunk_frames: First-chunk size. Larger trades
+                time-to-first-audio for slightly better onset quality.
+            x_vector_only_mode: Condition on the speaker embedding alone and skip
+                in-context learning from the reference. Faster, less faithful.
+            ref_audio: Reference clip for inline cloning — an ``http(s)`` URL or a
+                local file path. Only needed when ``voice`` is not already
+                registered on the deployment.
+            ref_text: Transcript of ``ref_audio``. Improves fidelity; without it
+                the server falls back to audio-only (x-vector).
+            word_timestamps: Request word-level alignment and forward it to
+                LiveKit as a timed transcript.
+            extra_config: Merged into ``session.config`` last, for server-side
+                fields newer than this plugin. Note that an unrecognized field
+                invalidates the whole config.
+            http_session: Optional aiohttp session to reuse.
+
+        Raises:
+            ValueError: If no API key or endpoint can be resolved, or if
+                ``voice`` is empty.
+        """
         api_key = api_key or os.environ.get("BASETEN_API_KEY")
         if not api_key:
             raise ValueError("Pass `api_key` or set BASETEN_API_KEY.")
@@ -391,6 +439,8 @@ class Qwen3TTS(tts.TTS):
 
 
 class Qwen3SynthesizeStream(tts.SynthesizeStream):
+    """One agent turn: text in over the input channel, PCM out via the emitter."""
+
     def __init__(self, *, tts: Qwen3TTS, conn_options: APIConnectOptions) -> None:
         super().__init__(tts=tts, conn_options=conn_options)
         self._tts: Qwen3TTS = tts

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/qwen3_tts.py
@@ -430,9 +430,11 @@ class Qwen3TTS(tts.TTS):
                     self._warm = warm
             if surplus:
                 # A turn started during the flush and parked its own socket on
-                # the way out, so ours is now redundant.
+                # the way out, so ours is redundant. Drop it but keep looping:
+                # _release could not have scheduled a keepalive for that socket
+                # (this task was still running, so not `done()`), and returning
+                # here would leave it to idle out on the server.
                 await self._shutdown_ws(warm.ws, notify=True)
-                return
 
     async def _empty_flush(self, ws: aiohttp.ClientWebSocketResponse) -> bool:
         try:

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/stt.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/stt.py
@@ -42,7 +42,9 @@ from livekit.agents.types import NOT_GIVEN, NotGivenOr
 from livekit.agents.utils import AudioBuffer, is_given
 from livekit.agents.voice.io import TimedString
 
+from . import qwen3_stt
 from .log import logger
+from .models import STTModels
 
 STTEncoding = Literal["pcm_s16le", "pcm_mulaw"]
 
@@ -84,6 +86,7 @@ class STT(stt.STT):
     def __init__(
         self,
         *,
+        model: STTModels = "whisper",
         api_key: str | None = None,
         model_endpoint: str | None = None,
         model_id: str | None = None,
@@ -91,15 +94,15 @@ class STT(stt.STT):
         sample_rate: int = 16000,
         encoding: NotGivenOr[STTEncoding] = NOT_GIVEN,
         buffer_size_seconds: float = 0.032,
-        language: str = "en",
+        language: NotGivenOr[str] = NOT_GIVEN,
         language_options: list[str] | None = None,
         enable_partial_transcripts: bool = True,
-        partial_transcript_interval_s: float = 1.0,
+        partial_transcript_interval_s: NotGivenOr[float] = NOT_GIVEN,
         final_transcript_max_duration_s: int = 30,
-        show_word_timestamps: bool = True,
+        show_word_timestamps: NotGivenOr[bool] = NOT_GIVEN,
         vad_threshold: float = 0.5,
-        vad_min_silence_duration_ms: int = 300,
-        vad_speech_pad_ms: int = 30,
+        vad_min_silence_duration_ms: NotGivenOr[int] = NOT_GIVEN,
+        vad_speech_pad_ms: NotGivenOr[int] = NOT_GIVEN,
         http_session: aiohttp.ClientSession | None = None,
     ):
         """Baseten Speech-to-Text provider.
@@ -132,8 +135,11 @@ class STT(stt.STT):
             sample_rate: Audio sample rate in Hz (default ``16000``).
             encoding: Audio encoding – ``pcm_s16le`` (default) or ``pcm_mulaw``.
             buffer_size_seconds: Audio buffer size in seconds.
-            language: BCP-47 language code (default ``en``).  Use ``auto`` for
-                automatic language detection.
+            language: For ``whisper``, a BCP-47 code (default ``en``); use
+                ``auto`` for detection. For ``qwen3-asr``, a Qwen3-ASR canonical
+                language name (``English``, ``Cantonese``) or ``auto``
+                (the default) — forcing one also sets the *output* language and
+                can translate, so use it only to pin what is actually spoken.
             language_options: Restrict automatic detection to this set of
                 language codes, e.g. ``["en", "de"]``.  Detection across all
                 supported languages is unreliable on the one- to two-second
@@ -144,15 +150,60 @@ class STT(stt.STT):
             enable_partial_transcripts: Emit interim transcripts while the speaker
                 is still talking.  Defaults to ``True``.
             partial_transcript_interval_s: Interval (seconds) between partial
-                transcript updates.
+                transcript updates. Defaults to 1.0 for ``whisper`` and 0.5 for
+                ``qwen3-asr``, matching each deployment's own default.
             final_transcript_max_duration_s: Maximum seconds of audio before the
                 server forces a final transcript.
-            show_word_timestamps: Include word-level timestamps in results.
+            show_word_timestamps: Include word-level timestamps. Defaults to
+                on for ``whisper``; off for ``qwen3-asr``, whose aligner is
+                opt-in on the deployment (``STREAM_ALIGNER=mms``).
             vad_threshold: Server-side VAD threshold (0.0–1.0).
-            vad_min_silence_duration_ms: Minimum silence (ms) to end an utterance.
-            vad_speech_pad_ms: Padding (ms) around detected speech.
+            vad_min_silence_duration_ms: Minimum silence (ms) to end an
+                utterance. Defaults to 300 (``whisper``) / 500 (``qwen3-asr``).
+            vad_speech_pad_ms: Padding (ms) around detected speech. Defaults to
+                30 (``whisper``) / 100 (``qwen3-asr``).
             http_session: Optional :class:`aiohttp.ClientSession` to reuse.
         """
+        self._model_name = model
+        self._qwen3: qwen3_stt._Qwen3Backend | None = None
+
+        if model == "qwen3-asr":
+            self._qwen3 = qwen3_stt._Qwen3Backend(
+                model_endpoint=model_endpoint,
+                model_id=model_id,
+                chain_id=chain_id,
+                api_key=api_key,
+                language=language if is_given(language) else "auto",
+                interim_results=enable_partial_transcripts,
+                partial_transcript_interval_s=(
+                    partial_transcript_interval_s
+                    if is_given(partial_transcript_interval_s)
+                    else 0.5
+                ),
+                final_transcript_max_duration_s=final_transcript_max_duration_s,
+                vad_threshold=vad_threshold,
+                vad_min_silence_duration_ms=(
+                    vad_min_silence_duration_ms if is_given(vad_min_silence_duration_ms) else 500
+                ),
+                vad_speech_pad_ms=vad_speech_pad_ms if is_given(vad_speech_pad_ms) else 100,
+                # Off unless asked for: the aligner is opt-in on the deployment
+                # (STREAM_ALIGNER), so defaulting it on would advertise a
+                # capability the server may silently not honour.
+                word_timestamps=show_word_timestamps if is_given(show_word_timestamps) else False,
+                http_session=http_session,
+            )
+            super().__init__(
+                capabilities=stt.STTCapabilities(
+                    streaming=True,
+                    interim_results=enable_partial_transcripts,
+                    aligned_transcript="word" if show_word_timestamps else False,
+                    offline_recognize=True,
+                )
+            )
+            self._session = http_session
+            self._streams = weakref.WeakSet[stt.SpeechStream]()
+            return
+
         super().__init__(
             capabilities=stt.STTCapabilities(
                 streaming=True,
@@ -197,15 +248,19 @@ class STT(stt.STT):
         self._opts = STTOptions(
             sample_rate=sample_rate,
             buffer_size_seconds=buffer_size_seconds,
-            language=LanguageCode(language),
+            language=LanguageCode(language if is_given(language) else "en"),
             language_options=[LanguageCode(lang) for lang in language_options or []],
             enable_partial_transcripts=enable_partial_transcripts,
-            partial_transcript_interval_s=partial_transcript_interval_s,
+            partial_transcript_interval_s=(
+                partial_transcript_interval_s if is_given(partial_transcript_interval_s) else 1.0
+            ),
             final_transcript_max_duration_s=final_transcript_max_duration_s,
-            show_word_timestamps=show_word_timestamps,
+            show_word_timestamps=(show_word_timestamps if is_given(show_word_timestamps) else True),
             vad_threshold=vad_threshold,
-            vad_min_silence_duration_ms=vad_min_silence_duration_ms,
-            vad_speech_pad_ms=vad_speech_pad_ms,
+            vad_min_silence_duration_ms=(
+                vad_min_silence_duration_ms if is_given(vad_min_silence_duration_ms) else 300
+            ),
+            vad_speech_pad_ms=vad_speech_pad_ms if is_given(vad_speech_pad_ms) else 30,
         )
 
         if is_given(encoding):
@@ -216,7 +271,7 @@ class STT(stt.STT):
 
     @property
     def model(self) -> str:
-        return "unknown"
+        return self._model_name
 
     @property
     def provider(self) -> str:
@@ -235,6 +290,10 @@ class STT(stt.STT):
         language: NotGivenOr[str] = NOT_GIVEN,
         conn_options: APIConnectOptions,
     ) -> stt.SpeechEvent:
+        if self._qwen3 is not None:
+            return await self._qwen3.recognize_via_stream(
+                self, buffer, language=language, conn_options=conn_options
+            )
         raise NotImplementedError("Not implemented")
 
     def stream(
@@ -242,7 +301,14 @@ class STT(stt.STT):
         *,
         language: NotGivenOr[str] = NOT_GIVEN,
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
-    ) -> SpeechStream:
+    ) -> stt.SpeechStream:
+        if self._qwen3 is not None:
+            qwen3_stream = self._qwen3.make_stream(
+                self, language=language, conn_options=conn_options
+            )
+            self._streams.add(qwen3_stream)
+            return qwen3_stream
+
         config = dataclasses.replace(self._opts)
         stream = SpeechStream(
             stt=self,
@@ -265,6 +331,13 @@ class STT(stt.STT):
         language_options: NotGivenOr[list[str]] = NOT_GIVEN,
         buffer_size_seconds: NotGivenOr[float] = NOT_GIVEN,
     ) -> None:
+        if self._qwen3 is not None:
+            self._qwen3.update_options(
+                language=language,
+                vad_threshold=vad_threshold,
+                vad_min_silence_duration_ms=vad_min_silence_duration_ms,
+            )
+            return
         if is_given(vad_threshold):
             self._opts.vad_threshold = vad_threshold
         if is_given(vad_min_silence_duration_ms):

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/stt.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/stt.py
@@ -336,7 +336,17 @@ class STT(stt.STT):
                 language=language,
                 vad_threshold=vad_threshold,
                 vad_min_silence_duration_ms=vad_min_silence_duration_ms,
+                vad_speech_pad_ms=vad_speech_pad_ms,
             )
+            # These are Whisper-only; say so rather than dropping them quietly.
+            for name, value in (
+                ("language_options", language_options),
+                ("buffer_size_seconds", buffer_size_seconds),
+            ):
+                if is_given(value):
+                    logger.warning(
+                        "%s does not apply to model=%r and was ignored", name, self._model_name
+                    )
             return
         if is_given(vad_threshold):
             self._opts.vad_threshold = vad_threshold

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/stt.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/stt.py
@@ -22,8 +22,8 @@ import json
 import os
 import ssl
 import weakref
-from dataclasses import dataclass
-from typing import Literal
+from dataclasses import dataclass, field
+from typing import Any, Literal
 
 import aiohttp
 import numpy as np
@@ -61,6 +61,7 @@ class STTOptions:
     buffer_size_seconds: float = 0.032
     encoding: str = "pcm_s16le"
     language: LanguageCode = LanguageCode("en")
+    language_options: list[LanguageCode] = field(default_factory=list)
 
     # Streaming params – controls how transcripts are delivered
     enable_partial_transcripts: bool = True
@@ -91,6 +92,7 @@ class STT(stt.STT):
         encoding: NotGivenOr[STTEncoding] = NOT_GIVEN,
         buffer_size_seconds: float = 0.032,
         language: str = "en",
+        language_options: list[str] | None = None,
         enable_partial_transcripts: bool = True,
         partial_transcript_interval_s: float = 1.0,
         final_transcript_max_duration_s: int = 30,
@@ -132,6 +134,13 @@ class STT(stt.STT):
             buffer_size_seconds: Audio buffer size in seconds.
             language: BCP-47 language code (default ``en``).  Use ``auto`` for
                 automatic language detection.
+            language_options: Restrict automatic detection to this set of
+                language codes, e.g. ``["en", "de"]``.  Detection across all
+                supported languages is unreliable on the one- to two-second
+                utterances typical of telephony, so scoping it to the languages
+                an agent actually supports is usually more accurate than
+                ``auto``.  Requires Baseten Whisper runtime v0.5.0 or newer;
+                empty (the default) leaves detection unrestricted.
             enable_partial_transcripts: Emit interim transcripts while the speaker
                 is still talking.  Defaults to ``True``.
             partial_transcript_interval_s: Interval (seconds) between partial
@@ -189,6 +198,7 @@ class STT(stt.STT):
             sample_rate=sample_rate,
             buffer_size_seconds=buffer_size_seconds,
             language=LanguageCode(language),
+            language_options=[LanguageCode(lang) for lang in language_options or []],
             enable_partial_transcripts=enable_partial_transcripts,
             partial_transcript_interval_s=partial_transcript_interval_s,
             final_transcript_max_duration_s=final_transcript_max_duration_s,
@@ -252,6 +262,7 @@ class STT(stt.STT):
         vad_min_silence_duration_ms: NotGivenOr[int] = NOT_GIVEN,
         vad_speech_pad_ms: NotGivenOr[int] = NOT_GIVEN,
         language: NotGivenOr[str] = NOT_GIVEN,
+        language_options: NotGivenOr[list[str]] = NOT_GIVEN,
         buffer_size_seconds: NotGivenOr[float] = NOT_GIVEN,
     ) -> None:
         if is_given(vad_threshold):
@@ -262,6 +273,8 @@ class STT(stt.STT):
             self._opts.vad_speech_pad_ms = vad_speech_pad_ms
         if is_given(language):
             self._opts.language = LanguageCode(language)
+        if is_given(language_options):
+            self._opts.language_options = [LanguageCode(lang) for lang in language_options]
         if is_given(buffer_size_seconds):
             self._opts.buffer_size_seconds = buffer_size_seconds
 
@@ -271,6 +284,7 @@ class STT(stt.STT):
                 vad_min_silence_duration_ms=vad_min_silence_duration_ms,
                 vad_speech_pad_ms=vad_speech_pad_ms,
                 language=language,
+                language_options=language_options,
                 buffer_size_seconds=buffer_size_seconds,
             )
 
@@ -310,6 +324,7 @@ class SpeechStream(stt.SpeechStream):
         vad_min_silence_duration_ms: NotGivenOr[int] = NOT_GIVEN,
         vad_speech_pad_ms: NotGivenOr[int] = NOT_GIVEN,
         language: NotGivenOr[str] = NOT_GIVEN,
+        language_options: NotGivenOr[list[str]] = NOT_GIVEN,
         buffer_size_seconds: NotGivenOr[float] = NOT_GIVEN,
     ) -> None:
         if is_given(vad_threshold):
@@ -320,6 +335,8 @@ class SpeechStream(stt.SpeechStream):
             self._opts.vad_speech_pad_ms = vad_speech_pad_ms
         if is_given(language):
             self._opts.language = LanguageCode(language)
+        if is_given(language_options):
+            self._opts.language_options = [LanguageCode(lang) for lang in language_options]
         if is_given(buffer_size_seconds):
             self._opts.buffer_size_seconds = buffer_size_seconds
 
@@ -534,7 +551,7 @@ class SpeechStream(stt.SpeechStream):
 
         # Build metadata matching Baseten's StreamingWhisperInput schema.
         # See: https://docs.baseten.co/reference/inference-api/predict-endpoints/streaming-transcription-api
-        metadata = {
+        metadata: dict[str, dict[str, Any]] = {
             "whisper_params": {
                 "audio_language": self._opts.language,
                 "show_word_timestamps": self._opts.show_word_timestamps,
@@ -552,6 +569,13 @@ class SpeechStream(stt.SpeechStream):
                 "speech_pad_ms": self._opts.vad_speech_pad_ms,
             },
         }
+
+        if self._opts.language_options:
+            # Omitted unless set: older Whisper runtimes (< v0.5.0) reject
+            # unknown whisper_params fields.
+            metadata["whisper_params"]["language_options"] = [
+                str(lang) for lang in self._opts.language_options
+            ]
 
         await ws.send_str(json.dumps(metadata))
         return ws

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/stt.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/stt.py
@@ -267,7 +267,7 @@ class STT(stt.STT):
             self._opts.encoding = encoding
 
         self._session = http_session
-        self._streams = weakref.WeakSet[SpeechStream]()
+        self._streams = weakref.WeakSet[stt.SpeechStream]()
 
     @property
     def model(self) -> str:
@@ -352,6 +352,10 @@ class STT(stt.STT):
             self._opts.buffer_size_seconds = buffer_size_seconds
 
         for stream in self._streams:
+            # Only the Whisper stream carries these knobs; a qwen3-asr stream
+            # cannot be in here, since that path returns above.
+            if not isinstance(stream, SpeechStream):
+                continue
             stream.update_options(
                 vad_threshold=vad_threshold,
                 vad_min_silence_duration_ms=vad_min_silence_duration_ms,

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/tts.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/tts.py
@@ -19,6 +19,7 @@ import os
 import ssl
 import weakref
 from dataclasses import dataclass, replace
+from typing import Any
 
 import aiohttp
 
@@ -32,6 +33,9 @@ from livekit.agents import (
 )
 from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, NotGivenOr
 from livekit.agents.utils import is_given
+
+from . import qwen3_tts
+from .models import TTSModels
 
 ssl_context = ssl.create_default_context()
 ssl_context.check_hostname = False
@@ -50,32 +54,112 @@ class _TTSOptions:
 
 
 class TTS(tts.TTS):
+    """Text-to-speech for a Baseten-hosted model.
+
+    ``model`` selects the wire protocol, since Baseten's TTS deployments do not
+    share one. ``orpheus`` (the default) is the existing behaviour; ``qwen3-tts``
+    speaks the session.config protocol and takes a registered voice clone.
+    """
+
     def __init__(
         self,
         *,
+        model: TTSModels = "orpheus",
         api_key: str | None = None,
         model_endpoint: str | None = None,
-        voice: str = "tara",
-        language: str = "en",
+        model_id: str | None = None,
+        chain_id: str | None = None,
+        voice: NotGivenOr[str] = NOT_GIVEN,
+        language: NotGivenOr[str] = NOT_GIVEN,
         temperature: float = 0.6,
         max_tokens: int = 2000,
         buffer_size: int = 10,
+        task_type: str = "Base",
+        instructions: str | None = None,
+        max_new_tokens: int | None = None,
+        initial_codec_chunk_frames: int | None = None,
+        x_vector_only_mode: bool | None = None,
+        ref_audio: str | None = None,
+        ref_text: str | None = None,
+        word_timestamps: bool = False,
+        extra_config: dict[str, Any] | None = None,
         http_session: aiohttp.ClientSession | None = None,
     ) -> None:
         """
         Initialize the Baseten TTS.
 
         Args:
+            model: Which deployment protocol to speak — ``orpheus`` (default) or
+                ``qwen3-tts``. They are not interchangeable.
             api_key: Baseten API key, or ``BASETEN_API_KEY`` env var.
+            model_id: Baseten truss model ID; builds the endpoint URL for you
+                (``qwen3-tts`` only).
+            chain_id: Baseten chain ID; builds the endpoint URL for you
+                (``qwen3-tts`` only).
+            task_type: ``qwen3-tts`` only. ``Base`` for the voice-cloning
+                checkpoint; ``CustomVoice``/``VoiceDesign`` deployments expose
+                preset speaker names.
+            instructions: ``qwen3-tts`` style prompt (CustomVoice/VoiceDesign).
+            max_new_tokens: ``qwen3-tts`` cap on audio tokens per sentence.
+            initial_codec_chunk_frames: ``qwen3-tts`` first-chunk size; larger
+                trades time-to-first-audio for onset quality.
+            x_vector_only_mode: ``qwen3-tts``; condition on the speaker embedding
+                alone and skip in-context learning from the reference.
+            ref_audio: ``qwen3-tts`` reference clip for inline cloning — an
+                http(s) URL or a local file path.
+            ref_text: Transcript of ``ref_audio``; improves clone fidelity.
+            word_timestamps: ``qwen3-tts``; forward word-level alignment to
+                LiveKit as a timed transcript.
+            extra_config: ``qwen3-tts``; merged into ``session.config`` last.
             model_endpoint: Baseten model endpoint, or ``BASETEN_MODEL_ENDPOINT`` env var.
                 Pass a ``wss://`` URL for streaming or an ``https://`` URL for non-streaming.
-            voice: Speaker voice. Defaults to "tara".
-            language: Language code. Defaults to "en".
+            voice: Speaker voice. Defaults to ``tara`` for ``orpheus``. Required
+                for ``qwen3-tts``, where it names a registered voice clone — that
+                checkpoint ships no built-in speakers (see `register_voice`).
+            language: Language code. Defaults to ``en`` for ``orpheus`` and
+                ``Auto`` for ``qwen3-tts``.
             temperature: Sampling temperature. Defaults to 0.6.
             max_tokens: Maximum tokens for generation. Defaults to 2000.
             buffer_size: Number of words per chunk for streaming. Defaults to 10.
             http_session: Optional aiohttp session to reuse.
+
+        Raises:
+            ValueError: If the API key or endpoint cannot be resolved, or if
+                ``model="qwen3-tts"`` without a ``voice``.
         """
+        self._model_name = model
+        self._qwen3: qwen3_tts._Qwen3Backend | None = None
+
+        if model == "qwen3-tts":
+            self._qwen3 = qwen3_tts._Qwen3Backend(
+                model_endpoint=model_endpoint,
+                model_id=model_id,
+                chain_id=chain_id,
+                api_key=api_key,
+                voice=voice if is_given(voice) else "",
+                task_type=task_type,
+                language=language if is_given(language) else "Auto",
+                instructions=instructions,
+                max_new_tokens=max_new_tokens,
+                initial_codec_chunk_frames=initial_codec_chunk_frames,
+                x_vector_only_mode=x_vector_only_mode,
+                ref_audio=ref_audio,
+                ref_text=ref_text,
+                word_timestamps=word_timestamps,
+                extra_config=extra_config,
+                http_session=http_session,
+            )
+            super().__init__(
+                capabilities=tts.TTSCapabilities(
+                    streaming=True, aligned_transcript=word_timestamps
+                ),
+                sample_rate=qwen3_tts.SAMPLE_RATE,
+                num_channels=qwen3_tts.NUM_CHANNELS,
+            )
+            self._session = http_session
+            self._streams = weakref.WeakSet[tts.SynthesizeStream]()
+            return
+
         api_key = api_key or os.environ.get("BASETEN_API_KEY")
 
         if not api_key:
@@ -105,18 +189,18 @@ class TTS(tts.TTS):
         self._model_endpoint = model_endpoint
 
         self._opts = _TTSOptions(
-            voice=voice,
-            language=language,
+            voice=voice if is_given(voice) else "tara",
+            language=language if is_given(language) else "en",
             temperature=temperature,
             max_tokens=max_tokens,
             buffer_size=buffer_size,
         )
         self._session = http_session
-        self._streams = weakref.WeakSet[SynthesizeStream]()
+        self._streams = weakref.WeakSet[tts.SynthesizeStream]()
 
     @property
     def model(self) -> str:
-        return "unknown"
+        return self._model_name
 
     @property
     def provider(self) -> str:
@@ -137,6 +221,9 @@ class TTS(tts.TTS):
         max_tokens: NotGivenOr[int] = NOT_GIVEN,
         buffer_size: NotGivenOr[int] = NOT_GIVEN,
     ) -> None:
+        if self._qwen3 is not None:
+            self._qwen3.update_options(voice=voice, language=language)
+            return
         if is_given(voice):
             self._opts.voice = voice
         if is_given(language):
@@ -150,20 +237,23 @@ class TTS(tts.TTS):
 
     def synthesize(
         self, text: str, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
-    ) -> ChunkedStream:
-        return ChunkedStream(
-            tts=self,
-            input_text=text,
-            conn_options=conn_options,
-        )
+    ) -> tts.ChunkedStream:
+        if self._qwen3 is not None:
+            # Qwen3-TTS is streaming-only; the framework helper disables retries
+            # on the inner stream and forwards timed transcripts.
+            return self._synthesize_with_stream(text, conn_options=conn_options)
+        return ChunkedStream(tts=self, input_text=text, conn_options=conn_options)
 
     def stream(
         self, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
-    ) -> SynthesizeStream:
-        stream = SynthesizeStream(
-            tts=self,
-            conn_options=conn_options,
-        )
+    ) -> tts.SynthesizeStream:
+        stream: tts.SynthesizeStream
+        if self._qwen3 is not None:
+            stream = qwen3_tts.Qwen3SynthesizeStream(
+                tts=self, backend=self._qwen3, conn_options=conn_options
+            )
+        else:
+            stream = SynthesizeStream(tts=self, conn_options=conn_options)
         self._streams.add(stream)
         return stream
 
@@ -171,6 +261,8 @@ class TTS(tts.TTS):
         for stream in list(self._streams):
             await stream.aclose()
         self._streams.clear()
+        if self._qwen3 is not None:
+            await self._qwen3.aclose()
 
 
 class ChunkedStream(tts.ChunkedStream):


### PR DESCRIPTION
## Summary

Baseten hosts **Qwen3-ASR Streaming** and **Qwen3-TTS** alongside the Whisper and Orpheus models this plugin already supports. They speak different wire protocols, so the existing `STT`/`TTS` classes can't reach them — pointing either at a Qwen3 endpoint connects and then produces nothing.

This adds `Qwen3STT` and `Qwen3TTS` as **separate classes**. The existing Orpheus/Whisper paths are untouched, so this is non-breaking.

| | `STT` / `TTS` | `Qwen3STT` / `Qwen3TTS` |
|---|---|---|
| STT audio | raw binary PCM | base64 `input_audio_buffer.append` |
| STT results | `message_type` / `transcript` | `type: "transcription"` / `segments[].text` |
| TTS transport | `{prompt, voice, …}`, or WS + `__END__` sentinel | `session.config` → `input.text` → `input.done` |
| TTS voices | preset names (`tara`) | registered voice clones |

```python
session = AgentSession(
    stt=baseten.Qwen3STT(model_id="your-qwen3-asr-model-id"),
    tts=baseten.Qwen3TTS(model_id="your-qwen3-tts-model-id", voice="your-voice"),
)
```

Both accept `model_endpoint`, `model_id`, or `chain_id` with the same precedence as `STT` (extracted into `_endpoint.py`).

## Notes on the design

A few protocol details drove decisions that aren't obvious from the diff:

- **`input.done` is a flush, not a close.** The session config stays in effect, so `Qwen3TTS` keeps one warm socket across turns. Re-dialing per utterance would add a connect plus a config round trip to every agent response.
- **Parked sockets need an application-level keepalive.** The server has a 30s idle timeout that protocol pings don't reset, so an idle socket reads as OPEN long after the server has given up. An empty `input.done` answers `session.done` with zero sentences and proves the *session* is alive.
- **Interrupted sockets are discarded, not parked.** Closing the socket is what stops in-flight generation; a graceful `session.close` would keep the GPU busy producing audio nobody hears.
- **One emitter segment per `SynthesizeStream`.** `push_text()` after a flush is dropped by the framework and `_main_task` raises on a segment-count mismatch, so a mid-stream flush means "synthesize what's buffered", never "start a new segment".
- **Qwen3-ASR reports a language *name*** (`"English"`), so `Qwen3STT` maps the common ones to ISO codes rather than passing a name where a code is expected.

## Voices

Qwen3-TTS Base ships no built-in speakers — there's no `tara` equivalent. `voice` names a registered clone, and `register_voice`/`list_voices` are exported to manage them. Worth knowing: the server stores uploaded voices on the container's local disk, so a runtime-registered voice lives on one replica and is lost on restart. The README documents baking the reference into the deployment instead, or passing `ref_audio`/`ref_text` to clone inline per session.


## Also: `language_options` for the existing Whisper `STT`

Bundled here because it is the same plugin and came out of the same customer
conversation. Baseten's streaming transcription API has accepted a
`language_options` list since Whisper runtime v0.5.0, which scopes detection to
the languages an agent actually supports. The plugin only ever sent a single
`audio_language`, forcing a choice between a fixed tag that mistranscribes the
other language and `auto`, which detects across all 99 and is unreliable on the
one- to two-second utterances typical of telephony.

```python
stt = baseten.STT(model_id="...", language="auto", language_options=["en", "de"])
```

Only added to the handshake when non-empty — `StreamingWhisperInput` uses
`extra="forbid"`, so sending it unconditionally would break anyone on an older
runtime. Also wired through `update_options` on both `STT` and `SpeechStream`.

Verified against a live Whisper Large V3 Turbo streaming deployment, with a
negative control: `language_options: ["en", "de"]` is accepted and transcribes
normally, while a deliberately misspelled field name closes the socket with
1011 — so acceptance confirms the field name rather than showing it was
silently ignored.

## Testing

Developed against `livekit-agents` 1.6.8 with a mock server implementing the Qwen3 protocols, driven through the real framework machinery (`AudioEmitter`, `RecognizeStream`, the retry loop) and through a real `AgentSession` with a real-time audio sink. Covered:

- TTS: token-by-token `push_text`, socket reuse without config resend, keepalive on a parked socket, barge-in discarding the socket, transient error retried / persistent error propagating, word timestamps rebased across sentence boundaries
- STT: handshake shape, `start_of_speech` → interim → final → `end_of_speech`, one-shot `recognize()`, partials disabled via `interim_results=False`
- `AgentSession`: TTS audio out with reuse across turns and `interrupt()` mid-playout; STT mic audio in surfacing interim + final user turns over consecutive VAD-bounded turns

I'm happy to contribute those as pytest suites if you'd like them in-tree — I left them out to keep the diff focused and avoid adding scripts your CI would try to collect.

## Live validation

Since opening this, both adapters have been run end to end against real Baseten
deployments of the same model-registry trusses they target (Qwen3-ASR streaming
on RTX Pro 6000, Qwen3-TTS Base on RTX Pro 6000), using real speech with ground
truth rather than synthetic audio.

**STT** — a mu-bench en-US utterance, streamed at 100ms frames:

```
partial: I want to get a higher limit on my
FINAL:   Hi, I want to get a higher limit on my credit card. | lang: en
truth:   Hi. I want to get a higher limit on my credit card.
```

100% word overlap, both through `Qwen3STT.stream()` directly and through a real
`AgentSession` (`user_input_transcribed`, 6 interims + 1 final). Confirms the
handshake, the base64 append frames, `type: "transcription"` parsing, the
`language_code: "English"` -> `en` mapping, and clean termination on the
commit-triggered final.

**TTS** — `voice.list` returns `{"voices": [], ...}` on the Base checkpoint,
confirming it ships no built-in speakers; `voice.add` cloning from a 14s
reference works; synthesis returns real 24kHz PCM; the second turn reuses the
warm socket (TTFA 1081ms vs a cold first turn).

**Round trip** — feeding the live TTS output back into the live STT transcribes
at 100% word overlap, so the synthesized audio is genuinely intelligible speech
and not just well-formed bytes.

One operational note worth stating: on a cold replica the first synthesis
exceeded the 60s session timeout and was retried by the framework before
succeeding. That is cold-start behavior rather than an adapter issue, but
production voice agents should keep `min_replica >= 1`.

`ruff check` and `ruff format` are clean.

