### PR TITLE
feat(openai): give each STT stream its own language

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import contextlib
+import dataclasses
 import json
 import os
 import time
@@ -316,6 +317,11 @@ class STT(stt.STT):
             connect_cb=self._connect_ws,
             close_cb=self._close_ws,
         )
+        # the languages each pooled connection carries, so a stream that wants none does not
+        # take one it cannot clear them on
+        self._configured_languages: weakref.WeakKeyDictionary[
+            aiohttp.ClientWebSocketResponse, list[str]
+        ] = weakref.WeakKeyDictionary()
 
     @property
     def model(self) -> str:
@@ -429,13 +435,17 @@ class STT(stt.STT):
         language: NotGivenOr[str | list[str]] = NOT_GIVEN,
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
     ) -> SpeechStream:
+        opts = dataclasses.replace(self._opts)
         if is_given(language):
-            # the options are shared, so this takes the path any other change takes
-            self.update_options(language=language)
+            opts.languages = _as_languages(language)
+            _validate_context(opts.model, opts.languages, opts.keywords)
         stream = SpeechStream(
             stt=self,
             pool=self._pool,
+            configured_languages=self._configured_languages,
             conn_options=conn_options,
+            opts=opts,
+            pinned_languages=is_given(language),
             vad_instance=self._vad,
         )
         self._streams.add(stream)
@@ -502,6 +512,7 @@ class STT(stt.STT):
         needs_reconnect = resolved_model != self._opts.model or (
             bool(self._opts.languages) and not languages
         )
+        languages_given = is_given(language) or is_given(detect_language)
         self._opts.model = resolved_model
         self._capabilities.keyterms = _supports_context_hints(resolved_model)
         self._opts.languages = languages
@@ -535,10 +546,7 @@ class STT(stt.STT):
             self._pool.invalidate()
 
         for stream in self._streams:
-            if needs_reconnect:
-                stream.reconnect()
-            else:
-                stream.apply_options()
+            stream._adopt(self._opts, languages_given=languages_given)
 
     def _update_session_keyterms(self, keyterms: list[str]) -> None:
         if not self.capabilities.keyterms:
@@ -549,7 +557,7 @@ class STT(stt.STT):
         self._session_keyterms = list(keyterms)
         self._opts.keywords = list(dict.fromkeys([*self._user_keywords, *keyterms]))
         for stream in self._streams:
-            stream.apply_options()
+            stream._adopt(self._opts, languages_given=False)
 
     async def _connect_ws(self, timeout: float) -> aiohttp.ClientWebSocketResponse:
         query_params: dict[str, str] = {
@@ -573,7 +581,9 @@ class STT(stt.STT):
         session = self._ensure_session()
         # the config is sent once the stream acquires the connection, since the pool also
         # hands back sockets it opened earlier
-        return await asyncio.wait_for(session.ws_connect(url, headers=headers), timeout)
+        ws = await asyncio.wait_for(session.ws_connect(url, headers=headers), timeout)
+        self._configured_languages[ws] = []  # nothing is set on it yet
+        return ws
 
     async def _close_ws(self, ws: aiohttp.ClientWebSocketResponse) -> None:
         await ws.close()
@@ -653,14 +663,20 @@ class SpeechStream(stt.SpeechStream):
         stt: STT,
         conn_options: APIConnectOptions,
         pool: utils.ConnectionPool[aiohttp.ClientWebSocketResponse],
+        configured_languages: weakref.WeakKeyDictionary[aiohttp.ClientWebSocketResponse, list[str]],
+        opts: _STTOptions,
+        pinned_languages: bool = False,
         vad_instance: vad.VAD | None = None,
     ) -> None:
         super().__init__(stt=stt, conn_options=conn_options, sample_rate=SAMPLE_RATE)
 
         self._pool = pool
-        # the STT mutates these in place; every acquired connection is configured from them
-        self._opts = stt._opts
-        self._language = _transcript_language(stt._opts.languages)
+        self._configured_languages = configured_languages
+        # this stream's own options; the STT pushes its changes in through _adopt
+        self._opts = opts
+        # a language given to stream() survives an STT change that does not name one
+        self._pinned_languages = pinned_languages
+        self._language = _transcript_language(opts.languages)
         self._request_id = ""
         self._reconnect_event = asyncio.Event()
         self._ws: aiohttp.ClientWebSocketResponse | None = None
@@ -669,6 +685,23 @@ class SpeechStream(stt.SpeechStream):
         self._config_lock = asyncio.Lock()
         self._vad = vad_instance
         self._speaking = False
+
+    def _adopt(self, opts: _STTOptions, *, languages_given: bool) -> None:
+        """Take the STT's options, keeping a language this stream was opened with."""
+        keep = self._pinned_languages and not languages_given
+        self._pinned_languages = keep
+        languages = self._opts.languages if keep else opts.languages
+        # gateways route on the ?model= in the upgrade URL, and `languages` cannot be cleared
+        # on an open session, so neither survives a session.update
+        needs_reconnect = opts.model != self._opts.model or (
+            bool(self._opts.languages) and not languages
+        )
+        self._opts = dataclasses.replace(opts, languages=languages)
+        self._language = _transcript_language(languages)
+        if needs_reconnect:
+            self._reconnect_event.set()
+        else:
+            self.apply_options()
 
     def apply_options(self) -> None:
         """Apply an option change on the open connection instead of reconnecting."""
@@ -694,11 +727,6 @@ class SpeechStream(stt.SpeechStream):
         except Exception:
             # a dropped update is not worth failing the stream over
             logger.warning("failed to update the transcription session", exc_info=True)
-
-    def reconnect(self) -> None:
-        """Rebuild the connection so it carries the current options. The STT drops the pool."""
-        self._language = _transcript_language(self._opts.languages)
-        self._reconnect_event.set()
 
     async def aclose(self) -> None:
         if self._update_task is not None:
@@ -930,6 +958,11 @@ class SpeechStream(stt.SpeechStream):
                 self._report_connection_acquired(
                     self._pool.last_acquire_time, self._pool.last_connection_reused
                 )
+                if not self._opts.languages and self._configured_languages.get(ws):
+                    # this stream wants detection, and `languages` cannot be cleared on a
+                    # session another stream set them on; take a connection of our own
+                    self._pool.remove(ws)
+                    continue
                 # published before the config is sent, so a change made during the send is
                 # applied after it rather than dropped as having no live connection
                 self._ws = ws
@@ -942,6 +975,7 @@ class SpeechStream(stt.SpeechStream):
                                 by_alias=True, exclude_unset=True
                             )
                         )
+                    self._configured_languages[ws] = list(self._opts.languages)
                 except (aiohttp.ClientError, ConnectionError) as e:
                     # the retry gets its own connection; no update should reach this one
                     self._ws = None

--- a/tests/test_plugin_openai_stt_context.py
+++ b/tests/test_plugin_openai_stt_context.py
@@ -563,36 +563,58 @@ async def test_a_rebuild_drops_the_idle_pooled_connection(
     await stream.aclose()
 
 
-async def test_a_stream_asking_to_detect_the_language_drops_the_pooled_connection() -> None:
-    # stream(language=...) is the same option change, so it needs the same rebuild
+async def test_a_stream_asking_to_detect_the_language_takes_its_own_connection() -> None:
+    # `languages` cannot be cleared on a session another stream set them on
     instance = _offline_stt(model="gpt-live-transcribe", language="en")
     session = _FakeSession()
     instance._session = session  # type: ignore[assignment]
-    instance._pool.put(await instance._pool.get(timeout=5))
+    pooled = await instance._pool.get(timeout=5)
+    instance._configured_languages[pooled] = ["en"]  # as an earlier stream left it
+    instance._pool.put(pooled)
 
     stream = instance.stream(language=[])
 
-    assert instance._opts.languages == []
+    assert stream._opts.languages == []
+    assert instance._opts.languages == ["en"]  # the STT default is untouched
     await _connected(stream)
     assert session.connects == 2
 
     await stream.aclose()
 
 
-async def test_a_stream_language_reaches_the_streams_already_open() -> None:
-    # the options are shared, so an open stream must hear about the change too
+async def test_a_stream_language_stays_out_of_the_streams_already_open() -> None:
     instance = _offline_stt(model="gpt-live-transcribe", language="en")
     open_stream = instance.stream()
-    ws = await _connected(open_stream)
+    await _connected(open_stream)
 
     later = instance.stream(language="fr")
-    await _settle(open_stream)
 
-    assert _sent_transcription(ws)["languages"] == ["fr"]
-    assert open_stream._language == "fr"
+    assert open_stream._opts.languages == ["en"]
+    assert open_stream._language == "en"
+    assert later._opts.languages == ["fr"]
 
     await open_stream.aclose()
     await later.aclose()
+
+
+async def test_an_stt_language_change_overrides_a_stream_of_its_own() -> None:
+    instance = _offline_stt(model="gpt-live-transcribe", language="en")
+    pinned = instance.stream(language="fr")
+    plain = instance.stream()
+
+    # a change that names no language leaves the pinned stream on its own
+    instance.update_options(keywords=["Acme Corp"])
+    assert pinned._opts.languages == ["fr"]
+    assert pinned._opts.keywords == ["Acme Corp"]  # the rest still reaches it
+    assert plain._opts.languages == ["en"]
+
+    # naming one takes the stream back
+    instance.update_options(language="de")
+    assert pinned._opts.languages == ["de"]
+    assert plain._opts.languages == ["de"]
+
+    await pinned.aclose()
+    await plain.aclose()
 
 
 async def test_session_keyterms_reach_the_next_connection() -> None:


### PR DESCRIPTION
Stacked on #6705, retarget to `main` once that merges.

`STT.stream(language=...)` set the language for every stream, because a `SpeechStream` aliased the STT's options object rather than holding its own. Two sessions sharing one STT instance could not transcribe different languages, and whichever caller ran last won.

Each stream now takes a copy of the options, the way the `google` and `assemblyai` plugins already do, and the STT pushes its own changes into every stream. A language named in `update_options` takes a pinned stream back; any other change (keywords, prompt, model) still reaches it while leaving it on the language it was opened with.

The connection pool needs one guard for this. `languages` cannot be cleared on a session another stream set them on, so a stream that asks for detection drops a pooled connection already carrying languages and takes one of its own. Connections record what they were configured with, and a freshly opened one starts empty.