### PR TITLE
Harden NVIDIA Speech STT and TTS support

### DIFF
--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import asyncio
@@ -241,7 +244,7 @@ class STT(
 
             except APIError as e:
                 retry_interval = conn_options._interval_for_retry(i)
-                if conn_options.max_retry == 0:
+                if conn_options.max_retry == 0 or not e.retryable:
                     self._emit_error(e, recoverable=False)
                     raise
                 elif i == conn_options.max_retry:

--- a/livekit-plugins/livekit-plugins-nvidia/README.md
+++ b/livekit-plugins/livekit-plugins-nvidia/README.md
@@ -38,24 +38,9 @@ tts = nvidia.TTS(
 )
 ```
 
-STT defaults to `inference_mode="auto"` for backward compatibility. Set it to
-`"streaming"` or `"offline"` when the deployed model supports only one API so
-LiveKit receives exact capabilities. For offline TTS models, set the TTS
-`inference_mode="offline"`; streaming TTS models use the default `"online"` mode.
+STT defaults to `inference_mode="auto"`; use `"streaming"` or `"offline"` to
+match the deployed model. TTS defaults to `"online"`; use `"offline"` for batch
+models.
 
 For local NVIDIA Speech deployments, pass the local `server` and set
 `use_ssl=False` when TLS is not enabled.
-
-The STT and TTS constructors keep common voice-agent options flat.
-Provider-specific endpointing is grouped under `EndpointingConfig`, and
-lower-level provider settings can be passed through the `options` escape hatch.
-
-The plugin supports `nvidia-riva-client` versions from 2.16 through 2.26.x.
-Zero-shot prompt and quality arguments are translated to the names used by the
-installed client, while unsupported options fail before a synthesis request is sent.
-
-LiveKit `SynthesizeStream` instances represent one text segment. Create a new stream
-after calling `flush()` instead of pushing another segment into the same stream.
-
-The experimental PersonaPlex realtime model is audio-in/audio-out only. Manual
-`generate_reply()` calls are not supported yet.

--- a/livekit-plugins/livekit-plugins-nvidia/README.md
+++ b/livekit-plugins/livekit-plugins-nvidia/README.md
@@ -1,8 +1,9 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # NVIDIA plugin for LiveKit Agents
 
-Support for [NVIDIA Riva](https://developer.nvidia.com/riva)'s speech AI services in LiveKit Agents.
-
-More information is available in the [NVIDIA Riva documentation](https://developer.nvidia.com/riva).
+Support for NVIDIA Speech AI services in LiveKit Agents.
 
 ## Installation
 
@@ -15,4 +16,46 @@ pip install livekit-plugins-nvidia
 You can either:
 
 1. Use an API key from NVIDIA. It can be set as an environment variable: `NVIDIA_API_KEY`
-2. Use you self hosted [Nim](https://developer.nvidia.com/nim) server.
+2. Use your self-hosted [NIM](https://developer.nvidia.com/nim) server.
+
+## Usage
+
+```python
+from livekit.plugins import nvidia
+
+stt = nvidia.STT(
+    model="parakeet-1.1b-en-US-asr-streaming-silero-vad-sortformer",
+    inference_mode="streaming",
+    server="grpc.nvcf.nvidia.com:443",
+    use_ssl=True,
+    endpointing=nvidia.EndpointingConfig(mode="low_latency"),
+)
+
+tts = nvidia.TTS(
+    voice="Magpie-Multilingual.EN-US.Leo",
+    sample_rate=16000,
+    inference_mode="online",
+)
+```
+
+STT defaults to `inference_mode="auto"` for backward compatibility. Set it to
+`"streaming"` or `"offline"` when the deployed model supports only one API so
+LiveKit receives exact capabilities. For offline TTS models, set the TTS
+`inference_mode="offline"`; streaming TTS models use the default `"online"` mode.
+
+For local NVIDIA Speech deployments, pass the local `server` and set
+`use_ssl=False` when TLS is not enabled.
+
+The STT and TTS constructors keep common voice-agent options flat.
+Provider-specific endpointing is grouped under `EndpointingConfig`, and
+lower-level provider settings can be passed through the `options` escape hatch.
+
+The plugin supports `nvidia-riva-client` versions from 2.16 through 2.26.x.
+Zero-shot prompt and quality arguments are translated to the names used by the
+installed client, while unsupported options fail before a synthesis request is sent.
+
+LiveKit `SynthesizeStream` instances represent one text segment. Create a new stream
+after calling `flush()` instead of pushing another segment into the same stream.
+
+The experimental PersonaPlex realtime model is audio-in/audio-out only. Manual
+`generate_reply()` calls are not supported yet.

--- a/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/__init__.py
+++ b/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright 2025 LiveKit, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,11 +38,19 @@ def __getattr__(name: str) -> typing.Any:
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-from .stt import STT, SpeechStream  # noqa: E402
+from .stt import STT, EndpointingConfig, SpeechStream  # noqa: E402
 from .tts import TTS, SynthesizeStream  # noqa: E402
 from .version import __version__  # noqa: E402
 
-__all__ = ["STT", "SpeechStream", "TTS", "SynthesizeStream", "realtime", "__version__"]
+__all__ = [
+    "STT",
+    "EndpointingConfig",
+    "SpeechStream",
+    "TTS",
+    "SynthesizeStream",
+    "realtime",
+    "__version__",
+]
 
 
 from livekit.agents import Plugin  # noqa: E402

--- a/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py
+++ b/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
 import asyncio
 import logging
 import os
@@ -5,15 +8,25 @@ import queue
 import threading
 from collections import Counter
 from collections.abc import Generator
+from contextlib import suppress
 from dataclasses import dataclass
+from typing import Any, Literal
 
+import grpc
 import riva.client
-from riva.client.proto.riva_asr_pb2 import SpeakerDiarizationConfig
+from riva.client.proto.riva_asr_pb2 import (
+    RivaSpeechRecognitionConfigRequest,
+    SpeakerDiarizationConfig,
+)
 
 from livekit import rtc
 from livekit.agents import (
     DEFAULT_API_CONNECT_OPTIONS,
+    APIConnectionError,
     APIConnectOptions,
+    APIError,
+    APIStatusError,
+    APITimeoutError,
     LanguageCode,
     stt,
 )
@@ -24,6 +37,21 @@ from livekit.agents.voice.io import TimedString
 from . import auth
 
 logger = logging.getLogger(__name__)
+
+
+EndpointingMode = Literal["low_latency"]
+InferenceMode = Literal["auto", "streaming", "offline"]
+
+
+@dataclass(frozen=True)
+class EndpointingConfig:
+    mode: EndpointingMode = "low_latency"
+    start_history: int | None = None
+    start_threshold: float | None = None
+    stop_history: int | None = None
+    stop_threshold: float | None = None
+    stop_history_eou: int | None = None
+    stop_threshold_eou: float | None = None
 
 
 @dataclass
@@ -37,6 +65,15 @@ class STTOptions:
     server: str
     enable_diarization: bool
     max_speaker_count: int
+    interim_results: bool
+    profanity_filter: bool
+    verbatim_transcripts: bool
+    boosted_lm_words: list[str] | None
+    boosted_lm_score: float
+    endpointing: EndpointingConfig | None
+    options: dict[str, Any]
+    enable_word_time_offsets: bool
+    inference_mode: InferenceMode
 
 
 class STT(stt.STT):
@@ -53,14 +90,28 @@ class STT(stt.STT):
         api_key: NotGivenOr[str] = NOT_GIVEN,
         enable_diarization: bool = False,
         max_speaker_count: int = 0,
+        interim_results: bool = True,
+        profanity_filter: bool = False,
+        verbatim_transcripts: bool = False,
+        boosted_lm_words: list[str] | None = None,
+        boosted_lm_score: float = 4.0,
+        endpointing: EndpointingConfig | None = None,
+        options: dict[str, Any] | None = None,
+        enable_word_time_offsets: bool = True,
+        inference_mode: InferenceMode = "auto",
     ):
+        if inference_mode not in ("auto", "streaming", "offline"):
+            raise ValueError("inference_mode must be 'auto', 'streaming', or 'offline'")
+
+        supports_streaming = inference_mode in ("auto", "streaming")
+        supports_offline = inference_mode in ("auto", "offline")
         super().__init__(
             capabilities=stt.STTCapabilities(
-                streaming=True,
-                interim_results=True,
+                streaming=supports_streaming,
+                interim_results=interim_results if supports_streaming else False,
                 diarization=enable_diarization,
-                aligned_transcript="word",
-                offline_recognize=False,
+                aligned_transcript="word" if enable_word_time_offsets else False,
+                offline_recognize=supports_offline,
             ),
         )
 
@@ -77,13 +128,17 @@ class STT(stt.STT):
             self.nvidia_api_key = os.getenv("NVIDIA_API_KEY", "")
             if use_ssl and not self.nvidia_api_key:
                 raise ValueError(
-                    "NVIDIA_API_KEY is not set while using SSL. Either pass api_key parameter, set NVIDIA_API_KEY environment variable "
-                    + "or disable SSL and use a locally hosted Riva NIM service."
+                    "NVIDIA_API_KEY is not set while using SSL. Either pass api_key parameter, "
+                    "set NVIDIA_API_KEY environment variable or disable SSL and use a locally "
+                    "hosted NVIDIA Speech service."
                 )
 
-        logger.info(f"Initializing NVIDIA STT with model: {model}, server: {server}")
+        logger.info("Initializing NVIDIA STT with model: %s, server: %s", model, server)
         logger.debug(
-            f"Function ID: {function_id}, LanguageCode: {language_code}, Sample rate: {sample_rate}"
+            "Function ID: %s, LanguageCode: %s, Sample rate: %s",
+            function_id,
+            language_code,
+            sample_rate,
         )
 
         self._opts = STTOptions(
@@ -96,16 +151,78 @@ class STT(stt.STT):
             use_ssl=use_ssl,
             enable_diarization=enable_diarization,
             max_speaker_count=max_speaker_count,
+            interim_results=interim_results,
+            profanity_filter=profanity_filter,
+            verbatim_transcripts=verbatim_transcripts,
+            boosted_lm_words=boosted_lm_words,
+            boosted_lm_score=boosted_lm_score,
+            endpointing=endpointing,
+            options=dict(options or {}),
+            enable_word_time_offsets=enable_word_time_offsets,
+            inference_mode=inference_mode,
         )
+        self._asr_service: riva.client.ASRService | None = None
 
-    def _recognize_impl(
+    @property
+    def model(self) -> str:
+        return self._opts.model
+
+    @property
+    def provider(self) -> str:
+        return "NVIDIA Speech"
+
+    def _ensure_asr_service(self) -> riva.client.ASRService:
+        if self._asr_service is None:
+            riva_auth = auth.create_riva_auth(
+                api_key=self.nvidia_api_key,
+                function_id=self._opts.function_id,
+                server=self._opts.server,
+                use_ssl=self._opts.use_ssl,
+            )
+            self._asr_service = riva.client.ASRService(riva_auth)
+        return self._asr_service
+
+    async def _recognize_impl(
         self,
         buffer: AudioBuffer,
         *,
         language: NotGivenOr[str] = NOT_GIVEN,
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
     ) -> stt.SpeechEvent:
-        raise NotImplementedError("Not implemented")
+        if self._opts.inference_mode == "streaming":
+            raise ValueError(
+                "recognize() requires inference_mode='offline'; use stream() for streaming models"
+            )
+
+        effective_language = (
+            LanguageCode(language) if is_given(language) else self._opts.language_code
+        )
+        frame = rtc.combine_audio_frames(buffer)
+        config = self._create_recognition_config(
+            language=effective_language,
+            sample_rate=frame.sample_rate,
+            audio_channel_count=frame.num_channels,
+        )
+        service = self._ensure_asr_service()
+
+        try:
+            response = await asyncio.wait_for(
+                asyncio.to_thread(service.offline_recognize, frame.data.tobytes(), config),
+                timeout=conn_options.timeout,
+            )
+        except asyncio.TimeoutError:
+            raise APITimeoutError("NVIDIA Speech STT request timed out") from None
+        except Exception as e:
+            raise _to_stt_api_error(e, operation="NVIDIA Speech offline STT request") from e
+
+        return _response_to_speech_event(
+            response,
+            language=effective_language,
+            request_id=f"nvidia-{id(response)}",
+            event_type=stt.SpeechEventType.FINAL_TRANSCRIPT,
+            enable_diarization=self._opts.enable_diarization,
+            is_final=True,
+        )
 
     def stream(
         self,
@@ -113,19 +230,89 @@ class STT(stt.STT):
         language: NotGivenOr[str] = NOT_GIVEN,
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
     ) -> stt.RecognizeStream:
+        if self._opts.inference_mode == "offline":
+            raise ValueError(
+                "stream() requires inference_mode='streaming'; use recognize() for offline models"
+            )
+
         effective_language = (
             LanguageCode(language) if is_given(language) else self._opts.language_code
         )
         return SpeechStream(stt=self, conn_options=conn_options, language=effective_language)
 
+    def _create_recognition_config(
+        self,
+        *,
+        language: LanguageCode,
+        sample_rate: int,
+        audio_channel_count: int,
+    ) -> riva.client.RecognitionConfig:
+        recognition_kwargs = {
+            "encoding": riva.client.AudioEncoding.LINEAR_PCM,
+            "language_code": language,
+            "model": self._opts.model,
+            "max_alternatives": 1,
+            "profanity_filter": self._opts.profanity_filter,
+            "enable_automatic_punctuation": self._opts.punctuate,
+            "verbatim_transcripts": self._opts.verbatim_transcripts,
+            "sample_rate_hertz": sample_rate,
+            "audio_channel_count": audio_channel_count,
+            "enable_word_time_offsets": self._opts.enable_word_time_offsets,
+        }
+        recognition_kwargs.update(self._opts.options.get("recognition_config", {}))
+        recognition_config = riva.client.RecognitionConfig(**recognition_kwargs)
+
+        if self._opts.enable_diarization:
+            diarization_config = SpeakerDiarizationConfig(
+                enable_speaker_diarization=True,
+                max_speaker_count=self._opts.max_speaker_count,
+            )
+            recognition_config.diarization_config.CopyFrom(diarization_config)
+
+        if self._opts.boosted_lm_words:
+            riva.client.add_word_boosting_to_config(
+                recognition_config,
+                self._opts.boosted_lm_words,
+                self._opts.boosted_lm_score,
+            )
+
+        return recognition_config
+
+    def _apply_streaming_config_extensions(
+        self,
+        streaming_config: riva.client.StreamingRecognitionConfig,
+    ) -> None:
+        endpointing_values = _endpointing_values(self._opts.endpointing)
+        if endpointing_values is not None:
+            riva.client.add_endpoint_parameters_to_config(
+                streaming_config,
+                *endpointing_values,
+            )
+
+        custom_configuration = self._opts.options.get("custom_configuration", "")
+        if custom_configuration and hasattr(riva.client, "add_custom_configuration_to_config"):
+            riva.client.add_custom_configuration_to_config(
+                streaming_config,
+                custom_configuration,
+            )
+        elif custom_configuration:
+            raise ValueError(
+                "custom_configuration is not supported by the installed nvidia-riva-client "
+                "version. Remove options['custom_configuration'] or install a version "
+                "that exposes add_custom_configuration_to_config."
+            )
+
     def log_asr_models(self, asr_service: riva.client.ASRService) -> dict:
         config_response = asr_service.stub.GetRivaSpeechRecognitionConfig(
-            riva.client.RivaSpeechRecognitionConfigRequest()
+            RivaSpeechRecognitionConfigRequest()
         )
 
         asr_models = {}
         for model_config in config_response.model_config:
-            if model_config.parameters.get("type") == "online":
+            model_type = model_config.parameters.get("type")
+            if self._opts.inference_mode == "auto" or model_type == (
+                "online" if self._opts.inference_mode == "streaming" else "offline"
+            ):
                 language_code = model_config.parameters["language_code"]
                 model = {"model": [model_config.model_name]}
                 if language_code in asr_models:
@@ -137,114 +324,210 @@ class STT(stt.STT):
         return asr_models
 
 
+@dataclass
+class _RecognitionAttempt:
+    audio_queue: queue.Queue[bytes | None]
+    done_fut: asyncio.Future[None]
+    thread: threading.Thread | None = None
+    input_closed: bool = False
+    final_transcript_emitted: bool = False
+
+
 class SpeechStream(stt.SpeechStream):
     def __init__(self, *, stt: STT, conn_options: APIConnectOptions, language: str):
         super().__init__(stt=stt, conn_options=conn_options, sample_rate=stt._opts.sample_rate)
         self._stt = stt
         self._language = language
 
-        self._audio_queue = queue.Queue()
-        self._shutdown_event = threading.Event()
-        self._recognition_thread = None
-
         self._speaking = False
         self._request_id = ""
 
-        self._auth = auth.create_riva_auth(
-            api_key=self._stt.nvidia_api_key,
-            function_id=self._stt._opts.function_id,
-            server=stt._opts.server,
-            use_ssl=stt._opts.use_ssl,
-        )
-        self._asr_service = riva.client.ASRService(self._auth)
-
-        self._event_loop = asyncio.get_running_loop()
-        self._done_fut = asyncio.Future()
+        self._asr_service = self._stt._ensure_asr_service()
 
     async def _run(self) -> None:
         config = self._create_streaming_config()
+        event_loop = asyncio.get_running_loop()
+        active_audio: list[bytes] = []
+        active_attempt: _RecognitionAttempt | None = None
 
-        self._recognition_thread = threading.Thread(
+        try:
+            async for data in self._input_ch:
+                if isinstance(data, rtc.AudioFrame):
+                    audio_bytes = data.data.tobytes()
+                    if not audio_bytes:
+                        continue
+
+                    if active_attempt is None:
+                        active_attempt = self._start_recognition_attempt(config, event_loop)
+                    active_audio.append(audio_bytes)
+                    active_attempt.audio_queue.put(audio_bytes)
+                elif isinstance(data, self._FlushSentinel) and active_attempt is not None:
+                    await self._finish_recognition_segment(
+                        config=config,
+                        audio=active_audio,
+                        attempt=active_attempt,
+                        event_loop=event_loop,
+                    )
+                    active_audio = []
+                    active_attempt = None
+        finally:
+            if active_attempt is not None:
+                self._close_attempt_input(active_attempt)
+                if not active_attempt.done_fut.done():
+                    with suppress(asyncio.CancelledError, asyncio.TimeoutError, Exception):
+                        await asyncio.wait_for(asyncio.shield(active_attempt.done_fut), timeout=1.0)
+                await self._join_attempt(active_attempt)
+
+    def _start_recognition_attempt(
+        self,
+        config: riva.client.StreamingRecognitionConfig,
+        event_loop: asyncio.AbstractEventLoop,
+    ) -> _RecognitionAttempt:
+        audio_queue: queue.Queue[bytes | None] = queue.Queue()
+        done_fut: asyncio.Future[None] = event_loop.create_future()
+        attempt = _RecognitionAttempt(audio_queue=audio_queue, done_fut=done_fut)
+        recognition_thread = threading.Thread(
             target=self._recognition_worker,
-            args=(config,),
+            args=(config, attempt, event_loop),
             name="nvidia-asr-recognition",
             daemon=True,
         )
-        self._recognition_thread.start()
+        attempt.thread = recognition_thread
+        recognition_thread.start()
+        return attempt
 
+    async def _finish_recognition_segment(
+        self,
+        *,
+        config: riva.client.StreamingRecognitionConfig,
+        audio: list[bytes],
+        attempt: _RecognitionAttempt,
+        event_loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        current_attempt = attempt
         try:
-            await self._collect_audio()
+            for retry_count in range(self._conn_options.max_retry + 1):
+                attempt_to_join = current_attempt
+                self._close_attempt_input(current_attempt)
+                try:
+                    await current_attempt.done_fut
+                    break
+                except APIError as e:
+                    if current_attempt.final_transcript_emitted:
+                        logger.warning(
+                            "NVIDIA Speech stream failed after a final transcript; "
+                            "not replaying audio"
+                        )
+                        break
+                    if not e.retryable:
+                        raise
+                    if retry_count == self._conn_options.max_retry:
+                        raise APIConnectionError(
+                            f"NVIDIA Speech streaming STT failed after {retry_count + 1} attempts",
+                            retryable=False,
+                        ) from e
 
+                    await asyncio.sleep(self._conn_options._interval_for_retry(retry_count))
+                    current_attempt = self._start_recognition_attempt(config, event_loop)
+                    for audio_chunk in audio:
+                        current_attempt.audio_queue.put(audio_chunk)
+                finally:
+                    await self._join_attempt(attempt_to_join)
         finally:
-            self._audio_queue.put(None)
-            await self._done_fut
+            self._finish_speech_segment()
+
+    @staticmethod
+    def _close_attempt_input(attempt: _RecognitionAttempt) -> None:
+        if not attempt.input_closed:
+            attempt.input_closed = True
+            attempt.audio_queue.put(None)
+
+    @staticmethod
+    async def _join_attempt(attempt: _RecognitionAttempt) -> None:
+        if attempt.thread is None or not attempt.thread.is_alive():
+            return
+        await asyncio.to_thread(attempt.thread.join, 1.0)
+        if attempt.thread.is_alive():
+            logger.warning("NVIDIA Speech recognition worker did not stop within one second")
+
+    def _finish_speech_segment(self) -> None:
+        if self._speaking:
+            self._speaking = False
+            self._event_ch.send_nowait(stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH))
+        self._request_id = ""
 
     def _create_streaming_config(self) -> riva.client.StreamingRecognitionConfig:
-        recognition_config = riva.client.RecognitionConfig(
-            encoding=riva.client.AudioEncoding.LINEAR_PCM,
-            language_code=self._language,
-            model=self._stt._opts.model,
-            max_alternatives=1,
-            enable_automatic_punctuation=self._stt._opts.punctuate,
-            sample_rate_hertz=self._stt._opts.sample_rate,
+        recognition_config = self._stt._create_recognition_config(
+            language=LanguageCode(self._language),
+            sample_rate=self._stt._opts.sample_rate,
             audio_channel_count=1,
-            enable_word_time_offsets=True,
         )
 
-        if self._stt._opts.enable_diarization:
-            diarization_config = SpeakerDiarizationConfig(
-                enable_speaker_diarization=True,
-                max_speaker_count=self._stt._opts.max_speaker_count,
-            )
-            recognition_config.diarization_config.CopyFrom(diarization_config)
-
-        return riva.client.StreamingRecognitionConfig(
+        streaming_config = riva.client.StreamingRecognitionConfig(
             config=recognition_config,
-            interim_results=True,
+            interim_results=self._stt._opts.interim_results,
         )
+        self._stt._apply_streaming_config_extensions(streaming_config)
+        return streaming_config
 
-    async def _collect_audio(self) -> None:
-        async for data in self._input_ch:
-            if isinstance(data, rtc.AudioFrame):
-                audio_bytes = data.data.tobytes()
-                if audio_bytes:
-                    self._audio_queue.put(audio_bytes)
-            elif isinstance(data, self._FlushSentinel):
-                break
-
-    def _recognition_worker(self, config: riva.client.StreamingRecognitionConfig) -> None:
+    def _recognition_worker(
+        self,
+        config: riva.client.StreamingRecognitionConfig,
+        attempt: _RecognitionAttempt,
+        event_loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        error: Exception | None = None
         try:
-            audio_generator = self._audio_chunk_generator()
+            audio_generator = self._audio_chunk_generator(attempt.audio_queue)
 
             response_generator = self._asr_service.streaming_response_generator(
                 audio_generator, config
             )
 
             for response in response_generator:
-                self._handle_response(response)
+                if self._handle_response(response, event_loop=event_loop):
+                    attempt.final_transcript_emitted = True
 
-        except Exception:
+        except Exception as e:
+            error = e
             logger.exception("Error in NVIDIA recognition thread")
         finally:
-            self._event_loop.call_soon_threadsafe(self._done_fut.set_result, None)
+            event_loop.call_soon_threadsafe(self._complete_done_future, attempt.done_fut, error)
 
-    def _audio_chunk_generator(self) -> Generator[bytes, None, None]:
+    def _complete_done_future(
+        self, done_fut: asyncio.Future[None], error: Exception | None
+    ) -> None:
+        if done_fut.done():
+            return
+        if error is not None:
+            done_fut.set_exception(
+                _to_stt_api_error(error, operation="NVIDIA Speech streaming STT request")
+            )
+        else:
+            done_fut.set_result(None)
+
+    def _audio_chunk_generator(
+        self, audio_queue: queue.Queue[bytes | None]
+    ) -> Generator[bytes, None, None]:
         """
-        The nvidia riva SDK requires a generator for realtime STT - so we have to
-        wrap the
+        The NVIDIA Speech SDK requires a generator for realtime STT, so the LiveKit
+        async input channel is bridged through a thread-safe queue.
         """
         while True:
-            audio_chunk = self._audio_queue.get()
+            audio_chunk = audio_queue.get()
 
             if not audio_chunk:
                 break
 
             yield audio_chunk
 
-    def _handle_response(self, response) -> None:
+    def _handle_response(self, response: Any, *, event_loop: asyncio.AbstractEventLoop) -> bool:
+        final_transcript_emitted = False
         try:
             if not hasattr(response, "results") or not response.results:
-                return
+                return False
+
+            self._request_id = f"nvidia-{id(response)}"
 
             for result in response.results:
                 if not hasattr(result, "alternatives") or not result.alternatives:
@@ -257,78 +540,285 @@ class SpeechStream(stt.SpeechStream):
                 if not transcript.strip():
                     continue
 
-                self._request_id = f"nvidia-{id(response)}"
-
-                if not self._speaking and transcript.strip():
+                if not self._speaking:
                     self._speaking = True
-                    self._event_loop.call_soon_threadsafe(
+                    event_loop.call_soon_threadsafe(
                         self._event_ch.send_nowait,
                         stt.SpeechEvent(type=stt.SpeechEventType.START_OF_SPEECH),
                     )
 
-                speech_data = self._convert_to_speech_data(alternative, is_final=is_final)
+                speech_data = _convert_to_speech_data(
+                    alternative,
+                    language=LanguageCode(self._language),
+                    start_time_offset=self.start_time_offset,
+                    enable_diarization=self._stt._opts.enable_diarization,
+                    is_final=is_final,
+                )
 
-                if is_final:
-                    self._event_loop.call_soon_threadsafe(
-                        self._event_ch.send_nowait,
-                        stt.SpeechEvent(
-                            type=stt.SpeechEventType.FINAL_TRANSCRIPT,
-                            request_id=self._request_id,
-                            alternatives=[speech_data],
-                        ),
-                    )
+                event_type = (
+                    stt.SpeechEventType.FINAL_TRANSCRIPT
+                    if is_final
+                    else stt.SpeechEventType.INTERIM_TRANSCRIPT
+                )
+                event_loop.call_soon_threadsafe(
+                    self._event_ch.send_nowait,
+                    stt.SpeechEvent(
+                        type=event_type,
+                        request_id=self._request_id,
+                        alternatives=[speech_data],
+                    ),
+                )
 
-                    if self._speaking:
-                        self._event_loop.call_soon_threadsafe(
-                            self._event_ch.send_nowait,
-                            stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH),
-                        )
-                else:
-                    self._event_loop.call_soon_threadsafe(
+                if is_final and self._speaking:
+                    final_transcript_emitted = True
+                    self._speaking = False
+                    event_loop.call_soon_threadsafe(
                         self._event_ch.send_nowait,
-                        stt.SpeechEvent(
-                            type=stt.SpeechEventType.INTERIM_TRANSCRIPT,
-                            request_id=self._request_id,
-                            alternatives=[speech_data],
-                        ),
+                        stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH),
                     )
 
         except Exception:
             logger.exception("Error handling response")
 
-    def _convert_to_speech_data(self, alternative, *, is_final: bool) -> stt.SpeechData:
-        transcript = getattr(alternative, "transcript", "")
-        confidence = getattr(alternative, "confidence", 0.0)
-        words = getattr(alternative, "words", [])
+        return final_transcript_emitted
 
-        start_time = 0.0
-        end_time = 0.0
-        speaker_id: str | None = None
-        if words:
-            start_time = getattr(words[0], "start_time", 0) / 1000.0 + self.start_time_offset
-            end_time = getattr(words[-1], "end_time", 0) / 1000.0 + self.start_time_offset
 
-            if self._stt._opts.enable_diarization and is_final:
-                speaker_tags = [getattr(word, "speaker_tag", 0) for word in words]
-                if speaker_tags:
-                    speaker = Counter(speaker_tags).most_common(1)[0][0]
-                    speaker_id = f"S{speaker}"
+def _to_stt_api_error(error: Exception, *, operation: str) -> APIError:
+    if isinstance(error, APIError):
+        return error
 
-        return stt.SpeechData(
-            language=LanguageCode(self._language),
-            start_time=start_time,
-            end_time=end_time,
-            confidence=confidence,
-            text=transcript,
-            speaker_id=speaker_id,
-            words=[
-                TimedString(
-                    text=getattr(word, "word", ""),
-                    start_time=getattr(word, "start_time", 0) + self.start_time_offset,
-                    end_time=getattr(word, "end_time", 0) + self.start_time_offset,
-                )
-                for word in words
-            ]
-            if words
-            else None,
+    if isinstance(error, grpc.RpcError):
+        code = error.code()
+        details = error.details() or str(error)
+        if code == grpc.StatusCode.DEADLINE_EXCEEDED:
+            return APITimeoutError(f"{operation} timed out: {details}")
+        if code == grpc.StatusCode.CANCELLED:
+            return APIConnectionError(f"{operation} was cancelled by NVIDIA Speech")
+
+        status_codes = {
+            grpc.StatusCode.INVALID_ARGUMENT: 400,
+            grpc.StatusCode.NOT_FOUND: 404,
+            grpc.StatusCode.ALREADY_EXISTS: 409,
+            grpc.StatusCode.PERMISSION_DENIED: 403,
+            grpc.StatusCode.RESOURCE_EXHAUSTED: 429,
+            grpc.StatusCode.FAILED_PRECONDITION: 400,
+            grpc.StatusCode.ABORTED: 409,
+            grpc.StatusCode.OUT_OF_RANGE: 400,
+            grpc.StatusCode.UNIMPLEMENTED: 501,
+            grpc.StatusCode.INTERNAL: 500,
+            grpc.StatusCode.UNAVAILABLE: 503,
+            grpc.StatusCode.DATA_LOSS: 500,
+            grpc.StatusCode.UNAUTHENTICATED: 401,
+        }
+        return APIStatusError(
+            f"{operation} failed: {details}",
+            status_code=status_codes.get(code, -1),
+            retryable=code
+            in {
+                grpc.StatusCode.UNKNOWN,
+                grpc.StatusCode.RESOURCE_EXHAUSTED,
+                grpc.StatusCode.ABORTED,
+                grpc.StatusCode.INTERNAL,
+                grpc.StatusCode.UNAVAILABLE,
+            },
         )
+
+    if isinstance(error, (TypeError, ValueError)):
+        return APIStatusError(f"{operation} failed: {error}", status_code=400, retryable=False)
+
+    return APIConnectionError(f"{operation} failed: {error}")
+
+
+def _endpointing_values(
+    endpointing: EndpointingConfig | None,
+) -> tuple[int, float, int, int, float, float] | None:
+    if endpointing is None:
+        return None
+
+    if endpointing.mode == "low_latency":
+        # Match the endpointing defaults used by NVIDIA's Pipecat service.
+        values = {
+            "start_history": -1,
+            "start_threshold": -1.0,
+            "stop_history": 500,
+            "stop_history_eou": 240,
+            "stop_threshold": -1.0,
+            "stop_threshold_eou": -1.0,
+        }
+    else:
+        raise ValueError(f"Unsupported NVIDIA endpointing mode: {endpointing.mode}")
+
+    for key in values:
+        override = getattr(endpointing, key)
+        if override is not None:
+            values[key] = override
+
+    return (
+        int(values["start_history"]),
+        float(values["start_threshold"]),
+        int(values["stop_history"]),
+        int(values["stop_history_eou"]),
+        float(values["stop_threshold"]),
+        float(values["stop_threshold_eou"]),
+    )
+
+
+def _response_to_speech_event(
+    response: Any,
+    *,
+    language: LanguageCode,
+    request_id: str,
+    event_type: stt.SpeechEventType,
+    enable_diarization: bool,
+    is_final: bool,
+) -> stt.SpeechEvent:
+    results = [
+        result for result in getattr(response, "results", []) if getattr(result, "alternatives", [])
+    ]
+    alternatives = [
+        _combine_result_alternatives(
+            [
+                result.alternatives[alternative_index]
+                for result in results
+                if len(result.alternatives) > alternative_index
+            ],
+            language=language,
+            start_time_offset=0.0,
+            enable_diarization=enable_diarization,
+            is_final=is_final,
+        )
+        for alternative_index in range(
+            max((len(result.alternatives) for result in results), default=0)
+        )
+    ]
+
+    if not alternatives:
+        alternatives.append(stt.SpeechData(language=language, text=""))
+
+    return stt.SpeechEvent(
+        type=event_type,
+        request_id=request_id,
+        alternatives=alternatives,
+    )
+
+
+def _combine_result_alternatives(
+    alternatives: list[Any],
+    *,
+    language: LanguageCode,
+    start_time_offset: float,
+    enable_diarization: bool,
+    is_final: bool,
+) -> stt.SpeechData:
+    transcripts = [
+        transcript.strip()
+        for alternative in alternatives
+        if (transcript := getattr(alternative, "transcript", ""))
+    ]
+    confidences = [
+        float(confidence)
+        for alternative in alternatives
+        if (confidence := getattr(alternative, "confidence", 0.0))
+    ]
+    words = [
+        word for alternative in alternatives for word in (getattr(alternative, "words", []) or [])
+    ]
+
+    start_time = 0.0
+    end_time = 0.0
+    speaker_id: str | None = None
+    timed_words: list[TimedString] | None = None
+
+    if words:
+        start_time = _time_offset_seconds(getattr(words[0], "start_time", 0)) + start_time_offset
+        end_time = _time_offset_seconds(getattr(words[-1], "end_time", 0)) + start_time_offset
+        timed_words = [
+            TimedString(
+                text=getattr(word, "word", ""),
+                start_time=_time_offset_seconds(getattr(word, "start_time", 0)) + start_time_offset,
+                end_time=_time_offset_seconds(getattr(word, "end_time", 0)) + start_time_offset,
+            )
+            for word in words
+        ]
+
+        if enable_diarization and is_final:
+            speaker_tags = [getattr(word, "speaker_tag", 0) for word in words]
+            if speaker_tags:
+                speaker = Counter(speaker_tags).most_common(1)[0][0]
+                speaker_id = f"S{speaker}"
+
+    return stt.SpeechData(
+        language=language,
+        start_time=start_time,
+        end_time=end_time,
+        confidence=(sum(confidences) / len(confidences)) if confidences else 0.0,
+        text=" ".join(transcripts),
+        speaker_id=speaker_id,
+        words=timed_words,
+    )
+
+
+def _convert_to_speech_data(
+    alternative: Any,
+    *,
+    language: LanguageCode,
+    start_time_offset: float,
+    enable_diarization: bool,
+    is_final: bool,
+) -> stt.SpeechData:
+    transcript = getattr(alternative, "transcript", "")
+    confidence = getattr(alternative, "confidence", 0.0)
+    words = list(getattr(alternative, "words", []) or [])
+
+    start_time = 0.0
+    end_time = 0.0
+    speaker_id: str | None = None
+    timed_words: list[TimedString] | None = None
+
+    if words:
+        start_time = _time_offset_seconds(getattr(words[0], "start_time", 0)) + start_time_offset
+        end_time = _time_offset_seconds(getattr(words[-1], "end_time", 0)) + start_time_offset
+        timed_words = [
+            TimedString(
+                text=getattr(word, "word", ""),
+                start_time=_time_offset_seconds(getattr(word, "start_time", 0)) + start_time_offset,
+                end_time=_time_offset_seconds(getattr(word, "end_time", 0)) + start_time_offset,
+            )
+            for word in words
+        ]
+
+        if enable_diarization and is_final:
+            speaker_tags = [getattr(word, "speaker_tag", 0) for word in words]
+            if speaker_tags:
+                speaker = Counter(speaker_tags).most_common(1)[0][0]
+                speaker_id = f"S{speaker}"
+
+    return stt.SpeechData(
+        language=language,
+        start_time=start_time,
+        end_time=end_time,
+        confidence=confidence,
+        text=transcript,
+        speaker_id=speaker_id,
+        words=timed_words,
+    )
+
+
+def _time_offset_seconds(value: Any) -> float:
+    if value is None:
+        return 0.0
+
+    seconds = getattr(value, "seconds", None)
+    nanos = getattr(value, "nanos", None)
+    if seconds is not None or nanos is not None:
+        return float(seconds or 0) + float(nanos or 0) / 1_000_000_000
+
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+    if isinstance(value, int):
+        return numeric / 1000.0
+
+    return numeric

--- a/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py
+++ b/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py
@@ -515,9 +515,13 @@ class SpeechStream(stt.SpeechStream):
         except APIError as error:
             api_error = error
         else:
-            api_error = APIConnectionError(
-                "NVIDIA Speech streaming STT connection ended unexpectedly"
-            )
+            await self._join_attempt(attempt)
+            replay_audio, _ = attempt.replay_snapshot()
+            next_attempt = self._start_recognition_attempt(config, event_loop)
+            for audio_chunk in replay_audio or []:
+                next_attempt.buffer_for_replay(audio_chunk, max_bytes=max_replay_bytes)
+                next_attempt.audio_queue.put(audio_chunk)
+            return next_attempt, 0
 
         await self._join_attempt(attempt)
 
@@ -876,9 +880,9 @@ def _combine_result_alternatives(
         if (transcript := getattr(alternative, "transcript", ""))
     ]
     confidences = [
-        float(confidence)
+        float(getattr(alternative, "confidence", 0.0) or 0.0)
         for alternative in alternatives
-        if (confidence := getattr(alternative, "confidence", 0.0))
+        if hasattr(alternative, "confidence")
     ]
     words = [
         word for alternative in alternatives for word in (getattr(alternative, "words", []) or [])

--- a/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py
+++ b/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py
@@ -370,6 +370,7 @@ class _RecognitionAttempt:
     replay_audio: list[bytes] = field(default_factory=list)
     replay_audio_bytes: int = 0
     replay_enabled: bool = True
+    final_transcript_received: bool = False
     replay_lock: threading.Lock = field(default_factory=threading.Lock)
 
     def buffer_for_replay(self, audio: bytes, *, max_bytes: int) -> None:
@@ -390,6 +391,7 @@ class _RecognitionAttempt:
     def mark_final_transcript(self) -> None:
         with self.replay_lock:
             self.final_transcript_emitted = True
+            self.final_transcript_received = True
             self.replay_audio.clear()
             self.replay_audio_bytes = 0
             self.replay_enabled = True
@@ -398,6 +400,10 @@ class _RecognitionAttempt:
         with self.replay_lock:
             audio = list(self.replay_audio) if self.replay_enabled else None
             return audio, self.final_transcript_emitted
+
+    def received_final_transcript(self) -> bool:
+        with self.replay_lock:
+            return self.final_transcript_received
 
 
 class SpeechStream(stt.SpeechStream):
@@ -415,34 +421,66 @@ class SpeechStream(stt.SpeechStream):
         config = self._create_streaming_config()
         event_loop = asyncio.get_running_loop()
         active_attempt: _RecognitionAttempt | None = None
+        streaming_retry_count = 0
         max_replay_bytes = (
             self._stt._opts.sample_rate * _PCM_BYTES_PER_SAMPLE * _MAX_REPLAY_AUDIO_SECONDS
         )
+        input_aiter = self._input_ch.__aiter__()
+        input_task = asyncio.create_task(anext(input_aiter))
 
         try:
-            async for data in self._input_ch:
-                if isinstance(data, rtc.AudioFrame):
-                    audio_bytes = data.data.tobytes()
-                    if not audio_bytes:
-                        continue
+            while True:
+                waiters: set[asyncio.Future[Any]] = {input_task}
+                if active_attempt is not None:
+                    waiters.add(active_attempt.done_fut)
 
-                    if active_attempt is None:
-                        active_attempt = self._start_recognition_attempt(config, event_loop)
-                    active_attempt.buffer_for_replay(audio_bytes, max_bytes=max_replay_bytes)
-                    active_attempt.audio_queue.put(audio_bytes)
-                elif isinstance(data, self._FlushSentinel) and active_attempt is not None:
-                    await self._finish_recognition_segment(
+                completed, _ = await asyncio.wait(
+                    waiters,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+
+                if input_task in completed:
+                    try:
+                        data = input_task.result()
+                    except StopAsyncIteration:
+                        break
+                    input_task = asyncio.create_task(anext(input_aiter))
+
+                    if isinstance(data, rtc.AudioFrame):
+                        audio_bytes = data.data.tobytes()
+                        if audio_bytes:
+                            if active_attempt is None:
+                                active_attempt = self._start_recognition_attempt(config, event_loop)
+                            active_attempt.buffer_for_replay(
+                                audio_bytes,
+                                max_bytes=max_replay_bytes,
+                            )
+                            active_attempt.audio_queue.put(audio_bytes)
+                    elif isinstance(data, self._FlushSentinel) and active_attempt is not None:
+                        await self._finish_recognition_segment(
+                            config=config,
+                            attempt=active_attempt,
+                            event_loop=event_loop,
+                        )
+                        active_attempt = None
+                        streaming_retry_count = 0
+
+                if active_attempt is not None and active_attempt.done_fut.done():
+                    active_attempt, streaming_retry_count = await self._restart_streaming_attempt(
                         config=config,
                         attempt=active_attempt,
                         event_loop=event_loop,
+                        retry_count=streaming_retry_count,
+                        max_replay_bytes=max_replay_bytes,
                     )
-                    active_attempt = None
         finally:
+            input_task.cancel()
+            with suppress(asyncio.CancelledError, StopAsyncIteration):
+                await input_task
             if active_attempt is not None:
                 self._close_attempt_input(active_attempt)
-                if not active_attempt.done_fut.done():
-                    with suppress(asyncio.CancelledError, asyncio.TimeoutError, Exception):
-                        await asyncio.wait_for(asyncio.shield(active_attempt.done_fut), timeout=1.0)
+                with suppress(asyncio.CancelledError, asyncio.TimeoutError, Exception):
+                    await asyncio.wait_for(asyncio.shield(active_attempt.done_fut), timeout=1.0)
                 await self._join_attempt(active_attempt)
 
     def _start_recognition_attempt(
@@ -462,6 +500,52 @@ class SpeechStream(stt.SpeechStream):
         attempt.thread = recognition_thread
         recognition_thread.start()
         return attempt
+
+    async def _restart_streaming_attempt(
+        self,
+        *,
+        config: riva.client.StreamingRecognitionConfig,
+        attempt: _RecognitionAttempt,
+        event_loop: asyncio.AbstractEventLoop,
+        retry_count: int,
+        max_replay_bytes: int,
+    ) -> tuple[_RecognitionAttempt, int]:
+        try:
+            attempt.done_fut.result()
+        except APIError as error:
+            api_error = error
+        else:
+            api_error = APIConnectionError(
+                "NVIDIA Speech streaming STT connection ended unexpectedly"
+            )
+
+        await self._join_attempt(attempt)
+
+        if attempt.received_final_transcript():
+            retry_count = 0
+        if not api_error.retryable:
+            raise api_error
+
+        replay_audio, _ = attempt.replay_snapshot()
+        if replay_audio is None:
+            raise APIConnectionError(
+                "NVIDIA Speech streaming STT failed after the retry buffer "
+                f"exceeded {_MAX_REPLAY_AUDIO_SECONDS} seconds",
+                retryable=False,
+            ) from api_error
+        if retry_count == self._conn_options.max_retry:
+            raise APIConnectionError(
+                f"NVIDIA Speech streaming STT failed after {retry_count + 1} attempts",
+                retryable=False,
+            ) from api_error
+
+        await asyncio.sleep(self._conn_options._interval_for_retry(retry_count))
+        next_attempt = self._start_recognition_attempt(config, event_loop)
+        for audio_chunk in replay_audio:
+            next_attempt.buffer_for_replay(audio_chunk, max_bytes=max_replay_bytes)
+            next_attempt.audio_queue.put(audio_chunk)
+
+        return next_attempt, retry_count + 1
 
     async def _finish_recognition_segment(
         self,

--- a/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py
+++ b/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py
@@ -115,13 +115,6 @@ class STT(stt.STT):
             ),
         )
 
-        if enable_diarization and "sortformer" not in model:
-            logger.warning(
-                "Speaker diarization is enabled but model '%s' may not support it. "
-                "Diarization requires a Sortformer-based model.",
-                model,
-            )
-
         if is_given(api_key):
             self.nvidia_api_key = api_key
         else:
@@ -132,14 +125,6 @@ class STT(stt.STT):
                     "set NVIDIA_API_KEY environment variable or disable SSL and use a locally "
                     "hosted NVIDIA Speech service."
                 )
-
-        logger.info("Initializing NVIDIA STT with model: %s, server: %s", model, server)
-        logger.debug(
-            "Function ID: %s, LanguageCode: %s, Sample rate: %s",
-            function_id,
-            language_code,
-            sample_rate,
-        )
 
         self._opts = STTOptions(
             model=model,
@@ -490,7 +475,6 @@ class SpeechStream(stt.SpeechStream):
 
         except Exception as e:
             error = e
-            logger.exception("Error in NVIDIA recognition thread")
         finally:
             event_loop.call_soon_threadsafe(self._complete_done_future, attempt.done_fut, error)
 
@@ -523,62 +507,58 @@ class SpeechStream(stt.SpeechStream):
 
     def _handle_response(self, response: Any, *, event_loop: asyncio.AbstractEventLoop) -> bool:
         final_transcript_emitted = False
-        try:
-            if not hasattr(response, "results") or not response.results:
-                return False
+        if not hasattr(response, "results") or not response.results:
+            return False
 
-            self._request_id = f"nvidia-{id(response)}"
+        self._request_id = f"nvidia-{id(response)}"
 
-            for result in response.results:
-                if not hasattr(result, "alternatives") or not result.alternatives:
-                    continue
+        for result in response.results:
+            if not hasattr(result, "alternatives") or not result.alternatives:
+                continue
 
-                alternative = result.alternatives[0]
-                transcript = getattr(alternative, "transcript", "")
-                is_final = getattr(result, "is_final", False)
+            alternative = result.alternatives[0]
+            transcript = getattr(alternative, "transcript", "")
+            is_final = getattr(result, "is_final", False)
 
-                if not transcript.strip():
-                    continue
+            if not transcript.strip():
+                continue
 
-                if not self._speaking:
-                    self._speaking = True
-                    event_loop.call_soon_threadsafe(
-                        self._event_ch.send_nowait,
-                        stt.SpeechEvent(type=stt.SpeechEventType.START_OF_SPEECH),
-                    )
-
-                speech_data = _convert_to_speech_data(
-                    alternative,
-                    language=LanguageCode(self._language),
-                    start_time_offset=self.start_time_offset,
-                    enable_diarization=self._stt._opts.enable_diarization,
-                    is_final=is_final,
-                )
-
-                event_type = (
-                    stt.SpeechEventType.FINAL_TRANSCRIPT
-                    if is_final
-                    else stt.SpeechEventType.INTERIM_TRANSCRIPT
-                )
+            if not self._speaking:
+                self._speaking = True
                 event_loop.call_soon_threadsafe(
                     self._event_ch.send_nowait,
-                    stt.SpeechEvent(
-                        type=event_type,
-                        request_id=self._request_id,
-                        alternatives=[speech_data],
-                    ),
+                    stt.SpeechEvent(type=stt.SpeechEventType.START_OF_SPEECH),
                 )
 
-                if is_final and self._speaking:
-                    final_transcript_emitted = True
-                    self._speaking = False
-                    event_loop.call_soon_threadsafe(
-                        self._event_ch.send_nowait,
-                        stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH),
-                    )
+            speech_data = _convert_to_speech_data(
+                alternative,
+                language=LanguageCode(self._language),
+                start_time_offset=self.start_time_offset,
+                enable_diarization=self._stt._opts.enable_diarization,
+                is_final=is_final,
+            )
 
-        except Exception:
-            logger.exception("Error handling response")
+            event_type = (
+                stt.SpeechEventType.FINAL_TRANSCRIPT
+                if is_final
+                else stt.SpeechEventType.INTERIM_TRANSCRIPT
+            )
+            event_loop.call_soon_threadsafe(
+                self._event_ch.send_nowait,
+                stt.SpeechEvent(
+                    type=event_type,
+                    request_id=self._request_id,
+                    alternatives=[speech_data],
+                ),
+            )
+
+            if is_final and self._speaking:
+                final_transcript_emitted = True
+                self._speaking = False
+                event_loop.call_soon_threadsafe(
+                    self._event_ch.send_nowait,
+                    stt.SpeechEvent(type=stt.SpeechEventType.END_OF_SPEECH),
+                )
 
         return final_transcript_emitted
 
@@ -766,41 +746,12 @@ def _convert_to_speech_data(
     enable_diarization: bool,
     is_final: bool,
 ) -> stt.SpeechData:
-    transcript = getattr(alternative, "transcript", "")
-    confidence = getattr(alternative, "confidence", 0.0)
-    words = list(getattr(alternative, "words", []) or [])
-
-    start_time = 0.0
-    end_time = 0.0
-    speaker_id: str | None = None
-    timed_words: list[TimedString] | None = None
-
-    if words:
-        start_time = _time_offset_seconds(getattr(words[0], "start_time", 0)) + start_time_offset
-        end_time = _time_offset_seconds(getattr(words[-1], "end_time", 0)) + start_time_offset
-        timed_words = [
-            TimedString(
-                text=getattr(word, "word", ""),
-                start_time=_time_offset_seconds(getattr(word, "start_time", 0)) + start_time_offset,
-                end_time=_time_offset_seconds(getattr(word, "end_time", 0)) + start_time_offset,
-            )
-            for word in words
-        ]
-
-        if enable_diarization and is_final:
-            speaker_tags = [getattr(word, "speaker_tag", 0) for word in words]
-            if speaker_tags:
-                speaker = Counter(speaker_tags).most_common(1)[0][0]
-                speaker_id = f"S{speaker}"
-
-    return stt.SpeechData(
+    return _combine_result_alternatives(
+        [alternative],
         language=language,
-        start_time=start_time,
-        end_time=end_time,
-        confidence=confidence,
-        text=transcript,
-        speaker_id=speaker_id,
-        words=timed_words,
+        start_time_offset=start_time_offset,
+        enable_diarization=enable_diarization,
+        is_final=is_final,
     )
 
 

--- a/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py
+++ b/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py
@@ -9,7 +9,7 @@ import threading
 from collections import Counter
 from collections.abc import Generator
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Literal
 
 import grpc
@@ -41,6 +41,9 @@ logger = logging.getLogger(__name__)
 
 EndpointingMode = Literal["low_latency"]
 InferenceMode = Literal["auto", "streaming", "offline"]
+
+_MAX_REPLAY_AUDIO_SECONDS = 30
+_PCM_BYTES_PER_SAMPLE = 2
 
 
 @dataclass(frozen=True)
@@ -364,6 +367,37 @@ class _RecognitionAttempt:
     thread: threading.Thread | None = None
     input_closed: bool = False
     final_transcript_emitted: bool = False
+    replay_audio: list[bytes] = field(default_factory=list)
+    replay_audio_bytes: int = 0
+    replay_enabled: bool = True
+    replay_lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def buffer_for_replay(self, audio: bytes, *, max_bytes: int) -> None:
+        with self.replay_lock:
+            if not self.replay_enabled:
+                return
+
+            self.final_transcript_emitted = False
+            if self.replay_audio_bytes + len(audio) > max_bytes:
+                self.replay_audio.clear()
+                self.replay_audio_bytes = 0
+                self.replay_enabled = False
+                return
+
+            self.replay_audio.append(audio)
+            self.replay_audio_bytes += len(audio)
+
+    def mark_final_transcript(self) -> None:
+        with self.replay_lock:
+            self.final_transcript_emitted = True
+            self.replay_audio.clear()
+            self.replay_audio_bytes = 0
+            self.replay_enabled = True
+
+    def replay_snapshot(self) -> tuple[list[bytes] | None, bool]:
+        with self.replay_lock:
+            audio = list(self.replay_audio) if self.replay_enabled else None
+            return audio, self.final_transcript_emitted
 
 
 class SpeechStream(stt.SpeechStream):
@@ -380,8 +414,10 @@ class SpeechStream(stt.SpeechStream):
     async def _run(self) -> None:
         config = self._create_streaming_config()
         event_loop = asyncio.get_running_loop()
-        active_audio: list[bytes] = []
         active_attempt: _RecognitionAttempt | None = None
+        max_replay_bytes = (
+            self._stt._opts.sample_rate * _PCM_BYTES_PER_SAMPLE * _MAX_REPLAY_AUDIO_SECONDS
+        )
 
         try:
             async for data in self._input_ch:
@@ -392,16 +428,14 @@ class SpeechStream(stt.SpeechStream):
 
                     if active_attempt is None:
                         active_attempt = self._start_recognition_attempt(config, event_loop)
-                    active_audio.append(audio_bytes)
+                    active_attempt.buffer_for_replay(audio_bytes, max_bytes=max_replay_bytes)
                     active_attempt.audio_queue.put(audio_bytes)
                 elif isinstance(data, self._FlushSentinel) and active_attempt is not None:
                     await self._finish_recognition_segment(
                         config=config,
-                        audio=active_audio,
                         attempt=active_attempt,
                         event_loop=event_loop,
                     )
-                    active_audio = []
                     active_attempt = None
         finally:
             if active_attempt is not None:
@@ -433,7 +467,6 @@ class SpeechStream(stt.SpeechStream):
         self,
         *,
         config: riva.client.StreamingRecognitionConfig,
-        audio: list[bytes],
         attempt: _RecognitionAttempt,
         event_loop: asyncio.AbstractEventLoop,
     ) -> None:
@@ -446,7 +479,8 @@ class SpeechStream(stt.SpeechStream):
                     await current_attempt.done_fut
                     break
                 except APIError as e:
-                    if current_attempt.final_transcript_emitted:
+                    replay_audio, final_transcript_emitted = current_attempt.replay_snapshot()
+                    if final_transcript_emitted and not replay_audio:
                         logger.warning(
                             "NVIDIA Speech stream failed after a final transcript; "
                             "not replaying audio"
@@ -459,10 +493,24 @@ class SpeechStream(stt.SpeechStream):
                             f"NVIDIA Speech streaming STT failed after {retry_count + 1} attempts",
                             retryable=False,
                         ) from e
+                    if replay_audio is None:
+                        raise APIConnectionError(
+                            "NVIDIA Speech streaming STT failed after the retry buffer "
+                            "exceeded 30 seconds",
+                            retryable=False,
+                        ) from e
 
                     await asyncio.sleep(self._conn_options._interval_for_retry(retry_count))
                     current_attempt = self._start_recognition_attempt(config, event_loop)
-                    for audio_chunk in audio:
+                    for audio_chunk in replay_audio:
+                        current_attempt.buffer_for_replay(
+                            audio_chunk,
+                            max_bytes=(
+                                self._stt._opts.sample_rate
+                                * _PCM_BYTES_PER_SAMPLE
+                                * _MAX_REPLAY_AUDIO_SECONDS
+                            ),
+                        )
                         current_attempt.audio_queue.put(audio_chunk)
                 finally:
                     await self._join_attempt(attempt_to_join)
@@ -519,7 +567,7 @@ class SpeechStream(stt.SpeechStream):
 
             for response in response_generator:
                 if self._handle_response(response, event_loop=event_loop):
-                    attempt.final_transcript_emitted = True
+                    attempt.mark_final_transcript()
 
         except Exception as e:
             error = e

--- a/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py
+++ b/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/stt.py
@@ -45,6 +45,22 @@ InferenceMode = Literal["auto", "streaming", "offline"]
 
 @dataclass(frozen=True)
 class EndpointingConfig:
+    """Configure NVIDIA Speech endpoint detection for streaming recognition.
+
+    Attributes:
+        mode: Endpointing preset. ``"low_latency"`` applies the plugin's low-latency
+            defaults before any field overrides.
+        start_history: VAD start-history override in audio frames.
+        start_threshold: Dimensionless VAD speech-start threshold override.
+        stop_history: VAD stop-history override in audio frames.
+        stop_threshold: Dimensionless VAD speech-stop threshold override.
+        stop_history_eou: End-of-utterance stop-history override in audio frames.
+        stop_threshold_eou: Dimensionless end-of-utterance stop-threshold override.
+
+    ``None`` leaves a field at the value selected by ``mode``. Values of ``-1`` or
+    ``-1.0`` ask NVIDIA Speech to use its model default for that field.
+    """
+
     mode: EndpointingMode = "low_latency"
     start_history: int | None = None
     start_threshold: float | None = None
@@ -100,6 +116,38 @@ class STT(stt.STT):
         enable_word_time_offsets: bool = True,
         inference_mode: InferenceMode = "auto",
     ):
+        """Create an NVIDIA Speech recognition client.
+
+        Args:
+            model: NVIDIA Speech model name sent with recognition requests.
+            function_id: NVIDIA-hosted NVCF function ID. Local deployments may use
+                the value expected by their gateway.
+            punctuate: Whether to enable automatic punctuation.
+            language_code: Recognition language code, such as ``"en-US"``.
+            sample_rate: Streaming input sample rate in Hz.
+            server: NVIDIA Speech gRPC endpoint.
+            use_ssl: Whether to use TLS for the gRPC connection.
+            api_key: NVIDIA API key. When omitted, reads ``NVIDIA_API_KEY``.
+            enable_diarization: Whether to request speaker diarization.
+            max_speaker_count: Maximum expected speakers when diarization is enabled.
+            interim_results: Whether streaming recognition emits interim transcripts.
+            profanity_filter: Whether to mask profane words in transcripts.
+            verbatim_transcripts: Whether to request verbatim transcript formatting.
+            boosted_lm_words: Words or phrases to boost during recognition.
+            boosted_lm_score: Global boost score applied to ``boosted_lm_words``.
+            endpointing: Streaming endpoint-detection settings. ``None`` leaves the
+                deployed model's endpointing configuration unchanged.
+            options: Provider-specific escape hatch. ``recognition_config`` values are
+                passed to ``riva.client.RecognitionConfig``; ``custom_configuration``
+                is applied to the streaming configuration when supported by the client.
+            enable_word_time_offsets: Whether to request word timestamps.
+            inference_mode: ``"streaming"`` or ``"offline"`` advertises only that
+                capability; ``"auto"`` preserves support for both APIs.
+
+        Raises:
+            ValueError: If the inference mode is invalid or hosted authentication is
+                enabled without an API key.
+        """
         if inference_mode not in ("auto", "streaming", "offline"):
             raise ValueError("inference_mode must be 'auto', 'streaming', or 'offline'")
 
@@ -582,7 +630,7 @@ def _to_stt_api_error(error: Exception, *, operation: str) -> APIError:
             grpc.StatusCode.PERMISSION_DENIED: 403,
             grpc.StatusCode.RESOURCE_EXHAUSTED: 429,
             grpc.StatusCode.FAILED_PRECONDITION: 400,
-            grpc.StatusCode.ABORTED: 409,
+            grpc.StatusCode.ABORTED: 503,
             grpc.StatusCode.OUT_OF_RANGE: 400,
             grpc.StatusCode.UNIMPLEMENTED: 501,
             grpc.StatusCode.INTERNAL: 500,

--- a/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/tts.py
+++ b/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/tts.py
@@ -66,6 +66,31 @@ class TTS(tts.TTS):
         options: dict[str, Any] | None = None,
         inference_mode: InferenceMode = "online",
     ):
+        """Create an NVIDIA Speech synthesis client.
+
+        Args:
+            server: NVIDIA Speech gRPC endpoint.
+            voice: Voice name exposed by the deployed synthesis model.
+            function_id: NVIDIA-hosted NVCF function ID. Local deployments may use
+                the value expected by their gateway.
+            language_code: Synthesis language code, such as ``"en-US"``.
+            sample_rate: Output PCM sample rate in Hz.
+            use_ssl: Whether to use TLS for the gRPC connection.
+            api_key: NVIDIA API key. When omitted, reads ``NVIDIA_API_KEY``.
+            audio_prompt_file: Reference-audio path for models supporting zero-shot
+                voice prompting.
+            quality: Zero-shot synthesis quality accepted by compatible clients.
+            word_tokenizer: Tokenizer used to split text submitted through ``stream()``
+                into synthesis requests.
+            options: Additional keyword arguments passed to the installed NVIDIA
+                synthesis client after compatibility validation.
+            inference_mode: ``"online"`` uses streaming synthesis; ``"offline"`` uses
+                the batch synthesis RPC.
+
+        Raises:
+            ValueError: If the inference mode is invalid or hosted authentication is
+                enabled without an API key.
+        """
         if inference_mode not in ("online", "offline"):
             raise ValueError("inference_mode must be either 'online' or 'offline'")
 
@@ -208,6 +233,8 @@ class TTS(tts.TTS):
 
 
 class ChunkedStream(tts.ChunkedStream):
+    """Synthesis stream for a complete NVIDIA Speech text request."""
+
     def __init__(
         self,
         *,

--- a/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/tts.py
+++ b/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/tts.py
@@ -3,7 +3,6 @@
 
 import asyncio
 import inspect
-import logging
 import os
 import queue
 import threading
@@ -31,9 +30,6 @@ from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, NotGive
 from livekit.agents.utils import is_given
 
 from . import auth
-
-logger = logging.getLogger(__name__)
-
 
 InferenceMode = Literal["online", "offline"]
 
@@ -241,8 +237,7 @@ class ChunkedStream(tts.ChunkedStream):
                 for response in self._tts._synthesize(self._input_text, self._opts):
                     event_loop.call_soon_threadsafe(output_emitter.push, response.audio)
             except Exception as e:
-                error = _to_tts_api_error(e, operation="NVIDIA Speech TTS request")
-                logger.exception("Error in NVIDIA chunked synthesis thread")
+                error = e
             finally:
                 event_loop.call_soon_threadsafe(_complete_future, done_fut, error)
 
@@ -309,8 +304,7 @@ class SynthesizeStream(tts.SynthesizeStream):
                         event_loop.call_soon_threadsafe(output_emitter.push, response.audio)
 
             except Exception as e:
-                error = _to_tts_api_error(e, operation="NVIDIA Speech TTS request")
-                logger.exception("Error in NVIDIA streaming synthesis thread")
+                error = e
             finally:
                 event_loop.call_soon_threadsafe(_complete_future, done_fut, error)
 

--- a/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/tts.py
+++ b/livekit-plugins/livekit-plugins-nvidia/livekit/plugins/nvidia/tts.py
@@ -1,24 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
 import asyncio
+import inspect
 import logging
 import os
 import queue
 import threading
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from os import PathLike
+from pathlib import Path
+from typing import Any, Literal
 
+import grpc
 import riva.client
 from riva.client.proto.riva_audio_pb2 import AudioEncoding
 
 from livekit.agents import (
+    APIConnectionError,
     APIConnectOptions,
+    APIError,
+    APIStatusError,
+    APITimeoutError,
     tokenize,
     tts,
     utils,
 )
-from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS
+from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, NotGivenOr
+from livekit.agents.utils import is_given
 
 from . import auth
 
 logger = logging.getLogger(__name__)
+
+
+InferenceMode = Literal["online", "offline"]
 
 
 @dataclass
@@ -30,6 +47,10 @@ class TTSOptions:
     use_ssl: bool
     language_code: str
     word_tokenizer: tokenize.WordTokenizer | tokenize.SentenceTokenizer
+    audio_prompt_file: str | PathLike[str] | None
+    quality: int | None
+    options: dict[str, Any]
+    inference_mode: InferenceMode
 
 
 class TTS(tts.TTS):
@@ -40,35 +61,53 @@ class TTS(tts.TTS):
         voice: str = "Magpie-Multilingual.EN-US.Leo",
         function_id: str = "877104f7-e885-42b9-8de8-f6e4c6303969",
         language_code: str = "en-US",
+        sample_rate: int = 16000,
         use_ssl: bool = True,
-        api_key: str | None = None,
+        api_key: NotGivenOr[str] = NOT_GIVEN,
+        audio_prompt_file: str | PathLike[str] | None = None,
+        quality: int | None = None,
+        word_tokenizer: tokenize.WordTokenizer | tokenize.SentenceTokenizer | None = None,
+        options: dict[str, Any] | None = None,
+        inference_mode: InferenceMode = "online",
     ):
+        if inference_mode not in ("online", "offline"):
+            raise ValueError("inference_mode must be either 'online' or 'offline'")
+
         super().__init__(
             capabilities=tts.TTSCapabilities(streaming=True),
-            sample_rate=16000,
+            sample_rate=sample_rate,
             num_channels=1,
         )
 
-        if api_key:
+        if is_given(api_key):
             self.nvidia_api_key = api_key
         else:
             self.nvidia_api_key = os.getenv("NVIDIA_API_KEY")
             if use_ssl and not self.nvidia_api_key:
                 raise ValueError(
-                    "NVIDIA_API_KEY is not set while using SSL. Either pass api_key parameter, set NVIDIA_API_KEY environment variable "
-                    + "or disable SSL and use a locally hosted Riva NIM service."
+                    "NVIDIA_API_KEY is not set while using SSL. Either pass api_key parameter, "
+                    "set NVIDIA_API_KEY environment variable or disable SSL and use a locally "
+                    "hosted NVIDIA Speech service."
                 )
 
         self._opts = TTSOptions(
             voice=voice,
             function_id=function_id,
             server=server,
-            sample_rate=16000,
+            sample_rate=sample_rate,
             use_ssl=use_ssl,
             language_code=language_code,
-            word_tokenizer=tokenize.blingfire.SentenceTokenizer(),
+            word_tokenizer=word_tokenizer or tokenize.blingfire.SentenceTokenizer(),
+            audio_prompt_file=audio_prompt_file,
+            quality=quality,
+            options=dict(options or {}),
+            inference_mode=inference_mode,
         )
-        self._tts_service = None
+        self._tts_service: riva.client.SpeechSynthesisService | None = None
+
+    @property
+    def provider(self) -> str:
+        return "NVIDIA Speech"
 
     def _ensure_session(self) -> riva.client.SpeechSynthesisService:
         if not self._tts_service:
@@ -81,6 +120,56 @@ class TTS(tts.TTS):
             self._tts_service = riva.client.SpeechSynthesisService(riva_auth)
         return self._tts_service
 
+    def _synthesize(self, text: str, opts: TTSOptions):
+        service = self._ensure_session()
+        synthesize_method = (
+            service.synthesize_online if opts.inference_mode == "online" else service.synthesize
+        )
+        parameters = inspect.signature(synthesize_method).parameters
+        kwargs = dict(opts.options)
+        kwargs.update(
+            {
+                "sample_rate_hz": opts.sample_rate,
+                "encoding": AudioEncoding.LINEAR_PCM,
+            }
+        )
+        if opts.audio_prompt_file is not None:
+            _set_compatible_option(
+                kwargs,
+                parameters=parameters,
+                names=("zero_shot_audio_prompt_file", "audio_prompt_file"),
+                value=Path(opts.audio_prompt_file),
+                option_name="audio_prompt_file",
+            )
+        if opts.quality is not None:
+            _set_compatible_option(
+                kwargs,
+                parameters=parameters,
+                names=("zero_shot_quality", "quality"),
+                value=opts.quality,
+                option_name="quality",
+            )
+        if opts.inference_mode == "offline":
+            kwargs["future"] = False
+
+        if not any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values()):
+            unsupported = kwargs.keys() - parameters.keys()
+            if unsupported:
+                names = ", ".join(sorted(unsupported))
+                raise ValueError(
+                    f"The installed nvidia-riva-client does not support TTS option(s): {names}"
+                )
+
+        response = synthesize_method(
+            text.lstrip("\n").strip(),
+            opts.voice,
+            opts.language_code,
+            **kwargs,
+        )
+        if opts.inference_mode == "online":
+            return response
+        return iter((response,))
+
     def list_voices(self) -> dict:
         service = self._ensure_session()
         config_response = service.stub.GetRivaSynthesisConfig(
@@ -88,7 +177,11 @@ class TTS(tts.TTS):
         )
         tts_models = {}
         for model_config in config_response.model_config:
-            language_code = model_config.parameters.get("language_code", "unknown")
+            language_codes = [
+                code.strip()
+                for code in model_config.parameters.get("language_code", "").split(",")
+                if code.strip()
+            ] or ["unknown"]
             voice_name = model_config.parameters.get("voice_name", "unknown")
             subvoices_str = model_config.parameters.get("subvoices", "")
 
@@ -98,10 +191,11 @@ class TTS(tts.TTS):
             else:
                 full_voice_names = [voice_name]
 
-            if language_code in tts_models:
-                tts_models[language_code]["voices"].extend(full_voice_names)
-            else:
-                tts_models[language_code] = {"voices": full_voice_names}
+            for language_code in language_codes:
+                voices = tts_models.setdefault(language_code, {"voices": []})["voices"]
+                for full_voice_name in full_voice_names:
+                    if full_voice_name not in voices:
+                        voices.append(full_voice_name)
 
         tts_models = dict(sorted(tts_models.items()))
         return tts_models
@@ -109,7 +203,7 @@ class TTS(tts.TTS):
     def synthesize(
         self, text: str, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
     ) -> tts.ChunkedStream:
-        return self._synthesize_with_stream(text, conn_options=conn_options)
+        return ChunkedStream(tts=self, input_text=text, conn_options=conn_options)
 
     def stream(
         self, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
@@ -117,10 +211,56 @@ class TTS(tts.TTS):
         return SynthesizeStream(tts=self, conn_options=conn_options, opts=self._opts)
 
 
+class ChunkedStream(tts.ChunkedStream):
+    def __init__(
+        self,
+        *,
+        tts: TTS,
+        input_text: str,
+        conn_options: APIConnectOptions,
+    ) -> None:
+        super().__init__(tts=tts, input_text=input_text, conn_options=conn_options)
+        self._tts: TTS = tts
+        self._opts = replace(tts._opts)
+
+    async def _run(self, output_emitter: tts.AudioEmitter) -> None:
+        request_id = utils.shortuuid()
+        output_emitter.initialize(
+            request_id=request_id,
+            sample_rate=self._opts.sample_rate,
+            num_channels=1,
+            mime_type="audio/pcm",
+        )
+
+        done_fut: asyncio.Future[None] = asyncio.Future()
+        event_loop = asyncio.get_running_loop()
+
+        def _synthesize_worker() -> None:
+            error: Exception | None = None
+            try:
+                for response in self._tts._synthesize(self._input_text, self._opts):
+                    event_loop.call_soon_threadsafe(output_emitter.push, response.audio)
+            except Exception as e:
+                error = _to_tts_api_error(e, operation="NVIDIA Speech TTS request")
+                logger.exception("Error in NVIDIA chunked synthesis thread")
+            finally:
+                event_loop.call_soon_threadsafe(_complete_future, done_fut, error)
+
+        synthesize_thread = threading.Thread(
+            target=_synthesize_worker,
+            name="nvidia-tts-chunked-synthesize",
+            daemon=True,
+        )
+        synthesize_thread.start()
+        await done_fut
+        output_emitter.flush()
+
+
 class SynthesizeStream(tts.SynthesizeStream):
     def __init__(self, *, tts: TTS, conn_options: APIConnectOptions, opts: TTSOptions):
         super().__init__(tts=tts, conn_options=conn_options)
-        self._opts = opts
+        self._tts: TTS = tts
+        self._opts = replace(opts)
 
     async def _run(self, output_emitter: tts.AudioEmitter) -> None:
         context_id = utils.shortuuid()
@@ -137,46 +277,42 @@ class SynthesizeStream(tts.SynthesizeStream):
         )
         output_emitter.start_segment(segment_id=context_id)
 
-        done_fut = asyncio.Future()
+        done_fut: asyncio.Future[None] = asyncio.Future()
 
         async def _input_task() -> None:
             async for data in self._input_ch:
                 if isinstance(data, self._FlushSentinel):
                     sent_tokenizer_stream.flush()
-                    continue
+                    break
                 sent_tokenizer_stream.push_text(data)
             sent_tokenizer_stream.end_input()
 
         async def _process_segments() -> None:
             async for word_stream in sent_tokenizer_stream:
-                token_q.put(word_stream)
+                token = word_stream.token
+                if not token.strip():
+                    continue
+                self._mark_started()
+                token_q.put(token)
             token_q.put(None)
 
         def _synthesize_worker() -> None:
+            error: Exception | None = None
             try:
-                service = self._tts._ensure_session()
                 while True:
                     token = token_q.get()
 
                     if not token:
                         break
 
-                    try:
-                        responses = service.synthesize_online(
-                            token.token,
-                            self._opts.voice,
-                            self._opts.language_code,
-                            sample_rate_hz=self._opts.sample_rate,
-                            encoding=AudioEncoding.LINEAR_PCM,
-                        )
-                        for response in responses:
-                            event_loop.call_soon_threadsafe(output_emitter.push, response.audio)
+                    for response in self._tts._synthesize(token, self._opts):
+                        event_loop.call_soon_threadsafe(output_emitter.push, response.audio)
 
-                    except Exception as e:
-                        logger.error(f"Error in synthesis: {e}")
-                        continue
+            except Exception as e:
+                error = _to_tts_api_error(e, operation="NVIDIA Speech TTS request")
+                logger.exception("Error in NVIDIA streaming synthesis thread")
             finally:
-                event_loop.call_soon_threadsafe(done_fut.set_result, None)
+                event_loop.call_soon_threadsafe(_complete_future, done_fut, error)
 
         synthesize_thread = threading.Thread(
             target=_synthesize_worker,
@@ -194,6 +330,81 @@ class SynthesizeStream(tts.SynthesizeStream):
             await asyncio.gather(*tasks)
         finally:
             token_q.put(None)
-            await done_fut
-            output_emitter.end_segment()
-            await sent_tokenizer_stream.aclose()
+            try:
+                await done_fut
+            finally:
+                output_emitter.end_segment()
+                await sent_tokenizer_stream.aclose()
+
+
+def _complete_future(fut: asyncio.Future[None], error: Exception | None) -> None:
+    if fut.done():
+        return
+    if error is not None:
+        fut.set_exception(_to_tts_api_error(error, operation="NVIDIA Speech TTS request"))
+    else:
+        fut.set_result(None)
+
+
+def _set_compatible_option(
+    kwargs: dict[str, Any],
+    *,
+    parameters: Mapping[str, inspect.Parameter],
+    names: tuple[str, ...],
+    value: Any,
+    option_name: str,
+) -> None:
+    for name in names:
+        if name in parameters:
+            kwargs[name] = value
+            return
+
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values()):
+        kwargs[names[0]] = value
+        return
+
+    raise ValueError(
+        f"The installed nvidia-riva-client does not support the TTS {option_name} option"
+    )
+
+
+def _to_tts_api_error(error: Exception, *, operation: str) -> APIError:
+    if isinstance(error, APIError):
+        return error
+
+    if isinstance(error, grpc.RpcError):
+        code = error.code()
+        details = error.details() or str(error)
+        if code == grpc.StatusCode.DEADLINE_EXCEEDED:
+            return APITimeoutError(f"{operation} timed out: {details}")
+        if code == grpc.StatusCode.CANCELLED:
+            return APIConnectionError(f"{operation} was cancelled by NVIDIA Speech")
+
+        status_codes = {
+            grpc.StatusCode.INVALID_ARGUMENT: 400,
+            grpc.StatusCode.NOT_FOUND: 404,
+            grpc.StatusCode.PERMISSION_DENIED: 403,
+            grpc.StatusCode.RESOURCE_EXHAUSTED: 429,
+            grpc.StatusCode.FAILED_PRECONDITION: 400,
+            grpc.StatusCode.OUT_OF_RANGE: 400,
+            grpc.StatusCode.UNIMPLEMENTED: 501,
+            grpc.StatusCode.INTERNAL: 500,
+            grpc.StatusCode.UNAVAILABLE: 503,
+            grpc.StatusCode.UNAUTHENTICATED: 401,
+        }
+        return APIStatusError(
+            f"{operation} failed: {details}",
+            status_code=status_codes.get(code, -1),
+            retryable=code
+            in {
+                grpc.StatusCode.UNKNOWN,
+                grpc.StatusCode.RESOURCE_EXHAUSTED,
+                grpc.StatusCode.INTERNAL,
+                grpc.StatusCode.UNAVAILABLE,
+            },
+        )
+
+    if isinstance(error, (TypeError, ValueError)):
+        return APIStatusError(f"{operation} failed: {error}", status_code=400, retryable=False)
+
+    return APIConnectionError(f"{operation} failed: {error}")

--- a/livekit-plugins/livekit-plugins-nvidia/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-nvidia/pyproject.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -22,8 +25,9 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
+    "grpcio>=1.51.1",
     "livekit-agents>=1.6.9",
-    "nvidia-riva-client",
+    "nvidia-riva-client>=2.16,<2.27",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_plugin_nvidia.py
+++ b/tests/test_plugin_nvidia.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import inspect
+import queue
 import threading
 from pathlib import Path
 from types import SimpleNamespace
@@ -352,6 +353,78 @@ async def test_stt_replays_segment_after_retryable_backend_failure(
 
     expected_audio = [_audio_frame(3).data.tobytes()]
     assert calls == [expected_audio, expected_audio]
+    await stream.aclose()
+
+
+async def test_stt_retry_buffer_is_bounded_and_resets_after_final() -> None:
+    attempt = nvidia_stt._RecognitionAttempt(
+        audio_queue=queue.Queue(),
+        done_fut=asyncio.get_running_loop().create_future(),
+    )
+
+    attempt.buffer_for_replay(b"1234", max_bytes=5)
+    assert attempt.replay_snapshot() == ([b"1234"], False)
+
+    attempt.buffer_for_replay(b"67", max_bytes=5)
+    assert attempt.replay_snapshot() == (None, False)
+    assert attempt.replay_audio_bytes == 0
+
+    attempt.buffer_for_replay(b"ignored", max_bytes=5)
+    assert attempt.replay_snapshot() == (None, False)
+
+    attempt.mark_final_transcript()
+    assert attempt.replay_snapshot() == ([], True)
+
+    attempt.buffer_for_replay(b"89", max_bytes=5)
+    assert attempt.replay_snapshot() == ([b"89"], False)
+
+
+async def test_stt_stream_bounds_replay_without_flush(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = nvidia_stt.STT(api_key="test-key")
+    consumed = 0
+    audio_consumed = threading.Event()
+    attempts: list[nvidia_stt._RecognitionAttempt] = []
+
+    class DrainingASRService:
+        def streaming_response_generator(self, audio_generator, config):
+            nonlocal consumed
+            for _ in audio_generator:
+                consumed += 1
+                if consumed == 101:
+                    audio_consumed.set()
+            return iter(())
+
+    original_start_attempt = nvidia_stt.SpeechStream._start_recognition_attempt
+
+    def capture_attempt(self, config, event_loop):
+        attempt = original_start_attempt(self, config, event_loop)
+        attempts.append(attempt)
+        return attempt
+
+    monkeypatch.setattr(service, "_ensure_asr_service", lambda: DrainingASRService())
+    monkeypatch.setattr(
+        nvidia_stt.SpeechStream,
+        "_create_streaming_config",
+        lambda self: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        nvidia_stt.SpeechStream,
+        "_start_recognition_attempt",
+        capture_attempt,
+    )
+    monkeypatch.setattr(nvidia_stt, "_MAX_REPLAY_AUDIO_SECONDS", 1)
+
+    stream = service.stream()
+    for _ in range(101):
+        stream.push_frame(_audio_frame())
+
+    assert await asyncio.to_thread(audio_consumed.wait, 1.0)
+    assert attempts[0].replay_snapshot() == (None, False)
+
+    stream.end_input()
+    await asyncio.wait_for(stream._task, timeout=2.0)
     await stream.aclose()
 
 

--- a/tests/test_plugin_nvidia.py
+++ b/tests/test_plugin_nvidia.py
@@ -356,6 +356,105 @@ async def test_stt_replays_segment_after_retryable_backend_failure(
     await stream.aclose()
 
 
+@pytest.mark.parametrize("termination", ["error", "normal"])
+async def test_stt_restarts_completed_worker_without_flush(
+    monkeypatch: pytest.MonkeyPatch,
+    termination: str,
+) -> None:
+    service = nvidia_stt.STT(api_key="test-key")
+    calls: list[list[bytes]] = []
+    first_attempt_finished = threading.Event()
+    restarted = threading.Event()
+    final_response = SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                is_final=True,
+                alternatives=[SimpleNamespace(transcript="reconnected", confidence=0.9, words=[])],
+            )
+        ]
+    )
+
+    class RestartingASRService:
+        def streaming_response_generator(self, audio_generator, config):
+            call_audio: list[bytes] = []
+            calls.append(call_audio)
+            call_number = len(calls)
+
+            def responses():
+                call_audio.append(next(audio_generator))
+                if call_number == 1:
+                    first_attempt_finished.set()
+                    if termination == "error":
+                        raise APIConnectionError("connection dropped")
+                    return
+
+                restarted.set()
+                yield final_response
+                call_audio.extend(audio_generator)
+
+            return responses()
+
+    monkeypatch.setattr(service, "_ensure_asr_service", lambda: RestartingASRService())
+    monkeypatch.setattr(
+        nvidia_stt.SpeechStream,
+        "_create_streaming_config",
+        lambda self: SimpleNamespace(),
+    )
+
+    stream = service.stream(conn_options=APIConnectOptions(max_retry=1, retry_interval=0))
+    first_frame = _audio_frame(3)
+    second_frame = _audio_frame(4)
+    stream.push_frame(first_frame)
+
+    assert await asyncio.to_thread(first_attempt_finished.wait, 1.0)
+    assert await asyncio.to_thread(restarted.wait, 1.0)
+
+    stream.push_frame(second_frame)
+    stream.end_input()
+    await asyncio.wait_for(stream._task, timeout=2.0)
+    events = [event async for event in stream]
+
+    assert calls == [
+        [first_frame.data.tobytes()],
+        [first_frame.data.tobytes(), second_frame.data.tobytes()],
+    ]
+    assert any(
+        event.type == nvidia_stt.stt.SpeechEventType.FINAL_TRANSCRIPT
+        and event.alternatives[0].text == "reconnected"
+        for event in events
+    )
+    await stream.aclose()
+
+
+async def test_stt_surfaces_midstream_retry_exhaustion_without_flush(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = nvidia_stt.STT(api_key="test-key")
+    calls: list[list[bytes]] = []
+
+    class FailingASRService:
+        def streaming_response_generator(self, audio_generator, config):
+            calls.append([next(audio_generator)])
+            raise APIConnectionError("connection dropped")
+
+    monkeypatch.setattr(service, "_ensure_asr_service", lambda: FailingASRService())
+    monkeypatch.setattr(
+        nvidia_stt.SpeechStream,
+        "_create_streaming_config",
+        lambda self: SimpleNamespace(),
+    )
+
+    stream = service.stream(conn_options=APIConnectOptions(max_retry=1, retry_interval=0))
+    frame = _audio_frame(3)
+    stream.push_frame(frame)
+
+    with pytest.raises(APIConnectionError, match="failed after 2 attempts"):
+        await asyncio.wait_for(stream._task, timeout=2.0)
+
+    assert calls == [[frame.data.tobytes()], [frame.data.tobytes()]]
+    await stream.aclose()
+
+
 async def test_stt_retry_buffer_is_bounded_and_resets_after_final() -> None:
     attempt = nvidia_stt._RecognitionAttempt(
         audio_queue=queue.Queue(),

--- a/tests/test_plugin_nvidia.py
+++ b/tests/test_plugin_nvidia.py
@@ -1,0 +1,748 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import inspect
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from livekit import rtc
+from livekit.agents import APIConnectionError, APIStatusError, LanguageCode
+from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, APIConnectOptions
+from livekit.plugins.nvidia import stt as nvidia_stt, tts as nvidia_tts
+
+pytestmark = pytest.mark.unit
+
+
+def _audio_frame(byte: int = 1) -> rtc.AudioFrame:
+    return rtc.AudioFrame(
+        data=bytes([byte, byte]) * 160,
+        sample_rate=16000,
+        num_channels=1,
+        samples_per_channel=160,
+    )
+
+
+@pytest.mark.parametrize("method_name", ["synthesize", "synthesize_online"])
+def test_installed_nvidia_speech_client_has_supported_tts_signature(
+    method_name: str,
+) -> None:
+    method = getattr(nvidia_tts.riva.client.SpeechSynthesisService, method_name)
+    parameters = inspect.signature(method).parameters
+
+    legacy_options = {"audio_prompt_file", "quality"}
+    current_options = {"zero_shot_audio_prompt_file", "zero_shot_quality"}
+    assert legacy_options <= parameters.keys() or current_options <= parameters.keys()
+
+
+def test_stt_reports_capabilities_for_selected_inference_mode() -> None:
+    automatic = nvidia_stt.STT(api_key="test-key")
+    streaming = nvidia_stt.STT(api_key="test-key", inference_mode="streaming")
+    offline = nvidia_stt.STT(api_key="test-key", inference_mode="offline")
+
+    assert automatic.capabilities.streaming is True
+    assert automatic.capabilities.offline_recognize is True
+    assert streaming.capabilities.streaming is True
+    assert streaming.capabilities.offline_recognize is False
+    assert streaming.capabilities.interim_results is True
+    assert offline.capabilities.streaming is False
+    assert offline.capabilities.offline_recognize is True
+    assert offline.capabilities.interim_results is False
+
+    with pytest.raises(ValueError, match="inference_mode='streaming'"):
+        offline.stream()
+
+
+async def test_streaming_stt_rejects_offline_recognize() -> None:
+    service = nvidia_stt.STT(api_key="test-key", inference_mode="streaming")
+
+    with pytest.raises(ValueError, match="inference_mode='offline'"):
+        await service.recognize([_audio_frame()])
+
+
+async def test_stt_auto_mode_preserves_offline_recognition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = nvidia_stt.STT(api_key="test-key")
+    response = SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                alternatives=[SimpleNamespace(transcript="hello", confidence=0.9, words=[])]
+            )
+        ]
+    )
+    fake_service = SimpleNamespace(offline_recognize=lambda audio, config: response)
+    monkeypatch.setattr(service, "_ensure_asr_service", lambda: fake_service)
+
+    event = await service.recognize([_audio_frame()], conn_options=APIConnectOptions(max_retry=0))
+
+    assert event.alternatives[0].text == "hello"
+
+
+def test_stt_builds_nvidia_speech_recognition_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+
+    def recognition_config(**kwargs):
+        captured["recognition"] = kwargs
+        return SimpleNamespace(
+            diarization_config=SimpleNamespace(
+                CopyFrom=lambda config: captured.setdefault("diarization", config)
+            )
+        )
+
+    monkeypatch.setattr(nvidia_stt.riva.client, "RecognitionConfig", recognition_config)
+    monkeypatch.setattr(
+        nvidia_stt.riva.client,
+        "add_word_boosting_to_config",
+        lambda config, words, score: captured.setdefault("word_boosting", (words, score)),
+    )
+
+    service = nvidia_stt.STT(
+        api_key="test-key",
+        model="parakeet-sortformer",
+        enable_diarization=True,
+        max_speaker_count=2,
+        profanity_filter=True,
+        verbatim_transcripts=True,
+        boosted_lm_words=["LiveKit"],
+        boosted_lm_score=7.0,
+    )
+
+    assert service.provider == "NVIDIA Speech"
+
+    service._create_recognition_config(
+        language=LanguageCode("en-US"),
+        sample_rate=48000,
+        audio_channel_count=2,
+    )
+
+    assert captured["recognition"]["model"] == "parakeet-sortformer"
+    assert captured["recognition"]["max_alternatives"] == 1
+    assert captured["recognition"]["profanity_filter"] is True
+    assert captured["recognition"]["verbatim_transcripts"] is True
+    assert captured["recognition"]["sample_rate_hertz"] == 48000
+    assert captured["recognition"]["audio_channel_count"] == 2
+    assert captured["word_boosting"] == (["LiveKit"], 7.0)
+    assert captured["diarization"].enable_speaker_diarization is True
+    assert captured["diarization"].max_speaker_count == 2
+
+
+def test_stt_applies_streaming_endpointing_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+    streaming_config = SimpleNamespace()
+
+    monkeypatch.setattr(
+        nvidia_stt.riva.client,
+        "add_endpoint_parameters_to_config",
+        lambda config, *args: captured.setdefault("endpointing", (config, args)),
+    )
+    monkeypatch.setattr(
+        nvidia_stt.riva.client,
+        "add_custom_configuration_to_config",
+        lambda config, custom: captured.setdefault("custom", (config, custom)),
+        raising=False,
+    )
+
+    service = nvidia_stt.STT(
+        api_key="test-key",
+        endpointing=nvidia_stt.EndpointingConfig(
+            start_history=11,
+            start_threshold=0.35,
+            stop_history=21,
+            stop_history_eou=31,
+            stop_threshold=0.45,
+            stop_threshold_eou=0.55,
+        ),
+        options={"custom_configuration": "enable_vad_endpointing:true"},
+    )
+
+    service._apply_streaming_config_extensions(streaming_config)
+
+    assert captured["endpointing"] == (
+        streaming_config,
+        (11, 0.35, 21, 31, 0.45, 0.55),
+    )
+    assert captured["custom"] == (streaming_config, "enable_vad_endpointing:true")
+
+
+def test_stt_rejects_unsupported_custom_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delattr(
+        nvidia_stt.riva.client,
+        "add_custom_configuration_to_config",
+        raising=False,
+    )
+    service = nvidia_stt.STT(
+        api_key="test-key",
+        options={"custom_configuration": "enable_vad_endpointing:true"},
+    )
+
+    with pytest.raises(ValueError, match="custom_configuration"):
+        service._apply_streaming_config_extensions(SimpleNamespace())
+
+
+def test_stt_endpointing_low_latency_preset() -> None:
+    assert nvidia_stt._endpointing_values(nvidia_stt.EndpointingConfig()) == (
+        -1,
+        -1.0,
+        500,
+        240,
+        -1.0,
+        -1.0,
+    )
+
+
+def test_stt_normalizes_word_timestamps_and_speaker_id() -> None:
+    words = [
+        SimpleNamespace(word="hello", start_time=1000, end_time=1250, speaker_tag=1),
+        SimpleNamespace(word="world", start_time=1.25, end_time=1.75, speaker_tag=1),
+    ]
+    alternative = SimpleNamespace(transcript="hello world", confidence=0.9, words=words)
+
+    speech_data = nvidia_stt._convert_to_speech_data(
+        alternative,
+        language=LanguageCode("en-US"),
+        start_time_offset=0.5,
+        enable_diarization=True,
+        is_final=True,
+    )
+
+    assert speech_data.start_time == 1.5
+    assert speech_data.end_time == 2.25
+    assert speech_data.words is not None
+    assert speech_data.words[0].start_time == 1.5
+    assert speech_data.words[0].end_time == 1.75
+    assert speech_data.words[1].start_time == 1.75
+    assert speech_data.words[1].end_time == 2.25
+    assert speech_data.speaker_id == "S1"
+
+
+def test_stt_normalizes_protobuf_duration_timestamps() -> None:
+    value = SimpleNamespace(seconds=2, nanos=500_000_000)
+
+    assert nvidia_stt._time_offset_seconds(value) == 2.5
+
+
+def test_stt_offline_combines_consecutive_results_into_complete_hypotheses() -> None:
+    def word(text: str, start: int, end: int, speaker_tag: int) -> SimpleNamespace:
+        return SimpleNamespace(
+            word=text,
+            start_time=start,
+            end_time=end,
+            speaker_tag=speaker_tag,
+        )
+
+    response = SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                alternatives=[
+                    SimpleNamespace(
+                        transcript="hello",
+                        confidence=0.8,
+                        words=[word("hello", 0, 500, 1)],
+                    ),
+                    SimpleNamespace(
+                        transcript="yellow",
+                        confidence=0.4,
+                        words=[word("yellow", 0, 500, 2)],
+                    ),
+                ]
+            ),
+            SimpleNamespace(
+                alternatives=[
+                    SimpleNamespace(
+                        transcript="world",
+                        confidence=0.9,
+                        words=[word("world", 500, 1000, 1)],
+                    ),
+                    SimpleNamespace(
+                        transcript="word",
+                        confidence=0.6,
+                        words=[word("word", 500, 1000, 2)],
+                    ),
+                ]
+            ),
+        ]
+    )
+
+    event = nvidia_stt._response_to_speech_event(
+        response,
+        language=LanguageCode("en-US"),
+        request_id="request-id",
+        event_type=nvidia_stt.stt.SpeechEventType.FINAL_TRANSCRIPT,
+        enable_diarization=True,
+        is_final=True,
+    )
+
+    assert len(event.alternatives) == 2
+    assert event.alternatives[0].text == "hello world"
+    assert event.alternatives[0].confidence == pytest.approx(0.85)
+    assert event.alternatives[0].speaker_id == "S1"
+    assert event.alternatives[0].words is not None
+    assert event.alternatives[0].words[-1].end_time == 1.0
+    assert event.alternatives[1].text == "yellow word"
+
+
+async def test_stt_flush_starts_a_new_backend_rpc_for_each_segment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = nvidia_stt.STT(api_key="test-key")
+    calls: list[list[bytes]] = []
+
+    class FakeASRService:
+        def streaming_response_generator(self, audio_generator, config):
+            calls.append(list(audio_generator))
+            return iter(())
+
+    monkeypatch.setattr(service, "_ensure_asr_service", lambda: FakeASRService())
+    monkeypatch.setattr(
+        nvidia_stt.SpeechStream,
+        "_create_streaming_config",
+        lambda self: SimpleNamespace(),
+    )
+
+    stream = service.stream()
+    stream.push_frame(_audio_frame(1))
+    stream.flush()
+    stream.push_frame(_audio_frame(2))
+    stream.flush()
+    stream.end_input()
+
+    await asyncio.wait_for(stream._task, timeout=2.0)
+
+    assert calls == [
+        [_audio_frame(1).data.tobytes()],
+        [_audio_frame(2).data.tobytes()],
+    ]
+    await stream.aclose()
+
+
+async def test_stt_replays_segment_after_retryable_backend_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = nvidia_stt.STT(api_key="test-key")
+    calls: list[list[bytes]] = []
+
+    class FakeASRService:
+        def streaming_response_generator(self, audio_generator, config):
+            calls.append(list(audio_generator))
+            if len(calls) == 1:
+                raise APIConnectionError("temporary failure")
+            return iter(())
+
+    monkeypatch.setattr(service, "_ensure_asr_service", lambda: FakeASRService())
+    monkeypatch.setattr(
+        nvidia_stt.SpeechStream,
+        "_create_streaming_config",
+        lambda self: SimpleNamespace(),
+    )
+
+    stream = service.stream(conn_options=APIConnectOptions(max_retry=1, retry_interval=0))
+    stream.push_frame(_audio_frame(3))
+    stream.end_input()
+
+    await asyncio.wait_for(stream._task, timeout=2.0)
+
+    expected_audio = [_audio_frame(3).data.tobytes()]
+    assert calls == [expected_audio, expected_audio]
+    await stream.aclose()
+
+
+async def test_stt_retry_exhaustion_does_not_trigger_audio_losing_outer_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = nvidia_stt.STT(api_key="test-key")
+    calls: list[list[bytes]] = []
+
+    class FailingASRService:
+        def streaming_response_generator(self, audio_generator, config):
+            calls.append(list(audio_generator))
+            raise APIConnectionError("temporary failure")
+
+    monkeypatch.setattr(service, "_ensure_asr_service", lambda: FailingASRService())
+    monkeypatch.setattr(
+        nvidia_stt.SpeechStream,
+        "_create_streaming_config",
+        lambda self: SimpleNamespace(),
+    )
+
+    stream = service.stream(conn_options=APIConnectOptions(max_retry=1, retry_interval=0))
+    stream.push_frame(_audio_frame(4))
+    stream.end_input()
+
+    with pytest.raises(APIConnectionError, match="failed after 2 attempts"):
+        await asyncio.wait_for(stream._task, timeout=2.0)
+
+    expected_audio = [_audio_frame(4).data.tobytes()]
+    assert calls == [expected_audio, expected_audio]
+    await stream.aclose()
+
+
+async def test_stt_closes_speech_segment_when_backend_has_no_final_transcript(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = nvidia_stt.STT(api_key="test-key")
+    interim_response = SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                is_final=False,
+                alternatives=[SimpleNamespace(transcript="hello", confidence=0.5, words=[])],
+            )
+        ]
+    )
+
+    class InterimOnlyASRService:
+        def streaming_response_generator(self, audio_generator, config):
+            list(audio_generator)
+            return iter((interim_response,))
+
+    monkeypatch.setattr(service, "_ensure_asr_service", lambda: InterimOnlyASRService())
+    monkeypatch.setattr(
+        nvidia_stt.SpeechStream,
+        "_create_streaming_config",
+        lambda self: SimpleNamespace(),
+    )
+
+    stream = service.stream(conn_options=APIConnectOptions(max_retry=0))
+    stream.push_frame(_audio_frame(5))
+    stream.end_input()
+
+    await asyncio.wait_for(stream._task, timeout=2.0)
+    events = [event async for event in stream]
+
+    assert [event.type for event in events] == [
+        nvidia_stt.stt.SpeechEventType.START_OF_SPEECH,
+        nvidia_stt.stt.SpeechEventType.INTERIM_TRANSCRIPT,
+        nvidia_stt.stt.SpeechEventType.END_OF_SPEECH,
+    ]
+    await stream.aclose()
+
+
+async def test_stt_cancellation_closes_backend_audio_generator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = nvidia_stt.STT(api_key="test-key")
+    started = threading.Event()
+    finished = threading.Event()
+
+    class BlockingASRService:
+        def streaming_response_generator(self, audio_generator, config):
+            started.set()
+            list(audio_generator)
+            finished.set()
+            return iter(())
+
+    monkeypatch.setattr(service, "_ensure_asr_service", lambda: BlockingASRService())
+    monkeypatch.setattr(
+        nvidia_stt.SpeechStream,
+        "_create_streaming_config",
+        lambda self: SimpleNamespace(),
+    )
+
+    stream = service.stream()
+    stream.push_frame(_audio_frame(6))
+    assert await asyncio.to_thread(started.wait, 1.0)
+
+    await asyncio.wait_for(stream.aclose(), timeout=2.0)
+
+    assert await asyncio.to_thread(finished.wait, 1.0)
+
+
+def test_stt_model_listing_uses_proto_request_and_inference_mode() -> None:
+    request: object | None = None
+
+    class FakeStub:
+        def GetRivaSpeechRecognitionConfig(self, value):
+            nonlocal request
+            request = value
+            return SimpleNamespace(
+                model_config=[
+                    SimpleNamespace(
+                        model_name="streaming-model",
+                        parameters={"type": "online", "language_code": "en-US"},
+                    ),
+                    SimpleNamespace(
+                        model_name="offline-model",
+                        parameters={"type": "offline", "language_code": "en-US"},
+                    ),
+                ]
+            )
+
+    service = nvidia_stt.STT(api_key="test-key", inference_mode="offline")
+    models = service.log_asr_models(SimpleNamespace(stub=FakeStub()))
+
+    assert isinstance(request, nvidia_stt.RivaSpeechRecognitionConfigRequest)
+    assert models == {"en-US": [{"model": ["offline-model"]}]}
+
+    automatic = nvidia_stt.STT(api_key="test-key")
+    assert automatic.log_asr_models(SimpleNamespace(stub=FakeStub())) == {
+        "en-US": [
+            {"model": ["streaming-model"]},
+            {"model": ["offline-model"]},
+        ]
+    }
+
+
+async def test_stt_stream_emits_transcript_events_from_nvidia_speech_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = nvidia_stt.STT(api_key="test-key")
+    monkeypatch.setattr(service, "_ensure_asr_service", lambda: SimpleNamespace())
+
+    def fake_create_task(coro, *args, **kwargs):
+        coro.close()
+        return MagicMock()
+
+    with patch("livekit.agents.stt.stt.asyncio.create_task", side_effect=fake_create_task):
+        stream = nvidia_stt.SpeechStream(
+            stt=service,
+            conn_options=DEFAULT_API_CONNECT_OPTIONS,
+            language="en-US",
+        )
+
+    response = SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                is_final=True,
+                alternatives=[SimpleNamespace(transcript="hello world", confidence=0.9)],
+            )
+        ]
+    )
+
+    stream._handle_response(response, event_loop=asyncio.get_running_loop())
+    await asyncio.sleep(0)
+
+    assert stream._event_ch.recv_nowait().type == nvidia_stt.stt.SpeechEventType.START_OF_SPEECH
+    transcript_event = stream._event_ch.recv_nowait()
+    assert transcript_event.type == nvidia_stt.stt.SpeechEventType.FINAL_TRANSCRIPT
+    assert transcript_event.alternatives[0].text == "hello world"
+    assert stream._event_ch.recv_nowait().type == nvidia_stt.stt.SpeechEventType.END_OF_SPEECH
+
+
+def test_tts_passes_locked_nvidia_speech_synthesize_online_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+    service = nvidia_tts.TTS(
+        api_key="test-key",
+        sample_rate=22050,
+        audio_prompt_file="prompt.wav",
+        quality=30,
+        options={"encoding": 999},
+    )
+
+    assert service.provider == "NVIDIA Speech"
+
+    class FakeSynthesisService:
+        def synthesize_online(
+            self,
+            text,
+            voice_name=None,
+            language_code="en-US",
+            encoding=nvidia_tts.AudioEncoding.LINEAR_PCM,
+            sample_rate_hz=44100,
+            audio_prompt_file=None,
+            audio_prompt_encoding=nvidia_tts.AudioEncoding.LINEAR_PCM,
+            quality=20,
+        ):
+            captured["text"] = text
+            captured["voice_name"] = voice_name
+            captured["language_code"] = language_code
+            captured["encoding"] = encoding
+            captured["sample_rate_hz"] = sample_rate_hz
+            captured["audio_prompt_file"] = audio_prompt_file
+            captured["audio_prompt_encoding"] = audio_prompt_encoding
+            captured["quality"] = quality
+            return [SimpleNamespace(audio=b"abc")]
+
+    monkeypatch.setattr(service, "_ensure_session", lambda: FakeSynthesisService())
+
+    responses = list(service._synthesize(" hello ", service._opts))
+
+    assert responses[0].audio == b"abc"
+    assert captured["text"] == "hello"
+    assert captured["voice_name"] == "Magpie-Multilingual.EN-US.Leo"
+    assert captured["language_code"] == "en-US"
+    assert captured["sample_rate_hz"] == 22050
+    assert captured["encoding"] == nvidia_tts.AudioEncoding.LINEAR_PCM
+    assert captured["audio_prompt_file"] == Path("prompt.wav")
+    assert captured["quality"] == 30
+
+
+def test_tts_translates_zero_shot_options_for_new_nvidia_speech_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+    service = nvidia_tts.TTS(
+        api_key="test-key",
+        audio_prompt_file="prompt.wav",
+        quality=30,
+        options={"custom_dictionary": {"LiveKit": "live kit"}},
+    )
+
+    class FakeSynthesisService:
+        def synthesize_online(
+            self,
+            text,
+            voice_name=None,
+            language_code="en-US",
+            encoding=nvidia_tts.AudioEncoding.LINEAR_PCM,
+            sample_rate_hz=44100,
+            zero_shot_audio_prompt_file=None,
+            zero_shot_quality=20,
+            custom_dictionary=None,
+            custom_configuration=None,
+        ):
+            captured.update(locals())
+            return [SimpleNamespace(audio=b"abc")]
+
+    monkeypatch.setattr(service, "_ensure_session", lambda: FakeSynthesisService())
+
+    list(service._synthesize("hello", service._opts))
+
+    assert captured["zero_shot_audio_prompt_file"] == Path("prompt.wav")
+    assert captured["zero_shot_quality"] == 30
+    assert captured["custom_dictionary"] == {"LiveKit": "live kit"}
+
+
+def test_tts_rejects_options_unsupported_by_installed_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = nvidia_tts.TTS(
+        api_key="test-key",
+        options={"custom_dictionary": {"LiveKit": "live kit"}},
+    )
+
+    class LegacySynthesisService:
+        def synthesize_online(
+            self,
+            text,
+            voice_name=None,
+            language_code="en-US",
+            encoding=nvidia_tts.AudioEncoding.LINEAR_PCM,
+            sample_rate_hz=44100,
+        ):
+            return []
+
+    monkeypatch.setattr(service, "_ensure_session", lambda: LegacySynthesisService())
+
+    with pytest.raises(ValueError, match="custom_dictionary"):
+        service._synthesize("hello", service._opts)
+
+
+def test_tts_uses_offline_rpc_for_batch_models(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+    service = nvidia_tts.TTS(
+        api_key="test-key",
+        inference_mode="offline",
+        audio_prompt_file="prompt.wav",
+        quality=30,
+        options={"custom_configuration": {"pace": "fast"}},
+    )
+
+    class FakeSynthesisService:
+        def synthesize(
+            self,
+            text,
+            voice_name=None,
+            language_code="en-US",
+            encoding=nvidia_tts.AudioEncoding.LINEAR_PCM,
+            sample_rate_hz=22050,
+            zero_shot_audio_prompt_file=None,
+            zero_shot_quality=20,
+            future=False,
+            custom_configuration=None,
+        ):
+            captured.update(locals())
+            return SimpleNamespace(audio=b"offline-audio")
+
+    monkeypatch.setattr(service, "_ensure_session", lambda: FakeSynthesisService())
+
+    responses = list(service._synthesize("hello", service._opts))
+
+    assert responses[0].audio == b"offline-audio"
+    assert captured["zero_shot_audio_prompt_file"] == Path("prompt.wav")
+    assert captured["zero_shot_quality"] == 30
+    assert captured["future"] is False
+    assert captured["custom_configuration"] == {"pace": "fast"}
+
+
+def test_tts_list_voices_splits_locales_and_deduplicates_voices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = nvidia_tts.TTS(api_key="test-key")
+    model_config = SimpleNamespace(
+        parameters={
+            "language_code": "en-US, fr-FR, en-US",
+            "voice_name": "Magpie-Multilingual",
+            "subvoices": "Leo:Male,Sofia:Female",
+        }
+    )
+    fake_service = SimpleNamespace(
+        stub=SimpleNamespace(
+            GetRivaSynthesisConfig=lambda request: SimpleNamespace(model_config=[model_config])
+        )
+    )
+    monkeypatch.setattr(service, "_ensure_session", lambda: fake_service)
+
+    assert service.list_voices() == {
+        "en-US": {"voices": ["Magpie-Multilingual.Leo", "Magpie-Multilingual.Sofia"]},
+        "fr-FR": {"voices": ["Magpie-Multilingual.Leo", "Magpie-Multilingual.Sofia"]},
+    }
+
+
+async def test_tts_stream_finishes_on_first_flush(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = nvidia_tts.TTS(api_key="test-key")
+
+    class FakeSynthesisService:
+        def synthesize_online(
+            self,
+            text,
+            voice_name=None,
+            language_code="en-US",
+            encoding=nvidia_tts.AudioEncoding.LINEAR_PCM,
+            sample_rate_hz=44100,
+        ):
+            return [SimpleNamespace(audio=b"\0\0" * 160)]
+
+    monkeypatch.setattr(service, "_ensure_session", lambda: FakeSynthesisService())
+
+    stream = service.stream()
+    stream.push_text("Hello world.")
+    stream.flush()
+
+    await asyncio.wait_for(stream._task, timeout=2.0)
+    await stream.aclose()
+
+
+def test_nvidia_invalid_argument_is_non_retryable() -> None:
+    error = TypeError("unexpected keyword argument")
+
+    mapped = nvidia_tts._to_tts_api_error(error, operation="NVIDIA Speech TTS request")
+
+    assert isinstance(mapped, APIStatusError)
+    assert mapped.status_code == 400
+    assert mapped.retryable is False
+
+
+def test_nvidia_provider_cancellation_is_not_graceful_499() -> None:
+    class CancelledRpcError(nvidia_tts.grpc.RpcError):
+        def code(self):
+            return nvidia_tts.grpc.StatusCode.CANCELLED
+
+        def details(self):
+            return "provider cancelled"
+
+    mapped = nvidia_tts._to_tts_api_error(
+        CancelledRpcError(), operation="NVIDIA Speech TTS request"
+    )
+
+    assert isinstance(mapped, APIConnectionError)
+    assert mapped.retryable is True

--- a/tests/test_plugin_nvidia.py
+++ b/tests/test_plugin_nvidia.py
@@ -756,3 +756,18 @@ def test_nvidia_provider_cancellation_is_not_graceful_499() -> None:
 
     assert isinstance(mapped, APIConnectionError)
     assert mapped.retryable is True
+
+
+def test_nvidia_aborted_stt_request_remains_retryable() -> None:
+    class AbortedRpcError(nvidia_stt.grpc.RpcError):
+        def code(self):
+            return nvidia_stt.grpc.StatusCode.ABORTED
+
+        def details(self):
+            return "provider aborted request"
+
+    mapped = nvidia_stt._to_stt_api_error(AbortedRpcError(), operation="NVIDIA Speech STT request")
+
+    assert isinstance(mapped, APIStatusError)
+    assert mapped.status_code == 503
+    assert mapped.retryable is True

--- a/tests/test_plugin_nvidia.py
+++ b/tests/test_plugin_nvidia.py
@@ -291,6 +291,22 @@ def test_stt_offline_combines_consecutive_results_into_complete_hypotheses() -> 
     assert event.alternatives[1].text == "yellow word"
 
 
+def test_stt_combined_confidence_includes_zero_values() -> None:
+    speech_data = nvidia_stt._combine_result_alternatives(
+        [
+            SimpleNamespace(transcript="low", confidence=0.0, words=[]),
+            SimpleNamespace(transcript="high", confidence=0.9, words=[]),
+        ],
+        language=LanguageCode("en-US"),
+        start_time_offset=0.0,
+        enable_diarization=False,
+        is_final=True,
+    )
+
+    assert speech_data.text == "low high"
+    assert speech_data.confidence == pytest.approx(0.45)
+
+
 async def test_stt_flush_starts_a_new_backend_rpc_for_each_segment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -421,6 +437,61 @@ async def test_stt_restarts_completed_worker_without_flush(
     assert any(
         event.type == nvidia_stt.stt.SpeechEventType.FINAL_TRANSCRIPT
         and event.alternatives[0].text == "reconnected"
+        for event in events
+    )
+    await stream.aclose()
+
+
+async def test_stt_clean_completion_does_not_consume_retry_budget_or_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = nvidia_stt.STT(api_key="test-key")
+    calls: list[list[bytes]] = []
+    final_response = SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                is_final=True,
+                alternatives=[SimpleNamespace(transcript="ready", confidence=0.9, words=[])],
+            )
+        ]
+    )
+    final_attempt_started = threading.Event()
+
+    class CleanEndingASRService:
+        def streaming_response_generator(self, audio_generator, config):
+            call_audio: list[bytes] = [next(audio_generator)]
+            calls.append(call_audio)
+            if len(calls) <= 3:
+                return iter(())
+
+            def responses():
+                final_attempt_started.set()
+                yield final_response
+                call_audio.extend(audio_generator)
+
+            return responses()
+
+    monkeypatch.setattr(service, "_ensure_asr_service", lambda: CleanEndingASRService())
+    monkeypatch.setattr(
+        nvidia_stt.SpeechStream,
+        "_create_streaming_config",
+        lambda self: SimpleNamespace(),
+    )
+
+    stream = service.stream(conn_options=APIConnectOptions(max_retry=1, retry_interval=10))
+    frame = _audio_frame(3)
+    stream.push_frame(frame)
+
+    assert await asyncio.to_thread(final_attempt_started.wait, 1.0)
+    stream.end_input()
+    await asyncio.wait_for(stream._task, timeout=2.0)
+    events = [event async for event in stream]
+
+    assert len(calls) == 4
+    assert all(call[0] == frame.data.tobytes() for call in calls)
+    assert any(
+        event.type == nvidia_stt.stt.SpeechEventType.FINAL_TRANSCRIPT
+        and event.alternatives[0].text == "ready"
         for event in events
     )
     await stream.aclose()

--- a/tests/test_plugin_nvidia.py
+++ b/tests/test_plugin_nvidia.py
@@ -526,6 +526,16 @@ async def test_stt_stream_emits_transcript_events_from_nvidia_speech_response(
     assert stream._event_ch.recv_nowait().type == nvidia_stt.stt.SpeechEventType.END_OF_SPEECH
 
 
+def test_stt_response_parsing_errors_are_not_suppressed() -> None:
+    stream = object.__new__(nvidia_stt.SpeechStream)
+    response = SimpleNamespace(
+        results=[SimpleNamespace(alternatives=[SimpleNamespace(transcript=None)])]
+    )
+
+    with pytest.raises(AttributeError):
+        stream._handle_response(response, event_loop=MagicMock())
+
+
 def test_tts_passes_locked_nvidia_speech_synthesize_online_options(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_stt_base.py
+++ b/tests/test_stt_base.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for base STT `RecognizeStream` fields (start_time, etc.)."""
 
 from __future__ import annotations
@@ -16,7 +19,7 @@ from livekit.agents.stt import (
     SpeechEventType,
     STTCapabilities,
 )
-from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS
+from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, APIConnectOptions
 from livekit.agents.utils.audio import AudioBuffer
 
 pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
@@ -67,6 +70,16 @@ class _NonRetryableStream(RecognizeStream):
     async def _run(self) -> None:
         self.run_count += 1
         raise APIStatusError("Unauthorized", status_code=401)
+
+
+class _NonRetryableBatchSTT(_DummySTT):
+    def __init__(self) -> None:
+        super().__init__()
+        self.recognize_count = 0
+
+    async def _recognize_impl(self, buffer: AudioBuffer, *, language, conn_options) -> SpeechEvent:
+        self.recognize_count += 1
+        raise APIConnectionError("invalid request", retryable=False)
 
 
 async def test_start_time_seeded_on_init() -> None:
@@ -138,3 +151,12 @@ async def test_non_retryable_error_is_not_retried() -> None:
     assert stream.run_count == 1
 
     await stream.aclose()
+
+
+async def test_batch_recognize_does_not_retry_non_retryable_api_error() -> None:
+    stt = _NonRetryableBatchSTT()
+
+    with pytest.raises(APIConnectionError, match="invalid request"):
+        await stt.recognize([], conn_options=APIConnectOptions(max_retry=3))
+
+    assert stt.recognize_count == 1

--- a/uv.lock
+++ b/uv.lock
@@ -3177,6 +3177,7 @@ requires-dist = [
 name = "livekit-plugins-nvidia"
 source = { editable = "livekit-plugins/livekit-plugins-nvidia" }
 dependencies = [
+    { name = "grpcio" },
     { name = "livekit-agents" },
     { name = "nvidia-riva-client" },
 ]
@@ -3189,9 +3190,10 @@ personaplex = [
 
 [package.metadata]
 requires-dist = [
+    { name = "grpcio", specifier = ">=1.51.1" },
     { name = "livekit-agents", editable = "livekit-agents" },
     { name = "livekit-agents", extras = ["codecs"], marker = "extra == 'personaplex'", editable = "livekit-agents" },
-    { name = "nvidia-riva-client" },
+    { name = "nvidia-riva-client", specifier = ">=2.16,<2.27" },
     { name = "sphn", marker = "extra == 'personaplex'", specifier = ">=0.2.0" },
 ]
 provides-extras = ["personaplex"]


### PR DESCRIPTION
Extend the NVIDIA plugin with production-ready streaming and offline speech support, configurable recognition behavior, improved error handling, and compatibility across supported NVIDIA Riva client versions.

  **Changes:**
-   Add streaming, offline, and backward-compatible automatic STT inference modes.
-   Add offline STT recognition and combine multipart results into complete hypotheses.
-   Keep LiveKit STT streams reusable across flush boundaries by restarting the backend recognition RPC per segment.
-   Replay buffered segment audio when retrying recoverable streaming failures.
-   Stop retrying deterministic and explicitly non-retryable API errors.
-   Add online and offline TTS inference modes.
-   Support the argument differences between `nvidia-riva-client` 2.16 and 2.26.
-   Restrict TTS output to LINEAR_PCM until additional encodings are decoded correctly.
-   Normalize TTS voice listings into individual locale entries.
-   Improve NVIDIA Speech error mapping and stream lifecycle handling.
-   Add NVIDIA Apache-2.0 SPDX notices to contributed files.
-   Document configuration, inference modes, local deployment, and supported client versions.

  **Testing**

-   `uv run --locked pytest tests/test_plugin_nvidia.py tests/test_stt_base.py --unit -q`
-   Result: 33 passed.
- 
-   `uv run --locked ruff check --output-format=github .`
-   Result: passed.
- 
-   `uv run --locked ruff format --check .`
-   Result: 915 files already formatted.
- 
-   Manually verified hosted STT with Parakeet CTC, Parakeet RNNT, Parakeet TDT, Nemotron, Whisper, and Canary models.
-   Manually verified hosted TTS with Magpie and Chatterbox using chunked and token-fed synthesis.
-   Validated compatibility with `nvidia-riva-client` 2.16 and 2.26.