### PR TITLE
fix(voice): complete AgentTask teardown after handoff failures

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -960,14 +960,17 @@ class AgentTask(Agent, Generic[TaskResult_T]):
 
         # TODO(theomonnom): could the RunResult watcher & the blocked_tasks share the same logic?
         self.__inactive_ev.clear()
-        suspended_handles: list[SpeechHandle | asyncio.Future[Any]] = []
-        pending_on_enter_task: asyncio.Task[None] | None = None
         try:
+            suspended_handles: list[SpeechHandle | asyncio.Future[Any]] = []
+            pending_on_enter_task: asyncio.Task[None] | None = None
             # use wait_on_enter=False to avoid deadlock: on_enter may spawn nested
             # AgentTasks that require user input, but session.run() can't return until
             # all watched handles complete — creating a circular wait.
             await session._update_activity(
-                self, previous_activity="pause", blocked_tasks=blocked_tasks, wait_on_enter=False
+                self,
+                previous_activity="pause",
+                blocked_tasks=blocked_tasks,
+                wait_on_enter=False,
             )
 
             if not self._activity and not self.done():
@@ -1001,55 +1004,53 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                         suspended_handles.append(blocked)
                 if suspended_handles:
                     run_state._mark_done_if_needed(None)
-        except Exception:
-            self.__inactive_ev.set()
-            raise
 
-        try:
-            return await asyncio.shield(self.__fut)
+            try:
+                return await asyncio.shield(self.__fut)
 
+            finally:
+                if speech_handle:
+                    with contextlib.suppress(RuntimeError):
+                        speech_handle.allow_interruptions = old_allow_interruptions
+
+                # run_state could have changed after self.__fut
+                run_state = session._global_run_state
+
+                # re-watch the suspended handles so the resumed parent activity
+                # is tracked by the current RunResult again
+                if run_state and not run_state.done():
+                    for handle in suspended_handles:
+                        run_state._watch_handle(handle)
+
+                if pending_on_enter_task:
+                    try:
+                        await asyncio.shield(pending_on_enter_task)
+                    except BaseException:
+                        logger.exception("error in on_enter task of agent %s", self.id)
+
+                if session._closing and self._activity is None:
+                    # the activity never started (session closing), skip the handoff;
+                    # the close path owns the previous activity
+                    pass
+                elif session.current_agent != self:
+                    logger.warning(
+                        f"{self.__class__.__name__} completed, but the agent has changed in the meantime. "
+                        "Ignoring handoff to the previous agent, likely due to `AgentSession.update_agent` being invoked."
+                    )
+                    await old_activity.aclose()
+                else:
+                    merged_chat_ctx = old_agent.chat_ctx.merge(
+                        self.chat_ctx,
+                        exclude_function_call=not self._preserve_function_call_history,
+                        exclude_instructions=True,
+                    )
+                    # set the chat_ctx directly, `session._update_activity` will sync it to the rt_session if needed
+                    old_agent._chat_ctx.items[:] = merged_chat_ctx.items
+
+                    await session._update_activity(
+                        old_agent, new_activity="resume", wait_on_enter=False
+                    )
         finally:
-            if speech_handle:
-                with contextlib.suppress(RuntimeError):
-                    speech_handle.allow_interruptions = old_allow_interruptions
-
-            # run_state could have changed after self.__fut
-            run_state = session._global_run_state
-
-            # re-watch the suspended handles so the resumed parent activity
-            # is tracked by the current RunResult again
-            if run_state and not run_state.done():
-                for handle in suspended_handles:
-                    run_state._watch_handle(handle)
-
-            if pending_on_enter_task:
-                try:
-                    await asyncio.shield(pending_on_enter_task)
-                except BaseException:
-                    logger.exception("error in on_enter task of agent %s", self.id)
-
-            if session._closing and self._activity is None:
-                # the activity never started (session closing), skip the handoff;
-                # the close path owns the previous activity
-                pass
-            elif session.current_agent != self:
-                logger.warning(
-                    f"{self.__class__.__name__} completed, but the agent has changed in the meantime. "
-                    "Ignoring handoff to the previous agent, likely due to `AgentSession.update_agent` being invoked."
-                )
-                await old_activity.aclose()
-            else:
-                merged_chat_ctx = old_agent.chat_ctx.merge(
-                    self.chat_ctx,
-                    exclude_function_call=not self._preserve_function_call_history,
-                    exclude_instructions=True,
-                )
-                # set the chat_ctx directly, `session._update_activity` will sync it to the rt_session if needed
-                old_agent._chat_ctx.items[:] = merged_chat_ctx.items
-
-                await session._update_activity(
-                    old_agent, new_activity="resume", wait_on_enter=False
-                )
             self.__inactive_ev.set()
 
     def __await__(self) -> Generator[None, None, TaskResult_T]:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1334,35 +1334,41 @@ class AgentActivity(RecognitionHooks):
                 return
 
             self._closed = True
-            self._cancel_preemptive_generation()
-            await self._session._keyterm_detector.aclose()
+            try:
+                self._cancel_preemptive_generation()
+                await self._session._keyterm_detector.aclose()
 
-            # on_exit_task should be awaited in `drain`
-            self._on_exit_task = None
+                # on_exit_task should be awaited in `drain`
+                self._on_exit_task = None
 
-            # cancel cancellable tools and await the rest before teardown
-            await self._tool_executor.drain()
+                # cancel cancellable tools and await the rest before teardown
+                await self._tool_executor.drain()
 
-            await self._close_session()
-            await asyncio.gather(*self._interrupt_background_speeches(force=False))
+                await self._close_session()
+                await asyncio.gather(*self._interrupt_background_speeches(force=False))
 
-            if self._scheduling_atask is not None:
-                await utils.aio.cancel_and_wait(self._scheduling_atask)
+                if self._scheduling_atask is not None:
+                    await utils.aio.cancel_and_wait(self._scheduling_atask)
 
-            # session-scoped toolsets are closed by the session; this only closes
-            # the agent's own toolsets + MCP — all of which outlive pause
-            toolsets = self._mcp_tools + [
-                tool for tool in self._agent.tools if isinstance(tool, llm.Toolset)
-            ]
-            if toolsets:
-                await asyncio.gather(
-                    *(toolset.aclose() for toolset in toolsets), return_exceptions=True
-                )
+                # session-scoped toolsets are closed by the session; this only closes
+                # the agent's own toolsets + MCP — all of which outlive pause
+                toolsets = self._mcp_tools + [
+                    tool for tool in self._agent.tools if isinstance(tool, llm.Toolset)
+                ]
+                if toolsets:
+                    await asyncio.gather(
+                        *(toolset.aclose() for toolset in toolsets), return_exceptions=True
+                    )
 
-            # final sweep: anything non-cancellable that survived drain dies here
-            await self._tool_executor.aclose()
+                # final sweep: anything non-cancellable that survived drain dies here
+                await self._tool_executor.aclose()
 
-            self._agent._activity = None
+                self._agent._activity = None
+            except BaseException:
+                # aclose is serialized by _lock; let the next caller retry any
+                # idempotent teardown steps that did not finish successfully
+                self._closed = False
+                raise
 
     def push_audio(self, frame: rtc.AudioFrame) -> None:
         if not self._started:

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1214,6 +1214,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 # notify AgentTask to complete and wait it to resume the parent agent
                 agent_task.cancel()
                 await agent_task._wait_for_inactive()
+                # The handoff normally closes this activity. Retry idempotently in case
+                # its close failed before the parent activity could resume.
+                await activity.aclose()
 
                 if old_agent := agent_task._old_agent:
                     activity = old_agent._activity

--- a/tests/test_agent_task_close_race.py
+++ b/tests/test_agent_task_close_race.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+from typing import Any
 
 import pytest
 
@@ -39,6 +41,49 @@ class _ParentAgent(Agent):
         self.exit_started.set()
 
 
+class _CompletingTask(AgentTask[None]):
+    def __init__(self) -> None:
+        super().__init__(instructions="completing task")
+        self.entered = asyncio.Event()
+        self.complete_task = asyncio.Event()
+
+    async def on_enter(self) -> None:
+        self.entered.set()
+        await self.complete_task.wait()
+        self.complete(None)
+
+
+class _TaskAwaitingParent(Agent):
+    def __init__(self, task: _CompletingTask) -> None:
+        super().__init__(instructions="task awaiting parent")
+        self.task = task
+        self.task_finished = asyncio.Event()
+        self.task_error: BaseException | None = None
+
+    async def on_enter(self) -> None:
+        try:
+            await self.task
+        except RuntimeError as e:
+            self.task_error = e
+        finally:
+            self.task_finished.set()
+
+
+class _GatedTaskAwaitingParent(Agent):
+    def __init__(self, task: AgentTask[Any]) -> None:
+        super().__init__(instructions="gated task awaiting parent")
+        self.task = task
+        self.start_task = asyncio.Event()
+        self.task_finished = asyncio.Event()
+
+    async def on_enter(self) -> None:
+        await self.start_task.wait()
+        try:
+            await self.task
+        finally:
+            self.task_finished.set()
+
+
 @pytest.mark.asyncio
 async def test_aclose_while_on_enter_awaits_agent_task() -> None:
     """Closing the session while on_enter awaits an AgentTask must not deadlock:
@@ -52,3 +97,79 @@ async def test_aclose_while_on_enter_awaits_agent_task() -> None:
     await asyncio.wait_for(session.aclose(), timeout=10.0)
 
     assert isinstance(agent.task_error, ToolError)
+
+
+@pytest.mark.asyncio
+async def test_aclose_finishes_when_agent_task_activity_close_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed AgentTask handoff must not leave the session close waiting forever."""
+    task = _CompletingTask()
+    parent = _TaskAwaitingParent(task)
+    session = AgentSession(llm=FakeLLM())
+    await session.start(parent)
+    await asyncio.wait_for(task.entered.wait(), timeout=5.0)
+
+    activity = task._activity
+    assert activity is not None
+    original_close_session = activity._close_session
+    close_attempts = 0
+
+    async def fail_close_session() -> None:
+        nonlocal close_attempts
+        close_attempts += 1
+        await original_close_session()
+        if close_attempts == 1:
+            raise RuntimeError("simulated AgentActivity._close_session failure")
+
+    monkeypatch.setattr(activity, "_close_session", fail_close_session)
+    task.complete_task.set()
+    await asyncio.wait_for(parent.task_finished.wait(), timeout=5.0)
+
+    assert isinstance(parent.task_error, RuntimeError)
+    await asyncio.wait_for(session.aclose(), timeout=1.0)
+
+    assert close_attempts == 2
+    assert activity._closed
+    assert task._activity is None
+    assert not session._started
+
+
+@pytest.mark.asyncio
+async def test_aclose_finishes_when_agent_task_setup_is_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation during AgentTask setup must not leave session close waiting forever."""
+    task = _SimpleTask()
+    parent = _GatedTaskAwaitingParent(task)
+    session = AgentSession(llm=FakeLLM())
+    await session.start(parent)
+
+    original_update_activity = session._update_activity
+    setup_started = asyncio.Event()
+
+    async def pause_after_task_activity_starts(agent: Agent, **kwargs: Any) -> None:
+        await original_update_activity(agent, **kwargs)
+        if agent is task:
+            setup_started.set()
+            await asyncio.Future()
+
+    monkeypatch.setattr(session, "_update_activity", pause_after_task_activity_starts)
+    parent.start_task.set()
+    await asyncio.wait_for(setup_started.wait(), timeout=5.0)
+
+    task_activity = task._activity
+    assert task_activity is not None
+    parent_activity = parent._activity
+    assert parent_activity is not None
+    parent_on_enter = parent_activity._on_enter_task
+    assert parent_on_enter is not None
+    parent_on_enter.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await parent_on_enter
+    await asyncio.wait_for(parent.task_finished.wait(), timeout=5.0)
+
+    await asyncio.wait_for(session.aclose(), timeout=1.0)
+
+    assert task_activity._closed
+    assert not session._started


### PR DESCRIPTION
## What changed

- guarantee an `AgentTask` signals inactivity across setup, wait, and handoff teardown failures
- make `AgentActivity.aclose()` retryable when teardown raises partway through
- have session close retry the current task activity before walking back to its parent

## Why

`AgentSession` waits for an active `AgentTask` to become inactive before it can continue closing. The event was set only after asynchronous handoff cleanup. If activity close or parent resume raised (including cancellation during setup), the signal was skipped and session shutdown could wait forever. A failed activity close also marked the activity closed before cleanup completed, preventing a later retry.

The inactive signal now covers the full handoff lifecycle, while teardown errors still propagate. A partially failed activity close rolls back its completed flag under the close lock so session shutdown can retry it.

## Impact

Session shutdown no longer deadlocks after an `AgentTask` handoff failure, and partially closed child activities can finish releasing their resources.

## Validation

- fail-before regression: `AgentSession.aclose()` timed out after an injected task-activity close failure
- fail-before regression: cancellation during task activity setup left session close waiting
- `pytest tests/test_agent_task_close_race.py tests/test_nested_agent_task.py --unit -q` — 5 passed
- broader AgentSession/AgentTask selection — 86 passed
- Ruff check and format check passed
- mypy passed for the changed voice modules

