### PR TITLE
fix(inference): don't crash the session on null usage token counts

### DIFF
--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -476,10 +476,10 @@ class LLMStream(llm.LLMStream):
                         usage_chunk = llm.ChatChunk(
                             id=chunk.id,
                             usage=llm.CompletionUsage(
-                                completion_tokens=chunk.usage.completion_tokens,
-                                prompt_tokens=chunk.usage.prompt_tokens,
+                                completion_tokens=chunk.usage.completion_tokens or 0,
+                                prompt_tokens=chunk.usage.prompt_tokens or 0,
                                 prompt_cached_tokens=cached_tokens or 0,
-                                total_tokens=chunk.usage.total_tokens,
+                                total_tokens=chunk.usage.total_tokens or 0,
                                 service_tier=getattr(chunk, "service_tier", None),
                             ),
                         )

--- a/tests/test_inference_llm_usage.py
+++ b/tests/test_inference_llm_usage.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import httpx
+import openai as openai_sdk
+import pytest
+
+from livekit.agents import llm
+from livekit.plugins import openai
+
+pytestmark = pytest.mark.unit
+
+
+# Some OpenAI-compatible proxies send a final chunk whose ``usage`` object is present
+# but has null numeric fields (rather than omitting ``usage`` entirely). The SDK-side
+# usage model is built leniently, so those nulls reach our ``CompletionUsage``
+# construction as ``None``. See issue #6595.
+_STREAM_WITH_NULL_USAGE = b"""data: {"id":"chatcmpl-test","choices":[{"delta":{"content":"ok","role":"assistant"},"finish_reason":null,"index":0}],"created":0,"model":"m","object":"chat.completion.chunk"}
+
+data: {"id":"chatcmpl-test","choices":[{"delta":{},"finish_reason":"stop","index":0}],"created":0,"model":"m","object":"chat.completion.chunk"}
+
+data: {"id":"chatcmpl-test","choices":[],"created":0,"model":"m","object":"chat.completion.chunk","usage":{"completion_tokens":null,"prompt_tokens":7,"total_tokens":null}}
+
+data: [DONE]
+
+"""
+
+
+class _NullUsageTransport(httpx.AsyncBaseTransport):
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        await request.aread()
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=_STREAM_WITH_NULL_USAGE,
+            request=request,
+        )
+
+
+async def test_null_usage_fields_do_not_crash_stream() -> None:
+    # A null field inside a non-null ``usage`` object must not raise a
+    # ValidationError (which the stream would wrap as a non-retryable
+    # APIConnectionError and terminate the session). Missing counts default to 0.
+    client = openai_sdk.AsyncClient(
+        api_key="test-key",
+        http_client=httpx.AsyncClient(transport=_NullUsageTransport()),
+    )
+    model = openai.LLM(model="m", client=client)
+
+    chat_ctx = llm.ChatContext()
+    chat_ctx.add_message(role="user", content="hi")
+
+    usage_chunks: list[llm.CompletionUsage] = []
+    stream = model.chat(chat_ctx=chat_ctx)
+    try:
+        async for chunk in stream:
+            if chunk.usage is not None:
+                usage_chunks.append(chunk.usage)
+    finally:
+        await stream.aclose()
+        await model.aclose()
+
+    assert len(usage_chunks) == 1
+    usage = usage_chunks[0]
+    assert usage.completion_tokens == 0
+    assert usage.prompt_tokens == 7
+    assert usage.total_tokens == 0


### PR DESCRIPTION
## Problem

Fixes #6595.

On the OpenAI-compatible streaming path (`inference/llm.py`, also used by the openai plugin, whose `LLMStream` inherits `_run` from here), the final chunk's usage is only guarded with `if chunk.usage is not None`. Some OpenAI-compatible proxies send a `usage` object that *is* present but has null numeric fields (e.g. `completion_tokens: null`).

`CompletionUsage` declares `completion_tokens`/`prompt_tokens`/`total_tokens` as required `int`, so a null raises a pydantic `ValidationError`. It's caught by the bare `except Exception` and re-raised as `APIConnectionError(retryable=False)` — a non-retryable error that terminates the whole `AgentSession`, killing an in-progress call, even though nothing is actually wrong with the connection.

## Fix

Default the three required counts to `0` (`x or 0`). This mirrors the guard the Google plugin already applies for the same class of "usage present but incomplete" payload (#5404); `prompt_cached_tokens` was already guarded here.

## Test

`tests/test_inference_llm_usage.py` drives the openai plugin `LLM` against a mock transport that streams a final chunk with `completion_tokens: null` / `total_tokens: null`. Verified A/B: it fails on `main` with exactly the reported `APIConnectionError` ← `ValidationError`, and passes with the fix, emitting a usage chunk with the counts defaulted to 0.

Thanks to @onur-yildirim-infinitusai for the precise diagnosis and repro.