### PR TITLE
fix(aws): keep Nova Sonic replies alive with IGNORE_ON_ENTER

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -1939,6 +1939,9 @@ class RealtimeSession(  # noqa: F811
                         return
 
                     if self._current_generation is generation:
+                        generation_created_time = getattr(
+                            generation, "_created_timestamp", time.time()
+                        )
                         while (
                             self._current_generation is generation
                             and not self._audio_end_turn_received
@@ -1956,9 +1959,12 @@ class RealtimeSession(  # noqa: F811
                                 return
 
                             last_audio_time = self._last_audio_output_time
-                            if last_audio_time == 0.0 or (
-                                time.time() - last_audio_time >= TOOL_RECYCLE_AUDIO_IDLE_TIMEOUT
-                            ):
+                            idle_since = (
+                                last_audio_time
+                                if last_audio_time > 0.0
+                                else generation_created_time
+                            )
+                            if time.time() - idle_since >= TOOL_RECYCLE_AUDIO_IDLE_TIMEOUT:
                                 break
 
                             await asyncio.sleep(min(0.1, TOOL_RECYCLE_AUDIO_IDLE_TIMEOUT))
@@ -2439,11 +2445,15 @@ class RealtimeSession(  # noqa: F811
                 pass
 
         if self._response_task:
-            try:
-                await asyncio.wait_for(self._response_task, timeout=1.0)
-            except asyncio.TimeoutError:
-                logger.warning("shutdown of output event loop timed out-- cancelling")
-                self._response_task.cancel()
+            if not self._response_task.done():
+                try:
+                    await asyncio.wait_for(self._response_task, timeout=1.0)
+                except asyncio.TimeoutError:
+                    logger.warning("shutdown of output event loop timed out-- cancelling")
+                    self._response_task.cancel()
+                except asyncio.CancelledError:
+                    if not self._response_task.cancelled():
+                        raise
             tasks.append(self._response_task)
 
         # must cancel the audio input task before closing the input stream

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -664,24 +664,54 @@ class RealtimeSession(  # noqa: F811
                 f"[SESSION] Session duration limit reached ({duration:.0f}s), initiating recycle"
             )
 
-            # Step 1: Wait for assistant to finish speaking (AUDIO contentEnd with END_TURN)
+            # Step 1: Wait for assistant to finish speaking (AUDIO contentEnd with END_TURN).
+            # An interrupted turn may never send END_TURN, so bound this wait by the
+            # same audio-idle grace period used by deferred tool recycling.
             if not self._audio_end_turn_received:
                 logger.info(
                     "[SESSION] Waiting for assistant to finish speaking (AUDIO END_TURN)..."
                 )
+                generation_created_time = getattr(
+                    self._current_generation, "_created_timestamp", time.time()
+                )
+                idle_since = (
+                    self._last_audio_output_time
+                    if self._last_audio_output_time > 0.0
+                    else generation_created_time
+                )
                 while not self._audio_end_turn_received:
-                    await asyncio.sleep(0.1)
-                logger.debug("[SESSION] Assistant finished speaking")
+                    if not self._is_sess_active.is_set():
+                        logger.debug("[SESSION] Session no longer active, skipping recycle")
+                        return
 
-            # Step 2: Wait for audio to fully stop (no new audio for 1 second)
+                    last_audio_time = self._last_audio_output_time
+                    if last_audio_time > idle_since:
+                        idle_since = last_audio_time
+
+                    if time.time() - idle_since >= TOOL_RECYCLE_AUDIO_IDLE_TIMEOUT:
+                        logger.warning(
+                            "[SESSION] Timed out waiting for AUDIO END_TURN after an idle "
+                            "period, proceeding with recycle"
+                        )
+                        break
+
+                    await asyncio.sleep(min(0.1, TOOL_RECYCLE_AUDIO_IDLE_TIMEOUT))
+                else:
+                    logger.debug("[SESSION] Assistant finished speaking")
+
+            # Step 2: Wait for audio to fully stop (no new audio for the idle grace period)
             logger.debug("[SESSION] Waiting for audio to fully stop...")
             last_audio_time = self._last_audio_output_time
             while True:
-                await asyncio.sleep(0.1)
+                poll_interval = min(0.1, TOOL_RECYCLE_AUDIO_IDLE_TIMEOUT)
+                await asyncio.sleep(poll_interval)
                 if self._last_audio_output_time == last_audio_time:
-                    await asyncio.sleep(0.9)
+                    await asyncio.sleep(max(0.0, TOOL_RECYCLE_AUDIO_IDLE_TIMEOUT - poll_interval))
                     if self._last_audio_output_time == last_audio_time:
-                        logger.debug("[SESSION] No new audio for 1s, proceeding with recycle")
+                        logger.debug(
+                            "[SESSION] No new audio for the idle grace period, proceeding "
+                            "with recycle"
+                        )
                         break
                 else:
                     logger.debug("[SESSION] New audio detected, continuing to wait...")

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -2347,13 +2347,13 @@ class RealtimeSession(  # noqa: F811
         logger.info("attempting to shutdown agent session")
 
         was_active = self._is_sess_active.is_set()
-        recycle_in_progress = (
-            self._tool_recycle_task is not None and not self._tool_recycle_task.done()
-        )
-        if recycle_in_progress:
-            self._tool_recycle_task.cancel()
+        recycle_task = self._tool_recycle_task
+        recycle_in_progress = False
+        if recycle_task is not None and not recycle_task.done():
+            recycle_in_progress = True
+            recycle_task.cancel()
             try:
-                await self._tool_recycle_task
+                await recycle_task
             except asyncio.CancelledError:
                 pass
 

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -70,6 +70,7 @@ MAX_MESSAGES = 40
 DEFAULT_MAX_SESSION_RESTART_ATTEMPTS = 3
 DEFAULT_MAX_SESSION_RESTART_DELAY = 10
 TOOL_RECYCLE_GENERATION_TIMEOUT = 2.0
+TOOL_RECYCLE_AUDIO_IDLE_TIMEOUT = 1.0
 RECOVERABLE_VALIDATION_ERROR_MESSAGES = (
     "InternalErrorCode=531::RST_STREAM closed stream. HTTP/2 error code: NO_ERROR",
     "System instability detected. Please retry your request.",
@@ -543,6 +544,7 @@ class RealtimeSession(  # noqa: F811
         self._session_recycle_task: asyncio.Task[None] | None = None
         self._tool_recycle_task: asyncio.Task[None] | None = None
         self._active_tool_names: set[str] = set()
+        self._is_shutting_down = False
         self._last_audio_output_time: float = 0.0  # Track when assistant last produced audio
         self._audio_end_turn_received: bool = False  # Track when assistant finishes speaking
         self._pending_generation_fut: asyncio.Future[llm.GenerationCreatedEvent] | None = None
@@ -742,7 +744,7 @@ class RealtimeSession(  # noqa: F811
                 try:
                     await self._response_task
                 except asyncio.CancelledError:
-                    if (current_task := asyncio.current_task()) and current_task.cancelling():
+                    if getattr(self, "_is_shutting_down", False):
                         raise
                     pass
 
@@ -752,7 +754,7 @@ class RealtimeSession(  # noqa: F811
             try:
                 await self._audio_input_task
             except asyncio.CancelledError:
-                if (current_task := asyncio.current_task()) and current_task.cancelling():
+                if getattr(self, "_is_shutting_down", False):
                     raise
                 pass
 
@@ -1121,6 +1123,8 @@ class RealtimeSession(  # noqa: F811
                 response_id=response_id,
                 _done_fut=asyncio.get_running_loop().create_future(),
             )
+            self._last_audio_output_time = 0.0
+            self._audio_end_turn_received = False
             generation_created = True
         else:
             logger.debug(
@@ -1935,7 +1939,44 @@ class RealtimeSession(  # noqa: F811
                         return
 
                     if self._current_generation is generation:
-                        self._close_current_generation()
+                        while (
+                            self._current_generation is generation
+                            and not self._audio_end_turn_received
+                        ):
+                            if not self._is_sess_active.is_set():
+                                logger.debug(
+                                    "[SESSION] Session no longer active, skipping tool recycle"
+                                )
+                                return
+
+                            if set(self._tools.function_tools) == self._active_tool_names:
+                                logger.debug(
+                                    "[SESSION] Tool changes were restored before tool recycle"
+                                )
+                                return
+
+                            last_audio_time = self._last_audio_output_time
+                            if last_audio_time == 0.0 or (
+                                time.time() - last_audio_time >= TOOL_RECYCLE_AUDIO_IDLE_TIMEOUT
+                            ):
+                                break
+
+                            await asyncio.sleep(min(0.1, TOOL_RECYCLE_AUDIO_IDLE_TIMEOUT))
+
+                        if self._current_generation is generation:
+                            if not self._is_sess_active.is_set():
+                                logger.debug(
+                                    "[SESSION] Session no longer active, skipping tool recycle"
+                                )
+                                return
+
+                            if set(self._tools.function_tools) == self._active_tool_names:
+                                logger.debug(
+                                    "[SESSION] Tool changes were restored before tool recycle"
+                                )
+                                return
+
+                            self._close_current_generation()
 
                 # A new generation can start after the one we waited for closes. Keep
                 # waiting so a tool recycle never tears down that newer response.
@@ -2350,6 +2391,7 @@ class RealtimeSession(  # noqa: F811
         """Gracefully shut down the realtime session and release network resources."""
         logger.info("attempting to shutdown agent session")
 
+        self._is_shutting_down = True
         was_active = self._is_sess_active.is_set()
         recycle_task = self._tool_recycle_task
         recycle_in_progress = False

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -540,6 +540,8 @@ class RealtimeSession(  # noqa: F811
         # Session recycling: proactively restart before credential expiry or 8-min limit
         self._session_start_time: float | None = None
         self._session_recycle_task: asyncio.Task[None] | None = None
+        self._tool_recycle_task: asyncio.Task[None] | None = None
+        self._active_tool_names: set[str] = set()
         self._last_audio_output_time: float = 0.0  # Track when assistant last produced audio
         self._audio_end_turn_received: bool = False  # Track when assistant finishes speaking
         self._pending_generation_fut: asyncio.Future[llm.GenerationCreatedEvent] | None = None
@@ -995,6 +997,7 @@ class RealtimeSession(  # noqa: F811
             # Step 1: Send session init events (session start, prompt start, system prompt)
             for event in init_events:
                 await self._send_raw_event(event)
+            self._active_tool_names = set(self._tools.function_tools)
 
             # Start session recycling timer
             self._session_start_time = time.time()
@@ -1878,12 +1881,15 @@ class RealtimeSession(  # noqa: F811
         # If tools actually changed and session is active, schedule a deferred recycle.
         # We defer because update_tools is often called from within a tool execution
         # callback, and the tool result is still being delivered to the current session.
-        if old_tools != new_tools and self._is_sess_active.is_set():
+        if new_tools != self._active_tool_names and self._is_sess_active.is_set():
             logger.info(
                 f"[SESSION] Tools changed (added={new_tools - old_tools}, "
                 f"removed={old_tools - new_tools}), scheduling deferred session recycle"
             )
-            asyncio.create_task(self._deferred_tool_recycle())
+            if self._tool_recycle_task is None or self._tool_recycle_task.done():
+                self._tool_recycle_task = asyncio.create_task(
+                    self._deferred_tool_recycle(), name="RealtimeSession._deferred_tool_recycle"
+                )
         else:
             logger.debug("Tool list updated locally")
 
@@ -1893,8 +1899,16 @@ class RealtimeSession(  # noqa: F811
         # before we tear down the session.
         await asyncio.sleep(0.15)
 
+        if self._current_generation and self._current_generation._done_fut:
+            logger.debug("[SESSION] Waiting for active generation before tool recycle")
+            await asyncio.shield(self._current_generation._done_fut)
+
         if not self._is_sess_active.is_set():
             logger.debug("[SESSION] Session no longer active, skipping tool recycle")
+            return
+
+        if set(self._tools.function_tools) == self._active_tool_names:
+            logger.debug("[SESSION] Tool changes were restored before recycle")
             return
 
         logger.info("[SESSION] Recycling session for updated tools")
@@ -1908,6 +1922,14 @@ class RealtimeSession(  # noqa: F811
             except utils.aio.channel.ChanEmpty:
                 break
         await self._graceful_session_recycle()
+
+    async def _wait_for_tool_recycle(self) -> None:
+        """Wait for a queued tool-set recycle before starting a reply."""
+        recycle_task = self._tool_recycle_task
+        if recycle_task is None or recycle_task.done():
+            return
+
+        await asyncio.shield(recycle_task)
 
     def update_options(self, *, tool_choice: NotGivenOr[llm.ToolChoice | None] = NOT_GIVEN) -> None:
         """Live update of inference options is not supported by Sonic yet."""
@@ -2134,6 +2156,7 @@ class RealtimeSession(  # noqa: F811
             # Send text message asynchronously
             async def _send_text() -> None:
                 try:
+                    await self._wait_for_tool_recycle()
                     # Wait for the bidirectional stream to be fully established
                     # (HTTP 200 received) and audio input flowing.
                     await self._stream_ready.wait()
@@ -2282,6 +2305,14 @@ class RealtimeSession(  # noqa: F811
     async def aclose(self) -> None:
         """Gracefully shut down the realtime session and release network resources."""
         logger.info("attempting to shutdown agent session")
+
+        if self._tool_recycle_task and not self._tool_recycle_task.done():
+            self._tool_recycle_task.cancel()
+            try:
+                await self._tool_recycle_task
+            except asyncio.CancelledError:
+                pass
+
         if not self._is_sess_active.is_set():
             logger.info("agent session already inactive")
             return

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -1922,6 +1922,14 @@ class RealtimeSession(  # noqa: F811
                     logger.warning(
                         "[SESSION] Timeout waiting for active generation, proceeding with tool recycle"
                     )
+                    if not self._is_sess_active.is_set():
+                        logger.debug("[SESSION] Session no longer active, skipping tool recycle")
+                        return
+
+                    if set(self._tools.function_tools) == self._active_tool_names:
+                        logger.debug("[SESSION] Tool changes were restored before tool recycle")
+                        return
+
                     if self._current_generation is generation:
                         self._close_current_generation()
 
@@ -2338,14 +2346,18 @@ class RealtimeSession(  # noqa: F811
         """Gracefully shut down the realtime session and release network resources."""
         logger.info("attempting to shutdown agent session")
 
-        if self._tool_recycle_task and not self._tool_recycle_task.done():
+        was_active = self._is_sess_active.is_set()
+        recycle_in_progress = (
+            self._tool_recycle_task is not None and not self._tool_recycle_task.done()
+        )
+        if recycle_in_progress:
             self._tool_recycle_task.cancel()
             try:
                 await self._tool_recycle_task
             except asyncio.CancelledError:
                 pass
 
-        if not self._is_sess_active.is_set():
+        if not was_active and not recycle_in_progress and not self._is_sess_active.is_set():
             logger.info("agent session already inactive")
             return
 

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -69,6 +69,7 @@ MAX_MESSAGE_SIZE = 1024
 MAX_MESSAGES = 40
 DEFAULT_MAX_SESSION_RESTART_ATTEMPTS = 3
 DEFAULT_MAX_SESSION_RESTART_DELAY = 10
+TOOL_RECYCLE_GENERATION_TIMEOUT = 2.0
 RECOVERABLE_VALIDATION_ERROR_MESSAGES = (
     "InternalErrorCode=531::RST_STREAM closed stream. HTTP/2 error code: NO_ERROR",
     "System instability detected. Please retry your request.",
@@ -982,12 +983,14 @@ class RealtimeSession(  # noqa: F811
                         f"{interactive_user_text[:60]}..."
                     )
 
+            tool_configuration = self._serialize_tool_config()
+            active_tool_names = set(self._tools.function_tools)
             init_events, history_events = self._event_builder.create_prompt_start_block(
                 voice_id=self._realtime_model._opts.voice,
                 sample_rate=DEFAULT_OUTPUT_SAMPLE_RATE,  # type: ignore
                 system_content=self._instructions,
                 chat_ctx=restart_ctx,
-                tool_configuration=self._serialize_tool_config(),
+                tool_configuration=tool_configuration,
                 max_tokens=self._realtime_model._opts.max_tokens,
                 top_p=self._realtime_model._opts.top_p,
                 temperature=self._realtime_model._opts.temperature,
@@ -997,7 +1000,7 @@ class RealtimeSession(  # noqa: F811
             # Step 1: Send session init events (session start, prompt start, system prompt)
             for event in init_events:
                 await self._send_raw_event(event)
-            self._active_tool_names = set(self._tools.function_tools)
+            self._active_tool_names = active_tool_names
 
             # Start session recycling timer
             self._session_start_time = time.time()
@@ -1023,6 +1026,7 @@ class RealtimeSession(  # noqa: F811
             # interactive contentStart events simultaneously.
             await asyncio.sleep(0.05)
             self._is_sess_active.set()
+            self._schedule_tool_recycle()
 
             # Step 6: If we popped a user message from history, send it as
             # interactive text now to trigger Nova Sonic to respond.
@@ -1866,9 +1870,7 @@ class RealtimeSession(  # noqa: F811
         The recycle is deferred to avoid conflicts with in-flight tool
         results that are still being delivered to the current session.
         """
-        old_tools = set(self._tools.function_tools.keys()) if self._tools.function_tools else set()
         self._tools = llm.ToolContext(tools)
-        new_tools = set(self._tools.function_tools.keys()) if self._tools.function_tools else set()
 
         if self._tools.function_tools:
             if self._tools_ready is None:
@@ -1876,22 +1878,30 @@ class RealtimeSession(  # noqa: F811
             if not self._tools_ready.done():
                 self._tools_ready.set_result(True)
                 logger.debug("Tool list has been injected (initial)")
-                return
+                if not self._is_sess_active.is_set():
+                    return
 
-        # If tools actually changed and session is active, schedule a deferred recycle.
-        # We defer because update_tools is often called from within a tool execution
-        # callback, and the tool result is still being delivered to the current session.
-        if new_tools != self._active_tool_names and self._is_sess_active.is_set():
-            logger.info(
-                f"[SESSION] Tools changed (added={new_tools - old_tools}, "
-                f"removed={old_tools - new_tools}), scheduling deferred session recycle"
-            )
-            if self._tool_recycle_task is None or self._tool_recycle_task.done():
-                self._tool_recycle_task = asyncio.create_task(
-                    self._deferred_tool_recycle(), name="RealtimeSession._deferred_tool_recycle"
-                )
-        else:
+        self._schedule_tool_recycle()
+
+    def _schedule_tool_recycle(self) -> None:
+        """Schedule a recycle when the local tools differ from the active session."""
+        if not self._is_sess_active.is_set():
             logger.debug("Tool list updated locally")
+            return
+
+        new_tools = set(self._tools.function_tools)
+        if new_tools == self._active_tool_names:
+            logger.debug("Tool list matches the active session")
+            return
+
+        logger.info(
+            f"[SESSION] Tools changed (added={new_tools - self._active_tool_names}, "
+            f"removed={self._active_tool_names - new_tools}), scheduling deferred session recycle"
+        )
+        if self._tool_recycle_task is None or self._tool_recycle_task.done():
+            self._tool_recycle_task = asyncio.create_task(
+                self._deferred_tool_recycle(), name="RealtimeSession._deferred_tool_recycle"
+            )
 
     async def _deferred_tool_recycle(self) -> None:
         """Wait for in-flight tool results to be delivered, then recycle."""
@@ -1899,29 +1909,51 @@ class RealtimeSession(  # noqa: F811
         # before we tear down the session.
         await asyncio.sleep(0.15)
 
-        if self._current_generation and self._current_generation._done_fut:
-            logger.debug("[SESSION] Waiting for active generation before tool recycle")
-            await asyncio.shield(self._current_generation._done_fut)
-
-        if not self._is_sess_active.is_set():
-            logger.debug("[SESSION] Session no longer active, skipping tool recycle")
-            return
-
-        if set(self._tools.function_tools) == self._active_tool_names:
-            logger.debug("[SESSION] Tool changes were restored before recycle")
-            return
-
-        logger.info("[SESSION] Recycling session for updated tools")
-        # Clear pending tools so stale results from update_chat_ctx are ignored
-        self._pending_tools.clear()
-        # Drain and discard any queued tool results
         while True:
-            try:
-                discarded = self._tool_results_ch.recv_nowait()
-                logger.debug(f"[SESSION] Discarding stale tool result: {discarded['tool_use_id']}")
-            except utils.aio.channel.ChanEmpty:
-                break
-        await self._graceful_session_recycle()
+            generation = self._current_generation
+            if generation and generation._done_fut:
+                logger.debug("[SESSION] Waiting for active generation before tool recycle")
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(generation._done_fut),
+                        timeout=TOOL_RECYCLE_GENERATION_TIMEOUT,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "[SESSION] Timeout waiting for active generation, proceeding with tool recycle"
+                    )
+                    if self._current_generation is generation:
+                        self._close_current_generation()
+
+                # A new generation can start after the one we waited for closes. Keep
+                # waiting so a tool recycle never tears down that newer response.
+                if (
+                    self._current_generation is not None
+                    and self._current_generation is not generation
+                ):
+                    continue
+
+            if not self._is_sess_active.is_set():
+                logger.debug("[SESSION] Session no longer active, skipping tool recycle")
+                return
+
+            if set(self._tools.function_tools) == self._active_tool_names:
+                logger.debug("[SESSION] Tool changes were restored before recycle")
+                return
+
+            logger.info("[SESSION] Recycling session for updated tools")
+            # Clear pending tools so stale results from update_chat_ctx are ignored
+            self._pending_tools.clear()
+            # Drain and discard any queued tool results
+            while True:
+                try:
+                    discarded = self._tool_results_ch.recv_nowait()
+                    logger.debug(
+                        f"[SESSION] Discarding stale tool result: {discarded['tool_use_id']}"
+                    )
+                except utils.aio.channel.ChanEmpty:
+                    break
+            await self._graceful_session_recycle()
 
     async def _wait_for_tool_recycle(self) -> None:
         """Wait for a queued tool-set recycle before starting a reply."""

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -742,6 +742,8 @@ class RealtimeSession(  # noqa: F811
                 try:
                     await self._response_task
                 except asyncio.CancelledError:
+                    if (current_task := asyncio.current_task()) and current_task.cancelling():
+                        raise
                     pass
 
         # Step 4: Cancel audio input task (blocked on channel, won't exit naturally)
@@ -750,6 +752,8 @@ class RealtimeSession(  # noqa: F811
             try:
                 await self._audio_input_task
             except asyncio.CancelledError:
+                if (current_task := asyncio.current_task()) and current_task.cancelling():
+                    raise
                 pass
 
         # Step 5: Close the stream (close events already sent in _session_recycle_timer)

--- a/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_tool_recycle.py
+++ b/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_tool_recycle.py
@@ -383,6 +383,53 @@ async def test_aclose_cleans_up_after_cancelling_recycle() -> None:
     session._stream_response.input_stream.close.assert_awaited_once()
 
 
+async def test_aclose_does_not_restart_after_cancelling_recycle_during_child_wait() -> None:
+    from livekit.plugins.aws.experimental.realtime import realtime_model
+
+    class _ChildCancellationWait:
+        def __init__(self) -> None:
+            self.cancel_called = asyncio.Event()
+            self._waiter = asyncio.get_running_loop().create_future()
+            self._cancelled = False
+
+        def done(self) -> bool:
+            return self._cancelled
+
+        def cancel(self) -> bool:
+            self._cancelled = True
+            self.cancel_called.set()
+            return True
+
+        def __await__(self):
+            return self._waiter.__await__()
+
+    session = object.__new__(realtime_model.RealtimeSession)
+    session._is_sess_active = asyncio.Event()
+    session._is_sess_active.set()
+    session._tool_results_ch = utils.aio.Chan()
+    session._response_task = None
+    session._audio_input_task = _ChildCancellationWait()
+    session._stream_response = None
+    session._realtime_model = SimpleNamespace(_model="test-model")
+    session._event_builder = SimpleNamespace(create_prompt_end_block=lambda: [])
+    session._send_raw_event = AsyncMock()
+    session._stream_ready = asyncio.Event()
+    session._audio_input_chan = utils.aio.Chan()
+    session._session_recycle_task = None
+    session._pending_generation_fut = None
+    session._main_atask = None
+    session._chat_ctx = SimpleNamespace(items=[])
+    session.initialize_streams = AsyncMock()
+
+    recycle_task = asyncio.create_task(session._graceful_session_recycle())
+    session._tool_recycle_task = recycle_task
+    await session._audio_input_task.cancel_called.wait()
+
+    await session.aclose()
+
+    session.initialize_streams.assert_not_awaited()
+
+
 async def test_tool_changes_during_recycle_are_applied() -> None:
     session = _session()
     first_recycle_started = asyncio.Event()

--- a/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_tool_recycle.py
+++ b/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_tool_recycle.py
@@ -142,6 +142,22 @@ async def test_tool_recycle_waits_for_active_generation() -> None:
     assert recycle_calls == 1
 
 
+async def test_session_recycle_timer_does_not_wait_forever_without_end_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from livekit.plugins.aws.experimental.realtime import realtime_model
+
+    session = _session()
+    session._stream_response = None
+    session._current_generation = None
+    session._graceful_session_recycle = AsyncMock()
+    monkeypatch.setattr(realtime_model, "TOOL_RECYCLE_AUDIO_IDLE_TIMEOUT", 0.01)
+
+    await asyncio.wait_for(session._session_recycle_timer(0.0), timeout=0.5)
+
+    session._graceful_session_recycle.assert_awaited_once()
+
+
 async def test_tool_recycle_waits_for_generation_that_replaces_completed_one() -> None:
     session = _session()
     first_done = asyncio.get_running_loop().create_future()

--- a/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_tool_recycle.py
+++ b/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_tool_recycle.py
@@ -362,6 +362,47 @@ async def test_tool_recycle_does_not_cut_off_active_audio_reply(
     assert recycle_calls == 1
 
 
+async def test_tool_recycle_allows_generation_before_first_audio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from livekit.plugins.aws.experimental.realtime import realtime_model
+
+    session = _session()
+    monkeypatch.setattr(realtime_model, "TOOL_RECYCLE_GENERATION_TIMEOUT", 0.01)
+    monkeypatch.setattr(realtime_model, "TOOL_RECYCLE_AUDIO_IDLE_TIMEOUT", 0.5)
+
+    generation_done = asyncio.get_running_loop().create_future()
+    session._current_generation = SimpleNamespace(
+        _done_fut=generation_done,
+        _created_timestamp=time.time(),
+    )
+    session._close_current_generation = MagicMock(  # type: ignore[method-assign]
+        side_effect=lambda: setattr(session, "_current_generation", None)
+    )
+    recycle_calls = 0
+
+    async def _fake_recycle() -> None:
+        nonlocal recycle_calls
+        recycle_calls += 1
+        session._active_tool_names = set(session._tools.function_tools)
+
+    session._graceful_session_recycle = _fake_recycle
+
+    await session.update_tools([second_tool])
+    recycle_task = session._tool_recycle_task
+    assert recycle_task is not None
+    await asyncio.sleep(0.2)
+
+    session._close_current_generation.assert_not_called()
+    assert not recycle_task.done()
+
+    session._audio_end_turn_received = True
+    await recycle_task
+
+    session._close_current_generation.assert_called_once()
+    assert recycle_calls == 1
+
+
 async def test_tool_recycle_timeout_does_not_close_restored_generation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -475,6 +516,57 @@ async def test_aclose_does_not_restart_after_cancelling_recycle_during_child_wai
     await session.aclose()
 
     session.initialize_streams.assert_not_awaited()
+
+
+async def test_aclose_continues_after_recycle_leaves_cancelled_response_task() -> None:
+    from livekit.plugins.aws.experimental.realtime import realtime_model
+
+    async def _wait_forever() -> None:
+        await asyncio.Future()
+
+    session = object.__new__(realtime_model.RealtimeSession)
+    session._is_sess_active = asyncio.Event()
+    recycle_started = asyncio.Event()
+
+    async def _recycle() -> None:
+        recycle_started.set()
+        session._is_sess_active.clear()
+        await asyncio.Future()
+
+    recycle_task = asyncio.create_task(_recycle())
+    await recycle_started.wait()
+
+    response_task = asyncio.create_task(_wait_forever())
+    response_task.cancel()
+    try:
+        await response_task
+    except asyncio.CancelledError:
+        pass
+
+    audio_input_task = asyncio.create_task(_wait_forever())
+    session._tool_recycle_task = recycle_task
+    session._response_task = response_task
+    session._audio_input_task = audio_input_task
+    session._pending_generation_fut = None
+    session._event_builder = SimpleNamespace(create_prompt_end_block=lambda: [])
+    session._send_raw_event = AsyncMock()
+    session._stream_response = SimpleNamespace(
+        output_stream=SimpleNamespace(closed=False, close=AsyncMock()),
+        input_stream=SimpleNamespace(closed=False, close=AsyncMock()),
+    )
+    session._session_recycle_task = None
+    session._main_atask = None
+    session._chat_ctx = SimpleNamespace(items=[])
+
+    try:
+        await session.aclose()
+    finally:
+        if not audio_input_task.done():
+            audio_input_task.cancel()
+        await asyncio.gather(audio_input_task, return_exceptions=True)
+
+    session._stream_response.input_stream.close.assert_awaited_once()
+    assert audio_input_task.cancelled()
 
 
 async def test_tool_changes_during_recycle_are_applied() -> None:

--- a/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_tool_recycle.py
+++ b/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_tool_recycle.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from livekit.agents import function_tool, utils
+from livekit import rtc
+from livekit.agents import function_tool, llm, utils
 from livekit.agents.llm import ToolContext
 
 pytestmark = pytest.mark.unit
@@ -75,6 +77,7 @@ async def test_update_tools_coalesces_pending_session_recycles() -> None:
     async def _fake_recycle() -> None:
         nonlocal recycle_calls
         recycle_calls += 1
+        session._active_tool_names = set(session._tools.function_tools)
 
     session._graceful_session_recycle = _fake_recycle
 
@@ -119,6 +122,7 @@ async def test_tool_recycle_waits_for_active_generation() -> None:
     async def _fake_recycle() -> None:
         nonlocal recycle_calls
         recycle_calls += 1
+        session._active_tool_names = set(session._tools.function_tools)
 
     session._graceful_session_recycle = _fake_recycle
 
@@ -132,6 +136,213 @@ async def test_tool_recycle_waits_for_active_generation() -> None:
     generation_done.set_result(None)
     await recycle_task
     assert recycle_calls == 1
+
+
+async def test_tool_recycle_waits_for_generation_that_replaces_completed_one() -> None:
+    session = _session()
+    first_done = asyncio.get_running_loop().create_future()
+    second_done = asyncio.get_running_loop().create_future()
+    first_generation = SimpleNamespace(_done_fut=first_done)
+    second_generation = SimpleNamespace(_done_fut=second_done)
+    session._current_generation = first_generation
+    recycle_calls = 0
+
+    async def _fake_recycle() -> None:
+        nonlocal recycle_calls
+        recycle_calls += 1
+        session._active_tool_names = set(session._tools.function_tools)
+
+    session._graceful_session_recycle = _fake_recycle
+
+    await session.update_tools([second_tool])
+    recycle_task = session._tool_recycle_task
+    assert recycle_task is not None
+    await asyncio.sleep(0.2)
+
+    session._current_generation = second_generation
+    first_done.set_result(None)
+    await asyncio.sleep(0)
+
+    assert recycle_calls == 0
+    assert not recycle_task.done()
+
+    second_done.set_result(None)
+    await recycle_task
+    assert recycle_calls == 1
+
+
+async def test_tool_recycle_keeps_audio_available_until_generation_finishes() -> None:
+    session = _session()
+    generation_done = asyncio.get_running_loop().create_future()
+    audio_ch = utils.aio.Chan[rtc.AudioFrame]()
+    session._current_generation = SimpleNamespace(
+        _done_fut=generation_done,
+        content_id_map={"audio-content": "ASSISTANT_AUDIO"},
+        message_gen=SimpleNamespace(audio_ch=audio_ch),
+    )
+    recycle_calls = 0
+
+    async def _fake_recycle() -> None:
+        nonlocal recycle_calls
+        recycle_calls += 1
+        session._active_tool_names = set(session._tools.function_tools)
+
+    session._graceful_session_recycle = _fake_recycle
+
+    await session.update_tools([second_tool])
+    recycle_task = session._tool_recycle_task
+    assert recycle_task is not None
+    await asyncio.sleep(0.2)
+
+    audio = b"\x01\x02" * 320
+    await session._handle_audio_output_content_event(
+        {
+            "event": {
+                "audioOutput": {
+                    "contentId": "audio-content",
+                    "content": base64.b64encode(audio).decode(),
+                }
+            }
+        }
+    )
+
+    frame = audio_ch.recv_nowait()
+    assert bytes(frame.data) == audio
+    assert not audio_ch.closed
+    assert recycle_calls == 0
+
+    generation_done.set_result(None)
+    await recycle_task
+    assert recycle_calls == 1
+
+
+async def test_initialize_stream_captures_prompt_tool_snapshot() -> None:
+    from livekit.plugins.aws.experimental.realtime.realtime_model import RealtimeSession
+
+    session = object.__new__(RealtimeSession)
+    session._realtime_model = SimpleNamespace(
+        model="amazon.nova-2-sonic-v1:0",
+        _model="amazon.nova-2-sonic-v1:0",
+        _opts=SimpleNamespace(
+            voice="tiffany",
+            max_tokens=100,
+            top_p=0.9,
+            temperature=0.5,
+            tool_choice=None,
+            turn_detection="MEDIUM",
+        ),
+    )
+    session._bedrock_client = SimpleNamespace(
+        invoke_model_with_bidirectional_stream=AsyncMock(return_value=object())
+    )
+    session._stream_response = object()
+    session._tools = ToolContext([first_tool])
+    session._chat_ctx = llm.ChatContext.empty()
+    session._instructions = "test instructions"
+    session._event_builder = MagicMock()
+    session._event_builder.create_prompt_start_block.return_value = (["session-start"], [])
+    tool_configuration = object()
+    session._serialize_tool_config = MagicMock(return_value=tool_configuration)
+    session._report_connection_acquired = MagicMock()
+    session._start_session_recycle_timer = MagicMock()
+    session._response_task = None
+    session._audio_input_task = None
+    session._tools_ready = asyncio.get_running_loop().create_future()
+    session._tools_ready.set_result(True)
+    session._is_sess_active = asyncio.Event()
+    session._stream_ready = asyncio.Event()
+    session._tool_recycle_task = None
+    session._session_recycle_task = None
+    session._active_tool_names = set()
+    session._pending_tools = set()
+    session._current_generation = None
+    session._tool_results_ch = utils.aio.Chan()
+    session._audio_input_chan = utils.aio.Chan()
+
+    async def _send_raw_event(_: str) -> None:
+        await session.update_tools([second_tool])
+
+    async def _noop() -> None:
+        return
+
+    session._send_raw_event = _send_raw_event
+    session._process_responses = _noop
+    session._process_audio_input = _noop
+
+    await session.initialize_streams(is_restart=True)
+
+    assert session._active_tool_names == {"first_tool"}
+    assert set(session._tools.function_tools) == {"second_tool"}
+    assert session._tool_recycle_task is not None
+    assert (
+        session._event_builder.create_prompt_start_block.call_args.kwargs["tool_configuration"]
+        is tool_configuration
+    )
+
+    await asyncio.gather(session._response_task, session._audio_input_task)
+
+    session._tool_recycle_task.cancel()
+    try:
+        await session._tool_recycle_task
+    except asyncio.CancelledError:
+        pass
+
+
+async def test_tool_recycle_times_out_on_stuck_generation(monkeypatch: pytest.MonkeyPatch) -> None:
+    from livekit.plugins.aws.experimental.realtime import realtime_model
+
+    session = _session()
+    monkeypatch.setattr(realtime_model, "TOOL_RECYCLE_GENERATION_TIMEOUT", 0.01)
+    session._current_generation = SimpleNamespace(_done_fut=asyncio.Future())
+    session._close_current_generation = MagicMock(  # type: ignore[method-assign]
+        side_effect=lambda: setattr(session, "_current_generation", None)
+    )
+    recycle_calls = 0
+
+    async def _fake_recycle() -> None:
+        nonlocal recycle_calls
+        recycle_calls += 1
+        session._active_tool_names = set(session._tools.function_tools)
+
+    session._graceful_session_recycle = _fake_recycle
+
+    await session.update_tools([second_tool])
+    recycle_task = session._tool_recycle_task
+    assert recycle_task is not None
+    await recycle_task
+
+    session._close_current_generation.assert_called_once()
+    assert recycle_calls == 1
+
+
+async def test_tool_changes_during_recycle_are_applied() -> None:
+    session = _session()
+    first_recycle_started = asyncio.Event()
+    allow_first_recycle = asyncio.Event()
+    recycle_calls = 0
+
+    async def _fake_recycle() -> None:
+        nonlocal recycle_calls
+        recycle_calls += 1
+        target_tool_names = set(session._tools.function_tools)
+        if recycle_calls == 1:
+            first_recycle_started.set()
+            await allow_first_recycle.wait()
+        session._active_tool_names = target_tool_names
+
+    session._graceful_session_recycle = _fake_recycle
+
+    await session.update_tools([second_tool])
+    recycle_task = session._tool_recycle_task
+    assert recycle_task is not None
+    await first_recycle_started.wait()
+
+    await session.update_tools([third_tool])
+    allow_first_recycle.set()
+    await recycle_task
+
+    assert recycle_calls == 2
+    assert session._active_tool_names == {"third_tool"}
 
 
 async def test_generate_reply_waits_for_pending_tool_recycle() -> None:

--- a/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_tool_recycle.py
+++ b/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_tool_recycle.py
@@ -315,6 +315,74 @@ async def test_tool_recycle_times_out_on_stuck_generation(monkeypatch: pytest.Mo
     assert recycle_calls == 1
 
 
+async def test_tool_recycle_timeout_does_not_close_restored_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from livekit.plugins.aws.experimental.realtime import realtime_model
+
+    session = _session()
+    monkeypatch.setattr(realtime_model, "TOOL_RECYCLE_GENERATION_TIMEOUT", 0.01)
+
+    wait_started = asyncio.Event()
+
+    class _TrackingFuture(asyncio.Future[None]):
+        def add_done_callback(self, callback, *, context=None):  # type: ignore[no-untyped-def]
+            wait_started.set()
+            return super().add_done_callback(callback, context=context)
+
+    generation_done = _TrackingFuture()
+    session._current_generation = SimpleNamespace(_done_fut=generation_done)
+    session._close_current_generation = MagicMock(  # type: ignore[method-assign]
+        side_effect=lambda: setattr(session, "_current_generation", None)
+    )
+
+    await session.update_tools([second_tool])
+    recycle_task = session._tool_recycle_task
+    assert recycle_task is not None
+    await wait_started.wait()
+
+    await session.update_tools([first_tool])
+    await recycle_task
+
+    session._close_current_generation.assert_not_called()
+    assert session._current_generation is not None
+
+
+async def test_aclose_cleans_up_after_cancelling_recycle() -> None:
+    from livekit.plugins.aws.experimental.realtime import realtime_model
+
+    session = object.__new__(realtime_model.RealtimeSession)
+    session._is_sess_active = asyncio.Event()
+    session._is_sess_active.set()
+    recycle_started = asyncio.Event()
+
+    async def _recycle() -> None:
+        recycle_started.set()
+        session._is_sess_active.clear()
+        await asyncio.Future()
+
+    session._tool_recycle_task = asyncio.create_task(_recycle())
+    await recycle_started.wait()
+
+    session._pending_generation_fut = None
+    session._event_builder = SimpleNamespace(create_prompt_end_block=lambda: [])
+    session._send_raw_event = AsyncMock()
+    session._stream_response = SimpleNamespace(
+        output_stream=SimpleNamespace(closed=False, close=AsyncMock()),
+        input_stream=SimpleNamespace(closed=False, close=AsyncMock()),
+    )
+    session._session_recycle_task = None
+    session._response_task = None
+    session._audio_input_task = None
+    session._main_atask = None
+    session._chat_ctx = SimpleNamespace(items=[])
+
+    await session.aclose()
+
+    session._stream_response.output_stream.close.assert_awaited_once()
+    session._stream_response.input_stream.close.assert_awaited_once()
+
+
 async def test_tool_changes_during_recycle_are_applied() -> None:
     session = _session()
     first_recycle_started = asyncio.Event()

--- a/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_tool_recycle.py
+++ b/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_tool_recycle.py
@@ -1,0 +1,211 @@
+"""Regression tests for Nova Sonic tool-set changes during realtime replies."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from livekit.agents import function_tool, utils
+from livekit.agents.llm import ToolContext
+
+pytestmark = pytest.mark.unit
+
+# The realtime plugin imports the optional AWS Smithy/Bedrock SDK. Keep these tests
+# hermetic so they can exercise the session state machine without AWS credentials.
+_AWS_STUBS = [
+    "boto3",
+    "aws_sdk_bedrock_runtime",
+    "aws_sdk_bedrock_runtime.client",
+    "aws_sdk_bedrock_runtime.models",
+    "aws_sdk_bedrock_runtime.config",
+    "smithy_aws_core",
+    "smithy_aws_core.identity",
+    "smithy_aws_event_stream",
+    "smithy_aws_event_stream.exceptions",
+    "smithy_core",
+    "smithy_core.aio",
+    "smithy_core.aio.interfaces",
+    "smithy_core.aio.interfaces.identity",
+]
+for _mod in _AWS_STUBS:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+
+@function_tool
+async def first_tool() -> None:
+    """First test tool."""
+
+
+@function_tool
+async def second_tool() -> None:
+    """Second test tool."""
+
+
+@function_tool
+async def third_tool() -> None:
+    """Third test tool."""
+
+
+def _session():
+    from livekit.plugins.aws.experimental.realtime.realtime_model import RealtimeSession
+
+    session = object.__new__(RealtimeSession)
+    session._tools = ToolContext([first_tool])
+    session._is_sess_active = asyncio.Event()
+    session._is_sess_active.set()
+    session._pending_tools = set()
+    session._tool_results_ch = utils.aio.Chan()
+    session._tools_ready = asyncio.get_running_loop().create_future()
+    session._tools_ready.set_result(True)
+    session._tool_recycle_task = None
+    session._active_tool_names = {"first_tool"}
+    session._current_generation = None
+    return session
+
+
+async def test_update_tools_coalesces_pending_session_recycles() -> None:
+    session = _session()
+    recycle_calls = 0
+
+    async def _fake_recycle() -> None:
+        nonlocal recycle_calls
+        recycle_calls += 1
+
+    session._graceful_session_recycle = _fake_recycle
+
+    await session.update_tools([second_tool])
+    recycle_task = session._tool_recycle_task
+    await session.update_tools([third_tool])
+
+    assert session._tool_recycle_task is recycle_task
+    await recycle_task
+
+    assert recycle_calls == 1
+    assert set(session.tools.function_tools) == {"third_tool"}
+
+
+async def test_restored_tool_set_skips_pending_recycle() -> None:
+    session = _session()
+    recycle_calls = 0
+
+    async def _fake_recycle() -> None:
+        nonlocal recycle_calls
+        recycle_calls += 1
+
+    session._graceful_session_recycle = _fake_recycle
+
+    await session.update_tools([second_tool])
+    recycle_task = session._tool_recycle_task
+    await session.update_tools([first_tool])
+
+    assert session._tool_recycle_task is recycle_task
+    await recycle_task
+
+    assert recycle_calls == 0
+    assert set(session.tools.function_tools) == {"first_tool"}
+
+
+async def test_tool_recycle_waits_for_active_generation() -> None:
+    session = _session()
+    generation_done = asyncio.get_running_loop().create_future()
+    session._current_generation = SimpleNamespace(_done_fut=generation_done)
+    recycle_calls = 0
+
+    async def _fake_recycle() -> None:
+        nonlocal recycle_calls
+        recycle_calls += 1
+
+    session._graceful_session_recycle = _fake_recycle
+
+    await session.update_tools([second_tool])
+    recycle_task = session._tool_recycle_task
+    await asyncio.sleep(0.2)
+
+    assert recycle_calls == 0
+    assert not recycle_task.done()
+
+    generation_done.set_result(None)
+    await recycle_task
+    assert recycle_calls == 1
+
+
+async def test_generate_reply_waits_for_pending_tool_recycle() -> None:
+    from livekit.plugins.aws.experimental.realtime.realtime_model import RealtimeSession
+
+    session = object.__new__(RealtimeSession)
+    session._realtime_model = SimpleNamespace(modalities="mixed", _generate_reply_timeout=1.0)
+    session._pending_generation_fut = None
+    session._stream_ready = asyncio.Event()
+    session._stream_ready.set()
+    send_called = asyncio.Event()
+
+    async def _send_text_message(*args, **kwargs) -> None:
+        send_called.set()
+
+    session._send_text_message = AsyncMock(side_effect=_send_text_message)
+
+    recycle_finished = asyncio.Event()
+
+    async def _wait_for_recycle() -> None:
+        await recycle_finished.wait()
+
+    session._tool_recycle_task = asyncio.create_task(_wait_for_recycle())
+
+    generation_fut = session.generate_reply(instructions="say hello")
+    await asyncio.sleep(0)
+    session._send_text_message.assert_not_awaited()
+
+    recycle_finished.set()
+    await asyncio.wait_for(send_called.wait(), timeout=1.0)
+    session._send_text_message.assert_awaited_once_with("say hello", interactive=True)
+    generation_fut.cancel()
+
+
+async def test_consecutive_on_enter_replies_coalesce_tool_set_changes() -> None:
+    """A restore before the next reply should reuse the pending session recycle."""
+    session = _session()
+    session._realtime_model = SimpleNamespace(modalities="mixed", _generate_reply_timeout=1.0)
+    session._stream_ready = asyncio.Event()
+    session._stream_ready.set()
+
+    sent_instructions: list[str] = []
+
+    async def _send_text_message(text: str, *, interactive: bool) -> None:
+        assert interactive
+        sent_instructions.append(text)
+
+    session._send_text_message = AsyncMock(side_effect=_send_text_message)
+    recycle_calls = 0
+
+    async def _fake_recycle() -> None:
+        nonlocal recycle_calls
+        recycle_calls += 1
+        session._active_tool_names = set(session._tools.function_tools)
+
+    session._graceful_session_recycle = _fake_recycle
+
+    for index, instructions in enumerate(("say hello", "introduce yourself", "say goodbye")):
+        await session.update_tools([second_tool])
+        generation_fut = session.generate_reply(instructions=instructions)
+
+        while len(sent_instructions) <= index:
+            await asyncio.sleep(0)
+
+        assert sent_instructions[index] == instructions
+        generation_fut.cancel()
+
+        if index < 2:
+            await session.update_tools([first_tool])
+
+    await session.update_tools([first_tool])
+    recycle_task = session._tool_recycle_task
+    assert recycle_task is not None
+    await recycle_task
+
+    assert sent_instructions == ["say hello", "introduce yourself", "say goodbye"]
+    assert recycle_calls == 2

--- a/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_tool_recycle.py
+++ b/livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_tool_recycle.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import sys
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -67,6 +68,9 @@ def _session():
     session._tool_recycle_task = None
     session._active_tool_names = {"first_tool"}
     session._current_generation = None
+    session._is_shutting_down = False
+    session._last_audio_output_time = 0.0
+    session._audio_end_turn_received = False
     return session
 
 
@@ -309,6 +313,49 @@ async def test_tool_recycle_times_out_on_stuck_generation(monkeypatch: pytest.Mo
     await session.update_tools([second_tool])
     recycle_task = session._tool_recycle_task
     assert recycle_task is not None
+    await recycle_task
+
+    session._close_current_generation.assert_called_once()
+    assert recycle_calls == 1
+
+
+async def test_tool_recycle_does_not_cut_off_active_audio_reply(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from livekit.plugins.aws.experimental.realtime import realtime_model
+
+    session = _session()
+    monkeypatch.setattr(realtime_model, "TOOL_RECYCLE_GENERATION_TIMEOUT", 0.01)
+    monkeypatch.setattr(realtime_model, "TOOL_RECYCLE_AUDIO_IDLE_TIMEOUT", 0.5)
+
+    generation_done = asyncio.get_running_loop().create_future()
+    session._current_generation = SimpleNamespace(_done_fut=generation_done)
+    session._last_audio_output_time = time.time()
+    session._audio_end_turn_received = False
+    session._close_current_generation = MagicMock(  # type: ignore[method-assign]
+        side_effect=lambda: setattr(session, "_current_generation", None)
+    )
+    recycle_calls = 0
+
+    async def _fake_recycle() -> None:
+        nonlocal recycle_calls
+        recycle_calls += 1
+        session._active_tool_names = set(session._tools.function_tools)
+
+    session._graceful_session_recycle = _fake_recycle
+
+    await session.update_tools([second_tool])
+    recycle_task = session._tool_recycle_task
+    assert recycle_task is not None
+    await asyncio.sleep(0.2)
+
+    session._last_audio_output_time = time.time()
+    await asyncio.sleep(0.2)
+
+    session._close_current_generation.assert_not_called()
+    assert not recycle_task.done()
+
+    session._audio_end_turn_received = True
     await recycle_task
 
     session._close_current_generation.assert_called_once()


### PR DESCRIPTION
Closes #6812

## What changed

Amazon Nova Sonic declares tools when a realtime session starts. `ToolFlag.IGNORE_ON_ENTER` temporarily changes the tool set around `generate_reply`, and the old path could queue overlapping session recycles. A later reply could then race the stream restart and stop producing audio.

This change:

- coalesces pending tool-set recycle tasks
- records the tool set actually sent in the prompt-start block
- waits for an in-flight generation before rebuilding the session
- bounds a stuck-generation wait and preserves the existing session recovery path
- keeps waiting if a newer generation replaces the one being drained
- makes the next reply wait for the pending recycle
- re-checks tool changes that arrive while a recycle is in flight
- skips a recycle when the tool set has already been restored

The regression coverage exercises consecutive replies, restored tool sets, active generations, stuck generations, generation replacement, prompt snapshot races, audio delivery, and reply gating without requiring AWS credentials.

## Validation

Local validation on Windows, using the isolated worktree virtual environment:

- `pytest livekit-plugins/livekit-plugins-aws/tests -q` (25 passed)
- `pytest tests/test_realtime_reply_chat_ctx.py tests/test_agent_session.py -q` (82 passed)
- `ruff check livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_tool_recycle.py` (passed)
- `ruff format --check livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py livekit-plugins/livekit-plugins-aws/tests/test_nova_sonic_tool_recycle.py` (passed)
- `git diff --check` (passed)

Remote CI is running for the follow-up commit. The repository's current mypy checks and the existing AWS typing baseline are tracked by CI; no package manifests or changelog files are part of this change.

## AI assistance

Codex assisted with investigating the reported behavior, drafting the regression coverage, and implementing the patch. I reviewed the resulting diff and ran the validation commands above.