### PR TITLE
fix(hotel_receptionist): pair near-miss rows in the expected-state diff

### DIFF
--- a/examples/hotel_receptionist/benchmark.py
+++ b/examples/hotel_receptionist/benchmark.py
@@ -99,6 +99,37 @@ def _rows(
     return cols, counter
 
 
+def _changed_fields(
+    cols: list[str], expected_row: tuple[Any, ...], actual_row: tuple[Any, ...]
+) -> list[str]:
+    return [
+        f"{col}: {want!r} != {got!r}"
+        for col, want, got in zip(cols, expected_row, actual_row, strict=True)
+        if want != got
+    ]
+
+
+def _pair_rows(
+    cols: list[str], missing: list[tuple[Any, ...]], unexpected: list[tuple[Any, ...]]
+) -> list[tuple[tuple[Any, ...], tuple[Any, ...]]]:
+    """Greedily pair each missing row with its nearest unexpected row.
+
+    A row the agent got *almost* right is one row, not one missing plus one
+    unexpected: pairing keeps the reported diff at the field that actually differs.
+    """
+    pairs: list[tuple[tuple[Any, ...], tuple[Any, ...]]] = []
+    remaining = list(unexpected)
+    for want in list(missing):
+        if not remaining:
+            break
+        got = min(remaining, key=lambda row: len(_changed_fields(cols, want, row)))
+        remaining.remove(got)
+        missing.remove(want)
+        unexpected.remove(got)
+        pairs.append((want, got))
+    return pairs
+
+
 def diff_databases(
     expected: apsw.Connection,
     actual: apsw.Connection,
@@ -112,10 +143,17 @@ def diff_databases(
         ecols, exp = _rows(expected, sql)
         acols, act = _rows(actual, sql)
         cols = ecols or acols
-        for row, n in (exp - act).items():
-            diffs.append(f"{table}: missing {n}x {dict(zip(cols, row, strict=True))}")
-        for row, n in (act - exp).items():
-            diffs.append(f"{table}: unexpected {n}x {dict(zip(cols, row, strict=True))}")
+        # repr key: rows mix None with str/int in the same column, so tuples aren't
+        # directly orderable.
+        missing = sorted((exp - act).elements(), key=repr)
+        unexpected = sorted((act - exp).elements(), key=repr)
+        for want, got in _pair_rows(cols, missing, unexpected):
+            fields = "; ".join(_changed_fields(cols, want, got))
+            diffs.append(f"{table}: row differs on {fields}")
+        for row in missing:
+            diffs.append(f"{table}: missing {dict(zip(cols, row, strict=True))}")
+        for row in unexpected:
+            diffs.append(f"{table}: unexpected {dict(zip(cols, row, strict=True))}")
     return diffs
 
 


### PR DESCRIPTION
## Summary

The expected-state grader reports a row the agent got *almost* right twice — once as `missing`, once as `unexpected` — each echoing every compared column. The one field that actually differs is buried in two near-identical dicts.

Greedily pair each missing row with its nearest unexpected row (fewest differing fields) and report only the changed fields. Unpaired rows still print as plain `missing` / `unexpected`.

```
- hotel_bookings: missing 1x {'guest_name': 'Ana Ruiz', 'nights': 2, 'room_type_view': 'king/ocean', ...}
- hotel_bookings: unexpected 1x {'guest_name': 'Ana Ruiz', 'nights': 3, 'room_type_view': 'king/ocean', ...}
+ hotel_bookings: row differs on nights: 2 != 3
```

Multiset differences are now expanded with `Counter.elements()` so pairing works per row; the `Nx` multiplicity prefix is gone and duplicates print one line each. Sorting uses a `repr` key because rows mix `None` with `str`/`int` in the same column, so tuples aren't directly orderable.

Extracted from #6567, which carries this alongside unrelated hotel-scenario work.

## Testing

- `ruff format --check` / `ruff check` clean; `mypy --strict` reports nothing in `benchmark.py`
- Exercised `diff_databases` against synthetic apsw DBs: single-field near miss pairs into one `row differs` line; a genuinely absent row still reports as `missing`; 2-expected/1-actual reports one pair plus one leftover; identical states and empty tables both return `[]`; `None`-vs-`str` columns sort without raising