### PR TITLE
fix(sarvam): align Sarvam TTS speaker, sample rate, and pace validation with Bulbul API (#6774)

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -216,6 +216,15 @@ SarvamTTSSpeakers = Literal[
     "tanya",
     "shruti",
     "kavitha",
+    "anand",
+    "tarun",
+    "sunny",
+    "mani",
+    "gokul",
+    "vijay",
+    "mohit",
+    "rehan",
+    "soham",
 ]
 
 # Model-Speaker compatibility mapping
@@ -294,8 +303,6 @@ MODEL_SPEAKER_COMPATIBILITY = {
             "priya",
             "neha",
             "roopa",
-            "amelia",
-            "sophia",
             "suhani",
             "rupali",
             "tanya",
@@ -317,6 +324,15 @@ MODEL_SPEAKER_COMPATIBILITY = {
             "aayan",
             "ashutosh",
             "advait",
+            "anand",
+            "tarun",
+            "sunny",
+            "mani",
+            "gokul",
+            "vijay",
+            "mohit",
+            "rehan",
+            "soham",
         ],
         "all": [
             "shubh",
@@ -342,13 +358,20 @@ MODEL_SPEAKER_COMPATIBILITY = {
             "aayan",
             "ashutosh",
             "advait",
-            "amelia",
-            "sophia",
             "suhani",
             "rupali",
             "tanya",
             "shruti",
             "kavitha",
+            "anand",
+            "tarun",
+            "sunny",
+            "mani",
+            "gokul",
+            "vijay",
+            "mohit",
+            "rehan",
+            "soham",
         ],
     },
 }
@@ -377,6 +400,16 @@ def validate_model_speaker_compatibility(model: str, speaker: str) -> bool:
         )
         return False
     return True
+
+
+def _validate_pace(model: str, pace: float) -> None:
+    """Validate pace parameter range per model (0.5-2.0 for v3/v3-beta, 0.3-3.0 for v2)."""
+    if model in ("bulbul:v3", "bulbul:v3-beta"):
+        if not 0.5 <= pace <= 2.0:
+            raise ValueError("Pace must be between 0.5 and 2.0")
+    else:
+        if not 0.3 <= pace <= 3.0:
+            raise ValueError("Pace must be between 0.3 and 3.0")
 
 
 @dataclass
@@ -514,8 +547,7 @@ class TTS(tts.TTS):
                 pitch,
             )
             pitch = max(-0.75, min(0.75, pitch))
-        if not 0.3 <= pace <= 3.0:
-            raise ValueError("Pace must be between 0.3 and 3.0")
+        _validate_pace(model, pace)
         if not 0.5 <= loudness <= 2.0:
             raise ValueError("Loudness must be between 0.5 and 2.0")
         if not 0.01 <= temperature <= 2.0:
@@ -795,8 +827,7 @@ class TTS(tts.TTS):
             self._opts.pitch = pitch
 
         if pace is not None:
-            if not 0.3 <= pace <= 3.0:
-                raise ValueError("Pace must be between 0.3 and 3.0")
+            _validate_pace(self._opts.model, pace)
             self._opts.pace = pace
 
         if loudness is not None:
@@ -860,6 +891,11 @@ class TTS(tts.TTS):
         self, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
     ) -> SynthesizeStream:
         """Create a streaming TTS session."""
+        if self._opts.speech_sample_rate not in (8000, 16000, 22050, 24000):
+            raise ValueError(
+                f"Speech sample rate {self._opts.speech_sample_rate} Hz is REST-only; "
+                "streaming supports 8000, 16000, 22050, and 24000 Hz."
+            )
         stream = SynthesizeStream(tts=self, conn_options=conn_options)
         self._streams.add(stream)
         return stream

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_language_probability.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_language_probability.py
@@ -39,6 +39,10 @@ def _make_stream_under_test() -> tuple[SpeechStream, list[Any]]:
     instance._build_log_context = lambda: {}  # type: ignore[attr-defined]
     instance._server_request_id = None  # type: ignore[attr-defined]
     instance._opts = MagicMock(language="en-IN")  # type: ignore[attr-defined]
+    instance._pending_eos = False  # type: ignore[attr-defined]
+    instance._pending_final_data = None  # type: ignore[attr-defined]
+    instance._eos_emitted_for_utterance = False  # type: ignore[attr-defined]
+    instance._positive_time = lambda t: t  # type: ignore[attr-defined]
     return instance, captured
 
 

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_language_probability.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_language_probability.py
@@ -16,6 +16,8 @@ import pytest
 from livekit.agents import stt
 from livekit.plugins.sarvam.stt import SpeechStream
 
+pytestmark = pytest.mark.unit
+
 # ---------------------------------------------------------------------------
 # Helpers — build a minimal STT instance + fake the channel/logger/state that
 # `_handle_transcript_data` touches. We bypass __init__ so the test doesn't

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_tts_validation.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_tts_validation.py
@@ -6,6 +6,8 @@ import pytest
 
 from livekit.plugins.sarvam import TTS
 
+pytestmark = pytest.mark.unit
+
 
 def test_v3_speaker_validation() -> None:
     """Test that all newly added v3 male speakers pass validation and amelia/sophia are rejected."""

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_tts_validation.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_tts_validation.py
@@ -1,0 +1,55 @@
+"""Tests for Sarvam TTS parameter validation (speakers, sample rates, model-specific pace)."""
+
+from __future__ import annotations
+
+import pytest
+
+from livekit.plugins.sarvam import TTS
+
+
+def test_v3_speaker_validation() -> None:
+    """Test that all newly added v3 male speakers pass validation and amelia/sophia are rejected."""
+    # Valid v3 male speakers
+    for speaker in ["anand", "tarun", "sunny", "mani", "gokul", "vijay", "mohit", "rehan", "soham"]:
+        tts = TTS(api_key="test-key", model="bulbul:v3", speaker=speaker)
+        assert tts._opts.speaker == speaker
+
+    # Invalid v3 speakers (amelia/sophia belong to v3-beta only)
+    for speaker in ["amelia", "sophia"]:
+        with pytest.raises(ValueError, match="is not compatible with model 'bulbul:v3'"):
+            TTS(api_key="test-key", model="bulbul:v3", speaker=speaker)
+
+
+@pytest.mark.asyncio
+async def test_streaming_sample_rate_gating() -> None:
+    """Test that REST-only sample rates (32000, 44100, 48000) are allowed in constructor but fail on stream()."""
+    tts_rest = TTS(api_key="test-key", model="bulbul:v3", speech_sample_rate=48000)
+    assert tts_rest._opts.speech_sample_rate == 48000
+
+    with pytest.raises(ValueError, match="REST-only"):
+        tts_rest.stream()
+
+    # Valid streaming sample rates
+    for rate in [8000, 16000, 22050, 24000]:
+        tts_stream = TTS(api_key="test-key", model="bulbul:v3", speech_sample_rate=rate)
+        # Verify stream creation succeeds without raising ValueError
+        stream = tts_stream.stream()
+        assert stream is not None
+
+
+def test_model_specific_pace_validation() -> None:
+    """Test that pace is validated per model (0.5-2.0 for v3/v3-beta, 0.3-3.0 for v2)."""
+    # bulbul:v3 rejects pace > 2.0
+    with pytest.raises(ValueError, match="Pace must be between 0.5 and 2.0"):
+        TTS(api_key="test-key", model="bulbul:v3", pace=2.5)
+
+    with pytest.raises(ValueError, match="Pace must be between 0.5 and 2.0"):
+        TTS(api_key="test-key", model="bulbul:v3-beta", pace=0.2)
+
+    # bulbul:v3 accepts pace 1.5
+    tts_v3 = TTS(api_key="test-key", model="bulbul:v3", pace=1.5)
+    assert tts_v3._opts.pace == 1.5
+
+    # bulbul:v2 accepts pace 2.5
+    tts_v2 = TTS(api_key="test-key", model="bulbul:v2", pace=2.5)
+    assert tts_v2._opts.pace == 2.5


### PR DESCRIPTION
## Description

Resolves #6774.

Fixes three parameter validation discrepancies in \livekit-plugins-sarvam\ TTS service:

1. **Speaker compatibility for \ulbul:v3\**:
   - Added 9 missing male speakers (\nand\, \	arun\, \sunny\, \mani\, \gokul\, \ijay\, \mohit\, \ehan\, \soham\) supported by Bulbul v3 API.
   - Removed \melia\ and \sophia\ from \ulbul:v3\ (v3-beta international speakers only).

2. **REST vs Streaming Sample Rate Gating**:
   - Sample rates \32000\, \44100\, and \48000\ Hz are accepted during \TTS\ initialization (valid for REST \synthesize()\), but calling \stream()\ now raises a clear \ValueError\ early rather than failing mid-session.

3. **Model-Aware Pace Validation**:
   - Added \_validate_pace\ helper so \ulbul:v3\ and \ulbul:v3-beta\ validate \pace\ in \[0.5, 2.0]\ while \ulbul:v2\ accepts \[0.3, 3.0]\.

## Related Issue

Fixes #6774

## Tests

- [x] Added unit tests in \	est_tts_validation.py\ covering v3 speakers, sample rate streaming gating, and model-specific pace limits.
- [x] Verified unit tests pass via \pytest\ (31 tests passed).