### PR TITLE
fix(xai): emit one final user transcript per turn

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1459,7 +1459,7 @@ class RealtimeSession(
             except asyncio.TimeoutError:
                 raise llm.RealtimeError("update_chat_ctx timed out.") from None
             finally:
-                # the waiters end with the update, so a late reply finds nothing to settle
+                self._chat_ctx_event_futures = {}
                 for ev in events:
                     if isinstance(ev, ConversationItemDeleteEvent):
                         self._item_delete_future.pop(ev.item_id, None)

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -886,8 +886,8 @@ class RealtimeSession(
         self._item_delete_future: dict[str, asyncio.Future] = {}
         self._item_create_future: dict[str, asyncio.Future] = {}
 
-        # item id per in-flight event id, so a rejection can be traced back to its item
-        self._chat_ctx_event_items: dict[str, str] = {}
+        # future per in-flight chat ctx event, so a rejection settles the one it answers
+        self._chat_ctx_event_futures: dict[str, asyncio.Future] = {}
 
         # generate_reply event_ids cancelled or timed out before response.created arrived; the
         # response is cancelled by id and discarded when it finally arrives
@@ -946,7 +946,9 @@ class RealtimeSession(
             if tools:
                 events.append(self._create_tools_update_event(tools))
 
-            # chat context
+            # chat context. the turn state goes first, since what it settles belongs in the
+            # mirror that is replayed below
+            self._reset_input_turn_state()
             chat_ctx = self.chat_ctx.copy(
                 exclude_function_call=True,
                 exclude_instructions=True,
@@ -956,7 +958,6 @@ class RealtimeSession(
             )
             old_chat_ctx = self._remote_chat_ctx
             self._remote_chat_ctx = llm.remote_chat_context.RemoteChatContext()
-            self._reset_input_turn_state()
             events.extend(self._create_update_chat_ctx_events(chat_ctx))
 
             try:
@@ -1433,20 +1434,20 @@ class RealtimeSession(
 
             events = self._create_update_chat_ctx_events(chat_ctx)
             futs: list[asyncio.Future[None]] = []
-            self._chat_ctx_event_items = {}
+            self._chat_ctx_event_futures = {}
 
             for ev in events:
                 futs.append(f := asyncio.Future[None]())
                 if isinstance(ev, ConversationItemDeleteEvent):
-                    item_id = ev.item_id
-                    self._item_delete_future[item_id] = f
+                    self._item_delete_future[ev.item_id] = f
                 else:
                     assert ev.item.id is not None
-                    item_id = ev.item.id
-                    self._item_create_future[item_id] = f
+                    self._item_create_future[ev.item.id] = f
 
+                # an updated item sends a delete and a create under the same id, so only the
+                # event id tells a rejection which of the two it answers
                 if ev.event_id:
-                    self._chat_ctx_event_items[ev.event_id] = item_id
+                    self._chat_ctx_event_futures[ev.event_id] = f
                 self.send_event(ev)
 
             if not futs:
@@ -1456,15 +1457,15 @@ class RealtimeSession(
                     asyncio.gather(*futs, return_exceptions=True), timeout=5.0
                 )
             except asyncio.TimeoutError:
-                # clean up timed-out futures so late server responses don't hit
-                # InvalidStateError when calling set_result on cancelled futures
+                raise llm.RealtimeError("update_chat_ctx timed out.") from None
+            finally:
+                # the waiters end with the update, so a late reply finds nothing to settle
                 for ev in events:
                     if isinstance(ev, ConversationItemDeleteEvent):
                         self._item_delete_future.pop(ev.item_id, None)
-                    elif isinstance(ev, ConversationItemCreateEvent):
+                    else:
                         assert ev.item.id is not None
                         self._item_create_future.pop(ev.item.id, None)
-                raise llm.RealtimeError("update_chat_ctx timed out.") from None
 
             # a rejected item is not worth failing the turn over
             if rejected := [str(r) for r in results if isinstance(r, BaseException)]:
@@ -1931,8 +1932,8 @@ class RealtimeSession(
             )
 
         if fut := self._item_create_future.pop(event.item.id, None):
-            if fut.cancelled():
-                logger.error(f"item create future for `{event.item.id}` was already cancelled")
+            if fut.done():
+                logger.error(f"item create future for `{event.item.id}` was already settled")
             else:
                 fut.set_result(None)
 
@@ -1950,8 +1951,8 @@ class RealtimeSession(
             )
 
         if fut := self._item_delete_future.pop(event.item_id, None):
-            if fut.cancelled():
-                logger.error(f"item delete future for `{event.item_id}` was already cancelled")
+            if fut.done():
+                logger.error(f"item delete future for `{event.item_id}` was already settled")
             else:
                 fut.set_result(None)
 
@@ -2273,12 +2274,13 @@ class RealtimeSession(
         # a rejected item event gets no deleted/added reply, so fail its future rather than
         # leave update_chat_ctx to stall inside the speech that awaits it
         if (event_id := event.error.event_id) and (
-            item_id := self._chat_ctx_event_items.pop(event_id, None)
+            fut := self._chat_ctx_event_futures.pop(event_id, None)
         ):
-            for pending in (self._item_delete_future, self._item_create_future):
-                if (fut := pending.pop(item_id, None)) and not fut.done():
-                    fut.set_exception(llm.RealtimeError(event.error.message))
-            return
+            if not fut.done():
+                fut.set_exception(llm.RealtimeError(event.error.message))
+            # a terminal one still has to end the session, whatever it came in reply to
+            if not _is_fatal_error(event.error):
+                return
 
         if event.error.message.startswith("Cancellation failed"):
             return

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -886,6 +886,9 @@ class RealtimeSession(
         self._item_delete_future: dict[str, asyncio.Future] = {}
         self._item_create_future: dict[str, asyncio.Future] = {}
 
+        # item id per in-flight event id, so a rejection can be traced back to its item
+        self._chat_ctx_event_items: dict[str, str] = {}
+
         # generate_reply event_ids cancelled or timed out before response.created arrived; the
         # response is cancelled by id and discarded when it finally arrives
         self._discarded_event_ids: set[str] = set()
@@ -1096,12 +1099,8 @@ class RealtimeSession(
                     self.emit("openai_client_event_queued", msg)
                     await ws_conn.send_str(json.dumps(msg))
 
-                    if lk_oai_debug:
-                        msg_copy = msg.copy()
-                        if msg_copy["type"] == "input_audio_buffer.append":
-                            msg_copy = {**msg_copy, "audio": "..."}
-
-                        logger.debug(f">>> {msg_copy}")
+                    if lk_oai_debug and msg["type"] != "input_audio_buffer.append":
+                        logger.debug(f">>> {msg}")
                 except Exception:
                     logger.exception("failed to send event")
 
@@ -1434,20 +1433,28 @@ class RealtimeSession(
 
             events = self._create_update_chat_ctx_events(chat_ctx)
             futs: list[asyncio.Future[None]] = []
+            self._chat_ctx_event_items = {}
 
             for ev in events:
                 futs.append(f := asyncio.Future[None]())
                 if isinstance(ev, ConversationItemDeleteEvent):
-                    self._item_delete_future[ev.item_id] = f
-                elif isinstance(ev, ConversationItemCreateEvent):
+                    item_id = ev.item_id
+                    self._item_delete_future[item_id] = f
+                else:
                     assert ev.item.id is not None
-                    self._item_create_future[ev.item.id] = f
+                    item_id = ev.item.id
+                    self._item_create_future[item_id] = f
+
+                if ev.event_id:
+                    self._chat_ctx_event_items[ev.event_id] = item_id
                 self.send_event(ev)
 
             if not futs:
                 return
             try:
-                await asyncio.wait_for(asyncio.gather(*futs, return_exceptions=True), timeout=5.0)
+                results = await asyncio.wait_for(
+                    asyncio.gather(*futs, return_exceptions=True), timeout=5.0
+                )
             except asyncio.TimeoutError:
                 # clean up timed-out futures so late server responses don't hit
                 # InvalidStateError when calling set_result on cancelled futures
@@ -1458,6 +1465,13 @@ class RealtimeSession(
                         assert ev.item.id is not None
                         self._item_create_future.pop(ev.item.id, None)
                 raise llm.RealtimeError("update_chat_ctx timed out.") from None
+
+            # a rejected item is not worth failing the turn over
+            if rejected := [str(r) for r in results if isinstance(r, BaseException)]:
+                logger.warning(
+                    f"{self._realtime_model._provider_label} rejected part of a chat context update",  # noqa: E501
+                    extra={"errors": rejected},
+                )
 
     def _create_update_chat_ctx_events(
         self, chat_ctx: llm.ChatContext
@@ -2256,6 +2270,16 @@ class RealtimeSession(
             logger.debug("Unknown response status: %s", event.response.status)
 
     def _handle_error(self, event: RealtimeErrorEvent) -> None:
+        # a rejected item event gets no deleted/added reply, so fail its future rather than
+        # leave update_chat_ctx to stall inside the speech that awaits it
+        if (event_id := event.error.event_id) and (
+            item_id := self._chat_ctx_event_items.pop(event_id, None)
+        ):
+            for pending in (self._item_delete_future, self._item_create_future):
+                if (fut := pending.pop(item_id, None)) and not fut.done():
+                    fut.set_exception(llm.RealtimeError(event.error.message))
+            return
+
         if event.error.message.startswith("Cancellation failed"):
             return
 

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/realtime/realtime_model.py
@@ -7,13 +7,19 @@ from openai.types.beta.realtime.session import TurnDetection
 from openai.types.realtime import (
     AudioTranscription,
     ConversationItemAdded,
+    ConversationItemCreateEvent,
     ConversationItemDeletedEvent,
+    ConversationItemDeleteEvent,
     ConversationItemInputAudioTranscriptionCompletedEvent,
+    InputAudioBufferSpeechStartedEvent,
     RealtimeAudioConfig,
     RealtimeAudioConfigInput,
     RealtimeAudioConfigOutput,
     RealtimeConversationItemFunctionCall,
     RealtimeSessionCreateRequest,
+    ResponseAudioDeltaEvent,
+    ResponseCreatedEvent,
+    ResponseTextDeltaEvent,
 )
 from openai.types.realtime.realtime_audio_input_turn_detection import ServerVad
 from openai.types.realtime.session_update_event import SessionUpdateEvent
@@ -29,6 +35,7 @@ from livekit.agents.types import (
 )
 from livekit.agents.utils import is_given
 from livekit.plugins import openai
+from livekit.plugins.openai.realtime.realtime_model import _DiscardedGeneration
 
 from ..log import logger
 from ..tools import XAITool
@@ -100,6 +107,10 @@ class RealtimeModel(openai.realtime.RealtimeModel):
 class RealtimeSession(openai.realtime.RealtimeSession):
     """xAI Realtime Session that supports xAI built-in tools."""
 
+    # the base __init__ resets the input turn state before the subclass body runs
+    _pending_transcription: ConversationItemInputAudioTranscriptionCompletedEvent | None = None
+    _response_spoke: bool = False
+
     def __init__(self, realtime_model: RealtimeModel) -> None:
         super().__init__(realtime_model)
         self._xai_model: RealtimeModel = realtime_model
@@ -109,7 +120,16 @@ class RealtimeSession(openai.realtime.RealtimeSession):
         self._session_connected_at = time.time()
         await super()._run_ws(ws_conn)
 
+    def _reset_input_turn_state(self) -> None:
+        # a reconnect voids every item id, so deliver the held transcript first
+        self._flush_input_transcription()
+        super()._reset_input_turn_state()
+        self._response_spoke = False
+
     async def aclose(self) -> None:
+        # nothing else ends the turn now, and the transcript must not go with the session
+        self._flush_input_transcription()
+
         # emit session duration metrics before closing (for xAI's per-minute billing)
         if self._session_connected_at > 0:
             session_duration = time.time() - self._session_connected_at
@@ -182,9 +202,75 @@ class RealtimeSession(openai.realtime.RealtimeSession):
 
         super()._handle_function_call(item)
 
+    def _create_update_chat_ctx_events(
+        self, chat_ctx: llm.ChatContext
+    ) -> list[ConversationItemCreateEvent | ConversationItemDeleteEvent]:
+        # stand the mirror's item in for a held turn, or the diff drops it and moves the reply
+        # ahead of it
+        pending = self._pending_transcription
+        node = self._remote_chat_ctx.get(pending.item_id) if pending else None
+        if node is not None and chat_ctx.get_by_id(node.item.id) is None:
+            chat_ctx = chat_ctx.copy()
+            index, previous = 0, node._prev
+            while previous is not None:
+                if (at := chat_ctx.index_by_id(previous.item.id)) is not None:
+                    index = at + 1
+                    break
+                previous = previous._prev
+            chat_ctx.items.insert(index, node.item.model_copy())
+
+        return super()._create_update_chat_ctx_events(chat_ctx)
+
+    def _discard_abandoned_response(self) -> None:
+        """Drop a response that xAI killed before it spoke, which nothing else reports."""
+        generation = self._current_generation
+        if (
+            generation is None
+            or self._response_spoke
+            or isinstance(generation, _DiscardedGeneration)
+        ):
+            return
+
+        logger.debug("discarding the response xAI left in flight")
+        self._close_current_generation()
+        # anything still in flight for it must not land on the response that follows
+        self._current_generation = _DiscardedGeneration()
+
+    def interrupt(self) -> None:
+        # the cancel names no response, so whichever one was in flight is over either way
+        super().interrupt()
+        self._discard_abandoned_response()
+
+    def _handle_response_created(self, event: ResponseCreatedEvent) -> None:
+        # a response that finished clears itself, so anything left here was abandoned
+        self._discard_abandoned_response()
+        self._close_current_generation()
+        self._response_spoke = False
+        super()._handle_response_created(event)
+
+    def _handle_input_audio_buffer_speech_started(
+        self, event: InputAudioBufferSpeechStartedEvent
+    ) -> None:
+        # xAI reuses the item across a pause, so a different id means the held turn is over
+        if self._pending_transcription and self._pending_transcription.item_id != event.item_id:
+            self._flush_input_transcription()
+
+        # the turn began at its first speech segment, so a resumed one must not restamp it
+        started_at = self._input_speech_started_at.get(event.item_id)
+        super()._handle_input_audio_buffer_speech_started(event)
+        if started_at is not None:
+            self._input_speech_started_at[event.item_id] = started_at
+
     def _handle_conversion_item_added(self, event: ConversationItemAdded) -> None:
-        # xAI's `conversation.item.added` event always has the previous_item_id as None
-        # replace it with the last item in the remote chat context
+        # xAI omits previous_item_id, or names an item it never announced, so append rather
+        # than lose the item and every later one anchored to it
+        if event.previous_item_id and not self._remote_chat_ctx.get(event.previous_item_id):
+            logger.warning(
+                "xAI anchored an item to one it never announced, appending it instead",
+                extra={"item_id": event.item.id, "previous_item_id": event.previous_item_id},
+            )
+            event.previous_item_id = None
+
         if event.previous_item_id is None:
             event.previous_item_id = (
                 self._remote_chat_ctx._tail.item.id if self._remote_chat_ctx._tail else None
@@ -203,30 +289,47 @@ class RealtimeSession(openai.realtime.RealtimeSession):
     def _handle_conversion_item_input_audio_transcription_completed(
         self, event: ConversationItemInputAudioTranscriptionCompletedEvent
     ) -> None:
-        # Unlike OpenAI, xAI streams partial transcripts through this same event,
-        # distinguishing them with a `status` field ("in_progress" for partials,
-        # "completed" for the final transcript). The OpenAI base handler ignores
-        # `status` and always emits is_final=True, so every partial would be
-        # surfaced as a final transcription (and a duplicate conversation item).
-        # Emit interim updates for in-progress transcripts and only delegate to the
-        # base handler for the final one.
-        if getattr(event, "status", None) == "in_progress":
-            self.emit(
-                "input_audio_transcription_completed",
-                llm.InputTranscriptionCompleted(
-                    item_id=event.item_id,
-                    transcript=event.transcript,
-                    is_final=False,
-                ),
-            )
+        # xAI re-transcribes the whole item at every commit, and the item outlives a pause,
+        # so only the last commit of a turn carries its final
+        if getattr(event, "status", None) != "in_progress":
+            if self._pending_transcription and self._pending_transcription.item_id != event.item_id:
+                self._flush_input_transcription()
+            self._pending_transcription = event
+
+        self.emit(
+            "input_audio_transcription_completed",
+            llm.InputTranscriptionCompleted(
+                item_id=event.item_id,
+                transcript=event.transcript,
+                is_final=False,
+            ),
+        )
+
+    def _flush_input_transcription(self) -> None:
+        """Deliver the held transcript as the single final of its item."""
+        if (event := self._pending_transcription) is None:
             return
 
-        # audio transcription is included when the item is added
-        # clear the content before appending the transcript to avoid duplicates
-        if remote_item := self._remote_chat_ctx.get(event.item_id):
-            if (
-                remote_item.item.type == "message"
-                and remote_item.item.raw_text_content == event.transcript
-            ):
-                remote_item.item.content.clear()
+        self._pending_transcription = None
+
+        # the transcript covers the item from the start, so it replaces the mirrored text
+        if (remote_item := self._remote_chat_ctx.get(event.item_id)) and (
+            remote_item.item.type == "message"
+        ):
+            remote_item.item.content = [
+                content for content in remote_item.item.content if not isinstance(content, str)
+            ]
         super()._handle_conversion_item_input_audio_transcription_completed(event)
+
+    def _handle_response_audio_delta(self, event: ResponseAudioDeltaEvent) -> None:
+        # xAI drops a response the user talks over without a word, so its first output is the
+        # only proof that the turn ended
+        self._response_spoke = True
+        self._flush_input_transcription()
+        super()._handle_response_audio_delta(event)
+
+    def _handle_response_text_delta(self, event: ResponseTextDeltaEvent) -> None:
+        # the same boundary, for a response that answers in text
+        self._response_spoke = True
+        self._flush_input_transcription()
+        super()._handle_response_text_delta(event)

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/types.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/types.py
@@ -58,8 +58,9 @@ GrokVoices = Literal[
 ]
 
 GrokRealtimeModels = Literal[
-    "grok-voice-think-fast-1.0",
     "grok-voice-fast-1.0",
+    "grok-voice-think-fast-1.0",
+    "grok-voice-think-fast-2.0",
 ]
 
 TTSLanguages = Literal[

--- a/tests/test_realtime/test_openai_realtime_model.py
+++ b/tests/test_realtime/test_openai_realtime_model.py
@@ -7,7 +7,7 @@ from typing import cast
 
 import pytest
 from openai.types.beta.realtime.session import TurnDetection as BetaTurnDetection
-from openai.types.realtime import RealtimeErrorEvent
+from openai.types.realtime import ConversationItemDeletedEvent, RealtimeErrorEvent
 from openai.types.realtime.realtime_audio_input_turn_detection import ServerVad
 
 from livekit.agents import llm
@@ -165,7 +165,7 @@ def _handle_error_session(
         SimpleNamespace(
             _realtime_model=SimpleNamespace(_provider_label="openai"),
             _opts=SimpleNamespace(turn_detection=turn_detection),
-            _chat_ctx_event_items={},
+            _chat_ctx_event_futures={},
             _emit_error=lambda error, recoverable: capture.update(recoverable=recoverable),
         ),
     )
@@ -263,28 +263,82 @@ def test_response_done_failed_transient_stays_recoverable() -> None:
     assert captured["recoverable"] is True
 
 
+def _chat_ctx_update_session() -> RealtimeSession:
+    """A session mid-update, with the delete and the create of one updated item in flight."""
+    session = _handle_error_session({})
+    session._item_delete_future = {"item_1": asyncio.Future()}
+    session._item_create_future = {"item_1": asyncio.Future()}
+    session._chat_ctx_event_futures = {
+        "chat_ctx_delete_abc": session._item_delete_future["item_1"],
+        "chat_ctx_create_abc": session._item_create_future["item_1"],
+    }
+    return session
+
+
+def _rejection(event_id: str, code: str = "invalid_request_error") -> RealtimeErrorEvent:
+    return RealtimeErrorEvent.construct(
+        type="error",
+        event_id=event_id,
+        error={
+            "message": "Item not found: item_1",
+            "type": "invalid_request_error",
+            "code": code,
+            "event_id": event_id,
+        },
+    )
+
+
 async def test_a_rejected_chat_ctx_event_releases_its_waiter() -> None:
     # a rejected delete gets an error instead of conversation.item.deleted, so nothing else
     # settles the future that update_chat_ctx awaits inside the speech
-    session = RealtimeSession.__new__(RealtimeSession)
-    session._item_delete_future = {}
-    session._item_create_future = {}
-    session._chat_ctx_event_items = {"chat_ctx_delete_abc": "item_1"}
-    session._item_delete_future["item_1"] = (waiter := asyncio.Future())
+    session = _chat_ctx_update_session()
+    waiter = session._item_delete_future["item_1"]
 
-    session._handle_error(
-        RealtimeErrorEvent.construct(
-            type="error",
-            event_id="chat_ctx_delete_abc",
-            error={
-                "message": "Item not found: item_1",
-                "type": "invalid_request_error",
-                "code": "invalid_request_error",
-                "event_id": "chat_ctx_delete_abc",
-            },
-        )
-    )
+    RealtimeSession._handle_error(session, _rejection("chat_ctx_delete_abc"))
 
     assert waiter.done(), "update_chat_ctx would wait out its timeout, and the speech with it"
     assert isinstance(waiter.exception(), llm.RealtimeError)
-    assert "item_1" not in session._item_delete_future
+
+
+async def test_a_rejected_waiter_is_not_settled_twice() -> None:
+    # the waiter stays parked under its item id, where a late reply would set a result on it
+    session = _chat_ctx_update_session()
+    session._remote_chat_ctx = RemoteChatContext()
+    session._input_transcript_accumulators = {}
+    session._input_speech_started_at = {}
+    waiter = session._item_delete_future["item_1"]
+    RealtimeSession._handle_error(session, _rejection("chat_ctx_delete_abc"))
+
+    RealtimeSession._handle_conversion_item_deleted(
+        session,
+        ConversationItemDeletedEvent.construct(
+            type="conversation.item.deleted", event_id="evt", item_id="item_1"
+        ),
+    )
+
+    assert isinstance(waiter.exception(), llm.RealtimeError)
+
+
+async def test_a_rejection_leaves_its_sibling_event_alone() -> None:
+    # an updated item is deleted and created under one id, and the create can still land
+    session = _chat_ctx_update_session()
+    sibling = session._item_create_future["item_1"]
+
+    RealtimeSession._handle_error(session, _rejection("chat_ctx_delete_abc"))
+
+    assert not sibling.done()
+    assert session._item_create_future["item_1"] is sibling
+
+
+async def test_a_fatal_error_on_a_chat_ctx_event_still_ends_the_session() -> None:
+    # the error names the event that drew it, and an exhausted quota must stop the session
+    session = _chat_ctx_update_session()
+    waiter = session._item_create_future["item_1"]
+
+    with pytest.raises(APIError) as exc_info:
+        RealtimeSession._handle_error(
+            session, _rejection("chat_ctx_create_abc", code="insufficient_quota")
+        )
+
+    assert exc_info.value.retryable is False
+    assert isinstance(waiter.exception(), llm.RealtimeError)

--- a/tests/test_realtime/test_openai_realtime_model.py
+++ b/tests/test_realtime/test_openai_realtime_model.py
@@ -7,7 +7,11 @@ from typing import cast
 
 import pytest
 from openai.types.beta.realtime.session import TurnDetection as BetaTurnDetection
-from openai.types.realtime import ConversationItemDeletedEvent, RealtimeErrorEvent
+from openai.types.realtime import (
+    ConversationItemCreateEvent,
+    ConversationItemDeletedEvent,
+    RealtimeErrorEvent,
+)
 from openai.types.realtime.realtime_audio_input_turn_detection import ServerVad
 
 from livekit.agents import llm
@@ -317,6 +321,35 @@ async def test_a_rejected_waiter_is_not_settled_twice() -> None:
     )
 
     assert isinstance(waiter.exception(), llm.RealtimeError)
+
+
+async def test_an_error_outliving_its_update_is_still_reported() -> None:
+    # an error that lands on a waiter the update already retired settles nothing, so it has to
+    # go down the ordinary path rather than pass for a rejected item
+    session = RealtimeSession.__new__(RealtimeSession)
+    session._realtime_model = SimpleNamespace(_provider_label="openai", _label="openai")  # type: ignore[assignment]
+    session._opts = SimpleNamespace(turn_detection=None)  # type: ignore[assignment]
+    session._update_chat_ctx_lock = asyncio.Lock()
+    session._remote_chat_ctx = RemoteChatContext()
+    session._item_delete_future = {}
+    session._item_create_future = {}
+    session._chat_ctx_event_futures = {}
+    sent: list[ConversationItemCreateEvent] = []
+    session.send_event = sent.append  # type: ignore[method-assign,assignment]
+    errors: list[llm.RealtimeModelError] = []
+    session.emit = lambda name, ev: errors.append(ev)  # type: ignore[method-assign,assignment]
+
+    chat_ctx = llm.ChatContext.empty()
+    chat_ctx.add_message(role="user", content="hello", id="item_1")
+    update = asyncio.create_task(session.update_chat_ctx(chat_ctx))
+    await asyncio.sleep(0)  # let it send the create and start waiting on it
+    assert (waiter := session._item_create_future.get("item_1")) is not None
+    waiter.set_result(None)  # what conversation.item.added does
+    await update
+
+    session._handle_error(_rejection(sent[0].event_id))
+
+    assert [e.recoverable for e in errors] == [True], "swallowed by a retired waiter"
 
 
 async def test_a_rejection_leaves_its_sibling_event_alone() -> None:

--- a/tests/test_realtime/test_openai_realtime_model.py
+++ b/tests/test_realtime/test_openai_realtime_model.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from types import SimpleNamespace
 from typing import cast
 
 import pytest
 from openai.types.beta.realtime.session import TurnDetection as BetaTurnDetection
+from openai.types.realtime import RealtimeErrorEvent
 from openai.types.realtime.realtime_audio_input_turn_detection import ServerVad
 
 from livekit.agents import llm
@@ -163,6 +165,7 @@ def _handle_error_session(
         SimpleNamespace(
             _realtime_model=SimpleNamespace(_provider_label="openai"),
             _opts=SimpleNamespace(turn_detection=turn_detection),
+            _chat_ctx_event_items={},
             _emit_error=lambda error, recoverable: capture.update(recoverable=recoverable),
         ),
     )
@@ -174,7 +177,7 @@ def test_handle_error_raises_on_fatal() -> None:
     captured: dict[str, object] = {}
     session = _handle_error_session(captured)
     event = SimpleNamespace(
-        error=SimpleNamespace(message="quota exceeded", code="insufficient_quota")
+        error=SimpleNamespace(event_id=None, message="quota exceeded", code="insufficient_quota")
     )
     with pytest.raises(APIError) as exc_info:
         RealtimeSession._handle_error(session, event)
@@ -185,14 +188,18 @@ def test_handle_error_raises_on_fatal() -> None:
 def test_handle_error_emits_transient_as_recoverable() -> None:
     captured: dict[str, object] = {}
     session = _handle_error_session(captured)
-    event = SimpleNamespace(error=SimpleNamespace(message="server hiccup", code="server_error"))
+    event = SimpleNamespace(
+        error=SimpleNamespace(event_id=None, message="server hiccup", code="server_error")
+    )
     RealtimeSession._handle_error(session, event)
     assert captured["recoverable"] is True
 
 
 def test_handle_error_ignores_cancellation_failed() -> None:
     captured: dict[str, object] = {}
-    event = SimpleNamespace(error=SimpleNamespace(message="Cancellation failed: no response"))
+    event = SimpleNamespace(
+        error=SimpleNamespace(event_id=None, message="Cancellation failed: no response")
+    )
     RealtimeSession._handle_error(_handle_error_session(captured), event)
     assert captured == {}  # early return, nothing emitted
 
@@ -200,6 +207,7 @@ def test_handle_error_ignores_cancellation_failed() -> None:
 def _empty_commit_event() -> SimpleNamespace:
     return SimpleNamespace(
         error=SimpleNamespace(
+            event_id=None,
             message="Error committing input audio buffer: buffer too small.",
             code="input_audio_buffer_commit_empty",
         )
@@ -253,3 +261,30 @@ def test_response_done_failed_transient_stays_recoverable() -> None:
     )
     RealtimeSession._handle_response_done_but_not_complete(session, event)
     assert captured["recoverable"] is True
+
+
+async def test_a_rejected_chat_ctx_event_releases_its_waiter() -> None:
+    # a rejected delete gets an error instead of conversation.item.deleted, so nothing else
+    # settles the future that update_chat_ctx awaits inside the speech
+    session = RealtimeSession.__new__(RealtimeSession)
+    session._item_delete_future = {}
+    session._item_create_future = {}
+    session._chat_ctx_event_items = {"chat_ctx_delete_abc": "item_1"}
+    session._item_delete_future["item_1"] = (waiter := asyncio.Future())
+
+    session._handle_error(
+        RealtimeErrorEvent.construct(
+            type="error",
+            event_id="chat_ctx_delete_abc",
+            error={
+                "message": "Item not found: item_1",
+                "type": "invalid_request_error",
+                "code": "invalid_request_error",
+                "event_id": "chat_ctx_delete_abc",
+            },
+        )
+    )
+
+    assert waiter.done(), "update_chat_ctx would wait out its timeout, and the speech with it"
+    assert isinstance(waiter.exception(), llm.RealtimeError)
+    assert "item_1" not in session._item_delete_future

--- a/tests/test_realtime/test_xai_realtime_model.py
+++ b/tests/test_realtime/test_xai_realtime_model.py
@@ -1,91 +1,381 @@
 from __future__ import annotations
 
-import pytest
-from openai.types.realtime import ConversationItemInputAudioTranscriptionCompletedEvent
+import asyncio
+from types import SimpleNamespace
 
-from livekit.agents import llm
+import pytest
+from openai.types.realtime import (
+    ConversationItemAdded,
+    ConversationItemCreateEvent,
+    ConversationItemDeleteEvent,
+    ConversationItemInputAudioTranscriptionCompletedEvent,
+    InputAudioBufferSpeechStartedEvent,
+    ResponseAudioDeltaEvent,
+    ResponseCreatedEvent,
+    ResponseTextDeltaEvent,
+)
+
+from livekit.agents import llm, utils
 from livekit.agents.llm.remote_chat_context import RemoteChatContext
+from livekit.plugins.openai.realtime.realtime_model import (
+    _DiscardedGeneration,
+    _MessageGeneration,
+)
 from livekit.plugins.xai.realtime.realtime_model import RealtimeSession
 
 pytestmark = pytest.mark.unit
 
 
 def _make_session() -> tuple[RealtimeSession, list[llm.InputTranscriptionCompleted]]:
-    # build a session instance without going through __init__ (no network/model needed)
+    # no network or model is needed, and a discarded generation skips the base bookkeeping
     session = RealtimeSession.__new__(RealtimeSession)
     session._remote_chat_ctx = RemoteChatContext()  # type: ignore[attr-defined]
+    session._current_generation = _DiscardedGeneration()  # type: ignore[attr-defined]
+    session._opts = SimpleNamespace(modalities=["audio", "text"])  # type: ignore[assignment]
+    session._item_create_future = {}  # type: ignore[attr-defined]
+    session._msg_ch = utils.aio.Chan()  # type: ignore[attr-defined]
     session._reset_input_turn_state()
 
     emitted: list[llm.InputTranscriptionCompleted] = []
-    session.emit = lambda name, ev: emitted.append(ev)  # type: ignore[method-assign,assignment]
+
+    def _emit(name: str, ev: object) -> None:
+        if name == "input_audio_transcription_completed":
+            emitted.append(ev)  # type: ignore[arg-type]
+
+    session.emit = _emit  # type: ignore[method-assign,assignment]
     return session, emitted
 
 
-def _completed_event(
-    *, item_id: str, transcript: str, status: str | None
-) -> ConversationItemInputAudioTranscriptionCompletedEvent:
+def _finals(emitted: list[llm.InputTranscriptionCompleted]) -> list[tuple[str, str]]:
+    return [(ev.item_id, ev.transcript) for ev in emitted if ev.is_final]
+
+
+def _transcript(session: RealtimeSession, item_id: str, text: str, *, status: str | None) -> None:
     payload: dict = {
         "type": "conversation.item.input_audio_transcription.completed",
         "event_id": "evt",
         "item_id": item_id,
         "content_index": 0,
-        "transcript": transcript,
+        "transcript": text,
     }
     if status is not None:
         payload["status"] = status
-    return ConversationItemInputAudioTranscriptionCompletedEvent.construct(**payload)
-
-
-def test_in_progress_transcript_emitted_as_interim() -> None:
-    session, emitted = _make_session()
-
     session._handle_conversion_item_input_audio_transcription_completed(
-        _completed_event(item_id="item_1", transcript="what is", status="in_progress")
+        ConversationItemInputAudioTranscriptionCompletedEvent.construct(**payload)
     )
 
-    assert len(emitted) == 1
-    assert emitted[0].item_id == "item_1"
-    assert emitted[0].transcript == "what is"
-    assert emitted[0].is_final is False
+
+def _commit(session: RealtimeSession, item_id: str, text: str) -> None:
+    """One audio-buffer commit, which re-sends the whole transcript of the item."""
+    _transcript(session, item_id, text, status="completed")
 
 
-def test_multiple_in_progress_transcripts_never_final() -> None:
+def _speech_started(session: RealtimeSession, item_id: str) -> None:
+    session._handle_input_audio_buffer_speech_started(
+        InputAudioBufferSpeechStartedEvent.construct(
+            type="input_audio_buffer.speech_started",
+            event_id="evt",
+            item_id=item_id,
+            audio_start_ms=0,
+        )
+    )
+
+
+def _agent_speaks(session: RealtimeSession) -> None:
+    """The first audio chunk of a response, which ends the turn."""
+    session._handle_response_audio_delta(
+        ResponseAudioDeltaEvent.construct(
+            type="response.output_audio.delta",
+            event_id="evt",
+            item_id="reply",
+            response_id="resp",
+            output_index=0,
+            content_index=0,
+            delta="",
+        )
+    )
+
+
+def _mirror(session: RealtimeSession, *items: tuple[str, str, str]) -> None:
+    """Fill the remote chat context with (item_id, role, text), in order."""
+    previous: str | None = None
+    for item_id, role, text in items:
+        session._remote_chat_ctx.insert(
+            previous, llm.ChatMessage(id=item_id, role=role, content=[text])
+        )
+        previous = item_id
+
+
+def _item_added(session: RealtimeSession, item_id: str, *, after: str | None) -> None:
+    session._handle_conversion_item_added(
+        ConversationItemAdded.construct(
+            type="conversation.item.added",
+            event_id="evt",
+            previous_item_id=after,
+            item={
+                "id": item_id,
+                "object": "realtime.item",
+                "type": "message",
+                "status": "in_progress",
+                "role": "assistant",
+                "content": [],
+            },
+        )
+    )
+
+
+def _response_created(session: RealtimeSession) -> None:
+    session._handle_response_created(
+        ResponseCreatedEvent.construct(
+            type="response.created",
+            event_id="evt",
+            response={"id": "resp", "object": "realtime.response", "output": []},
+        )
+    )
+
+
+def _reply_item_announced(session: RealtimeSession, item_id: str, *, after: str) -> None:
+    """Announce the reply item of a response that can then be abandoned unspoken."""
+    session._remote_chat_ctx.insert(
+        after, llm.ChatMessage(id=item_id, role="assistant", content=[])
+    )
+    session._current_generation.messages[item_id] = _MessageGeneration(  # type: ignore[union-attr]
+        message_id=item_id,
+        text_ch=utils.aio.Chan(),
+        audio_ch=utils.aio.Chan(),
+        modalities=asyncio.Future(),
+    )
+
+
+# -- when a turn becomes final ----------------------------------------------------------------
+
+
+def test_in_progress_transcripts_are_never_final() -> None:
     session, emitted = _make_session()
 
     for partial in ["what is", "what is my", "what is my name"]:
-        session._handle_conversion_item_input_audio_transcription_completed(
-            _completed_event(item_id="item_1", transcript=partial, status="in_progress")
-        )
+        _transcript(session, "item_1", partial, status="in_progress")
 
-    assert len(emitted) == 3
-    assert all(ev.is_final is False for ev in emitted)
-    assert [ev.transcript for ev in emitted] == [
-        "what is",
-        "what is my",
-        "what is my name",
+    assert _finals(emitted) == []
+    assert [ev.transcript for ev in emitted] == ["what is", "what is my", "what is my name"]
+
+
+def test_committed_transcript_is_final_once_the_agent_answers() -> None:
+    session, emitted = _make_session()
+
+    _commit(session, "item_1", "what is my name")
+    assert _finals(emitted) == [], "a commit is not the end of the turn"
+
+    _agent_speaks(session)
+    assert _finals(emitted) == [("item_1", "what is my name")]
+
+
+def test_missing_status_is_treated_as_committed() -> None:
+    # an event without a `status` field is held like a committed one
+    session, emitted = _make_session()
+
+    _transcript(session, "item_1", "what is my name", status=None)
+    _agent_speaks(session)
+
+    assert _finals(emitted) == [("item_1", "what is my name")]
+
+
+def test_text_only_response_ends_the_turn() -> None:
+    session, emitted = _make_session()
+
+    _commit(session, "item_1", "what is my name")
+    session._handle_response_text_delta(
+        ResponseTextDeltaEvent.construct(
+            type="response.output_text.delta",
+            event_id="evt",
+            item_id="reply",
+            response_id="resp",
+            output_index=0,
+            content_index=0,
+            delta="your",
+        )
+    )
+
+    assert _finals(emitted) == [("item_1", "what is my name")]
+
+
+def test_pause_within_a_turn_yields_one_final() -> None:
+    # the item outlives the pause and is re-transcribed from the start, "ones" to "once",
+    # so there is no delta to send and only the last commit is the final (#6710)
+    session, emitted = _make_session()
+
+    _commit(session, "item_1", "Hello, how are you? Last ones.")
+    _commit(session, "item_1", "Hello, how are you? Last once. I paid twice.")
+    _agent_speaks(session)
+
+    assert _finals(emitted) == [("item_1", "Hello, how are you? Last once. I paid twice.")]
+
+
+def test_abandoned_response_does_not_end_the_turn() -> None:
+    # a response the user talks over is dropped unspoken, so only a speaking one ends the turn
+    session, emitted = _make_session()
+
+    _commit(session, "item_1", "hello")
+    _commit(session, "item_1", "hello and one more thing")
+    assert _finals(emitted) == []
+
+    _agent_speaks(session)
+    assert _finals(emitted) == [("item_1", "hello and one more thing")]
+
+
+def test_next_turn_finalizes_one_the_agent_never_answered() -> None:
+    # the rescue when no response speaks: a different item id at speech start ends the turn
+    session, emitted = _make_session()
+
+    _commit(session, "item_1", "are you there")
+    _speech_started(session, "item_1")
+    assert _finals(emitted) == [], "the same item means the turn resumed"
+
+    _speech_started(session, "item_2")
+    assert _finals(emitted) == [("item_1", "are you there")]
+
+
+def test_a_new_item_transcript_finalizes_the_previous_turn() -> None:
+    session, emitted = _make_session()
+
+    _commit(session, "item_1", "hello")
+    _commit(session, "item_2", "are you there")
+
+    assert _finals(emitted) == [("item_1", "hello")]
+
+
+def test_reconnect_delivers_the_held_transcript() -> None:
+    # item ids do not survive a reconnect, so deliver the turn before they go
+    session, emitted = _make_session()
+
+    _commit(session, "item_1", "are you still there")
+    session._reset_input_turn_state()
+
+    assert _finals(emitted) == [("item_1", "are you still there")]
+    assert session._pending_transcription is None
+
+
+def test_speech_onset_survives_a_resumed_turn() -> None:
+    # the final reads the onset once, so a resumed segment must not overwrite it
+    session, _ = _make_session()
+
+    _speech_started(session, "item_1")
+    first = session._input_speech_started_at["item_1"]
+    _speech_started(session, "item_1")
+
+    assert session._input_speech_started_at["item_1"] == first
+
+
+# -- keeping the mirror and the reconcile honest -----------------------------------------------
+
+
+def test_remote_item_holds_the_transcript_once() -> None:
+    # the mirror is replayed on reconnect, so an append per commit resends the turn each time
+    session, _ = _make_session()
+    _mirror(session, ("item_1", "user", ""))
+
+    _commit(session, "item_1", "Hello, how are you? Last ones.")
+    _commit(session, "item_1", "Hello, how are you? Last once. I paid twice.")
+    _agent_speaks(session)
+
+    remote = session._remote_chat_ctx.get("item_1")
+    assert remote is not None
+    assert remote.item.content == ["Hello, how are you? Last once. I paid twice."]
+
+
+def test_held_turn_is_not_deleted_from_the_server() -> None:
+    # a held turn is missing from the agent's context, and a stale read deletes it
+    session, _ = _make_session()
+    _mirror(session, ("item_1", "user", ""), ("stale", "assistant", "dropped"))
+    _commit(session, "item_1", "are you there")
+
+    events = session._create_update_chat_ctx_events(llm.ChatContext.empty())
+
+    deleted = {ev.item_id for ev in events if isinstance(ev, ConversationItemDeleteEvent)}
+    assert "item_1" not in deleted
+    assert "stale" in deleted, "an item the agent really dropped still goes"
+
+
+def test_held_turn_keeps_the_reply_anchored_behind_it() -> None:
+    # the reply item opens while the turn is held, so a stand-in at the end reorders them
+    session, _ = _make_session()
+    _mirror(
+        session,
+        ("earlier", "assistant", "hi"),
+        ("item_1", "user", ""),
+        ("reply", "assistant", "the full reply"),
+    )
+    _commit(session, "item_1", "are you there")
+
+    agent_ctx = llm.ChatContext.empty()
+    agent_ctx.items.append(llm.ChatMessage(id="earlier", role="assistant", content=["hi"]))
+    agent_ctx.items.append(llm.ChatMessage(id="reply", role="assistant", content=["the trunc"]))
+    events = session._create_update_chat_ctx_events(agent_ctx)
+
+    created = {
+        ev.item.id: ev.previous_item_id
+        for ev in events
+        if isinstance(ev, ConversationItemCreateEvent)
+    }
+    assert created == {"reply": "item_1"}, "the truncated reply must stay behind the user turn"
+
+
+def test_an_item_anchored_to_an_unannounced_one_is_appended() -> None:
+    # xAI anchors an item to a segment it dropped unannounced, so append rather than strand
+    # everything behind it
+    session, _ = _make_session()
+    _mirror(session, ("item_1", "user", "hello"))
+
+    _item_added(session, "item_2", after="never_announced")
+    _item_added(session, "reply", after="item_2")
+
+    assert [item.id for item in session._remote_chat_ctx.to_chat_ctx().items] == [
+        "item_1",
+        "item_2",
+        "reply",
     ]
 
 
-def test_completed_transcript_emitted_as_final() -> None:
-    session, emitted = _make_session()
-
-    session._handle_conversion_item_input_audio_transcription_completed(
-        _completed_event(item_id="item_1", transcript="what is my name", status="completed")
-    )
-
-    assert len(emitted) == 1
-    assert emitted[0].item_id == "item_1"
-    assert emitted[0].transcript == "what is my name"
-    assert emitted[0].is_final is True
+# -- dropping a response xAI abandoned ---------------------------------------------------------
 
 
-def test_missing_status_defaults_to_final() -> None:
-    # be defensive: an event without a `status` field is treated as final
-    session, emitted = _make_session()
+async def test_interrupting_discards_a_response_that_never_spoke() -> None:
+    # the next response.created lands after the commit, which a pause puts past the timeout
+    session, _ = _make_session()
+    _mirror(session, ("item_1", "user", "hello"))
+    _response_created(session)
+    _reply_item_announced(session, "phantom", after="item_1")
+    generation = session._current_generation
 
-    session._handle_conversion_item_input_audio_transcription_completed(
-        _completed_event(item_id="item_1", transcript="what is my name", status=None)
-    )
+    session.interrupt()
 
-    assert len(emitted) == 1
-    assert emitted[0].is_final is True
+    assert generation._done_fut.done(), "the speech would wait out the timeout otherwise"
+    # xAI drops such an item only sometimes, and anchors later ones to it either way
+    assert session._remote_chat_ctx.get("phantom") is not None
+
+
+async def test_a_speaking_response_is_left_alone() -> None:
+    # a real barge-in goes through the normal interruption path, not the discard
+    session, _ = _make_session()
+    _mirror(session, ("item_1", "user", "hello"))
+    _response_created(session)
+    _reply_item_announced(session, "real", after="item_1")
+    session._response_spoke = True  # what the first output delta sets
+    generation = session._current_generation
+
+    session.interrupt()
+
+    assert not generation._done_fut.done()
+
+
+async def test_a_silent_response_survives_the_user_speaking_over_it() -> None:
+    # a speech start is no proof of a drop, and a discard there loses the reply still coming
+    session, _ = _make_session()
+    _mirror(session, ("item_1", "user", "hello"))
+    _response_created(session)
+    _reply_item_announced(session, "thinking", after="item_1")
+    generation = session._current_generation
+
+    _speech_started(session, "item_1")
+
+    assert not generation._done_fut.done()

--- a/tests/test_realtime/test_xai_realtime_model.py
+++ b/tests/test_realtime/test_xai_realtime_model.py
@@ -245,14 +245,19 @@ def test_a_new_item_transcript_finalizes_the_previous_turn() -> None:
 
 
 def test_reconnect_delivers_the_held_transcript() -> None:
-    # item ids do not survive a reconnect, so deliver the turn before they go
+    # item ids do not survive a reconnect, so deliver the turn before they go, and into the
+    # mirror that is replayed to the new session
     session, emitted = _make_session()
+    _mirror(session, ("item_1", "user", ""))
 
     _commit(session, "item_1", "are you still there")
     session._reset_input_turn_state()
 
     assert _finals(emitted) == [("item_1", "are you still there")]
     assert session._pending_transcription is None
+    remote = session._remote_chat_ctx.get("item_1")
+    assert remote is not None
+    assert remote.item.content == ["are you still there"], "the turn is replayed without it"
 
 
 def test_speech_onset_survives_a_resumed_turn() -> None:


### PR DESCRIPTION
Fixes livekit/agents#6710

xAI sends the transcript of an input item through `conversation.item.input_audio_transcription.completed` at every audio commit, and the item stays open across the pause that caused the commit.

Each of those events transcribes the item again from the start, punctuation and wording with it, so a final on every commit sent the same words back in a new form. One turn became several: repeated `user_input_transcribed` events, a duplicate message in `session.history`, and a new transcript segment on the client each time.

The plugin now holds the transcript and delivers the last one when the response speaks. That is the only signal xAI gives that the turn ended: it opens a response at every commit and drops the ones the user talks over, with no output and no `response.done`.

**What else this corrects**

A dropped response left its streams open, so the speech waiting on them ended only when the interruption timeout cancelled it after five seconds. It is now closed when the interruption sends its cancel.

An item anchored to one that xAI announced and then dropped was rejected by the remote chat context, which stranded every later item behind it. It is appended instead, with a warning.

A rejected item event never gets the `conversation.item.deleted` reply that settles it, so `update_chat_ctx` waited out its own five second timeout. Because the interrupted path awaits that update inside the speech, it took the speech down with it. The future now fails on the rejection, and `update_chat_ctx` logs a warning and continues. This part is in the openai plugin, since nothing about it is specific to xAI.

Also adds `grok-voice-think-fast-2.0` to the supported realtime models.

**Alternative**

[#6711](<https://github.com/livekit/agents/issues/6711>) proposed fixing this in `RoomIO`, by keying the transcript segment on `item_id`. It is closed in favor of this one, because it reaches only the room transcription output: the console and any other `TextOutput` still see the repeated finals, as do `AgentSession.history` and the remote chat context.