### PR TITLE
test: stabilize text email collection eval

### DIFF
--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -22,7 +22,9 @@ async def test_collect_email(input_modality: Literal["text", "audio"]) -> None:
         await sess.start(beta.workflows.GetEmailTask())
 
         result = await sess.run(
-            user_input="My email address is theo at livekit dot io?", input_modality=input_modality
+            user_input="My email address is theo at livekit dot io?",
+            input_modality=input_modality,
+            output_type=(beta.workflows.GetEmailResult if input_modality == "text" else None),
         )
 
         if input_modality == "text":


### PR DESCRIPTION
The text email eval occasionally gets a plain-text model response instead of the update tool call. Declaring GetEmailResult activates the existing missing-output retry for text only; audio keeps its separate confirmation turn.

The original failure passed on rerun, confirming the flake.

Fixes AGT-3265