### PR TITLE
fix(google): allow explicit project for Speech-to-Text

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -150,6 +150,7 @@ class STT(stt.STT):
         enable_voice_activity_events: bool = False,
         model: SpeechModels | str = "latest_long",
         location: str = "global",
+        project: NotGivenOr[str] = NOT_GIVEN,
         profanity_filter: bool = False,
         sample_rate: int = 16000,
         min_confidence_threshold: float = _default_min_confidence,
@@ -185,6 +186,7 @@ class STT(stt.STT):
             enable_voice_activity_events(bool): whether to enable voice activity events (default: False)
             model(SpeechModels): the model to use for recognition default: "latest_long"
             location(str): the location to use for recognition default: "global"
+            project(str): the Google Cloud project to use for recognition
             profanity_filter(bool): whether to filter out profanities default: False
             sample_rate(int): the sample rate of the audio default: 16000
             min_confidence_threshold(float): minimum confidence threshold for recognition
@@ -247,7 +249,7 @@ class STT(stt.STT):
         self._credentials_info = credentials_info
         self._credentials_file = credentials_file
         self._credentials = credentials
-        self._project_id: str | None = None
+        self._project_id: str | None = project if is_given(project) else None
 
         if (
             not is_given(credentials)
@@ -333,7 +335,8 @@ class STT(stt.STT):
                 self._credentials_file,
                 scopes=["https://www.googleapis.com/auth/cloud-platform"],
             )
-            self._project_id = project_id
+            if self._project_id is None:
+                self._project_id = project_id
             client = client_cls(credentials=credentials, client_options=client_options)
         else:
             client = client_cls(client_options=client_options)

--- a/tests/test_google_credentials.py
+++ b/tests/test_google_credentials.py
@@ -51,6 +51,15 @@ class TestSTTCredentials:
         recognizer = stt_instance._get_recognizer(client)
         assert recognizer == "projects/test-project-123/locations/global/recognizers/_"
 
+    async def test_recognizer_uses_explicit_project(self) -> None:
+        creds = AnonymousCredentials()
+        stt_instance = STT(credentials=creds, project="explicit-project")
+        client = await stt_instance._create_client(timeout=1.0)
+
+        assert stt_instance._get_recognizer(client) == (
+            "projects/explicit-project/locations/global/recognizers/_"
+        )
+
     async def test_clear_error_when_project_unresolvable(self, monkeypatch) -> None:
         # no project on the credentials and no ADC available: the error must
         # say what is wrong instead of a confusing "default credentials not


### PR DESCRIPTION
## Summary

- add an optional `project` argument to `google.STT`
- prefer the explicit project when building the Speech-to-Text v2 recognizer resource
- keep credential-derived project discovery as the fallback for existing callers

Fixes #6772

## Validation

- `uv run pytest tests/test_google_credentials.py -q`
- `uv run --group typing mypy --platform linux -p livekit.plugins.google`
- `uv run ruff check .`
- `uv run ruff format --check .`

The full `pytest --unit` run reached 1,530 passing tests but also hit unrelated baseline failures/internal errors in the repository's audio decoder, IPC, and concurrent async test infrastructure under Python 3.14.