### PR TITLE
fix(sarvam): validate TTS parameters against the live Bulbul API

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -99,6 +99,13 @@ _CODEC_TO_MIME: dict[str, str] = {
 
 _TELEPHONY_CODECS: frozenset[str] = frozenset({"mulaw", "alaw"})
 
+# 32000 / 44100 / 48000 Hz are documented as REST-only; the WebSocket endpoint
+# is capped at 24 kHz. bulbul:v3 / v3-beta reject the higher rates with an error
+# frame, so streaming is restricted to STREAMING_SAMPLE_RATES for every model.
+# See https://docs.sarvam.ai/api/getting-started/models/bulbul
+ALLOWED_SAMPLE_RATES: frozenset[int] = frozenset({8000, 16000, 22050, 24000, 32000, 44100, 48000})
+STREAMING_SAMPLE_RATES: frozenset[int] = frozenset({8000, 16000, 22050, 24000})
+
 
 def _codec_to_mime_type(codec: str) -> str:
     """Map a Sarvam output_audio_codec value to the MIME type the framework decoder expects."""
@@ -322,7 +329,8 @@ class SarvamTTSOptions:
         output_audio_bitrate: Output audio bitrate
         min_buffer_size: Minimum character length for flushing
         max_chunk_length: Maximum chunk length for sentence splitting
-        speech_sample_rate: Audio sample rate (8000, 16000, 22050, 24000, 32000, 44100, or 48000)
+        speech_sample_rate: Audio sample rate (8000, 16000, 22050, 24000, 32000, 44100, or
+            48000). 32000 and above are REST-only; stream() requires 24000 or below.
         enable_preprocessing: Whether to use text preprocessing (bulbul:v2 only)
         dict_id: Custom pronunciation dictionary ID (bulbul:v3 only)
         enable_cached_responses: Enable response caching beta feature (bulbul:v1/v2 only)
@@ -365,7 +373,8 @@ class TTS(tts.TTS):
         target_language_code: BCP-47 language code for supported Indian languages
         model: Sarvam TTS model to use (bulbul:v2)
         speaker: Voice to use for synthesis
-        speech_sample_rate: Audio sample rate in Hz
+        speech_sample_rate: Audio sample rate in Hz. Streaming only accepts 8000, 16000,
+            22050 or 24000; 32000, 44100 and 48000 are REST-only.
         num_channels: Number of audio channels (Sarvam outputs mono)
         pitch: Voice pitch adjustment (-0.75 to 0.75) - only supported in v2 for now
         pace: Speech rate multiplier (0.3 to 3.0)
@@ -455,9 +464,20 @@ class TTS(tts.TTS):
             raise ValueError("min_buffer_size must be between 30 and 200")
         if not 50 <= max_chunk_length <= 500:
             raise ValueError("max_chunk_length must be between 50 and 500")
-        if speech_sample_rate not in [8000, 16000, 22050, 24000, 32000, 44100, 48000]:
+        if speech_sample_rate not in ALLOWED_SAMPLE_RATES:
             raise ValueError(
-                "Sample rate must be one of 8000, 16000, 22050, 24000, 32000, 44100, or 48000 Hz"
+                "Sample rate must be one of "
+                f"{', '.join(str(r) for r in sorted(ALLOWED_SAMPLE_RATES))} Hz"
+            )
+        if speech_sample_rate not in STREAMING_SAMPLE_RATES:
+            # Valid for synthesize() but not for stream(); an AgentSession always
+            # streams, so warn now and fail with a clear error in SynthesizeStream
+            # rather than surfacing an opaque server error frame mid-session.
+            logger.warning(
+                "speech_sample_rate %d Hz is only supported over the REST endpoint; "
+                "streaming (stream()) supports %s Hz and will raise if used.",
+                speech_sample_rate,
+                ", ".join(str(r) for r in sorted(STREAMING_SAMPLE_RATES)),
             )
         if output_audio_codec not in ALLOWED_OUTPUT_AUDIO_CODECS:
             raise ValueError(
@@ -900,6 +920,14 @@ class SynthesizeStream(tts.SynthesizeStream):
         self._ws_conn: aiohttp.ClientWebSocketResponse | None = None
 
     async def _run(self, output_emitter: tts.AudioEmitter) -> None:
+        if self._opts.speech_sample_rate not in STREAMING_SAMPLE_RATES:
+            raise ValueError(
+                f"speech_sample_rate {self._opts.speech_sample_rate} Hz is not supported over "
+                "the streaming (WebSocket) endpoint; use one of "
+                f"{', '.join(str(r) for r in sorted(STREAMING_SAMPLE_RATES))} Hz, "
+                "or call synthesize() instead."
+            )
+
         self._segments_ch = utils.aio.Chan[tokenize.SentenceStream]()
         request_id = utils.shortuuid()
         self._client_request_id = request_id

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -107,6 +107,27 @@ ALLOWED_SAMPLE_RATES: frozenset[int] = frozenset({8000, 16000, 22050, 24000, 320
 STREAMING_SAMPLE_RATES: frozenset[int] = frozenset({8000, 16000, 22050, 24000})
 
 
+# ``pace`` is accepted over a narrower range on bulbul:v3 / v3-beta than on
+# bulbul:v2; the server rejects anything outside it. Verified against the live
+# API; see https://docs.sarvam.ai/api/getting-started/models/bulbul
+_V3_PACE_RANGE: tuple[float, float] = (0.5, 2.0)
+_V2_PACE_RANGE: tuple[float, float] = (0.3, 3.0)
+
+
+def pace_range(model: str) -> tuple[float, float]:
+    """Return the inclusive ``(min, max)`` pace accepted by ``model``."""
+    if model.startswith("bulbul:v3"):
+        return _V3_PACE_RANGE
+    return _V2_PACE_RANGE
+
+
+def _validate_pace(pace: float, model: str) -> None:
+    """Raise ``ValueError`` if ``pace`` is outside the range ``model`` accepts."""
+    low, high = pace_range(model)
+    if not low <= pace <= high:
+        raise ValueError(f"Pace must be between {low} and {high} for {model}")
+
+
 def _codec_to_mime_type(codec: str) -> str:
     """Map a Sarvam output_audio_codec value to the MIME type the framework decoder expects."""
     mime = _CODEC_TO_MIME.get(codec)
@@ -323,7 +344,7 @@ class SarvamTTSOptions:
         text: The text to synthesize (will be provided by stream adapter)
         speaker: Voice to use for synthesis
         pitch: Voice pitch adjustment (-0.75 to 0.75)
-        pace: Speech rate multiplier (0.3 to 3.0)
+        pace: Speech rate multiplier (0.5 to 2.0 on bulbul:v3 / v3-beta, 0.3 to 3.0 on bulbul:v2)
         loudness: Volume multiplier (0.5 to 2.0)
         temperature: Sampling temperature (0.01 to 2.0), used for v3 and v3-beta
         output_audio_bitrate: Output audio bitrate
@@ -377,7 +398,7 @@ class TTS(tts.TTS):
             22050 or 24000; 32000, 44100 and 48000 are REST-only.
         num_channels: Number of audio channels (Sarvam outputs mono)
         pitch: Voice pitch adjustment (-0.75 to 0.75) - only supported in v2 for now
-        pace: Speech rate multiplier (0.3 to 3.0)
+        pace: Speech rate multiplier (0.5 to 2.0 on bulbul:v3 / v3-beta, 0.3 to 3.0 on bulbul:v2)
         loudness: Volume multiplier (0.5 to 2.0) - only supported in v2 for now
         temperature: Sampling temperature (0.01 to 2.0), only used in v3 and v3-beta
         dict_id: Custom pronunciation dictionary ID (bulbul:v3 only)
@@ -450,8 +471,7 @@ class TTS(tts.TTS):
                 pitch,
             )
             pitch = max(-0.75, min(0.75, pitch))
-        if not 0.3 <= pace <= 3.0:
-            raise ValueError("Pace must be between 0.3 and 3.0")
+        _validate_pace(pace, model)
         if not 0.5 <= loudness <= 2.0:
             raise ValueError("Loudness must be between 0.5 and 2.0")
         if not 0.01 <= temperature <= 2.0:
@@ -714,6 +734,9 @@ class TTS(tts.TTS):
                         f"Speaker '{self._opts.speaker}' incompatible with {self._opts.model}. "
                         f"Compatible speakers: {', '.join(compatible_speakers(self._opts.model))}"
                     )
+            if pace is None:
+                # The pace already in effect may be out of range for the new model.
+                _validate_pace(self._opts.pace, self._opts.model)
         if speaker is not None:
             if not speaker.strip():
                 raise ValueError("Speaker cannot be empty")
@@ -735,8 +758,7 @@ class TTS(tts.TTS):
             self._opts.pitch = pitch
 
         if pace is not None:
-            if not 0.3 <= pace <= 3.0:
-                raise ValueError("Pace must be between 0.3 and 3.0")
+            _validate_pace(pace, self._opts.model)
             self._opts.pace = pace
 
         if loudness is not None:

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -173,16 +173,15 @@ SarvamTTSLanguages = Literal[
 ]
 
 SarvamTTSSpeakers = Literal[
-    # bulbul:v2 Female (lowercase)
+    # bulbul:v2 only
     "anushka",
     "manisha",
     "vidya",
     "arya",
-    # bulbul:v2 Male (lowercase)
     "abhilash",
     "karun",
     "hitesh",
-    # bulbul:v3-beta Customer Care
+    # bulbul:v3 and bulbul:v3-beta
     "shubh",
     "ritu",
     "rahul",
@@ -198,7 +197,6 @@ SarvamTTSSpeakers = Literal[
     "manan",
     "sumit",
     "priya",
-    # bulbul:v3-beta Content Creation
     "aditya",
     "kabir",
     "neha",
@@ -207,150 +205,74 @@ SarvamTTSSpeakers = Literal[
     "aayan",
     "ashutosh",
     "advait",
-    # bulbul:v3-beta International
-    "amelia",
-    "sophia",
-    # bulbul:v3
     "suhani",
     "rupali",
     "tanya",
     "shruti",
     "kavitha",
+    "anand",
+    "tarun",
+    "sunny",
+    "mani",
+    "gokul",
+    "vijay",
+    "mohit",
+    "rehan",
+    "soham",
 ]
 
-# Model-Speaker compatibility mapping
-MODEL_SPEAKER_COMPATIBILITY = {
-    "bulbul:v2": {
-        "female": ["anushka", "manisha", "vidya", "arya"],
-        "male": ["abhilash", "karun", "hitesh"],
-        "all": ["anushka", "manisha", "vidya", "arya", "abhilash", "karun", "hitesh"],
-    },
-    "bulbul:v3-beta": {
-        "female": [
-            "ritu",
-            "pooja",
-            "simran",
-            "kavya",
-            "ishita",
-            "shreya",
-            "priya",
-            "neha",
-            "roopa",
-            "amelia",
-            "sophia",
-        ],
-        "male": [
-            "shubh",
-            "rahul",
-            "amit",
-            "ratan",
-            "rohan",
-            "dev",
-            "manan",
-            "sumit",
-            "aditya",
-            "kabir",
-            "varun",
-            "aayan",
-            "ashutosh",
-            "advait",
-        ],
-        "all": [
-            "shubh",
-            "ritu",
-            "rahul",
-            "pooja",
-            "simran",
-            "kavya",
-            "amit",
-            "ratan",
-            "rohan",
-            "dev",
-            "ishita",
-            "shreya",
-            "manan",
-            "sumit",
-            "priya",
-            "aditya",
-            "kabir",
-            "neha",
-            "varun",
-            "roopa",
-            "aayan",
-            "ashutosh",
-            "advait",
-            "amelia",
-            "sophia",
-        ],
-    },
-    "bulbul:v3": {
-        "female": [
-            "ritu",
-            "pooja",
-            "simran",
-            "kavya",
-            "ishita",
-            "shreya",
-            "priya",
-            "neha",
-            "roopa",
-            "amelia",
-            "sophia",
-            "suhani",
-            "rupali",
-            "tanya",
-            "shruti",
-            "kavitha",
-        ],
-        "male": [
-            "shubh",
-            "rahul",
-            "amit",
-            "ratan",
-            "rohan",
-            "dev",
-            "manan",
-            "sumit",
-            "aditya",
-            "kabir",
-            "varun",
-            "aayan",
-            "ashutosh",
-            "advait",
-        ],
-        "all": [
-            "shubh",
-            "ritu",
-            "rahul",
-            "pooja",
-            "simran",
-            "kavya",
-            "amit",
-            "ratan",
-            "rohan",
-            "dev",
-            "ishita",
-            "shreya",
-            "manan",
-            "sumit",
-            "priya",
-            "aditya",
-            "kabir",
-            "neha",
-            "varun",
-            "roopa",
-            "aayan",
-            "ashutosh",
-            "advait",
-            "amelia",
-            "sophia",
-            "suhani",
-            "rupali",
-            "tanya",
-            "shruti",
-            "kavitha",
-        ],
-    },
+# Speakers accepted by each model, verified against the live Sarvam API and
+# https://docs.sarvam.ai/api/getting-started/models/bulbul (the two agree exactly).
+# bulbul:v3 and bulbul:v3-beta share one speaker set; bulbul:v2 has its own.
+_V2_SPEAKERS: frozenset[str] = frozenset(
+    {"anushka", "abhilash", "manisha", "vidya", "arya", "karun", "hitesh"}
+)
+_V3_SPEAKERS: frozenset[str] = frozenset(
+    {
+        "aayan",
+        "aditya",
+        "advait",
+        "amit",
+        "anand",
+        "ashutosh",
+        "dev",
+        "gokul",
+        "ishita",
+        "kabir",
+        "kavitha",
+        "kavya",
+        "manan",
+        "mani",
+        "mohit",
+        "neha",
+        "pooja",
+        "priya",
+        "rahul",
+        "ratan",
+        "rehan",
+        "ritu",
+        "rohan",
+        "roopa",
+        "rupali",
+        "shreya",
+        "shruti",
+        "shubh",
+        "simran",
+        "soham",
+        "suhani",
+        "sumit",
+        "sunny",
+        "tanya",
+        "tarun",
+        "varun",
+        "vijay",
+    }
+)
+
+MODEL_SPEAKER_COMPATIBILITY: dict[str, frozenset[str]] = {
+    "bulbul:v2": _V2_SPEAKERS,
+    "bulbul:v3-beta": _V3_SPEAKERS,
+    "bulbul:v3": _V3_SPEAKERS,
 }
 
 
@@ -363,17 +285,22 @@ class ConnectionState(enum.Enum):
     FAILED = "failed"
 
 
+def compatible_speakers(model: str) -> list[str]:
+    """Return the speakers accepted by ``model``, sorted; empty if the model is unknown."""
+    return sorted(MODEL_SPEAKER_COMPATIBILITY.get(model, frozenset()))
+
+
 def validate_model_speaker_compatibility(model: str, speaker: str) -> bool:
     """Validate that the speaker is compatible with the model version."""
     if model not in MODEL_SPEAKER_COMPATIBILITY:
         logger.warning(f"Unknown model '{model}', skipping compatibility check")
         return True
 
-    compatible_speakers = MODEL_SPEAKER_COMPATIBILITY[model]["all"]
-    if speaker.lower() not in compatible_speakers:
+    if speaker.lower() not in MODEL_SPEAKER_COMPATIBILITY[model]:
+        compatible_speakers_ = compatible_speakers(model)
         logger.error(
             f"Speaker '{speaker}' is not compatible with model '{model}'. "
-            f"Compatible speakers for {model}: {', '.join(compatible_speakers)}"
+            f"Compatible speakers for {model}: {', '.join(compatible_speakers_)}"
         )
         return False
     return True
@@ -539,10 +466,9 @@ class TTS(tts.TTS):
 
         # Validate model-speaker compatibility
         if not validate_model_speaker_compatibility(model, speaker):
-            compatible_speakers = MODEL_SPEAKER_COMPATIBILITY.get(model, {}).get("all", [])
             raise ValueError(
                 f"Speaker '{speaker}' is not compatible with model '{model}'. "
-                f"Please choose a compatible speaker from: {', '.join(compatible_speakers)}"
+                f"Please choose a compatible speaker from: {', '.join(compatible_speakers(model))}"
             )
 
         # Initialize word tokenizer for streaming
@@ -764,23 +690,17 @@ class TTS(tts.TTS):
             self._opts.model = model
             if speaker is None and self._opts.speaker is not None:
                 if not validate_model_speaker_compatibility(self._opts.model, self._opts.speaker):
-                    compatible_speakers = MODEL_SPEAKER_COMPATIBILITY.get(self._opts.model, {}).get(
-                        "all", []
-                    )
                     raise ValueError(
                         f"Speaker '{self._opts.speaker}' incompatible with {self._opts.model}. "
-                        f"Compatible speakers: {', '.join(compatible_speakers)}"
+                        f"Compatible speakers: {', '.join(compatible_speakers(self._opts.model))}"
                     )
         if speaker is not None:
             if not speaker.strip():
                 raise ValueError("Speaker cannot be empty")
             if not validate_model_speaker_compatibility(self._opts.model, speaker):
-                compatible_speakers = MODEL_SPEAKER_COMPATIBILITY.get(self._opts.model, {}).get(
-                    "all", []
-                )
                 raise ValueError(
                     f"Speaker '{speaker}' incompatible with {self._opts.model}. "
-                    f"Compatible speakers: {', '.join(compatible_speakers)}"
+                    f"Compatible speakers: {', '.join(compatible_speakers(self._opts.model))}"
                 )
             self._opts.speaker = speaker
 

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -718,34 +718,46 @@ class TTS(tts.TTS):
         send_completion_event: bool | None = None,
         output_audio_codec: str | None = None,
     ) -> None:
-        """Update TTS options with validation."""
+        """Update TTS options with validation.
+
+        The update is atomic: every value is validated against the *candidate*
+        configuration first, and nothing is assigned unless all checks pass. A
+        ``ValueError`` therefore leaves the current options untouched, instead
+        of half-applying an update that would fail server-side later.
+        """
+        updates: dict[str, object] = {}
+
         if target_language_code is not None:
             if not target_language_code.strip():
                 raise ValueError("Target language code cannot be empty")
-            self._opts.target_language_code = LanguageCode(target_language_code)
+            updates["target_language_code"] = LanguageCode(target_language_code)
 
+        # model, speaker and pace are interdependent, so resolve the candidate
+        # values for all three before validating any of them.
         if model is not None:
             if not model.strip():
                 raise ValueError("Model cannot be empty")
-            self._opts.model = model
-            if speaker is None and self._opts.speaker is not None:
-                if not validate_model_speaker_compatibility(self._opts.model, self._opts.speaker):
-                    raise ValueError(
-                        f"Speaker '{self._opts.speaker}' incompatible with {self._opts.model}. "
-                        f"Compatible speakers: {', '.join(compatible_speakers(self._opts.model))}"
-                    )
-            if pace is None:
-                # The pace already in effect may be out of range for the new model.
-                _validate_pace(self._opts.pace, self._opts.model)
+            updates["model"] = model
         if speaker is not None:
             if not speaker.strip():
                 raise ValueError("Speaker cannot be empty")
-            if not validate_model_speaker_compatibility(self._opts.model, speaker):
+            updates["speaker"] = speaker
+
+        candidate_model = model if model is not None else self._opts.model
+        candidate_speaker = speaker if speaker is not None else self._opts.speaker
+
+        if (model is not None or speaker is not None) and candidate_speaker is not None:
+            if not validate_model_speaker_compatibility(candidate_model, candidate_speaker):
                 raise ValueError(
-                    f"Speaker '{speaker}' incompatible with {self._opts.model}. "
-                    f"Compatible speakers: {', '.join(compatible_speakers(self._opts.model))}"
+                    f"Speaker '{candidate_speaker}' incompatible with {candidate_model}. "
+                    f"Compatible speakers: {', '.join(compatible_speakers(candidate_model))}"
                 )
-            self._opts.speaker = speaker
+
+        if model is not None or pace is not None:
+            # A new model may narrow the range around the pace already in effect.
+            _validate_pace(pace if pace is not None else self._opts.pace, candidate_model)
+        if pace is not None:
+            updates["pace"] = pace
 
         if pitch is not None:
             if not -0.75 <= pitch <= 0.75:
@@ -755,21 +767,17 @@ class TTS(tts.TTS):
                     pitch,
                 )
                 pitch = max(-0.75, min(0.75, pitch))
-            self._opts.pitch = pitch
-
-        if pace is not None:
-            _validate_pace(pace, self._opts.model)
-            self._opts.pace = pace
+            updates["pitch"] = pitch
 
         if loudness is not None:
             if not 0.5 <= loudness <= 2.0:
                 raise ValueError("Loudness must be between 0.5 and 2.0")
-            self._opts.loudness = loudness
+            updates["loudness"] = loudness
 
         if temperature is not None:
             if not 0.01 <= temperature <= 2.0:
                 raise ValueError("Temperature must be between 0.01 and 2.0")
-            self._opts.temperature = temperature
+            updates["temperature"] = temperature
 
         if output_audio_bitrate is not None:
             if output_audio_bitrate not in ALLOWED_OUTPUT_AUDIO_BITRATES:
@@ -777,29 +785,29 @@ class TTS(tts.TTS):
                     "output_audio_bitrate must be one of "
                     f"{', '.join(sorted(ALLOWED_OUTPUT_AUDIO_BITRATES))}"
                 )
-            self._opts.output_audio_bitrate = output_audio_bitrate
+            updates["output_audio_bitrate"] = output_audio_bitrate
 
         if min_buffer_size is not None:
             if not 30 <= min_buffer_size <= 200:
                 raise ValueError("min_buffer_size must be between 30 and 200")
-            self._opts.min_buffer_size = min_buffer_size
+            updates["min_buffer_size"] = min_buffer_size
 
         if max_chunk_length is not None:
             if not 50 <= max_chunk_length <= 500:
                 raise ValueError("max_chunk_length must be between 50 and 500")
-            self._opts.max_chunk_length = max_chunk_length
+            updates["max_chunk_length"] = max_chunk_length
 
         if enable_preprocessing is not None:
-            self._opts.enable_preprocessing = enable_preprocessing
+            updates["enable_preprocessing"] = enable_preprocessing
 
         if dict_id is not None:
-            self._opts.dict_id = dict_id
+            updates["dict_id"] = dict_id
 
         if enable_cached_responses is not None:
-            self._opts.enable_cached_responses = enable_cached_responses
+            updates["enable_cached_responses"] = enable_cached_responses
 
         if send_completion_event is not None:
-            self._opts.send_completion_event = send_completion_event
+            updates["send_completion_event"] = send_completion_event
 
         if output_audio_codec is not None:
             if output_audio_codec not in ALLOWED_OUTPUT_AUDIO_CODECS:
@@ -807,7 +815,11 @@ class TTS(tts.TTS):
                     "output_audio_codec must be one of "
                     f"{','.join(sorted(ALLOWED_OUTPUT_AUDIO_CODECS))}"
                 )
-            self._opts.output_audio_codec = output_audio_codec
+            updates["output_audio_codec"] = output_audio_codec
+
+        # Every check passed -- apply the whole update.
+        for field, value in updates.items():
+            setattr(self._opts, field, value)
 
     # Implement the abstract synthesize method
     def synthesize(

--- a/tests/test_plugin_sarvam_tts.py
+++ b/tests/test_plugin_sarvam_tts.py
@@ -114,6 +114,37 @@ def test_switching_to_v2_widens_the_allowed_pace() -> None:
     assert tts._opts.pace == 3.0
 
 
+def test_failed_update_leaves_model_and_speaker_untouched() -> None:
+    tts = TTS(model="bulbul:v2", speaker="anushka", api_key=API_KEY)
+    with pytest.raises(ValueError, match="incompatible"):
+        tts.update_options(model="bulbul:v3")  # anushka is not a v3 speaker
+    assert tts._opts.model == "bulbul:v2"
+    assert tts._opts.speaker == "anushka"
+
+
+def test_failed_pace_update_leaves_model_untouched() -> None:
+    tts = TTS(model="bulbul:v2", speaker="anushka", pace=3.0, api_key=API_KEY)
+    with pytest.raises(ValueError, match="Pace must be between 0.5 and 2.0"):
+        tts.update_options(model="bulbul:v3", speaker="shubh")
+    assert tts._opts.model == "bulbul:v2"
+    assert tts._opts.speaker == "anushka"
+    assert tts._opts.pace == 3.0
+
+
+def test_failed_update_does_not_apply_earlier_valid_fields() -> None:
+    tts = TTS(model="bulbul:v3", speaker="shubh", api_key=API_KEY)
+    with pytest.raises(ValueError, match="Loudness"):
+        tts.update_options(target_language_code="hi-IN", pace=1.5, loudness=9.0)
+    assert tts._opts.target_language_code == "en-IN"
+    assert tts._opts.pace == 1.0
+
+
+def test_model_and_speaker_change_together_is_accepted() -> None:
+    tts = TTS(model="bulbul:v2", speaker="anushka", api_key=API_KEY)
+    tts.update_options(model="bulbul:v3", speaker="shubh")
+    assert (tts._opts.model, tts._opts.speaker) == ("bulbul:v3", "shubh")
+
+
 def test_unsupported_sample_rate_still_rejected() -> None:
     with pytest.raises(ValueError, match="Sample rate must be one of"):
         TTS(speech_sample_rate=12345, api_key=API_KEY)

--- a/tests/test_plugin_sarvam_tts.py
+++ b/tests/test_plugin_sarvam_tts.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import pytest
 
 from livekit.plugins.sarvam.tts import (
+    ALLOWED_SAMPLE_RATES,
     MODEL_SPEAKER_COMPATIBILITY,
+    STREAMING_SAMPLE_RATES,
     TTS,
     compatible_speakers,
     validate_model_speaker_compatibility,
@@ -48,3 +50,29 @@ def test_v2_speaker_rejected_on_v3() -> None:
 def test_compatible_speakers_is_sorted_and_empty_for_unknown_model() -> None:
     assert compatible_speakers("bulbul:v2") == sorted(V2_SPEAKERS)
     assert compatible_speakers("bulbul:v9") == []
+
+
+def test_streaming_sample_rates_are_a_documented_subset() -> None:
+    assert STREAMING_SAMPLE_RATES == {8000, 16000, 22050, 24000}
+    assert STREAMING_SAMPLE_RATES < ALLOWED_SAMPLE_RATES
+    assert ALLOWED_SAMPLE_RATES - STREAMING_SAMPLE_RATES == {32000, 44100, 48000}
+
+
+@pytest.mark.parametrize("rate", [32000, 44100, 48000])
+def test_high_rates_construct_but_reject_streaming(rate: int) -> None:
+    tts = TTS(model="bulbul:v3", speech_sample_rate=rate, api_key=API_KEY)
+    assert tts.sample_rate == rate  # synthesize() still works at this rate
+    assert rate not in STREAMING_SAMPLE_RATES
+
+
+@pytest.mark.parametrize("rate", [32000, 44100, 48000])
+def test_rest_only_rates_construct_on_v2_too(rate: int) -> None:
+    # REST-only rates are valid for synthesize() on every model; stream() rejects them.
+    tts = TTS(model="bulbul:v2", speaker="anushka", speech_sample_rate=rate, api_key=API_KEY)
+    assert tts.sample_rate == rate
+    assert rate not in STREAMING_SAMPLE_RATES
+
+
+def test_unsupported_sample_rate_still_rejected() -> None:
+    with pytest.raises(ValueError, match="Sample rate must be one of"):
+        TTS(speech_sample_rate=12345, api_key=API_KEY)

--- a/tests/test_plugin_sarvam_tts.py
+++ b/tests/test_plugin_sarvam_tts.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+
+from livekit.plugins.sarvam.tts import (
+    MODEL_SPEAKER_COMPATIBILITY,
+    TTS,
+    compatible_speakers,
+    validate_model_speaker_compatibility,
+)
+
+pytestmark = pytest.mark.plugin("sarvam")
+
+API_KEY = "test-key-not-used"
+
+# Verified against the live Sarvam API and the bulbul docs.
+V2_SPEAKERS = {"anushka", "abhilash", "manisha", "vidya", "arya", "karun", "hitesh"}
+V3_ONLY_SPEAKERS = {"anand", "tarun", "sunny", "mani", "gokul", "vijay", "mohit", "rehan", "soham"}
+NOT_REAL_SPEAKERS = {"amelia", "sophia", "niharika"}
+
+
+def test_v2_speaker_set_is_exact() -> None:
+    assert MODEL_SPEAKER_COMPATIBILITY["bulbul:v2"] == V2_SPEAKERS
+
+
+def test_v3_and_v3_beta_share_a_speaker_set() -> None:
+    assert MODEL_SPEAKER_COMPATIBILITY["bulbul:v3"] == MODEL_SPEAKER_COMPATIBILITY["bulbul:v3-beta"]
+    assert len(MODEL_SPEAKER_COMPATIBILITY["bulbul:v3"]) == 37
+
+
+@pytest.mark.parametrize("speaker", sorted(V3_ONLY_SPEAKERS))
+def test_v3_speakers_are_accepted(speaker: str) -> None:
+    assert validate_model_speaker_compatibility("bulbul:v3", speaker)
+    TTS(model="bulbul:v3", speaker=speaker, api_key=API_KEY)
+
+
+@pytest.mark.parametrize("speaker", sorted(NOT_REAL_SPEAKERS))
+def test_speakers_the_api_rejects_are_not_offered(speaker: str) -> None:
+    for model in MODEL_SPEAKER_COMPATIBILITY:
+        assert speaker not in MODEL_SPEAKER_COMPATIBILITY[model]
+
+
+def test_v2_speaker_rejected_on_v3() -> None:
+    with pytest.raises(ValueError, match="not compatible"):
+        TTS(model="bulbul:v3", speaker="anushka", api_key=API_KEY)
+
+
+def test_compatible_speakers_is_sorted_and_empty_for_unknown_model() -> None:
+    assert compatible_speakers("bulbul:v2") == sorted(V2_SPEAKERS)
+    assert compatible_speakers("bulbul:v9") == []

--- a/tests/test_plugin_sarvam_tts.py
+++ b/tests/test_plugin_sarvam_tts.py
@@ -8,6 +8,7 @@ from livekit.plugins.sarvam.tts import (
     STREAMING_SAMPLE_RATES,
     TTS,
     compatible_speakers,
+    pace_range,
     validate_model_speaker_compatibility,
 )
 
@@ -71,6 +72,46 @@ def test_rest_only_rates_construct_on_v2_too(rate: int) -> None:
     tts = TTS(model="bulbul:v2", speaker="anushka", speech_sample_rate=rate, api_key=API_KEY)
     assert tts.sample_rate == rate
     assert rate not in STREAMING_SAMPLE_RATES
+
+
+def test_pace_range_is_per_model() -> None:
+    assert pace_range("bulbul:v3") == (0.5, 2.0)
+    assert pace_range("bulbul:v3-beta") == (0.5, 2.0)
+    assert pace_range("bulbul:v2") == (0.3, 3.0)
+
+
+@pytest.mark.parametrize("pace", [0.4, 2.5])
+def test_v2_only_pace_rejected_on_v3(pace: float) -> None:
+    with pytest.raises(ValueError, match="Pace must be between 0.5 and 2.0"):
+        TTS(model="bulbul:v3", pace=pace, api_key=API_KEY)
+
+
+@pytest.mark.parametrize("pace", [0.3, 1.0, 3.0])
+def test_v2_accepts_its_wider_pace_range(pace: float) -> None:
+    TTS(model="bulbul:v2", speaker="anushka", pace=pace, api_key=API_KEY)
+
+
+@pytest.mark.parametrize("pace", [0.5, 1.0, 2.0])
+def test_v3_accepts_its_own_range(pace: float) -> None:
+    TTS(model="bulbul:v3", pace=pace, api_key=API_KEY)
+
+
+def test_update_options_validates_pace_against_current_model() -> None:
+    tts = TTS(model="bulbul:v3", api_key=API_KEY)
+    with pytest.raises(ValueError, match="Pace must be between 0.5 and 2.0"):
+        tts.update_options(pace=2.5)
+
+
+def test_switching_to_v3_rechecks_the_pace_already_set() -> None:
+    tts = TTS(model="bulbul:v2", speaker="anushka", pace=3.0, api_key=API_KEY)
+    with pytest.raises(ValueError, match="Pace must be between 0.5 and 2.0"):
+        tts.update_options(model="bulbul:v3", speaker="shubh")
+
+
+def test_switching_to_v2_widens_the_allowed_pace() -> None:
+    tts = TTS(model="bulbul:v3", pace=2.0, api_key=API_KEY)
+    tts.update_options(model="bulbul:v2", speaker="anushka", pace=3.0)
+    assert tts._opts.pace == 3.0
 
 
 def test_unsupported_sample_rate_still_rejected() -> None:


### PR DESCRIPTION
Fixes #6774

The Sarvam TTS plugin's client-side validation disagreed with the Bulbul API in
three places. Each fix is a separate commit.

### 1. Speaker table for `bulbul:v3`

The plugin listed 30 speakers; the API and the docs both accept 37. Since
`validate_model_speaker_compatibility` raises, `anand, tarun, sunny, mani,
gokul, vijay, mohit, rehan, soham` were unusable despite synthesizing fine.
`amelia` and `sophia` were offered but rejected by the API.

v3 and v3-beta accept the same set, so they now share one frozenset. The
per-model `female`/`male` keys were dropped — only `"all"` was ever read, and
the split couldn't be verified against the API.

### 2. REST-only sample rates when streaming

32000/44100/48000 Hz are REST-only, but the constructor accepted them
unconditionally, so `synthesize()` worked while `stream()` failed on every call
with `Speech sample rate can only be 8000, 16000, 22050, 24000 Hz`. An
`AgentSession` always streams, so this hit the first utterance.

`SynthesizeStream` now fails fast with a clear local error before taking a
pooled connection; the constructor warns at config time. `synthesize()` still
accepts the full range.

### 3. `pace` range per model

v3/v3-beta accept 0.5–2.0, v2 accepts 0.3–3.0. The plugin applied the v2 range
to both, so `pace=2.5` on v3 passed validation then 400'd. The range is now
resolved per model, and `update_options(model=...)` re-checks the pace already
in effect.

### Verification

All findings were confirmed against the live API (REST and WebSocket) with a
real key, and cross-checked with the Bulbul docs — the docs and the API agree on
the 37-speaker list exactly. Boundary values were exercised on both endpoints;
`pace` output length scales inversely with the value at both limits, confirming
the parameter takes effect rather than being ignored.

New tests in `tests/test_plugin_sarvam_tts.py` (36, hermetic — dummy key, no
network).