### PR TITLE
feat(evals): add ReliabilityObserver for external reliability scoring

### DIFF
--- a/livekit-agents/livekit/agents/evals/__init__.py
+++ b/livekit-agents/livekit/agents/evals/__init__.py
@@ -16,6 +16,11 @@ from .judge import (
     task_completion_judge,
     tool_use_judge,
 )
+from .reliability import (
+    ReliabilityObserver,
+    ReliabilityReporter,
+    ReliabilityTrace,
+)
 
 __all__ = [
     # Evaluation
@@ -35,4 +40,8 @@ __all__ = [
     "safety_judge",
     "task_completion_judge",
     "tool_use_judge",
+    # Reliability
+    "ReliabilityObserver",
+    "ReliabilityReporter",
+    "ReliabilityTrace",
 ]

--- a/livekit-agents/livekit/agents/evals/reliability.py
+++ b/livekit-agents/livekit/agents/evals/reliability.py
@@ -32,7 +32,17 @@ class ReliabilityTrace:
     """Fraction of turns with complete, non-empty transcripts (0.0 to 1.0)."""
 
     tool_reliability: float = 1.0
-    """Fraction of tool calls that succeeded without errors (0.0 to 1.0)."""
+    """Fraction of tool calls that succeeded without errors (0.0 to 1.0).
+
+    Derived from tool_calls and tool_failures when record_tool_call() is used.
+    Can be set directly for custom scoring.
+    """
+
+    tool_calls: int = 0
+    """Total number of tool calls observed."""
+
+    tool_failures: int = 0
+    """Number of tool calls that failed."""
 
     response_latency_ms: list[float] = field(default_factory=list)
     """Per-turn response latency in milliseconds."""
@@ -41,7 +51,10 @@ class ReliabilityTrace:
     """Number of times the user interrupted the agent."""
 
     provider_errors: list[str] = field(default_factory=list)
-    """Provider error messages observed during the session."""
+    """Provider error messages (STT/LLM/TTS) observed during the session."""
+
+    tool_errors: list[str] = field(default_factory=list)
+    """Tool execution error messages observed during the session."""
 
     session_complete: bool = False
     """Whether the session completed normally (vs. crashed/timed out)."""
@@ -56,7 +69,9 @@ class ReliabilityTrace:
         Penalizes interruptions and incomplete sessions.
         """
         if self.turn_count == 0:
-            return 0.0
+            # No turns observed: no evidence of bad turn handling.
+            # Penalize only if the session did not complete normally.
+            return 1.0 if self.session_complete else 0.75
         penalty = (self.interruptions / self.turn_count) * 0.5
         if not self.session_complete:
             penalty += 0.25
@@ -106,8 +121,10 @@ class ReliabilityTrace:
         """Serialize to a provider-neutral dict for external scoring.
 
         Args:
-            include_transcript: If False (default), only metadata is included.
-                Set to True to opt-in to exporting transcript content.
+            include_transcript: If False (default), only metadata and scores
+                are included. Set to True to opt-in to exporting raw observed
+                facts (response latency samples, tool call counts, error
+                messages) so external scorers can recompute or debug.
         """
         d: dict[str, Any] = {
             "session_id": self.session_id,
@@ -117,7 +134,6 @@ class ReliabilityTrace:
             "turn_count": self.turn_count,
             "interruptions": self.interruptions,
             "session_complete": self.session_complete,
-            "provider_errors": self.provider_errors,
             "scores": {
                 "turn_handling": self.turn_handling_score,
                 "transcript_integrity": self.transcript_integrity_score,
@@ -140,6 +156,15 @@ class ReliabilityTrace:
             }
         if include_transcript:
             d["transcript_exported"] = True
+            d["raw"] = {
+                "response_latency_ms": self.response_latency_ms,
+                "transcript_integrity": self.transcript_integrity,
+                "tool_reliability": self.tool_reliability,
+                "tool_calls": self.tool_calls,
+                "tool_failures": self.tool_failures,
+                "provider_errors": self.provider_errors,
+                "tool_errors": self.tool_errors,
+            }
         else:
             d["transcript_exported"] = False
         return d
@@ -202,8 +227,17 @@ class ReliabilityObserver:
             observer.attach(session)
             await session.start(agent=MyAgent(), room=ctx.room)
             # ... session runs ...
-            # observer.flush() is called automatically on shutdown
+            # Call flush() in your shutdown handler:
+            ctx.add_shutdown_callback(observer.flush)
         ```
+
+    Note:
+        attach() stores the session reference but does not automatically
+        wire up event listeners or shutdown callbacks. Integrations are
+        responsible for calling record_turn(), record_interruption(),
+        record_tool_call(), and flush() from their own event handlers and
+        shutdown callbacks. This keeps the observer dependent only on the
+        public event surface and avoids coupling to internal session state.
     """
 
     def __init__(
@@ -234,18 +268,19 @@ class ReliabilityObserver:
         return self._trace
 
     def attach(self, session: Any) -> None:
-        """Attach observers to an AgentSession before session.start().
+        """Attach to an AgentSession before session.start().
 
-        This is the encouraged integration pattern: attach before start
-        so the full session lifecycle is captured. Uses public event
-        listeners, not internal hooks.
+        Stores the session reference for the observer. Does NOT automatically
+        wire up event listeners or shutdown callbacks. Integrations must call
+        record_turn(), record_interruption(), record_tool_call(), and flush()
+        from their own event handlers and shutdown callbacks.
+
+        This intentionally avoids internal/private session attributes so
+        external integrations depend only on the public event surface.
 
         Args:
             session: The AgentSession to observe.
         """
-        # Use public event hooks where available.
-        # This intentionally avoids internal/private session attributes
-        # so external integrations depend only on the public event surface.
         self._session = session
 
     def record_turn(self, *, latency_ms: float | None = None) -> None:
@@ -258,11 +293,28 @@ class ReliabilityObserver:
         """Record a user interruption."""
         self._trace.interruptions += 1
 
+    def record_tool_call(self, *, success: bool = True, error: str | None = None) -> None:
+        """Record a tool call and its outcome.
+
+        Updates tool_calls and tool_failures counters and recomputes
+        tool_reliability from those counters.
+        """
+        self._trace.tool_calls += 1
+        if not success:
+            self._trace.tool_failures += 1
+            if error:
+                self._trace.tool_errors.append(error)
+        if self._trace.tool_calls > 0:
+            self._trace.tool_reliability = (
+                self._trace.tool_calls - self._trace.tool_failures
+            ) / self._trace.tool_calls
+
     def record_tool_error(self, error: str) -> None:
-        """Record a tool execution error."""
-        self._trace.provider_errors.append(error)
-        # Recompute tool reliability based on errors vs. total tool calls.
-        # This is a simple heuristic; integrations can override trace fields directly.
+        """Record a tool execution error.
+
+        Convenience method equivalent to record_tool_call(success=False, error=error).
+        """
+        self.record_tool_call(success=False, error=error)
 
     def record_provider_error(self, error: str) -> None:
         """Record a provider-level error (STT/LLM/TTS)."""
@@ -280,8 +332,9 @@ class ReliabilityObserver:
     async def flush(self) -> None:
         """Flush the trace to the reporter. Idempotent.
 
-        Called automatically during session shutdown if attached via
-        register_shutdown_callback. Safe to call multiple times.
+        Integrations should call this from their shutdown callback, e.g.:
+            ctx.add_shutdown_callback(observer.flush)
+        Safe to call multiple times.
         """
         if self._flushed:
             return

--- a/livekit-agents/livekit/agents/evals/reliability.py
+++ b/livekit-agents/livekit/agents/evals/reliability.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from ..job import JobContext
+from ..log import logger
+from .evaluation import EvaluationResult
+from .judge import JudgmentResult
+
+
+@dataclass
+class ReliabilityTrace:
+    """Provider-neutral reliability trace for post-call diagnosis.
+
+    Captures the observed facts of an AgentSession for external scoring.
+    Designed to be serialized and sent to an external reliability service.
+    """
+
+    session_id: str = ""
+    """Unique identifier for the session."""
+
+    started_at: float = field(default_factory=time.monotonic)
+    """Monotonic timestamp when the session started."""
+
+    ended_at: float | None = None
+    """Monotonic timestamp when the session ended, or None if still running."""
+
+    turn_count: int = 0
+    """Number of user turns observed."""
+
+    transcript_integrity: float = 1.0
+    """Fraction of turns with complete, non-empty transcripts (0.0 to 1.0)."""
+
+    tool_reliability: float = 1.0
+    """Fraction of tool calls that succeeded without errors (0.0 to 1.0)."""
+
+    response_latency_ms: list[float] = field(default_factory=list)
+    """Per-turn response latency in milliseconds."""
+
+    interruptions: int = 0
+    """Number of times the user interrupted the agent."""
+
+    provider_errors: list[str] = field(default_factory=list)
+    """Provider error messages observed during the session."""
+
+    session_complete: bool = False
+    """Whether the session completed normally (vs. crashed/timed out)."""
+
+    evaluation: EvaluationResult | None = None
+    """Optional JudgeGroup evaluation result, if one was run."""
+
+    @property
+    def turn_handling_score(self) -> float:
+        """Score from 0.0 to 1.0 based on turn handling quality.
+
+        Penalizes interruptions and incomplete sessions.
+        """
+        if self.turn_count == 0:
+            return 0.0
+        penalty = (self.interruptions / self.turn_count) * 0.5
+        if not self.session_complete:
+            penalty += 0.25
+        return max(0.0, 1.0 - penalty)
+
+    @property
+    def transcript_integrity_score(self) -> float:
+        """Score from 0.0 to 1.0 for transcript completeness."""
+        return max(0.0, min(1.0, self.transcript_integrity))
+
+    @property
+    def tool_reliability_score(self) -> float:
+        """Score from 0.0 to 1.0 for tool execution reliability."""
+        return max(0.0, min(1.0, self.tool_reliability))
+
+    @property
+    def response_latency_score(self) -> float:
+        """Score from 0.0 to 1.0 based on response latency.
+
+        Uses a simple threshold: <2000ms = 1.0, >5000ms = 0.0, linear between.
+        """
+        if not self.response_latency_ms:
+            return 1.0
+        avg_ms = sum(self.response_latency_ms) / len(self.response_latency_ms)
+        if avg_ms <= 2000:
+            return 1.0
+        if avg_ms >= 5000:
+            return 0.0
+        return 1.0 - (avg_ms - 2000) / 3000
+
+    @property
+    def overall_score(self) -> float:
+        """Composite reliability score from 0.0 to 1.0.
+
+        Weighted average of the four reliability components:
+        turn handling (25%), transcript integrity (25%),
+        tool reliability (25%), response latency (25%).
+        """
+        return (
+            0.25 * self.turn_handling_score
+            + 0.25 * self.transcript_integrity_score
+            + 0.25 * self.tool_reliability_score
+            + 0.25 * self.response_latency_score
+        )
+
+    def to_dict(self, *, include_transcript: bool = False) -> dict[str, Any]:
+        """Serialize to a provider-neutral dict for external scoring.
+
+        Args:
+            include_transcript: If False (default), only metadata is included.
+                Set to True to opt-in to exporting transcript content.
+        """
+        d: dict[str, Any] = {
+            "session_id": self.session_id,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "duration_s": (self.ended_at - self.started_at) if self.ended_at else None,
+            "turn_count": self.turn_count,
+            "interruptions": self.interruptions,
+            "session_complete": self.session_complete,
+            "provider_errors": self.provider_errors,
+            "scores": {
+                "turn_handling": self.turn_handling_score,
+                "transcript_integrity": self.transcript_integrity_score,
+                "tool_reliability": self.tool_reliability_score,
+                "response_latency": self.response_latency_score,
+                "overall": self.overall_score,
+            },
+        }
+        if self.evaluation:
+            d["evaluation"] = {
+                "score": self.evaluation.score,
+                "all_passed": self.evaluation.all_passed,
+                "judgments": {
+                    name: {
+                        "verdict": j.verdict,
+                        "reasoning": j.reasoning,
+                    }
+                    for name, j in self.evaluation.judgments.items()
+                },
+            }
+        if include_transcript:
+            d["transcript_exported"] = True
+        else:
+            d["transcript_exported"] = False
+        return d
+
+
+class ReliabilityReporter(Protocol):
+    """Protocol for any object that can report a reliability trace externally.
+
+    Implement this interface to send ReliabilityTrace data to an external
+    reliability scoring service. This keeps vendor dependencies out of the
+    core package while enabling post-call diagnosis and regression testing.
+    """
+
+    @property
+    def name(self) -> str:
+        """Name identifying this reporter."""
+        ...
+
+    async def report(self, trace: ReliabilityTrace) -> None:
+        """Send a reliability trace to an external service.
+
+        Called during session shutdown. Should be idempotent and
+        handle network failures gracefully (the trace is already captured).
+        """
+        ...
+
+
+class _NullReporter:
+    """Default reporter that logs the trace but does not export it."""
+
+    @property
+    def name(self) -> str:
+        return "null"
+
+    async def report(self, trace: ReliabilityTrace) -> None:
+        logger.debug(f"Reliability trace for session {trace.session_id}: score={trace.overall_score:.3f}")
+
+
+class ReliabilityObserver:
+    """Observes an AgentSession and builds a ReliabilityTrace for post-call diagnosis.
+
+    Attach before session.start() to capture the full session lifecycle.
+    Flushes the trace to a ReliabilityReporter during shutdown.
+
+    Example:
+        ```python
+        async def entrypoint(ctx: JobContext):
+            observer = ReliabilityObserver(
+                session_id=ctx.job.id,
+                reporter=my_reporter,
+            )
+            session = AgentSession(
+                vad=inference.VAD(),
+                stt=deepgram.STT(),
+                llm=openai.LLM(),
+                tts=cartesia.TTS(),
+            )
+            observer.attach(session)
+            await session.start(agent=MyAgent(), room=ctx.room)
+            # ... session runs ...
+            # observer.flush() is called automatically on shutdown
+        ```
+    """
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        reporter: ReliabilityReporter | None = None,
+        include_transcript: bool = False,
+    ) -> None:
+        """Initialize the observer.
+
+        Args:
+            session_id: Unique identifier for this session (e.g. ctx.job.id).
+            reporter: External reporter to send the trace to. Defaults to
+                a null reporter that logs but does not export.
+            include_transcript: If True, transcript content is included in
+                the exported trace. Default is False (metadata-only) for
+                privacy. Explicitly opt-in to export transcript content.
+        """
+        self._trace = ReliabilityTrace(session_id=session_id)
+        self._reporter: ReliabilityReporter = reporter or _NullReporter()
+        self._include_transcript = include_transcript
+        self._flushed = False
+
+    @property
+    def trace(self) -> ReliabilityTrace:
+        """The current reliability trace being built."""
+        return self._trace
+
+    def attach(self, session: Any) -> None:
+        """Attach observers to an AgentSession before session.start().
+
+        This is the encouraged integration pattern: attach before start
+        so the full session lifecycle is captured. Uses public event
+        listeners, not internal hooks.
+
+        Args:
+            session: The AgentSession to observe.
+        """
+        # Use public event hooks where available.
+        # This intentionally avoids internal/private session attributes
+        # so external integrations depend only on the public event surface.
+        self._session = session
+
+    def record_turn(self, *, latency_ms: float | None = None) -> None:
+        """Record a completed user turn."""
+        self._trace.turn_count += 1
+        if latency_ms is not None:
+            self._trace.response_latency_ms.append(latency_ms)
+
+    def record_interruption(self) -> None:
+        """Record a user interruption."""
+        self._trace.interruptions += 1
+
+    def record_tool_error(self, error: str) -> None:
+        """Record a tool execution error."""
+        self._trace.provider_errors.append(error)
+        # Recompute tool reliability based on errors vs. total tool calls.
+        # This is a simple heuristic; integrations can override trace fields directly.
+
+    def record_provider_error(self, error: str) -> None:
+        """Record a provider-level error (STT/LLM/TTS)."""
+        self._trace.provider_errors.append(error)
+
+    def mark_complete(self) -> None:
+        """Mark the session as completed normally."""
+        self._trace.ended_at = time.monotonic()
+        self._trace.session_complete = True
+
+    def set_evaluation(self, result: EvaluationResult) -> None:
+        """Attach a JudgeGroup evaluation result to the trace."""
+        self._trace.evaluation = result
+
+    async def flush(self) -> None:
+        """Flush the trace to the reporter. Idempotent.
+
+        Called automatically during session shutdown if attached via
+        register_shutdown_callback. Safe to call multiple times.
+        """
+        if self._flushed:
+            return
+        self._flushed = True
+        if self._trace.ended_at is None:
+            self._trace.ended_at = time.monotonic()
+        try:
+            await self._reporter.report(self._trace)
+        except Exception as e:
+            logger.warning(f"Reliability reporter '{self._reporter.name}' failed: {e}")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the trace to a provider-neutral dict.
+
+        Respects the include_transcript flag set at init time.
+        """
+        return self._trace.to_dict(include_transcript=self._include_transcript)

--- a/livekit-agents/livekit/agents/evals/reliability.py
+++ b/livekit-agents/livekit/agents/evals/reliability.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-import asyncio
 import time
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
-from ..job import JobContext
 from ..log import logger
 from .evaluation import EvaluationResult
-from .judge import JudgmentResult
 
 
 @dataclass
@@ -178,7 +175,9 @@ class _NullReporter:
         return "null"
 
     async def report(self, trace: ReliabilityTrace) -> None:
-        logger.debug(f"Reliability trace for session {trace.session_id}: score={trace.overall_score:.3f}")
+        logger.debug(
+            f"Reliability trace for session {trace.session_id}: score={trace.overall_score:.3f}"
+        )
 
 
 class ReliabilityObserver:

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -1,0 +1,170 @@
+import pytest
+
+from livekit.agents.evals import (
+    EvaluationResult,
+    ReliabilityObserver,
+    ReliabilityTrace,
+)
+from livekit.agents.evals.judge import JudgmentResult
+
+
+def test_reliability_trace_defaults():
+    trace = ReliabilityTrace(session_id="test-1")
+    assert trace.session_id == "test-1"
+    assert trace.turn_count == 0
+    assert trace.interruptions == 0
+    assert trace.session_complete is False
+    assert trace.transcript_integrity == 1.0
+    assert trace.tool_reliability == 1.0
+    assert trace.response_latency_ms == []
+    assert trace.provider_errors == []
+
+
+def test_reliability_trace_overall_score_perfect():
+    trace = ReliabilityTrace(
+        session_id="test-perfect",
+        turn_count=5,
+        interruptions=0,
+        session_complete=True,
+        transcript_integrity=1.0,
+        tool_reliability=1.0,
+        response_latency_ms=[500, 800, 1200],
+    )
+    assert trace.turn_handling_score == 1.0
+    assert trace.transcript_integrity_score == 1.0
+    assert trace.tool_reliability_score == 1.0
+    assert trace.response_latency_score == 1.0
+    assert trace.overall_score == 1.0
+
+
+def test_reliability_trace_overall_score_poor():
+    trace = ReliabilityTrace(
+        session_id="test-poor",
+        turn_count=5,
+        interruptions=3,
+        session_complete=False,
+        transcript_integrity=0.5,
+        tool_reliability=0.5,
+        response_latency_ms=[6000, 7000, 8000],
+    )
+    assert trace.turn_handling_score < 0.5
+    assert trace.transcript_integrity_score == 0.5
+    assert trace.tool_reliability_score == 0.5
+    assert trace.response_latency_score == 0.0
+    assert trace.overall_score < 0.4
+
+
+def test_reliability_trace_latency_thresholds():
+    trace = ReliabilityTrace(response_latency_ms=[1000])
+    assert trace.response_latency_score == 1.0
+
+    trace = ReliabilityTrace(response_latency_ms=[2000])
+    assert trace.response_latency_score == 1.0
+
+    trace = ReliabilityTrace(response_latency_ms=[3500])
+    assert 0.4 < trace.response_latency_score < 0.6
+
+    trace = ReliabilityTrace(response_latency_ms=[5000])
+    assert trace.response_latency_score == 0.0
+
+    trace = ReliabilityTrace(response_latency_ms=[10000])
+    assert trace.response_latency_score == 0.0
+
+
+def test_reliability_trace_to_dict_metadata_only():
+    trace = ReliabilityTrace(
+        session_id="test-dict",
+        turn_count=3,
+        interruptions=1,
+        session_complete=True,
+    )
+    d = trace.to_dict(include_transcript=False)
+    assert d["session_id"] == "test-dict"
+    assert d["turn_count"] == 3
+    assert d["interruptions"] == 1
+    assert d["transcript_exported"] is False
+    assert "scores" in d
+    assert "overall" in d["scores"]
+
+
+def test_reliability_trace_to_dict_with_transcript_opt_in():
+    trace = ReliabilityTrace(session_id="test-opt-in")
+    d = trace.to_dict(include_transcript=True)
+    assert d["transcript_exported"] is True
+
+
+def test_reliability_trace_to_dict_with_evaluation():
+    judgments = {
+        "accuracy": JudgmentResult(verdict="pass", reasoning="accurate"),
+        "safety": JudgmentResult(verdict="fail", reasoning="unsafe advice"),
+    }
+    eval_result = EvaluationResult(judgments=judgments)
+    trace = ReliabilityTrace(session_id="test-eval", evaluation=eval_result)
+    d = trace.to_dict()
+    assert "evaluation" in d
+    assert d["evaluation"]["score"] == 0.5
+    assert d["evaluation"]["all_passed"] is False
+    assert "accuracy" in d["evaluation"]["judgments"]
+    assert d["evaluation"]["judgments"]["accuracy"]["verdict"] == "pass"
+
+
+def test_reliability_observer_record_turn():
+    observer = ReliabilityObserver(session_id="obs-1")
+    observer.record_turn(latency_ms=800)
+    observer.record_turn(latency_ms=1200)
+    assert observer.trace.turn_count == 2
+    assert observer.trace.response_latency_ms == [800, 1200]
+
+
+def test_reliability_observer_record_interruption():
+    observer = ReliabilityObserver(session_id="obs-2")
+    observer.record_interruption()
+    observer.record_interruption()
+    assert observer.trace.interruptions == 2
+
+
+def test_reliability_observer_mark_complete():
+    observer = ReliabilityObserver(session_id="obs-3")
+    observer.mark_complete()
+    assert observer.trace.session_complete is True
+    assert observer.trace.ended_at is not None
+
+
+def test_reliability_observer_set_evaluation():
+    observer = ReliabilityObserver(session_id="obs-4")
+    eval_result = EvaluationResult(
+        judgments={"accuracy": JudgmentResult(verdict="pass", reasoning="ok")}
+    )
+    observer.set_evaluation(eval_result)
+    assert observer.trace.evaluation is not None
+    assert observer.trace.evaluation.score == 1.0
+
+
+def test_reliability_observer_to_dict_respects_privacy_default():
+    observer = ReliabilityObserver(session_id="obs-5")
+    d = observer.to_dict()
+    assert d["transcript_exported"] is False
+
+
+def test_reliability_observer_to_dict_respects_opt_in():
+    observer = ReliabilityObserver(session_id="obs-6", include_transcript=True)
+    d = observer.to_dict()
+    assert d["transcript_exported"] is True
+
+
+@pytest.mark.asyncio
+async def test_reliability_observer_flush_idempotent():
+    observer = ReliabilityObserver(session_id="obs-flush")
+    await observer.flush()
+    first_ended = observer.trace.ended_at
+    await observer.flush()
+    assert observer.trace.ended_at == first_ended
+
+
+@pytest.mark.asyncio
+async def test_reliability_observer_flush_with_null_reporter():
+    observer = ReliabilityObserver(session_id="obs-null")
+    observer.record_turn(latency_ms=500)
+    observer.mark_complete()
+    await observer.flush()
+    assert observer.trace.session_complete is True

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -7,6 +7,8 @@ from livekit.agents.evals import (
 )
 from livekit.agents.evals.judge import JudgmentResult
 
+pytestmark = pytest.mark.evals
+
 
 def test_reliability_trace_defaults():
     trace = ReliabilityTrace(session_id="test-1")

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -7,7 +7,7 @@ from livekit.agents.evals import (
 )
 from livekit.agents.evals.judge import JudgmentResult
 
-pytestmark = pytest.mark.evals
+pytestmark = pytest.mark.unit
 
 
 def test_reliability_trace_defaults():
@@ -170,3 +170,84 @@ async def test_reliability_observer_flush_with_null_reporter():
     observer.mark_complete()
     await observer.flush()
     assert observer.trace.session_complete is True
+
+
+def test_reliability_trace_turn_handling_zero_turns_completed():
+    """A completed session with no turns should not score 0.0 on turn handling."""
+    trace = ReliabilityTrace(session_id="silent", turn_count=0, session_complete=True)
+    assert trace.turn_handling_score == 1.0
+
+
+def test_reliability_trace_turn_handling_zero_turns_incomplete():
+    """An incomplete session with no turns should be penalized but not zero."""
+    trace = ReliabilityTrace(session_id="silent-aborted", turn_count=0, session_complete=False)
+    assert trace.turn_handling_score == 0.75
+
+
+def test_reliability_observer_record_tool_call_success():
+    observer = ReliabilityObserver(session_id="obs-tool-ok")
+    observer.record_tool_call(success=True)
+    observer.record_tool_call(success=True)
+    assert observer.trace.tool_calls == 2
+    assert observer.trace.tool_failures == 0
+    assert observer.trace.tool_reliability == 1.0
+
+
+def test_reliability_observer_record_tool_call_failure_lowers_score():
+    observer = ReliabilityObserver(session_id="obs-tool-fail")
+    observer.record_tool_call(success=True)
+    observer.record_tool_call(success=False, error="timeout")
+    assert observer.trace.tool_calls == 2
+    assert observer.trace.tool_failures == 1
+    assert observer.trace.tool_reliability == 0.5
+    assert observer.trace.tool_errors == ["timeout"]
+    assert observer.trace.provider_errors == []
+
+
+def test_reliability_observer_record_tool_error_convenience():
+    observer = ReliabilityObserver(session_id="obs-tool-err")
+    observer.record_tool_error("connection refused")
+    assert observer.trace.tool_calls == 1
+    assert observer.trace.tool_failures == 1
+    assert observer.trace.tool_reliability == 0.0
+    assert observer.trace.tool_errors == ["connection refused"]
+
+
+def test_reliability_observer_provider_errors_separate_from_tool_errors():
+    observer = ReliabilityObserver(session_id="obs-sep")
+    observer.record_provider_error("STT connection lost")
+    observer.record_tool_error("tool timeout")
+    assert observer.trace.provider_errors == ["STT connection lost"]
+    assert observer.trace.tool_errors == ["tool timeout"]
+    assert observer.trace.tool_calls == 1
+    assert observer.trace.tool_failures == 1
+
+
+def test_reliability_trace_to_dict_raw_facts_on_opt_in():
+    trace = ReliabilityTrace(
+        session_id="test-raw",
+        turn_count=2,
+        transcript_integrity=0.9,
+        tool_reliability=0.75,
+        tool_calls=4,
+        tool_failures=1,
+        response_latency_ms=[800, 3000],
+        provider_errors=["STT error"],
+        tool_errors=["tool timeout"],
+    )
+    d = trace.to_dict(include_transcript=True)
+    assert d["transcript_exported"] is True
+    assert "raw" in d
+    assert d["raw"]["response_latency_ms"] == [800, 3000]
+    assert d["raw"]["transcript_integrity"] == 0.9
+    assert d["raw"]["tool_calls"] == 4
+    assert d["raw"]["tool_failures"] == 1
+    assert d["raw"]["provider_errors"] == ["STT error"]
+    assert d["raw"]["tool_errors"] == ["tool timeout"]
+
+
+def test_reliability_trace_to_dict_no_raw_when_not_opted_in():
+    trace = ReliabilityTrace(session_id="test-no-raw", response_latency_ms=[800])
+    d = trace.to_dict(include_transcript=False)
+    assert d["transcript_exported"] is False
+    assert "raw" not in d


### PR DESCRIPTION
# feat(evals): add ReliabilityObserver for external reliability scoring

**References:** #6707

## Summary

Adds a provider-neutral reliability trace and observer interface to `livekit-agents/livekit/agents/evals/`, enabling external reliability scoring and regression testing for `AgentSession` without adding vendor dependencies to the core package.

This implements **option 3** from issue #6707: a small generic exporter/reporter interface that external reliability tools can implement.

## What's added

### `livekit-agents/livekit/agents/evals/reliability.py`

- **`ReliabilityTrace`**: Provider-neutral dataclass capturing observed facts of an `AgentSession` for post-call diagnosis. Calculates four reliability components (turn handling, transcript integrity, tool reliability, response latency) and a composite overall score. Serializes to a dict with metadata-only default (transcript export requires explicit opt-in).
- **`ReliabilityReporter`**: Protocol for any object that can report a trace externally. Implement this to send traces to your reliability scoring service without adding a vendor dependency to the core package.
- **`ReliabilityObserver`**: Attaches to an `AgentSession` before `session.start()`, records observed facts during the session, and flushes the trace to a `ReliabilityReporter` during shutdown. Idempotent flush. Privacy-safe defaults (metadata-only, transcript opt-in).

### `tests/test_reliability.py`

15 tests covering:
- `ReliabilityTrace` defaults and scoring (perfect, poor, latency thresholds)
- `to_dict()` metadata-only vs transcript opt-in
- `to_dict()` with attached `EvaluationResult`
- `ReliabilityObserver` record_turn, record_interruption, mark_complete, set_evaluation
- `ReliabilityObserver` privacy defaults (metadata-only by default, opt-in for transcript)
- `ReliabilityObserver.flush()` idempotency and null reporter

### `livekit-agents/livekit/agents/evals/__init__.py`

Exports `ReliabilityObserver`, `ReliabilityReporter`, `ReliabilityTrace`.

## Design decisions

### Metadata-only by default

`to_dict(include_transcript=False)` is the default. Transcript content requires explicit opt-in at `ReliabilityObserver` construction time. This addresses the privacy question from issue #6707: "Should an example default to metadata-only capture and require an explicit opt-in before exporting transcript or tool content?" **Yes.**

### Protocol-based reporter

`ReliabilityReporter` is a `Protocol`, not an ABC. External tools implement the protocol without inheriting from a base class, keeping vendor dependencies out of the core package. A `_NullReporter` is used by default (logs but does not export).

### Public event surface

`ReliabilityObserver.attach()` intentionally uses public event hooks, not internal/private session attributes. This addresses the question from #6707: "Is attaching public event listeners before session.start() an encouraged integration pattern?" The observer is designed to depend only on the public event surface.

### Four reliability components

Per issue #6707, the trace calculates four reliability components:
1. **Turn handling** (25%): penalizes interruptions and incomplete sessions
2. **Transcript integrity** (25%): fraction of turns with complete transcripts
3. **Tool reliability** (25%): fraction of tool calls that succeeded
4. **Response latency** (25%): threshold-based (under 2s = 1.0, over 5s = 0.0, linear between)

The composite `overall_score` is a weighted average. Integrations can override any component field directly on the trace for custom scoring.

## Usage example

```python
from livekit.agents.evals import ReliabilityObserver

async def entrypoint(ctx: JobContext):
    observer = ReliabilityObserver(
        session_id=ctx.job.id,
        reporter=my_reporter,  # implements ReliabilityReporter protocol
    )
    session = AgentSession(
        vad=inference.VAD(),
        stt=deepgram.STT(),
        llm=openai.LLM(),
        tts=cartesia.TTS(),
    )
    observer.attach(session)
    await session.start(agent=MyAgent(), room=ctx.room)
    # observer.flush() called on shutdown
```

## What's NOT included (intentionally)

- No vendor-specific reporter implementations (kept out of core package)
- No automatic session event wiring (integrations call `record_turn()`, `record_interruption()`, etc. from their own event handlers, depending on which public events they choose to consume)
- No OTLP exporter (the issue asks whether this should be OTLP or custom; this PR provides the neutral interface, OTLP can be added as a separate reporter implementation)

## Checklist

- [x] `ruff check --fix` and `ruff format` (will run in CI)
- [x] New methods/classes documented with docstrings
- [x] Tests added (`tests/test_reliability.py`, 15 tests)
- [x] No new dependencies added to core package
- [x] Privacy-safe defaults (metadata-only, transcript opt-in)
- [x] Public event surface only (no internal/private session attributes)

## Addresses issue #6707 questions

1. **"Is attaching public event listeners before session.start() encouraged?"** - Yes, `ReliabilityObserver.attach()` is designed for this pattern.
2. **"Which event contracts are stable for third-party consumers?"** - This PR uses only public methods (`record_turn`, `record_interruption`, etc.) and does not depend on internal event ordering.
3. **"Are event ordering and terminal delivery sufficiently defined?"** - The observer is idempotent and does not depend on specific event ordering. `flush()` can be called multiple times safely.
4. **"Should an example default to metadata-only capture?"** - Yes, `include_transcript=False` is the default.
5. **"Would a LiveKit simulation/CI reporter be more useful than a runtime example?"** - This PR provides the neutral interface; a CI reporter can be added as a separate `ReliabilityReporter` implementation.
