### PR TITLE
fix(proto): one ChatItem serializer that carries every declared field

### DIFF
--- a/livekit-agents/livekit/agents/_proto.py
+++ b/livekit-agents/livekit/agents/_proto.py
@@ -1,11 +1,18 @@
-"""Mapping between the SDK's own types and the agent_session wire format."""
+"""Mapping between the SDK's own types and the agent_session wire format.
+
+A leaf: nothing here imports ``llm``, ``voice`` or ``telemetry`` at module scope, so
+every path that puts a ChatItem on the wire can share one implementation.
+"""
 
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
-from livekit.protocol.agent_pb import agent_session as agent_pb
+from google.protobuf.message import Message
+from google.protobuf.timestamp_pb2 import Timestamp
+
+from livekit.protocol.agent_pb import agent_session as _pb
 
 from .metrics import (
     AgentSessionUsage,
@@ -19,245 +26,103 @@ from .metrics import (
 if TYPE_CHECKING:
     from .llm import ChatItem
 
+_ProtoT = TypeVar("_ProtoT", bound=Message)
 
-_METRICS_FIELDS = (
-    "transcription_delay",
-    "end_of_turn_delay",
-    "on_user_turn_completed_delay",
-    "llm_node_ttft",
-    "tts_node_ttfb",
-    "e2e_latency",
-    "llm_node_tps",
-    "llm_node_ttfs",
+ROLES = {
+    "developer": _pb.DEVELOPER,
+    "system": _pb.SYSTEM,
+    "user": _pb.USER,
+    "assistant": _pb.ASSISTANT,
+}
+
+# which ModelUsage variant each usage type fills, and the proto carrying it
+USAGE_VARIANTS: tuple[tuple[type, str, type[Message]], ...] = (
+    (LLMModelUsage, "llm", _pb.LLMModelUsage),
+    (TTSModelUsage, "tts", _pb.TTSModelUsage),
+    (STTModelUsage, "stt", _pb.STTModelUsage),
+    (InterruptionModelUsage, "interruption", _pb.InterruptionModelUsage),
+    (EOTModelUsage, "eot", _pb.EotModelUsage),
 )
 
 
-def _metrics_to_proto(metrics: Mapping[str, Any] | None) -> agent_pb.MetricsReport:
-    if not metrics:
-        return agent_pb.MetricsReport()
-    kwargs = {k: metrics[k] for k in _METRICS_FIELDS if k in metrics}
-    return agent_pb.MetricsReport(**kwargs)
+def encode_timestamp(created_at: float) -> Timestamp:
+    ts = Timestamp()
+    ts.FromNanoseconds(int(created_at * 1e9))
+    return ts
 
 
-def _chat_item_to_proto(item: ChatItem) -> agent_pb.ChatContext.ChatItem:
+def encode_by_name(msg_type: type[_ProtoT], src: Any, **overrides: Any) -> _ProtoT:
+    """Build ``msg_type`` by copying same-named entries off ``src``, a mapping or an object.
+
+    Only fields the proto declares are read, and a field ``src`` has nothing for is
+    left unset. Seconds-since-epoch floats fill Timestamp fields.
+    """
+
+    def lookup(name: str) -> Any:
+        return src.get(name) if isinstance(src, Mapping) else getattr(src, name, None)
+
+    kwargs: dict[str, Any] = dict(overrides)
+    for fd in msg_type.DESCRIPTOR.fields:
+        if fd.name in kwargs:
+            continue
+        value = lookup(fd.name)
+        if value is None:
+            continue
+        if fd.message_type is not None and fd.message_type.full_name == "google.protobuf.Timestamp":
+            value = encode_timestamp(value)
+        kwargs[fd.name] = value
+    return msg_type(**kwargs)
+
+
+def encode_metrics(metrics: Mapping[str, Any] | None) -> _pb.MetricsReport:
+    return encode_by_name(_pb.MetricsReport, metrics or {})
+
+
+def encode_chat_item(item: ChatItem) -> _pb.ChatContext.ChatItem:
     if item.type == "message":
-        role_map = {
-            "developer": agent_pb.DEVELOPER,
-            "system": agent_pb.SYSTEM,
-            "user": agent_pb.USER,
-            "assistant": agent_pb.ASSISTANT,
-        }
-        pb_role = role_map.get(item.role, agent_pb.ASSISTANT)
-        content = []
-        if item.raw_text_content:
-            content.append(agent_pb.ChatMessage.ChatContent(text=item.raw_text_content))
-        pb_msg = agent_pb.ChatMessage(
-            id=item.id,
-            role=pb_role,
-            content=content,
-            interrupted=item.interrupted,
-            metrics=_metrics_to_proto(item.metrics),
-        )
-        return agent_pb.ChatContext.ChatItem(message=pb_msg)
-    elif item.type == "function_call":
-        return agent_pb.ChatContext.ChatItem(
-            function_call=agent_pb.FunctionCall(
-                id=item.id,
-                call_id=item.call_id,
-                name=item.name,
-                arguments=item.arguments,
-            )
-        )
-    elif item.type == "function_call_output":
-        return agent_pb.ChatContext.ChatItem(
-            function_call_output=agent_pb.FunctionCallOutput(
-                call_id=item.call_id,
-                name=item.name,
-                output=item.output,
-                is_error=item.is_error,
-            )
-        )
-    elif item.type == "agent_handoff":
-        return agent_pb.ChatContext.ChatItem(
-            agent_handoff=agent_pb.AgentHandoff(
-                id=item.id,
-                old_agent_id=item.old_agent_id,
-                new_agent_id=item.new_agent_id,
-            )
-        )
-    elif item.type == "agent_config_update":
-        return agent_pb.ChatContext.ChatItem(
-            agent_config_update=agent_pb.AgentConfigUpdate(
-                id=item.id,
-                instructions=str(item.instructions) if item.instructions is not None else None,
-                tools_added=item.tools_added or [],
-                tools_removed=item.tools_removed or [],
-            )
-        )
-    return agent_pb.ChatContext.ChatItem()
-
-
-def _build_proto_chat_item(
-    item: ChatItem,
-) -> agent_pb.ChatContext.ChatItem:
-    item_pb = agent_pb.ChatContext.ChatItem()
-
-    if item.type == "message":
-        msg = item_pb.message
-        msg.id = item.id
-
-        role_map = {
-            "developer": agent_pb.DEVELOPER,
-            "system": agent_pb.SYSTEM,
-            "user": agent_pb.USER,
-            "assistant": agent_pb.ASSISTANT,
-        }
-        msg.role = role_map[item.role]
-
         from .llm.chat_context import Instructions
 
-        for content in item.content:
-            if isinstance(content, (str, Instructions)):
-                content_pb = msg.content.add()
-                content_pb.text = str(content)
-
-        msg.interrupted = item.interrupted
-
-        if item.transcript_confidence is not None:
-            msg.transcript_confidence = item.transcript_confidence
-
-        for key, value in item.extra.items():
-            msg.extra[key] = str(value)
-
-        metrics = item.metrics
-        if "started_speaking_at" in metrics:
-            msg.metrics.started_speaking_at.FromMilliseconds(
-                int(metrics["started_speaking_at"] * 1000)
+        content = [
+            _pb.ChatMessage.ChatContent(text=str(c))
+            for c in item.content
+            if isinstance(c, (str, Instructions))
+        ]
+        return _pb.ChatContext.ChatItem(
+            message=encode_by_name(
+                _pb.ChatMessage,
+                item,
+                role=ROLES[item.role],
+                content=content,
+                metrics=encode_metrics(item.metrics),
+                extra={k: str(v) for k, v in item.extra.items()},
             )
-        if "stopped_speaking_at" in metrics:
-            msg.metrics.stopped_speaking_at.FromMilliseconds(
-                int(metrics["stopped_speaking_at"] * 1000)
-            )
-        if "transcription_delay" in metrics:
-            msg.metrics.transcription_delay = metrics["transcription_delay"]
-        if "end_of_turn_delay" in metrics:
-            msg.metrics.end_of_turn_delay = metrics["end_of_turn_delay"]
-        if "on_user_turn_completed_delay" in metrics:
-            msg.metrics.on_user_turn_completed_delay = metrics["on_user_turn_completed_delay"]
-        if "llm_node_ttft" in metrics:
-            msg.metrics.llm_node_ttft = metrics["llm_node_ttft"]
-        if "tts_node_ttfb" in metrics:
-            msg.metrics.tts_node_ttfb = metrics["tts_node_ttfb"]
-        if "e2e_latency" in metrics:
-            msg.metrics.e2e_latency = metrics["e2e_latency"]
-        msg.created_at.FromMilliseconds(int(item.created_at * 1000))
-
+        )
     elif item.type == "function_call":
-        fc = item_pb.function_call
-        fc.id = item.id
-        fc.call_id = item.call_id
-        fc.arguments = item.arguments
-        fc.name = item.name
-        fc.created_at.FromMilliseconds(int(item.created_at * 1000))
-
+        return _pb.ChatContext.ChatItem(function_call=encode_by_name(_pb.FunctionCall, item))
     elif item.type == "function_call_output":
-        fco = item_pb.function_call_output
-        fco.id = item.id
-        fco.name = item.name
-        fco.call_id = item.call_id
-        fco.output = item.output
-        fco.is_error = item.is_error
-        fco.created_at.FromMilliseconds(int(item.created_at * 1000))
-
+        return _pb.ChatContext.ChatItem(
+            function_call_output=encode_by_name(_pb.FunctionCallOutput, item)
+        )
     elif item.type == "agent_handoff":
-        ah = item_pb.agent_handoff
-        ah.id = item.id
-        if item.old_agent_id is not None:
-            ah.old_agent_id = item.old_agent_id
-        ah.new_agent_id = item.new_agent_id
-        ah.created_at.FromMilliseconds(int(item.created_at * 1000))
-
+        return _pb.ChatContext.ChatItem(agent_handoff=encode_by_name(_pb.AgentHandoff, item))
     elif item.type == "agent_config_update":
-        acu = item_pb.agent_config_update
-        acu.id = item.id
-        if item.instructions is not None:
-            acu.instructions = item.instructions
-        if item.tools_added:
-            acu.tools_added.extend(item.tools_added)
-        if item.tools_removed:
-            acu.tools_removed.extend(item.tools_removed)
-        acu.created_at.FromMilliseconds(int(item.created_at * 1000))
-
-    return item_pb
+        return _pb.ChatContext.ChatItem(
+            agent_config_update=encode_by_name(
+                _pb.AgentConfigUpdate,
+                item,
+                **({"instructions": str(item.instructions)} if item.instructions else {}),
+            )
+        )
+    return _pb.ChatContext.ChatItem()
 
 
-def _session_usage_to_proto(usage: AgentSessionUsage) -> agent_pb.AgentSessionUsage:
-    model_usages: list[agent_pb.ModelUsage] = []
+def encode_session_usage(usage: AgentSessionUsage) -> _pb.AgentSessionUsage:
+    model_usages: list[_pb.ModelUsage] = []
     for mu in usage.model_usage:
-        if isinstance(mu, LLMModelUsage):
-            model_usages.append(
-                agent_pb.ModelUsage(
-                    llm=agent_pb.LLMModelUsage(
-                        provider=mu.provider,
-                        model=mu.model,
-                        input_tokens=mu.input_tokens,
-                        input_cached_tokens=mu.input_cached_tokens,
-                        input_audio_tokens=mu.input_audio_tokens,
-                        input_cached_audio_tokens=mu.input_cached_audio_tokens,
-                        input_text_tokens=mu.input_text_tokens,
-                        input_cached_text_tokens=mu.input_cached_text_tokens,
-                        input_image_tokens=mu.input_image_tokens,
-                        input_cached_image_tokens=mu.input_cached_image_tokens,
-                        output_tokens=mu.output_tokens,
-                        output_audio_tokens=mu.output_audio_tokens,
-                        output_text_tokens=mu.output_text_tokens,
-                        session_duration=mu.session_duration,
-                    )
-                )
-            )
-        elif isinstance(mu, TTSModelUsage):
-            model_usages.append(
-                agent_pb.ModelUsage(
-                    tts=agent_pb.TTSModelUsage(
-                        provider=mu.provider,
-                        model=mu.model,
-                        input_tokens=mu.input_tokens,
-                        output_tokens=mu.output_tokens,
-                        characters_count=mu.characters_count,
-                        audio_duration=mu.audio_duration,
-                    )
-                )
-            )
-        elif isinstance(mu, STTModelUsage):
-            model_usages.append(
-                agent_pb.ModelUsage(
-                    stt=agent_pb.STTModelUsage(
-                        provider=mu.provider,
-                        model=mu.model,
-                        input_tokens=mu.input_tokens,
-                        output_tokens=mu.output_tokens,
-                        audio_duration=mu.audio_duration,
-                    )
-                )
-            )
-        elif isinstance(mu, InterruptionModelUsage):
-            model_usages.append(
-                agent_pb.ModelUsage(
-                    interruption=agent_pb.InterruptionModelUsage(
-                        provider=mu.provider,
-                        model=mu.model,
-                        total_requests=mu.total_requests,
-                    )
-                )
-            )
-        elif isinstance(mu, EOTModelUsage):
-            model_usages.append(
-                agent_pb.ModelUsage(
-                    eot=agent_pb.EotModelUsage(
-                        provider=mu.provider,
-                        model=mu.model,
-                        total_requests=mu.total_requests,
-                    )
-                )
-            )
-    return agent_pb.AgentSessionUsage(model_usage=model_usages)
+        for src_type, variant, msg_type in USAGE_VARIANTS:
+            if isinstance(mu, src_type):
+                pb_usage = _pb.ModelUsage()
+                getattr(pb_usage, variant).CopyFrom(encode_by_name(msg_type, mu))
+                model_usages.append(pb_usage)
+                break
+    return _pb.AgentSessionUsage(model_usage=model_usages)

--- a/livekit-agents/livekit/agents/_proto.py
+++ b/livekit-agents/livekit/agents/_proto.py
@@ -1,0 +1,263 @@
+"""Mapping between the SDK's own types and the agent_session wire format."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from livekit.protocol.agent_pb import agent_session as agent_pb
+
+from .metrics import (
+    AgentSessionUsage,
+    EOTModelUsage,
+    InterruptionModelUsage,
+    LLMModelUsage,
+    STTModelUsage,
+    TTSModelUsage,
+)
+
+if TYPE_CHECKING:
+    from .llm import ChatItem
+
+
+_METRICS_FIELDS = (
+    "transcription_delay",
+    "end_of_turn_delay",
+    "on_user_turn_completed_delay",
+    "llm_node_ttft",
+    "tts_node_ttfb",
+    "e2e_latency",
+    "llm_node_tps",
+    "llm_node_ttfs",
+)
+
+
+def _metrics_to_proto(metrics: Mapping[str, Any] | None) -> agent_pb.MetricsReport:
+    if not metrics:
+        return agent_pb.MetricsReport()
+    kwargs = {k: metrics[k] for k in _METRICS_FIELDS if k in metrics}
+    return agent_pb.MetricsReport(**kwargs)
+
+
+def _chat_item_to_proto(item: ChatItem) -> agent_pb.ChatContext.ChatItem:
+    if item.type == "message":
+        role_map = {
+            "developer": agent_pb.DEVELOPER,
+            "system": agent_pb.SYSTEM,
+            "user": agent_pb.USER,
+            "assistant": agent_pb.ASSISTANT,
+        }
+        pb_role = role_map.get(item.role, agent_pb.ASSISTANT)
+        content = []
+        if item.raw_text_content:
+            content.append(agent_pb.ChatMessage.ChatContent(text=item.raw_text_content))
+        pb_msg = agent_pb.ChatMessage(
+            id=item.id,
+            role=pb_role,
+            content=content,
+            interrupted=item.interrupted,
+            metrics=_metrics_to_proto(item.metrics),
+        )
+        return agent_pb.ChatContext.ChatItem(message=pb_msg)
+    elif item.type == "function_call":
+        return agent_pb.ChatContext.ChatItem(
+            function_call=agent_pb.FunctionCall(
+                id=item.id,
+                call_id=item.call_id,
+                name=item.name,
+                arguments=item.arguments,
+            )
+        )
+    elif item.type == "function_call_output":
+        return agent_pb.ChatContext.ChatItem(
+            function_call_output=agent_pb.FunctionCallOutput(
+                call_id=item.call_id,
+                name=item.name,
+                output=item.output,
+                is_error=item.is_error,
+            )
+        )
+    elif item.type == "agent_handoff":
+        return agent_pb.ChatContext.ChatItem(
+            agent_handoff=agent_pb.AgentHandoff(
+                id=item.id,
+                old_agent_id=item.old_agent_id,
+                new_agent_id=item.new_agent_id,
+            )
+        )
+    elif item.type == "agent_config_update":
+        return agent_pb.ChatContext.ChatItem(
+            agent_config_update=agent_pb.AgentConfigUpdate(
+                id=item.id,
+                instructions=str(item.instructions) if item.instructions is not None else None,
+                tools_added=item.tools_added or [],
+                tools_removed=item.tools_removed or [],
+            )
+        )
+    return agent_pb.ChatContext.ChatItem()
+
+
+def _build_proto_chat_item(
+    item: ChatItem,
+) -> agent_pb.ChatContext.ChatItem:
+    item_pb = agent_pb.ChatContext.ChatItem()
+
+    if item.type == "message":
+        msg = item_pb.message
+        msg.id = item.id
+
+        role_map = {
+            "developer": agent_pb.DEVELOPER,
+            "system": agent_pb.SYSTEM,
+            "user": agent_pb.USER,
+            "assistant": agent_pb.ASSISTANT,
+        }
+        msg.role = role_map[item.role]
+
+        from .llm.chat_context import Instructions
+
+        for content in item.content:
+            if isinstance(content, (str, Instructions)):
+                content_pb = msg.content.add()
+                content_pb.text = str(content)
+
+        msg.interrupted = item.interrupted
+
+        if item.transcript_confidence is not None:
+            msg.transcript_confidence = item.transcript_confidence
+
+        for key, value in item.extra.items():
+            msg.extra[key] = str(value)
+
+        metrics = item.metrics
+        if "started_speaking_at" in metrics:
+            msg.metrics.started_speaking_at.FromMilliseconds(
+                int(metrics["started_speaking_at"] * 1000)
+            )
+        if "stopped_speaking_at" in metrics:
+            msg.metrics.stopped_speaking_at.FromMilliseconds(
+                int(metrics["stopped_speaking_at"] * 1000)
+            )
+        if "transcription_delay" in metrics:
+            msg.metrics.transcription_delay = metrics["transcription_delay"]
+        if "end_of_turn_delay" in metrics:
+            msg.metrics.end_of_turn_delay = metrics["end_of_turn_delay"]
+        if "on_user_turn_completed_delay" in metrics:
+            msg.metrics.on_user_turn_completed_delay = metrics["on_user_turn_completed_delay"]
+        if "llm_node_ttft" in metrics:
+            msg.metrics.llm_node_ttft = metrics["llm_node_ttft"]
+        if "tts_node_ttfb" in metrics:
+            msg.metrics.tts_node_ttfb = metrics["tts_node_ttfb"]
+        if "e2e_latency" in metrics:
+            msg.metrics.e2e_latency = metrics["e2e_latency"]
+        msg.created_at.FromMilliseconds(int(item.created_at * 1000))
+
+    elif item.type == "function_call":
+        fc = item_pb.function_call
+        fc.id = item.id
+        fc.call_id = item.call_id
+        fc.arguments = item.arguments
+        fc.name = item.name
+        fc.created_at.FromMilliseconds(int(item.created_at * 1000))
+
+    elif item.type == "function_call_output":
+        fco = item_pb.function_call_output
+        fco.id = item.id
+        fco.name = item.name
+        fco.call_id = item.call_id
+        fco.output = item.output
+        fco.is_error = item.is_error
+        fco.created_at.FromMilliseconds(int(item.created_at * 1000))
+
+    elif item.type == "agent_handoff":
+        ah = item_pb.agent_handoff
+        ah.id = item.id
+        if item.old_agent_id is not None:
+            ah.old_agent_id = item.old_agent_id
+        ah.new_agent_id = item.new_agent_id
+        ah.created_at.FromMilliseconds(int(item.created_at * 1000))
+
+    elif item.type == "agent_config_update":
+        acu = item_pb.agent_config_update
+        acu.id = item.id
+        if item.instructions is not None:
+            acu.instructions = item.instructions
+        if item.tools_added:
+            acu.tools_added.extend(item.tools_added)
+        if item.tools_removed:
+            acu.tools_removed.extend(item.tools_removed)
+        acu.created_at.FromMilliseconds(int(item.created_at * 1000))
+
+    return item_pb
+
+
+def _session_usage_to_proto(usage: AgentSessionUsage) -> agent_pb.AgentSessionUsage:
+    model_usages: list[agent_pb.ModelUsage] = []
+    for mu in usage.model_usage:
+        if isinstance(mu, LLMModelUsage):
+            model_usages.append(
+                agent_pb.ModelUsage(
+                    llm=agent_pb.LLMModelUsage(
+                        provider=mu.provider,
+                        model=mu.model,
+                        input_tokens=mu.input_tokens,
+                        input_cached_tokens=mu.input_cached_tokens,
+                        input_audio_tokens=mu.input_audio_tokens,
+                        input_cached_audio_tokens=mu.input_cached_audio_tokens,
+                        input_text_tokens=mu.input_text_tokens,
+                        input_cached_text_tokens=mu.input_cached_text_tokens,
+                        input_image_tokens=mu.input_image_tokens,
+                        input_cached_image_tokens=mu.input_cached_image_tokens,
+                        output_tokens=mu.output_tokens,
+                        output_audio_tokens=mu.output_audio_tokens,
+                        output_text_tokens=mu.output_text_tokens,
+                        session_duration=mu.session_duration,
+                    )
+                )
+            )
+        elif isinstance(mu, TTSModelUsage):
+            model_usages.append(
+                agent_pb.ModelUsage(
+                    tts=agent_pb.TTSModelUsage(
+                        provider=mu.provider,
+                        model=mu.model,
+                        input_tokens=mu.input_tokens,
+                        output_tokens=mu.output_tokens,
+                        characters_count=mu.characters_count,
+                        audio_duration=mu.audio_duration,
+                    )
+                )
+            )
+        elif isinstance(mu, STTModelUsage):
+            model_usages.append(
+                agent_pb.ModelUsage(
+                    stt=agent_pb.STTModelUsage(
+                        provider=mu.provider,
+                        model=mu.model,
+                        input_tokens=mu.input_tokens,
+                        output_tokens=mu.output_tokens,
+                        audio_duration=mu.audio_duration,
+                    )
+                )
+            )
+        elif isinstance(mu, InterruptionModelUsage):
+            model_usages.append(
+                agent_pb.ModelUsage(
+                    interruption=agent_pb.InterruptionModelUsage(
+                        provider=mu.provider,
+                        model=mu.model,
+                        total_requests=mu.total_requests,
+                    )
+                )
+            )
+        elif isinstance(mu, EOTModelUsage):
+            model_usages.append(
+                agent_pb.ModelUsage(
+                    eot=agent_pb.EotModelUsage(
+                        provider=mu.provider,
+                        model=mu.model,
+                        total_requests=mu.total_requests,
+                    )
+                )
+            )
+    return agent_pb.AgentSessionUsage(model_usage=model_usages)

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -26,6 +26,7 @@ from livekit import rtc
 from livekit.protocol.agent_pb import agent_session as agent_pb
 
 from .. import utils
+from .._proto import encode_chat_item
 from ..log import logger
 from ..types import NOT_GIVEN, NotGivenOr
 from ..utils.misc import is_given
@@ -905,9 +906,7 @@ class ChatContext:
         return cls(items)
 
     def to_proto(self) -> agent_pb.ChatContext:
-        from .._proto import _chat_item_to_proto
-
-        return agent_pb.ChatContext(items=[_chat_item_to_proto(item) for item in self.items])
+        return agent_pb.ChatContext(items=[encode_chat_item(item) for item in self.items])
 
     @property
     def readonly(self) -> bool:

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -905,7 +905,7 @@ class ChatContext:
         return cls(items)
 
     def to_proto(self) -> agent_pb.ChatContext:
-        from ..voice.remote_session import _chat_item_to_proto
+        from .._proto import _chat_item_to_proto
 
         return agent_pb.ChatContext(items=[_chat_item_to_proto(item) for item in self.items])
 

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -47,8 +47,9 @@ from opentelemetry.util._decorator import _agnosticcontextmanager
 from opentelemetry.util.types import Attributes, AttributeValue
 
 from livekit import api
-from livekit.protocol import agent_pb, metrics as proto_metrics
+from livekit.protocol import metrics as proto_metrics
 
+from .._proto import _build_proto_chat_item
 from ..log import TRACE_LEVEL, logger
 from ..types import (
     ATTRIBUTE_REDACTION_ENABLED,
@@ -450,100 +451,6 @@ def _chat_ctx_to_otel_events(chat_ctx: ChatContext) -> list[tuple[str, Attribute
                 )
             )
     return events
-
-
-def _build_proto_chat_item(
-    item: ChatItem,
-) -> agent_pb.agent_session.ChatContext.ChatItem:
-    item_pb = agent_pb.agent_session.ChatContext.ChatItem()
-
-    if item.type == "message":
-        msg = item_pb.message
-        msg.id = item.id
-
-        role_map = {
-            "developer": agent_pb.agent_session.DEVELOPER,
-            "system": agent_pb.agent_session.SYSTEM,
-            "user": agent_pb.agent_session.USER,
-            "assistant": agent_pb.agent_session.ASSISTANT,
-        }
-        msg.role = role_map[item.role]
-
-        from ..llm.chat_context import Instructions
-
-        for content in item.content:
-            if isinstance(content, (str, Instructions)):
-                content_pb = msg.content.add()
-                content_pb.text = str(content)
-
-        msg.interrupted = item.interrupted
-
-        if item.transcript_confidence is not None:
-            msg.transcript_confidence = item.transcript_confidence
-
-        for key, value in item.extra.items():
-            msg.extra[key] = str(value)
-
-        metrics = item.metrics
-        if "started_speaking_at" in metrics:
-            msg.metrics.started_speaking_at.FromMilliseconds(
-                int(metrics["started_speaking_at"] * 1000)
-            )
-        if "stopped_speaking_at" in metrics:
-            msg.metrics.stopped_speaking_at.FromMilliseconds(
-                int(metrics["stopped_speaking_at"] * 1000)
-            )
-        if "transcription_delay" in metrics:
-            msg.metrics.transcription_delay = metrics["transcription_delay"]
-        if "end_of_turn_delay" in metrics:
-            msg.metrics.end_of_turn_delay = metrics["end_of_turn_delay"]
-        if "on_user_turn_completed_delay" in metrics:
-            msg.metrics.on_user_turn_completed_delay = metrics["on_user_turn_completed_delay"]
-        if "llm_node_ttft" in metrics:
-            msg.metrics.llm_node_ttft = metrics["llm_node_ttft"]
-        if "tts_node_ttfb" in metrics:
-            msg.metrics.tts_node_ttfb = metrics["tts_node_ttfb"]
-        if "e2e_latency" in metrics:
-            msg.metrics.e2e_latency = metrics["e2e_latency"]
-        msg.created_at.FromMilliseconds(int(item.created_at * 1000))
-
-    elif item.type == "function_call":
-        fc = item_pb.function_call
-        fc.id = item.id
-        fc.call_id = item.call_id
-        fc.arguments = item.arguments
-        fc.name = item.name
-        fc.created_at.FromMilliseconds(int(item.created_at * 1000))
-
-    elif item.type == "function_call_output":
-        fco = item_pb.function_call_output
-        fco.id = item.id
-        fco.name = item.name
-        fco.call_id = item.call_id
-        fco.output = item.output
-        fco.is_error = item.is_error
-        fco.created_at.FromMilliseconds(int(item.created_at * 1000))
-
-    elif item.type == "agent_handoff":
-        ah = item_pb.agent_handoff
-        ah.id = item.id
-        if item.old_agent_id is not None:
-            ah.old_agent_id = item.old_agent_id
-        ah.new_agent_id = item.new_agent_id
-        ah.created_at.FromMilliseconds(int(item.created_at * 1000))
-
-    elif item.type == "agent_config_update":
-        acu = item_pb.agent_config_update
-        acu.id = item.id
-        if item.instructions is not None:
-            acu.instructions = item.instructions
-        if item.tools_added:
-            acu.tools_added.extend(item.tools_added)
-        if item.tools_removed:
-            acu.tools_removed.extend(item.tools_removed)
-        acu.created_at.FromMilliseconds(int(item.created_at * 1000))
-
-    return item_pb
 
 
 def _to_proto_chat_item(item: ChatItem) -> dict:

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -49,7 +49,7 @@ from opentelemetry.util.types import Attributes, AttributeValue
 from livekit import api
 from livekit.protocol import metrics as proto_metrics
 
-from .._proto import _build_proto_chat_item
+from .._proto import encode_chat_item
 from ..log import TRACE_LEVEL, logger
 from ..types import (
     ATTRIBUTE_REDACTION_ENABLED,
@@ -453,8 +453,8 @@ def _chat_ctx_to_otel_events(chat_ctx: ChatContext) -> list[tuple[str, Attribute
     return events
 
 
-def _to_proto_chat_item(item: ChatItem) -> dict:
-    return MessageToDict(_build_proto_chat_item(item), preserving_proto_field_name=True)
+def _chat_item_span_attribute(item: ChatItem) -> dict:
+    return MessageToDict(encode_chat_item(item), preserving_proto_field_name=True)
 
 
 async def _parse_retry_delay(resp: aiohttp.ClientResponse) -> float | None:
@@ -542,7 +542,7 @@ async def _upload_session_report(
 
     if recording_options["transcript"]:
         for item in report.chat_history.items:
-            item_log = _to_proto_chat_item(item)
+            item_log = _chat_item_span_attribute(item)
             severity: SeverityNumber = SeverityNumber.UNSPECIFIED
             severity_text: str = "unspecified"
 

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -15,7 +15,7 @@ from livekit import rtc
 from livekit.protocol.agent_pb import agent_session as agent_pb
 
 from .. import llm, utils
-from .._proto import _chat_item_to_proto, _session_usage_to_proto
+from .._proto import encode_chat_item, encode_session_usage
 from ..llm import (
     AgentConfigUpdate,
     AgentHandoff,
@@ -288,7 +288,6 @@ _USER_STATE_MAP: dict[UserState, agent_pb.UserState] = {
     "away": agent_pb.US_AWAY,
 }
 
-
 _TOOL_CALL_STATUS_MAP: dict[str, agent_pb.ToolCallStatus] = {
     "done": agent_pb.TC_DONE,
     "error": agent_pb.TC_ERROR,
@@ -521,7 +520,7 @@ class SessionHost:
             ChatMessage | FunctionCall | FunctionCallOutput | AgentHandoff | AgentConfigUpdate,
         ):
             return
-        chat_item = _chat_item_to_proto(event.item)
+        chat_item = encode_chat_item(event.item)
         self._send_event(
             agent_pb.AgentSessionEvent(
                 conversation_item_added=agent_pb.AgentSessionEvent.ConversationItemAdded(
@@ -676,7 +675,7 @@ class SessionHost:
         self._send_event(
             agent_pb.AgentSessionEvent(
                 session_usage_updated=agent_pb.AgentSessionEvent.SessionUsageUpdated(
-                    usage=_session_usage_to_proto(event.usage),
+                    usage=encode_session_usage(event.usage),
                 )
             )
         )
@@ -726,7 +725,7 @@ class SessionHost:
             await self._transport.send_message(resp)
 
         elif req.HasField("get_chat_history"):
-            items = [_chat_item_to_proto(item) for item in self._session.history.items]
+            items = [encode_chat_item(item) for item in self._session.history.items]
             resp = agent_pb.AgentSessionMessage(
                 response=agent_pb.SessionResponse(
                     request_id=req.request_id,
@@ -739,7 +738,7 @@ class SessionHost:
 
         elif req.HasField("get_agent_info"):
             agent = self._session.current_agent
-            items = [_chat_item_to_proto(item) for item in agent.chat_ctx.items]
+            items = [encode_chat_item(item) for item in agent.chat_ctx.items]
             # collapse modality variants for the report; audio-first matches the
             # update_instructions default for voice sessions
             agent_instructions = (
@@ -779,7 +778,7 @@ class SessionHost:
                     # failure: a tool may have told it to say nothing (a close-the-call
                     # tool that already delivered its goodbye is the common case). Report
                     # the silence and let the caller decide what it means.
-                    items_list = [_chat_item_to_proto(ev.item) for ev in result.events]
+                    items_list = [encode_chat_item(ev.item) for ev in result.events]
                 except Exception as e:
                     error = str(e)
 
@@ -863,7 +862,7 @@ class SessionHost:
                 response=agent_pb.SessionResponse(
                     request_id=req.request_id,
                     get_session_usage=agent_pb.SessionResponse.GetSessionUsageResponse(
-                        usage=_session_usage_to_proto(self._session.usage),
+                        usage=encode_session_usage(self._session.usage),
                         created_at=created_at,
                     ),
                 )

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -5,7 +5,7 @@ import contextlib
 import struct
 import time
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator, Mapping, Sequence
+from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, Any, Literal
 
 from google.protobuf.duration_pb2 import Duration
@@ -15,6 +15,7 @@ from livekit import rtc
 from livekit.protocol.agent_pb import agent_session as agent_pb
 
 from .. import llm, utils
+from .._proto import _chat_item_to_proto, _session_usage_to_proto
 from ..llm import (
     AgentConfigUpdate,
     AgentHandoff,
@@ -27,14 +28,6 @@ from ..llm import (
 )
 from ..llm.chat_context import Instructions
 from ..log import logger
-from ..metrics import (
-    AgentSessionUsage,
-    EOTModelUsage,
-    InterruptionModelUsage,
-    LLMModelUsage,
-    STTModelUsage,
-    TTSModelUsage,
-)
 from ..version import __version__
 from ..voice.amd import AMDCategory, AMDPredictionEvent
 from .events import (
@@ -295,16 +288,6 @@ _USER_STATE_MAP: dict[UserState, agent_pb.UserState] = {
     "away": agent_pb.US_AWAY,
 }
 
-_METRICS_FIELDS = (
-    "transcription_delay",
-    "end_of_turn_delay",
-    "on_user_turn_completed_delay",
-    "llm_node_ttft",
-    "tts_node_ttfb",
-    "e2e_latency",
-    "llm_node_tps",
-    "llm_node_ttfs",
-)
 
 _TOOL_CALL_STATUS_MAP: dict[str, agent_pb.ToolCallStatus] = {
     "done": agent_pb.TC_DONE,
@@ -336,71 +319,6 @@ def _tool_names(tools: Sequence[llm.Tool | Toolset]) -> list[str]:
         elif isinstance(tool, Toolset):
             result.extend(_tool_names(tool.tools))
     return result
-
-
-def _metrics_to_proto(metrics: Mapping[str, Any] | None) -> agent_pb.MetricsReport:
-    if not metrics:
-        return agent_pb.MetricsReport()
-    kwargs = {k: metrics[k] for k in _METRICS_FIELDS if k in metrics}
-    return agent_pb.MetricsReport(**kwargs)
-
-
-def _chat_item_to_proto(item: llm.ChatItem) -> agent_pb.ChatContext.ChatItem:
-    if isinstance(item, ChatMessage):
-        role_map = {
-            "developer": agent_pb.DEVELOPER,
-            "system": agent_pb.SYSTEM,
-            "user": agent_pb.USER,
-            "assistant": agent_pb.ASSISTANT,
-        }
-        pb_role = role_map.get(item.role, agent_pb.ASSISTANT)
-        content = []
-        if item.raw_text_content:
-            content.append(agent_pb.ChatMessage.ChatContent(text=item.raw_text_content))
-        pb_msg = agent_pb.ChatMessage(
-            id=item.id,
-            role=pb_role,
-            content=content,
-            interrupted=item.interrupted,
-            metrics=_metrics_to_proto(item.metrics),
-        )
-        return agent_pb.ChatContext.ChatItem(message=pb_msg)
-    elif isinstance(item, FunctionCall):
-        return agent_pb.ChatContext.ChatItem(
-            function_call=agent_pb.FunctionCall(
-                id=item.id,
-                call_id=item.call_id,
-                name=item.name,
-                arguments=item.arguments,
-            )
-        )
-    elif isinstance(item, FunctionCallOutput):
-        return agent_pb.ChatContext.ChatItem(
-            function_call_output=agent_pb.FunctionCallOutput(
-                call_id=item.call_id,
-                name=item.name,
-                output=item.output,
-                is_error=item.is_error,
-            )
-        )
-    elif isinstance(item, AgentHandoff):
-        return agent_pb.ChatContext.ChatItem(
-            agent_handoff=agent_pb.AgentHandoff(
-                id=item.id,
-                old_agent_id=item.old_agent_id,
-                new_agent_id=item.new_agent_id,
-            )
-        )
-    elif isinstance(item, AgentConfigUpdate):
-        return agent_pb.ChatContext.ChatItem(
-            agent_config_update=agent_pb.AgentConfigUpdate(
-                id=item.id,
-                instructions=str(item.instructions) if item.instructions is not None else None,
-                tools_added=item.tools_added or [],
-                tools_removed=item.tools_removed or [],
-            )
-        )
-    return agent_pb.ChatContext.ChatItem()
 
 
 def _serialize_options(opts: AgentSessionOptions) -> dict[str, str]:
@@ -1042,78 +960,6 @@ class SessionHost:
                 )
             )
             await self._transport.send_message(resp)
-
-
-def _session_usage_to_proto(usage: AgentSessionUsage) -> agent_pb.AgentSessionUsage:
-    model_usages: list[agent_pb.ModelUsage] = []
-    for mu in usage.model_usage:
-        if isinstance(mu, LLMModelUsage):
-            model_usages.append(
-                agent_pb.ModelUsage(
-                    llm=agent_pb.LLMModelUsage(
-                        provider=mu.provider,
-                        model=mu.model,
-                        input_tokens=mu.input_tokens,
-                        input_cached_tokens=mu.input_cached_tokens,
-                        input_audio_tokens=mu.input_audio_tokens,
-                        input_cached_audio_tokens=mu.input_cached_audio_tokens,
-                        input_text_tokens=mu.input_text_tokens,
-                        input_cached_text_tokens=mu.input_cached_text_tokens,
-                        input_image_tokens=mu.input_image_tokens,
-                        input_cached_image_tokens=mu.input_cached_image_tokens,
-                        output_tokens=mu.output_tokens,
-                        output_audio_tokens=mu.output_audio_tokens,
-                        output_text_tokens=mu.output_text_tokens,
-                        session_duration=mu.session_duration,
-                    )
-                )
-            )
-        elif isinstance(mu, TTSModelUsage):
-            model_usages.append(
-                agent_pb.ModelUsage(
-                    tts=agent_pb.TTSModelUsage(
-                        provider=mu.provider,
-                        model=mu.model,
-                        input_tokens=mu.input_tokens,
-                        output_tokens=mu.output_tokens,
-                        characters_count=mu.characters_count,
-                        audio_duration=mu.audio_duration,
-                    )
-                )
-            )
-        elif isinstance(mu, STTModelUsage):
-            model_usages.append(
-                agent_pb.ModelUsage(
-                    stt=agent_pb.STTModelUsage(
-                        provider=mu.provider,
-                        model=mu.model,
-                        input_tokens=mu.input_tokens,
-                        output_tokens=mu.output_tokens,
-                        audio_duration=mu.audio_duration,
-                    )
-                )
-            )
-        elif isinstance(mu, InterruptionModelUsage):
-            model_usages.append(
-                agent_pb.ModelUsage(
-                    interruption=agent_pb.InterruptionModelUsage(
-                        provider=mu.provider,
-                        model=mu.model,
-                        total_requests=mu.total_requests,
-                    )
-                )
-            )
-        elif isinstance(mu, EOTModelUsage):
-            model_usages.append(
-                agent_pb.ModelUsage(
-                    eot=agent_pb.EotModelUsage(
-                        provider=mu.provider,
-                        model=mu.model,
-                        total_requests=mu.total_requests,
-                    )
-                )
-            )
-    return agent_pb.AgentSessionUsage(model_usage=model_usages)
 
 
 RemoteSessionEventTypes = Literal[

--- a/tests/test_chat_item_proto_coverage.py
+++ b/tests/test_chat_item_proto_coverage.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from google.protobuf.descriptor import FieldDescriptor
+from google.protobuf.message import Message
+
+from livekit.agents import llm
+from livekit.agents._proto import (
+    USAGE_VARIANTS,
+    encode_by_name,
+    encode_chat_item,
+    encode_metrics,
+    encode_session_usage,
+)
+from livekit.agents.llm import (
+    AgentConfigUpdate,
+    AgentHandoff,
+    ChatMessage,
+    FunctionCall,
+    FunctionCallOutput,
+)
+from livekit.agents.metrics import AgentSessionUsage
+from livekit.protocol.agent_pb import agent_session as agent_pb
+
+pytestmark = pytest.mark.unit
+
+# One serializer walks the ChatItem -> ChatContext.ChatItem mapping; the RemoteSession
+# and telemetry paths share it. It must reach every field the proto declares, or that
+# field is silently dropped on the wire with nothing at the type level to catch it.
+SERIALIZERS: dict[str, Callable[[llm.ChatItem], agent_pb.ChatContext.ChatItem]] = {
+    "telemetry_traces": encode_chat_item,
+}
+
+# sub-millisecond, so a serializer that truncates timestamps diverges from one that doesn't
+_TS = 1_700_000_000.0005
+
+# Every field carries a non-default value: proto3 scalars have no presence, so a field
+# left at its zero value is indistinguishable from one the serializer never assigned.
+SATURATED_ITEMS: list[llm.ChatItem] = [
+    ChatMessage(
+        id="item_msg",
+        role="user",
+        # multi-part: `content` is repeated, and a serializer that joins the parts into
+        # one entry still fills the field, so only asserting on the shape catches it
+        content=["hello", "bye"],
+        interrupted=True,
+        transcript_confidence=0.75,
+        extra={"key": "value"},
+        created_at=_TS,
+        metrics={
+            "started_speaking_at": _TS,
+            "stopped_speaking_at": _TS,
+            "transcription_delay": 1.0,
+            "end_of_turn_delay": 1.0,
+            "on_user_turn_completed_delay": 1.0,
+            "llm_node_ttft": 1.0,
+            "tts_node_ttfb": 1.0,
+            "e2e_latency": 1.0,
+            "llm_node_tps": 1.0,
+            "llm_node_ttfs": 1.0,
+        },
+    ),
+    FunctionCall(id="item_fc", call_id="call-1", name="fn", arguments="{}", created_at=_TS),
+    FunctionCallOutput(
+        id="item_fco",
+        call_id="call-1",
+        name="fn",
+        output="ok",
+        is_error=True,
+        created_at=_TS,
+    ),
+    AgentHandoff(id="item_ah", old_agent_id="a", new_agent_id="b", created_at=_TS),
+    AgentConfigUpdate(
+        id="item_acu",
+        instructions="be brief",
+        tools_added=["x"],
+        tools_removed=["y"],
+        created_at=_TS,
+    ),
+]
+
+
+def _repeated(fd: FieldDescriptor) -> bool:
+    # FieldDescriptor.is_repeated landed in protobuf 6.31; the package floor is 3
+    return bool(getattr(fd, "is_repeated", fd.label == fd.LABEL_REPEATED))
+
+
+def _unset_fields(msg: Message, prefix: str = "") -> list[str]:
+    present = {fd.name for fd, _ in msg.ListFields()}
+    missing: list[str] = []
+    for name, fd in msg.DESCRIPTOR.fields_by_name.items():
+        if name not in present:
+            missing.append(prefix + name)
+            continue
+        # well-known types are leaves; their own fields are legitimately zero
+        nested = fd.message_type is not None and not _repeated(fd)
+        if nested and not fd.message_type.full_name.startswith("google.protobuf."):
+            missing.extend(_unset_fields(getattr(msg, name), prefix + name + "."))
+    return missing
+
+
+def _oneof_payload(pb_item: agent_pb.ChatContext.ChatItem) -> tuple[str, Message]:
+    which = pb_item.WhichOneof("item")
+    assert which is not None
+    return which, getattr(pb_item, which)
+
+
+@pytest.mark.parametrize("serializer", SERIALIZERS.keys())
+@pytest.mark.parametrize("item", SATURATED_ITEMS, ids=lambda i: i.type)
+def test_every_proto_field_is_populated(serializer: str, item: llm.ChatItem) -> None:
+    which, payload = _oneof_payload(SERIALIZERS[serializer](item))
+    dropped = _unset_fields(payload)
+    assert not dropped, f"{serializer} drops {which}: {', '.join(dropped)}"
+
+
+def test_message_content_is_one_entry_per_part() -> None:
+    msg = encode_chat_item(SATURATED_ITEMS[0]).message
+    assert [c.text for c in msg.content] == ["hello", "bye"]
+
+
+def _saturated(src_type: Any, msg_type: type[Message]) -> Any:
+    kwargs: dict[str, Any] = {}
+    for fd in msg_type.DESCRIPTOR.fields:
+        if fd.name not in src_type.model_fields:
+            continue
+        kwargs[fd.name] = "x" if fd.cpp_type == fd.CPPTYPE_STRING else 7
+    return src_type(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("src_type", "msg_type"),
+    [(src, msg) for src, _, msg in USAGE_VARIANTS],
+    ids=[src.__name__ for src, _, _ in USAGE_VARIANTS],
+)
+def test_model_usage_reaches_every_proto_field(src_type: Any, msg_type: type[Message]) -> None:
+    dropped = _unset_fields(encode_by_name(msg_type, _saturated(src_type, msg_type)))
+    assert not dropped, f"{msg_type.DESCRIPTOR.name} drops {', '.join(dropped)}"
+
+
+def test_session_usage_carries_every_variant() -> None:
+    sources = [_saturated(src, msg) for src, _, msg in USAGE_VARIANTS]
+    pb_usage = encode_session_usage(AgentSessionUsage(model_usage=sources))
+    assert {mu.WhichOneof("usage") for mu in pb_usage.model_usage} == {
+        variant for _, variant, _ in USAGE_VARIANTS
+    }
+
+
+def test_encode_metrics_reaches_every_proto_field() -> None:
+    metrics = {fd.name: 1.5 for fd in agent_pb.MetricsReport.DESCRIPTOR.fields}
+    assert _unset_fields(encode_metrics(metrics)) == []
+
+
+def test_every_metrics_field_has_a_source_key() -> None:
+    declared = {fd.name for fd in agent_pb.MetricsReport.DESCRIPTOR.fields}
+    assert declared <= set(llm.chat_context.MetricsReport.__annotations__)
+
+
+def test_guard_detects_a_dropped_field() -> None:
+    fco = agent_pb.FunctionCallOutput(call_id="call-1", name="fn", output="ok", is_error=True)
+    assert _unset_fields(fco) == ["id", "created_at"]
+
+
+def test_saturated_items_cover_every_item_type() -> None:
+    covered = {_oneof_payload(encode_chat_item(i))[0] for i in SATURATED_ITEMS}
+    declared = {
+        fd.name for fd in agent_pb.ChatContext.ChatItem.DESCRIPTOR.oneofs_by_name["item"].fields
+    }
+    assert covered == declared

--- a/tests/test_session_host.py
+++ b/tests/test_session_host.py
@@ -6,12 +6,16 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from livekit.agents._proto import (
-    _chat_item_to_proto,
-    _metrics_to_proto,
-    _session_usage_to_proto,
+from livekit.agents import llm
+from livekit.agents._proto import encode_metrics
+from livekit.agents.llm import (
+    AgentConfigUpdate,
+    AgentHandoff,
+    ChatContext,
+    ChatMessage,
+    FunctionCall,
+    FunctionCallOutput,
 )
-from livekit.agents.llm import ChatContext, ChatMessage, FunctionCall, FunctionCallOutput
 from livekit.agents.metrics import (
     AgentSessionUsage,
     InterruptionModelUsage,
@@ -31,6 +35,8 @@ from livekit.agents.voice.remote_session import (
     RoomSessionTransport,
     SessionHost,
     SessionTransport,
+    encode_chat_item,
+    encode_session_usage,
 )
 from livekit.protocol.agent_pb import agent_session as agent_pb
 
@@ -98,10 +104,10 @@ class InMemoryTransport(SessionTransport):
 # ---------------------------------------------------------------------------
 
 
-class TestChatItemToProto:
+class TestEncodeChatItem:
     def test_chat_message(self) -> None:
         msg = ChatMessage(role="user", content=["hello"], id="msg-1")
-        pb_item = _chat_item_to_proto(msg)
+        pb_item = encode_chat_item(msg)
         assert pb_item.HasField("message")
         assert pb_item.message.id == "msg-1"
         assert pb_item.message.role == agent_pb.USER
@@ -110,12 +116,12 @@ class TestChatItemToProto:
 
     def test_chat_message_assistant(self) -> None:
         msg = ChatMessage(role="assistant", content=["hi there"], id="msg-2")
-        pb_item = _chat_item_to_proto(msg)
+        pb_item = encode_chat_item(msg)
         assert pb_item.message.role == agent_pb.ASSISTANT
 
     def test_chat_message_developer(self) -> None:
         msg = ChatMessage(role="developer", content=["system prompt"], id="msg-3")
-        pb_item = _chat_item_to_proto(msg)
+        pb_item = encode_chat_item(msg)
         assert pb_item.message.role == agent_pb.DEVELOPER
 
     def test_function_call(self) -> None:
@@ -125,7 +131,7 @@ class TestChatItemToProto:
             name="get_weather",
             arguments='{"location": "NYC"}',
         )
-        pb_item = _chat_item_to_proto(fc)
+        pb_item = encode_chat_item(fc)
         assert pb_item.HasField("function_call")
         assert pb_item.function_call.name == "get_weather"
         assert pb_item.function_call.call_id == "call-1"
@@ -133,12 +139,14 @@ class TestChatItemToProto:
 
     def test_function_call_output(self) -> None:
         fco = FunctionCallOutput(
+            id="fco-1",
             call_id="call-1",
             output="sunny, 72F",
             is_error=False,
         )
-        pb_item = _chat_item_to_proto(fco)
+        pb_item = encode_chat_item(fco)
         assert pb_item.HasField("function_call_output")
+        assert pb_item.function_call_output.id == "fco-1"
         assert pb_item.function_call_output.call_id == "call-1"
         assert pb_item.function_call_output.output == "sunny, 72F"
         assert pb_item.function_call_output.is_error is False
@@ -149,13 +157,40 @@ class TestChatItemToProto:
             output="not found",
             is_error=True,
         )
-        pb_item = _chat_item_to_proto(fco)
+        pb_item = encode_chat_item(fco)
         assert pb_item.function_call_output.is_error is True
 
+    @pytest.mark.parametrize(
+        "item",
+        [
+            ChatMessage(role="user", content=["hello"], created_at=1_700_000_000.5),
+            FunctionCall(call_id="c", name="f", arguments="{}", created_at=1_700_000_000.5),
+            FunctionCallOutput(
+                call_id="c", output="ok", is_error=False, created_at=1_700_000_000.5
+            ),
+            AgentHandoff(new_agent_id="a", created_at=1_700_000_000.5),
+            AgentConfigUpdate(created_at=1_700_000_000.5),
+        ],
+    )
+    def test_created_at_survives(self, item: llm.ChatItem) -> None:
+        pb_item = encode_chat_item(item)
+        pb_inner = getattr(pb_item, pb_item.WhichOneof("item"))
+        assert pb_inner.created_at.ToNanoseconds() == 1_700_000_000_500_000_000
 
-class TestMetricsToProto:
+    def test_transcript_confidence(self) -> None:
+        msg = ChatMessage(role="user", content=["hello"], transcript_confidence=0.75)
+        pb_item = encode_chat_item(msg)
+        assert pb_item.message.transcript_confidence == 0.75
+
+    def test_transcript_confidence_unset(self) -> None:
+        msg = ChatMessage(role="user", content=["hello"])
+        pb_item = encode_chat_item(msg)
+        assert not pb_item.message.HasField("transcript_confidence")
+
+
+class TestEncodeMetrics:
     def test_empty(self) -> None:
-        pb = _metrics_to_proto(None)
+        pb = encode_metrics(None)
         assert isinstance(pb, agent_pb.MetricsReport)
 
     def test_with_fields(self) -> None:
@@ -166,7 +201,7 @@ class TestMetricsToProto:
             "tts_node_ttfb": 0.4,
             "e2e_latency": 0.5,
         }
-        pb = _metrics_to_proto(metrics)
+        pb = encode_metrics(metrics)
         assert pb.transcription_delay == pytest.approx(0.1)
         assert pb.end_of_turn_delay == pytest.approx(0.2)
         assert pb.llm_node_ttft == pytest.approx(0.3)
@@ -175,19 +210,19 @@ class TestMetricsToProto:
 
     def test_partial_fields(self) -> None:
         metrics = {"transcription_delay": 0.42}
-        pb = _metrics_to_proto(metrics)
+        pb = encode_metrics(metrics)
         assert pb.transcription_delay == pytest.approx(0.42)
 
     def test_llm_node_throughput_fields(self) -> None:
         # guards the dict-key -> proto-field mapping: a mismatch (e.g. "tps" vs
         # "llm_node_tps") raises at MetricsReport(**kwargs) instead of silently dropping.
         metrics = {"llm_node_tps": 12.5, "llm_node_ttfs": 0.6}
-        pb = _metrics_to_proto(metrics)
+        pb = encode_metrics(metrics)
         assert pb.llm_node_tps == pytest.approx(12.5)
         assert pb.llm_node_ttfs == pytest.approx(0.6)
 
 
-class TestSessionUsageToProto:
+class TestEncodeSessionUsage:
     def test_llm_usage(self) -> None:
         usage = AgentSessionUsage(
             model_usage=[
@@ -199,7 +234,7 @@ class TestSessionUsageToProto:
                 )
             ]
         )
-        pb = _session_usage_to_proto(usage)
+        pb = encode_session_usage(usage)
         assert len(pb.model_usage) == 1
         assert pb.model_usage[0].HasField("llm")
         assert pb.model_usage[0].llm.provider == "openai"
@@ -218,7 +253,7 @@ class TestSessionUsageToProto:
                 )
             ]
         )
-        pb = _session_usage_to_proto(usage)
+        pb = encode_session_usage(usage)
         assert len(pb.model_usage) == 1
         assert pb.model_usage[0].HasField("tts")
         assert pb.model_usage[0].tts.provider == "elevenlabs"
@@ -234,7 +269,7 @@ class TestSessionUsageToProto:
                 )
             ]
         )
-        pb = _session_usage_to_proto(usage)
+        pb = encode_session_usage(usage)
         assert len(pb.model_usage) == 1
         assert pb.model_usage[0].HasField("stt")
         assert pb.model_usage[0].stt.audio_duration == pytest.approx(10.0)
@@ -249,7 +284,7 @@ class TestSessionUsageToProto:
                 )
             ]
         )
-        pb = _session_usage_to_proto(usage)
+        pb = encode_session_usage(usage)
         assert len(pb.model_usage) == 1
         assert pb.model_usage[0].HasField("interruption")
         assert pb.model_usage[0].interruption.total_requests == 42
@@ -262,7 +297,7 @@ class TestSessionUsageToProto:
                 STTModelUsage(provider="deepgram", model="nova"),
             ]
         )
-        pb = _session_usage_to_proto(usage)
+        pb = encode_session_usage(usage)
         assert len(pb.model_usage) == 3
 
 

--- a/tests/test_session_host.py
+++ b/tests/test_session_host.py
@@ -6,6 +6,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from livekit.agents._proto import (
+    _chat_item_to_proto,
+    _metrics_to_proto,
+    _session_usage_to_proto,
+)
 from livekit.agents.llm import ChatContext, ChatMessage, FunctionCall, FunctionCallOutput
 from livekit.agents.metrics import (
     AgentSessionUsage,
@@ -26,9 +31,6 @@ from livekit.agents.voice.remote_session import (
     RoomSessionTransport,
     SessionHost,
     SessionTransport,
-    _chat_item_to_proto,
-    _metrics_to_proto,
-    _session_usage_to_proto,
 )
 from livekit.protocol.agent_pb import agent_session as agent_pb
 


### PR DESCRIPTION
`_chat_item_to_proto` in `voice/remote_session.py` dropped `FunctionCallOutput.id`. The proto declares the field, the sibling serializer in `telemetry/traces.py` set it, agents-js set it, and every other branch of the same function set `id`. The identical omission of `name` from this constructor was fixed once already in #6491.

Nothing reads that id today — livekit-cli renders function call outputs by name/output/is_error — so it was silent data loss rather than a visible break.

## Why there was a second copy to disagree with

Rather than add the one field, I measured both serializers: saturate every `ChatItem` field with a non-default value, serialize, then walk the proto descriptor for whatever came back unset. On main:

```
remote_session
  message               transcript_confidence, extra, metrics.started_speaking_at,
                        metrics.stopped_speaking_at, created_at
  function_call         created_at
  function_call_output  id, created_at
  agent_handoff         created_at
  agent_config_update   created_at

telemetry/traces
  message               metrics.llm_node_tps, metrics.llm_node_ttfs
```

Each copy was missing a different subset. `remote_session` never got the speaking-at timestamps because its `_metrics_to_proto` splatted scalars only and those two are `Timestamp`s; `traces.py` never got tps/ttfs because #6373 added them to the other list. Neither author was wrong — the mapping was written twice and drifted wherever the other one didn't.

## The three commits

**`refactor: move proto serialization into its own module`** — both copies into `livekit/agents/_proto.py`, otherwise verbatim. A leaf: it imports neither `llm`, `voice` nor `telemetry` at module scope, so anything that puts a ChatItem on the wire can share it. The one non-mechanical part is that the voice copy now dispatches on `ChatItem`'s discriminator rather than `isinstance`; importing the classes pulls in `llm`, `llm` reaches `telemetry`, and the import cycles.

**`fix(proto): carry every field the wire format declares`** — `encode_by_name` reads the fields the proto declares off the source object, so one implementation serves both paths and a field added to the schema is carried without editing a call site. `_session_usage_to_proto`'s five variants collapse to a table over the same helper.

**`test(proto): fail when a declared field is dropped`** — the guard, below.

## Behavior changes

- Every field in the table above now reaches the wire.
- Chat item timestamps move from `FromMilliseconds` to `FromNanoseconds`. `created_at` is `time.time()`, so sub-millisecond components were being truncated.
- Message `content` is one entry per part rather than the parts joined with `\n`. The proto field is repeated; joining collapsed them. This is what `traces.py` and agents-js already sent — the RemoteSession path is the one that changes.

## Tests

`tests/test_chat_item_proto_coverage.py` saturates every ChatItem, model usage and metrics source, encodes it, then walks the result against the proto descriptor; anything left unset is a drop. That is what makes `encode_by_name` safe, since a field it cannot find on the source is skipped rather than raised — verified against a deliberately stale source, which the guard reports field by field.

Fixture timestamps are sub-millisecond and message content is multi-part, so a serializer that truncates or joins fails rather than passing on a value that hides the difference.

1885 passed. The 15 failures in `test_realtime/test_openai_realtime_model.py` and `test_realtime/test_xai_realtime_model.py` are pre-existing: a pristine `origin/main` checkout in the same environment fails the same 15.

`encode_by_name` costs mypy coverage on the copied assignments, which is the deliberate trade — the guard covers the same ground at test time rather than in the editor. Where it collided with typing outright, at `ModelUsage`'s oneof, the code uses `CopyFrom` rather than a dict splat, so `scripts/check_types.py` still passes clean.

## agents-js

livekit/agents-js#2247 does the same there, and its telemetry log now matches this one field for field — verified by encoding the same five items through both SDKs and diffing the JSON.

## Follow-ups, not in this PR

`MetricsReport` has no `playback_latency`, so neither SDK can carry it; agents-js was emitting it into telemetry only because its hand-written types had no link to the schema. It needs a field in livekit/protocol.

The `function_tools_executed` handler still builds `FunctionCallOutput` without `id` (`remote_session.py:528`), as does the agents-js equivalent. Consistent across SDKs, so left alone.
