### PR TITLE
fix(deps): pin openai below 3

### DIFF
--- a/livekit-agents/pyproject.toml
+++ b/livekit-agents/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "opentelemetry-sdk>=1.39.0,<1.45",
     "opentelemetry-exporter-otlp>=1.39.0,<1.45",
     "prometheus-client>=0.22",
-    "openai>=2",
+    "openai>=2,<3",
     "aiofiles>=24",
     "json-repair==0.60.1",
     "pyyaml>=6.0.3",

--- a/livekit-plugins/livekit-plugins-azure/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-azure/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
-    "livekit-agents>=1.6.9",
+    "livekit-agents[openai]>=1.6.9",
     "azure-cognitiveservices-speech>=1.48.2",
 ]
 

--- a/livekit-plugins/livekit-plugins-baseten/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-baseten/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "livekit-agents>=1.6.9",
+    "livekit-agents[openai]>=1.6.9",
     "aiohttp",
     "livekit",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2674,13 +2674,13 @@ name = "livekit-plugins-azure"
 source = { editable = "livekit-plugins/livekit-plugins-azure" }
 dependencies = [
     { name = "azure-cognitiveservices-speech" },
-    { name = "livekit-agents" },
+    { name = "livekit-agents", extra = ["openai"] },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "azure-cognitiveservices-speech", specifier = ">=1.48.2" },
-    { name = "livekit-agents", editable = "livekit-agents" },
+    { name = "livekit-agents", extras = ["openai"], editable = "livekit-agents" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2250,7 +2250,7 @@ requires-dist = [
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "numpy", marker = "extra == 'codecs'", specifier = ">=1.26.0" },
-    { name = "openai", specifier = ">=2" },
+    { name = "openai", specifier = ">=2,<3" },
     { name = "opentelemetry-api", specifier = ">=1.39.0,<1.45" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.39.0,<1.45" },
     { name = "opentelemetry-sdk", specifier = ">=1.39.0,<1.45" },
@@ -2689,14 +2689,14 @@ source = { editable = "livekit-plugins/livekit-plugins-baseten" }
 dependencies = [
     { name = "aiohttp" },
     { name = "livekit" },
-    { name = "livekit-agents" },
+    { name = "livekit-agents", extra = ["openai"] },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "aiohttp" },
     { name = "livekit" },
-    { name = "livekit-agents", editable = "livekit-agents" },
+    { name = "livekit-agents", extras = ["openai"], editable = "livekit-agents" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Problem**

OpenAI 3 makes HTTPX2 the default client and no longer installs `httpx`. `livekit-agents` imports `httpx` in `inference/llm.py` and never declared it. Twelve plugins import it too, and none of them declared it. They all received it through `openai`.

That supply is gone, so a fresh install of the current release fails:

```
$ pip install livekit-agents
$ python -c "import livekit.agents"
ModuleNotFoundError: No module named 'httpx'
```

Every install since OpenAI 3.0.0 shipped is affected.

**Fix**

Pin `openai` below 3. Every openai 2.x release depends on `httpx`, so this one line restores the supply for core and for all twelve plugins.

A move to HTTPX2 is the durable answer, but it changes the public `timeout: httpx.Timeout` parameter on nine plugin constructors. That belongs in a minor release. #6826 starts this work for the inference client.

This branch also corrects two plugins that import the openai plugin and never declared it. `azure/responses/llm.py` and `baseten/llm.py` import it, and each package imports those modules from its `__init__.py`, so the dependency is not optional. A clean install of either plugin fails with `ImportError: cannot import name 'openai' from 'livekit.plugins'`. That fault is older than OpenAI 3 and is independent of the pin.
