### PR TITLE
fix(hotel_receptionist): don't pass simulation runs the grading never checked

### DIFF
--- a/examples/hotel_receptionist/agent.py
+++ b/examples/hotel_receptionist/agent.py
@@ -70,27 +70,31 @@ _SEED_DB_BYTES = build_seed_bytes(TODAY)
 
 
 async def on_simulation_end(ctx: SimulationContext) -> None:
-    # Grade the run on final DB state: build the scenario's `expected_state` on a
-    # fresh seed, then diff it against the agent's DB. The diff compares
-    # agent-decided facts only (room type, dates, extras, status), so minted
-    # codes / order / which-king don't matter and the agent need not reproduce the
-    # statements — while collateral damage still surfaces.
-    expected_state = ctx.userdata().get("expected_state") or []
-    if not expected_state:
-        return
+    db_diffs: list[str] = []
+    expected_state = ctx.userdata().get("expected_state")
+    if expected_state:
+        # Grade the run on final DB state: build the scenario's `expected_state` on a
+        # fresh seed, then diff it against the agent's DB. The diff compares
+        # agent-decided facts only (room type, dates, extras, status), so minted
+        # codes / order / which-king don't matter and the agent need not reproduce the
+        # statements — while collateral damage still surfaces.
+        session = ctx.job_context.primary_session
+        expected = await build_expected(_SEED_DB_BYTES, expected_state)
+        try:
+            db_diffs = diff_databases(expected.connection, session.userdata.db.connection)
+        finally:
+            await expected.aclose()
 
-    session = ctx.job_context.primary_session
-    expected = await build_expected(_SEED_DB_BYTES, expected_state)
-    try:
-        diffs = diff_databases(expected.connection, session.userdata.db.connection)
-    finally:
-        await expected.aclose()
-
-    # Veto the run if the final DB state diverged. The effective result is the AND of
-    # this check and the simulator's conversation judgment, so a mismatch fails a run
-    # the simulator passed; a match simply leaves the simulator's verdict to stand.
-    if diffs:
-        ctx.fail(reason="final DB diverges from expected: " + " | ".join(diffs[:8]))
+    # A run passes only if both the conversation and the DB check pass. A scenario
+    # with no DB check is graded on the conversation alone.
+    if db_diffs:
+        reason = "final DB diverges from expected: " + " | ".join(db_diffs[:8])
+        ctx.fail(reason=reason)
+        ctx.job_context.tagger.fail(reason=reason)
+    elif ctx.simulator_verdict.success:
+        ctx.job_context.tagger.success(reason=ctx.simulator_verdict.reason)
+    else:
+        ctx.job_context.tagger.fail(reason=ctx.simulator_verdict.reason)
 
 
 async def on_session_end(ctx: JobContext) -> None:
@@ -119,76 +123,6 @@ async def on_session_end(ctx: JobContext) -> None:
     await judges.evaluate(report.chat_history)
 
     userdata = ctx.primary_session.userdata
-
-    db_diffs: list[str] = []
-    try:
-        sim_ctx = ctx.simulation_context()
-        if sim_ctx is None:
-            logger.info(
-                "local expected-state diff skipped: no simulation context "
-                "(job/room metadata carried no SimulationDispatch)"
-            )
-        expected_state = (sim_ctx.userdata().get("expected_state") if sim_ctx else None) or []
-        if sim_ctx is not None and not expected_state:
-            logger.info("local expected-state diff skipped: scenario has no expected_state")
-        if expected_state:
-            logger.info("running local expected-state diff (%d statement(s))", len(expected_state))
-            expected = await build_expected(_SEED_DB_BYTES, expected_state)
-            try:
-                db_diffs = diff_databases(expected.connection, userdata.db.connection)
-            finally:
-                await expected.aclose()
-    except Exception:
-        logger.exception("error running local expected-state diff")
-
-    # "Did the call do real work?" is a DB question, not per-tool bookkeeping:
-    # compare the final DB against the untouched seed. Any change in the
-    # transactional tables (booking, cancellation, modification, dispute,
-    # followup, late-arrival note...) counts.
-    try:
-        seed_db = HotelDB.from_bytes(_SEED_DB_BYTES)
-        try:
-            state_changes = diff_databases(seed_db.connection, userdata.db.connection)
-        finally:
-            await seed_db.aclose()
-    except Exception:
-        logger.exception("error diffing final DB against seed")
-        state_changes = []
-
-    # Read-only calls (policy questions, availability checks, booking lookups)
-    # are real work too - a Q&A call that answered from a successful read tool
-    # shouldn't be tagged as having accomplished nothing.
-    read_tools = {
-        "lookup_policy",
-        "lookup_booking",
-        "lookup_invoice",
-        "lookup_restaurant_reservation",
-        "check_room_availability",
-        "check_restaurant_availability",
-        "lookup_guest_history",
-    }
-    call_names = {
-        item.call_id: item.name
-        for item in report.chat_history.items
-        if item.type == "function_call"
-    }
-    served_reads = any(
-        item.type == "function_call_output"
-        and not item.is_error
-        and call_names.get(item.call_id) in read_tools
-        for item in report.chat_history.items
-    )
-
-    if db_diffs:
-        ctx.tagger.fail(reason="final DB diverges from expected: " + " | ".join(db_diffs[:8]))
-    elif state_changes or served_reads:
-        ctx.tagger.success()
-    else:
-        ctx.tagger.fail(
-            reason="The call accomplished nothing: no state was changed (booking, "
-            "cancellation, modification, dispute, followup, message, wake-up call...) "
-            "and no information was looked up for the caller."
-        )
 
     logger.info("session tags: %s", ctx.tagger.tags)
 

--- a/examples/hotel_receptionist/agent.py
+++ b/examples/hotel_receptionist/agent.py
@@ -82,31 +82,45 @@ def _expected_state_statements(userdata: dict[str, object]) -> list[str] | None:
 
 
 async def on_simulation_end(ctx: SimulationContext) -> None:
-    db_diffs: list[str] = []
-    expected_state = _expected_state_statements(ctx.userdata())
-    if expected_state is not None:
-        # Grade the run on final DB state: build the scenario's `expected_state` on a
-        # fresh seed, then diff it against the agent's DB. The diff compares
-        # agent-decided facts only (room type, dates, extras, status), so minted
-        # codes / order / which-king don't matter and the agent need not reproduce the
-        # statements — while collateral damage still surfaces.
-        session = ctx.job_context.primary_session
-        expected = await build_expected(_SEED_DB_BYTES, expected_state)
-        try:
-            db_diffs = diff_databases(expected.connection, session.userdata.db.connection)
-        finally:
-            await expected.aclose()
+    tagger = ctx.job_context.tagger
+    failure: str | None = None
+    graded = False
+    try:
+        expected_state = _expected_state_statements(ctx.userdata())
+        graded = expected_state is not None
+        if expected_state is not None:
+            # Grade the run on final DB state: build the scenario's `expected_state` on a
+            # fresh seed, then diff it against the agent's DB. The diff compares
+            # agent-decided facts only (room type, dates, extras, status), so minted
+            # codes / order / which-king don't matter and the agent need not reproduce the
+            # statements — while collateral damage still surfaces.
+            session = ctx.job_context.primary_session
+            expected = await build_expected(_SEED_DB_BYTES, expected_state)
+            try:
+                diffs = diff_databases(expected.connection, session.userdata.db.connection)
+            finally:
+                await expected.aclose()
+            if diffs:
+                failure = "final DB diverges from expected: " + " | ".join(diffs[:8])
+    except Exception as exc:
+        # Grading that can't run is not a pass. The prefix tells a broken scenario
+        # apart from a failing agent.
+        logger.exception("expected-state grading failed")
+        failure = f"expected-state grading failed: {exc}"
+
+    # Most scenarios skip the DB check on purpose, so the run has to record
+    # whether it ran at all.
+    tagger.add("state:graded" if graded else "state:ungraded")
 
     # A run passes only if both the conversation and the DB check pass. A scenario
     # with no DB check is graded on the conversation alone.
-    if db_diffs:
-        reason = "final DB diverges from expected: " + " | ".join(db_diffs[:8])
-        ctx.fail(reason=reason)
-        ctx.job_context.tagger.fail(reason=reason)
+    if failure:
+        ctx.fail(reason=failure)
+        tagger.fail(reason=failure)
     elif ctx.simulator_verdict.success:
-        ctx.job_context.tagger.success(reason=ctx.simulator_verdict.reason)
+        tagger.success(reason=ctx.simulator_verdict.reason)
     else:
-        ctx.job_context.tagger.fail(reason=ctx.simulator_verdict.reason)
+        tagger.fail(reason=ctx.simulator_verdict.reason)
 
 
 async def on_session_end(ctx: JobContext) -> None:

--- a/examples/hotel_receptionist/agent.py
+++ b/examples/hotel_receptionist/agent.py
@@ -69,10 +69,22 @@ server = AgentServer()
 _SEED_DB_BYTES = build_seed_bytes(TODAY)
 
 
+def _expected_state_statements(userdata: dict[str, object]) -> list[str] | None:
+    """No key means the DB isn't checked; null or [] means it must come back unchanged."""
+    if "expected_state" not in userdata:
+        return None
+    statements = userdata["expected_state"]
+    if statements is None:
+        return []
+    if not isinstance(statements, list) or not all(isinstance(s, str) for s in statements):
+        raise TypeError("expected_state must be a list of SQL statements")
+    return statements
+
+
 async def on_simulation_end(ctx: SimulationContext) -> None:
     db_diffs: list[str] = []
-    expected_state = ctx.userdata().get("expected_state")
-    if expected_state:
+    expected_state = _expected_state_statements(ctx.userdata())
+    if expected_state is not None:
         # Grade the run on final DB state: build the scenario's `expected_state` on a
         # fresh seed, then diff it against the agent's DB. The diff compares
         # agent-decided facts only (room type, dates, extras, status), so minted


### PR DESCRIPTION
The hotel receptionist's simulation grading now has one contract, enforced in one place.

### What a scenario declares

`userdata.expected_state` says how the final DB should be judged:

| Value | Meaning |
|---|---|
| key omitted | the DB isn't graded; the conversation verdict alone decides the run |
| `null` or `[]` | the DB must come back exactly as seeded |
| list of SQL statements | the DB must match a fresh seed with those statements applied |
| anything else | rejected at parse time |

An omitted key and an empty list are different declarations: one opts out of state grading, the other asserts that nothing was written. Scenarios that assert an absence depend on it — the restaurant booking a guest can't complete without a phone number is graded entirely on no reservation appearing.

The comparison is by state, not by statement. It reads the facts the agent decided — room type, dates, extras, status — so confirmation codes, row order, and which particular room of a type don't matter, and the agent never has to reproduce the SQL. Writes nobody asked for still surface.

### How a run is graded

`on_simulation_end` is the only place that sets an outcome. A run passes when both the conversation and the DB check pass:

- DB diverges → the run fails and vetoes the simulator's verdict, naming the fields that differ
- DB matches, or isn't graded → the simulator's conversation verdict stands, with its reason carried through
- grading itself can't run (malformed `expected_state`, SQL that won't execute) → the run fails, behind a prefix that tells a broken scenario from a failing agent

Every run is tagged `state:graded` or `state:ungraded`. Most scenarios skip the DB check deliberately, and the outcome alone can't distinguish that from a forgotten assertion.

`on_session_end` runs the judges, logs tags, dumps artifacts, and closes the DB. It sets no outcome: it fires after `on_simulation_end`, and the tagger holds one outcome slot.

### What this replaces

The field was read as `get("expected_state") or []` and tested for truth, so `[]` and `null` skipped grading instead of asserting an unchanged DB. `on_session_end` derived its own outcome from a heuristic and, running later, overwrote the simulator's — failing conversation-only scenarios for correctly doing nothing, and marking production calls failed with no simulator involved. Grading that raised left a run with no verdict at all.

Net 50 insertions, 90 deletions: the seed diff and the read-tool allowlist in `on_session_end` fed nothing but the deleted heuristic, and the expected-state diff was duplicated there.

### Verification

`examples/` is excluded from collection (`--ignore=examples`, `testpaths = ["tests"]`), so this is verified out of tree against a real seeded DB: the parser contract, the stray-write veto, both broken-scenario paths, and conversation-only pass and fail. `mypy --strict` on this file goes from 2 pre-existing errors to 0.

Overlaps #6567, which reworks the same two functions. Whichever lands second needs a manual resolution.
