### PR TITLE
fix: don't count discarded room audio as played

### DIFF
--- a/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
+++ b/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
@@ -544,11 +544,26 @@ class RecorderAudioOutput(io.AudioOutput):
         if self.__recording_io.recording:
             self.__acc_frames.append(frame)
 
-        if self.__started_time is None:
-            self.__started_time = time.time()
+        if self.__started_time is None or self._last_speech_start_time is None:
+            capture_time = time.time()
 
-        if self._last_speech_start_time is None:
-            self._last_speech_start_time = time.time()
+            if self.__started_time is None:
+                self.__started_time = capture_time
+
+            if self._last_speech_start_time is None:
+                # exclude pauses from before this segment.
+                self.__pause_wall_times = [
+                    (max(start, capture_time), end)
+                    for start, end in self.__pause_wall_times
+                    if end > capture_time
+                ]
+                # a pause cannot start before the segment
+                if self.__current_pause_start is not None:
+                    self.__current_pause_start = max(
+                        self.__current_pause_start,
+                        capture_time,
+                    )
+                self._last_speech_start_time = capture_time
 
     def flush(self) -> None:
         super().flush()

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -64,6 +64,8 @@ class _ParticipantAudioOutput(io.AudioOutput):
         self._forwarding_task: asyncio.Task[None] | None = None
 
         self._pushed_duration: float = 0.0
+        self._source_pushed_duration: float = 0.0
+        self._source_discarded_duration: float = 0.0
 
         self._playback_enabled = asyncio.Event()
         self._playback_enabled.set()
@@ -166,15 +168,20 @@ class _ParticipantAudioOutput(io.AudioOutput):
         if interrupted:
             queued_duration = self._audio_source.queued_duration
             while not self._audio_buf.empty():
-                queued_duration += self._audio_buf.recv_nowait().duration
+                self._audio_buf.recv_nowait()
 
-            pushed_duration = max(pushed_duration - queued_duration, 0)
+            pushed_duration = max(
+                self._source_pushed_duration - self._source_discarded_duration - queued_duration,
+                0,
+            )
             self._audio_source.clear_queue()
             wait_for_playout.cancel()
         else:
             wait_for_interruption.cancel()
 
         self._pushed_duration = 0
+        self._source_pushed_duration = 0
+        self._source_discarded_duration = 0
         self._interrupted_event.clear()
         self._first_frame_event.clear()
         self.on_playback_finished(playback_position=pushed_duration, interrupted=interrupted)
@@ -182,6 +189,7 @@ class _ParticipantAudioOutput(io.AudioOutput):
     async def _forward_audio(self) -> None:
         async for frame in self._audio_buf:
             if not self._playback_enabled.is_set():
+                self._source_discarded_duration += self._audio_source.queued_duration
                 self._audio_source.clear_queue()
                 await self._playback_enabled.wait()
                 # TODO(long): save the frames in the queue and play them later
@@ -197,6 +205,7 @@ class _ParticipantAudioOutput(io.AudioOutput):
             if not self._first_frame_event.is_set():
                 self._first_frame_event.set()
                 self.on_playback_started(created_at=time.time())
+            self._source_pushed_duration += frame.duration
             await self._audio_source.capture_frame(frame)
 
 

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -163,17 +163,17 @@ class _ParticipantAudioOutput(io.AudioOutput):
         )
 
         interrupted = self._interrupted_event.is_set()
-        pushed_duration = self._pushed_duration
+        pushed_duration = max(
+            self._source_pushed_duration - self._source_discarded_duration,
+            0,
+        )
 
         if interrupted:
             queued_duration = self._audio_source.queued_duration
             while not self._audio_buf.empty():
                 self._audio_buf.recv_nowait()
 
-            pushed_duration = max(
-                self._source_pushed_duration - self._source_discarded_duration - queued_duration,
-                0,
-            )
+            pushed_duration = max(pushed_duration - queued_duration, 0)
             self._audio_source.clear_queue()
             wait_for_playout.cancel()
         else:
@@ -192,7 +192,8 @@ class _ParticipantAudioOutput(io.AudioOutput):
                 self._source_discarded_duration += self._audio_source.queued_duration
                 self._audio_source.clear_queue()
                 await self._playback_enabled.wait()
-                # TODO(long): save the frames in the queue and play them later
+                # TODO(long): preserve or report cleared frames so RecorderIO can reconstruct
+                # discarded mid-stream audio instead of only correcting playback duration.
                 # TODO(long): ignore frames from previous syllable
 
             if self._interrupted_event.is_set() or self._pushed_duration == 0:

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -69,6 +69,9 @@ class _ParticipantAudioOutput(io.AudioOutput):
 
         self._playback_enabled = asyncio.Event()
         self._playback_enabled.set()
+        # set only when _forward_audio is neither holding nor submitting a frame
+        self._forwarding_idle = asyncio.Event()
+        self._forwarding_idle.set()
         # playback_started fires once per segment; a mid-segment pause/resume does not re-arm this
         self._first_frame_event = asyncio.Event()
 
@@ -148,13 +151,15 @@ class _ParticipantAudioOutput(io.AudioOutput):
         wait_for_interruption = asyncio.create_task(self._interrupted_event.wait())
 
         async def _wait_buffered_audio() -> None:
-            while not self._audio_buf.empty():
-                if not self._playback_enabled.is_set():
-                    await self._playback_enabled.wait()
-
-                await self._audio_source.wait_for_playout()
-                # avoid deadlock when clear_buffer called before capture_frame
+            while True:
+                await self._playback_enabled.wait()
+                await self._forwarding_idle.wait()
+                # The forwarder may have acquired another frame before this task resumes.
+                if self._forwarding_idle.is_set() and self._audio_buf.empty():
+                    break
                 await asyncio.sleep(0)
+
+            await self._audio_source.wait_for_playout()
 
         wait_for_playout = asyncio.create_task(_wait_buffered_audio())
         await asyncio.wait(
@@ -188,26 +193,30 @@ class _ParticipantAudioOutput(io.AudioOutput):
 
     async def _forward_audio(self) -> None:
         async for frame in self._audio_buf:
-            if not self._playback_enabled.is_set():
-                self._source_discarded_duration += self._audio_source.queued_duration
-                self._audio_source.clear_queue()
-                await self._playback_enabled.wait()
-                # TODO(long): preserve or report cleared frames so RecorderIO can reconstruct
-                # discarded mid-stream audio instead of only correcting playback duration.
-                # TODO(long): ignore frames from previous syllable
+            self._forwarding_idle.clear()
+            try:
+                if not self._playback_enabled.is_set():
+                    self._source_discarded_duration += self._audio_source.queued_duration
+                    self._audio_source.clear_queue()
+                    await self._playback_enabled.wait()
+                    # TODO(long): preserve or report cleared frames so RecorderIO can reconstruct
+                    # discarded mid-stream audio instead of only correcting playback duration.
+                    # TODO(long): ignore frames from previous syllable
 
-            if self._interrupted_event.is_set() or self._pushed_duration == 0:
-                if self._interrupted_event.is_set() and self._flush_task:
-                    await self._flush_task
+                if self._interrupted_event.is_set() or self._pushed_duration == 0:
+                    if self._interrupted_event.is_set() and self._flush_task:
+                        await self._flush_task
 
-                # ignore frames if interrupted
-                continue
+                    # ignore frames if interrupted
+                    continue
 
-            if not self._first_frame_event.is_set():
-                self._first_frame_event.set()
-                self.on_playback_started(created_at=time.time())
-            self._source_pushed_duration += frame.duration
-            await self._audio_source.capture_frame(frame)
+                if not self._first_frame_event.is_set():
+                    self._first_frame_event.set()
+                    self.on_playback_started(created_at=time.time())
+                self._source_pushed_duration += frame.duration
+                await self._audio_source.capture_frame(frame)
+            finally:
+                self._forwarding_idle.set()
 
 
 class _ParticipantLegacyTranscriptionOutput:

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -66,6 +66,7 @@ class _ParticipantAudioOutput(io.AudioOutput):
         self._pushed_duration: float = 0.0
         self._source_pushed_duration: float = 0.0
         self._source_discarded_duration: float = 0.0
+        self._interruption_generation = 0
 
         self._playback_enabled = asyncio.Event()
         self._playback_enabled.set()
@@ -174,6 +175,7 @@ class _ParticipantAudioOutput(io.AudioOutput):
         )
 
         if interrupted:
+            self._interruption_generation += 1
             queued_duration = self._audio_source.queued_duration
             while not self._audio_buf.empty():
                 self._audio_buf.recv_nowait()
@@ -193,12 +195,16 @@ class _ParticipantAudioOutput(io.AudioOutput):
 
     async def _forward_audio(self) -> None:
         async for frame in self._audio_buf:
+            interruption_generation = self._interruption_generation
             self._forwarding_idle.clear()
             try:
                 if not self._playback_enabled.is_set():
                     self._source_discarded_duration += self._audio_source.queued_duration
                     self._audio_source.clear_queue()
                     await self._playback_enabled.wait()
+                    # drop a paused frame when its original segment was interrupted.
+                    if interruption_generation != self._interruption_generation:
+                        continue
                     # TODO(long): preserve or report cleared frames so RecorderIO can reconstruct
                     # discarded mid-stream audio instead of only correcting playback duration.
                     # TODO(long): ignore frames from previous syllable

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -153,11 +153,11 @@ class _ParticipantAudioOutput(io.AudioOutput):
 
         async def _wait_buffered_audio() -> None:
             while True:
-                await self._playback_enabled.wait()
                 await self._forwarding_idle.wait()
-                # The forwarder may have acquired another frame before this task resumes.
-                if self._forwarding_idle.is_set() and self._audio_buf.empty():
+                if self._audio_buf.empty():
                     break
+
+                await self._playback_enabled.wait()
                 await asyncio.sleep(0)
 
             await self._audio_source.wait_for_playout()

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -19,7 +19,7 @@ from livekit.agents.voice.agent_session import (
     _RECORDING_ALL_ON,
     RecordingOptions,
 )
-from livekit.agents.voice.recorder_io.recorder_io import _split_frame
+from livekit.agents.voice.recorder_io.recorder_io import RecorderAudioOutput, _split_frame
 from livekit.protocol import metrics as proto_metrics
 
 from .fake_io import FakeAudioInput, FakeAudioOutput, FakeTextOutput
@@ -600,7 +600,94 @@ async def test_recorder_io_not_created_when_audio_false() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Group 5: _split_frame (encode-path helper)
+# Group 5: RecorderAudioOutput pause alignment
+# ---------------------------------------------------------------------------
+
+
+async def test_recorder_output_drops_pauses_before_the_segment() -> None:
+    frame = rtc.AudioFrame(bytes(960 * 2), 48000, 1, 960)  # 20ms
+    recording_io = MagicMock(recording=True)
+    writes: list[list[rtc.AudioFrame]] = []
+    output = RecorderAudioOutput(
+        recording_io=recording_io,
+        audio_output=None,
+        write_fnc=writes.append,
+    )
+    now = 10.0
+
+    with patch("livekit.agents.voice.recorder_io.recorder_io.time.time", side_effect=lambda: now):
+        output.pause()
+        now = 10.5
+        output.resume()
+
+        now = 11.0
+        await output.capture_frame(frame)
+        output.flush()
+
+        now = 11.02
+        output.on_playback_finished(playback_position=frame.duration, interrupted=False)
+
+    assert len(writes) == 1
+    assert sum(f.samples_per_channel for f in writes[0]) == pytest.approx(
+        frame.samples_per_channel, abs=1
+    )
+
+
+async def test_recorder_output_clips_a_pause_that_overlaps_the_segment() -> None:
+    frame = rtc.AudioFrame(bytes(960 * 2), 48000, 1, 960)  # 20ms
+    recording_io = MagicMock(recording=True)
+    writes: list[list[rtc.AudioFrame]] = []
+    output = RecorderAudioOutput(
+        recording_io=recording_io,
+        audio_output=None,
+        write_fnc=writes.append,
+    )
+    now = 10.0
+
+    with patch("livekit.agents.voice.recorder_io.recorder_io.time.time", side_effect=lambda: now):
+        output.pause()
+
+        now = 10.5
+        await output.capture_frame(frame)
+
+        now = 10.7
+        output.resume()
+        output.flush()
+
+        now = 10.72
+        output.on_playback_finished(playback_position=frame.duration, interrupted=False)
+
+    assert len(writes) == 1
+    assert sum(f.samples_per_channel for f in writes[0]) == pytest.approx(10560, abs=1)
+
+
+async def test_recorder_output_keeps_trailing_silence_for_a_midsegment_pause() -> None:
+    frame = rtc.AudioFrame(bytes(4800 * 2), 48000, 1, 4800)  # 100ms
+    recording_io = MagicMock(recording=True)
+    writes: list[list[rtc.AudioFrame]] = []
+    output = RecorderAudioOutput(
+        recording_io=recording_io,
+        audio_output=None,
+        write_fnc=writes.append,
+    )
+    now = 10.0
+
+    with patch("livekit.agents.voice.recorder_io.recorder_io.time.time", side_effect=lambda: now):
+        await output.capture_frame(frame)
+
+        now = 10.05
+        output.pause()
+        output.flush()
+
+        now = 10.2
+        output.on_playback_finished(playback_position=0.05, interrupted=True)
+
+    assert len(writes) == 1
+    assert sum(f.samples_per_channel for f in writes[0]) == pytest.approx(9600, abs=1)
+
+
+# ---------------------------------------------------------------------------
+# Group 6: _split_frame (encode-path helper)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -9,6 +9,7 @@ import pytest
 
 from livekit import rtc
 from livekit.agents import utils
+from livekit.agents.voice.io import PlaybackFinishedEvent
 from livekit.agents.voice.room_io._input import (
     _ParticipantAudioInputStream,
     _ParticipantInputStream,
@@ -369,7 +370,7 @@ async def test_selector_returns_noise_cancellation_options() -> None:
     await stream.aclose()
 
 
-# -- audio output playback_started tests --------------------------------------
+# -- audio output tests -------------------------------------------------------
 
 
 class _FakeAudioSource:
@@ -388,6 +389,20 @@ class _FakeAudioSource:
 
     async def aclose(self) -> None:
         pass
+
+
+class _QueuedAudioSource(_FakeAudioSource):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.clear_count = 0
+
+    async def capture_frame(self, frame: rtc.AudioFrame) -> None:
+        await super().capture_frame(frame)
+        self.queued_duration += frame.duration
+
+    def clear_queue(self) -> None:
+        self.clear_count += 1
+        self.queued_duration = 0.0
 
 
 @pytest.mark.asyncio
@@ -428,3 +443,42 @@ async def test_audio_output_playback_started_fires_once_across_pause_resume() ->
     assert len(started) == 1
 
     await utils.aio.cancel_and_wait(forward_task)
+
+
+@pytest.mark.asyncio
+async def test_audio_output_does_not_report_discarded_audio_as_played() -> None:
+    frame = rtc.AudioFrame(bytes(24000 * 2), 48000, 1, 24000)  # 500ms
+    next_frame = rtc.AudioFrame(bytes(960 * 2), 48000, 1, 960)  # 20ms
+
+    with patch("livekit.rtc.AudioSource", _QueuedAudioSource):
+        output = _ParticipantAudioOutput(
+            _FakeRoom(),
+            sample_rate=48000,
+            num_channels=1,
+            track_publish_options=rtc.TrackPublishOptions(),
+        )
+    output._subscribed_fut.set_result(None)  # skip track publish/subscription
+    forward_task = asyncio.create_task(output._forward_audio())
+
+    finished: list[PlaybackFinishedEvent] = []
+    output.on("playback_finished", finished.append)
+
+    try:
+        await output.capture_frame(frame)
+        await asyncio.sleep(0)
+        assert output._audio_source.queued_duration > 0
+
+        output.pause()
+        await output.capture_frame(next_frame)
+        output.flush()
+        await asyncio.sleep(0)
+        assert output._audio_source.clear_count == 1
+
+        output.clear_buffer()
+        await output.wait_for_playout()
+    finally:
+        await utils.aio.cancel_and_wait(forward_task)
+
+    assert len(finished) == 1
+    assert finished[0].interrupted
+    assert finished[0].playback_position == 0

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -411,14 +411,32 @@ class _QueuedAudioSource(_FakeAudioSource):
         self.queued_duration = 0.0
 
 
+class _WaitObservedEvent(asyncio.Event):
+    def __init__(self) -> None:
+        super().__init__()
+        self.wait_started = asyncio.Event()
+
+    async def wait(self) -> bool:
+        self.wait_started.set()
+        return await super().wait()
+
+
 class _BlockingAudioSource(_QueuedAudioSource):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.wait_started = asyncio.Event()
+        self.capture_started = asyncio.Event()
+        self.capture_allowed = asyncio.Event()
+        self.playout_started = asyncio.Event()
         self.playout_allowed = asyncio.Event()
 
+    async def capture_frame(self, frame: rtc.AudioFrame) -> None:
+        if not self.capture_started.is_set():
+            self.capture_started.set()
+            await self.capture_allowed.wait()
+        await super().capture_frame(frame)
+
     async def wait_for_playout(self) -> None:
-        self.wait_started.set()
+        self.playout_started.set()
         await self.playout_allowed.wait()
         await super().wait_for_playout()
 
@@ -537,8 +555,9 @@ async def test_audio_output_excludes_discarded_audio_after_resume() -> None:
 
 
 @pytest.mark.asyncio
-async def test_audio_output_waits_for_source_playout_after_buffer_drains() -> None:
-    frame = rtc.AudioFrame(bytes(24000 * 2), 48000, 1, 24000)  # 500ms
+async def test_audio_output_waits_for_active_submission_and_source_playout() -> None:
+    # One progressive chunk leaves no buffered remainder after the forwarder dequeues it.
+    frame = rtc.AudioFrame(bytes(960 * 2), 48000, 1, 960)  # 20ms
 
     with patch("livekit.rtc.AudioSource", _BlockingAudioSource):
         output = _ParticipantAudioOutput(
@@ -547,32 +566,35 @@ async def test_audio_output_waits_for_source_playout_after_buffer_drains() -> No
             num_channels=1,
             track_publish_options=rtc.TrackPublishOptions(),
         )
+    forwarding_idle = _WaitObservedEvent()
+    forwarding_idle.set()
+    output._forwarding_idle = forwarding_idle
     output._subscribed_fut.set_result(None)  # skip track publish/subscription
     forward_task = asyncio.create_task(output._forward_audio())
     playout_task: asyncio.Task[PlaybackFinishedEvent] | None = None
-    source_wait_task: asyncio.Task[bool] | None = None
 
     try:
         await output.capture_frame(frame)
-        await asyncio.sleep(0)
+        await asyncio.wait_for(output._audio_source.capture_started.wait(), timeout=1.0)
+
         output.flush()
         playout_task = asyncio.create_task(output.wait_for_playout())
-        source_wait_task = asyncio.create_task(output._audio_source.wait_started.wait())
+        await asyncio.wait_for(forwarding_idle.wait_started.wait(), timeout=1.0)
 
-        done, _ = await asyncio.wait(
-            (source_wait_task, playout_task),
-            timeout=1.0,
-            return_when=asyncio.FIRST_COMPLETED,
-        )
+        assert not playout_task.done()
+        assert not output._audio_source.playout_started.is_set()
 
-        assert source_wait_task in done
+        output._audio_source.capture_allowed.set()
+        await asyncio.wait_for(output._audio_source.playout_started.wait(), timeout=1.0)
         assert not playout_task.done()
 
         output._audio_source.playout_allowed.set()
         finished = await playout_task
     finally:
-        if source_wait_task is not None and not source_wait_task.done():
-            await utils.aio.cancel_and_wait(source_wait_task)
+        output._audio_source.capture_allowed.set()
+        output._audio_source.playout_allowed.set()
+        if output._flush_task is not None and not output._flush_task.done():
+            await output._flush_task
         if playout_task is not None and not playout_task.done():
             await utils.aio.cancel_and_wait(playout_task)
         await utils.aio.cancel_and_wait(forward_task)

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -411,6 +411,18 @@ class _QueuedAudioSource(_FakeAudioSource):
         self.queued_duration = 0.0
 
 
+class _BlockingAudioSource(_QueuedAudioSource):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.wait_started = asyncio.Event()
+        self.playout_allowed = asyncio.Event()
+
+    async def wait_for_playout(self) -> None:
+        self.wait_started.set()
+        await self.playout_allowed.wait()
+        await super().wait_for_playout()
+
+
 @pytest.mark.asyncio
 async def test_audio_output_playback_started_fires_once_across_pause_resume() -> None:
     """A mid-segment pause/resume (false interruption) must not re-announce playback_started.
@@ -522,3 +534,48 @@ async def test_audio_output_excludes_discarded_audio_after_resume() -> None:
 
     assert not finished.interrupted
     assert finished.playback_position == pytest.approx(output._audio_source.played_duration)
+
+
+@pytest.mark.asyncio
+async def test_audio_output_waits_for_source_playout_after_buffer_drains() -> None:
+    frame = rtc.AudioFrame(bytes(24000 * 2), 48000, 1, 24000)  # 500ms
+
+    with patch("livekit.rtc.AudioSource", _BlockingAudioSource):
+        output = _ParticipantAudioOutput(
+            _FakeRoom(),
+            sample_rate=48000,
+            num_channels=1,
+            track_publish_options=rtc.TrackPublishOptions(),
+        )
+    output._subscribed_fut.set_result(None)  # skip track publish/subscription
+    forward_task = asyncio.create_task(output._forward_audio())
+    playout_task: asyncio.Task[PlaybackFinishedEvent] | None = None
+    source_wait_task: asyncio.Task[bool] | None = None
+
+    try:
+        await output.capture_frame(frame)
+        await asyncio.sleep(0)
+        output.flush()
+        playout_task = asyncio.create_task(output.wait_for_playout())
+        source_wait_task = asyncio.create_task(output._audio_source.wait_started.wait())
+
+        done, _ = await asyncio.wait(
+            (source_wait_task, playout_task),
+            timeout=1.0,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        assert source_wait_task in done
+        assert not playout_task.done()
+
+        output._audio_source.playout_allowed.set()
+        finished = await playout_task
+    finally:
+        if source_wait_task is not None and not source_wait_task.done():
+            await utils.aio.cancel_and_wait(source_wait_task)
+        if playout_task is not None and not playout_task.done():
+            await utils.aio.cancel_and_wait(playout_task)
+        await utils.aio.cancel_and_wait(forward_task)
+
+    assert not finished.interrupted
+    assert finished.playback_position == pytest.approx(frame.duration)

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -430,10 +430,10 @@ class _BlockingAudioSource(_QueuedAudioSource):
         self.playout_allowed = asyncio.Event()
 
     async def capture_frame(self, frame: rtc.AudioFrame) -> None:
+        await super().capture_frame(frame)
         if not self.capture_started.is_set():
             self.capture_started.set()
             await self.capture_allowed.wait()
-        await super().capture_frame(frame)
 
     async def wait_for_playout(self) -> None:
         self.playout_started.set()
@@ -552,6 +552,52 @@ async def test_audio_output_excludes_discarded_audio_after_resume() -> None:
 
     assert not finished.interrupted
     assert finished.playback_position == pytest.approx(output._audio_source.played_duration)
+
+
+@pytest.mark.asyncio
+async def test_audio_output_drops_a_paused_frame_from_an_interrupted_segment() -> None:
+    old_frame = rtc.AudioFrame(b"\x01\x00" * 960, 48000, 1, 960)  # 20ms
+    new_frame = rtc.AudioFrame(b"\x02\x00" * 1920, 48000, 1, 1920)  # 40ms
+
+    with patch("livekit.rtc.AudioSource", _QueuedAudioSource):
+        output = _ParticipantAudioOutput(
+            _FakeRoom(),
+            sample_rate=48000,
+            num_channels=1,
+            track_publish_options=rtc.TrackPublishOptions(),
+        )
+    playback_enabled = _WaitObservedEvent()
+    playback_enabled.set()
+    output._playback_enabled = playback_enabled
+    output._subscribed_fut.set_result(None)  # skip track publish/subscription
+    forward_task = asyncio.create_task(output._forward_audio())
+
+    try:
+        output.pause()
+        await output.capture_frame(old_frame)
+        await asyncio.wait_for(playback_enabled.wait_started.wait(), timeout=1.0)
+        assert output._audio_buf.empty()
+        assert not output._forwarding_idle.is_set()
+
+        output.flush()
+        output.clear_buffer()
+        interrupted = await output.wait_for_playout()
+
+        output.resume()
+        await output.capture_frame(new_frame)
+        output.flush()
+        finished = await output.wait_for_playout()
+    finally:
+        output.resume()
+        if output._flush_task is not None and not output._flush_task.done():
+            await output._flush_task
+        await utils.aio.cancel_and_wait(forward_task)
+
+    assert interrupted.interrupted
+    assert interrupted.playback_position == 0
+    assert not finished.interrupted
+    assert finished.playback_position == pytest.approx(new_frame.duration)
+    assert b"".join(bytes(f.data) for f in output._audio_source.captured) == bytes(new_frame.data)
 
 
 @pytest.mark.asyncio

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -396,10 +396,12 @@ class _QueuedAudioSource(_FakeAudioSource):
         super().__init__(*args, **kwargs)
         self.clear_count = 0
         self.played_duration = 0.0
+        self.frame_queued = asyncio.Event()
 
     async def capture_frame(self, frame: rtc.AudioFrame) -> None:
         await super().capture_frame(frame)
         self.queued_duration += frame.duration
+        self.frame_queued.set()
 
     async def wait_for_playout(self) -> None:
         await asyncio.sleep(0)
@@ -552,6 +554,37 @@ async def test_audio_output_excludes_discarded_audio_after_resume() -> None:
 
     assert not finished.interrupted
     assert finished.playback_position == pytest.approx(output._audio_source.played_duration)
+
+
+@pytest.mark.asyncio
+async def test_audio_output_finishes_playout_when_paused_after_forwarding_drains() -> None:
+    frame = rtc.AudioFrame(bytes(960 * 2), 48000, 1, 960)  # 20ms
+
+    with patch("livekit.rtc.AudioSource", _QueuedAudioSource):
+        output = _ParticipantAudioOutput(
+            _FakeRoom(),
+            sample_rate=48000,
+            num_channels=1,
+            track_publish_options=rtc.TrackPublishOptions(),
+        )
+    output._subscribed_fut.set_result(None)  # skip track publish/subscription
+    forward_task = asyncio.create_task(output._forward_audio())
+
+    try:
+        await output.capture_frame(frame)
+        await asyncio.wait_for(output._audio_source.frame_queued.wait(), timeout=1.0)
+
+        output.flush()
+        output.pause()
+        finished = await asyncio.wait_for(output.wait_for_playout(), timeout=1.0)
+    finally:
+        output.resume()
+        if output._flush_task is not None and not output._flush_task.done():
+            await output._flush_task
+        await utils.aio.cancel_and_wait(forward_task)
+
+    assert not finished.interrupted
+    assert finished.playback_position == pytest.approx(frame.duration)
 
 
 @pytest.mark.asyncio

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -395,10 +395,16 @@ class _QueuedAudioSource(_FakeAudioSource):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.clear_count = 0
+        self.played_duration = 0.0
 
     async def capture_frame(self, frame: rtc.AudioFrame) -> None:
         await super().capture_frame(frame)
         self.queued_duration += frame.duration
+
+    async def wait_for_playout(self) -> None:
+        await asyncio.sleep(0)
+        self.played_duration += self.queued_duration
+        self.queued_duration = 0.0
 
     def clear_queue(self) -> None:
         self.clear_count += 1
@@ -482,3 +488,37 @@ async def test_audio_output_does_not_report_discarded_audio_as_played() -> None:
     assert len(finished) == 1
     assert finished[0].interrupted
     assert finished[0].playback_position == 0
+
+
+@pytest.mark.asyncio
+async def test_audio_output_excludes_discarded_audio_after_resume() -> None:
+    frame = rtc.AudioFrame(bytes(24000 * 2), 48000, 1, 24000)  # 500ms
+    resumed_frame = rtc.AudioFrame(bytes(9600 * 2), 48000, 1, 9600)  # 200ms
+
+    with patch("livekit.rtc.AudioSource", _QueuedAudioSource):
+        output = _ParticipantAudioOutput(
+            _FakeRoom(),
+            sample_rate=48000,
+            num_channels=1,
+            track_publish_options=rtc.TrackPublishOptions(),
+        )
+    output._subscribed_fut.set_result(None)  # skip track publish/subscription
+    forward_task = asyncio.create_task(output._forward_audio())
+
+    try:
+        await output.capture_frame(frame)
+        await asyncio.sleep(0)
+
+        output.pause()
+        await output.capture_frame(resumed_frame)
+        output.flush()
+        await asyncio.sleep(0)
+        assert output._audio_source.clear_count == 1
+
+        output.resume()
+        finished = await output.wait_for_playout()
+    finally:
+        await utils.aio.cancel_and_wait(forward_task)
+
+    assert not finished.interrupted
+    assert finished.playback_position == pytest.approx(output._audio_source.played_duration)


### PR DESCRIPTION
**Problem:** Pausing RoomIO cleared queued agent audio, but interruption accounting later treated it as played. RecorderIO then padded the user track to match audio that never played.

**Behavior:** Interrupted playback now derives position from audio sent to the source, excluding queued and discarded durations. Buffered or pause-held frames never count as playout.

Fixes AGT-3231