### PR TITLE
fix(audio): don't report a stopped playback as a decode error

### DIFF
--- a/livekit-agents/livekit/agents/utils/audio.py
+++ b/livekit-agents/livekit/agents/utils/audio.py
@@ -233,6 +233,7 @@ async def audio_frames_from_file(
     decoder = AudioStreamDecoder(sample_rate=sample_rate, num_channels=num_channels)
 
     async def file_reader() -> None:
+        aborted = False
         try:
             async with aiofiles.open(file_path, mode="rb") as f:
                 while True:
@@ -241,8 +242,14 @@ async def audio_frames_from_file(
                         break
 
                     decoder.push(chunk)
+        except asyncio.CancelledError:
+            aborted = True
+            raise
         finally:
-            decoder.end_input()
+            # a cancelled read leaves a truncated file, not an end of input: signalling EOF
+            # would make the decoder report the abort as invalid audio. aclose() closes it.
+            if not aborted:
+                decoder.end_input()
 
     reader_task = asyncio.create_task(file_reader())
 

--- a/livekit-agents/livekit/agents/utils/codecs/decoder.py
+++ b/livekit-agents/livekit/agents/utils/codecs/decoder.py
@@ -462,7 +462,9 @@ class AudioStreamDecoder:
                     self._emit_av_frame(f)
 
         except Exception:
-            logger.exception("error decoding audio")
+            # a close tears the input down mid-decode, which PyAV reports as invalid data
+            if not self._closed:
+                logger.exception("error decoding audio")
         finally:
             self._loop.call_soon_threadsafe(self._output_ch.close)
             if container:
@@ -489,14 +491,21 @@ class AudioStreamDecoder:
         if self._closed:
             return
 
-        self.end_input()
+        if self._is_wav:
+            # decoded inline, there is no worker thread to wind down
+            self.end_input()
+            self._closed = True
+            return
+
+        # set before tearing the input down, so the decode thread can tell this close
+        # from a real decode failure
         self._closed = True
 
-        if self._input_buf is not None:
-            self._input_buf.close()
-
-        if not self._started:
+        if self._input_buf is None:
+            self._output_ch.close()  # nothing was ever pushed, no frame will come
             return
+
+        self._input_buf.close()
 
         try:
             async for _ in self._output_ch:

--- a/tests/test_audio_decoder.py
+++ b/tests/test_audio_decoder.py
@@ -1,15 +1,21 @@
+import asyncio
+import contextlib
 import io
+import logging
 import os
 import struct
 import threading
 import time
+from collections.abc import AsyncGenerator
 from concurrent.futures import ThreadPoolExecutor
 
 import aiohttp
 import pytest
 
+from livekit import rtc
 from livekit.agents import inference
 from livekit.agents.stt import SpeechEventType
+from livekit.agents.utils.audio import audio_frames_from_file
 from livekit.agents.utils.codecs import AudioStreamDecoder, StreamBuffer
 from livekit.agents.utils.misc import is_cloud
 
@@ -483,3 +489,50 @@ async def test_wav_multi_chunk_with_resampling():
     expected = samples_per_chunk * num_chunks * out_rate // src_rate
     assert abs(total_samples - expected) <= out_rate // 50  # within 20ms tolerance
     await decoder.aclose()
+
+
+def _decode_errors(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [r.getMessage() for r in caplog.records if "error decoding" in r.getMessage()]
+
+
+@pytest.mark.asyncio
+async def test_aclose_while_probing_is_not_an_error(caplog: pytest.LogCaptureFixture) -> None:
+    """Closing a decoder mid-probe is intentional and must not be reported as a decode failure."""
+    with open(TEST_AUDIO_FILEPATH, "rb") as f:
+        head = f.read(16)  # far less than av.open needs to probe the container
+
+    decoder = AudioStreamDecoder()
+    decoder.push(head)
+    await asyncio.sleep(0.05)  # the decode thread is now blocked reading inside av.open
+
+    with caplog.at_level(logging.DEBUG, logger="livekit.agents"):
+        await decoder.aclose()
+        await asyncio.sleep(0.05)
+
+    assert _decode_errors(caplog) == []
+
+
+@pytest.mark.asyncio
+async def test_stop_before_first_frame_is_not_an_error(caplog: pytest.LogCaptureFixture) -> None:
+    """The BackgroundAudioPlayer stop() path: aborting playback is not a decode failure.
+
+    A stop that lands before the first frame catches the decode thread while it still probes
+    the container, which is the window every report in the wild falls into.
+    """
+
+    async def drain(gen: AsyncGenerator[rtc.AudioFrame, None]) -> None:
+        async for _ in gen:
+            pass
+
+    with caplog.at_level(logging.DEBUG, logger="livekit.agents"):
+        for i in range(120):
+            gen = audio_frames_from_file(TEST_AUDIO_FILEPATH)
+            task = asyncio.create_task(drain(gen))
+            await asyncio.sleep((i % 20) * 0.0001)  # sweep the probe window
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            await gen.aclose()  # what PlayHandle.stop() ultimately triggers
+        await asyncio.sleep(0.05)
+
+    assert _decode_errors(caplog) == []

--- a/tests/test_audio_decoder.py
+++ b/tests/test_audio_decoder.py
@@ -492,7 +492,21 @@ async def test_wav_multi_chunk_with_resampling():
 
 
 def _decode_errors(caplog: pytest.LogCaptureFixture) -> list[str]:
-    return [r.getMessage() for r in caplog.records if "error decoding" in r.getMessage()]
+    """Decode errors, each tagged with the decoder state that let it through the close guard."""
+    errors = []
+    for record in caplog.records:
+        if "error decoding" not in record.getMessage() or not record.exc_info:
+            continue
+        exc_type, _, tb = record.exc_info
+        decoder = tb.tb_frame.f_locals.get("self") if tb else None
+        buf = getattr(decoder, "_input_buf", None)
+        errors.append(
+            f"{exc_type.__name__ if exc_type else '?'}"
+            f"(closed={getattr(decoder, '_closed', None)},"
+            f" eof={getattr(buf, '_eof', None)},"
+            f" buf_closed={getattr(buf, '_closed', None)})"
+        )
+    return errors
 
 
 @pytest.mark.asyncio

--- a/tests/test_audio_decoder.py
+++ b/tests/test_audio_decoder.py
@@ -6,13 +6,11 @@ import os
 import struct
 import threading
 import time
-from collections.abc import AsyncGenerator
 from concurrent.futures import ThreadPoolExecutor
 
 import aiohttp
 import pytest
 
-from livekit import rtc
 from livekit.agents import inference
 from livekit.agents.stt import SpeechEventType
 from livekit.agents.utils.audio import audio_frames_from_file
@@ -491,24 +489,6 @@ async def test_wav_multi_chunk_with_resampling():
     await decoder.aclose()
 
 
-def _decode_errors(caplog: pytest.LogCaptureFixture) -> list[str]:
-    """Decode errors, each tagged with the decoder state that let it through the close guard."""
-    errors = []
-    for record in caplog.records:
-        if "error decoding" not in record.getMessage() or not record.exc_info:
-            continue
-        exc_type, _, tb = record.exc_info
-        decoder = tb.tb_frame.f_locals.get("self") if tb else None
-        buf = getattr(decoder, "_input_buf", None)
-        errors.append(
-            f"{exc_type.__name__ if exc_type else '?'}"
-            f"(closed={getattr(decoder, '_closed', None)},"
-            f" eof={getattr(buf, '_eof', None)},"
-            f" buf_closed={getattr(buf, '_closed', None)})"
-        )
-    return errors
-
-
 @pytest.mark.asyncio
 async def test_aclose_while_probing_is_not_an_error(caplog: pytest.LogCaptureFixture) -> None:
     """Closing a decoder mid-probe is intentional and must not be reported as a decode failure."""
@@ -523,30 +503,44 @@ async def test_aclose_while_probing_is_not_an_error(caplog: pytest.LogCaptureFix
         await decoder.aclose()
         await asyncio.sleep(0.05)
 
-    assert _decode_errors(caplog) == []
+    assert [r.getMessage() for r in caplog.records if "error decoding" in r.getMessage()] == []
 
 
 @pytest.mark.asyncio
-async def test_stop_before_first_frame_is_not_an_error(caplog: pytest.LogCaptureFixture) -> None:
-    """The BackgroundAudioPlayer stop() path: aborting playback is not a decode failure.
+async def test_aborted_read_does_not_signal_end_of_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The BackgroundAudioPlayer stop() path: an aborted read is a truncated file, not an EOF.
 
-    A stop that lands before the first frame catches the decode thread while it still probes
-    the container, which is the window every report in the wild falls into.
+    Signalling the end of input hands the partial file to PyAV as a complete container, which
+    it then reports as invalid data.
     """
+    real_push, real_end_input = AudioStreamDecoder.push, AudioStreamDecoder.end_input
+    pushes: list[None] = []
+    ends: list[None] = []
 
-    async def drain(gen: AsyncGenerator[rtc.AudioFrame, None]) -> None:
+    def slow_push(self: AudioStreamDecoder, chunk: bytes) -> None:
+        pushes.append(None)
+        time.sleep(0.005)  # hold the reader mid-file for the whole test
+        real_push(self, chunk)
+
+    def spy_end_input(self: AudioStreamDecoder) -> None:
+        ends.append(None)
+        real_end_input(self)
+
+    monkeypatch.setattr(AudioStreamDecoder, "push", slow_push)
+    monkeypatch.setattr(AudioStreamDecoder, "end_input", spy_end_input)
+
+    gen = audio_frames_from_file(TEST_AUDIO_FILEPATH)
+
+    async def drain() -> None:
         async for _ in gen:
             pass
 
-    with caplog.at_level(logging.DEBUG, logger="livekit.agents"):
-        for i in range(120):
-            gen = audio_frames_from_file(TEST_AUDIO_FILEPATH)
-            task = asyncio.create_task(drain(gen))
-            await asyncio.sleep((i % 20) * 0.0001)  # sweep the probe window
-            task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
-            await gen.aclose()  # what PlayHandle.stop() ultimately triggers
-        await asyncio.sleep(0.05)
+    task = asyncio.create_task(drain())
+    await asyncio.sleep(0.005)  # one chunk in, many chunks from the end
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+    await gen.aclose()  # what PlayHandle.stop() ultimately triggers
 
-    assert _decode_errors(caplog) == []
+    assert pushes, "the reader never ran, so the abort was never exercised"
+    assert ends == []


### PR DESCRIPTION
**Problem**

A stop on a `BackgroundAudioPlayer` clip writes `error decoding audio` to the log. PyAV raises `av.error.InvalidDataError` or `EOFError` from `av.open`. The stop is intentional and the audio file is correct. A clip that loops hits this often, because `_loop_audio_frames` opens a new container for each iteration.

When the input closes, the decode thread can still read the container header. Two paths close it. `audio_frames_from_file` cancels the reader task, and the `finally` block of the reader calls `decoder.end_input()`. PyAV then reads a part of the file as a complete container. `aclose()` closes the `StreamBuffer` while the thread reads it. `_decode_loop` reports both windows through one `except Exception` block.

**Fix**

A cancelled read no longer signals an end of input. `aclose()` marks the decoder closed before it closes the input. `_decode_loop` writes no error after that flag is set. The WAV path already had this guard.

Real decode errors stay visible. Garbage input, a corrupt file, and a missing file all report as before.

This change keeps #3863 open. The other reports there come from a mime and encoding mismatch. That is a real decode error, and the log keeps it.