### PR TITLE
fix(worker): log the reconnect after a stable connection drops at INFO

### DIFF
--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -18,11 +18,13 @@ import asyncio
 import contextlib
 import datetime
 import inspect
+import logging
 import math
 import multiprocessing as mp
 import os
 import sys
 import threading
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import Enum
@@ -60,6 +62,12 @@ ASSIGNMENT_TIMEOUT = 7.5
 UPDATE_STATUS_INTERVAL = 2.5
 UPDATE_LOAD_INTERVAL = 0.5
 HEARTBEAT_INTERVAL = 30
+# how long the control-plane connection must stay up before losing it is treated as
+# routine churn rather than a worker that cannot hold a connection
+STABLE_CONNECTION_INTERVAL = 30
+# the control plane going away underneath a working worker: the server closing the
+# connection, or the socket itself failing. Anything else is a fault worth reporting.
+CONNECTION_LOST_ERRORS = (APIStatusError, aiohttp.ClientError, OSError)
 WORKER_PROTOCOL_VERSION = 1
 DRAIN_TIMEOUT = 3600  # 1hr
 
@@ -1082,6 +1090,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
         retry_count = 0
         ws: aiohttp.ClientWebSocketResponse | None = None
         while not self._closed:
+            serving_since: float | None = None
             try:
                 self._connecting = True
                 join_jwt = (
@@ -1148,6 +1157,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                 # report all active jobs to the server after registration
                 await self._report_active_jobs()
 
+                serving_since = time.perf_counter()
                 await self._run_ws(ws)
             except Exception as e:
                 if self._closed:
@@ -1162,7 +1172,18 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                 retry_delay = min(retry_count * 2, 10)
                 retry_count += 1
 
-                logger.warning(
+                # losing a connection that stayed up retries at 0s, because the successful
+                # connect already reset retry_count, and that first retry normally succeeds.
+                # Everything else keeps warning: a worker that never connected, one dropping
+                # faster than STABLE_CONNECTION_INTERVAL, a retry that had to back off, and
+                # any fault that isn't the connection going away.
+                was_stable = (
+                    serving_since is not None
+                    and isinstance(e, CONNECTION_LOST_ERRORS)
+                    and time.perf_counter() - serving_since >= STABLE_CONNECTION_INTERVAL
+                )
+                logger.log(
+                    logging.INFO if was_stable and retry_delay == 0 else logging.WARNING,
                     f"failed to connect to livekit, retrying in {retry_delay}s",
                     extra={"retry_count": retry_count, "max_retry": self._max_retry, "error": e},
                 )

--- a/tests/test_worker_connection.py
+++ b/tests/test_worker_connection.py
@@ -3,27 +3,34 @@
 When the worker's connection task exhausts ``max_retry`` it raises, and that
 failure must surface out of ``AgentServer.run()`` instead of leaving the worker
 hanging forever (https://github.com/livekit/agents/issues/6083).
+
+The retry logs carry a second expectation: losing a connection that had been up and
+stable is routine churn, while a connection that never came up, one that keeps
+dropping straight away, and any retry that has to back off are all worth a warning
+(https://github.com/livekit/agents/issues/6108).
 """
 
 from __future__ import annotations
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from livekit.agents.job import JobContext
-from livekit.agents.worker import AgentServer
+from livekit.agents.worker import STABLE_CONNECTION_INTERVAL, AgentServer
+from livekit.protocol import agent
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.no_concurrent]
 
 
-def _make_server() -> AgentServer:
+def _make_server(*, max_retry: int = 0) -> AgentServer:
     server = AgentServer(
         ws_url="ws://127.0.0.1:1",  # unreachable: connection refused
         api_key="devkey",
         api_secret="devsecret",
-        max_retry=0,
+        max_retry=max_retry,
         num_idle_processes=0,
     )
 
@@ -33,6 +40,57 @@ def _make_server() -> AgentServer:
 
     server._simulation = True  # skip binding the health HTTP server
     return server
+
+
+def _registered_ws() -> MagicMock:
+    """A websocket that answers the register handshake, so the worker comes up."""
+    response = agent.ServerMessage()
+    response.register.worker_id = "W_test"
+
+    ws = MagicMock()
+    ws.send_bytes = AsyncMock()
+    ws.receive_bytes = AsyncMock(return_value=response.SerializeToString())
+    ws.close = AsyncMock()
+    return ws
+
+
+def _unregistered_ws() -> MagicMock:
+    """A websocket that upgrades but never answers the register handshake."""
+    ws = MagicMock()
+    ws.send_bytes = AsyncMock()
+    ws.receive_bytes = AsyncMock(side_effect=ConnectionResetError())
+    ws.close = AsyncMock()
+    return ws
+
+
+def _serves_for(seconds: float, error: Exception | None = None) -> AsyncMock:
+    """A _run_ws that holds the connection open for `seconds`, then fails with `error`."""
+
+    async def _run(ws) -> None:
+        await asyncio.sleep(seconds)
+        raise error or ConnectionResetError()
+
+    return AsyncMock(side_effect=_run)
+
+
+async def _retry_logs(server: AgentServer, connects: list, caplog) -> list[logging.LogRecord]:
+    """Run the connection task to exhaustion and return its retry log records."""
+    # run() normally clears _closed and builds the process pool; we drive the connection
+    # task on its own, so stand both up here.
+    server._closed = False
+    server._proc_pool = MagicMock(processes=[])
+    server._http_session = MagicMock()
+    server._http_session.ws_connect = AsyncMock(side_effect=connects)
+
+    with caplog.at_level(logging.DEBUG, logger="livekit.agents"):
+        with pytest.raises(RuntimeError, match="failed to connect"):
+            await server._connection_task()
+
+    return [
+        r
+        for r in caplog.records
+        if r.getMessage().startswith("failed to connect to livekit, retrying")
+    ]
 
 
 async def test_run_raises_when_connection_exhausts_retries() -> None:
@@ -50,3 +108,116 @@ async def test_run_raises_when_connection_exhausts_retries() -> None:
         finally:
             await server.aclose()
             await server.aclose()  # repeated aclose() stays a no-op
+
+
+@pytest.mark.virtual_time
+async def test_reconnect_after_a_stable_connection_drops_is_reported_at_info(caplog) -> None:
+    server = _make_server(max_retry=1)
+
+    with patch.object(server, "_run_ws", _serves_for(STABLE_CONNECTION_INTERVAL * 10)):
+        records = await _retry_logs(server, [_registered_ws(), ConnectionRefusedError()], caplog)
+
+    assert [record.getMessage() for record in records] == [
+        "failed to connect to livekit, retrying in 0s"
+    ]
+    assert records[0].levelno == logging.INFO
+
+
+@pytest.mark.virtual_time
+async def test_connection_flapping_below_the_stable_interval_stays_at_warning(caplog) -> None:
+    """A worker that registers and loses the connection straight back is not self-healing.
+
+    Every accepted connect resets ``retry_count``, so this never backs off and never
+    exhausts ``max_retry``. Demoting it would hide a control plane that is failing
+    continuously behind a silent hot loop.
+    """
+    server = _make_server(max_retry=1)
+
+    with patch.object(server, "_run_ws", _serves_for(STABLE_CONNECTION_INTERVAL / 10)):
+        records = await _retry_logs(server, [_registered_ws(), ConnectionRefusedError()], caplog)
+
+    assert [record.getMessage() for record in records] == [
+        "failed to connect to livekit, retrying in 0s"
+    ]
+    assert records[0].levelno == logging.WARNING
+
+
+async def test_startup_connection_failure_is_reported_at_warning(caplog) -> None:
+    server = _make_server(max_retry=1)
+
+    records = await _retry_logs(
+        server, [ConnectionRefusedError(), ConnectionRefusedError()], caplog
+    )
+
+    assert [record.getMessage() for record in records] == [
+        "failed to connect to livekit, retrying in 0s"
+    ]
+    assert records[0].levelno == logging.WARNING
+
+
+@pytest.mark.virtual_time
+async def test_backed_off_retry_is_reported_at_warning_even_after_a_stable_connection(
+    caplog,
+) -> None:
+    server = _make_server(max_retry=2)
+
+    with patch.object(server, "_run_ws", _serves_for(STABLE_CONNECTION_INTERVAL * 10)):
+        records = await _retry_logs(
+            server,
+            [_registered_ws(), ConnectionRefusedError(), ConnectionRefusedError()],
+            caplog,
+        )
+
+    assert [record.getMessage() for record in records] == [
+        "failed to connect to livekit, retrying in 0s",
+        "failed to connect to livekit, retrying in 2s",
+    ]
+    assert records[0].levelno == logging.INFO
+    assert records[1].levelno == logging.WARNING
+
+
+@pytest.mark.virtual_time
+async def test_register_failures_stay_at_warning_after_an_earlier_stable_connection(
+    caplog,
+) -> None:
+    """A control plane that accepts the upgrade but never registers is a real outage.
+
+    ``retry_count`` resets on every accepted upgrade, so each of these attempts computes a
+    0s delay. They must stay loud rather than inherit the quiet path from the connection
+    that was serving earlier in the loop.
+    """
+    server = _make_server(max_retry=1)
+
+    with patch.object(server, "_run_ws", _serves_for(STABLE_CONNECTION_INTERVAL * 10)):
+        records = await _retry_logs(
+            server,
+            [_registered_ws(), _unregistered_ws(), ConnectionRefusedError()],
+            caplog,
+        )
+
+    assert [record.getMessage() for record in records] == [
+        "failed to connect to livekit, retrying in 0s",
+        "failed to connect to livekit, retrying in 0s",
+    ]
+    assert records[0].levelno == logging.INFO
+    assert records[1].levelno == logging.WARNING
+
+
+@pytest.mark.virtual_time
+async def test_a_fault_that_is_not_the_connection_dropping_stays_at_warning(caplog) -> None:
+    """Only losing the connection is routine.
+
+    A bug in a message handler, or a message the worker cannot parse, surfaces through the
+    same retry path after an arbitrarily long uptime. Those are worth reporting however
+    long the connection had been up.
+    """
+    server = _make_server(max_retry=1)
+
+    run_ws = _serves_for(STABLE_CONNECTION_INTERVAL * 10, RuntimeError("bad server message"))
+    with patch.object(server, "_run_ws", run_ws):
+        records = await _retry_logs(server, [_registered_ws(), ConnectionRefusedError()], caplog)
+
+    assert [record.getMessage() for record in records] == [
+        "failed to connect to livekit, retrying in 0s"
+    ]
+    assert records[0].levelno == logging.WARNING


### PR DESCRIPTION
Closes #6108.

## Problem

`Worker._connection_task` resets `retry_count` to `0` at `worker.py:1118`, immediately after a successful `ws_connect`. Every failure after that computes `retry_delay = min(0 * 2, 10)`, so the first retry following any control-plane websocket drop logs:

```
WARNING failed to connect to livekit, retrying in 0s
```

and then reconnects successfully. The reporter sees these a few times a day across worker replicas, every one self-healing. They trip warning-level alerting with nothing behind them, so operators learn to filter the whole message, which then hides the backoff events that do matter.

## Solution

Log that retry at INFO instead, under two conditions:

- the connection had been up for at least `STABLE_CONNECTION_INTERVAL` (30s) before it dropped, and
- the failure was the connection going away: `APIStatusError` from the unexpected-close path in `_run_ws`, `aiohttp.ClientError`, or `OSError`.

Everything else stays at WARNING: a worker that never connected, one dropping faster than the interval, any retry that had to back off, and any fault that is not a lost connection.

Both conditions are load-bearing. Demoting on `retry_delay == 0` alone silences real outages, which I verified against this base commit before settling on the current shape:

| Scenario | `main` | plain `retry_delay == 0` demotion | this PR |
|---|---|---|---|
| Upgrade accepted, register handshake never answered (3670 retries in 2s) | WARNING | INFO | WARNING |
| Registers, then drops straight back (3450 retries in 2s) | WARNING | INFO | WARNING |
| Stable connection drops, retry succeeds | WARNING | INFO | INFO |

Neither hot loop backs off or reaches `max_retry`, because `retry_count` is reset by the accepted upgrade, so demoting them would have made a permanently broken worker silent.

## Scope

One behaviour change, in one function. I deliberately left the `retry_count` reset at line 1118 alone: moving it is what would actually stop those two hot loops, but it changes backoff and `max_retry` semantics well beyond this issue, so it belongs in its own change with a maintainer's call on the semantics.

`STABLE_CONNECTION_INTERVAL` is a policy choice and I would rather you pick it than me. Any duration threshold moves the blind spot instead of removing it: a proxy that kills the connection every 31s still logs INFO forever. If you prefer a rate limit on the demotion, escalating when the quiet reconnect fires more than N times in a window, I will switch it. Raised the same question on the issue.

## Validation

Base commit `060f107`, all commands run locally.

- `uv run pytest tests/test_worker_connection.py --unit` → 7 passed. Six are new, one per row of the table above plus the backoff and non-transport-fault cases. Each was confirmed red before the fix and green after.
- `uv run pytest tests/ --unit` → 1498 passed, 5 skipped. Baseline on a clean tree is 1492 passed, so the 6 new tests are the only difference.
- `uv run pytest tests/test_worker_connection.py --unit --concurrent` → 7 passed. The module is marked `no_concurrent` because the `virtual_time` clock is process-global, matching `test_connection_pool.py` and the other virtual-time modules.
- `uv run ruff check` and `uv run ruff format --check` on both changed files → clean.
- `uv run python scripts/check_types.py` → 2 errors, both pre-existing missing `cv2` and `loguru` stubs in `livekit-plugins-bithuman`. Identical on a clean tree; nothing in the changed files.

The 3670 and 3450 figures come from driving `_connection_task` with a stubbed `ws_connect` for 2 seconds and counting the retry records.

## Note

I opened this without waiting for a reply on the issue, since the failing behaviour is unambiguous and the change is small. The threshold question above is the one assumption I made on your behalf, and I am happy to rework it.

This change was written with AI assistance. Every claim above comes from a command I ran on the base commit.
