### PR TITLE
fix(google): handle unsupported tool_choice values in the realtime plugin

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -579,7 +579,6 @@ class RealtimeSession(llm.RealtimeSession):
         if is_given(tool_choice):
             # no per-response tool_choice on Gemini; "none" is emulated by rejecting any tool
             # call emitted during the turn (see _reject_tool_calls).
-            self._opts.tool_choice = tool_choice
             if tool_choice == "none":
                 logger.warning(
                     "the Google Realtime API has no tool_choice='none'; tool calls emitted "
@@ -590,6 +589,8 @@ class RealtimeSession(llm.RealtimeSession):
                     f"tool_choice='{tool_choice}' is not supported by the Google Realtime API, "
                     "falling back to 'auto'."
                 )
+                tool_choice = "auto"
+            self._opts.tool_choice = tool_choice
 
         if should_restart:
             self._mark_restart_needed()
@@ -743,6 +744,10 @@ class RealtimeSession(llm.RealtimeSession):
     ) -> asyncio.Future[llm.GenerationCreatedEvent]:
         if is_given(tools):
             logger.warning("per-response tools is not supported by Google Realtime API, ignoring")
+        if is_given(tool_choice):
+            logger.warning(
+                "per-response tool_choice is not supported by Google Realtime API, ignoring"
+            )
         if not self._realtime_model.capabilities.mutable_chat_context:
             logger.warning(
                 f"generate_reply is not compatible with '{self._opts.model}' and will be ignored."

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -7,7 +7,7 @@ from contextlib import asynccontextmanager
 import pytest
 from google.genai import types
 
-from livekit.agents import utils
+from livekit.agents import llm, utils
 from livekit.plugins.google.realtime.realtime_api import RealtimeModel, RealtimeSession
 
 pytestmark = pytest.mark.unit
@@ -130,3 +130,78 @@ async def test_session_close_releases_the_genai_client(
         monkeypatch.setattr(session._client.aio, "aclose", _spy)
 
     assert closed
+
+
+async def test_tool_choice_never_reaches_the_connect_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No tool_choice value may leak into the LiveConnectConfig sent to the API.
+
+    The Google Realtime API rejects a tool_choice parameter (issue #4770), so whatever the
+    user asks for, the connect config must stay free of it.
+    """
+    choices: list[llm.ToolChoice] = [
+        "auto",
+        "none",
+        "required",
+        {"type": "function", "function": {"name": "get_weather"}},
+    ]
+    async with _make_session(monkeypatch) as session:
+        for choice in choices:
+            session.update_options(tool_choice=choice)
+            payload = session._build_connect_config().model_dump(exclude_none=True)
+            assert "tool_choice" not in payload
+            assert "tool_config" not in payload
+
+
+async def test_update_options_tool_choice_none_is_emulated(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """tool_choice='none' is kept and emulated by rejecting tool calls, with a warning."""
+    async with _make_session(monkeypatch) as session:
+        with caplog.at_level(logging.WARNING):
+            session.update_options(tool_choice="none")
+
+        assert session._opts.tool_choice == "none"
+        assert any("tool_choice='none'" in r.message for r in caplog.records)
+
+
+async def test_update_options_unsupported_tool_choice_falls_back_to_auto(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Values the API cannot express warn and are normalized to 'auto'.
+
+    The session must store what it actually does - keeping 'required' around while warning
+    about an 'auto' fallback leaves the state lying about the behavior (issue #4770).
+    """
+    async with _make_session(monkeypatch) as session:
+        with caplog.at_level(logging.WARNING):
+            session.update_options(tool_choice="required")
+            session.update_options(
+                tool_choice={"type": "function", "function": {"name": "get_weather"}}
+            )
+
+        assert session._opts.tool_choice == "auto"
+        not_supported = [
+            r for r in caplog.records if "not supported by the Google Realtime API" in r.message
+        ]
+        assert len(not_supported) == 2
+
+
+async def test_generate_reply_warns_on_tool_choice(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """generate_reply has no per-response tool_choice; it must warn instead of dropping it
+    silently, the same way per-response tools is handled (issue #4770)."""
+    async with _make_session(monkeypatch) as session:
+        with caplog.at_level(logging.WARNING):
+            fut = session.generate_reply(tool_choice="none")
+
+        assert any("per-response tool_choice" in r.message for r in caplog.records)
+
+        # don't leave the generation pending until its 5s timeout fires; cancelling fires
+        # interrupt(), which is a no-op here because _make_session closed the send channel
+        fut.cancel()

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -195,13 +195,16 @@ async def test_generate_reply_warns_on_tool_choice(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """generate_reply has no per-response tool_choice; it must warn instead of dropping it
-    silently, the same way per-response tools is handled (issue #4770)."""
+    silently, the same way per-response tools is handled (issue #4770).
+    """
     async with _make_session(monkeypatch) as session:
         with caplog.at_level(logging.WARNING):
             fut = session.generate_reply(tool_choice="none")
 
         assert any("per-response tool_choice" in r.message for r in caplog.records)
+        # the per-response value must not leak into the session options either
+        assert not utils.is_given(session._opts.tool_choice)
 
         # don't leave the generation pending until its 5s timeout fires; cancelling fires
-        # interrupt(), which is a no-op here because _make_session closed the send channel
+        # interrupt(), which is a no-op here since manual activity detection is off
         fut.cancel()


### PR DESCRIPTION
Closes #4770

The Google Realtime API does not support a `tool_choice` parameter. Session-level `none` is already emulated by rejecting tool calls, but two other paths were misleading:

- `generate_reply(tool_choice=...)` accepted the option and silently ignored it. It now warns, matching the existing warning for per-response `tools`.
- `update_options(tool_choice=...)` warned that unsupported values would fall back to `auto`, but still stored the unsupported value. It now normalizes the stored state to `auto` as well.

I added credential-free unit tests covering the warnings, the existing `none` emulation, and the invariant that no `tool_choice` value reaches `LiveConnectConfig`.

I used Kimi to help with the implementation and testing. I am responsible for the PR and happy to fix anything I missed.

Best Regards, Tarik