### PR TITLE
fix(hotel_receptionist): give card capture a no-usable-card exit

### DIFF
--- a/examples/hotel_receptionist/get_card.py
+++ b/examples/hotel_receptionist/get_card.py
@@ -22,6 +22,8 @@ Expect noisy voice transcription: digits read aloud ('four' -> 4, 'oh'/'zero' ->
 Never read the full card number or the security code back to the caller; refer to the card by its last four digits only. If a tool rejects a value, ask the caller to repeat just that detail - don't start the whole card over. If the caller switches cards mid-way, just record the new values; recording a field again replaces it.
 
 If the caller refuses to provide the card, call decline_card_capture.
+
+Caller has no usable card right now (their card is expired or keeps failing and they have no other card to give): don't keep asking for another card. Reassure them there's no pressure - the booking stays held - and call decline_card_capture with the reason; the receptionist arranges the retry from there.
 """
 
 
@@ -122,7 +124,10 @@ class GetCardTask(AgentTask[GetCardResult]):
         if not 0 <= year <= 99:
             raise ToolError("that expiration year is invalid - ask the caller to repeat it")
         if (2000 + year, month) < (TODAY.year, TODAY.month):
-            raise ToolError("that date is in the past, the card is expired - ask for another card")
+            raise ToolError(
+                "that date is in the past, the card is expired - ask if they have another "
+                "card; if they have no other card right now, call decline_card_capture"
+            )
         self._expiration = f"{month:02d}/{year:02d}"
         return f"expiration recorded | {self._status()}"
 
@@ -180,10 +185,10 @@ class GetCardTask(AgentTask[GetCardResult]):
 
     @function_tool(flags=ToolFlag.IGNORE_ON_ENTER)
     async def decline_card_capture(self, reason: str) -> None:
-        """The caller explicitly refuses to provide their card.
+        """End the card capture without a card: the caller explicitly refuses to provide one, or cannot provide a usable card right now (their only card is expired or won't validate and they have no other card to give).
 
         Args:
-            reason: A short explanation of why the caller declined.
+            reason: A short explanation of why no card could be taken.
         """
         if not self.done():
             self.complete(ToolError(f"couldn't get the card details: {reason}"))

--- a/examples/hotel_receptionist/get_card.py
+++ b/examples/hotel_receptionist/get_card.py
@@ -21,9 +21,7 @@ Expect noisy voice transcription: digits read aloud ('four' -> 4, 'oh'/'zero' ->
 
 Never read the full card number or the security code back to the caller; refer to the card by its last four digits only. If a tool rejects a value, ask the caller to repeat just that detail - don't start the whole card over. If the caller switches cards mid-way, just record the new values; recording a field again replaces it.
 
-If the caller refuses to provide the card, call decline_card_capture.
-
-Caller has no usable card right now (their card is expired or keeps failing and they have no other card to give): don't keep asking for another card. Reassure them there's no pressure - the booking stays held - and call decline_card_capture with the reason; the receptionist arranges the retry from there.
+If the caller refuses to provide the card, or has no other card to give after theirs came back expired, don't keep asking - call decline_card_capture with the reason.
 """
 
 
@@ -125,8 +123,9 @@ class GetCardTask(AgentTask[GetCardResult]):
             raise ToolError("that expiration year is invalid - ask the caller to repeat it")
         if (2000 + year, month) < (TODAY.year, TODAY.month):
             raise ToolError(
-                "that date is in the past, the card is expired - ask if they have another "
-                "card; if they have no other card right now, call decline_card_capture"
+                f"the date I have is {month:02d}/{year:02d}, which is in the past - confirm the "
+                "expiration with the caller; if the card really is expired and they have no "
+                "other card, call decline_card_capture"
             )
         self._expiration = f"{month:02d}/{year:02d}"
         return f"expiration recorded | {self._status()}"
@@ -185,7 +184,7 @@ class GetCardTask(AgentTask[GetCardResult]):
 
     @function_tool(flags=ToolFlag.IGNORE_ON_ENTER)
     async def decline_card_capture(self, reason: str) -> None:
-        """End the card capture without a card: the caller explicitly refuses to provide one, or cannot provide a usable card right now (their only card is expired or won't validate and they have no other card to give).
+        """End the card capture without a card: the caller refuses to provide one, or has no other card after theirs came back expired.
 
         Args:
             reason: A short explanation of why no card could be taken.


### PR DESCRIPTION
## Summary

A caller whose only card is expired had no way out of `GetCardTask`. The expired-date `ToolError` told the agent to ask for another card, and `decline_card_capture` was documented as refusal-only, so the agent kept re-asking a caller who had already said they had nothing else to give.

Three changes route that dead end to the existing exit, kept to what the sub-task can actually observe:

- task instructions: if the caller refuses, or has no other card after theirs came back expired, don't keep asking - call `decline_card_capture` with the reason
- the expired-date `ToolError` first asks to confirm the date (a past date in voice is usually a misheard year), and names `decline_card_capture` only if the card really is expired and there's no other card
- `decline_card_capture`'s docstring widens from "the caller explicitly refuses" to also cover the expired-with-no-other-card case

The sub-task does not speak any reassurance about the booking: it is also opened for a new booking that isn't written yet, so "the booking stays held" would be false there. The caller-facing script for the card-update path stays where it already lives, in the receptionist's instructions.

Follow-up: #7177 (stacked) gives `BookRoomTask` a directive when the capture ends without a card, so the loop doesn't move up a level.

Cherry-picked from #6567 (2a5175745), `get_card.py` only, then narrowed as above.

## Testing

- `pytest examples/hotel_receptionist/ tests/test_tools.py --allow-uncategorized` (114 passed)
- `ruff format --check` and `ruff check` clean
- Scenario 15 ("Caller pushing about a declined card") simulated with this change plus #7177: [passed](https://cloud.livekit.io/projects/p_6hxckww6414/simulations/runs/SR_Jek87RtxnTMM). It reaches `GetCardTask` through `start_card_update` and the new wording did not misfire on "I don't have another card on me right now".