### PR TITLE
fix: migrate http clients to httpx2

### DIFF
--- a/livekit-agents/livekit/agents/cli/log.py
+++ b/livekit-agents/livekit/agents/cli/log.py
@@ -16,6 +16,8 @@ from ..plugin import Plugin
 NOISY_LOGGERS = [
     "httpx",
     "httpcore",
+    "httpx2",
+    "httpcore2",
     "openai",
     "watchfiles",
     "anthropic",

--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -4,7 +4,7 @@ import os
 from dataclasses import dataclass
 from typing import Any, Literal, cast
 
-import httpx
+import httpx2
 import openai
 from openai.types.chat import (
     ChatCompletionChunk,
@@ -270,10 +270,10 @@ class LLM(llm.LLM):
             api_key=create_access_token(self._opts.api_key, self._opts.api_secret),
             base_url=self._opts.base_url,
             max_retries=0,
-            http_client=httpx.AsyncClient(
-                timeout=httpx.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
+            http_client=openai.DefaultAsyncHttpx2Client(
+                timeout=httpx2.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
                 follow_redirects=True,
-                limits=httpx.Limits(
+                limits=httpx2.Limits(
                     max_connections=50, max_keepalive_connections=50, keepalive_expiry=120
                 ),
             ),
@@ -451,7 +451,7 @@ class LLMStream(llm.LLMStream):
                 model=self._model,
                 stream_options={"include_usage": True},
                 stream=True,
-                timeout=httpx.Timeout(self._conn_options.timeout),
+                timeout=self._conn_options.timeout,
                 **self._extra_kwargs,
             )
 
@@ -486,9 +486,9 @@ class LLMStream(llm.LLMStream):
 
         except openai.APITimeoutError:
             raise APITimeoutError(retryable=retryable) from None
-        except httpx.TimeoutException as e:
+        except httpx2.TimeoutException as e:
             # Only the request call runs inside the openai client's error mapping, so a
-            # timeout waiting on the stream body arrives as the raw httpx exception.
+            # timeout waiting on the stream body arrives as the raw httpx2 exception.
             raise APITimeoutError(retryable=retryable) from e
         except openai.APIStatusError as e:
             if e.status_code == 429:

--- a/livekit-agents/livekit/agents/llm/mcp.py
+++ b/livekit-agents/livekit/agents/llm/mcp.py
@@ -1,30 +1,28 @@
-# mypy: disable-error-code=unused-ignore
-
 from __future__ import annotations
 
 import asyncio
 import json
 from abc import ABC, abstractmethod
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass
-from datetime import timedelta
 from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlparse
 
-from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+import httpx2
 from typing_extensions import Self, TypedDict
 
 from ..log import logger
+from ..utils import httpx_compat
 
 try:
-    import httpx
     import mcp.types
     from mcp import ClientSession, stdio_client
     from mcp.client.sse import sse_client
     from mcp.client.stdio import StdioServerParameters
-    from mcp.client.streamable_http import GetSessionIdCallback, streamable_http_client
+    from mcp.client.streamable_http import streamable_http_client
+    from mcp.shared._stream_protocols import ReadStream, WriteStream
     from mcp.shared.message import SessionMessage
 except ImportError as e:
     raise ImportError(
@@ -155,9 +153,7 @@ class MCPServer(ABC):
                 async with ClientSession(
                     receive_stream,
                     send_stream,
-                    read_timeout_seconds=timedelta(seconds=self._read_timeout)
-                    if self._read_timeout
-                    else None,
+                    read_timeout_seconds=self._read_timeout or None,
                 ) as client:
                     await client.initialize()
                     self._client = client
@@ -196,7 +192,7 @@ class MCPServer(ABC):
             self._make_function_tool(
                 tool.name,
                 tool.description,
-                tool.inputSchema,
+                tool.input_schema,
                 tool.meta,
                 options=_resolve_tool_options(options.get(tool.name)),
             )
@@ -215,7 +211,7 @@ class MCPServer(ABC):
         async def _resolve(
             tool_result: mcp.types.CallToolResult, raw_arguments: dict[str, Any]
         ) -> Any:
-            if tool_result.isError:
+            if tool_result.is_error:
                 error_str = "\n".join(
                     part.text if hasattr(part, "text") else str(part)
                     for part in tool_result.content
@@ -306,13 +302,8 @@ class MCPServer(ABC):
         self,
     ) -> AbstractAsyncContextManager[
         tuple[
-            MemoryObjectReceiveStream[SessionMessage | Exception],
-            MemoryObjectSendStream[SessionMessage],
-        ]
-        | tuple[
-            MemoryObjectReceiveStream[SessionMessage | Exception],
-            MemoryObjectSendStream[SessionMessage],
-            GetSessionIdCallback,
+            ReadStream[SessionMessage | Exception],
+            WriteStream[SessionMessage],
         ]
     ]: ...
 
@@ -345,7 +336,7 @@ class MCPServerHTTP(MCPServer):
         url: str,
         transport_type: Literal["sse", "streamable_http"] | None = None,
         allowed_tools: list[str] | None = None,
-        headers: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
         timeout: float = 5,
         sse_read_timeout: float = 60 * 5,
         client_session_timeout_seconds: float = 5,
@@ -373,35 +364,35 @@ class MCPServerHTTP(MCPServer):
             # Fall back to URL-based detection for backward compatibility
             self._use_streamable_http = self._should_use_streamable_http(url)
 
-        self._http_client: httpx.AsyncClient | None = None
+        self._http_client: httpx2.AsyncClient | None = None
 
     @property
-    def headers(self) -> dict[str, Any]:
+    def headers(self) -> dict[str, str]:
         return self._headers
 
     @headers.setter
-    def headers(self, headers: dict[str, Any]) -> None:
+    def headers(self, headers: dict[str, str]) -> None:
         self._headers = headers
         if self._http_client is not None:
             self._http_client.headers = headers
 
     def _create_http_client(
         self,
-        headers: dict[str, Any] | None = None,
-        timeout: httpx.Timeout | None = None,
-        auth: httpx.Auth | None = None,
-    ) -> httpx.AsyncClient:
+        headers: dict[str, str] | None = None,
+        timeout: httpx_compat.HTTPXTimeout | None = None,
+        auth: httpx2.Auth | None = None,
+    ) -> httpx2.AsyncClient:
         # ported from mcp.shared._httpx_utils.create_mcp_http_client
         kwargs: dict[str, Any] = {
             "follow_redirects": True,
-            "timeout": timeout
+            "timeout": httpx_compat.to_httpx2_timeout(timeout)
             if timeout is not None
-            else httpx.Timeout(self._timeout, read=self._sse_read_timeout),
+            else httpx2.Timeout(self._timeout, read=self._sse_read_timeout),
             "headers": headers if headers is not None else self._headers,
         }
         if auth is not None:
             kwargs["auth"] = auth
-        self._http_client = httpx.AsyncClient(**kwargs)
+        self._http_client = httpx2.AsyncClient(**kwargs)
         return self._http_client
 
     def _should_use_streamable_http(self, url: str) -> bool:
@@ -419,28 +410,29 @@ class MCPServerHTTP(MCPServer):
         self,
     ) -> AbstractAsyncContextManager[
         tuple[
-            MemoryObjectReceiveStream[SessionMessage | Exception],
-            MemoryObjectSendStream[SessionMessage],
-        ]
-        | tuple[
-            MemoryObjectReceiveStream[SessionMessage | Exception],
-            MemoryObjectSendStream[SessionMessage],
-            GetSessionIdCallback,
+            ReadStream[SessionMessage | Exception],
+            WriteStream[SessionMessage],
         ]
     ]:
         if self._use_streamable_http:
 
             @asynccontextmanager
-            async def _streamable_http_with_client():  # type: ignore[no-untyped-def]
+            async def _streamable_http_with_client() -> AsyncIterator[
+                tuple[
+                    ReadStream[SessionMessage | Exception],
+                    WriteStream[SessionMessage],
+                ]
+            ]:
                 async with self._create_http_client() as http_client:
                     async with streamable_http_client(
-                        url=self.url, http_client=http_client
+                        url=self.url,
+                        http_client=http_client,
                     ) as streams:
                         yield streams
 
-            return _streamable_http_with_client()  # type: ignore[return-value]
+            return _streamable_http_with_client()
         else:
-            return sse_client(  # type: ignore[no-any-return]
+            return sse_client(
                 url=self.url,
                 headers=self._headers,
                 timeout=self._timeout,
@@ -516,11 +508,11 @@ class MCPServerStdio(MCPServer):
         self,
     ) -> AbstractAsyncContextManager[
         tuple[
-            MemoryObjectReceiveStream[SessionMessage | Exception],
-            MemoryObjectSendStream[SessionMessage],
+            ReadStream[SessionMessage | Exception],
+            WriteStream[SessionMessage],
         ]
     ]:
-        return stdio_client(  # type: ignore[no-any-return]
+        return stdio_client(
             StdioServerParameters(command=self.command, args=self.args, env=self.env, cwd=self.cwd)
         )
 

--- a/livekit-agents/livekit/agents/utils/httpx_compat.py
+++ b/livekit-agents/livekit/agents/utils/httpx_compat.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import warnings
+from collections.abc import Mapping
+from typing import TypeAlias
+
+import httpx
+import httpx2
+
+HTTPXTimeout: TypeAlias = httpx2.Timeout | httpx.Timeout
+HTTPXLimits: TypeAlias = httpx2.Limits | httpx.Limits
+
+LegacyTimeoutException = httpx.TimeoutException
+
+_DEPRECATION_MESSAGE = (
+    "httpx.Timeout inputs are deprecated and will no longer be supported in LiveKit Agents 2.0. "
+    "Use httpx2.Timeout instead."
+)
+
+
+def warn_on_legacy_timeout(timeout: HTTPXTimeout | None) -> None:
+    if isinstance(timeout, httpx.Timeout):
+        warnings.warn(_DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=3)
+
+
+def to_httpx2_timeout(timeout: HTTPXTimeout | None) -> httpx2.Timeout | None:
+    if timeout is None or isinstance(timeout, httpx2.Timeout):
+        return timeout
+
+    return httpx2.Timeout(
+        connect=timeout.connect,
+        read=timeout.read,
+        write=timeout.write,
+        pool=timeout.pool,
+    )
+
+
+def to_legacy_timeout(timeout: HTTPXTimeout) -> httpx.Timeout:
+    if isinstance(timeout, httpx.Timeout):
+        return timeout
+
+    return httpx.Timeout(
+        connect=timeout.connect,
+        read=timeout.read,
+        write=timeout.write,
+        pool=timeout.pool,
+    )
+
+
+def legacy_async_client(
+    *,
+    timeout: HTTPXTimeout,
+    limits: HTTPXLimits,
+    headers: Mapping[str, str] | None = None,
+    follow_redirects: bool = False,
+) -> httpx.AsyncClient:
+    if isinstance(limits, httpx2.Limits):
+        resolved_limits = httpx.Limits(
+            max_connections=limits.max_connections,
+            max_keepalive_connections=limits.max_keepalive_connections,
+            keepalive_expiry=limits.keepalive_expiry,
+        )
+    else:
+        resolved_limits = limits
+
+    return httpx.AsyncClient(
+        timeout=to_legacy_timeout(timeout),
+        limits=resolved_limits,
+        headers=headers,
+        follow_redirects=follow_redirects,
+    )

--- a/livekit-agents/pyproject.toml
+++ b/livekit-agents/pyproject.toml
@@ -49,7 +49,10 @@ dependencies = [
     "opentelemetry-sdk>=1.39.0,<1.45",
     "opentelemetry-exporter-otlp>=1.39.0,<1.45",
     "prometheus-client>=0.22",
-    "openai>=2,<3",
+    # Keep legacy HTTPX for compatibility with user inputs and upstream SDKs until 2.0.
+    "httpx>=0.27,<1",
+    "httpx2>=2.7,<3",
+    "openai>=3,<4",
     "aiofiles>=24",
     "json-repair==0.60.1",
     "pyyaml>=6.0.3",
@@ -61,7 +64,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-mcp = ["mcp>=1.24.0, <2"]
+mcp = ["mcp>=2,<3"]
 codecs = ["numpy>=1.26.0"]
 images = ["pillow>=10.3.0"]
 anam = ["livekit-plugins-anam>=1.6.10"]

--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
@@ -19,7 +19,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, Literal, cast
 
-import httpx
+import httpx2
 
 import anthropic
 from livekit.agents import APIConnectionError, APIStatusError, APITimeoutError, llm
@@ -32,7 +32,7 @@ from livekit.agents.types import (
     APIConnectOptions,
     NotGivenOr,
 )
-from livekit.agents.utils import is_given
+from livekit.agents.utils import httpx_compat, is_given
 
 from .models import ChatModels
 from .utils import CACHE_CONTROL_EPHEMERAL
@@ -75,7 +75,7 @@ class LLM(llm.LLM):
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
         caching: NotGivenOr[Literal["ephemeral"]] = NOT_GIVEN,
-        timeout: NotGivenOr[httpx.Timeout] = NOT_GIVEN,
+        timeout: NotGivenOr[httpx_compat.HTTPXTimeout] = NOT_GIVEN,
         max_retries: NotGivenOr[int] = NOT_GIVEN,
         _strict_tool_schema: bool = True,
     ) -> None:
@@ -92,11 +92,11 @@ class LLM(llm.LLM):
         client (anthropic.AsyncClient | None): The Anthropic client to use. Defaults to None.
         max_retries (int, optional): Vendor client retries. Defaults to 0 because the framework
             owns retries via ``conn_options``.
-        timeout (httpx.Timeout | None): HTTP timeout configuration for the underlying httpx client.
-            Defaults to ``httpx.Timeout(5.0, read=30.0)``, which keeps a tight connect timeout
+        timeout (httpx2.Timeout | None): HTTP timeout configuration for the underlying client.
+            Defaults to ``httpx2.Timeout(5.0, read=30.0)``, which keeps a tight connect timeout
             while allowing up to 30 s between streamed chunks — long enough for Claude's
             adaptive-thinking phases without masking genuine network stalls.
-            Pass a custom ``httpx.Timeout`` to override (e.g. ``httpx.Timeout(5.0, read=60.0)``
+            Pass a custom ``httpx2.Timeout`` to override (e.g. ``httpx2.Timeout(5.0, read=60.0)``
             for very large contexts or extended thinking budgets).
         temperature (float, optional): The temperature for the Anthropic API. Defaults to None.
         parallel_tool_calls (bool, optional): Whether to parallelize tool calls. Defaults to None.
@@ -124,14 +124,22 @@ class LLM(llm.LLM):
                 " ANTHROPIC_API_KEY environment variable"
             )
 
+        if is_given(timeout):
+            httpx_compat.warn_on_legacy_timeout(cast(httpx_compat.HTTPXTimeout | None, timeout))
+        resolved_timeout = (
+            httpx_compat.to_httpx2_timeout(cast(httpx_compat.HTTPXTimeout, timeout))
+            if is_given(timeout) and timeout is not None
+            else httpx2.Timeout(5.0, read=30.0)
+        )
+        assert resolved_timeout is not None
         self._client = client or anthropic.AsyncClient(
             api_key=anthropic_api_key,
             base_url=base_url if is_given(base_url) else None,
             max_retries=max_retries if is_given(max_retries) else 0,
-            http_client=httpx.AsyncClient(
-                timeout=timeout or httpx.Timeout(5.0, read=30.0),
+            http_client=httpx_compat.legacy_async_client(
+                timeout=resolved_timeout,
                 follow_redirects=True,
-                limits=httpx.Limits(
+                limits=httpx2.Limits(
                     max_connections=1000,
                     max_keepalive_connections=100,
                     keepalive_expiry=120,

--- a/livekit-plugins/livekit-plugins-anthropic/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-anthropic/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3 :: Only",
 ]
-dependencies = ["livekit-agents>=1.6.10", "anthropic>=0.41", "httpx"]
+dependencies = ["livekit-agents>=1.6.10", "anthropic>=0.41"]
 
 [project.urls]
 Documentation = "https://docs.livekit.io"

--- a/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-azure/livekit/plugins/azure/responses/llm.py
@@ -1,4 +1,3 @@
-import httpx
 from openai import AsyncAzureOpenAI
 from openai.types import Reasoning
 from openai.types.shared_params import ResponsesModel
@@ -8,8 +7,9 @@ from livekit.agents.types import (
     NOT_GIVEN,
     NotGivenOr,
 )
+from livekit.agents.utils import httpx_compat
 from livekit.plugins import openai
-from livekit.plugins.openai.utils import AsyncAzureADTokenProvider
+from livekit.plugins.openai.utils import AsyncAzureADTokenProvider, create_http_client
 
 
 class LLM(openai.responses.LLM):
@@ -30,7 +30,7 @@ class LLM(openai.responses.LLM):
         temperature: NotGivenOr[float] = NOT_GIVEN,
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
-        timeout: httpx.Timeout | None = None,
+        timeout: httpx_compat.HTTPXTimeout | None = None,
         reasoning: NotGivenOr[Reasoning] = NOT_GIVEN,
         max_output_tokens: NotGivenOr[int] = NOT_GIVEN,
     ) -> None:
@@ -44,6 +44,8 @@ class LLM(openai.responses.LLM):
         - `azure_endpoint` from `AZURE_OPENAI_ENDPOINT`
         """  # noqa: E501
 
+        httpx_compat.warn_on_legacy_timeout(timeout)
+        timeout = httpx_compat.to_httpx2_timeout(timeout)
         azure_client = AsyncAzureOpenAI(
             max_retries=0,
             azure_endpoint=azure_endpoint,
@@ -55,9 +57,7 @@ class LLM(openai.responses.LLM):
             organization=organization,
             project=project,
             base_url=base_url,
-            timeout=timeout
-            if timeout
-            else httpx.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
+            http_client=create_http_client(timeout),
         )  # type: ignore
 
         super().__init__(

--- a/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/llm.py
+++ b/livekit-plugins/livekit-plugins-baseten/livekit/plugins/baseten/llm.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 
-import httpx
 import openai
 from openai.types import ReasoningEffort
 
@@ -11,7 +10,7 @@ from livekit.agents.types import (
     NOT_GIVEN,
     NotGivenOr,
 )
-from livekit.agents.utils import is_given
+from livekit.agents.utils import httpx_compat, is_given
 from livekit.plugins.openai import LLM as OpenAILLM
 
 from .models import LLMModels
@@ -33,7 +32,7 @@ class LLM(OpenAILLM):
         reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
         base_url: NotGivenOr[str] = "https://inference.baseten.co/v1",
         client: openai.AsyncClient | None = None,
-        timeout: httpx.Timeout | None = None,
+        timeout: httpx_compat.HTTPXTimeout | None = None,
     ):
         """
         Create a new instance of Baseten LLM.
@@ -51,6 +50,8 @@ class LLM(OpenAILLM):
             if model == "openai/gpt-oss-120b":
                 reasoning_effort = "low"
 
+        httpx_compat.warn_on_legacy_timeout(timeout)
+        timeout = httpx_compat.to_httpx2_timeout(timeout)
         super().__init__(
             model=model,
             api_key=api_key,

--- a/livekit-plugins/livekit-plugins-cambai/README.md
+++ b/livekit-plugins/livekit-plugins-cambai/README.md
@@ -130,7 +130,7 @@ async def entrypoint(ctx: agents.JobContext):
 - **enhance_named_entities** (bool): Enhanced pronunciation (default: False)
 - **sample_rate** (int | None): Audio sample rate (auto-detected from model if None)
 - **base_url** (str): API base URL
-- **http_session** (httpx.AsyncClient | None): Reusable HTTP session
+- **http_session** (aiohttp.ClientSession | None): Reusable HTTP session
 
 ### Available Models
 

--- a/livekit-plugins/livekit-plugins-cerebras/livekit/plugins/cerebras/llm.py
+++ b/livekit-plugins/livekit-plugins-cerebras/livekit/plugins/cerebras/llm.py
@@ -19,7 +19,7 @@ import json
 import os
 from typing import Any
 
-import httpx
+import httpx2
 import msgpack
 import openai
 from openai._models import FinalRequestOptions
@@ -31,8 +31,9 @@ from livekit.agents.types import (
     NOT_GIVEN,
     NotGivenOr,
 )
-from livekit.agents.utils import is_given
+from livekit.agents.utils import httpx_compat, is_given
 from livekit.plugins.openai import LLM as OpenAILLM
+from livekit.plugins.openai.utils import create_http_client
 
 from .models import CerebrasChatModels
 
@@ -62,7 +63,7 @@ class _CerebrasClient(openai.AsyncClient):
         options: FinalRequestOptions,
         *,
         retries_taken: int = 0,
-    ) -> httpx.Request:
+    ) -> httpx2.Request:
         if not (self._use_msgpack or self._use_gzip):
             return super()._build_request(options, retries_taken=retries_taken)
 
@@ -116,7 +117,7 @@ class LLM(OpenAILLM):
         prompt_cache_key: NotGivenOr[str] = NOT_GIVEN,
         top_p: NotGivenOr[float] = NOT_GIVEN,
         max_completion_tokens: NotGivenOr[int] = NOT_GIVEN,
-        timeout: httpx.Timeout | None = None,
+        timeout: httpx_compat.HTTPXTimeout | None = None,
         max_retries: NotGivenOr[int] = NOT_GIVEN,
         gzip_compression: bool = True,
         msgpack_encoding: bool = True,
@@ -135,6 +136,8 @@ class LLM(OpenAILLM):
         """
 
         cerebras_api_key = _get_api_key(api_key)
+        httpx_compat.warn_on_legacy_timeout(timeout)
+        timeout = httpx_compat.to_httpx2_timeout(timeout)
 
         created_client = False
         if client is None and (gzip_compression or msgpack_encoding):
@@ -144,17 +147,7 @@ class LLM(OpenAILLM):
                 api_key=cerebras_api_key,
                 base_url=base_url if is_given(base_url) else None,
                 max_retries=max_retries if is_given(max_retries) else 0,
-                http_client=httpx.AsyncClient(
-                    timeout=timeout
-                    if timeout
-                    else httpx.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
-                    follow_redirects=True,
-                    limits=httpx.Limits(
-                        max_connections=50,
-                        max_keepalive_connections=50,
-                        keepalive_expiry=120,
-                    ),
-                ),
+                http_client=create_http_client(timeout),
             )
             created_client = True
 

--- a/livekit-plugins/livekit-plugins-cerebras/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-cerebras/pyproject.toml
@@ -23,9 +23,8 @@ classifiers = [
 ]
 dependencies = [
     "livekit-agents[codecs, openai]>=1.6.10",
-    # _CerebrasClient._build_request sets options.content on FinalRequestOptions,
-    # a field added in openai 2.16.0 (binary request streaming support).
-    "openai>=2.16.0",
+    # _CerebrasClient uses the OpenAI 3 HTTPX2 request types.
+    "openai>=3,<4",
     "msgpack>=1.0",
     "msgpack-types>=0.7.0",
 ]

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/aiplatform_llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/aiplatform_llm.py
@@ -30,7 +30,7 @@ from collections.abc import AsyncGenerator, Callable, Generator
 from dataclasses import dataclass
 from typing import Any, Literal
 
-import httpx
+import httpx2
 import openai
 from openai.types.chat import ChatCompletionToolChoiceOptionParam, completion_create_params
 
@@ -46,13 +46,13 @@ from livekit.agents.types import (
     APIConnectOptions,
     NotGivenOr,
 )
-from livekit.agents.utils import is_given
+from livekit.agents.utils import httpx_compat, is_given
 
 ApiVersion = Literal["v1", "v1beta1"]
 
 
-class _GoogleBearerAuth(httpx.Auth):
-    """httpx auth handler that injects a Google OAuth bearer token.
+class _GoogleBearerAuth(httpx2.Auth):
+    """HTTPX2 auth handler that injects a Google OAuth bearer token.
 
     Accepts either a static token (useful for short-lived testing) or
     ``google.auth.credentials.Credentials``, which are refreshed lazily
@@ -91,14 +91,14 @@ class _GoogleBearerAuth(httpx.Auth):
         return self._static_token or ""
 
     def sync_auth_flow(
-        self, request: httpx.Request
-    ) -> Generator[httpx.Request, httpx.Response, None]:
+        self, request: httpx2.Request
+    ) -> Generator[httpx2.Request, httpx2.Response, None]:
         request.headers["Authorization"] = f"Bearer {self._current_token()}"
         yield request
 
     async def async_auth_flow(
-        self, request: httpx.Request
-    ) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        self, request: httpx2.Request
+    ) -> AsyncGenerator[httpx2.Request, httpx2.Response]:
         request.headers["Authorization"] = f"Bearer {self._current_token()}"
         yield request
 
@@ -153,7 +153,7 @@ class AIPlatformLLM(llm.LLM):
         extra_query: NotGivenOr[dict[str, str]] = NOT_GIVEN,
         strict_tool_schema: bool = True,
         client: openai.AsyncClient | None = None,
-        timeout: httpx.Timeout | None = None,
+        timeout: httpx_compat.HTTPXTimeout | None = None,
     ) -> None:
         """Create a new AIPlatformLLM.
 
@@ -183,6 +183,8 @@ class AIPlatformLLM(llm.LLM):
                 responsible for those concerns.
         """
         super().__init__()
+        httpx_compat.warn_on_legacy_timeout(timeout)
+        timeout = httpx_compat.to_httpx2_timeout(timeout)
 
         self._opts = _AIPlatformOptions(
             model=model,
@@ -226,13 +228,13 @@ class AIPlatformLLM(llm.LLM):
                 api_key="ignored-auth-comes-from-httpx-auth",
                 base_url=base_url,
                 max_retries=0,
-                http_client=httpx.AsyncClient(
+                http_client=openai.DefaultAsyncHttpx2Client(
                     auth=auth,
                     timeout=timeout
                     if timeout is not None
-                    else httpx.Timeout(connect=10.0, read=10.0, write=10.0, pool=5.0),
+                    else httpx2.Timeout(connect=10.0, read=10.0, write=10.0, pool=5.0),
                     follow_redirects=True,
-                    limits=httpx.Limits(
+                    limits=httpx2.Limits(
                         max_connections=50,
                         max_keepalive_connections=50,
                         keepalive_expiry=120,

--- a/livekit-plugins/livekit-plugins-groq/livekit/plugins/groq/services.py
+++ b/livekit-plugins/livekit-plugins-groq/livekit/plugins/groq/services.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 
-import httpx
 import openai
 from openai.types import ReasoningEffort
 
@@ -11,7 +10,7 @@ from livekit.agents.types import (
     NOT_GIVEN,
     NotGivenOr,
 )
-from livekit.agents.utils import is_given
+from livekit.agents.utils import httpx_compat, is_given
 from livekit.plugins.openai import LLM as OpenAILLM, STT as OpenAISTT
 
 from .models import LLMModels, STTModels
@@ -35,7 +34,7 @@ class LLM(OpenAILLM):
         max_completion_tokens: NotGivenOr[int] = NOT_GIVEN,
         reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
         service_tier: NotGivenOr[str] = NOT_GIVEN,
-        timeout: httpx.Timeout | None = None,
+        timeout: httpx_compat.HTTPXTimeout | None = None,
         max_retries: NotGivenOr[int] = NOT_GIVEN,
         client: openai.AsyncClient | None = None,
     ):
@@ -52,6 +51,8 @@ class LLM(OpenAILLM):
             elif model in ["qwen/qwen3-32b"]:
                 reasoning_effort = "none"
 
+        httpx_compat.warn_on_legacy_timeout(timeout)
+        timeout = httpx_compat.to_httpx2_timeout(timeout)
         super().__init__(
             model=model,
             api_key=_get_api_key(api_key),

--- a/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/tts.py
+++ b/livekit-plugins/livekit-plugins-mistralai/livekit/plugins/mistralai/tts.py
@@ -7,8 +7,6 @@ import uuid
 from dataclasses import dataclass, replace
 from typing import Literal
 
-import httpx
-
 from livekit.agents import (
     APIConnectionError,
     APIConnectOptions,
@@ -17,7 +15,7 @@ from livekit.agents import (
     tts,
 )
 from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, NotGivenOr
-from livekit.agents.utils import is_given
+from livekit.agents.utils import httpx_compat, is_given
 from mistralai.client import Mistral
 from mistralai.client.errors import SDKError
 
@@ -184,7 +182,7 @@ class ChunkedStream(tts.ChunkedStream):
 
             output_emitter.flush()
 
-        except httpx.TimeoutException as e:
+        except httpx_compat.LegacyTimeoutException as e:
             raise APITimeoutError() from e
         except SDKError as e:
             raise APIStatusError(e.message, status_code=e.status_code, body=e.body) from e

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -19,8 +19,6 @@ from dataclasses import asdict, dataclass
 from typing import Any, Literal
 from urllib.parse import urlparse
 
-import httpx
-
 import openai
 from livekit.agents import llm
 from livekit.agents.inference.llm import LLMStream as _LLMStream
@@ -35,7 +33,7 @@ from livekit.agents.types import (
     APIConnectOptions,
     NotGivenOr,
 )
-from livekit.agents.utils import is_given
+from livekit.agents.utils import httpx_compat, is_given
 from openai.types import ReasoningEffort
 from openai.types.chat import ChatCompletionToolChoiceOptionParam, completion_create_params
 
@@ -55,7 +53,7 @@ from .models import (
     XAIChatModels,
     _supports_reasoning_effort,
 )
-from .utils import AsyncAzureADTokenProvider
+from .utils import AsyncAzureADTokenProvider, create_http_client
 
 lk_oai_debug = int(os.getenv("LK_OPENAI_DEBUG", 0))
 
@@ -103,7 +101,7 @@ class LLM(llm.LLM):
         store: NotGivenOr[bool] = NOT_GIVEN,
         metadata: NotGivenOr[dict[str, str]] = NOT_GIVEN,
         max_completion_tokens: NotGivenOr[int] = NOT_GIVEN,
-        timeout: httpx.Timeout | None = None,
+        timeout: httpx_compat.HTTPXTimeout | None = None,
         max_retries: NotGivenOr[int] = NOT_GIVEN,
         service_tier: NotGivenOr[str] = NOT_GIVEN,
         reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
@@ -122,6 +120,8 @@ class LLM(llm.LLM):
         ``OPENAI_API_KEY`` environmental variable.
         """
         super().__init__()
+        httpx_compat.warn_on_legacy_timeout(timeout)
+        timeout = httpx_compat.to_httpx2_timeout(timeout)
 
         if not is_given(reasoning_effort) and _supports_reasoning_effort(model):
             if model in ["gpt-5.1", "gpt-5.2", "gpt-5.4", "gpt-5.4-mini"]:
@@ -162,17 +162,7 @@ class LLM(llm.LLM):
             api_key=api_key if is_given(api_key) else None,
             base_url=base_url if is_given(base_url) else None,
             max_retries=max_retries if is_given(max_retries) else 0,
-            http_client=httpx.AsyncClient(
-                timeout=timeout
-                if timeout
-                else httpx.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
-                follow_redirects=True,
-                limits=httpx.Limits(
-                    max_connections=50,
-                    max_keepalive_connections=50,
-                    keepalive_expiry=120,
-                ),
-            ),
+            http_client=create_http_client(timeout),
         )
 
     async def _prewarm_impl(self) -> None:
@@ -212,7 +202,7 @@ class LLM(llm.LLM):
         temperature: NotGivenOr[float] = NOT_GIVEN,
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
-        timeout: httpx.Timeout | None = None,
+        timeout: httpx_compat.HTTPXTimeout | None = None,
         reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
         top_p: NotGivenOr[float] = NOT_GIVEN,
         verbosity: NotGivenOr[Verbosity] = NOT_GIVEN,
@@ -228,6 +218,8 @@ class LLM(llm.LLM):
         - `azure_endpoint` from `AZURE_OPENAI_ENDPOINT`
         """  # noqa: E501
 
+        httpx_compat.warn_on_legacy_timeout(timeout)
+        timeout = httpx_compat.to_httpx2_timeout(timeout)
         azure_client = openai.AsyncAzureOpenAI(
             max_retries=0,
             azure_endpoint=azure_endpoint,
@@ -239,9 +231,7 @@ class LLM(llm.LLM):
             organization=organization,
             project=project,
             base_url=base_url,
-            timeout=timeout
-            if timeout
-            else httpx.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
+            http_client=create_http_client(timeout),
         )  # type: ignore
 
         llm = LLM(
@@ -459,7 +449,7 @@ class LLM(llm.LLM):
         safety_identifier: NotGivenOr[str] = NOT_GIVEN,
         prompt_cache_key: NotGivenOr[str] = NOT_GIVEN,
         top_p: NotGivenOr[float] = NOT_GIVEN,
-        timeout: httpx.Timeout | None = None,
+        timeout: httpx_compat.HTTPXTimeout | None = None,
     ) -> LLM:
         """
         Create a new instance of OpenRouter LLM.
@@ -473,6 +463,9 @@ class LLM(llm.LLM):
             raise ValueError(
                 "OpenRouter API key is required, either as argument or set OPENROUTER_API_KEY environment variable"
             )
+
+        httpx_compat.warn_on_legacy_timeout(timeout)
+        timeout = httpx_compat.to_httpx2_timeout(timeout)
 
         # Set up analytics headers for OpenRouter
         default_headers: dict[str, str] = {}

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Literal, cast
 
 import aiohttp
-import httpx
+import httpx2
 from yarl import URL
 
 import openai
@@ -25,7 +25,7 @@ from livekit.agents.types import (
     APIConnectOptions,
     NotGivenOr,
 )
-from livekit.agents.utils import is_given
+from livekit.agents.utils import httpx_compat, is_given
 from openai.types import Reasoning
 from openai.types.responses import (
     ResponseCompletedEvent,
@@ -45,6 +45,7 @@ from openai.types.shared_params import ResponsesModel
 from ..log import logger
 from ..models import _supports_reasoning_effort
 from ..tools import OpenAITool
+from ..utils import create_http_client
 
 ServiceTier = Literal["auto", "default", "flex", "scale", "priority"]
 Verbosity = Literal["low", "medium", "high"]
@@ -225,7 +226,7 @@ class LLM(llm.LLM):
         service_tier: NotGivenOr[ServiceTier] = NOT_GIVEN,
         verbosity: NotGivenOr[Verbosity] = NOT_GIVEN,
         max_output_tokens: NotGivenOr[int] = NOT_GIVEN,
-        timeout: httpx.Timeout | None = None,
+        timeout: httpx_compat.HTTPXTimeout | None = None,
     ) -> None:
         """
         Create a new instance of OpenAI Responses LLM.
@@ -234,6 +235,8 @@ class LLM(llm.LLM):
         ``OPENAI_API_KEY`` environmental variable.
         """
         super().__init__()
+        httpx_compat.warn_on_legacy_timeout(timeout)
+        timeout = httpx_compat.to_httpx2_timeout(timeout)
 
         if not is_given(reasoning) and _supports_reasoning_effort(model):
             if model in ["gpt-5.1", "gpt-5.2", "gpt-5.4", "gpt-5.4-mini"]:
@@ -288,17 +291,7 @@ class LLM(llm.LLM):
                 api_key=api_key if is_given(api_key) else None,
                 base_url=base_url if is_given(base_url) else None,
                 max_retries=0,
-                http_client=httpx.AsyncClient(
-                    timeout=timeout
-                    if timeout
-                    else httpx.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
-                    follow_redirects=True,
-                    limits=httpx.Limits(
-                        max_connections=50,
-                        max_keepalive_connections=50,
-                        keepalive_expiry=120,
-                    ),
-                ),
+                http_client=create_http_client(timeout),
             )
 
     async def aclose(self) -> None:
@@ -506,7 +499,7 @@ class LLMStream(llm.LLMStream):
                         tools=tool_schemas,
                         input=cast(str | ResponseInputParam | openai.Omit, chat_ctx),
                         stream=True,
-                        timeout=httpx.Timeout(self._conn_options.timeout),
+                        timeout=httpx2.Timeout(self._conn_options.timeout),
                         **self._extra_kwargs,
                     ),
                 )

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass, field
 from urllib.parse import urlencode, urlparse
 
 import aiohttp
-import httpx
+import httpx2
 from pydantic import TypeAdapter
 
 import openai
@@ -48,7 +48,7 @@ from livekit.agents.types import (
     NOT_GIVEN,
     NotGivenOr,
 )
-from livekit.agents.utils import AudioBuffer, is_given
+from livekit.agents.utils import AudioBuffer, httpx_compat, is_given
 from openai.types.audio import Transcription, TranscriptionVerbose
 from openai.types.beta.realtime.transcription_session_update_param import (
     SessionTurnDetection,
@@ -72,7 +72,7 @@ from openai.types.realtime.session_update_event import SessionUpdateEvent
 
 from .log import logger
 from .models import STTModels
-from .utils import AsyncAzureADTokenProvider
+from .utils import AsyncAzureADTokenProvider, create_http_client
 
 # OpenAI Realtime API has a timeout of 15 mins, we'll attempt to restart the session
 # before that timeout is reached
@@ -306,15 +306,7 @@ class STT(stt.STT):
             max_retries=0,
             api_key=api_key if is_given(api_key) else None,
             base_url=base_url if is_given(base_url) else None,
-            http_client=httpx.AsyncClient(
-                timeout=httpx.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
-                follow_redirects=True,
-                limits=httpx.Limits(
-                    max_connections=50,
-                    max_keepalive_connections=50,
-                    keepalive_expiry=120,
-                ),
-            ),
+            http_client=create_http_client(),
         )
 
         self._streams = weakref.WeakSet[SpeechStream]()
@@ -354,7 +346,7 @@ class STT(stt.STT):
         project: str | None = None,
         base_url: str | None = None,
         use_realtime: NotGivenOr[bool] = NOT_GIVEN,
-        timeout: httpx.Timeout | None = None,
+        timeout: httpx_compat.HTTPXTimeout | None = None,
         vad: NotGivenOr[vad.VAD | None] = NOT_GIVEN,
     ) -> STT:
         """
@@ -369,6 +361,8 @@ class STT(stt.STT):
         - `azure_endpoint` from `AZURE_OPENAI_ENDPOINT`
         """  # noqa: E501
 
+        httpx_compat.warn_on_legacy_timeout(timeout)
+        timeout = httpx_compat.to_httpx2_timeout(timeout)
         azure_client = openai.AsyncAzureOpenAI(
             max_retries=0,
             azure_endpoint=azure_endpoint,
@@ -380,9 +374,7 @@ class STT(stt.STT):
             organization=organization,
             project=project,
             base_url=base_url,
-            timeout=timeout
-            if timeout
-            else httpx.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
+            http_client=create_http_client(timeout),
         )  # type: ignore
 
         return STT(
@@ -637,7 +629,7 @@ class STT(stt.STT):
                 temperature=self._opts.temperature
                 if is_given(self._opts.temperature)
                 else openai.omit,
-                timeout=httpx.Timeout(30, connect=conn_options.timeout),
+                timeout=httpx2.Timeout(30, connect=conn_options.timeout),
             )
 
             # the detected language beats the hint, dominant code first; an empty list keeps it

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -20,7 +20,7 @@ import json
 from dataclasses import dataclass, replace
 from typing import Literal
 
-import httpx
+import httpx2
 
 import openai
 from livekit.agents import (
@@ -31,10 +31,10 @@ from livekit.agents import (
     tts,
 )
 from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, NotGivenOr
-from livekit.agents.utils import aio, is_given
+from livekit.agents.utils import aio, httpx_compat, is_given
 
 from .models import TTSModels, TTSVoices
-from .utils import AsyncAzureADTokenProvider
+from .utils import AsyncAzureADTokenProvider, create_http_client
 
 SAMPLE_RATE = 24000
 NUM_CHANNELS = 1
@@ -100,13 +100,7 @@ class TTS(tts.TTS):
             max_retries=0,
             api_key=api_key if is_given(api_key) else None,
             base_url=base_url if is_given(base_url) else None,
-            http_client=httpx.AsyncClient(
-                timeout=httpx.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
-                follow_redirects=True,
-                limits=httpx.Limits(
-                    max_connections=50, max_keepalive_connections=50, keepalive_expiry=120
-                ),
-            ),
+            http_client=create_http_client(),
         )
 
         self._prewarm_task: asyncio.Task | None = None
@@ -153,7 +147,7 @@ class TTS(tts.TTS):
         project: str | None = None,
         base_url: str | None = None,
         response_format: NotGivenOr[RESPONSE_FORMATS] = NOT_GIVEN,
-        timeout: httpx.Timeout | None = None,
+        timeout: httpx_compat.HTTPXTimeout | None = None,
     ) -> TTS:
         """
         Create a new instance of Azure OpenAI TTS.
@@ -168,6 +162,8 @@ class TTS(tts.TTS):
         - `azure_endpoint` from `AZURE_OPENAI_ENDPOINT`
         """
 
+        httpx_compat.warn_on_legacy_timeout(timeout)
+        timeout = httpx_compat.to_httpx2_timeout(timeout)
         azure_client = openai.AsyncAzureOpenAI(
             max_retries=0,
             azure_endpoint=azure_endpoint,
@@ -179,9 +175,7 @@ class TTS(tts.TTS):
             organization=organization,
             project=project,
             base_url=base_url,
-            timeout=timeout
-            if timeout
-            else httpx.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
+            http_client=create_http_client(timeout),
         )  # type: ignore
 
         tts = TTS(
@@ -238,7 +232,7 @@ class AudioChunkedStream(tts.ChunkedStream):
             speed=self._opts.speed,
             instructions=self._opts.instructions or openai.omit,
             stream_format="audio",
-            timeout=httpx.Timeout(30, connect=self._conn_options.timeout),
+            timeout=httpx2.Timeout(30, connect=self._conn_options.timeout),
         )
 
         try:
@@ -282,7 +276,7 @@ class SSEChunkedStream(tts.ChunkedStream):
             speed=self._opts.speed,
             instructions=self._opts.instructions or openai.omit,
             stream_format="sse",
-            timeout=httpx.Timeout(30, connect=self._conn_options.timeout),
+            timeout=httpx2.Timeout(30, connect=self._conn_options.timeout),
         )
 
         try:

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/utils.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/utils.py
@@ -3,7 +3,23 @@ from __future__ import annotations
 import os
 from collections.abc import Awaitable, Callable
 
+import httpx2
+
+import openai
+
 AsyncAzureADTokenProvider = Callable[[], str | Awaitable[str]]
+
+
+def create_http_client(timeout: httpx2.Timeout | None = None) -> httpx2.AsyncClient:
+    return openai.DefaultAsyncHttpx2Client(
+        timeout=timeout or httpx2.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
+        follow_redirects=True,
+        limits=httpx2.Limits(
+            max_connections=50,
+            max_keepalive_connections=50,
+            keepalive_expiry=120,
+        ),
+    )
 
 
 def get_base_url(base_url: str | None) -> str:
@@ -12,4 +28,4 @@ def get_base_url(base_url: str | None) -> str:
     return base_url
 
 
-__all__ = ["get_base_url", "AsyncAzureADTokenProvider"]
+__all__ = ["get_base_url", "create_http_client", "AsyncAzureADTokenProvider"]

--- a/livekit-plugins/livekit-plugins-openai/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-openai/pyproject.toml
@@ -23,8 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "livekit-agents[codecs, images]>=1.6.10",
-    # keywords/languages on the transcription APIs landed in 2.50
-    "openai[realtime]>=2.50",
+    "openai[realtime]>=3,<4",
 ]
 
 

--- a/livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/llm.py
+++ b/livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/llm.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import os
 
-import httpx
 import openai
 
 from livekit.agents.llm import ToolChoice
@@ -24,7 +23,7 @@ from livekit.agents.types import (
     NOT_GIVEN,
     NotGivenOr,
 )
-from livekit.agents.utils import is_given
+from livekit.agents.utils import httpx_compat, is_given
 from livekit.plugins.openai import LLM as OpenAILLM
 
 from .models import PerplexityChatModels
@@ -47,7 +46,7 @@ class LLM(OpenAILLM):
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
         top_p: NotGivenOr[float] = NOT_GIVEN,
-        timeout: httpx.Timeout | None = None,
+        timeout: httpx_compat.HTTPXTimeout | None = None,
     ):
         """
         Create a new instance of Perplexity LLM.
@@ -62,6 +61,8 @@ class LLM(OpenAILLM):
                 "PERPLEXITY_API_KEY environmental variable"
             )
 
+        httpx_compat.warn_on_legacy_timeout(timeout)
+        timeout = httpx_compat.to_httpx2_timeout(timeout)
         super().__init__(
             model=model,
             api_key=api_key,

--- a/livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/responses/llm.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 
-import httpx
+import httpx2
 import openai as openai_api
 from openai.types import Reasoning
 
@@ -11,8 +11,9 @@ from livekit.agents.types import (
     NOT_GIVEN,
     NotGivenOr,
 )
-from livekit.agents.utils import is_given
+from livekit.agents.utils import httpx_compat, is_given
 from livekit.plugins import openai
+from livekit.plugins.openai.utils import create_http_client
 
 from ..models import PerplexityResponsesModels
 from ..version import __version__
@@ -25,24 +26,14 @@ def _create_client(
     *,
     api_key: str,
     base_url: str,
-    timeout: httpx.Timeout | None,
+    timeout: httpx2.Timeout | None,
 ) -> openai_api.AsyncClient:
     return openai_api.AsyncClient(
         api_key=api_key,
         base_url=base_url,
         default_headers=_ATTRIBUTION_HEADER,
         max_retries=0,
-        http_client=httpx.AsyncClient(
-            timeout=timeout
-            if timeout
-            else httpx.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
-            follow_redirects=True,
-            limits=httpx.Limits(
-                max_connections=50,
-                max_keepalive_connections=50,
-                keepalive_expiry=120,
-            ),
-        ),
+        http_client=create_http_client(timeout),
     )
 
 
@@ -57,7 +48,7 @@ class LLM(openai.responses.LLM):
         temperature: NotGivenOr[float] = NOT_GIVEN,
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
-        timeout: httpx.Timeout | None = None,
+        timeout: httpx_compat.HTTPXTimeout | None = None,
         reasoning: NotGivenOr[Reasoning] = NOT_GIVEN,
         max_output_tokens: NotGivenOr[int] = NOT_GIVEN,
     ) -> None:
@@ -75,6 +66,8 @@ class LLM(openai.responses.LLM):
             )
 
         resolved_base_url = base_url if is_given(base_url) else PERPLEXITY_RESPONSES_BASE_URL
+        httpx_compat.warn_on_legacy_timeout(timeout)
+        timeout = httpx_compat.to_httpx2_timeout(timeout)
         client = _create_client(api_key=api_key, base_url=resolved_base_url, timeout=timeout)
 
         super().__init__(

--- a/livekit-plugins/livekit-plugins-rtzr/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-rtzr/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 ]
 dependencies = [
     "livekit-agents>=1.6.10",
-    "httpx>=0.24.0",
     "aiohttp>=3.9.0",
 ]
 

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/llm/client.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/llm/client.py
@@ -18,14 +18,13 @@ import os
 import platform
 from typing import Any
 
-import httpx
 import openai
 from openai.types import ReasoningEffort
 
 from livekit.agents import __version__ as livekit_version
 from livekit.agents.llm import ToolChoice
 from livekit.agents.types import NOT_GIVEN, NotGivenOr
-from livekit.agents.utils import is_given
+from livekit.agents.utils import httpx_compat, is_given
 from livekit.plugins.openai.llm import LLM as OpenAILLM
 
 from .models import SarvamLLMModels
@@ -72,7 +71,7 @@ class LLM(OpenAILLM):
         presence_penalty: NotGivenOr[float] = NOT_GIVEN,
         extra_headers: NotGivenOr[dict[str, str]] = NOT_GIVEN,
         extra_body: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
-        timeout: httpx.Timeout | None = None,
+        timeout: httpx_compat.HTTPXTimeout | None = None,
     ) -> None:
         """
         Create a new instance of Sarvam LLM.
@@ -104,6 +103,8 @@ class LLM(OpenAILLM):
             merged_body["presence_penalty"] = presence_penalty
         filtered_body = _filter_extra_body(merged_body)
 
+        httpx_compat.warn_on_legacy_timeout(timeout)
+        timeout = httpx_compat.to_httpx2_timeout(timeout)
         super().__init__(
             model=validated_model,
             api_key=sarvam_api_key,

--- a/livekit-plugins/livekit-plugins-speechify/livekit/plugins/speechify/tts.py
+++ b/livekit-plugins/livekit-plugins-speechify/livekit/plugins/speechify/tts.py
@@ -20,7 +20,7 @@ import os
 from dataclasses import dataclass, replace
 from typing import Any, cast
 
-import httpx
+import httpx2
 
 from livekit.agents import (
     APIConnectionError,
@@ -37,7 +37,7 @@ from livekit.agents.types import (
     NOT_GIVEN,
     NotGivenOr,
 )
-from livekit.agents.utils import is_given
+from livekit.agents.utils import httpx_compat, is_given
 from livekit.agents.voice.io import TimedString
 from speechify.client import AsyncSpeechify
 from speechify.core.api_error import ApiError
@@ -149,14 +149,14 @@ class TTS(tts.TTS):
                     "Speechify API key is required, either as the api_key argument "
                     "or via the SPEECHIFY_API_KEY environment variable"
                 )
-            # Fixed httpx.AsyncClient default header so every request the SDK
-            # issues is attributed to this integration, regardless of call site.
+            # Set the SDK client's default header so every request is attributed
+            # to this integration, regardless of call site.
             # Timeout/limits mirror the openai plugin's owned-client defaults —
-            # httpx's own 5s default is too short for longer synthesis requests.
-            self._httpx_client = httpx.AsyncClient(
+            # The SDK client's 5s default is too short for longer synthesis requests.
+            self._httpx_client = httpx_compat.legacy_async_client(
                 headers={CALLER_HEADER: "livekit"},
-                timeout=httpx.Timeout(connect=15.0, read=30.0, write=30.0, pool=5.0),
-                limits=httpx.Limits(
+                timeout=httpx2.Timeout(connect=15.0, read=30.0, write=30.0, pool=5.0),
+                limits=httpx2.Limits(
                     max_connections=50, max_keepalive_connections=50, keepalive_expiry=120
                 ),
             )

--- a/livekit-plugins/livekit-plugins-spitch/livekit/plugins/spitch/stt.py
+++ b/livekit-plugins/livekit-plugins-spitch/livekit/plugins/spitch/stt.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 from dataclasses import dataclass
 
-import httpx
+import httpx2
 
 import spitch
 from livekit import rtc
@@ -17,7 +17,7 @@ from livekit.agents import (
     NotGivenOr,
 )
 from livekit.agents.stt import stt
-from livekit.agents.utils import AudioBuffer
+from livekit.agents.utils import AudioBuffer, httpx_compat
 from livekit.agents.voice.io import TimedString
 from spitch import AsyncSpitch
 
@@ -72,7 +72,9 @@ class STT(stt.STT):
             resp = await self._client.speech.transcribe(
                 language=config.language.language,
                 content=data,
-                timeout=httpx.Timeout(30, connect=conn_options.timeout),
+                timeout=httpx_compat.to_legacy_timeout(
+                    httpx2.Timeout(30, connect=conn_options.timeout)
+                ),
                 timestamp="word" if "mansa" in model else None,
             )
 

--- a/livekit-plugins/livekit-plugins-spitch/livekit/plugins/spitch/tts.py
+++ b/livekit-plugins/livekit-plugins-spitch/livekit/plugins/spitch/tts.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 
-import httpx
+import httpx2
 
 import spitch
 from livekit.agents import (
@@ -15,6 +15,7 @@ from livekit.agents import (
     LanguageCode,
     tts,
 )
+from livekit.agents.utils import httpx_compat
 from spitch import AsyncSpitch
 
 SAMPLE_RATE = 24_000
@@ -80,7 +81,9 @@ class ChunkedStream(tts.ChunkedStream):
             language=self._opts.language.language,
             voice=self._opts.voice,  # type: ignore
             format="mp3",
-            timeout=httpx.Timeout(30, connect=self._conn_options.timeout),
+            timeout=httpx_compat.to_legacy_timeout(
+                httpx2.Timeout(30, connect=self._conn_options.timeout)
+            ),
         )
 
         request_id = str(uuid.uuid4().hex)[:12]

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/responses/llm.py
@@ -1,6 +1,5 @@
 import os
 
-import httpx
 from openai.types import Reasoning
 
 from livekit.agents.llm import ToolChoice
@@ -8,7 +7,7 @@ from livekit.agents.types import (
     NOT_GIVEN,
     NotGivenOr,
 )
-from livekit.agents.utils import is_given
+from livekit.agents.utils import httpx_compat, is_given
 from livekit.plugins import openai
 
 from ..tools import XAITool
@@ -30,7 +29,7 @@ class LLM(openai.responses.LLM):
         temperature: NotGivenOr[float] = NOT_GIVEN,
         parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
         tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
-        timeout: httpx.Timeout | None = None,
+        timeout: httpx_compat.HTTPXTimeout | None = None,
         reasoning: NotGivenOr[Reasoning] = NOT_GIVEN,
         max_output_tokens: NotGivenOr[int] = NOT_GIVEN,
     ) -> None:
@@ -39,6 +38,8 @@ class LLM(openai.responses.LLM):
             raise ValueError(
                 "XAI API key is required, either as argument or set XAI_API_KEY environmental variable"  # noqa: E501
             )
+        httpx_compat.warn_on_legacy_timeout(timeout)
+        timeout = httpx_compat.to_httpx2_timeout(timeout)
         super().__init__(
             model=model,
             base_url=base_url if is_given(base_url) else XAI_BASE_URL,

--- a/tests/test_async_mcp.py
+++ b/tests/test_async_mcp.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
-from typing import Any, get_type_hints
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from typing import Any, Literal, get_type_hints
 
+import httpx2
 import pytest
+from mcp.shared.message import SessionMessage
+from mcp.types import JSONRPCNotification, JSONRPCRequest, JSONRPCResponse
 
 from livekit.agents.llm.async_toolset import AsyncToolset
 from livekit.agents.llm.mcp import (
     MCPServer,
+    MCPServerHTTP,
     MCPToolOptions,
     MCPToolset,
     _resolve_tool_options,
@@ -18,11 +25,129 @@ from livekit.agents.voice.tool_executor import has_cancellable_tool
 pytestmark = pytest.mark.unit
 
 
+async def test_http_server_uses_httpx2_client() -> None:
+    server = MCPServerHTTP("https://example.com/mcp")
+    client = server._create_http_client()
+
+    try:
+        assert isinstance(client, httpx2.AsyncClient)
+    finally:
+        await client.aclose()
+
+
+class _SSEStream(httpx2.AsyncByteStream):
+    def __init__(self) -> None:
+        self._closed = asyncio.Event()
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        yield b"event: endpoint\ndata: /messages/?session_id=test-session\n\n"
+        await self._closed.wait()
+
+    async def aclose(self) -> None:
+        self._closed.set()
+
+
+class _MockTransportMCPServer(MCPServerHTTP):
+    def __init__(
+        self,
+        url: str,
+        *,
+        transport_type: Literal["sse", "streamable_http"],
+        transport: httpx2.AsyncBaseTransport,
+    ) -> None:
+        super().__init__(url, transport_type=transport_type)
+        self._transport = transport
+
+    def _create_http_client(
+        self,
+        headers: dict[str, str] | None = None,
+        timeout: httpx2.Timeout | None = None,
+        auth: httpx2.Auth | None = None,
+    ) -> httpx2.AsyncClient:
+        return httpx2.AsyncClient(
+            transport=self._transport,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
+        )
+
+
+async def test_streamable_http_sends_request_with_httpx2() -> None:
+    requests: list[httpx2.Request] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        await request.aread()
+        requests.append(request)
+        body = json.loads(request.content)
+        return httpx2.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={"jsonrpc": "2.0", "id": body["id"], "result": {}},
+            request=request,
+        )
+
+    server = _MockTransportMCPServer(
+        "https://example.com/mcp",
+        transport_type="streamable_http",
+        transport=httpx2.MockTransport(handler),
+    )
+    async with server.client_streams() as (read_stream, write_stream):
+        await write_stream.send(
+            SessionMessage(JSONRPCRequest(jsonrpc="2.0", id=1, method="tools/list"))
+        )
+        reply = await asyncio.wait_for(read_stream.receive(), timeout=2)
+
+    assert isinstance(reply.message, JSONRPCResponse)
+    assert [(request.method, str(request.url)) for request in requests] == [
+        ("POST", "https://example.com/mcp")
+    ]
+
+
+async def test_sse_sends_request_with_httpx2() -> None:
+    requests: list[httpx2.Request] = []
+    posted = asyncio.Event()
+    sse_stream = _SSEStream()
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        await request.aread()
+        requests.append(request)
+        if request.method == "GET":
+            return httpx2.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                stream=sse_stream,
+                request=request,
+            )
+
+        posted.set()
+        return httpx2.Response(202, request=request)
+
+    server = _MockTransportMCPServer(
+        "https://example.com/sse",
+        transport_type="sse",
+        transport=httpx2.MockTransport(handler),
+    )
+    async with server.client_streams() as (_, write_stream):
+        await write_stream.send(
+            SessionMessage(JSONRPCNotification(jsonrpc="2.0", method="notifications/test"))
+        )
+        await asyncio.wait_for(posted.wait(), timeout=2)
+
+    assert [(request.method, str(request.url)) for request in requests] == [
+        ("GET", "https://example.com/sse"),
+        ("POST", "https://example.com/messages/?session_id=test-session"),
+    ]
+    assert json.loads(requests[1].content) == {
+        "jsonrpc": "2.0",
+        "method": "notifications/test",
+    }
+
+
 class _FakeToolDesc:
     def __init__(self, name: str) -> None:
         self.name = name
         self.description = "echo back"
-        self.inputSchema: dict[str, Any] = {"type": "object", "properties": {}}
+        self.input_schema: dict[str, Any] = {"type": "object", "properties": {}}
         self.meta = None
 
 

--- a/tests/test_httpx_compat.py
+++ b/tests/test_httpx_compat.py
@@ -1,0 +1,61 @@
+import httpx
+import httpx2
+import pytest
+
+from livekit.agents.utils import httpx_compat
+
+pytestmark = pytest.mark.unit
+
+
+def test_httpx2_timeout_passes_through() -> None:
+    timeout = httpx2.Timeout(connect=1, read=2, write=3, pool=4)
+
+    assert httpx_compat.to_httpx2_timeout(timeout) is timeout
+
+
+def test_legacy_timeout_warning_and_conversion_are_separate() -> None:
+    timeout = httpx.Timeout(connect=1, read=2, write=3, pool=4)
+
+    with pytest.warns(DeprecationWarning, match="no longer be supported.*2.0"):
+        httpx_compat.warn_on_legacy_timeout(timeout)
+
+    converted = httpx_compat.to_httpx2_timeout(timeout)
+
+    assert isinstance(converted, httpx2.Timeout)
+    assert converted.connect == 1
+    assert converted.read == 2
+    assert converted.write == 3
+    assert converted.pool == 4
+
+
+def test_httpx2_timeout_converts_for_legacy_sdk_without_warning() -> None:
+    timeout = httpx2.Timeout(connect=1, read=2, write=3, pool=4)
+
+    converted = httpx_compat.to_legacy_timeout(timeout)
+
+    assert isinstance(converted, httpx.Timeout)
+    assert converted.connect == 1
+    assert converted.read == 2
+    assert converted.write == 3
+    assert converted.pool == 4
+
+
+@pytest.mark.asyncio
+async def test_legacy_client_converts_httpx2_configuration() -> None:
+    client = httpx_compat.legacy_async_client(
+        timeout=httpx2.Timeout(connect=1, read=2, write=3, pool=4),
+        limits=httpx2.Limits(
+            max_connections=10,
+            max_keepalive_connections=5,
+            keepalive_expiry=30,
+        ),
+    )
+
+    try:
+        assert isinstance(client, httpx.AsyncClient)
+        assert client.timeout.connect == 1
+        assert client.timeout.read == 2
+        assert client.timeout.write == 3
+        assert client.timeout.pool == 4
+    finally:
+        await client.aclose()

--- a/tests/test_inference_llm_retry.py
+++ b/tests/test_inference_llm_retry.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 from collections.abc import AsyncIterator, Callable
 
-import httpx
+import httpx2
 import openai
 import pytest
 
@@ -81,7 +81,7 @@ _USAGE = _sse(
 )
 
 
-class _StallingStream(httpx.AsyncByteStream):
+class _StallingStream(httpx2.AsyncByteStream):
     """Yields the given SSE bytes, then stalls out like a provider going quiet."""
 
     def __init__(self, chunks: list[bytes]) -> None:
@@ -90,10 +90,10 @@ class _StallingStream(httpx.AsyncByteStream):
     async def __aiter__(self) -> AsyncIterator[bytes]:
         for chunk in self._chunks:
             yield chunk
-        raise httpx.ReadTimeout("stalled mid-stream")
+        raise httpx2.ReadTimeout("stalled mid-stream")
 
 
-class _CompletedStream(httpx.AsyncByteStream):
+class _CompletedStream(httpx2.AsyncByteStream):
     """Yields the given SSE bytes, then ends the stream cleanly."""
 
     def __init__(self, chunks: list[bytes]) -> None:
@@ -106,14 +106,14 @@ class _CompletedStream(httpx.AsyncByteStream):
 
 
 def _llm_for(
-    responder: Callable[[int], httpx.AsyncByteStream],
-) -> tuple[LLM, list[httpx.Request], list[LLMMetrics]]:
-    attempts: list[httpx.Request] = []
+    responder: Callable[[int], httpx2.AsyncByteStream],
+) -> tuple[LLM, list[httpx2.Request], list[LLMMetrics]]:
+    attempts: list[httpx2.Request] = []
     metrics: list[LLMMetrics] = []
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         attempts.append(request)
-        return httpx.Response(
+        return httpx2.Response(
             200,
             headers={"content-type": "text/event-stream"},
             stream=responder(len(attempts)),
@@ -126,7 +126,7 @@ def _llm_for(
         api_key=fake_secret,
         base_url="http://inference.test/v1",
         max_retries=0,
-        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(handler)),
     )
     llm_model.on("metrics_collected", metrics.append)
     return llm_model, attempts, metrics
@@ -141,7 +141,16 @@ def _drain(llm_model: LLM, *, max_retry: int):
     )
 
 
-async def _run(chunks: list[bytes], *, max_retry: int) -> tuple[Exception, list[httpx.Request]]:
+@pytest.mark.asyncio
+async def test_llm_uses_httpx2_transport() -> None:
+    fake_secret = "f" * 32
+    llm_model = LLM(model="openai/gpt-4o", api_key=fake_secret, api_secret=fake_secret)
+
+    assert isinstance(llm_model._client._client, httpx2.AsyncClient)
+    await llm_model.aclose()
+
+
+async def _run(chunks: list[bytes], *, max_retry: int) -> tuple[Exception, list[httpx2.Request]]:
     llm_model, attempts, _ = _llm_for(lambda _: _StallingStream(chunks))
 
     with pytest.raises(Exception) as exc_info:  # noqa: PT011
@@ -153,8 +162,8 @@ async def _run(chunks: list[bytes], *, max_retry: int) -> tuple[Exception, list[
 
 
 async def _run_to_completion(
-    responder: Callable[[int], httpx.AsyncByteStream], *, max_retry: int
-) -> tuple[list[LLMMetrics], list[httpx.Request]]:
+    responder: Callable[[int], httpx2.AsyncByteStream], *, max_retry: int
+) -> tuple[list[LLMMetrics], list[httpx2.Request]]:
     llm_model, attempts, metrics = _llm_for(responder)
 
     # aclose() awaits the metrics monitor, so metrics are settled once the block exits
@@ -208,7 +217,7 @@ async def test_stream_read_timeout_is_a_timeout_error() -> None:
 async def test_ttft_spans_the_retry() -> None:
     """The clock runs until generation, not until the failed attempt's metadata."""
 
-    def responder(attempt: int) -> httpx.AsyncByteStream:
+    def responder(attempt: int) -> httpx2.AsyncByteStream:
         if attempt == 1:
             return _StallingStream([_METADATA_ONLY])
         return _CompletedStream([_METADATA_ONLY, _TEXT, _USAGE])

--- a/tests/test_inference_llm_usage.py
+++ b/tests/test_inference_llm_usage.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import httpx
+import httpx2
 import openai as openai_sdk
 import pytest
 
 from livekit.agents import llm
-from livekit.plugins import openai
+from livekit.plugins import groq, openai
 
 pytestmark = pytest.mark.unit
 
@@ -25,15 +28,36 @@ data: [DONE]
 """
 
 
-class _NullUsageTransport(httpx.AsyncBaseTransport):
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+class _NullUsageTransport(httpx2.AsyncBaseTransport):
+    async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
         await request.aread()
-        return httpx.Response(
+        return httpx2.Response(
             200,
             headers={"content-type": "text/event-stream"},
             content=_STREAM_WITH_NULL_USAGE,
             request=request,
         )
+
+
+async def test_openai_llm_uses_httpx2_and_warns_for_legacy_timeout() -> None:
+    with pytest.warns(DeprecationWarning, match="LiveKit Agents 2.0") as warnings:
+        model = openai.LLM(api_key="test-key", timeout=httpx.Timeout(5))
+
+    try:
+        assert isinstance(model._client._client, httpx2.AsyncClient)
+        assert Path(warnings[0].filename).resolve() == Path(__file__).resolve()
+    finally:
+        await model.aclose()
+
+
+async def test_openai_wrapper_warning_points_to_application() -> None:
+    with pytest.warns(DeprecationWarning, match="LiveKit Agents 2.0") as warnings:
+        model = groq.LLM(api_key="test-key", timeout=httpx.Timeout(5))
+
+    try:
+        assert Path(warnings[0].filename).resolve() == Path(__file__).resolve()
+    finally:
+        await model.aclose()
 
 
 async def test_null_usage_fields_do_not_crash_stream() -> None:
@@ -42,7 +66,7 @@ async def test_null_usage_fields_do_not_crash_stream() -> None:
     # APIConnectionError and terminate the session). Missing counts default to 0.
     client = openai_sdk.AsyncClient(
         api_key="test-key",
-        http_client=httpx.AsyncClient(transport=_NullUsageTransport()),
+        http_client=httpx2.AsyncClient(transport=_NullUsageTransport()),
     )
     model = openai.LLM(model="m", client=client)
 

--- a/tests/test_inference_utils.py
+++ b/tests/test_inference_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-import httpx
+import httpx2
 import openai
 import pytest
 
@@ -57,9 +57,9 @@ def test_extract_quota_usage_empty_when_no_quota_headers() -> None:
     assert extract_quota_usage({"Content-Type": "application/json"}) == {}
 
 
-def test_extract_quota_usage_case_insensitive_with_httpx_headers() -> None:
-    """HTTP/2 lowercases field names on the wire; httpx.Headers lookup still matches."""
-    headers = httpx.Headers(
+def test_extract_quota_usage_case_insensitive_with_httpx2_headers() -> None:
+    """HTTP/2 lowercases field names on the wire; httpx2.Headers lookup still matches."""
+    headers = httpx2.Headers(
         {
             "x-livekit-inference-rpm-limit": "100",
             "x-livekit-inference-rpm-used": "42",
@@ -73,14 +73,14 @@ def test_extract_quota_usage_case_insensitive_with_httpx_headers() -> None:
 
 def test_llm_stream_logs_quota_on_429(caplog: pytest.LogCaptureFixture) -> None:
     """A 429 from the gateway logs a warning carrying the quota snapshot."""
-    response = httpx.Response(
+    response = httpx2.Response(
         429,
         headers={
             "x-request-id": "req_123",
             "X-LiveKit-Inference-RPM-Limit": "100",
             "X-LiveKit-Inference-RPM-Used": "101",
         },
-        request=httpx.Request("POST", "https://agent-gateway.livekit.cloud/v1/chat/completions"),
+        request=httpx2.Request("POST", "https://agent-gateway.livekit.cloud/v1/chat/completions"),
     )
     err = openai.APIStatusError("rate limited", response=response, body=None)
 
@@ -103,9 +103,9 @@ def test_llm_stream_logs_quota_on_429(caplog: pytest.LogCaptureFixture) -> None:
 
 def test_llm_stream_logs_429_without_quota_headers(caplog: pytest.LogCaptureFixture) -> None:
     """A 429 with no quota telemetry still logs, just without quota fields."""
-    response = httpx.Response(
+    response = httpx2.Response(
         429,
-        request=httpx.Request("POST", "https://agent-gateway.livekit.cloud/v1/chat/completions"),
+        request=httpx2.Request("POST", "https://agent-gateway.livekit.cloud/v1/chat/completions"),
     )
     err = openai.APIStatusError("rate limited", response=response, body=None)
 

--- a/tests/test_plugin_anthropic.py
+++ b/tests/test_plugin_anthropic.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import httpx
+import httpx2
 import pytest
 
 from livekit.agents import APIConnectOptions, llm
@@ -38,7 +39,7 @@ class TestHttpxTimeoutDefaults:
         assert connect <= 10.0, f"connect timeout {connect}s is unexpectedly long"
 
     def test_default_timeout_is_split(self) -> None:
-        """Default must be an httpx.Timeout object, not a flat scalar."""
+        """The Anthropic SDK boundary must receive its legacy timeout object."""
         llm = _make_llm()
         t = llm._client._client.timeout
         assert isinstance(t, httpx.Timeout)
@@ -47,12 +48,20 @@ class TestHttpxTimeoutDefaults:
 
 class TestHttpxTimeoutCustom:
     def test_custom_timeout_honored(self) -> None:
-        """A caller-supplied httpx.Timeout is passed through to the httpx client."""
-        custom = httpx.Timeout(3.0, read=120.0)
+        """A caller-supplied HTTPX2 timeout reaches the Anthropic SDK client."""
+        custom = httpx2.Timeout(3.0, read=120.0)
         llm = _make_llm(timeout=custom)
         t = llm._client._client.timeout
         assert t.read == 120.0
         assert t.connect == 3.0
+
+    def test_legacy_timeout_warns_and_remains_supported(self) -> None:
+        custom = httpx.Timeout(3.0, read=120.0)
+
+        with pytest.warns(DeprecationWarning, match="LiveKit Agents 2.0"):
+            llm = _make_llm(timeout=custom)
+
+        assert llm._client._client.timeout.read == 120.0
 
     def test_none_timeout_uses_default(self) -> None:
         """Passing timeout=None must fall back to the built-in default."""
@@ -68,7 +77,7 @@ class TestHttpxTimeoutCustom:
             http_client=httpx.AsyncClient(timeout=httpx.Timeout(1.0)),
         )
         # timeout= argument should have no effect here
-        llm = _make_llm(client=tight_client, timeout=httpx.Timeout(5.0, read=999.0))
+        llm = _make_llm(client=tight_client, timeout=httpx2.Timeout(5.0, read=999.0))
         assert llm._client._client.timeout.read == 1.0
 
 

--- a/tests/test_plugin_cerebras.py
+++ b/tests/test_plugin_cerebras.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 
-import httpx
+import httpx2
 import pytest
 
 from livekit.agents import Agent, AgentSession, RunContext, function_tool, llm
@@ -16,14 +16,14 @@ CHAT_MODEL = "gpt-oss-120b"
 TOOL_MODEL = "gpt-oss-120b"
 
 
-class HeaderCapturingTransport(httpx.AsyncBaseTransport):
+class HeaderCapturingTransport(httpx2.AsyncBaseTransport):
     """Wraps a real transport, capturing outgoing request headers for assertion."""
 
     def __init__(self) -> None:
-        self._inner = httpx.AsyncHTTPTransport()
-        self.captured_requests: list[httpx.Request] = []
+        self._inner = httpx2.AsyncHTTPTransport()
+        self.captured_requests: list[httpx2.Request] = []
 
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+    async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
         self.captured_requests.append(request)
         return await self._inner.handle_async_request(request)
 
@@ -78,7 +78,7 @@ def _cerebras_llm_with_transport(
     *, use_gzip: bool, use_msgpack: bool
 ) -> tuple[LLM, HeaderCapturingTransport]:
     transport = HeaderCapturingTransport()
-    http_client = httpx.AsyncClient(transport=transport)
+    http_client = httpx2.AsyncClient(transport=transport)
     client = _CerebrasClient(
         use_gzip=use_gzip,
         use_msgpack=use_msgpack,

--- a/tests/test_plugin_cerebras_request.py
+++ b/tests/test_plugin_cerebras_request.py
@@ -4,7 +4,7 @@ import gzip
 import inspect
 from typing import Any
 
-import httpx
+import httpx2
 import msgpack
 import pytest
 
@@ -25,14 +25,14 @@ data: [DONE]
 """
 
 
-class _MockChatCompletionsTransport(httpx.AsyncBaseTransport):
+class _MockChatCompletionsTransport(httpx2.AsyncBaseTransport):
     def __init__(self) -> None:
-        self.requests: list[httpx.Request] = []
+        self.requests: list[httpx2.Request] = []
 
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+    async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
         await request.aread()
         self.requests.append(request)
-        return httpx.Response(
+        return httpx2.Response(
             200,
             headers={"content-type": "text/event-stream"},
             content=_STREAM_RESPONSE,
@@ -40,14 +40,14 @@ class _MockChatCompletionsTransport(httpx.AsyncBaseTransport):
         )
 
 
-async def _capture_chat_request(max_completion_tokens: int | None = None) -> httpx.Request:
+async def _capture_chat_request(max_completion_tokens: int | None = None) -> httpx2.Request:
     transport = _MockChatCompletionsTransport()
     client = _CerebrasClient(
         use_gzip=True,
         use_msgpack=True,
         api_key="test-key",
         base_url="https://api.cerebras.ai/v1",
-        http_client=httpx.AsyncClient(transport=transport),
+        http_client=httpx2.AsyncClient(transport=transport),
     )
     if max_completion_tokens is None:
         model = LLM(model="gpt-oss-120b", api_key="test-key", client=client)
@@ -76,7 +76,7 @@ async def _capture_chat_request(max_completion_tokens: int | None = None) -> htt
     return transport.requests[0]
 
 
-def _request_payload(request: httpx.Request) -> dict[str, Any]:
+def _request_payload(request: httpx2.Request) -> dict[str, Any]:
     body = gzip.decompress(request.content)
     payload = msgpack.unpackb(body, raw=False)
     assert isinstance(payload, dict)

--- a/tests/test_plugin_openai_stt_context.py
+++ b/tests/test_plugin_openai_stt_context.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from typing import Any
 
 import aiohttp
-import httpx
+import httpx2
 import openai
 import pytest
 
@@ -713,27 +713,27 @@ async def test_session_keyterms_reach_the_next_connection() -> None:
     assert config["keywords"] == ["Acme Corp"]
 
 
-async def _transcription_form(instance: stt.STT, captured: list[httpx.Request]) -> str:
+async def _transcription_form(instance: stt.STT, captured: list[httpx2.Request]) -> str:
     event = await instance._recognize_impl(_silence(), conn_options=DEFAULT_API_CONNECT_OPTIONS)
     assert event.alternatives[0].text == "hello"
     return captured[0].read().decode("utf-8", errors="replace")
 
 
 def _mock_client(
-    captured: list[httpx.Request], body: dict[str, Any] | None = None
+    captured: list[httpx2.Request], body: dict[str, Any] | None = None
 ) -> openai.AsyncClient:
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         captured.append(request)
-        return httpx.Response(200, json=body or {"text": "hello"})
+        return httpx2.Response(200, json=body or {"text": "hello"})
 
     return openai.AsyncClient(
         api_key="test-key",
-        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(handler)),
     )
 
 
 async def test_file_transcription_sends_bracketed_form_fields() -> None:
-    captured: list[httpx.Request] = []
+    captured: list[httpx2.Request] = []
     instance = stt.STT(
         model="gpt-transcribe",
         client=_mock_client(captured),
@@ -761,7 +761,7 @@ async def test_file_transcription_sends_bracketed_form_fields() -> None:
 async def test_file_transcription_reports_the_detected_language(
     detected: list[dict[str, str]], dominant: str
 ) -> None:
-    captured: list[httpx.Request] = []
+    captured: list[httpx2.Request] = []
     instance = stt.STT(
         model="gpt-transcribe",
         client=_mock_client(captured, {"text": "hello", "languages": detected}),
@@ -804,7 +804,7 @@ async def test_realtime_reports_the_detected_language() -> None:
 
 
 async def test_file_transcription_earlier_model_keeps_singular_language() -> None:
-    captured: list[httpx.Request] = []
+    captured: list[httpx2.Request] = []
     instance = stt.STT(model="whisper-1", client=_mock_client(captured), language="en-US")
 
     body = await _transcription_form(instance, captured)

--- a/uv.lock
+++ b/uv.lock
@@ -1404,6 +1404,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1425,6 +1438,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -1918,6 +1957,8 @@ dependencies = [
     { name = "colorama" },
     { name = "docstring-parser" },
     { name = "eval-type-backport" },
+    { name = "httpx" },
+    { name = "httpx2" },
     { name = "json-repair" },
     { name = "livekit" },
     { name = "livekit-api" },
@@ -2171,6 +2212,8 @@ requires-dist = [
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "eval-type-backport" },
+    { name = "httpx", specifier = ">=0.27,<1" },
+    { name = "httpx2", specifier = ">=2.7,<3" },
     { name = "json-repair", specifier = "==0.60.1" },
     { name = "livekit", specifier = "==1.1.14" },
     { name = "livekit-api", specifier = ">=1.2.0,<2" },
@@ -2246,11 +2289,11 @@ requires-dist = [
     { name = "livekit-plugins-upliftai", marker = "extra == 'upliftai'", editable = "livekit-plugins/livekit-plugins-upliftai" },
     { name = "livekit-plugins-xai", marker = "extra == 'xai'", editable = "livekit-plugins/livekit-plugins-xai" },
     { name = "livekit-protocol", specifier = ">=1.1.21,<2" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.24.0,<2" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=2,<3" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "numpy", marker = "extra == 'codecs'", specifier = ">=1.26.0" },
-    { name = "openai", specifier = ">=2,<3" },
+    { name = "openai", specifier = ">=3,<4" },
     { name = "opentelemetry-api", specifier = ">=1.39.0,<1.45" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.39.0,<1.45" },
     { name = "opentelemetry-sdk", specifier = ">=1.39.0,<1.45" },
@@ -2587,14 +2630,12 @@ name = "livekit-plugins-anthropic"
 source = { editable = "livekit-plugins/livekit-plugins-anthropic" }
 dependencies = [
     { name = "anthropic" },
-    { name = "httpx" },
     { name = "livekit-agents" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.41" },
-    { name = "httpx" },
     { name = "livekit-agents", editable = "livekit-agents" },
 ]
 
@@ -2791,7 +2832,7 @@ requires-dist = [
     { name = "livekit-agents", extras = ["codecs", "openai"], editable = "livekit-agents" },
     { name = "msgpack", specifier = ">=1.0" },
     { name = "msgpack-types", specifier = ">=0.7.0" },
-    { name = "openai", specifier = ">=2.16.0" },
+    { name = "openai", specifier = ">=3,<4" },
 ]
 
 [[package]]
@@ -3213,7 +3254,7 @@ vertex = [
 requires-dist = [
     { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0.0" },
     { name = "livekit-agents", extras = ["codecs", "images"], editable = "livekit-agents" },
-    { name = "openai", extras = ["realtime"], specifier = ">=2.50" },
+    { name = "openai", extras = ["realtime"], specifier = ">=3,<4" },
 ]
 provides-extras = ["vertex"]
 
@@ -3294,14 +3335,12 @@ name = "livekit-plugins-rtzr"
 source = { editable = "livekit-plugins/livekit-plugins-rtzr" }
 dependencies = [
     { name = "aiohttp" },
-    { name = "httpx" },
     { name = "livekit-agents" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
-    { name = "httpx", specifier = ">=0.24.0" },
     { name = "livekit-agents", editable = "livekit-agents" },
 ]
 
@@ -3771,15 +3810,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -3789,9 +3828,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -4206,21 +4258,21 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.53.0"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/cf/36e3e7235fdf6d125c052acc0970924611b17a20a4fe580596faf4566a65/openai-2.53.0.tar.gz", hash = "sha256:baf5802ad08980e1d9d561e1b996e800c8bcd14af5847c6d0e7a5cc59e4d4116", size = 1099435, upload-time = "2026-08-03T21:42:01.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/8c/2f500e8be09d1ae98c530467962535198b02cd4550cd418bbbaedc8b2910/openai-3.0.0.tar.gz", hash = "sha256:ffd00ef1678d70957e1f1ed98d5bfcf1d661f41ea4482f22e7d0144a66435a49", size = 1123740, upload-time = "2026-08-12T01:55:50.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/0f/cc6afea3542a5142c5d8fc8211c5e059a8375105d004a41dfa2c7948dbb0/openai-2.53.0-py3-none-any.whl", hash = "sha256:c694ffc747a3c4d1663ef2b07b811315a476164ee5efa3a993967349ebca7618", size = 1659829, upload-time = "2026-08-03T21:41:59.581Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/0d/9850e7eddb5e66da4439ed503e78e09ad1fd0195e6df51e4236c75763581/openai-3.0.0-py3-none-any.whl", hash = "sha256:8d32ac3a6647a66910d6cb8a64f0fa5a6c823604b6e82db83d9d055c6709bd51", size = 1665775, upload-time = "2026-08-12T01:55:48.678Z" },
 ]
 
 [package.optional-dependencies]
@@ -4937,9 +4989,9 @@ name = "pydantic-settings"
 version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "python-dotenv", marker = "python_full_version < '3.14'" },
+    { name = "typing-inspection", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
@@ -5977,6 +6029,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912, upload-time = "2026-01-16T10:38:39.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Behavior:** Upgrade OpenAI to 3, MCP to 2, and repository-owned HTTP transports to HTTPX2. Use one OpenAI client policy and test real MCP SSE and streamable HTTP requests.

**Compatibility:** Keep legacy `httpx.Timeout` inputs working through 1.x. Warnings point to application call sites. Remove support in 2.0. Keep HTTPX 1 adapters only for upstream SDKs that still require them.

Addresses AGT-3286

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> we need to add httpx because the new openai client dropped it and we did not declare it
>
> change of plan, can we upgrade to httpx2 instead?
>
> there is a migration guide: https://github.com/openai/openai-python/blob/main/httpx2.md as well, we should double check.
>
> we need a backward compatible change for the entire code base, not just inference... we need to deprecate the httpx version and warn the user that we are dropping them in 2.0.
>
> not just openai sdk, plain httpx usage should be updated too
>
> then we can stick with DefaultAsyncHttpx2Client
>
> i thought mcp can support httpx2 already?
>
> yeah, we should fix all three

</details>