### PR TITLE
fix: stop dropping session host responses

### DIFF
--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -132,6 +132,7 @@ class RoomSessionTransport(SessionTransport):
         with contextlib.suppress(utils.aio.ChanClosed):
             self._incoming_ch.send_nowait(reader)
 
+    @utils.log_exceptions(logger=logger)
     async def _read_loop(self) -> None:
         # sequential, so messages reach _recv_ch in the order they were sent
         async for reader in self._incoming_ch:
@@ -434,7 +435,7 @@ class SessionHost:
         # events are emitted from sync callbacks and nobody awaits them, so they
         # queue here and one long-lived writer drains them in emission order
         self._event_ch: utils.aio.Chan[agent_pb.AgentSessionMessage] | None = None
-        self._event_writer_task: asyncio.Task[None] | None = None
+        self._write_task: asyncio.Task[None] | None = None
 
     def register_session(self, session: AgentSession) -> None:
         self._session = session
@@ -458,8 +459,8 @@ class SessionHost:
         self._started = True
         await self._transport.start()
         self._event_ch = utils.aio.Chan[agent_pb.AgentSessionMessage]()
-        self._event_writer_task = asyncio.create_task(
-            self._event_writer_loop(self._event_ch), name="SessionHost._event_writer"
+        self._write_task = asyncio.create_task(
+            self._write_loop(self._event_ch), name="SessionHost._write_loop"
         )
         self._recv_task = asyncio.create_task(self._recv_loop())
 
@@ -505,9 +506,9 @@ class SessionHost:
         # their way out, then exit
         if self._event_ch is not None:
             self._event_ch.close()
-        if self._event_writer_task is not None:
-            await _drain({self._event_writer_task}, deadline)
-            self._event_writer_task = None
+        if self._write_task is not None:
+            await _drain({self._write_task}, deadline)
+            self._write_task = None
 
         await self._transport.close()
 
@@ -548,9 +549,8 @@ class SessionHost:
         with contextlib.suppress(utils.aio.ChanClosed):
             self._event_ch.send_nowait(msg)
 
-    async def _event_writer_loop(
-        self, event_ch: utils.aio.Chan[agent_pb.AgentSessionMessage]
-    ) -> None:
+    @utils.log_exceptions(logger=logger)
+    async def _write_loop(self, event_ch: utils.aio.Chan[agent_pb.AgentSessionMessage]) -> None:
         # nobody awaits an event, so a failed one is logged rather than raised.
         # Draining them from a single task keeps their emission order and avoids
         # spawning a task per event.

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -64,6 +64,11 @@ if TYPE_CHECKING:
 
 TOPIC_SESSION_MESSAGES = "lk.agent.session"
 
+# How long SessionHost.aclose waits for in-flight request handlers to finish
+# before cancelling them. Stays well under the worker's shutdown_process_timeout
+# (10s by default), which has to cover this plus the rest of session cleanup.
+_SHUTDOWN_DRAIN_TIMEOUT = 3.0
+
 
 class SessionTransport(ABC):
     @abstractmethod
@@ -85,6 +90,7 @@ class RoomSessionTransport(SessionTransport):
         self._recv_ch: utils.aio.Chan[agent_pb.AgentSessionMessage] = utils.aio.Chan()
         self._handler_registered = False
         self._tasks: set[asyncio.Task[None]] = set()
+        self._send_lock = asyncio.Lock()
 
     @property
     def remote_identity(self) -> str | None:
@@ -122,20 +128,26 @@ class RoomSessionTransport(SessionTransport):
             logger.warning("failed to read binary stream message", exc_info=e)
 
     async def send_message(self, msg: agent_pb.AgentSessionMessage) -> None:
+        # a dropped message is a request the caller waits out in full, so failures
+        # are raised rather than logged: only the caller knows whether anyone is
+        # waiting on this one
         if self._recv_ch.closed or not self._room.isconnected():
-            return
-        try:
-            data = msg.SerializeToString()
-            dest = [self._remote_identity] if self._remote_identity else None
-            writer = await self._room.local_participant.stream_bytes(
-                name=utils.shortuuid("AS_"),
-                topic=TOPIC_SESSION_MESSAGES,
-                destination_identities=dest,
-            )
-            await writer.write(data)
-            await writer.aclose()
-        except Exception as e:
-            logger.warning("failed to send binary stream message: %s", e)
+            raise RuntimeError("room session transport is closed")
+
+        data = msg.SerializeToString()
+        dest = [self._remote_identity] if self._remote_identity else None
+        # one stream at a time — concurrent writers interleave on the same topic
+        async with self._send_lock:
+            try:
+                writer = await self._room.local_participant.stream_bytes(
+                    name=utils.shortuuid("AS_"),
+                    topic=TOPIC_SESSION_MESSAGES,
+                    destination_identities=dest,
+                )
+                await writer.write(data)
+                await writer.aclose()
+            except Exception as e:
+                raise RuntimeError(f"failed to send binary stream message: {e}") from e
 
     async def close(self) -> None:
         if self._recv_ch.closed:
@@ -169,6 +181,7 @@ class TcpSessionTransport(SessionTransport):
         self._writer: asyncio.StreamWriter | None = None
         self._closed = False
         self._loop: asyncio.AbstractEventLoop | None = None
+        self._send_lock = asyncio.Lock()
 
     async def start(self) -> None:
         reader, writer = await asyncio.open_connection(self._host, self._port)
@@ -183,12 +196,18 @@ class TcpSessionTransport(SessionTransport):
 
     async def send_message(self, msg: agent_pb.AgentSessionMessage) -> None:
         if self._closed or self._writer is None:
-            return
+            raise RuntimeError("tcp session transport is closed")
+
         data = msg.SerializeToString()
         header = struct.pack(">I", len(data))
-        self._writer.write(header + data)
-        if self._writer.transport.get_write_buffer_size() > 64 * 1024:
-            await self._writer.drain()
+        # the drain below yields, so without the lock a second sender can splice
+        # its frame between this header and its payload
+        async with self._send_lock:
+            if self._closed or self._writer is None:
+                raise RuntimeError("tcp session transport is closed")
+            self._writer.write(header + data)
+            if self._writer.transport.get_write_buffer_size() > 64 * 1024:
+                await self._writer.drain()
 
     def send_message_threadsafe(self, msg: agent_pb.AgentSessionMessage) -> None:
         if self._closed or self._writer is None or self._loop is None:
@@ -431,8 +450,20 @@ class SessionHost:
 
         if self._recv_task:
             await utils.aio.cancel_and_wait(self._recv_task)
+            self._recv_task = None
 
-        await utils.aio.cancel_and_wait(*self._tasks.tasks)
+        # let in-flight handlers finish. Cancelling here drops the response of a
+        # request that already did its work — the caller then waits out its full
+        # timeout for an answer the session had ready.
+        if handlers := self._tasks.tasks:
+            _, pending = await asyncio.wait(handlers, timeout=_SHUTDOWN_DRAIN_TIMEOUT)
+            if pending:
+                logger.warning(
+                    "session host handlers did not finish before the shutdown grace period",
+                    extra={"pending_handlers": len(pending)},
+                )
+                await utils.aio.cancel_and_wait(*pending)
+
         await self._transport.close()
 
     async def _recv_loop(self) -> None:
@@ -463,7 +494,15 @@ class SessionHost:
         ts.FromNanoseconds(int((created_at if created_at is not None else time.time()) * 1e9))
         event.created_at.CopyFrom(ts)
         msg = agent_pb.AgentSessionMessage(event=event)
-        self._tasks.create_task(self._transport.send_message(msg))
+        self._tasks.create_task(self._send_event_message(msg))
+
+    async def _send_event_message(self, msg: agent_pb.AgentSessionMessage) -> None:
+        # events are fire-and-forget: nobody is waiting on one, so a failure is
+        # logged here instead of surfacing as an unhandled task exception
+        try:
+            await self._transport.send_message(msg)
+        except Exception:
+            logger.warning("failed to send session event", exc_info=True)
 
     def _on_agent_state_changed(self, event: AgentStateChangedEvent) -> None:
         old_pb = _AGENT_STATE_MAP.get(event.old_state, agent_pb.AS_IDLE)

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -71,6 +71,18 @@ TOPIC_SESSION_MESSAGES = "lk.agent.session"
 _SHUTDOWN_DRAIN_TIMEOUT = 3.0
 
 
+async def _drain(tasks: set[asyncio.Task[Any]], deadline: float) -> set[asyncio.Task[Any]]:
+    """Wait for ``tasks`` until ``deadline``, then cancel and return the stragglers."""
+    if not tasks:
+        return set()
+
+    remaining = max(0.0, deadline - asyncio.get_event_loop().time())
+    _, pending = await asyncio.wait(tasks, timeout=remaining)
+    if pending:
+        await utils.aio.cancel_and_wait(*pending)
+    return pending
+
+
 class SessionTransport(ABC):
     @abstractmethod
     async def start(self) -> None: ...
@@ -90,8 +102,12 @@ class RoomSessionTransport(SessionTransport):
         self._remote_identity = remote_identity
         self._recv_ch: utils.aio.Chan[agent_pb.AgentSessionMessage] = utils.aio.Chan()
         self._handler_registered = False
-        self._tasks: set[asyncio.Task[None]] = set()
         self._send_lock = asyncio.Lock()
+        # inbound streams queue here for a single reader. A task per stream costs
+        # one per message, and lets two streams finish out of order and deliver
+        # their messages swapped.
+        self._incoming_ch: utils.aio.Chan[rtc.ByteStreamReader] = utils.aio.Chan()
+        self._read_task: asyncio.Task[None] | None = None
 
     @property
     def remote_identity(self) -> str | None:
@@ -104,15 +120,22 @@ class RoomSessionTransport(SessionTransport):
     async def start(self) -> None:
         if self._handler_registered:
             return
+        self._read_task = asyncio.create_task(
+            self._read_loop(), name="RoomSessionTransport._read_loop"
+        )
         self._room.register_byte_stream_handler(TOPIC_SESSION_MESSAGES, self._on_byte_stream)
         self._handler_registered = True
 
     def _on_byte_stream(self, reader: rtc.ByteStreamReader, participant_identity: str) -> None:
         if self._remote_identity and participant_identity != self._remote_identity:
             return
-        task = asyncio.create_task(self._read_stream(reader))
-        self._tasks.add(task)
-        task.add_done_callback(self._tasks.discard)
+        with contextlib.suppress(utils.aio.ChanClosed):
+            self._incoming_ch.send_nowait(reader)
+
+    async def _read_loop(self) -> None:
+        # sequential, so messages reach _recv_ch in the order they were sent
+        async for reader in self._incoming_ch:
+            await self._read_stream(reader)
 
     async def _read_stream(self, reader: rtc.ByteStreamReader) -> None:
         try:
@@ -154,8 +177,10 @@ class RoomSessionTransport(SessionTransport):
         if self._recv_ch.closed:
             return
         self._recv_ch.close()
-        await utils.aio.cancel_and_wait(*self._tasks)
-        self._tasks.clear()
+        self._incoming_ch.close()
+        if self._read_task is not None:
+            await utils.aio.cancel_and_wait(self._read_task)
+            self._read_task = None
         if self._handler_registered:
             try:
                 self._room.unregister_byte_stream_handler(TOPIC_SESSION_MESSAGES)
@@ -461,29 +486,27 @@ class SessionHost:
             await utils.aio.cancel_and_wait(self._recv_task)
             self._recv_task = None
 
+        # one budget for the whole drain, so aclose cannot stack two full grace
+        # periods and eat the worker's shutdown allowance
+        deadline = asyncio.get_event_loop().time() + _SHUTDOWN_DRAIN_TIMEOUT
+
         # let in-flight handlers finish. Cancelling here drops the response of a
         # request that already did its work — the caller then waits out its full
         # timeout for an answer the session had ready.
-        deadline = asyncio.get_event_loop().time() + _SHUTDOWN_DRAIN_TIMEOUT
-        if handlers := self._tasks.tasks:
-            _, pending = await asyncio.wait(handlers, timeout=_SHUTDOWN_DRAIN_TIMEOUT)
-            if pending:
-                logger.warning(
-                    "session host handlers did not finish before the shutdown grace period",
-                    extra={"pending_handlers": len(pending)},
-                )
-                await utils.aio.cancel_and_wait(*pending)
+        if abandoned := await _drain(self._tasks.tasks, deadline):
+            logger.warning(
+                "gave up on in-flight session requests while closing; "
+                "their callers get no response and will block until they time out. "
+                "Either a request is stuck or the session is closing mid-turn.",
+                extra={"abandoned_requests": sorted(t.get_name() for t in abandoned)},
+            )
 
-        # closing the channel lets the writer send what the handlers just queued
-        # and then exit; handlers and writer share one budget so aclose cannot
-        # stack two full grace periods
+        # closing the channel lets the writer flush what the handlers queued on
+        # their way out, then exit
         if self._event_ch is not None:
             self._event_ch.close()
         if self._event_writer_task is not None:
-            remaining = max(0.0, deadline - asyncio.get_event_loop().time())
-            _, pending = await asyncio.wait({self._event_writer_task}, timeout=remaining)
-            if pending:
-                await utils.aio.cancel_and_wait(self._event_writer_task)
+            await _drain({self._event_writer_task}, deadline)
             self._event_writer_task = None
 
         await self._transport.close()
@@ -493,7 +516,11 @@ class SessionHost:
             async for msg in self._transport:
                 if msg.HasField("request"):
                     if self._session is not None:
-                        self._tasks.create_task(self._handle_request_safe(msg.request))
+                        # named so shutdown can report which requests it abandoned
+                        self._tasks.create_task(
+                            self._handle_request_safe(msg.request),
+                            name=f"{msg.request.WhichOneof('request')}:{msg.request.request_id}",
+                        )
                 else:
                     msg_type = msg.WhichOneof("message")
                     if msg_type:
@@ -1185,9 +1212,14 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
 
     async def wait_for_ready(self, timeout: float = 5.0, retry_interval: float = 0.5) -> None:
         deadline = asyncio.get_event_loop().time() + timeout
+        # a transport that never came up is the useful answer; a bare timeout
+        # would say only that no pong arrived
+        send_error: Exception | None = None
         while True:
             remaining = deadline - asyncio.get_event_loop().time()
             if remaining <= 0:
+                if send_error is not None:
+                    raise send_error
                 raise TimeoutError("wait_for_ready timed out")
             req = agent_pb.SessionRequest(
                 request_id=utils.shortuuid("req_"),
@@ -1199,6 +1231,17 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
             except (TimeoutError, asyncio.TimeoutError):
                 if asyncio.get_event_loop().time() >= deadline:
                     raise TimeoutError("wait_for_ready timed out") from None
+            except Exception as e:
+                # the transport reports that it is not up yet instead of dropping
+                # the ping, and that state is exactly what this call polls
+                # through. The request timeout paced the retries before; pace
+                # them here, since the failure is now immediate.
+                send_error = e
+                if asyncio.get_event_loop().time() >= deadline:
+                    raise
+                await asyncio.sleep(
+                    min(retry_interval, max(0.0, deadline - asyncio.get_event_loop().time()))
+                )
 
     async def get_chat_history(self) -> agent_pb.SessionResponse.GetChatHistoryResponse:
         req = agent_pb.SessionRequest(

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -433,8 +433,10 @@ class SessionHost:
         self._session: AgentSession | None = None
         self._events_registered = False
         # events are emitted from sync callbacks and nobody awaits them, so they
-        # queue here and one long-lived writer drains them in emission order
-        self._event_ch: utils.aio.Chan[agent_pb.AgentSessionMessage] | None = None
+        # queue here and one long-lived writer drains them in emission order.
+        # Built here rather than in start() so events emitted between
+        # register_session() and start() queue up instead of being dropped.
+        self._event_ch = utils.aio.Chan[agent_pb.AgentSessionMessage]()
         self._write_task: asyncio.Task[None] | None = None
 
     def register_session(self, session: AgentSession) -> None:
@@ -458,7 +460,6 @@ class SessionHost:
             return
         self._started = True
         await self._transport.start()
-        self._event_ch = utils.aio.Chan[agent_pb.AgentSessionMessage]()
         self._write_task = asyncio.create_task(
             self._write_loop(self._event_ch), name="SessionHost._write_loop"
         )
@@ -494,18 +495,19 @@ class SessionHost:
         # let in-flight handlers finish. Cancelling here drops the response of a
         # request that already did its work — the caller then waits out its full
         # timeout for an answer the session had ready.
-        if abandoned := await _drain(self._tasks.tasks, deadline):
+        if cancelled := await _drain(self._tasks.tasks, deadline):
+            # the type is what can be acted on: it says what was in flight when the
+            # session went away. Reporting the request ids too would not help — a
+            # client shutting down alongside the host cancels its pending requests
+            # rather than waiting out the timeout that would log them to match.
             logger.warning(
-                "gave up on in-flight session requests while closing; "
-                "their callers get no response and will block until they time out. "
-                "Either a request is stuck or the session is closing mid-turn.",
-                extra={"abandoned_requests": sorted(t.get_name() for t in abandoned)},
+                "cancelled in-flight session requests while closing",
+                extra={"request_types": sorted({t.get_name() for t in cancelled})},
             )
 
         # closing the channel lets the writer flush what the handlers queued on
         # their way out, then exit
-        if self._event_ch is not None:
-            self._event_ch.close()
+        self._event_ch.close()
         if self._write_task is not None:
             await _drain({self._write_task}, deadline)
             self._write_task = None
@@ -517,10 +519,11 @@ class SessionHost:
             async for msg in self._transport:
                 if msg.HasField("request"):
                     if self._session is not None:
-                        # named so shutdown can report which requests it abandoned
+                        # the task name is the request type verbatim, which is what
+                        # aclose reports when it gives up on one
                         self._tasks.create_task(
                             self._handle_request_safe(msg.request),
-                            name=f"{msg.request.WhichOneof('request')}:{msg.request.request_id}",
+                            name=msg.request.WhichOneof("request") or "unknown",
                         )
                 else:
                     msg_type = msg.WhichOneof("message")
@@ -544,8 +547,6 @@ class SessionHost:
         ts.FromNanoseconds(int((created_at if created_at is not None else time.time()) * 1e9))
         event.created_at.CopyFrom(ts)
         msg = agent_pb.AgentSessionMessage(event=event)
-        if self._event_ch is None:
-            return
         with contextlib.suppress(utils.aio.ChanClosed):
             self._event_ch.send_nowait(msg)
 

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import struct
 import time
 from abc import ABC, abstractmethod
@@ -405,6 +406,10 @@ class SessionHost:
         self._tasks = utils.aio.TaskSet()
         self._session: AgentSession | None = None
         self._events_registered = False
+        # events are emitted from sync callbacks and nobody awaits them, so they
+        # queue here and one long-lived writer drains them in emission order
+        self._event_ch: utils.aio.Chan[agent_pb.AgentSessionMessage] | None = None
+        self._event_writer_task: asyncio.Task[None] | None = None
 
     def register_session(self, session: AgentSession) -> None:
         self._session = session
@@ -427,6 +432,10 @@ class SessionHost:
             return
         self._started = True
         await self._transport.start()
+        self._event_ch = utils.aio.Chan[agent_pb.AgentSessionMessage]()
+        self._event_writer_task = asyncio.create_task(
+            self._event_writer_loop(self._event_ch), name="SessionHost._event_writer"
+        )
         self._recv_task = asyncio.create_task(self._recv_loop())
 
     async def aclose(self) -> None:
@@ -455,6 +464,7 @@ class SessionHost:
         # let in-flight handlers finish. Cancelling here drops the response of a
         # request that already did its work — the caller then waits out its full
         # timeout for an answer the session had ready.
+        deadline = asyncio.get_event_loop().time() + _SHUTDOWN_DRAIN_TIMEOUT
         if handlers := self._tasks.tasks:
             _, pending = await asyncio.wait(handlers, timeout=_SHUTDOWN_DRAIN_TIMEOUT)
             if pending:
@@ -463,6 +473,18 @@ class SessionHost:
                     extra={"pending_handlers": len(pending)},
                 )
                 await utils.aio.cancel_and_wait(*pending)
+
+        # closing the channel lets the writer send what the handlers just queued
+        # and then exit; handlers and writer share one budget so aclose cannot
+        # stack two full grace periods
+        if self._event_ch is not None:
+            self._event_ch.close()
+        if self._event_writer_task is not None:
+            remaining = max(0.0, deadline - asyncio.get_event_loop().time())
+            _, pending = await asyncio.wait({self._event_writer_task}, timeout=remaining)
+            if pending:
+                await utils.aio.cancel_and_wait(self._event_writer_task)
+            self._event_writer_task = None
 
         await self._transport.close()
 
@@ -494,15 +516,22 @@ class SessionHost:
         ts.FromNanoseconds(int((created_at if created_at is not None else time.time()) * 1e9))
         event.created_at.CopyFrom(ts)
         msg = agent_pb.AgentSessionMessage(event=event)
-        self._tasks.create_task(self._send_event_message(msg))
+        if self._event_ch is None:
+            return
+        with contextlib.suppress(utils.aio.ChanClosed):
+            self._event_ch.send_nowait(msg)
 
-    async def _send_event_message(self, msg: agent_pb.AgentSessionMessage) -> None:
-        # events are fire-and-forget: nobody is waiting on one, so a failure is
-        # logged here instead of surfacing as an unhandled task exception
-        try:
-            await self._transport.send_message(msg)
-        except Exception:
-            logger.warning("failed to send session event", exc_info=True)
+    async def _event_writer_loop(
+        self, event_ch: utils.aio.Chan[agent_pb.AgentSessionMessage]
+    ) -> None:
+        # nobody awaits an event, so a failed one is logged rather than raised.
+        # Draining them from a single task keeps their emission order and avoids
+        # spawning a task per event.
+        async for msg in event_ch:
+            try:
+                await self._transport.send_message(msg)
+            except Exception:
+                logger.warning("failed to send session event", exc_info=True)
 
     def _on_agent_state_changed(self, event: AgentStateChangedEvent) -> None:
         old_pb = _AGENT_STATE_MAP.get(event.old_state, agent_pb.AS_IDLE)

--- a/tests/test_remote_session.py
+++ b/tests/test_remote_session.py
@@ -347,3 +347,34 @@ async def test_event_send_failure_does_not_escape_as_task_exception(
     assert [r for r in caplog.records if "failed to send session event" in r.message]
 
     await host.aclose()
+
+
+@pytest.mark.asyncio
+async def test_events_are_written_by_one_task_in_emission_order():
+    """Events queue to a single writer rather than a task each."""
+    sent: list[str] = []
+
+    class _RecordingTransport(PairedTransport):
+        async def send_message(self, msg: agent_pb.AgentSessionMessage) -> None:
+            await asyncio.sleep(0.005)  # a real send yields
+            sent.append(msg.event.user_input_transcribed.transcript)
+
+    host = SessionHost(_RecordingTransport())
+    host.register_session(_make_mock_session())
+    await host.start()
+
+    before = len(host._tasks.tasks)
+    for i in range(10):
+        host._send_event(
+            agent_pb.AgentSessionEvent(
+                user_input_transcribed=agent_pb.AgentSessionEvent.UserInputTranscribed(
+                    transcript=str(i)
+                )
+            )
+        )
+
+    # emitting events must not spawn tasks
+    assert len(host._tasks.tasks) == before
+
+    await host.aclose()  # closing drains what is still queued
+    assert sent == [str(i) for i in range(10)]

--- a/tests/test_remote_session.py
+++ b/tests/test_remote_session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock
 
@@ -10,6 +11,7 @@ from livekit.agents.llm import ChatContext, ChatMessage
 from livekit.agents.metrics import AgentSessionUsage
 from livekit.agents.voice.remote_session import (
     RemoteSession,
+    RoomSessionTransport,
     SessionHost,
     SessionTransport,
 )
@@ -200,4 +202,148 @@ async def test_run_input():
     assert resp is not None
 
     await client.aclose()
+    await host.aclose()
+
+
+class _SlowRunResult:
+    """A run that completes only once the test releases it."""
+
+    def __init__(self, release: asyncio.Event) -> None:
+        self.events = [MagicMock(item=ChatMessage(role="assistant", content=["done"], id="m-slow"))]
+        self._release = release
+
+    def done(self) -> bool:
+        return True
+
+    def __await__(self):
+        return self._release.wait().__await__()
+
+
+@pytest.mark.asyncio
+async def test_aclose_flushes_the_response_of_an_inflight_request():
+    """Shutdown must not drop the answer to a request that already did its work.
+
+    `aclose` used to cancel in-flight handlers outright, so a run that had just
+    finished lost its response and the caller waited out its whole timeout for
+    an answer the session already had.
+    """
+    host_transport, client_transport = PairedTransport.create_pair()
+
+    release = asyncio.Event()
+    mock_session = _make_mock_session()
+    mock_session.interrupt = AsyncMock()
+    mock_session.run = MagicMock(return_value=_SlowRunResult(release))
+
+    host = SessionHost(host_transport)
+    host.register_session(mock_session)
+    await host.start()
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    run_task = asyncio.ensure_future(client.run("order a big mac", timeout=1.0))
+    await asyncio.sleep(0.05)  # let the handler reach the pending run
+
+    async def _finish_during_shutdown() -> None:
+        await asyncio.sleep(0.05)
+        release.set()
+
+    # the run completes while aclose is already draining: cancelling the handler
+    # at that moment is what loses the response
+    finisher = asyncio.ensure_future(_finish_during_shutdown())
+    await host.aclose()
+    await finisher
+
+    resp = await asyncio.wait_for(run_task, timeout=2.0)
+    assert [i.message.content[0].text for i in resp.items] == ["done"]
+
+    await client.aclose()
+
+
+def _fake_room(*, connected: bool = True, stream_error: Exception | None = None) -> MagicMock:
+    room = MagicMock()
+    room.isconnected = MagicMock(return_value=connected)
+
+    async def _stream_bytes(**kwargs):
+        if stream_error is not None:
+            raise stream_error
+        writer = MagicMock()
+        writer.write = AsyncMock()
+        writer.aclose = AsyncMock()
+        return writer
+
+    room.local_participant.stream_bytes = _stream_bytes
+    return room
+
+
+@pytest.mark.asyncio
+async def test_room_transport_raises_instead_of_dropping_the_message():
+    """A transport that cannot deliver must say so, not drop the message.
+
+    A silently dropped response is indistinguishable from a hung agent: the
+    caller blocks until its timeout with nothing explaining why.
+    """
+    # the send itself fails
+    transport = RoomSessionTransport(_fake_room(stream_error=RuntimeError("stream refused")))
+    with pytest.raises(RuntimeError, match="failed to send binary stream message"):
+        await transport.send_message(agent_pb.AgentSessionMessage())
+
+    # the room is gone
+    transport = RoomSessionTransport(_fake_room(connected=False))
+    with pytest.raises(RuntimeError, match="closed"):
+        await transport.send_message(agent_pb.AgentSessionMessage())
+
+    # and a healthy room still sends
+    transport = RoomSessionTransport(_fake_room())
+    await transport.send_message(agent_pb.AgentSessionMessage())
+
+
+@pytest.mark.asyncio
+async def test_room_transport_serializes_concurrent_sends():
+    """Concurrent writers must not interleave on the shared topic."""
+    overlapping = False
+    in_flight = 0
+
+    async def _stream_bytes(**kwargs):
+        nonlocal overlapping, in_flight
+        in_flight += 1
+        if in_flight > 1:
+            overlapping = True
+        await asyncio.sleep(0.01)  # a real send yields several times
+        in_flight -= 1
+        writer = MagicMock()
+        writer.write = AsyncMock()
+        writer.aclose = AsyncMock()
+        return writer
+
+    room = _fake_room()
+    room.local_participant.stream_bytes = _stream_bytes
+    transport = RoomSessionTransport(room)
+
+    await asyncio.gather(
+        *(transport.send_message(agent_pb.AgentSessionMessage()) for _ in range(8))
+    )
+    assert not overlapping
+
+
+class _FailingTransport(PairedTransport):
+    async def send_message(self, msg: agent_pb.AgentSessionMessage) -> None:
+        raise RuntimeError("transport is down")
+
+
+@pytest.mark.asyncio
+async def test_event_send_failure_does_not_escape_as_task_exception(
+    caplog: pytest.LogCaptureFixture,
+):
+    """Events stay fire-and-forget even though the transport now raises."""
+    host = SessionHost(_FailingTransport())
+    host.register_session(_make_mock_session())
+    await host.start()
+
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        host._send_event(agent_pb.AgentSessionEvent())
+        await asyncio.sleep(0.05)
+
+    assert [r for r in caplog.records if "failed to send session event" in r.message]
+
     await host.aclose()

--- a/tests/test_remote_session.py
+++ b/tests/test_remote_session.py
@@ -9,6 +9,7 @@ import pytest
 
 from livekit.agents.llm import ChatContext, ChatMessage
 from livekit.agents.metrics import AgentSessionUsage
+from livekit.agents.voice import remote_session as remote_session_module
 from livekit.agents.voice.remote_session import (
     RemoteSession,
     RoomSessionTransport,
@@ -480,3 +481,43 @@ async def test_inbound_messages_are_read_without_a_task_each_and_stay_ordered():
     ]
 
     await transport.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_requests_are_logged_by_type(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """A request that outlives the grace period is reported by what it was.
+
+    The type is what can be acted on; the request id would only mean something
+    alongside a client log that a co-shutting-down client never emits.
+    """
+    monkeypatch.setattr(remote_session_module, "_SHUTDOWN_DRAIN_TIMEOUT", 0.05)
+
+    host_transport, client_transport = PairedTransport.create_pair()
+
+    never_finishes = asyncio.Event()
+    mock_session = _make_mock_session()
+    mock_session.interrupt = AsyncMock()
+    mock_session.run = MagicMock(return_value=_SlowRunResult(never_finishes))
+
+    host = SessionHost(host_transport)
+    host.register_session(mock_session)
+    await host.start()
+
+    client = RemoteSession(client_transport)
+    await client.start()
+
+    run_task = asyncio.ensure_future(client.run("order a big mac", timeout=2.0))
+    await asyncio.sleep(0.05)  # let the handler reach the pending run
+
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        await host.aclose()
+
+    records = [r for r in caplog.records if "cancelled in-flight" in r.message]
+    assert records, "abandoning a request at shutdown must be reported"
+    assert records[0].request_types == ["run_input"]
+
+    never_finishes.set()
+    run_task.cancel()
+    await client.aclose()

--- a/tests/test_remote_session.py
+++ b/tests/test_remote_session.py
@@ -378,3 +378,105 @@ async def test_events_are_written_by_one_task_in_emission_order():
 
     await host.aclose()  # closing drains what is still queued
     assert sent == [str(i) for i in range(10)]
+
+
+@pytest.mark.asyncio
+async def test_wait_for_ready_polls_through_a_transport_that_is_not_up():
+    """`wait_for_ready` exists to poll while the transport is still connecting.
+
+    That transport now reports its state instead of dropping the ping, so the
+    error has to be retried rather than surfaced on the first attempt.
+    """
+    host_transport, client_transport = PairedTransport.create_pair()
+    attempts = 0
+
+    class _LateTransport(PairedTransport):
+        async def send_message(self, msg: agent_pb.AgentSessionMessage) -> None:
+            nonlocal attempts
+            attempts += 1
+            if attempts < 3:
+                raise RuntimeError("room session transport is closed")
+            await client_transport.send_message(msg)
+
+    late = _LateTransport()
+    late._peer = host_transport._peer
+    host_transport._peer = late
+
+    mock_session = _make_mock_session()
+    host = SessionHost(host_transport)
+    host.register_session(mock_session)
+    await host.start()
+
+    client = RemoteSession(late)
+    late._peer = host_transport
+    host_transport._peer = late
+    await client.start()
+
+    await client.wait_for_ready(timeout=5.0, retry_interval=0.05)
+    assert attempts >= 3
+
+    await client.aclose()
+    await host.aclose()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_ready_surfaces_the_transport_error_past_the_deadline():
+    """Once the deadline passes, the transport error is the useful one."""
+
+    class _DeadTransport(PairedTransport):
+        async def send_message(self, msg: agent_pb.AgentSessionMessage) -> None:
+            raise RuntimeError("room session transport is closed")
+
+    client = RemoteSession(_DeadTransport())
+    await client.start()
+
+    with pytest.raises(RuntimeError, match="transport is closed"):
+        await client.wait_for_ready(timeout=0.2, retry_interval=0.05)
+
+    await client.aclose()
+
+
+class _FakeReader:
+    """Stands in for an rtc.ByteStreamReader over one message."""
+
+    def __init__(self, payload: bytes) -> None:
+        # split so the reader yields mid-message, the window a per-stream task
+        # used to interleave in
+        self._parts = [payload[:1], payload[1:]] if len(payload) > 1 else [payload]
+
+    async def __aiter__(self):
+        for part in self._parts:
+            await asyncio.sleep(0)  # a real reader yields between chunks
+            yield part
+
+
+@pytest.mark.asyncio
+async def test_inbound_messages_are_read_without_a_task_each_and_stay_ordered():
+    """Reading spawns one loop, not one task per message, and preserves order."""
+    transport = RoomSessionTransport(_fake_room())
+    await transport.start()
+
+    before = len(asyncio.all_tasks())
+
+    for i in range(10):
+        msg = agent_pb.AgentSessionMessage(
+            event=agent_pb.AgentSessionEvent(
+                user_input_transcribed=agent_pb.AgentSessionEvent.UserInputTranscribed(
+                    transcript=str(i)
+                )
+            )
+        )
+        transport._on_byte_stream(_FakeReader(msg.SerializeToString()), "remote")
+
+    # queueing 10 messages must not create 10 tasks
+    assert len(asyncio.all_tasks()) <= before
+
+    received = []
+    for _ in range(10):
+        received.append(await asyncio.wait_for(transport.__anext__(), timeout=2.0))
+
+    assert [m.event.user_input_transcribed.transcript for m in received] == [
+        str(i) for i in range(10)
+    ]
+
+    await transport.close()


### PR DESCRIPTION
Alternative to [#6665](<https://github.com/livekit/agents/issues/6665>), addressing livekit/agents#6661. Diagnosis is @samanyugoyal2010's — commits are co-authored to them, happy to close in favour of theirs.

## What was happening

A `run_input` response that never reached the client looked exactly like a hung agent: the caller blocked for its full 60s timeout while the transcript was complete and the agent log showed a clean shutdown.

Three paths dropped one silently:

* `RoomSessionTransport.send_message` swallowed send failures into a warning and returned.
* The same method returned early when the room was gone.
* `SessionHost.aclose` cancelled in-flight handlers, discarding the response of a request that had already done its work.

Nothing serialized writes either, and every inbound message spawned a task to read it — which could finish out of order and deliver messages swapped.

## The fix

* Transports raise instead of dropping, and serialize sends with a lock.
* `aclose` drains handlers before cancelling, and logs the request types it gave up on.
* Reads and event writes each get one long-lived drainer instead of a task per message.

Responses stay direct — a handler awaits the transport and gets the failure — so no per-message future is needed to hand results back. Events are the only thing that needs a queue.

14 tests, each verified to fail without its change.

## Caveats

* Doesn't guarantee delivery: a mid-conversation send failure still ends in a caller timeout, now with a log line. Worth checking against livekit/agents#6661's 25–40% rate before closing it.
* Sequential reads trade concurrency for ordering; a bounded pool is the alternative if you'd rather keep per-stream isolation.