### PR TITLE
fix(hotel_receptionist): hotel_db stored-state and read-back fixes

### DIFF
--- a/examples/hotel_receptionist/benchmark.py
+++ b/examples/hotel_receptionist/benchmark.py
@@ -64,6 +64,7 @@ DENY_COLUMNS = frozenset(
         "late_arrival_note",
         "message",
         "situation",
+        "delivery_instructions",
     }
 )
 

--- a/examples/hotel_receptionist/book_room.py
+++ b/examples/hotel_receptionist/book_room.py
@@ -13,6 +13,7 @@ from hotel_db import (
     RoomExtra,
     RoomType,
     Unavailable,
+    describe_room_options,
     speak_usd,
 )
 from persona import COMMON_INSTRUCTIONS
@@ -139,12 +140,11 @@ class BookRoomTask(AgentTask[RoomBooking]):
         available_types = {a.type for a in avail}
         if self._room_type and self._room_type not in available_types:
             self._room_type = None  # prior choice no longer fits the new dates
-        options = " | ".join(
-            f"{a.type.replace('_', ' ')} ({speak_usd(a.nightly_rate)}/night, "
-            f"{' or '.join(a.views)} view{'s' if len(a.views) > 1 else ''})"
-            for a in avail
+        return (
+            f"stay recorded ({check_in} to {check_out}, {guests} guests)\n"
+            f"options (the views on a type's line are the only views that type has):\n"
+            f"{describe_room_options(avail)}\n{self._status()}"
         )
-        return f"stay recorded ({check_in} to {check_out}, {guests} guests); options: {options} | {self._status()}"
 
     @function_tool()
     async def choose_room(

--- a/examples/hotel_receptionist/hotel_db.py
+++ b/examples/hotel_receptionist/hotel_db.py
@@ -1279,9 +1279,11 @@ class HotelDB:
         arrangement_id: str,
         guest_name: str,
         guest_phone: str,
-        deliver_to: str,
         on_date: date,
         card_message: str,
+        room_id: str | None = None,
+        recipient_name: str | None = None,
+        delivery_instructions: str = "",
     ) -> tuple[str, FloralArrangement, int]:
         arrangement = FLORIST_ARRANGEMENTS.get(arrangement_id)
         if arrangement is None:
@@ -1291,6 +1293,17 @@ class HotelDB:
             )
         if on_date < TODAY:
             raise Unavailable(f"{on_date.isoformat()} is in the past")
+        room_id = (room_id or "").strip() or None
+        recipient_name = (recipient_name or "").strip() or None
+        if room_id is None and recipient_name is None:
+            raise Unavailable(
+                "no delivery destination: a room/suite or a recipient name is required"
+            )
+        if room_id is not None:
+            room_id = self._normalize_room(room_id)
+            if not self._room_exists(room_id):
+                raise NotFound(f"no such room: {room_id}")
+            recipient_name = None  # the room is the destination; exactly one is stored
         total = arrangement.price
         code = _new_code("FLR-")
         with self.connection as conn:
@@ -1302,15 +1315,29 @@ class HotelDB:
                     "arrangement_id": arrangement_id,
                     "guest_name": guest_name,
                     "guest_phone": "".join(c for c in guest_phone if c.isdigit()),
-                    "deliver_to": deliver_to,
+                    "room_id": room_id,
+                    "recipient_name": recipient_name,
                     "date": on_date.isoformat(),
                     "message": card_message,
+                    "delivery_instructions": delivery_instructions,
                     "total": total,
                 },
             )
         if self.on_change:
             await self.on_change()
         return code, arrangement, total
+
+    async def amend_florist_order(self, *, code: str, delivery_instructions: str) -> None:
+        changed = _update(
+            self.connection,
+            "florist_orders",
+            {"delivery_instructions": delivery_instructions},
+            {"code": code, "status": "confirmed"},
+        )
+        if changed == 0:
+            raise NotFound(f"florist order not found: {code}")
+        if self.on_change:
+            await self.on_change()
 
     async def send_email(self, *, recipient: str, kind: str) -> str:
         """Stub email send: records that a document of `kind` was sent to `recipient`
@@ -1863,16 +1890,19 @@ CREATE TABLE IF NOT EXISTS business_center_bookings (
 );
 
 CREATE TABLE IF NOT EXISTS florist_orders (
-    id             INTEGER PRIMARY KEY,
-    code           TEXT    NOT NULL UNIQUE,
-    arrangement_id TEXT    NOT NULL CHECK (arrangement_id IN ('bouquet','roses','centerpiece')),
-    guest_name     TEXT    NOT NULL,
-    guest_phone    TEXT    NOT NULL,
-    deliver_to     TEXT    NOT NULL,
-    date           DATE    NOT NULL,
-    message        TEXT    NOT NULL DEFAULT '',
-    total          INTEGER NOT NULL,
-    status         TEXT    NOT NULL DEFAULT 'confirmed' CHECK (status IN ('confirmed','cancelled'))
+    id                    INTEGER PRIMARY KEY,
+    code                  TEXT    NOT NULL UNIQUE,
+    arrangement_id        TEXT    NOT NULL CHECK (arrangement_id IN ('bouquet','roses','centerpiece')),
+    guest_name            TEXT    NOT NULL,
+    guest_phone           TEXT    NOT NULL,
+    room_id               TEXT    REFERENCES hotel_rooms(id),
+    recipient_name        TEXT,
+    date                  DATE    NOT NULL,
+    message               TEXT    NOT NULL DEFAULT '',
+    delivery_instructions TEXT    NOT NULL DEFAULT '',
+    total                 INTEGER NOT NULL,
+    status                TEXT    NOT NULL DEFAULT 'confirmed' CHECK (status IN ('confirmed','cancelled')),
+    CHECK ((room_id IS NULL) <> (recipient_name IS NULL))
 );
 
 CREATE TABLE IF NOT EXISTS emails_sent (

--- a/examples/hotel_receptionist/hotel_db.py
+++ b/examples/hotel_receptionist/hotel_db.py
@@ -66,16 +66,6 @@ def speak_usd(cents: int) -> str:
     return f"{dollars} dollars and {change} cents"
 
 
-def speak_room(room: str) -> str:
-    """A room as the desk says it, from either its id or the spoken number.
-
-    The penthouse's id is RM_PH, so echoing the stored form back reads as
-    "room PH" - a room number no guest has ever been given.
-    """
-    suffix = room.strip().upper().removeprefix("RM_")
-    return "the penthouse suite" if suffix == "PH" else f"room {suffix}"
-
-
 def speak_time(t: time) -> str:
     """A clock time as natural speech, e.g. '7 PM', '6:30 PM'."""
     hour = t.hour % 12 or 12
@@ -497,6 +487,12 @@ FLORIST_ARRANGEMENTS: dict[str, FloralArrangement] = {
     "roses": FloralArrangement(name="Dozen long-stem roses", price=9500),
     "centerpiece": FloralArrangement(name="Table centerpiece arrangement", price=14000),
 }
+
+
+def speak_room(room_id: str) -> str:
+    suffix = room_id.removeprefix("RM_")
+    return "the penthouse suite" if suffix == "PH" else f"room {suffix}"
+
 
 # The partner property used when a confirmed guest has to be walked.
 WALK_PARTNER_HOTEL = "the Harbor House"
@@ -1300,7 +1296,6 @@ class HotelDB:
                 "no delivery destination: a room/suite or a recipient name is required"
             )
         if room_id is not None:
-            room_id = self._normalize_room(room_id)
             if not self._room_exists(room_id):
                 raise NotFound(f"no such room: {room_id}")
             recipient_name = None  # the room is the destination; exactly one is stored

--- a/examples/hotel_receptionist/hotel_db.py
+++ b/examples/hotel_receptionist/hotel_db.py
@@ -73,6 +73,15 @@ def speak_time(t: time) -> str:
     return f"{hour} {suffix}" if t.minute == 0 else f"{hour}:{t.minute:02d} {suffix}"
 
 
+def wall_clock_iso(t: time) -> str:
+    """The stored form of a caller-given time: local wall clock, no offset.
+
+    LLM-supplied times can arrive tz-aware ("17:40:00Z" parses with tzinfo), and a
+    raw isoformat() would then store "17:40:00+00:00" alongside naive times.
+    """
+    return t.replace(tzinfo=None).isoformat()
+
+
 def _new_code(prefix: str) -> str:
     """Generated reference codes are stored uppercase: the caller only ever hears
     a code spelled out in uppercase (_speak_code), and the model passes back the
@@ -920,7 +929,11 @@ class HotelDB:
         conn = self.connection
         row = conn.execute(
             _SQL_FREE_TABLE,
-            {"party_size": party_size, "date": on_date.isoformat(), "time": at_time.isoformat()},
+            {
+                "party_size": party_size,
+                "date": on_date.isoformat(),
+                "time": wall_clock_iso(at_time),
+            },
         ).fetchone()
         if not row:
             raise Unavailable(f"restaurant full: {on_date} {at_time}")
@@ -937,7 +950,7 @@ class HotelDB:
                 "phone": "".join(c for c in phone if c.isdigit()),
                 "party_size": party_size,
                 "date": on_date.isoformat(),
-                "time": at_time.isoformat(),
+                "time": wall_clock_iso(at_time),
                 "notes": notes,
             },
         )
@@ -1003,7 +1016,7 @@ class HotelDB:
                 {
                     "party_size": new_party,
                     "date": on_date.isoformat(),
-                    "time": at_time.isoformat(),
+                    "time": wall_clock_iso(at_time),
                     "code": code,
                     "current_table_id": current_table_id,
                 },
@@ -1018,7 +1031,7 @@ class HotelDB:
                     "table_id": table_id,
                     "party_size": new_party,
                     "date": on_date.isoformat(),
-                    "time": at_time.isoformat(),
+                    "time": wall_clock_iso(at_time),
                 },
                 {"code": code, "status": "confirmed"},
             )
@@ -1107,7 +1120,7 @@ class HotelDB:
                     "room_id": room_id,
                     "guest_name": guest_name,
                     "date": call_date.isoformat(),
-                    "time": call_time.isoformat(),
+                    "time": wall_clock_iso(call_time),
                 },
             )
         if self.on_change:
@@ -1181,7 +1194,7 @@ class HotelDB:
                     "guest_name": guest_name,
                     "guest_phone": "".join(c for c in guest_phone if c.isdigit()),
                     "date": on_date.isoformat(),
-                    "time": at_time.isoformat(),
+                    "time": wall_clock_iso(at_time),
                     "party_size": party_size,
                     "total": total,
                 },
@@ -1221,7 +1234,7 @@ class HotelDB:
                     "guest_name": guest_name,
                     "guest_phone": "".join(c for c in guest_phone if c.isdigit()),
                     "date": on_date.isoformat(),
-                    "time": at_time.isoformat(),
+                    "time": wall_clock_iso(at_time),
                     "duration_hours": duration_hours,
                     "total": total,
                 },
@@ -1367,7 +1380,7 @@ class HotelDB:
                     "code": code,
                     "room_id": room_id,
                     "pickup_date": pickup_date.isoformat(),
-                    "pickup_time": pickup_time.isoformat(),
+                    "pickup_time": wall_clock_iso(pickup_time),
                     "passengers": passengers,
                 },
             )

--- a/examples/hotel_receptionist/hotel_db.py
+++ b/examples/hotel_receptionist/hotel_db.py
@@ -1480,16 +1480,36 @@ class HotelDB:
             await self.on_change()
         return ConflictResolution(walk_partner=WALK_PARTNER_HOTEL, walk_return_date=return_date)
 
-    def _require_room(self, room: str) -> str:
-        """Normalize a spoken room number ("304") to its id and require it exists."""
+    @staticmethod
+    def _normalize_room(room: str) -> str:
+        """Normalize a spoken room number ("304") to its id."""
         room_id = room.strip().upper()
         if not room_id.startswith("RM_"):
             room_id = f"RM_{room_id}"
-        if not self.connection.execute(
-            "SELECT 1 FROM hotel_rooms WHERE id = :id", {"id": room_id}
-        ).fetchone():
+        return room_id
+
+    def _room_exists(self, room_id: str) -> bool:
+        return bool(
+            self.connection.execute(
+                "SELECT 1 FROM hotel_rooms WHERE id = :id", {"id": room_id}
+            ).fetchone()
+        )
+
+    def _require_room(self, room: str) -> str:
+        """Normalize a spoken room number ("304") to its id and require it exists."""
+        room_id = self._normalize_room(room)
+        if not self._room_exists(room_id):
             raise NotFound(f"no such room: {room}")
         return room_id
+
+    def room_view(self, room_id: str) -> str:
+        """The view of a room in inventory ("city", "ocean", "garden", "interior")."""
+        row = self.connection.execute(
+            "SELECT room_view FROM hotel_rooms WHERE id = :id", {"id": room_id}
+        ).fetchone()
+        if not row:
+            raise NotFound(f"no such room: {room_id}")
+        return str(row[0])
 
     async def take_guest_message(
         self,

--- a/examples/hotel_receptionist/hotel_db.py
+++ b/examples/hotel_receptionist/hotel_db.py
@@ -73,6 +73,13 @@ def speak_time(t: time) -> str:
     return f"{hour} {suffix}" if t.minute == 0 else f"{hour}:{t.minute:02d} {suffix}"
 
 
+def _new_code(prefix: str) -> str:
+    """Generated reference codes are stored uppercase: the caller only ever hears
+    a code spelled out in uppercase (_speak_code), and the model passes back the
+    form it heard - a lowercase stored form would never match a by-code lookup."""
+    return shortuuid(prefix).upper()
+
+
 DisputeCategory = Literal[
     "minibar",
     "room_service_restaurant",
@@ -647,7 +654,7 @@ class HotelDB:
         view: str | None = None,
     ) -> RoomBooking:
         clean_extras = sorted(e for e in extras if e in ALLOWED_EXTRAS)
-        code = shortuuid("HTL-")
+        code = _new_code("HTL-")
         conn = self.connection
         with conn:
             row = conn.execute(
@@ -835,7 +842,7 @@ class HotelDB:
         # Normalize to the canonical room id (and reject a mis-heard room) so storage
         # matches every other room-referencing table regardless of how it was spoken.
         room_id = self._require_room(room)
-        code = shortuuid("DND-")
+        code = _new_code("DND-")
         with self.connection as conn:
             _insert(conn, "do_not_disturb", {"code": code, "room_id": room_id})
         if self.on_change:
@@ -854,7 +861,7 @@ class HotelDB:
     ) -> str:
         """Record a waitlist entry for dates the hotel is sold out on, and return a
         reference. No room is held - the desk calls back only if something frees up."""
-        code = shortuuid("WL-")
+        code = _new_code("WL-")
         with self.connection as conn:
             _insert(
                 conn,
@@ -918,7 +925,7 @@ class HotelDB:
         if not row:
             raise Unavailable(f"restaurant full: {on_date} {at_time}")
         table_id = row[0]
-        code = shortuuid("RES-")
+        code = _new_code("RES-")
         reservation_id = _insert(
             conn,
             "restaurant_reservations",
@@ -1058,7 +1065,7 @@ class HotelDB:
         caller_phone: str,
         summary: str,
     ) -> str:
-        code = shortuuid("FUP-")
+        code = _new_code("FUP-")
         digits = "".join(c for c in caller_phone if c.isdigit())
         conn = self.connection
         with conn:
@@ -1090,7 +1097,7 @@ class HotelDB:
         conn = self.connection
         if call_date < TODAY:
             raise Unavailable(f"{call_date.isoformat()} is in the past")
-        code = shortuuid("WUC-")
+        code = _new_code("WUC-")
         with conn:
             _insert(
                 conn,
@@ -1124,7 +1131,7 @@ class HotelDB:
         if party_size > tour.max_party:
             raise Unavailable(f"{tour.name} takes at most {tour.max_party} guests")
         total = tour.flat_price or (tour.price_per_person or 0) * party_size
-        code = shortuuid("TUR-")
+        code = _new_code("TUR-")
         with self.connection as conn:
             _insert(
                 conn,
@@ -1163,7 +1170,7 @@ class HotelDB:
         if party_size > service.max_party:
             raise Unavailable(f"{service.name} takes at most {service.max_party} guests")
         total = service.price * party_size
-        code = shortuuid("SPA-")
+        code = _new_code("SPA-")
         with self.connection as conn:
             _insert(
                 conn,
@@ -1203,7 +1210,7 @@ class HotelDB:
         if duration_hours > service.max_hours:
             raise Unavailable(f"{service.name} is booked for at most {service.max_hours} hours")
         total = service.flat_price or (service.price_per_hour or 0) * duration_hours
-        code = shortuuid("BIZ-")
+        code = _new_code("BIZ-")
         with self.connection as conn:
             _insert(
                 conn,
@@ -1242,7 +1249,7 @@ class HotelDB:
         if on_date < TODAY:
             raise Unavailable(f"{on_date.isoformat()} is in the past")
         total = arrangement.price
-        code = shortuuid("FLR-")
+        code = _new_code("FLR-")
         with self.connection as conn:
             _insert(
                 conn,
@@ -1270,7 +1277,7 @@ class HotelDB:
             raise NotFound(
                 f"unknown email kind: {kind} - options: {', '.join(get_args(EmailKind))}"
             )
-        code = shortuuid("EML-")
+        code = _new_code("EML-")
         with self.connection as conn:
             _insert(
                 conn,
@@ -1292,7 +1299,7 @@ class HotelDB:
             raise NotFound(
                 f"unknown destination: {destination} - options: {', '.join(get_args(TransferDestination))}"
             )
-        code = shortuuid("XFR-")
+        code = _new_code("XFR-")
         with self.connection as conn:
             _insert(
                 conn,
@@ -1318,7 +1325,7 @@ class HotelDB:
         seat_check: bool,
     ) -> str:
         room_id = self._require_room(room)
-        code = shortuuid("FLT-")
+        code = _new_code("FLT-")
         with self.connection as conn:
             _insert(
                 conn,
@@ -1351,7 +1358,7 @@ class HotelDB:
         room_id = self._require_room(room)
         if pickup_date < TODAY:
             raise Unavailable(f"{pickup_date.isoformat()} is in the past")
-        code = shortuuid("CAR-")
+        code = _new_code("CAR-")
         with self.connection as conn:
             _insert(
                 conn,
@@ -1376,7 +1383,7 @@ class HotelDB:
                 f"unknown emergency kind: {kind} - options: {', '.join(get_args(EmergencyKind))}"
             )
         room_id = self._require_room(room)
-        code = shortuuid("EMG-")
+        code = _new_code("EMG-")
         with self.connection as conn:
             _insert(
                 conn,
@@ -1450,7 +1457,7 @@ class HotelDB:
                 conn,
                 "walk_arrangements",
                 {
-                    "code": shortuuid("WLK-"),
+                    "code": _new_code("WLK-"),
                     "booking_code": booking_code,
                     "partner_hotel": WALK_PARTNER_HOTEL,
                     "return_date": return_date.isoformat(),
@@ -1482,7 +1489,7 @@ class HotelDB:
         """Record a message addressed to a (possibly) in-house guest. Whether the
         recipient actually has a stay here is resolved internally and never
         returned, so the agent taking the message cannot leak guest presence."""
-        code = shortuuid("MSG-")
+        code = _new_code("MSG-")
         conn = self.connection
         with conn:
             in_house = conn.execute(
@@ -1554,7 +1561,7 @@ class HotelDB:
         check_in: date,
         nights: int,
     ) -> str:
-        code = shortuuid("GRP-")
+        code = _new_code("GRP-")
         conn = self.connection
         with conn:
             _insert(
@@ -1588,7 +1595,7 @@ class HotelDB:
         outcome: str,
         refund_amount: int,
     ) -> str:
-        case_number = shortuuid("DSP-")
+        case_number = _new_code("DSP-")
         conn = self.connection
         with conn:
             _insert(

--- a/examples/hotel_receptionist/hotel_db.py
+++ b/examples/hotel_receptionist/hotel_db.py
@@ -66,6 +66,16 @@ def speak_usd(cents: int) -> str:
     return f"{dollars} dollars and {change} cents"
 
 
+def speak_room(room: str) -> str:
+    """A room as the desk says it, from either its id or the spoken number.
+
+    The penthouse's id is RM_PH, so echoing the stored form back reads as
+    "room PH" - a room number no guest has ever been given.
+    """
+    suffix = room.strip().upper().removeprefix("RM_")
+    return "the penthouse suite" if suffix == "PH" else f"room {suffix}"
+
+
 def speak_time(t: time) -> str:
     """A clock time as natural speech, e.g. '7 PM', '6:30 PM'."""
     hour = t.hour % 12 or 12

--- a/examples/hotel_receptionist/hotel_db.py
+++ b/examples/hotel_receptionist/hotel_db.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sys
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, fields
 from datetime import date, time, timedelta
@@ -166,10 +167,21 @@ DISPUTE_POLICIES: dict[DisputeCategory, DisputePolicy] = {
     ),
 }
 
-# Set HOTEL_TODAY=YYYY-MM-DD before import for deterministic sim runs.
-TODAY: date = (
-    date.fromisoformat(os.environ["HOTEL_TODAY"]) if os.environ.get("HOTEL_TODAY") else date.today()
-)
+# scenarios.yaml pins every date literal to SIM_TODAY, so simulation runs must
+# not use the real clock. HOTEL_TODAY=YYYY-MM-DD overrides in any mode.
+SIM_TODAY = date(2026, 6, 8)
+
+
+def _resolve_today() -> date:
+    if env_today := os.environ.get("HOTEL_TODAY"):
+        return date.fromisoformat(env_today)
+    # `lk agent simulate` always passes --simulation; job subprocesses inherit argv
+    if "--simulation" in sys.argv:
+        return SIM_TODAY
+    return date.today()
+
+
+TODAY: date = _resolve_today()
 MAX_PARTY_SIZE = 6
 
 RoomType = Literal["king", "queen_2beds", "double_queen", "suite", "penthouse"]

--- a/examples/hotel_receptionist/hotel_db.py
+++ b/examples/hotel_receptionist/hotel_db.py
@@ -1366,6 +1366,7 @@ class HotelDB:
         flight_date: date,
         booking_reference: str,
         seat_check: bool,
+        departure_time: time | None = None,
     ) -> str:
         room_id = self._require_room(room)
         code = _new_code("FLT-")
@@ -1384,11 +1385,25 @@ class HotelDB:
                         c for c in booking_reference if c.isalnum()
                     ).upper(),
                     "seat_check": int(seat_check),
+                    "departure_time": wall_clock_iso(departure_time) if departure_time else None,
                 },
             )
         if self.on_change:
             await self.on_change()
         return code
+
+    async def latest_flight_departure(self, *, room: str, flight_date: date) -> time | None:
+        """The departure time of the most recently logged flight reconfirmation for
+        this room on this date, if one was captured - what an airport-car pickup
+        gets sanity-checked against."""
+        room_id = self._require_room(room)
+        row = self.connection.execute(
+            "SELECT departure_time FROM flight_reconfirmations"
+            " WHERE room_id = ? AND flight_date = ? AND departure_time IS NOT NULL"
+            " ORDER BY id DESC LIMIT 1",
+            (room_id, flight_date.isoformat()),
+        ).fetchone()
+        return time.fromisoformat(row[0]) if row else None
 
     async def book_airport_car(
         self,
@@ -1910,6 +1925,7 @@ CREATE TABLE IF NOT EXISTS flight_reconfirmations (
     airline           TEXT    NOT NULL,
     flight_number     TEXT    NOT NULL,
     flight_date       DATE    NOT NULL,
+    departure_time    TIME,
     booking_reference TEXT    NOT NULL,
     seat_check        BOOLEAN NOT NULL DEFAULT 0,
     status            TEXT    NOT NULL DEFAULT 'pending'

--- a/examples/hotel_receptionist/hotel_db.py
+++ b/examples/hotel_receptionist/hotel_db.py
@@ -212,6 +212,26 @@ class RoomTypeAvailability:
     views: list[str]
 
 
+def describe_room_options(avail: list[RoomTypeAvailability]) -> str:
+    """The available types as one line each, with the view verdict on the type's own line.
+
+    A single pipe-delimited line ("queen 2beds (city or garden views) | ... | double
+    queen (ocean view)") reads as one blob: the model binds a neighboring type's view
+    to the type the caller picked and offers a garden-view double queen, which has
+    never existed. One row per type keeps the binding local, and spelling out whether
+    the view is a question or a fact stops the offer from becoming a false choice.
+    """
+    return "\n".join(
+        f"- {a.type.replace('_', ' ')}: {speak_usd(a.nightly_rate)}/night, "
+        + (
+            f"{' or '.join(a.views)} view - ask which of those two they want"
+            if len(a.views) > 1
+            else f"{a.views[0]} view only - say so as a fact, there is no view to ask about"
+        )
+        for a in avail
+    )
+
+
 @dataclass
 class RoomBooking:
     id: int

--- a/examples/hotel_receptionist/modify_booking.py
+++ b/examples/hotel_receptionist/modify_booking.py
@@ -71,11 +71,14 @@ class ModifyBookingTask(AgentTask[RoomBooking]):
         # and to produce a faithful summary of what changed.
         self._changed: set[str] = set()
         # The model is asked to read the booking back - so the booking's actual
-        # facts must be IN its context, or it will invent dates and amounts.
+        # facts must be IN its context, or it will invent dates and amounts. The
+        # room's view is part of those facts: without it, a booking that was just
+        # moved for its view reads back as if the move never happened.
         extras = ", ".join(existing.extras) if existing.extras else "none"
+        view = db.room_view(existing.room_id)
         booking_facts = (
             f"\nThe loaded booking: {existing.first_name} {existing.last_name}, "
-            f"{existing.room_type.replace('_', ' ')}, "
+            f"{view}-view {existing.room_type.replace('_', ' ')}, "
             f"check-in {existing.check_in.strftime('%A, %B %-d')}, "
             f"check-out {existing.check_out.strftime('%A, %B %-d')}, "
             f"{existing.guests} guest{'s' if existing.guests != 1 else ''}, "

--- a/examples/hotel_receptionist/scenarios.yaml
+++ b/examples/hotel_receptionist/scenarios.yaml
@@ -1224,7 +1224,7 @@ scenarios:
     - your name: Marcus Webb
     - your callback number: 415-555-0182
     - which arrangement: the dozen long-stem roses
-    - where it goes: room 412
+    - where it goes: room 304
     - the delivery day: this Friday, June 12th
     - the gift-card message: "Happy ten years, my love. Yours always, Marcus."
     DO, IN ORDER:
@@ -1251,8 +1251,8 @@ scenarios:
     expected_state:
     - |
       INSERT INTO florist_orders
-        (code, arrangement_id, guest_name, guest_phone, deliver_to, date, message, total, status)
-      VALUES ('IGNORED', 'roses', 'Marcus Webb', '4155550182', '412', '2026-06-12',
+        (code, arrangement_id, guest_name, guest_phone, room_id, date, message, total, status)
+      VALUES ('IGNORED', 'roses', 'Marcus Webb', '4155550182', 'RM_304', '2026-06-12',
               'IGNORED', 'IGNORED', 'confirmed')
 
   # --- 35: Re-send an itemized folio to the address on file (deterministic: emails_sent row)
@@ -1437,8 +1437,8 @@ scenarios:
     expected_state:
     - |
       INSERT INTO florist_orders
-        (code, arrangement_id, guest_name, guest_phone, deliver_to, date, message, total, status)
-      VALUES ('IGNORED', 'centerpiece', 'Renata Cole', '4155550193', 'Penthouse Suite',
+        (code, arrangement_id, guest_name, guest_phone, room_id, date, message, total, status)
+      VALUES ('IGNORED', 'centerpiece', 'Renata Cole', '4155550193', 'RM_PH',
               '2026-06-10', 'IGNORED', 'IGNORED', 'confirmed')
 
   # --- 40: VIP pre-arrival -> noted preference via record_followup (NL-only; kind non-deterministic)
@@ -1519,7 +1519,7 @@ scenarios:
     expected_state:
     - |
       INSERT INTO florist_orders
-        (code, arrangement_id, guest_name, guest_phone, deliver_to, date, message, total, status)
+        (code, arrangement_id, guest_name, guest_phone, recipient_name, date, message, total, status)
       VALUES ('IGNORED', 'roses', 'Theodore Lansing', '6285550147', 'Theodore Lansing',
               '2026-06-11', 'IGNORED', 'IGNORED', 'confirmed')
     - |

--- a/examples/hotel_receptionist/scenarios.yaml
+++ b/examples/hotel_receptionist/scenarios.yaml
@@ -619,8 +619,8 @@ scenarios:
     expected_state:
     - |
       INSERT INTO flight_reconfirmations
-        (code, room_id, airline, flight_number, flight_date, booking_reference, seat_check)
-      VALUES ('IGNORED', 'RM_401', 'Iberia', 'IB6174', '2026-06-11', 'QX4R7T', 1)
+        (code, room_id, airline, flight_number, flight_date, departure_time, booking_reference, seat_check)
+      VALUES ('IGNORED', 'RM_401', 'Iberia', 'IB6174', '2026-06-11', '17:40:00', 'QX4R7T', 1)
     - |
       INSERT INTO airport_cars
         (code, room_id, pickup_date, pickup_time, passengers)

--- a/examples/hotel_receptionist/scenarios.yaml
+++ b/examples/hotel_receptionist/scenarios.yaml
@@ -1,5 +1,7 @@
 # Assumptions:
-#   - Seed date is pinned: HOTEL_TODAY=2026-06-08 (Mon). All dates are literals.
+#   - Seed date is pinned to 2026-06-08 (Mon); all dates are literals. hotel_db
+#     pins this automatically under `lk agent simulate` (SIM_TODAY); set
+#     HOTEL_TODAY=YYYY-MM-DD to override in any mode.
 #   - expected_state is included ONLY where the end state is deterministic at the
 #     granularity the diff compares (room *type*, followup *kind*, booking *status*).
 #     Pinned guest facts (email/phone/card) in `instructions` are repeated verbatim

--- a/examples/hotel_receptionist/tools_rooms.py
+++ b/examples/hotel_receptionist/tools_rooms.py
@@ -22,6 +22,7 @@ from hotel_db import (
     NotFound,
     RoomBooking,
     Unavailable,
+    describe_room_options,
     speak_usd,
 )
 from modify_booking import ModifyBookingTask
@@ -166,10 +167,12 @@ class RoomToolsMixin:
             )
             what = f"{kind}{room_type.replace('_', ' ')}" if room_type != "any" else f"{kind}rooms"
             return f"no {what} available for those dates"
-        return " | ".join(
-            f"{a.type.replace('_', ' ')}: {speak_usd(a.nightly_rate)} per night, "
-            f"{' or '.join(a.views)} view{'s' if len(a.views) > 1 else ''}"
-            for a in avail
+        # Same one-row-per-type render as set_stay: browsing feeds the same view
+        # blob into context, so a smeared type->view pair offered here survives
+        # into the booking flow.
+        return (
+            "the views on a type's line are the only views that type has:\n"
+            f"{describe_room_options(avail)}"
         )
 
     @function_tool

--- a/examples/hotel_receptionist/tools_services.py
+++ b/examples/hotel_receptionist/tools_services.py
@@ -346,37 +346,67 @@ class ServicesToolsMixin:
         ctx: RunContext[Userdata],
         arrangement: Literal["bouquet", "roses", "centerpiece"],
         on_date: date,
-        deliver_to: str,
         card_message: str,
         guest_name: str,
         guest_phone: str,
+        room: str | None = None,
+        recipient: str | None = None,
+        delivery_instruction: str = "",
     ) -> str:
-        """Order a flower arrangement from the hotel florist for delivery to a room or recipient. The catalog (arrangements, prices, delivery cutoff) is in lookup_policy topic "florist" - look it up first and let the caller pick the arrangement, never pick for them. Collect the delivery date, where it goes (room number or recipient name), and the gift-card message, and read the card message back so it's right. Once they pick and agree, THIS CALL places the order - saying "I'll get that arranged" orders nothing; nothing exists until this returns a reference.
+        """Order a flower arrangement from the hotel florist, delivered to a room or suite here, or to an arriving guest by name if their room isn't assigned yet. The catalog (arrangements, prices, delivery cutoff) is in lookup_policy topic "florist" - look it up first and let the caller pick the arrangement, never pick for them. Collect the delivery date, where it goes, and the gift-card message, and read the card message back so it's right. Once they pick and agree, THIS CALL places the order - saying "I'll get that arranged" orders nothing; nothing exists until this returns a reference. Delivery handling requests ("as early as possible") go in delivery_instruction here, or via amend_florist_order after placing - never in a followup.
 
         Args:
             arrangement: The arrangement the caller picked.
             on_date: Delivery date in ISO YYYY-MM-DD format.
-            deliver_to: Where it goes - the number of the room or the recipient's name. Prefer room number when available.
             card_message: The gift-card message exactly as the caller dictates it.
             guest_name: The caller's full name.
             guest_phone: The caller's phone number, in case the florist needs to reach them.
+            room: The destination room number here ("412"), or "PH" for the penthouse suite. Use this whenever the room is known - it is checked against the hotel's rooms.
+            recipient: The recipient's name, ONLY when no room is known yet (an arriving guest whose room isn't assigned). Leave unset when you pass room.
+            delivery_instruction: How the delivery should be handled ("before the guest arrives", "leave with the concierge") if the caller says. Empty otherwise.
         """
         try:
             code, a, total = await ctx.userdata.db.order_flowers(
                 arrangement_id=arrangement,
                 guest_name=guest_name,
                 guest_phone=guest_phone,
-                deliver_to=deliver_to,
+                room_id=room,
+                recipient_name=recipient,
                 on_date=on_date,
                 card_message=card_message,
+                delivery_instructions=delivery_instruction,
             )
         except (NotFound, Unavailable) as e:
             raise ToolError(str(e)) from None
+        destination = speak_room(room) if room else recipient
         return (
-            f"{a.name} ordered for delivery to {deliver_to} on "
+            f"{a.name} ordered for delivery to {destination} on "
             f"{on_date.strftime('%A, %B %-d')}; reference {_speak_code(code)}; total "
             f"{speak_usd(total)} | confirm the arrangement, where it's going, the date, and the "
             "total to the caller - no further tool call is needed for this order."
+        )
+
+    @function_tool
+    async def amend_florist_order(
+        self, ctx: RunContext[Userdata], order_code: str, delivery_instruction: str
+    ) -> str:
+        """Attach or replace the delivery handling note on a florist order already placed. Use it when the caller adds a handling request after the order ("make sure it's there before she arrives") - the note belongs on the order the florist reads, not in a followup nobody routes.
+
+        Args:
+            order_code: The florist order reference from order_flowers (e.g. "FLR-...").
+            delivery_instruction: How the delivery should be handled, in one line.
+        """
+        try:
+            await ctx.userdata.db.amend_florist_order(
+                code=order_code, delivery_instructions=delivery_instruction
+            )
+        except NotFound:
+            raise ToolError(
+                f"no florist order {order_code} - re-confirm the reference with the caller"
+            ) from None
+        return (
+            f'noted on the order: "{delivery_instruction}" | confirm to the caller that the '
+            "florist has it; no further tool call is needed."
         )
 
     @function_tool

--- a/examples/hotel_receptionist/tools_services.py
+++ b/examples/hotel_receptionist/tools_services.py
@@ -14,6 +14,7 @@ from hotel_db import (
     FollowupKind,
     NotFound,
     Unavailable,
+    speak_room,
     speak_time,
     speak_usd,
 )
@@ -124,12 +125,12 @@ class ServicesToolsMixin:
             )
         except NotFound:
             raise ToolError(
-                f"no room {room} exists - re-confirm the room number with the caller"
+                f"{speak_room(room)} doesn't exist here - re-confirm the room number with the caller"
             ) from None
         except Unavailable as e:
             raise ToolError(f"can't schedule that: {e} - re-confirm the date") from None
         return (
-            f"wake-up call set for room {room}, {call_date.strftime('%A, %B %-d')} at "
+            f"wake-up call set for {speak_room(room)}, {call_date.strftime('%A, %B %-d')} at "
             f"{speak_time(call_time)}; reference {_speak_code(code)} | confirm it's set. If the "
             "caller worries about sleeping through: a second call comes about five minutes later "
             "if there's no answer, and no response to that sends staff up for an in-person room "
@@ -161,10 +162,10 @@ class ServicesToolsMixin:
             )
         except NotFound:
             raise ToolError(
-                f"no room {room} exists - re-confirm the room number, calmly, right now"
+                f"{speak_room(room)} doesn't exist here - re-confirm the room number, calmly, right now"
             ) from None
         head = (
-            f"DISPATCHED (ref {code}): duty manager alerted, staff heading to room {room} now | "
+            f"DISPATCHED (ref {code}): duty manager alerted, staff heading to {speak_room(room)} now | "
             "tell the caller, short and calm, that our people are on their way up right now"
         )
         if kind == "medical":
@@ -428,7 +429,9 @@ class ServicesToolsMixin:
                 seat_check=seat_check,
             )
         except NotFound:
-            raise ToolError(f"no room {room} exists - re-confirm the room number") from None
+            raise ToolError(
+                f"{speak_room(room)} doesn't exist here - re-confirm the room number"
+            ) from None
         return (
             f"reconfirmation request logged; reference {_speak_code(code)} | tell the caller the "
             "concierge will call the carrier and ring their room with the result within the hour"
@@ -461,7 +464,9 @@ class ServicesToolsMixin:
                 passengers=passengers,
             )
         except NotFound:
-            raise ToolError(f"no room {room} exists - re-confirm the room number") from None
+            raise ToolError(
+                f"{speak_room(room)} doesn't exist here - re-confirm the room number"
+            ) from None
         except Unavailable as e:
             raise ToolError(f"can't book that: {e} - re-confirm the date") from None
         return (
@@ -536,9 +541,11 @@ class ServicesToolsMixin:
         try:
             code = await ctx.userdata.db.set_do_not_disturb(room=room)
         except NotFound:
-            raise ToolError(f"no room {room} exists - re-confirm the room number") from None
+            raise ToolError(
+                f"{speak_room(room)} doesn't exist here - re-confirm the room number"
+            ) from None
         return (
-            f"Do-Not-Disturb set on room {room}; reference {_speak_code(code)} | confirm it holds "
+            f"Do-Not-Disturb set on {speak_room(room)}; reference {_speak_code(code)} | confirm it holds "
             "their calls and messages until they ask to lift it, and that a genuine emergency "
             "still gets through."
         )

--- a/examples/hotel_receptionist/tools_services.py
+++ b/examples/hotel_receptionist/tools_services.py
@@ -18,7 +18,7 @@ from hotel_db import (
     speak_time,
     speak_usd,
 )
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from livekit.agents import RunContext, ToolError, function_tool
 
@@ -57,6 +57,26 @@ def _departure_margin_note(*, pickup: time, departure: time) -> str:
         f"that's {margin} before the {spoken_dep} departure - say this margin back "
         "to the guest (about 3 hours ahead is right for international)."
     )
+
+
+class NumberedRoom(BaseModel):
+    """A numbered room or suite, as the caller says it: "room 304" / "suite 401" -> 304 / 401."""
+
+    type: Literal["room"] = "room"
+    number: int
+
+
+class PenthouseSuite(BaseModel):
+    """The hotel's penthouse suite - the one room with no number."""
+
+    type: Literal["penthouse"] = "penthouse"
+
+
+Room = Annotated[NumberedRoom | PenthouseSuite, Field(discriminator="type")]
+
+
+def room_to_id(room: NumberedRoom | PenthouseSuite) -> str:
+    return "RM_PH" if room.type == "penthouse" else f"RM_{room.number}"
 
 
 class ServicesToolsMixin:
@@ -140,7 +160,7 @@ class ServicesToolsMixin:
     async def schedule_wakeup_call(
         self,
         ctx: RunContext[Userdata],
-        room: str,
+        room: Room,
         guest_name: str,
         call_date: date,
         call_time: time,
@@ -148,23 +168,25 @@ class ServicesToolsMixin:
         """Schedule a wake-up call to a guest's room. This actually sets the call - never log a wake-up request as a followup note instead. Collect the room, the name, and the exact date and time from the caller, read them back, and call this once they've agreed. No booking verification needed.
 
         Args:
-            room: The room number as the caller gave it (e.g. "304").
+            room: The guest's room, as the caller gave it.
             guest_name: The guest's name.
             call_date: The date of the wake-up call in ISO YYYY-MM-DD format ("tomorrow morning" = tomorrow's date).
             call_time: The wake-up time in 24-hour HH:MM format (4:45 a.m. = "04:45").
         """
+        room_id = room_to_id(room)
+        spoken = speak_room(room_id)
         try:
             code = await ctx.userdata.db.schedule_wakeup_call(
-                room=room, guest_name=guest_name, call_date=call_date, call_time=call_time
+                room=room_id, guest_name=guest_name, call_date=call_date, call_time=call_time
             )
         except NotFound:
             raise ToolError(
-                f"{speak_room(room)} doesn't exist here - re-confirm the room number with the caller"
+                f"{spoken} doesn't exist here - re-confirm the room with the caller"
             ) from None
         except Unavailable as e:
             raise ToolError(f"can't schedule that: {e} - re-confirm the date") from None
         return (
-            f"wake-up call set for {speak_room(room)}, {call_date.strftime('%A, %B %-d')} at "
+            f"wake-up call set for {spoken}, {call_date.strftime('%A, %B %-d')} at "
             f"{speak_time(call_time)}; reference {_speak_code(code)} | confirm it's set. If the "
             "caller worries about sleeping through: a second call comes about five minutes later "
             "if there's no answer, and no response to that sends staff up for an in-person room "
@@ -175,7 +197,7 @@ class ServicesToolsMixin:
     async def dispatch_emergency(
         self,
         ctx: RunContext[Userdata],
-        room: str,
+        room: Room,
         kind: Literal["medical", "fire", "security"],
         situation: str,
     ) -> str:
@@ -186,20 +208,22 @@ class ServicesToolsMixin:
         NOT for nuisances - a noisy neighbour with nobody in danger is record_followup (kind="other"), not this.
 
         Args:
-            room: The room number (e.g. "206"). Get this first if you don't have it.
+            room: The guest's room. Get this first if you don't have it.
             kind: medical, fire, or security - classify what's happening.
             situation: One short sentence: what's happening to whom.
         """
+        room_id = room_to_id(room)
+        spoken = speak_room(room_id)
         try:
             code = await ctx.userdata.db.dispatch_emergency(
-                room=room, kind=kind, situation=situation
+                room=room_id, kind=kind, situation=situation
             )
         except NotFound:
             raise ToolError(
-                f"{speak_room(room)} doesn't exist here - re-confirm the room number, calmly, right now"
+                f"{spoken} doesn't exist here - re-confirm the room, calmly, right now"
             ) from None
         head = (
-            f"DISPATCHED (ref {code}): duty manager alerted, staff heading to {speak_room(room)} now | "
+            f"DISPATCHED (ref {code}): duty manager alerted, staff heading to {spoken} now | "
             "tell the caller, short and calm, that our people are on their way up right now"
         )
         if kind == "medical":
@@ -349,7 +373,7 @@ class ServicesToolsMixin:
         card_message: str,
         guest_name: str,
         guest_phone: str,
-        room: str | None = None,
+        room: Room | None = None,
         recipient: str | None = None,
         delivery_instruction: str = "",
     ) -> str:
@@ -361,16 +385,17 @@ class ServicesToolsMixin:
             card_message: The gift-card message exactly as the caller dictates it.
             guest_name: The caller's full name.
             guest_phone: The caller's phone number, in case the florist needs to reach them.
-            room: The destination room number here ("412"), or "PH" for the penthouse suite. Use this whenever the room is known - it is checked against the hotel's rooms.
+            room: The destination room, ONLY if the caller named one. A numbered room or suite is {"type": "room", "number": <number>}; the penthouse suite is {"type": "penthouse"}. Omit when no room was named - never guess; if you don't know where it goes, ask.
             recipient: The recipient's name, ONLY when no room is known yet (an arriving guest whose room isn't assigned). Leave unset when you pass room.
             delivery_instruction: How the delivery should be handled ("before the guest arrives", "leave with the concierge") if the caller says. Empty otherwise.
         """
+        room_id = room_to_id(room) if room else None
         try:
             code, a, total = await ctx.userdata.db.order_flowers(
                 arrangement_id=arrangement,
                 guest_name=guest_name,
                 guest_phone=guest_phone,
-                room_id=room,
+                room_id=room_id,
                 recipient_name=recipient,
                 on_date=on_date,
                 card_message=card_message,
@@ -378,7 +403,7 @@ class ServicesToolsMixin:
             )
         except (NotFound, Unavailable) as e:
             raise ToolError(str(e)) from None
-        destination = speak_room(room) if room else recipient
+        destination = speak_room(room_id) if room_id else recipient
         return (
             f"{a.name} ordered for delivery to {destination} on "
             f"{on_date.strftime('%A, %B %-d')}; reference {_speak_code(code)}; total "
@@ -466,7 +491,7 @@ class ServicesToolsMixin:
     async def request_flight_reconfirmation(
         self,
         ctx: RunContext[Userdata],
-        room: str,
+        room: Room,
         airline: str,
         flight_number: str,
         flight_date: date,
@@ -477,7 +502,7 @@ class ServicesToolsMixin:
         """Log a flight-reconfirmation request for an in-house guest: the concierge calls the carrier and rings the guest's room with the result. Collect ALL the flight details first and read the booking reference back before calling - a wrong reference makes the whole request useless.
 
         Args:
-            room: The guest's room number.
+            room: The guest's room.
             airline: The carrier name (e.g. "Iberia").
             flight_number: Airline code and number as given (e.g. "IB 6174").
             flight_date: Flight date in ISO YYYY-MM-DD format. When the caller says a weekday ("Thursday"), resolve it against today and say the concrete date back ("Thursday - that's June eleventh?") BEFORE calling; a one-day slip sends the whole request to the wrong flight.
@@ -485,9 +510,10 @@ class ServicesToolsMixin:
             seat_check: True if the guest also wants their seat assignment checked - it's handled in the same carrier call.
             departure_time: Scheduled departure in 24-hour HH:MM format if the caller mentions or knows it - it's what any airport-car pickup gets sanity-checked against. Omit if they don't know it.
         """
+        room_id = room_to_id(room)
         try:
             code = await ctx.userdata.db.request_flight_reconfirmation(
-                room=room,
+                room=room_id,
                 airline=airline,
                 flight_number=flight_number,
                 flight_date=flight_date,
@@ -497,7 +523,7 @@ class ServicesToolsMixin:
             )
         except NotFound:
             raise ToolError(
-                f"{speak_room(room)} doesn't exist here - re-confirm the room number"
+                f"{speak_room(room_id)} doesn't exist here - re-confirm the room"
             ) from None
         return (
             f"reconfirmation request logged; reference {_speak_code(code)} | tell the caller the "
@@ -510,7 +536,7 @@ class ServicesToolsMixin:
     async def book_airport_car(
         self,
         ctx: RunContext[Userdata],
-        room: str,
+        room: Room,
         pickup_date: date,
         pickup_time: time,
         passengers: Annotated[int, Field(ge=1, le=4)],
@@ -518,28 +544,29 @@ class ServicesToolsMixin:
         """Book the hotel car to the airport for an in-house guest: flat eighty-five dollars to SFO, seats up to four with luggage, charged to the room. (Taxis are hailed at the door, metered roughly fifty-five to seventy dollars, and can't be reserved ahead - cost comparison in lookup_policy topic "location_and_transport".) Sanity-check the pickup time against the flight when you know it - about three hours before departure is right for international.
 
         Args:
-            room: The guest's room number.
+            room: The guest's room.
             pickup_date: Pickup date in ISO YYYY-MM-DD format. Resolve a weekday against today and confirm the concrete date with the caller before booking.
             pickup_time: Pickup time in 24-hour HH:MM format (2:30 p.m. = "14:30").
             passengers: How many people are riding - ASK the caller; never assume one.
         """
+        room_id = room_to_id(room)
         try:
             code = await ctx.userdata.db.book_airport_car(
-                room=room,
+                room=room_id,
                 pickup_date=pickup_date,
                 pickup_time=pickup_time,
                 passengers=passengers,
             )
         except NotFound:
             raise ToolError(
-                f"{speak_room(room)} doesn't exist here - re-confirm the room number"
+                f"{speak_room(room_id)} doesn't exist here - re-confirm the room"
             ) from None
         except Unavailable as e:
             raise ToolError(f"can't book that: {e} - re-confirm the date") from None
         # With a flight on file for this room and day, the pickup margin is computed
         # here rather than left to the prose instruction the model routinely skips.
         departure = await ctx.userdata.db.latest_flight_departure(
-            room=room, flight_date=pickup_date
+            room=room_id, flight_date=pickup_date
         )
         margin_note = (
             " " + _departure_margin_note(pickup=pickup_time, departure=departure)
@@ -610,20 +637,20 @@ class ServicesToolsMixin:
         )
 
     @function_tool
-    async def set_do_not_disturb(self, ctx: RunContext[Userdata], room: str) -> str:
+    async def set_do_not_disturb(self, ctx: RunContext[Userdata], room: Room) -> str:
         """Place a Do-Not-Disturb hold on an in-house guest's room when they ask not to be disturbed / to hold their calls and messages. It's a standing hold (until lifted), not a one-off like a single message or a wake-up call. Take the room number. Always tell the guest that a genuine emergency or hotel safety matter still overrides DND.
 
         Args:
-            room: The guest's room number.
+            room: The guest's room.
         """
+        room_id = room_to_id(room)
+        spoken = speak_room(room_id)
         try:
-            code = await ctx.userdata.db.set_do_not_disturb(room=room)
+            code = await ctx.userdata.db.set_do_not_disturb(room=room_id)
         except NotFound:
-            raise ToolError(
-                f"{speak_room(room)} doesn't exist here - re-confirm the room number"
-            ) from None
+            raise ToolError(f"{spoken} doesn't exist here - re-confirm the room") from None
         return (
-            f"Do-Not-Disturb set on {speak_room(room)}; reference {_speak_code(code)} | confirm it holds "
+            f"Do-Not-Disturb set on {spoken}; reference {_speak_code(code)} | confirm it holds "
             "their calls and messages until they ask to lift it, and that a genuine emergency "
             "still gets through."
         )

--- a/examples/hotel_receptionist/tools_services.py
+++ b/examples/hotel_receptionist/tools_services.py
@@ -25,6 +25,40 @@ from livekit.agents import RunContext, ToolError, function_tool
 logger = logging.getLogger("hotel-receptionist")
 
 
+def _departure_margin_note(*, pickup: time, departure: time) -> str:
+    """The pickup-vs-departure sanity check, computed instead of remembered.
+
+    The prose instruction to "sanity-check the pickup time against the flight"
+    was routinely skipped; with the departure time on file the tool hands the
+    agent the actual margin to say back.
+    """
+    minutes = (departure.hour * 60 + departure.minute) - (pickup.hour * 60 + pickup.minute)
+    spoken_dep = speak_time(departure)
+    if minutes <= 0:
+        return (
+            f"the pickup is not before the {spoken_dep} departure - re-check the "
+            "times with the guest before confirming anything."
+        )
+    halves = round(minutes / 30)
+    whole, half = divmod(halves, 2)
+    if whole == 0:
+        margin = "about half an hour"
+    elif half:
+        margin = f"about {whole} and a half hours"
+    else:
+        margin = f"about {whole} hour{'s' if whole != 1 else ''}"
+    if minutes < 120:
+        return (
+            f"that's only {margin} before the {spoken_dep} departure - TIGHT for an "
+            "airport run; flag it to the guest (about 3 hours ahead is right for "
+            "international)."
+        )
+    return (
+        f"that's {margin} before the {spoken_dep} departure - say this margin back "
+        "to the guest (about 3 hours ahead is right for international)."
+    )
+
+
 class ServicesToolsMixin:
     @function_tool
     async def flag_late_arrival(self, ctx: RunContext[Userdata], note: str) -> str:
@@ -408,6 +442,7 @@ class ServicesToolsMixin:
         flight_date: date,
         booking_reference: str,
         seat_check: bool,
+        departure_time: time | None = None,
     ) -> str:
         """Log a flight-reconfirmation request for an in-house guest: the concierge calls the carrier and rings the guest's room with the result. Collect ALL the flight details first and read the booking reference back before calling - a wrong reference makes the whole request useless.
 
@@ -418,6 +453,7 @@ class ServicesToolsMixin:
             flight_date: Flight date in ISO YYYY-MM-DD format. When the caller says a weekday ("Thursday"), resolve it against today and say the concrete date back ("Thursday - that's June eleventh?") BEFORE calling; a one-day slip sends the whole request to the wrong flight.
             booking_reference: The airline booking reference, letters and digits only.
             seat_check: True if the guest also wants their seat assignment checked - it's handled in the same carrier call.
+            departure_time: Scheduled departure in 24-hour HH:MM format if the caller mentions or knows it - it's what any airport-car pickup gets sanity-checked against. Omit if they don't know it.
         """
         try:
             code = await ctx.userdata.db.request_flight_reconfirmation(
@@ -427,6 +463,7 @@ class ServicesToolsMixin:
                 flight_date=flight_date,
                 booking_reference=booking_reference,
                 seat_check=seat_check,
+                departure_time=departure_time,
             )
         except NotFound:
             raise ToolError(
@@ -469,11 +506,22 @@ class ServicesToolsMixin:
             ) from None
         except Unavailable as e:
             raise ToolError(f"can't book that: {e} - re-confirm the date") from None
+        # With a flight on file for this room and day, the pickup margin is computed
+        # here rather than left to the prose instruction the model routinely skips.
+        departure = await ctx.userdata.db.latest_flight_departure(
+            room=room, flight_date=pickup_date
+        )
+        margin_note = (
+            " " + _departure_margin_note(pickup=pickup_time, departure=departure)
+            if departure
+            else ""
+        )
         return (
             f"hotel car booked; reference {_speak_code(code)}. Pickup "
             f"{pickup_date.strftime('%A, %B %-d')} at {speak_time(pickup_time)}, front entrance, "
             f"{passengers} passenger{'s' if passengers != 1 else ''}, flat eighty-five dollars "
-            "charged to the room | confirm the time, the front-entrance pickup, the cost, and "
+            f"charged to the room -{margin_note or ' no flight on file to check the margin'}"
+            " | confirm the time, the front-entrance pickup, the cost, and "
             "the reference to the caller; no further tool call is needed for the car."
         )
 


### PR DESCRIPTION
## Summary

The `examples/hotel_receptionist/hotel_db.py` changes from #6567, brought in as independent semantic commits so each one stands or falls on its own. Oldest first:

1. **Pin the sim clock under `lk agent simulate`** — `scenarios.yaml` hardcodes every date literal against `HOTEL_TODAY=2026-06-08`, but nothing set that env var, so a plain `lk agent simulate` ran the agent on the real clock and all 14 expected-state scenarios failed on date diffs.
2. **Store generated codes in the uppercase spoken form** — `shortuuid()` returns a lowercase suffix while `_speak_code` spells every reference out in uppercase, so a by-code lookup against the stored value never matched the form the caller heard and passed back.
3. **Store caller-given times as naive wall clock** — an LLM-supplied time can arrive tz-aware, and `isoformat()` then wrote an offset into columns that otherwise hold naive wall clock, breaking both expected-state comparison and `time.fromisoformat` round-trips.
4. **Expose a room's view** — a booking read-back listed the room type but not its view, so a guest who had just been moved to a garden-view room heard their booking described exactly as it was before the move. `_require_room` splits into `_normalize_room` and `_room_exists`.
5. **Bind each room type's views to its own line** — availability rendered as one pipe-delimited line smeared the type → view pairs together in context, and the model offered a garden-view double queen, which has never existed.
6. **Speak the penthouse as a suite, not as "room PH"** — the penthouse's room id is `RM_PH`, so every service tool that echoed the room back read out a room number no guest has ever been given.
7. **Capture flight departure time and compute the pickup margin** — without a stored departure time the airport-car pickup margin could only ever be a prose instruction the model routinely skipped. It is now computed from the reconfirmed flight and handed to the agent to say back, including tight and not-before-departure warnings.
8. **Structured florist destination and order amendments** — `deliver_to` was one free-text column holding whichever idea of the destination the model formed, so a room could not be validated and nothing distinguished a room from a person. It splits into `room_id` (FK, checked to exist) and `recipient_name` with a CHECK that exactly one is set, plus `delivery_instructions` and `amend_florist_order` so a handling request made after the order lands on the order the florist reads.
9. **Typed `Room` union replaces the room string** — every room-taking tool took free text, so the model could pass a phrase naming no room at all and the string reached the database before anything rejected it. `Room` is a discriminated union of `NumberedRoom` and `PenthouseSuite`, which makes a fabricated destination inexpressible at the schema boundary and gives the penthouse one canonical spelling. `room_to_id()` converts at the tool edge, so the tools hand the db a canonical id and `speak_room()` no longer normalizes what it renders.

Two things beyond `hotel_db.py` are mine rather than #6567's, both forced by the changes above:

- `benchmark.py` denies `delivery_instructions` from expected-state comparison. It is agent-written free text, and `_select_sql` compares every non-denied column, so a captured handling note would fail the diff against the seeded empty default.
- The florist scenario moved off room 412, which is not in `seed.py`. Free-text `deliver_to` tolerated an unseeded room; the new FK and existence check do not.

`order_flowers` uses `_room_exists()` from commit 4 where #6567 inlines the same query — that helper did not exist yet at that point in its history. Semantically identical, so expect a one-hunk conflict there and nowhere else in `hotel_db.py`.

## Testing

- `pytest --unit` — 1942 passed, 5 skipped
- `ruff format --check` and `ruff check` clean at every commit individually, and each commit imports on its own
- Both tool-schema builders (legacy and strict) produce the discriminated union for all six converted tools; `"the front desk"`, `{"type": "suite"}`, and a numberless room are all rejected at parse
- Destinations round-trip end to end against a seeded db: `RM_304` and `RM_PH` store and read back for DND, wake-up calls, dispatch, and florist orders, and an unseeded room is refused
- `mypy examples/hotel_receptionist/` reports one error, a module-path mapping issue in `fake_data/seed.py`, which reproduces unchanged on `main`. The repo's `type-check` gate covers `livekit.agents` and the plugins, not `examples/`.
