### PR TITLE
fix(deepgram): end_time should be the last word, not the first

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -915,7 +915,7 @@ def live_transcription_to_speech_data(
         sd = stt.SpeechData(
             language=LanguageCode(language),
             start_time=next((word.get("start", 0) for word in alt["words"]), 0) + start_time_offset,
-            end_time=next((word.get("end", 0) for word in alt["words"]), 0) + start_time_offset,
+            end_time=(alt["words"][-1].get("end", 0) if alt["words"] else 0) + start_time_offset,
             confidence=alt["confidence"],
             text=alt["transcript"],
             speaker_id=f"S{speaker}" if speaker is not None else None,


### PR DESCRIPTION
`live_transcription_to_speech_data` takes both `start_time` and `end_time` from the first word, since `next()` returns the first item of the generator:

```python
start_time=next((word.get("start", 0) for word in alt["words"]), 0) + start_time_offset,
end_time=next((word.get("end", 0) for word in alt["words"]), 0) + start_time_offset,
```

`prerecorded_transcription_to_speech_event` in the same file uses `alt["words"][-1]["end"]`, which is what this changes the streaming path to match.

It shows up on barge-in. `audio_recognition.py` drops a held transcript whose `end_time` falls before the cutoff, so "wait, I have a question" is judged on when "wait" ended and the whole turn can be discarded. Easy to miss because interim results are often a single word, where first and last are the same.
