### PR TITLE
fix: stabilize LiveKit pronunciation with Fish Audio

### DIFF
--- a/examples/homepage/agent.py
+++ b/examples/homepage/agent.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from behaviors.frontend_attributes import publish_frontend_attributes
 from behaviors.user_away import check_in_when_user_away
 from dotenv import load_dotenv
+from filters.pronunciation import pronounce_livekit
 from knowledge_base import KnowledgeBase
 from prompts import prompt
 
@@ -78,6 +79,7 @@ async def homepage_agent(ctx: JobContext):
         ),
         preemptive_generation=True,
         expressive=True,
+        tts_text_transforms=["filter_markdown", "filter_emoji", pronounce_livekit],
     )
 
     check_in_when_user_away(session)

--- a/examples/homepage/filters/pronunciation.py
+++ b/examples/homepage/filters/pronunciation.py
@@ -1,7 +1,4 @@
-"""Rewrite "LiveKit" and "LiveKit's" so the TTS pronounces them correctly.
-
-Fish Audio reads one word of CMU Arpabet per phoneme tag as a custom pronunciation:
-https://docs.fish.audio/developer-guide/core-features/fine-grained-control#phoneme-control
+"""Rewrite "LiveKit" and "LiveKit's" with TTS-friendly spellings.
 
 The rewrite only trusts complete words: LLM chunk boundaries land anywhere,
 so a per-chunk regex would both miss a "Live"/"Kit" split across chunks and
@@ -13,15 +10,13 @@ back time-to-first-audio.
 import re
 from collections.abc import AsyncIterable
 
-LIVEKIT_PHONEMES = "<|phoneme_start|>L AY1 V<|phoneme_end|> <|phoneme_start|>K IH1 T<|phoneme_end|>"
-LIVEKITS_PHONEMES = (
-    "<|phoneme_start|>L AY1 V<|phoneme_end|> <|phoneme_start|>K IH1 T S<|phoneme_end|>"
-)
+LIVEKIT_PRONUNCIATION = "Lyve Kit"
+LIVEKITS_PRONUNCIATION = "Lyve Kit's"
 _LIVEKIT_RE = re.compile(r"\blivekit(?P<possessive>['’]s)?\b", re.IGNORECASE)
 
 
 def _replace_livekit(match: re.Match[str]) -> str:
-    return LIVEKITS_PHONEMES if match.group("possessive") else LIVEKIT_PHONEMES
+    return LIVEKITS_PRONUNCIATION if match.group("possessive") else LIVEKIT_PRONUNCIATION
 
 
 async def _whole_words(chunks: AsyncIterable[str]) -> AsyncIterable[str]:

--- a/examples/homepage/filters/pronunciation.py
+++ b/examples/homepage/filters/pronunciation.py
@@ -1,6 +1,6 @@
 """Rewrite "LiveKit" and "LiveKit's" so the TTS pronounces them correctly.
 
-Fish Audio reads CMU Arpabet wrapped in phoneme tags as a custom pronunciation:
+Fish Audio reads one word of CMU Arpabet per phoneme tag as a custom pronunciation:
 https://docs.fish.audio/developer-guide/core-features/fine-grained-control#phoneme-control
 
 The rewrite only trusts complete words: LLM chunk boundaries land anywhere,
@@ -13,8 +13,10 @@ back time-to-first-audio.
 import re
 from collections.abc import AsyncIterable
 
-LIVEKIT_PHONEMES = "<|phoneme_start|>L AY1 V K IH2 T<|phoneme_end|>"
-LIVEKITS_PHONEMES = "<|phoneme_start|>L AY1 V K IH2 T S<|phoneme_end|>"
+LIVEKIT_PHONEMES = "<|phoneme_start|>L AY1 V<|phoneme_end|> <|phoneme_start|>K IH1 T<|phoneme_end|>"
+LIVEKITS_PHONEMES = (
+    "<|phoneme_start|>L AY1 V<|phoneme_end|> <|phoneme_start|>K IH1 T S<|phoneme_end|>"
+)
 _LIVEKIT_RE = re.compile(r"\blivekit(?P<possessive>['’]s)?\b", re.IGNORECASE)
 
 

--- a/examples/homepage/filters/pronunciation.py
+++ b/examples/homepage/filters/pronunciation.py
@@ -1,7 +1,7 @@
-"""Rewrite "LiveKit" so the TTS pronounces it correctly.
+"""Rewrite "LiveKit" and "LiveKit's" so the TTS pronounces them correctly.
 
-Inworld TTS reads a single word's IPA transcription wrapped in slashes as a
-custom pronunciation: https://docs.inworld.ai/tts/capabilities/custom-pronunciation
+Fish Audio reads CMU Arpabet wrapped in phoneme tags as a custom pronunciation:
+https://docs.fish.audio/developer-guide/core-features/fine-grained-control#phoneme-control
 
 The rewrite only trusts complete words: LLM chunk boundaries land anywhere,
 so a per-chunk regex would both miss a "Live"/"Kit" split across chunks and
@@ -13,8 +13,13 @@ back time-to-first-audio.
 import re
 from collections.abc import AsyncIterable
 
-LIVEKIT_IPA = "/ˈlaɪvkɪt/"  # noqa: RUF001 - intentional IPA characters
-_LIVEKIT_RE = re.compile(r"\blivekit\b", re.IGNORECASE)
+LIVEKIT_PHONEMES = "<|phoneme_start|>L AY1 V K IH2 T<|phoneme_end|>"
+LIVEKITS_PHONEMES = "<|phoneme_start|>L AY1 V K IH2 T S<|phoneme_end|>"
+_LIVEKIT_RE = re.compile(r"\blivekit(?P<possessive>['’]s)?\b", re.IGNORECASE)
+
+
+def _replace_livekit(match: re.Match[str]) -> str:
+    return LIVEKITS_PHONEMES if match.group("possessive") else LIVEKIT_PHONEMES
 
 
 async def _whole_words(chunks: AsyncIterable[str]) -> AsyncIterable[str]:
@@ -31,4 +36,4 @@ async def _whole_words(chunks: AsyncIterable[str]) -> AsyncIterable[str]:
 
 async def pronounce_livekit(text: AsyncIterable[str]) -> AsyncIterable[str]:
     async for word in _whole_words(text):
-        yield _LIVEKIT_RE.sub(LIVEKIT_IPA, word)
+        yield _LIVEKIT_RE.sub(_replace_livekit, word)

--- a/examples/homepage/tests/unit/test_pronunciation.py
+++ b/examples/homepage/tests/unit/test_pronunciation.py
@@ -1,5 +1,9 @@
 import pytest
-from filters.pronunciation import LIVEKIT_PHONEMES, LIVEKITS_PHONEMES, pronounce_livekit
+from filters.pronunciation import (
+    LIVEKIT_PRONUNCIATION,
+    LIVEKITS_PRONUNCIATION,
+    pronounce_livekit,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -14,11 +18,9 @@ async def _speak(*chunks: str) -> str:
 
 @pytest.mark.asyncio
 async def test_pronounce_livekit() -> None:
-    assert LIVEKIT_PHONEMES.count("<|phoneme_start|>") == 2
-    assert LIVEKITS_PHONEMES.count("<|phoneme_start|>") == 2
-    assert await _speak("I love LiveKit.") == f"I love {LIVEKIT_PHONEMES}."
-    assert await _speak("livekit is great") == f"{LIVEKIT_PHONEMES} is great"
-    assert await _speak("Live", "Kit rocks") == f"{LIVEKIT_PHONEMES} rocks"
-    assert await _speak("LiveKit's SDK") == f"{LIVEKITS_PHONEMES} SDK"
-    assert await _speak("LiveKit’s SDK") == f"{LIVEKITS_PHONEMES} SDK"
+    assert await _speak("I love LiveKit.") == f"I love {LIVEKIT_PRONUNCIATION}."
+    assert await _speak("livekit is great") == f"{LIVEKIT_PRONUNCIATION} is great"
+    assert await _speak("Live", "Kit rocks") == f"{LIVEKIT_PRONUNCIATION} rocks"
+    assert await _speak("LiveKit's SDK") == f"{LIVEKITS_PRONUNCIATION} SDK"
+    assert await _speak("LiveKit’s SDK") == f"{LIVEKITS_PRONUNCIATION} SDK"
     assert await _speak("LiveKitten is not a product") == "LiveKitten is not a product"

--- a/examples/homepage/tests/unit/test_pronunciation.py
+++ b/examples/homepage/tests/unit/test_pronunciation.py
@@ -1,5 +1,5 @@
 import pytest
-from filters.pronunciation import LIVEKIT_IPA, pronounce_livekit
+from filters.pronunciation import LIVEKIT_PHONEMES, LIVEKITS_PHONEMES, pronounce_livekit
 
 pytestmark = pytest.mark.unit
 
@@ -14,7 +14,9 @@ async def _speak(*chunks: str) -> str:
 
 @pytest.mark.asyncio
 async def test_pronounce_livekit() -> None:
-    assert await _speak("I love LiveKit.") == f"I love {LIVEKIT_IPA}."
-    assert await _speak("livekit is great") == f"{LIVEKIT_IPA} is great"
-    assert await _speak("Live", "Kit rocks") == f"{LIVEKIT_IPA} rocks"
+    assert await _speak("I love LiveKit.") == f"I love {LIVEKIT_PHONEMES}."
+    assert await _speak("livekit is great") == f"{LIVEKIT_PHONEMES} is great"
+    assert await _speak("Live", "Kit rocks") == f"{LIVEKIT_PHONEMES} rocks"
+    assert await _speak("LiveKit's SDK") == f"{LIVEKITS_PHONEMES} SDK"
+    assert await _speak("LiveKit’s SDK") == f"{LIVEKITS_PHONEMES} SDK"
     assert await _speak("LiveKitten is not a product") == "LiveKitten is not a product"

--- a/examples/homepage/tests/unit/test_pronunciation.py
+++ b/examples/homepage/tests/unit/test_pronunciation.py
@@ -14,6 +14,8 @@ async def _speak(*chunks: str) -> str:
 
 @pytest.mark.asyncio
 async def test_pronounce_livekit() -> None:
+    assert LIVEKIT_PHONEMES.count("<|phoneme_start|>") == 2
+    assert LIVEKITS_PHONEMES.count("<|phoneme_start|>") == 2
     assert await _speak("I love LiveKit.") == f"I love {LIVEKIT_PHONEMES}."
     assert await _speak("livekit is great") == f"{LIVEKIT_PHONEMES} is great"
     assert await _speak("Live", "Kit rocks") == f"{LIVEKIT_PHONEMES} rocks"


### PR DESCRIPTION
Fish Audio intermittently ignores phoneme controls and pronounces LiveKit like “live in California.” Use the TTS-only spelling “Lyve Kit” to preserve the intended “live music” sound without changing the LLM response or user-facing transcript.

Addresses MARKT-1004

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> homepage agent is using fish audio, and we should replace LiveKit or LiveKit's with  https://docs.fish.audio/developer-guide/core-features/fine-grained-control#phoneme-control
>
> it is live as in live music
>
> I tried it on their website. it is a coin flip with <|phoneme_start|>L AY1 V<|phoneme_end|>
>
> Lyve Kit feels close enough

</details>
