### PR TITLE
fix(voice): keep the turn transcript when the tts sends no word timings

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3905,7 +3905,7 @@ class AgentActivity(RecognitionHooks):
                         and (tts.capabilities.aligned_transcript or not tts.capabilities.streaming)
                         and (timed_texts := await tts_gen_data.timed_texts_fut)
                     ):
-                        tr_text_input = timed_texts
+                        tr_text_input = _aligned_transcript_or_text(timed_texts, tr_text_input)
                         read_transcript_from_tts = True
 
                     tasks.append(tts_task)

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -5,7 +5,7 @@ import contextvars
 import heapq
 import json
 import time
-from collections.abc import AsyncIterable, Coroutine
+from collections.abc import AsyncGenerator, AsyncIterable, Coroutine
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -105,6 +105,29 @@ if TYPE_CHECKING:
 _AgentActivityContextVar = contextvars.ContextVar["AgentActivity"]("agents_activity")
 _SpeechHandleContextVar = contextvars.ContextVar["SpeechHandle"]("agents_speech_handle")
 _IdleHoldContextVar = contextvars.ContextVar[bool]("agents_idle_hold", default=False)
+
+
+async def _aligned_transcript_or_text(
+    timed_texts: AsyncIterable[str], text: AsyncIterable[str]
+) -> AsyncGenerator[str, None]:
+    """Forward the TTS-aligned transcript, falling back to the spoken text.
+
+    ``aligned_transcript`` says the TTS was asked for word timings, not that this
+    model/language pair returns any. When none arrive the aligned stream is simply
+    empty, and forwarding it alone would leave the turn with no transcript.
+    """
+    aligned = False
+    async for timed_text in timed_texts:
+        aligned = True
+        yield timed_text
+
+    if not aligned:
+        logger.warning(
+            "no aligned transcript was returned from tts, "
+            "forwarding the generated text without word timings"
+        )
+        async for chunk in text:
+            yield chunk
 
 
 def _transcripts_equivalent(first: str, second: str | None) -> bool:
@@ -2852,7 +2875,7 @@ class AgentActivity(RecognitionHooks):
                     and (tts.capabilities.aligned_transcript or not tts.capabilities.streaming)
                     and (timed_texts := await tts_gen_data.timed_texts_fut)
                 ):
-                    text_source = timed_texts
+                    text_source = _aligned_transcript_or_text(timed_texts, text_source)
 
                 forward_audio_task, audio_out = perform_audio_forwarding(
                     audio_output=audio_output, tts_output=tts_gen_data.audio_ch
@@ -3354,7 +3377,10 @@ class AgentActivity(RecognitionHooks):
                 and use_aligned_transcript
                 and (timed_texts := await segment.tts.timed_texts_fut)
             ):
-                transcript = timed_texts
+                # the channel exists as soon as the node streams, before any timed
+                # word has arrived, so a TTS that advertises alignment it doesn't
+                # deliver would leave the segment with no transcript at all
+                transcript = _aligned_transcript_or_text(timed_texts, segment.text)
                 read_transcript_from_tts = True
 
             tr_node = self._agent.transcription_node(transcript, model_settings)

--- a/tests/test_aligned_transcript_fallback.py
+++ b/tests/test_aligned_transcript_fallback.py
@@ -1,0 +1,104 @@
+"""The agent transcript must survive a TTS that advertises alignment it never sends (#6493).
+
+``capabilities.aligned_transcript`` says word timings were *requested*, not that the
+model/language pair returns any, and the timed channel exists as soon as the node
+streams — before a single timed word has arrived. Committing the turn's transcript to
+that channel therefore left the turn with no transcript at all whenever the provider
+sent none, which is what surfaced as "no agent transcript was returned from tts".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterable
+
+import pytest
+
+from livekit.agents.types import TimedString
+from livekit.agents.voice.agent_activity import _aligned_transcript_or_text
+from livekit.agents.voice.events import ConversationItemAddedEvent
+
+from .fake_session import FakeActions, create_session, run_session
+from .fake_tts import FakeTTS
+from .test_agent_session import MyAgent
+
+pytestmark = pytest.mark.unit
+
+
+async def _stream(*items: str) -> AsyncIterable[str]:
+    for item in items:
+        yield item
+
+
+async def _collect(source: AsyncIterable[str]) -> list[str]:
+    return [chunk async for chunk in source]
+
+
+async def test_aligned_transcript_is_forwarded_when_it_arrives() -> None:
+    timed = _stream(
+        TimedString("hello ", start_time=0.0, end_time=0.5),
+        TimedString("there", start_time=0.5, end_time=1.0),
+    )
+    text = _stream("hello there")
+
+    forwarded = await _collect(_aligned_transcript_or_text(timed, text))
+
+    assert forwarded == ["hello ", "there"]
+    # the timings are what the aligned path exists for, so they must survive
+    assert all(isinstance(chunk, TimedString) for chunk in forwarded)
+    # the spoken text was left untouched
+    assert await _collect(text) == ["hello there"]
+
+
+async def test_falls_back_to_the_spoken_text_when_no_timings_arrive(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    timed = _stream()  # the provider advertised alignment and sent none
+    text = _stream("hello ", "there")
+
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        forwarded = await _collect(_aligned_transcript_or_text(timed, text))
+
+    assert forwarded == ["hello ", "there"], "the turn would otherwise have no transcript"
+    assert any("no aligned transcript" in record.message for record in caplog.records)
+
+
+async def test_partial_alignment_is_not_duplicated(caplog: pytest.LogCaptureFixture) -> None:
+    # one timed word is proof the provider aligns; the rest is its business, and
+    # replaying the spoken text on top would repeat what was already forwarded
+    timed = _stream(TimedString("hello", start_time=0.0, end_time=0.5))
+    text = _stream("hello there")
+
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        forwarded = await _collect(_aligned_transcript_or_text(timed, text))
+
+    assert forwarded == ["hello"]
+    assert not [r for r in caplog.records if "no aligned transcript" in r.message]
+
+
+async def test_turn_keeps_its_transcript_when_the_tts_sends_no_timings() -> None:
+    # end to end: the session's TTS claims alignment (as cartesia/elevenlabs do by
+    # default) while emitting audio only, which is the shape reported in #6493 for a
+    # model/language pair that cannot align
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.0, "Hello, how are you?", stt_delay=0.1)
+    actions.add_llm("I'm doing well, thank you!", ttft=0.1, duration=0.2)
+    actions.add_tts(2.0, ttfb=0.2, duration=0.2)
+
+    session = create_session(actions, extra_kwargs={"use_tts_aligned_transcript": True})
+    assert isinstance(session.tts, FakeTTS)
+    session.tts._capabilities.aligned_transcript = True
+
+    conversation: list[ConversationItemAddedEvent] = []
+    session.on("conversation_item_added", conversation.append)
+
+    await asyncio.wait_for(run_session(session, MyAgent()), timeout=30)
+
+    agent_messages = [
+        ev.item for ev in conversation if ev.item.type == "message" and ev.item.role == "assistant"
+    ]
+    assert agent_messages, "the agent turn was never recorded"
+    assert agent_messages[0].text_content, (
+        "the agent turn has no transcript: the aligned channel was empty and nothing fell back"
+    )


### PR DESCRIPTION
Addresses the framework half of #6493 — the part #6637 leaves open, offered there.

## Problem

`capabilities.aligned_transcript` says word timings were *requested*, not that the model/language pair returns any. The timed channel is handed to the caller as soon as the TTS node turns out to be streaming, before a single timed word has arrived:

```python
timed_text_ch = aio.Chan[io.TimedString]()
timed_texts_fut.set_result(timed_text_ch)     # generation.py
```

so the truthiness check that selects it commits the whole turn to that channel:

```python
if ... and (timed_texts := await segment.tts.timed_texts_fut):
    transcript = timed_texts
```

When the provider sends no timings, that channel simply closes empty and **the turn ends up with no transcript at all** — nothing in the room transcription, nothing on the stored assistant message. The only signal is the warning the reporter opened the issue about:

```
`use_tts_aligned_transcript` is enabled but no agent transcript was returned from tts
```

This is provider-independent: #6493 reports it against both Cartesia and ElevenLabs.

## Fix

The aligned stream is forwarded exactly as before. If it turns out to carry nothing, the spoken text is forwarded instead, so the turn keeps its transcript and only loses the word timings it was never going to get. One timed word is enough to treat the provider as aligning, so a partial alignment is never doubled up with a replay of the text.

The text is safe to read at that point: it is a separate buffered channel (pipeline path) or the unread half of a tee (`say()` path), populated regardless of who consumes it. Both TTS paths are covered.

The existing warning is left in place as a backstop for the case where neither source produced anything; the new one names what actually happened and fires as soon as the aligned stream closes empty.

## Verification

`tests/test_aligned_transcript_fallback.py`:

- the aligned transcript is forwarded, `TimedString` timings intact, when timings arrive
- the spoken text is forwarded, with a warning, when none arrive
- a partial alignment is not followed by a replay of the text
- end to end through a session whose TTS advertises alignment and emits audio only: the assistant turn still has `text_content`. That test fails on `main` (empty transcript) and passes here.

`ruff format --check`, `ruff check` and `mypy -p livekit.agents` pass. On the full `pytest --unit`, 1730 pass; the 5 failures in `tests/test_ipc.py` are a local environment problem (subprocess spawn timeouts on this Windows box) and reproduce identically with this change reverted.

Based on `8a6d302` rather than the tip only because pushing the newer base needs a `workflow` OAuth scope I don't have; happy to rebase.


---

**Update:** extended to the third site. A realtime model that emits text has its transcript produced by the same TTS, through the other half of the same tee, so it lost the turn transcript identically. All three places that select the aligned stream now share the fallback.
