### PR TITLE
docs: require confirmation for non-patch version bumps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,11 @@ This project uses **uv** as the package manager. All commands run from the repos
 make install          # Install all dependencies with dev extras (uv sync --all-extras --dev)
 ```
 
+### Versioning
+
+- Use a `patch` version bump by default.
+- Do not use a `minor` or `major` version bump unless a human explicitly confirms the bump level.
+
 ### Code Quality
 ```bash
 make format           # Format code with ruff


### PR DESCRIPTION
Agents can select a minor or major bump for a patch-level change and produce an unintended release. Make patch the default and require explicit human confirmation before a non-patch version bump.

Addresses AGT-3285

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> we should update the agents.md to avoid use minor or major patch level unless confirmed with a human
>
> create a PR

</details>