### PR TITLE
ci: bump gh-action-pypi-publish for metadata 2.5 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -234,7 +234,7 @@ jobs:
         run: ls -la dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26 # v1.14.2
 
   docs:
     name: Publish docs


### PR DESCRIPTION
All 73 publish jobs for v1.6.10 failed with `InvalidDistribution: '2.5' is not a valid metadata version`; nothing reached PyPI.

hatchling 1.32.0 (2026-08-11) emits `Metadata-Version: 2.5`, and `[build-system] requires = ["hatchling"]` is unpinned. The pinned action image (2026-02-18) ships `packaging==25.0`, which tops out at 2.4, so `verify-metadata` rejects the wheel before upload. PyPI itself accepts 2.5.

v1.14.2 ships `packaging==26.2` + `twine==7.0.0`, which accept 2.5.