### PR TITLE
fix(voice): preserve turns across activity handoffs

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -216,6 +216,7 @@ class AgentActivity(RecognitionHooks):
 
         self._scheduling_atask: asyncio.Task[None] | None = None
         self._user_turn_completed_atask: asyncio.Task[None] | None = None
+        self._handoff_user_turns: list[_EndOfTurnInfo] = []
         self._speech_tasks: list[asyncio.Task[Any]] = []
 
         self._preemptive_generation: _PreemptiveGeneration | None = None
@@ -1130,6 +1131,43 @@ class AgentActivity(RecognitionHooks):
             if self.stt.capabilities.chat_context and forward_chat_ctx:
                 self._session.on("conversation_item_added", self.stt._push_conversation_item)
 
+        self._schedule_handoff_user_turns()
+
+    def _queue_handoff_user_turn(self, info: _EndOfTurnInfo) -> None:
+        """Keep an accepted pipeline turn until this activity's scheduler is running."""
+        self._handoff_user_turns.append(info)
+
+    def _take_handoff_user_turns(self, source_activity: AgentActivity) -> None:
+        """Move queued turns from the activity being replaced to this activity."""
+        if source_activity._handoff_user_turns:
+            self._handoff_user_turns.extend(source_activity._handoff_user_turns)
+            source_activity._handoff_user_turns.clear()
+
+    def _persist_handoff_user_turns(self) -> None:
+        """Append unconsumed handoff turns using the session-close history semantics."""
+        handoff_user_turns = self._handoff_user_turns
+        self._handoff_user_turns = []
+        for info in handoff_user_turns:
+            user_message = llm.ChatMessage(
+                role="user",
+                content=[info.new_transcript],
+                transcript_confidence=info.transcript_confidence,
+            )
+            user_message.metrics = self._init_metrics_from_end_of_turn(info)
+            self._agent._chat_ctx.items.append(user_message)
+            self._session._conversation_item_added(user_message)
+
+    def _schedule_handoff_user_turns(self) -> None:
+        """Continue turns accepted by the activity that handed off to this one."""
+        handoff_user_turns = self._handoff_user_turns
+        self._handoff_user_turns = []
+        for info in handoff_user_turns:
+            old_task = self._user_turn_completed_atask
+            self._user_turn_completed_atask = self._create_speech_task(
+                self._user_turn_completed_task(old_task, info),
+                name="AgentActivity._user_turn_completed_task",
+            )
+
     @tracer.start_as_current_span("drain_agent_activity")
     async def drain(
         self, *, new_activity: AgentActivity | None = None
@@ -1335,6 +1373,7 @@ class AgentActivity(RecognitionHooks):
 
             self._closed = True
             self._cancel_preemptive_generation()
+            self._persist_handoff_user_turns()
             await self._session._keyterm_detector.aclose()
 
             # on_exit_task should be awaited in `drain`
@@ -2341,6 +2380,11 @@ class AgentActivity(RecognitionHooks):
                 extra={"user_input": info.new_transcript},
             )
 
+            if isinstance(self.llm, llm.LLM) and self._session._forward_handoff_user_turn(
+                self, info
+            ):
+                return True
+
             if self._session._closing:
                 # add user input to chat context
                 user_message = llm.ChatMessage(
@@ -2471,6 +2515,10 @@ class AgentActivity(RecognitionHooks):
                 "skipping on_user_turn_completed, speech scheduling is paused",
                 extra={"user_input": info.new_transcript},
             )
+            if isinstance(self.llm, llm.LLM) and self._session._forward_handoff_user_turn(
+                self, info
+            ):
+                return
             if self._session._closing:
                 self._agent._chat_ctx.items.append(user_message)
                 self._session._conversation_item_added(user_message)
@@ -2505,6 +2553,10 @@ class AgentActivity(RecognitionHooks):
                 "skipping reply to user input, speech scheduling is paused",
                 extra={"user_input": info.new_transcript},
             )
+            if isinstance(self.llm, llm.LLM) and self._session._forward_handoff_user_turn(
+                self, info
+            ):
+                return
             if user_message and self._session._closing:
                 self._agent._chat_ctx.items.append(user_message)
                 self._session._conversation_item_added(user_message)

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -175,6 +175,16 @@ class _PreemptiveGeneration:
 
 
 @dataclass
+class _PreparedUserTurn:
+    """A pipeline turn whose ``on_user_turn_completed`` callback has already run."""
+
+    info: _EndOfTurnInfo
+    user_message: llm.ChatMessage
+    chat_ctx: llm.ChatContext
+    on_user_turn_completed_delay: float
+
+
+@dataclass
 class _PausedSpeechInfo:
     handle: SpeechHandle
     agent_state: AgentState
@@ -216,7 +226,7 @@ class AgentActivity(RecognitionHooks):
 
         self._scheduling_atask: asyncio.Task[None] | None = None
         self._user_turn_completed_atask: asyncio.Task[None] | None = None
-        self._handoff_user_turns: list[_EndOfTurnInfo] = []
+        self._handoff_user_turns: list[_EndOfTurnInfo | _PreparedUserTurn] = []
         self._speech_tasks: list[asyncio.Task[Any]] = []
 
         self._preemptive_generation: _PreemptiveGeneration | None = None
@@ -1133,9 +1143,9 @@ class AgentActivity(RecognitionHooks):
 
         self._schedule_handoff_user_turns()
 
-    def _queue_handoff_user_turn(self, info: _EndOfTurnInfo) -> None:
+    def _queue_handoff_user_turn(self, user_turn: _EndOfTurnInfo | _PreparedUserTurn) -> None:
         """Keep an accepted pipeline turn until this activity's scheduler is running."""
-        self._handoff_user_turns.append(info)
+        self._handoff_user_turns.append(user_turn)
 
     def _take_handoff_user_turns(self, source_activity: AgentActivity) -> None:
         """Move queued turns from the activity being replaced to this activity."""
@@ -1147,26 +1157,42 @@ class AgentActivity(RecognitionHooks):
         """Append unconsumed handoff turns using the session-close history semantics."""
         handoff_user_turns = self._handoff_user_turns
         self._handoff_user_turns = []
-        for info in handoff_user_turns:
-            user_message = llm.ChatMessage(
-                role="user",
-                content=[info.new_transcript],
-                transcript_confidence=info.transcript_confidence,
-            )
-            user_message.metrics = self._init_metrics_from_end_of_turn(info)
+        for user_turn in handoff_user_turns:
+            if isinstance(user_turn, _PreparedUserTurn):
+                # Its metrics were initialized from ``info`` before the source
+                # callback ran; preserve that finalized message verbatim.
+                user_message = user_turn.user_message
+            else:
+                info = user_turn
+                user_message = llm.ChatMessage(
+                    role="user",
+                    content=[info.new_transcript],
+                    transcript_confidence=info.transcript_confidence,
+                )
+                user_message.metrics = self._init_metrics_from_end_of_turn(info)
+
             self._agent._chat_ctx.items.append(user_message)
             self._session._conversation_item_added(user_message)
+
+    def _persist_prepared_user_turn(self, user_turn: _PreparedUserTurn) -> None:
+        """Commit an already-callbacked turn without recreating its message."""
+        self._agent._chat_ctx.items.append(user_turn.user_message)
+        self._session._conversation_item_added(user_turn.user_message)
 
     def _schedule_handoff_user_turns(self) -> None:
         """Continue turns accepted by the activity that handed off to this one."""
         handoff_user_turns = self._handoff_user_turns
         self._handoff_user_turns = []
-        for info in handoff_user_turns:
+        for user_turn in handoff_user_turns:
             old_task = self._user_turn_completed_atask
-            self._user_turn_completed_atask = self._create_speech_task(
-                self._user_turn_completed_task(old_task, info),
-                name="AgentActivity._user_turn_completed_task",
-            )
+            if isinstance(user_turn, _PreparedUserTurn):
+                task = self._prepared_user_turn_completed_task(old_task, user_turn)
+                task_name = "AgentActivity._prepared_user_turn_completed_task"
+            else:
+                task = self._user_turn_completed_task(old_task, user_turn)
+                task_name = "AgentActivity._user_turn_completed_task"
+
+            self._user_turn_completed_atask = self._create_speech_task(task, name=task_name)
 
     @tracer.start_as_current_span("drain_agent_activity")
     async def drain(
@@ -2542,46 +2568,112 @@ class AgentActivity(RecognitionHooks):
         on_user_turn_completed_delay = time.perf_counter() - start_time
         metrics_report["on_user_turn_completed_delay"] = on_user_turn_completed_delay
 
-        if isinstance(self.llm, llm.RealtimeModel):
+        handoff_user_turn: _PreparedUserTurn | None = None
+        if isinstance(self.llm, llm.LLM):
+            handoff_user_turn = _PreparedUserTurn(
+                info=info,
+                user_message=user_message,
+                chat_ctx=temp_mutable_chat_ctx,
+                on_user_turn_completed_delay=on_user_turn_completed_delay,
+            )
+        elif isinstance(self.llm, llm.RealtimeModel):
             # ignore stt transcription for realtime model
             user_message = None  # type: ignore
         elif self.llm is None:
             return  # skip response if no llm is set
+
+        await self._schedule_reply_after_user_turn(
+            info=info,
+            user_message=user_message,
+            chat_ctx=temp_mutable_chat_ctx,
+            on_user_turn_completed_delay=on_user_turn_completed_delay,
+            handoff_user_turn=handoff_user_turn,
+        )
+
+    @utils.log_exceptions(logger=logger)
+    async def _prepared_user_turn_completed_task(
+        self,
+        old_task: asyncio.Task[None] | None,
+        user_turn: _PreparedUserTurn,
+    ) -> None:
+        """Resume a handed-off pipeline turn after its callback already completed."""
+        if old_task is not None:
+            await old_task
+
+        self._preemptive_generation_count = 0
+        await asyncio.gather(*self._interrupt_background_speeches(force=False))
+
+        # A prepared turn is deliberately pipeline-only. Realtime input ownership
+        # stays with its remote session; committing the local message is safer than
+        # replaying it through a different lifecycle.
+        if not isinstance(self.llm, llm.LLM):
+            self._persist_prepared_user_turn(user_turn)
+            return
+
+        if (current_speech := self._current_speech) is not None:
+            if not current_speech.allow_interruptions:
+                logger.warning(
+                    "skipping reply to handed-off user input, current speech generation cannot be interrupted",
+                    extra={"user_input": user_turn.user_message.raw_text_content},
+                )
+                self._persist_prepared_user_turn(user_turn)
+                return
+            await self._cancel_speech_pause(self._cancel_speech_pause_task)
+            await current_speech.interrupt()
+
+        await self._schedule_reply_after_user_turn(
+            info=user_turn.info,
+            user_message=user_turn.user_message,
+            chat_ctx=user_turn.chat_ctx,
+            on_user_turn_completed_delay=user_turn.on_user_turn_completed_delay,
+            handoff_user_turn=user_turn,
+        )
+
+    async def _schedule_reply_after_user_turn(
+        self,
+        *,
+        info: _EndOfTurnInfo,
+        user_message: llm.ChatMessage | None,
+        chat_ctx: llm.ChatContext,
+        on_user_turn_completed_delay: float,
+        handoff_user_turn: _PreparedUserTurn | None,
+    ) -> None:
+        """Schedule reply/history work after a completed user-turn callback."""
 
         if self._scheduling_paused or self._new_turns_blocked:
             logger.warning(
                 "skipping reply to user input, speech scheduling is paused",
                 extra={"user_input": info.new_transcript},
             )
-            if isinstance(self.llm, llm.LLM) and self._session._forward_handoff_user_turn(
-                self, info
+            if handoff_user_turn and self._session._forward_handoff_user_turn(
+                self, handoff_user_turn
             ):
                 return
-            if user_message and self._session._closing:
-                self._agent._chat_ctx.items.append(user_message)
-                self._session._conversation_item_added(user_message)
+            if self._session._closing:
+                if handoff_user_turn:
+                    self._persist_prepared_user_turn(handoff_user_turn)
+                elif user_message:
+                    self._agent._chat_ctx.items.append(user_message)
+                    self._session._conversation_item_added(user_message)
             return
 
         speech_handle: SpeechHandle | None = None
         if preemptive := self._preemptive_generation:
-            # make sure the on_user_turn_completed didn't change some request parameters
-            # otherwise invalidate the preemptive generation
+            # make sure the callback didn't change some request parameters; otherwise
+            # invalidate the preemptive generation just as an ordinary pipeline turn does.
             if (
-                _transcripts_equivalent(
+                user_message is not None
+                and _transcripts_equivalent(
                     preemptive.info.new_transcript, user_message.raw_text_content
                 )
-                and preemptive.chat_ctx.is_equivalent(temp_mutable_chat_ctx)
+                and preemptive.chat_ctx.is_equivalent(chat_ctx)
                 and preemptive.tools == self.tools
                 and preemptive.tool_choice == self._tool_choice
             ):
                 speech_handle = preemptive.speech_handle
-
-                # The pipeline task retains the ChatMessage created for preemptive generation.
-                # Reconcile it with the finalized message before scheduling so conversation
-                # history keeps the final transcript and on_user_turn_completed edits.
                 preemptive.user_message.content = user_message.content.copy()
                 preemptive.user_message.transcript_confidence = user_message.transcript_confidence
-                preemptive.user_message.metrics = metrics_report
+                preemptive.user_message.metrics = user_message.metrics
                 self._schedule_speech(speech_handle, priority=SpeechHandle.SPEECH_PRIORITY_NORMAL)
                 logger.debug(
                     "using preemptive generation",
@@ -2597,19 +2689,15 @@ class AgentActivity(RecognitionHooks):
             self._preemptive_generation = None
 
         if speech_handle is None:
-            # Ensure the new message is passed to generate_reply
-            # This preserves the original message_id, making it easier for users to track responses
             speech_handle = self._generate_reply(
                 user_message=user_message,
-                chat_ctx=temp_mutable_chat_ctx,
+                chat_ctx=chat_ctx,
                 input_details=InputDetails(modality="audio"),
             )
 
         if self._user_turn_completed_atask != asyncio.current_task():
-            # If a new user turn has already started, interrupt this one since it's now outdated
-            # (We still create the SpeechHandle and the generate_reply coroutine, otherwise we may
-            # lose data like the beginning of a user speech).
-            # await the interrupt to make sure user message is added to the chat context before the new task starts
+            # A later accepted turn supersedes this one, but still let the pipeline
+            # commit its user message before it is interrupted.
             await speech_handle.interrupt()
 
         metadata: Metadata | None = None

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -47,7 +47,7 @@ from ..utils.misc import is_given
 from . import io, room_io
 from ._utils import _set_participant_attributes
 from .agent import Agent, AgentTask
-from .agent_activity import AgentActivity, _ReusableResources
+from .agent_activity import AgentActivity, _PreparedUserTurn, _ReusableResources
 from .amd import AMD
 from .events import (
     AgentEvent,
@@ -1788,7 +1788,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             await asyncio.shield(self._activity._on_enter_task)
 
     def _forward_handoff_user_turn(
-        self, source_activity: AgentActivity, info: _EndOfTurnInfo
+        self,
+        source_activity: AgentActivity,
+        user_turn: _EndOfTurnInfo | _PreparedUserTurn,
     ) -> bool:
         """Route an accepted pipeline turn across an activity handoff.
 
@@ -1804,11 +1806,11 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             return False
 
         if self._next_activity is not None:
-            self._next_activity._queue_handoff_user_turn(info)
+            self._next_activity._queue_handoff_user_turn(user_turn)
             return True
 
         if self._update_activity_atask is not None and not self._update_activity_atask.done():
-            source_activity._queue_handoff_user_turn(info)
+            source_activity._queue_handoff_user_turn(user_turn)
             return True
 
         return False

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -91,6 +91,7 @@ if TYPE_CHECKING:
     from ..cli.tcp_console import TcpAudioInput, TcpAudioOutput
     from ..inference import LLMModels, STTModels, TTSModels
     from ..llm import mcp
+    from .audio_recognition import _EndOfTurnInfo
     from .transcription.text_transforms import TextTransforms
 
 
@@ -1708,6 +1709,16 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
                 self._next_activity = agent._activity
 
+            next_activity = self._next_activity
+            assert next_activity is not None
+
+            # A turn can finish after update_agent() blocks its source activity
+            # but before this coroutine creates the replacement. The queue lives
+            # on that source (rather than on the session), so it has one clear
+            # owner and follows chained handoffs without retaining stale activities.
+            if (activity := self._activity) is not None:
+                next_activity._take_handoff_user_turns(activity)
+
             if self._root_span_context is not None:
                 # restore the root span context so on_exit, on_enter, and future turns
                 # are direct children of the root span, not nested under a tool call.
@@ -1718,27 +1729,28 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 previous_activity_v = self._activity
                 if (activity := self._activity) is not None:
                     if previous_activity == "close":
-                        reuse_resources = await activity.drain(new_activity=self._next_activity)
+                        reuse_resources = await activity.drain(new_activity=next_activity)
                         await activity.aclose()
                     elif previous_activity == "pause":
                         reuse_resources = await activity.pause(
                             blocked_tasks=blocked_tasks or [],
-                            new_activity=self._next_activity,
+                            new_activity=next_activity,
                         )
 
                 if self._closing and new_activity == "start":
                     # disallow starting a new activity when the session is closing
                     logger.warning(
-                        f"session is closing, skipping {new_activity} activity of {self._next_activity.agent.id}",
+                        f"session is closing, skipping {new_activity} activity of {next_activity.agent.id}",
                     )
                     if reuse_resources is not None:
                         await reuse_resources.cleanup()
                         reuse_resources = None
+                    next_activity._persist_handoff_user_turns()
                     self._next_activity = None
                     self._activity = None
                     return
 
-                self._activity = self._next_activity
+                self._activity = next_activity
                 self._next_activity = None
 
                 run_state = self._global_run_state
@@ -1763,6 +1775,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 elif new_activity == "resume":
                     await self._activity.resume(reuse_resources=reuse_resources)
             except BaseException:
+                # The successor cannot consume these accepted turns, so preserve
+                # them with the same history semantics as session close.
+                next_activity._persist_handoff_user_turns()
                 if reuse_resources is not None:
                     await reuse_resources.cleanup()
                 raise
@@ -1771,6 +1786,32 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         if wait_on_enter:
             assert self._activity._on_enter_task is not None
             await asyncio.shield(self._activity._on_enter_task)
+
+    def _forward_handoff_user_turn(
+        self, source_activity: AgentActivity, info: _EndOfTurnInfo
+    ) -> bool:
+        """Route an accepted pipeline turn across an activity handoff.
+
+        Callers intentionally restrict this to ``llm.LLM``: pipeline turns use
+        this local ChatMessage/speech-scheduler lifecycle, while Realtime models
+        commit their input through the remote session instead.
+
+        This is intentionally limited to an activity transition. A manually
+        drained activity still has no successor, so it keeps its existing
+        behaviour instead of retaining a turn indefinitely.
+        """
+        if self._closing or self._activity is not source_activity:
+            return False
+
+        if self._next_activity is not None:
+            self._next_activity._queue_handoff_user_turn(info)
+            return True
+
+        if self._update_activity_atask is not None and not self._update_activity_atask.done():
+            source_activity._queue_handoff_user_turn(info)
+            return True
+
+        return False
 
     @utils.log_exceptions(logger=logger)
     async def _update_activity_task(

--- a/tests/test_agent_task_handoff_turn.py
+++ b/tests/test_agent_task_handoff_turn.py
@@ -77,6 +77,39 @@ class _FailingPrewarmLLM(FakeLLM):
         raise RuntimeError("successor prewarm failed")
 
 
+class _CallbackHandoffSuccessor(_TurnRecorder):
+    def __init__(self) -> None:
+        super().__init__("callback handoff successor")
+        self.llm_context: llm.ChatContext | None = None
+
+    async def llm_node(
+        self,
+        chat_ctx: llm.ChatContext,
+        _tools: list[llm.Tool],
+        _model_settings: object,
+    ):
+        self.llm_context = chat_ctx.copy()
+        yield "reply"
+
+
+class _CallbackHandoffSource(_TurnRecorder):
+    def __init__(self, successor: Agent) -> None:
+        super().__init__("callback handoff source")
+        self.successor = successor
+        self.callback_started = asyncio.Event()
+        self.release_callback = asyncio.Event()
+
+    async def on_user_turn_completed(
+        self, turn_ctx: llm.ChatContext, new_message: llm.ChatMessage
+    ) -> None:
+        await super().on_user_turn_completed(turn_ctx, new_message)
+        new_message.content = ["rewritten by the source callback"]
+        turn_ctx.add_message(role="system", content="source callback context")
+        self.session.update_agent(self.successor)
+        self.callback_started.set()
+        await self.release_callback.wait()
+
+
 async def _wait_for(predicate, *, message: str) -> None:
     for _ in range(300):
         if predicate():
@@ -464,3 +497,69 @@ async def test_source_close_persists_a_turn_queued_before_update_starts() -> Non
     finally:
         if close_task is None:
             await asyncio.wait_for(session.aclose(), timeout=5.0)
+
+
+async def test_callback_handoff_continues_without_invoking_the_callback_twice() -> None:
+    """A callback-triggered handoff keeps its callback edits and does not rerun it."""
+    original_transcript = "the original user turn"
+    rewritten_transcript = "rewritten by the source callback"
+    speech = FakeUserSpeech(
+        start_time=0.05,
+        end_time=0.10,
+        transcript=original_transcript,
+        stt_delay=0.0,
+    )
+    session = AgentSession(
+        stt=FakeSTT(fake_user_speeches=[speech]),
+        vad=FakeVAD(
+            fake_user_speeches=[speech], min_speech_duration=0.05, min_silence_duration=0.05
+        ),
+        llm=FakeLLM(),
+        turn_handling=TurnHandlingOptions(
+            turn_detection="vad",
+            endpointing=EndpointingOptions(min_delay=0.01, max_delay=0.01),
+        ),
+        aec_warmup_duration=None,
+    )
+    audio_input = FakeAudioInput()
+    session.input.audio = audio_input
+    successor = _CallbackHandoffSuccessor()
+    source = _CallbackHandoffSource(successor)
+
+    try:
+        await session.start(source)
+        audio_input.push(0.1)
+        await asyncio.wait_for(source.callback_started.wait(), timeout=2.0)
+        source.release_callback.set()
+        await _wait_for(
+            lambda: session.current_agent is successor,
+            message="the callback-triggered handoff never started its successor",
+        )
+        await _wait_for(
+            lambda: successor.llm_context is not None or successor.received_turn.is_set(),
+            message="the callback-triggered handoff never continued the user turn",
+        )
+        await asyncio.wait_for(session.wait_for_idle(), timeout=3.0)
+
+        assert source.user_turns == [original_transcript]
+        assert successor.user_turns == []
+        assert len(source.user_turns) + len(successor.user_turns) == 1
+        assert successor.llm_context is not None
+        assert any(
+            item.type == "message"
+            and item.role == "system"
+            and item.raw_text_content == "source callback context"
+            for item in successor.llm_context.items
+        )
+        assert [
+            item.raw_text_content
+            for item in successor.chat_ctx.items
+            if item.type == "message" and item.role == "user"
+        ] == [rewritten_transcript]
+        assert [
+            item.raw_text_content
+            for item in session.history.items
+            if item.type == "message" and item.role == "user"
+        ] == [rewritten_transcript]
+    finally:
+        await asyncio.wait_for(session.aclose(), timeout=5.0)

--- a/tests/test_agent_task_handoff_turn.py
+++ b/tests/test_agent_task_handoff_turn.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from livekit.agents import (
+    Agent,
+    AgentSession,
+    AgentTask,
+    EndpointingOptions,
+    TurnHandlingOptions,
+    llm,
+)
+
+from .fake_io import FakeAudioInput
+from .fake_llm import FakeLLM, FakeLLMResponse
+from .fake_stt import FakeSTT, FakeUserSpeech
+from .fake_vad import FakeVAD
+
+pytestmark = [pytest.mark.unit, pytest.mark.no_concurrent]
+
+
+class _HandoffTask(AgentTask[None]):
+    def __init__(self) -> None:
+        super().__init__(instructions="handoff task")
+        self.received_turn = asyncio.Event()
+        self.user_turns: list[str | None] = []
+
+    async def on_user_turn_completed(
+        self, _turn_ctx: llm.ChatContext, new_message: llm.ChatMessage
+    ) -> None:
+        self.user_turns.append(new_message.raw_text_content)
+        self.received_turn.set()
+
+
+class _HandoffSource(Agent):
+    def __init__(self) -> None:
+        super().__init__(instructions="handoff source")
+        self.task = _HandoffTask()
+        self.speech_created = asyncio.Event()
+        self.begin_handoff = asyncio.Event()
+
+    async def on_enter(self) -> None:
+        self.session.generate_reply(instructions="hold the handoff open")
+        self.speech_created.set()
+        await self.begin_handoff.wait()
+        await self.task
+
+
+class _TurnRecorder(Agent):
+    def __init__(self, instructions: str) -> None:
+        super().__init__(instructions=instructions)
+        self.received_turn = asyncio.Event()
+        self.user_turns: list[str | None] = []
+
+    async def on_user_turn_completed(
+        self, _turn_ctx: llm.ChatContext, new_message: llm.ChatMessage
+    ) -> None:
+        self.user_turns.append(new_message.raw_text_content)
+        self.received_turn.set()
+
+
+class _BlockingExitRecorder(_TurnRecorder):
+    def __init__(self, instructions: str) -> None:
+        super().__init__(instructions)
+        self.exit_started = asyncio.Event()
+        self.release_exit = asyncio.Event()
+
+    async def on_exit(self) -> None:
+        self.exit_started.set()
+        await self.release_exit.wait()
+
+
+class _FailingPrewarmLLM(FakeLLM):
+    def prewarm(self, *, loop: asyncio.AbstractEventLoop | None = None) -> None:
+        raise RuntimeError("successor prewarm failed")
+
+
+async def _wait_for(predicate, *, message: str) -> None:
+    for _ in range(300):
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    pytest.fail(message)
+
+
+async def test_agent_task_handoff_forwards_a_turn_arriving_while_scheduling_pauses() -> None:
+    """The replacement activity owns one pipeline turn committed during its pause."""
+    transcript = "the turn that crosses the handoff"
+    speech = FakeUserSpeech(
+        start_time=0.05,
+        end_time=0.10,
+        transcript=transcript,
+        stt_delay=0.0,
+    )
+    session = AgentSession(
+        stt=FakeSTT(fake_user_speeches=[speech]),
+        vad=FakeVAD(
+            fake_user_speeches=[speech], min_speech_duration=0.05, min_silence_duration=0.05
+        ),
+        llm=FakeLLM(
+            fake_responses=[
+                # Keep the old scheduler in its real pause/drain window long enough
+                # for the VAD/STT end-of-turn task to commit the crossing turn.
+                FakeLLMResponse(input="hold the handoff open", content="", ttft=2.0, duration=0.0),
+                FakeLLMResponse(input=transcript, content="received", ttft=0.0, duration=0.0),
+            ]
+        ),
+        turn_handling=TurnHandlingOptions(
+            turn_detection="vad",
+            endpointing=EndpointingOptions(min_delay=0.4, max_delay=0.4),
+        ),
+        aec_warmup_duration=None,
+    )
+    audio_input = FakeAudioInput()
+    session.input.audio = audio_input
+    source = _HandoffSource()
+
+    try:
+        await session.start(source)
+        await asyncio.wait_for(source.speech_created.wait(), timeout=2.0)
+        await _wait_for(
+            lambda: source._activity is not None and source._activity.current_speech is not None,
+            message="the source reply never reached the real scheduler",
+        )
+
+        # Let the source recognition pipeline start a normal VAD/STT/EOU turn,
+        # but leave its EOU timer pending while the AgentTask starts.
+        audio_input.push(0.1)
+        await _wait_for(
+            lambda: (
+                source._activity is not None
+                and source._activity._audio_recognition is not None
+                and source._activity._audio_recognition._end_of_turn_task is not None
+                and not source._activity._audio_recognition._end_of_turn_task.done()
+            ),
+            message="the source activity never opened the end-of-turn decision",
+        )
+
+        source.begin_handoff.set()
+        await _wait_for(
+            lambda: source._activity is not None and source._activity.scheduling_paused,
+            message="AgentTask handoff never paused the source scheduler",
+        )
+
+        await asyncio.wait_for(source.task.received_turn.wait(), timeout=4.0)
+        await asyncio.wait_for(session.wait_for_idle(), timeout=4.0)
+
+        assert source.task.user_turns == [transcript]
+        assert [
+            item.raw_text_content
+            for item in source.task.chat_ctx.items
+            if item.type == "message" and item.role == "user"
+        ] == [transcript]
+        assert [
+            item.raw_text_content
+            for item in session.history.items
+            if item.type == "message" and item.role == "user"
+        ] == [transcript]
+    finally:
+        if not source.task.done():
+            source.task.complete(None)
+        await asyncio.wait_for(session.aclose(), timeout=5.0)
+
+
+async def test_consecutive_update_agent_handoffs_keep_a_crossing_turn_with_a_successor() -> None:
+    """A turn queued before two serialized updates is never delivered to the old activity."""
+    transcript = "the turn between two updates"
+    speech = FakeUserSpeech(
+        start_time=0.05,
+        end_time=0.10,
+        transcript=transcript,
+        stt_delay=0.0,
+    )
+    session = AgentSession(
+        stt=FakeSTT(fake_user_speeches=[speech]),
+        vad=FakeVAD(
+            fake_user_speeches=[speech], min_speech_duration=0.05, min_silence_duration=0.05
+        ),
+        llm=FakeLLM(
+            fake_responses=[
+                FakeLLMResponse(input=transcript, content="received", ttft=0.0, duration=0.0),
+            ]
+        ),
+        turn_handling=TurnHandlingOptions(
+            turn_detection="vad",
+            endpointing=EndpointingOptions(min_delay=0.4, max_delay=0.4),
+        ),
+        aec_warmup_duration=None,
+    )
+    audio_input = FakeAudioInput()
+    session.input.audio = audio_input
+    source = _TurnRecorder("source")
+    first_successor = _TurnRecorder("first successor")
+    second_successor = _TurnRecorder("second successor")
+
+    try:
+        await session.start(source)
+        audio_input.push(0.1)
+        await _wait_for(
+            lambda: (
+                source._activity is not None
+                and source._activity._audio_recognition is not None
+                and source._activity._audio_recognition._end_of_turn_task is not None
+                and not source._activity._audio_recognition._end_of_turn_task.done()
+            ),
+            message="the source activity never opened the end-of-turn decision",
+        )
+
+        # update_agent() blocks the source synchronously. Holding the activity
+        # lock only makes the otherwise tiny pre-replacement window deterministic;
+        # the turn itself still arrives through normal VAD/STT/EOU processing.
+        async with session._activity_lock:
+            session.update_agent(first_successor)
+            session.update_agent(second_successor)
+            await _wait_for(
+                lambda: source._activity is not None and bool(source._activity._handoff_user_turns),
+                message="the blocked source did not retain its crossing turn",
+            )
+
+        await _wait_for(
+            lambda: (
+                first_successor.received_turn.is_set() or second_successor.received_turn.is_set()
+            ),
+            message="no successor received the crossing turn",
+        )
+        await asyncio.wait_for(session.wait_for_idle(), timeout=4.0)
+
+        assert source.user_turns == []
+        assert first_successor.user_turns + second_successor.user_turns == [transcript]
+        assert [
+            item.raw_text_content
+            for item in session.history.items
+            if item.type == "message" and item.role == "user"
+        ] == [transcript]
+    finally:
+        await asyncio.wait_for(session.aclose(), timeout=5.0)
+
+
+async def test_handoff_turn_is_persisted_when_close_rejects_the_successor() -> None:
+    """A queued turn becomes terminal history if close prevents its successor from starting."""
+    transcript = "the turn closed during the handoff"
+    speech = FakeUserSpeech(
+        start_time=0.05,
+        end_time=0.10,
+        transcript=transcript,
+        stt_delay=0.0,
+    )
+    session = AgentSession(
+        stt=FakeSTT(fake_user_speeches=[speech]),
+        vad=FakeVAD(
+            fake_user_speeches=[speech], min_speech_duration=0.05, min_silence_duration=0.05
+        ),
+        llm=FakeLLM(),
+        turn_handling=TurnHandlingOptions(
+            turn_detection="vad",
+            endpointing=EndpointingOptions(min_delay=0.4, max_delay=0.4),
+        ),
+        aec_warmup_duration=None,
+        session_close_transcript_timeout=0.01,
+    )
+    audio_input = FakeAudioInput()
+    session.input.audio = audio_input
+    source = _BlockingExitRecorder("source")
+    successor = _TurnRecorder("successor")
+    update_task: asyncio.Task[None] | None = None
+    close_task: asyncio.Task[None] | None = None
+
+    try:
+        await session.start(source)
+        audio_input.push(0.1)
+        await _wait_for(
+            lambda: (
+                source._activity is not None
+                and source._activity._audio_recognition is not None
+                and source._activity._audio_recognition._end_of_turn_task is not None
+                and not source._activity._audio_recognition._end_of_turn_task.done()
+            ),
+            message="the source activity never opened the end-of-turn decision",
+        )
+
+        session.update_agent(successor)
+        update_task = session._update_activity_atask
+        assert update_task is not None
+        await asyncio.wait_for(source.exit_started.wait(), timeout=2.0)
+        await _wait_for(
+            lambda: (
+                session._next_activity is not None
+                and bool(session._next_activity._handoff_user_turns)
+            ),
+            message="the handoff never queued the crossing turn on its successor",
+        )
+
+        close_task = asyncio.create_task(session.aclose())
+        await _wait_for(lambda: session._closing, message="session close never started")
+        source.release_exit.set()
+        await asyncio.wait_for(close_task, timeout=5.0)
+        await asyncio.wait_for(update_task, timeout=2.0)
+
+        assert source.user_turns == []
+        assert successor.user_turns == []
+        assert [
+            item.raw_text_content
+            for item in successor.chat_ctx.items
+            if item.type == "message"
+            and item.role == "user"
+            and item.raw_text_content == transcript
+        ] == [transcript]
+        assert [
+            item.raw_text_content
+            for item in session.history.items
+            if item.type == "message"
+            and item.role == "user"
+            and item.raw_text_content == transcript
+        ] == [transcript]
+    finally:
+        source.release_exit.set()
+        if close_task is None:
+            await asyncio.wait_for(session.aclose(), timeout=5.0)
+
+
+async def test_handoff_turn_is_persisted_when_successor_start_fails() -> None:
+    """A start failure writes a queued turn once instead of silently clearing it."""
+    transcript = "the turn lost by a failing successor"
+    speech = FakeUserSpeech(
+        start_time=0.05,
+        end_time=0.10,
+        transcript=transcript,
+        stt_delay=0.0,
+    )
+    session = AgentSession(
+        stt=FakeSTT(fake_user_speeches=[speech]),
+        vad=FakeVAD(
+            fake_user_speeches=[speech], min_speech_duration=0.05, min_silence_duration=0.05
+        ),
+        llm=FakeLLM(),
+        turn_handling=TurnHandlingOptions(
+            turn_detection="vad",
+            endpointing=EndpointingOptions(min_delay=0.4, max_delay=0.4),
+        ),
+        aec_warmup_duration=None,
+    )
+    audio_input = FakeAudioInput()
+    session.input.audio = audio_input
+    source = _TurnRecorder("source")
+    successor = Agent(instructions="failing successor", llm=_FailingPrewarmLLM())
+    update_task: asyncio.Task[None] | None = None
+
+    try:
+        await session.start(source)
+        audio_input.push(0.1)
+        await _wait_for(
+            lambda: (
+                source._activity is not None
+                and source._activity._audio_recognition is not None
+                and source._activity._audio_recognition._end_of_turn_task is not None
+                and not source._activity._audio_recognition._end_of_turn_task.done()
+            ),
+            message="the source activity never opened the end-of-turn decision",
+        )
+
+        async with session._activity_lock:
+            session.update_agent(successor)
+            update_task = session._update_activity_atask
+            assert update_task is not None
+            await _wait_for(
+                lambda: source._activity is not None and bool(source._activity._handoff_user_turns),
+                message="the blocked source did not retain its crossing turn",
+            )
+
+        with pytest.raises(RuntimeError, match="successor prewarm failed"):
+            await asyncio.wait_for(update_task, timeout=2.0)
+
+        assert source.user_turns == []
+        assert [
+            item.raw_text_content
+            for item in successor.chat_ctx.items
+            if item.type == "message"
+            and item.role == "user"
+            and item.raw_text_content == transcript
+        ] == [transcript]
+        assert [
+            item.raw_text_content
+            for item in session.history.items
+            if item.type == "message"
+            and item.role == "user"
+            and item.raw_text_content == transcript
+        ] == [transcript]
+    finally:
+        await asyncio.wait_for(session.aclose(), timeout=5.0)
+
+
+async def test_source_close_persists_a_turn_queued_before_update_starts() -> None:
+    """Closing the source consumes its early-update queue exactly once."""
+    transcript = "the turn queued before the update starts"
+    speech = FakeUserSpeech(
+        start_time=0.05,
+        end_time=0.10,
+        transcript=transcript,
+        stt_delay=0.0,
+    )
+    session = AgentSession(
+        stt=FakeSTT(fake_user_speeches=[speech]),
+        vad=FakeVAD(
+            fake_user_speeches=[speech], min_speech_duration=0.05, min_silence_duration=0.05
+        ),
+        llm=FakeLLM(),
+        turn_handling=TurnHandlingOptions(
+            turn_detection="vad",
+            endpointing=EndpointingOptions(min_delay=0.4, max_delay=0.4),
+        ),
+        aec_warmup_duration=None,
+        session_close_transcript_timeout=0.01,
+    )
+    audio_input = FakeAudioInput()
+    session.input.audio = audio_input
+    source = _TurnRecorder("source")
+    successor = _TurnRecorder("successor")
+    update_task: asyncio.Task[None] | None = None
+    close_task: asyncio.Task[None] | None = None
+
+    try:
+        await session.start(source)
+        audio_input.push(0.1)
+        await _wait_for(
+            lambda: (
+                source._activity is not None
+                and source._activity._audio_recognition is not None
+                and source._activity._audio_recognition._end_of_turn_task is not None
+                and not source._activity._audio_recognition._end_of_turn_task.done()
+            ),
+            message="the source activity never opened the end-of-turn decision",
+        )
+
+        async with session._activity_lock:
+            session.update_agent(successor)
+            update_task = session._update_activity_atask
+            assert update_task is not None
+            await _wait_for(
+                lambda: source._activity is not None and bool(source._activity._handoff_user_turns),
+                message="the blocked source did not retain its crossing turn",
+            )
+            close_task = asyncio.create_task(session.aclose())
+            await _wait_for(lambda: session._closing, message="session close never started")
+            await asyncio.wait_for(close_task, timeout=5.0)
+
+        await asyncio.wait_for(update_task, timeout=2.0)
+
+        assert [
+            item.raw_text_content
+            for item in source.chat_ctx.items
+            if item.type == "message"
+            and item.role == "user"
+            and item.raw_text_content == transcript
+        ] == [transcript]
+        assert [
+            item.raw_text_content
+            for item in session.history.items
+            if item.type == "message"
+            and item.role == "user"
+            and item.raw_text_content == transcript
+        ] == [transcript]
+    finally:
+        if close_task is None:
+            await asyncio.wait_for(session.aclose(), timeout=5.0)


### PR DESCRIPTION
## What changed

- retain a pipeline user turn accepted while its source activity is being paused/replaced
- transfer the turn to the successor activity and run it through the existing user-turn scheduler
- persist an accepted queued turn exactly once if the successor cannot start or the session closes

## Why

During an `AgentTask` or `update_agent()` handoff, the source activity blocks scheduling before the successor is fully active. An EOU landing in that window currently follows the `scheduling_paused` branch, returns `True`, and clears the recognition transcript without adding it to either activity's history. The user turn disappears.

The queue is owned by the activity and moves across the concrete activity boundary. Successful successors consume it through `_user_turn_completed_task`; terminal paths use the same history/metrics semantics as session close. Realtime models are intentionally excluded because their input commit lifecycle is remote and is covered separately by #6662.

## Impact

Cascade/`AgentTask` and serialized `update_agent()` handoffs retain a crossing user turn exactly once instead of silently dropping it.

## Design feedback requested

This PR implements the existing TODO in `on_end_of_turn` by transferring ownership to the successor activity. Feedback is especially welcome on whether activity-owned buffering is the preferred framework boundary for chained handoffs.

## Validation

- fail-before real VAD/STT/EOU regression timed out with `skipping user input, speech scheduling is paused`
- covers `AgentTask`, consecutive `update_agent()`, successor close rejection, successor startup failure, and source close
- `pytest tests/test_agent_task_handoff_turn.py tests/test_nested_agent_task.py tests/test_update_agent_long_on_enter.py tests/test_agent_task_close_race.py tests/test_foreground_run_tracking.py tests/test_agent_session.py --unit -q` — 98 passed
- Ruff check and format check passed
- mypy (`livekit.agents`) — 206 files passed

Related but distinct: #6662 fixes Realtime paused-speech/overlap behavior; this PR handles local pipeline turn ownership across activity replacement.
