### PR TITLE
Revert "(google llm): strip thought summaries" (#6428)

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -558,12 +558,8 @@ class LLMStream(llm.LLMStream):
 
                 for part in candidate.content.parts:
                     chat_chunk = self._parse_part(request_id, part)
+                    response_generated = True
                     if chat_chunk is not None:
-                        # Only count parts that actually produce output. Thought
-                        # summaries (dropped in _parse_part) must not mark the
-                        # response as generated, otherwise a thought-only turn would
-                        # be treated as successful and skip the retry below.
-                        response_generated = True
                         retryable = False
                         self._event_ch.send_nowait(chat_chunk)
 
@@ -634,12 +630,6 @@ class LLMStream(llm.LLMStream):
             return chat_chunk
 
         if not part.text:
-            return None
-
-        # Drop thought summaries: when include_thoughts is enabled Gemini streams its
-        # reasoning back as parts flagged part.thought=True. These must not reach
-        # ChoiceDelta.content, otherwise TTS would speak the model's internal reasoning.
-        if part.thought:
             return None
 
         return llm.ChatChunk(

--- a/tests/test_plugin_google_llm.py
+++ b/tests/test_plugin_google_llm.py
@@ -71,17 +71,6 @@ class TestParsePartFunctionCall:
 
         assert chunk is None
 
-    def test_thought_summary_part_returns_none(self, llm_stream: LLMStream):
-        # include_thoughts streams reasoning back as parts flagged thought=True; these
-        # must be dropped so TTS never speaks the model's internal reasoning.
-        part = types.Part(
-            text="**Calculating Refill Dates** I'm processing the timeline", thought=True
-        )
-
-        chunk = llm_stream._parse_part("test-id", part)
-
-        assert chunk is None
-
 
 class TestCachedContentOption:
     """Verify the ``cached_content`` constructor option propagates from


### PR DESCRIPTION
Reverts #6428. Thought-summary filtering is now handled in the inference gateway, so the plugin-side stripping is redundant.

Refs [LKINF-378](https://linear.app/livekit/issue/LKINF-378/revert-thought-channel-leak-pr-in-agent-framework)

## What this undoes

In `livekit-plugins-google/livekit/plugins/google/llm.py`:
- `_parse_part` no longer drops parts flagged `part.thought=True`
- `response_generated = True` moves back outside the `chat_chunk is not None` check

And removes `test_thought_summary_part_returns_none` from `tests/test_plugin_google_llm.py`.

Note: `realtime/realtime_api.py` also has an `if part.thought` check, but that came from #4248 and is left in place.

## Testing

`uv run pytest tests/test_plugin_google_llm.py` — 22 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)