### PR TITLE
fix: support adaptive interruption without word timestamps

### DIFF
--- a/livekit-agents/livekit/agents/stt/stream_adapter.py
+++ b/livekit-agents/livekit/agents/stt/stream_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import AsyncIterable
 from typing import TYPE_CHECKING, Any
 
@@ -127,9 +128,13 @@ class StreamAdapterWrapper(RecognizeStream):
                 if event.type == VADEventType.START_OF_SPEECH:
                     self._event_ch.send_nowait(SpeechEvent(SpeechEventType.START_OF_SPEECH))
                 elif event.type == VADEventType.END_OF_SPEECH:
+                    speech_end_time = (
+                        time.time() - event.silence_duration - event.inference_duration
+                    )
                     self._event_ch.send_nowait(
                         SpeechEvent(
                             type=SpeechEventType.END_OF_SPEECH,
+                            speech_end_time=speech_end_time,
                         )
                     )
 
@@ -149,6 +154,11 @@ class StreamAdapterWrapper(RecognizeStream):
                         SpeechEvent(
                             type=SpeechEventType.FINAL_TRANSCRIPT,
                             alternatives=[t_event.alternatives[0]],
+                            speech_end_time=(
+                                t_event.speech_end_time
+                                if t_event.speech_end_time is not None
+                                else speech_end_time
+                            ),
                         )
                     )
 

--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -122,6 +122,8 @@ class SpeechEvent:
     speech_start_time: float | None = None
     """server-reported wall-clock time of speech onset, when the provider sends
     a separate speech-start signal carrying onset timing."""
+    created_at: float = field(default_factory=lambda: time.time())
+    """Wall-clock time when this event was created."""
 
 
 @dataclass

--- a/livekit-agents/livekit/agents/stt/stt.py
+++ b/livekit-agents/livekit/agents/stt/stt.py
@@ -124,6 +124,8 @@ class SpeechEvent:
     a separate speech-start signal carrying onset timing."""
     created_at: float = field(default_factory=lambda: time.time())
     """Wall-clock time when this event was created."""
+    speech_end_time: float | None = None
+    """Wall-clock time when the recognized speech ended, when known."""
 
 
 @dataclass

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import AsyncGenerator, AsyncIterable, Coroutine, Generator
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
 from livekit import rtc
@@ -526,6 +526,17 @@ class Agent:
                 forward_task = asyncio.create_task(_forward_input())
                 try:
                     async for event in stream:
+                        if (
+                            event.speech_end_time is None
+                            and wrapped_stt.capabilities.aligned_transcript
+                            and event.alternatives
+                            and event.alternatives[0].end_time > 0
+                        ):
+                            speech_end_time = (
+                                _audio_input_started_at + event.alternatives[0].end_time
+                            )
+                            if speech_end_time <= event.created_at:
+                                event = replace(event, speech_end_time=speech_end_time)
                         yield event
                 finally:
                     await utils.aio.cancel_and_wait(forward_task)

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import AsyncGenerator, AsyncIterable, Coroutine, Generator
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
 from livekit import rtc
@@ -526,17 +526,6 @@ class Agent:
                 forward_task = asyncio.create_task(_forward_input())
                 try:
                     async for event in stream:
-                        if (
-                            event.speech_end_time is None
-                            and wrapped_stt.capabilities.aligned_transcript
-                            and event.alternatives
-                            and event.alternatives[0].end_time > 0
-                        ):
-                            speech_end_time = (
-                                _audio_input_started_at + event.alternatives[0].end_time
-                            )
-                            if speech_end_time <= event.created_at:
-                                event = replace(event, speech_end_time=speech_end_time)
                         yield event
                 finally:
                     await utils.aio.cancel_and_wait(forward_task)

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -302,6 +302,7 @@ class AgentActivity(RecognitionHooks):
         )
         self._interruption_detection_enabled: bool = self._interruption_detector is not None
         self._pending_interruption: inference.OverlappingSpeechEvent | None = None
+        self._audio_activity_interruption_in_progress: bool = False
 
         # this allows taking over audio interruption temporarily until interruption is detected
         # by default it is true unless turn_detection is manual or realtime_llm
@@ -2080,6 +2081,16 @@ class AgentActivity(RecognitionHooks):
 
     def _interrupt_by_audio_activity(self) -> None:
         """Interrupt the current speech or generation from detected audio activity."""
+        if self._audio_activity_interruption_in_progress:
+            return
+
+        self._audio_activity_interruption_in_progress = True
+        try:
+            self._interrupt_by_audio_activity_once()
+        finally:
+            self._audio_activity_interruption_in_progress = False
+
+    def _interrupt_by_audio_activity_once(self) -> None:
         if not self._interruption_by_audio_activity_enabled:
             return
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -301,8 +301,7 @@ class AgentActivity(RecognitionHooks):
             self._resolve_interruption_detection()
         )
         self._interruption_detection_enabled: bool = self._interruption_detector is not None
-        self._pending_interruption: inference.OverlappingSpeechEvent | None = None
-        self._audio_activity_interruption_in_progress: bool = False
+        self._interruption_detected: bool = False
 
         # this allows taking over audio interruption temporarily until interruption is detected
         # by default it is true unless turn_detection is manual or realtime_llm
@@ -482,6 +481,19 @@ class AgentActivity(RecognitionHooks):
     @property
     def interruption_enabled(self) -> bool:
         return self._interruption_detection_enabled
+
+    @property
+    def interruption_by_audio_activity_enabled(self) -> bool:
+        return self._interruption_by_audio_activity_enabled
+
+    @interruption_by_audio_activity_enabled.setter
+    def interruption_by_audio_activity_enabled(self, enabled: bool) -> None:
+        if self._audio_recognition:
+            self._audio_recognition._cancel_backchannel_boundary()
+
+        self._interruption_by_audio_activity_enabled = (
+            enabled and self._default_interruption_by_audio_activity_enabled
+        )
 
     @property
     def mcp_servers(self) -> list[mcp.MCPServer] | None:
@@ -1981,6 +1993,12 @@ class AgentActivity(RecognitionHooks):
 
         self._session._on_error(error)
 
+    def _on_end_of_agent_speech(self, *, ended_at: float) -> None:
+        if self._audio_recognition is not None:
+            self._audio_recognition._on_end_of_agent_speech(ended_at=ended_at)
+
+        self._interruption_detected = False
+
     def _on_input_speech_started(self, _: llm.InputSpeechStartedEvent) -> None:
         if self.vad is None or self.using_default_vad:
             self._session._update_user_state("speaking")
@@ -2074,23 +2092,8 @@ class AgentActivity(RecognitionHooks):
 
         self._schedule_speech(handle, SpeechHandle.SPEECH_PRIORITY_NORMAL)
 
-    def _on_end_of_agent_speech(self, *, ended_at: float) -> None:
-        if self._audio_recognition is not None:
-            self._audio_recognition._on_end_of_agent_speech(ended_at=ended_at)
-        self._pending_interruption = None
-
     def _interrupt_by_audio_activity(self) -> None:
         """Interrupt the current speech or generation from detected audio activity."""
-        if self._audio_activity_interruption_in_progress:
-            return
-
-        self._audio_activity_interruption_in_progress = True
-        try:
-            self._interrupt_by_audio_activity_once()
-        finally:
-            self._audio_activity_interruption_in_progress = False
-
-    def _interrupt_by_audio_activity_once(self) -> None:
         if not self._interruption_by_audio_activity_enabled:
             return
 
@@ -2100,13 +2103,10 @@ class AgentActivity(RecognitionHooks):
 
         if self._rt_turn_detection_enabled:
             # ignore if realtime model has turn detection enabled
-            self._pending_interruption = None
+            self._interruption_detected = False
             return
 
         interruption_options = self._session.options.interruption
-        if self._audio_recognition is not None:
-            self._audio_recognition._release_transcripts_for_audio_activity()
-
         if (
             self.stt is not None
             and interruption_options["min_words"] > 0
@@ -2150,16 +2150,14 @@ class AgentActivity(RecognitionHooks):
                 self._session._update_agent_state("listening")
                 self._on_end_of_agent_speech(ended_at=time.time())
                 if self.interruption_enabled:
-                    self._restore_interruption_by_audio_activity()
+                    self.interruption_by_audio_activity_enabled = True
             else:
                 if self._rt_session is not None:
                     self._rt_session.interrupt()
 
                 self._current_speech.interrupt()
-        elif self._current_speech is None or (
-            not self._current_speech.interrupted and not self._current_speech.allow_interruptions
-        ):
-            self._pending_interruption = None
+        elif self._current_speech is None or not self._current_speech.interrupted:
+            self._interruption_detected = False
 
     # region recognition hooks
 
@@ -2174,7 +2172,7 @@ class AgentActivity(RecognitionHooks):
                 started_at=speech_start_time,
                 speech_duration=ev.speech_duration if ev else 0.0,
                 user_speaking_span=self._session._user_speaking_span,
-                detect_overlap=self._pending_interruption is None,
+                skip_adaptive_interruption=self._interruption_detected,
             )
         self._user_silence_event.clear()
         self._stt_eos_received = False
@@ -2208,7 +2206,7 @@ class AgentActivity(RecognitionHooks):
             self._audio_recognition._on_end_of_speech(
                 ended_at=speech_end_time,
                 user_speaking_span=self._session._user_speaking_span,
-                interruption=self._pending_interruption is not None
+                interruption=self._interruption_detected
                 if self._interruption_detection_enabled
                 else NOT_GIVEN,
             )
@@ -2268,17 +2266,17 @@ class AgentActivity(RecognitionHooks):
 
     def on_overlap_speech(self, ev: inference.OverlappingSpeechEvent) -> None:
         if ev.is_interruption:
-            self._pending_interruption = ev
-            self._interruption_by_audio_activity_enabled = False
+            self._interruption_detected = True
 
         self._session.emit("overlapping_speech", ev)
         if self._audio_recognition is not None:
-            self._audio_recognition._apply_overlap_speech_event(ev)
+            # Release held transcripts before re-enabling VAD interruption.
+            self._audio_recognition._on_overlap_speech_event(ev)
 
         if not ev.is_interruption:
             return
 
-        self._restore_interruption_by_audio_activity()
+        self.interruption_by_audio_activity_enabled = True
         self._interrupt_by_audio_activity()
 
     def on_interim_transcript(self, ev: stt.SpeechEvent, *, speaking: bool | None) -> None:
@@ -2843,7 +2841,7 @@ class AgentActivity(RecognitionHooks):
             )
             self._on_end_of_agent_speech(ended_at=time.time())
             if self.interruption_enabled:
-                self._restore_interruption_by_audio_activity()
+                self.interruption_by_audio_activity_enabled = True
 
     @utils.log_exceptions(logger=logger)
     async def _tts_task(
@@ -3075,7 +3073,7 @@ class AgentActivity(RecognitionHooks):
             )
             self._on_end_of_agent_speech(ended_at=time.time())
             if self.interruption_enabled:
-                self._restore_interruption_by_audio_activity()
+                self.interruption_by_audio_activity_enabled = True
 
         if audio_out is not None and not audio_out.first_frame_fut.done():
             audio_out.first_frame_fut.cancel()
@@ -3569,14 +3567,14 @@ class AgentActivity(RecognitionHooks):
             self._session._update_agent_state("thinking")
             self._on_end_of_agent_speech(ended_at=time.time())
             if self.interruption_enabled:
-                self._restore_interruption_by_audio_activity()
+                self.interruption_by_audio_activity_enabled = True
         elif self._session.agent_state == "speaking":
             # a running tool keeps the agent busy; "listening" would arm the away timer
             tool_running = not speech_handle.interrupted and not exe_task.done()
             self._session._update_agent_state("thinking" if tool_running else "listening")
             self._on_end_of_agent_speech(ended_at=time.time())
             if self.interruption_enabled:
-                self._restore_interruption_by_audio_activity()
+                self.interruption_by_audio_activity_enabled = True
 
         for out in segment_outputs:
             if out.audio_out is not None and not out.audio_out.first_frame_fut.done():
@@ -4148,7 +4146,7 @@ class AgentActivity(RecognitionHooks):
             )
             self._on_end_of_agent_speech(ended_at=time.time())
             if self.interruption_enabled:
-                self._restore_interruption_by_audio_activity()
+                self.interruption_by_audio_activity_enabled = True
             current_span.set_attribute(
                 trace_types.ATTR_SPEECH_INTERRUPTED, speech_handle.interrupted
             )
@@ -4606,7 +4604,8 @@ class AgentActivity(RecognitionHooks):
 
     def _disable_vad_interruption_soon(self) -> None:
         """Disable VAD interruption after the backchannel boundary expires."""
-        if self._audio_recognition and self._audio_recognition._backchannel_boundary_active:
+        audio_recognition = self._audio_recognition
+        if audio_recognition and audio_recognition._backchannel_boundary_active:
 
             def _disable_vad_interruption() -> None:
                 # only disable it if the agent is still speaking
@@ -4615,19 +4614,12 @@ class AgentActivity(RecognitionHooks):
                     and self._interruption_by_audio_activity_enabled
                 ):
                     logger.trace("backchannel boundary expired")
-                    self._interruption_by_audio_activity_enabled = False
+                    self.interruption_by_audio_activity_enabled = False
 
-            self._audio_recognition._backchannel_boundary_callback = _disable_vad_interruption
-        else:
-            self._interruption_by_audio_activity_enabled = False
-
-    def _restore_interruption_by_audio_activity(self) -> None:
-        if self._audio_recognition:
-            self._audio_recognition._cancel_backchannel_boundary()
-
-        self._interruption_by_audio_activity_enabled = (
-            self._default_interruption_by_audio_activity_enabled
-        )
+            audio_recognition._backchannel_boundary_callback = _disable_vad_interruption
+        # keep vad interruption active if user is still speaking
+        elif audio_recognition is None or not audio_recognition._speaking:
+            self.interruption_by_audio_activity_enabled = False
 
     def _fallback_to_vad_interruption(
         self, error: inference.InterruptionDetectionError | None = None
@@ -4641,14 +4633,14 @@ class AgentActivity(RecognitionHooks):
         if not self._interruption_detection_enabled:
             return
 
+        self._interruption_detected = False
         self._interruption_detection_enabled = False
-        self._restore_interruption_by_audio_activity()
+        self.interruption_by_audio_activity_enabled = True
 
         if isinstance(self._interruption_detector, inference.AdaptiveInterruptionDetector):
             self._interruption_detector.off("metrics_collected", self._on_metrics_collected)
             self._interruption_detector.off("error", self._on_error)
 
-        self._pending_interruption = None
         if self._audio_recognition:
             # this also releases any held transcripts
             self._audio_recognition._update_interruption_detection(None)
@@ -4704,7 +4696,6 @@ class AgentActivity(RecognitionHooks):
             # realtime commits turns manually; barge-in withholds the commit, so no STT is needed
             can_gatekeep = not self._rt_turn_detection_enabled
         else:
-            # Local arrival time plus VAD makes transcript alignment unnecessary.
             can_gatekeep = self.stt is not None
 
         if (

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2261,7 +2261,10 @@ class AgentActivity(RecognitionHooks):
     def on_interruption(self, ev: inference.OverlappingSpeechEvent) -> None:
         now = time.time()
         if self._audio_recognition:
-            flush_start = self._audio_recognition._transcript_flush_start(now=now)
+            flush_start = self._audio_recognition._transcript_flush_start(
+                now=now,
+                vad_speech_started_at=ev.overlap_started_at,
+            )
             self._audio_recognition._flush_held_transcripts(flush_start=flush_start)
 
         # apply the normal interruption thresholds after held transcripts are processed

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2102,6 +2102,8 @@ class AgentActivity(RecognitionHooks):
 
         if self._rt_turn_detection_enabled:
             # ignore if realtime model has turn detection enabled
+            if self._audio_recognition is not None:
+                self._audio_recognition._clear_pending_interruption()
             return
 
         interruption_options = self._session.options.interruption
@@ -2154,9 +2156,7 @@ class AgentActivity(RecognitionHooks):
                 audio_output.pause()
                 self._session._update_agent_state("listening")
                 if self._audio_recognition:
-                    self._audio_recognition._on_end_of_agent_speech(
-                        ended_at=time.time()
-                    )
+                    self._audio_recognition._on_end_of_agent_speech(ended_at=time.time())
                 if self.interruption_enabled:
                     self._restore_interruption_by_audio_activity()
             else:
@@ -2164,6 +2164,11 @@ class AgentActivity(RecognitionHooks):
                     self._rt_session.interrupt()
 
                 self._current_speech.interrupt()
+        elif self._current_speech is None or (
+            not self._current_speech.interrupted and not self._current_speech.allow_interruptions
+        ):
+            if self._audio_recognition is not None:
+                self._audio_recognition._clear_pending_interruption()
 
     # region recognition hooks
 
@@ -2181,7 +2186,10 @@ class AgentActivity(RecognitionHooks):
             )
         self._user_silence_event.clear()
         self._stt_eos_received = False
-        self._interruption_detected = False
+        if not (
+            self._audio_recognition is not None and self._audio_recognition._interruption_pending
+        ):
+            self._interruption_detected = False
 
         # cancel the timer when user starts speaking but leave the paused state unchanged
         self._cancel_false_interruption_timer()

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1984,6 +1984,8 @@ class AgentActivity(RecognitionHooks):
 
     def _on_overlap_speech_ended(self, ev: inference.OverlappingSpeechEvent) -> None:
         self._interruption_detected = ev.is_interruption
+        if ev.is_interruption:
+            self._interruption_by_audio_activity_enabled = False
         self._session.emit("overlapping_speech", ev)
 
     def _on_input_speech_started(self, _: llm.InputSpeechStartedEvent) -> None:
@@ -2079,23 +2081,28 @@ class AgentActivity(RecognitionHooks):
 
         self._schedule_speech(handle, SpeechHandle.SPEECH_PRIORITY_NORMAL)
 
-    def _interrupt_by_audio_activity(self) -> bool:
-        """Interrupt the current speech or generation from detected audio activity.
-
-        Returns whether the current speech was paused or interrupted.
-        """
+    def _interrupt_by_audio_activity(self) -> None:
+        """Interrupt the current speech or generation from detected audio activity."""
         if not self._interruption_by_audio_activity_enabled:
-            return False
+            return
 
         if self._session._aec_warmup_remaining > 0 and self._session._aec_warmup_timer is not None:
             # disable interruption from audio activity while aec warmup is active
-            return False
+            return
 
         if self._rt_turn_detection_enabled:
             # ignore if realtime model has turn detection enabled
-            return False
+            return
 
         interruption_options = self._session.options.interruption
+        if self._audio_recognition is not None:
+            # suppress re-entry while released events run their transcript hooks
+            self._interruption_by_audio_activity_enabled = False
+            try:
+                self._audio_recognition._release_transcripts_for_audio_activity()
+            finally:
+                self._interruption_by_audio_activity_enabled = True
+
         if (
             self.stt is not None
             and interruption_options["min_words"] > 0
@@ -2105,7 +2112,7 @@ class AgentActivity(RecognitionHooks):
 
             # TODO(long): better word splitting for multi-language
             if len(split_words(text, split_character=True)) < interruption_options["min_words"]:
-                return False
+                return
 
         if self._rt_session is not None:
             self._rt_session.start_user_activity()
@@ -2148,10 +2155,6 @@ class AgentActivity(RecognitionHooks):
                     self._rt_session.interrupt()
 
                 self._current_speech.interrupt()
-
-            return True
-
-        return False
 
     # region recognition hooks
 
@@ -2258,20 +2261,9 @@ class AgentActivity(RecognitionHooks):
         ):
             self._rt_session.clear_audio()
 
-    def on_interruption(self, ev: inference.OverlappingSpeechEvent) -> None:
-        now = time.time()
-        if self._audio_recognition:
-            flush_start = self._audio_recognition._transcript_flush_start(
-                now=now,
-                vad_speech_started_at=ev.overlap_started_at,
-            )
-            self._audio_recognition._flush_held_transcripts(flush_start=flush_start)
-
-        # apply the normal interruption thresholds after held transcripts are processed
+    def on_interruption(self, _ev: inference.OverlappingSpeechEvent) -> None:
         self._restore_interruption_by_audio_activity()
-        interrupted = self._interrupt_by_audio_activity()
-        if interrupted and self._audio_recognition:
-            self._audio_recognition._on_end_of_agent_speech(ended_at=now)
+        self._interrupt_by_audio_activity()
 
     def on_interim_transcript(self, ev: stt.SpeechEvent, *, speaking: bool | None) -> None:
         if isinstance(self.llm, llm.RealtimeModel) and self.llm.capabilities.user_transcription:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -312,6 +312,9 @@ class AgentActivity(RecognitionHooks):
         self._default_interruption_by_audio_activity_enabled = (
             self._interruption_by_audio_activity_enabled
         )
+        # re-entrancy guard: releasing held transcripts runs their hooks synchronously,
+        # and those hooks call _interrupt_by_audio_activity again
+        self._releasing_held_transcripts: bool = False
 
         # speeches that audio playout finished but not done because of tool calls
         self._background_speeches: set[SpeechHandle] = set()
@@ -1985,6 +1988,9 @@ class AgentActivity(RecognitionHooks):
     def _on_overlap_speech_ended(self, ev: inference.OverlappingSpeechEvent) -> None:
         self._interruption_detected = ev.is_interruption
         if ev.is_interruption:
+            # suspend VAD-triggered interrupts until on_interruption restores the flag and
+            # interrupts; this emitter callback fires before the verdict reaches the
+            # interruption task, so the suspend always precedes the restore
             self._interruption_by_audio_activity_enabled = False
         self._session.emit("overlapping_speech", ev)
 
@@ -2083,6 +2089,10 @@ class AgentActivity(RecognitionHooks):
 
     def _interrupt_by_audio_activity(self) -> None:
         """Interrupt the current speech or generation from detected audio activity."""
+        if self._releasing_held_transcripts:
+            # re-entry from a released event's transcript hook; the outer call interrupts
+            return
+
         if not self._interruption_by_audio_activity_enabled:
             return
 
@@ -2096,12 +2106,11 @@ class AgentActivity(RecognitionHooks):
 
         interruption_options = self._session.options.interruption
         if self._audio_recognition is not None:
-            # suppress re-entry while released events run their transcript hooks
-            self._interruption_by_audio_activity_enabled = False
+            self._releasing_held_transcripts = True
             try:
                 self._audio_recognition._release_transcripts_for_audio_activity()
             finally:
-                self._interruption_by_audio_activity_enabled = True
+                self._releasing_held_transcripts = False
 
         if (
             self.stt is not None
@@ -2262,6 +2271,7 @@ class AgentActivity(RecognitionHooks):
             self._rt_session.clear_audio()
 
     def on_interruption(self, _ev: inference.OverlappingSpeechEvent) -> None:
+        # restore the flag that _on_overlap_speech_ended suspended, then interrupt
         self._restore_interruption_by_audio_activity()
         self._interrupt_by_audio_activity()
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -734,6 +734,9 @@ class AgentActivity(RecognitionHooks):
                     self._agent.stt_node if resolved_stt else None,
                     model=resolved_stt.model if isinstance(resolved_stt, stt.STT) else None,
                     provider=resolved_stt.provider if isinstance(resolved_stt, stt.STT) else None,
+                    aligned_transcript=bool(resolved_stt.capabilities.aligned_transcript)
+                    if isinstance(resolved_stt, stt.STT)
+                    else False,
                     reset_context=True,
                 )
             self._session._keyterm_detector.swap_stt(resolved_stt)
@@ -1143,6 +1146,9 @@ class AgentActivity(RecognitionHooks):
             turn_detection=self._turn_detection,
             stt_model=self.stt.model if self.stt else None,
             stt_provider=self.stt.provider if self.stt else None,
+            stt_aligned_transcript=bool(self.stt.capabilities.aligned_transcript)
+            if self.stt
+            else False,
         )
         stt_pipeline = reuse_resources.stt_pipeline if reuse_resources else None
         turn_detector_stream = reuse_resources.turn_detector_stream if reuse_resources else None

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -301,7 +301,7 @@ class AgentActivity(RecognitionHooks):
             self._resolve_interruption_detection()
         )
         self._interruption_detection_enabled: bool = self._interruption_detector is not None
-        self._interruption_detected: bool = False
+        self._pending_interruption: inference.OverlappingSpeechEvent | None = None
 
         # this allows taking over audio interruption temporarily until interruption is detected
         # by default it is true unless turn_detection is manual or realtime_llm
@@ -312,9 +312,6 @@ class AgentActivity(RecognitionHooks):
         self._default_interruption_by_audio_activity_enabled = (
             self._interruption_by_audio_activity_enabled
         )
-        # re-entrancy guard: releasing held transcripts runs their hooks synchronously,
-        # and those hooks call _interrupt_by_audio_activity again
-        self._releasing_held_transcripts: bool = False
 
         # speeches that audio playout finished but not done because of tool calls
         self._background_speeches: set[SpeechHandle] = set()
@@ -1020,7 +1017,6 @@ class AgentActivity(RecognitionHooks):
         if isinstance(self._interruption_detector, inference.AdaptiveInterruptionDetector):
             self._interruption_detector.on("metrics_collected", self._on_metrics_collected)
             self._interruption_detector.on("error", self._on_error)
-            self._interruption_detector.on("overlapping_speech", self._on_overlap_speech_ended)
 
         if isinstance(self._turn_detection, inference.TurnDetector):
             self._turn_detection.on("metrics_collected", self._on_metrics_collected)
@@ -1385,7 +1381,6 @@ class AgentActivity(RecognitionHooks):
         if isinstance(self._interruption_detector, inference.AdaptiveInterruptionDetector):
             self._interruption_detector.off("metrics_collected", self._on_metrics_collected)
             self._interruption_detector.off("error", self._on_error)
-            self._interruption_detector.off("overlapping_speech", self._on_overlap_speech_ended)
 
         if isinstance(self._turn_detection, inference.TurnDetector):
             self._turn_detection.off("metrics_collected", self._on_metrics_collected)
@@ -1985,15 +1980,6 @@ class AgentActivity(RecognitionHooks):
 
         self._session._on_error(error)
 
-    def _on_overlap_speech_ended(self, ev: inference.OverlappingSpeechEvent) -> None:
-        self._interruption_detected = ev.is_interruption
-        if ev.is_interruption:
-            # suspend VAD-triggered interrupts until on_interruption restores the flag and
-            # interrupts; this emitter callback fires before the verdict reaches the
-            # interruption task, so the suspend always precedes the restore
-            self._interruption_by_audio_activity_enabled = False
-        self._session.emit("overlapping_speech", ev)
-
     def _on_input_speech_started(self, _: llm.InputSpeechStartedEvent) -> None:
         if self.vad is None or self.using_default_vad:
             self._session._update_user_state("speaking")
@@ -2087,12 +2073,13 @@ class AgentActivity(RecognitionHooks):
 
         self._schedule_speech(handle, SpeechHandle.SPEECH_PRIORITY_NORMAL)
 
+    def _on_end_of_agent_speech(self, *, ended_at: float) -> None:
+        if self._audio_recognition is not None:
+            self._audio_recognition._on_end_of_agent_speech(ended_at=ended_at)
+        self._pending_interruption = None
+
     def _interrupt_by_audio_activity(self) -> None:
         """Interrupt the current speech or generation from detected audio activity."""
-        if self._releasing_held_transcripts:
-            # re-entry from a released event's transcript hook; the outer call interrupts
-            return
-
         if not self._interruption_by_audio_activity_enabled:
             return
 
@@ -2102,17 +2089,12 @@ class AgentActivity(RecognitionHooks):
 
         if self._rt_turn_detection_enabled:
             # ignore if realtime model has turn detection enabled
-            if self._audio_recognition is not None:
-                self._audio_recognition._clear_pending_interruption()
+            self._pending_interruption = None
             return
 
         interruption_options = self._session.options.interruption
         if self._audio_recognition is not None:
-            self._releasing_held_transcripts = True
-            try:
-                self._audio_recognition._release_transcripts_for_audio_activity()
-            finally:
-                self._releasing_held_transcripts = False
+            self._audio_recognition._release_transcripts_for_audio_activity()
 
         if (
             self.stt is not None
@@ -2155,8 +2137,7 @@ class AgentActivity(RecognitionHooks):
                 self._update_paused_speech(self._current_speech, timeout)
                 audio_output.pause()
                 self._session._update_agent_state("listening")
-                if self._audio_recognition:
-                    self._audio_recognition._on_end_of_agent_speech(ended_at=time.time())
+                self._on_end_of_agent_speech(ended_at=time.time())
                 if self.interruption_enabled:
                     self._restore_interruption_by_audio_activity()
             else:
@@ -2167,8 +2148,7 @@ class AgentActivity(RecognitionHooks):
         elif self._current_speech is None or (
             not self._current_speech.interrupted and not self._current_speech.allow_interruptions
         ):
-            if self._audio_recognition is not None:
-                self._audio_recognition._clear_pending_interruption()
+            self._pending_interruption = None
 
     # region recognition hooks
 
@@ -2183,13 +2163,10 @@ class AgentActivity(RecognitionHooks):
                 started_at=speech_start_time,
                 speech_duration=ev.speech_duration if ev else 0.0,
                 user_speaking_span=self._session._user_speaking_span,
+                detect_overlap=self._pending_interruption is None,
             )
         self._user_silence_event.clear()
         self._stt_eos_received = False
-        if not (
-            self._audio_recognition is not None and self._audio_recognition._interruption_pending
-        ):
-            self._interruption_detected = False
 
         # cancel the timer when user starts speaking but leave the paused state unchanged
         self._cancel_false_interruption_timer()
@@ -2220,7 +2197,7 @@ class AgentActivity(RecognitionHooks):
             self._audio_recognition._on_end_of_speech(
                 ended_at=speech_end_time,
                 user_speaking_span=self._session._user_speaking_span,
-                interruption=self._interruption_detected
+                interruption=self._pending_interruption is not None
                 if self._interruption_detection_enabled
                 else NOT_GIVEN,
             )
@@ -2278,8 +2255,18 @@ class AgentActivity(RecognitionHooks):
         ):
             self._rt_session.clear_audio()
 
-    def on_interruption(self, _ev: inference.OverlappingSpeechEvent) -> None:
-        # restore the flag that _on_overlap_speech_ended suspended, then interrupt
+    def on_overlap_speech(self, ev: inference.OverlappingSpeechEvent) -> None:
+        if ev.is_interruption:
+            self._pending_interruption = ev
+            self._interruption_by_audio_activity_enabled = False
+
+        self._session.emit("overlapping_speech", ev)
+        if self._audio_recognition is not None:
+            self._audio_recognition._apply_overlap_speech_event(ev)
+
+        if not ev.is_interruption:
+            return
+
         self._restore_interruption_by_audio_activity()
         self._interrupt_by_audio_activity()
 
@@ -2843,8 +2830,7 @@ class AgentActivity(RecognitionHooks):
             self._session._update_agent_state(
                 "thinking" if self._background_speeches else "listening"
             )
-            if self._audio_recognition:
-                self._audio_recognition._on_end_of_agent_speech(ended_at=time.time())
+            self._on_end_of_agent_speech(ended_at=time.time())
             if self.interruption_enabled:
                 self._restore_interruption_by_audio_activity()
 
@@ -3076,8 +3062,7 @@ class AgentActivity(RecognitionHooks):
             self._session._update_agent_state(
                 "thinking" if self._background_speeches else "listening"
             )
-            if self._audio_recognition:
-                self._audio_recognition._on_end_of_agent_speech(ended_at=time.time())
+            self._on_end_of_agent_speech(ended_at=time.time())
             if self.interruption_enabled:
                 self._restore_interruption_by_audio_activity()
 
@@ -3571,16 +3556,14 @@ class AgentActivity(RecognitionHooks):
 
         if not speech_handle.interrupted and len(tool_output.output) > 0:
             self._session._update_agent_state("thinking")
-            if self._audio_recognition:
-                self._audio_recognition._on_end_of_agent_speech(ended_at=time.time())
+            self._on_end_of_agent_speech(ended_at=time.time())
             if self.interruption_enabled:
                 self._restore_interruption_by_audio_activity()
         elif self._session.agent_state == "speaking":
             # a running tool keeps the agent busy; "listening" would arm the away timer
             tool_running = not speech_handle.interrupted and not exe_task.done()
             self._session._update_agent_state("thinking" if tool_running else "listening")
-            if self._audio_recognition:
-                self._audio_recognition._on_end_of_agent_speech(ended_at=time.time())
+            self._on_end_of_agent_speech(ended_at=time.time())
             if self.interruption_enabled:
                 self._restore_interruption_by_audio_activity()
 
@@ -4152,8 +4135,7 @@ class AgentActivity(RecognitionHooks):
             self._session._update_agent_state(
                 "thinking" if self._background_speeches else "listening"
             )
-            if self._audio_recognition:
-                self._audio_recognition._on_end_of_agent_speech(ended_at=time.time())
+            self._on_end_of_agent_speech(ended_at=time.time())
             if self.interruption_enabled:
                 self._restore_interruption_by_audio_activity()
             current_span.set_attribute(
@@ -4654,8 +4636,8 @@ class AgentActivity(RecognitionHooks):
         if isinstance(self._interruption_detector, inference.AdaptiveInterruptionDetector):
             self._interruption_detector.off("metrics_collected", self._on_metrics_collected)
             self._interruption_detector.off("error", self._on_error)
-            self._interruption_detector.off("overlapping_speech", self._on_overlap_speech_ended)
 
+        self._pending_interruption = None
         if self._audio_recognition:
             # this also releases any held transcripts
             self._audio_recognition._update_interruption_detection(None)
@@ -4711,7 +4693,7 @@ class AgentActivity(RecognitionHooks):
             # realtime commits turns manually; barge-in withholds the commit, so no STT is needed
             can_gatekeep = not self._rt_turn_detection_enabled
         else:
-            # the STT pipeline gatekeeps events by local arrival time and VAD state
+            # Local arrival time plus VAD makes transcript alignment unnecessary.
             can_gatekeep = self.stt is not None
 
         if (

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2079,26 +2079,21 @@ class AgentActivity(RecognitionHooks):
 
         self._schedule_speech(handle, SpeechHandle.SPEECH_PRIORITY_NORMAL)
 
-    def _interrupt_by_audio_activity(
-        self, *, ignore_user_transcript_until: float | None = None
-    ) -> None:
-        """
-        Interrupt the current speech or generation, and optionally ignore the user transcript until the given timestamp.
+    def _interrupt_by_audio_activity(self) -> bool:
+        """Interrupt the current speech or generation from detected audio activity.
 
-        Args:
-            ignore_user_transcript_until: The timestamp until which the user transcript should be ignored.
-                If None, the user transcript will be ignored until the current time.
+        Returns whether the current speech was paused or interrupted.
         """
         if not self._interruption_by_audio_activity_enabled:
-            return
+            return False
 
         if self._session._aec_warmup_remaining > 0 and self._session._aec_warmup_timer is not None:
             # disable interruption from audio activity while aec warmup is active
-            return
+            return False
 
         if self._rt_turn_detection_enabled:
             # ignore if realtime model has turn detection enabled
-            return
+            return False
 
         interruption_options = self._session.options.interruption
         if (
@@ -2110,7 +2105,7 @@ class AgentActivity(RecognitionHooks):
 
             # TODO(long): better word splitting for multi-language
             if len(split_words(text, split_character=True)) < interruption_options["min_words"]:
-                return
+                return False
 
         if self._rt_session is not None:
             self._rt_session.start_user_activity()
@@ -2144,7 +2139,7 @@ class AgentActivity(RecognitionHooks):
                 self._session._update_agent_state("listening")
                 if self._audio_recognition:
                     self._audio_recognition._on_end_of_agent_speech(
-                        ignore_user_transcript_until=ignore_user_transcript_until or time.time()
+                        ended_at=time.time()
                     )
                 if self.interruption_enabled:
                     self._restore_interruption_by_audio_activity()
@@ -2153,6 +2148,10 @@ class AgentActivity(RecognitionHooks):
                     self._rt_session.interrupt()
 
                 self._current_speech.interrupt()
+
+            return True
+
+        return False
 
     # region recognition hooks
 
@@ -2260,16 +2259,16 @@ class AgentActivity(RecognitionHooks):
             self._rt_session.clear_audio()
 
     def on_interruption(self, ev: inference.OverlappingSpeechEvent) -> None:
-        # restore interruption by audio activity and then immediately interrupt
+        now = time.time()
+        if self._audio_recognition:
+            flush_start = self._audio_recognition._transcript_flush_start(now=now)
+            self._audio_recognition._flush_held_transcripts(flush_start=flush_start)
+
+        # apply the normal interruption thresholds after held transcripts are processed
         self._restore_interruption_by_audio_activity()
-        self._interrupt_by_audio_activity(
-            ignore_user_transcript_until=ev.overlap_started_at or ev.detected_at
-        )
-        # flush held transcripts if the pause path did not already end agent speech
-        if self._audio_recognition and self._paused_speech is None:
-            self._audio_recognition._on_end_of_agent_speech(
-                ignore_user_transcript_until=ev.overlap_started_at or ev.detected_at
-            )
+        interrupted = self._interrupt_by_audio_activity()
+        if interrupted and self._audio_recognition:
+            self._audio_recognition._on_end_of_agent_speech(ended_at=now)
 
     def on_interim_transcript(self, ev: stt.SpeechEvent, *, speaking: bool | None) -> None:
         if isinstance(self.llm, llm.RealtimeModel) and self.llm.capabilities.user_transcription:
@@ -2832,9 +2831,7 @@ class AgentActivity(RecognitionHooks):
                 "thinking" if self._background_speeches else "listening"
             )
             if self._audio_recognition:
-                self._audio_recognition._on_end_of_agent_speech(
-                    ignore_user_transcript_until=time.time()
-                )
+                self._audio_recognition._on_end_of_agent_speech(ended_at=time.time())
             if self.interruption_enabled:
                 self._restore_interruption_by_audio_activity()
 
@@ -3067,9 +3064,7 @@ class AgentActivity(RecognitionHooks):
                 "thinking" if self._background_speeches else "listening"
             )
             if self._audio_recognition:
-                self._audio_recognition._on_end_of_agent_speech(
-                    ignore_user_transcript_until=time.time()
-                )
+                self._audio_recognition._on_end_of_agent_speech(ended_at=time.time())
             if self.interruption_enabled:
                 self._restore_interruption_by_audio_activity()
 
@@ -3564,9 +3559,7 @@ class AgentActivity(RecognitionHooks):
         if not speech_handle.interrupted and len(tool_output.output) > 0:
             self._session._update_agent_state("thinking")
             if self._audio_recognition:
-                self._audio_recognition._on_end_of_agent_speech(
-                    ignore_user_transcript_until=time.time()
-                )
+                self._audio_recognition._on_end_of_agent_speech(ended_at=time.time())
             if self.interruption_enabled:
                 self._restore_interruption_by_audio_activity()
         elif self._session.agent_state == "speaking":
@@ -3574,9 +3567,7 @@ class AgentActivity(RecognitionHooks):
             tool_running = not speech_handle.interrupted and not exe_task.done()
             self._session._update_agent_state("thinking" if tool_running else "listening")
             if self._audio_recognition:
-                self._audio_recognition._on_end_of_agent_speech(
-                    ignore_user_transcript_until=time.time()
-                )
+                self._audio_recognition._on_end_of_agent_speech(ended_at=time.time())
             if self.interruption_enabled:
                 self._restore_interruption_by_audio_activity()
 
@@ -4149,9 +4140,7 @@ class AgentActivity(RecognitionHooks):
                 "thinking" if self._background_speeches else "listening"
             )
             if self._audio_recognition:
-                self._audio_recognition._on_end_of_agent_speech(
-                    ignore_user_transcript_until=time.time()
-                )
+                self._audio_recognition._on_end_of_agent_speech(ended_at=time.time())
             if self.interruption_enabled:
                 self._restore_interruption_by_audio_activity()
             current_span.set_attribute(
@@ -4709,12 +4698,8 @@ class AgentActivity(RecognitionHooks):
             # realtime commits turns manually; barge-in withholds the commit, so no STT is needed
             can_gatekeep = not self._rt_turn_detection_enabled
         else:
-            # the STT pipeline gatekeeps by holding and flushing transcripts
-            can_gatekeep = (
-                self.stt is not None
-                and self.stt.capabilities.aligned_transcript
-                and self.stt.capabilities.streaming
-            )
+            # the STT pipeline gatekeeps events by local arrival time and VAD state
+            can_gatekeep = self.stt is not None
 
         if (
             not can_gatekeep

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -630,12 +630,16 @@ class AudioRecognition:
             return
         await self._user_silence_ev.wait()
 
-    def _transcript_flush_start(self, *, now: float) -> float:
+    def _transcript_flush_start(
+        self, *, now: float, vad_speech_started_at: float | None = None
+    ) -> float:
         """Return the earliest event creation time retained during a flush."""
         end_boundary = self._backchannel_boundary[1] if self._backchannel_boundary else 0.0
         flush_start = now - end_boundary
-        if self._active_vad_speech_started_at is not None:
-            flush_start = min(flush_start, self._active_vad_speech_started_at)
+        if vad_speech_started_at is None:
+            vad_speech_started_at = self._active_vad_speech_started_at
+        if vad_speech_started_at is not None:
+            flush_start = min(flush_start, vad_speech_started_at)
         if self._agent_speech_started_at is not None:
             flush_start = max(flush_start, self._agent_speech_started_at)
         return flush_start
@@ -645,8 +649,6 @@ class AudioRecognition:
             self._transcript_buffer.popleft()
 
     def _hold_stt_event(self, ev: stt.SpeechEvent) -> None:
-        flush_start = self._transcript_flush_start(now=ev.created_at)
-        self._trim_held_transcripts(flush_start=flush_start)
         self._transcript_buffer.append(ev)
 
     def _flush_held_transcripts(
@@ -1332,9 +1334,6 @@ class AudioRecognition:
                 self._hooks.on_end_of_speech(ev)
 
             self._active_vad_speech_started_at = None
-            if self._agent_speaking:
-                flush_start = self._transcript_flush_start(now=time.time())
-                self._trim_held_transcripts(flush_start=flush_start)
             self._vad_speech_started = False
             self._speaking = False
             speech_end_time = time.time() - ev.silence_duration - ev.inference_duration
@@ -1359,6 +1358,10 @@ class AudioRecognition:
     async def _on_overlap_speech_event(self, ev: inference.OverlappingSpeechEvent) -> None:
         # every verdict is terminal for its overlap, including one the cooldown then ignores
         self._overlap_open = False
+
+        if not ev.is_interruption and self._agent_speaking:
+            flush_start = self._transcript_flush_start(now=ev.detected_at)
+            self._trim_held_transcripts(flush_start=flush_start)
 
         if self._backchannel_boundary_active and not ev.is_interruption:
             logger.trace(

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -6,7 +6,7 @@ import math
 import time
 from collections import deque
 from collections.abc import AsyncIterable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 from opentelemetry import trace
@@ -250,6 +250,7 @@ class AudioRecognition:
         turn_detection: TurnDetectionMode | None,
         stt_model: str | None = None,
         stt_provider: str | None = None,
+        stt_aligned_transcript: bool = False,
     ) -> None:
         self._session = session
         self._hooks = hooks
@@ -265,6 +266,7 @@ class AudioRecognition:
         self._using_default_vad = using_default_vad
         self._stt_model = stt_model
         self._stt_provider = stt_provider
+        self._stt_aligned_transcript = stt_aligned_transcript
         self._turn_detection_mode = turn_detection if isinstance(turn_detection, str) else None
         self._vad_base_turn_detection = self._turn_detection_mode in ("vad", None)
         self._user_turn_committed = False  # true if user turn ended but EOU task not done
@@ -580,6 +582,8 @@ class AudioRecognition:
             or self._backchannel_boundary_active
             or started_in_boundary
         ):
+            # VAD/STT owns the rest of this agent-speech interval because this
+            # overlap's transcript can arrive after VAD EOS.
             self._hooks.interruption_by_audio_activity_enabled = True
             self._flush_held_transcripts()
             return
@@ -811,6 +815,7 @@ class AudioRecognition:
         pipeline: _STTPipeline | None = None,
         model: NotGivenOr[str | None] = NOT_GIVEN,
         provider: NotGivenOr[str | None] = NOT_GIVEN,
+        aligned_transcript: NotGivenOr[bool] = NOT_GIVEN,
         reset_context: bool = False,
     ) -> None:
         self._stt = stt
@@ -820,6 +825,8 @@ class AudioRecognition:
             self._stt_model = model
         if is_given(provider):
             self._stt_provider = provider
+        if is_given(aligned_transcript):
+            self._stt_aligned_transcript = aligned_transcript
         # speaker metadata belongs to the old stream; drop it so a new STT starts clean
         if reset_context:
             self.stt_context = None
@@ -1109,6 +1116,17 @@ class AudioRecognition:
         return self._audio_transcript
 
     async def _on_stt_event(self, ev: stt.SpeechEvent) -> None:
+        if (
+            ev.speech_end_time is None
+            and self._stt_aligned_transcript
+            and ev.alternatives
+            and ev.alternatives[0].end_time > 0
+            and self._input_started_at is not None
+        ):
+            speech_end_time = self._input_started_at + ev.alternatives[0].end_time
+            if speech_end_time <= ev.created_at:
+                ev = replace(ev, speech_end_time=speech_end_time)
+
         # Collect provider-known STT ids for this user turn. The actual attribute
         # is written once when the user_turn span ends (see _on_end_of_turn), to
         # avoid ordering issues with span creation.

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -166,7 +166,7 @@ class _STTPipeline:
         self._event_ch = aio.Chan[stt.SpeechEvent]()
         self._pump_task = asyncio.create_task(self._stt_pump())
         self._pump_task.add_done_callback(lambda _: self._event_ch.close())
-        # wall-clock anchor for this stream, used in STT driven timestamps and barge-in
+        # wall-clock anchor for this stream, used for STT-derived turn metrics
         self.input_started_at: float | None = None
 
     @property
@@ -293,12 +293,12 @@ class AudioRecognition:
         self._interruption_atask: asyncio.Task[None] | None = None
         self._interruption_detection = interruption_detection
         self._interruption_ch: aio.Chan[inference.InterruptionDataFrameType] | None = None
-        self._ignore_user_transcript_until: NotGivenOr[float] = NOT_GIVEN
         self._transcript_buffer: deque[SpeechEvent] = deque()
         self._interruption_enabled: bool = interruption_detection is not None and vad is not None
         # Tracks active audio playout, independently of the generation lifecycle.
         self._agent_speaking: bool = False
         self._agent_speech_started_at: float | None = None
+        self._active_vad_speech_started_at: float | None = None
         # turn-scoped backchannel-over-agent verdict from adaptive interruption, consumed and reset at end of turn
         self._overlap_in_current_turn: bool = False
         self._turn_backchannel_over_agent: bool = False
@@ -491,7 +491,7 @@ class AudioRecognition:
                 user_speaking_span=self._session._user_speaking_span,
             )
 
-    def _on_end_of_agent_speech(self, *, ignore_user_transcript_until: float) -> None:
+    def _on_end_of_agent_speech(self, *, ended_at: float) -> None:
         """Mark the end of active agent speech.
 
         This can occur while the generation remains active, such as when playout is paused.
@@ -499,42 +499,33 @@ class AudioRecognition:
         self._cancel_backchannel_boundary()
 
         if self._agent_speaking:
-            self._endpointing.on_end_of_agent_speech(ended_at=time.time())
+            self._endpointing.on_end_of_agent_speech(ended_at=ended_at)
         if not self._adaptive_interruption_active:
             self._agent_speaking = False
+            self._agent_speech_started_at = None
             return
 
         if self._agent_speaking:
             # close any unresolved overlap before resetting the detector
-            self._on_end_of_overlap_speech(ended_at=time.time(), agent_ended=True)
+            self._on_end_of_overlap_speech(ended_at=ended_at, agent_ended=True)
 
         self._interruption_ch.send_nowait(_AgentSpeechEndedSentinel())  # type: ignore[union-attr]
 
         if self._agent_speaking:
-            end_cooldown: float = (
-                self._backchannel_boundary[1] if self._backchannel_boundary else 0.0
-            )
-
-            ignore_until = (
-                ignore_user_transcript_until
-                if not is_given(self._ignore_user_transcript_until)
-                else min(ignore_user_transcript_until, self._ignore_user_transcript_until)
-            )
+            flush_start = self._transcript_flush_start(now=ended_at)
             logger.trace(
                 "flushing held transcripts",
                 extra={
-                    "ignore_until": ignore_until,
-                    "end_cooldown": end_cooldown,
+                    "flush_start": flush_start,
+                    "vad_speech_started_at": self._active_vad_speech_started_at,
                 },
             )
-            self._ignore_user_transcript_until = ignore_until - end_cooldown
-
-            # flush held transcripts if possible
-            task = asyncio.create_task(self._flush_held_transcripts(cooldown=end_cooldown))
-            task.add_done_callback(lambda _: self._tasks.discard(task))
-            self._tasks.add(task)
+            # disable the gate before re-emitting so the held events cannot be held again
+            self._agent_speaking = False
+            self._flush_held_transcripts(flush_start=flush_start)
 
         self._agent_speaking = False
+        self._agent_speech_started_at = None
 
     def _on_start_of_speech(
         self,
@@ -639,147 +630,41 @@ class AudioRecognition:
             return
         await self._user_silence_ev.wait()
 
-    @utils.log_exceptions(logger=logger)
-    async def _flush_held_transcripts(self, cooldown: float, force: bool = False) -> None:
-        """Flush held transcripts.
+    def _transcript_flush_start(self, *, now: float) -> float:
+        """Return the earliest event creation time retained during a flush."""
+        end_boundary = self._backchannel_boundary[1] if self._backchannel_boundary else 0.0
+        flush_start = now - end_boundary
+        if self._active_vad_speech_started_at is not None:
+            flush_start = min(flush_start, self._active_vad_speech_started_at)
+        if self._agent_speech_started_at is not None:
+            flush_start = max(flush_start, self._agent_speech_started_at)
+        return flush_start
 
-        When ``force`` is True, all buffered events are emitted unconditionally; this
-        is used during interruption-detector teardown when the ignore-window gating
-        can no longer be trusted.
+    def _trim_held_transcripts(self, *, flush_start: float) -> None:
+        while self._transcript_buffer and (self._transcript_buffer[0].created_at < flush_start):
+            self._transcript_buffer.popleft()
 
-        Otherwise, drop transcripts whose *end time* falls before
-        ``ignore_user_transcript_until - cooldown`` and re-emit the rest. Events
-        without timestamps are treated as the next valid event.
-        """
+    def _hold_stt_event(self, ev: stt.SpeechEvent) -> None:
+        flush_start = self._transcript_flush_start(now=ev.created_at)
+        self._trim_held_transcripts(flush_start=flush_start)
+        self._transcript_buffer.append(ev)
+
+    def _flush_held_transcripts(
+        self, *, flush_start: float | None = None, force: bool = False
+    ) -> None:
+        """Synchronously emit held events in provider order."""
         if not self._transcript_buffer:
-            self._reset_interruption_detection()
             return
 
-        if force:
-            events_to_emit = list(self._transcript_buffer)
-            # reset before emitting to avoid recursive calls
-            self._reset_interruption_detection()
-            for ev in events_to_emit:
-                await self._on_stt_event(ev)
-            return
+        if not force:
+            assert flush_start is not None
+            self._trim_held_transcripts(flush_start=flush_start)
 
-        if (
-            not self._interruption_enabled
-            or not is_given(self._ignore_user_transcript_until)
-            or self._input_started_at is None
-        ):
-            self._reset_interruption_detection()
-            return
-
-        emit_from_index: int | None = None
-        should_flush = False
-        for i, ev in enumerate(self._transcript_buffer):
-            # always try to emit from a sentinel event
-            if not ev.alternatives:
-                emit_from_index = min(emit_from_index, i) if emit_from_index is not None else i
-                continue
-            if ev.alternatives[0].start_time == ev.alternatives[0].end_time == 0:
-                self._reset_interruption_detection()
-                return
-
-            if ev.alternatives[0].end_time > 0 and self._within_ignore_window(
-                ev.alternatives[0].end_time + self._input_started_at
-            ):
-                # reset the index to emit from the next valid event
-                emit_from_index = None
-            else:
-                # break since we found a valid event to emit from
-                emit_from_index = min(emit_from_index, i) if emit_from_index is not None else i
-                should_flush = True
-                break
-
-        events_to_emit = (
-            list(self._transcript_buffer)[int(emit_from_index) :]
-            if emit_from_index is not None and should_flush
-            else []
-        )
-        _ignore_user_transcript_until = self._ignore_user_transcript_until
-        _input_started_at = self._input_started_at
-        # reset before emitting to avoid recursive calls
-        self._reset_interruption_detection()
-
-        for ev in events_to_emit:
-            added_delay = 0.0
-            if ev.alternatives and ev.alternatives[0].end_time > 0:
-                added_delay = max(
-                    0,
-                    (
-                        ev.alternatives[0].end_time
-                        + _input_started_at
-                        - _ignore_user_transcript_until
-                    )
-                    + (cooldown or 0.0),
-                )
-            logger.trace(
-                "re-emitting held user transcript",
-                extra={
-                    "event": ev.type,
-                    "cooldown": cooldown,
-                    "added_delay": added_delay,
-                },
-            )
-            await self._on_stt_event(ev)
-
-    def _reset_interruption_detection(self) -> None:
-        """Reset relevant states for adaptive interruption detection."""
+        events_to_emit = list(self._transcript_buffer)
         self._transcript_buffer.clear()
-        self._ignore_user_transcript_until = NOT_GIVEN
-        # keep the anchor while a newer agent-speech cycle is active, so a stale flush
-        # can't clear an anchor that cycle has already set
-        if not self._agent_speaking:
-            self._agent_speech_started_at = None
-
-    def _within_ignore_window(self, event_time: float) -> bool:
-        """Whether a wall-clock event time falls inside the active ignore-user-transcript window."""
-        if not is_given(self._ignore_user_transcript_until):
-            return False
-        lower = self._agent_speech_started_at or 0.0
-        upper = min(time.time(), self._ignore_user_transcript_until)
-        return lower < event_time < upper
-
-    def _should_hold_stt_event(self, ev: stt.SpeechEvent) -> bool:
-        """Test if the event should be held until the ignore_user_transcript_until timestamp."""
-        if not self._interruption_enabled:
-            return False
-
-        if self._agent_speaking:
-            return True
-
-        # reset when the user starts speaking after the agent speech
-        # this could let a transcript pass through if the user starts
-        # speaking right before the agent speech ends, not ideal but
-        # better than swallowing the transcript.
-        if ev.type == stt.SpeechEventType.START_OF_SPEECH:
-            self._ignore_user_transcript_until = NOT_GIVEN
-            return False
-
-        if not is_given(self._ignore_user_transcript_until):
-            return False
-        # sentinel events are always held until
-        # we have something concrete to release them
-        if not ev.alternatives:
-            return True
-        if (
-            # most vendors don't set timestamps properly, in which case we just assume
-            # it is a valid event after the ignore_user_transcript_until timestamp
-            is_given(self._input_started_at)
-            # check if the event should be held if
-            # 1. the stt input stream has started
-            # 2. the current event has a valid start and end time, relative to the input stream start time
-            # 3. the event's wall-clock time falls inside the bounded ignore-user-transcript window
-            and self._input_started_at is not None
-            and not (ev.alternatives[0].start_time == ev.alternatives[0].end_time == 0)
-            and ev.alternatives[0].start_time > 0
-            and self._within_ignore_window(ev.alternatives[0].start_time + self._input_started_at)
-        ):
-            return True
-
-        return False
+        for ev in events_to_emit:
+            logger.trace("re-emitting held STT event", extra={"event": ev.type})
+            self._process_stt_event(ev)
 
     def _push_audio(
         self, frame: rtc.AudioFrame, *, stt_frame: rtc.AudioFrame | None = None
@@ -904,7 +789,6 @@ class AudioRecognition:
             self._stt_pipeline = pipeline
             # reset interruption handling related state
             self._transcript_buffer.clear()
-            self._ignore_user_transcript_until = NOT_GIVEN
         else:
             self._cancel_transcription_timeout()
 
@@ -991,7 +875,6 @@ class AudioRecognition:
                 )
             )
             self._transcript_buffer.clear()
-            self._ignore_user_transcript_until = NOT_GIVEN
         elif self._interruption_atask is not None:
             task = asyncio.create_task(aio.cancel_and_wait(self._interruption_atask))
             task.add_done_callback(lambda _: self._tasks.discard(task))
@@ -999,9 +882,7 @@ class AudioRecognition:
             self._interruption_atask = None
             self._interruption_ch = None
             self._cancel_backchannel_boundary()
-            flush_task = asyncio.create_task(self._flush_held_transcripts(cooldown=0.0, force=True))
-            flush_task.add_done_callback(lambda _: self._tasks.discard(flush_task))
-            self._tasks.add(flush_task)
+            self._flush_held_transcripts(force=True)
 
         self._interruption_enabled = (
             self._interruption_detection is not None and self._vad is not None
@@ -1195,6 +1076,18 @@ class AudioRecognition:
             # and EOU task is done or this is an interim transcript
             return
 
+        if (
+            ev.type != stt.SpeechEventType.RECOGNITION_USAGE
+            and self._adaptive_interruption_active
+            and self._agent_speaking
+        ):
+            logger.trace("holding STT event during agent speech", extra={"event": ev.type})
+            self._hold_stt_event(ev)
+            return
+
+        self._process_stt_event(ev)
+
+    def _process_stt_event(self, ev: stt.SpeechEvent) -> None:
         # Keep the timeout armed for interim and preflight transcripts; either may never
         # be followed by a final transcript.
         if (
@@ -1203,31 +1096,6 @@ class AudioRecognition:
             and ev.alternatives[0].text
         ):
             self._mark_turn_transcribed()
-
-        # handle interruption detection
-        # - hold the event until the ignore_user_transcript_until expires
-        # - release only relevant events
-        # - allow RECOGNITION_USAGE to pass through immediately
-        if ev.type != stt.SpeechEventType.RECOGNITION_USAGE and self._interruption_enabled:
-            if self._should_hold_stt_event(ev):
-                logger.trace(
-                    "holding STT event until ignore_user_transcript_until expires",
-                    extra={
-                        "event": ev.type,
-                        "ignore_user_transcript_until": self._ignore_user_transcript_until
-                        if is_given(self._ignore_user_transcript_until)
-                        else None,
-                    },
-                )
-                self._transcript_buffer.append(ev)
-                return
-
-            if self._transcript_buffer:
-                end_cooldown: float = (
-                    self._backchannel_boundary[1] if self._backchannel_boundary else 0.0
-                )
-                await self._flush_held_transcripts(cooldown=end_cooldown)
-                # no return here to allow the new event to be processed normally
 
         has_stt_end_time = bool(
             len(ev.alternatives) > 0
@@ -1414,6 +1282,7 @@ class AudioRecognition:
     async def _on_vad_event(self, ev: vad.VADEvent) -> None:
         if ev.type == vad.VADEventType.START_OF_SPEECH:
             speech_start_time = time.time() - ev.speech_duration - ev.inference_duration
+            self._active_vad_speech_started_at = speech_start_time
             if not self._vad_speech_started:
                 self._speech_start_time = speech_start_time
                 self._vad_speech_started = True
@@ -1462,6 +1331,10 @@ class AudioRecognition:
             with tracer.use_span(self._ensure_user_turn_span()):
                 self._hooks.on_end_of_speech(ev)
 
+            self._active_vad_speech_started_at = None
+            if self._agent_speaking:
+                flush_start = self._transcript_flush_start(now=time.time())
+                self._trim_held_transcripts(flush_start=flush_start)
             self._vad_speech_started = False
             self._speaking = False
             speech_end_time = time.time() - ev.silence_duration - ev.inference_duration
@@ -1902,6 +1775,7 @@ class AudioRecognition:
                     self._hooks.on_end_of_speech(None)
                 self._speaking = False
                 self._vad_speech_started = False
+            self._active_vad_speech_started_at = None
 
     @utils.log_exceptions(logger=logger)
     async def _interruption_task(

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -563,6 +563,9 @@ class AudioRecognition:
         # overlap over agent speech started this turn; gates verdict acceptance below
         self._overlap_in_current_turn = True
         self._overlap_open = True
+        # a prior release (e.g. a failed interrupt attempt) must not leave later overlaps
+        # un-gated; each overlap holds its transcripts until its own verdict
+        self._transcript_gate_active = True
         self._interruption_ch.send_nowait(  # type: ignore[union-attr]
             _OverlapSpeechStartedSentinel(
                 speech_duration=speech_duration,

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -133,7 +133,7 @@ class _UserTurnTracker:
 
 
 class RecognitionHooks(Protocol):
-    def on_interruption(self, ev: inference.OverlappingSpeechEvent) -> None: ...
+    def on_overlap_speech(self, ev: inference.OverlappingSpeechEvent) -> None: ...
     def on_backchannel_confirmed(self) -> None: ...
     def on_start_of_speech(self, ev: vad.VADEvent | None, speech_start_time: float) -> None: ...
     def on_vad_inference_done(self, ev: vad.VADEvent) -> None: ...
@@ -166,7 +166,7 @@ class _STTPipeline:
         self._event_ch = aio.Chan[stt.SpeechEvent]()
         self._pump_task = asyncio.create_task(self._stt_pump())
         self._pump_task.add_done_callback(lambda _: self._event_ch.close())
-        # wall-clock anchor for this stream, used for STT-derived turn metrics
+        # STT-derived turn metrics use this stream's wall-clock anchor.
         self.input_started_at: float | None = None
 
     @property
@@ -305,7 +305,6 @@ class AudioRecognition:
         self._turn_backchannel_over_agent: bool = False
         # an overlap is open right now, awaiting a verdict; several can occur within one turn
         self._overlap_open: bool = False
-        self._pending_interruption: inference.OverlappingSpeechEvent | None = None
 
         _backchannel_boundary: float | tuple[float, float] | None = (
             session.options.interruption.get("backchannel_boundary")
@@ -507,7 +506,6 @@ class AudioRecognition:
             self._drain_transcript_gate()
             self._agent_speaking = False
             self._agent_speech_started_at = None
-            self._clear_pending_interruption()
             return
 
         if self._agent_speaking:
@@ -528,18 +526,19 @@ class AudioRecognition:
                 vad_speech_started_at=self._active_vad_speech_started_at,
             )
 
-        # the sentinel sent above resets the detector stream, dropping any open overlap
+        # The reset sentinel drops any overlap still open.
         self._overlap_open = False
         self._drain_transcript_gate()
         self._agent_speaking = False
         self._agent_speech_started_at = None
-        self._clear_pending_interruption()
 
     def _on_start_of_speech(
         self,
         started_at: float,
         speech_duration: float = 0.0,
         user_speaking_span: trace.Span | None = None,
+        *,
+        detect_overlap: bool = True,
     ) -> None:
         self._endpointing.on_start_of_speech(
             started_at=started_at, overlapping=self._agent_speaking
@@ -549,11 +548,12 @@ class AudioRecognition:
         if not self._agent_speaking:
             self._overlap_in_current_turn = False
 
-        self._on_start_of_overlap_speech(
-            started_at=started_at,
-            speech_duration=speech_duration,
-            user_speaking_span=user_speaking_span,
-        )
+        if detect_overlap:
+            self._on_start_of_overlap_speech(
+                started_at=started_at,
+                speech_duration=speech_duration,
+                user_speaking_span=user_speaking_span,
+            )
 
     def _on_start_of_overlap_speech(
         self,
@@ -561,17 +561,12 @@ class AudioRecognition:
         speech_duration: float = 0.0,
         user_speaking_span: trace.Span | None = None,
     ) -> None:
-        if (
-            self._interruption_pending
-            or not self._adaptive_interruption_active
-            or not self._agent_speaking
-        ):
+        if not self._adaptive_interruption_active or not self._agent_speaking:
             return
         # overlap over agent speech started this turn; gates verdict acceptance below
         self._overlap_in_current_turn = True
         self._overlap_open = True
-        # a prior release (e.g. a failed interrupt attempt) must not leave later overlaps
-        # un-gated; each overlap holds its transcripts until its own verdict
+        # A later overlap must re-arm a gate released by a failed interrupt attempt.
         self._sync_transcript_gate()
         self._interruption_ch.send_nowait(  # type: ignore[union-attr]
             _OverlapSpeechStartedSentinel(
@@ -645,23 +640,10 @@ class AudioRecognition:
             return
         await self._user_silence_ev.wait()
 
-    @property
-    def _interruption_pending(self) -> bool:
-        return self._pending_interruption is not None
-
-    def _clear_pending_interruption(self) -> None:
-        self._pending_interruption = None
-
     def _sync_transcript_gate(self) -> None:
-        """Arm the transcript gate iff the agent is speaking and adaptive interruption is active."""
-        self._transcript_gate_active = (
-            self._agent_speaking
-            and self._adaptive_interruption_active
-            and not self._interruption_pending
-        )
+        self._transcript_gate_active = self._agent_speaking and self._adaptive_interruption_active
 
     def _transcript_flush_start(self, *, now: float, vad_speech_started_at: float | None) -> float:
-        """Return the earliest event creation time retained during a flush."""
         end_boundary = self._backchannel_boundary[1] if self._backchannel_boundary else 0.0
         flush_start = now - end_boundary
         if vad_speech_started_at is not None:
@@ -1394,7 +1376,7 @@ class AudioRecognition:
             if self._session.amd is not None:
                 self._session.amd._on_user_speech_ended(ev.silence_duration)
 
-    async def _on_overlap_speech_event(self, ev: inference.OverlappingSpeechEvent) -> None:
+    def _apply_overlap_speech_event(self, ev: inference.OverlappingSpeechEvent) -> None:
         # every verdict is terminal for its overlap, including one the cooldown then ignores
         self._overlap_open = False
 
@@ -1405,7 +1387,6 @@ class AudioRecognition:
             return
 
         if ev.is_interruption:
-            self._pending_interruption = ev
             self._release_transcript_gate(
                 at=ev.detected_at,
                 vad_speech_started_at=ev.overlap_started_at,
@@ -1424,9 +1405,6 @@ class AudioRecognition:
             # clear the backchannel audio, but only between segments — else we'd clip a real turn
             if not ev.is_interruption and not self._speaking:
                 self._hooks.on_backchannel_confirmed()
-
-        if ev.is_interruption:
-            self._hooks.on_interruption(ev)
 
     def _on_missing_eot_prediction(self) -> None:
         if self._turn_detector_flushed:
@@ -1849,7 +1827,7 @@ class AudioRecognition:
 
         try:
             async for ev in stream:
-                await self._on_overlap_speech_event(ev)
+                self._hooks.on_overlap_speech(ev)
         except APIError:
             # avoid already emitted error from the stream
             return

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -472,7 +472,7 @@ class AudioRecognition:
         """
         self._agent_speaking = True
         self._agent_speech_started_at = started_at
-        self._transcript_gate_active = self._adaptive_interruption_active
+        self._sync_transcript_gate()
         self._endpointing.on_start_of_agent_speech(started_at=started_at)
 
         # reset user turn tracker when agent starts speaking
@@ -565,7 +565,7 @@ class AudioRecognition:
         self._overlap_open = True
         # a prior release (e.g. a failed interrupt attempt) must not leave later overlaps
         # un-gated; each overlap holds its transcripts until its own verdict
-        self._transcript_gate_active = True
+        self._sync_transcript_gate()
         self._interruption_ch.send_nowait(  # type: ignore[union-attr]
             _OverlapSpeechStartedSentinel(
                 speech_duration=speech_duration,
@@ -638,6 +638,10 @@ class AudioRecognition:
             return
         await self._user_silence_ev.wait()
 
+    def _sync_transcript_gate(self) -> None:
+        """Arm the transcript gate iff the agent is speaking and adaptive interruption is active."""
+        self._transcript_gate_active = self._agent_speaking and self._adaptive_interruption_active
+
     def _transcript_flush_start(self, *, now: float, vad_speech_started_at: float | None) -> float:
         """Return the earliest event creation time retained during a flush."""
         end_boundary = self._backchannel_boundary[1] if self._backchannel_boundary else 0.0
@@ -688,7 +692,7 @@ class AudioRecognition:
         if not enabled:
             self._drain_transcript_gate()
         elif not was_enabled:
-            self._transcript_gate_active = self._agent_speaking
+            self._sync_transcript_gate()
 
     def _push_audio(
         self, frame: rtc.AudioFrame, *, stt_frame: rtc.AudioFrame | None = None
@@ -892,7 +896,6 @@ class AudioRecognition:
         self._interruption_detection = interruption_detection
         self._overlap_open = False  # the stream it belonged to is gone either way
         if interruption_detection is not None:
-            self._transcript_gate_active = self._agent_speaking
             self._interruption_ch = aio.Chan[inference.InterruptionDataFrameType]()
             self._interruption_atask = asyncio.create_task(
                 self._interruption_task(
@@ -900,6 +903,7 @@ class AudioRecognition:
                 )
             )
             self._transcript_buffer.clear()
+            self._sync_transcript_gate()
         else:
             if self._interruption_atask is not None:
                 task = asyncio.create_task(aio.cancel_and_wait(self._interruption_atask))

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -305,6 +305,7 @@ class AudioRecognition:
         self._turn_backchannel_over_agent: bool = False
         # an overlap is open right now, awaiting a verdict; several can occur within one turn
         self._overlap_open: bool = False
+        self._pending_interruption: inference.OverlappingSpeechEvent | None = None
 
         _backchannel_boundary: float | tuple[float, float] | None = (
             session.options.interruption.get("backchannel_boundary")
@@ -506,6 +507,7 @@ class AudioRecognition:
             self._drain_transcript_gate()
             self._agent_speaking = False
             self._agent_speech_started_at = None
+            self._clear_pending_interruption()
             return
 
         if self._agent_speaking:
@@ -531,6 +533,7 @@ class AudioRecognition:
         self._drain_transcript_gate()
         self._agent_speaking = False
         self._agent_speech_started_at = None
+        self._clear_pending_interruption()
 
     def _on_start_of_speech(
         self,
@@ -558,7 +561,11 @@ class AudioRecognition:
         speech_duration: float = 0.0,
         user_speaking_span: trace.Span | None = None,
     ) -> None:
-        if not self._adaptive_interruption_active or not self._agent_speaking:
+        if (
+            self._interruption_pending
+            or not self._adaptive_interruption_active
+            or not self._agent_speaking
+        ):
             return
         # overlap over agent speech started this turn; gates verdict acceptance below
         self._overlap_in_current_turn = True
@@ -638,9 +645,20 @@ class AudioRecognition:
             return
         await self._user_silence_ev.wait()
 
+    @property
+    def _interruption_pending(self) -> bool:
+        return self._pending_interruption is not None
+
+    def _clear_pending_interruption(self) -> None:
+        self._pending_interruption = None
+
     def _sync_transcript_gate(self) -> None:
         """Arm the transcript gate iff the agent is speaking and adaptive interruption is active."""
-        self._transcript_gate_active = self._agent_speaking and self._adaptive_interruption_active
+        self._transcript_gate_active = (
+            self._agent_speaking
+            and self._adaptive_interruption_active
+            and not self._interruption_pending
+        )
 
     def _transcript_flush_start(self, *, now: float, vad_speech_started_at: float | None) -> float:
         """Return the earliest event creation time retained during a flush."""
@@ -1387,6 +1405,7 @@ class AudioRecognition:
             return
 
         if ev.is_interruption:
+            self._pending_interruption = ev
             self._release_transcript_gate(
                 at=ev.detected_at,
                 vad_speech_started_at=ev.overlap_started_at,

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -294,6 +294,7 @@ class AudioRecognition:
         self._interruption_detection = interruption_detection
         self._interruption_ch: aio.Chan[inference.InterruptionDataFrameType] | None = None
         self._transcript_buffer: deque[SpeechEvent] = deque()
+        self._transcript_gate_active: bool = False
         self._interruption_enabled: bool = interruption_detection is not None and vad is not None
         # Tracks active audio playout, independently of the generation lifecycle.
         self._agent_speaking: bool = False
@@ -471,6 +472,7 @@ class AudioRecognition:
         """
         self._agent_speaking = True
         self._agent_speech_started_at = started_at
+        self._transcript_gate_active = self._adaptive_interruption_active
         self._endpointing.on_start_of_agent_speech(started_at=started_at)
 
         # reset user turn tracker when agent starts speaking
@@ -501,6 +503,7 @@ class AudioRecognition:
         if self._agent_speaking:
             self._endpointing.on_end_of_agent_speech(ended_at=ended_at)
         if not self._adaptive_interruption_active:
+            self._drain_transcript_gate()
             self._agent_speaking = False
             self._agent_speech_started_at = None
             return
@@ -512,18 +515,20 @@ class AudioRecognition:
         self._interruption_ch.send_nowait(_AgentSpeechEndedSentinel())  # type: ignore[union-attr]
 
         if self._agent_speaking:
-            flush_start = self._transcript_flush_start(now=ended_at)
             logger.trace(
                 "flushing held transcripts",
                 extra={
-                    "flush_start": flush_start,
                     "vad_speech_started_at": self._active_vad_speech_started_at,
                 },
             )
-            # disable the gate before re-emitting so the held events cannot be held again
-            self._agent_speaking = False
-            self._flush_held_transcripts(flush_start=flush_start)
+            self._release_transcript_gate(
+                at=ended_at,
+                vad_speech_started_at=self._active_vad_speech_started_at,
+            )
 
+        # the sentinel sent above resets the detector stream, dropping any open overlap
+        self._overlap_open = False
+        self._drain_transcript_gate()
         self._agent_speaking = False
         self._agent_speech_started_at = None
 
@@ -630,14 +635,10 @@ class AudioRecognition:
             return
         await self._user_silence_ev.wait()
 
-    def _transcript_flush_start(
-        self, *, now: float, vad_speech_started_at: float | None = None
-    ) -> float:
+    def _transcript_flush_start(self, *, now: float, vad_speech_started_at: float | None) -> float:
         """Return the earliest event creation time retained during a flush."""
         end_boundary = self._backchannel_boundary[1] if self._backchannel_boundary else 0.0
         flush_start = now - end_boundary
-        if vad_speech_started_at is None:
-            vad_speech_started_at = self._active_vad_speech_started_at
         if vad_speech_started_at is not None:
             flush_start = min(flush_start, vad_speech_started_at)
         if self._agent_speech_started_at is not None:
@@ -648,25 +649,43 @@ class AudioRecognition:
         while self._transcript_buffer and (self._transcript_buffer[0].created_at < flush_start):
             self._transcript_buffer.popleft()
 
-    def _hold_stt_event(self, ev: stt.SpeechEvent) -> None:
-        self._transcript_buffer.append(ev)
-
-    def _flush_held_transcripts(
-        self, *, flush_start: float | None = None, force: bool = False
-    ) -> None:
-        """Synchronously emit held events in provider order."""
+    def _drain_transcript_gate(self) -> None:
+        """Disable the gate and synchronously emit all held events in provider order."""
+        self._transcript_gate_active = False
         if not self._transcript_buffer:
             return
-
-        if not force:
-            assert flush_start is not None
-            self._trim_held_transcripts(flush_start=flush_start)
 
         events_to_emit = list(self._transcript_buffer)
         self._transcript_buffer.clear()
         for ev in events_to_emit:
             logger.trace("re-emitting held STT event", extra={"event": ev.type})
             self._process_stt_event(ev)
+
+    def _release_transcript_gate(self, *, at: float, vad_speech_started_at: float | None) -> None:
+        if not self._transcript_gate_active:
+            return
+        flush_start = self._transcript_flush_start(
+            now=at,
+            vad_speech_started_at=vad_speech_started_at,
+        )
+        self._trim_held_transcripts(flush_start=flush_start)
+        self._drain_transcript_gate()
+
+    def _release_transcripts_for_audio_activity(self) -> None:
+        if not self._transcript_gate_active:
+            return
+        self._release_transcript_gate(
+            at=time.time(),
+            vad_speech_started_at=self._active_vad_speech_started_at,
+        )
+
+    def _set_interruption_enabled(self, enabled: bool) -> None:
+        was_enabled = self._interruption_enabled
+        self._interruption_enabled = enabled
+        if not enabled:
+            self._drain_transcript_gate()
+        elif not was_enabled:
+            self._transcript_gate_active = self._agent_speaking
 
     def _push_audio(
         self, frame: rtc.AudioFrame, *, stt_frame: rtc.AudioFrame | None = None
@@ -843,7 +862,7 @@ class AudioRecognition:
             self._vad_ch = None
             self._vad_stream = None
 
-        self._interruption_enabled = (
+        self._set_interruption_enabled(
             self._interruption_detection is not None and self._vad is not None
         )
 
@@ -870,6 +889,7 @@ class AudioRecognition:
         self._interruption_detection = interruption_detection
         self._overlap_open = False  # the stream it belonged to is gone either way
         if interruption_detection is not None:
+            self._transcript_gate_active = self._agent_speaking
             self._interruption_ch = aio.Chan[inference.InterruptionDataFrameType]()
             self._interruption_atask = asyncio.create_task(
                 self._interruption_task(
@@ -877,16 +897,16 @@ class AudioRecognition:
                 )
             )
             self._transcript_buffer.clear()
-        elif self._interruption_atask is not None:
-            task = asyncio.create_task(aio.cancel_and_wait(self._interruption_atask))
-            task.add_done_callback(lambda _: self._tasks.discard(task))
-            self._tasks.add(task)
-            self._interruption_atask = None
+        else:
+            if self._interruption_atask is not None:
+                task = asyncio.create_task(aio.cancel_and_wait(self._interruption_atask))
+                task.add_done_callback(lambda _: self._tasks.discard(task))
+                self._tasks.add(task)
+                self._interruption_atask = None
             self._interruption_ch = None
             self._cancel_backchannel_boundary()
-            self._flush_held_transcripts(force=True)
 
-        self._interruption_enabled = (
+        self._set_interruption_enabled(
             self._interruption_detection is not None and self._vad is not None
         )
 
@@ -1079,26 +1099,20 @@ class AudioRecognition:
             return
 
         if (
-            ev.type != stt.SpeechEventType.RECOGNITION_USAGE
-            and self._adaptive_interruption_active
-            and self._agent_speaking
-        ):
-            logger.trace("holding STT event during agent speech", extra={"event": ev.type})
-            self._hold_stt_event(ev)
-            return
-
-        self._process_stt_event(ev)
-
-    def _process_stt_event(self, ev: stt.SpeechEvent) -> None:
-        # Keep the timeout armed for interim and preflight transcripts; either may never
-        # be followed by a final transcript.
-        if (
             ev.type == stt.SpeechEventType.FINAL_TRANSCRIPT
             and ev.alternatives
             and ev.alternatives[0].text
         ):
             self._mark_turn_transcribed()
 
+        if ev.type != stt.SpeechEventType.RECOGNITION_USAGE and self._transcript_gate_active:
+            logger.trace("holding STT event during agent speech", extra={"event": ev.type})
+            self._transcript_buffer.append(ev)
+            return
+
+        self._process_stt_event(ev)
+
+    def _process_stt_event(self, ev: stt.SpeechEvent) -> None:
         has_stt_end_time = bool(
             len(ev.alternatives) > 0
             and ev.alternatives[0].end_time > 0
@@ -1365,8 +1379,16 @@ class AudioRecognition:
             )
             return
 
-        if not ev.is_interruption and self._agent_speaking:
-            flush_start = self._transcript_flush_start(now=ev.detected_at)
+        if ev.is_interruption:
+            self._release_transcript_gate(
+                at=ev.detected_at,
+                vad_speech_started_at=ev.overlap_started_at,
+            )
+        elif self._transcript_gate_active:
+            flush_start = self._transcript_flush_start(
+                now=ev.detected_at,
+                vad_speech_started_at=self._active_vad_speech_started_at,
+            )
             self._trim_held_transcripts(flush_start=flush_start)
 
         # only honor the verdict while this turn's overlap is unresolved so a late verdict
@@ -1808,6 +1830,8 @@ class AudioRecognition:
         finally:
             await aio.cancel_and_wait(forward_task)
             await stream.aclose()
+            if self._interruption_ch is audio_input:
+                self._drain_transcript_gate()
 
     def _cancel_transcription_timeout(self) -> None:
         if (handle := getattr(self, "_transcription_timeout_handle", None)) is not None:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -133,6 +133,12 @@ class _UserTurnTracker:
 
 
 class RecognitionHooks(Protocol):
+    @property
+    def interruption_by_audio_activity_enabled(self) -> bool: ...
+
+    @interruption_by_audio_activity_enabled.setter
+    def interruption_by_audio_activity_enabled(self, enabled: bool) -> None: ...
+
     def on_overlap_speech(self, ev: inference.OverlappingSpeechEvent) -> None: ...
     def on_backchannel_confirmed(self) -> None: ...
     def on_start_of_speech(self, ev: vad.VADEvent | None, speech_start_time: float) -> None: ...
@@ -166,7 +172,7 @@ class _STTPipeline:
         self._event_ch = aio.Chan[stt.SpeechEvent]()
         self._pump_task = asyncio.create_task(self._stt_pump())
         self._pump_task.add_done_callback(lambda _: self._event_ch.close())
-        # STT-derived turn metrics use this stream's wall-clock anchor.
+        # wall-clock anchor for stream-based (STT and barge-in) timestamps
         self.input_started_at: float | None = None
 
     @property
@@ -470,9 +476,9 @@ class AudioRecognition:
         This lifecycle follows audible playout, not the generation. Resuming paused playout
         starts a new active-speech interval.
         """
+        self._transcript_gate_active = False
         self._agent_speaking = True
         self._agent_speech_started_at = started_at
-        self._sync_transcript_gate()
         self._endpointing.on_start_of_agent_speech(started_at=started_at)
 
         # reset user turn tracker when agent starts speaking
@@ -503,7 +509,8 @@ class AudioRecognition:
         if self._agent_speaking:
             self._endpointing.on_end_of_agent_speech(ended_at=ended_at)
         if not self._adaptive_interruption_active:
-            self._drain_transcript_gate()
+            self._flush_held_transcripts()
+            self._overlap_open = False
             self._agent_speaking = False
             self._agent_speech_started_at = None
             return
@@ -514,21 +521,19 @@ class AudioRecognition:
 
         self._interruption_ch.send_nowait(_AgentSpeechEndedSentinel())  # type: ignore[union-attr]
 
-        if self._agent_speaking:
+        if self._agent_speaking and self._transcript_gate_active:
             logger.trace(
                 "flushing held transcripts",
                 extra={
                     "vad_speech_started_at": self._active_vad_speech_started_at,
                 },
             )
-            self._release_transcript_gate(
-                at=ended_at,
+            self._flush_held_transcripts(
+                resolved_at=ended_at,
                 vad_speech_started_at=self._active_vad_speech_started_at,
             )
 
-        # The reset sentinel drops any overlap still open.
         self._overlap_open = False
-        self._drain_transcript_gate()
         self._agent_speaking = False
         self._agent_speech_started_at = None
 
@@ -538,7 +543,7 @@ class AudioRecognition:
         speech_duration: float = 0.0,
         user_speaking_span: trace.Span | None = None,
         *,
-        detect_overlap: bool = True,
+        skip_adaptive_interruption: bool = False,
     ) -> None:
         self._endpointing.on_start_of_speech(
             started_at=started_at, overlapping=self._agent_speaking
@@ -548,7 +553,7 @@ class AudioRecognition:
         if not self._agent_speaking:
             self._overlap_in_current_turn = False
 
-        if detect_overlap:
+        if not skip_adaptive_interruption:
             self._on_start_of_overlap_speech(
                 started_at=started_at,
                 speech_duration=speech_duration,
@@ -563,11 +568,26 @@ class AudioRecognition:
     ) -> None:
         if not self._adaptive_interruption_active or not self._agent_speaking:
             return
+
+        start_boundary = self._backchannel_boundary[0] if self._backchannel_boundary else 0.0
+        started_in_boundary = (
+            start_boundary > 0
+            and self._agent_speech_started_at is not None
+            and started_at <= self._agent_speech_started_at + start_boundary
+        )
+        if (
+            self._hooks.interruption_by_audio_activity_enabled
+            or self._backchannel_boundary_active
+            or started_in_boundary
+        ):
+            self._hooks.interruption_by_audio_activity_enabled = True
+            self._flush_held_transcripts()
+            return
+
         # overlap over agent speech started this turn; gates verdict acceptance below
         self._overlap_in_current_turn = True
         self._overlap_open = True
-        # A later overlap must re-arm a gate released by a failed interrupt attempt.
-        self._sync_transcript_gate()
+        self._transcript_gate_active = True
         self._interruption_ch.send_nowait(  # type: ignore[union-attr]
             _OverlapSpeechStartedSentinel(
                 speech_duration=speech_duration,
@@ -640,25 +660,50 @@ class AudioRecognition:
             return
         await self._user_silence_ev.wait()
 
-    def _sync_transcript_gate(self) -> None:
-        self._transcript_gate_active = self._agent_speaking and self._adaptive_interruption_active
-
-    def _transcript_flush_start(self, *, now: float, vad_speech_started_at: float | None) -> float:
+    def _trim_held_transcripts(
+        self,
+        *,
+        resolved_at: float,
+        vad_speech_started_at: float | None,
+    ) -> None:
         end_boundary = self._backchannel_boundary[1] if self._backchannel_boundary else 0.0
-        flush_start = now - end_boundary
+        trim_start = resolved_at - end_boundary
         if vad_speech_started_at is not None:
-            flush_start = min(flush_start, vad_speech_started_at)
+            trim_start = min(trim_start, vad_speech_started_at)
         if self._agent_speech_started_at is not None:
-            flush_start = max(flush_start, self._agent_speech_started_at)
-        return flush_start
+            trim_start = max(trim_start, self._agent_speech_started_at)
 
-    def _trim_held_transcripts(self, *, flush_start: float) -> None:
-        while self._transcript_buffer and (self._transcript_buffer[0].created_at < flush_start):
+        while self._transcript_buffer:
+            event = self._transcript_buffer[0]
+            # Known speech timing takes precedence; arrival time is the fallback.
+            if event.speech_end_time is not None:
+                should_trim = event.speech_end_time < trim_start and (
+                    self._agent_speech_started_at is None
+                    or self._agent_speech_started_at < event.speech_end_time
+                )
+            else:
+                should_trim = event.created_at < trim_start
+
+            if not should_trim:
+                # Keep the provider-ordered suffix. Events have no stable utterance ID,
+                # so filtering later events can separate SOS, transcripts, and EOS.
+                break
             self._transcript_buffer.popleft()
 
-    def _drain_transcript_gate(self) -> None:
-        """Disable the gate and synchronously emit all held events in provider order."""
+    def _flush_held_transcripts(
+        self,
+        *,
+        resolved_at: float | None = None,
+        vad_speech_started_at: float | None = None,
+    ) -> None:
+        """Stop holding transcripts and emit the retained events in provider order."""
         self._transcript_gate_active = False
+        if resolved_at is not None:
+            self._trim_held_transcripts(
+                resolved_at=resolved_at,
+                vad_speech_started_at=vad_speech_started_at,
+            )
+
         if not self._transcript_buffer:
             return
 
@@ -668,31 +713,10 @@ class AudioRecognition:
             logger.trace("re-emitting held STT event", extra={"event": ev.type})
             self._process_stt_event(ev)
 
-    def _release_transcript_gate(self, *, at: float, vad_speech_started_at: float | None) -> None:
-        if not self._transcript_gate_active:
-            return
-        flush_start = self._transcript_flush_start(
-            now=at,
-            vad_speech_started_at=vad_speech_started_at,
-        )
-        self._trim_held_transcripts(flush_start=flush_start)
-        self._drain_transcript_gate()
-
-    def _release_transcripts_for_audio_activity(self) -> None:
-        if not self._transcript_gate_active:
-            return
-        self._release_transcript_gate(
-            at=time.time(),
-            vad_speech_started_at=self._active_vad_speech_started_at,
-        )
-
     def _set_interruption_enabled(self, enabled: bool) -> None:
-        was_enabled = self._interruption_enabled
         self._interruption_enabled = enabled
         if not enabled:
-            self._drain_transcript_gate()
-        elif not was_enabled:
-            self._sync_transcript_gate()
+            self._flush_held_transcripts()
 
     def _push_audio(
         self, frame: rtc.AudioFrame, *, stt_frame: rtc.AudioFrame | None = None
@@ -893,6 +917,7 @@ class AudioRecognition:
     def _update_interruption_detection(
         self, interruption_detection: inference.AdaptiveInterruptionDetector | None
     ) -> None:
+        self._flush_held_transcripts()
         self._interruption_detection = interruption_detection
         self._overlap_open = False  # the stream it belonged to is gone either way
         if interruption_detection is not None:
@@ -902,8 +927,6 @@ class AudioRecognition:
                     interruption_detection, self._interruption_ch, self._interruption_atask
                 )
             )
-            self._transcript_buffer.clear()
-            self._sync_transcript_gate()
         else:
             if self._interruption_atask is not None:
                 task = asyncio.create_task(aio.cancel_and_wait(self._interruption_atask))
@@ -1111,6 +1134,12 @@ class AudioRecognition:
             and ev.alternatives[0].text
         ):
             self._mark_turn_transcribed()
+            # whenever there is a final transcript when the gate is off
+            # fall back to vad interruption for the rest of the turn:
+            # - late STT transcript during backchannel boundary
+            # - late STT transcript when no overlap speech has been detected
+            if self._agent_speaking and not self._transcript_gate_active:
+                self._hooks.interruption_by_audio_activity_enabled = True
 
         if ev.type != stt.SpeechEventType.RECOGNITION_USAGE and self._transcript_gate_active:
             logger.trace("holding STT event during agent speech", extra={"event": ev.type})
@@ -1376,7 +1405,7 @@ class AudioRecognition:
             if self._session.amd is not None:
                 self._session.amd._on_user_speech_ended(ev.silence_duration)
 
-    def _apply_overlap_speech_event(self, ev: inference.OverlappingSpeechEvent) -> None:
+    def _on_overlap_speech_event(self, ev: inference.OverlappingSpeechEvent) -> None:
         # every verdict is terminal for its overlap, including one the cooldown then ignores
         self._overlap_open = False
 
@@ -1386,17 +1415,16 @@ class AudioRecognition:
             )
             return
 
-        if ev.is_interruption:
-            self._release_transcript_gate(
-                at=ev.detected_at,
+        if ev.is_interruption and self._transcript_gate_active:
+            self._flush_held_transcripts(
+                resolved_at=ev.detected_at,
                 vad_speech_started_at=ev.overlap_started_at,
             )
         elif self._transcript_gate_active:
-            flush_start = self._transcript_flush_start(
-                now=ev.detected_at,
+            self._trim_held_transcripts(
+                resolved_at=ev.detected_at,
                 vad_speech_started_at=self._active_vad_speech_started_at,
             )
-            self._trim_held_transcripts(flush_start=flush_start)
 
         # only honor the verdict while this turn's overlap is unresolved so a late verdict
         # can't leak into the next turn; an interruption supersedes a prior backchannel
@@ -1835,7 +1863,7 @@ class AudioRecognition:
             await aio.cancel_and_wait(forward_task)
             await stream.aclose()
             if self._interruption_ch is audio_input:
-                self._drain_transcript_gate()
+                self._flush_held_transcripts()
 
     def _cancel_transcription_timeout(self) -> None:
         if (handle := getattr(self, "_transcription_timeout_handle", None)) is not None:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -1359,15 +1359,15 @@ class AudioRecognition:
         # every verdict is terminal for its overlap, including one the cooldown then ignores
         self._overlap_open = False
 
-        if not ev.is_interruption and self._agent_speaking:
-            flush_start = self._transcript_flush_start(now=ev.detected_at)
-            self._trim_held_transcripts(flush_start=flush_start)
-
         if self._backchannel_boundary_active and not ev.is_interruption:
             logger.trace(
                 "ignoring backchannel event during backchannel boundary cooldown, falling back to vad"
             )
             return
+
+        if not ev.is_interruption and self._agent_speaking:
+            flush_start = self._transcript_flush_start(now=ev.detected_at)
+            self._trim_held_transcripts(flush_start=flush_start)
 
         # only honor the verdict while this turn's overlap is unresolved so a late verdict
         # can't leak into the next turn; an interruption supersedes a prior backchannel

--- a/livekit-agents/livekit/agents/voice/turn.py
+++ b/livekit-agents/livekit/agents/voice/turn.py
@@ -183,8 +183,8 @@ class InterruptionOptions(TypedDict, total=False):
     speech classified as a backchannel by the adaptive detector is suppressed
     (events flagged as interruptions still pass through). Use a tuple to apply
     different values for start and end separately. ``None`` disables. Defaults
-    to ``(1.0, 1.0)``. End value accounts for STT transcript timestamp
-    inaccuracy."""
+    to ``(1.0, 1.0)``. The end value preserves transcripts received near the
+    end of agent speech."""
 
 
 _INTERRUPTION_DEFAULTS: InterruptionOptions = {

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -339,12 +339,12 @@ async def test_tool_call() -> None:
     def _record_agent_speech_end(
         recognition: AudioRecognition,
         *,
-        ignore_user_transcript_until: float,
+        ended_at: float,
     ) -> None:
         agent_speech_end_states.append(session.agent_state)
         on_end_of_agent_speech(
             recognition,
-            ignore_user_transcript_until=ignore_user_transcript_until,
+            ended_at=ended_at,
         )
 
     with patch.object(
@@ -1386,35 +1386,37 @@ async def test_backchannel_boundary_releases_end_boundary_transcript() -> None:
         vad=None,
         using_default_vad=False,
         interruption_detection=None,
-        turn_detection="vad",
+        turn_detection="manual",
     )
     recognition._interruption_enabled = True
     recognition._interruption_ch = aio.Chan[inference.InterruptionDataFrameType]()
-    input_started_at = time.time() - 10.0
-    # the input anchor lives on the STT pipeline (see _STTPipeline.input_started_at)
-    recognition._stt_pipeline = SimpleNamespace(input_started_at=input_started_at)  # type: ignore[assignment]
 
     try:
-        # the agent speaks for a couple of seconds so the held transcript still lands
-        # after the agent-speech start (the lower bound of the ignore window)
-        recognition._on_start_of_agent_speech(started_at=time.time() - 2.0)
-        speech_ended_at = time.time()
-        recognition._on_end_of_agent_speech(ignore_user_transcript_until=speech_ended_at)
-
-        assert not recognition._should_hold_stt_event(
+        recognition._on_start_of_agent_speech(started_at=8.0)
+        await recognition._on_stt_event(
+            _final_transcript_event(
+                text="before the boundary", start_time=0.0, end_time=0.0, created_at=9.0
+            )
+        )
+        await recognition._on_stt_event(
             _final_transcript_event(
                 text="near the boundary",
-                start_time=speech_ended_at - input_started_at - 0.25,
-                end_time=speech_ended_at - input_started_at,
+                start_time=10_000.0,
+                end_time=20_000.0,
+                created_at=9.75,
             )
         )
-        assert recognition._should_hold_stt_event(
+        recognition._on_end_of_agent_speech(ended_at=10.0)
+        await recognition._on_stt_event(
             _final_transcript_event(
-                text="before the boundary",
-                start_time=speech_ended_at - input_started_at - 0.75,
-                end_time=speech_ended_at - input_started_at - 0.5,
+                text="after agent", start_time=0.0, end_time=0.0, created_at=10.1
             )
         )
+
+        assert recognition._hooks.final_transcripts == [  # type: ignore[attr-defined]
+            "near the boundary",
+            "after agent",
+        ]
     finally:
         recognition._interruption_ch.close()
         await _close_test_session(session)
@@ -1579,6 +1581,7 @@ async def test_stt_pipeline_recreates_stream_after_unrecoverable_error(
         ev = await asyncio.wait_for(pipeline.event_ch.recv(), timeout=5)
         assert ev.type == SpeechEventType.FINAL_TRANSCRIPT
         assert ev.alternatives[0].text == "recovered"
+        assert ev.created_at > 0
         assert attempts == 2
     finally:
         await pipeline.aclose()
@@ -1779,7 +1782,7 @@ async def test_force_flush_held_transcripts_emits_buffered_events() -> None:
     )
 
     try:
-        await recognition._flush_held_transcripts(cooldown=0.0, force=True)
+        recognition._flush_held_transcripts(force=True)
 
         assert hooks.final_transcripts == ["held transcript"]
         assert not recognition._transcript_buffer
@@ -1787,7 +1790,7 @@ async def test_force_flush_held_transcripts_emits_buffered_events() -> None:
         await _close_test_session(session)
 
 
-async def test_held_final_transcript_cancels_transcription_timeout() -> None:
+async def test_held_final_transcript_cancels_timeout_only_after_flush() -> None:
     session = create_session(FakeActions())
     hooks = _TestRecognitionHooks()
     recognition = AudioRecognition(
@@ -1798,9 +1801,10 @@ async def test_held_final_transcript_cancels_transcription_timeout() -> None:
         vad=None,
         using_default_vad=False,
         interruption_detection=None,
-        turn_detection="vad",
+        turn_detection="manual",
     )
     recognition._interruption_enabled = True
+    recognition._interruption_ch = aio.Chan[inference.InterruptionDataFrameType]()
     recognition._agent_speaking = True
     timeout_handle = asyncio.get_running_loop().call_later(60.0, lambda: None)
     recognition._transcription_timeout_handle = timeout_handle
@@ -1809,12 +1813,20 @@ async def test_held_final_transcript_cancels_transcription_timeout() -> None:
     try:
         await recognition._on_stt_event(event)
 
-        assert timeout_handle.cancelled()
-        assert recognition._turn_transcript_received
+        assert not timeout_handle.cancelled()
+        assert not recognition._turn_transcript_received
         assert list(recognition._transcript_buffer) == [event]
         assert hooks.final_transcripts == []
+
+        recognition._flush_held_transcripts(force=True)
+
+        assert timeout_handle.cancelled()
+        assert recognition._turn_transcript_received
+        assert hooks.final_transcripts == ["held transcript"]
+        assert recognition._current_transcript == "held transcript"
     finally:
         timeout_handle.cancel()
+        recognition._interruption_ch.close()
         await _close_test_session(session)
 
 
@@ -2310,8 +2322,10 @@ def _backchannel_event() -> inference.OverlappingSpeechEvent:
     )
 
 
-def _final_transcript_event(*, text: str, start_time: float, end_time: float) -> SpeechEvent:
-    return SpeechEvent(
+def _final_transcript_event(
+    *, text: str, start_time: float, end_time: float, created_at: float | None = None
+) -> SpeechEvent:
+    ev = SpeechEvent(
         type=SpeechEventType.FINAL_TRANSCRIPT,
         alternatives=[
             SpeechData(
@@ -2322,6 +2336,9 @@ def _final_transcript_event(*, text: str, start_time: float, end_time: float) ->
             )
         ],
     )
+    if created_at is not None:
+        ev.created_at = created_at
+    return ev
 
 
 async def _close_test_session(session: object) -> None:

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -1763,7 +1763,7 @@ async def test_vad_fallback_uses_next_vad_inference_event(
         await _close_test_session(session)
 
 
-async def test_force_flush_held_transcripts_emits_buffered_events() -> None:
+async def test_drain_transcript_gate_emits_buffered_events() -> None:
     actions = FakeActions()
     session = create_session(actions)
     hooks = _TestRecognitionHooks()
@@ -1782,7 +1782,7 @@ async def test_force_flush_held_transcripts_emits_buffered_events() -> None:
     )
 
     try:
-        recognition._flush_held_transcripts(force=True)
+        recognition._drain_transcript_gate()
 
         assert hooks.final_transcripts == ["held transcript"]
         assert not recognition._transcript_buffer
@@ -1790,7 +1790,7 @@ async def test_force_flush_held_transcripts_emits_buffered_events() -> None:
         await _close_test_session(session)
 
 
-async def test_held_final_transcript_cancels_timeout_only_after_flush() -> None:
+async def test_held_final_transcript_cancels_timeout_on_arrival() -> None:
     session = create_session(FakeActions())
     hooks = _TestRecognitionHooks()
     recognition = AudioRecognition(
@@ -1803,9 +1803,7 @@ async def test_held_final_transcript_cancels_timeout_only_after_flush() -> None:
         interruption_detection=None,
         turn_detection="manual",
     )
-    recognition._interruption_enabled = True
-    recognition._interruption_ch = aio.Chan[inference.InterruptionDataFrameType]()
-    recognition._agent_speaking = True
+    recognition._transcript_gate_active = True
     timeout_handle = asyncio.get_running_loop().call_later(60.0, lambda: None)
     recognition._transcription_timeout_handle = timeout_handle
     event = _final_transcript_event(text="held transcript", start_time=0.0, end_time=1.0)
@@ -1813,12 +1811,12 @@ async def test_held_final_transcript_cancels_timeout_only_after_flush() -> None:
     try:
         await recognition._on_stt_event(event)
 
-        assert not timeout_handle.cancelled()
-        assert not recognition._turn_transcript_received
+        assert timeout_handle.cancelled()
+        assert recognition._turn_transcript_received
         assert list(recognition._transcript_buffer) == [event]
         assert hooks.final_transcripts == []
 
-        recognition._flush_held_transcripts(force=True)
+        recognition._drain_transcript_gate()
 
         assert timeout_handle.cancelled()
         assert recognition._turn_transcript_received
@@ -1826,7 +1824,50 @@ async def test_held_final_transcript_cancels_timeout_only_after_flush() -> None:
         assert recognition._current_transcript == "held transcript"
     finally:
         timeout_handle.cancel()
-        recognition._interruption_ch.close()
+        await _close_test_session(session)
+
+
+async def test_true_verdict_releases_late_transcripts() -> None:
+    session = create_session(FakeActions())
+    hooks = _TestRecognitionHooks()
+    recognition = AudioRecognition(
+        session,
+        hooks=hooks,
+        endpointing=BaseEndpointing(min_delay=0.1, max_delay=1.0),
+        stt=None,
+        vad=None,
+        using_default_vad=False,
+        interruption_detection=None,
+        turn_detection="manual",
+    )
+    recognition._transcript_gate_active = True
+    recognition._agent_speaking = True
+    recognition._agent_speech_started_at = time.time() - 1.0
+    overlap_started_at = time.time() - 0.5
+    recognition._transcript_buffer.append(
+        _final_transcript_event(
+            text="already held",
+            start_time=0.0,
+            end_time=0.0,
+            created_at=overlap_started_at,
+        )
+    )
+
+    try:
+        await recognition._on_overlap_speech_event(
+            inference.OverlappingSpeechEvent(
+                is_interruption=True,
+                overlap_started_at=overlap_started_at,
+            )
+        )
+        await recognition._on_stt_event(
+            _final_transcript_event(text="arrived later", start_time=0.0, end_time=0.0)
+        )
+
+        assert hooks.final_transcripts == ["already held", "arrived later"]
+        assert len(hooks.interruptions) == 1
+        assert not recognition._transcript_buffer
+    finally:
         await _close_test_session(session)
 
 

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -1302,19 +1302,26 @@ async def test_backchannel_boundary_suppresses_start_boundary_backchannel() -> N
 
     try:
         recognition._on_start_of_agent_speech(started_at=time.time())
-        # backchannels during the cooldown are dropped (they are a no-op anyway,
-        # but this guards against the gate firing on `on_interruption`)
-        await recognition._on_overlap_speech_event(_backchannel_event())
+        # backchannels during the cooldown are dropped
+        event = _backchannel_event()
+        hooks.on_overlap_speech(event)
+        recognition._apply_overlap_speech_event(event)
         assert hooks.interruptions == []
 
         # a real interruption during the cooldown must still fire
-        await recognition._on_overlap_speech_event(_interruption_event())
+        event = _interruption_event()
+        hooks.on_overlap_speech(event)
+        recognition._apply_overlap_speech_event(event)
         assert len(hooks.interruptions) == 1
 
         # after cooldown, both event types behave normally
         await asyncio.sleep(0.06)
-        await recognition._on_overlap_speech_event(_backchannel_event())
-        await recognition._on_overlap_speech_event(_interruption_event())
+        backchannel_event = _backchannel_event()
+        hooks.on_overlap_speech(backchannel_event)
+        recognition._apply_overlap_speech_event(backchannel_event)
+        interruption_event = _interruption_event()
+        hooks.on_overlap_speech(interruption_event)
+        recognition._apply_overlap_speech_event(interruption_event)
         assert len(hooks.interruptions) == 2
     finally:
         await _close_test_session(session)
@@ -1854,12 +1861,12 @@ async def test_true_verdict_releases_late_transcripts() -> None:
     )
 
     try:
-        await recognition._on_overlap_speech_event(
-            inference.OverlappingSpeechEvent(
-                is_interruption=True,
-                overlap_started_at=overlap_started_at,
-            )
+        event = inference.OverlappingSpeechEvent(
+            is_interruption=True,
+            overlap_started_at=overlap_started_at,
         )
+        hooks.on_overlap_speech(event)
+        recognition._apply_overlap_speech_event(event)
         await recognition._on_stt_event(
             _final_transcript_event(text="arrived later", start_time=0.0, end_time=0.0)
         )
@@ -2314,8 +2321,9 @@ class _TestRecognitionHooks:
         self.interruptions: list[inference.OverlappingSpeechEvent] = []
         self.final_transcripts: list[str] = []
 
-    def on_interruption(self, ev: inference.OverlappingSpeechEvent) -> None:
-        self.interruptions.append(ev)
+    def on_overlap_speech(self, ev: inference.OverlappingSpeechEvent) -> None:
+        if ev.is_interruption:
+            self.interruptions.append(ev)
 
     def on_backchannel_confirmed(self) -> None:
         pass

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -1305,23 +1305,23 @@ async def test_backchannel_boundary_suppresses_start_boundary_backchannel() -> N
         # backchannels during the cooldown are dropped
         event = _backchannel_event()
         hooks.on_overlap_speech(event)
-        recognition._apply_overlap_speech_event(event)
+        recognition._on_overlap_speech_event(event)
         assert hooks.interruptions == []
 
         # a real interruption during the cooldown must still fire
         event = _interruption_event()
         hooks.on_overlap_speech(event)
-        recognition._apply_overlap_speech_event(event)
+        recognition._on_overlap_speech_event(event)
         assert len(hooks.interruptions) == 1
 
         # after cooldown, both event types behave normally
         await asyncio.sleep(0.06)
         backchannel_event = _backchannel_event()
         hooks.on_overlap_speech(backchannel_event)
-        recognition._apply_overlap_speech_event(backchannel_event)
+        recognition._on_overlap_speech_event(backchannel_event)
         interruption_event = _interruption_event()
         hooks.on_overlap_speech(interruption_event)
-        recognition._apply_overlap_speech_event(interruption_event)
+        recognition._on_overlap_speech_event(interruption_event)
         assert len(hooks.interruptions) == 2
     finally:
         await _close_test_session(session)
@@ -1400,6 +1400,7 @@ async def test_backchannel_boundary_releases_end_boundary_transcript() -> None:
 
     try:
         recognition._on_start_of_agent_speech(started_at=8.0)
+        recognition._on_start_of_speech(started_at=8.1)
         await recognition._on_stt_event(
             _final_transcript_event(
                 text="before the boundary", start_time=0.0, end_time=0.0, created_at=9.0
@@ -1770,7 +1771,7 @@ async def test_vad_fallback_uses_next_vad_inference_event(
         await _close_test_session(session)
 
 
-async def test_drain_transcript_gate_emits_buffered_events() -> None:
+async def test_flush_held_transcripts_emits_buffered_events() -> None:
     actions = FakeActions()
     session = create_session(actions)
     hooks = _TestRecognitionHooks()
@@ -1789,7 +1790,7 @@ async def test_drain_transcript_gate_emits_buffered_events() -> None:
     )
 
     try:
-        recognition._drain_transcript_gate()
+        recognition._flush_held_transcripts()
 
         assert hooks.final_transcripts == ["held transcript"]
         assert not recognition._transcript_buffer
@@ -1823,7 +1824,7 @@ async def test_held_final_transcript_cancels_timeout_on_arrival() -> None:
         assert list(recognition._transcript_buffer) == [event]
         assert hooks.final_transcripts == []
 
-        recognition._drain_transcript_gate()
+        recognition._flush_held_transcripts()
 
         assert timeout_handle.cancelled()
         assert recognition._turn_transcript_received
@@ -1866,7 +1867,7 @@ async def test_true_verdict_releases_late_transcripts() -> None:
             overlap_started_at=overlap_started_at,
         )
         hooks.on_overlap_speech(event)
-        recognition._apply_overlap_speech_event(event)
+        recognition._on_overlap_speech_event(event)
         await recognition._on_stt_event(
             _final_transcript_event(text="arrived later", start_time=0.0, end_time=0.0)
         )
@@ -2320,6 +2321,7 @@ class _TestRecognitionHooks:
     def __init__(self) -> None:
         self.interruptions: list[inference.OverlappingSpeechEvent] = []
         self.final_transcripts: list[str] = []
+        self.interruption_by_audio_activity_enabled = False
 
     def on_overlap_speech(self, ev: inference.OverlappingSpeechEvent) -> None:
         if ev.is_interruption:

--- a/tests/test_audio_recognition_handoff.py
+++ b/tests/test_audio_recognition_handoff.py
@@ -7,7 +7,6 @@ import pytest
 
 from livekit import rtc
 from livekit.agents import Agent
-from livekit.agents.types import NOT_GIVEN
 from livekit.agents.utils import aio
 from livekit.agents.voice.agent import ModelSettings
 from livekit.agents.voice.agent_activity import AgentActivity
@@ -215,7 +214,6 @@ def _stub_recognition() -> AudioRecognition:
     ar._stt_consumer_atask = None  # type: ignore[attr-defined]
     ar._stt_pipeline = None  # type: ignore[attr-defined]
     ar._transcript_buffer = MagicMock()  # type: ignore[attr-defined]
-    ar._ignore_user_transcript_until = NOT_GIVEN  # type: ignore[attr-defined]
     return ar
 
 

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections import deque
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from livekit.agents import Agent, AgentSession, TurnHandlingOptions, inference
+from livekit.agents import Agent, AgentSession, TurnHandlingOptions
 from livekit.agents.voice.agent_activity import AgentActivity, _PausedSpeechInfo
 from livekit.agents.voice.audio_recognition import (
     AudioRecognition,
@@ -71,6 +72,8 @@ def _recognition(hooks: AgentActivity, last_speaking_time: float) -> AudioRecogn
     ar._turn_detector_flushed = False
     ar._turn_detector_late_prediction_warned = False
     ar._agent_speaking = False
+    ar._transcript_buffer = deque()
+    ar._transcript_gate_active = False
     ar._interruption_enabled = False
     ar._interruption_ch = None
     ar._vad_base_turn_detection = True
@@ -199,7 +202,7 @@ async def test_committed_turn_suppresses_the_resume(monkeypatch: pytest.MonkeyPa
     session = _session()
     activity, _ = _paused_activity(session)
     # a confirmed interruption: on_end_of_turn commits and the reply task interrupts the pause
-    activity._pending_interruption = inference.OverlappingSpeechEvent(is_interruption=True)
+    activity._interruption_detected = True
     activity._create_speech_task = _swallow_task  # type: ignore[method-assign, assignment]
 
     events: list[str] = []
@@ -256,7 +259,7 @@ async def test_skipped_reply_keeps_the_resume_armed(monkeypatch: pytest.MonkeyPa
 
     session = _session()
     activity, _ = _paused_activity(session)
-    activity._pending_interruption = inference.OverlappingSpeechEvent(is_interruption=True)
+    activity._interruption_detected = True
     activity._create_speech_task = _swallow_task  # type: ignore[method-assign, assignment]
 
     events: list[str] = []

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from livekit.agents import Agent, AgentSession, TurnHandlingOptions
+from livekit.agents import Agent, AgentSession, TurnHandlingOptions, inference
 from livekit.agents.voice.agent_activity import AgentActivity, _PausedSpeechInfo
 from livekit.agents.voice.audio_recognition import (
     AudioRecognition,
@@ -199,7 +199,7 @@ async def test_committed_turn_suppresses_the_resume(monkeypatch: pytest.MonkeyPa
     session = _session()
     activity, _ = _paused_activity(session)
     # a confirmed interruption: on_end_of_turn commits and the reply task interrupts the pause
-    activity._interruption_detected = True
+    activity._pending_interruption = inference.OverlappingSpeechEvent(is_interruption=True)
     activity._create_speech_task = _swallow_task  # type: ignore[method-assign, assignment]
 
     events: list[str] = []
@@ -256,7 +256,7 @@ async def test_skipped_reply_keeps_the_resume_armed(monkeypatch: pytest.MonkeyPa
 
     session = _session()
     activity, _ = _paused_activity(session)
-    activity._interruption_detected = True
+    activity._pending_interruption = inference.OverlappingSpeechEvent(is_interruption=True)
     activity._create_speech_task = _swallow_task  # type: ignore[method-assign, assignment]
 
     events: list[str] = []

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -10,11 +10,12 @@ from __future__ import annotations
 import asyncio
 import time
 from collections import deque
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 
 from livekit.agents import Agent, AgentSession, TurnHandlingOptions
+from livekit.agents.inference import OverlappingSpeechEvent
 from livekit.agents.voice.agent_activity import AgentActivity, _PausedSpeechInfo
 from livekit.agents.voice.audio_recognition import (
     AudioRecognition,
@@ -332,15 +333,17 @@ async def test_interruption_event_does_not_end_agent_again_after_pausing(
     handle._generations = []
     activity._paused_speech = None
     activity._audio_recognition = MagicMock()
-    event = MagicMock(overlap_started_at=1.0, detected_at=2.0)
+    event = OverlappingSpeechEvent(
+        is_interruption=True,
+        overlap_started_at=1.0,
+        detected_at=2.0,
+    )
 
-    activity.on_interruption(event)
+    activity.on_overlap_speech(event)
     assert activity._paused_speech is not None
     await session.aclose()
 
-    activity._audio_recognition._on_end_of_agent_speech.assert_called_once_with(
-        ignore_user_transcript_until=1.0
-    )
+    activity._audio_recognition._on_end_of_agent_speech.assert_called_once_with(ended_at=ANY)
 
 
 async def test_handing_over_a_paused_speech_does_not_end_the_agent_turn(

--- a/tests/test_inference_stt_aligned_transcript_claim.py
+++ b/tests/test_inference_stt_aligned_transcript_claim.py
@@ -1,13 +1,11 @@
-"""`inference.STT` must not claim word-aligned transcripts for models with no word data.
+"""Test inference STT alignment claims and adaptive-interruption eligibility.
 
 The gateway's Cartesia Ink-2 translator emits ``Words: []`` with ``Start`` = the
 audio-time offset and ``Duration`` = billed audio bytes / bytes-per-second — a billing
 figure, not the utterance span. Cartesia's Turns API sends no word timings to forward.
 
-That flag is load-bearing: `AgentActivity._resolve_interruption_detection` uses it as the
-`can_gatekeep` test for enabling adaptive interruption, which then disables the fast
-VAD interruption path once the backchannel boundary expires. So a false claim costs
-barge-in latency on exactly the models least able to make up for it.
+Adaptive interruption uses local STT arrival times and VAD state. The alignment claim
+still describes provider output, but it does not control adaptive-interruption eligibility.
 """
 
 from __future__ import annotations
@@ -25,10 +23,8 @@ from livekit.agents import (
     inference,
 )
 from livekit.agents.inference.stt import SpeechStream as InferenceSpeechStream
-from livekit.agents.stt import SpeechData, SpeechEvent, SpeechEventType
 from livekit.agents.types import NOT_GIVEN
 from livekit.agents.voice.agent_activity import AgentActivity
-from livekit.agents.voice.audio_recognition import AudioRecognition
 
 from .fake_llm import FakeLLM
 from .fake_stt import FakeUserSpeech
@@ -140,85 +136,21 @@ def test_gateway_ink2_payload_carries_no_word_alignment() -> None:
     assert data.end_time == 12.5
 
 
-def _recognition_awaiting_flush(
-    *, ignore_until: float, input_started_at: float
-) -> AudioRecognition:
-    """An AudioRecognition mid-ignore-window, as it sits just after agent speech ends."""
-    ar = AudioRecognition.__new__(AudioRecognition)
-    ar._interruption_enabled = True
-    ar._agent_speaking = False
-    ar._ignore_user_transcript_until = ignore_until
-    # _input_started_at is a read-only property over the STT pipeline
-    ar._stt_pipeline = SimpleNamespace(input_started_at=input_started_at)
-    ar._agent_speech_started_at = input_started_at
-    return ar
-
-
-def _final(*, start_time: float, end_time: float) -> SpeechEvent:
-    return SpeechEvent(
-        type=SpeechEventType.FINAL_TRANSCRIPT,
-        alternatives=[
-            SpeechData(
-                text="are you open on sunday",
-                language="en",
-                start_time=start_time,
-                end_time=end_time,
-            )
-        ],
-    )
-
-
-def test_gateway_timestamps_defeat_the_transcript_gate() -> None:
-    """Adaptive interruption's transcript gate cannot act on the gateway's Ink-2 output.
-
-    `_should_hold_stt_event` requires ``start_time > 0``, and the gateway pins ``start`` to
-    the audio-time offset — 0 until a reconnect. So the half of adaptive interruption that
-    is supposed to gatekeep transcripts is inert for this model, even though its
-    ``aligned_transcript`` claim is what switched adaptive on.
-    """
-    import time
-
-    now = time.time()
-    ar = _recognition_awaiting_flush(ignore_until=now + 1.0, input_started_at=now - 5.0)
-
-    gateway_shaped = _final(start_time=0.0, end_time=12.5)
-    properly_aligned = _final(start_time=4.5, end_time=5.2)
-
-    assert ar._should_hold_stt_event(gateway_shaped) is False
-    assert ar._should_hold_stt_event(properly_aligned) is True
-
-
-def test_reconnect_offset_makes_the_gate_use_a_billing_span() -> None:
-    """After a reconnect the gate does engage — on a window derived from billed bytes.
-
-    `RecognizeStream` accumulates `start_time_offset` across retries, so post-reconnect
-    ``start_time > 0`` and the hold decision is made with ``end_time - start_time`` equal
-    to the audio billed since the previous turn.
-    """
-    import time
-
-    now = time.time()
-    ar = _recognition_awaiting_flush(ignore_until=now + 1.0, input_started_at=now - 5.0)
-
-    # offset 4.5s after a reconnect; duration is still the 12.5s billing figure
-    post_reconnect = _final(start_time=4.5, end_time=17.0)
-    assert ar._should_hold_stt_event(post_reconnect) is True
-    assert (
-        post_reconnect.alternatives[0].end_time - post_reconnect.alternatives[0].start_time == 12.5
-    )
-
-
-def _build_session(*, aligned_transcript: object, mode: str | None = None) -> AgentSession:
+def _build_session(
+    *, aligned_transcript: object, mode: str | None = None, streaming: bool = True
+) -> AgentSession:
     speech = FakeUserSpeech(start_time=0.5, end_time=2.0, transcript="hello", stt_delay=0.0)
     interruption = InterruptionOptions(resume_false_interruption=False)
     if mode is not None:
         interruption["mode"] = mode  # type: ignore[typeddict-item]
+    stt_impl = TurnScriptedSTT(
+        turns=[ScriptedTurn(speech_start=0.55, final_at=2.6, final_text="hello")],
+        aligned_transcript=aligned_transcript,  # type: ignore[arg-type]
+    )
+    stt_impl._capabilities.streaming = streaming
     return AgentSession[None](
         vad=FakeVAD(fake_user_speeches=[speech]),
-        stt=TurnScriptedSTT(
-            turns=[ScriptedTurn(speech_start=0.55, final_at=2.6, final_text="hello")],
-            aligned_transcript=aligned_transcript,  # type: ignore[arg-type]
-        ),
+        stt=stt_impl,
         llm=FakeLLM(fake_responses=[]),
         tts=FakeTTS(fake_responses=[]),
         turn_handling=TurnHandlingOptions(
@@ -232,30 +164,48 @@ def _build_session(*, aligned_transcript: object, mode: str | None = None) -> Ag
 
 
 @pytest.mark.parametrize(
-    ("aligned_transcript", "expect_adaptive"),
+    "aligned_transcript",
     [
-        pytest.param("word", True, id="claims-word-alignment"),
-        pytest.param(False, False, id="reports-no-alignment"),
+        pytest.param("word", id="claims-word-alignment"),
+        pytest.param(False, id="reports-no-alignment"),
     ],
 )
-def test_alignment_claim_alone_enables_adaptive_interruption(
+def test_alignment_claim_does_not_control_adaptive_interruption(
     aligned_transcript: object,
-    expect_adaptive: bool,
     monkeypatch: pytest.MonkeyPatch,
     _fake_credentials: None,
 ) -> None:
-    """Only the capability flag differs, yet it decides whether adaptive interruption runs.
-
-    Dev mode (`lk agent dev` / `console`) and LiveKit Cloud hosted agents auto-enable
-    adaptive; plain production leaves it off unless `interruption.mode` is set.
-    """
+    """Dev mode enables adaptive interruption for aligned and unaligned STTs."""
     monkeypatch.setenv("LIVEKIT_DEV_MODE", "1")
 
     session = _build_session(aligned_transcript=aligned_transcript)
     # AgentActivity resolves interruption detection in __init__, before any I/O starts
     activity = AgentActivity(Agent(instructions="You are a helpful assistant."), session)
 
-    assert activity._interruption_detection_enabled is expect_adaptive
+    assert activity._interruption_detection_enabled is True
+
+
+def test_non_streaming_stt_can_use_adaptive_interruption(
+    monkeypatch: pytest.MonkeyPatch, _fake_credentials: None
+) -> None:
+    monkeypatch.setenv("LIVEKIT_DEV_MODE", "1")
+
+    session = _build_session(aligned_transcript=False, streaming=False)
+    activity = AgentActivity(Agent(instructions="You are a helpful assistant."), session)
+
+    assert activity._interruption_detection_enabled is True
+
+
+def test_explicit_adaptive_mode_accepts_unaligned_stt(
+    monkeypatch: pytest.MonkeyPatch, _fake_credentials: None
+) -> None:
+    monkeypatch.delenv("LIVEKIT_DEV_MODE", raising=False)
+    monkeypatch.delenv("LIVEKIT_REMOTE_EOT_URL", raising=False)
+
+    session = _build_session(aligned_transcript=False, mode="adaptive")
+    activity = AgentActivity(Agent(instructions="You are a helpful assistant."), session)
+
+    assert activity._interruption_detection_enabled is True
 
 
 def test_adaptive_stays_off_in_plain_production(

--- a/tests/test_interruption_hold_window.py
+++ b/tests/test_interruption_hold_window.py
@@ -1,17 +1,8 @@
-"""Unit tests for the bounded ignore-user-transcript window in ``AudioRecognition``.
-
-The adaptive-interruption hold logic decides whether an STT transcript falls inside
-the window during which user transcripts are ignored while overlapping speech is
-adjudicated. It must bound the event's wall-clock time so a *mis-anchored* timestamp
-— e.g. from a fallback STT leg that reset its timeline and reports near-zero relative
-timestamps — cannot be mistaken for a transcript inside the window and held (which
-would wedge the user's turn). The valid window is
-``agent_start < event_time < min(now, ignore_until)``.
-"""
+"""Unit tests for the VAD-based adaptive-interruption transcript gate."""
 
 from __future__ import annotations
 
-import time
+from collections import deque
 from unittest.mock import MagicMock
 
 import pytest
@@ -24,69 +15,115 @@ pytestmark = pytest.mark.unit
 
 def _make_recognition(
     *,
-    ignore_until: float,
-    agent_started: float | None,
-    input_started: float,
+    vad_sos: float | None,
+    agent_sos: float | None = None,
+    end_boundary: float = 1.0,
 ) -> AudioRecognition:
-    ar = AudioRecognition.__new__(AudioRecognition)
-    ar._interruption_enabled = True
-    ar._agent_speaking = False
-    ar._ignore_user_transcript_until = ignore_until
-    ar._agent_speech_started_at = agent_started
-    pipeline = MagicMock()
-    pipeline.input_started_at = input_started
-    ar._stt_pipeline = pipeline
-    return ar
+    recognition = AudioRecognition.__new__(AudioRecognition)
+    recognition._agent_speech_started_at = agent_sos
+    recognition._active_vad_speech_started_at = vad_sos
+    recognition._backchannel_boundary = (0.0, end_boundary)
+    recognition._transcript_buffer = deque()
+    recognition._process_stt_event = MagicMock()  # type: ignore[method-assign]
+    return recognition
 
 
-def _final(start: float, end: float) -> SpeechEvent:
+def _event(
+    text: str,
+    *,
+    created_at: float = 0.0,
+    start_time: float = 0.0,
+    end_time: float = 0.0,
+) -> SpeechEvent:
     return SpeechEvent(
         type=SpeechEventType.FINAL_TRANSCRIPT,
-        alternatives=[SpeechData(language="", text="hi", start_time=start, end_time=end)],
+        alternatives=[
+            SpeechData(
+                language="",
+                text=text,
+                start_time=start_time,
+                end_time=end_time,
+            )
+        ],
+        created_at=created_at,
     )
 
 
-def test_holds_in_window_transcript() -> None:
-    # input started at t=1000; agent spoke from t=1005; ignore window until t=1010.
-    ar = _make_recognition(ignore_until=1010.0, agent_started=1005.0, input_started=1000.0)
-    # event audio at +7s -> wall 1007, inside [1005, 1010) -> ignored, held
-    assert ar._should_hold_stt_event(_final(7.0, 8.0)) is True
+def _held_text(recognition: AudioRecognition) -> list[str]:
+    return [event.alternatives[0].text for event in recognition._transcript_buffer]
 
 
-def test_does_not_hold_timestamp_anchored_before_agent_speech() -> None:
-    # The regression: a mis-anchored leg reports a near-zero relative timestamp,
-    # computing to a wall-clock *before* the agent started speaking. That cannot belong
-    # to this agent's overlap window and must NOT be held.
-    ar = _make_recognition(ignore_until=1010.0, agent_started=1005.0, input_started=1000.0)
-    # event audio at +2s -> wall 1002, before agent_started 1005 -> not held
-    assert ar._should_hold_stt_event(_final(2.0, 3.0)) is False
+def test_active_vad_utterance_extends_past_end_boundary() -> None:
+    recognition = _make_recognition(vad_sos=5.0, end_boundary=1.0)
+
+    recognition._hold_stt_event(_event("before", created_at=4.0))
+    recognition._hold_stt_event(_event("utterance start", created_at=5.0))
+    recognition._hold_stt_event(_event("utterance end", created_at=9.5))
+
+    assert recognition._transcript_flush_start(now=10.0) == 5.0
+    assert _held_text(recognition) == ["utterance start", "utterance end"]
 
 
-def test_does_not_hold_after_ignore_cutoff() -> None:
-    ar = _make_recognition(ignore_until=1010.0, agent_started=1005.0, input_started=1000.0)
-    # event audio at +15s -> wall 1015, after ignore cutoff 1010 -> not held
-    assert ar._should_hold_stt_event(_final(15.0, 16.0)) is False
+def test_flush_start_does_not_precede_agent_speech() -> None:
+    recognition = _make_recognition(vad_sos=5.0, agent_sos=8.0, end_boundary=1.0)
+
+    assert recognition._transcript_flush_start(now=10.0) == 8.0
 
 
-def test_does_not_hold_timestamp_in_the_future() -> None:
-    # Upper bound is clamped to now: a timestamp computed into the future (the
-    # over-anchored variant) is outside the window and not held.
-    now = time.time()
-    ar = _make_recognition(
-        ignore_until=now + 100.0,
-        agent_started=now - 1.0,
-        input_started=now,
+def test_end_boundary_is_used_without_active_vad_utterance() -> None:
+    recognition = _make_recognition(vad_sos=None, end_boundary=1.0)
+
+    recognition._hold_stt_event(_event("old", created_at=8.0))
+    recognition._hold_stt_event(_event("near end", created_at=9.5))
+
+    flush_start = recognition._transcript_flush_start(now=10.0)
+    recognition._flush_held_transcripts(flush_start=flush_start)
+
+    emitted = [
+        call.args[0].alternatives[0].text
+        for call in recognition._process_stt_event.call_args_list  # type: ignore[attr-defined]
+    ]
+    assert emitted == ["near end"]
+    assert not recognition._transcript_buffer
+
+
+def test_provider_timestamps_do_not_affect_gate() -> None:
+    recognition = _make_recognition(vad_sos=None, end_boundary=1.0)
+    stale_arrival_with_future_word_time = _event(
+        "stale",
+        created_at=8.0,
+        start_time=10_000.0,
+        end_time=20_000.0,
     )
-    # event audio at +200s -> wall now+200, beyond now -> not held
-    assert ar._should_hold_stt_event(_final(200.0, 201.0)) is False
+    recent_arrival_without_word_times = _event("recent", created_at=9.5)
+
+    recognition._transcript_buffer.extend(
+        [stale_arrival_with_future_word_time, recent_arrival_without_word_times]
+    )
+    recognition._flush_held_transcripts(flush_start=9.0)
+
+    emitted = [
+        call.args[0].alternatives[0].text
+        for call in recognition._process_stt_event.call_args_list  # type: ignore[attr-defined]
+    ]
+    assert emitted == ["recent"]
 
 
-def test_lower_bound_is_agent_start_across_multiple_overlaps() -> None:
-    # A turn may contain several overlap episodes. The lower bound stays at the agent
-    # speech start, so a transcript from an *earlier* overlap is still held even after a
-    # later overlap occurs (the bound must not advance to the latest overlap start).
-    ar = _make_recognition(ignore_until=1010.0, agent_started=1005.0, input_started=1000.0)
-    # first overlap transcript at +6s -> wall 1006, still inside [1005, 1010) -> held
-    assert ar._should_hold_stt_event(_final(6.0, 6.5)) is True
-    # later overlap transcript at +8s -> wall 1008 -> also held
-    assert ar._should_hold_stt_event(_final(8.0, 8.5)) is True
+def test_force_flush_preserves_provider_order() -> None:
+    recognition = _make_recognition(vad_sos=5.0)
+    events = [
+        SpeechEvent(
+            type=SpeechEventType.INTERIM_TRANSCRIPT,
+            alternatives=[SpeechData(language="", text="interim")],
+            created_at=5.0,
+        ),
+        _event("final", created_at=5.1),
+        SpeechEvent(type=SpeechEventType.END_OF_SPEECH, created_at=5.2),
+    ]
+    recognition._transcript_buffer.extend(events)
+
+    recognition._flush_held_transcripts(force=True)
+
+    emitted = [call.args[0] for call in recognition._process_stt_event.call_args_list]  # type: ignore[attr-defined]
+    assert emitted == events
+    assert not recognition._transcript_buffer

--- a/tests/test_interruption_hold_window.py
+++ b/tests/test_interruption_hold_window.py
@@ -60,7 +60,26 @@ def test_active_vad_utterance_extends_past_end_boundary() -> None:
     recognition._hold_stt_event(_event("utterance start", created_at=5.0))
     recognition._hold_stt_event(_event("utterance end", created_at=9.5))
 
-    assert recognition._transcript_flush_start(now=10.0) == 5.0
+    flush_start = recognition._transcript_flush_start(now=10.0)
+    recognition._flush_held_transcripts(flush_start=flush_start)
+
+    emitted = [
+        call.args[0].alternatives[0].text
+        for call in recognition._process_stt_event.call_args_list  # type: ignore[attr-defined]
+    ]
+    assert flush_start == 5.0
+    assert emitted == ["utterance start", "utterance end"]
+
+
+def test_events_remain_held_until_overlap_verdict() -> None:
+    recognition = _make_recognition(vad_sos=5.0, end_boundary=1.0)
+
+    recognition._hold_stt_event(_event("utterance start", created_at=5.0))
+
+    # the true verdict can already be queued when VAD EOS clears the active utterance
+    recognition._active_vad_speech_started_at = None
+    recognition._hold_stt_event(_event("utterance end", created_at=7.0))
+
     assert _held_text(recognition) == ["utterance start", "utterance end"]
 
 

--- a/tests/test_interruption_hold_window.py
+++ b/tests/test_interruption_hold_window.py
@@ -24,6 +24,7 @@ def _make_recognition(
     recognition._active_vad_speech_started_at = vad_sos
     recognition._backchannel_boundary = (0.0, end_boundary)
     recognition._transcript_buffer = deque()
+    recognition._transcript_gate_active = True
     recognition._process_stt_event = MagicMock()  # type: ignore[method-assign]
     return recognition
 
@@ -49,19 +50,22 @@ def _event(
     )
 
 
-def _held_text(recognition: AudioRecognition) -> list[str]:
-    return [event.alternatives[0].text for event in recognition._transcript_buffer]
-
-
 def test_active_vad_utterance_extends_past_end_boundary() -> None:
     recognition = _make_recognition(vad_sos=5.0, end_boundary=1.0)
 
-    recognition._hold_stt_event(_event("before", created_at=4.0))
-    recognition._hold_stt_event(_event("utterance start", created_at=5.0))
-    recognition._hold_stt_event(_event("utterance end", created_at=9.5))
+    recognition._transcript_buffer.extend(
+        [
+            _event("before", created_at=4.0),
+            _event("utterance start", created_at=5.0),
+            _event("utterance end", created_at=9.5),
+        ]
+    )
 
-    flush_start = recognition._transcript_flush_start(now=10.0)
-    recognition._flush_held_transcripts(flush_start=flush_start)
+    flush_start = recognition._transcript_flush_start(
+        now=10.0,
+        vad_speech_started_at=5.0,
+    )
+    recognition._release_transcript_gate(at=10.0, vad_speech_started_at=5.0)
 
     emitted = [
         call.args[0].alternatives[0].text
@@ -71,32 +75,20 @@ def test_active_vad_utterance_extends_past_end_boundary() -> None:
     assert emitted == ["utterance start", "utterance end"]
 
 
-def test_events_remain_held_until_overlap_verdict() -> None:
-    recognition = _make_recognition(vad_sos=5.0, end_boundary=1.0)
-
-    recognition._hold_stt_event(_event("utterance start", created_at=5.0))
-
-    # the true verdict can already be queued when VAD EOS clears the active utterance
-    recognition._active_vad_speech_started_at = None
-    recognition._hold_stt_event(_event("utterance end", created_at=7.0))
-
-    assert _held_text(recognition) == ["utterance start", "utterance end"]
-
-
 def test_flush_start_does_not_precede_agent_speech() -> None:
     recognition = _make_recognition(vad_sos=5.0, agent_sos=8.0, end_boundary=1.0)
 
-    assert recognition._transcript_flush_start(now=10.0) == 8.0
+    assert recognition._transcript_flush_start(now=10.0, vad_speech_started_at=5.0) == 8.0
 
 
 def test_end_boundary_is_used_without_active_vad_utterance() -> None:
     recognition = _make_recognition(vad_sos=None, end_boundary=1.0)
 
-    recognition._hold_stt_event(_event("old", created_at=8.0))
-    recognition._hold_stt_event(_event("near end", created_at=9.5))
+    recognition._transcript_buffer.extend(
+        [_event("old", created_at=8.0), _event("near end", created_at=9.5)]
+    )
 
-    flush_start = recognition._transcript_flush_start(now=10.0)
-    recognition._flush_held_transcripts(flush_start=flush_start)
+    recognition._release_transcript_gate(at=10.0, vad_speech_started_at=None)
 
     emitted = [
         call.args[0].alternatives[0].text
@@ -119,7 +111,7 @@ def test_provider_timestamps_do_not_affect_gate() -> None:
     recognition._transcript_buffer.extend(
         [stale_arrival_with_future_word_time, recent_arrival_without_word_times]
     )
-    recognition._flush_held_transcripts(flush_start=9.0)
+    recognition._release_transcript_gate(at=10.0, vad_speech_started_at=None)
 
     emitted = [
         call.args[0].alternatives[0].text
@@ -128,7 +120,7 @@ def test_provider_timestamps_do_not_affect_gate() -> None:
     assert emitted == ["recent"]
 
 
-def test_force_flush_preserves_provider_order() -> None:
+def test_drain_preserves_provider_order() -> None:
     recognition = _make_recognition(vad_sos=5.0)
     events = [
         SpeechEvent(
@@ -141,8 +133,25 @@ def test_force_flush_preserves_provider_order() -> None:
     ]
     recognition._transcript_buffer.extend(events)
 
-    recognition._flush_held_transcripts(force=True)
+    recognition._drain_transcript_gate()
 
     emitted = [call.args[0] for call in recognition._process_stt_event.call_args_list]  # type: ignore[attr-defined]
     assert emitted == events
+    assert not recognition._transcript_buffer
+
+
+def test_disabling_vad_drains_the_transcript_gate() -> None:
+    recognition = _make_recognition(vad_sos=5.0)
+    event = _event("held", created_at=5.0)
+    recognition._transcript_buffer.append(event)
+    recognition._interruption_enabled = True
+    recognition._interruption_detection = MagicMock()
+    recognition._vad = MagicMock()
+    recognition._vad_atask = None
+    recognition._turn_detector = None
+
+    recognition._update_vad(None)
+
+    recognition._process_stt_event.assert_called_once_with(event)  # type: ignore[attr-defined]
+    assert not recognition._transcript_gate_active
     assert not recognition._transcript_buffer

--- a/tests/test_interruption_hold_window.py
+++ b/tests/test_interruption_hold_window.py
@@ -140,6 +140,25 @@ def test_drain_preserves_provider_order() -> None:
     assert not recognition._transcript_buffer
 
 
+def test_new_overlap_rearms_a_released_gate() -> None:
+    # a failed interrupt attempt (e.g. below min_words) releases the gate mid-speech;
+    # the next overlap in the same agent speech must hold its transcripts again
+    recognition = _make_recognition(vad_sos=None, agent_sos=0.0)
+    recognition._endpointing = MagicMock()
+    recognition._turn_backchannel_over_agent = False
+    recognition._overlap_in_current_turn = False
+    recognition._overlap_open = False
+    recognition._agent_speaking = True
+    recognition._interruption_enabled = True
+    recognition._interruption_ch = MagicMock(closed=False)
+    recognition._transcript_gate_active = False
+
+    recognition._on_start_of_speech(started_at=6.0)
+
+    assert recognition._transcript_gate_active
+    recognition._interruption_ch.send_nowait.assert_called_once()
+
+
 def test_disabling_vad_drains_the_transcript_gate() -> None:
     recognition = _make_recognition(vad_sos=5.0)
     event = _event("held", created_at=5.0)

--- a/tests/test_interruption_hold_window.py
+++ b/tests/test_interruption_hold_window.py
@@ -25,7 +25,6 @@ def _make_recognition(
     recognition._backchannel_boundary = (0.0, end_boundary)
     recognition._transcript_buffer = deque()
     recognition._transcript_gate_active = True
-    recognition._pending_interruption = None
     recognition._process_stt_event = MagicMock()  # type: ignore[method-assign]
     return recognition
 

--- a/tests/test_interruption_hold_window.py
+++ b/tests/test_interruption_hold_window.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import asyncio
 from collections import deque
+from collections.abc import AsyncIterable, AsyncIterator
 from unittest.mock import MagicMock
 
 import pytest
 
+from livekit import rtc
+from livekit.agents import ModelSettings
 from livekit.agents.stt import SpeechData, SpeechEvent, SpeechEventType
-from livekit.agents.voice.audio_recognition import AudioRecognition
+from livekit.agents.voice.audio_recognition import AudioRecognition, _STTPipeline
 
 pytestmark = pytest.mark.unit
 
@@ -27,6 +30,7 @@ def _make_recognition(
     recognition._backchannel_boundary_timer = None
     recognition._transcript_buffer = deque()
     recognition._transcript_gate_active = True
+    recognition._stt_aligned_transcript = False
     recognition._hooks = MagicMock()
     recognition._hooks.interruption_by_audio_activity_enabled = False
     recognition._process_stt_event = MagicMock()  # type: ignore[method-assign]
@@ -218,7 +222,7 @@ def test_agent_speech_does_not_arm_gate_without_overlap() -> None:
     assert not recognition._transcript_gate_active
 
 
-async def test_delayed_overlap_from_start_boundary_stays_with_audio_activity() -> None:
+async def test_start_boundary_uses_audio_activity_for_agent_speech_interval() -> None:
     recognition = _make_recognition(vad_sos=None)
     recognition._agent_speaking = False
     recognition._interruption_enabled = True
@@ -240,6 +244,16 @@ async def test_delayed_overlap_from_start_boundary_stays_with_audio_activity() -
     assert not recognition._overlap_open
     recognition._interruption_ch.send_nowait.assert_called_once()
 
+    recognition._speaking = True
+    recognition._on_end_of_speech(ended_at=5.75)
+    recognition._speaking = False
+    recognition._on_start_of_speech(started_at=6.5)
+
+    assert recognition._hooks.interruption_by_audio_activity_enabled
+    assert not recognition._transcript_gate_active
+    assert not recognition._overlap_open
+    recognition._interruption_ch.send_nowait.assert_called_once()
+
 
 async def test_ungated_final_during_agent_speech_uses_audio_activity() -> None:
     recognition = _make_recognition(vad_sos=None)
@@ -255,6 +269,53 @@ async def test_ungated_final_during_agent_speech_uses_audio_activity() -> None:
 
     assert recognition._hooks.interruption_by_audio_activity_enabled
     recognition._process_stt_event.assert_called_once_with(event)  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize(
+    ("aligned_transcript", "speech_end_time", "end_time", "expected_speech_end_time"),
+    [
+        (True, None, 9.0, 10.0),
+        (False, None, 9.0, None),
+        (True, 8.0, 9.0, 8.0),
+        (True, None, 11.0, None),
+    ],
+)
+async def test_custom_stt_node_normalizes_aligned_speech_end_time(
+    aligned_transcript: bool,
+    speech_end_time: float | None,
+    end_time: float,
+    expected_speech_end_time: float | None,
+) -> None:
+    event = _event(
+        "custom",
+        created_at=11.0,
+        end_time=end_time,
+        speech_end_time=speech_end_time,
+    )
+
+    async def custom_stt_node(
+        _audio: AsyncIterable[rtc.AudioFrame], _model_settings: ModelSettings
+    ) -> AsyncIterator[SpeechEvent]:
+        yield event
+
+    pipeline = _STTPipeline(custom_stt_node)
+    pipeline.input_started_at = 1.0
+    recognition = _make_recognition(vad_sos=None)
+    recognition._stt_pipeline = pipeline
+    recognition._stt_aligned_transcript = aligned_transcript
+    recognition._agent_speaking = True
+    recognition._turn_detection_mode = "vad"
+    recognition._user_turn_committed = False
+    recognition._stt_request_ids = []
+    recognition._mark_turn_transcribed = MagicMock()  # type: ignore[method-assign]
+
+    try:
+        received = await asyncio.wait_for(pipeline.event_ch.recv(), timeout=1.0)
+        await recognition._on_stt_event(received)
+    finally:
+        await pipeline.aclose()
+
+    assert recognition._transcript_buffer[0].speech_end_time == expected_speech_end_time
 
 
 def test_disabling_vad_flushes_held_transcripts() -> None:

--- a/tests/test_interruption_hold_window.py
+++ b/tests/test_interruption_hold_window.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections import deque
 from unittest.mock import MagicMock
 
@@ -23,8 +24,11 @@ def _make_recognition(
     recognition._agent_speech_started_at = agent_sos
     recognition._active_vad_speech_started_at = vad_sos
     recognition._backchannel_boundary = (0.0, end_boundary)
+    recognition._backchannel_boundary_timer = None
     recognition._transcript_buffer = deque()
     recognition._transcript_gate_active = True
+    recognition._hooks = MagicMock()
+    recognition._hooks.interruption_by_audio_activity_enabled = False
     recognition._process_stt_event = MagicMock()  # type: ignore[method-assign]
     return recognition
 
@@ -35,6 +39,7 @@ def _event(
     created_at: float = 0.0,
     start_time: float = 0.0,
     end_time: float = 0.0,
+    speech_end_time: float | None = None,
 ) -> SpeechEvent:
     return SpeechEvent(
         type=SpeechEventType.FINAL_TRANSCRIPT,
@@ -47,6 +52,7 @@ def _event(
             )
         ],
         created_at=created_at,
+        speech_end_time=speech_end_time,
     )
 
 
@@ -61,24 +67,28 @@ def test_active_vad_utterance_extends_past_end_boundary() -> None:
         ]
     )
 
-    flush_start = recognition._transcript_flush_start(
-        now=10.0,
-        vad_speech_started_at=5.0,
-    )
-    recognition._release_transcript_gate(at=10.0, vad_speech_started_at=5.0)
+    recognition._flush_held_transcripts(resolved_at=10.0, vad_speech_started_at=5.0)
 
     emitted = [
         call.args[0].alternatives[0].text
         for call in recognition._process_stt_event.call_args_list  # type: ignore[attr-defined]
     ]
-    assert flush_start == 5.0
     assert emitted == ["utterance start", "utterance end"]
 
 
-def test_flush_start_does_not_precede_agent_speech() -> None:
+def test_trim_does_not_precede_agent_speech() -> None:
     recognition = _make_recognition(vad_sos=5.0, agent_sos=8.0, end_boundary=1.0)
+    recognition._transcript_buffer.extend(
+        [_event("before agent", created_at=7.5), _event("during agent", created_at=8.0)]
+    )
 
-    assert recognition._transcript_flush_start(now=10.0, vad_speech_started_at=5.0) == 8.0
+    recognition._flush_held_transcripts(resolved_at=10.0, vad_speech_started_at=5.0)
+
+    emitted = [
+        call.args[0].alternatives[0].text
+        for call in recognition._process_stt_event.call_args_list  # type: ignore[attr-defined]
+    ]
+    assert emitted == ["during agent"]
 
 
 def test_end_boundary_is_used_without_active_vad_utterance() -> None:
@@ -88,7 +98,7 @@ def test_end_boundary_is_used_without_active_vad_utterance() -> None:
         [_event("old", created_at=8.0), _event("near end", created_at=9.5)]
     )
 
-    recognition._release_transcript_gate(at=10.0, vad_speech_started_at=None)
+    recognition._flush_held_transcripts(resolved_at=10.0, vad_speech_started_at=None)
 
     emitted = [
         call.args[0].alternatives[0].text
@@ -111,7 +121,7 @@ def test_provider_timestamps_do_not_affect_gate() -> None:
     recognition._transcript_buffer.extend(
         [stale_arrival_with_future_word_time, recent_arrival_without_word_times]
     )
-    recognition._release_transcript_gate(at=10.0, vad_speech_started_at=None)
+    recognition._flush_held_transcripts(resolved_at=10.0, vad_speech_started_at=None)
 
     emitted = [
         call.args[0].alternatives[0].text
@@ -120,7 +130,37 @@ def test_provider_timestamps_do_not_affect_gate() -> None:
     assert emitted == ["recent"]
 
 
-def test_drain_preserves_provider_order() -> None:
+def test_speech_end_time_preserves_a_delayed_prior_transcript() -> None:
+    recognition = _make_recognition(vad_sos=None, agent_sos=8.0, end_boundary=1.0)
+    recognition._transcript_buffer.append(
+        _event(
+            "prior speech",
+            created_at=8.5,
+            speech_end_time=7.5,
+        )
+    )
+
+    recognition._flush_held_transcripts(resolved_at=10.0, vad_speech_started_at=None)
+
+    recognition._process_stt_event.assert_called_once()  # type: ignore[attr-defined]
+
+
+def test_speech_end_time_discards_a_delayed_backchannel() -> None:
+    recognition = _make_recognition(vad_sos=None, agent_sos=8.0, end_boundary=1.0)
+    recognition._transcript_buffer.append(
+        _event(
+            "backchannel",
+            created_at=9.5,
+            speech_end_time=8.5,
+        )
+    )
+
+    recognition._flush_held_transcripts(resolved_at=10.0, vad_speech_started_at=None)
+
+    recognition._process_stt_event.assert_not_called()  # type: ignore[attr-defined]
+
+
+def test_flushing_held_transcripts_preserves_provider_order() -> None:
     recognition = _make_recognition(vad_sos=5.0)
     events = [
         SpeechEvent(
@@ -133,11 +173,12 @@ def test_drain_preserves_provider_order() -> None:
     ]
     recognition._transcript_buffer.extend(events)
 
-    recognition._drain_transcript_gate()
+    recognition._flush_held_transcripts()
 
     emitted = [call.args[0] for call in recognition._process_stt_event.call_args_list]  # type: ignore[attr-defined]
     assert emitted == events
     assert not recognition._transcript_buffer
+    assert not recognition._transcript_gate_active
 
 
 def test_new_overlap_rearms_a_released_gate() -> None:
@@ -159,7 +200,64 @@ def test_new_overlap_rearms_a_released_gate() -> None:
     recognition._interruption_ch.send_nowait.assert_called_once()
 
 
-def test_disabling_vad_drains_the_transcript_gate() -> None:
+def test_agent_speech_does_not_arm_gate_without_overlap() -> None:
+    recognition = _make_recognition(vad_sos=None)
+    recognition._agent_speaking = False
+    recognition._interruption_enabled = True
+    recognition._interruption_ch = MagicMock(closed=False)
+    recognition._endpointing = MagicMock()
+    recognition._backchannel_boundary = None
+    recognition._overlap_in_current_turn = False
+    recognition._overlap_open = False
+    recognition._turn_backchannel_over_agent = False
+    recognition._user_silence_ev = asyncio.Event()
+    recognition._user_silence_ev.set()
+
+    recognition._on_start_of_agent_speech(started_at=5.0)
+
+    assert not recognition._transcript_gate_active
+
+
+async def test_delayed_overlap_from_start_boundary_stays_with_audio_activity() -> None:
+    recognition = _make_recognition(vad_sos=None)
+    recognition._agent_speaking = False
+    recognition._interruption_enabled = True
+    recognition._interruption_ch = MagicMock(closed=False)
+    recognition._endpointing = MagicMock()
+    recognition._backchannel_boundary = (1.0, 1.0)
+    recognition._overlap_in_current_turn = False
+    recognition._overlap_open = False
+    recognition._turn_backchannel_over_agent = False
+    recognition._user_silence_ev = asyncio.Event()
+    recognition._user_silence_ev.set()
+
+    recognition._on_start_of_agent_speech(started_at=5.0)
+    recognition._cancel_backchannel_boundary()
+    recognition._on_start_of_speech(started_at=5.5)
+
+    assert recognition._hooks.interruption_by_audio_activity_enabled
+    assert not recognition._transcript_gate_active
+    assert not recognition._overlap_open
+    recognition._interruption_ch.send_nowait.assert_called_once()
+
+
+async def test_ungated_final_during_agent_speech_uses_audio_activity() -> None:
+    recognition = _make_recognition(vad_sos=None)
+    recognition._agent_speaking = True
+    recognition._transcript_gate_active = False
+    recognition._turn_detection_mode = "vad"
+    recognition._user_turn_committed = False
+    recognition._stt_request_ids = []
+    recognition._mark_turn_transcribed = MagicMock()  # type: ignore[method-assign]
+
+    event = _event("late final", created_at=5.2)
+    await recognition._on_stt_event(event)
+
+    assert recognition._hooks.interruption_by_audio_activity_enabled
+    recognition._process_stt_event.assert_called_once_with(event)  # type: ignore[attr-defined]
+
+
+def test_disabling_vad_flushes_held_transcripts() -> None:
     recognition = _make_recognition(vad_sos=5.0)
     event = _event("held", created_at=5.0)
     recognition._transcript_buffer.append(event)

--- a/tests/test_interruption_hold_window.py
+++ b/tests/test_interruption_hold_window.py
@@ -25,6 +25,7 @@ def _make_recognition(
     recognition._backchannel_boundary = (0.0, end_boundary)
     recognition._transcript_buffer = deque()
     recognition._transcript_gate_active = True
+    recognition._pending_interruption = None
     recognition._process_stt_event = MagicMock()  # type: ignore[method-assign]
     return recognition
 

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections import deque
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -45,61 +46,73 @@ def _end_of_turn_info(
     )
 
 
-def test_adaptive_verdict_flushes_before_normal_interruption_thresholds() -> None:
+def test_adaptive_verdict_delegates_interruption_policy() -> None:
     activity = AgentActivity.__new__(AgentActivity)
     calls: list[str] = []
-    activity._audio_recognition = MagicMock()
-    activity._audio_recognition._current_transcript = ""
-
-    def _flush(**_: object) -> None:
-        calls.append("flush")
-        activity._audio_recognition._current_transcript = "enough words"
-
-    def _interrupt() -> bool:
-        calls.append("interrupt")
-        assert activity._audio_recognition._current_transcript == "enough words"
-        return True
 
     activity._restore_interruption_by_audio_activity = MagicMock(  # type: ignore[method-assign]
         side_effect=lambda: calls.append("restore")
     )
     activity._interrupt_by_audio_activity = MagicMock(  # type: ignore[method-assign]
-        side_effect=_interrupt
+        side_effect=lambda: calls.append("interrupt")
     )
-    activity._audio_recognition._flush_held_transcripts.side_effect = _flush
-    activity._paused_speech = None
-
-    event = OverlappingSpeechEvent(
-        is_interruption=True,
-        detected_at=7.0,
-        overlap_started_at=5.0,
-    )
-    activity.on_interruption(event)
-
-    assert calls == ["flush", "restore", "interrupt"]
-    assert (
-        activity._audio_recognition._transcript_flush_start.call_args.kwargs[
-            "vad_speech_started_at"
-        ]
-        == event.overlap_started_at
-    )
-    activity._interrupt_by_audio_activity.assert_called_once_with()  # type: ignore[attr-defined]
-    activity._audio_recognition._on_end_of_agent_speech.assert_called_once()
-
-
-def test_adaptive_verdict_does_not_end_agent_when_min_words_rejects() -> None:
-    activity = AgentActivity.__new__(AgentActivity)
-    activity._restore_interruption_by_audio_activity = MagicMock()  # type: ignore[method-assign]
-    activity._interrupt_by_audio_activity = MagicMock(  # type: ignore[method-assign]
-        return_value=False
-    )
-    activity._audio_recognition = MagicMock()
-    activity._paused_speech = None
 
     activity.on_interruption(OverlappingSpeechEvent(is_interruption=True))
 
-    activity._audio_recognition._flush_held_transcripts.assert_called_once()
-    activity._audio_recognition._on_end_of_agent_speech.assert_not_called()
+    assert calls == ["restore", "interrupt"]
+    activity._interrupt_by_audio_activity.assert_called_once_with()  # type: ignore[attr-defined]
+
+
+def test_positive_verdict_suspends_vad_before_transcript_release() -> None:
+    activity = AgentActivity.__new__(AgentActivity)
+    activity._interruption_by_audio_activity_enabled = True
+    activity._session = MagicMock()
+
+    event = OverlappingSpeechEvent(is_interruption=True)
+    activity._on_overlap_speech_ended(event)
+
+    assert not activity._interruption_by_audio_activity_enabled
+    activity._session.emit.assert_called_once_with("overlapping_speech", event)
+
+
+def test_audio_activity_releases_held_transcripts_before_min_words() -> None:
+    activity = AgentActivity.__new__(AgentActivity)
+    activity._interruption_by_audio_activity_enabled = True
+    activity._rt_turn_detection_enabled = False
+    activity._rt_session = None
+    activity._agent = MagicMock()
+    activity._session = MagicMock()
+    activity._session._text_only = False
+    activity._session._aec_warmup_remaining = 0
+    activity._session._aec_warmup_timer = None
+    activity._session.options = SimpleNamespace(interruption={"min_words": 2})
+    activity._session.agent_state = "speaking"
+    activity._audio_recognition = MagicMock()
+    activity._audio_recognition._current_transcript = ""
+    activity._audio_recognition._endpointing.overlapping = True
+
+    released = False
+
+    def _release_transcripts() -> None:
+        nonlocal released
+        activity._audio_recognition._current_transcript = "enough words"
+        if not released:
+            released = True
+            activity._interrupt_by_audio_activity()
+
+    activity._audio_recognition._release_transcripts_for_audio_activity.side_effect = (
+        _release_transcripts
+    )
+    activity._current_speech = MagicMock()
+    activity._current_speech.interrupted = False
+    activity._current_speech.allow_interruptions = True
+    activity._cancel_false_interruption_timer = MagicMock()  # type: ignore[method-assign]
+    activity._pause_enabled = MagicMock(return_value=False)  # type: ignore[method-assign]
+
+    activity._interrupt_by_audio_activity()
+
+    activity._audio_recognition._release_transcripts_for_audio_activity.assert_called_once_with()
+    activity._current_speech.interrupt.assert_called_once_with()
 
 
 def _realtime_barge_in_session() -> AgentSession:
@@ -274,6 +287,7 @@ async def test_backchannel_confirmed_noop_when_barge_in_disabled(
 def _recognition_for_overlap(*, speaking: bool = False) -> AudioRecognition:
     ar = AudioRecognition.__new__(AudioRecognition)
     ar._agent_speaking = False
+    ar._transcript_gate_active = False
     ar._backchannel_boundary_timer = None
     ar._overlap_in_current_turn = True
     ar._turn_backchannel_over_agent = False
@@ -306,6 +320,7 @@ async def test_false_verdict_trims_finished_backchannel() -> None:
     old_event = MagicMock(created_at=8.0)
     recent_event = MagicMock(created_at=9.5)
     ar._agent_speaking = True
+    ar._transcript_gate_active = True
     ar._agent_speech_started_at = None
     ar._active_vad_speech_started_at = None
     ar._backchannel_boundary = (0.0, 1.0)
@@ -327,6 +342,7 @@ async def test_boundary_fallback_preserves_held_transcripts() -> None:
     early_event = MagicMock(created_at=9.0)
     recent_event = MagicMock(created_at=9.75)
     ar._agent_speaking = True
+    ar._transcript_gate_active = True
     ar._agent_speech_started_at = 9.0
     ar._active_vad_speech_started_at = None
     ar._backchannel_boundary = (3.0, 0.5)
@@ -404,6 +420,7 @@ def _recognition_with_interruption_ch() -> tuple[AudioRecognition, _RecordingCha
     ar._interruption_enabled = True
     ar._interruption_ch = ch  # type: ignore[assignment]
     ar._agent_speaking = False
+    ar._transcript_gate_active = False
     ar._active_vad_speech_started_at = None
     ar._endpointing = MagicMock()
     ar._backchannel_boundary = None

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -69,9 +69,20 @@ def test_adaptive_verdict_flushes_before_normal_interruption_thresholds() -> Non
     activity._audio_recognition._flush_held_transcripts.side_effect = _flush
     activity._paused_speech = None
 
-    activity.on_interruption(MagicMock(spec=OverlappingSpeechEvent))
+    event = OverlappingSpeechEvent(
+        is_interruption=True,
+        detected_at=7.0,
+        overlap_started_at=5.0,
+    )
+    activity.on_interruption(event)
 
     assert calls == ["flush", "restore", "interrupt"]
+    assert (
+        activity._audio_recognition._transcript_flush_start.call_args.kwargs[
+            "vad_speech_started_at"
+        ]
+        == event.overlap_started_at
+    )
     activity._interrupt_by_audio_activity.assert_called_once_with()  # type: ignore[attr-defined]
     activity._audio_recognition._on_end_of_agent_speech.assert_called_once()
 
@@ -85,7 +96,7 @@ def test_adaptive_verdict_does_not_end_agent_when_min_words_rejects() -> None:
     activity._audio_recognition = MagicMock()
     activity._paused_speech = None
 
-    activity.on_interruption(MagicMock(spec=OverlappingSpeechEvent))
+    activity.on_interruption(OverlappingSpeechEvent(is_interruption=True))
 
     activity._audio_recognition._flush_held_transcripts.assert_called_once()
     activity._audio_recognition._on_end_of_agent_speech.assert_not_called()
@@ -262,6 +273,7 @@ async def test_backchannel_confirmed_noop_when_barge_in_disabled(
 
 def _recognition_for_overlap(*, speaking: bool = False) -> AudioRecognition:
     ar = AudioRecognition.__new__(AudioRecognition)
+    ar._agent_speaking = False
     ar._backchannel_boundary_timer = None
     ar._overlap_in_current_turn = True
     ar._turn_backchannel_over_agent = False
@@ -287,6 +299,27 @@ async def test_user_ended_overlap_latches_backchannel() -> None:
     ar = _recognition_for_overlap()
     await ar._on_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=False))
     assert ar._turn_backchannel_over_agent is True
+
+
+async def test_false_verdict_trims_finished_backchannel() -> None:
+    ar = _recognition_for_overlap()
+    old_event = MagicMock(created_at=8.0)
+    recent_event = MagicMock(created_at=9.5)
+    ar._agent_speaking = True
+    ar._agent_speech_started_at = None
+    ar._active_vad_speech_started_at = None
+    ar._backchannel_boundary = (0.0, 1.0)
+    ar._transcript_buffer = deque([old_event, recent_event])
+
+    await ar._on_overlap_speech_event(
+        OverlappingSpeechEvent(
+            is_interruption=False,
+            agent_ended=False,
+            detected_at=10.0,
+        )
+    )
+
+    assert list(ar._transcript_buffer) == [recent_event]
 
 
 async def test_confirmed_backchannel_between_segments_clears_audio() -> None:

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -322,6 +322,28 @@ async def test_false_verdict_trims_finished_backchannel() -> None:
     assert list(ar._transcript_buffer) == [recent_event]
 
 
+async def test_boundary_fallback_preserves_held_transcripts() -> None:
+    ar = _recognition_for_overlap()
+    early_event = MagicMock(created_at=9.0)
+    recent_event = MagicMock(created_at=9.75)
+    ar._agent_speaking = True
+    ar._agent_speech_started_at = 9.0
+    ar._active_vad_speech_started_at = None
+    ar._backchannel_boundary = (3.0, 0.5)
+    ar._backchannel_boundary_timer = MagicMock()
+    ar._transcript_buffer = deque([early_event, recent_event])
+
+    await ar._on_overlap_speech_event(
+        OverlappingSpeechEvent(
+            is_interruption=False,
+            agent_ended=False,
+            detected_at=10.0,
+        )
+    )
+
+    assert list(ar._transcript_buffer) == [early_event, recent_event]
+
+
 async def test_confirmed_backchannel_between_segments_clears_audio() -> None:
     # confirmed between segments (user silent) — cleared so it can't prefix the next turn
     ar = _recognition_for_overlap(speaking=False)

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -78,6 +78,7 @@ def test_positive_verdict_suspends_vad_before_transcript_release() -> None:
 def test_audio_activity_releases_held_transcripts_before_min_words() -> None:
     activity = AgentActivity.__new__(AgentActivity)
     activity._interruption_by_audio_activity_enabled = True
+    activity._releasing_held_transcripts = False
     activity._rt_turn_detection_enabled = False
     activity._rt_session = None
     activity._agent = MagicMock()

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections import deque
 from unittest.mock import MagicMock
 
 import pytest
 
-from livekit.agents import NOT_GIVEN, Agent, AgentSession, TurnHandlingOptions
+from livekit.agents import Agent, AgentSession, TurnHandlingOptions
 from livekit.agents.inference import OverlappingSpeechEvent
 from livekit.agents.voice.agent_activity import AgentActivity
 from livekit.agents.voice.audio_recognition import (
@@ -44,6 +45,52 @@ def _end_of_turn_info(
     )
 
 
+def test_adaptive_verdict_flushes_before_normal_interruption_thresholds() -> None:
+    activity = AgentActivity.__new__(AgentActivity)
+    calls: list[str] = []
+    activity._audio_recognition = MagicMock()
+    activity._audio_recognition._current_transcript = ""
+
+    def _flush(**_: object) -> None:
+        calls.append("flush")
+        activity._audio_recognition._current_transcript = "enough words"
+
+    def _interrupt() -> bool:
+        calls.append("interrupt")
+        assert activity._audio_recognition._current_transcript == "enough words"
+        return True
+
+    activity._restore_interruption_by_audio_activity = MagicMock(  # type: ignore[method-assign]
+        side_effect=lambda: calls.append("restore")
+    )
+    activity._interrupt_by_audio_activity = MagicMock(  # type: ignore[method-assign]
+        side_effect=_interrupt
+    )
+    activity._audio_recognition._flush_held_transcripts.side_effect = _flush
+    activity._paused_speech = None
+
+    activity.on_interruption(MagicMock(spec=OverlappingSpeechEvent))
+
+    assert calls == ["flush", "restore", "interrupt"]
+    activity._interrupt_by_audio_activity.assert_called_once_with()  # type: ignore[attr-defined]
+    activity._audio_recognition._on_end_of_agent_speech.assert_called_once()
+
+
+def test_adaptive_verdict_does_not_end_agent_when_min_words_rejects() -> None:
+    activity = AgentActivity.__new__(AgentActivity)
+    activity._restore_interruption_by_audio_activity = MagicMock()  # type: ignore[method-assign]
+    activity._interrupt_by_audio_activity = MagicMock(  # type: ignore[method-assign]
+        return_value=False
+    )
+    activity._audio_recognition = MagicMock()
+    activity._paused_speech = None
+
+    activity.on_interruption(MagicMock(spec=OverlappingSpeechEvent))
+
+    activity._audio_recognition._flush_held_transcripts.assert_called_once()
+    activity._audio_recognition._on_end_of_agent_speech.assert_not_called()
+
+
 def _realtime_barge_in_session() -> AgentSession:
     return AgentSession(
         llm=FakeRealtimeModel(capabilities=fake_capabilities(turn_detection=False)),
@@ -73,8 +120,7 @@ async def test_adaptive_interruption_enabled_for_realtime_without_stt(
 async def test_adaptive_interruption_still_requires_stt_for_non_realtime(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # the STT pipeline path is unchanged: without an aligned streaming STT there is
-    # nothing to gatekeep, so adaptive interruption stays disabled
+    # the non-realtime gate still needs STT because VAD alone cannot provide text
     monkeypatch.setenv("LIVEKIT_API_KEY", "k")
     monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
 
@@ -303,16 +349,15 @@ def _recognition_with_interruption_ch() -> tuple[AudioRecognition, _RecordingCha
     ar._interruption_enabled = True
     ar._interruption_ch = ch  # type: ignore[assignment]
     ar._agent_speaking = False
-    ar._agent_speech_started_at = None
+    ar._active_vad_speech_started_at = None
     ar._endpointing = MagicMock()
     ar._backchannel_boundary = None
     ar._backchannel_boundary_timer = None
     ar._backchannel_boundary_callback = None
-    ar._ignore_user_transcript_until = NOT_GIVEN
     ar._overlap_in_current_turn = False
     ar._overlap_open = False
     ar._turn_backchannel_over_agent = False
-    ar._transcript_buffer = []
+    ar._transcript_buffer = deque()
     ar._tasks = set()
     ar._user_silence_ev = asyncio.Event()
     ar._user_silence_ev.set()
@@ -331,7 +376,7 @@ async def test_agent_speech_end_closes_overlap_before_reset() -> None:
     ar._on_start_of_speech(started_at=time.time())
     ch.sent.clear()
 
-    ar._on_end_of_agent_speech(ignore_user_transcript_until=time.time())
+    ar._on_end_of_agent_speech(ended_at=time.time())
 
     assert _sentinel_names(ch) == [
         "_OverlapSpeechEndedSentinel",
@@ -345,7 +390,7 @@ async def test_user_speech_ending_after_agent_end_does_not_close_overlap_again()
     ar, ch = _recognition_with_interruption_ch()
     ar._on_start_of_agent_speech(started_at=time.time())
     ar._on_start_of_speech(started_at=time.time())
-    ar._on_end_of_agent_speech(ignore_user_transcript_until=time.time())
+    ar._on_end_of_agent_speech(ended_at=time.time())
     ch.sent.clear()
 
     ar._on_end_of_speech(ended_at=time.time())
@@ -359,7 +404,7 @@ async def test_resume_restarts_the_detector() -> None:
     user_started_at = time.time()
     ar._speaking = True
     ar._on_start_of_speech(started_at=user_started_at)
-    ar._on_end_of_agent_speech(ignore_user_transcript_until=time.time())
+    ar._on_end_of_agent_speech(ended_at=time.time())
     ch.sent.clear()
 
     resumed_at = time.time()
@@ -396,7 +441,7 @@ async def test_real_end_of_agent_speech_still_tears_down() -> None:
     ar._on_start_of_speech(started_at=time.time())
     ch.sent.clear()
 
-    ar._on_end_of_agent_speech(ignore_user_transcript_until=time.time())
+    ar._on_end_of_agent_speech(ended_at=time.time())
 
     assert _sentinel_names(ch) == [
         "_OverlapSpeechEndedSentinel",

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -78,8 +78,9 @@ def test_adaptive_verdict_transition_is_owned_by_activity() -> None:
     activity._interrupt_by_audio_activity.assert_called_once_with()  # type: ignore[attr-defined]
 
 
-def test_audio_activity_releases_held_transcripts_before_min_words() -> None:
+def test_audio_activity_release_is_non_reentrant_and_precedes_min_words() -> None:
     activity = AgentActivity.__new__(AgentActivity)
+    activity._audio_activity_interruption_in_progress = False
     activity._interruption_by_audio_activity_enabled = True
     activity._rt_turn_detection_enabled = False
     activity._rt_session = None
@@ -96,6 +97,7 @@ def test_audio_activity_releases_held_transcripts_before_min_words() -> None:
 
     def _release_transcripts() -> None:
         activity._audio_recognition._current_transcript = "enough words"
+        activity._interrupt_by_audio_activity()
 
     activity._audio_recognition._release_transcripts_for_audio_activity.side_effect = (
         _release_transcripts
@@ -110,10 +112,12 @@ def test_audio_activity_releases_held_transcripts_before_min_words() -> None:
 
     activity._audio_recognition._release_transcripts_for_audio_activity.assert_called_once_with()
     activity._current_speech.interrupt.assert_called_once_with()
+    assert not activity._audio_activity_interruption_in_progress
 
 
 def test_rejected_audio_interruption_clears_pending_verdict() -> None:
     activity = AgentActivity.__new__(AgentActivity)
+    activity._audio_activity_interruption_in_progress = False
     activity._interruption_by_audio_activity_enabled = True
     activity._rt_turn_detection_enabled = False
     activity._rt_session = None

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -116,6 +116,41 @@ def test_audio_activity_releases_held_transcripts_before_min_words() -> None:
     activity._current_speech.interrupt.assert_called_once_with()
 
 
+def test_rejected_audio_interruption_clears_pending_verdict() -> None:
+    activity = AgentActivity.__new__(AgentActivity)
+    activity._interruption_by_audio_activity_enabled = True
+    activity._releasing_held_transcripts = False
+    activity._rt_turn_detection_enabled = False
+    activity._rt_session = None
+    activity._agent = MagicMock()
+    activity._session = MagicMock()
+    activity._session._aec_warmup_remaining = 0
+    activity._session._aec_warmup_timer = None
+    activity._session.options = SimpleNamespace(interruption={"min_words": 0})
+    activity._audio_recognition = MagicMock()
+    activity._current_speech = None
+
+    activity._interrupt_by_audio_activity()
+
+    activity._audio_recognition._clear_pending_interruption.assert_called_once_with()
+
+
+def test_replayed_start_preserves_pending_positive_verdict() -> None:
+    activity = AgentActivity.__new__(AgentActivity)
+    activity._session = MagicMock()
+    activity._session.agent_state = "speaking"
+    activity._audio_recognition = MagicMock()
+    activity._audio_recognition._interruption_pending = True
+    activity._user_silence_event = asyncio.Event()
+    activity._stt_eos_received = True
+    activity._interruption_detected = True
+    activity._cancel_false_interruption_timer = MagicMock()  # type: ignore[method-assign]
+
+    activity.on_start_of_speech(None, speech_start_time=time.time())
+
+    assert activity._interruption_detected is True
+
+
 def _realtime_barge_in_session() -> AgentSession:
     return AgentSession(
         llm=FakeRealtimeModel(capabilities=fake_capabilities(turn_detection=False)),
@@ -429,6 +464,7 @@ def _recognition_with_interruption_ch() -> tuple[AudioRecognition, _RecordingCha
     ar._backchannel_boundary_callback = None
     ar._overlap_in_current_turn = False
     ar._overlap_open = False
+    ar._pending_interruption = None
     ar._turn_backchannel_over_agent = False
     ar._transcript_buffer = deque()
     ar._tasks = set()
@@ -441,6 +477,35 @@ def _recognition_with_interruption_ch() -> tuple[AudioRecognition, _RecordingCha
 
 def _sentinel_names(ch: _RecordingChan) -> list[str]:
     return [type(item).__name__ for item in ch.sent]
+
+
+async def test_positive_verdict_blocks_replayed_start_from_reopening_overlap() -> None:
+    ar, ch = _recognition_with_interruption_ch()
+    ar._agent_speaking = True
+    ar._agent_speech_started_at = 9.0
+    ar._overlap_in_current_turn = True
+    ar._overlap_open = True
+    ar._transcript_gate_active = True
+    ar._transcript_buffer.append(MagicMock(created_at=9.5))
+    ar._process_stt_event = MagicMock(  # type: ignore[method-assign]
+        side_effect=lambda _: ar._on_start_of_speech(started_at=9.5)
+    )
+
+    event = OverlappingSpeechEvent(
+        is_interruption=True,
+        detected_at=10.0,
+        overlap_started_at=9.0,
+    )
+    await ar._on_overlap_speech_event(event)
+
+    assert ar._pending_interruption is event
+    assert ar._overlap_open is False
+    assert ar._transcript_gate_active is False
+    assert _sentinel_names(ch) == []
+
+    ar._on_end_of_agent_speech(ended_at=10.1)
+
+    assert ar._pending_interruption is None
 
 
 async def test_agent_speech_end_closes_overlap_before_reset() -> None:

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -46,10 +46,23 @@ def _end_of_turn_info(
     )
 
 
-def test_adaptive_verdict_delegates_interruption_policy() -> None:
+def test_adaptive_verdict_transition_is_owned_by_activity() -> None:
     activity = AgentActivity.__new__(AgentActivity)
+    activity._pending_interruption = None
+    activity._interruption_by_audio_activity_enabled = True
+    activity._audio_recognition = MagicMock()
+    activity._session = MagicMock()
     calls: list[str] = []
 
+    event = OverlappingSpeechEvent(is_interruption=True)
+
+    def _apply_verdict(ev: OverlappingSpeechEvent) -> None:
+        assert ev is event
+        assert activity._pending_interruption is event
+        assert not activity._interruption_by_audio_activity_enabled
+        calls.append("apply")
+
+    activity._audio_recognition._apply_overlap_speech_event.side_effect = _apply_verdict
     activity._restore_interruption_by_audio_activity = MagicMock(  # type: ignore[method-assign]
         side_effect=lambda: calls.append("restore")
     )
@@ -57,28 +70,17 @@ def test_adaptive_verdict_delegates_interruption_policy() -> None:
         side_effect=lambda: calls.append("interrupt")
     )
 
-    activity.on_interruption(OverlappingSpeechEvent(is_interruption=True))
+    activity.on_overlap_speech(event)
 
-    assert calls == ["restore", "interrupt"]
-    activity._interrupt_by_audio_activity.assert_called_once_with()  # type: ignore[attr-defined]
-
-
-def test_positive_verdict_suspends_vad_before_transcript_release() -> None:
-    activity = AgentActivity.__new__(AgentActivity)
-    activity._interruption_by_audio_activity_enabled = True
-    activity._session = MagicMock()
-
-    event = OverlappingSpeechEvent(is_interruption=True)
-    activity._on_overlap_speech_ended(event)
-
-    assert not activity._interruption_by_audio_activity_enabled
+    assert calls == ["apply", "restore", "interrupt"]
+    assert activity._pending_interruption is event
     activity._session.emit.assert_called_once_with("overlapping_speech", event)
+    activity._interrupt_by_audio_activity.assert_called_once_with()  # type: ignore[attr-defined]
 
 
 def test_audio_activity_releases_held_transcripts_before_min_words() -> None:
     activity = AgentActivity.__new__(AgentActivity)
     activity._interruption_by_audio_activity_enabled = True
-    activity._releasing_held_transcripts = False
     activity._rt_turn_detection_enabled = False
     activity._rt_session = None
     activity._agent = MagicMock()
@@ -92,14 +94,8 @@ def test_audio_activity_releases_held_transcripts_before_min_words() -> None:
     activity._audio_recognition._current_transcript = ""
     activity._audio_recognition._endpointing.overlapping = True
 
-    released = False
-
     def _release_transcripts() -> None:
-        nonlocal released
         activity._audio_recognition._current_transcript = "enough words"
-        if not released:
-            released = True
-            activity._interrupt_by_audio_activity()
 
     activity._audio_recognition._release_transcripts_for_audio_activity.side_effect = (
         _release_transcripts
@@ -119,7 +115,6 @@ def test_audio_activity_releases_held_transcripts_before_min_words() -> None:
 def test_rejected_audio_interruption_clears_pending_verdict() -> None:
     activity = AgentActivity.__new__(AgentActivity)
     activity._interruption_by_audio_activity_enabled = True
-    activity._releasing_held_transcripts = False
     activity._rt_turn_detection_enabled = False
     activity._rt_session = None
     activity._agent = MagicMock()
@@ -129,10 +124,11 @@ def test_rejected_audio_interruption_clears_pending_verdict() -> None:
     activity._session.options = SimpleNamespace(interruption={"min_words": 0})
     activity._audio_recognition = MagicMock()
     activity._current_speech = None
+    activity._pending_interruption = OverlappingSpeechEvent(is_interruption=True)
 
     activity._interrupt_by_audio_activity()
 
-    activity._audio_recognition._clear_pending_interruption.assert_called_once_with()
+    assert activity._pending_interruption is None
 
 
 def test_replayed_start_preserves_pending_positive_verdict() -> None:
@@ -140,15 +136,37 @@ def test_replayed_start_preserves_pending_positive_verdict() -> None:
     activity._session = MagicMock()
     activity._session.agent_state = "speaking"
     activity._audio_recognition = MagicMock()
-    activity._audio_recognition._interruption_pending = True
+    activity._pending_interruption = OverlappingSpeechEvent(is_interruption=True)
     activity._user_silence_event = asyncio.Event()
     activity._stt_eos_received = True
-    activity._interruption_detected = True
     activity._cancel_false_interruption_timer = MagicMock()  # type: ignore[method-assign]
 
-    activity.on_start_of_speech(None, speech_start_time=time.time())
+    speech_start_time = time.time()
+    activity.on_start_of_speech(None, speech_start_time=speech_start_time)
 
-    assert activity._interruption_detected is True
+    activity._audio_recognition._on_start_of_speech.assert_called_once_with(
+        started_at=speech_start_time,
+        speech_duration=0.0,
+        user_speaking_span=activity._session._user_speaking_span,
+        detect_overlap=False,
+    )
+
+
+def test_agent_speech_end_clears_pending_verdict_after_recognition_teardown() -> None:
+    activity = AgentActivity.__new__(AgentActivity)
+    event = OverlappingSpeechEvent(is_interruption=True)
+    activity._pending_interruption = event
+    activity._audio_recognition = MagicMock()
+
+    def _end_agent_speech(*, ended_at: float) -> None:
+        assert ended_at == 10.0
+        assert activity._pending_interruption is event
+
+    activity._audio_recognition._on_end_of_agent_speech.side_effect = _end_agent_speech
+
+    activity._on_end_of_agent_speech(ended_at=10.0)
+
+    assert activity._pending_interruption is None
 
 
 def _realtime_barge_in_session() -> AgentSession:
@@ -236,7 +254,6 @@ async def test_unjudged_overlap_over_a_paused_speech_commits(
     current_speech.done.return_value = False
     current_speech.interrupted = False
     activity._current_speech = current_speech
-    activity._interruption_detected = False
     activity._update_paused_speech(current_speech, timeout=2.0)
 
     assert activity.on_end_of_turn(_end_of_turn_info(backchannel_over_agent=False)) is True
@@ -273,7 +290,6 @@ async def test_backchannel_dropped_after_agent_finishes_speaking(
     activity._scheduling_paused = False  # simulate a running session
 
     activity._current_speech = None  # agent has finished speaking
-    activity._interruption_detected = False
 
     # backchannel verdict for this turn survives the agent stopping
     assert activity.on_end_of_turn(_end_of_turn_info(backchannel_over_agent=True)) is False
@@ -344,14 +360,14 @@ def _overlap_event(*, is_interruption: bool, agent_ended: bool) -> OverlappingSp
     return OverlappingSpeechEvent(is_interruption=is_interruption, agent_ended=agent_ended)
 
 
-async def test_user_ended_overlap_latches_backchannel() -> None:
+def test_user_ended_overlap_latches_backchannel() -> None:
     # the user's overlap ended on its own with no interruption flagged — a real backchannel
     ar = _recognition_for_overlap()
-    await ar._on_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=False))
+    ar._apply_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=False))
     assert ar._turn_backchannel_over_agent is True
 
 
-async def test_false_verdict_trims_finished_backchannel() -> None:
+def test_false_verdict_trims_finished_backchannel() -> None:
     ar = _recognition_for_overlap()
     old_event = MagicMock(created_at=8.0)
     recent_event = MagicMock(created_at=9.5)
@@ -362,7 +378,7 @@ async def test_false_verdict_trims_finished_backchannel() -> None:
     ar._backchannel_boundary = (0.0, 1.0)
     ar._transcript_buffer = deque([old_event, recent_event])
 
-    await ar._on_overlap_speech_event(
+    ar._apply_overlap_speech_event(
         OverlappingSpeechEvent(
             is_interruption=False,
             agent_ended=False,
@@ -373,7 +389,7 @@ async def test_false_verdict_trims_finished_backchannel() -> None:
     assert list(ar._transcript_buffer) == [recent_event]
 
 
-async def test_boundary_fallback_preserves_held_transcripts() -> None:
+def test_boundary_fallback_preserves_held_transcripts() -> None:
     ar = _recognition_for_overlap()
     early_event = MagicMock(created_at=9.0)
     recent_event = MagicMock(created_at=9.75)
@@ -385,7 +401,7 @@ async def test_boundary_fallback_preserves_held_transcripts() -> None:
     ar._backchannel_boundary_timer = MagicMock()
     ar._transcript_buffer = deque([early_event, recent_event])
 
-    await ar._on_overlap_speech_event(
+    ar._apply_overlap_speech_event(
         OverlappingSpeechEvent(
             is_interruption=False,
             agent_ended=False,
@@ -396,46 +412,45 @@ async def test_boundary_fallback_preserves_held_transcripts() -> None:
     assert list(ar._transcript_buffer) == [early_event, recent_event]
 
 
-async def test_confirmed_backchannel_between_segments_clears_audio() -> None:
+def test_confirmed_backchannel_between_segments_clears_audio() -> None:
     # confirmed between segments (user silent) — cleared so it can't prefix the next turn
     ar = _recognition_for_overlap(speaking=False)
-    await ar._on_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=False))
+    ar._apply_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=False))
     ar._hooks.on_backchannel_confirmed.assert_called_once()
 
 
-async def test_confirmed_backchannel_while_speaking_defers_clear() -> None:
+def test_confirmed_backchannel_while_speaking_defers_clear() -> None:
     # user already mid next-segment — latch the verdict but defer the clear (else we'd clip it)
     ar = _recognition_for_overlap(speaking=True)
-    await ar._on_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=False))
+    ar._apply_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=False))
     assert ar._turn_backchannel_over_agent is True
     ar._hooks.on_backchannel_confirmed.assert_not_called()
 
 
-async def test_agent_ended_overlap_is_not_a_backchannel() -> None:
+def test_agent_ended_overlap_is_not_a_backchannel() -> None:
     # the overlap ended because the agent finished, not the user — the user may still be
     # mid-turn, so this inconclusive verdict must not mark the turn a backchannel
     ar = _recognition_for_overlap()
-    await ar._on_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=True))
+    ar._apply_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=True))
     assert ar._turn_backchannel_over_agent is False
     ar._hooks.on_backchannel_confirmed.assert_not_called()
 
 
-async def test_agent_ended_overlap_preserves_prior_backchannel() -> None:
+def test_agent_ended_overlap_preserves_prior_backchannel() -> None:
     # a real backchannel was already latched this turn; the later agent-ended overlap is a
     # no-op and must not clear it
     ar = _recognition_for_overlap()
     ar._turn_backchannel_over_agent = True
-    await ar._on_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=True))
+    ar._apply_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=True))
     assert ar._turn_backchannel_over_agent is True
 
 
-async def test_interruption_clears_backchannel() -> None:
+def test_interruption_clears_backchannel() -> None:
     # a confirmed interruption supersedes any prior backchannel verdict for the turn
     ar = _recognition_for_overlap()
     ar._turn_backchannel_over_agent = True
-    await ar._on_overlap_speech_event(_overlap_event(is_interruption=True, agent_ended=False))
+    ar._apply_overlap_speech_event(_overlap_event(is_interruption=True, agent_ended=False))
     assert ar._turn_backchannel_over_agent is False
-    ar._hooks.on_interruption.assert_called_once()
     ar._hooks.on_backchannel_confirmed.assert_not_called()
 
 
@@ -464,7 +479,6 @@ def _recognition_with_interruption_ch() -> tuple[AudioRecognition, _RecordingCha
     ar._backchannel_boundary_callback = None
     ar._overlap_in_current_turn = False
     ar._overlap_open = False
-    ar._pending_interruption = None
     ar._turn_backchannel_over_agent = False
     ar._transcript_buffer = deque()
     ar._tasks = set()
@@ -479,7 +493,7 @@ def _sentinel_names(ch: _RecordingChan) -> list[str]:
     return [type(item).__name__ for item in ch.sent]
 
 
-async def test_positive_verdict_blocks_replayed_start_from_reopening_overlap() -> None:
+def test_positive_verdict_does_not_reopen_overlap_during_transcript_replay() -> None:
     ar, ch = _recognition_with_interruption_ch()
     ar._agent_speaking = True
     ar._agent_speech_started_at = 9.0
@@ -488,7 +502,7 @@ async def test_positive_verdict_blocks_replayed_start_from_reopening_overlap() -
     ar._transcript_gate_active = True
     ar._transcript_buffer.append(MagicMock(created_at=9.5))
     ar._process_stt_event = MagicMock(  # type: ignore[method-assign]
-        side_effect=lambda _: ar._on_start_of_speech(started_at=9.5)
+        side_effect=lambda _: ar._on_start_of_speech(started_at=9.5, detect_overlap=False)
     )
 
     event = OverlappingSpeechEvent(
@@ -496,16 +510,11 @@ async def test_positive_verdict_blocks_replayed_start_from_reopening_overlap() -
         detected_at=10.0,
         overlap_started_at=9.0,
     )
-    await ar._on_overlap_speech_event(event)
+    ar._apply_overlap_speech_event(event)
 
-    assert ar._pending_interruption is event
     assert ar._overlap_open is False
     assert ar._transcript_gate_active is False
     assert _sentinel_names(ch) == []
-
-    ar._on_end_of_agent_speech(ended_at=10.1)
-
-    assert ar._pending_interruption is None
 
 
 async def test_agent_speech_end_closes_overlap_before_reset() -> None:
@@ -564,7 +573,7 @@ async def test_a_resolved_overlap_is_not_closed_again() -> None:
     ar, ch = _recognition_with_interruption_ch()
     ar._on_start_of_agent_speech(started_at=time.time())
     ar._on_start_of_speech(started_at=time.time())
-    await ar._on_overlap_speech_event(_overlap_event(is_interruption=True, agent_ended=False))
+    ar._apply_overlap_speech_event(_overlap_event(is_interruption=True, agent_ended=False))
     ch.sent.clear()
 
     ar._on_end_of_speech(ended_at=time.time())

--- a/tests/test_realtime_adaptive_interruption.py
+++ b/tests/test_realtime_adaptive_interruption.py
@@ -46,10 +46,11 @@ def _end_of_turn_info(
     )
 
 
-def test_adaptive_verdict_transition_is_owned_by_activity() -> None:
+def test_adaptive_verdict_enables_audio_activity_after_releasing_gate() -> None:
     activity = AgentActivity.__new__(AgentActivity)
-    activity._pending_interruption = None
-    activity._interruption_by_audio_activity_enabled = True
+    activity._interruption_detected = False
+    activity._interruption_by_audio_activity_enabled = False
+    activity._default_interruption_by_audio_activity_enabled = True
     activity._audio_recognition = MagicMock()
     activity._session = MagicMock()
     calls: list[str] = []
@@ -58,29 +59,33 @@ def test_adaptive_verdict_transition_is_owned_by_activity() -> None:
 
     def _apply_verdict(ev: OverlappingSpeechEvent) -> None:
         assert ev is event
-        assert activity._pending_interruption is event
+        assert activity._interruption_detected
         assert not activity._interruption_by_audio_activity_enabled
         calls.append("apply")
 
-    activity._audio_recognition._apply_overlap_speech_event.side_effect = _apply_verdict
-    activity._restore_interruption_by_audio_activity = MagicMock(  # type: ignore[method-assign]
-        side_effect=lambda: calls.append("restore")
+    def _interrupt() -> None:
+        assert activity._interruption_by_audio_activity_enabled
+        calls.append("interrupt")
+
+    activity._audio_recognition._on_overlap_speech_event.side_effect = _apply_verdict
+    activity._audio_recognition._cancel_backchannel_boundary.side_effect = lambda: calls.append(
+        "enable"
     )
     activity._interrupt_by_audio_activity = MagicMock(  # type: ignore[method-assign]
-        side_effect=lambda: calls.append("interrupt")
+        side_effect=_interrupt
     )
 
     activity.on_overlap_speech(event)
 
-    assert calls == ["apply", "restore", "interrupt"]
-    assert activity._pending_interruption is event
+    assert calls == ["apply", "enable", "interrupt"]
+    assert activity._interruption_detected
+    assert activity._interruption_by_audio_activity_enabled
     activity._session.emit.assert_called_once_with("overlapping_speech", event)
     activity._interrupt_by_audio_activity.assert_called_once_with()  # type: ignore[attr-defined]
 
 
-def test_audio_activity_release_is_non_reentrant_and_precedes_min_words() -> None:
+def test_audio_activity_waits_for_min_words() -> None:
     activity = AgentActivity.__new__(AgentActivity)
-    activity._audio_activity_interruption_in_progress = False
     activity._interruption_by_audio_activity_enabled = True
     activity._rt_turn_detection_enabled = False
     activity._rt_session = None
@@ -92,16 +97,8 @@ def test_audio_activity_release_is_non_reentrant_and_precedes_min_words() -> Non
     activity._session.options = SimpleNamespace(interruption={"min_words": 2})
     activity._session.agent_state = "speaking"
     activity._audio_recognition = MagicMock()
-    activity._audio_recognition._current_transcript = ""
+    activity._audio_recognition._current_transcript = "short"
     activity._audio_recognition._endpointing.overlapping = True
-
-    def _release_transcripts() -> None:
-        activity._audio_recognition._current_transcript = "enough words"
-        activity._interrupt_by_audio_activity()
-
-    activity._audio_recognition._release_transcripts_for_audio_activity.side_effect = (
-        _release_transcripts
-    )
     activity._current_speech = MagicMock()
     activity._current_speech.interrupted = False
     activity._current_speech.allow_interruptions = True
@@ -110,14 +107,16 @@ def test_audio_activity_release_is_non_reentrant_and_precedes_min_words() -> Non
 
     activity._interrupt_by_audio_activity()
 
-    activity._audio_recognition._release_transcripts_for_audio_activity.assert_called_once_with()
+    activity._current_speech.interrupt.assert_not_called()
+
+    activity._audio_recognition._current_transcript = "now enough words"
+    activity._interrupt_by_audio_activity()
+
     activity._current_speech.interrupt.assert_called_once_with()
-    assert not activity._audio_activity_interruption_in_progress
 
 
-def test_rejected_audio_interruption_clears_pending_verdict() -> None:
+def test_rejected_audio_interruption_clears_confirmed_verdict() -> None:
     activity = AgentActivity.__new__(AgentActivity)
-    activity._audio_activity_interruption_in_progress = False
     activity._interruption_by_audio_activity_enabled = True
     activity._rt_turn_detection_enabled = False
     activity._rt_session = None
@@ -128,19 +127,45 @@ def test_rejected_audio_interruption_clears_pending_verdict() -> None:
     activity._session.options = SimpleNamespace(interruption={"min_words": 0})
     activity._audio_recognition = MagicMock()
     activity._current_speech = None
-    activity._pending_interruption = OverlappingSpeechEvent(is_interruption=True)
+    activity._interruption_detected = True
 
     activity._interrupt_by_audio_activity()
 
-    assert activity._pending_interruption is None
+    assert not activity._interruption_detected
 
 
-def test_replayed_start_preserves_pending_positive_verdict() -> None:
+def test_boundary_expiry_disables_audio_activity_interruption() -> None:
     activity = AgentActivity.__new__(AgentActivity)
     activity._session = MagicMock()
     activity._session.agent_state = "speaking"
     activity._audio_recognition = MagicMock()
-    activity._pending_interruption = OverlappingSpeechEvent(is_interruption=True)
+    activity._audio_recognition._backchannel_boundary_active = True
+    activity._interruption_by_audio_activity_enabled = True
+
+    activity._disable_vad_interruption_soon()
+    activity._audio_recognition._backchannel_boundary_callback()
+
+    assert not activity._interruption_by_audio_activity_enabled
+
+
+def test_active_user_speech_keeps_audio_activity_for_zero_boundary() -> None:
+    activity = AgentActivity.__new__(AgentActivity)
+    activity._audio_recognition = MagicMock()
+    activity._audio_recognition._backchannel_boundary_active = False
+    activity._audio_recognition._speaking = True
+    activity._interruption_by_audio_activity_enabled = True
+
+    activity._disable_vad_interruption_soon()
+
+    assert activity._interruption_by_audio_activity_enabled
+
+
+def test_replayed_start_preserves_confirmed_interruption() -> None:
+    activity = AgentActivity.__new__(AgentActivity)
+    activity._session = MagicMock()
+    activity._session.agent_state = "speaking"
+    activity._audio_recognition = MagicMock()
+    activity._interruption_detected = True
     activity._user_silence_event = asyncio.Event()
     activity._stt_eos_received = True
     activity._cancel_false_interruption_timer = MagicMock()  # type: ignore[method-assign]
@@ -152,25 +177,24 @@ def test_replayed_start_preserves_pending_positive_verdict() -> None:
         started_at=speech_start_time,
         speech_duration=0.0,
         user_speaking_span=activity._session._user_speaking_span,
-        detect_overlap=False,
+        skip_adaptive_interruption=True,
     )
 
 
-def test_agent_speech_end_clears_pending_verdict_after_recognition_teardown() -> None:
+def test_agent_speech_end_clears_confirmed_interruption_after_recognition_teardown() -> None:
     activity = AgentActivity.__new__(AgentActivity)
-    event = OverlappingSpeechEvent(is_interruption=True)
-    activity._pending_interruption = event
+    activity._interruption_detected = True
     activity._audio_recognition = MagicMock()
 
     def _end_agent_speech(*, ended_at: float) -> None:
         assert ended_at == 10.0
-        assert activity._pending_interruption is event
+        assert activity._interruption_detected
 
     activity._audio_recognition._on_end_of_agent_speech.side_effect = _end_agent_speech
 
     activity._on_end_of_agent_speech(ended_at=10.0)
 
-    assert activity._pending_interruption is None
+    assert not activity._interruption_detected
 
 
 def _realtime_barge_in_session() -> AgentSession:
@@ -351,6 +375,7 @@ def _recognition_for_overlap(*, speaking: bool = False) -> AudioRecognition:
     if not speaking:
         ar._user_silence_ev.set()  # silent (between segments) unless told otherwise
     ar._hooks = MagicMock()
+    ar._hooks.interruption_by_audio_activity_enabled = False
     return ar
 
 
@@ -367,14 +392,14 @@ def _overlap_event(*, is_interruption: bool, agent_ended: bool) -> OverlappingSp
 def test_user_ended_overlap_latches_backchannel() -> None:
     # the user's overlap ended on its own with no interruption flagged — a real backchannel
     ar = _recognition_for_overlap()
-    ar._apply_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=False))
+    ar._on_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=False))
     assert ar._turn_backchannel_over_agent is True
 
 
 def test_false_verdict_trims_finished_backchannel() -> None:
     ar = _recognition_for_overlap()
-    old_event = MagicMock(created_at=8.0)
-    recent_event = MagicMock(created_at=9.5)
+    old_event = MagicMock(created_at=8.0, speech_end_time=None)
+    recent_event = MagicMock(created_at=9.5, speech_end_time=None)
     ar._agent_speaking = True
     ar._transcript_gate_active = True
     ar._agent_speech_started_at = None
@@ -382,7 +407,7 @@ def test_false_verdict_trims_finished_backchannel() -> None:
     ar._backchannel_boundary = (0.0, 1.0)
     ar._transcript_buffer = deque([old_event, recent_event])
 
-    ar._apply_overlap_speech_event(
+    ar._on_overlap_speech_event(
         OverlappingSpeechEvent(
             is_interruption=False,
             agent_ended=False,
@@ -395,8 +420,8 @@ def test_false_verdict_trims_finished_backchannel() -> None:
 
 def test_boundary_fallback_preserves_held_transcripts() -> None:
     ar = _recognition_for_overlap()
-    early_event = MagicMock(created_at=9.0)
-    recent_event = MagicMock(created_at=9.75)
+    early_event = MagicMock(created_at=9.0, speech_end_time=None)
+    recent_event = MagicMock(created_at=9.75, speech_end_time=None)
     ar._agent_speaking = True
     ar._transcript_gate_active = True
     ar._agent_speech_started_at = 9.0
@@ -405,7 +430,7 @@ def test_boundary_fallback_preserves_held_transcripts() -> None:
     ar._backchannel_boundary_timer = MagicMock()
     ar._transcript_buffer = deque([early_event, recent_event])
 
-    ar._apply_overlap_speech_event(
+    ar._on_overlap_speech_event(
         OverlappingSpeechEvent(
             is_interruption=False,
             agent_ended=False,
@@ -419,14 +444,14 @@ def test_boundary_fallback_preserves_held_transcripts() -> None:
 def test_confirmed_backchannel_between_segments_clears_audio() -> None:
     # confirmed between segments (user silent) — cleared so it can't prefix the next turn
     ar = _recognition_for_overlap(speaking=False)
-    ar._apply_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=False))
+    ar._on_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=False))
     ar._hooks.on_backchannel_confirmed.assert_called_once()
 
 
 def test_confirmed_backchannel_while_speaking_defers_clear() -> None:
     # user already mid next-segment — latch the verdict but defer the clear (else we'd clip it)
     ar = _recognition_for_overlap(speaking=True)
-    ar._apply_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=False))
+    ar._on_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=False))
     assert ar._turn_backchannel_over_agent is True
     ar._hooks.on_backchannel_confirmed.assert_not_called()
 
@@ -435,7 +460,7 @@ def test_agent_ended_overlap_is_not_a_backchannel() -> None:
     # the overlap ended because the agent finished, not the user — the user may still be
     # mid-turn, so this inconclusive verdict must not mark the turn a backchannel
     ar = _recognition_for_overlap()
-    ar._apply_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=True))
+    ar._on_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=True))
     assert ar._turn_backchannel_over_agent is False
     ar._hooks.on_backchannel_confirmed.assert_not_called()
 
@@ -445,7 +470,7 @@ def test_agent_ended_overlap_preserves_prior_backchannel() -> None:
     # no-op and must not clear it
     ar = _recognition_for_overlap()
     ar._turn_backchannel_over_agent = True
-    ar._apply_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=True))
+    ar._on_overlap_speech_event(_overlap_event(is_interruption=False, agent_ended=True))
     assert ar._turn_backchannel_over_agent is True
 
 
@@ -453,7 +478,7 @@ def test_interruption_clears_backchannel() -> None:
     # a confirmed interruption supersedes any prior backchannel verdict for the turn
     ar = _recognition_for_overlap()
     ar._turn_backchannel_over_agent = True
-    ar._apply_overlap_speech_event(_overlap_event(is_interruption=True, agent_ended=False))
+    ar._on_overlap_speech_event(_overlap_event(is_interruption=True, agent_ended=False))
     assert ar._turn_backchannel_over_agent is False
     ar._hooks.on_backchannel_confirmed.assert_not_called()
 
@@ -489,6 +514,7 @@ def _recognition_with_interruption_ch() -> tuple[AudioRecognition, _RecordingCha
     ar._user_silence_ev = asyncio.Event()
     ar._user_silence_ev.set()
     ar._hooks = MagicMock()
+    ar._hooks.interruption_by_audio_activity_enabled = False
     ar._session = MagicMock()
     return ar, ch
 
@@ -504,9 +530,11 @@ def test_positive_verdict_does_not_reopen_overlap_during_transcript_replay() -> 
     ar._overlap_in_current_turn = True
     ar._overlap_open = True
     ar._transcript_gate_active = True
-    ar._transcript_buffer.append(MagicMock(created_at=9.5))
+    ar._transcript_buffer.append(MagicMock(created_at=9.5, speech_end_time=None))
     ar._process_stt_event = MagicMock(  # type: ignore[method-assign]
-        side_effect=lambda _: ar._on_start_of_speech(started_at=9.5, detect_overlap=False)
+        side_effect=lambda _: ar._on_start_of_speech(
+            started_at=9.5, skip_adaptive_interruption=True
+        )
     )
 
     event = OverlappingSpeechEvent(
@@ -514,7 +542,7 @@ def test_positive_verdict_does_not_reopen_overlap_during_transcript_replay() -> 
         detected_at=10.0,
         overlap_started_at=9.0,
     )
-    ar._apply_overlap_speech_event(event)
+    ar._on_overlap_speech_event(event)
 
     assert ar._overlap_open is False
     assert ar._transcript_gate_active is False
@@ -549,7 +577,7 @@ async def test_user_speech_ending_after_agent_end_does_not_close_overlap_again()
     assert _sentinel_names(ch) == []
 
 
-async def test_resume_restarts_the_detector() -> None:
+async def test_resume_with_active_user_speech_stays_with_audio_activity() -> None:
     ar, ch = _recognition_with_interruption_ch()
     ar._on_start_of_agent_speech(started_at=time.time())
     user_started_at = time.time()
@@ -558,15 +586,13 @@ async def test_resume_restarts_the_detector() -> None:
     ar._on_end_of_agent_speech(ended_at=time.time())
     ch.sent.clear()
 
+    ar._hooks.interruption_by_audio_activity_enabled = True
     resumed_at = time.time()
     ar._on_start_of_agent_speech(started_at=resumed_at)
 
-    assert _sentinel_names(ch) == [
-        "_AgentSpeechStartedSentinel",
-        "_OverlapSpeechStartedSentinel",
-    ]
-    assert ch.sent[1]._speech_duration == 0.0  # type: ignore[attr-defined]
-    assert ch.sent[1]._started_at == resumed_at  # type: ignore[attr-defined]
+    assert _sentinel_names(ch) == ["_AgentSpeechStartedSentinel"]
+    assert ar._hooks.interruption_by_audio_activity_enabled
+    assert not ar._transcript_gate_active
     ar._endpointing.on_start_of_speech.assert_called_once_with(
         started_at=user_started_at, overlapping=True
     )
@@ -577,7 +603,7 @@ async def test_a_resolved_overlap_is_not_closed_again() -> None:
     ar, ch = _recognition_with_interruption_ch()
     ar._on_start_of_agent_speech(started_at=time.time())
     ar._on_start_of_speech(started_at=time.time())
-    ar._apply_overlap_speech_event(_overlap_event(is_interruption=True, agent_ended=False))
+    ar._on_overlap_speech_event(_overlap_event(is_interruption=True, agent_ended=False))
     ch.sent.clear()
 
     ar._on_end_of_speech(ended_at=time.time())

--- a/tests/test_stt_base.py
+++ b/tests/test_stt_base.py
@@ -4,20 +4,28 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Literal
 
 import pytest
 
-from livekit.agents import APIConnectionError, APIStatusError
+from livekit import rtc
+from livekit.agents import Agent, APIConnectionError, APIStatusError, ModelSettings
 from livekit.agents.stt import (
     STT,
     RecognizeStream,
     SpeechData,
     SpeechEvent,
     SpeechEventType,
+    StreamAdapter,
     STTCapabilities,
 )
 from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS
-from livekit.agents.utils.audio import AudioBuffer
+from livekit.agents.utils.audio import AudioBuffer, silence_frame
+
+from .fake_stt import FakeSTT, FakeUserSpeech
+from .fake_vad import FakeVAD
 
 pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
@@ -30,9 +38,11 @@ class _DummyStream(RecognizeStream):
         *,
         stt: STT,
         fail_first_run: bool = False,
+        event: SpeechEvent | None = None,
     ) -> None:
         super().__init__(stt=stt, conn_options=DEFAULT_API_CONNECT_OPTIONS)
         self._fail_first_run = fail_first_run
+        self._event = event
         self._run_count = 0
 
     async def _run(self) -> None:
@@ -41,7 +51,8 @@ class _DummyStream(RecognizeStream):
             raise APIConnectionError("fake failure to trigger retry")
         # emit a final and exit so _main_task can complete normally
         self._event_ch.send_nowait(
-            SpeechEvent(
+            self._event
+            or SpeechEvent(
                 type=SpeechEventType.FINAL_TRANSCRIPT,
                 alternatives=[SpeechData(language="", text="hello")],
             )
@@ -49,14 +60,26 @@ class _DummyStream(RecognizeStream):
 
 
 class _DummySTT(STT):
-    def __init__(self) -> None:
-        super().__init__(capabilities=STTCapabilities(streaming=True, interim_results=False))
+    def __init__(
+        self,
+        *,
+        aligned_transcript: Literal["chunk", False] = False,
+        event: SpeechEvent | None = None,
+    ) -> None:
+        super().__init__(
+            capabilities=STTCapabilities(
+                streaming=True,
+                interim_results=False,
+                aligned_transcript=aligned_transcript,
+            )
+        )
+        self._event = event
 
     async def _recognize_impl(self, buffer: AudioBuffer, *, language, conn_options) -> SpeechEvent:
         raise NotImplementedError
 
     def stream(self, *, language=None, conn_options=DEFAULT_API_CONNECT_OPTIONS) -> _DummyStream:
-        return _DummyStream(stt=self)
+        return _DummyStream(stt=self, event=self._event)
 
 
 class _NonRetryableStream(RecognizeStream):
@@ -138,3 +161,80 @@ async def test_non_retryable_error_is_not_retried() -> None:
     assert stream.run_count == 1
 
     await stream.aclose()
+
+
+async def test_stream_adapter_keeps_vad_speech_end_on_delayed_final(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frame = silence_frame(duration=0.1, sample_rate=16_000)
+    monkeypatch.setattr("livekit.agents.stt.stream_adapter.utils.merge_frames", lambda _: frame)
+    speech = FakeUserSpeech(
+        start_time=0.0,
+        end_time=0.1,
+        transcript="hello",
+        stt_delay=0.0,
+    )
+    batch_stt = FakeSTT(fake_transcript="hello", fake_timeout=0.5)
+    batch_stt._capabilities.streaming = False
+    adapter = StreamAdapter(
+        stt=batch_stt,
+        vad=FakeVAD(
+            fake_user_speeches=[speech],
+            min_speech_duration=0.01,
+            min_silence_duration=0.3,
+        ),
+    )
+
+    try:
+        async with adapter.stream() as stream:
+            stream.push_frame(frame)
+            stream.end_input()
+            events = [event async for event in stream]
+    finally:
+        await adapter.aclose()
+
+    end_event = next(event for event in events if event.type == SpeechEventType.END_OF_SPEECH)
+    final_event = next(event for event in events if event.type == SpeechEventType.FINAL_TRANSCRIPT)
+
+    assert end_event.speech_end_time is not None
+    assert final_event.speech_end_time == end_event.speech_end_time
+    assert final_event.created_at - end_event.created_at == pytest.approx(0.5, abs=0.01)
+
+
+@pytest.mark.parametrize(
+    ("aligned_transcript", "has_speech_end_time"),
+    [("chunk", True), (False, False)],
+)
+async def test_default_stt_node_normalizes_only_aligned_speech_end_time(
+    aligned_transcript: Literal["chunk", False],
+    has_speech_end_time: bool,
+) -> None:
+    input_started_at = time.time() - 10.0
+    event = SpeechEvent(
+        type=SpeechEventType.FINAL_TRANSCRIPT,
+        alternatives=[SpeechData(language="", text="hello", end_time=9.0)],
+    )
+    stt_impl = _DummySTT(aligned_transcript=aligned_transcript, event=event)
+    agent = Agent(instructions="test")
+    agent._activity = SimpleNamespace(  # type: ignore[assignment]
+        stt=stt_impl,
+        vad=None,
+        session=SimpleNamespace(
+            conn_options=SimpleNamespace(stt_conn_options=DEFAULT_API_CONNECT_OPTIONS),
+            _recorder_io=None,
+            _started_at=None,
+        ),
+        _audio_recognition=SimpleNamespace(_input_started_at=input_started_at),
+    )
+
+    async def _empty_audio() -> AsyncIterator[rtc.AudioFrame]:
+        if False:
+            yield silence_frame(duration=0.1, sample_rate=16_000)
+
+    events = [item async for item in Agent.default.stt_node(agent, _empty_audio(), ModelSettings())]
+
+    assert len(events) == 1
+    if has_speech_end_time:
+        assert events[0].speech_end_time == input_started_at + 9.0
+    else:
+        assert events[0].speech_end_time is None

--- a/tests/test_stt_base.py
+++ b/tests/test_stt_base.py
@@ -4,14 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import AsyncIterator
-from types import SimpleNamespace
-from typing import Literal
 
 import pytest
 
-from livekit import rtc
-from livekit.agents import Agent, APIConnectionError, APIStatusError, ModelSettings
+from livekit.agents import APIConnectionError, APIStatusError
 from livekit.agents.stt import (
     STT,
     RecognizeStream,
@@ -38,11 +34,9 @@ class _DummyStream(RecognizeStream):
         *,
         stt: STT,
         fail_first_run: bool = False,
-        event: SpeechEvent | None = None,
     ) -> None:
         super().__init__(stt=stt, conn_options=DEFAULT_API_CONNECT_OPTIONS)
         self._fail_first_run = fail_first_run
-        self._event = event
         self._run_count = 0
 
     async def _run(self) -> None:
@@ -51,8 +45,7 @@ class _DummyStream(RecognizeStream):
             raise APIConnectionError("fake failure to trigger retry")
         # emit a final and exit so _main_task can complete normally
         self._event_ch.send_nowait(
-            self._event
-            or SpeechEvent(
+            SpeechEvent(
                 type=SpeechEventType.FINAL_TRANSCRIPT,
                 alternatives=[SpeechData(language="", text="hello")],
             )
@@ -60,26 +53,14 @@ class _DummyStream(RecognizeStream):
 
 
 class _DummySTT(STT):
-    def __init__(
-        self,
-        *,
-        aligned_transcript: Literal["chunk", False] = False,
-        event: SpeechEvent | None = None,
-    ) -> None:
-        super().__init__(
-            capabilities=STTCapabilities(
-                streaming=True,
-                interim_results=False,
-                aligned_transcript=aligned_transcript,
-            )
-        )
-        self._event = event
+    def __init__(self) -> None:
+        super().__init__(capabilities=STTCapabilities(streaming=True, interim_results=False))
 
     async def _recognize_impl(self, buffer: AudioBuffer, *, language, conn_options) -> SpeechEvent:
         raise NotImplementedError
 
     def stream(self, *, language=None, conn_options=DEFAULT_API_CONNECT_OPTIONS) -> _DummyStream:
-        return _DummyStream(stt=self, event=self._event)
+        return _DummyStream(stt=self)
 
 
 class _NonRetryableStream(RecognizeStream):
@@ -199,42 +180,3 @@ async def test_stream_adapter_keeps_vad_speech_end_on_delayed_final(
     assert end_event.speech_end_time is not None
     assert final_event.speech_end_time == end_event.speech_end_time
     assert final_event.created_at - end_event.created_at == pytest.approx(0.5, abs=0.01)
-
-
-@pytest.mark.parametrize(
-    ("aligned_transcript", "has_speech_end_time"),
-    [("chunk", True), (False, False)],
-)
-async def test_default_stt_node_normalizes_only_aligned_speech_end_time(
-    aligned_transcript: Literal["chunk", False],
-    has_speech_end_time: bool,
-) -> None:
-    input_started_at = time.time() - 10.0
-    event = SpeechEvent(
-        type=SpeechEventType.FINAL_TRANSCRIPT,
-        alternatives=[SpeechData(language="", text="hello", end_time=9.0)],
-    )
-    stt_impl = _DummySTT(aligned_transcript=aligned_transcript, event=event)
-    agent = Agent(instructions="test")
-    agent._activity = SimpleNamespace(  # type: ignore[assignment]
-        stt=stt_impl,
-        vad=None,
-        session=SimpleNamespace(
-            conn_options=SimpleNamespace(stt_conn_options=DEFAULT_API_CONNECT_OPTIONS),
-            _recorder_io=None,
-            _started_at=None,
-        ),
-        _audio_recognition=SimpleNamespace(_input_started_at=input_started_at),
-    )
-
-    async def _empty_audio() -> AsyncIterator[rtc.AudioFrame]:
-        if False:
-            yield silence_frame(duration=0.1, sample_rate=16_000)
-
-    events = [item async for item in Agent.default.stt_node(agent, _empty_audio(), ModelSettings())]
-
-    assert len(events) == 1
-    if has_speech_end_time:
-        assert events[0].speech_end_time == input_started_at + 9.0
-    else:
-        assert events[0].speech_end_time is None


### PR DESCRIPTION
Adaptive interruption currently requires aligned word timestamps, which excludes STT providers such as Ink-2. Gate transcripts by local event creation time and active VAD speech instead. Held transcripts flush in provider order before normal interruption thresholds apply.

Fixes AGT-3235