### PR TITLE
feat(voice): add speech_id to assistant message metrics

### DIFF
--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -301,6 +301,14 @@ class MetricsReport(TypedDict, total=False):
     provider-side logs.
     """
 
+    speech_id: str
+    """ID of the `SpeechHandle` that produced this turn.
+
+    Assistant `ChatMessage` only. Matches the `lk.speech_id` span attribute and the
+    `speech_id` on `metrics_collected` events, so a stored message can be correlated with
+    its trace or with the per-component metrics of the same turn.
+    """
+
     llm_metadata: MetricsMetadata
     tts_metadata: MetricsMetadata
     stt_metadata: MetricsMetadata

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2940,7 +2940,7 @@ class AgentActivity(RecognitionHooks):
         current_span.set_attribute(trace_types.ATTR_RESPONSE_TEXT, forwarded_text)
 
         if forwarded_text and add_to_chat_ctx:
-            assistant_metrics: llm.MetricsReport = {}
+            assistant_metrics: llm.MetricsReport = {"speech_id": speech_handle.id}
 
             if tts_gen_data and tts_gen_data.ttfb is not None:
                 assistant_metrics["tts_node_ttfb"] = tts_gen_data.ttfb
@@ -3391,7 +3391,7 @@ class AgentActivity(RecognitionHooks):
                 break
 
         stopped_speaking_at = time.time()
-        assistant_metrics: llm.MetricsReport = {}
+        assistant_metrics: llm.MetricsReport = {"speech_id": speech_handle.id}
 
         if self.llm:
             assistant_metrics["llm_metadata"] = self.llm.metrics_metadata
@@ -4020,7 +4020,7 @@ class AgentActivity(RecognitionHooks):
         def _create_assistant_message(
             message_id: str, forwarded_text: str, interrupted: bool
         ) -> llm.ChatMessage:
-            assistant_metrics: llm.MetricsReport = {}
+            assistant_metrics: llm.MetricsReport = {"speech_id": speech_handle.id}
 
             if generation_ev.response_id:
                 assistant_metrics["provider_request_ids"] = [generation_ev.response_id]

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -47,6 +47,7 @@ from livekit.agents.voice.audio_recognition import AudioRecognition, _EndOfTurnI
 from livekit.agents.voice.endpointing import BaseEndpointing
 from livekit.agents.voice.events import FunctionToolsExecutedEvent
 from livekit.agents.voice.io import PlaybackFinishedEvent
+from livekit.agents.voice.transcription.synchronizer import _SyncedAudioOutput
 
 from .fake_session import FakeActions, create_session, run_session
 
@@ -301,6 +302,70 @@ async def test_llm_node_ttfs_anchors_on_synthesis_start() -> None:
     assert "llm_node_ttfs" in metrics
     check_timestamp(metrics["llm_node_ttfs"], 2.0, speed_factor=speed)
     check_timestamp(metrics["tts_node_ttfb"], 0.2, speed_factor=speed)
+
+
+async def test_assistant_metrics_share_speech_id_with_tts_metrics() -> None:
+    # TTSMetrics.ttfb is the TTS provider's own latency, while the assistant message's
+    # tts_node_ttfb also covers sentence-tokenizer buffering. Their difference is the
+    # tokenizer overhead, but computing it requires pairing the two for the same turn, and
+    # metrics_collected events are not part of the session report -- so the assistant
+    # message has to carry the correlation id itself
+    speed = 1
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "Hello, how are you?", stt_delay=0.2)
+    actions.add_llm("I'm doing well, thank you!", ttft=0.1, duration=0.3)
+    actions.add_tts(2.0, ttfb=0.2, duration=0.3)
+
+    session = create_session(actions, speed_factor=speed)
+    agent = MyAgent()
+
+    metrics_events: list[MetricsCollectedEvent] = []
+    conversation_events: list[ConversationItemAddedEvent] = []
+    session.on("metrics_collected", metrics_events.append)
+    session.on("conversation_item_added", conversation_events.append)
+
+    await asyncio.wait_for(run_session(session, agent), timeout=SESSION_TIMEOUT)
+
+    assistant_messages = [
+        ev.item
+        for ev in conversation_events
+        if ev.item.type == "message" and ev.item.role == "assistant"
+    ]
+    tts_metrics = [ev.metrics for ev in metrics_events if ev.metrics.type == "tts_metrics"]
+    assert len(assistant_messages) == 1
+    assert len(tts_metrics) == 1
+    assert tts_metrics[0].speech_id is not None
+
+    metrics = assistant_messages[0].metrics
+    assert metrics["speech_id"] == tts_metrics[0].speech_id
+
+
+async def test_say_assistant_metrics_carry_speech_id() -> None:
+    # session.say goes through the standalone tts task rather than the reply pipeline, and
+    # it stores an assistant message too, so it needs the same correlation id
+    actions = FakeActions()
+    actions.add_tts(1.0, input="Hello from say", ttfb=0.2, duration=0.3)
+
+    session = create_session(actions, with_stt=False)
+    audio_output = session.output.audio
+    assert isinstance(audio_output, _SyncedAudioOutput)
+
+    conversation_events: list[ConversationItemAddedEvent] = []
+    session.on("conversation_item_added", conversation_events.append)
+
+    await session.start(MyAgent())
+    speech_handle = session.say("Hello from say")
+    await speech_handle
+    await session.aclose()
+    await audio_output._synchronizer.aclose()
+
+    assistant_messages = [
+        ev.item
+        for ev in conversation_events
+        if ev.item.type == "message" and ev.item.role == "assistant"
+    ]
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0].metrics["speech_id"] == speech_handle.id
 
 
 async def test_tool_call() -> None:

--- a/tests/test_realtime_message_metrics.py
+++ b/tests/test_realtime_message_metrics.py
@@ -62,6 +62,7 @@ async def test_realtime_response_id_is_available_on_assistant_message() -> None:
     ]
     assert len(assistant_messages) == 1
     assert assistant_messages[0].metrics["provider_request_ids"] == ["provider-response-id"]
+    assert assistant_messages[0].metrics["speech_id"] == speech_handle.id
 
 
 async def _transcribed_user_messages(


### PR DESCRIPTION
Closes #4387.

### Problem

`TTSMetrics` carries a `speech_id`, and the `llm_node` / `tts_node` spans set `lk.speech_id`, but the assistant `ChatMessage` those describe carries no such id. `metrics_collected` events are not part of `SessionReport`, so joining a stored message to its trace or to the per-component metrics of the same turn takes external bookkeeping. One commenter on #4387 keeps an `item.id -> speech_id` map by hand.

### Change

`MetricsReport` gains an optional `speech_id`, populated in the three paths that store an assistant message:

- `session.say` (`_tts_task_impl`)
- the reply pipeline (`_pipeline_reply_task_impl`)
- realtime generation (`_realtime_generation_task_impl`)

This follows the `provider_request_ids` precedent: a new key on the existing `TypedDict`, so no existing field changes.

`_early_assistant_metrics` is left alone on purpose — it only feeds console rendering and never reaches a stored message.

### One correction to the issue's framing

#4387 asks for this so `tts_node_ttfb - TTSMetrics.ttfb` gives sentence-tokenizer overhead. That subtraction no longer measures anything. `tts_node_ttfb` now anchors on the text handed to the TTS provider, so it reads the same as `TTSMetrics.ttfb`: both came out at 0.19998 for the same turn on the fake harness. The LLM-to-TTS buffering the reporter wanted is already exposed as `llm_node_ttfs`.

The id still looks worth having for the other reason, joining a persisted message to its `lk.speech_id` span, so I've written it up that way. Close this if you'd rather not add the field.

### Tests

All three failed before the change:

- `test_assistant_metrics_share_speech_id_with_tts_metrics` — pipeline path; asserts the message's id matches the one on the `tts_metrics` event from the same run
- `test_say_assistant_metrics_carry_speech_id` — `session.say` path
- an added assertion on `test_realtime_response_id_is_available_on_assistant_message` — realtime path

`pytest --unit` gives 1520 passed with no new failures against main. `ruff check`, `ruff format --check`, and `mypy --platform linux -p livekit.agents` are clean.
