### PR TITLE
fix: respect non-retryable STT errors

### DIFF
--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -465,7 +465,7 @@ class RecognizeStream(ABC):
                 last_start_time = time.time()
                 return await self._run()
             except APIError as e:
-                if max_retries == 0:
+                if not e.retryable or max_retries == 0:
                     self._emit_error(e, recoverable=False)
                     raise
                 elif self._num_retries == max_retries:

--- a/livekit-agents/livekit/agents/utils/connection_pool.py
+++ b/livekit-agents/livekit/agents/utils/connection_pool.py
@@ -183,9 +183,7 @@ class ConnectionPool(Generic[T]):
                         conn = await self._connect(timeout=self._connect_timeout)
                         self._available.add(conn)
             except Exception as e:
-                # Swallow the error so asyncio does not log an unretrieved task
-                # exception. Log only the exception type: str(e) / repr(e) can
-                # embed request headers or URL credentials (?api_key=, &jwt_token=).
+                # exception details can contain request headers or URL credentials.
                 logger.warning(
                     "failed to prewarm connection pool",
                     extra={"exception_type": type(e).__name__},

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/_recognize_streams/auto_finalize_recognize_stream.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/_recognize_streams/auto_finalize_recognize_stream.py
@@ -409,14 +409,12 @@ class AutoFinalizeRecognizeStream(CartesiaRecognizeStream):
         except asyncio.TimeoutError:
             raise APIConnectionError("failed to connect to cartesia", retryable=True) from None
         except aiohttp.ClientResponseError as e:
-            # Do not chain the aiohttp error: RequestInfo embeds auth headers and
-            # can leak API keys via Task/exception repr in logs (see #6739).
+            # authentication headers can appear in RequestInfo.
             raise APIStatusError(
                 message=e.message, status_code=e.status, request_id=None, body=None
             ) from None
         except Exception as e:
-            # Do not chain the cause: some transport errors embed auth headers or
-            # URL credentials that would leak via __cause__ / traceback (see #6739).
+            # transport errors can contain credentials in URLs.
             raise APIConnectionError(
                 f"failed to connect to cartesia ({type(e).__name__})",
                 retryable=True,

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/_recognize_streams/legacy_recognize_stream.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/_recognize_streams/legacy_recognize_stream.py
@@ -333,14 +333,12 @@ class LegacyRecognizeStream(CartesiaRecognizeStream):
         except asyncio.TimeoutError:
             raise APIConnectionError("failed to connect to cartesia") from None
         except aiohttp.ClientResponseError as e:
-            # Do not chain the aiohttp error: RequestInfo embeds auth headers and
-            # can leak API keys via Task/exception repr in logs (see #6739).
+            # authentication headers can appear in RequestInfo.
             raise APIStatusError(
                 message=e.message, status_code=e.status, request_id=None, body=None
             ) from None
         except Exception as e:
-            # Do not chain the cause: some transport errors embed auth headers or
-            # URL credentials that would leak via __cause__ / traceback (see #6739).
+            # transport errors can contain credentials in URLs.
             raise APIConnectionError(
                 f"failed to connect to cartesia ({type(e).__name__})",
             ) from None

--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -228,14 +228,12 @@ class TTS(tts.TTS):
         except asyncio.TimeoutError:
             raise APITimeoutError() from None
         except aiohttp.ClientResponseError as e:
-            # Do not chain the aiohttp error: RequestInfo embeds auth headers and
-            # can leak API keys via Task/exception repr in logs (see #6739).
+            # authentication headers can appear in RequestInfo.
             raise APIStatusError(
                 message=e.message, status_code=e.status, request_id=None, body=None
             ) from None
         except Exception as e:
-            # Do not chain the cause: some transport errors embed auth headers or
-            # URL credentials that would leak via __cause__ / traceback (see #6739).
+            # transport errors can contain credentials in URLs.
             raise APIConnectionError(type(e).__name__) from None
 
         c_request_id = ws._response.headers.get(REQUEST_ID_HEADER)

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -99,8 +99,6 @@ async def test_get_expired():
 
 @pytest.mark.asyncio
 async def test_prewarm_failure_does_not_leak_api_key_in_logs(caplog):
-    """Prewarm must swallow connect failures so asyncio never logs an unretrieved
-    task whose exception repr embeds auth headers (livekit/agents#6739)."""
     secret = "cartesia-secret-api-key-do-not-log"
 
     async def failing_connect(timeout: float):
@@ -124,7 +122,6 @@ async def test_prewarm_failure_does_not_leak_api_key_in_logs(caplog):
 
 @pytest.mark.asyncio
 async def test_prewarm_failure_does_not_leak_url_credentials_in_logs(caplog):
-    """str(exception) can embed ?api_key= / &jwt_token=; logs must not include them."""
     secret_key = "url-secret-api-key-do-not-log"
     secret_jwt = "url-secret-jwt-token-do-not-log"
 

--- a/tests/test_plugin_cartesia_tts.py
+++ b/tests/test_plugin_cartesia_tts.py
@@ -1,5 +1,3 @@
-"""Cartesia TTS websocket connect must not leak API keys via exception repr."""
-
 from __future__ import annotations
 
 from unittest.mock import MagicMock
@@ -55,7 +53,6 @@ async def test_connect_ws_redacts_api_key_from_handshake_error():
 
 @pytest.mark.asyncio
 async def test_connect_ws_generic_error_does_not_chain_cause():
-    """Generic connect failures must not chain __cause__ (may embed auth headers)."""
     from livekit.plugins.cartesia import TTS
 
     tts = TTS(api_key=SECRET_API_KEY)

--- a/tests/test_stt_base.py
+++ b/tests/test_stt_base.py
@@ -7,7 +7,7 @@ import time
 
 import pytest
 
-from livekit.agents import APIConnectionError
+from livekit.agents import APIConnectionError, APIStatusError
 from livekit.agents.stt import (
     STT,
     RecognizeStream,
@@ -57,6 +57,16 @@ class _DummySTT(STT):
 
     def stream(self, *, language=None, conn_options=DEFAULT_API_CONNECT_OPTIONS) -> _DummyStream:
         return _DummyStream(stt=self)
+
+
+class _NonRetryableStream(RecognizeStream):
+    def __init__(self, *, stt: STT) -> None:
+        super().__init__(stt=stt, conn_options=DEFAULT_API_CONNECT_OPTIONS)
+        self.run_count = 0
+
+    async def _run(self) -> None:
+        self.run_count += 1
+        raise APIStatusError("Unauthorized", status_code=401)
 
 
 async def test_start_time_seeded_on_init() -> None:
@@ -113,5 +123,18 @@ async def test_start_time_reseeded_on_retry() -> None:
     assert stream.start_time != sentinel
     # And it should be a recent wall-clock value.
     assert time.time() - stream.start_time < 5.0
+
+    await stream.aclose()
+
+
+async def test_non_retryable_error_is_not_retried() -> None:
+    stt = _DummySTT()
+    stream = _NonRetryableStream(stt=stt)
+
+    with pytest.raises(APIStatusError) as exc_info:
+        await stream._task
+
+    assert exc_info.value.status_code == 401
+    assert stream.run_count == 1
 
     await stream.aclose()


### PR DESCRIPTION
**Why:** Cartesia wraps failed WebSocket handshakes as `APIStatusError`. The STT retry loop ignored `retryable=False`, so 401 responses retried four times and ended as `APIConnectionError`.

Preserve the original status error and fail immediately. Trim change-narrative comments from the credential-redaction patch.

Fixes AGT-3238