### PR TITLE
feat(evals): run judges at low inference priority

### DIFF
--- a/livekit-agents/livekit/agents/evals/evaluation.py
+++ b/livekit-agents/livekit/agents/evals/evaluation.py
@@ -109,7 +109,8 @@ class JudgeGroup:
             llm: The LLM to use for evaluation. Can be an LLM instance or a model
                 string like "openai/gpt-4o-mini" (uses LiveKit inference gateway).
                 Model strings default to the lowest reasoning effort the model
-                supports; pass a configured LLM instance to override.
+                supports and to low inference priority; pass a configured LLM
+                instance to override.
             judges: The judges to run during evaluation.
         """
         if isinstance(llm, str):
@@ -120,7 +121,9 @@ class JudgeGroup:
             if (effort := min_reasoning_effort(llm)) is not None:
                 extra_kwargs["reasoning_effort"] = effort
 
-            self._llm: LLM = InferenceLLM(llm, extra_kwargs=extra_kwargs)
+            # Judges run after the conversation, so no caller is waiting on them:
+            # they must not compete with live voice traffic for gateway quota.
+            self._llm: LLM = InferenceLLM(llm, inference_class="low", extra_kwargs=extra_kwargs)
         else:
             self._llm = llm
 

--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -173,7 +173,9 @@ XAIModels = Literal[
 
 LLMModels = OpenAIModels | GoogleModels | KimiModels | DeepSeekModels | ZAIModels | XAIModels
 
-InferenceClass = Literal["priority", "standard"]
+InferenceClass = Literal["priority", "standard", "low"]
+"""Scheduling class for a request. ``low`` yields to voice traffic, so it is only
+appropriate for work no caller is waiting on."""
 
 
 class ChatCompletionOptions(TypedDict, total=False):


### PR DESCRIPTION
Judges fan out concurrently the moment a session ends (`asyncio.gather` over every judge), so each run adds a burst of gateway requests that no caller is waiting on. Today those requests carry no priority header at all — `JudgeGroup` never passes `inference_class`, and the header is only set when it is truthy — so they land in the same lane as live voice traffic and eat into the same RPM/TPM quota.

- `InferenceClass` gains `low` alongside `priority` / `standard`.
- `JudgeGroup` passes `inference_class="low"` when it builds the LLM from a model string. Passing a configured `LLM` instance still wins, so callers keep full control.

This is the framework half of the problem raised in #team-inference on 2026-07-20: simulations hitting the LLM requests-per-minute limit, with LLM-as-a-judge named as the driver. Gateway-side scheduling is tracked separately in LKINF-387.

**Needs confirming before merge:** the `low` value matches the header value quoted in #team-inference (`X-LiveKit-Inference-Priority: low`), but I have not verified the gateway accepts it. If unknown values are ignored this is inert until LKINF-387 lands; if the gateway validates and rejects, it would break judge runs.

**Cross-SDK parity:** `agents-js` has the same union at `agents/src/inference/llm.ts` and needs the same widening. It has no `JudgeGroup`, so the default has no counterpart there.