### PR TITLE
fix(ipc): don't raise from is_alive after the inference process is closed

### DIFF
--- a/livekit-agents/livekit/agents/ipc/inference_proc_executor.py
+++ b/livekit-agents/livekit/agents/ipc/inference_proc_executor.py
@@ -110,4 +110,8 @@ class InferenceProcExecutor(SupervisedProc):
         return extra
 
     def is_alive(self) -> bool:
-        return self._proc.is_alive()
+        try:
+            return self._proc.is_alive()
+        except ValueError:
+            # the process object is closed after _supervise_task exits
+            return False

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -654,3 +654,16 @@ def test_log_queue_drains_before_stop():
         f"Expected {NUM_LOGS} records, got {len(received)}. "
         f"Lost {NUM_LOGS - len(received)} tail log records."
     )
+
+
+def test_inference_executor_is_alive_after_proc_closed() -> None:
+    from livekit.agents.ipc.inference_proc_executor import InferenceProcExecutor
+
+    # after the supervise task exits it closes the process object; is_alive must
+    # report dead instead of raising (the health check endpoint relies on this)
+    executor = InferenceProcExecutor.__new__(InferenceProcExecutor)
+    proc = mp.get_context("spawn").Process(target=None)
+    proc.close()
+    executor._proc = proc
+
+    assert executor.is_alive() is False


### PR DESCRIPTION
Fixes #6672

Once the shared inference subprocess exits, `_supervise_task` closes the `multiprocessing.Process` object, and any later `is_alive()` call raises `ValueError: process object is closed`. The worker's health-check endpoint calls `is_alive()` unguarded, so every probe after that point returned an unhandled 500 instead of the intended 503.

This applies the same guard already used in `_send_kill_signal` (#4500, #4694): a closed process object is reported as not alive, so `health_check` returns `503 inference process not running`.

Added a regression test in `tests/test_ipc.py`