### PR TITLE
feat(azure): replace unknown tts model string with host/region + voice

### DIFF
--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/tts.py
@@ -16,6 +16,7 @@ import asyncio
 import os
 from dataclasses import dataclass, replace
 from typing import Literal
+from urllib.parse import urlparse
 
 import aiohttp
 
@@ -199,7 +200,18 @@ class TTS(tts.TTS):
 
     @property
     def model(self) -> str:
-        return "unknown"
+        if self._opts.speech_endpoint:
+            endpoint = self._opts.speech_endpoint.strip()
+            parsed = urlparse(endpoint if "://" in endpoint else f"//{endpoint}")
+            location = parsed.hostname or endpoint
+        elif self._opts.region:
+            location = self._opts.region
+        else:
+            return "unknown"
+        model = f"{location}:{self._opts.voice}"
+        if self._opts.deployment_id:
+            model += f":{self._opts.deployment_id}"
+        return model
 
     @property
     def provider(self) -> str:

--- a/tests/test_plugin_azure_tts.py
+++ b/tests/test_plugin_azure_tts.py
@@ -1,0 +1,63 @@
+import pytest
+
+pytestmark = pytest.mark.plugin("azure")
+
+VOICE = "en-US-JennyNeural"
+
+
+@pytest.fixture(autouse=True)
+def _clear_azure_env(monkeypatch):
+    # clearing in order to make sure naming rules behave correctly (ci exports these)
+    for var in ("AZURE_SPEECH_KEY", "AZURE_SPEECH_REGION", "AZURE_SPEECH_ENDPOINT"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _tts(**kwargs):
+    from livekit.plugins.azure import TTS
+
+    return TTS(voice=VOICE, **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        # region path (key + region)
+        ({"speech_key": "k", "speech_region": "eastus"}, f"eastus:{VOICE}"),
+        # endpoint path: host from a well-formed URL
+        (
+            {"speech_endpoint": "https://eastus.tts.speech.microsoft.com/cognitiveservices/v1"},
+            f"eastus.tts.speech.microsoft.com:{VOICE}",
+        ),
+        # both set: endpoint wins over region
+        (
+            {
+                "speech_key": "k",
+                "speech_region": "eastus",
+                "speech_endpoint": "https://custom.example.com/v1",
+            },
+            f"custom.example.com:{VOICE}",
+        ),
+        # no scheme endpoint + path: host-only
+        (
+            {"speech_endpoint": "eastus.tts.speech.microsoft.com/path"},
+            f"eastus.tts.speech.microsoft.com:{VOICE}",
+        ),
+        # surrounding whitespaces stripped
+        (
+            {"speech_endpoint": "  https://eastus.tts.speech.microsoft.com  "},
+            f"eastus.tts.speech.microsoft.com:{VOICE}",
+        ),
+        # deployment id appended to endpoint
+        (
+            {"speech_endpoint": "https://custom.example.com/v1", "deployment_id": "cnv-123"},
+            f"custom.example.com:{VOICE}:cnv-123",
+        ),
+        # deployment id appended to region
+        (
+            {"speech_key": "k", "speech_region": "eastus", "deployment_id": "cnv-123"},
+            f"eastus:{VOICE}:cnv-123",
+        ),
+    ],
+)
+def test_model_derivation(kwargs, expected):
+    assert _tts(**kwargs).model == expected


### PR DESCRIPTION
Replace the hard-coded `unknown` model string in the Azure TTS with `{endpoint|region}:{voice}`, allowing upstream system such as telemetry providers to identify and price the TTS part of the voice pipeline. Observability only.

Closes #6760. Follows the behaviour of `get_endpoint_url` for naming: endpoint first (tries parsing URL in order to get the host), region second. If `deployment_id` is included it gets appended to the end.

Added `tests/test_plugin_azure_tts.py` with different cases.