### PR TITLE
feat(sarvam): add glm5.2, gemma4 and sarvam-105b-conversations model support

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/llm/client.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/llm/client.py
@@ -22,8 +22,7 @@ import httpx
 import openai
 from openai.types import ReasoningEffort
 
-from livekit.agents import __version__ as livekit_version
-from livekit.agents import llm
+from livekit.agents import __version__ as livekit_version, llm
 from livekit.agents.llm import ChatContext, ToolChoice
 from livekit.agents.llm.chat_context import ImageContent
 from livekit.agents.types import (
@@ -38,6 +37,8 @@ from livekit.plugins.openai.llm import LLM as OpenAILLM
 from .models import SarvamLLMModels
 
 SARVAM_API_BASE = "https://api.sarvam.ai"
+SARVAM_LLM_BASE_URL_V1 = f"{SARVAM_API_BASE}/v1"
+SARVAM_LLM_BASE_URL_V2 = f"{SARVAM_API_BASE}/v2"
 USER_AGENT = f"Livekit/{livekit_version} Python/{platform.python_version()}"
 
 # ---------------------------------------------------------------------------
@@ -100,8 +101,8 @@ def _resolve_base_url(model: str) -> str:
     ``sarvam-105b-conversations`` uses ``/v1``; all other models use ``/v2``.
     """
     if model in _V1_MODELS:
-        return f"{SARVAM_API_BASE}/v1"
-    return f"{SARVAM_API_BASE}/v2"
+        return SARVAM_LLM_BASE_URL_V1
+    return SARVAM_LLM_BASE_URL_V2
 
 
 def _api_version(model: str) -> str:
@@ -111,8 +112,7 @@ def _api_version(model: str) -> str:
 def _validate_model(model: str) -> str:
     if model not in _SUPPORTED_MODELS:
         raise ValueError(
-            f"Unsupported Sarvam model '{model}'. "
-            f"Supported models: {sorted(_SUPPORTED_MODELS)}"
+            f"Unsupported Sarvam model '{model}'. Supported models: {sorted(_SUPPORTED_MODELS)}"
         )
     return model
 
@@ -189,9 +189,7 @@ class LLM(OpenAILLM):
         sarvam_api_key = _get_api_key(api_key)
 
         # Resolve base URL: explicit > model-derived
-        resolved_base_url = (
-            base_url if is_given(base_url) else _resolve_base_url(validated_model)
-        )
+        resolved_base_url = base_url if is_given(base_url) else _resolve_base_url(validated_model)
 
         # ---- Merge auth / telemetry headers (always enforced) ----
         merged_headers: dict[str, str] = {}
@@ -315,20 +313,22 @@ class LLM(OpenAILLM):
         # --- Image rejection on non-vision models ---
         if model not in _VISION_MODELS and _has_image_content(chat_ctx):
             raise ValueError(
-                f"Model '{model}' does not support image input. "
+                f"Image input is not supported for model '{model}'. "
                 f"Use 'gemma4' for vision capabilities."
             )
 
         # --- tool_choice without tools ---
-        effective_tool_choice = (
-            tool_choice if is_given(tool_choice) else self._opts.tool_choice
-        )
+        # 'none' and 'auto' are always valid (they don't require tools).
+        # 'required' and named-function tool_choice require a non-empty tools array.
+        effective_tool_choice = tool_choice if is_given(tool_choice) else self._opts.tool_choice
         effective_tools = tools or []
         if is_given(effective_tool_choice) and not effective_tools:
-            raise ValueError(
-                "tool_choice requires a non-empty tools array. "
-                "Provide tools or set tool_choice to 'none' or 'auto'."
-            )
+            tc_str = effective_tool_choice if isinstance(effective_tool_choice, str) else "function"
+            if tc_str not in ("none", "auto"):
+                raise ValueError(
+                    "tool_choice requires a non-empty tools array. "
+                    "Provide tools or set tool_choice to 'none' or 'auto'."
+                )
 
         # --- Strip unsupported fields from caller-provided extra_kwargs ---
         merged_extra: dict[str, Any] = {}

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/llm/client.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/llm/client.py
@@ -23,23 +23,67 @@ import openai
 from openai.types import ReasoningEffort
 
 from livekit.agents import __version__ as livekit_version
-from livekit.agents.llm import ToolChoice
-from livekit.agents.types import NOT_GIVEN, NotGivenOr
+from livekit.agents import llm
+from livekit.agents.llm import ChatContext, ToolChoice
+from livekit.agents.llm.chat_context import ImageContent
+from livekit.agents.types import (
+    DEFAULT_API_CONNECT_OPTIONS,
+    NOT_GIVEN,
+    APIConnectOptions,
+    NotGivenOr,
+)
 from livekit.agents.utils import is_given
 from livekit.plugins.openai.llm import LLM as OpenAILLM
 
 from .models import SarvamLLMModels
 
-SARVAM_LLM_BASE_URL = "https://api.sarvam.ai/v1"
+SARVAM_API_BASE = "https://api.sarvam.ai"
 USER_AGENT = f"Livekit/{livekit_version} Python/{platform.python_version()}"
-_SUPPORTED_MODELS = {
-    "sarvam-m",
-    "sarvam-30b",
-    "sarvam-30b-16k",  # deprecated by Sarvam, kept for backward compatibility
+
+# ---------------------------------------------------------------------------
+# Model capability / endpoint tables
+# ---------------------------------------------------------------------------
+
+_SUPPORTED_MODELS: set[str] = {
+    "gemma4",
     "sarvam-105b",
-    "sarvam-105b-32k",  # deprecated by Sarvam, kept for backward compatibility
+    "glm5.2",
+    "sarvam-105b-conversations",
 }
-_ALLOWED_EXTRA_BODY_PARAMS = {
+
+# Models that use the /v1 endpoint (everything else uses /v2)
+_V1_MODELS: set[str] = {
+    "sarvam-105b-conversations",
+}
+
+# Models that support vision (image input)
+_VISION_MODELS: set[str] = {
+    "gemma4",
+}
+
+# Models that support reasoning_effort
+_REASONING_EFFORT_MODELS: set[str] = {
+    "gemma4",
+    "sarvam-105b",
+    "glm5.2",
+}
+
+# Models that support wiki_grounding
+_WIKI_GROUNDING_MODELS: set[str] = {
+    "gemma4",
+    "sarvam-105b",
+    "glm5.2",
+}
+
+# OpenAI SDK fields the Sarvam API does not accept
+_UNSUPPORTED_OAI_FIELDS: set[str] = {
+    "stream_options",
+    "max_completion_tokens",
+    "service_tier",
+}
+
+# Fields allowed in extra_body (Sarvam-specific pass-through)
+_ALLOWED_EXTRA_BODY_PARAMS: set[str] = {
     "frequency_penalty",
     "max_tokens",
     "n",
@@ -50,13 +94,74 @@ _ALLOWED_EXTRA_BODY_PARAMS = {
 }
 
 
+def _resolve_base_url(model: str) -> str:
+    """Return the Sarvam API base URL for *model*.
+
+    ``sarvam-105b-conversations`` uses ``/v1``; all other models use ``/v2``.
+    """
+    if model in _V1_MODELS:
+        return f"{SARVAM_API_BASE}/v1"
+    return f"{SARVAM_API_BASE}/v2"
+
+
+def _api_version(model: str) -> str:
+    return "v1" if model in _V1_MODELS else "v2"
+
+
+def _validate_model(model: str) -> str:
+    if model not in _SUPPORTED_MODELS:
+        raise ValueError(
+            f"Unsupported Sarvam model '{model}'. "
+            f"Supported models: {sorted(_SUPPORTED_MODELS)}"
+        )
+    return model
+
+
+def _get_api_key(key: NotGivenOr[str]) -> str:
+    sarvam_api_key = key if is_given(key) else os.environ.get("SARVAM_API_KEY")
+    if not sarvam_api_key:
+        raise ValueError(
+            "SARVAM_API_KEY is required, either as argument or "
+            "set SARVAM_API_KEY environment variable"
+        )
+    return sarvam_api_key
+
+
+def _filter_extra_body(extra_body: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in extra_body.items() if k in _ALLOWED_EXTRA_BODY_PARAMS}
+
+
+def _has_image_content(chat_ctx: ChatContext) -> bool:
+    """Return True if any user message in *chat_ctx* carries an image."""
+    for msg in chat_ctx.messages():
+        if msg.role != "user":
+            continue
+        for item in msg.content:
+            if isinstance(item, ImageContent):
+                return True
+    return False
+
+
 class LLM(OpenAILLM):
+    """Sarvam LLM service — OpenAI-compatible chat completions.
+
+    Supports four models:
+
+    * ``gemma4`` — vision-capable, ``/v2`` endpoint
+    * ``sarvam-105b`` — text-only, ``/v2`` endpoint
+    * ``glm5.2`` — text-only, ``/v2`` endpoint
+    * ``sarvam-105b-conversations`` — multi-turn optimized, ``/v1`` endpoint
+
+    The endpoint (``/v1`` vs ``/v2``) is resolved automatically from the model.
+    An explicit ``base_url`` always overrides automatic resolution.
+    """
+
     def __init__(
         self,
         *,
-        model: str | SarvamLLMModels = "sarvam-30b",
+        model: str | SarvamLLMModels = "sarvam-105b",
         api_key: NotGivenOr[str] = NOT_GIVEN,
-        base_url: NotGivenOr[str] = SARVAM_LLM_BASE_URL,
+        base_url: NotGivenOr[str] = NOT_GIVEN,
         client: openai.AsyncClient | None = None,
         user: NotGivenOr[str] = NOT_GIVEN,
         temperature: NotGivenOr[float] = NOT_GIVEN,
@@ -77,21 +182,30 @@ class LLM(OpenAILLM):
         """
         Create a new instance of Sarvam LLM.
 
-        ``api_key`` must be set to your Sarvam API key, either using the argument or by setting
-        the ``SARVAM_API_KEY`` environment variable.
+        ``api_key`` must be set to your Sarvam API key, either using the
+        argument or by setting the ``SARVAM_API_KEY`` environment variable.
         """
         validated_model = _validate_model(model)
         sarvam_api_key = _get_api_key(api_key)
-        merged_headers = dict(extra_headers) if is_given(extra_headers) else {}
-        # Sarvam chat-completions auth and telemetry headers are always enforced.
+
+        # Resolve base URL: explicit > model-derived
+        resolved_base_url = (
+            base_url if is_given(base_url) else _resolve_base_url(validated_model)
+        )
+
+        # ---- Merge auth / telemetry headers (always enforced) ----
+        merged_headers: dict[str, str] = {}
+        if is_given(extra_headers):
+            merged_headers.update(extra_headers)
         merged_headers["api-subscription-key"] = sarvam_api_key
         merged_headers["User-Agent"] = USER_AGENT
 
-        merged_body = dict(extra_body) if is_given(extra_body) else {}
+        # ---- Build extra_body with Sarvam-specific fields ----
+        merged_body: dict[str, Any] = {}
+        if is_given(extra_body):
+            merged_body.update(extra_body)
         if is_given(max_tokens):
             merged_body["max_tokens"] = max_tokens
-        if is_given(wiki_grounding):
-            merged_body["wiki_grounding"] = wiki_grounding
         if is_given(stop):
             merged_body["stop"] = stop
         if is_given(n):
@@ -102,22 +216,44 @@ class LLM(OpenAILLM):
             merged_body["frequency_penalty"] = frequency_penalty
         if is_given(presence_penalty):
             merged_body["presence_penalty"] = presence_penalty
+
+        # wiki_grounding — only for supported models
+        if is_given(wiki_grounding):
+            if validated_model in _WIKI_GROUNDING_MODELS:
+                merged_body["wiki_grounding"] = wiki_grounding
+            # silently drop for unsupported models
+
         filtered_body = _filter_extra_body(merged_body)
+
+        # reasoning_effort — only for supported models
+        effective_reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN
+        if is_given(reasoning_effort):
+            if validated_model in _REASONING_EFFORT_MODELS:
+                effective_reasoning_effort = reasoning_effort
+            # silently drop for unsupported models
 
         super().__init__(
             model=validated_model,
             api_key=sarvam_api_key,
-            base_url=base_url,
+            base_url=resolved_base_url,
             client=client,
             user=user,
             temperature=temperature,
             top_p=top_p,
             tool_choice=tool_choice,
-            reasoning_effort=reasoning_effort,
+            reasoning_effort=effective_reasoning_effort,
             extra_headers=merged_headers,
             extra_body=filtered_body if filtered_body else NOT_GIVEN,
             timeout=timeout,
         )
+
+        # Track the API key and version for runtime model switching
+        self._sarvam_api_key = sarvam_api_key
+        self._sarvam_api_version = _api_version(validated_model)
+
+    # ------------------------------------------------------------------
+    # Public overrides
+    # ------------------------------------------------------------------
 
     @property
     def model(self) -> str:
@@ -127,23 +263,117 @@ class LLM(OpenAILLM):
     def provider(self) -> str:
         return "Sarvam"
 
+    def update_options(
+        self,
+        *,
+        model: NotGivenOr[str] = NOT_GIVEN,
+    ) -> None:
+        """Update the model at runtime.
 
-def _get_api_key(key: NotGivenOr[str]) -> str:
-    sarvam_api_key = key if is_given(key) else os.environ.get("SARVAM_API_KEY")
-    if not sarvam_api_key:
-        raise ValueError(
-            "SARVAM_API_KEY is required, either as argument or set SARVAM_API_KEY environment variable"
+        Validates the new model and recreates the underlying client when the
+        API version changes (``/v1`` ↔ ``/v2``).  When both old and new models
+        share the same endpoint, the client is **not** recreated.
+        """
+        if not is_given(model):
+            return
+
+        new_model = _validate_model(model)
+        new_version = _api_version(new_model)
+
+        if new_version != self._sarvam_api_version:
+            # Endpoint changed — recreate the client pointing at the new URL
+            new_base_url = _resolve_base_url(new_model)
+            self._client = _create_sarvam_client(
+                api_key=self._sarvam_api_key,
+                base_url=new_base_url,
+            )
+            self._sarvam_api_version = new_version
+
+        self._opts.model = new_model
+
+    def chat(
+        self,
+        *,
+        chat_ctx: ChatContext,
+        tools: list[llm.Tool] | None = None,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+        parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
+        tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
+        response_format: NotGivenOr[Any] = NOT_GIVEN,
+        extra_kwargs: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
+    ) -> Any:
+        """Build a chat-completion stream with Sarvam-specific param stripping.
+
+        * Strips ``stream_options``, ``max_completion_tokens``, ``service_tier``
+          (the Sarvam API does not accept these OpenAI SDK fields).
+        * Strips ``reasoning_effort`` for models that don't support it.
+        * Rejects images sent to non-vision models (client-side ``ValueError``).
+        * Rejects ``tool_choice`` without a non-empty ``tools`` array.
+        """
+        model = self._opts.model
+
+        # --- Image rejection on non-vision models ---
+        if model not in _VISION_MODELS and _has_image_content(chat_ctx):
+            raise ValueError(
+                f"Model '{model}' does not support image input. "
+                f"Use 'gemma4' for vision capabilities."
+            )
+
+        # --- tool_choice without tools ---
+        effective_tool_choice = (
+            tool_choice if is_given(tool_choice) else self._opts.tool_choice
         )
-    return sarvam_api_key
+        effective_tools = tools or []
+        if is_given(effective_tool_choice) and not effective_tools:
+            raise ValueError(
+                "tool_choice requires a non-empty tools array. "
+                "Provide tools or set tool_choice to 'none' or 'auto'."
+            )
 
+        # --- Strip unsupported fields from caller-provided extra_kwargs ---
+        merged_extra: dict[str, Any] = {}
+        if is_given(extra_kwargs):
+            merged_extra.update(extra_kwargs)
 
-def _validate_model(model: str) -> str:
-    if model not in _SUPPORTED_MODELS:
-        raise ValueError(
-            f"Unsupported Sarvam model '{model}'. Supported models: {sorted(_SUPPORTED_MODELS)}"
+        for field in _UNSUPPORTED_OAI_FIELDS:
+            merged_extra.pop(field, None)
+
+        # Strip reasoning_effort for unsupported models at chat-time too
+        if model not in _REASONING_EFFORT_MODELS:
+            merged_extra.pop("reasoning_effort", None)
+
+        return super().chat(
+            chat_ctx=chat_ctx,
+            tools=tools,
+            conn_options=conn_options,
+            parallel_tool_calls=parallel_tool_calls,
+            tool_choice=tool_choice,
+            response_format=response_format,
+            extra_kwargs=merged_extra if merged_extra else NOT_GIVEN,
         )
-    return model
 
 
-def _filter_extra_body(extra_body: dict[str, Any]) -> dict[str, Any]:
-    return {k: v for k, v in extra_body.items() if k in _ALLOWED_EXTRA_BODY_PARAMS}
+def _create_sarvam_client(
+    *,
+    api_key: str,
+    base_url: str,
+) -> openai.AsyncClient:
+    """Create an ``openai.AsyncClient`` with Sarvam auth headers."""
+    return openai.AsyncClient(
+        api_key=api_key,
+        base_url=base_url,
+        max_retries=0,
+        default_headers={
+            "api-subscription-key": api_key,
+            "User-Agent": USER_AGENT,
+        },
+        http_client=httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=15.0, read=60.0, write=5.0, pool=5.0),
+            follow_redirects=True,
+            limits=httpx.Limits(
+                max_connections=50,
+                max_keepalive_connections=50,
+                keepalive_expiry=120,
+            ),
+        ),
+    )

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/llm/models.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/llm/models.py
@@ -15,9 +15,8 @@
 from typing import Literal
 
 SarvamLLMModels = Literal[
-    "sarvam-m",
-    "sarvam-30b",
-    "sarvam-30b-16k",  # deprecated, kept for backward compatibility
+    "gemma4",
     "sarvam-105b",
-    "sarvam-105b-32k",  # deprecated, kept for backward compatibility
+    "glm5.2",
+    "sarvam-105b-conversations",
 ]

--- a/tests/test_plugin_sarvam_llm.py
+++ b/tests/test_plugin_sarvam_llm.py
@@ -1,0 +1,590 @@
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import openai
+import pytest
+
+from livekit.agents import APIStatusError
+from livekit.agents.inference.llm import LLMStream as InferenceLLMStream
+from livekit.agents.llm import ChatContext, ImageContent
+from livekit.agents.types import NOT_GIVEN
+from livekit.agents.utils import is_given
+from livekit.plugins.sarvam.llm.client import (
+    LLM as SarvamLLM,
+    SARVAM_LLM_BASE_URL_V1,
+    SARVAM_LLM_BASE_URL_V2,
+    USER_AGENT,
+    _filter_extra_body,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_async_client() -> openai.AsyncClient:
+    return cast(openai.AsyncClient, MagicMock())
+
+
+def _chat_ctx(text: str = "hello") -> ChatContext:
+    ctx = ChatContext.empty()
+    ctx.add_message(role="user", content=text)
+    return ctx
+
+
+def _chat_ctx_with_image() -> ChatContext:
+    ctx = ChatContext.empty()
+    ctx.add_message(
+        role="user",
+        content=[
+            "describe this image",
+            ImageContent(image="data:image/png;base64,iVBORw0KGgo="),
+        ],
+    )
+    return ctx
+
+
+def _has_not_given(params: dict[str, Any]) -> bool:
+    """Recursively check if NOT_GIVEN sentinel leaked into params."""
+    NOT_GIVEN_REPR = repr(NOT_GIVEN)
+    if NOT_GIVEN_REPR in repr(params):
+        return True
+    for v in params.values():
+        if isinstance(v, dict):
+            if _has_not_given(v):
+                return True
+        elif isinstance(v, list):
+            for item in v:
+                if isinstance(item, dict) and _has_not_given(item):
+                    return True
+        elif repr(v) == NOT_GIVEN_REPR:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Constructor — model validation
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_rejects_unsupported_model() -> None:
+    with pytest.raises(ValueError, match="Unsupported Sarvam model"):
+        SarvamLLM(
+            model="sarvam-unknown",
+            api_key="sk_test",
+            client=_fake_async_client(),
+        )
+
+
+def test_constructor_rejects_old_30b_model() -> None:
+    with pytest.raises(ValueError, match="Unsupported Sarvam model"):
+        SarvamLLM(
+            model="sarvam-30b",
+            api_key="sk_test",
+            client=_fake_async_client(),
+        )
+
+
+@pytest.mark.parametrize("model", ["gemma4", "sarvam-105b", "sarvam-105b-conversations", "glm5.2"])
+def test_constructor_accepts_each_supported_model(model: str) -> None:
+    llm = SarvamLLM(model=model, api_key="sk_test", client=_fake_async_client())
+    assert llm.model == model
+
+
+def test_default_model_is_sarvam_105b() -> None:
+    llm = SarvamLLM(api_key="sk_test", client=_fake_async_client())
+    assert llm.model == "sarvam-105b"
+
+
+# ---------------------------------------------------------------------------
+# Auth and headers
+# ---------------------------------------------------------------------------
+
+
+def test_auth_headers_injected() -> None:
+    llm = SarvamLLM(api_key="sk_test", client=_fake_async_client())
+    headers = llm._opts.extra_headers
+    assert headers["api-subscription-key"] == "sk_test"
+    assert headers["User-Agent"] == USER_AGENT
+
+
+def test_custom_headers_merged() -> None:
+    llm = SarvamLLM(
+        api_key="sk_test",
+        client=_fake_async_client(),
+        extra_headers={
+            "api-subscription-key": "override_attempt",
+            "User-Agent": "override_attempt",
+            "X-Custom": "kept",
+        },
+    )
+    headers = llm._opts.extra_headers
+    # Sarvam headers override caller values on conflict
+    assert headers["api-subscription-key"] == "sk_test"
+    assert headers["User-Agent"] == USER_AGENT
+    # Caller-provided non-conflicting headers are preserved
+    assert headers["X-Custom"] == "kept"
+
+
+def test_base_url_default() -> None:
+    # Don't pass a mock client so a real AsyncClient is created with the default base_url
+    llm = SarvamLLM(api_key="sk_test")
+    assert str(llm._client._base_url).rstrip("/") == SARVAM_LLM_BASE_URL_V2.rstrip("/")
+    import asyncio
+
+    asyncio.get_event_loop().run_until_complete(llm.aclose())
+
+
+def test_explicit_base_url_overrides_default() -> None:
+    custom = "https://custom.sarvam.ai/v2"
+    llm = SarvamLLM(api_key="sk_test", base_url=custom)
+    assert str(llm._client._base_url).rstrip("/") == custom.rstrip("/")
+    import asyncio
+
+    asyncio.get_event_loop().run_until_complete(llm.aclose())
+
+
+# ---------------------------------------------------------------------------
+# Extra body filtering
+# ---------------------------------------------------------------------------
+
+
+def test_filters_unsupported_extra_body_fields() -> None:
+    llm = SarvamLLM(
+        api_key="sk_test",
+        client=_fake_async_client(),
+        extra_body={
+            "max_tokens": 64,
+            "wiki_grounding": True,
+            "service_tier": "flex",
+            "unknown_field": "drop-me",
+        },
+    )
+    assert llm._opts.extra_body == {
+        "max_tokens": 64,
+        "wiki_grounding": True,
+    }
+
+
+def test_filter_extra_body_function() -> None:
+    result = _filter_extra_body(
+        {
+            "max_tokens": 100,
+            "wiki_grounding": True,
+            "service_tier": "flex",
+            "unknown": "drop",
+            "n": 2,
+        }
+    )
+    assert result == {"max_tokens": 100, "wiki_grounding": True, "n": 2}
+
+
+# ---------------------------------------------------------------------------
+# Capability gating — wiki_grounding and reasoning_effort
+# ---------------------------------------------------------------------------
+
+
+def test_wiki_grounding_in_extra_body() -> None:
+    llm = SarvamLLM(
+        api_key="sk_test",
+        client=_fake_async_client(),
+        wiki_grounding=True,
+    )
+    assert llm._opts.extra_body["wiki_grounding"] is True
+
+
+def test_reasoning_effort_set_for_supported_model() -> None:
+    llm = SarvamLLM(
+        model="sarvam-105b",
+        api_key="sk_test",
+        client=_fake_async_client(),
+        reasoning_effort="high",
+    )
+    assert llm._opts.reasoning_effort == "high"
+
+
+def test_reasoning_effort_set_for_gemma4() -> None:
+    llm = SarvamLLM(
+        model="gemma4",
+        api_key="sk_test",
+        client=_fake_async_client(),
+        reasoning_effort="low",
+    )
+    assert llm._opts.reasoning_effort == "low"
+
+
+def test_reasoning_effort_set_for_glm52() -> None:
+    llm = SarvamLLM(
+        model="glm5.2",
+        api_key="sk_test",
+        client=_fake_async_client(),
+        reasoning_effort="medium",
+    )
+    assert llm._opts.reasoning_effort == "medium"
+
+
+def test_reasoning_effort_not_given_by_default() -> None:
+    llm = SarvamLLM(api_key="sk_test", client=_fake_async_client())
+    assert not is_given(llm._opts.reasoning_effort)
+
+
+# ---------------------------------------------------------------------------
+# Image rejection on non-vision models
+# ---------------------------------------------------------------------------
+
+
+def test_image_rejected_on_non_vision_model() -> None:
+    llm = SarvamLLM(
+        model="sarvam-105b",
+        api_key="sk_test",
+        client=_fake_async_client(),
+    )
+    with pytest.raises(ValueError, match="Image input is not supported"):
+        llm.chat(chat_ctx=_chat_ctx_with_image())
+
+
+def test_image_rejected_on_glm52() -> None:
+    llm = SarvamLLM(
+        model="glm5.2",
+        api_key="sk_test",
+        client=_fake_async_client(),
+    )
+    with pytest.raises(ValueError, match="Image input is not supported"):
+        llm.chat(chat_ctx=_chat_ctx_with_image())
+
+
+@pytest.mark.asyncio
+async def test_image_accepted_on_vision_model() -> None:
+    llm = SarvamLLM(
+        model="gemma4",
+        api_key="sk_test",
+        client=_fake_async_client(),
+    )
+    # Should not raise
+    stream = llm.chat(chat_ctx=_chat_ctx_with_image())
+    assert stream is not None
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_vision_validation_skips_non_dict_messages() -> None:
+    """Non-message items (function calls, tool outputs) should not cause errors."""
+    ctx = ChatContext.empty()
+    ctx.add_message(role="user", content="hello")
+    # Add a function call output (non-message item)
+    from livekit.agents.llm import FunctionCallOutput
+
+    ctx.insert(FunctionCallOutput(call_id="test_call", output="result", is_error=False))
+    llm = SarvamLLM(
+        model="sarvam-105b",
+        api_key="sk_test",
+        client=_fake_async_client(),
+    )
+    # Should not raise
+    stream = llm.chat(chat_ctx=ctx)
+    await stream.aclose()
+
+
+# ---------------------------------------------------------------------------
+# tool_choice validation
+# ---------------------------------------------------------------------------
+
+
+def test_tool_choice_without_tools_raises() -> None:
+    llm = SarvamLLM(api_key="sk_test", client=_fake_async_client())
+    with pytest.raises(ValueError, match="tool_choice requires a non-empty tools array"):
+        llm.chat(chat_ctx=_chat_ctx(), tool_choice="required")
+
+
+@pytest.mark.asyncio
+async def test_tool_choice_none_without_tools_ok() -> None:
+    llm = SarvamLLM(api_key="sk_test", client=_fake_async_client())
+    # Should not raise
+    stream = llm.chat(chat_ctx=_chat_ctx(), tool_choice="none")
+    assert stream is not None
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_tool_choice_auto_without_tools_ok() -> None:
+    llm = SarvamLLM(api_key="sk_test", client=_fake_async_client())
+    stream = llm.chat(chat_ctx=_chat_ctx(), tool_choice="auto")
+    assert stream is not None
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_tool_choice_with_tools_allowed() -> None:
+    llm = SarvamLLM(api_key="sk_test", client=_fake_async_client())
+    from livekit.agents.llm import function_tool
+
+    @function_tool
+    def get_weather(city: str) -> str:
+        return "sunny"
+
+    stream = llm.chat(
+        chat_ctx=_chat_ctx("weather?"),
+        tools=[get_weather],
+        tool_choice="auto",
+    )
+    assert stream is not None
+    await stream.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Unsupported OpenAI fields stripped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unsupported_fields_stripped_from_stream() -> None:
+    llm = SarvamLLM(api_key="sk_test", client=_fake_async_client())
+    stream = llm.chat(chat_ctx=_chat_ctx())
+    for field in ("stream_options", "max_completion_tokens", "service_tier"):
+        assert field not in stream._extra_kwargs
+    await stream.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Core fields forwarded
+# ---------------------------------------------------------------------------
+
+
+def test_core_fields_forwarded_to_opts() -> None:
+    llm = SarvamLLM(
+        api_key="sk_test",
+        client=_fake_async_client(),
+        temperature=0.7,
+        top_p=0.9,
+        max_tokens=512,
+        stop=["END"],
+        n=2,
+        seed=42,
+        frequency_penalty=0.5,
+        presence_penalty=0.3,
+    )
+    assert llm._opts.temperature == 0.7
+    assert llm._opts.top_p == 0.9
+    assert llm._opts.extra_body["max_tokens"] == 512
+    assert llm._opts.extra_body["stop"] == ["END"]
+    assert llm._opts.extra_body["n"] == 2
+    assert llm._opts.extra_body["seed"] == 42
+    assert llm._opts.extra_body["frequency_penalty"] == 0.5
+    assert llm._opts.extra_body["presence_penalty"] == 0.3
+
+
+# ---------------------------------------------------------------------------
+# Provider and model properties
+# ---------------------------------------------------------------------------
+
+
+def test_provider_is_sarvam() -> None:
+    llm = SarvamLLM(api_key="sk_test", client=_fake_async_client())
+    assert llm.provider == "Sarvam"
+
+
+def test_model_property_returns_model() -> None:
+    llm = SarvamLLM(model="gemma4", api_key="sk_test", client=_fake_async_client())
+    assert llm.model == "gemma4"
+
+
+# ---------------------------------------------------------------------------
+# API key validation
+# ---------------------------------------------------------------------------
+
+
+def test_missing_api_key_raises() -> None:
+    # Ensure no env var leaks in
+    import os
+
+    old = os.environ.pop("SARVAM_API_KEY", None)
+    try:
+        with pytest.raises(ValueError, match="SARVAM_API_KEY is required"):
+            SarvamLLM(client=_fake_async_client())
+    finally:
+        if old:
+            os.environ["SARVAM_API_KEY"] = old
+
+
+# ---------------------------------------------------------------------------
+# Error propagation (from existing test)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sarvam_entry_points_share_native_status_error_behavior(monkeypatch) -> None:
+    async def _raise_native_api_status_error(self) -> None:  # pragma: no cover - monkeypatched
+        raise APIStatusError(
+            "native provider error",
+            status_code=422,
+            request_id="req_test",
+            body={"error": "bad request"},
+            retryable=False,
+        )
+
+    monkeypatch.setattr(InferenceLLMStream, "_run", _raise_native_api_status_error)
+
+    sarvam_stream = SarvamLLM(api_key="sk_test", client=_fake_async_client()).chat(
+        chat_ctx=_chat_ctx()
+    )
+    streams = (sarvam_stream,)
+
+    try:
+        for stream in streams:
+            with pytest.raises(APIStatusError) as excinfo:
+                await stream._run()
+
+            assert excinfo.value.message == "native provider error"
+            assert excinfo.value.status_code == 422
+            assert excinfo.value.body == {"error": "bad request"}
+    finally:
+        for stream in streams:
+            await stream.aclose()
+
+
+# ---------------------------------------------------------------------------
+# No NOT_GIVEN sentinel leaks
+# ---------------------------------------------------------------------------
+
+
+def test_no_not_given_in_extra_body() -> None:
+    llm = SarvamLLM(
+        api_key="sk_test",
+        client=_fake_async_client(),
+        wiki_grounding=True,
+        max_tokens=100,
+    )
+    if is_given(llm._opts.extra_body):
+        assert not _has_not_given(llm._opts.extra_body)
+
+
+def test_no_not_given_in_extra_headers() -> None:
+    llm = SarvamLLM(api_key="sk_test", client=_fake_async_client())
+    if is_given(llm._opts.extra_headers):
+        assert not _has_not_given(llm._opts.extra_headers)
+
+
+# ---------------------------------------------------------------------------
+# Optional fields omitted when unset
+# ---------------------------------------------------------------------------
+
+
+def test_optional_fields_omitted_when_unset() -> None:
+    llm = SarvamLLM(api_key="sk_test", client=_fake_async_client())
+    # wiki_grounding should not be in extra_body when not set
+    if is_given(llm._opts.extra_body):
+        assert "wiki_grounding" not in llm._opts.extra_body
+    # reasoning_effort should not be given when not set
+    assert not is_given(llm._opts.reasoning_effort)
+
+
+# ---------------------------------------------------------------------------
+# sarvam-105b-conversations — endpoint routing and capability gating
+# ---------------------------------------------------------------------------
+
+
+def test_conversations_resolves_to_v1_endpoint() -> None:
+    llm = SarvamLLM(model="sarvam-105b-conversations", api_key="sk_test")
+    assert str(llm._client._base_url).rstrip("/") == SARVAM_LLM_BASE_URL_V1.rstrip("/")
+    import asyncio
+
+    asyncio.get_event_loop().run_until_complete(llm.aclose())
+
+
+def test_v2_models_resolve_to_v2_endpoint() -> None:
+    """Non-conversations models resolve to /v2."""
+    for model in ["sarvam-105b", "gemma4", "glm5.2"]:
+        llm = SarvamLLM(model=model, api_key="sk_test")
+        assert str(llm._client._base_url).rstrip("/") == SARVAM_LLM_BASE_URL_V2.rstrip("/")
+        import asyncio
+
+        asyncio.get_event_loop().run_until_complete(llm.aclose())
+
+
+def test_conversations_strips_reasoning_effort() -> None:
+    """reasoning_effort is not supported on conversations — should not be set in opts."""
+    llm = SarvamLLM(
+        model="sarvam-105b-conversations",
+        api_key="sk_test",
+        client=_fake_async_client(),
+        reasoning_effort="high",
+    )
+    assert not is_given(llm._opts.reasoning_effort)
+
+
+@pytest.mark.asyncio
+async def test_conversations_strips_reasoning_effort_from_stream() -> None:
+    """reasoning_effort should be absent from built stream params for conversations."""
+    llm = SarvamLLM(
+        model="sarvam-105b-conversations",
+        api_key="sk_test",
+        client=_fake_async_client(),
+    )
+    stream = llm.chat(chat_ctx=_chat_ctx())
+    assert "reasoning_effort" not in stream._extra_kwargs
+    await stream.aclose()
+
+
+def test_conversations_strips_wiki_grounding() -> None:
+    """wiki_grounding is not supported on conversations — should not appear in extra_body."""
+    llm = SarvamLLM(
+        model="sarvam-105b-conversations",
+        api_key="sk_test",
+        client=_fake_async_client(),
+        wiki_grounding=True,
+    )
+    if is_given(llm._opts.extra_body):
+        assert "wiki_grounding" not in llm._opts.extra_body
+
+
+def test_conversations_rejects_image_input() -> None:
+    """Conversations model does not support vision — image raises ValueError."""
+    llm = SarvamLLM(
+        model="sarvam-105b-conversations",
+        api_key="sk_test",
+        client=_fake_async_client(),
+    )
+    with pytest.raises(ValueError, match="Image input is not supported"):
+        llm.chat(chat_ctx=_chat_ctx_with_image())
+
+
+@pytest.mark.asyncio
+async def test_conversations_supports_tool_calling() -> None:
+    """Conversations model supports tool calling — tools and tool_choice pass through."""
+    llm = SarvamLLM(
+        model="sarvam-105b-conversations",
+        api_key="sk_test",
+        client=_fake_async_client(),
+    )
+    from livekit.agents.llm import function_tool
+
+    @function_tool
+    def get_weather(city: str) -> str:
+        return "sunny"
+
+    stream = llm.chat(
+        chat_ctx=_chat_ctx("weather?"),
+        tools=[get_weather],
+        tool_choice="auto",
+    )
+    assert stream is not None
+    await stream.aclose()
+
+
+def test_explicit_base_url_overrides_conversations_v1() -> None:
+    """Explicit base_url wins even for conversations model."""
+    custom = "https://custom.sarvam.ai/v1"
+    llm = SarvamLLM(
+        model="sarvam-105b-conversations",
+        api_key="sk_test",
+        base_url=custom,
+    )
+    assert str(llm._client._base_url).rstrip("/") == custom.rstrip("/")
+    import asyncio
+
+    asyncio.get_event_loop().run_until_complete(llm.aclose())


### PR DESCRIPTION
## Summary

This PR rewrites the Sarvam LLM plugin to support the latest Sarvam model lineup while removing deprecated models.

### Highlights
- Added support for the latest supported Sarvam models
- Automatic routing to the correct API version (`/v1` vs `/v2`)
- Per-model capability validation for vision, `reasoning_effort`, and `wiki_grounding`
- Improved validation and error handling
- Comprehensive test coverage (40 tests)

## Supported Models

| Model | Endpoint |
| ------ | -------- |
| `gemma4` | `/v2` |
| `sarvam-105b` | `/v2` |
| `glm5.2` | `/v2` |
| `sarvam-105b-conversations` | `/v1` |

---

## Changes

### `livekit/plugins/sarvam/llm/models.py`

#### Removed models
- `sarvam-m`
- `sarvam-30b`
- `sarvam-30b-16k`
- `sarvam-105b-32k`

#### Added models
- `gemma4`
- `sarvam-105b`
- `glm5.2`
- `sarvam-105b-conversations`

---

### `livekit/plugins/sarvam/llm/client.py`

> Complete rewrite of the client implementation.

#### Endpoint routing
- `sarvam-105b-conversations` routes to `https://api.sarvam.ai/v1`
- All other models route to `https://api.sarvam.ai/v2`
- Explicit `base_url` always takes precedence

#### Authentication
- Always injects:
  - `api-subscription-key`
  - `User-Agent`
- Overrides conflicting caller-provided values

#### Model validation
- Unsupported models raise `ValueError` before any network request
- Error message lists all supported models

#### Default model
- Changed default model from `sarvam-30b` → `sarvam-105b`

#### Capability gating

**`reasoning_effort`**
- ✅ `gemma4`
- ✅ `sarvam-105b`
- ✅ `glm5.2`
- ❌ `sarvam-105b-conversations` (silently stripped)

**`wiki_grounding`**
- Supported only for `/v2` models

**Vision**
- Supported only by `gemma4`

#### Request sanitization

The following fields are stripped before sending requests:

- `stream_options`
- `max_completion_tokens`
- `service_tier`

Additionally, `reasoning_effort` is stripped at chat time for unsupported models as a safety net.

#### Image validation
- Non-vision models reject `ImageContent` with `ValueError` before making an API request

#### Tool validation
- `tool_choice` without a non-empty `tools` array raises `ValueError`

#### Runtime model switching
`update_options()` now:
- Validates the new model
- Recreates the underlying `openai.AsyncClient` when switching between `/v1` and `/v2`
- Reuses the existing client for switches within the same API version

#### Client factory
Added `_create_sarvam_client()` to centralize creation of `openai.AsyncClient` with:
- Sarvam authentication headers
- 60-second read timeout
- Connection limits

---

### `tests/test_plugin_sarvam_llm.py`

Added **40 tests** covering:

- Model validation
- Endpoint routing
- Authentication headers
- Capability gating
- Field stripping
- Image rejection
- `tool_choice` validation
- Conversations-specific stripping
- `NOT_GIVEN` sentinel handling

---

## Model Capability Matrix

| Model | Endpoint | Vision | reasoning_effort | wiki_grounding | Tools |
| ------ | -------- | :----: | :--------------: | :------------: | :---: |
| `gemma4` | `/v2` | ✅ | ✅ | ✅ | ✅ |
| `sarvam-105b` | `/v2` | ❌ | ✅ | ✅ | ✅ |
| `glm5.2` | `/v2` | ❌ | ✅ | ✅ | ✅ |
| `sarvam-105b-conversations` | `/v1` | ❌ | ❌ | ❌ | ✅ |

---

## Test Coverage

| Model | Coverage |
| ------ | -------- |
| `gemma4` | Streaming, usage, tool calls, reasoning, wiki grounding, error handling |
| `sarvam-105b` | Streaming, usage, tool calls, reasoning, wiki grounding, error handling |
| `glm5.2` | Streaming, usage, tool calls, reasoning, wiki grounding, error handling |
| `sarvam-105b-conversations` | Streaming, usage, tool calls, image rejection, reasoning stripping, error handling |

---

## Breaking Changes

- Removed support for:
  - `sarvam-m`
  - `sarvam-30b`
  - `sarvam-30b-16k`
  - `sarvam-105b-32k`
- Creating `LLM(model="<deprecated-model>")` now raises `ValueError`
- Default model changed from `sarvam-30b` to `sarvam-105b`
- Default base URL is now model-dependent:
  - `/v2` for most models
  - `/v1` for `sarvam-105b-conversations`