### PR TITLE
ci: pin the publish action to a commit, not a tag object

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -234,7 +234,7 @@ jobs:
         run: ls -la dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26 # v1.14.2
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   docs:
     name: Publish docs


### PR DESCRIPTION
**Problem**

#6836 pinned the publish action to `a892a5a`, which is the annotated tag object of `v1.14.2`, not the commit it points to. The 1.6.10 republish then stopped:

```
Unable to find image 'ghcr.io/pypa/gh-action-pypi-publish:a892a5a61159132606e93a2fa6f4358831b04d26'
docker: Error response from daemon: manifest unknown
```

`gh-action-pypi-publish` is a composite action. It builds a Docker action at run time from `github.action_ref` and pulls `ghcr.io/pypa/gh-action-pypi-publish:<that ref>`. The pin must therefore be a ref with a published image. A tag object is not one.

The registry agrees:

```
dc37677b (the commit)   HTTP 200
a892a5a  (the tag)      HTTP 404
```

**Fix**

Pin the commit that `v1.14.2` points to. It is the same tree #6836 intended, with `twine==7.0.0` and `packaging==26.2`, which accept the `Metadata-Version: 2.5` wheels that hatchling 1.32.0 produces.

To confirm a pin of this kind, ask the API for the commit. A tag object gives 422:

```
gh api repos/pypa/gh-action-pypi-publish/commits/<sha>
```
