### PR TITLE
fix(telemetry): log a warning when the audio recording can't be read at upload time

### DIFF
--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -689,9 +689,9 @@ async def _upload_session_report(
             audio_bytes = b""
             logger.warning(
                 "failed to read audio recording for session report upload, "
-                "uploading without the audio part (path=%s): %s",
+                "uploading without the audio part (path=%s)",
                 report.audio_recording_path,
-                e,
+                exc_info=e,
             )
 
     url = f"{observability_url}/observability/recordings/v0"

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -685,8 +685,14 @@ async def _upload_session_report(
         try:
             async with aiofiles.open(report.audio_recording_path, "rb") as f:
                 audio_bytes = await f.read()
-        except Exception:
+        except Exception as e:
             audio_bytes = b""
+            logger.warning(
+                "failed to read audio recording for session report upload, "
+                "uploading without the audio part (path=%s): %s",
+                report.audio_recording_path,
+                e,
+            )
 
     url = f"{observability_url}/observability/recordings/v0"
 


### PR DESCRIPTION
Fixes #6832.

A failed read of the local audio recording during session-report upload is currently swallowed bare, so the upload succeeds with the `audio` multipart part silently missing and nothing in the logs. This keeps the existing behavior (the report still uploads without audio rather than failing outright) and adds a warning naming the path and the exception, matching the style of the retry warning in the same function.

A runnable offline repro demonstrating the silent path is in #6832; re-running it against this branch shows the warning firing with the path and the underlying errno. Happy to add a unit test asserting the warning fires if you'd like one in-tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)