### PR TITLE
fix: handle RoomIO microphone track replacement

### DIFF
--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -18,6 +18,8 @@ from .types import NoiseCancellationParams, NoiseCancellationSelector
 
 T = TypeVar("T", bound=rtc.AudioFrame | rtc.VideoFrame)
 
+_AUDIO_STREAM_REATTACH_DELAY = 0.5
+
 
 class _StreamReadResult(NamedTuple):
     received_frame: bool
@@ -368,8 +370,8 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
 
             # An RTC stream may reach EOS while its track remains subscribed.
             track = publication.track
-            self._close_stream()
             if track is None or not publication.subscribed:
+                self._close_stream()
                 return read_result
 
             if read_result.received_frame:
@@ -377,10 +379,21 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             else:
                 consecutive_empty_streams += 1
             if consecutive_empty_streams > 1:
+                self._close_stream()
                 logger.warning(
                     "replacement audio stream closed before receiving frames; not reattaching",
                     extra={"participant": participant.identity, "track_id": track.sid},
                 )
+                return read_result
+
+            await asyncio.sleep(_AUDIO_STREAM_REATTACH_DELAY)
+
+            if self._stream is not stream or self._publication is not publication:
+                return read_result
+
+            track = publication.track
+            self._close_stream()
+            if track is None or not publication.subscribed:
                 return read_result
 
             stream = self._create_stream(track, participant)

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -345,14 +345,14 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                     "error reading pre-connect audio buffer", extra=logging_extra, exc_info=e
                 )
 
-        first_stream = True
-        allow_empty_reattach = True
+        is_initial_stream = True
+        consecutive_empty_streams = 0
         silent_samples = int(self._sample_rate * 0.5)
         while True:
             read_result = await super()._forward_task(None, stream, publication, participant)
 
             # push a silent frame to flush the stt final result if any
-            if first_stream or read_result.forwarded_frame:
+            if is_initial_stream or read_result.forwarded_frame:
                 await self._data_ch.send(
                     rtc.AudioFrame(
                         b"\x00\x00" * silent_samples,
@@ -361,7 +361,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                         samples_per_channel=silent_samples,
                     )
                 )
-            first_stream = False
+            is_initial_stream = False
 
             if self._stream is not stream or self._publication is not publication:
                 return read_result
@@ -371,7 +371,12 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             self._close_stream()
             if track is None or not publication.subscribed:
                 return read_result
-            if not read_result.received_frame and not allow_empty_reattach:
+
+            if read_result.received_frame:
+                consecutive_empty_streams = 0
+            else:
+                consecutive_empty_streams += 1
+            if consecutive_empty_streams > 1:
                 logger.warning(
                     "replacement audio stream closed before receiving frames; not reattaching",
                     extra={"participant": participant.identity, "track_id": track.sid},
@@ -381,7 +386,6 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             stream = self._create_stream(track, participant)
             self._stream = stream
             self._publication = publication
-            allow_empty_reattach = read_result.received_frame
 
     def _resample_frames(self, frames: Iterable[rtc.AudioFrame]) -> Iterable[rtc.AudioFrame]:
         resampler: rtc.AudioResampler | None = None

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Iterable
-from typing import Any, Generic, TypeVar, cast
+from typing import Any, Generic, NamedTuple, TypeVar, cast
 
 from typing_extensions import override
 
@@ -17,6 +17,11 @@ from ._pre_connect_audio import PreConnectAudioHandler
 from .types import NoiseCancellationParams, NoiseCancellationSelector
 
 T = TypeVar("T", bound=rtc.AudioFrame | rtc.VideoFrame)
+
+
+class _StreamReadResult(NamedTuple):
+    received_frame: bool
+    forwarded_frame: bool
 
 
 class _ParticipantInputStream(Generic[T], ABC):
@@ -45,7 +50,7 @@ class _ParticipantInputStream(Generic[T], ABC):
         self._participant_identity: str | None = None
         self._attached = True
 
-        self._forward_atask: asyncio.Task[tuple[bool, bool]] | None = None
+        self._forward_atask: asyncio.Task[_StreamReadResult] | None = None
         self._tasks: set[asyncio.Task[Any]] = set()
 
         self._room.on("track_subscribed", self._on_track_available)
@@ -136,11 +141,11 @@ class _ParticipantInputStream(Generic[T], ABC):
     @log_exceptions(logger=logger)
     async def _forward_task(
         self,
-        old_task: asyncio.Task[tuple[bool, bool]] | None,
+        old_task: asyncio.Task[_StreamReadResult] | None,
         stream: rtc.VideoStream | rtc.AudioStream,
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
-    ) -> tuple[bool, bool]:
+    ) -> _StreamReadResult:
         if old_task:
             await aio.cancel_and_wait(old_task)
 
@@ -162,7 +167,10 @@ class _ParticipantInputStream(Generic[T], ABC):
             await self._data_ch.send(frame)
 
         logger.debug("stream closed", extra=extra)
-        return received_frame, forwarded_frame
+        return _StreamReadResult(
+            received_frame=received_frame,
+            forwarded_frame=forwarded_frame,
+        )
 
     def _process_frame(self, frame: T) -> None:
         """Hook for subclasses to process frames in-place before forwarding."""
@@ -296,11 +304,11 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
     @override
     async def _forward_task(
         self,
-        old_task: asyncio.Task[tuple[bool, bool]] | None,
+        old_task: asyncio.Task[_StreamReadResult] | None,
         stream: rtc.AudioStream,  # type: ignore[override]
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
-    ) -> tuple[bool, bool]:
+    ) -> _StreamReadResult:
         if old_task:
             await aio.cancel_and_wait(old_task)
 
@@ -341,12 +349,10 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         allow_empty_reattach = True
         silent_samples = int(self._sample_rate * 0.5)
         while True:
-            received_frame, forwarded_frame = await super()._forward_task(
-                None, stream, publication, participant
-            )
+            read_result = await super()._forward_task(None, stream, publication, participant)
 
             # push a silent frame to flush the stt final result if any
-            if first_stream or forwarded_frame:
+            if first_stream or read_result.forwarded_frame:
                 await self._data_ch.send(
                     rtc.AudioFrame(
                         b"\x00\x00" * silent_samples,
@@ -358,24 +364,24 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             first_stream = False
 
             if self._stream is not stream or self._publication is not publication:
-                return received_frame, forwarded_frame
+                return read_result
 
             # An RTC stream may reach EOS while its track remains subscribed.
             track = publication.track
             self._close_stream()
             if track is None or not publication.subscribed:
-                return received_frame, forwarded_frame
-            if not received_frame and not allow_empty_reattach:
+                return read_result
+            if not read_result.received_frame and not allow_empty_reattach:
                 logger.warning(
                     "replacement audio stream closed before receiving frames; not reattaching",
                     extra={"participant": participant.identity, "track_id": track.sid},
                 )
-                return received_frame, forwarded_frame
+                return read_result
 
             stream = self._create_stream(track, participant)
             self._stream = stream
             self._publication = publication
-            allow_empty_reattach = received_frame
+            allow_empty_reattach = read_result.received_frame
 
     def _resample_frames(self, frames: Iterable[rtc.AudioFrame]) -> Iterable[rtc.AudioFrame]:
         resampler: rtc.AudioResampler | None = None

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -261,11 +261,13 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         self._noise_cancellation = noise_cancellation
         self._pre_connect_audio_handler = pre_connect_audio_handler
         self._apm: rtc.AudioProcessingModule | None = None
+        self._stream_received_frame = False
         if auto_gain_control:
             self._apm = rtc.AudioProcessingModule(auto_gain_control=True)
 
     @override
     def _process_frame(self, frame: rtc.AudioFrame) -> None:
+        self._stream_received_frame = True
         if self._apm is not None:
             self._apm.process_stream(frame)
 
@@ -332,19 +334,25 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                     "error reading pre-connect audio buffer", extra=logging_extra, exc_info=e
                 )
 
+        first_stream = True
+        allow_empty_reattach = True
         silent_samples = int(self._sample_rate * 0.5)
         while True:
+            self._stream_received_frame = False
             await super()._forward_task(None, stream, publication, participant)
+            received_frame = self._stream_received_frame
 
             # push a silent frame to flush the stt final result if any
-            await self._data_ch.send(
-                rtc.AudioFrame(
-                    b"\x00\x00" * silent_samples,
-                    sample_rate=self._sample_rate,
-                    num_channels=self._num_channels,
-                    samples_per_channel=silent_samples,
+            if first_stream or received_frame:
+                await self._data_ch.send(
+                    rtc.AudioFrame(
+                        b"\x00\x00" * silent_samples,
+                        sample_rate=self._sample_rate,
+                        num_channels=self._num_channels,
+                        samples_per_channel=silent_samples,
+                    )
                 )
-            )
+            first_stream = False
 
             if self._stream is not stream or self._publication is not publication:
                 return
@@ -354,10 +362,17 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             self._close_stream()
             if track is None or not publication.subscribed:
                 return
+            if not received_frame and not allow_empty_reattach:
+                logger.warning(
+                    "replacement audio stream closed before receiving frames; not reattaching",
+                    extra={"participant": participant.identity, "track_id": track.sid},
+                )
+                return
 
             stream = self._create_stream(track, participant)
             self._stream = stream
             self._publication = publication
+            allow_empty_reattach = False
 
     def _resample_frames(self, frames: Iterable[rtc.AudioFrame]) -> Iterable[rtc.AudioFrame]:
         resampler: rtc.AudioResampler | None = None

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -18,8 +18,6 @@ from .types import NoiseCancellationParams, NoiseCancellationSelector
 
 T = TypeVar("T", bound=rtc.AudioFrame | rtc.VideoFrame)
 
-_AUDIO_STREAM_REATTACH_DELAY = 0.5
-
 
 class _ParticipantInputStream(Generic[T], ABC):
     """
@@ -49,7 +47,7 @@ class _ParticipantInputStream(Generic[T], ABC):
         self._attached = True
         self._closed = False
 
-        self._forward_atask: asyncio.Task[bool] | None = None
+        self._forward_atask: asyncio.Task[None] | None = None
         self._tasks: set[asyncio.Task[Any]] = set()
 
         self._room.on("track_subscribed", self._on_track_available)
@@ -147,12 +145,12 @@ class _ParticipantInputStream(Generic[T], ABC):
     @log_exceptions(logger=logger)
     async def _forward_task(
         self,
-        old_task: asyncio.Task[bool] | None,
+        old_task: asyncio.Task[None] | None,
         stream: rtc.VideoStream | rtc.AudioStream,
         track: rtc.RemoteTrack,
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
-    ) -> bool:
+    ) -> None:
         if old_task:
             await aio.cancel_and_wait(old_task)
 
@@ -161,18 +159,15 @@ class _ParticipantInputStream(Generic[T], ABC):
             "source": rtc.TrackSource.Name(publication.source),
         }
         logger.debug("start reading stream", extra=extra)
-        forwarded_frame = False
         async for event in stream:
             if not self._attached:
                 # drop frames if the stream is detached
                 continue
-            forwarded_frame = True
             frame = cast(T, event.frame)
             self._process_frame(frame)
             await self._data_ch.send(frame)
 
         logger.debug("stream closed", extra=extra)
-        return forwarded_frame
 
     def _process_frame(self, frame: T) -> None:
         """Hook for subclasses to process frames in-place before forwarding."""
@@ -203,19 +198,6 @@ class _ParticipantInputStream(Generic[T], ABC):
             task.add_done_callback(self._tasks.discard)
             self._tasks.add(task)
         self._update_processor(None)
-
-    def _is_active(
-        self,
-        track: rtc.RemoteTrack,
-        publication: rtc.RemoteTrackPublication,
-        stream: rtc.VideoStream | rtc.AudioStream,
-    ) -> bool:
-        return (
-            not self._closed
-            and self._track is track
-            and self._publication is publication
-            and self._stream is stream
-        )
 
     def _on_track_available(
         self,
@@ -351,12 +333,12 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
     @override
     async def _forward_task(
         self,
-        old_task: asyncio.Task[bool] | None,
+        old_task: asyncio.Task[None] | None,
         stream: rtc.AudioStream,  # type: ignore[override]
         track: rtc.RemoteTrack,
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
-    ) -> bool:
+    ) -> None:
         if old_task:
             await aio.cancel_and_wait(old_task)
 
@@ -397,7 +379,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                     "error reading pre-connect audio buffer", extra=logging_extra, exc_info=e
                 )
 
-        forwarded_frame = await super()._forward_task(None, stream, track, publication, participant)
+        await super()._forward_task(None, stream, track, publication, participant)
         silent_samples = int(self._sample_rate * 0.5)
         await self._data_ch.send(
             rtc.AudioFrame(
@@ -407,50 +389,6 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                 samples_per_channel=silent_samples,
             )
         )
-
-        if not self._is_active(track, publication, stream):
-            return forwarded_frame
-
-        if publication.track is not track or not publication.subscribed:
-            self._close_stream()
-            return forwarded_frame
-
-        # An RTC stream can unexpectedly reach EOS while its concrete track remains subscribed.
-        # Wait once before rebuilding it. A second EOS ends this recovery path.
-        await asyncio.sleep(_AUDIO_STREAM_REATTACH_DELAY)
-
-        if not self._is_active(track, publication, stream):
-            return forwarded_frame
-        if publication.track is not track or not publication.subscribed:
-            self._close_stream()
-            return forwarded_frame
-
-        self._close_stream()
-        recovery_stream = self._create_stream(track, participant)
-        self._stream = recovery_stream
-        self._track = track
-        self._publication = publication
-
-        recovery_forwarded_frame = await super()._forward_task(
-            None, recovery_stream, track, publication, participant
-        )
-        if recovery_forwarded_frame:
-            await self._data_ch.send(
-                rtc.AudioFrame(
-                    b"\x00\x00" * silent_samples,
-                    sample_rate=self._sample_rate,
-                    num_channels=self._num_channels,
-                    samples_per_channel=silent_samples,
-                )
-            )
-
-        if self._is_active(track, publication, recovery_stream):
-            self._close_stream()
-            logger.warning(
-                "replacement audio stream closed; not reattaching",
-                extra={"participant": participant.identity, "track_id": track.sid},
-            )
-        return recovery_forwarded_frame
 
     def _resample_frames(self, frames: Iterable[rtc.AudioFrame]) -> Iterable[rtc.AudioFrame]:
         resampler: rtc.AudioResampler | None = None

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Iterable
-from typing import Any, Generic, NamedTuple, TypeVar, cast
+from typing import Any, Generic, TypeVar, cast
 
 from typing_extensions import override
 
@@ -19,11 +19,6 @@ from .types import NoiseCancellationParams, NoiseCancellationSelector
 T = TypeVar("T", bound=rtc.AudioFrame | rtc.VideoFrame)
 
 _AUDIO_STREAM_REATTACH_DELAY = 0.5
-
-
-class _StreamReadResult(NamedTuple):
-    received_frame: bool
-    forwarded_frame: bool
 
 
 class _ParticipantInputStream(Generic[T], ABC):
@@ -48,14 +43,17 @@ class _ParticipantInputStream(Generic[T], ABC):
 
         self._data_ch = aio.Chan[T]()
         self._publication: rtc.RemoteTrackPublication | None = None
+        self._track: rtc.RemoteTrack | None = None
         self._stream: rtc.VideoStream | rtc.AudioStream | None = None
         self._participant_identity: str | None = None
         self._attached = True
+        self._closed = False
 
-        self._forward_atask: asyncio.Task[_StreamReadResult] | None = None
+        self._forward_atask: asyncio.Task[bool] | None = None
         self._tasks: set[asyncio.Task[Any]] = set()
 
         self._room.on("track_subscribed", self._on_track_available)
+        self._room.on("track_unsubscribed", self._on_track_unsubscribed)
         self._room.on("track_unpublished", self._on_track_unavailable)
 
         self._processor = processor
@@ -125,8 +123,13 @@ class _ParticipantInputStream(Generic[T], ABC):
                 self._on_track_available(publication.track, publication, participant)
 
     async def aclose(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+
         stream = self._stream
         self._stream = None
+        self._track = None
         self._publication = None
         if stream:
             await stream.aclose()
@@ -137,17 +140,19 @@ class _ParticipantInputStream(Generic[T], ABC):
             await aio.cancel_and_wait(self._forward_atask)
 
         self._room.off("track_subscribed", self._on_track_available)
+        self._room.off("track_unsubscribed", self._on_track_unsubscribed)
         self._room.off("track_unpublished", self._on_track_unavailable)
         self._data_ch.close()
 
     @log_exceptions(logger=logger)
     async def _forward_task(
         self,
-        old_task: asyncio.Task[_StreamReadResult] | None,
+        old_task: asyncio.Task[bool] | None,
         stream: rtc.VideoStream | rtc.AudioStream,
+        track: rtc.RemoteTrack,
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
-    ) -> _StreamReadResult:
+    ) -> bool:
         if old_task:
             await aio.cancel_and_wait(old_task)
 
@@ -156,10 +161,8 @@ class _ParticipantInputStream(Generic[T], ABC):
             "source": rtc.TrackSource.Name(publication.source),
         }
         logger.debug("start reading stream", extra=extra)
-        received_frame = False
         forwarded_frame = False
         async for event in stream:
-            received_frame = True
             if not self._attached:
                 # drop frames if the stream is detached
                 continue
@@ -169,10 +172,7 @@ class _ParticipantInputStream(Generic[T], ABC):
             await self._data_ch.send(frame)
 
         logger.debug("stream closed", extra=extra)
-        return _StreamReadResult(
-            received_frame=received_frame,
-            forwarded_frame=forwarded_frame,
-        )
+        return forwarded_frame
 
     def _process_frame(self, frame: T) -> None:
         """Hook for subclasses to process frames in-place before forwarding."""
@@ -194,13 +194,28 @@ class _ParticipantInputStream(Generic[T], ABC):
         self._processor_owned = processor is not None
 
     def _close_stream(self) -> None:
-        if self._stream is not None:
-            task = asyncio.create_task(self._stream.aclose())
+        stream = self._stream
+        self._stream = None
+        self._track = None
+        self._publication = None
+        if stream is not None:
+            task = asyncio.create_task(stream.aclose())
             task.add_done_callback(self._tasks.discard)
             self._tasks.add(task)
-            self._stream = None
-            self._publication = None
         self._update_processor(None)
+
+    def _is_active(
+        self,
+        track: rtc.RemoteTrack,
+        publication: rtc.RemoteTrackPublication,
+        stream: rtc.VideoStream | rtc.AudioStream,
+    ) -> bool:
+        return (
+            not self._closed
+            and self._track is track
+            and self._publication is publication
+            and self._stream is stream
+        )
 
     def _on_track_available(
         self,
@@ -209,19 +224,48 @@ class _ParticipantInputStream(Generic[T], ABC):
         participant: rtc.RemoteParticipant,
     ) -> bool:
         if (
-            self._participant_identity != participant.identity
+            self._closed
+            or self._participant_identity != participant.identity
             or publication.source not in self._accepted_sources
-            or (self._publication and self._publication.sid == publication.sid)
+            or (
+                self._publication is not None
+                and self._publication.sid == publication.sid
+                and self._track is track
+            )
         ):
             return False
 
         self._close_stream()
         self._stream = self._create_stream(track, participant)
+        self._track = track
         self._publication = publication
         self._forward_atask = asyncio.create_task(
-            self._forward_task(self._forward_atask, self._stream, publication, participant)
+            self._forward_task(self._forward_atask, self._stream, track, publication, participant)
         )
         return True
+
+    def _on_track_unsubscribed(
+        self,
+        track: rtc.RemoteTrack,
+        publication: rtc.RemoteTrackPublication,
+        participant: rtc.RemoteParticipant,
+    ) -> None:
+        if (
+            self._track is not track
+            or not self._publication
+            or self._publication.sid != publication.sid
+            or participant.identity != self._participant_identity
+        ):
+            return
+
+        self._close_stream()
+
+        # subscribe to the first available track
+        for candidate in participant.track_publications.values():
+            if candidate.sid == publication.sid or candidate.track is None:
+                continue
+            if self._on_track_available(candidate.track, candidate, participant):
+                return
 
     def _on_track_unavailable(
         self, publication: rtc.RemoteTrackPublication, participant: rtc.RemoteParticipant
@@ -275,6 +319,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         self._frame_size_ms = frame_size_ms
         self._noise_cancellation = noise_cancellation
         self._pre_connect_audio_handler = pre_connect_audio_handler
+        self._pre_connect_audio_publications: set[tuple[str, str]] = set()
         self._apm: rtc.AudioProcessingModule | None = None
         if auto_gain_control:
             self._apm = rtc.AudioProcessingModule(auto_gain_control=True)
@@ -306,26 +351,31 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
     @override
     async def _forward_task(
         self,
-        old_task: asyncio.Task[_StreamReadResult] | None,
+        old_task: asyncio.Task[bool] | None,
         stream: rtc.AudioStream,  # type: ignore[override]
+        track: rtc.RemoteTrack,
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
-    ) -> _StreamReadResult:
+    ) -> bool:
         if old_task:
             await aio.cancel_and_wait(old_task)
 
+        pre_connect_key = (participant.identity, publication.sid)
         if (
             self._pre_connect_audio_handler
-            and publication.track
             and AudioTrackFeature.TF_PRECONNECT_BUFFER in publication.audio_features
+            and pre_connect_key not in self._pre_connect_audio_publications
         ):
+            self._pre_connect_audio_publications.add(pre_connect_key)
             logging_extra = {
-                "track_id": publication.track.sid,
+                "track_id": track.sid,
                 "participant": participant.identity,
             }
             try:
                 duration: float = 0
-                frames = await self._pre_connect_audio_handler.wait_for_data(publication.track.sid)
+                frames = await self._pre_connect_audio_handler.wait_for_data(
+                    logging_extra["track_id"]
+                )
                 for frame in self._resample_frames(self._apply_audio_processor(frames)):
                     if self._attached:
                         await self._data_ch.send(frame)
@@ -347,58 +397,60 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                     "error reading pre-connect audio buffer", extra=logging_extra, exc_info=e
                 )
 
-        is_initial_stream = True
-        consecutive_empty_streams = 0
+        forwarded_frame = await super()._forward_task(None, stream, track, publication, participant)
         silent_samples = int(self._sample_rate * 0.5)
-        while True:
-            read_result = await super()._forward_task(None, stream, publication, participant)
+        await self._data_ch.send(
+            rtc.AudioFrame(
+                b"\x00\x00" * silent_samples,
+                sample_rate=self._sample_rate,
+                num_channels=self._num_channels,
+                samples_per_channel=silent_samples,
+            )
+        )
 
-            # push a silent frame to flush the stt final result if any
-            if is_initial_stream or read_result.forwarded_frame:
-                await self._data_ch.send(
-                    rtc.AudioFrame(
-                        b"\x00\x00" * silent_samples,
-                        sample_rate=self._sample_rate,
-                        num_channels=self._num_channels,
-                        samples_per_channel=silent_samples,
-                    )
-                )
-            is_initial_stream = False
+        if not self._is_active(track, publication, stream):
+            return forwarded_frame
 
-            if self._stream is not stream or self._publication is not publication:
-                return read_result
-
-            # An RTC stream may reach EOS while its track remains subscribed.
-            track = publication.track
-            if track is None or not publication.subscribed:
-                self._close_stream()
-                return read_result
-
-            if read_result.received_frame:
-                consecutive_empty_streams = 0
-            else:
-                consecutive_empty_streams += 1
-            if consecutive_empty_streams > 1:
-                self._close_stream()
-                logger.warning(
-                    "replacement audio stream closed before receiving frames; not reattaching",
-                    extra={"participant": participant.identity, "track_id": track.sid},
-                )
-                return read_result
-
-            await asyncio.sleep(_AUDIO_STREAM_REATTACH_DELAY)
-
-            if self._stream is not stream or self._publication is not publication:
-                return read_result
-
-            track = publication.track
+        if publication.track is not track or not publication.subscribed:
             self._close_stream()
-            if track is None or not publication.subscribed:
-                return read_result
+            return forwarded_frame
 
-            stream = self._create_stream(track, participant)
-            self._stream = stream
-            self._publication = publication
+        # An RTC stream can unexpectedly reach EOS while its concrete track remains subscribed.
+        # Wait once before rebuilding it. A second EOS ends this recovery path.
+        await asyncio.sleep(_AUDIO_STREAM_REATTACH_DELAY)
+
+        if not self._is_active(track, publication, stream):
+            return forwarded_frame
+        if publication.track is not track or not publication.subscribed:
+            self._close_stream()
+            return forwarded_frame
+
+        self._close_stream()
+        recovery_stream = self._create_stream(track, participant)
+        self._stream = recovery_stream
+        self._track = track
+        self._publication = publication
+
+        recovery_forwarded_frame = await super()._forward_task(
+            None, recovery_stream, track, publication, participant
+        )
+        if recovery_forwarded_frame:
+            await self._data_ch.send(
+                rtc.AudioFrame(
+                    b"\x00\x00" * silent_samples,
+                    sample_rate=self._sample_rate,
+                    num_channels=self._num_channels,
+                    samples_per_channel=silent_samples,
+                )
+            )
+
+        if self._is_active(track, publication, recovery_stream):
+            self._close_stream()
+            logger.warning(
+                "replacement audio stream closed; not reattaching",
+                extra={"participant": participant.identity, "track_id": track.sid},
+            )
+        return recovery_forwarded_frame
 
     def _resample_frames(self, frames: Iterable[rtc.AudioFrame]) -> Iterable[rtc.AudioFrame]:
         resampler: rtc.AudioResampler | None = None

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -48,6 +48,7 @@ class _ParticipantInputStream(Generic[T], ABC):
         self._closed = False
 
         self._forward_atask: asyncio.Task[None] | None = None
+        self._forward_tasks: set[asyncio.Task[None]] = set()
         self._tasks: set[asyncio.Task[Any]] = set()
 
         self._room.on("track_subscribed", self._on_track_available)
@@ -134,8 +135,9 @@ class _ParticipantInputStream(Generic[T], ABC):
         if self._processor:
             self._processor._close()
             self._processor = None
-        if self._forward_atask:
-            await aio.cancel_and_wait(self._forward_atask)
+        if self._forward_tasks:
+            await aio.cancel_and_wait(*self._forward_tasks)
+        self._forward_atask = None
 
         self._room.off("track_subscribed", self._on_track_available)
         self._room.off("track_unsubscribed", self._on_track_unsubscribed)
@@ -221,9 +223,12 @@ class _ParticipantInputStream(Generic[T], ABC):
         self._stream = self._create_stream(track, participant)
         self._track = track
         self._publication = publication
-        self._forward_atask = asyncio.create_task(
+        forward_task = asyncio.create_task(
             self._forward_task(self._forward_atask, self._stream, track, publication, participant)
         )
+        self._forward_atask = forward_task
+        self._forward_tasks.add(forward_task)
+        forward_task.add_done_callback(self._forward_tasks.discard)
         return True
 
     def _on_track_unsubscribed(
@@ -242,7 +247,7 @@ class _ParticipantInputStream(Generic[T], ABC):
 
         self._close_stream()
 
-        # subscribe to the first available track
+        # Same-publication replacements arrive through track_subscribed.
         for candidate in participant.track_publications.values():
             if candidate.sid == publication.sid or candidate.track is None:
                 continue
@@ -348,7 +353,6 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             and AudioTrackFeature.TF_PRECONNECT_BUFFER in publication.audio_features
             and pre_connect_key not in self._pre_connect_audio_publications
         ):
-            self._pre_connect_audio_publications.add(pre_connect_key)
             logging_extra = {
                 "track_id": track.sid,
                 "participant": participant.identity,
@@ -358,6 +362,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                 frames = await self._pre_connect_audio_handler.wait_for_data(
                     logging_extra["track_id"]
                 )
+                self._pre_connect_audio_publications.add(pre_connect_key)
                 for frame in self._resample_frames(self._apply_audio_processor(frames)):
                     if self._attached:
                         await self._data_ch.send(frame)
@@ -380,15 +385,16 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                 )
 
         await super()._forward_task(None, stream, track, publication, participant)
-        silent_samples = int(self._sample_rate * 0.5)
-        await self._data_ch.send(
-            rtc.AudioFrame(
-                b"\x00\x00" * silent_samples,
-                sample_rate=self._sample_rate,
-                num_channels=self._num_channels,
-                samples_per_channel=silent_samples,
+        if self._attached:
+            silent_samples = int(self._sample_rate * 0.5)
+            await self._data_ch.send(
+                rtc.AudioFrame(
+                    b"\x00\x00" * silent_samples,
+                    sample_rate=self._sample_rate,
+                    num_channels=self._num_channels,
+                    samples_per_channel=silent_samples,
+                )
             )
-        )
 
     def _resample_frames(self, frames: Iterable[rtc.AudioFrame]) -> Iterable[rtc.AudioFrame]:
         resampler: rtc.AudioResampler | None = None

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -118,10 +118,11 @@ class _ParticipantInputStream(Generic[T], ABC):
                 self._on_track_available(publication.track, publication, participant)
 
     async def aclose(self) -> None:
-        if self._stream:
-            await self._stream.aclose()
-            self._stream = None
+        stream = self._stream
+        self._stream = None
         self._publication = None
+        if stream:
+            await stream.aclose()
         if self._processor:
             self._processor._close()
             self._processor = None
@@ -331,18 +332,32 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                     "error reading pre-connect audio buffer", extra=logging_extra, exc_info=e
                 )
 
-        await super()._forward_task(old_task, stream, publication, participant)
-
-        # push a silent frame to flush the stt final result if any
         silent_samples = int(self._sample_rate * 0.5)
-        await self._data_ch.send(
-            rtc.AudioFrame(
-                b"\x00\x00" * silent_samples,
-                sample_rate=self._sample_rate,
-                num_channels=self._num_channels,
-                samples_per_channel=silent_samples,
+        while True:
+            await super()._forward_task(None, stream, publication, participant)
+
+            # push a silent frame to flush the stt final result if any
+            await self._data_ch.send(
+                rtc.AudioFrame(
+                    b"\x00\x00" * silent_samples,
+                    sample_rate=self._sample_rate,
+                    num_channels=self._num_channels,
+                    samples_per_channel=silent_samples,
+                )
             )
-        )
+
+            if self._stream is not stream or self._publication is not publication:
+                return
+
+            # An RTC stream may reach EOS while its track remains subscribed.
+            track = publication.track
+            self._close_stream()
+            if track is None or not publication.subscribed:
+                return
+
+            stream = self._create_stream(track, participant)
+            self._stream = stream
+            self._publication = publication
 
     def _resample_frames(self, frames: Iterable[rtc.AudioFrame]) -> Iterable[rtc.AudioFrame]:
         resampler: rtc.AudioResampler | None = None

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -45,7 +45,7 @@ class _ParticipantInputStream(Generic[T], ABC):
         self._participant_identity: str | None = None
         self._attached = True
 
-        self._forward_atask: asyncio.Task[None] | None = None
+        self._forward_atask: asyncio.Task[tuple[bool, bool]] | None = None
         self._tasks: set[asyncio.Task[Any]] = set()
 
         self._room.on("track_subscribed", self._on_track_available)
@@ -136,11 +136,11 @@ class _ParticipantInputStream(Generic[T], ABC):
     @log_exceptions(logger=logger)
     async def _forward_task(
         self,
-        old_task: asyncio.Task[None] | None,
+        old_task: asyncio.Task[tuple[bool, bool]] | None,
         stream: rtc.VideoStream | rtc.AudioStream,
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
-    ) -> None:
+    ) -> tuple[bool, bool]:
         if old_task:
             await aio.cancel_and_wait(old_task)
 
@@ -149,15 +149,20 @@ class _ParticipantInputStream(Generic[T], ABC):
             "source": rtc.TrackSource.Name(publication.source),
         }
         logger.debug("start reading stream", extra=extra)
+        received_frame = False
+        forwarded_frame = False
         async for event in stream:
+            received_frame = True
             if not self._attached:
                 # drop frames if the stream is detached
                 continue
+            forwarded_frame = True
             frame = cast(T, event.frame)
             self._process_frame(frame)
             await self._data_ch.send(frame)
 
         logger.debug("stream closed", extra=extra)
+        return received_frame, forwarded_frame
 
     def _process_frame(self, frame: T) -> None:
         """Hook for subclasses to process frames in-place before forwarding."""
@@ -261,13 +266,11 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         self._noise_cancellation = noise_cancellation
         self._pre_connect_audio_handler = pre_connect_audio_handler
         self._apm: rtc.AudioProcessingModule | None = None
-        self._stream_received_frame = False
         if auto_gain_control:
             self._apm = rtc.AudioProcessingModule(auto_gain_control=True)
 
     @override
     def _process_frame(self, frame: rtc.AudioFrame) -> None:
-        self._stream_received_frame = True
         if self._apm is not None:
             self._apm.process_stream(frame)
 
@@ -293,11 +296,11 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
     @override
     async def _forward_task(
         self,
-        old_task: asyncio.Task[None] | None,
+        old_task: asyncio.Task[tuple[bool, bool]] | None,
         stream: rtc.AudioStream,  # type: ignore[override]
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
-    ) -> None:
+    ) -> tuple[bool, bool]:
         if old_task:
             await aio.cancel_and_wait(old_task)
 
@@ -338,12 +341,12 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         allow_empty_reattach = True
         silent_samples = int(self._sample_rate * 0.5)
         while True:
-            self._stream_received_frame = False
-            await super()._forward_task(None, stream, publication, participant)
-            received_frame = self._stream_received_frame
+            received_frame, forwarded_frame = await super()._forward_task(
+                None, stream, publication, participant
+            )
 
             # push a silent frame to flush the stt final result if any
-            if first_stream or received_frame:
+            if first_stream or forwarded_frame:
                 await self._data_ch.send(
                     rtc.AudioFrame(
                         b"\x00\x00" * silent_samples,
@@ -355,24 +358,24 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             first_stream = False
 
             if self._stream is not stream or self._publication is not publication:
-                return
+                return received_frame, forwarded_frame
 
             # An RTC stream may reach EOS while its track remains subscribed.
             track = publication.track
             self._close_stream()
             if track is None or not publication.subscribed:
-                return
+                return received_frame, forwarded_frame
             if not received_frame and not allow_empty_reattach:
                 logger.warning(
                     "replacement audio stream closed before receiving frames; not reattaching",
                     extra={"participant": participant.identity, "track_id": track.sid},
                 )
-                return
+                return received_frame, forwarded_frame
 
             stream = self._create_stream(track, participant)
             self._stream = stream
             self._publication = publication
-            allow_empty_reattach = False
+            allow_empty_reattach = received_frame
 
     def _resample_frames(self, frames: Iterable[rtc.AudioFrame]) -> Iterable[rtc.AudioFrame]:
         resampler: rtc.AudioResampler | None = None

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -374,12 +374,14 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                     )
 
             except asyncio.TimeoutError:
+                self._pre_connect_audio_publications.add(pre_connect_key)
                 logger.warning(
                     "timeout waiting for pre-connect audio buffer",
                     extra=logging_extra,
                 )
 
             except Exception as e:
+                self._pre_connect_audio_publications.add(pre_connect_key)
                 logger.error(
                     "error reading pre-connect audio buffer", extra=logging_extra, exc_info=e
                 )

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -59,14 +59,23 @@ class _FakeRoom:
 
 
 class _MockAudioStream:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.ended = asyncio.Event()
+
     def __aiter__(self):
         return self
 
     async def __anext__(self):
+        self.started.set()
+        await self.ended.wait()
         raise StopAsyncIteration
 
     async def aclose(self) -> None:
-        pass
+        self.ended.set()
+
+    def end(self) -> None:
+        self.ended.set()
 
 
 class _MockFrameProcessor(rtc.FrameProcessor[rtc.AudioFrame]):
@@ -134,8 +143,12 @@ def _make_track_available_args(
     publication = MagicMock()
     publication.source = rtc.TrackSource.SOURCE_MICROPHONE
     publication.sid = sid
+    publication.track = track
+    publication.subscribed = True
+    publication.audio_features = []
     participant = MagicMock()
     participant.identity = identity
+    participant.track_publications = {sid: publication}
     return track, publication, participant
 
 
@@ -261,6 +274,77 @@ async def test_roomio_aclose_unregisters_disconnect_and_closes_transcription_out
 
 
 @pytest.mark.asyncio
+async def test_audio_input_reattaches_when_stream_closes_while_track_is_subscribed() -> None:
+    room = _FakeRoom()
+    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
+    audio_input.set_participant("test-user")
+    track, publication, participant = _make_track_available_args()
+    first_stream = _MockAudioStream()
+    replacement_stream = _MockAudioStream()
+
+    with patch(
+        "livekit.rtc.AudioStream.from_track",
+        side_effect=[first_stream, replacement_stream],
+    ) as create_stream:
+        assert audio_input._on_track_available(track, publication, participant)
+        await asyncio.wait_for(first_stream.started.wait(), timeout=1)
+
+        first_stream.end()
+
+        await asyncio.wait_for(replacement_stream.started.wait(), timeout=1)
+
+    assert create_stream.call_count == 2
+    assert audio_input._stream is replacement_stream
+    assert audio_input._publication is publication
+
+    await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_audio_input_does_not_reattach_after_unsubscribe() -> None:
+    room = _FakeRoom()
+    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
+    audio_input.set_participant("test-user")
+    track, publication, participant = _make_track_available_args()
+    rtc_stream = _MockAudioStream()
+
+    with patch("livekit.rtc.AudioStream.from_track", return_value=rtc_stream) as create_stream:
+        assert audio_input._on_track_available(track, publication, participant)
+        await asyncio.wait_for(rtc_stream.started.wait(), timeout=1)
+
+        publication.track = None
+        publication.subscribed = False
+        rtc_stream.end()
+        assert audio_input._forward_atask is not None
+        await audio_input._forward_atask
+
+    create_stream.assert_called_once()
+    assert audio_input._stream is None
+    assert audio_input._publication is None
+
+    await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_audio_input_does_not_reattach_during_close() -> None:
+    room = _FakeRoom()
+    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
+    audio_input.set_participant("test-user")
+    track, publication, participant = _make_track_available_args()
+    rtc_stream = _MockAudioStream()
+
+    with patch("livekit.rtc.AudioStream.from_track", return_value=rtc_stream) as create_stream:
+        assert audio_input._on_track_available(track, publication, participant)
+        await asyncio.wait_for(rtc_stream.started.wait(), timeout=1)
+
+        await audio_input.aclose()
+
+    create_stream.assert_called_once()
+    assert audio_input._stream is None
+    assert audio_input._publication is None
+
+
+@pytest.mark.asyncio
 async def test_direct_processor_lifecycle() -> None:
     """Direct FrameProcessor survives track transitions and is only closed on aclose()."""
     room = _FakeRoom()
@@ -343,6 +427,7 @@ async def test_selector_processor_track_disappears() -> None:
     assert stream._processor is processor
 
     # track unpublished with no replacement
+    participant.track_publications.clear()
     stream._on_track_unavailable(publication, participant)
 
     assert processor.close_calls == 1

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -63,17 +63,14 @@ class _MockAudioStream:
     def __init__(self) -> None:
         self.started = asyncio.Event()
         self.ended = asyncio.Event()
-        self._events: asyncio.Queue[rtc.AudioFrame | None] = asyncio.Queue()
 
     def __aiter__(self):
         return self
 
     async def __anext__(self):
         self.started.set()
-        frame = await self._events.get()
-        if frame is None:
-            raise StopAsyncIteration
-        return SimpleNamespace(frame=frame)
+        await self.ended.wait()
+        raise StopAsyncIteration
 
     async def aclose(self) -> None:
         self.end()
@@ -82,10 +79,6 @@ class _MockAudioStream:
         if self.ended.is_set():
             return
         self.ended.set()
-        self._events.put_nowait(None)
-
-    def push_frame(self, frame: rtc.AudioFrame) -> None:
-        self._events.put_nowait(frame)
 
 
 class _MockFrameProcessor(rtc.FrameProcessor[rtc.AudioFrame]):
@@ -301,7 +294,13 @@ async def test_audio_input_replaces_concrete_track_for_same_publication() -> Non
         assert audio_input._on_track_available(old_track, publication, participant)
         await asyncio.wait_for(old_stream.started.wait(), timeout=1)
 
+        publication.track = None
+        publication.subscribed = False
+        audio_input._on_track_unsubscribed(old_track, publication, participant)
+        await asyncio.wait_for(old_stream.ended.wait(), timeout=1)
+
         publication.track = new_track
+        publication.subscribed = True
         assert audio_input._on_track_available(new_track, publication, participant)
         await asyncio.wait_for(new_stream.started.wait(), timeout=1)
 
@@ -362,90 +361,21 @@ async def test_stale_track_unsubscribe_does_not_close_replacement() -> None:
 
 
 @pytest.mark.asyncio
-async def test_audio_input_reattaches_once_after_unexpected_eos() -> None:
+async def test_audio_input_closes_active_track_on_unsubscribe() -> None:
     room = _FakeRoom()
     audio_input = _make_audio_input_stream(room, noise_cancellation=None)
     audio_input.set_participant("test-user")
     track, publication, participant = _make_track_available_args()
-    initial_stream = _MockAudioStream()
-    recovery_stream = _MockAudioStream()
+    rtc_stream = _MockAudioStream()
 
-    with patch(
-        "livekit.rtc.AudioStream.from_track", side_effect=[initial_stream, recovery_stream]
-    ) as create_stream:
+    with patch("livekit.rtc.AudioStream.from_track", return_value=rtc_stream) as create_stream:
         assert audio_input._on_track_available(track, publication, participant)
-        await asyncio.wait_for(initial_stream.started.wait(), timeout=1)
+        await asyncio.wait_for(rtc_stream.started.wait(), timeout=1)
 
-        initial_stream.end()
-        await asyncio.wait_for(recovery_stream.started.wait(), timeout=1)
-
-    assert create_stream.call_count == 2
-    assert audio_input._stream is recovery_stream
-    assert audio_input._track is track
-
-    await audio_input.aclose()
-
-
-@pytest.mark.asyncio
-async def test_empty_recovery_stream_stops_without_retries_or_extra_silence() -> None:
-    room = _FakeRoom()
-    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
-    audio_input.set_participant("test-user")
-    track, publication, participant = _make_track_available_args()
-    initial_stream = _MockAudioStream()
-    recovery_stream = _MockAudioStream()
-
-    with patch(
-        "livekit.rtc.AudioStream.from_track", side_effect=[initial_stream, recovery_stream]
-    ) as create_stream:
-        assert audio_input._on_track_available(track, publication, participant)
-        await asyncio.wait_for(initial_stream.started.wait(), timeout=1)
-
-        initial_stream.end()
-        await asyncio.wait_for(recovery_stream.started.wait(), timeout=1)
-        recovery_stream.end()
-        assert audio_input._forward_atask is not None
-        await audio_input._forward_atask
-
-    assert create_stream.call_count == 2
-    assert audio_input._data_ch.qsize() == 1
-    assert audio_input._stream is None
-    assert audio_input._track is None
-    assert audio_input._publication is None
-
-    await audio_input.aclose()
-
-
-@pytest.mark.asyncio
-async def test_unsubscribe_during_recovery_delay_prevents_reattachment() -> None:
-    room = _FakeRoom()
-    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
-    audio_input.set_participant("test-user")
-    track, publication, participant = _make_track_available_args()
-    initial_stream = _MockAudioStream()
-    recovery_delay_started = asyncio.Event()
-    finish_recovery_delay = asyncio.Event()
-
-    async def recovery_delay(delay: float) -> None:
-        assert delay == 0.5
-        recovery_delay_started.set()
-        await finish_recovery_delay.wait()
-
-    with (
-        patch("livekit.agents.voice.room_io._input.asyncio.sleep", side_effect=recovery_delay),
-        patch("livekit.rtc.AudioStream.from_track", return_value=initial_stream) as create_stream,
-    ):
-        assert audio_input._on_track_available(track, publication, participant)
-        await asyncio.wait_for(initial_stream.started.wait(), timeout=1)
-
-        initial_stream.end()
-        await asyncio.wait_for(recovery_delay_started.wait(), timeout=1)
         publication.subscribed = False
         publication.track = None
         audio_input._on_track_unsubscribed(track, publication, participant)
-        finish_recovery_delay.set()
-        assert audio_input._forward_atask is not None
-        await audio_input._forward_atask
+        await asyncio.wait_for(rtc_stream.ended.wait(), timeout=1)
 
     create_stream.assert_called_once()
     assert audio_input._stream is None
@@ -455,38 +385,7 @@ async def test_unsubscribe_during_recovery_delay_prevents_reattachment() -> None
 
 
 @pytest.mark.asyncio
-async def test_aclose_during_recovery_delay_prevents_reattachment() -> None:
-    room = _FakeRoom()
-    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
-    audio_input.set_participant("test-user")
-    track, publication, participant = _make_track_available_args()
-    initial_stream = _MockAudioStream()
-    recovery_delay_started = asyncio.Event()
-    finish_recovery_delay = asyncio.Event()
-
-    async def recovery_delay(delay: float) -> None:
-        assert delay == 0.5
-        recovery_delay_started.set()
-        await finish_recovery_delay.wait()
-
-    with (
-        patch("livekit.agents.voice.room_io._input.asyncio.sleep", side_effect=recovery_delay),
-        patch("livekit.rtc.AudioStream.from_track", return_value=initial_stream) as create_stream,
-    ):
-        assert audio_input._on_track_available(track, publication, participant)
-        await asyncio.wait_for(initial_stream.started.wait(), timeout=1)
-
-        initial_stream.end()
-        await asyncio.wait_for(recovery_delay_started.wait(), timeout=1)
-        await audio_input.aclose()
-
-    create_stream.assert_called_once()
-    assert audio_input._stream is None
-    assert audio_input._track is None
-
-
-@pytest.mark.asyncio
-async def test_pre_connect_audio_runs_once_across_replacement_and_recovery() -> None:
+async def test_pre_connect_audio_runs_once_across_concrete_track_replacement() -> None:
     room = _FakeRoom()
     pre_connect_audio_handler = SimpleNamespace(wait_for_data=AsyncMock(return_value=[]))
     audio_input = _ParticipantAudioInputStream(
@@ -505,11 +404,10 @@ async def test_pre_connect_audio_runs_once_across_replacement_and_recovery() -> 
     new_track.sid = "TRK_new"
     initial_stream = _MockAudioStream()
     replacement_stream = _MockAudioStream()
-    recovery_stream = _MockAudioStream()
 
     with patch(
         "livekit.rtc.AudioStream.from_track",
-        side_effect=[initial_stream, replacement_stream, recovery_stream],
+        side_effect=[initial_stream, replacement_stream],
     ):
         assert audio_input._on_track_available(old_track, publication, participant)
         await asyncio.wait_for(initial_stream.started.wait(), timeout=1)
@@ -518,16 +416,13 @@ async def test_pre_connect_audio_runs_once_across_replacement_and_recovery() -> 
         assert audio_input._on_track_available(new_track, publication, participant)
         await asyncio.wait_for(replacement_stream.started.wait(), timeout=1)
 
-        replacement_stream.end()
-        await asyncio.wait_for(recovery_stream.started.wait(), timeout=1)
-
     pre_connect_audio_handler.wait_for_data.assert_awaited_once_with("TRK_old")
 
     await audio_input.aclose()
 
 
 @pytest.mark.asyncio
-async def test_selector_processor_lifecycle_across_replacement_and_recovery() -> None:
+async def test_selector_processor_lifecycle_across_concrete_track_replacement() -> None:
     room = _FakeRoom()
     processors: list[_MockFrameProcessor] = []
 
@@ -542,11 +437,10 @@ async def test_selector_processor_lifecycle_across_replacement_and_recovery() ->
     new_track = MagicMock()
     initial_stream = _MockAudioStream()
     replacement_stream = _MockAudioStream()
-    recovery_stream = _MockAudioStream()
 
     with patch(
         "livekit.rtc.AudioStream.from_track",
-        side_effect=[initial_stream, replacement_stream, recovery_stream],
+        side_effect=[initial_stream, replacement_stream],
     ):
         assert audio_input._on_track_available(old_track, publication, participant)
         await asyncio.wait_for(initial_stream.started.wait(), timeout=1)
@@ -556,51 +450,11 @@ async def test_selector_processor_lifecycle_across_replacement_and_recovery() ->
         await asyncio.wait_for(replacement_stream.started.wait(), timeout=1)
         assert processors[0].close_calls == 1
 
-        replacement_stream.end()
-        await asyncio.wait_for(recovery_stream.started.wait(), timeout=1)
-        assert processors[1].close_calls == 1
-
-        recovery_stream.end()
-        assert audio_input._forward_atask is not None
-        await audio_input._forward_atask
-
-    assert len(processors) == 3
-    assert [processor.close_calls for processor in processors] == [1, 1, 1]
+    assert len(processors) == 2
+    assert [processor.close_calls for processor in processors] == [1, 0]
 
     await audio_input.aclose()
-    assert [processor.close_calls for processor in processors] == [1, 1, 1]
-
-
-@pytest.mark.asyncio
-async def test_detached_frames_do_not_allow_additional_recovery() -> None:
-    room = _FakeRoom()
-    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
-    audio_input.set_participant("test-user")
-    audio_input.on_detached()
-    track, publication, participant = _make_track_available_args()
-    initial_stream = _MockAudioStream()
-    recovery_stream = _MockAudioStream()
-    frame = rtc.AudioFrame(bytes(480 * 2), 24000, 1, 480)
-
-    with patch(
-        "livekit.rtc.AudioStream.from_track", side_effect=[initial_stream, recovery_stream]
-    ) as create_stream:
-        assert audio_input._on_track_available(track, publication, participant)
-        await asyncio.wait_for(initial_stream.started.wait(), timeout=1)
-
-        initial_stream.push_frame(frame)
-        initial_stream.end()
-        await asyncio.wait_for(recovery_stream.started.wait(), timeout=1)
-        recovery_stream.push_frame(frame)
-        recovery_stream.end()
-        assert audio_input._forward_atask is not None
-        await audio_input._forward_atask
-
-    assert create_stream.call_count == 2
-    assert audio_input._data_ch.qsize() == 1
-    assert audio_input._stream is None
-
-    await audio_input.aclose()
+    assert [processor.close_calls for processor in processors] == [1, 1]
 
 
 @pytest.mark.asyncio

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -81,6 +81,11 @@ class _MockAudioStream:
         self.ended.set()
 
 
+class _NonClosingMockAudioStream(_MockAudioStream):
+    async def aclose(self) -> None:
+        pass
+
+
 class _MockFrameProcessor(rtc.FrameProcessor[rtc.AudioFrame]):
     def __init__(self) -> None:
         self._enabled = True
@@ -187,6 +192,35 @@ async def test_participant_input_stream_aclose_unregisters_track_events() -> Non
     assert room.listener_count("track_subscribed") == 0
     assert room.listener_count("track_unsubscribed") == 0
     assert room.listener_count("track_unpublished") == 0
+
+
+@pytest.mark.asyncio
+async def test_audio_input_aclose_cancels_superseded_forward_task() -> None:
+    room = _FakeRoom()
+    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
+    audio_input.set_participant("test-user")
+    old_track, publication, participant = _make_track_available_args()
+    new_track = MagicMock()
+    old_stream = _NonClosingMockAudioStream()
+    new_stream = _MockAudioStream()
+
+    with patch(
+        "livekit.rtc.AudioStream.from_track",
+        side_effect=[old_stream, new_stream],
+    ):
+        assert audio_input._on_track_available(old_track, publication, participant)
+        await asyncio.wait_for(old_stream.started.wait(), timeout=1)
+        old_forward_task = audio_input._forward_atask
+        assert old_forward_task is not None
+
+        publication.track = new_track
+        assert audio_input._on_track_available(new_track, publication, participant)
+        await audio_input.aclose()
+
+    old_forward_task_done = old_forward_task.done()
+    if not old_forward_task_done:
+        await utils.aio.cancel_and_wait(old_forward_task)
+    assert old_forward_task_done
 
 
 @pytest.mark.asyncio
@@ -419,6 +453,73 @@ async def test_pre_connect_audio_runs_once_across_concrete_track_replacement() -
     pre_connect_audio_handler.wait_for_data.assert_awaited_once_with(publication.sid)
 
     await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pre_connect_audio_retries_after_track_switch_cancels_fetch() -> None:
+    room = _FakeRoom()
+    first_fetch_started = asyncio.Event()
+    fetch_count = 0
+
+    async def wait_for_data(_track_id: str) -> list[rtc.AudioFrame]:
+        nonlocal fetch_count
+        fetch_count += 1
+        if fetch_count == 1:
+            first_fetch_started.set()
+            await asyncio.Event().wait()
+        return []
+
+    pre_connect_audio_handler = SimpleNamespace(wait_for_data=AsyncMock(side_effect=wait_for_data))
+    audio_input = _ParticipantAudioInputStream(
+        room,
+        sample_rate=24000,
+        num_channels=1,
+        noise_cancellation=None,
+        auto_gain_control=False,
+        pre_connect_audio_handler=pre_connect_audio_handler,
+    )
+    audio_input.set_participant("test-user")
+    old_track, publication, participant = _make_track_available_args()
+    publication.audio_features = [AudioTrackFeature.TF_PRECONNECT_BUFFER]
+    new_track = MagicMock()
+    new_track.sid = publication.sid
+    initial_stream = _MockAudioStream()
+    replacement_stream = _MockAudioStream()
+
+    with patch(
+        "livekit.rtc.AudioStream.from_track",
+        side_effect=[initial_stream, replacement_stream],
+    ):
+        assert audio_input._on_track_available(old_track, publication, participant)
+        await asyncio.wait_for(first_fetch_started.wait(), timeout=1)
+
+        publication.track = new_track
+        assert audio_input._on_track_available(new_track, publication, participant)
+        await asyncio.wait_for(replacement_stream.started.wait(), timeout=1)
+
+    await audio_input.aclose()
+    assert pre_connect_audio_handler.wait_for_data.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_audio_input_does_not_flush_silence_when_detached() -> None:
+    room = _FakeRoom()
+    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
+    audio_input.set_participant("test-user")
+    track, publication, participant = _make_track_available_args()
+    rtc_stream = _MockAudioStream()
+
+    with patch("livekit.rtc.AudioStream.from_track", return_value=rtc_stream):
+        assert audio_input._on_track_available(track, publication, participant)
+        await asyncio.wait_for(rtc_stream.started.wait(), timeout=1)
+        audio_input.on_detached()
+        rtc_stream.end()
+        assert audio_input._forward_atask is not None
+        await audio_input._forward_atask
+
+    queued_frames = audio_input._data_ch.qsize()
+    await audio_input.aclose()
+    assert queued_frames == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -325,6 +325,52 @@ async def test_audio_input_reattaches_when_stream_closes_while_track_is_subscrib
 
 
 @pytest.mark.asyncio
+async def test_audio_input_waits_before_reattaching_productive_stream() -> None:
+    room = _FakeRoom()
+    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
+    audio_input.set_participant("test-user")
+    track, publication, participant = _make_track_available_args()
+    first_stream = _MockAudioStream()
+    replacement_stream = _MockAudioStream()
+    frame = rtc.AudioFrame(bytes(480 * 2), 24000, 1, 480)
+    reconnect_started = asyncio.Event()
+    allow_reconnect = asyncio.Event()
+
+    async def wait_before_reconnect(delay: float) -> None:
+        assert delay == 0.5
+        reconnect_started.set()
+        await allow_reconnect.wait()
+
+    with (
+        patch(
+            "livekit.agents.voice.room_io._input.asyncio.sleep",
+            side_effect=wait_before_reconnect,
+        ) as reconnect_sleep,
+        patch(
+            "livekit.rtc.AudioStream.from_track",
+            side_effect=[first_stream, replacement_stream],
+        ) as create_stream,
+    ):
+        assert audio_input._on_track_available(track, publication, participant)
+        await asyncio.wait_for(first_stream.started.wait(), timeout=1)
+
+        first_stream.push_frame(frame)
+        first_stream.end()
+        await asyncio.wait_for(reconnect_started.wait(), timeout=1)
+
+        create_stream.assert_called_once()
+        assert audio_input._stream is first_stream
+
+        allow_reconnect.set()
+        await asyncio.wait_for(replacement_stream.started.wait(), timeout=1)
+
+    reconnect_sleep.assert_awaited_once_with(0.5)
+    assert create_stream.call_count == 2
+
+    await audio_input.aclose()
+
+
+@pytest.mark.asyncio
 async def test_audio_input_counts_frames_received_while_detached_for_reattach_limit() -> None:
     room = _FakeRoom()
     audio_input = _make_audio_input_stream(room, noise_cancellation=None)

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -291,6 +291,49 @@ async def test_audio_input_reattaches_when_stream_closes_while_track_is_subscrib
     first_stream = _MockAudioStream()
     replacement_stream = _MockAudioStream()
     second_replacement_stream = _MockAudioStream()
+    final_replacement_stream = _MockAudioStream()
+    frame = rtc.AudioFrame(bytes(480 * 2), 24000, 1, 480)
+
+    with patch(
+        "livekit.rtc.AudioStream.from_track",
+        side_effect=[
+            first_stream,
+            replacement_stream,
+            second_replacement_stream,
+            final_replacement_stream,
+        ],
+    ) as create_stream:
+        assert audio_input._on_track_available(track, publication, participant)
+        await asyncio.wait_for(first_stream.started.wait(), timeout=1)
+
+        first_stream.push_frame(frame)
+        first_stream.end()
+        await asyncio.wait_for(replacement_stream.started.wait(), timeout=1)
+
+        replacement_stream.push_frame(frame)
+        replacement_stream.end()
+        await asyncio.wait_for(second_replacement_stream.started.wait(), timeout=1)
+
+        second_replacement_stream.end()
+        await asyncio.wait_for(final_replacement_stream.started.wait(), timeout=1)
+
+    assert create_stream.call_count == 4
+    assert audio_input._stream is final_replacement_stream
+    assert audio_input._publication is publication
+
+    await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_audio_input_counts_frames_received_while_detached_for_reattach_limit() -> None:
+    room = _FakeRoom()
+    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
+    audio_input.set_participant("test-user")
+    audio_input.on_detached()
+    track, publication, participant = _make_track_available_args()
+    first_stream = _MockAudioStream()
+    replacement_stream = _MockAudioStream()
+    second_replacement_stream = _MockAudioStream()
     frame = rtc.AudioFrame(bytes(480 * 2), 24000, 1, 480)
 
     with patch(
@@ -304,11 +347,11 @@ async def test_audio_input_reattaches_when_stream_closes_while_track_is_subscrib
         first_stream.end()
         await asyncio.wait_for(replacement_stream.started.wait(), timeout=1)
 
-        replacement_stream.push_frame(frame)
         replacement_stream.end()
         await asyncio.wait_for(second_replacement_stream.started.wait(), timeout=1)
 
     assert create_stream.call_count == 3
+    assert audio_input._data_ch.qsize() == 1
     assert audio_input._stream is second_replacement_stream
     assert audio_input._publication is publication
 

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -21,6 +21,7 @@ from livekit.agents.voice.room_io._output import (
 )
 from livekit.agents.voice.room_io.room_io import RoomIO
 from livekit.agents.voice.room_io.types import NoiseCancellationParams
+from livekit.rtc._proto.track_pb2 import AudioTrackFeature
 
 pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
@@ -179,16 +180,18 @@ def _make_audio_input_stream(
 
 
 @pytest.mark.asyncio
-async def test_participant_input_stream_aclose_unregisters_track_unpublished() -> None:
+async def test_participant_input_stream_aclose_unregisters_track_events() -> None:
     room = _FakeRoom()
     stream = _NoopAudioInputStream(room)
 
     assert room.listener_count("track_subscribed") == 1
+    assert room.listener_count("track_unsubscribed") == 1
     assert room.listener_count("track_unpublished") == 1
 
     await stream.aclose()
 
     assert room.listener_count("track_subscribed") == 0
+    assert room.listener_count("track_unsubscribed") == 0
     assert room.listener_count("track_unpublished") == 0
 
 
@@ -283,200 +286,321 @@ async def test_roomio_aclose_unregisters_disconnect_and_closes_transcription_out
 
 
 @pytest.mark.asyncio
-async def test_audio_input_reattaches_when_stream_closes_while_track_is_subscribed() -> None:
+async def test_audio_input_replaces_concrete_track_for_same_publication() -> None:
+    room = _FakeRoom()
+    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
+    audio_input.set_participant("test-user")
+    old_track, publication, participant = _make_track_available_args()
+    new_track = MagicMock()
+    old_stream = _MockAudioStream()
+    new_stream = _MockAudioStream()
+
+    with patch(
+        "livekit.rtc.AudioStream.from_track", side_effect=[old_stream, new_stream]
+    ) as create_stream:
+        assert audio_input._on_track_available(old_track, publication, participant)
+        await asyncio.wait_for(old_stream.started.wait(), timeout=1)
+
+        publication.track = new_track
+        assert audio_input._on_track_available(new_track, publication, participant)
+        await asyncio.wait_for(new_stream.started.wait(), timeout=1)
+
+    assert create_stream.call_count == 2
+    assert audio_input._stream is new_stream
+    assert audio_input._track is new_track
+
+    await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_audio_input_ignores_duplicate_event_for_active_track() -> None:
     room = _FakeRoom()
     audio_input = _make_audio_input_stream(room, noise_cancellation=None)
     audio_input.set_participant("test-user")
     track, publication, participant = _make_track_available_args()
-    first_stream = _MockAudioStream()
+    rtc_stream = _MockAudioStream()
+
+    with patch("livekit.rtc.AudioStream.from_track", return_value=rtc_stream) as create_stream:
+        assert audio_input._on_track_available(track, publication, participant)
+        await asyncio.wait_for(rtc_stream.started.wait(), timeout=1)
+
+        assert not audio_input._on_track_available(track, publication, participant)
+
+    create_stream.assert_called_once()
+    assert audio_input._stream is rtc_stream
+    assert audio_input._track is track
+
+    await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stale_track_unsubscribe_does_not_close_replacement() -> None:
+    room = _FakeRoom()
+    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
+    audio_input.set_participant("test-user")
+    old_track, publication, participant = _make_track_available_args()
+    new_track = MagicMock()
+    old_stream = _MockAudioStream()
+    new_stream = _MockAudioStream()
+
+    with patch("livekit.rtc.AudioStream.from_track", side_effect=[old_stream, new_stream]):
+        assert audio_input._on_track_available(old_track, publication, participant)
+        await asyncio.wait_for(old_stream.started.wait(), timeout=1)
+
+        publication.track = new_track
+        assert audio_input._on_track_available(new_track, publication, participant)
+        await asyncio.wait_for(new_stream.started.wait(), timeout=1)
+
+        audio_input._on_track_unsubscribed(old_track, publication, participant)
+        await asyncio.sleep(0)
+
+    assert audio_input._stream is new_stream
+    assert audio_input._track is new_track
+    assert not new_stream.ended.is_set()
+
+    await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_audio_input_reattaches_once_after_unexpected_eos() -> None:
+    room = _FakeRoom()
+    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
+    audio_input.set_participant("test-user")
+    track, publication, participant = _make_track_available_args()
+    initial_stream = _MockAudioStream()
+    recovery_stream = _MockAudioStream()
+
+    with patch(
+        "livekit.rtc.AudioStream.from_track", side_effect=[initial_stream, recovery_stream]
+    ) as create_stream:
+        assert audio_input._on_track_available(track, publication, participant)
+        await asyncio.wait_for(initial_stream.started.wait(), timeout=1)
+
+        initial_stream.end()
+        await asyncio.wait_for(recovery_stream.started.wait(), timeout=1)
+
+    assert create_stream.call_count == 2
+    assert audio_input._stream is recovery_stream
+    assert audio_input._track is track
+
+    await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_empty_recovery_stream_stops_without_retries_or_extra_silence() -> None:
+    room = _FakeRoom()
+    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
+    audio_input.set_participant("test-user")
+    track, publication, participant = _make_track_available_args()
+    initial_stream = _MockAudioStream()
+    recovery_stream = _MockAudioStream()
+
+    with patch(
+        "livekit.rtc.AudioStream.from_track", side_effect=[initial_stream, recovery_stream]
+    ) as create_stream:
+        assert audio_input._on_track_available(track, publication, participant)
+        await asyncio.wait_for(initial_stream.started.wait(), timeout=1)
+
+        initial_stream.end()
+        await asyncio.wait_for(recovery_stream.started.wait(), timeout=1)
+        recovery_stream.end()
+        assert audio_input._forward_atask is not None
+        await audio_input._forward_atask
+
+    assert create_stream.call_count == 2
+    assert audio_input._data_ch.qsize() == 1
+    assert audio_input._stream is None
+    assert audio_input._track is None
+    assert audio_input._publication is None
+
+    await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_during_recovery_delay_prevents_reattachment() -> None:
+    room = _FakeRoom()
+    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
+    audio_input.set_participant("test-user")
+    track, publication, participant = _make_track_available_args()
+    initial_stream = _MockAudioStream()
+    recovery_delay_started = asyncio.Event()
+    finish_recovery_delay = asyncio.Event()
+
+    async def recovery_delay(delay: float) -> None:
+        assert delay == 0.5
+        recovery_delay_started.set()
+        await finish_recovery_delay.wait()
+
+    with (
+        patch("livekit.agents.voice.room_io._input.asyncio.sleep", side_effect=recovery_delay),
+        patch("livekit.rtc.AudioStream.from_track", return_value=initial_stream) as create_stream,
+    ):
+        assert audio_input._on_track_available(track, publication, participant)
+        await asyncio.wait_for(initial_stream.started.wait(), timeout=1)
+
+        initial_stream.end()
+        await asyncio.wait_for(recovery_delay_started.wait(), timeout=1)
+        publication.subscribed = False
+        publication.track = None
+        audio_input._on_track_unsubscribed(track, publication, participant)
+        finish_recovery_delay.set()
+        assert audio_input._forward_atask is not None
+        await audio_input._forward_atask
+
+    create_stream.assert_called_once()
+    assert audio_input._stream is None
+    assert audio_input._track is None
+
+    await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_aclose_during_recovery_delay_prevents_reattachment() -> None:
+    room = _FakeRoom()
+    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
+    audio_input.set_participant("test-user")
+    track, publication, participant = _make_track_available_args()
+    initial_stream = _MockAudioStream()
+    recovery_delay_started = asyncio.Event()
+    finish_recovery_delay = asyncio.Event()
+
+    async def recovery_delay(delay: float) -> None:
+        assert delay == 0.5
+        recovery_delay_started.set()
+        await finish_recovery_delay.wait()
+
+    with (
+        patch("livekit.agents.voice.room_io._input.asyncio.sleep", side_effect=recovery_delay),
+        patch("livekit.rtc.AudioStream.from_track", return_value=initial_stream) as create_stream,
+    ):
+        assert audio_input._on_track_available(track, publication, participant)
+        await asyncio.wait_for(initial_stream.started.wait(), timeout=1)
+
+        initial_stream.end()
+        await asyncio.wait_for(recovery_delay_started.wait(), timeout=1)
+        await audio_input.aclose()
+
+    create_stream.assert_called_once()
+    assert audio_input._stream is None
+    assert audio_input._track is None
+
+
+@pytest.mark.asyncio
+async def test_pre_connect_audio_runs_once_across_replacement_and_recovery() -> None:
+    room = _FakeRoom()
+    pre_connect_audio_handler = SimpleNamespace(wait_for_data=AsyncMock(return_value=[]))
+    audio_input = _ParticipantAudioInputStream(
+        room,
+        sample_rate=24000,
+        num_channels=1,
+        noise_cancellation=None,
+        auto_gain_control=False,
+        pre_connect_audio_handler=pre_connect_audio_handler,
+    )
+    audio_input.set_participant("test-user")
+    old_track, publication, participant = _make_track_available_args()
+    old_track.sid = "TRK_old"
+    publication.audio_features = [AudioTrackFeature.TF_PRECONNECT_BUFFER]
+    new_track = MagicMock()
+    new_track.sid = "TRK_new"
+    initial_stream = _MockAudioStream()
     replacement_stream = _MockAudioStream()
-    second_replacement_stream = _MockAudioStream()
-    final_replacement_stream = _MockAudioStream()
-    frame = rtc.AudioFrame(bytes(480 * 2), 24000, 1, 480)
+    recovery_stream = _MockAudioStream()
 
     with patch(
         "livekit.rtc.AudioStream.from_track",
-        side_effect=[
-            first_stream,
-            replacement_stream,
-            second_replacement_stream,
-            final_replacement_stream,
-        ],
-    ) as create_stream:
-        assert audio_input._on_track_available(track, publication, participant)
-        await asyncio.wait_for(first_stream.started.wait(), timeout=1)
-
-        first_stream.push_frame(frame)
-        first_stream.end()
-        await asyncio.wait_for(replacement_stream.started.wait(), timeout=1)
-
-        replacement_stream.push_frame(frame)
-        replacement_stream.end()
-        await asyncio.wait_for(second_replacement_stream.started.wait(), timeout=1)
-
-        second_replacement_stream.end()
-        await asyncio.wait_for(final_replacement_stream.started.wait(), timeout=1)
-
-    assert create_stream.call_count == 4
-    assert audio_input._stream is final_replacement_stream
-    assert audio_input._publication is publication
-
-    await audio_input.aclose()
-
-
-@pytest.mark.asyncio
-async def test_audio_input_waits_before_reattaching_productive_stream() -> None:
-    room = _FakeRoom()
-    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
-    audio_input.set_participant("test-user")
-    track, publication, participant = _make_track_available_args()
-    first_stream = _MockAudioStream()
-    replacement_stream = _MockAudioStream()
-    frame = rtc.AudioFrame(bytes(480 * 2), 24000, 1, 480)
-    reconnect_started = asyncio.Event()
-    allow_reconnect = asyncio.Event()
-
-    async def wait_before_reconnect(delay: float) -> None:
-        assert delay == 0.5
-        reconnect_started.set()
-        await allow_reconnect.wait()
-
-    with (
-        patch(
-            "livekit.agents.voice.room_io._input.asyncio.sleep",
-            side_effect=wait_before_reconnect,
-        ) as reconnect_sleep,
-        patch(
-            "livekit.rtc.AudioStream.from_track",
-            side_effect=[first_stream, replacement_stream],
-        ) as create_stream,
+        side_effect=[initial_stream, replacement_stream, recovery_stream],
     ):
-        assert audio_input._on_track_available(track, publication, participant)
-        await asyncio.wait_for(first_stream.started.wait(), timeout=1)
+        assert audio_input._on_track_available(old_track, publication, participant)
+        await asyncio.wait_for(initial_stream.started.wait(), timeout=1)
 
-        first_stream.push_frame(frame)
-        first_stream.end()
-        await asyncio.wait_for(reconnect_started.wait(), timeout=1)
-
-        create_stream.assert_called_once()
-        assert audio_input._stream is first_stream
-
-        allow_reconnect.set()
+        publication.track = new_track
+        assert audio_input._on_track_available(new_track, publication, participant)
         await asyncio.wait_for(replacement_stream.started.wait(), timeout=1)
 
-    reconnect_sleep.assert_awaited_once_with(0.5)
-    assert create_stream.call_count == 2
+        replacement_stream.end()
+        await asyncio.wait_for(recovery_stream.started.wait(), timeout=1)
+
+    pre_connect_audio_handler.wait_for_data.assert_awaited_once_with("TRK_old")
 
     await audio_input.aclose()
 
 
 @pytest.mark.asyncio
-async def test_audio_input_counts_frames_received_while_detached_for_reattach_limit() -> None:
+async def test_selector_processor_lifecycle_across_replacement_and_recovery() -> None:
+    room = _FakeRoom()
+    processors: list[_MockFrameProcessor] = []
+
+    def selector(_params: NoiseCancellationParams) -> _MockFrameProcessor:
+        processor = _MockFrameProcessor()
+        processors.append(processor)
+        return processor
+
+    audio_input = _make_audio_input_stream(room, noise_cancellation=selector)
+    audio_input.set_participant("test-user")
+    old_track, publication, participant = _make_track_available_args()
+    new_track = MagicMock()
+    initial_stream = _MockAudioStream()
+    replacement_stream = _MockAudioStream()
+    recovery_stream = _MockAudioStream()
+
+    with patch(
+        "livekit.rtc.AudioStream.from_track",
+        side_effect=[initial_stream, replacement_stream, recovery_stream],
+    ):
+        assert audio_input._on_track_available(old_track, publication, participant)
+        await asyncio.wait_for(initial_stream.started.wait(), timeout=1)
+
+        publication.track = new_track
+        assert audio_input._on_track_available(new_track, publication, participant)
+        await asyncio.wait_for(replacement_stream.started.wait(), timeout=1)
+        assert processors[0].close_calls == 1
+
+        replacement_stream.end()
+        await asyncio.wait_for(recovery_stream.started.wait(), timeout=1)
+        assert processors[1].close_calls == 1
+
+        recovery_stream.end()
+        assert audio_input._forward_atask is not None
+        await audio_input._forward_atask
+
+    assert len(processors) == 3
+    assert [processor.close_calls for processor in processors] == [1, 1, 1]
+
+    await audio_input.aclose()
+    assert [processor.close_calls for processor in processors] == [1, 1, 1]
+
+
+@pytest.mark.asyncio
+async def test_detached_frames_do_not_allow_additional_recovery() -> None:
     room = _FakeRoom()
     audio_input = _make_audio_input_stream(room, noise_cancellation=None)
     audio_input.set_participant("test-user")
     audio_input.on_detached()
     track, publication, participant = _make_track_available_args()
-    first_stream = _MockAudioStream()
-    replacement_stream = _MockAudioStream()
-    second_replacement_stream = _MockAudioStream()
+    initial_stream = _MockAudioStream()
+    recovery_stream = _MockAudioStream()
     frame = rtc.AudioFrame(bytes(480 * 2), 24000, 1, 480)
 
     with patch(
-        "livekit.rtc.AudioStream.from_track",
-        side_effect=[first_stream, replacement_stream, second_replacement_stream],
+        "livekit.rtc.AudioStream.from_track", side_effect=[initial_stream, recovery_stream]
     ) as create_stream:
         assert audio_input._on_track_available(track, publication, participant)
-        await asyncio.wait_for(first_stream.started.wait(), timeout=1)
+        await asyncio.wait_for(initial_stream.started.wait(), timeout=1)
 
-        first_stream.push_frame(frame)
-        first_stream.end()
-        await asyncio.wait_for(replacement_stream.started.wait(), timeout=1)
-
-        replacement_stream.end()
-        await asyncio.wait_for(second_replacement_stream.started.wait(), timeout=1)
-
-    assert create_stream.call_count == 3
-    assert audio_input._data_ch.qsize() == 1
-    assert audio_input._stream is second_replacement_stream
-    assert audio_input._publication is publication
-
-    await audio_input.aclose()
-
-
-@pytest.mark.asyncio
-async def test_audio_input_stops_reattaching_when_replacement_closes_without_frames() -> None:
-    room = _FakeRoom()
-    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
-    audio_input.set_participant("test-user")
-    track, publication, participant = _make_track_available_args()
-    first_stream = _MockAudioStream()
-    replacement_stream = _MockAudioStream()
-
-    with patch(
-        "livekit.rtc.AudioStream.from_track",
-        side_effect=[first_stream, replacement_stream],
-    ) as create_stream:
-        assert audio_input._on_track_available(track, publication, participant)
-        await asyncio.wait_for(first_stream.started.wait(), timeout=1)
-
-        first_stream.end()
-        await asyncio.wait_for(replacement_stream.started.wait(), timeout=1)
-
-        replacement_stream.end()
+        initial_stream.push_frame(frame)
+        initial_stream.end()
+        await asyncio.wait_for(recovery_stream.started.wait(), timeout=1)
+        recovery_stream.push_frame(frame)
+        recovery_stream.end()
         assert audio_input._forward_atask is not None
         await audio_input._forward_atask
 
     assert create_stream.call_count == 2
     assert audio_input._data_ch.qsize() == 1
     assert audio_input._stream is None
-    assert audio_input._publication is None
 
     await audio_input.aclose()
-
-
-@pytest.mark.asyncio
-async def test_audio_input_does_not_reattach_after_unsubscribe() -> None:
-    room = _FakeRoom()
-    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
-    audio_input.set_participant("test-user")
-    track, publication, participant = _make_track_available_args()
-    rtc_stream = _MockAudioStream()
-
-    with patch("livekit.rtc.AudioStream.from_track", return_value=rtc_stream) as create_stream:
-        assert audio_input._on_track_available(track, publication, participant)
-        await asyncio.wait_for(rtc_stream.started.wait(), timeout=1)
-
-        publication.track = None
-        publication.subscribed = False
-        rtc_stream.end()
-        assert audio_input._forward_atask is not None
-        await audio_input._forward_atask
-
-    create_stream.assert_called_once()
-    assert audio_input._stream is None
-    assert audio_input._publication is None
-
-    await audio_input.aclose()
-
-
-@pytest.mark.asyncio
-async def test_audio_input_does_not_reattach_during_close() -> None:
-    room = _FakeRoom()
-    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
-    audio_input.set_participant("test-user")
-    track, publication, participant = _make_track_available_args()
-    rtc_stream = _MockAudioStream()
-
-    with patch("livekit.rtc.AudioStream.from_track", return_value=rtc_stream) as create_stream:
-        assert audio_input._on_track_available(track, publication, participant)
-        await asyncio.wait_for(rtc_stream.started.wait(), timeout=1)
-
-        await audio_input.aclose()
-
-    create_stream.assert_called_once()
-    assert audio_input._stream is None
-    assert audio_input._publication is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -62,20 +62,29 @@ class _MockAudioStream:
     def __init__(self) -> None:
         self.started = asyncio.Event()
         self.ended = asyncio.Event()
+        self._events: asyncio.Queue[rtc.AudioFrame | None] = asyncio.Queue()
 
     def __aiter__(self):
         return self
 
     async def __anext__(self):
         self.started.set()
-        await self.ended.wait()
-        raise StopAsyncIteration
+        frame = await self._events.get()
+        if frame is None:
+            raise StopAsyncIteration
+        return SimpleNamespace(frame=frame)
 
     async def aclose(self) -> None:
-        self.ended.set()
+        self.end()
 
     def end(self) -> None:
+        if self.ended.is_set():
+            return
         self.ended.set()
+        self._events.put_nowait(None)
+
+    def push_frame(self, frame: rtc.AudioFrame) -> None:
+        self._events.put_nowait(frame)
 
 
 class _MockFrameProcessor(rtc.FrameProcessor[rtc.AudioFrame]):
@@ -281,6 +290,39 @@ async def test_audio_input_reattaches_when_stream_closes_while_track_is_subscrib
     track, publication, participant = _make_track_available_args()
     first_stream = _MockAudioStream()
     replacement_stream = _MockAudioStream()
+    second_replacement_stream = _MockAudioStream()
+    frame = rtc.AudioFrame(bytes(480 * 2), 24000, 1, 480)
+
+    with patch(
+        "livekit.rtc.AudioStream.from_track",
+        side_effect=[first_stream, replacement_stream, second_replacement_stream],
+    ) as create_stream:
+        assert audio_input._on_track_available(track, publication, participant)
+        await asyncio.wait_for(first_stream.started.wait(), timeout=1)
+
+        first_stream.push_frame(frame)
+        first_stream.end()
+        await asyncio.wait_for(replacement_stream.started.wait(), timeout=1)
+
+        replacement_stream.push_frame(frame)
+        replacement_stream.end()
+        await asyncio.wait_for(second_replacement_stream.started.wait(), timeout=1)
+
+    assert create_stream.call_count == 3
+    assert audio_input._stream is second_replacement_stream
+    assert audio_input._publication is publication
+
+    await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_audio_input_stops_reattaching_when_replacement_closes_without_frames() -> None:
+    room = _FakeRoom()
+    audio_input = _make_audio_input_stream(room, noise_cancellation=None)
+    audio_input.set_participant("test-user")
+    track, publication, participant = _make_track_available_args()
+    first_stream = _MockAudioStream()
+    replacement_stream = _MockAudioStream()
 
     with patch(
         "livekit.rtc.AudioStream.from_track",
@@ -290,12 +332,16 @@ async def test_audio_input_reattaches_when_stream_closes_while_track_is_subscrib
         await asyncio.wait_for(first_stream.started.wait(), timeout=1)
 
         first_stream.end()
-
         await asyncio.wait_for(replacement_stream.started.wait(), timeout=1)
 
+        replacement_stream.end()
+        assert audio_input._forward_atask is not None
+        await audio_input._forward_atask
+
     assert create_stream.call_count == 2
-    assert audio_input._stream is replacement_stream
-    assert audio_input._publication is publication
+    assert audio_input._data_ch.qsize() == 1
+    assert audio_input._stream is None
+    assert audio_input._publication is None
 
     await audio_input.aclose()
 

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -143,6 +143,7 @@ def _make_track_available_args(
     identity: str = "test-user", sid: str = "TR_123"
 ) -> tuple[MagicMock, MagicMock, MagicMock]:
     track = MagicMock()
+    track.sid = sid
     publication = MagicMock()
     publication.source = rtc.TrackSource.SOURCE_MICROPHONE
     publication.sid = sid
@@ -398,10 +399,9 @@ async def test_pre_connect_audio_runs_once_across_concrete_track_replacement() -
     )
     audio_input.set_participant("test-user")
     old_track, publication, participant = _make_track_available_args()
-    old_track.sid = "TRK_old"
     publication.audio_features = [AudioTrackFeature.TF_PRECONNECT_BUFFER]
     new_track = MagicMock()
-    new_track.sid = "TRK_new"
+    new_track.sid = publication.sid
     initial_stream = _MockAudioStream()
     replacement_stream = _MockAudioStream()
 
@@ -416,7 +416,7 @@ async def test_pre_connect_audio_runs_once_across_concrete_track_replacement() -
         assert audio_input._on_track_available(new_track, publication, participant)
         await asyncio.wait_for(replacement_stream.started.wait(), timeout=1)
 
-    pre_connect_audio_handler.wait_for_data.assert_awaited_once_with("TRK_old")
+    pre_connect_audio_handler.wait_for_data.assert_awaited_once_with(publication.sid)
 
     await audio_input.aclose()
 

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -502,6 +502,43 @@ async def test_pre_connect_audio_retries_after_track_switch_cancels_fetch() -> N
 
 
 @pytest.mark.asyncio
+async def test_pre_connect_audio_does_not_retry_after_timeout() -> None:
+    room = _FakeRoom()
+    pre_connect_audio_handler = SimpleNamespace(
+        wait_for_data=AsyncMock(side_effect=asyncio.TimeoutError)
+    )
+    audio_input = _ParticipantAudioInputStream(
+        room,
+        sample_rate=24000,
+        num_channels=1,
+        noise_cancellation=None,
+        auto_gain_control=False,
+        pre_connect_audio_handler=pre_connect_audio_handler,
+    )
+    audio_input.set_participant("test-user")
+    old_track, publication, participant = _make_track_available_args()
+    publication.audio_features = [AudioTrackFeature.TF_PRECONNECT_BUFFER]
+    new_track = MagicMock()
+    new_track.sid = publication.sid
+    initial_stream = _MockAudioStream()
+    replacement_stream = _MockAudioStream()
+
+    with patch(
+        "livekit.rtc.AudioStream.from_track",
+        side_effect=[initial_stream, replacement_stream],
+    ):
+        assert audio_input._on_track_available(old_track, publication, participant)
+        await asyncio.wait_for(initial_stream.started.wait(), timeout=1)
+
+        publication.track = new_track
+        assert audio_input._on_track_available(new_track, publication, participant)
+        await asyncio.wait_for(replacement_stream.started.wait(), timeout=1)
+
+    await audio_input.aclose()
+    assert pre_connect_audio_handler.wait_for_data.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_audio_input_does_not_flush_silence_when_detached() -> None:
     room = _FakeRoom()
     audio_input = _make_audio_input_stream(room, noise_cancellation=None)


### PR DESCRIPTION
RoomIO treated the publication SID as track identity, so a replacement concrete track under the same publication was ignored. It also did not observe `track_unsubscribed`.

Track concrete identity and make the SDK unsubscribe and subscribe events authoritative. This avoids speculative stream recovery and follows the RTC lifecycle.

Addresses AGT-3239