### PR TITLE
fix(cartesia): redact API keys from websocket handshake errors

### DIFF
--- a/livekit-agents/livekit/agents/utils/connection_pool.py
+++ b/livekit-agents/livekit/agents/utils/connection_pool.py
@@ -184,9 +184,12 @@ class ConnectionPool(Generic[T]):
                         self._available.add(conn)
             except Exception as e:
                 # Swallow the error so asyncio does not log an unretrieved task
-                # exception. Use %s (str) rather than %r: aiohttp ClientResponseError
-                # embeds request headers (including API keys) in its repr.
-                logger.warning("failed to prewarm connection pool: %s", e)
+                # exception. Log only the exception type: str(e) / repr(e) can
+                # embed request headers or URL credentials (?api_key=, &jwt_token=).
+                logger.warning(
+                    "failed to prewarm connection pool",
+                    extra={"exception_type": type(e).__name__},
+                )
 
         task = asyncio.create_task(_prewarm_impl())
         self._prewarm_task = weakref.ref(task)

--- a/livekit-agents/livekit/agents/utils/connection_pool.py
+++ b/livekit-agents/livekit/agents/utils/connection_pool.py
@@ -177,10 +177,16 @@ class ConnectionPool(Generic[T]):
             return
 
         async def _prewarm_impl() -> None:
-            async with self._connect_lock:
-                if not self._connections:
-                    conn = await self._connect(timeout=self._connect_timeout)
-                    self._available.add(conn)
+            try:
+                async with self._connect_lock:
+                    if not self._connections:
+                        conn = await self._connect(timeout=self._connect_timeout)
+                        self._available.add(conn)
+            except Exception as e:
+                # Swallow the error so asyncio does not log an unretrieved task
+                # exception. Use %s (str) rather than %r: aiohttp ClientResponseError
+                # embeds request headers (including API keys) in its repr.
+                logger.warning("failed to prewarm connection pool: %s", e)
 
         task = asyncio.create_task(_prewarm_impl())
         self._prewarm_task = weakref.ref(task)

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/_recognize_streams/auto_finalize_recognize_stream.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/_recognize_streams/auto_finalize_recognize_stream.py
@@ -414,8 +414,13 @@ class AutoFinalizeRecognizeStream(CartesiaRecognizeStream):
             raise APIStatusError(
                 message=e.message, status_code=e.status, request_id=None, body=None
             ) from None
-        except aiohttp.ClientConnectorError as e:
-            raise APIConnectionError("failed to connect to cartesia", retryable=True) from e
+        except Exception as e:
+            # Do not chain the cause: some transport errors embed auth headers or
+            # URL credentials that would leak via __cause__ / traceback (see #6739).
+            raise APIConnectionError(
+                f"failed to connect to cartesia ({type(e).__name__})",
+                retryable=True,
+            ) from None
         return ws
 
     def _send_transcript_event(self, event_type: stt.SpeechEventType, transcript: str) -> None:

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/_recognize_streams/auto_finalize_recognize_stream.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/_recognize_streams/auto_finalize_recognize_stream.py
@@ -24,6 +24,7 @@ import aiohttp
 from livekit import rtc
 from livekit.agents import (
     APIConnectionError,
+    APIStatusError,
     LanguageCode,
     stt,
     utils,
@@ -405,7 +406,15 @@ class AutoFinalizeRecognizeStream(CartesiaRecognizeStream):
                 "Established new Cartesia STT WebSocket connection",
                 extra={"cartesia_request_id": c_request_id},
             )
-        except (aiohttp.ClientConnectorError, asyncio.TimeoutError) as e:
+        except asyncio.TimeoutError:
+            raise APIConnectionError("failed to connect to cartesia", retryable=True) from None
+        except aiohttp.ClientResponseError as e:
+            # Do not chain the aiohttp error: RequestInfo embeds auth headers and
+            # can leak API keys via Task/exception repr in logs (see #6739).
+            raise APIStatusError(
+                message=e.message, status_code=e.status, request_id=None, body=None
+            ) from None
+        except aiohttp.ClientConnectorError as e:
             raise APIConnectionError("failed to connect to cartesia", retryable=True) from e
         return ws
 

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/_recognize_streams/legacy_recognize_stream.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/_recognize_streams/legacy_recognize_stream.py
@@ -24,6 +24,7 @@ import aiohttp
 from livekit import rtc
 from livekit.agents import (
     APIConnectionError,
+    APIStatusError,
     LanguageCode,
     stt,
     utils,
@@ -329,7 +330,15 @@ class LegacyRecognizeStream(CartesiaRecognizeStream):
                 "Established new Cartesia STT WebSocket connection",
                 extra={"cartesia_request_id": self._request_id},
             )
-        except (aiohttp.ClientConnectorError, asyncio.TimeoutError) as e:
+        except asyncio.TimeoutError:
+            raise APIConnectionError("failed to connect to cartesia") from None
+        except aiohttp.ClientResponseError as e:
+            # Do not chain the aiohttp error: RequestInfo embeds auth headers and
+            # can leak API keys via Task/exception repr in logs (see #6739).
+            raise APIStatusError(
+                message=e.message, status_code=e.status, request_id=None, body=None
+            ) from None
+        except aiohttp.ClientConnectorError as e:
             raise APIConnectionError("failed to connect to cartesia") from e
         return ws
 

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/_recognize_streams/legacy_recognize_stream.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/_recognize_streams/legacy_recognize_stream.py
@@ -338,8 +338,12 @@ class LegacyRecognizeStream(CartesiaRecognizeStream):
             raise APIStatusError(
                 message=e.message, status_code=e.status, request_id=None, body=None
             ) from None
-        except aiohttp.ClientConnectorError as e:
-            raise APIConnectionError("failed to connect to cartesia") from e
+        except Exception as e:
+            # Do not chain the cause: some transport errors embed auth headers or
+            # URL credentials that would leak via __cause__ / traceback (see #6739).
+            raise APIConnectionError(
+                f"failed to connect to cartesia ({type(e).__name__})",
+            ) from None
         return ws
 
     def _process_stream_event(self, data: STTEventMessage) -> None:

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -234,7 +234,9 @@ class TTS(tts.TTS):
                 message=e.message, status_code=e.status, request_id=None, body=None
             ) from None
         except Exception as e:
-            raise APIConnectionError() from e
+            # Do not chain the cause: some transport errors embed auth headers or
+            # URL credentials that would leak via __cause__ / traceback (see #6739).
+            raise APIConnectionError(type(e).__name__) from None
 
         c_request_id = ws._response.headers.get(REQUEST_ID_HEADER)
         logger.debug(

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -214,16 +214,28 @@ class TTS(tts.TTS):
     async def _connect_ws(self, timeout: float) -> aiohttp.ClientWebSocketResponse:
         session = self._ensure_session()
         url = self._opts.get_ws_url(f"/tts/websocket?cartesia_version={self._opts.api_version}")
-        ws = await asyncio.wait_for(
-            session.ws_connect(
-                url,
-                headers={
-                    "User-Agent": USER_AGENT,
-                    API_AUTH_HEADER: self._opts.api_key,
-                },
-            ),
-            timeout,
-        )
+        try:
+            ws = await asyncio.wait_for(
+                session.ws_connect(
+                    url,
+                    headers={
+                        "User-Agent": USER_AGENT,
+                        API_AUTH_HEADER: self._opts.api_key,
+                    },
+                ),
+                timeout,
+            )
+        except asyncio.TimeoutError:
+            raise APITimeoutError() from None
+        except aiohttp.ClientResponseError as e:
+            # Do not chain the aiohttp error: RequestInfo embeds auth headers and
+            # can leak API keys via Task/exception repr in logs (see #6739).
+            raise APIStatusError(
+                message=e.message, status_code=e.status, request_id=None, body=None
+            ) from None
+        except Exception as e:
+            raise APIConnectionError() from e
+
         c_request_id = ws._response.headers.get(REQUEST_ID_HEADER)
         logger.debug(
             "Established new Cartesia TTS WebSocket connection",
@@ -547,6 +559,8 @@ class SynthesizeStream(tts.SynthesizeStream):
             raise APIStatusError(
                 message=e.message, status_code=e.status, request_id=None, body=None
             ) from None
+        except APIError:
+            raise
         except Exception as e:
             logger.exception(
                 "Cartesia connection error. Include the cartesia_context_id to support@cartesia.ai for help debugging.",

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -115,4 +115,35 @@ async def test_prewarm_failure_does_not_leak_api_key_in_logs(caplog):
 
     assert secret not in repr(task)
     assert all(secret not in record.getMessage() for record in caplog.records)
-    assert any("failed to prewarm connection pool" in r.getMessage() for r in caplog.records)
+    warning_records = [
+        r for r in caplog.records if "failed to prewarm connection pool" in r.getMessage()
+    ]
+    assert warning_records
+    assert warning_records[0].exception_type == "WSServerHandshakeError"
+
+
+@pytest.mark.asyncio
+async def test_prewarm_failure_does_not_leak_url_credentials_in_logs(caplog):
+    """str(exception) can embed ?api_key= / &jwt_token=; logs must not include them."""
+    secret_key = "url-secret-api-key-do-not-log"
+    secret_jwt = "url-secret-jwt-token-do-not-log"
+
+    async def failing_connect(timeout: float):
+        raise ConnectionError(
+            f"wss://example.com/ws?api_key={secret_key}&jwt_token={secret_jwt}"
+        )
+
+    pool = ConnectionPool(connect_cb=failing_connect)
+    with caplog.at_level("WARNING"):
+        pool.prewarm()
+        task = pool._prewarm_task()
+        assert task is not None
+        await task
+
+    assert all(secret_key not in record.getMessage() for record in caplog.records)
+    assert all(secret_jwt not in record.getMessage() for record in caplog.records)
+    warning_records = [
+        r for r in caplog.records if "failed to prewarm connection pool" in r.getMessage()
+    ]
+    assert warning_records
+    assert warning_records[0].exception_type == "ConnectionError"

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -129,9 +129,7 @@ async def test_prewarm_failure_does_not_leak_url_credentials_in_logs(caplog):
     secret_jwt = "url-secret-jwt-token-do-not-log"
 
     async def failing_connect(timeout: float):
-        raise ConnectionError(
-            f"wss://example.com/ws?api_key={secret_key}&jwt_token={secret_jwt}"
-        )
+        raise ConnectionError(f"wss://example.com/ws?api_key={secret_key}&jwt_token={secret_jwt}")
 
     pool = ConnectionPool(connect_cb=failing_connect)
     with caplog.at_level("WARNING"):

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -1,6 +1,9 @@
 import time
 
 import pytest
+from aiohttp import RequestInfo, WSServerHandshakeError
+from multidict import CIMultiDict, CIMultiDictProxy
+from yarl import URL
 
 from livekit.agents.utils import ConnectionPool
 
@@ -24,6 +27,15 @@ def dummy_connect_factory():
         return DummyConnection(counter)
 
     return dummy_connect
+
+
+def _handshake_error_with_api_key(api_key: str) -> WSServerHandshakeError:
+    url = URL("wss://api.cartesia.ai/tts/websocket")
+    headers = CIMultiDict({"Host": "api.cartesia.ai", "X-API-Key": api_key})
+    request_info = RequestInfo(
+        url=url, method="GET", headers=CIMultiDictProxy(headers), real_url=url
+    )
+    return WSServerHandshakeError(request_info, (), status=401, message="Unauthorized")
 
 
 @pytest.mark.asyncio
@@ -83,3 +95,24 @@ async def test_get_expired():
 
     conn2 = await pool.get(timeout=10.0)
     assert conn2 is not conn, "Expected a new connection to be returned."
+
+
+@pytest.mark.asyncio
+async def test_prewarm_failure_does_not_leak_api_key_in_logs(caplog):
+    """Prewarm must swallow connect failures so asyncio never logs an unretrieved
+    task whose exception repr embeds auth headers (livekit/agents#6739)."""
+    secret = "cartesia-secret-api-key-do-not-log"
+
+    async def failing_connect(timeout: float):
+        raise _handshake_error_with_api_key(secret)
+
+    pool = ConnectionPool(connect_cb=failing_connect)
+    with caplog.at_level("WARNING"):
+        pool.prewarm()
+        task = pool._prewarm_task()
+        assert task is not None
+        await task
+
+    assert secret not in repr(task)
+    assert all(secret not in record.getMessage() for record in caplog.records)
+    assert any("failed to prewarm connection pool" in r.getMessage() for r in caplog.records)

--- a/tests/test_plugin_cartesia_tts.py
+++ b/tests/test_plugin_cartesia_tts.py
@@ -59,9 +59,7 @@ async def test_connect_ws_generic_error_does_not_chain_cause():
     from livekit.plugins.cartesia import TTS
 
     tts = TTS(api_key=SECRET_API_KEY)
-    leaky = ConnectionError(
-        f"wss://api.cartesia.ai/tts/websocket?api_key={SECRET_API_KEY}"
-    )
+    leaky = ConnectionError(f"wss://api.cartesia.ai/tts/websocket?api_key={SECRET_API_KEY}")
 
     async def _raise(*_args, **_kwargs):
         raise leaky

--- a/tests/test_plugin_cartesia_tts.py
+++ b/tests/test_plugin_cartesia_tts.py
@@ -1,0 +1,53 @@
+"""Cartesia TTS websocket connect must not leak API keys via exception repr."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import RequestInfo, WSServerHandshakeError
+from multidict import CIMultiDict, CIMultiDictProxy
+from yarl import URL
+
+from livekit.agents import APIStatusError
+
+pytestmark = pytest.mark.plugin("cartesia")
+
+SECRET_API_KEY = "cartesia-secret-api-key-do-not-log"
+
+
+def _handshake_error_with_api_key(api_key: str) -> WSServerHandshakeError:
+    url = URL("wss://api.cartesia.ai/tts/websocket")
+    headers = CIMultiDict(
+        {
+            "Host": "api.cartesia.ai",
+            "User-Agent": "LiveKit Agents Cartesia Plugin/test",
+            "X-API-Key": api_key,
+        }
+    )
+    request_info = RequestInfo(
+        url=url, method="GET", headers=CIMultiDictProxy(headers), real_url=url
+    )
+    return WSServerHandshakeError(request_info, (), status=401, message="Unauthorized")
+
+
+@pytest.mark.asyncio
+async def test_connect_ws_redacts_api_key_from_handshake_error():
+    from livekit.plugins.cartesia import TTS
+
+    tts = TTS(api_key=SECRET_API_KEY)
+
+    async def _raise(*_args, **_kwargs):
+        raise _handshake_error_with_api_key(SECRET_API_KEY)
+
+    session = MagicMock()
+    session.ws_connect = MagicMock(side_effect=_raise)
+    tts._session = session
+
+    with pytest.raises(APIStatusError) as exc_info:
+        await tts._connect_ws(timeout=5.0)
+
+    err = exc_info.value
+    assert err.status_code == 401
+    assert SECRET_API_KEY not in repr(err)
+    assert err.__cause__ is None

--- a/tests/test_plugin_cartesia_tts.py
+++ b/tests/test_plugin_cartesia_tts.py
@@ -9,7 +9,7 @@ from aiohttp import RequestInfo, WSServerHandshakeError
 from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
-from livekit.agents import APIStatusError
+from livekit.agents import APIConnectionError, APIStatusError
 
 pytestmark = pytest.mark.plugin("cartesia")
 
@@ -51,3 +51,30 @@ async def test_connect_ws_redacts_api_key_from_handshake_error():
     assert err.status_code == 401
     assert SECRET_API_KEY not in repr(err)
     assert err.__cause__ is None
+
+
+@pytest.mark.asyncio
+async def test_connect_ws_generic_error_does_not_chain_cause():
+    """Generic connect failures must not chain __cause__ (may embed auth headers)."""
+    from livekit.plugins.cartesia import TTS
+
+    tts = TTS(api_key=SECRET_API_KEY)
+    leaky = ConnectionError(
+        f"wss://api.cartesia.ai/tts/websocket?api_key={SECRET_API_KEY}"
+    )
+
+    async def _raise(*_args, **_kwargs):
+        raise leaky
+
+    session = MagicMock()
+    session.ws_connect = MagicMock(side_effect=_raise)
+    tts._session = session
+
+    with pytest.raises(APIConnectionError) as exc_info:
+        await tts._connect_ws(timeout=5.0)
+
+    err = exc_info.value
+    assert err.__cause__ is None
+    assert str(err) == "ConnectionError"
+    assert SECRET_API_KEY not in repr(err)
+    assert SECRET_API_KEY not in str(err)


### PR DESCRIPTION
## Summary
- Wrap Cartesia TTS/STT websocket handshake failures as `APIStatusError`/`APIConnectionError` without chaining the aiohttp cause, so `X-API-Key` in `RequestInfo` cannot appear in exception/`Task` repr logs.
- Make `ConnectionPool.prewarm()` swallow connect failures and log with `%s` (str) instead of leaving an unretrieved task exception (the path that published Cartesia API keys).

## Test plan
- [x] `pytest tests/test_connection_pool.py tests/test_plugin_cartesia_tts.py -v --unit --plugin cartesia`
- [ ] Confirm a failed Cartesia TTS prewarm no longer logs `X-API-Key` / raw API key material

Fixes #6739