### PR TITLE
fix: report which handles are holding a stalled run open

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -946,7 +946,7 @@ class AgentTask(Agent, Generic[TaskResult_T]):
         # (the parent speech may predate the run, e.g. created in on_enter)
         if (run_state := session._global_run_state) and not run_state.done():
             for task in blocked_tasks:
-                run_state._watch_handle(task)
+                run_state._watch_handle(task, label="blocked_task")
 
         if (
             task_info.function_call
@@ -983,7 +983,7 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                 if run_state and not run_state.done():
                     # watch the on_enter task as a guard so RunResult won't complete
                     # before on_enter has registered its own speech handles
-                    run_state._watch_handle(on_enter_task)
+                    run_state._watch_handle(on_enter_task, label="agent_task_on_enter")
                     pending_on_enter_task = on_enter_task
                 else:
                     # no active run to guard — just wait for on_enter directly
@@ -1020,7 +1020,7 @@ class AgentTask(Agent, Generic[TaskResult_T]):
             # is tracked by the current RunResult again
             if run_state and not run_state.done():
                 for handle in suspended_handles:
-                    run_state._watch_handle(handle)
+                    run_state._watch_handle(handle, label="resumed_after_agent_task")
 
             if pending_on_enter_task:
                 try:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1995,7 +1995,7 @@ class AgentActivity(RecognitionHooks):
 
         if (fut := self._pending_auto_tool_reply_fut) and not fut.done():
             if (run_state := self._session._global_run_state) is not None and not run_state.done():
-                run_state._watch_handle(handle)
+                run_state._watch_handle(handle, label="auto_tool_reply")
             self._pending_auto_tool_reply_fut = None
             fut.set_result(None)
 
@@ -4214,7 +4214,7 @@ class AgentActivity(RecognitionHooks):
                                 self._pending_auto_tool_reply_fut = None
 
                     task = asyncio.create_task(_wait_for_auto_tool_reply())
-                    run_state._watch_handle(task)
+                    run_state._watch_handle(task, label="auto_tool_reply_wait")
 
                 chat_ctx = self._rt_session.chat_ctx.copy()
                 chat_ctx.items.extend(new_fnc_outputs)

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -817,6 +817,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         )
         self._global_run_state = run_state
         self.generate_reply(user_input=user_input, input_modality=input_modality)
+        # a run drives one turn, so it is expected to complete; report it if it
+        # does not, naming the handles still holding it open
+        run_state._start_stall_watchdog()
         return run_state
 
     @overload
@@ -1430,7 +1433,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 add_to_chat_ctx=add_to_chat_ctx,
             )
             if run_state:
-                run_state._watch_handle(handle)
+                run_state._watch_handle(handle, label="say")
 
         return handle
 
@@ -1496,7 +1499,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 input_details=InputDetails(modality=input_modality),
             )
             if run_state:
-                run_state._watch_handle(handle)
+                run_state._watch_handle(handle, label="generate_reply")
 
         return handle
 
@@ -1605,7 +1608,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             if run_state:
                 # don't mark the RunResult as done, if there is currently an agent transition happening.  # noqa: E501
                 # (used to make sure we're correctly adding the AgentHandoffResult before completion)  # noqa: E501
-                run_state._watch_handle(task)
+                run_state._watch_handle(task, label="agent_handoff")
 
     async def wait_for_idle(self) -> AgentActivity:
         """Wait until the current activity is idle and return it. Re-targets on handoff.
@@ -1650,7 +1653,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         guard: asyncio.Future[None] | None = None
         if run_state is not None and run_state is self._global_run_state and not run_state.done():
             guard = asyncio.get_running_loop().create_future()
-            run_state._watch_handle(guard)
+            run_state._watch_handle(guard, label="foreground_hold")
             self._foreground_guards.add(guard)
 
         try:
@@ -1783,7 +1786,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         # watch on_enter so the run captures its output without awaiting it
         if (activity := self._activity) is not None and activity._on_enter_task is not None:
             if (run_state := self._global_run_state) is not None and not run_state.done():
-                run_state._watch_handle(activity._on_enter_task)
+                run_state._watch_handle(activity._on_enter_task, label="on_enter")
 
     def _emit_debug_message(self, payload: dict[str, Any]) -> None:
         """:meta private: internal — emit a debug/trace payload to the debugger/recorder."""

--- a/livekit-agents/livekit/agents/voice/run_result.py
+++ b/livekit-agents/livekit/agents/voice/run_result.py
@@ -6,6 +6,7 @@ import contextvars
 import functools
 import json
 import os
+import time
 import weakref
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
@@ -35,6 +36,12 @@ if TYPE_CHECKING:
 
 
 lk_evals_verbose = int(os.getenv("LIVEKIT_EVALS_VERBOSE", 0))
+
+# How long a run may stay pending before it is reported as stalled. A run that
+# outlives this is not necessarily broken (a slow tool is enough), but callers
+# driving turns over `session.run()` usually give up around a minute, so the
+# report has to land while the run is still stuck and its handles observable.
+STALL_WARN_AFTER = 30.0
 
 _OUTPUT_RETRY_PROMPT = (
     "You have not provided the final output yet. Call the appropriate function "
@@ -105,6 +112,10 @@ class RunResult(Generic[Run_T]):
         session: AgentSession | None = None,
     ) -> None:
         self._handles: set[SpeechHandle | asyncio.Future[Any]] = set()
+        # what each watched handle is, for the stall diagnostics below. A run only
+        # completes once every handle here is done, so when one never completes the
+        # run hangs; the label is what turns that into a nameable culprit.
+        self._handle_labels: dict[SpeechHandle | asyncio.Future[Any], str] = {}
 
         if not is_given(output_options):
             output_options = RunOutputOptions()
@@ -121,6 +132,10 @@ class RunResult(Generic[Run_T]):
         self._session = session
         self._recorded_items: list[RunEvent] = []
         self._final_output: Run_T | None = None
+
+        self._started_at = time.time()
+        self._stall_watchdog_atask: asyncio.Task[None] | None = None
+        self._done_fut.add_done_callback(lambda _: self._cancel_stall_watchdog())
 
         self.__last_speech_handle: SpeechHandle | None = None
 
@@ -215,11 +230,14 @@ class RunResult(Generic[Run_T]):
             index = self._find_insertion_index(created_at=event.item.created_at)
             self._recorded_items.insert(index, event)
 
-    def _watch_handle(self, handle: SpeechHandle | asyncio.Future[Any]) -> None:
+    def _watch_handle(
+        self, handle: SpeechHandle | asyncio.Future[Any], *, label: str = "unknown"
+    ) -> None:
         if self._done_fut.done():
             return
 
         self._handles.add(handle)
+        self._handle_labels.setdefault(handle, label)
 
         if isinstance(handle, SpeechHandle):
             handle._add_item_added_callback(self._item_added)
@@ -236,6 +254,65 @@ class RunResult(Generic[Run_T]):
         if isinstance(handle, SpeechHandle):
             handle._remove_item_added_callback(self._item_added)
         return True
+
+    def _pending_handles(self) -> list[str]:
+        """Describe the handles this run is still waiting on.
+
+        A run completes only once every watched handle is done, so this is the
+        list of reasons it has not completed yet. Empty means the run is only
+        waiting on its own bookkeeping.
+        """
+        pending: list[str] = []
+        for handle in self._handles:
+            if handle.done():
+                continue
+
+            label = self._handle_labels.get(handle, "unknown")
+            if isinstance(handle, SpeechHandle):
+                pending.append(f"{label}(speech_id={handle.id})")
+            elif isinstance(handle, asyncio.Task):
+                pending.append(f"{label}(task={handle.get_name()})")
+            else:
+                pending.append(label)
+
+        return sorted(pending)
+
+    def _start_stall_watchdog(self) -> None:
+        """Report what the run is waiting on if it stays pending for too long.
+
+        A run that never completes is otherwise silent from the agent's side:
+        the caller times out with nothing naming the handle that held it open,
+        while the transcript looks complete because the reply itself did land.
+        """
+        if self._stall_watchdog_atask is not None or self._done_fut.done():
+            return
+
+        self._stall_watchdog_atask = asyncio.create_task(
+            self._stall_watchdog(), name="RunResult._stall_watchdog"
+        )
+
+    def _cancel_stall_watchdog(self) -> None:
+        if self._stall_watchdog_atask is not None:
+            self._stall_watchdog_atask.cancel()
+            self._stall_watchdog_atask = None
+
+    async def _stall_watchdog(self) -> None:
+        from ..log import logger
+
+        await asyncio.sleep(STALL_WARN_AFTER)
+        if self._done_fut.done():
+            return
+
+        # not necessarily a bug — a slow tool looks the same from here — so this
+        # stays a warning and the run is left running
+        logger.warning(
+            "run has not completed yet, it is still waiting on the handles below",
+            extra={
+                "elapsed": round(time.time() - self._started_at, 1),
+                "pending_handles": self._pending_handles(),
+                "user_input": self._user_input,
+            },
+        )
 
     def _mark_done_if_needed(self, handle: SpeechHandle | asyncio.Future[Any] | None) -> None:
         if isinstance(handle, SpeechHandle):

--- a/tests/test_run_result_stall.py
+++ b/tests/test_run_result_stall.py
@@ -1,0 +1,170 @@
+"""A run that never completes must say what is holding it open.
+
+`RunResult` completes only once every watched handle is done. When one never
+completes, the run hangs and the caller times out with nothing naming the
+culprit — the transcript looks complete, because the reply itself did land, so
+the failure reads as spurious. These tests pin the diagnostic that names it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from livekit.agents import function_tool
+from livekit.agents.llm import FunctionToolCall
+from livekit.agents.voice import Agent, AgentSession, run_result as run_result_module
+
+from .fake_llm import FakeLLM, FakeLLMResponse
+
+pytestmark = pytest.mark.unit
+
+
+async def _start_session() -> tuple[AgentSession, Agent]:
+    session = AgentSession()
+    agent = Agent(
+        instructions="test agent",
+        llm=FakeLLM(
+            fake_responses=[
+                FakeLLMResponse(input="hello", content="hi there", ttft=0.0, duration=0.0)
+            ]
+        ),
+    )
+    await session.start(agent=agent)
+    return session, agent
+
+
+@pytest.mark.asyncio
+async def test_pending_handles_names_the_blocking_handle():
+    session, _ = await _start_session()
+
+    result = session.run(user_input="hello")
+    await asyncio.wait_for(result, timeout=10.0)
+
+    # a completed run is waiting on nothing
+    assert result._pending_handles() == []
+
+    # an unresolved handle watched by the run is reported under its label
+    blocker: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    result._done_fut = asyncio.Future()  # re-open so _watch_handle takes the handle
+    result._watch_handle(blocker, label="foreground_hold")
+    assert result._pending_handles() == ["foreground_hold"]
+
+    blocker.set_result(None)
+    assert result._pending_handles() == []
+
+    await session.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stall_watchdog_reports_pending_handles(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """A run held open past the threshold logs the handles it is waiting on."""
+    monkeypatch.setattr(run_result_module, "STALL_WARN_AFTER", 0.05)
+
+    session, _ = await _start_session()
+
+    result = session.run(user_input="hello")
+    await asyncio.wait_for(result, timeout=10.0)
+
+    # hold the completed run open the way a never-resolving guard would
+    result._done_fut = asyncio.Future()
+    blocker: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    result._watch_handle(blocker, label="foreground_hold")
+
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        result._stall_watchdog_atask = None  # allow a second arming for the test
+        result._start_stall_watchdog()
+        await asyncio.sleep(0.2)
+
+    stalls = [r for r in caplog.records if "still waiting on" in r.message]
+    assert stalls, "expected a stall warning naming the pending handles"
+    assert stalls[0].pending_handles == ["foreground_hold"]
+    assert stalls[0].user_input == "hello"
+
+    blocker.set_result(None)
+    result._done_fut.set_result(None)
+    await session.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stall_watchdog_is_silent_for_a_normal_turn(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """A turn that completes must not warn, however low the threshold."""
+    monkeypatch.setattr(run_result_module, "STALL_WARN_AFTER", 0.05)
+
+    session, _ = await _start_session()
+
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        result = session.run(user_input="hello")
+        await asyncio.wait_for(result, timeout=10.0)
+        await asyncio.sleep(0.2)
+
+    assert [r for r in caplog.records if "still waiting on" in r.message] == []
+    assert result._stall_watchdog_atask is None
+
+    await session.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stall_watchdog_reports_a_real_stalled_run(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """The 6661 shape: a run that genuinely never completes names its handle.
+
+    A tool that never returns holds the reply's speech handle open, so the run
+    stays pending forever. The warning has to point at the speech handle that
+    `generate_reply` registered, rather than leaving the caller to guess.
+    """
+    monkeypatch.setattr(run_result_module, "STALL_WARN_AFTER", 0.05)
+
+    tool_entered = asyncio.Event()
+    release_tool = asyncio.Event()
+
+    class StallingAgent(Agent):
+        @function_tool
+        async def never_returns(self) -> str:
+            """A tool that hangs until the test releases it."""
+            tool_entered.set()
+            await release_tool.wait()
+            return "released"
+
+    session = AgentSession()
+    agent = StallingAgent(
+        instructions="test agent",
+        llm=FakeLLM(
+            fake_responses=[
+                FakeLLMResponse(
+                    input="hello",
+                    content="",
+                    ttft=0.0,
+                    duration=0.0,
+                    tool_calls=[
+                        FunctionToolCall(name="never_returns", arguments="{}", call_id="1")
+                    ],
+                )
+            ]
+        ),
+    )
+    await session.start(agent=agent)
+
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        result = session.run(user_input="hello")
+        await asyncio.wait_for(tool_entered.wait(), timeout=5.0)
+        await asyncio.sleep(0.2)
+
+    assert not result.done(), "the hanging tool should have kept the run pending"
+
+    stalls = [r for r in caplog.records if "still waiting on" in r.message]
+    assert stalls, "a run stuck on a hanging tool must be reported"
+    assert stalls[0].pending_handles == [
+        p for p in stalls[0].pending_handles if p.startswith("generate_reply(speech_id=")
+    ], f"expected the reply handle to be named, got {stalls[0].pending_handles}"
+    assert stalls[0].pending_handles
+
+    release_tool.set()
+    await asyncio.wait_for(session.aclose(), timeout=10.0)


### PR DESCRIPTION
Diagnostics for livekit/agents#6661. **This does not fix the stall** — it names it, so the next report arrives with the responsible handle instead of a bare timeout.

## Problem

`RunResult` completes only once every watched handle is done:

```python
if all(handle.done() for handle in self._handles):
    self._mark_done()
```

So a handle that never completes hangs the run. From the agent's side that is completely silent — the caller times out, and the transcript looks complete because the reply itself did land, so the failure reads as spurious. livekit/agents#6661 describes exactly that shape: `Agent did not respond within 60.0s on turn N` on turns the transcript shows were answered, 25–40% of jobs, uncorrelated with scenario or tool.

Today there is no way to tell which of the watched handles held the run open, and there are several candidates: the reply's speech handle, a foreground hold guard, `on_enter`, an agent handoff, the AgentTask suspend/resume path, the realtime auto tool reply.

Worth noting the close path can hold a run open too — `_aclose_impl` only resolves `_global_run_state` at `agent_session.py:1300`, after awaiting `agent_task._wait_for_inactive()` and `activity.interrupt(force=True)`. Anything stuck in that drain keeps the run pending in the meantime.

## Change

* `_watch_handle(handle, *, label=...)` — every registration site now says what it is registering.
* `RunResult._pending_handles()` — renders the not-yet-done handles, e.g. `["generate_reply(speech_id=speech_ab12)"]` or `["foreground_hold"]`.
* `session.run()` arms a watchdog that logs those once the run outlives `STALL_WARN_AFTER` (30s), and stands down when the run completes.

A slow tool is indistinguishable from a stall at this level, so it stays a `warning` and the run is left running.

## Tests

`tests/test_run_result_stall.py`, four cases. The last one is the real thing: a function tool that never returns holds the reply's speech handle open, the run stays pending, and the warning names it:

```
run has not completed yet, it is still waiting on the handles below
  pending_handles=['generate_reply(speech_id=speech_...)']  user_input='hello'
```

Plus a negative case pinning that a turn which completes never warns, however low the threshold.