### PR TITLE
fix(plugins): declare undeclared imports, cap openai below 3

### DIFF
--- a/livekit-plugins/livekit-plugins-azure/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-azure/pyproject.toml
@@ -22,8 +22,9 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
-    "livekit-agents>=1.6.9",
+    "livekit-agents[openai]>=1.6.9",
     "azure-cognitiveservices-speech>=1.48.2",
+    "httpx",
 ]
 
 [project.urls]

--- a/livekit-plugins/livekit-plugins-baseten/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-baseten/pyproject.toml
@@ -23,9 +23,10 @@ classifiers = [
 ]
 
 dependencies = [
-    "livekit-agents>=1.6.9",
+    "livekit-agents[openai]>=1.6.9",
     "aiohttp",
     "livekit",
+    "httpx",
 ]
 
 [project.urls]

--- a/livekit-plugins/livekit-plugins-cerebras/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-cerebras/pyproject.toml
@@ -25,9 +25,10 @@ dependencies = [
     "livekit-agents[codecs, openai]>=1.6.9",
     # _CerebrasClient._build_request sets options.content on FinalRequestOptions,
     # a field added in openai 2.16.0 (binary request streaming support).
-    "openai>=2.16.0",
+    "openai>=2.16.0,<3",
     "msgpack>=1.0",
     "msgpack-types>=0.7.0",
+    "httpx",
 ]
 
 [project.urls]

--- a/livekit-plugins/livekit-plugins-google/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-google/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "google-cloud-texttospeech >= 2.32, < 3",
     "google-genai >= 1.68; python_version >= '3.10'",
     "livekit-agents>=1.6.9",
+    "httpx",
+    "openai<3",
 ]
 
 [project.urls]

--- a/livekit-plugins/livekit-plugins-groq/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-groq/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "livekit-agents[codecs, openai]>=1.6.9",
     "aiohttp",
     "livekit",
+    "httpx",
 ]
 
 [project.urls]

--- a/livekit-plugins/livekit-plugins-mistralai/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-mistralai/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 dependencies = [
     "livekit-agents>=1.6.9",
     "mistralai[realtime]>=2.0.0,<3.0.0",
+    "httpx",
 ]
 
 [project.urls]

--- a/livekit-plugins/livekit-plugins-openai/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-openai/pyproject.toml
@@ -24,7 +24,9 @@ classifiers = [
 dependencies = [
     "livekit-agents[codecs, images]>=1.6.9",
     # keywords/languages on the transcription APIs landed in 2.50
-    "openai[realtime]>=2.50",
+    # openai 3 defaults to httpx2; these clients still hand it legacy httpx objects
+    "openai[realtime]>=2.50,<3",
+    "httpx",
 ]
 
 

--- a/livekit-plugins/livekit-plugins-perplexity/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-perplexity/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "livekit-agents[openai]>=1.6.9",
+    "httpx",
 ]
 
 [project.urls]

--- a/livekit-plugins/livekit-plugins-sarvam/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-sarvam/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3 :: Only",
 ]
-dependencies = ["livekit-agents[codecs, openai]>=1.6.9", "numpy>=1.26"]
+dependencies = ["livekit-agents[codecs, openai]>=1.6.9", "numpy>=1.26", "httpx"]
 
 [project.urls]
 Documentation = "https://docs.livekit.io"

--- a/livekit-plugins/livekit-plugins-speechify/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-speechify/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3 :: Only",
 ]
-dependencies = ["livekit-agents[codecs]>=1.6.9", "speechify-api>=3.0.1"]
+dependencies = ["livekit-agents[codecs]>=1.6.9", "speechify-api>=3.0.1", "httpx"]
 
 [project.urls]
 Documentation = "https://docs.livekit.io"

--- a/livekit-plugins/livekit-plugins-spitch/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-spitch/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3 :: Only",
 ]
-dependencies = ["livekit-agents[codecs]>=1.6.9", "spitch>=1.47.0"]
+dependencies = ["livekit-agents[codecs]>=1.6.9", "spitch>=1.47.0", "httpx"]
 
 [project.urls]
 Documentation = "https://docs.livekit.io"

--- a/livekit-plugins/livekit-plugins-xai/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-xai/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "livekit-agents[openai]>=1.6.9",
+    "httpx",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -2715,13 +2715,15 @@ name = "livekit-plugins-azure"
 source = { editable = "livekit-plugins/livekit-plugins-azure" }
 dependencies = [
     { name = "azure-cognitiveservices-speech" },
-    { name = "livekit-agents" },
+    { name = "httpx" },
+    { name = "livekit-agents", extra = ["openai"] },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "azure-cognitiveservices-speech", specifier = ">=1.48.2" },
-    { name = "livekit-agents", editable = "livekit-agents" },
+    { name = "httpx" },
+    { name = "livekit-agents", extras = ["openai"], editable = "livekit-agents" },
 ]
 
 [[package]]
@@ -2729,15 +2731,17 @@ name = "livekit-plugins-baseten"
 source = { editable = "livekit-plugins/livekit-plugins-baseten" }
 dependencies = [
     { name = "aiohttp" },
+    { name = "httpx" },
     { name = "livekit" },
-    { name = "livekit-agents" },
+    { name = "livekit-agents", extra = ["openai"] },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "aiohttp" },
+    { name = "httpx" },
     { name = "livekit" },
-    { name = "livekit-agents", editable = "livekit-agents" },
+    { name = "livekit-agents", extras = ["openai"], editable = "livekit-agents" },
 ]
 
 [[package]]
@@ -2821,6 +2825,7 @@ requires-dist = [{ name = "livekit-agents", editable = "livekit-agents" }]
 name = "livekit-plugins-cerebras"
 source = { editable = "livekit-plugins/livekit-plugins-cerebras" }
 dependencies = [
+    { name = "httpx" },
     { name = "livekit-agents", extra = ["codecs", "openai"] },
     { name = "msgpack" },
     { name = "msgpack-types" },
@@ -2829,10 +2834,11 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx" },
     { name = "livekit-agents", extras = ["codecs", "openai"], editable = "livekit-agents" },
     { name = "msgpack", specifier = ">=1.0" },
     { name = "msgpack-types", specifier = ">=0.7.0" },
-    { name = "openai", specifier = ">=2.16.0" },
+    { name = "openai", specifier = ">=2.16.0,<3" },
 ]
 
 [[package]]
@@ -2959,7 +2965,9 @@ dependencies = [
     { name = "google-cloud-speech" },
     { name = "google-cloud-texttospeech" },
     { name = "google-genai" },
+    { name = "httpx" },
     { name = "livekit-agents" },
+    { name = "openai" },
 ]
 
 [package.metadata]
@@ -2968,7 +2976,9 @@ requires-dist = [
     { name = "google-cloud-speech", specifier = ">=2,<3" },
     { name = "google-cloud-texttospeech", specifier = ">=2.32,<3" },
     { name = "google-genai", marker = "python_full_version >= '3.10'", specifier = ">=1.68" },
+    { name = "httpx" },
     { name = "livekit-agents", editable = "livekit-agents" },
+    { name = "openai", specifier = "<3" },
 ]
 
 [[package]]
@@ -2992,6 +3002,7 @@ name = "livekit-plugins-groq"
 source = { editable = "livekit-plugins/livekit-plugins-groq" }
 dependencies = [
     { name = "aiohttp" },
+    { name = "httpx" },
     { name = "livekit" },
     { name = "livekit-agents", extra = ["codecs", "openai"] },
 ]
@@ -2999,6 +3010,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp" },
+    { name = "httpx" },
     { name = "livekit" },
     { name = "livekit-agents", extras = ["codecs", "openai"], editable = "livekit-agents" },
 ]
@@ -3170,12 +3182,14 @@ requires-dist = [{ name = "livekit-agents", extras = ["codecs"], editable = "liv
 name = "livekit-plugins-mistralai"
 source = { editable = "livekit-plugins/livekit-plugins-mistralai" }
 dependencies = [
+    { name = "httpx" },
     { name = "livekit-agents" },
     { name = "mistralai", extra = ["realtime"] },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx" },
     { name = "livekit-agents", editable = "livekit-agents" },
     { name = "mistralai", extras = ["realtime"], specifier = ">=2.0.0,<3.0.0" },
 ]
@@ -3241,6 +3255,7 @@ provides-extras = ["personaplex"]
 name = "livekit-plugins-openai"
 source = { editable = "livekit-plugins/livekit-plugins-openai" }
 dependencies = [
+    { name = "httpx" },
     { name = "livekit-agents", extra = ["codecs", "images"] },
     { name = "openai", extra = ["realtime"] },
 ]
@@ -3253,8 +3268,9 @@ vertex = [
 [package.metadata]
 requires-dist = [
     { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0.0" },
+    { name = "httpx" },
     { name = "livekit-agents", extras = ["codecs", "images"], editable = "livekit-agents" },
-    { name = "openai", extras = ["realtime"], specifier = ">=2.50" },
+    { name = "openai", extras = ["realtime"], specifier = ">=2.50,<3" },
 ]
 provides-extras = ["vertex"]
 
@@ -3262,11 +3278,15 @@ provides-extras = ["vertex"]
 name = "livekit-plugins-perplexity"
 source = { editable = "livekit-plugins/livekit-plugins-perplexity" }
 dependencies = [
+    { name = "httpx" },
     { name = "livekit-agents", extra = ["openai"] },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "livekit-agents", extras = ["openai"], editable = "livekit-agents" }]
+requires-dist = [
+    { name = "httpx" },
+    { name = "livekit-agents", extras = ["openai"], editable = "livekit-agents" },
+]
 
 [[package]]
 name = "livekit-plugins-phonic"
@@ -3360,12 +3380,14 @@ requires-dist = [{ name = "livekit-agents", editable = "livekit-agents" }]
 name = "livekit-plugins-sarvam"
 source = { editable = "livekit-plugins/livekit-plugins-sarvam" }
 dependencies = [
+    { name = "httpx" },
     { name = "livekit-agents", extra = ["codecs", "openai"] },
     { name = "numpy" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx" },
     { name = "livekit-agents", extras = ["codecs", "openai"], editable = "livekit-agents" },
     { name = "numpy", specifier = ">=1.26" },
 ]
@@ -3466,12 +3488,14 @@ requires-dist = [
 name = "livekit-plugins-speechify"
 source = { editable = "livekit-plugins/livekit-plugins-speechify" }
 dependencies = [
+    { name = "httpx" },
     { name = "livekit-agents", extra = ["codecs"] },
     { name = "speechify-api" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx" },
     { name = "livekit-agents", extras = ["codecs"], editable = "livekit-agents" },
     { name = "speechify-api", specifier = ">=3.0.1" },
 ]
@@ -3494,12 +3518,14 @@ requires-dist = [
 name = "livekit-plugins-spitch"
 source = { editable = "livekit-plugins/livekit-plugins-spitch" }
 dependencies = [
+    { name = "httpx" },
     { name = "livekit-agents", extra = ["codecs"] },
     { name = "spitch" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx" },
     { name = "livekit-agents", extras = ["codecs"], editable = "livekit-agents" },
     { name = "spitch", specifier = ">=1.47.0" },
 ]
@@ -3589,11 +3615,15 @@ requires-dist = [
 name = "livekit-plugins-xai"
 source = { editable = "livekit-plugins/livekit-plugins-xai" }
 dependencies = [
+    { name = "httpx" },
     { name = "livekit-agents", extra = ["openai"] },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "livekit-agents", extras = ["openai"], editable = "livekit-agents" }]
+requires-dist = [
+    { name = "httpx" },
+    { name = "livekit-agents", extras = ["openai"], editable = "livekit-agents" },
+]
 
 [[package]]
 name = "livekit-protocol"


### PR DESCRIPTION
Stacked on #6826.

**What breaks**

Twelve plugins import `httpx` at module level and never declare it. They received it from `livekit-agents`, which received it from `openai`.

OpenAI 3 moved to HTTPX2 and no longer installs `httpx`. #6826 corrects `livekit-agents`. The plugins still fail.

With #6826 applied, a clean install gives this result:

```
import livekit.agents          → OK
import livekit.plugins.openai  → ModuleNotFoundError: No module named 'httpx'
```

**What this changes**

Declare `httpx` in the twelve plugins that import it.

Cap `openai` below 3 in the plugins that give a legacy httpx client to an openai client. OpenAI 3 accepts such a client at runtime, but its type annotations reject it. A move to HTTPX2 changes public constructor signatures, so it belongs in a separate change.

Declare three more imports that no package listed. The google plugin imports `openai` in `aiplatform_llm.py`. The azure and baseten plugins import the openai plugin. All three fail on a clean install today, with or without OpenAI 3.
