### PR TITLE
fix(room_io): key user transcript segments on the transcription item_id

### DIFF
--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -219,6 +219,7 @@ class _ParticipantLegacyTranscriptionOutput:
         self._room.on("local_track_published", self._on_local_track_published)
         self._flush_task: asyncio.Task[None] | None = None
         self._closed = False
+        self._next_segment_id: str | None = None
 
         self._reset_state()
         self.set_participant(participant)
@@ -257,6 +258,21 @@ class _ParticipantLegacyTranscriptionOutput:
         self._capturing = False
         self._pushed_text = ""
 
+    def set_segment_id(self, segment_id: str) -> None:
+        """Key the next segment on an upstream id (e.g. a realtime item_id), so a
+        repeated final for the same item reuses the segment id and clients revise
+        the segment in place instead of rendering a new one."""
+        if self._capturing:
+            if self._current_id == segment_id:
+                return
+            if self._pushed_text:
+                self.flush()
+            else:
+                # nothing visible was published yet: re-key the open segment
+                self._current_id = segment_id
+                return
+        self._next_segment_id = segment_id
+
     @utils.log_exceptions(logger=logger)
     async def capture_text(self, text: str) -> None:
         if self._participant_identity is None or self._track_id is None:
@@ -267,6 +283,9 @@ class _ParticipantLegacyTranscriptionOutput:
 
         if not self._capturing:
             self._reset_state()
+            if self._next_segment_id is not None:
+                self._current_id = self._next_segment_id
+                self._next_segment_id = None
             self._capturing = True
 
         if self._is_delta_stream:
@@ -385,6 +404,7 @@ class _ParticipantStreamTranscriptionOutput:
         self._room.on("local_track_published", self._on_local_track_published)
         self._flush_atask: asyncio.Task[None] | None = None
         self._closed = False
+        self._next_segment_id: str | None = None
 
         self._reset_state()
         self.set_participant(participant)
@@ -458,6 +478,21 @@ class _ParticipantStreamTranscriptionOutput:
             attributes=attributes,
         )
 
+    def set_segment_id(self, segment_id: str) -> None:
+        """Key the next segment on an upstream id (e.g. a realtime item_id), so a
+        repeated final for the same item reuses the segment id and clients revise
+        the segment in place instead of rendering a new one."""
+        if self._capturing:
+            if self._current_id == segment_id:
+                return
+            if self._latest_text:
+                self.flush()
+            else:
+                # nothing visible was published yet: re-key the open segment
+                self._current_id = segment_id
+                return
+        self._next_segment_id = segment_id
+
     @utils.log_exceptions(logger=logger)
     async def capture_text(self, text: str) -> None:
         if self._participant_identity is None:
@@ -468,6 +503,9 @@ class _ParticipantStreamTranscriptionOutput:
 
         if not self._capturing:
             self._reset_state()
+            if self._next_segment_id is not None:
+                self._current_id = self._next_segment_id
+                self._next_segment_id = None
             self._capturing = True
 
         # the raw text (expressive markup intact) arrives here; publish only the visible
@@ -618,6 +656,10 @@ class _ParticipantTranscriptionOutput(io.TextOutput):
     def set_participant(self, participant: rtc.Participant | str | None) -> None:
         for source in self.__outputs:
             source.set_participant(participant)
+
+    def set_segment_id(self, segment_id: str) -> None:
+        for source in self.__outputs:
+            source.set_segment_id(segment_id)
 
     async def capture_text(self, text: str) -> None:
         await asyncio.gather(*[sink.capture_text(text) for sink in self.__outputs])

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -366,6 +366,12 @@ class RoomIO:
             if self._user_tr_output is None:
                 continue
 
+            if ev.item_id:
+                # a realtime provider may re-finalize the same item with a longer
+                # revision; keying the segment on the item id lets clients update
+                # it in place instead of rendering each final as a new segment
+                self._user_tr_output.set_segment_id(f"SG_{ev.item_id}")
+
             await self._user_tr_output.capture_text(ev.transcript)
             if ev.is_final:
                 self._user_tr_output.flush()

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -9,12 +9,15 @@ import pytest
 
 from livekit import rtc
 from livekit.agents import utils
+from livekit.agents.types import ATTRIBUTE_TRANSCRIPTION_SEGMENT_ID
+from livekit.agents.voice.events import UserInputTranscribedEvent
 from livekit.agents.voice.room_io._input import (
     _ParticipantAudioInputStream,
     _ParticipantInputStream,
 )
 from livekit.agents.voice.room_io._output import (
     _ParticipantAudioOutput,
+    _ParticipantLegacyTranscriptionOutput,
     _ParticipantStreamTranscriptionOutput,
     _ParticipantTranscriptionOutput,
 )
@@ -189,6 +192,124 @@ async def test_transcription_output_aclose_unregisters_and_closes_resources() ->
     assert room.listener_count("local_track_published") == 0
     assert legacy_output._flush_task is not None and legacy_output._flush_task.done()
     assert writer.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_transcription_output_reuses_segment_id_for_repeated_finals() -> None:
+    room = _FakeRoom()
+    seg_ids: list[str] = []
+
+    async def _stream_text(**kwargs) -> _FakeWriter:
+        seg_ids.append(kwargs["attributes"][ATTRIBUTE_TRANSCRIPTION_SEGMENT_ID])
+        return _FakeWriter()
+
+    room.local_participant.stream_text = AsyncMock(side_effect=_stream_text)
+
+    output = _ParticipantStreamTranscriptionOutput(
+        room=room, is_delta_stream=False, participant="user"
+    )
+
+    async def _publish_final(item_id: str, text: str) -> None:
+        output.set_segment_id(f"SG_{item_id}")
+        await output.capture_text(text)
+        output.flush()
+        assert output._flush_atask is not None
+        await output._flush_atask
+
+    # a provider re-finalizing the same item must reuse the same segment id
+    await _publish_final("item1", "hello")
+    await _publish_final("item1", "hello world")
+    await _publish_final("item2", "bye")
+
+    # non-delta streams open one writer per capture and one per flush
+    assert seg_ids == ["SG_item1"] * 4 + ["SG_item2"] * 2
+
+
+@pytest.mark.asyncio
+async def test_transcription_output_rekeys_empty_open_segment_in_place() -> None:
+    room = _FakeRoom()
+    seg_ids: list[str] = []
+
+    async def _stream_text(**kwargs) -> _FakeWriter:
+        seg_ids.append(kwargs["attributes"][ATTRIBUTE_TRANSCRIPTION_SEGMENT_ID])
+        return _FakeWriter()
+
+    room.local_participant.stream_text = AsyncMock(side_effect=_stream_text)
+
+    output = _ParticipantStreamTranscriptionOutput(
+        room=room, is_delta_stream=False, participant="user"
+    )
+
+    # an empty interim (e.g. realtime input_speech_stopped) opens a segment with
+    # nothing published; keying it afterwards must not leak an empty segment
+    await output.capture_text("")
+    output.set_segment_id("SG_item1")
+    await output.capture_text("hello")
+    output.flush()
+    assert output._flush_atask is not None
+    await output._flush_atask
+
+    assert seg_ids == ["SG_item1"] * 2
+
+
+@pytest.mark.asyncio
+async def test_legacy_transcription_output_reuses_segment_id_for_repeated_finals() -> None:
+    room = _FakeRoom()
+    published: list[rtc.TranscriptionSegment] = []
+
+    async def _publish_transcription(transcription: rtc.Transcription) -> None:
+        published.extend(transcription.segments)
+
+    room.local_participant.publish_transcription = AsyncMock(side_effect=_publish_transcription)
+
+    output = _ParticipantLegacyTranscriptionOutput(room=room, participant="user")
+    output._track_id = "TR_123"
+
+    for text in ("hello", "hello world"):
+        output.set_segment_id("SG_item1")
+        await output.capture_text(text)
+        output.flush()
+        assert output._flush_task is not None
+        await output._flush_task
+
+    assert {seg.id for seg in published} == {"SG_item1"}
+    assert published[-1].final and published[-1].text == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_forward_user_transcript_keys_segments_on_item_id() -> None:
+    calls: list[tuple[str, ...]] = []
+
+    async def _capture_text(text: str) -> None:
+        calls.append(("capture", text))
+
+    fake_output = SimpleNamespace(
+        set_segment_id=lambda seg_id: calls.append(("set", seg_id)),
+        capture_text=_capture_text,
+        flush=lambda: calls.append(("flush",)),
+    )
+
+    room_io = RoomIO.__new__(RoomIO)
+    room_io._user_tr_output = fake_output
+
+    ch = utils.aio.Chan[UserInputTranscribedEvent]()
+    task = asyncio.create_task(RoomIO._forward_user_transcript(room_io, ch))
+    ch.send_nowait(UserInputTranscribedEvent(transcript="hi", is_final=True, item_id="item1"))
+    ch.send_nowait(UserInputTranscribedEvent(transcript="hi there", is_final=True, item_id="item1"))
+    ch.send_nowait(UserInputTranscribedEvent(transcript="no id", is_final=True))
+    ch.close()
+    await task
+
+    assert calls == [
+        ("set", "SG_item1"),
+        ("capture", "hi"),
+        ("flush",),
+        ("set", "SG_item1"),
+        ("capture", "hi there"),
+        ("flush",),
+        ("capture", "no id"),
+        ("flush",),
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A realtime provider may finalize the same input-audio transcription item more than once, each time with a longer revision of the transcript. RoomIO ignored ev.item_id when forwarding user transcripts, so every final opened a fresh segment id and clients rendered N stacked segments, each containing all of its predecessors — while the chat context correctly collapsed the revisions into one message via _upsert_item.

Derive the segment id from the item id when present, so a repeated final for the same item reuses the segment id and clients revise the segment in place. Events without an item_id (the STT path) keep the previous behavior. An open segment with no visible text yet (e.g. the empty interim emitted on input_speech_stopped) is re-keyed in place instead of flushed, so no empty orphan segment is published.

Fixes #6710