### PR TITLE
fix(hotel_receptionist): stop a restaurant modification silently resizing the party

### DIFF
--- a/examples/hotel_receptionist/tools_restaurant.py
+++ b/examples/hotel_receptionist/tools_restaurant.py
@@ -134,7 +134,7 @@ class RestaurantToolsMixin:
             confirmation_code: confirmation code like 'RES-X9Y2'.
             new_date: the new date, in ISO YYYY-MM-DD format (e.g. "2026-01-20").
             new_time: the new time, in 24-hour HH:MM format (e.g. "18:00").
-            new_party_size: new number of guests; omit to keep the current party size.
+            new_party_size: new number of guests, ONLY when the caller states the new number. "Keep it the same" means OMIT this parameter - the reservation keeps its current size when omitted. Never fill it with a number the caller didn't say.
         """
         if new_date < TODAY:
             raise ToolError("the new date can't be in the past")

--- a/examples/hotel_receptionist/tools_restaurant.py
+++ b/examples/hotel_receptionist/tools_restaurant.py
@@ -127,7 +127,8 @@ class RestaurantToolsMixin:
         """Move an existing confirmed restaurant reservation to a new date/time (and
         optionally a new party size), keeping the same confirmation code. Restaurants
         verify with last name + confirmation code (no card, no email). Read the new
-        details back to the caller before calling this.
+        details back to the caller before calling this, and relay the party size from
+        this tool's return when confirming - it's how a wrong count gets caught.
 
         Args:
             last_name: caller's last name.
@@ -164,5 +165,7 @@ class RestaurantToolsMixin:
             f"Done - your reservation is now {speak_time(updated.time)} on "
             f"{updated.date.strftime('%A, %B %-d')} for "
             f"{updated.party_size} guest{'s' if updated.party_size != 1 else ''}, "
-            f"under confirmation code {_speak_code(updated.code)}."
+            f"under confirmation code {_speak_code(updated.code)}. "
+            "| confirm the new date, time, AND the party size above to the caller - if the "
+            "party size isn't what they expect, this is their chance to catch it."
         )

--- a/examples/hotel_receptionist/tools_restaurant.py
+++ b/examples/hotel_receptionist/tools_restaurant.py
@@ -69,7 +69,8 @@ class RestaurantToolsMixin:
     ) -> str:
         """Read-only lookup of a confirmed restaurant reservation. Use this when the caller wants
         to check or recall their reservation details (date, time, party size, notes) without
-        changing or cancelling it.
+        changing or cancelling it - and before a modification that keeps some details "the
+        same", so you know the current values being kept.
 
         Args:
             last_name: caller's last name.


### PR DESCRIPTION
## Summary

The `examples/hotel_receptionist/tools_restaurant.py` changes from #6567, brought in as independent semantic commits so each one stands or falls on its own. Wording is verbatim from #6567. Oldest first:

1. **Look up a restaurant reservation before a "keep it the same" change** — a caller who says "same party size, just move it to Friday" leaves the current values only in the reservation record, so nothing the model can see says what "the same" is. `lookup_restaurant_reservation` now names that case, so the current values are in context before the modification.
2. **Stop `modify_restaurant_reservation` inventing a party size** — "omit to keep the current party size" reads as a description of a default rather than an instruction, so the model fills the parameter anyway, with a number it guessed rather than one the caller stated, and silently resizes the reservation. Omission is now stated as the instruction for that case.
3. **Read the party size back on a restaurant modification** — the stored party size is what the modification actually wrote, and confirming only date and time leaves a wrong count unspoken and so uncorrectable. The tool return now directs the read-back, and the docstring says why.

2 and 3 are separate on purpose: 2 keeps a wrong count from being written, 3 catches one that got written anyway, whatever wrote it.

**Not included.** #6567 also wraps `start_restaurant_booking` in a `try/except RestaurantReservationNotCreatedError`. #6801 already covers that case, landing the same behavior differently: `BookRestaurantTask` completes with a plain `ToolError`, which propagates out of the `await`, so the tool needs no catch and no `ToolError` subclass. One nuance of #6567's wording has no home in either PR — it also tells the agent not to offer to connect or transfer the caller to the restaurant when they ask to hold the table without a phone number. That belongs on #6801's instruction text if it's wanted.

One thing worth a second opinion, inherited from #6567's wording rather than introduced here: under a strict tool schema `new_party_size` is `required` with type `["integer", "null"]`, so the model cannot literally omit it and must pass `null` instead. Both land as `None` and both leave the party size untouched (verified below), so the behavior is right in both modes, but "OMIT this parameter" is what a strict-mode model reads.

## Testing

- `ruff check` and `ruff format --check` clean on each of the three commits individually
- Both tool-schema builders (`build_legacy_openai_schema` and `build_strict_openai_schema`) carry the new description and parameter text for `lookup_restaurant_reservation` and `modify_restaurant_reservation`
- End to end against a seeded db: a party of 4 moved to a new date/time keeps `party_size == 4` both with `new_party_size` omitted and with it explicitly `null`, and the tool return reads back `4 guests` followed by the new confirm directive

Exercising the tool path at all needs a workaround for a bug this PR does not touch: `book_restaurant` stores the code lowercase while `find_restaurant_reservation` uppercases the code it searches for, so no by-code lookup can ever match. That is #6805's second commit. On `main` today, `lookup_restaurant_reservation`, `cancel_restaurant_reservation`, and `modify_restaurant_reservation` all fail against any reservation booked in-session, independent of anything here.
