### PR TITLE
feat(fishaudio): enable quality-guard on all TTS requests

### DIFF
--- a/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/tts.py
+++ b/livekit-plugins/livekit-plugins-fishaudio/livekit/plugins/fishaudio/tts.py
@@ -408,6 +408,9 @@ def _build_tts_request(opts: _TTSOptions, *, text: str = "") -> dict[str, Any]:
         "prosody": prosody,
         "top_p": opts.top_p,
         "temperature": opts.temperature,
+        # Server-side reliability feature, deliberately not exposed as an option:
+        # every synthesis request runs with the quality guard enabled.
+        "features": ["quality-guard"],
     }
     # Generation-tuning fields have no plugin default: they are omitted unless
     # set so Fish's server-side defaults stay in effect.

--- a/tests/test_plugin_fishaudio_tts.py
+++ b/tests/test_plugin_fishaudio_tts.py
@@ -153,6 +153,13 @@ def test_normalize_loudness_with_speed_and_volume():
     assert prosody == {"speed": 1.2, "volume": -3.0, "normalize_loudness": True}
 
 
+def test_quality_guard_always_enabled():
+    """Every request carries the quality-guard feature flag; it is not configurable."""
+    from livekit.plugins.fishaudio.tts import _build_tts_request
+
+    assert _build_tts_request(TTS_opts(), text="hi")["features"] == ["quality-guard"]
+
+
 def test_generation_tuning_omitted_by_default():
     """Unset tuning params are absent from the request so Fish's defaults apply."""
     from livekit.plugins.fishaudio.tts import _build_tts_request


### PR DESCRIPTION
Adds `features: ["quality-guard"]` to every Fish Audio TTS request body, on both the HTTP (`/v1/tts`) and WebSocket (`/v1/tts/live`) paths.

Quality guard is a server-side reliability feature that increases the stability of generations by catching errors and automatically retrying — built for our enterprise users. It has no drawback, so it's enabled always by default rather than exposed as an option.

- Verified live against both endpoints: the field is accepted and synthesis is unaffected.
- Unit test pins the flag on every request.