### PR TITLE
fix(voice): preserve transcript flush during session close

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1248,6 +1248,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                     audio_recognition._commit_user_turn(
                         audio_detached=True,
                         transcript_timeout=self._opts.session_close_transcript_timeout,
+                        session_close=True,
                     )
 
                 await activity.aclose()

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -7,7 +7,7 @@ import time
 from collections import deque
 from collections.abc import AsyncIterable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
 
 from opentelemetry import trace
 from opentelemetry.sdk.trace import ReadableSpan
@@ -811,9 +811,11 @@ class AudioRecognition:
             try:
                 commit_user_turn_atask = self._commit_user_turn_atask
                 if commit_user_turn_atask is not None:
-                    if commit_user_turn_atask is getattr(
-                        self, "_session_close_commit_user_turn_atask", None
-                    ):
+                    session_close_commit_user_turn_atask = cast(
+                        asyncio.Task[None] | None,
+                        getattr(self, "_session_close_commit_user_turn_atask", None),
+                    )
+                    if commit_user_turn_atask is session_close_commit_user_turn_atask:
                         await _finish_close_flush(commit_user_turn_atask)
                     else:
                         await aio.cancel_and_wait(commit_user_turn_atask)
@@ -835,7 +837,11 @@ class AudioRecognition:
 
                 end_of_turn_task = self._end_of_turn_task
                 if end_of_turn_task is not None:
-                    if end_of_turn_task is getattr(self, "_session_close_end_of_turn_atask", None):
+                    session_close_end_of_turn_atask = cast(
+                        asyncio.Task[None] | None,
+                        getattr(self, "_session_close_end_of_turn_atask", None),
+                    )
+                    if end_of_turn_task is session_close_end_of_turn_atask:
                         await _finish_close_flush(end_of_turn_task)
                     else:
                         await aio.cancel_and_wait(end_of_turn_task)

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -249,9 +249,11 @@ class AudioRecognition:
         self._hooks = hooks
         self._audio_input_atask: asyncio.Task[None] | None = None
         self._commit_user_turn_atask: asyncio.Task[None] | None = None
+        self._session_close_commit_user_turn_atask: asyncio.Task[None] | None = None
         self._stt_consumer_atask: asyncio.Task[None] | None = None
         self._vad_atask: asyncio.Task[None] | None = None
         self._end_of_turn_task: asyncio.Task[None] | None = None
+        self._session_close_end_of_turn_atask: asyncio.Task[None] | None = None
         self._endpointing: BaseEndpointing = endpointing
         self._turn_detector = turn_detection if not isinstance(turn_detection, str) else None
         self._stt = stt
@@ -792,42 +794,86 @@ class AudioRecognition:
 
     async def _aclose(self) -> None:
         self._closing.set()
+
+        async def _cleanup() -> None:
+            flush_error: BaseException | None = None
+
+            async def _finish_close_flush(task: asyncio.Task[None]) -> None:
+                nonlocal flush_error
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                except BaseException as exc:
+                    if flush_error is None:
+                        flush_error = exc
+
+            try:
+                if self._commit_user_turn_atask is not None:
+                    if self._commit_user_turn_atask is self._session_close_commit_user_turn_atask:
+                        await _finish_close_flush(self._commit_user_turn_atask)
+                    else:
+                        await aio.cancel_and_wait(self._commit_user_turn_atask)
+
+                if self._stt_pipeline is not None:
+                    await self._stt_pipeline.aclose()
+                    self._stt_pipeline = None
+
+                await aio.cancel_and_wait(*self._tasks)
+
+                if self._stt_consumer_atask is not None:
+                    await aio.cancel_and_wait(self._stt_consumer_atask)
+
+                if self._vad_atask is not None:
+                    await aio.cancel_and_wait(self._vad_atask)
+
+                if self._interruption_atask is not None:
+                    await aio.cancel_and_wait(self._interruption_atask)
+
+                if self._end_of_turn_task is not None:
+                    if self._end_of_turn_task is self._session_close_end_of_turn_atask:
+                        await _finish_close_flush(self._end_of_turn_task)
+                    else:
+                        await aio.cancel_and_wait(self._end_of_turn_task)
+
+                if self._turn_detector_stream is not None:
+                    await self._turn_detector_stream.aclose()
+                    self._turn_detector_stream = None
+                self._turn_detector_prediction_fut = None
+
+                if self._backchannel_boundary_timer is not None:
+                    self._backchannel_boundary_timer.cancel()
+                    self._backchannel_boundary_timer = None
+                    self._backchannel_boundary_callback = None
+
+                if flush_error is not None:
+                    raise flush_error
+            finally:
+                self._cancel_transcription_timeout()
+                # EOU normally ends this span, but teardown cancels EOU before a
+                # pending speech segment necessarily produces a transcript.
+                self._end_user_turn_span()
+
+        cleanup_task = asyncio.create_task(_cleanup())
+        outer_cancelled = False
+        while not cleanup_task.done():
+            try:
+                await asyncio.shield(cleanup_task)
+            except asyncio.CancelledError:
+                outer_cancelled = True
+            except BaseException:
+                break
+
         try:
-            if self._commit_user_turn_atask is not None:
-                await aio.cancel_and_wait(self._commit_user_turn_atask)
+            cleanup_task.result()
+        except BaseException as exc:
+            if outer_cancelled:
+                logger.error("audio recognition cleanup failed after cancellation", exc_info=exc)
+                raise asyncio.CancelledError from exc
+            raise
 
-            if self._stt_pipeline is not None:
-                await self._stt_pipeline.aclose()
-                self._stt_pipeline = None
-
-            await aio.cancel_and_wait(*self._tasks)
-
-            if self._stt_consumer_atask is not None:
-                await aio.cancel_and_wait(self._stt_consumer_atask)
-
-            if self._vad_atask is not None:
-                await aio.cancel_and_wait(self._vad_atask)
-
-            if self._interruption_atask is not None:
-                await aio.cancel_and_wait(self._interruption_atask)
-
-            if self._end_of_turn_task is not None:
-                await aio.cancel_and_wait(self._end_of_turn_task)
-
-            if self._turn_detector_stream is not None:
-                await self._turn_detector_stream.aclose()
-                self._turn_detector_stream = None
-            self._turn_detector_prediction_fut = None
-
-            if self._backchannel_boundary_timer is not None:
-                self._backchannel_boundary_timer.cancel()
-                self._backchannel_boundary_timer = None
-                self._backchannel_boundary_callback = None
-        finally:
-            self._cancel_transcription_timeout()
-            # EOU normally ends this span, but teardown cancels EOU before a
-            # pending speech segment necessarily produces a transcript.
-            self._end_user_turn_span()
+        if outer_cancelled:
+            raise asyncio.CancelledError
 
     def _update_stt(
         self,
@@ -1043,6 +1089,7 @@ class AudioRecognition:
         transcript_timeout: float,
         stt_flush_duration: float = 2.0,
         skip_reply: bool = False,
+        session_close: bool = False,
     ) -> asyncio.Future[str]:
         loop = asyncio.get_running_loop()
         fut: asyncio.Future[str] = loop.create_future()
@@ -1109,6 +1156,8 @@ class AudioRecognition:
                 skip_reply=skip_reply,
                 trigger="manual",
             )
+            if session_close:
+                self._session_close_end_of_turn_atask = self._end_of_turn_task
             self._user_turn_committed = True
             if not fut.done():
                 fut.set_result(transcript)
@@ -1126,6 +1175,9 @@ class AudioRecognition:
 
         self._commit_user_turn_atask = asyncio.create_task(_commit_user_turn())
         self._commit_user_turn_atask.add_done_callback(_on_task_done)
+        if session_close:
+            self._session_close_commit_user_turn_atask = self._commit_user_turn_atask
+            fut.add_done_callback(lambda done: None if done.cancelled() else done.exception())
         return fut
 
     @property

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -809,11 +809,14 @@ class AudioRecognition:
                         flush_error = exc
 
             try:
-                if self._commit_user_turn_atask is not None:
-                    if self._commit_user_turn_atask is self._session_close_commit_user_turn_atask:
-                        await _finish_close_flush(self._commit_user_turn_atask)
+                commit_user_turn_atask = self._commit_user_turn_atask
+                if commit_user_turn_atask is not None:
+                    if commit_user_turn_atask is getattr(
+                        self, "_session_close_commit_user_turn_atask", None
+                    ):
+                        await _finish_close_flush(commit_user_turn_atask)
                     else:
-                        await aio.cancel_and_wait(self._commit_user_turn_atask)
+                        await aio.cancel_and_wait(commit_user_turn_atask)
 
                 if self._stt_pipeline is not None:
                     await self._stt_pipeline.aclose()
@@ -830,11 +833,12 @@ class AudioRecognition:
                 if self._interruption_atask is not None:
                     await aio.cancel_and_wait(self._interruption_atask)
 
-                if self._end_of_turn_task is not None:
-                    if self._end_of_turn_task is self._session_close_end_of_turn_atask:
-                        await _finish_close_flush(self._end_of_turn_task)
+                end_of_turn_task = self._end_of_turn_task
+                if end_of_turn_task is not None:
+                    if end_of_turn_task is getattr(self, "_session_close_end_of_turn_atask", None):
+                        await _finish_close_flush(end_of_turn_task)
                     else:
-                        await aio.cancel_and_wait(self._end_of_turn_task)
+                        await aio.cancel_and_wait(end_of_turn_task)
 
                 if self._turn_detector_stream is not None:
                     await self._turn_detector_stream.aclose()

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -49,6 +49,7 @@ from livekit.agents.voice.events import FunctionToolsExecutedEvent
 from livekit.agents.voice.io import PlaybackFinishedEvent
 
 from .fake_session import FakeActions, create_session, run_session
+from .fake_stt import FakeSTT
 
 pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
@@ -240,6 +241,50 @@ async def test_events_and_metrics() -> None:
     assert metrics_events[2].metrics.type == "tts_metrics"
     check_timestamp(metrics_events[2].metrics.ttfb, 0.2, speed_factor=speed)
     check_timestamp(metrics_events[2].metrics.audio_duration, 2.0, speed_factor=speed)
+
+
+async def test_aclose_flushes_pending_interim_transcript() -> None:
+    """A normal session close commits an STT interim transcript that is still flushing."""
+    session = create_session(
+        FakeActions(),
+        turn_handling={"endpointing": {"min_delay": 0.0, "max_delay": 0.0}},
+        extra_kwargs={"session_close_transcript_timeout": 0.01},
+    )
+    final_transcripts: list[UserInputTranscribedEvent] = []
+    interim_received = asyncio.Event()
+    agent = MyAgent()
+
+    def on_transcript(event: UserInputTranscribedEvent) -> None:
+        if event.transcript == "last words":
+            if event.is_final:
+                final_transcripts.append(event)
+            else:
+                interim_received.set()
+
+    session.on("user_input_transcribed", on_transcript)
+
+    synchronizer = session.output.audio._synchronizer
+    try:
+        await session.start(agent)
+        stt = session.stt
+        assert isinstance(stt, FakeSTT)
+        stream = await asyncio.wait_for(stt.stream_ch.recv(), timeout=1)
+        stream.send_fake_transcript("last words", is_final=False)
+        await asyncio.wait_for(interim_received.wait(), timeout=1)
+
+        await session.aclose()
+
+        assert [event.transcript for event in final_transcripts] == ["last words"]
+        for chat_ctx in (agent.chat_ctx, session.history):
+            assert [
+                item.text_content
+                for item in chat_ctx.items
+                if item.type == "message" and item.role == "user"
+            ] == ["last words"]
+    finally:
+        if session._started:
+            await session.aclose()
+        await synchronizer.aclose()
 
 
 async def test_tts_node_ttfb_excludes_upstream_latency() -> None:

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -37,6 +37,8 @@ class TestAudioRecognitionAclose:
         audio_recognition._interruption_atask = None
         audio_recognition._turn_detector_stream = None
         audio_recognition._commit_user_turn_atask = None
+        audio_recognition._session_close_commit_user_turn_atask = None
+        audio_recognition._session_close_end_of_turn_atask = None
         audio_recognition._end_of_turn_task = None
         audio_recognition._vad_ch = None
         audio_recognition._interruption_ch = None
@@ -153,6 +155,96 @@ class TestAudioRecognitionAclose:
         # Both tasks are now done (not orphaned)
         assert commit_task.done()
         assert end_of_turn_task.done()
+
+    @pytest.mark.asyncio
+    async def test_aclose_propagates_outer_cancellation_after_finishing_cleanup(self) -> None:
+        """Outer cancellation waits for the close flush and all remaining cleanup."""
+        audio_recognition = self._create_audio_recognition()
+        flush_started = asyncio.Event()
+        release_flush = asyncio.Event()
+
+        async def flush() -> None:
+            flush_started.set()
+            await release_flush.wait()
+
+        flush_task = asyncio.create_task(flush())
+        audio_recognition._commit_user_turn_atask = flush_task
+        audio_recognition._session_close_commit_user_turn_atask = flush_task
+        stt_pipeline = MagicMock()
+        stt_pipeline.aclose = AsyncMock()
+        audio_recognition._stt_pipeline = stt_pipeline
+        turn_detector_stream = MagicMock()
+        turn_detector_stream.aclose = AsyncMock()
+        audio_recognition._turn_detector_stream = turn_detector_stream
+        background_tasks = [asyncio.create_task(asyncio.Event().wait()) for _ in range(4)]
+        audio_recognition._tasks = {background_tasks[0]}
+        audio_recognition._stt_consumer_atask = background_tasks[1]
+        audio_recognition._vad_atask = background_tasks[2]
+        audio_recognition._interruption_atask = background_tasks[3]
+        close_task = asyncio.create_task(audio_recognition._aclose())
+
+        try:
+            await flush_started.wait()
+            close_task.cancel()
+            await asyncio.sleep(0)
+
+            assert not close_task.done()
+            assert not flush_task.cancelled()
+
+            release_flush.set()
+            with pytest.raises(asyncio.CancelledError):
+                await close_task
+
+            assert flush_task.done()
+            assert not flush_task.cancelled()
+            stt_pipeline.aclose.assert_awaited_once()
+            turn_detector_stream.aclose.assert_awaited_once()
+            assert all(task.cancelled() for task in background_tasks)
+        finally:
+            release_flush.set()
+            await asyncio.gather(close_task, flush_task, *background_tasks, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("flush_task_attr", ["_commit_user_turn_atask", "_end_of_turn_task"])
+    async def test_aclose_cancels_non_session_close_flushes(self, flush_task_attr: str) -> None:
+        """Generic commit and EOU work retain the normal activity-teardown cancellation policy."""
+        audio_recognition = self._create_audio_recognition()
+        flush_task = asyncio.create_task(asyncio.Event().wait())
+        setattr(audio_recognition, flush_task_attr, flush_task)
+
+        await audio_recognition._aclose()
+
+        assert flush_task.cancelled()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "flush_task_attr",
+        ["_session_close_commit_user_turn_atask", "_session_close_end_of_turn_atask"],
+    )
+    async def test_aclose_propagates_session_close_flush_errors_after_cleanup(
+        self, flush_task_attr: str
+    ) -> None:
+        """A failed close-owned flush is observed only after the remaining teardown finishes."""
+        audio_recognition = self._create_audio_recognition()
+
+        async def fail_flush() -> None:
+            raise RuntimeError("transcript flush failed")
+
+        flush_task = asyncio.create_task(fail_flush())
+        setattr(audio_recognition, flush_task_attr, flush_task)
+        if flush_task_attr == "_session_close_commit_user_turn_atask":
+            audio_recognition._commit_user_turn_atask = flush_task
+        else:
+            audio_recognition._end_of_turn_task = flush_task
+
+        turn_detector_stream = MagicMock()
+        turn_detector_stream.aclose = AsyncMock()
+        audio_recognition._turn_detector_stream = turn_detector_stream
+
+        with pytest.raises(RuntimeError, match="transcript flush failed"):
+            await audio_recognition._aclose()
+
+        turn_detector_stream.aclose.assert_awaited_once()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(("is_recording", "expected_end_count"), [(True, 1), (False, 0)])

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -37,8 +37,6 @@ class TestAudioRecognitionAclose:
         audio_recognition._interruption_atask = None
         audio_recognition._turn_detector_stream = None
         audio_recognition._commit_user_turn_atask = None
-        audio_recognition._session_close_commit_user_turn_atask = None
-        audio_recognition._session_close_end_of_turn_atask = None
         audio_recognition._end_of_turn_task = None
         audio_recognition._vad_ch = None
         audio_recognition._interruption_ch = None
@@ -207,7 +205,7 @@ class TestAudioRecognitionAclose:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("flush_task_attr", ["_commit_user_turn_atask", "_end_of_turn_task"])
     async def test_aclose_cancels_non_session_close_flushes(self, flush_task_attr: str) -> None:
-        """Generic commit and EOU work retain the normal activity-teardown cancellation policy."""
+        """Missing close markers leave ordinary commit and EOU work cancellable."""
         audio_recognition = self._create_audio_recognition()
         flush_task = asyncio.create_task(asyncio.Event().wait())
         setattr(audio_recognition, flush_task_attr, flush_task)


### PR DESCRIPTION
## What changed

- distinguish the transcript flush explicitly started by normal `AgentSession` close from ordinary commit/EOU tasks
- drain that close-owned commit and its resulting EOU task instead of cancelling them
- keep the remaining audio-recognition teardown cancellation-safe and surface close-flush failures after cleanup

## Why

Normal session close starts `_commit_user_turn(...)` with `session_close_transcript_timeout` and immediately closes the activity. `AudioRecognition._aclose()` then cancelled the same commit task (and its EOU task), so an interim/final transcript still being flushed could never reach conversation history.

Only the exact tasks owned by normal session close are preserved. Public commits, handoff teardown, and error-close tasks retain the existing cancellation behavior. If outer cancellation arrives, cleanup is reaped before `CancelledError` is propagated.

## Impact

The last user utterance can finish committing during normal session shutdown, so `session_close_transcript_timeout` again provides its intended transcript-capture behavior without broadening waits on unrelated close paths.

## Validation

- fail-before regression: a real `AgentSession` close emitted no final transcript/history item for a pending interim transcript
- direct assertions cover both agent chat context and session history, exactly once
- cancellation cleanup, ordinary-task cancellation, and close-owned child-error regressions included
- `pytest tests/test_audio_recognition_aclose.py tests/test_agent_session.py --unit -q` — 92 passed
- handoff selection — 13 passed
- Ruff check and format check passed
- mypy (`livekit.agents`) — 206 files passed

