### PR TITLE
fix(cli): support log level in thin console

### DIFF
--- a/livekit-agents/livekit/agents/__main__.py
+++ b/livekit-agents/livekit/agents/__main__.py
@@ -60,7 +60,12 @@ def _dispatch(server: AgentServer, args: argparse.Namespace) -> None:
     from .cli.cli import _run_tcp_console, _run_worker
 
     if args.command == "console":
-        _run_tcp_console(server=server, connect_addr=args.connect_addr, record=args.record)
+        _run_tcp_console(
+            server=server,
+            connect_addr=args.connect_addr,
+            record=args.record,
+            log_level=args.log_level,
+        )
     elif args.command == "start":
         _run_worker(
             server=server,
@@ -125,6 +130,7 @@ def main(argv: list[str] | None = None) -> int:
     console_p.add_argument("entrypoint", nargs="?")
     console_p.add_argument("--connect-addr", required=True)
     console_p.add_argument("--record", action="store_true", default=False)
+    console_p.add_argument("--log-level", default="DEBUG")
 
     args = parser.parse_args(argv)
 

--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -193,7 +193,13 @@ class AgentsConsole:
                 sess.output.transcription = text_output
 
 
-def _run_tcp_console(*, server: AgentServer, connect_addr: str, record: bool = False) -> None:
+def _run_tcp_console(
+    *,
+    server: AgentServer,
+    connect_addr: str,
+    record: bool = False,
+    log_level: str = "DEBUG",
+) -> None:
     """Run console in TCP mode — connects to the Go CLI's TCP server."""
     from ..voice.remote_session import TcpSessionTransport
     from .tcp_console import TcpAudioInput, TcpAudioOutput
@@ -201,7 +207,7 @@ def _run_tcp_console(*, server: AgentServer, connect_addr: str, record: bool = F
     host, port_str = connect_addr.rsplit(":", 1)
     port = int(port_str)
 
-    setup_logging("DEBUG", devmode=True, console=True)
+    setup_logging(log_level, devmode=True, console=True)
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)

--- a/tests/test_cli_log_level.py
+++ b/tests/test_cli_log_level.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 from typer.testing import CliRunner
 
+import livekit.agents.__main__ as thin_cli
 from livekit.agents.cli._legacy import _build_cli
 from livekit.agents.worker import AgentServer, ServerEnvOption, ServerOptions
 
@@ -149,6 +150,37 @@ class TestDevCommandLogLevel:
         result = runner.invoke(app, ["dev", "--no-reload"])
         assert result.exit_code == 0
         assert mock_run_worker.call_args.kwargs["args"].log_level == "CRITICAL"
+
+
+class TestThinConsoleLogLevel:
+    @patch("livekit.agents.cli.cli._run_tcp_console")
+    @patch("livekit.agents.__main__._discover_server")
+    def test_cli_arg_is_forwarded(self, mock_discover_server, mock_run_console):
+        server = _make_server()
+        mock_discover_server.return_value = server
+
+        result = thin_cli.main(
+            ["console", "--connect-addr", "127.0.0.1:9876", "--log-level", "ERROR"]
+        )
+
+        assert result == 0
+        mock_run_console.assert_called_once_with(
+            server=server,
+            connect_addr="127.0.0.1:9876",
+            record=False,
+            log_level="ERROR",
+        )
+
+    @patch("livekit.agents.cli.cli._run_tcp_console")
+    @patch("livekit.agents.__main__._discover_server")
+    def test_default_log_level_is_debug(self, mock_discover_server, mock_run_console):
+        server = _make_server()
+        mock_discover_server.return_value = server
+
+        result = thin_cli.main(["console", "--connect-addr", "127.0.0.1:9876"])
+
+        assert result == 0
+        assert mock_run_console.call_args.kwargs["log_level"] == "DEBUG"
 
 
 class TestLogLevelValidation:


### PR DESCRIPTION
## Summary

- accept `--log-level` in the thin Python console entrypoint
- forward the selected level to TCP console logging
- preserve `DEBUG` as the default

This is the Python SDK companion for livekit/livekit-cli#934. The Go CLI needs to forward its console log-level selection to this thin entrypoint; without this support, the Python parser rejects the flag and TCP console logging remains hardcoded to `DEBUG`.

## Testing

- `make check`
- `make unit-tests PYTEST_ARGS="--no-concurrent --ignore=tests/test_room.py"` (1,887 passed, 3 skipped)
- `uv run pytest tests/test_cli_log_level.py --unit --no-concurrent -q`
