### PR TITLE
fix(hotel_receptionist): stop the restaurant flow implying a table it never reserved

### DIFF
--- a/examples/hotel_receptionist/book_restaurant.py
+++ b/examples/hotel_receptionist/book_restaurant.py
@@ -25,6 +25,16 @@ Each tool's return ends with a directive for the next action (e.g. "next: call o
 Never speak the same question twice in a row. If a field was just captured ("name recorded", "time recorded"), it is DONE - asking for it again stalls the call; the only valid next move is the directive in the last tool return.
 """
 
+_RESTAURANT_PHONE_INSTRUCTIONS = """\
+Caller cannot provide the phone number or does not have it handy: call
+`decline_phone_number_capture` immediately. Do not say or imply that the table or
+reservation is booked.
+"""
+
+
+class RestaurantReservationNotCreatedError(ToolError):
+    """The restaurant flow ended before a reservation was written."""
+
 
 class BookRestaurantTask(AgentTask[RestaurantReservation]):
     """Restaurant booking as one focused task, mirroring BookRoomTask: `set_party`
@@ -137,9 +147,18 @@ class BookRestaurantTask(AgentTask[RestaurantReservation]):
     @function_tool()
     async def open_phone_dialog(self) -> str:
         """Open the phone dialog. It collects the guest's phone number (read back and confirmed) from the caller."""
-        r = await beta.workflows.GetPhoneNumberTask(
-            chat_ctx=speech_only(self.chat_ctx), extra_instructions=COMMON_INSTRUCTIONS
-        )
+        try:
+            r = await beta.workflows.GetPhoneNumberTask(
+                chat_ctx=speech_only(self.chat_ctx),
+                extra_instructions=f"{COMMON_INSTRUCTIONS}\n\n{_RESTAURANT_PHONE_INSTRUCTIONS}",
+            )
+        except beta.workflows.PhoneNumberCaptureDeclinedError:
+            error = RestaurantReservationNotCreatedError(
+                "reservation not created: a phone number is required"
+            )
+            if not self.done():
+                self.complete(error)
+            return f"{error} | never tell the caller the table is reserved"
         self._phone = r.phone_number
         return f"phone recorded: {self._phone} | {self._status()}"
 

--- a/examples/hotel_receptionist/tools_restaurant.py
+++ b/examples/hotel_receptionist/tools_restaurant.py
@@ -8,7 +8,7 @@ from typing import Annotated
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-from book_restaurant import BookRestaurantTask
+from book_restaurant import BookRestaurantTask, RestaurantReservationNotCreatedError
 from common import Userdata, _speak_code
 from context import speech_only
 from hotel_db import (
@@ -49,9 +49,18 @@ class RestaurantToolsMixin:
     @function_tool
     async def start_restaurant_booking(self, ctx: RunContext[Userdata]) -> str | None:
         """Start the restaurant-reservation flow. Call it the moment the caller wants a table - the flow collects date, party size, time, name, and phone itself. Its return is the FINAL result of the reservation: relay it and move on - nothing further to confirm or call afterwards."""
-        reservation = await BookRestaurantTask(
-            db=ctx.userdata.db, chat_ctx=speech_only(self.chat_ctx)
-        )
+        try:
+            reservation = await BookRestaurantTask(
+                db=ctx.userdata.db, chat_ctx=speech_only(self.chat_ctx)
+            )
+        except RestaurantReservationNotCreatedError:
+            return (
+                "No reservation was created because a phone number is required. "
+                "| tell the caller the table is not reserved; do not use success wording. "
+                "If they ask to hold the table or make an exception without a number: say "
+                "no table is held and invite them to call back with one - do not offer to "
+                "connect or transfer them to the restaurant."
+            )
         return (
             f"You're set for {speak_time(reservation.time)} on "
             f"{reservation.date.strftime('%A, %B %-d')} for "

--- a/livekit-agents/livekit/agents/beta/workflows/__init__.py
+++ b/livekit-agents/livekit/agents/beta/workflows/__init__.py
@@ -4,7 +4,11 @@ from .dob import GetDOBResult, GetDOBTask
 from .dtmf_inputs import GetDtmfResult, GetDtmfTask
 from .email_address import GetEmailResult, GetEmailTask
 from .name import GetNameResult, GetNameTask
-from .phone_number import GetPhoneNumberResult, GetPhoneNumberTask
+from .phone_number import (
+    GetPhoneNumberResult,
+    GetPhoneNumberTask,
+    PhoneNumberCaptureDeclinedError,
+)
 from .task_group import TaskCompletedEvent, TaskGroup, TaskGroupResult
 from .utils import WorkflowInstructions
 from .warm_transfer import WarmTransferResult, WarmTransferTask
@@ -25,6 +29,7 @@ __all__ = [
     "GetNameResult",
     "GetPhoneNumberTask",
     "GetPhoneNumberResult",
+    "PhoneNumberCaptureDeclinedError",
     "TaskCompletedEvent",
     "TaskGroup",
     "TaskGroupResult",

--- a/livekit-agents/livekit/agents/beta/workflows/phone_number.py
+++ b/livekit-agents/livekit/agents/beta/workflows/phone_number.py
@@ -59,6 +59,16 @@ class GetPhoneNumberResult:
     phone_number: str
 
 
+class PhoneNumberCaptureDeclinedError(ToolError):
+    def __init__(self, reason: str) -> None:
+        super().__init__(f"couldn't get the phone number: {reason}")
+        self._reason = reason
+
+    @property
+    def reason(self) -> str:
+        return self._reason
+
+
 class GetPhoneNumberTask(AgentTask[GetPhoneNumberResult]):
     def __init__(
         self,
@@ -179,7 +189,7 @@ class GetPhoneNumberTask(AgentTask[GetPhoneNumberResult]):
             reason: A short explanation of why the user declined to provide the phone number
         """
         if not self.done():
-            self.complete(ToolError(f"couldn't get the phone number: {reason}"))
+            self.complete(PhoneNumberCaptureDeclinedError(reason))
 
     def _confirmation_required(self, ctx: RunContext) -> bool:
         if is_given(self._require_confirmation):


### PR DESCRIPTION
A caller who won't give a phone number ended `BookRestaurantTask` with a bare `ToolError`, and `start_restaurant_booking` let it propagate. The receptionist read the failed tool call as a booked table and spoke a confirmation for a reservation that was never written.

Cherry-picked out of #6567, which bundles this with a lot of unrelated hotel-receptionist work.

## Changes

**Library** — `decline_phone_number_capture` completed the task with a bare `ToolError`, indistinguishable from any other failure, so a caller that wants to react to a refusal (rather than to a crash) had only the message text to match on. `PhoneNumberCaptureDeclinedError` subclasses `ToolError` with the identical message, so existing callers are unaffected.

**Example** — `RestaurantReservationNotCreatedError` is what the restaurant flow now completes with when the phone dialog is declined. `open_phone_dialog` catches the declined error and returns wording that states the outcome; `start_restaurant_booking` catches it and reports a non-reservation instead of falling through to the success string. The phone dialog also gets instructions to decline rather than stall when the caller has no number.

## Testing

- Full unit gate: 1942 passed, 5 skipped.
- ruff format + check clean; mypy clean on the changed library file.