### PR TITLE
fix(silero): update bundled VAD checkpoint to v6.2

### DIFF
--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/resources/silero_vad.onnx
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/resources/silero_vad.onnx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:597d30b3ec076608d059477bb14cfeffdf951bf5cae370d38f65d33bbfe82004
+oid sha256:1a153a22f4509e292a94e67d6f9b85e8deb25b4988682b7e174c65279d8788e3
 size 2327524

--- a/tests/test_vad.py
+++ b/tests/test_vad.py
@@ -2,10 +2,13 @@ import asyncio
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any
 
+import numpy as np
 import pytest
 
 from livekit.agents import vad
 from livekit.agents.inference import VAD as InferenceVAD
+from livekit.local_inference import VAD as NativeVAD, VAD_WINDOW_SAMPLES
+from livekit.plugins.silero import onnx_model
 
 from . import utils
 
@@ -174,3 +177,29 @@ async def test_file_vad(sample_rate):
 
     assert start_of_speech_i > 0, "no start of speech detected"
     assert start_of_speech_i == end_of_speech_i, "start and end of speech mismatch"
+
+
+async def test_plugin_checkpoint_matches_inference_vad() -> None:
+    """The silero plugin and inference.VAD must run the same underlying checkpoint.
+
+    They ship the model separately -- an onnx file in the plugin, baked-in weights in
+    livekit-local-inference -- so nothing but this test keeps the two from drifting apart.
+    """
+    frames, *_ = await utils.make_test_speech(sample_rate=16000)
+    pcm = frames[0].data
+
+    plugin_model = onnx_model.OnnxModel(
+        onnx_session=onnx_model.new_inference_session(force_cpu=True), sample_rate=16000
+    )
+    native_model = NativeVAD()
+
+    windows = 0
+    for i in range(0, len(pcm) - VAD_WINDOW_SAMPLES + 1, VAD_WINDOW_SAMPLES):
+        window = np.ascontiguousarray(pcm[i : i + VAD_WINDOW_SAMPLES], dtype=np.int16)
+        plugin_p = plugin_model(np.divide(window, np.iinfo(np.int16).max, dtype=np.float32))
+        assert plugin_p == pytest.approx(native_model.predict(window), abs=1e-3), (
+            f"checkpoints diverge at window {i // VAD_WINDOW_SAMPLES}"
+        )
+        windows += 1
+
+    assert windows > 100, "test audio too short to be meaningful"


### PR DESCRIPTION
**Problem**

The plugin bundled the v6.1 Silero checkpoint, while `inference.VAD` already ran v6.2 through `livekit-local-inference`. Each ships the model separately, so the two drifted apart. v6.1 misses short utterances that v6.2 detects.

**Fix**

The bundled ONNX file now holds the v6.2 model: [https://github.com/snakers4/silero-vad/releases/tag/v6.2](<https://github.com/snakers4/silero-vad/releases/tag/v6.2>). The signature is unchanged, so no code changes. A new test asserts the plugin and `inference.VAD` agree, so they cannot drift again.

`VAD.load()` still accepts `onnx_file_path` to stay on v6.1.

Fixes livekit/agents#6815