### PR TITLE
fix(ivr): keep loop detection enabled without scikit-learn

### DIFF
--- a/livekit-agents/livekit/agents/voice/ivr/ivr_activity.py
+++ b/livekit-agents/livekit/agents/voice/ivr/ivr_activity.py
@@ -139,6 +139,8 @@ class TfidfLoopDetector:
         if len(self._transcribed_chunks) < 2:
             return False
 
+        # Rebuild the matrix for each chunk so the vocabulary and IDF reflect the
+        # current window. This is bounded by the small window size above.
         doc_matrix = self._tfidf_matrix(self._transcribed_chunks)
         last_chunk_similarity = doc_matrix[:-1] @ doc_matrix[-1]
 

--- a/livekit-agents/livekit/agents/voice/ivr/ivr_activity.py
+++ b/livekit-agents/livekit/agents/voice/ivr/ivr_activity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -8,6 +9,8 @@ from livekit.agents import llm
 
 from ...log import logger
 from ...utils.aio.debounce import Debounced
+
+_TOKEN_PATTERN = re.compile(r"(?u)\b\w\w+\b")
 
 if TYPE_CHECKING:
     from ..agent_session import AgentSession
@@ -132,26 +135,12 @@ class TfidfLoopDetector:
             self._transcribed_chunks = self._transcribed_chunks[-self._window_size :]
 
     def check_loop_detection(self) -> bool:
-        try:
-            from sklearn.feature_extraction.text import TfidfVectorizer  # type: ignore
-            from sklearn.metrics.pairwise import cosine_similarity  # type: ignore
-        except ImportError:
-            logger.warning(
-                "TfidfLoopDetector: sklearn is not installed; loop detection is disabled. Please install the 'scikit-learn' package to enable loop detection."
-            )
-            return False
-
-        vectorizer = TfidfVectorizer()
-
         # Need at least two chunks to compute similarity against the last chunk
         if len(self._transcribed_chunks) < 2:
             return False
 
-        # NOTE: currently this is O(n^2) in the number of chunks, let's figure out a more efficient
-        # way if this become a bottleneck later.
-        doc_matrix = vectorizer.fit_transform(self._transcribed_chunks)
-        doc_similarity = cosine_similarity(doc_matrix)
-        last_chunk_similarity = doc_similarity[-1][:-1]
+        doc_matrix = self._tfidf_matrix(self._transcribed_chunks)
+        last_chunk_similarity = doc_matrix[:-1] @ doc_matrix[-1]
 
         if (
             last_chunk_similarity.size > 0
@@ -162,3 +151,27 @@ class TfidfLoopDetector:
             self._num_consecutive_similar_chunks = 0
 
         return self._num_consecutive_similar_chunks >= self._consecutive_threshold
+
+    @staticmethod
+    def _tfidf_matrix(chunks: list[str]) -> np.ndarray:
+        """Build an L2-normalized TF-IDF matrix for the transcribed chunks."""
+
+        tokenized_chunks = [_TOKEN_PATTERN.findall(chunk.lower()) for chunk in chunks]
+        vocabulary = sorted({token for tokens in tokenized_chunks for token in tokens})
+        if not vocabulary:
+            return np.zeros((len(chunks), 0))
+
+        token_indexes = {token: index for index, token in enumerate(vocabulary)}
+        term_frequency = np.zeros((len(chunks), len(vocabulary)))
+        for chunk_index, tokens in enumerate(tokenized_chunks):
+            for token in tokens:
+                term_frequency[chunk_index, token_indexes[token]] += 1
+
+        document_frequency = np.count_nonzero(term_frequency, axis=0)
+        inverse_document_frequency = np.log((1 + len(chunks)) / (1 + document_frequency)) + 1
+        tfidf = term_frequency * inverse_document_frequency
+        norms = np.linalg.norm(tfidf, axis=1, keepdims=True)
+        normalized_tfidf: np.ndarray = np.divide(
+            tfidf, norms, out=np.zeros_like(tfidf), where=norms != 0
+        )
+        return normalized_tfidf

--- a/tests/test_ivr_activity.py
+++ b/tests/test_ivr_activity.py
@@ -1,3 +1,5 @@
+import builtins
+
 import pytest
 
 from livekit.agents.voice.ivr.ivr_activity import TfidfLoopDetector
@@ -49,6 +51,32 @@ def test_tfidf_detects_loop_on_repeated_user_speech() -> None:
     ]
 
     assert _count_loops(transcripts) == 3
+
+
+def test_tfidf_detects_loop_without_scikit_learn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Detects loops on a default install without the optional scikit-learn package."""
+
+    real_import = builtins.__import__
+
+    def import_without_scikit_learn(name: str, *args: object, **kwargs: object) -> object:
+        if name == "sklearn" or name.startswith("sklearn."):
+            raise ImportError("scikit-learn is not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_scikit_learn)
+
+    transcripts = [
+        "Welcome to automated phone system",
+        "Type 1 for sales",
+        "Type 2 for support",
+        "Type 3 for billing",
+        "Welcome to automated phone system",
+        "Type 1 for sales",
+        "Type 2 for support",
+        "Type 3 for billing",
+    ]
+
+    assert _count_loops(transcripts) == 2
 
 
 def test_tfidf_resets_after_novel_speech() -> None:

--- a/tests/test_ivr_activity.py
+++ b/tests/test_ivr_activity.py
@@ -63,6 +63,7 @@ def test_tfidf_detects_loop_without_scikit_learn(monkeypatch: pytest.MonkeyPatch
             raise ImportError("scikit-learn is not installed")
         return real_import(name, *args, **kwargs)
 
+    # This guard ensures the detector does not accidentally regain a runtime sklearn import.
     monkeypatch.setattr(builtins, "__import__", import_without_scikit_learn)
 
     transcripts = [


### PR DESCRIPTION
## Summary

`TfidfLoopDetector` currently imports scikit-learn at runtime, but `scikit-learn` is only in the repository's development dependency group. On a normal `livekit-agents` install, IVR loop detection therefore logs a warning and always returns `False`.

This replaces the small TF-IDF and cosine-similarity calculation with NumPy, which is already a runtime dependency. The existing thresholds and detector state behavior are unchanged.

Fixes #6778

## Validation

- `uv run pytest tests/test_ivr_activity.py --unit -q`
- `uv run ruff check livekit-agents/livekit/agents/voice/ivr/ivr_activity.py tests/test_ivr_activity.py`
- `uv run ruff format --check livekit-agents/livekit/agents/voice/ivr/ivr_activity.py tests/test_ivr_activity.py`
- Compared the NumPy TF-IDF matrix and cosine similarities against scikit-learn across representative corpora.

The repository-wide unit suite passed 1,907 tests when run sequentially; 9 room tests could not start because `livekit-server` is not installed in the local environment. The repository type-check command also reports three pre-existing missing stubs for optional `cv2`, `loguru`, and `boto3` integrations; the changed files produce no type errors.

## AI assistance

AI assistance was used during implementation and review. I reviewed the resulting changes and test output and am responsible for the contribution.
