### PR TITLE
(expressive example): update readme

### DIFF
--- a/examples/expressive_agent/README.md
+++ b/examples/expressive_agent/README.md
@@ -1,11 +1,11 @@
 # Expressive agent
 
-A free-form voice agent that demonstrates [Expressive Mode](https://docs.livekit.io/agents/build/expressive/).
+A free-form voice agent that demonstrates [expressive mode](https://docs.livekit.io/agents/models/tts/expressive/).
 There is no task and no tool: you talk to it like a friend, and it matches your
 register. Tell it good news and it gets excited; tell it something went wrong
 and it drops the energy.
 
-Expressive Mode is the single `expressive=True` flag on `AgentSession`. With it
+Expressive mode is the single `expressive=True` flag on `AgentSession`. With it
 enabled the framework injects the TTS provider's markup guide into the LLM
 prompt, so the model emits inline delivery tags (emotion, pacing, non-verbal
 sounds) that the TTS renders and the transcript never shows.
@@ -18,7 +18,7 @@ sounds) that the TTS renders and the transcript never shows.
 - `protocol.py` is the whole frontend contract: the dispatch metadata shape, the
   attributes echoed back, and the voice table those metadata values name.
 
-The pipeline uses LiveKit Inference with Gemma 4 31B, Deepgram Nova-3, Fish
+The pipeline uses LiveKit Inference with Gemma 4 31B, Assembly AI Universal-3.5 Pro, Fish
 Audio S2.1 Pro, and the LiveKit turn detector.
 
 ## Run locally
@@ -43,7 +43,7 @@ directions:
 { "expressive": true, "tts": "fishaudio" }
 ```
 
-- `expressive` (default `true`) toggles Expressive Mode.
+- `expressive` (default `true`) toggles expressive mode.
 - `tts` selects a voice from `protocol.py`: `fishaudio`, `inworld`, `cartesia`, or `xai`.
 
 Both values are echoed back as participant attributes (`expressive`,
@@ -59,6 +59,6 @@ The comparison is the point of the demo. Run it once with `expressive=True` and
 once with `expressive=False`, and say the same thing to each. The words come out
 much the same; the delivery does not.
 
-Expressive Mode requires a `livekit.agents.inference.TTS` model that declares a
+Expressive mode requires a `livekit.agents.inference.TTS` model that declares a
 markup dialect. Fish Audio, Inworld TTS 2, Cartesia Sonic 3, and xAI qualify;
 providers without a dialect synthesize normally and the flag stays inert.


### PR DESCRIPTION
Updated references to 'Expressive Mode' to 'expressive mode' for consistency. Adjusted the description of the TTS model requirements and the pipeline components.