### PR TITLE
fix(voice): don't leak a play task started while closing

### DIFF
--- a/livekit-agents/livekit/agents/voice/background_audio.py
+++ b/livekit-agents/livekit/agents/voice/background_audio.py
@@ -176,6 +176,7 @@ class BackgroundAudioPlayer:
         self._lock = asyncio.Lock()
 
         self._mixer_atask: asyncio.Task[None] | None = None
+        self._closed = False
 
         self._play_tasks: list[asyncio.Task[None]] = []
 
@@ -260,6 +261,9 @@ class BackgroundAudioPlayer:
             PlayHandle: An object representing the playback handle. This can be
             awaited or stopped manually.
         """  # noqa: E501
+        if self._closed:
+            raise RuntimeError("BackgroundAudio is closed")
+
         if not self._mixer_atask:
             raise RuntimeError("BackgroundAudio is not started")
 
@@ -342,6 +346,10 @@ class BackgroundAudioPlayer:
             if not self._mixer_atask:
                 return  # not started
 
+            # set before the first await: play() gates on this, so no new play task can be
+            # appended after cancel_and_wait has snapshotted the list below
+            self._closed = True
+
             await cancel_and_wait(*self._play_tasks)
 
             await cancel_and_wait(self._mixer_atask)
@@ -368,7 +376,9 @@ class BackgroundAudioPlayer:
         return None
 
     def _agent_state_changed(self, ev: AgentStateChangedEvent) -> None:
-        if not self._thinking_sound:
+        if self._closed or not self._thinking_sound:
+            # aclose() unregisters this listener, but only after awaiting; a state change
+            # arriving in between must not start a new sound
             return
 
         if ev.new_state == "thinking":

--- a/tests/test_background_audio.py
+++ b/tests/test_background_audio.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncGenerator
+from unittest.mock import MagicMock
+
+import pytest
+
+from livekit import rtc
+from livekit.agents.voice.background_audio import BackgroundAudioPlayer
+
+pytestmark = pytest.mark.unit
+
+
+async def _frames() -> AsyncGenerator[rtc.AudioFrame, None]:
+    # long enough that the play task cannot finish on its own during the test
+    for _ in range(1000):
+        yield rtc.AudioFrame.create(48000, 1, 4800)
+        await asyncio.sleep(0.01)
+
+
+def _started_player() -> BackgroundAudioPlayer:
+    """A player in the state `start()` leaves behind, without needing a live room.
+
+    `start()` publishes a track to a real room; everything `play()` and `aclose()`
+    touch is already built in `__init__`, so only the room, session and mixer task
+    have to be stood in for.
+    """
+    player = BackgroundAudioPlayer()
+    player._room = MagicMock()
+    player._agent_session = None
+    player._mixer_atask = asyncio.create_task(asyncio.sleep(3600))
+    return player
+
+
+async def test_aclose_does_not_leave_a_play_task_running() -> None:
+    # aclose() passes *self._play_tasks to cancel_and_wait, which snapshots the list, and
+    # only clears _mixer_atask (the flag play() gates on) after awaiting. A play() landing
+    # in that window is never cancelled, so it outlives the player whose mixer and audio
+    # source have already been closed.
+    player = _started_player()
+
+    closing = asyncio.create_task(player.aclose())
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    with contextlib.suppress(RuntimeError):
+        player.play(_frames())
+
+    await closing
+
+    still_running = [task for task in player._play_tasks if not task.done()]
+    assert still_running == []
+
+
+async def test_play_handle_from_a_closing_player_never_hangs() -> None:
+    # whatever play() hands back has to reach playout-done, otherwise `await handle`
+    # blocks forever: the mixer that would drive its generator is already closed
+    player = _started_player()
+
+    closing = asyncio.create_task(player.aclose())
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    handle = None
+    with contextlib.suppress(RuntimeError):
+        handle = player.play(_frames())
+
+    await closing
+
+    if handle is not None:
+        await asyncio.wait_for(handle.wait_for_playout(), timeout=1.0)


### PR DESCRIPTION
### Problem

`BackgroundAudioPlayer.aclose()` can return while a play task it never cancelled is still running.

`aclose()` passes `*self._play_tasks` to `cancel_and_wait`, so the list is snapshotted at that call. It then awaits twice before clearing `self._mixer_atask`, which is the only attribute `play()` gates on. A `play()` landing in that window is accepted and appends to `_play_tasks` after the snapshot, so nothing cancels it. The mixer and audio source are then closed underneath it: `_run_mixer_task` is gone, nothing drives the generator, `_mark_playout_done()` is never called. Awaiting that handle blocks forever and the task outlives the player.

This is reachable from the framework itself, not only from direct `play()` calls. `_agent_state_changed` calls `play()` for the thinking sound, and `aclose()` unregisters that listener only after the same awaits.

### Change

Mark the player closed before the first await in `aclose()`, and reject `play()` once closed. The flag is set with no await in between, so nothing can be appended after the snapshot. `_agent_state_changed` gets the same guard, so a state change arriving before the listener is unregistered cannot start a sound.

### Tests

`BackgroundAudioPlayer` had no tests; these are the first two. Both fail before the change:

- `test_aclose_does_not_leave_a_play_task_running` fails on a play task still alive after `aclose()` returned
- `test_play_handle_from_a_closing_player_never_hangs` fails with `TimeoutError`, the handle never reaching playout-done

Before the fix they also trip the suite's leaked-task teardown check, which is the same leak seen from the other side. The tests stand the player up without a live room: `start()` only adds track publishing, and everything `play()` and `aclose()` touch is built in `__init__`.

### Relationship to #6149 and #6056

I found this while reading the teardown path for those two SIGABRT reports. It does not explain them. The leaked task adds a stream to the mixer, but `_run_mixer_task` is the only caller of `AudioSource.capture_frame` and is already cancelled by that point, so nothing here reaches native memory. Those reports still look like a use-after-free below the Python layer. Treating this as a separate, self-contained teardown bug.

### Verification

`pytest --unit` gives 1520 passed with the failure set unchanged from `main`. `ruff check`, `ruff format --check`, and `mypy --platform linux -p livekit.agents` are clean.
