### PR TITLE
fix(voice): don't raise when interrupting a cancelled or finished speech

### DIFF
--- a/livekit-agents/livekit/agents/voice/speech_handle.py
+++ b/livekit-agents/livekit/agents/voice/speech_handle.py
@@ -161,11 +161,16 @@ class SpeechHandle:
         """Interrupt the current speech generation.
 
         Raises:
-            RuntimeError: If this speech handle does not allow interruptions.
+            RuntimeError: If this speech handle is still running and does not allow
+                interruptions.
 
         Returns:
             SpeechHandle: The same speech handle that was interrupted.
         """
+        if self.interrupted or self.done():
+            # already cancelled or finished: nothing to interrupt, and protection is moot
+            return self
+
         if not force and not self._allow_interruptions:
             raise RuntimeError("This generation handle does not allow interruptions")
 

--- a/tests/test_interrupt_protected_speech.py
+++ b/tests/test_interrupt_protected_speech.py
@@ -1,10 +1,10 @@
 """``AgentActivity.interrupt()`` and queued speeches that disallow interruptions.
 
-``SpeechHandle.interrupt()`` raises for such a handle, and the queue loop used
-to let that raise escape: the remaining queued speeches were left playing and
-the returned future never resolved. Interrupting *past* the protected speech
-would be wrong too — the ones behind it still play, so skipping one in the
-middle would leave a gap in the conversation.
+``SpeechHandle.interrupt()`` raises for such a handle while it is running, and
+the queue loop used to let that raise escape: the remaining queued speeches
+were left playing and the returned future never resolved. Interrupting *past*
+the protected speech would be wrong too — the ones behind it still play, so
+skipping one in the middle would leave a gap in the conversation.
 """
 
 import heapq
@@ -30,6 +30,23 @@ def _make_activity() -> AgentActivity:
 def _enqueue(activity: AgentActivity, speech: SpeechHandle, *, priority: int = 0) -> None:
     """Queue a speech the way _schedule_speech does (a heap, not a list)."""
     heapq.heappush(activity._speech_q, (-priority, time.perf_counter_ns(), speech))
+
+
+async def test_an_interrupted_protected_handle_is_left_alone() -> None:
+    handle = SpeechHandle.create(allow_interruptions=False)
+    handle.interrupt(force=True)
+
+    assert handle.interrupt() is handle  # must not raise
+    assert handle.interrupted
+    handle._mark_done()
+
+
+async def test_a_done_protected_handle_is_left_alone() -> None:
+    handle = SpeechHandle.create(allow_interruptions=False)
+    handle._mark_done()
+
+    assert handle.interrupt() is handle  # must not raise
+    assert not handle.interrupted
 
 
 class TestInterruptQueuedSpeeches:
@@ -78,6 +95,24 @@ class TestInterruptQueuedSpeeches:
             assert not head.interrupted
             assert not middle.interrupted
             assert not tail.interrupted
+        finally:
+            await _close_test_session(activity._session)
+
+    async def test_a_cancelled_protected_speech_does_not_shield_the_queue(self) -> None:
+        # it is never going to play, so it cannot leave a gap behind it either
+        activity = _make_activity()
+        activity._rt_session = Mock()
+        protected = SpeechHandle.create(allow_interruptions=False)
+        behind = SpeechHandle.create(allow_interruptions=True)
+        for speech in (protected, behind):
+            _enqueue(activity, speech)
+        # e.g. the caller cancelling the handle its own say() returned
+        protected.interrupt(force=True)
+
+        try:
+            activity.interrupt()
+
+            assert behind.interrupted
         finally:
             await _close_test_session(activity._session)
 


### PR DESCRIPTION
**Problem**

`SpeechHandle.interrupt()` tested `allow_interruptions` before it tested the state of the handle, so a handle with `allow_interruptions=False` raised `RuntimeError` even after it was interrupted or done.

The `allow_interruptions` setter already refuses to set protection on a handle that is interrupted, because protection has no meaning in that state. `interrupt()` did not agree with it.

Callers that walk a group of handles then need a special case for handles that can never play. In `AgentActivity.interrupt()` (added in #6644), a queued protected handle that the caller already cancelled stopped the queue walk. The interruptible speeches behind it kept playing, and the warning named a handle that never plays.

Reachable today: `session.say("hold please", allow_interruptions=False)` queues behind another speech, and the caller cancels the returned handle with `handle.interrupt(force=True)`. The handle stays in `_speech_q` until the scheduling task drops it. A `session.interrupt()` in that window stops at the dead handle.

**Change**

`interrupt()` returns the handle unchanged when it is interrupted or done, before the `allow_interruptions` test. `Task.cancel()` and `Future.cancel()` do the same on work that is finished.

`AgentActivity.interrupt()` needs no change. The walk stops seeing a `RuntimeError` that it must not see.

One behavior change: `session.interrupt(force=True)` followed by `session.interrupt()` no longer raises on a protected current speech.
