### PR TITLE
fix: treat a silent agent turn as silence, not a run_input error

### DIFF
--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -761,12 +761,13 @@ class SessionHost:
                 try:
                     result: RunResult[None] = self._session.run(user_input=text)
                     await result
+                    # an empty list is a turn the agent chose to stay silent on, not a
+                    # failure: a tool may have told it to say nothing (a close-the-call
+                    # tool that already delivered its goodbye is the common case). Report
+                    # the silence and let the caller decide what it means.
                     items_list = [_chat_item_to_proto(ev.item) for ev in result.events]
                 except Exception as e:
                     error = str(e)
-
-                if not items_list and not error:
-                    error = "agent produced no response items"
 
             resp = agent_pb.AgentSessionMessage(
                 response=agent_pb.SessionResponse(

--- a/tests/test_run_input_errors.py
+++ b/tests/test_run_input_errors.py
@@ -1,5 +1,8 @@
 """Test that LLM errors propagate through session.run() → RunResult,
-including the full e2e path through SessionHost → RemoteSession."""
+including the full e2e path through SessionHost → RemoteSession.
+
+Also pins the other side of that contract: a turn the agent stays silent on
+is reported as a silent turn, not as an error."""
 
 from __future__ import annotations
 
@@ -129,6 +132,40 @@ async def test_run_input_error_e2e_through_remote_session():
 
     with pytest.raises(RuntimeError, match="failed"):
         await client.run("order a big mac", timeout=10.0)
+
+    await client.aclose()
+    await host.aclose()
+    await session.aclose()
+
+
+@pytest.mark.asyncio
+async def test_run_silent_turn_is_not_an_error():
+    """A turn that produces no items is a silent agent, not a failed one.
+
+    An LLM can return a completion with no text and no tool calls — a
+    close-the-call tool whose output tells the model it has already said
+    goodbye is the usual way to get there. Every item-add site in
+    ``agent_activity`` is guarded on non-empty text, so such a turn reaches
+    ``RunResult`` with zero events. That must come back as an empty item list
+    rather than an error, so the caller can decide what the silence means.
+    """
+    host_transport, client_transport = PairedTransport.create_pair()
+
+    session = AgentSession()
+    # FakeLLM yields an empty completion for any input outside its response map
+    agent = Agent(instructions="test agent", llm=FakeLLM())
+
+    host = SessionHost(host_transport)
+    host.register_session(session)
+
+    await session.start(agent=agent)
+    await host.start()
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    resp = await client.run("okay, thank you", timeout=10.0)
+    assert list(resp.items) == []
 
     await client.aclose()
     await host.aclose()


### PR DESCRIPTION
## Problem

`SessionHost` turns a run that produced no chat items into an error:

```python
if not items_list and not error:
    error = "agent produced no response items"
```

The caller sees it as a raised `RuntimeError`, so the turn — and, in simulations, the whole job — is scored as an agent failure.

An empty turn is a legitimate outcome. An LLM can return a completion with no text and no tool calls, and every item-add site in `agent_activity` is guarded on non-empty text (`if forwarded_text:`), so nothing lands in the chat context or in `RunResult.events`.

Agents that induce this on purpose hit it reliably. A close-the-call tool whose output tells the model it has already said goodbye and should now say nothing gets exactly that:

```
OUT : "You've already said goodbye - do NOT give another farewell, sign-off,
       or filler. If the caller just asked a real question, answer it in one
       short sentence; otherwise say nothing."
USER: "Okay, thank you."        <- agent emits nothing, turn fails
```

Agent-side traces for that turn confirm the model, not the framework, produced the silence:

```
[agent_turn]  dur=0.28s  lk.interrupted=False
  [llm_node]    lk.response.text=''
    [llm_request] gen_ai.usage.output_tokens=1
```

One output token, empty response text, no tool call, not interrupted — and the transcript up to that point is complete and correct.

## Fix

Report the empty item list and let the caller decide what the silence means. Simulation drivers already model a silent turn explicitly, so they can end the call cleanly instead of failing it.

## Test

`test_run_silent_turn_is_not_an_error` drives a real `AgentSession` whose LLM returns an empty completion through `SessionHost` → `RemoteSession`. Without the fix it fails with the exact production error:

```
RuntimeError: session request run_input failed: agent produced no response items
```