### PR TITLE
fix(tokenize): don't stall TTS streaming on angle-bracketed prose

### DIFF
--- a/livekit-agents/livekit/agents/tokenize/token_stream.py
+++ b/livekit-agents/livekit/agents/tokenize/token_stream.py
@@ -13,8 +13,12 @@ TokenizeCallable = Callable[[str], list[str] | list[tuple[str, int, int]]]
 
 # the tag name must start with a letter so "<5>" / "<3 wins>" are not counted as
 # tags — this keeps the depth counter consistent with the letter-start tail check
-# in _has_unclosed_xml_tags (all TTS markup tags are letter-named)
-_XML_TAG_RE = re.compile(r"<(/?)([A-Za-z]\w*)[^>]*?(/?)\s*>")
+# in _has_unclosed_xml_tags (all TTS markup tags are letter-named).
+# The name must also be followed by whitespace, "/" or ">", as it is in real markup:
+# without that, angle-bracketed prose like <https://lk.io> or <bob@example.com>
+# parses as an open tag and holds every later sentence until flush. Hyphens are part
+# of the name so xAI's <higher-pitch>/<build-intensity> still match.
+_XML_TAG_RE = re.compile(r"<(/?)([A-Za-z][\w-]*)(?=[\s/>])[^>]*?(/?)\s*>")
 
 
 def _has_unclosed_xml_tags(text: str) -> bool:

--- a/tests/test_tokenizer_xml_markup.py
+++ b/tests/test_tokenizer_xml_markup.py
@@ -665,6 +665,48 @@ class TestPlainTextAngleBrackets:
         assert "bob@example.com" in ev.token
         stream.end_input()
 
+    def test_angle_bracketed_prose_is_not_a_tag(self) -> None:
+        # regression: an XML name is followed by whitespace, "/" or ">". Without that
+        # rule the depth counter read a markdown autolink or an angle-bracketed address
+        # as an unclosed open tag, so depth stayed > 0 and every later sentence was held
+        # until flush — the same end-of-turn batching the bare "<" fix removed
+        from livekit.agents.tokenize.token_stream import _has_unclosed_xml_tags
+
+        assert not _has_unclosed_xml_tags("Docs are at <https://docs.livekit.io> today.")
+        assert not _has_unclosed_xml_tags("Email me at <bob@example.com> please.")
+        assert not _has_unclosed_xml_tags("Press <ctrl+c> to quit.")
+        assert not _has_unclosed_xml_tags("See <http://example.com/a?b=1> for details.")
+
+    def test_hyphenated_tag_names_still_counted(self) -> None:
+        # the guard must not over-correct: xAI's prosody tags carry hyphens, and an
+        # unclosed one still has to hold the sentence
+        from livekit.agents.tokenize.token_stream import _has_unclosed_xml_tags
+
+        assert _has_unclosed_xml_tags("<higher-pitch>no way")
+        assert not _has_unclosed_xml_tags("<higher-pitch>no way</higher-pitch> done")
+        assert not _has_unclosed_xml_tags('<break time="500ms"/> done')
+
+    @pytest.mark.asyncio
+    async def test_autolink_streams_with_xml_aware(self) -> None:
+        # end-to-end: an expressive agent quoting a URL must keep streaming
+        tok = SentenceTokenizer(min_sentence_len=1, stream_context_len=5, xml_aware=True)
+        stream = tok.stream()
+        stream.push_text(
+            "Docs are at <https://docs.livekit.io> now. And a second sentence to split."
+        )
+        ev = await asyncio.wait_for(stream.__anext__(), timeout=1)
+        assert "docs.livekit.io" in ev.token
+        stream.end_input()
+
+    @pytest.mark.asyncio
+    async def test_email_streams_with_xml_aware(self) -> None:
+        tok = SentenceTokenizer(min_sentence_len=1, stream_context_len=5, xml_aware=True)
+        stream = tok.stream()
+        stream.push_text("Email me at <bob@example.com> please. Second sentence for the split.")
+        ev = await asyncio.wait_for(stream.__anext__(), timeout=1)
+        assert "bob@example.com" in ev.token
+        stream.end_input()
+
 
 # ===========================================================================
 # Universal transcript stripping (provider-agnostic, used by the transcript sinks)


### PR DESCRIPTION
`_XML_TAG_RE` matched any `<letter...>`, so a markdown autolink or an angle-bracketed
address parsed as an open XML tag. With `xml_aware=True` (expressive agents) the depth
counter in `_has_unclosed_xml_tags` then never returned to zero, and every later
sentence was held until flush — streaming TTS degraded to end-of-turn batching for the
rest of the turn.

Measured on `main`, first sentence emitted before flush:

```
text                                          xml_aware=True   xml_aware=False
Docs are at <https://docs.livekit.io> now.    stalled          streams
Email me at <bob@example.com> please.         stalled          streams
Press <ctrl+c> to quit.                       stalled          streams
Note that 3 < 5 holds.                        streams          streams
```

Require the tag name to be followed by whitespace, `/` or `>`, as it is in real markup.
Hyphens join the name so xAI's `<higher-pitch>` / `<build-intensity>` still match.

```python
_XML_TAG_RE = re.compile(r"<(/?)([A-Za-z][\w-]*)(?=[\s/>])[^>]*?(/?)\s*>")
```

This is the same regression class as the bare `<` and digit-named `<5>` fixes that
`TestPlainTextAngleBrackets` already documents; the existing
`test_tag_shaped_text_streams_when_not_xml_aware` covers `<bob@example.com>` but only
asserts the `xml_aware=False` path, so the broken case sat next to a passing test.

`filter_markdown` does not remove these spans (it rewrites `[text](url)` but leaves
autolinks and addresses intact), so they do reach the tokenizer.

All three consumers of the regex were checked — the depth counter, `_is_xml_only`, and
`_xml_wrap_tokenizer`'s strip-and-remap. Stricter matching is correct for all three: an
autolink is text, so it shouldn't be stripped before blingfire either.

## Testing

Full `--unit` gate, before and after:

| | passed | skipped | errors |
|---|---|---|---|
| `main` (baseline) | 1335 | 5 | 9 |
| this branch | 1339 | 5 | 9 |

The +4 are the new tests. The 9 errors are a pre-existing `Event loop is closed`
INTERNALERROR from `tests/concurrency.py` on Python 3.14 — identical on both sides,
unrelated to this change.

I don't have data on how often models emit angle-bracket autolinks, so I'm not claiming
a frequency. The case for the fix is that it's one line, strictly more correct, and when
it does fire the cost is every remaining sentence in the turn.
