### PR TITLE
fix: respect agent endpointing delay during reply hold-off

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2167,7 +2167,7 @@ class AgentActivity(RecognitionHooks):
         if (
             ev.speaking
             # allow some silence between utterances during active speech
-            and ev.raw_accumulated_silence <= self._session.options.endpointing["min_delay"] / 2
+            and ev.raw_accumulated_silence <= self.min_endpointing_delay / 2
         ):
             self._user_silence_event.clear()
         else:

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -2445,6 +2445,55 @@ async def test_agent_turn_detection_override_resolves_endpointing_per_activity()
         await session.aclose()
 
 
+@pytest.mark.parametrize(
+    ("session_min_delay", "agent_min_delay", "reply_held"),
+    [
+        pytest.param(0.2, 1.0, True, id="agent-holds-longer"),
+        pytest.param(1.0, 0.2, False, id="agent-releases-earlier"),
+    ],
+)
+async def test_reply_holdoff_uses_agent_endpointing_delay(
+    session_min_delay: float, agent_min_delay: float, reply_held: bool
+) -> None:
+    """VAD silence uses the active agent's delay for pending reply hold-off."""
+    from livekit.agents.voice.agent_session import AgentSession
+
+    from .fake_vad import FakeVAD
+
+    session = AgentSession(
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling={
+            "turn_detection": "vad",
+            "endpointing": {"min_delay": session_min_delay},
+        },
+    )
+    try:
+        activity = AgentActivity(
+            Agent(
+                instructions="test",
+                turn_handling={"endpointing": {"min_delay": agent_min_delay}},
+            ),
+            session,
+        )
+        assert activity.endpointing_opts["min_delay"] == agent_min_delay
+
+        activity.on_vad_inference_done(
+            vad.VADEvent(
+                type=vad.VADEventType.INFERENCE_DONE,
+                samples_index=0,
+                timestamp=0.0,
+                speech_duration=0.0,
+                silence_duration=0.25,
+                speaking=True,
+                raw_accumulated_silence=0.25,
+            )
+        )
+
+        assert activity._user_silence_event.is_set() == (not reply_held)
+    finally:
+        await session.aclose()
+
+
 async def test_runtime_endpointing_opts_survive_handoff() -> None:
     """update_options changes are recorded as overrides, so a new activity keeps them."""
     from livekit.agents.voice.agent_session import AgentSession


### PR DESCRIPTION
Pending reply hold-off used the session endpointing delay even when the active agent overrides it. This could release speech too early or keep it blocked too long.

Use the activity-resolved minimum delay and cover both override directions.

Addresses AGT-3281

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> Reply hold-off during user speech ignores per-agent endpointing settings
>
> The silence threshold that decides whether a pending reply keeps waiting is read from the session-wide setting (this.agentSession.sessionOptions.turnHandling.endpointing.minDelay at agents/src/voice/agent_activity.ts:1526) instead of the value actually in effect for the current agent, so replies can be released too early or held too long when an agent customizes it.
> Impact: Agents that configure their own end-of-turn timing can start talking over the user, or wait longer than configured, because the hold-off uses a different delay than the turn detection actually uses.
>
> I am fixing Python first.
>
> create a PR. and create a Node-js PR too.

</details>