### PR TITLE
feat(openai): support context hints in STT

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -3,7 +3,8 @@ from typing import Literal, TypedDict
 
 from openai.types import AudioModel
 
-STTModels = AudioModel | Literal["gpt-live-transcribe"]
+# AudioModel covers the transcriptions endpoint; these two are served only over realtime
+STTModels = AudioModel | Literal["gpt-live-transcribe", "gpt-realtime-whisper"]
 TTSModels = Literal["tts-1", "tts-1-hd", "gpt-4o-mini-tts"]
 TTSVoices = Literal[
     "alloy",

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -3,7 +3,7 @@ from typing import Literal, TypedDict
 
 from openai.types import AudioModel
 
-STTModels = AudioModel
+STTModels = AudioModel | Literal["gpt-live-transcribe"]
 TTSModels = Literal["tts-1", "tts-1-hd", "gpt-4o-mini-tts"]
 TTSVoices = Literal[
     "alloy",

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -108,6 +108,13 @@ def _as_languages(language: str | list[str]) -> list[str]:
     return [code for code in language if code]
 
 
+def _as_turn_detection(
+    turn_detection: SessionTurnDetection,
+) -> RealtimeTranscriptionSessionAudioInputTurnDetection:
+    """Validate a turn-detection dict, filling in the `type` the union is tagged on."""
+    return _TURN_DETECTION.validate_python({"type": "server_vad", **turn_detection})
+
+
 def _validate_context(model: str, languages: list[str], keywords: list[str]) -> None:
     """Raise when keywords or several languages go to a model that takes neither."""
     if _supports_context_hints(model):
@@ -129,7 +136,7 @@ class _STTOptions:
     model: STTModels | str
     languages: list[str]
     detect_language: bool
-    turn_detection: SessionTurnDetection
+    turn_detection: RealtimeTranscriptionSessionAudioInputTurnDetection
     keywords: list[str] = field(default_factory=list)
     prompt: NotGivenOr[str] = NOT_GIVEN
     noise_reduction_type: NotGivenOr[str] = NOT_GIVEN
@@ -163,7 +170,7 @@ def _session_update(opts: _STTOptions) -> SessionUpdateEvent:
     )
     # leave the field unset for models that reject it; the rest get server-side VAD
     if not _is_realtime_only(opts.model):
-        audio_input.turn_detection = _TURN_DETECTION.validate_python(opts.turn_detection)
+        audio_input.turn_detection = opts.turn_detection
 
     if opts.noise_reduction_type:
         audio_input.noise_reduction = NoiseReduction(type=opts.noise_reduction_type)
@@ -275,7 +282,7 @@ class STT(stt.STT):
             model=model,
             prompt=prompt,
             keywords=resolved_keywords,
-            turn_detection=turn_detection,
+            turn_detection=_as_turn_detection(turn_detection),
             temperature=temperature,
         )
         if is_given(noise_reduction_type):
@@ -434,9 +441,6 @@ class STT(stt.STT):
         if is_given(language):
             opts.languages = _as_languages(language)
             _validate_context(opts.model, opts.languages, opts.keywords)
-            if opts.languages != self._opts.languages:
-                # the pool would otherwise hand this stream a socket carrying another language
-                self._pool.invalidate()
         stream = SpeechStream(
             stt=self,
             pool=self._pool,
@@ -513,7 +517,7 @@ class STT(stt.STT):
                 )
 
         languages_changed = languages != self._opts.languages
-        needs_reconnect = resolved_model != self._opts.model or languages_changed
+        model_changed = resolved_model != self._opts.model
         # a stream keeps a language of its own unless this call names or moves the language
         languages_given = is_given(language) or languages_changed
         self._opts.model = resolved_model
@@ -533,7 +537,7 @@ class STT(stt.STT):
         if is_given(prompt):
             self._opts.prompt = prompt
         if is_given(turn_detection):
-            self._opts.turn_detection = turn_detection
+            self._opts.turn_detection = _as_turn_detection(turn_detection)
         if is_given(noise_reduction_type):
             self._opts.noise_reduction_type = noise_reduction_type
         if is_given(temperature):
@@ -545,12 +549,13 @@ class STT(stt.STT):
             else:
                 self._opts.temperature = temperature
 
-        if needs_reconnect:
-            # the streams do this too, but `_streams` is empty between two speech sessions
-            self._pool.invalidate()
-
         for stream in self._streams:
             stream.update_options(language=languages if languages_given else NOT_GIVEN)
+
+        if model_changed:
+            # every stream has dropped its own socket by now, so this reaches the idle ones the
+            # pool holds between two speech sessions
+            self._pool.invalidate()
 
     def _update_session_keyterms(self, keyterms: list[str]) -> None:
         if not self.capabilities.keyterms:
@@ -690,13 +695,17 @@ class SpeechStream(stt.SpeechStream):
         if is_given(language):
             opts.languages = _as_languages(language)
             _validate_context(opts.model, opts.languages, opts.keywords)
-        # a language cannot be cleared on an open session, nor can a pooled socket carrying
-        # another one be reused; gateways route on the ?model= in the URL
-        rebuild = opts.model != self._opts.model or opts.languages != self._opts.languages
+        # a session.update can set a language but never clear one, and gateways route on the
+        # ?model= in the URL
+        cleared_language = bool(self._opts.languages) and not opts.languages
+        rebuild = opts.model != self._opts.model or cleared_language
         self._opts = opts
         self._language = _transcript_language(opts.languages)
         if rebuild:
-            self._pool.invalidate()
+            # only this stream's own socket: invalidating the pool would close the ones the
+            # other streams are still reading from
+            if self._ws is not None:
+                self._pool.remove(self._ws)
             self._reconnect_event.set()
         else:
             self._update_task = asyncio.create_task(
@@ -947,6 +956,11 @@ class SpeechStream(stt.SpeechStream):
             # a segment left open across the reconnect gap would fuse into the next utterance
             self._stop_speaking()
             async with self._pool.connection(timeout=self._conn_options.timeout) as ws:
+                if self._pool.last_connection_reused and not self._opts.languages:
+                    # detecting the language needs a session that was never given one, and a
+                    # pooled socket carries whatever the stream before it set
+                    self._pool.remove(ws)
+                    continue
                 self._report_connection_acquired(
                     self._pool.last_acquire_time, self._pool.last_connection_reused
                 )

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -135,11 +135,6 @@ class _STTOptions:
     temperature: NotGivenOr[float] = NOT_GIVEN
 
 
-def _iso_codes(languages: list[str]) -> list[str]:
-    """Deduplicated ISO-639-1 codes; the API rejects regional tags such as en-US."""
-    return list(dict.fromkeys(LanguageCode(code).language for code in languages))
-
-
 def _transcription(opts: _STTOptions) -> AudioTranscription:
     """The transcription config: `languages` and `keywords`, or a single `language`."""
     transcription = AudioTranscription(model=opts.model)
@@ -151,9 +146,11 @@ def _transcription(opts: _STTOptions) -> AudioTranscription:
         transcription.keywords = opts.keywords
         # `languages` rejects both an empty array and null, so it can only be replaced
         if opts.languages:
-            transcription.languages = _iso_codes(opts.languages)
+            transcription.languages = list(
+                dict.fromkeys(LanguageCode(lang).language for lang in opts.languages)
+            )
     elif opts.languages:
-        transcription.language = _iso_codes(opts.languages)[0]
+        transcription.language = LanguageCode(opts.languages[0]).language
     return transcription
 
 
@@ -290,7 +287,7 @@ class STT(stt.STT):
 
         self._vad = vad if is_given(vad) else None
         # an explicit `vad=None` means the caller commits the audio buffer itself
-        self._vad_opted_out = is_given(vad) and vad is None
+        self._vad_opted_out = vad is None
 
         if is_given(api_key) and not api_key:
             raise ValueError(

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -38,6 +38,7 @@ from livekit.agents import (
     APIStatusError,
     APITimeoutError,
     LanguageCode,
+    inference,
     stt,
     utils,
     vad,
@@ -84,16 +85,21 @@ _TURN_DETECTION: TypeAdapter[RealtimeTranscriptionSessionAudioInputTurnDetection
     RealtimeTranscriptionSessionAudioInputTurnDetection
 )
 
+# these models are served only over the realtime API, and without server-side endpointing: they
+# reject any turn_detection config and emit no speech_started/stopped, so the client has to commit
+# the audio buffer to close a segment (e.g. driven by a VAD)
+_REALTIME_ONLY_MODELS = ("gpt-realtime-whisper", "gpt-live-transcribe")
+# these accept a plural `languages` list and `keywords`; earlier models take a single `language`
+# and no keywords
+_CONTEXT_HINT_MODELS = ("gpt-transcribe", "gpt-live-transcribe")
+
 
 def _requires_client_commit(model: str) -> bool:
-    # these models reject any turn_detection config and emit no speech_started/stopped;
-    # the client must commit the audio buffer to close a segment (e.g. driven by a VAD).
-    return model.startswith(("gpt-realtime-whisper", "gpt-live-transcribe"))
+    return model.startswith(_REALTIME_ONLY_MODELS)
 
 
 def _supports_context_hints(model: str) -> bool:
-    # earlier models take a single `language` and no keywords
-    return model.startswith(("gpt-transcribe", "gpt-live-transcribe"))
+    return model.startswith(_CONTEXT_HINT_MODELS)
 
 
 def _as_languages(language: str | list[str]) -> list[str]:
@@ -107,15 +113,11 @@ def _validate_context(model: str, languages: list[str], keywords: list[str]) -> 
     """Raise when keywords or several languages go to a model that takes neither."""
     if _supports_context_hints(model):
         return
+    supported = " and ".join(_CONTEXT_HINT_MODELS)
     if keywords:
-        raise ValueError(
-            f"keywords are only supported by gpt-transcribe and gpt-live-transcribe, not {model}"
-        )
+        raise ValueError(f"keywords are only supported by {supported}, not {model}")
     if len(languages) > 1:
-        raise ValueError(
-            f"{model} accepts a single language; only gpt-transcribe and "
-            "gpt-live-transcribe accept a list"
-        )
+        raise ValueError(f"{model} accepts a single language; only {supported} accept a list")
 
 
 def _transcript_language(languages: list[str]) -> LanguageCode:
@@ -191,7 +193,7 @@ class STT(stt.STT):
         base_url: NotGivenOr[str] = NOT_GIVEN,
         api_key: NotGivenOr[str] = NOT_GIVEN,
         client: openai.AsyncClient | None = None,
-        use_realtime: bool = False,
+        use_realtime: NotGivenOr[bool] = NOT_GIVEN,
         vad: NotGivenOr[vad.VAD | None] = NOT_GIVEN,
     ):
         """
@@ -216,14 +218,19 @@ class STT(stt.STT):
             base_url: Custom base URL for OpenAI API.
             api_key: Your OpenAI API key. If not provided, will use the OPENAI_API_KEY environment variable.
             client: Optional pre-configured OpenAI AsyncClient instance.
-            use_realtime: Whether to use the realtime transcription API. (default: False)
+            use_realtime: Whether to use the realtime transcription API. Defaults to True for
+                `gpt-realtime-whisper` and `gpt-live-transcribe`, which are served only there,
+                and to False otherwise.
             vad: Optional Voice Activity Detector used to commit the audio buffer when the model
                 does not support server-side turn detection (`gpt-realtime-whisper`,
                 `gpt-live-transcribe`).
-                When not provided and the model requires it, Silero VAD is auto-loaded with default
-                settings. Pass `vad=None` to opt out of the auto-load and drive
+                When not provided and the model requires it, the bundled Silero VAD is used with
+                default settings. Pass `vad=None` to opt out and drive
                 `input_audio_buffer.commit` yourself.
         """  # noqa: E501
+
+        if not is_given(use_realtime):
+            use_realtime = _requires_client_commit(model)
 
         if use_realtime and is_given(temperature):
             logger.warning(
@@ -239,15 +246,7 @@ class STT(stt.STT):
                 )
                 turn_detection = NOT_GIVEN
             if not is_given(vad):
-                try:
-                    from livekit.plugins.silero import VAD as SileroVAD
-                except ImportError as e:
-                    raise ImportError(
-                        f"livekit-plugins-silero is required for {model} "
-                        "(no server-side endpointing). Pass `vad=None` to opt out and drive "
-                        "`input_audio_buffer.commit` manually."
-                    ) from e
-                vad = SileroVAD.load()
+                vad = inference.VAD(model="silero")
 
         super().__init__(
             capabilities=stt.STTCapabilities(
@@ -346,7 +345,7 @@ class STT(stt.STT):
         organization: str | None = None,
         project: str | None = None,
         base_url: str | None = None,
-        use_realtime: bool = False,
+        use_realtime: NotGivenOr[bool] = NOT_GIVEN,
         timeout: httpx.Timeout | None = None,
         vad: NotGivenOr[vad.VAD | None] = NOT_GIVEN,
     ) -> STT:
@@ -754,7 +753,10 @@ class SpeechStream(stt.SpeechStream):
                         self._start_speaking()
                     elif ev.type == vad.VADEventType.END_OF_SPEECH:
                         self._stop_speaking()
-                        await ws.send_json({"type": "input_audio_buffer.commit"})
+                        # a model with server-side endpointing closes the segment itself, so a
+                        # commit from here would cut it a second time
+                        if _requires_client_commit(self._opts.model):
+                            await ws.send_json({"type": "input_audio_buffer.commit"})
             except (aiohttp.ClientError, ConnectionError) as e:
                 if closing_ws:
                     return

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -135,20 +135,25 @@ class _STTOptions:
     temperature: NotGivenOr[float] = NOT_GIVEN
 
 
+def _iso_codes(languages: list[str]) -> list[str]:
+    """Deduplicated ISO-639-1 codes; the API rejects regional tags such as en-US."""
+    return list(dict.fromkeys(LanguageCode(code).language for code in languages))
+
+
 def _transcription(opts: _STTOptions) -> AudioTranscription:
     """The transcription config: `languages` and `keywords`, or a single `language`."""
     transcription = AudioTranscription(model=opts.model)
-    if is_given(opts.prompt) and opts.prompt:
+    # a field left out of a session.update keeps its previous value, so anything that can
+    # be cleared is always sent
+    if is_given(opts.prompt):
         transcription.prompt = opts.prompt
-    if opts.keywords:
+    if _supports_context_hints(opts.model):
         transcription.keywords = opts.keywords
-    if opts.languages:
-        # both fields want ISO-639-1; the API rejects regional tags such as en-US
-        codes = list(dict.fromkeys(LanguageCode(code).language for code in opts.languages))
-        if _supports_context_hints(opts.model):
-            transcription.languages = codes
-        else:
-            transcription.language = codes[0]
+        # `languages` rejects both an empty array and null, so it can only be replaced
+        if opts.languages:
+            transcription.languages = _iso_codes(opts.languages)
+    elif opts.languages:
+        transcription.language = _iso_codes(opts.languages)[0]
     return transcription
 
 
@@ -284,6 +289,8 @@ class STT(stt.STT):
         self._session_keyterms: list[str] = []
 
         self._vad = vad if is_given(vad) else None
+        # an explicit `vad=None` means the caller commits the audio buffer itself
+        self._vad_opted_out = is_given(vad) and vad is None
 
         if is_given(api_key) and not api_key:
             raise ValueError(
@@ -473,10 +480,22 @@ class STT(stt.STT):
             languages = []
         user_keywords = list(keywords) if is_given(keywords) else self._user_keywords
         _validate_context(resolved_model, languages, user_keywords)
+        if (
+            _requires_client_commit(resolved_model)
+            and not _requires_client_commit(self._opts.model)
+            and self._vad is None
+            and not self._vad_opted_out
+        ):
+            raise ValueError(
+                f"{resolved_model} has no server-side endpointing, so it needs a `vad` to "
+                "commit the audio buffer; pass one to the constructor, or pass `vad=None` "
+                "to drive `input_audio_buffer.commit` yourself"
+            )
 
-        # gateways route on the ?model= in the upgrade URL, so only a model change
-        # can't be expressed as a session.update
+        # a reconnect is the only way to apply these: gateways route on the ?model= in the
+        # upgrade URL, and `languages` cannot be cleared on an open session
         model_changed = resolved_model != self._opts.model
+        languages_cleared = bool(self._opts.languages) and not languages
         self._opts.model = resolved_model
         self._capabilities.keyterms = _supports_context_hints(resolved_model)
         self._opts.languages = languages
@@ -505,7 +524,7 @@ class STT(stt.STT):
                 self._opts.temperature = temperature
 
         for stream in self._streams:
-            if model_changed:
+            if model_changed or languages_cleared:
                 stream.reconnect()
             else:
                 stream.apply_options()
@@ -885,9 +904,15 @@ class SpeechStream(stt.SpeechStream):
                     self._pool.last_acquire_time, self._pool.last_connection_reused
                 )
                 # a pooled connection may have been configured for older options
-                await ws.send_json(
-                    _session_update(self._opts).model_dump(by_alias=True, exclude_unset=True)
-                )
+                try:
+                    await ws.send_json(
+                        _session_update(self._opts).model_dump(by_alias=True, exclude_unset=True)
+                    )
+                except (aiohttp.ClientError, ConnectionError) as e:
+                    # a pooled socket can die while idle; keep that retryable
+                    raise APIConnectionError(
+                        "OpenAI Realtime STT connection closed unexpectedly"
+                    ) from e
                 vad_stream = self._vad.stream() if self._vad is not None else None
                 # option updates are sent on whichever connection is live
                 self._ws = ws

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -484,25 +484,20 @@ class STT(stt.STT):
             for stream in self._streams:
                 _validate_context(resolved_model, stream._opts.languages, user_keywords)
 
-        # the transport is fixed at construction: AgentSession wraps a non-streaming STT once.
-        # the realtime API serves every model, so only this direction can break
-        if not self.capabilities.streaming and _is_realtime_only(resolved_model):
-            raise ValueError(
-                f"{resolved_model} is served only over the realtime API, and this STT was "
-                "created for the transcriptions endpoint; pass `use_realtime=True` to the "
-                "constructor to reach it"
-            )
-        if (
-            _is_realtime_only(resolved_model)
-            and not _is_realtime_only(self._opts.model)
-            and self._vad is None
-            and not self._vad_opted_out
-        ):
-            raise ValueError(
-                f"{resolved_model} has no server-side endpointing, so it needs a `vad` to "
-                "commit the audio buffer; pass one to the constructor, or pass `vad=None` "
-                "to drive `input_audio_buffer.commit` yourself"
-            )
+        # the transport is fixed at construction: AgentSession wraps a non-streaming STT once
+        if is_given(model) and _is_realtime_only(model):
+            if not self.capabilities.streaming:
+                raise ValueError(
+                    f"{resolved_model} is served only over the realtime API, and this STT was "
+                    "created for the transcriptions endpoint; pass `use_realtime=True` to the "
+                    "constructor to reach it"
+                )
+            if self._vad is None and not self._vad_opted_out:
+                raise ValueError(
+                    f"{resolved_model} has no server-side endpointing, so it needs a `vad` to "
+                    "commit the audio buffer; pass one to the constructor, or pass `vad=None` "
+                    "to drive `input_audio_buffer.commit` yourself"
+                )
 
         needs_reconnect = resolved_model != self._opts.model or languages != self._opts.languages
         languages_given = is_given(language) or is_given(detect_language)

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -500,8 +500,9 @@ class STT(stt.STT):
 
         # a reconnect is the only way to apply these: gateways route on the ?model= in the
         # upgrade URL, and `languages` cannot be cleared on an open session
-        model_changed = resolved_model != self._opts.model
-        languages_cleared = bool(self._opts.languages) and not languages
+        needs_reconnect = resolved_model != self._opts.model or (
+            bool(self._opts.languages) and not languages
+        )
         self._opts.model = resolved_model
         self._capabilities.keyterms = _supports_context_hints(resolved_model)
         self._opts.languages = languages
@@ -529,8 +530,13 @@ class STT(stt.STT):
             else:
                 self._opts.temperature = temperature
 
+        if needs_reconnect:
+            # the pool keeps idle sockets for reuse, and `_streams` may be empty between two
+            # speech sessions, so the drop happens here rather than per stream
+            self._pool.invalidate()
+
         for stream in self._streams:
-            if model_changed or languages_cleared:
+            if needs_reconnect:
                 stream.reconnect()
             else:
                 stream.apply_options()
@@ -691,9 +697,8 @@ class SpeechStream(stt.SpeechStream):
             logger.warning("failed to update the transcription session", exc_info=True)
 
     def reconnect(self) -> None:
-        """Drop the connection so the next one is built with the current options."""
+        """Rebuild the connection so it carries the current options. The STT drops the pool."""
         self._language = _transcript_language(self._opts.languages)
-        self._pool.invalidate()
         self._reconnect_event.set()
 
     async def aclose(self) -> None:

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -48,7 +48,7 @@ from livekit.agents.types import (
     NotGivenOr,
 )
 from livekit.agents.utils import AudioBuffer, is_given
-from openai.types.audio import TranscriptionVerbose
+from openai.types.audio import Transcription, TranscriptionVerbose
 from openai.types.beta.realtime.transcription_session_update_param import (
     SessionTurnDetection,
 )
@@ -94,7 +94,7 @@ _REALTIME_ONLY_MODELS = ("gpt-realtime-whisper", "gpt-live-transcribe")
 _CONTEXT_HINT_MODELS = ("gpt-transcribe", "gpt-live-transcribe")
 
 
-def _requires_client_commit(model: str) -> bool:
+def _is_realtime_only(model: str) -> bool:
     return model.startswith(_REALTIME_ONLY_MODELS)
 
 
@@ -163,7 +163,7 @@ def _session_update(opts: _STTOptions) -> SessionUpdateEvent:
         transcription=_transcription(opts),
     )
     # leave the field unset for models that reject it; the rest get server-side VAD
-    if not _requires_client_commit(opts.model):
+    if not _is_realtime_only(opts.model):
         audio_input.turn_detection = _TURN_DETECTION.validate_python(opts.turn_detection)
 
     if opts.noise_reduction_type:
@@ -230,7 +230,7 @@ class STT(stt.STT):
         """  # noqa: E501
 
         if not is_given(use_realtime):
-            use_realtime = _requires_client_commit(model)
+            use_realtime = _is_realtime_only(model)
 
         if use_realtime and is_given(temperature):
             logger.warning(
@@ -239,7 +239,7 @@ class STT(stt.STT):
             )
             temperature = NOT_GIVEN
 
-        if use_realtime and _requires_client_commit(model):
+        if use_realtime and _is_realtime_only(model):
             if is_given(turn_detection):
                 logger.warning(
                     "turn_detection is not supported for %s; ignoring the provided value", model
@@ -476,9 +476,19 @@ class STT(stt.STT):
             languages = []
         user_keywords = list(keywords) if is_given(keywords) else self._user_keywords
         _validate_context(resolved_model, languages, user_keywords)
+
+        # the transport is fixed for the life of the instance: AgentSession wraps a non-streaming
+        # STT in a StreamAdapter once, so `streaming` cannot flip under a running pipeline. the
+        # other direction needs no guard, since the realtime API serves every model.
+        if not self.capabilities.streaming and _is_realtime_only(resolved_model):
+            raise ValueError(
+                f"{resolved_model} is served only over the realtime API, and this STT was "
+                "created for the transcriptions endpoint; pass `use_realtime=True` to the "
+                "constructor to reach it"
+            )
         if (
-            _requires_client_commit(resolved_model)
-            and not _requires_client_commit(self._opts.model)
+            _is_realtime_only(resolved_model)
+            and not _is_realtime_only(self._opts.model)
             and self._vad is None
             and not self._vad_opted_out
         ):
@@ -608,9 +618,13 @@ class STT(stt.STT):
                 timeout=httpx.Timeout(30, connect=conn_options.timeout),
             )
 
+            # what the model detected beats the hint that was sent, the first code being the
+            # dominant one; an empty list means nothing was detected reliably, so the hint stands
             sd = stt.SpeechData(text=resp.text, language=_transcript_language(self._opts.languages))
             if isinstance(resp, TranscriptionVerbose) and resp.language:
                 sd.language = LanguageCode(resp.language)
+            elif isinstance(resp, Transcription) and resp.languages:
+                sd.language = LanguageCode(resp.languages[0].code)
 
             return stt.SpeechEvent(
                 type=stt.SpeechEventType.FINAL_TRANSCRIPT,
@@ -755,7 +769,7 @@ class SpeechStream(stt.SpeechStream):
                         self._stop_speaking()
                         # a model with server-side endpointing closes the segment itself, so a
                         # commit from here would cut it a second time
-                        if _requires_client_commit(self._opts.model):
+                        if _is_realtime_only(self._opts.model):
                             await ws.send_json({"type": "input_audio_buffer.commit"})
             except (aiohttp.ClientError, ConnectionError) as e:
                 if closing_ws:
@@ -838,6 +852,12 @@ class SpeechStream(stt.SpeechStream):
                         current_text = ""
                         transcript = data.get("transcript", "")
                         item_id = data.get("item_id", "")
+                        # what the model detected beats the hint that was sent
+                        detected = [
+                            LanguageCode(lang["code"])
+                            for lang in data.get("languages") or []
+                            if lang.get("code")
+                        ]
 
                         if transcript:
                             self._event_ch.send_nowait(
@@ -847,7 +867,7 @@ class SpeechStream(stt.SpeechStream):
                                     alternatives=[
                                         stt.SpeechData(
                                             text=transcript,
-                                            language=self._language,
+                                            language=detected[0] if detected else self._language,
                                         )
                                     ],
                                 )

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import contextlib
+import dataclasses
 import json
 import os
 import time
@@ -85,12 +86,10 @@ _TURN_DETECTION: TypeAdapter[RealtimeTranscriptionSessionAudioInputTurnDetection
     RealtimeTranscriptionSessionAudioInputTurnDetection
 )
 
-# these models are served only over the realtime API, and without server-side endpointing: they
-# reject any turn_detection config and emit no speech_started/stopped, so the client has to commit
-# the audio buffer to close a segment (e.g. driven by a VAD)
+# realtime-only, and with no server-side endpointing: they reject turn_detection and emit no
+# speech_started/stopped, so the client commits the buffer to close a segment
 _REALTIME_ONLY_MODELS = ("gpt-realtime-whisper", "gpt-live-transcribe")
-# these accept a plural `languages` list and `keywords`; earlier models take a single `language`
-# and no keywords
+# these take a plural `languages` list and `keywords`; earlier models take neither
 _CONTEXT_HINT_MODELS = ("gpt-transcribe", "gpt-live-transcribe")
 
 
@@ -429,13 +428,18 @@ class STT(stt.STT):
         language: NotGivenOr[str | list[str]] = NOT_GIVEN,
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
     ) -> SpeechStream:
+        opts = dataclasses.replace(self._opts)
         if is_given(language):
-            # the options are shared, so this takes the path any other change takes
-            self.update_options(language=language)
+            opts.languages = _as_languages(language)
+            _validate_context(opts.model, opts.languages, opts.keywords)
+            if opts.languages != self._opts.languages:
+                # the pool would otherwise hand this stream a socket carrying another language
+                self._pool.invalidate()
         stream = SpeechStream(
             stt=self,
             pool=self._pool,
             conn_options=conn_options,
+            opts=opts,
             vad_instance=self._vad,
         )
         self._streams.add(stream)
@@ -475,10 +479,13 @@ class STT(stt.STT):
             languages = []
         user_keywords = list(keywords) if is_given(keywords) else self._user_keywords
         _validate_context(resolved_model, languages, user_keywords)
+        if not is_given(language):
+            # a stream keeps its own language, which the new model may not take
+            for stream in self._streams:
+                _validate_context(resolved_model, stream._opts.languages, user_keywords)
 
-        # the transport is fixed for the life of the instance: AgentSession wraps a non-streaming
-        # STT in a StreamAdapter once, so `streaming` cannot flip under a running pipeline. the
-        # other direction needs no guard, since the realtime API serves every model.
+        # the transport is fixed at construction: AgentSession wraps a non-streaming STT once.
+        # the realtime API serves every model, so only this direction can break
         if not self.capabilities.streaming and _is_realtime_only(resolved_model):
             raise ValueError(
                 f"{resolved_model} is served only over the realtime API, and this STT was "
@@ -497,11 +504,8 @@ class STT(stt.STT):
                 "to drive `input_audio_buffer.commit` yourself"
             )
 
-        # a reconnect is the only way to apply these: gateways route on the ?model= in the
-        # upgrade URL, and `languages` cannot be cleared on an open session
-        needs_reconnect = resolved_model != self._opts.model or (
-            bool(self._opts.languages) and not languages
-        )
+        needs_reconnect = resolved_model != self._opts.model or languages != self._opts.languages
+        languages_given = is_given(language) or is_given(detect_language)
         self._opts.model = resolved_model
         self._capabilities.keyterms = _supports_context_hints(resolved_model)
         self._opts.languages = languages
@@ -530,15 +534,11 @@ class STT(stt.STT):
                 self._opts.temperature = temperature
 
         if needs_reconnect:
-            # the pool keeps idle sockets for reuse, and `_streams` may be empty between two
-            # speech sessions, so the drop happens here rather than per stream
+            # the streams do this too, but `_streams` is empty between two speech sessions
             self._pool.invalidate()
 
         for stream in self._streams:
-            if needs_reconnect:
-                stream.reconnect()
-            else:
-                stream.apply_options()
+            stream.update_options(language=languages if languages_given else NOT_GIVEN)
 
     def _update_session_keyterms(self, keyterms: list[str]) -> None:
         if not self.capabilities.keyterms:
@@ -549,7 +549,7 @@ class STT(stt.STT):
         self._session_keyterms = list(keyterms)
         self._opts.keywords = list(dict.fromkeys([*self._user_keywords, *keyterms]))
         for stream in self._streams:
-            stream.apply_options()
+            stream.update_options()
 
     async def _connect_ws(self, timeout: float) -> aiohttp.ClientWebSocketResponse:
         query_params: dict[str, str] = {
@@ -623,8 +623,7 @@ class STT(stt.STT):
                 timeout=httpx.Timeout(30, connect=conn_options.timeout),
             )
 
-            # what the model detected beats the hint that was sent, the first code being the
-            # dominant one; an empty list means nothing was detected reliably, so the hint stands
+            # the detected language beats the hint, dominant code first; an empty list keeps it
             sd = stt.SpeechData(text=resp.text, language=_transcript_language(self._opts.languages))
             if isinstance(resp, TranscriptionVerbose) and resp.language:
                 sd.language = LanguageCode(resp.language)
@@ -653,14 +652,16 @@ class SpeechStream(stt.SpeechStream):
         stt: STT,
         conn_options: APIConnectOptions,
         pool: utils.ConnectionPool[aiohttp.ClientWebSocketResponse],
+        opts: _STTOptions,
         vad_instance: vad.VAD | None = None,
     ) -> None:
         super().__init__(stt=stt, conn_options=conn_options, sample_rate=SAMPLE_RATE)
 
         self._pool = pool
-        # the STT mutates these in place; every acquired connection is configured from them
-        self._opts = stt._opts
-        self._language = _transcript_language(stt._opts.languages)
+        # this stream's own options, and the STT's to refresh them from
+        self._opts = opts
+        self._stt: STT = stt
+        self._language = _transcript_language(opts.languages)
         self._request_id = ""
         self._reconnect_event = asyncio.Event()
         self._ws: aiohttp.ClientWebSocketResponse | None = None
@@ -670,12 +671,25 @@ class SpeechStream(stt.SpeechStream):
         self._vad = vad_instance
         self._speaking = False
 
-    def apply_options(self) -> None:
-        """Apply an option change on the open connection instead of reconnecting."""
-        self._language = _transcript_language(self._opts.languages)
-        self._update_task = asyncio.create_task(
-            self._send_update(_session_update(self._opts), old_task=self._update_task)
-        )
+    def update_options(self, *, language: NotGivenOr[str | list[str]] = NOT_GIVEN) -> None:
+        """Set the language for this stream alone, and take the rest from the STT."""
+        # only a named language moves this stream off its own
+        opts = dataclasses.replace(self._stt._opts, languages=self._opts.languages)
+        if is_given(language):
+            opts.languages = _as_languages(language)
+            _validate_context(opts.model, opts.languages, opts.keywords)
+        # a language cannot be cleared on an open session, nor can a pooled socket carrying
+        # another one be reused; gateways route on the ?model= in the URL
+        rebuild = opts.model != self._opts.model or opts.languages != self._opts.languages
+        self._opts = opts
+        self._language = _transcript_language(opts.languages)
+        if rebuild:
+            self._pool.invalidate()
+            self._reconnect_event.set()
+        else:
+            self._update_task = asyncio.create_task(
+                self._send_update(_session_update(opts), old_task=self._update_task)
+            )
 
     async def _send_update(
         self, event: SessionUpdateEvent, *, old_task: asyncio.Task[None] | None
@@ -694,11 +708,6 @@ class SpeechStream(stt.SpeechStream):
         except Exception:
             # a dropped update is not worth failing the stream over
             logger.warning("failed to update the transcription session", exc_info=True)
-
-    def reconnect(self) -> None:
-        """Rebuild the connection so it carries the current options. The STT drops the pool."""
-        self._language = _transcript_language(self._opts.languages)
-        self._reconnect_event.set()
 
     async def aclose(self) -> None:
         if self._update_task is not None:
@@ -771,8 +780,7 @@ class SpeechStream(stt.SpeechStream):
                         self._start_speaking()
                     elif ev.type == vad.VADEventType.END_OF_SPEECH:
                         self._stop_speaking()
-                        # a model with server-side endpointing closes the segment itself, so a
-                        # commit from here would cut it a second time
+                        # a server-endpointed model closes the segment itself; this would cut it twice
                         if _is_realtime_only(self._opts.model):
                             await ws.send_json({"type": "input_audio_buffer.commit"})
             except (aiohttp.ClientError, ConnectionError) as e:
@@ -930,11 +938,11 @@ class SpeechStream(stt.SpeechStream):
                 self._report_connection_acquired(
                     self._pool.last_acquire_time, self._pool.last_connection_reused
                 )
-                # published before the config is sent, so a change made during the send is
-                # applied after it rather than dropped as having no live connection
+                # published before the config is sent, so a change made during the send lands
+                # after it rather than finding no live connection
                 self._ws = ws
-                # a pooled connection may have been configured for older options. the lock is
-                # taken before the first await, so no queued update can overtake this one.
+                # a pooled connection may carry older options; the lock is taken before the
+                # first await, so no queued update overtakes this one
                 try:
                     async with self._config_lock:
                         await ws.send_json(

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -647,6 +647,8 @@ class SpeechStream(stt.SpeechStream):
         self._reconnect_event = asyncio.Event()
         self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._update_task: asyncio.Task[None] | None = None
+        # serializes the config a connection is set up with against any later change to it
+        self._config_lock = asyncio.Lock()
         self._vad = vad_instance
         self._speaking = False
 
@@ -664,11 +666,13 @@ class SpeechStream(stt.SpeechStream):
             with contextlib.suppress(Exception):
                 await old_task
 
-        if self._ws is None:
+        ws = self._ws
+        if ws is None:
             return  # the next connection is configured when the stream acquires it
 
         try:
-            await self._ws.send_json(event.model_dump(by_alias=True, exclude_unset=True))
+            async with self._config_lock:
+                await ws.send_json(event.model_dump(by_alias=True, exclude_unset=True))
         except Exception:
             # a dropped update is not worth failing the stream over
             logger.warning("failed to update the transcription session", exc_info=True)
@@ -900,19 +904,24 @@ class SpeechStream(stt.SpeechStream):
                 self._report_connection_acquired(
                     self._pool.last_acquire_time, self._pool.last_connection_reused
                 )
-                # a pooled connection may have been configured for older options
+                # published before the config is sent, so a change made during the send is
+                # applied after it rather than dropped as having no live connection
+                self._ws = ws
+                # a pooled connection may have been configured for older options. the lock is
+                # taken before the first await, so no queued update can overtake this one.
                 try:
-                    await ws.send_json(
-                        _session_update(self._opts).model_dump(by_alias=True, exclude_unset=True)
-                    )
+                    async with self._config_lock:
+                        await ws.send_json(
+                            _session_update(self._opts).model_dump(
+                                by_alias=True, exclude_unset=True
+                            )
+                        )
                 except (aiohttp.ClientError, ConnectionError) as e:
                     # a pooled socket can die while idle; keep that retryable
                     raise APIConnectionError(
                         "OpenAI Realtime STT connection closed unexpectedly"
                     ) from e
                 vad_stream = self._vad.stream() if self._vad is not None else None
-                # option updates are sent on whichever connection is live
-                self._ws = ws
                 tasks = [
                     asyncio.create_task(send_task(ws, vad_stream)),
                     asyncio.create_task(recv_task(ws)),

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -16,16 +16,17 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import json
 import os
 import time
 import weakref
-from dataclasses import dataclass
-from typing import Any
+from dataclasses import dataclass, field
 from urllib.parse import urlencode, urlparse
 
 import aiohttp
 import httpx
+from pydantic import TypeAdapter
 
 import openai
 from livekit import rtc
@@ -50,6 +51,22 @@ from openai.types.audio import TranscriptionVerbose
 from openai.types.beta.realtime.transcription_session_update_param import (
     SessionTurnDetection,
 )
+from openai.types.realtime.audio_transcription import AudioTranscription
+from openai.types.realtime.realtime_audio_formats import AudioPCM
+from openai.types.realtime.realtime_transcription_session_audio import (
+    RealtimeTranscriptionSessionAudio,
+)
+from openai.types.realtime.realtime_transcription_session_audio_input import (
+    NoiseReduction,
+    RealtimeTranscriptionSessionAudioInput,
+)
+from openai.types.realtime.realtime_transcription_session_audio_input_turn_detection import (
+    RealtimeTranscriptionSessionAudioInputTurnDetection,
+)
+from openai.types.realtime.realtime_transcription_session_create_request import (
+    RealtimeTranscriptionSessionCreateRequest,
+)
+from openai.types.realtime.session_update_event import SessionUpdateEvent
 
 from .log import logger
 from .models import STTModels
@@ -62,33 +79,110 @@ _max_session_duration = 10 * 60
 _delta_transcript_interval = 0.5
 SAMPLE_RATE = 24000
 NUM_CHANNELS = 1
+# turn_detection is a discriminated union, so a plain dict needs an adapter to validate
+_TURN_DETECTION: TypeAdapter[RealtimeTranscriptionSessionAudioInputTurnDetection] = TypeAdapter(
+    RealtimeTranscriptionSessionAudioInputTurnDetection
+)
 
 
-def _is_whisper_realtime(model: str) -> bool:
-    # gpt-realtime-whisper rejects any turn_detection config; the client must
-    # commit the audio buffer manually (e.g. driven by an external VAD).
-    return model.startswith("gpt-realtime-whisper")
+def _requires_client_commit(model: str) -> bool:
+    # these models reject any turn_detection config and emit no speech_started/stopped;
+    # the client must commit the audio buffer to close a segment (e.g. driven by a VAD).
+    return model.startswith(("gpt-realtime-whisper", "gpt-live-transcribe"))
+
+
+def _supports_context_hints(model: str) -> bool:
+    # earlier models take a single `language` and no keywords
+    return model.startswith(("gpt-transcribe", "gpt-live-transcribe"))
+
+
+def _as_languages(language: str | list[str]) -> list[str]:
+    """Wrap a single code into a list, dropping empty strings."""
+    if isinstance(language, str):
+        return [language] if language else []
+    return [code for code in language if code]
+
+
+def _validate_context(model: str, languages: list[str], keywords: list[str]) -> None:
+    """Raise when keywords or several languages go to a model that takes neither."""
+    if _supports_context_hints(model):
+        return
+    if keywords:
+        raise ValueError(
+            f"keywords are only supported by gpt-transcribe and gpt-live-transcribe, not {model}"
+        )
+    if len(languages) > 1:
+        raise ValueError(
+            f"{model} accepts a single language; only gpt-transcribe and "
+            "gpt-live-transcribe accept a list"
+        )
+
+
+def _transcript_language(languages: list[str]) -> LanguageCode:
+    """The code to tag transcripts with, empty unless exactly one language is set."""
+    return LanguageCode(languages[0]) if len(languages) == 1 else LanguageCode("")
 
 
 @dataclass
 class _STTOptions:
     model: STTModels | str
-    language: LanguageCode
+    languages: list[str]
     detect_language: bool
     turn_detection: SessionTurnDetection
+    keywords: list[str] = field(default_factory=list)
     prompt: NotGivenOr[str] = NOT_GIVEN
     noise_reduction_type: NotGivenOr[str] = NOT_GIVEN
     temperature: NotGivenOr[float] = NOT_GIVEN
+
+
+def _transcription(opts: _STTOptions) -> AudioTranscription:
+    """The transcription config: `languages` and `keywords`, or a single `language`."""
+    transcription = AudioTranscription(model=opts.model)
+    if is_given(opts.prompt) and opts.prompt:
+        transcription.prompt = opts.prompt
+    if opts.keywords and _supports_context_hints(opts.model):
+        transcription.keywords = opts.keywords
+    if opts.languages:
+        # both fields want ISO-639-1; the API rejects regional tags such as en-US
+        codes = list(dict.fromkeys(LanguageCode(code).language for code in opts.languages))
+        if _supports_context_hints(opts.model):
+            transcription.languages = codes
+        else:
+            transcription.language = codes[0]
+    return transcription
+
+
+def _session_update(opts: _STTOptions) -> SessionUpdateEvent:
+    """The `session.update` event for the current config."""
+    audio_input = RealtimeTranscriptionSessionAudioInput(
+        format=AudioPCM(rate=SAMPLE_RATE, type="audio/pcm"),
+        transcription=_transcription(opts),
+    )
+    # leave the field unset for models that reject it; the rest get server-side VAD
+    if not _requires_client_commit(opts.model):
+        audio_input.turn_detection = _TURN_DETECTION.validate_python(opts.turn_detection)
+
+    if opts.noise_reduction_type:
+        audio_input.noise_reduction = NoiseReduction(type=opts.noise_reduction_type)
+
+    return SessionUpdateEvent(
+        type="session.update",
+        session=RealtimeTranscriptionSessionCreateRequest(
+            type="transcription",
+            audio=RealtimeTranscriptionSessionAudio(input=audio_input),
+        ),
+    )
 
 
 class STT(stt.STT):
     def __init__(
         self,
         *,
-        language: str = "en",
+        language: str | list[str] = "en",
         detect_language: bool = False,
         model: STTModels | str = "gpt-4o-mini-transcribe",
         prompt: NotGivenOr[str] = NOT_GIVEN,
+        keywords: NotGivenOr[list[str]] = NOT_GIVEN,
         turn_detection: NotGivenOr[SessionTurnDetection] = NOT_GIVEN,
         noise_reduction_type: NotGivenOr[str] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
@@ -103,12 +197,16 @@ class STT(stt.STT):
 
         Args:
             language: The language code to use for transcription (e.g., "en" for English).
+                gpt-transcribe and gpt-live-transcribe accept a list for code-switched audio.
             detect_language: Whether to automatically detect the language.
             model: The OpenAI model to use for transcription.
-            prompt: Optional text prompt to guide the transcription. Only supported for whisper-1.
+            prompt: Optional free-form description of the audio, such as its topic or setting.
+            keywords: Literal terms to expect, such as product names or acronyms. Only for
+                gpt-transcribe and gpt-live-transcribe, and only a hint.
             turn_detection: When using realtime transcription, this controls how model detects the user is done speaking.
                 Final transcripts are generated only after the turn is over. See: https://platform.openai.com/docs/guides/realtime-vad
-                Ignored for `gpt-realtime-whisper`, which does not support server-side turn detection.
+                Ignored for `gpt-realtime-whisper` and `gpt-live-transcribe`, which do not
+                support server-side turn detection.
             noise_reduction_type: Type of noise reduction to apply. "near_field" or "far_field"
                 This isn't needed when using LiveKit's noise cancellation.
             temperature: Sampling temperature between 0 and 1. Lower values make the
@@ -118,7 +216,8 @@ class STT(stt.STT):
             client: Optional pre-configured OpenAI AsyncClient instance.
             use_realtime: Whether to use the realtime transcription API. (default: False)
             vad: Optional Voice Activity Detector used to commit the audio buffer when the model
-                does not support server-side turn detection (e.g. `gpt-realtime-whisper`).
+                does not support server-side turn detection (`gpt-realtime-whisper`,
+                `gpt-live-transcribe`).
                 When not provided and the model requires it, Silero VAD is auto-loaded with default
                 settings. Pass `vad=None` to opt out of the auto-load and drive
                 `input_audio_buffer.commit` yourself.
@@ -131,8 +230,7 @@ class STT(stt.STT):
             )
             temperature = NOT_GIVEN
 
-        whisper_realtime = use_realtime and _is_whisper_realtime(model)
-        if whisper_realtime:
+        if use_realtime and _requires_client_commit(model):
             if is_given(turn_detection):
                 logger.warning(
                     "turn_detection is not supported for %s; ignoring the provided value", model
@@ -143,7 +241,7 @@ class STT(stt.STT):
                     from livekit.plugins.silero import VAD as SileroVAD
                 except ImportError as e:
                     raise ImportError(
-                        "livekit-plugins-silero is required for the gpt-realtime-whisper model "
+                        f"livekit-plugins-silero is required for {model} "
                         "(no server-side endpointing). Pass `vad=None` to opt out and drive "
                         "`input_audio_buffer.commit` manually."
                     ) from e
@@ -151,11 +249,15 @@ class STT(stt.STT):
 
         super().__init__(
             capabilities=stt.STTCapabilities(
-                streaming=use_realtime, interim_results=use_realtime, aligned_transcript=False
+                streaming=use_realtime,
+                interim_results=use_realtime,
+                aligned_transcript=False,
+                keyterms=_supports_context_hints(model),
             )
         )
-        if detect_language:
-            language = ""
+        languages = [] if detect_language else _as_languages(language)
+        resolved_keywords = list(keywords) if is_given(keywords) else []
+        _validate_context(model, languages, resolved_keywords)
 
         if not is_given(turn_detection):
             turn_detection = {
@@ -166,15 +268,20 @@ class STT(stt.STT):
             }
 
         self._opts = _STTOptions(
-            language=LanguageCode(language),
+            languages=languages,
             detect_language=detect_language,
             model=model,
             prompt=prompt,
+            keywords=resolved_keywords,
             turn_detection=turn_detection,
             temperature=temperature,
         )
         if is_given(noise_reduction_type):
             self._opts.noise_reduction_type = noise_reduction_type
+
+        # user keywords; _opts.keywords holds the effective set (user + session)
+        self._user_keywords: list[str] = list(self._opts.keywords)
+        self._session_keyterms: list[str] = []
 
         self._vad = vad if is_given(vad) else None
 
@@ -218,10 +325,11 @@ class STT(stt.STT):
     @staticmethod
     def with_azure(
         *,
-        language: str = "en",
+        language: str | list[str] = "en",
         detect_language: bool = False,
         model: STTModels | str = "gpt-4o-mini-transcribe",
         prompt: NotGivenOr[str] = NOT_GIVEN,
+        keywords: NotGivenOr[list[str]] = NOT_GIVEN,
         turn_detection: NotGivenOr[SessionTurnDetection] = NOT_GIVEN,
         noise_reduction_type: NotGivenOr[str] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
@@ -271,6 +379,7 @@ class STT(stt.STT):
             detect_language=detect_language,
             model=model,
             prompt=prompt,
+            keywords=keywords,
             turn_detection=turn_detection,
             noise_reduction_type=noise_reduction_type,
             temperature=temperature,
@@ -286,7 +395,7 @@ class STT(stt.STT):
         api_key: NotGivenOr[str] = NOT_GIVEN,
         base_url: str = "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1",
         client: openai.AsyncClient | None = None,
-        language: str = "en",
+        language: str | list[str] = "en",
         detect_language: bool = False,
         prompt: NotGivenOr[str] = NOT_GIVEN,
     ) -> STT:
@@ -314,11 +423,13 @@ class STT(stt.STT):
     def stream(
         self,
         *,
-        language: NotGivenOr[str] = NOT_GIVEN,
+        language: NotGivenOr[str | list[str]] = NOT_GIVEN,
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
     ) -> SpeechStream:
         if is_given(language):
-            self._opts.language = LanguageCode(language)
+            languages = _as_languages(language)
+            _validate_context(self._opts.model, languages, self._opts.keywords)
+            self._opts.languages = languages
         stream = SpeechStream(
             stt=self,
             pool=self._pool,
@@ -332,33 +443,47 @@ class STT(stt.STT):
         self,
         *,
         model: NotGivenOr[STTModels | str] = NOT_GIVEN,
-        language: NotGivenOr[str] = NOT_GIVEN,
+        language: NotGivenOr[str | list[str]] = NOT_GIVEN,
         detect_language: NotGivenOr[bool] = NOT_GIVEN,
         prompt: NotGivenOr[str] = NOT_GIVEN,
+        keywords: NotGivenOr[list[str]] = NOT_GIVEN,
         turn_detection: NotGivenOr[SessionTurnDetection] = NOT_GIVEN,
         noise_reduction_type: NotGivenOr[str] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
     ) -> None:
         """
-        Update the options for the speech stream. Most options are updated at the
-        connection level. SpeechStreams will be recreated when options are updated.
+        Update the options for the speech stream. Open streams apply the change in place;
+        only a new `model` reconnects them.
 
         Args:
-            language: The language to transcribe in.
+            language: The language to transcribe in, or a list for gpt-transcribe and
+                gpt-live-transcribe.
             detect_language: Whether to automatically detect the language.
             model: The model to use for transcription.
-            prompt: Optional text prompt to guide the transcription. Only supported for whisper-1.
+            prompt: Optional free-form description of the audio.
+            keywords: Literal terms to expect. Only for gpt-transcribe and gpt-live-transcribe.
             turn_detection: When using realtime, this controls how model detects the user is done speaking.
             noise_reduction_type: Type of noise reduction to apply. "near_field" or "far_field"
             temperature: Sampling temperature between 0 and 1. Not supported for realtime transcription.
         """  # noqa: E501
-        if is_given(model):
-            self._opts.model = model
-        if is_given(language):
-            self._opts.language = LanguageCode(language)
+        # resolve first: an unsupported combination must raise before anything is applied
+        resolved_model = model if is_given(model) else self._opts.model
+        languages = _as_languages(language) if is_given(language) else self._opts.languages
+        if is_given(detect_language) and detect_language:
+            languages = []
+        user_keywords = list(keywords) if is_given(keywords) else self._user_keywords
+        _validate_context(resolved_model, languages, user_keywords)
+
+        # gateways route on the ?model= in the upgrade URL, so only a model change
+        # can't be expressed as a session.update
+        model_changed = resolved_model != self._opts.model
+        self._opts.model = resolved_model
+        self._capabilities.keyterms = _supports_context_hints(resolved_model)
+        self._opts.languages = languages
+        self._user_keywords = user_keywords
+        self._opts.keywords = list(dict.fromkeys([*user_keywords, *self._session_keyterms]))
         if is_given(detect_language):
             self._opts.detect_language = detect_language
-            self._opts.language = LanguageCode("")
         if is_given(prompt):
             self._opts.prompt = prompt
         if is_given(turn_detection):
@@ -375,44 +500,23 @@ class STT(stt.STT):
                 self._opts.temperature = temperature
 
         for stream in self._streams:
-            if is_given(language):
-                stream.update_options(language=language)
+            if model_changed:
+                stream.reconnect()
+            else:
+                stream.apply_options(self._opts)
+
+    def _update_session_keyterms(self, keyterms: list[str]) -> None:
+        if not self.capabilities.keyterms:
+            super()._update_session_keyterms(keyterms)
+            return
+        if keyterms == self._session_keyterms:
+            return
+        self._session_keyterms = list(keyterms)
+        self._opts.keywords = list(dict.fromkeys([*self._user_keywords, *keyterms]))
+        for stream in self._streams:
+            stream.apply_options(self._opts)
 
     async def _connect_ws(self, timeout: float) -> aiohttp.ClientWebSocketResponse:
-        prompt = self._opts.prompt if is_given(self._opts.prompt) else ""
-        transcription_config: dict[str, Any] = {
-            "model": self._opts.model,
-        }
-        if prompt:
-            transcription_config["prompt"] = prompt
-        if self._opts.language:
-            transcription_config["language"] = self._opts.language.language
-
-        input_config: dict[str, Any] = {
-            "format": {
-                "type": "audio/pcm",
-                "rate": SAMPLE_RATE,
-            },
-            "transcription": transcription_config,
-        }
-        # gpt-realtime-whisper rejects any turn_detection config — omit the key entirely.
-        # For other models, send the configured turn_detection (server-side VAD).
-        if not _is_whisper_realtime(self._opts.model):
-            input_config["turn_detection"] = self._opts.turn_detection
-
-        if self._opts.noise_reduction_type:
-            input_config["noise_reduction"] = {"type": self._opts.noise_reduction_type}
-
-        realtime_config: dict[str, Any] = {
-            "type": "session.update",
-            "session": {
-                "type": "transcription",
-                "audio": {
-                    "input": input_config,
-                },
-            },
-        }
-
         query_params: dict[str, str] = {
             "intent": "transcription",
         }
@@ -433,7 +537,8 @@ class STT(stt.STT):
 
         session = self._ensure_session()
         ws = await asyncio.wait_for(session.ws_connect(url, headers=headers), timeout)
-        await ws.send_json(realtime_config)
+        event = _session_update(self._opts)
+        await ws.send_json(event.model_dump(by_alias=True, exclude_unset=True))
         return ws
 
     async def _close_ws(self, ws: aiohttp.ClientWebSocketResponse) -> None:
@@ -449,20 +554,23 @@ class STT(stt.STT):
         self,
         buffer: AudioBuffer,
         *,
-        language: NotGivenOr[str] = NOT_GIVEN,
+        language: NotGivenOr[str | list[str]] = NOT_GIVEN,
         conn_options: APIConnectOptions,
     ) -> stt.SpeechEvent:
+        if is_given(language):
+            languages = _as_languages(language)
+            _validate_context(self._opts.model, languages, self._opts.keywords)
+            self._opts.languages = languages
+
         try:
-            if is_given(language):
-                self._opts.language = LanguageCode(language)
             data = rtc.combine_audio_frames(buffer).to_wav_bytes()
-            prompt = self._opts.prompt if is_given(self._opts.prompt) else openai.omit
 
             format = "json"
             if self._opts.model == "whisper-1":
                 # verbose_json returns language and other details, only supported for whisper-1
                 format = "verbose_json"
 
+            transcription = _transcription(self._opts)
             resp = await self._client.audio.transcriptions.create(
                 file=(
                     "file.wav",
@@ -470,8 +578,10 @@ class STT(stt.STT):
                     "audio/wav",
                 ),
                 model=self._opts.model,  # type: ignore
-                language=self._opts.language.language if self._opts.language else "",
-                prompt=prompt,
+                language=transcription.language or openai.omit,
+                languages=transcription.languages or openai.omit,
+                keywords=transcription.keywords or openai.omit,
+                prompt=transcription.prompt or openai.omit,
                 response_format=format,
                 temperature=self._opts.temperature
                 if is_given(self._opts.temperature)
@@ -479,7 +589,7 @@ class STT(stt.STT):
                 timeout=httpx.Timeout(30, connect=conn_options.timeout),
             )
 
-            sd = stt.SpeechData(text=resp.text, language=self._opts.language)
+            sd = stt.SpeechData(text=resp.text, language=_transcript_language(self._opts.languages))
             if isinstance(resp, TranscriptionVerbose) and resp.language:
                 sd.language = LanguageCode(resp.language)
 
@@ -510,20 +620,47 @@ class SpeechStream(stt.SpeechStream):
         super().__init__(stt=stt, conn_options=conn_options, sample_rate=SAMPLE_RATE)
 
         self._pool = pool
-        self._language = stt._opts.language
+        self._language = _transcript_language(stt._opts.languages)
         self._request_id = ""
         self._reconnect_event = asyncio.Event()
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._update_task: asyncio.Task[None] | None = None
         self._vad = vad_instance
         self._speaking = False
 
-    def update_options(
-        self,
-        *,
-        language: str,
+    def apply_options(self, opts: _STTOptions) -> None:
+        """Apply an option change on the open connection instead of reconnecting."""
+        self._language = _transcript_language(opts.languages)
+        self._update_task = asyncio.create_task(
+            self._send_update(_session_update(opts), old_task=self._update_task)
+        )
+
+    async def _send_update(
+        self, event: SessionUpdateEvent, *, old_task: asyncio.Task[None] | None
     ) -> None:
-        self._language = LanguageCode(language)
+        if old_task is not None:
+            with contextlib.suppress(Exception):
+                await old_task
+
+        if self._ws is None:
+            return  # the next connection is built from the current options anyway
+
+        try:
+            await self._ws.send_json(event.model_dump(by_alias=True, exclude_unset=True))
+        except Exception:
+            # a dropped update is not worth failing the stream over
+            logger.warning("failed to update the transcription session", exc_info=True)
+
+    def reconnect(self) -> None:
+        """Drop the connection so the next one is built with the current options."""
         self._pool.invalidate()
         self._reconnect_event.set()
+
+    async def aclose(self) -> None:
+        if self._update_task is not None:
+            await utils.aio.gracefully_cancel(self._update_task)
+
+        await super().aclose()
 
     def _start_speaking(self) -> None:
         if self._speaking:
@@ -741,6 +878,8 @@ class SpeechStream(stt.SpeechStream):
                     self._pool.last_acquire_time, self._pool.last_connection_reused
                 )
                 vad_stream = self._vad.stream() if self._vad is not None else None
+                # option updates are sent on whichever connection is live
+                self._ws = ws
                 tasks = [
                     asyncio.create_task(send_task(ws, vad_stream)),
                     asyncio.create_task(recv_task(ws)),
@@ -765,6 +904,7 @@ class SpeechStream(stt.SpeechStream):
 
                     self._reconnect_event.clear()
                 finally:
+                    self._ws = None
                     await utils.aio.gracefully_cancel(*tasks, wait_reconnect_task)
                     tasks_group.cancel()
                     tasks_group.exception()  # retrieve the exception

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -140,7 +140,7 @@ def _transcription(opts: _STTOptions) -> AudioTranscription:
     transcription = AudioTranscription(model=opts.model)
     if is_given(opts.prompt) and opts.prompt:
         transcription.prompt = opts.prompt
-    if opts.keywords and _supports_context_hints(opts.model):
+    if opts.keywords:
         transcription.keywords = opts.keywords
     if opts.languages:
         # both fields want ISO-639-1; the API rejects regional tags such as en-US
@@ -481,7 +481,12 @@ class STT(stt.STT):
         self._capabilities.keyterms = _supports_context_hints(resolved_model)
         self._opts.languages = languages
         self._user_keywords = user_keywords
-        self._opts.keywords = list(dict.fromkeys([*user_keywords, *self._session_keyterms]))
+        # detected keyterms must not survive a switch to a model that rejects keywords
+        self._opts.keywords = (
+            list(dict.fromkeys([*user_keywords, *self._session_keyterms]))
+            if self.capabilities.keyterms
+            else []
+        )
         if is_given(detect_language):
             self._opts.detect_language = detect_language
         if is_given(prompt):
@@ -503,7 +508,7 @@ class STT(stt.STT):
             if model_changed:
                 stream.reconnect()
             else:
-                stream.apply_options(self._opts)
+                stream.apply_options()
 
     def _update_session_keyterms(self, keyterms: list[str]) -> None:
         if not self.capabilities.keyterms:
@@ -514,7 +519,7 @@ class STT(stt.STT):
         self._session_keyterms = list(keyterms)
         self._opts.keywords = list(dict.fromkeys([*self._user_keywords, *keyterms]))
         for stream in self._streams:
-            stream.apply_options(self._opts)
+            stream.apply_options()
 
     async def _connect_ws(self, timeout: float) -> aiohttp.ClientWebSocketResponse:
         query_params: dict[str, str] = {
@@ -536,10 +541,9 @@ class STT(stt.STT):
             url = url.replace("http", "ws", 1)
 
         session = self._ensure_session()
-        ws = await asyncio.wait_for(session.ws_connect(url, headers=headers), timeout)
-        event = _session_update(self._opts)
-        await ws.send_json(event.model_dump(by_alias=True, exclude_unset=True))
-        return ws
+        # the config is sent once the stream acquires the connection, since the pool also
+        # hands back sockets it opened earlier
+        return await asyncio.wait_for(session.ws_connect(url, headers=headers), timeout)
 
     async def _close_ws(self, ws: aiohttp.ClientWebSocketResponse) -> None:
         await ws.close()
@@ -620,6 +624,8 @@ class SpeechStream(stt.SpeechStream):
         super().__init__(stt=stt, conn_options=conn_options, sample_rate=SAMPLE_RATE)
 
         self._pool = pool
+        # the STT mutates these in place; every acquired connection is configured from them
+        self._opts = stt._opts
         self._language = _transcript_language(stt._opts.languages)
         self._request_id = ""
         self._reconnect_event = asyncio.Event()
@@ -628,11 +634,11 @@ class SpeechStream(stt.SpeechStream):
         self._vad = vad_instance
         self._speaking = False
 
-    def apply_options(self, opts: _STTOptions) -> None:
+    def apply_options(self) -> None:
         """Apply an option change on the open connection instead of reconnecting."""
-        self._language = _transcript_language(opts.languages)
+        self._language = _transcript_language(self._opts.languages)
         self._update_task = asyncio.create_task(
-            self._send_update(_session_update(opts), old_task=self._update_task)
+            self._send_update(_session_update(self._opts), old_task=self._update_task)
         )
 
     async def _send_update(
@@ -643,7 +649,7 @@ class SpeechStream(stt.SpeechStream):
                 await old_task
 
         if self._ws is None:
-            return  # the next connection is built from the current options anyway
+            return  # the next connection is configured when the stream acquires it
 
         try:
             await self._ws.send_json(event.model_dump(by_alias=True, exclude_unset=True))
@@ -653,6 +659,7 @@ class SpeechStream(stt.SpeechStream):
 
     def reconnect(self) -> None:
         """Drop the connection so the next one is built with the current options."""
+        self._language = _transcript_language(self._opts.languages)
         self._pool.invalidate()
         self._reconnect_event.set()
 
@@ -876,6 +883,10 @@ class SpeechStream(stt.SpeechStream):
             async with self._pool.connection(timeout=self._conn_options.timeout) as ws:
                 self._report_connection_acquired(
                     self._pool.last_acquire_time, self._pool.last_connection_reused
+                )
+                # a pooled connection may have been configured for older options
+                await ws.send_json(
+                    _session_update(self._opts).model_dump(by_alias=True, exclude_unset=True)
                 )
                 vad_stream = self._vad.stream() if self._vad is not None else None
                 # option updates are sent on whichever connection is live

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -255,7 +255,9 @@ class STT(stt.STT):
                 keyterms=_supports_context_hints(model),
             )
         )
-        languages = [] if detect_language else _as_languages(language)
+        # the last language asked for, kept while detection is on so it can be restored
+        self._specified_languages = _as_languages(language)
+        languages = [] if detect_language else self._specified_languages
         resolved_keywords = list(keywords) if is_given(keywords) else []
         _validate_context(model, languages, resolved_keywords)
 
@@ -463,8 +465,9 @@ class STT(stt.STT):
 
         Args:
             language: The language to transcribe in, or a list for gpt-transcribe and
-                gpt-live-transcribe.
-            detect_language: Whether to automatically detect the language.
+                gpt-live-transcribe. An empty list detects the language.
+            detect_language: Whether to detect the language. Turning it off falls back to the
+                last language asked for.
             model: The model to use for transcription.
             prompt: Optional free-form description of the audio.
             keywords: Literal terms to expect. Only for gpt-transcribe and gpt-live-transcribe.
@@ -474,9 +477,19 @@ class STT(stt.STT):
         """  # noqa: E501
         # resolve first: an unsupported combination must raise before anything is applied
         resolved_model = model if is_given(model) else self._opts.model
-        languages = _as_languages(language) if is_given(language) else self._opts.languages
-        if is_given(detect_language) and detect_language:
+        if is_given(language):
+            languages = _as_languages(language)
+        elif detect_language:
             languages = []
+        elif detect_language is False and not self._opts.languages:
+            logger.warning(
+                "detect_language=False names no language, falling back to %s; "
+                "pass `language` to transcribe in another",
+                self._specified_languages,
+            )
+            languages = self._specified_languages
+        else:
+            languages = self._opts.languages
         user_keywords = list(keywords) if is_given(keywords) else self._user_keywords
         _validate_context(resolved_model, languages, user_keywords)
         if not is_given(language):
@@ -499,11 +512,15 @@ class STT(stt.STT):
                     "to drive `input_audio_buffer.commit` yourself"
                 )
 
-        needs_reconnect = resolved_model != self._opts.model or languages != self._opts.languages
-        languages_given = is_given(language) or is_given(detect_language)
+        languages_changed = languages != self._opts.languages
+        needs_reconnect = resolved_model != self._opts.model or languages_changed
+        # a stream keeps a language of its own unless this call names or moves the language
+        languages_given = is_given(language) or languages_changed
         self._opts.model = resolved_model
         self._capabilities.keyterms = _supports_context_hints(resolved_model)
         self._opts.languages = languages
+        if languages:
+            self._specified_languages = languages
         self._user_keywords = user_keywords
         # detected keyterms must not survive a switch to a model that rejects keywords
         self._opts.keywords = (

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -430,9 +430,8 @@ class STT(stt.STT):
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
     ) -> SpeechStream:
         if is_given(language):
-            languages = _as_languages(language)
-            _validate_context(self._opts.model, languages, self._opts.keywords)
-            self._opts.languages = languages
+            # the options are shared, so this takes the path any other change takes
+            self.update_options(language=language)
         stream = SpeechStream(
             stt=self,
             pool=self._pool,
@@ -944,6 +943,8 @@ class SpeechStream(stt.SpeechStream):
                             )
                         )
                 except (aiohttp.ClientError, ConnectionError) as e:
+                    # the retry gets its own connection; no update should reach this one
+                    self._ws = None
                     # a pooled socket can die while idle; keep that retryable
                     raise APIConnectionError(
                         "OpenAI Realtime STT connection closed unexpectedly"

--- a/livekit-plugins/livekit-plugins-openai/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-openai/pyproject.toml
@@ -23,7 +23,8 @@ classifiers = [
 ]
 dependencies = [
     "livekit-agents[codecs, images]>=1.6.8",
-    "openai[realtime]>=2.36",
+    # keywords/languages on the transcription APIs landed in 2.50
+    "openai[realtime]>=2.50",
 ]
 
 

--- a/tests/test_plugin_openai_stt_context.py
+++ b/tests/test_plugin_openai_stt_context.py
@@ -145,6 +145,35 @@ async def test_detect_language_omits_the_language_hint() -> None:
     assert "language" not in config
 
 
+async def test_detect_language_falls_back_to_the_last_language(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # detection is the absence of a language, so turning it off has to name one again
+    instance = stt.STT(api_key="test-key", model="gpt-live-transcribe", language="en")
+    instance.update_options(language="de")
+
+    instance.update_options(detect_language=True)
+    assert instance._opts.languages == []
+    assert not caplog.records  # asking for detection says everything it needs to
+
+    # turning it off names none, so it falls back to the last one asked for and says so
+    instance.update_options(detect_language=False)
+    assert instance._opts.languages == ["de"]
+    assert "falling back to ['de']" in caplog.text
+
+    # naming one alongside it leaves nothing to guess
+    caplog.clear()
+    instance.update_options(detect_language=True)
+    instance.update_options(detect_language=False, language="es")
+    assert instance._opts.languages == ["es"]
+    assert not caplog.records
+
+    # and turning it off when it was never on changes nothing
+    instance.update_options(detect_language=False)
+    assert instance._opts.languages == ["es"]
+    assert not caplog.records
+
+
 async def test_single_language_list_works_on_every_model() -> None:
     instance = stt.STT(api_key="test-key", model="whisper-1", language=["fr"])
 
@@ -637,6 +666,10 @@ async def test_an_stt_language_change_overrides_a_stream_of_its_own() -> None:
     instance.update_options(language="de")
     assert pinned._opts.languages == ["de"]
     assert plain._opts.languages == ["de"]
+
+    # so does asking for detection
+    instance.update_options(language=[])
+    assert pinned._opts.languages == []
 
     await pinned.aclose()
     await plain.aclose()

--- a/tests/test_plugin_openai_stt_context.py
+++ b/tests/test_plugin_openai_stt_context.py
@@ -48,11 +48,15 @@ def _offline_stt(**kwargs: Any) -> stt.STT:
     return instance
 
 
+def _audio_input(instance: stt.STT) -> dict[str, Any]:
+    payload = stt._session_update(instance._opts).model_dump(by_alias=True, exclude_unset=True)
+    audio_input = payload["session"]["audio"]["input"]
+    assert isinstance(audio_input, dict)
+    return audio_input
+
+
 async def _transcription_config(instance: stt.STT) -> dict[str, Any]:
-    session = _FakeSession()
-    instance._session = session  # type: ignore[assignment]
-    await instance._connect_ws(5)
-    config = session.ws.sent[0]["session"]["audio"]["input"]["transcription"]
+    config = _audio_input(instance)["transcription"]
     assert isinstance(config, dict)
     return config
 
@@ -248,9 +252,23 @@ async def test_a_new_model_reconnects() -> None:
     stream = instance.stream()
     await _connected(stream)
 
-    instance.update_options(model="gpt-4o-mini-transcribe")
+    instance.update_options(model="gpt-4o-mini-transcribe", language="fr")
 
     assert stream._reconnect_event.is_set()
+    # the transcripts of the rebuilt connection carry the new language, not the old one
+    assert stream._language == "fr"
+
+    await stream.aclose()
+
+
+async def test_detected_keyterms_do_not_block_a_new_stream() -> None:
+    instance = _offline_stt(model="gpt-live-transcribe")
+    instance._update_session_keyterms(["Acme Corp"])
+    instance.update_options(model="gpt-4o-mini-transcribe", keywords=[])
+
+    # the detected terms are gone, so an explicit language does not trip validation
+    stream = instance.stream(language="fr")
+    assert instance._opts.keywords == []
 
     await stream.aclose()
 
@@ -270,11 +288,30 @@ async def test_live_transcribe_omits_turn_detection() -> None:
     # the model rejects any turn_detection config and needs a client-side commit
     instance = stt.STT(api_key="test-key", model="gpt-live-transcribe", use_realtime=True, vad=None)
 
-    session = _FakeSession()
-    instance._session = session  # type: ignore[assignment]
-    await instance._connect_ws(5)
+    assert "turn_detection" not in _audio_input(instance)
 
-    assert "turn_detection" not in session.ws.sent[0]["session"]["audio"]["input"]
+    # every other model still gets server-side VAD
+    other = stt.STT(api_key="test-key", model="gpt-4o-mini-transcribe", use_realtime=True)
+    assert _audio_input(other)["turn_detection"]["type"] == "server_vad"
+
+
+async def test_a_reused_connection_is_reconfigured() -> None:
+    # the pool hands back sockets it configured earlier, so acquiring must re-send the config
+    instance = _offline_stt(model="gpt-live-transcribe")
+    first = instance.stream()
+    ws = await _connected(first)
+    await first.aclose()
+
+    # the change lands while nothing is streaming, so no live socket receives it
+    instance.update_options(keywords=["Acme Corp"])
+    assert "keywords" not in _sent_transcription(ws)
+
+    second = instance.stream()
+    await _connected(second)
+
+    assert _sent_transcription(ws)["keywords"] == ["Acme Corp"]
+
+    await second.aclose()
 
 
 async def test_session_keyterms_reach_the_next_connection() -> None:

--- a/tests/test_plugin_openai_stt_context.py
+++ b/tests/test_plugin_openai_stt_context.py
@@ -1,24 +1,34 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import Callable
 from typing import Any
 
+import aiohttp
 import httpx
 import openai
 import pytest
 
 from livekit import rtc
 from livekit.agents import DEFAULT_API_CONNECT_OPTIONS, inference, vad
-from livekit.agents.stt import SpeechEventType
+from livekit.agents.stt import SpeechEvent, SpeechEventType
 from livekit.plugins.openai import stt
 
 pytestmark = pytest.mark.unit
 
 
+class _FakeMessage:
+    type = aiohttp.WSMsgType.TEXT
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.data = json.dumps(payload)
+
+
 class _FakeWebSocket:
     def __init__(self) -> None:
         self.sent: list[dict[str, Any]] = []
+        self.incoming: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
         self.fail_next = False
         self.block_first: asyncio.Event | None = None
 
@@ -32,8 +42,7 @@ class _FakeWebSocket:
         self.sent.append(data)
 
     async def receive(self) -> object:
-        await asyncio.Event().wait()  # a connection that never says anything
-        raise AssertionError("unreachable")
+        return _FakeMessage(await self.incoming.get())
 
     async def close(self) -> None:
         pass
@@ -325,6 +334,23 @@ async def test_switching_to_a_client_commit_model_needs_a_vad() -> None:
     assert opted_out._opts.model == "gpt-live-transcribe"
 
 
+async def test_switching_to_a_realtime_only_model_needs_the_realtime_transport() -> None:
+    # the transcriptions endpoint does not serve these models at all, and the transport cannot
+    # change once AgentSession has wrapped a non-streaming STT in a StreamAdapter
+    instance = stt.STT(api_key="test-key", model="gpt-transcribe", vad=None)
+    assert instance.capabilities.streaming is False
+
+    for model in ("gpt-live-transcribe", "gpt-realtime-whisper"):
+        with pytest.raises(ValueError, match="served only over the realtime API"):
+            instance.update_options(model=model)
+    assert instance._opts.model == "gpt-transcribe"
+
+    # the realtime API serves every model, so that direction stays open
+    realtime = stt.STT(api_key="test-key", model="gpt-live-transcribe", vad=None)
+    realtime.update_options(model="gpt-transcribe")
+    assert realtime._opts.model == "gpt-transcribe"
+
+
 async def test_detected_keyterms_do_not_block_a_new_stream() -> None:
     instance = _offline_stt(model="gpt-live-transcribe")
     instance._update_session_keyterms(["Acme Corp"])
@@ -522,10 +548,12 @@ async def _transcription_form(instance: stt.STT, captured: list[httpx.Request]) 
     return captured[0].read().decode("utf-8", errors="replace")
 
 
-def _mock_client(captured: list[httpx.Request]) -> openai.AsyncClient:
+def _mock_client(
+    captured: list[httpx.Request], body: dict[str, Any] | None = None
+) -> openai.AsyncClient:
     def handler(request: httpx.Request) -> httpx.Response:
         captured.append(request)
-        return httpx.Response(200, json={"text": "hello"})
+        return httpx.Response(200, json=body or {"text": "hello"})
 
     return openai.AsyncClient(
         api_key="test-key",
@@ -549,6 +577,59 @@ async def test_file_transcription_sends_bracketed_form_fields() -> None:
     assert 'name="languages[]"\r\n\r\nen' in body
     assert 'name="languages[]"\r\n\r\nfr' in body
     assert 'name="language"' not in body
+
+
+@pytest.mark.parametrize(
+    ("detected", "dominant"),
+    [
+        ([{"code": "fr"}], "fr"),  # what the model heard wins over the hint
+        ([], "en"),  # nothing detected reliably, so the hint stands
+        ([{"code": "en"}, {"code": "fr"}], "en"),  # code-switched: the dominant code comes first
+    ],
+)
+async def test_file_transcription_reports_the_detected_language(
+    detected: list[dict[str, str]], dominant: str
+) -> None:
+    captured: list[httpx.Request] = []
+    instance = stt.STT(
+        model="gpt-transcribe",
+        client=_mock_client(captured, {"text": "hello", "languages": detected}),
+        language="en",
+    )
+
+    event = await instance._recognize_impl(_silence(), conn_options=DEFAULT_API_CONNECT_OPTIONS)
+
+    assert event.alternatives[0].language == dominant
+
+
+async def test_realtime_reports_the_detected_language() -> None:
+    # the hint is a list, so there is no single code to fall back on
+    instance = _offline_stt(model="gpt-live-transcribe", language=["en", "fr"], vad=None)
+    stream = instance.stream()
+    ws = await _connected(stream)
+    assert stream._language == ""
+
+    ws.incoming.put_nowait(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "item_1",
+            "transcript": "bonjour, hello",
+            "languages": [{"code": "fr"}, {"code": "en"}],
+        }
+    )
+
+    final: SpeechEvent | None = None
+    try:
+        async for event in stream:
+            if event.type == SpeechEventType.FINAL_TRANSCRIPT:
+                final = event
+                break
+    finally:
+        await stream.aclose()
+
+    assert final is not None
+    assert final.alternatives[0].text == "bonjour, hello"
+    assert final.alternatives[0].language == "fr"
 
 
 async def test_file_transcription_earlier_model_keeps_singular_language() -> None:

--- a/tests/test_plugin_openai_stt_context.py
+++ b/tests/test_plugin_openai_stt_context.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import openai
+import pytest
+
+from livekit import rtc
+from livekit.agents import DEFAULT_API_CONNECT_OPTIONS
+from livekit.plugins.openai import stt
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeWebSocket:
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+        self.fail_next = False
+
+    async def send_json(self, data: dict[str, Any]) -> None:
+        if self.fail_next:
+            self.fail_next = False
+            raise ConnectionResetError("socket went away")
+        self.sent.append(data)
+
+    async def receive(self) -> object:
+        await asyncio.Event().wait()  # a connection that never says anything
+        raise AssertionError("unreachable")
+
+    async def close(self) -> None:
+        pass
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.ws = _FakeWebSocket()
+
+    async def ws_connect(self, url: str, **_kwargs: object) -> _FakeWebSocket:
+        return self.ws
+
+
+def _offline_stt(**kwargs: Any) -> stt.STT:
+    """An STT whose streams connect to a fake socket instead of the network."""
+    instance = stt.STT(api_key="test-key", **kwargs)
+    instance._session = _FakeSession()  # type: ignore[assignment]
+    return instance
+
+
+async def _transcription_config(instance: stt.STT) -> dict[str, Any]:
+    session = _FakeSession()
+    instance._session = session  # type: ignore[assignment]
+    await instance._connect_ws(5)
+    config = session.ws.sent[0]["session"]["audio"]["input"]["transcription"]
+    assert isinstance(config, dict)
+    return config
+
+
+async def test_realtime_sends_keywords_and_languages() -> None:
+    instance = stt.STT(
+        api_key="test-key",
+        model="gpt-live-transcribe",
+        prompt="A customer support call.",
+        keywords=["premium plan", "AC-42"],
+        language=["en", "fr"],
+    )
+
+    config = await _transcription_config(instance)
+
+    assert config["prompt"] == "A customer support call."
+    assert config["keywords"] == ["premium plan", "AC-42"]
+    assert config["languages"] == ["en", "fr"]
+    # the singular field must not go alongside the plural one
+    assert "language" not in config
+
+
+async def test_realtime_language_codes_are_normalized() -> None:
+    # the API only takes ISO-639-1, and rejects regional tags such as en-US
+    instance = stt.STT(
+        api_key="test-key", model="gpt-transcribe", language=["en-US", "yue", "zh-cn", "zh-tw"]
+    )
+
+    config = await _transcription_config(instance)
+
+    # yue survives as its own language; the zh regions collapse into one entry
+    assert config["languages"] == ["en", "yue", "zh"]
+
+
+async def test_realtime_earlier_model_keeps_singular_language() -> None:
+    instance = stt.STT(api_key="test-key", model="gpt-4o-mini-transcribe", language="en-US")
+
+    config = await _transcription_config(instance)
+
+    assert config["language"] == "en"
+    assert "languages" not in config
+    assert "keywords" not in config
+
+
+async def test_realtime_defaults_to_english() -> None:
+    instance = stt.STT(api_key="test-key", model="gpt-4o-mini-transcribe")
+
+    config = await _transcription_config(instance)
+
+    assert config["language"] == "en"
+
+
+async def test_detect_language_omits_the_language_hint() -> None:
+    instance = stt.STT(api_key="test-key", model="gpt-4o-mini-transcribe", detect_language=True)
+
+    config = await _transcription_config(instance)
+
+    assert "language" not in config
+
+
+async def test_single_language_list_works_on_every_model() -> None:
+    instance = stt.STT(api_key="test-key", model="whisper-1", language=["fr"])
+
+    config = await _transcription_config(instance)
+
+    assert config["language"] == "fr"
+
+
+async def test_multiple_languages_rejected_by_earlier_models() -> None:
+    with pytest.raises(ValueError, match="accepts a single language"):
+        stt.STT(api_key="test-key", model="gpt-4o-transcribe", language=["en", "fr"])
+
+    instance = stt.STT(api_key="test-key", model="gpt-4o-transcribe")
+    with pytest.raises(ValueError, match="accepts a single language"):
+        instance.update_options(language=["en", "fr"])
+    assert instance._opts.languages == ["en"]
+
+
+async def test_keywords_rejected_by_earlier_models() -> None:
+    with pytest.raises(ValueError, match="keywords are only supported by"):
+        stt.STT(api_key="test-key", model="gpt-4o-transcribe", keywords=["AC-42"])
+
+
+async def test_switching_to_an_earlier_model_rejects_the_current_hints() -> None:
+    instance = stt.STT(
+        api_key="test-key", model="gpt-live-transcribe", keywords=["AC-42"], language=["en", "fr"]
+    )
+
+    with pytest.raises(ValueError, match="keywords are only supported by"):
+        instance.update_options(model="gpt-4o-transcribe")
+
+    # nothing was applied
+    assert instance._opts.model == "gpt-live-transcribe"
+    assert instance.capabilities.keyterms is True
+    assert instance._opts.languages == ["en", "fr"]
+
+
+@pytest.mark.parametrize(
+    ("model", "supported"),
+    [
+        ("gpt-transcribe", True),
+        ("gpt-live-transcribe", True),
+        ("gpt-4o-transcribe", False),
+        ("whisper-1", False),
+    ],
+)
+def test_keyterms_capability_follows_the_model(model: str, supported: bool) -> None:
+    instance = stt.STT(api_key="test-key", model=model)
+    assert instance.capabilities.keyterms is supported
+
+    instance.update_options(model=model)
+    assert instance.capabilities.keyterms is supported
+
+
+async def _connected(stream: stt.SpeechStream) -> _FakeWebSocket:
+    for _ in range(200):
+        if stream._ws is not None:
+            return stream._ws  # type: ignore[return-value]
+        await asyncio.sleep(0.005)
+    raise AssertionError("the stream never opened a connection")
+
+
+async def _settle(stream: stt.SpeechStream) -> None:
+    if stream._update_task is not None:
+        await asyncio.wait([stream._update_task])
+
+
+def _sent_transcription(ws: _FakeWebSocket) -> dict[str, Any]:
+    config = ws.sent[-1]["session"]["audio"]["input"]["transcription"]
+    assert isinstance(config, dict)
+    return config
+
+
+async def test_session_keyterms_merge_behind_user_keywords() -> None:
+    instance = _offline_stt(model="gpt-live-transcribe", keywords=["AC-42", "billing"])
+    stream = instance.stream()
+    ws = await _connected(stream)
+
+    instance._update_session_keyterms(["billing", "Acme Corp"])
+    await _settle(stream)
+
+    # user keywords first, no duplicates, and the live connection carries the merge
+    assert instance._opts.keywords == ["AC-42", "billing", "Acme Corp"]
+    assert _sent_transcription(ws)["keywords"] == ["AC-42", "billing", "Acme Corp"]
+
+    # user keywords survive a keyterm update
+    instance._update_session_keyterms([])
+    await _settle(stream)
+    assert _sent_transcription(ws)["keywords"] == ["AC-42", "billing"]
+
+    await stream.aclose()
+
+
+async def test_options_apply_without_a_reconnect() -> None:
+    instance = _offline_stt(model="gpt-live-transcribe")
+    stream = instance.stream()
+    ws = await _connected(stream)
+
+    instance.update_options(keywords=["Acme Corp"], prompt="a support call")
+    await _settle(stream)
+    assert _sent_transcription(ws)["keywords"] == ["Acme Corp"]
+    assert _sent_transcription(ws)["prompt"] == "a support call"
+
+    instance.update_options(language="fr")
+    await _settle(stream)
+    assert _sent_transcription(ws)["languages"] == ["fr"]
+    assert stream._language == "fr"
+
+    assert not stream._reconnect_event.is_set()
+
+    await stream.aclose()
+
+
+async def test_a_failed_update_does_not_break_the_next_one() -> None:
+    instance = _offline_stt(model="gpt-live-transcribe")
+    stream = instance.stream()
+    ws = await _connected(stream)
+
+    ws.fail_next = True
+    instance.update_options(keywords=["dropped"])
+    await _settle(stream)
+
+    instance.update_options(keywords=["applied"])
+    await _settle(stream)
+    assert _sent_transcription(ws)["keywords"] == ["applied"]
+
+    await stream.aclose()
+
+
+async def test_a_new_model_reconnects() -> None:
+    # gateways route on the ?model= in the upgrade URL, so this one can't be a session.update
+    instance = _offline_stt(model="gpt-live-transcribe")
+    stream = instance.stream()
+    await _connected(stream)
+
+    instance.update_options(model="gpt-4o-mini-transcribe")
+
+    assert stream._reconnect_event.is_set()
+
+    await stream.aclose()
+
+
+async def test_detected_keyterms_do_not_follow_a_model_downgrade() -> None:
+    instance = _offline_stt(model="gpt-live-transcribe")
+    instance._update_session_keyterms(["Acme Corp"])
+
+    # clearing the user keywords passes validation, but the detected ones must not leak
+    instance.update_options(model="gpt-4o-mini-transcribe", keywords=[])
+
+    config = await _transcription_config(instance)
+    assert "keywords" not in config
+
+
+async def test_live_transcribe_omits_turn_detection() -> None:
+    # the model rejects any turn_detection config and needs a client-side commit
+    instance = stt.STT(api_key="test-key", model="gpt-live-transcribe", use_realtime=True, vad=None)
+
+    session = _FakeSession()
+    instance._session = session  # type: ignore[assignment]
+    await instance._connect_ws(5)
+
+    assert "turn_detection" not in session.ws.sent[0]["session"]["audio"]["input"]
+
+
+async def test_session_keyterms_reach_the_next_connection() -> None:
+    instance = stt.STT(api_key="test-key", model="gpt-live-transcribe")
+    instance._update_session_keyterms(["Acme Corp"])
+
+    config = await _transcription_config(instance)
+
+    assert config["keywords"] == ["Acme Corp"]
+
+
+async def _transcription_form(instance: stt.STT, captured: list[httpx.Request]) -> str:
+    frame = rtc.AudioFrame(
+        data=b"\x00\x00" * 2400, sample_rate=24000, num_channels=1, samples_per_channel=2400
+    )
+    event = await instance._recognize_impl(frame, conn_options=DEFAULT_API_CONNECT_OPTIONS)
+    assert event.alternatives[0].text == "hello"
+    return captured[0].read().decode("utf-8", errors="replace")
+
+
+def _mock_client(captured: list[httpx.Request]) -> openai.AsyncClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"text": "hello"})
+
+    return openai.AsyncClient(
+        api_key="test-key",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+
+async def test_file_transcription_sends_bracketed_form_fields() -> None:
+    captured: list[httpx.Request] = []
+    instance = stt.STT(
+        model="gpt-transcribe",
+        client=_mock_client(captured),
+        keywords=["premium plan", "AC-42"],
+        language=["en", "fr"],
+    )
+
+    body = await _transcription_form(instance, captured)
+
+    assert 'name="keywords[]"\r\n\r\npremium plan' in body
+    assert 'name="keywords[]"\r\n\r\nAC-42' in body
+    assert 'name="languages[]"\r\n\r\nen' in body
+    assert 'name="languages[]"\r\n\r\nfr' in body
+    assert 'name="language"' not in body
+
+
+async def test_file_transcription_earlier_model_keeps_singular_language() -> None:
+    captured: list[httpx.Request] = []
+    instance = stt.STT(model="whisper-1", client=_mock_client(captured), language="en-US")
+
+    body = await _transcription_form(instance, captured)
+
+    assert 'name="language"\r\n\r\nen' in body
+    assert 'name="languages[]"' not in body

--- a/tests/test_plugin_openai_stt_context.py
+++ b/tests/test_plugin_openai_stt_context.py
@@ -563,6 +563,38 @@ async def test_a_rebuild_drops_the_idle_pooled_connection(
     await stream.aclose()
 
 
+async def test_a_stream_asking_to_detect_the_language_drops_the_pooled_connection() -> None:
+    # stream(language=...) is the same option change, so it needs the same rebuild
+    instance = _offline_stt(model="gpt-live-transcribe", language="en")
+    session = _FakeSession()
+    instance._session = session  # type: ignore[assignment]
+    instance._pool.put(await instance._pool.get(timeout=5))
+
+    stream = instance.stream(language=[])
+
+    assert instance._opts.languages == []
+    await _connected(stream)
+    assert session.connects == 2
+
+    await stream.aclose()
+
+
+async def test_a_stream_language_reaches_the_streams_already_open() -> None:
+    # the options are shared, so an open stream must hear about the change too
+    instance = _offline_stt(model="gpt-live-transcribe", language="en")
+    open_stream = instance.stream()
+    ws = await _connected(open_stream)
+
+    later = instance.stream(language="fr")
+    await _settle(open_stream)
+
+    assert _sent_transcription(ws)["languages"] == ["fr"]
+    assert open_stream._language == "fr"
+
+    await open_stream.aclose()
+    await later.aclose()
+
+
 async def test_session_keyterms_reach_the_next_connection() -> None:
     instance = stt.STT(api_key="test-key", model="gpt-live-transcribe")
     instance._update_session_keyterms(["Acme Corp"])

--- a/tests/test_plugin_openai_stt_context.py
+++ b/tests/test_plugin_openai_stt_context.py
@@ -18,11 +18,15 @@ class _FakeWebSocket:
     def __init__(self) -> None:
         self.sent: list[dict[str, Any]] = []
         self.fail_next = False
+        self.block_first: asyncio.Event | None = None
 
     async def send_json(self, data: dict[str, Any]) -> None:
         if self.fail_next:
             self.fail_next = False
             raise ConnectionResetError("socket went away")
+        if self.block_first is not None:
+            blocked, self.block_first = self.block_first, None
+            await blocked.wait()
         self.sent.append(data)
 
     async def receive(self) -> object:
@@ -184,10 +188,14 @@ async def _settle(stream: stt.SpeechStream) -> None:
         await asyncio.wait([stream._update_task])
 
 
-def _sent_transcription(ws: _FakeWebSocket) -> dict[str, Any]:
-    config = ws.sent[-1]["session"]["audio"]["input"]["transcription"]
+def _transcription_of(payload: dict[str, Any]) -> dict[str, Any]:
+    config = payload["session"]["audio"]["input"]["transcription"]
     assert isinstance(config, dict)
     return config
+
+
+def _sent_transcription(ws: _FakeWebSocket) -> dict[str, Any]:
+    return _transcription_of(ws.sent[-1])
 
 
 async def test_session_keyterms_merge_behind_user_keywords() -> None:
@@ -336,6 +344,33 @@ async def test_live_transcribe_omits_turn_detection() -> None:
     # every other model still gets server-side VAD
     other = stt.STT(api_key="test-key", model="gpt-4o-mini-transcribe", use_realtime=True)
     assert _audio_input(other)["turn_detection"]["type"] == "server_vad"
+
+
+async def test_an_update_during_connection_setup_is_not_lost() -> None:
+    instance = _offline_stt(model="gpt-live-transcribe")
+    session = _FakeSession()
+    instance._session = session  # type: ignore[assignment]
+    release = asyncio.Event()
+    session.ws.block_first = release  # hold the stream inside its setup send
+
+    stream = instance.stream()
+    ws = session.ws
+    for _ in range(200):  # wait until the stream is suspended inside that send
+        if ws.block_first is None:
+            break
+        await asyncio.sleep(0.005)
+    else:
+        raise AssertionError("the setup send never started")
+    assert ws.sent == []
+
+    instance.update_options(keywords=["Acme Corp"])
+    release.set()
+    await _settle(stream)
+
+    # the change is applied after the setup config rather than dropped or overtaken by it
+    assert [_transcription_of(p).get("keywords") for p in ws.sent] == [[], ["Acme Corp"]]
+
+    await stream.aclose()
 
 
 async def test_a_reused_connection_is_reconfigured() -> None:

--- a/tests/test_plugin_openai_stt_context.py
+++ b/tests/test_plugin_openai_stt_context.py
@@ -51,8 +51,10 @@ class _FakeWebSocket:
 class _FakeSession:
     def __init__(self) -> None:
         self.ws = _FakeWebSocket()
+        self.connects = 0
 
     async def ws_connect(self, url: str, **_kwargs: object) -> _FakeWebSocket:
+        self.connects += 1
         return self.ws
 
 
@@ -531,6 +533,34 @@ async def test_a_reused_connection_is_reconfigured() -> None:
     assert _sent_transcription(ws)["keywords"] == ["Acme Corp"]
 
     await second.aclose()
+
+
+@pytest.mark.parametrize(
+    ("change", "connects"),
+    [
+        # gateways route on the ?model= in the upgrade URL, so a reused socket keeps the old one
+        ({"model": "gpt-4o-mini-transcribe"}, 2),
+        ({"detect_language": True}, 2),  # `languages` cannot be cleared on an open session
+        ({"keywords": ["Acme Corp"]}, 1),  # a session.update on acquire carries this one
+    ],
+)
+async def test_a_rebuild_drops_the_idle_pooled_connection(
+    change: dict[str, Any], connects: int
+) -> None:
+    instance = _offline_stt(model="gpt-live-transcribe")
+    session = _FakeSession()
+    instance._session = session  # type: ignore[assignment]
+    # a socket the pool holds with no stream attached, as between two speech sessions
+    instance._pool.put(await instance._pool.get(timeout=5))
+    assert not instance._streams
+
+    instance.update_options(**change)
+
+    stream = instance.stream()
+    await _connected(stream)
+    assert session.connects == connects
+
+    await stream.aclose()
 
 
 async def test_session_keyterms_reach_the_next_connection() -> None:

--- a/tests/test_plugin_openai_stt_context.py
+++ b/tests/test_plugin_openai_stt_context.py
@@ -261,6 +261,49 @@ async def test_a_new_model_reconnects() -> None:
     await stream.aclose()
 
 
+async def test_cleared_keywords_and_prompt_are_sent_as_empty() -> None:
+    # an omitted field keeps its previous value, so clearing has to be explicit
+    instance = _offline_stt(model="gpt-live-transcribe", keywords=["AC-42"], prompt="a call")
+    stream = instance.stream()
+    ws = await _connected(stream)
+
+    instance.update_options(keywords=[], prompt="")
+    await _settle(stream)
+
+    assert _sent_transcription(ws)["keywords"] == []
+    assert _sent_transcription(ws)["prompt"] == ""
+
+    await stream.aclose()
+
+
+async def test_clearing_the_language_reconnects() -> None:
+    # the API rejects both an empty array and null for `languages`
+    instance = _offline_stt(model="gpt-live-transcribe", language=["en", "fr"])
+    stream = instance.stream()
+    await _connected(stream)
+
+    instance.update_options(detect_language=True)
+
+    assert instance._opts.languages == []
+    assert stream._reconnect_event.is_set()
+
+    await stream.aclose()
+
+
+async def test_switching_to_a_client_commit_model_needs_a_vad() -> None:
+    instance = stt.STT(api_key="test-key", model="gpt-4o-mini-transcribe", use_realtime=True)
+
+    with pytest.raises(ValueError, match="no server-side endpointing"):
+        instance.update_options(model="gpt-live-transcribe")
+
+    # an explicit vad=None means the caller commits the buffer itself
+    opted_out = stt.STT(
+        api_key="test-key", model="gpt-4o-mini-transcribe", use_realtime=True, vad=None
+    )
+    opted_out.update_options(model="gpt-live-transcribe")
+    assert opted_out._opts.model == "gpt-live-transcribe"
+
+
 async def test_detected_keyterms_do_not_block_a_new_stream() -> None:
     instance = _offline_stt(model="gpt-live-transcribe")
     instance._update_session_keyterms(["Acme Corp"])
@@ -304,7 +347,7 @@ async def test_a_reused_connection_is_reconfigured() -> None:
 
     # the change lands while nothing is streaming, so no live socket receives it
     instance.update_options(keywords=["Acme Corp"])
-    assert "keywords" not in _sent_transcription(ws)
+    assert _sent_transcription(ws)["keywords"] == []  # the idle socket has not seen it
 
     second = instance.stream()
     await _connected(second)

--- a/tests/test_plugin_openai_stt_context.py
+++ b/tests/test_plugin_openai_stt_context.py
@@ -352,6 +352,11 @@ async def test_switching_to_a_realtime_only_model_needs_the_realtime_transport()
     realtime.update_options(model="gpt-transcribe")
     assert realtime._opts.model == "gpt-transcribe"
 
+    # an explicit use_realtime=False keeps that pairing, and it stays usable
+    pinned = stt.STT(api_key="test-key", model="gpt-live-transcribe", use_realtime=False, vad=None)
+    pinned.update_options(prompt="a support call")
+    assert pinned._opts.prompt == "a support call"
+
 
 async def test_detected_keyterms_do_not_block_a_new_stream() -> None:
     instance = _offline_stt(model="gpt-live-transcribe")

--- a/tests/test_plugin_openai_stt_context.py
+++ b/tests/test_plugin_openai_stt_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from typing import Any
 
 import httpx
@@ -8,7 +9,8 @@ import openai
 import pytest
 
 from livekit import rtc
-from livekit.agents import DEFAULT_API_CONNECT_OPTIONS
+from livekit.agents import DEFAULT_API_CONNECT_OPTIONS, inference, vad
+from livekit.agents.stt import SpeechEventType
 from livekit.plugins.openai import stt
 
 pytestmark = pytest.mark.unit
@@ -52,11 +54,22 @@ def _offline_stt(**kwargs: Any) -> stt.STT:
     return instance
 
 
-def _audio_input(instance: stt.STT) -> dict[str, Any]:
-    payload = stt._session_update(instance._opts).model_dump(by_alias=True, exclude_unset=True)
+def _audio_input_of(payload: dict[str, Any]) -> dict[str, Any]:
     audio_input = payload["session"]["audio"]["input"]
     assert isinstance(audio_input, dict)
     return audio_input
+
+
+def _audio_input(instance: stt.STT) -> dict[str, Any]:
+    return _audio_input_of(
+        stt._session_update(instance._opts).model_dump(by_alias=True, exclude_unset=True)
+    )
+
+
+def _silence() -> rtc.AudioFrame:
+    return rtc.AudioFrame(
+        data=b"\x00\x00" * 2400, sample_rate=24000, num_channels=1, samples_per_channel=2400
+    )
 
 
 async def _transcription_config(instance: stt.STT) -> dict[str, Any]:
@@ -189,7 +202,7 @@ async def _settle(stream: stt.SpeechStream) -> None:
 
 
 def _transcription_of(payload: dict[str, Any]) -> dict[str, Any]:
-    config = payload["session"]["audio"]["input"]["transcription"]
+    config = _audio_input_of(payload)["transcription"]
     assert isinstance(config, dict)
     return config
 
@@ -335,6 +348,34 @@ async def test_detected_keyterms_do_not_follow_a_model_downgrade() -> None:
     assert "keywords" not in config
 
 
+@pytest.mark.parametrize(
+    ("model", "realtime"),
+    [
+        ("gpt-live-transcribe", True),
+        ("gpt-realtime-whisper", True),
+        ("gpt-4o-mini-transcribe", False),
+        ("whisper-1", False),
+    ],
+)
+def test_use_realtime_defaults_to_the_only_transport_a_model_has(
+    model: str, realtime: bool
+) -> None:
+    instance = stt.STT(api_key="test-key", model=model, vad=None)
+    assert instance.capabilities.streaming is realtime
+
+    # an explicit value still wins
+    off = stt.STT(api_key="test-key", model=model, vad=None, use_realtime=False)
+    assert off.capabilities.streaming is False
+
+
+def test_a_client_commit_model_loads_the_bundled_vad() -> None:
+    # no livekit-plugins-silero dependency: the VAD ships with livekit-agents
+    instance = stt.STT(api_key="test-key", model="gpt-live-transcribe")
+    assert isinstance(instance._vad, inference.VAD)
+
+    assert stt.STT(api_key="test-key", model="gpt-4o-mini-transcribe")._vad is None
+
+
 async def test_live_transcribe_omits_turn_detection() -> None:
     # the model rejects any turn_detection config and needs a client-side commit
     instance = stt.STT(api_key="test-key", model="gpt-live-transcribe", use_realtime=True, vad=None)
@@ -344,6 +385,80 @@ async def test_live_transcribe_omits_turn_detection() -> None:
     # every other model still gets server-side VAD
     other = stt.STT(api_key="test-key", model="gpt-4o-mini-transcribe", use_realtime=True)
     assert _audio_input(other)["turn_detection"]["type"] == "server_vad"
+
+
+class _OneShotVAD(vad.VAD):
+    """A VAD that closes one segment per stream, on the first frame it sees."""
+
+    def __init__(self) -> None:
+        super().__init__(capabilities=vad.VADCapabilities(update_interval=0.1))
+
+    def stream(self) -> vad.VADStream:
+        return _OneShotVADStream(self)
+
+
+class _OneShotVADStream(vad.VADStream):
+    async def _main_task(self) -> None:
+        done = False
+        # the input has to be drained until it ends, or the stream closes under its consumer
+        async for frame in self._input_ch:
+            if done or not isinstance(frame, rtc.AudioFrame):
+                continue
+            done = True
+            for type in (vad.VADEventType.START_OF_SPEECH, vad.VADEventType.END_OF_SPEECH):
+                self._event_ch.send_nowait(
+                    vad.VADEvent(
+                        type=type,
+                        samples_index=0,
+                        timestamp=0.0,
+                        speech_duration=0.0,
+                        silence_duration=0.0,
+                    )
+                )
+
+
+def _of_type(ws: _FakeWebSocket, type: str) -> list[dict[str, Any]]:
+    return [payload for payload in ws.sent if payload.get("type") == type]
+
+
+async def _wait_for(what: str, ready: Callable[[], bool]) -> None:
+    for _ in range(200):
+        if ready():
+            return
+        await asyncio.sleep(0.005)
+    raise AssertionError(f"timed out waiting for {what}")
+
+
+async def test_the_vad_stops_committing_once_the_server_endpoints() -> None:
+    # the client VAD and server-side turn detection would otherwise both close the segment
+    instance = _offline_stt(model="gpt-live-transcribe", vad=_OneShotVAD())
+    stream = instance.stream()
+    ws = await _connected(stream)
+    ends = 0
+
+    async def collect() -> None:
+        nonlocal ends
+        async for ev in stream:
+            if ev.type == SpeechEventType.END_OF_SPEECH:
+                ends += 1
+
+    collector = asyncio.create_task(collect())
+
+    stream.push_frame(_silence())
+    await _wait_for("the first commit", lambda: len(_of_type(ws, "input_audio_buffer.commit")) == 1)
+
+    instance.update_options(model="gpt-4o-mini-transcribe")
+    await _wait_for("the rebuilt connection", lambda: len(_of_type(ws, "session.update")) == 2)
+    assert "turn_detection" in _audio_input_of(_of_type(ws, "session.update")[-1])
+
+    # the rebuilt connection has its own VAD stream, so the segment closes a second time
+    stream.push_frame(_silence())
+    await _wait_for("the second segment", lambda: ends == 2)
+    await asyncio.sleep(0.05)  # a commit would follow the segment straight away
+    assert len(_of_type(ws, "input_audio_buffer.commit")) == 1
+
+    await stream.aclose()
+    await collector
 
 
 async def test_an_update_during_connection_setup_is_not_lost() -> None:
@@ -402,10 +517,7 @@ async def test_session_keyterms_reach_the_next_connection() -> None:
 
 
 async def _transcription_form(instance: stt.STT, captured: list[httpx.Request]) -> str:
-    frame = rtc.AudioFrame(
-        data=b"\x00\x00" * 2400, sample_rate=24000, num_channels=1, samples_per_channel=2400
-    )
-    event = await instance._recognize_impl(frame, conn_options=DEFAULT_API_CONNECT_OPTIONS)
+    event = await instance._recognize_impl(_silence(), conn_options=DEFAULT_API_CONNECT_OPTIONS)
     assert event.alternatives[0].text == "hello"
     return captured[0].read().decode("utf-8", errors="replace")
 

--- a/tests/test_plugin_openai_stt_context.py
+++ b/tests/test_plugin_openai_stt_context.py
@@ -252,12 +252,12 @@ async def test_options_apply_without_a_reconnect() -> None:
     assert _sent_transcription(ws)["keywords"] == ["Acme Corp"]
     assert _sent_transcription(ws)["prompt"] == "a support call"
 
-    instance.update_options(language="fr")
-    await _settle(stream)
-    assert _sent_transcription(ws)["languages"] == ["fr"]
-    assert stream._language == "fr"
-
     assert not stream._reconnect_event.is_set()
+
+    # a language is the exception: it always rebuilds
+    instance.update_options(language="fr")
+    assert stream._language == "fr"
+    assert stream._reconnect_event.is_set()
 
     await stream.aclose()
 
@@ -563,8 +563,8 @@ async def test_a_rebuild_drops_the_idle_pooled_connection(
     await stream.aclose()
 
 
-async def test_a_stream_asking_to_detect_the_language_drops_the_pooled_connection() -> None:
-    # stream(language=...) is the same option change, so it needs the same rebuild
+async def test_a_stream_with_its_own_language_takes_its_own_connection() -> None:
+    # a pooled socket carries whatever language the stream before it set
     instance = _offline_stt(model="gpt-live-transcribe", language="en")
     session = _FakeSession()
     instance._session = session  # type: ignore[assignment]
@@ -572,27 +572,69 @@ async def test_a_stream_asking_to_detect_the_language_drops_the_pooled_connectio
 
     stream = instance.stream(language=[])
 
-    assert instance._opts.languages == []
+    assert stream._opts.languages == []
+    assert instance._opts.languages == ["en"]  # the STT default is untouched
     await _connected(stream)
     assert session.connects == 2
 
     await stream.aclose()
 
 
-async def test_a_stream_language_reaches_the_streams_already_open() -> None:
-    # the options are shared, so an open stream must hear about the change too
+async def test_a_stream_language_stays_out_of_the_streams_already_open() -> None:
     instance = _offline_stt(model="gpt-live-transcribe", language="en")
     open_stream = instance.stream()
-    ws = await _connected(open_stream)
+    await _connected(open_stream)
 
     later = instance.stream(language="fr")
-    await _settle(open_stream)
 
-    assert _sent_transcription(ws)["languages"] == ["fr"]
-    assert open_stream._language == "fr"
+    assert open_stream._opts.languages == ["en"]
+    assert open_stream._language == "en"
+    assert later._opts.languages == ["fr"]
 
     await open_stream.aclose()
     await later.aclose()
+
+
+async def test_a_stream_switches_its_own_language() -> None:
+    instance = _offline_stt(model="gpt-live-transcribe", language="en")
+    stream = instance.stream()
+    await _connected(stream)
+    other = instance.stream()
+
+    stream.update_options(language="fr")
+
+    # the stream rebuilds on its own language, and nothing else moves
+    assert stream._reconnect_event.is_set()
+    assert stream._language == "fr"
+    assert other._opts.languages == ["en"]
+    assert instance._opts.languages == ["en"]
+
+    # and it is pinned, so an STT change that names no language leaves it alone
+    instance.update_options(keywords=["Acme Corp"])
+    assert stream._opts.languages == ["fr"]
+
+    await stream.aclose()
+    await other.aclose()
+
+
+async def test_an_stt_language_change_overrides_a_stream_of_its_own() -> None:
+    instance = _offline_stt(model="gpt-live-transcribe", language="en")
+    pinned = instance.stream(language="fr")
+    plain = instance.stream()
+
+    # a change that names no language leaves the pinned stream on its own
+    instance.update_options(keywords=["Acme Corp"])
+    assert pinned._opts.languages == ["fr"]
+    assert pinned._opts.keywords == ["Acme Corp"]  # the rest still reaches it
+    assert plain._opts.languages == ["en"]
+
+    # naming one takes the stream back
+    instance.update_options(language="de")
+    assert pinned._opts.languages == ["de"]
+    assert plain._opts.languages == ["de"]
+
+    await pinned.aclose()
+    await plain.aclose()
 
 
 async def test_session_keyterms_reach_the_next_connection() -> None:

--- a/tests/test_plugin_openai_stt_context.py
+++ b/tests/test_plugin_openai_stt_context.py
@@ -31,6 +31,7 @@ class _FakeWebSocket:
         self.incoming: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
         self.fail_next = False
         self.block_first: asyncio.Event | None = None
+        self.closed = False
 
     async def send_json(self, data: dict[str, Any]) -> None:
         if self.fail_next:
@@ -45,7 +46,7 @@ class _FakeWebSocket:
         return _FakeMessage(await self.incoming.get())
 
     async def close(self) -> None:
-        pass
+        self.closed = True
 
 
 class _FakeSession:
@@ -283,10 +284,12 @@ async def test_options_apply_without_a_reconnect() -> None:
 
     assert not stream._reconnect_event.is_set()
 
-    # a language is the exception: it always rebuilds
+    # a language reaches the open connection too, and the transcripts follow it
     instance.update_options(language="fr")
+    await _settle(stream)
     assert stream._language == "fr"
-    assert stream._reconnect_event.is_set()
+    assert _sent_transcription(ws)["languages"] == ["fr"]
+    assert not stream._reconnect_event.is_set()
 
     await stream.aclose()
 
@@ -447,6 +450,27 @@ async def test_live_transcribe_omits_turn_detection() -> None:
     # every other model still gets server-side VAD
     other = stt.STT(api_key="test-key", model="gpt-4o-mini-transcribe", use_realtime=True)
     assert _audio_input(other)["turn_detection"]["type"] == "server_vad"
+
+
+async def test_turn_detection_without_a_type_is_still_sent() -> None:
+    # SessionTurnDetection leaves every key optional, so a caller can tune one setting alone
+    instance = stt.STT(
+        api_key="test-key",
+        model="gpt-4o-mini-transcribe",
+        use_realtime=True,
+        turn_detection={"silence_duration_ms": 800},
+    )
+
+    assert _audio_input(instance)["turn_detection"] == {
+        "type": "server_vad",
+        "silence_duration_ms": 800,
+    }
+
+    instance.update_options(turn_detection={"type": "semantic_vad", "eagerness": "low"})
+    assert _audio_input(instance)["turn_detection"] == {
+        "type": "semantic_vad",
+        "eagerness": "low",
+    }
 
 
 class _OneShotVAD(vad.VAD):
@@ -617,13 +641,17 @@ async def test_a_stream_with_its_own_language_takes_its_own_connection() -> None
 async def test_a_stream_language_stays_out_of_the_streams_already_open() -> None:
     instance = _offline_stt(model="gpt-live-transcribe", language="en")
     open_stream = instance.stream()
-    await _connected(open_stream)
+    ws = await _connected(open_stream)
 
     later = instance.stream(language="fr")
+    await _connected(later)
 
     assert open_stream._opts.languages == ["en"]
     assert open_stream._language == "en"
     assert later._opts.languages == ["fr"]
+    # the new stream sets its language with a session.update, so the connection the open one
+    # is reading from stays up
+    assert not ws.closed
 
     await open_stream.aclose()
     await later.aclose()
@@ -632,13 +660,14 @@ async def test_a_stream_language_stays_out_of_the_streams_already_open() -> None
 async def test_a_stream_switches_its_own_language() -> None:
     instance = _offline_stt(model="gpt-live-transcribe", language="en")
     stream = instance.stream()
-    await _connected(stream)
+    ws = await _connected(stream)
     other = instance.stream()
 
     stream.update_options(language="fr")
+    await _settle(stream)
 
-    # the stream rebuilds on its own language, and nothing else moves
-    assert stream._reconnect_event.is_set()
+    # the stream carries its own language over its own connection, and nothing else moves
+    assert _sent_transcription(ws)["languages"] == ["fr"]
     assert stream._language == "fr"
     assert other._opts.languages == ["en"]
     assert instance._opts.languages == ["en"]

--- a/uv.lock
+++ b/uv.lock
@@ -3197,7 +3197,7 @@ vertex = [
 requires-dist = [
     { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0.0" },
     { name = "livekit-agents", extras = ["codecs", "images"], editable = "livekit-agents" },
-    { name = "openai", extras = ["realtime"], specifier = ">=2.36" },
+    { name = "openai", extras = ["realtime"], specifier = ">=2.50" },
 ]
 provides-extras = ["vertex"]
 
@@ -4190,7 +4190,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.46.0"
+version = "2.53.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4202,9 +4202,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/ac/f725c4efbda8657d02be684607e5a2e5ce362e4790fdbcbdfb7c15018647/openai-2.46.0.tar.gz", hash = "sha256:0421e0735ac41451cad894af4cddf0435bfbf8cbc538ac0e15b3c062f2ddc06a", size = 1114628, upload-time = "2026-07-17T02:48:06.05Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/cf/36e3e7235fdf6d125c052acc0970924611b17a20a4fe580596faf4566a65/openai-2.53.0.tar.gz", hash = "sha256:baf5802ad08980e1d9d561e1b996e800c8bcd14af5847c6d0e7a5cc59e4d4116", size = 1099435, upload-time = "2026-08-03T21:42:01.664Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/7b/206238ebcb50b235942b1c66dba4974776f2057402a8d91c399be587d66a/openai-2.46.0-py3-none-any.whl", hash = "sha256:672381db55efb3a1e2610f29304c130cccdd0b319bace4d492b2443cb64c1e7c", size = 1637556, upload-time = "2026-07-17T02:48:03.695Z" },
+    { url = "https://files.pythonhosted.org/packages/78/0f/cc6afea3542a5142c5d8fc8211c5e059a8375105d004a41dfa2c7948dbb0/openai-2.53.0-py3-none-any.whl", hash = "sha256:c694ffc747a3c4d1663ef2b07b811315a476164ee5efa3a993967349ebca7618", size = 1659829, upload-time = "2026-08-03T21:41:59.581Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
`gpt-transcribe` and `gpt-live-transcribe` accept context hints: `keywords` for literal terms expected in the audio, and a plural `languages` list for code-switched speech.

- `language` now takes a `str` or a `list[str]`; more than one language raises on models that accept only one, and codes are normalized to ISO-639-1 because the API rejects regional tags such as `en-US`.
- `keywords` gives the plugin somewhere to put terms, so `stt_context_options` and automatic keyterm detection now reach OpenAI STT. Detected terms merge behind the user's own and apply with a `session.update` on the open connection; only a change of `model` reconnects.
- `gpt-live-transcribe` rejects any `turn_detection` config and emits no `speech_started`/`speech_stopped`, so it joins `gpt-realtime-whisper` on the client-commit path.
- Requires `openai>=2.50`, where `keywords`/`languages` became typed on both transcription APIs.