### PR TITLE
feat(llm): export FallbackRealtimeSession as a public class (#6553)

### DIFF
--- a/livekit-agents/livekit/agents/llm/__init__.py
+++ b/livekit-agents/livekit/agents/llm/__init__.py
@@ -88,7 +88,6 @@ __all__ = [
     "AvailabilityChangedEvent",
     "RealtimeModelFallbackAdapter",
     "FallbackRealtimeSession",
-    "_FallbackRealtimeSession",
     "RealtimeAvailabilityChangedEvent",
     "ToolChoice",
     "Tool",

--- a/livekit-agents/livekit/agents/llm/__init__.py
+++ b/livekit-agents/livekit/agents/llm/__init__.py
@@ -42,7 +42,7 @@ from .realtime_fallback_adapter import (
     FallbackRealtimeSession,
     RealtimeAvailabilityChangedEvent,
     RealtimeModelFallbackAdapter,
-    _FallbackRealtimeSession,
+    _FallbackRealtimeSession as _FallbackRealtimeSession,
 )
 from .tool_context import (
     DuplicateScope,

--- a/livekit-agents/livekit/agents/llm/__init__.py
+++ b/livekit-agents/livekit/agents/llm/__init__.py
@@ -39,8 +39,10 @@ from .realtime import (
     RemoteItemAddedEvent,
 )
 from .realtime_fallback_adapter import (
+    FallbackRealtimeSession,
     RealtimeAvailabilityChangedEvent,
     RealtimeModelFallbackAdapter,
+    _FallbackRealtimeSession,
 )
 from .tool_context import (
     DuplicateScope,
@@ -85,6 +87,8 @@ __all__ = [
     "FallbackAdapter",
     "AvailabilityChangedEvent",
     "RealtimeModelFallbackAdapter",
+    "FallbackRealtimeSession",
+    "_FallbackRealtimeSession",
     "RealtimeAvailabilityChangedEvent",
     "ToolChoice",
     "Tool",

--- a/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
@@ -118,7 +118,7 @@ class RealtimeModelFallbackAdapter(
         self._models = models
         self._cooldown = cooldown
         self._regenerate_on_swap = regenerate_on_swap
-        self._sessions: weakref.WeakSet[_FallbackRealtimeSession] = weakref.WeakSet()
+        self._sessions: weakref.WeakSet[FallbackRealtimeSession] = weakref.WeakSet()
 
         # the model currently serving sessions; used to label metrics & traces
         self._active_instance: RealtimeModel = models[0]
@@ -136,8 +136,8 @@ class RealtimeModelFallbackAdapter(
         """Metadata of the model currently serving sessions (the primary until a swap)."""
         return self._active_instance.metrics_metadata
 
-    def session(self, *, turn_detection_disabled: bool = False) -> _FallbackRealtimeSession:
-        sess = _FallbackRealtimeSession(self, turn_detection_disabled=turn_detection_disabled)
+    def session(self, *, turn_detection_disabled: bool = False) -> FallbackRealtimeSession:
+        sess = FallbackRealtimeSession(self, turn_detection_disabled=turn_detection_disabled)
         self._sessions.add(sess)
         return sess
 
@@ -156,7 +156,7 @@ class RealtimeModelFallbackAdapter(
             await model.aclose()
 
 
-class _FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_changed"]]):
+class FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_changed"]]):
     """Bound once by AgentActivity; swaps the inner child session internally."""
 
     def __init__(
@@ -455,3 +455,7 @@ class _FallbackRealtimeSession(RealtimeSession[Literal["realtime_availability_ch
             await aio.cancel_and_wait(self._swap_task)
         self._unbind(self._active)
         await self._active.aclose()
+
+
+# Backward compatibility alias
+_FallbackRealtimeSession = FallbackRealtimeSession

--- a/tests/test_realtime_fallback.py
+++ b/tests/test_realtime_fallback.py
@@ -5,7 +5,12 @@ import asyncio
 import pytest
 
 from livekit import rtc
-from livekit.agents.llm import ChatContext, RealtimeModelFallbackAdapter
+from livekit.agents.llm import (
+    ChatContext,
+    FallbackRealtimeSession,
+    RealtimeModelFallbackAdapter,
+    _FallbackRealtimeSession,
+)
 
 from .fake_realtime import FakeRealtimeModel, fake_capabilities
 
@@ -618,3 +623,13 @@ async def test_emits_availability_changed_on_recovery() -> None:
     await session._swap_task
 
     assert any(e.realtime_model is primary and e.available is True for e in events)
+
+
+def test_fallback_realtime_session_is_public() -> None:
+    primary = FakeRealtimeModel()
+    adapter = RealtimeModelFallbackAdapter([primary])
+    session = adapter.session()
+
+    assert isinstance(session, FallbackRealtimeSession)
+    assert isinstance(session, _FallbackRealtimeSession)
+    assert FallbackRealtimeSession is _FallbackRealtimeSession


### PR DESCRIPTION
## Description

Resolves #6553.

Exported \FallbackRealtimeSession\ as a public class in \livekit.agents.llm\ and \livekit.agents.llm.realtime_fallback_adapter\. 

This enables callers and plugins to perform \isinstance(rt_session, FallbackRealtimeSession)\ checks directly when attaching provider-specific realtime session event handlers.

For backward compatibility, \_FallbackRealtimeSession\ is preserved as an alias.

## Related Issue

Fixes #6553

## Tests

- [x] Added \	est_fallback_realtime_session_is_public\ in \	est_realtime_fallback.py\ to verify public export and \isinstance\ checks.
- [x] Verified unit tests pass via \pytest tests/test_realtime_fallback.py\ (39 tests passed).