### PR TITLE
feat(inference): log gateway quota headers when LLM requests hit a 429

### DIFF
--- a/livekit-agents/livekit/agents/inference/_utils.py
+++ b/livekit-agents/livekit/agents/inference/_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import os
 import platform
+from collections.abc import Mapping
 
 from livekit import api
 
@@ -18,6 +19,33 @@ HEADER_AGENT_ID = "X-LiveKit-Agent-ID"
 HEADER_WORKER_TOKEN = "X-LiveKit-Worker-Token"
 HEADER_INFERENCE_PROVIDER = "X-LiveKit-Inference-Provider"
 HEADER_INFERENCE_PRIORITY = "X-LiveKit-Inference-Priority"
+
+# Quota telemetry headers the inference gateway stamps on LLM completions
+# responses (including 429 rejections). RPM/TPM are per-minute rate limits;
+# Credits is a cumulative token-credit balance. The gateway omits a dimension's
+# headers when it has no data for it, so absence means "not enforced / unknown",
+# never zero.
+QUOTA_HEADER_FIELDS: dict[str, str] = {
+    "X-LiveKit-Inference-RPM-Limit": "rpm_limit",
+    "X-LiveKit-Inference-RPM-Used": "rpm_used",
+    "X-LiveKit-Inference-TPM-Limit": "tpm_limit",
+    "X-LiveKit-Inference-TPM-Used": "tpm_used",
+    "X-LiveKit-Inference-Credits-Limit": "credits_limit",
+    "X-LiveKit-Inference-Credits-Used": "credits_used",
+}
+
+
+def extract_quota_usage(headers: Mapping[str, str]) -> dict[str, str]:
+    """Extract the gateway's quota headers into log-friendly fields.
+
+    Only dimensions the gateway actually stamped are returned; an empty dict
+    means the response carried no quota telemetry.
+    """
+    return {
+        field: value
+        for header, field in QUOTA_HEADER_FIELDS.items()
+        if (value := headers.get(header))
+    }
 
 
 def get_default_inference_url() -> str:

--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -31,6 +31,7 @@ from ._utils import (
     HEADER_INFERENCE_PRIORITY,
     HEADER_INFERENCE_PROVIDER,
     create_access_token,
+    extract_quota_usage,
     get_default_inference_url,
     get_inference_headers,
 )
@@ -487,6 +488,8 @@ class LLMStream(llm.LLMStream):
         except openai.APITimeoutError:
             raise APITimeoutError(retryable=retryable) from None
         except openai.APIStatusError as e:
+            if e.status_code == 429:
+                self._log_rate_limited(e)
             raise APIStatusError(
                 e.message,
                 status_code=e.status_code,
@@ -496,6 +499,16 @@ class LLMStream(llm.LLMStream):
             ) from None
         except Exception as e:
             raise APIConnectionError(retryable=retryable) from e
+
+    def _log_rate_limited(self, e: openai.APIStatusError) -> None:
+        """Log the gateway's quota snapshot when a request is rejected with 429.
+
+        The gateway stamps X-LiveKit-Inference-{RPM,TPM,Credits}-{Limit,Used}
+        on rejections so customers can see which limit they hit and by how much.
+        """
+        extra: dict[str, Any] = {"model": self._model, "request_id": e.request_id}
+        extra.update(extract_quota_usage(e.response.headers))
+        logger.warning("LLM request rate limited by inference gateway", extra=extra)
 
     def _parse_choice(
         self, id: str, choice: Choice, thinking_filter: llm_utils.ThinkingTokenFilter

--- a/tests/test_inference_utils.py
+++ b/tests/test_inference_utils.py
@@ -14,6 +14,10 @@ The fakes below keep them separate so the tests exercise the real code path.
 
 from __future__ import annotations
 
+import logging
+
+import httpx
+import openai
 import pytest
 
 from livekit.agents.inference._utils import (
@@ -21,8 +25,10 @@ from livekit.agents.inference._utils import (
     HEADER_JOB_ID,
     HEADER_ROOM_ID,
     HEADER_USER_AGENT,
+    extract_quota_usage,
     get_inference_headers,
 )
+from livekit.agents.inference.llm import LLMStream
 
 pytestmark = pytest.mark.unit
 
@@ -136,6 +142,113 @@ def test_omits_agent_header_when_sid_empty(monkeypatch: pytest.MonkeyPatch) -> N
     headers = get_inference_headers()
 
     assert HEADER_AGENT_ID not in headers
+
+
+def test_extract_quota_usage_returns_all_stamped_dimensions() -> None:
+    """Every quota header the gateway stamps maps to its log-friendly field."""
+    headers = {
+        "X-LiveKit-Inference-RPM-Limit": "100",
+        "X-LiveKit-Inference-RPM-Used": "101",
+        "X-LiveKit-Inference-TPM-Limit": "50000",
+        "X-LiveKit-Inference-TPM-Used": "48000",
+        "X-LiveKit-Inference-Credits-Limit": "1000000",
+        "X-LiveKit-Inference-Credits-Used": "999999",
+    }
+
+    usage = extract_quota_usage(headers)
+
+    assert usage == {
+        "rpm_limit": "100",
+        "rpm_used": "101",
+        "tpm_limit": "50000",
+        "tpm_used": "48000",
+        "credits_limit": "1000000",
+        "credits_used": "999999",
+    }
+
+
+def test_extract_quota_usage_omits_missing_dimensions() -> None:
+    """A dimension the gateway didn't stamp (not enforced) is left out entirely."""
+    headers = {
+        "X-LiveKit-Inference-RPM-Limit": "100",
+        "X-LiveKit-Inference-RPM-Used": "101",
+    }
+
+    usage = extract_quota_usage(headers)
+
+    assert usage == {"rpm_limit": "100", "rpm_used": "101"}
+
+
+def test_extract_quota_usage_empty_when_no_quota_headers() -> None:
+    """A response with no quota telemetry yields an empty dict."""
+    assert extract_quota_usage({}) == {}
+    assert extract_quota_usage({"Content-Type": "application/json"}) == {}
+
+
+def test_extract_quota_usage_case_insensitive_with_httpx_headers() -> None:
+    """HTTP/2 lowercases field names on the wire; httpx.Headers lookup still matches."""
+    headers = httpx.Headers(
+        {
+            "x-livekit-inference-rpm-limit": "100",
+            "x-livekit-inference-rpm-used": "42",
+        }
+    )
+
+    usage = extract_quota_usage(headers)
+
+    assert usage == {"rpm_limit": "100", "rpm_used": "42"}
+
+
+def test_llm_stream_logs_quota_on_429(caplog: pytest.LogCaptureFixture) -> None:
+    """A 429 from the gateway logs a warning carrying the quota snapshot."""
+    response = httpx.Response(
+        429,
+        headers={
+            "x-request-id": "req_123",
+            "X-LiveKit-Inference-RPM-Limit": "100",
+            "X-LiveKit-Inference-RPM-Used": "101",
+        },
+        request=httpx.Request("POST", "https://agent-gateway.livekit.cloud/v1/chat/completions"),
+    )
+    err = openai.APIStatusError("rate limited", response=response, body=None)
+
+    # bypass __init__: it spawns the request task; _log_rate_limited only needs _model
+    stream = LLMStream.__new__(LLMStream)
+    stream._model = "openai/gpt-4o"
+
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        stream._log_rate_limited(err)
+
+    record = next(
+        r for r in caplog.records if r.message == "LLM request rate limited by inference gateway"
+    )
+    assert record.model == "openai/gpt-4o"
+    assert record.request_id == "req_123"
+    assert record.rpm_limit == "100"
+    assert record.rpm_used == "101"
+    assert not hasattr(record, "tpm_limit")
+
+
+def test_llm_stream_logs_429_without_quota_headers(caplog: pytest.LogCaptureFixture) -> None:
+    """A 429 with no quota telemetry still logs, just without quota fields."""
+    response = httpx.Response(
+        429,
+        request=httpx.Request("POST", "https://agent-gateway.livekit.cloud/v1/chat/completions"),
+    )
+    err = openai.APIStatusError("rate limited", response=response, body=None)
+
+    stream = LLMStream.__new__(LLMStream)
+    stream._model = "openai/gpt-4o"
+
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        stream._log_rate_limited(err)
+
+    record = next(
+        r for r in caplog.records if r.message == "LLM request rate limited by inference gateway"
+    )
+    assert record.model == "openai/gpt-4o"
+    assert not hasattr(record, "rpm_limit")
+    assert not hasattr(record, "rpm_used")
 
 
 def test_no_job_context_returns_only_user_agent(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

When an `inference.LLM` request is rejected with a 429, customers currently get a bare `APIStatusError` with no indication of which limit they hit or by how much. The agent gateway now stamps quota telemetry headers on LLM completions responses (livekit/agent-gateway, `X-LiveKit-Inference-*`), including on rate-limit rejections — this PR surfaces that snapshot in the agent logs.

On a 429, `inference.LLM` now emits a structured warning before raising:

```
LLM request rate limited by inference gateway
  model=openai/gpt-4o request_id=req_123
  rpm_limit=100 rpm_used=101 tpm_limit=50000 tpm_used=48000
  credits_limit=1000000 credits_used=999999
```

- `X-LiveKit-Inference-RPM-{Limit,Used}` — requests/min for the project × model bucket
- `X-LiveKit-Inference-TPM-{Limit,Used}` — tokens/min
- `X-LiveKit-Inference-Credits-{Limit,Used}` — cumulative token-credit balance

Only dimensions the gateway actually stamped are logged (a missing header means "not enforced / no data", never zero), so responses from older gateways just log model + request_id. The existing `APIStatusError` raise path is unchanged.

## Changes

- `inference/_utils.py`: `extract_quota_usage()` maps the gateway's quota headers to log-friendly fields (`rpm_limit`, `tpm_used`, …)
- `inference/llm.py`: `LLMStream._log_rate_limited()` logs the quota snapshot on 429 before re-raising
- `tests/test_inference_utils.py`: unit coverage for header extraction (all dimensions, partial, empty, case-insensitive `httpx.Headers`) and the 429 log path (with and without quota headers)

## Testing

```
uv run pytest tests/test_inference_utils.py --unit   # 11 passed
```

`ruff format` / `ruff check` clean; `make type-check` shows only the pre-existing `boto3` stub error in the AWS plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)