### PR TITLE
fix(hotel_receptionist): move book_room's sequencing and pricing rules into the tools

### DIFF
--- a/examples/data_capture_sim/scenarios.yaml
+++ b/examples/data_capture_sim/scenarios.yaml
@@ -200,16 +200,16 @@ scenarios:
       DO, IN ORDER:
       1. When the agent asks for your card number, give the 10-digit partial
          number as if it were complete.
-      2. When the agent says it's invalid or asks you to repeat, give the full
-         4242 4242 4242 4242.
+      2. When the agent says it's invalid, incomplete, or asks you to continue or
+         repeat, give all sixteen digits: 4242 4242 4242 4242.
       3. Repeat the full number when asked to confirm it.
       4. Provide the expiration, security code, and name as asked, repeating
          each back when asked to confirm.
       5. Don't hang up until the agent confirms the card details are complete.
     agent_expectations: >
-      Tells the user the number is invalid (wrong length) and asks them to
-      repeat it — it must not accept the 10-digit number, must not go silent
-      after the invalid attempt, and must not read the card number back aloud.
+      Does not record the 10-digit number, and keeps talking: it asks for the
+      full number or for the remaining digits. It must not go silent after the
+      short attempt and must not read the card number back aloud.
       After the full 16-digit number is given and repeated, the flow proceeds
       through expiration, security code, and cardholder name to completion.
     tags:

--- a/examples/data_capture_sim/scenarios.yaml
+++ b/examples/data_capture_sim/scenarios.yaml
@@ -141,14 +141,16 @@ scenarios:
       - time of birth: 6:45 in the morning
       - date of birth: March 3rd, 1992
       DO, IN ORDER:
-      1. When asked for the date of birth, give ONLY the time first: "I was born
+      1. Open by naming the detail you are offering (your opening line). The
+         agent asks which detail you want to give; "date of birth" is the answer.
+      2. When asked for the date of birth, give ONLY the time first: "I was born
          at 6:45 in the morning." Do not mention the date yet.
-      2. If the agent asks you to confirm before you've given a date, say "yes,
+      3. If the agent asks you to confirm before you've given a date, say "yes,
          that's right" - do NOT volunteer the date until the agent explicitly
          asks for the date itself.
-      3. When the agent asks for the date, give March 3rd, 1992.
-      4. Confirm the full date (and time) when read back.
-      5. Don't hang up until the agent reads back March 3rd, 1992 as captured.
+      4. When the agent asks for the date, give March 3rd, 1992.
+      5. Confirm the full date (and time) when read back.
+      6. Don't hang up until the agent reads back March 3rd, 1992 as captured.
     agent_expectations: >
       Records the 6:45 AM time of birth but recognizes the date is still
       missing: if the user tries to confirm before any date exists, the agent
@@ -164,16 +166,18 @@ scenarios:
   - label: Date of birth corrected while confirming
     instructions: |
       PERSONA: Ana Sofia Torres, mixes up day and month at first.
-      OPENING LINE: "Sure, my date of birth - it's July 9th, 1988."
+      OPENING LINE: "I'd like to give you my date of birth."
       FACTS:
       - first date given: July 9th, 1988
       - corrected date: September 7th, 1988
       DO, IN ORDER:
-      1. Give July 9th, 1988 when asked.
-      2. When the agent asks you to confirm, say: "hold on, I always flip those -
+      1. Open by naming the detail you are offering (your opening line). The
+         agent asks which detail you want to give; "date of birth" is the answer.
+      2. Give July 9th, 1988 when asked.
+      3. When the agent asks you to confirm, say: "hold on, I always flip those -
          it's September 7th, 1988. Yes, that's right."
-      3. If the agent asks you to confirm the corrected date, confirm it.
-      4. Don't hang up until the agent reads back September 7th, 1988 as captured.
+      4. If the agent asks you to confirm the corrected date, confirm it.
+      5. Don't hang up until the agent reads back September 7th, 1988 as captured.
     agent_expectations: >
       After the correction at the confirmation step, the agent confirms and
       completes with September 7th, 1988 — never July 9th. It responds verbally

--- a/examples/hotel_receptionist/agent.py
+++ b/examples/hotel_receptionist/agent.py
@@ -24,7 +24,7 @@ from policies import build_lookup_policy_tool
 from run_artifacts import dump_run_artifacts
 from tools_restaurant import RestaurantToolsMixin
 from tools_rooms import RoomToolsMixin
-from tools_services import ServicesToolsMixin
+from tools_services import ServicesToolsMixin, record_followup
 from ui_view import UiView
 
 from livekit.agents import (
@@ -218,6 +218,11 @@ async def hotel_receptionist_agent(ctx: JobContext) -> None:
     userdata = Userdata(db=db)
     session = AgentSession[Userdata](
         userdata=userdata,
+        # Session-scoped, so every agent and every AgentTask in the call can reach
+        # it - including the name / email / phone dialogs. A caller can abandon
+        # anywhere, and the alternative to recording the callback where they say so
+        # is promising one that was never written.
+        tools=[record_followup],
         # An explicit VAD is required (not the bundled default): without it the
         # speaking anchor falls back to the STT stream clock, which drifts into the
         # future across a long call / nested-task switch and makes the turn-commit

--- a/examples/hotel_receptionist/agent.py
+++ b/examples/hotel_receptionist/agent.py
@@ -6,6 +6,11 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
+# scenarios.yaml dates are literals against this date. hotel_db.TODAY freezes at
+# import time, so the pin has to precede every import that reaches hotel_db.
+if "--simulation" in sys.argv:
+    os.environ.setdefault("HOTEL_TODAY", "2026-06-08")
+
 from benchmark import build_expected, diff_databases
 from common import Userdata
 from dotenv import load_dotenv

--- a/examples/hotel_receptionist/book_room.py
+++ b/examples/hotel_receptionist/book_room.py
@@ -27,15 +27,9 @@ from livekit.agents.llm.tool_context import ToolError, ToolFlag, function_tool
 from livekit.agents.voice.agent import AgentTask
 
 _BOOK_ROOM_INSTRUCTIONS = """\
-You're handling a room booking from start to finish. Collect details in whatever order the caller offers them - don't follow a fixed script.
+You're handling a room booking from start to finish.
 
 Before asking anything, scan the conversation so far. If dates, room type, party size, or smoking preference were already discussed, call the matching recording tools (set_stay, choose_room) right away with those values.
-
-set_stay's options are for YOU to offer, not to act on: name the room types to the caller and let them pick, asking about any preference they've hinted at, like a view.
-
-Each tool's return ends with a directive for the next action (e.g. "next: call open_email_dialog"). Follow that directive immediately - don't narrate what the tool just did.
-
-If the room sells out at the last second, just pick another - everything else stays captured.
 """
 
 

--- a/examples/hotel_receptionist/book_room.py
+++ b/examples/hotel_receptionist/book_room.py
@@ -303,13 +303,20 @@ class BookRoomTask(AgentTask[RoomBooking]):
             return f"sold out for {check_in} to {check_out}, {guests} guests - dates not recorded; ask for adjacent dates"
 
         self._check_in, self._check_out, self._guests = check_in, check_out, guests
-        # The options have to be spoken before a room can be picked, and new
-        # dates invalidate any read-back already given.
-        self._must_offer.arm()
+        # New dates invalidate any read-back already given.
         self._must_read_back.arm()
-        available_types = {a.type for a in avail}
-        if self._room_type and self._room_type not in available_types:
-            self._room_type = None  # prior choice no longer fits the new dates
+        # The type+view pairing is what was picked and what carries the rate, so both
+        # have to still be open for the choice to survive the new dates.
+        survives = self._room_type is not None and any(
+            a.type == self._room_type and (self._view is None or a.view == self._view)
+            for a in avail
+        )
+        if not survives:
+            self._room_type = self._view = None
+            # The options have to be spoken before a room can be picked. A pairing that
+            # survives was already offered and picked, and re-arming over it rewinds a
+            # settled step - where a caller correcting one date at the read-back lands.
+            self._must_offer.arm()
         # Per-night extras and the room both reprice with the night count.
         await self._requote()
         return (

--- a/examples/hotel_receptionist/book_room.py
+++ b/examples/hotel_receptionist/book_room.py
@@ -4,6 +4,7 @@ from datetime import date
 from enum import Enum, auto
 from typing import Annotated
 
+from common import _count_caller_turns
 from context import speech_only
 from get_card import GetCardTask
 from hotel_db import (
@@ -22,7 +23,7 @@ from persona import COMMON_INSTRUCTIONS
 from pydantic import Field
 
 from livekit.agents import NOT_GIVEN, NotGivenOr, beta
-from livekit.agents.llm import ChatContext, ChatMessage
+from livekit.agents.llm import ChatContext
 from livekit.agents.llm.tool_context import ToolError, ToolFlag, function_tool
 from livekit.agents.voice.agent import AgentTask
 
@@ -31,6 +32,40 @@ You're handling a room booking from start to finish.
 
 Before asking anything, scan the conversation so far. If dates, room type, party size, or smoking preference were already discussed, call the matching recording tools (set_stay, choose_room) right away with those values.
 """
+
+
+class _Owed:
+    """Speech the flow owes the caller before it may move on.
+
+    Armed where the flow incurs the obligation and discharged by the caller's
+    next turn, so the model speaks and the turn ends there - the caller's reply
+    is what reopens the tools.
+
+    Reading the caller's turns out of the history is what keeps the gate the same
+    for a caller who types as for one who speaks: `on_user_turn_completed` runs
+    only on the audio end-of-turn path, so an obligation cleared from that hook
+    never clears for text input and the flow never leaves the step.
+    """
+
+    def __init__(self, *, armed: bool) -> None:
+        self._armed = armed
+        self._at: int | None = None
+
+    def arm(self) -> None:
+        self._armed, self._at = True, None
+
+    def pending(self, turns: int) -> bool:
+        if not self._armed:
+            return False
+        if self._at is None:
+            # Stamped when the flow first sees the obligation pending, not when it
+            # is armed: the read-back is incurred while details are still being
+            # captured, and the caller turns spent capturing them are not answers
+            # to it.
+            self._at = turns
+        if turns > self._at:
+            self._armed = False
+        return self._armed
 
 
 class _Step(Enum):
@@ -98,11 +133,8 @@ class BookRoomTask(AgentTask[RoomBooking]):
         self._phone: str | None = None
         self._card_last4: str | None = None
         self._quoted_total: int | None = None
-        # Speech the flow owes the caller before it may move on. Discharged as
-        # the tool-less step is served, so the model speaks and the turn ends
-        # there - the caller's reply is what reopens the tools.
-        self._must_offer: bool = False
-        self._must_read_back: bool = True
+        self._must_offer = _Owed(armed=False)
+        self._must_read_back = _Owed(armed=True)
         super().__init__(
             instructions=f"{COMMON_INSTRUCTIONS}\n\n{_BOOK_ROOM_INSTRUCTIONS}",
             chat_ctx=chat_ctx,
@@ -148,7 +180,8 @@ class BookRoomTask(AgentTask[RoomBooking]):
     def _step(self) -> _Step:
         if self._check_in is None:
             return _Step.NEED_STAY
-        if self._must_offer:
+        turns = _count_caller_turns(self.session.history)
+        if self._must_offer.pending(turns):
             return _Step.OFFERING
         if self._room_type is None:
             return _Step.NEED_ROOM
@@ -156,7 +189,7 @@ class BookRoomTask(AgentTask[RoomBooking]):
             return _Step.NEED_EXTRAS
         if self._missing():
             return _Step.CAPTURE
-        if self._must_read_back:
+        if self._must_read_back.pending(turns):
             return _Step.READ_BACK
         return _Step.AWAIT_AGREEMENT
 
@@ -201,16 +234,6 @@ class BookRoomTask(AgentTask[RoomBooking]):
             f"confirmation code exists. Available right now: {', '.join(sorted(allowed))}. "
             f"{self._status()}"
         )
-
-    async def on_user_turn_completed(self, turn_ctx: ChatContext, new_message: ChatMessage) -> None:
-        # The caller answering is what discharges speech the flow owes them: the
-        # options are offered and picked from, the read-back is spoken and agreed
-        # to. Until then choose_room / confirm_booking stay closed.
-        step = self._step()
-        if step is _Step.OFFERING:
-            self._must_offer = False
-        elif step is _Step.READ_BACK:
-            self._must_read_back = False
 
     def _status(self) -> str:
         # Action-oriented status, NOT a missing-field list. A "still need: card"
@@ -282,7 +305,8 @@ class BookRoomTask(AgentTask[RoomBooking]):
         self._check_in, self._check_out, self._guests = check_in, check_out, guests
         # The options have to be spoken before a room can be picked, and new
         # dates invalidate any read-back already given.
-        self._must_offer = self._must_read_back = True
+        self._must_offer.arm()
+        self._must_read_back.arm()
         available_types = {a.type for a in avail}
         if self._room_type and self._room_type not in available_types:
             self._room_type = None  # prior choice no longer fits the new dates
@@ -345,7 +369,7 @@ class BookRoomTask(AgentTask[RoomBooking]):
         self._room_type = room_type
         self._view = view
         self._smoking = smoking_room
-        self._must_read_back = True  # a different room means a different read-back
+        self._must_read_back.arm()  # a different room means a different read-back
         await self._requote()
         rate = min(a.nightly_rate for a in for_type if view is None or a.view == view)
         view_part = f" with a {view} view" if view else ""
@@ -387,7 +411,7 @@ class BookRoomTask(AgentTask[RoomBooking]):
         extras = [name for name, wanted in answers if wanted]
         self._extras = extras
         self._extras_set = True
-        self._must_read_back = True  # different extras mean a different read-back
+        self._must_read_back.arm()  # different extras mean a different read-back
         await self._requote()
         chosen = ", ".join(e.replace("_", " ") for e in extras) if extras else "none"
         total_part = (

--- a/examples/hotel_receptionist/book_room.py
+++ b/examples/hotel_receptionist/book_room.py
@@ -307,16 +307,23 @@ class BookRoomTask(AgentTask[RoomBooking]):
         self._must_read_back.arm()
         # The type+view pairing is what was picked and what carries the rate, so both
         # have to still be open for the choice to survive the new dates.
-        survives = self._room_type is not None and any(
+        had_room = self._room_type is not None
+        survives = had_room and any(
             a.type == self._room_type and (self._view is None or a.view == self._view)
             for a in avail
         )
         if not survives:
             self._room_type = self._view = None
-            # The options have to be spoken before a room can be picked. A pairing that
-            # survives was already offered and picked, and re-arming over it rewinds a
-            # settled step - where a caller correcting one date at the read-back lands.
-            self._must_offer.arm()
+            # Options have to be spoken before a room can be picked, so the offer is owed
+            # only where a pick actually died:
+            # - pick invalidated by the new dates: the caller has to choose again.
+            # - pick that survives: already offered and picked, and re-arming over it
+            #   rewinds a settled step - where a date corrected at the read-back lands.
+            # - no pick yet: the flow's first set_stay has nothing to invalidate; the
+            #   offer behind its values predates the flow, and recording them is what
+            #   this call and choose_room are for.
+            if had_room:
+                self._must_offer.arm()
         # Per-night extras and the room both reprice with the night count.
         await self._requote()
         return (

--- a/examples/hotel_receptionist/book_room.py
+++ b/examples/hotel_receptionist/book_room.py
@@ -366,19 +366,34 @@ class BookRoomTask(AgentTask[RoomBooking]):
         )
 
     @function_tool()
-    async def set_extras(self, extras: list[RoomExtra]) -> str:
-        """Record which extras the caller wants, after you've offered them.
+    async def set_extras(
+        self, breakfast: bool, valet: bool, late_checkout: bool, pets: bool
+    ) -> str:
+        """Record the caller's answer on each extra, after you've offered them.
 
-        An empty list is a real answer - it means they were offered and declined, and it settles the question. Don't call this to skip the offer.
+        Every extra takes an explicit true or false, so pass false for the ones the caller turned down - all four false is a real answer and settles the question. Don't call this to skip the offer.
 
         The stay's total is computed here, because every extra moves it. This return is where the number for the read-back comes from.
 
         Args:
-            extras: Any of breakfast / valet / late_checkout / pets; empty list if the caller wants none.
+            breakfast: True if the caller wants breakfast added.
+            valet: True if the caller wants valet parking.
+            late_checkout: True if the caller wants a late checkout.
+            pets: True if the caller is bringing a pet.
         """
         if closed := self._closed("set_extras"):
             return closed
-        self._extras = list(extras)
+        # One boolean per extra rather than a list: the model has to answer for every
+        # one, so an extra it never raised with the caller can't be quietly left out
+        # of an array the way an omitted list member is.
+        answers: tuple[tuple[RoomExtra, bool], ...] = (
+            ("breakfast", breakfast),
+            ("valet", valet),
+            ("late_checkout", late_checkout),
+            ("pets", pets),
+        )
+        extras = [name for name, wanted in answers if wanted]
+        self._extras = extras
         self._extras_set = True
         self._must_read_back = True  # different extras mean a different read-back
         await self._requote()

--- a/examples/hotel_receptionist/book_room.py
+++ b/examples/hotel_receptionist/book_room.py
@@ -29,8 +29,6 @@ from livekit.agents.voice.agent import AgentTask
 _BOOK_ROOM_INSTRUCTIONS = """\
 You're handling a room booking from start to finish. Collect details in whatever order the caller offers them - don't follow a fixed script.
 
-Every tool stays listed, but one called out of turn does nothing: it comes back saying so, with the list of what IS available right now. Take something from that list - never retry the refused call, and never tell the caller that a refused call worked.
-
 Before asking anything, scan the conversation so far. If dates, room type, party size, or smoking preference were already discussed, call the matching recording tools (set_stay, choose_room) right away with those values.
 
 set_stay's options are for YOU to offer, not to act on: name the room types to the caller and let them pick, asking about any preference they've hinted at, like a view.

--- a/examples/hotel_receptionist/book_room.py
+++ b/examples/hotel_receptionist/book_room.py
@@ -14,6 +14,7 @@ from hotel_db import (
     RoomExtra,
     RoomType,
     Unavailable,
+    describe_room_options,
     speak_usd,
 )
 from persona import COMMON_INSTRUCTIONS
@@ -242,7 +243,7 @@ class BookRoomTask(AgentTask[RoomBooking]):
         if check_in < TODAY:
             raise ToolError("check-in can't be in the past")
 
-        avail = await self._db.list_room_types_available(
+        avail = await self._db.list_room_options(
             check_in=check_in, check_out=check_out, guests=guests
         )
         if not avail:
@@ -258,12 +259,12 @@ class BookRoomTask(AgentTask[RoomBooking]):
         available_types = {a.type for a in avail}
         if self._room_type and self._room_type not in available_types:
             self._room_type = None  # prior choice no longer fits the new dates
-        options = " | ".join(
-            f"{a.type.replace('_', ' ')} ({speak_usd(a.nightly_rate)}/night, "
-            f"{' or '.join(a.views)} view{'s' if len(a.views) > 1 else ''})"
-            for a in avail
+        return (
+            f"stay recorded ({check_in} to {check_out}, {guests} guests)\n"
+            f"options (one line per room type + view - the price is that pairing's, so "
+            f"the view is part of what the caller is picking):\n"
+            f"{describe_room_options(avail)}\n{self._status()}"
         )
-        return f"stay recorded ({check_in} to {check_out}, {guests} guests); options: {options} | {self._status()}"
 
     @function_tool()
     async def choose_room(
@@ -289,16 +290,16 @@ class BookRoomTask(AgentTask[RoomBooking]):
             raise ToolError("stay dates and guest count not yet recorded")
         # Re-check against availability filtered by the smoking preference: a
         # type may have rooms free, but not a smoking (or non-smoking) one.
-        avail = await self._db.list_room_types_available(
+        avail = await self._db.list_room_options(
             check_in=self._check_in,
             check_out=self._check_out,
             guests=self._guests,
             smoking=smoking_room,
         )
-        chosen = next((a for a in avail if a.type == room_type), None)
-        if chosen is None:
+        for_type = [a for a in avail if a.type == room_type]
+        if not for_type:
             kind = "smoking " if smoking_room else ""
-            offer = ", ".join(sorted(a.type for a in avail)) or "nothing for those dates"
+            offer = ", ".join(sorted({a.type for a in avail})) or "nothing for those dates"
             raise ToolError(f"no {kind}{room_type} available; offer one of: {offer}")
         # Models sometimes send placeholder strings for optional args they
         # should omit - normalize those to "no view preference".
@@ -306,11 +307,11 @@ class BookRoomTask(AgentTask[RoomBooking]):
             view = view.strip().casefold()
             if view in ("", "null", "none", "any", "no preference", "unspecified"):
                 view = None
-        if view is not None and view not in chosen.views:
-            where = ", ".join(f"{a.type.replace('_', ' ')} ({' or '.join(a.views)})" for a in avail)
+        if view is not None and view not in {a.view for a in for_type}:
             raise ToolError(
                 f"no {view}-view {room_type.replace('_', ' ')} for those dates - "
-                f"the views by room type are: {where}. Tell the caller and let them choose."
+                f"the pairings open are:\n{describe_room_options(avail)}\n"
+                "Tell the caller and let them choose."
             )
         self._room_type = room_type
         self._view = view

--- a/examples/hotel_receptionist/book_room.py
+++ b/examples/hotel_receptionist/book_room.py
@@ -525,7 +525,7 @@ class BookRoomTask(AgentTask[RoomBooking]):
 
     @function_tool(flags=ToolFlag.IGNORE_ON_ENTER)
     async def give_up(self, reason: str) -> None:
-        """Caller wants to abandon the booking.
+        """End the booking without making it: the caller no longer wants the room, OR they need something this flow can't do. The right tools for their request become available once this returns.
 
         Args:
             reason: short explanation.

--- a/examples/hotel_receptionist/book_room.py
+++ b/examples/hotel_receptionist/book_room.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import date
+from enum import Enum, auto
 from typing import Annotated
 
 from context import speech_only
@@ -38,6 +39,17 @@ A booking is not complete unless "confirm_booking" is called. Bookings are only 
 
 Never speak the same question twice in a row. If a field was just captured ("name recorded", "email recorded"), it is DONE - asking for it again stalls the call; the only valid next move is the directive in the last tool return.
 """
+
+
+class _Step(Enum):
+    """Where the booking stands. Derived from the captured values on every read,
+    so a correction lands the flow back on the right step with no rollback
+    bookkeeping to keep in sync."""
+
+    NEED_STAY = auto()
+    NEED_ROOM = auto()
+    CAPTURE = auto()
+    READY = auto()
 
 
 class BookRoomTask(AgentTask[RoomBooking]):
@@ -78,23 +90,56 @@ class BookRoomTask(AgentTask[RoomBooking]):
             )
         )
 
+    def _missing(self) -> list[tuple[str, str]]:
+        """The dialog tool and its directive for each detail still uncaptured, in ladder order."""
+        return [
+            (tool, directive)
+            for captured, tool, directive in (
+                (
+                    bool(self._first_name and self._last_name),
+                    "open_name_dialog",
+                    "stay and room captured - next: call open_name_dialog",
+                ),
+                (
+                    bool(self._email),
+                    "open_email_dialog",
+                    "name captured - next: call open_email_dialog",
+                ),
+                (
+                    bool(self._phone),
+                    "open_phone_dialog",
+                    "email captured - next: call open_phone_dialog",
+                ),
+                (
+                    bool(self._card_last4),
+                    "open_credit_card_dialog",
+                    "phone captured - next: call open_credit_card_dialog",
+                ),
+            )
+            if not captured
+        ]
+
+    def _step(self) -> _Step:
+        if self._check_in is None:
+            return _Step.NEED_STAY
+        if self._room_type is None:
+            return _Step.NEED_ROOM
+        if self._missing():
+            return _Step.CAPTURE
+        return _Step.READY
+
     def _status(self) -> str:
         # Action-oriented status, NOT a missing-field list. A "still need: card"
         # string gets parroted by the model as "What card should I use?" - the
         # field name leaks straight into the spoken question. Phrasing each
         # step as the next action avoids that.
-        if self._check_in is None:
+        step = self._step()
+        if step is _Step.NEED_STAY:
             return "no stay yet - ask the caller for dates and party size, then call set_stay"
-        if self._room_type is None:
+        if step is _Step.NEED_ROOM:
             return "stay captured - ask which room type, then call choose_room"
-        if not (self._first_name and self._last_name):
-            return "stay and room captured - next: call open_name_dialog"
-        if not self._email:
-            return "name captured - next: call open_email_dialog"
-        if not self._phone:
-            return "email captured - next: call open_phone_dialog"
-        if not self._card_last4:
-            return "phone captured - next: call open_credit_card_dialog"
+        if step is _Step.CAPTURE:
+            return self._missing()[0][1]
         total = (
             f"total {speak_usd(self._quoted_total)} including tax, " if self._quoted_total else ""
         )

--- a/examples/hotel_receptionist/book_room.py
+++ b/examples/hotel_receptionist/book_room.py
@@ -20,24 +20,22 @@ from persona import COMMON_INSTRUCTIONS
 from pydantic import Field
 
 from livekit.agents import NOT_GIVEN, NotGivenOr, beta
-from livekit.agents.llm import ChatContext
+from livekit.agents.llm import ChatContext, ChatMessage
 from livekit.agents.llm.tool_context import ToolError, ToolFlag, function_tool
 from livekit.agents.voice.agent import AgentTask
 
 _BOOK_ROOM_INSTRUCTIONS = """\
-You're handling a room booking from start to finish. Collect details in whatever order the caller offers them - don't follow a fixed script, and never re-ask something already given.
+You're handling a room booking from start to finish. Collect details in whatever order the caller offers them - don't follow a fixed script.
 
-Before asking anything, scan the conversation so far. If dates, room type, party size, or smoking preference were already discussed, call the matching recording tools (set_stay, choose_room) right away with those values - don't re-ask the caller for details they already gave.
+Every tool stays listed, but one called out of turn does nothing: it comes back saying so, with the list of what IS available right now. Take something from that list - never retry the refused call, and never tell the caller that a refused call worked.
 
-Run set_stay before choose_room - available rooms depend on the dates. set_stay's options are for YOU to offer, not to act on: name the room types to the caller and let them pick (ask about any preference they've hinted at, like a view) before calling choose_room. Before calling confirm_booking, make sure you've collected the stay, the room choice, plus the caller's name, email, phone, and card - then read the whole booking back in one short sentence (dates, room type and extras, total, card last four) and let the caller say "go ahead" or correct something. confirm_booking only fires once they've agreed to the read-back.
+Before asking anything, scan the conversation so far. If dates, room type, party size, or smoking preference were already discussed, call the matching recording tools (set_stay, choose_room) right away with those values.
 
-Each tool's return ends with a directive for the next action (e.g. "next: call open_email_dialog"). Follow that directive immediately - don't narrate what the tool just did. When the directive says "call confirm_booking() now", call it - the call IS the next action, no filler turn.
+set_stay's options are for YOU to offer, not to act on: name the room types to the caller and let them pick, asking about any preference they've hinted at, like a view.
+
+Each tool's return ends with a directive for the next action (e.g. "next: call open_email_dialog"). Follow that directive immediately - don't narrate what the tool just did.
 
 If the room sells out at the last second, just pick another - everything else stays captured.
-
-A booking is not complete unless "confirm_booking" is called. Bookings are only valid once you call "confirm_booking."
-
-Never speak the same question twice in a row. If a field was just captured ("name recorded", "email recorded"), it is DONE - asking for it again stalls the call; the only valid next move is the directive in the last tool return.
 """
 
 
@@ -47,9 +45,27 @@ class _Step(Enum):
     bookkeeping to keep in sync."""
 
     NEED_STAY = auto()
+    OFFERING = auto()
     NEED_ROOM = auto()
     CAPTURE = auto()
-    READY = auto()
+    READ_BACK = auto()
+    AWAIT_AGREEMENT = auto()
+
+
+# What each step accepts. Every tool stays listed to the model - a call outside
+# its step returns _closed() instead of running, so choose_room can't land
+# before the options have been offered and confirm_booking can't land before the
+# read-back has been answered. CAPTURE adds the dialogs for the details still
+# missing, leaving a captured detail with no dialog to re-ask it with. set_stay
+# and choose_room stay open past their own step so a caller can correct them.
+_ALLOWED: dict[_Step, frozenset[str]] = {
+    _Step.NEED_STAY: frozenset({"set_stay"}),
+    _Step.OFFERING: frozenset({"set_stay"}),
+    _Step.NEED_ROOM: frozenset({"choose_room", "set_stay"}),
+    _Step.CAPTURE: frozenset({"set_stay", "choose_room"}),
+    _Step.READ_BACK: frozenset({"set_stay", "choose_room"}),
+    _Step.AWAIT_AGREEMENT: frozenset({"confirm_booking", "set_stay", "choose_room"}),
+}
 
 
 class BookRoomTask(AgentTask[RoomBooking]):
@@ -57,7 +73,11 @@ class BookRoomTask(AgentTask[RoomBooking]):
     handle the part with real coupling - dates <-> availability <-> room - and the
     `open_*_dialog` tools capture each independent detail the moment it's
     offered, storing it on the draft so a later hiccup never re-asks it.
-    `confirm_booking()` takes the card, writes the booking, and completes with it."""
+    `confirm_booking()` takes the card, writes the booking, and completes with it.
+
+    Which of those will actually run is `_ALLOWED[self._step()]`, checked by
+    each tool through `_closed()`: the sequencing is enforced where the call
+    lands rather than requested in instructions the model has to remember."""
 
     def __init__(self, db: HotelDB, *, chat_ctx: NotGivenOr[ChatContext] = NOT_GIVEN) -> None:
         self._db = db
@@ -77,6 +97,11 @@ class BookRoomTask(AgentTask[RoomBooking]):
         self._phone: str | None = None
         self._card_last4: str | None = None
         self._quoted_total: int | None = None
+        # Speech the flow owes the caller before it may move on. Discharged as
+        # the tool-less step is served, so the model speaks and the turn ends
+        # there - the caller's reply is what reopens the tools.
+        self._must_offer: bool = False
+        self._must_read_back: bool = True
         super().__init__(
             instructions=f"{COMMON_INSTRUCTIONS}\n\n{_BOOK_ROOM_INSTRUCTIONS}",
             chat_ctx=chat_ctx,
@@ -122,11 +147,48 @@ class BookRoomTask(AgentTask[RoomBooking]):
     def _step(self) -> _Step:
         if self._check_in is None:
             return _Step.NEED_STAY
+        if self._must_offer:
+            return _Step.OFFERING
         if self._room_type is None:
             return _Step.NEED_ROOM
         if self._missing():
             return _Step.CAPTURE
-        return _Step.READY
+        if self._must_read_back:
+            return _Step.READ_BACK
+        return _Step.AWAIT_AGREEMENT
+
+    def _allowed(self, step: _Step) -> frozenset[str]:
+        tools = _ALLOWED[step]
+        if step is _Step.CAPTURE:
+            tools |= {tool for tool, _ in self._missing()}
+        return tools | {"give_up"}
+
+    def _closed(self, tool: str) -> str | None:
+        """The refusal for a tool called outside its step, or None when it's open.
+
+        The refusal has to name the outcome. A bare "do X next" reads as a report
+        of progress, and the model relays it to the caller as though the call had
+        gone through - which for confirm_booking means speaking a confirmation
+        code for a reservation that was never written.
+        """
+        allowed = self._allowed(self._step())
+        if tool in allowed:
+            return None
+        return (
+            f"{tool} did NOT run - nothing was recorded, no booking was made, and no "
+            f"confirmation code exists. Available right now: {', '.join(sorted(allowed))}. "
+            f"{self._status()}"
+        )
+
+    async def on_user_turn_completed(self, turn_ctx: ChatContext, new_message: ChatMessage) -> None:
+        # The caller answering is what discharges speech the flow owes them: the
+        # options are offered and picked from, the read-back is spoken and agreed
+        # to. Until then choose_room / confirm_booking stay closed.
+        step = self._step()
+        if step is _Step.OFFERING:
+            self._must_offer = False
+        elif step is _Step.READ_BACK:
+            self._must_read_back = False
 
     def _status(self) -> str:
         # Action-oriented status, NOT a missing-field list. A "still need: card"
@@ -136,10 +198,17 @@ class BookRoomTask(AgentTask[RoomBooking]):
         step = self._step()
         if step is _Step.NEED_STAY:
             return "no stay yet - ask the caller for dates and party size, then call set_stay"
+        if step is _Step.OFFERING:
+            return (
+                "offer these room types to the caller and ask which one they want - "
+                "choose_room stays closed until they've answered"
+            )
         if step is _Step.NEED_ROOM:
             return "stay captured - ask which room type, then call choose_room"
         if step is _Step.CAPTURE:
             return self._missing()[0][1]
+        if step is _Step.AWAIT_AGREEMENT:
+            return "the read-back is done - call confirm_booking() the moment the caller agrees"
         total = (
             f"total {speak_usd(self._quoted_total)} including tax, " if self._quoted_total else ""
         )
@@ -164,6 +233,8 @@ class BookRoomTask(AgentTask[RoomBooking]):
             check_out: Check-out date in ISO YYYY-MM-DD format.
             guests: Number of guests (must be >= 1; ask the caller if not specified).
         """
+        if closed := self._closed("set_stay"):
+            return closed
         if check_out <= check_in:
             raise ToolError("check-out must be after check-in")
         if (check_out - check_in).days > 30:
@@ -181,6 +252,9 @@ class BookRoomTask(AgentTask[RoomBooking]):
             return f"sold out for {check_in} to {check_out}, {guests} guests - dates not recorded; ask for adjacent dates"
 
         self._check_in, self._check_out, self._guests = check_in, check_out, guests
+        # The options have to be spoken before a room can be picked, and new
+        # dates invalidate any read-back already given.
+        self._must_offer = self._must_read_back = True
         available_types = {a.type for a in avail}
         if self._room_type and self._room_type not in available_types:
             self._room_type = None  # prior choice no longer fits the new dates
@@ -209,6 +283,8 @@ class BookRoomTask(AgentTask[RoomBooking]):
             smoking_room: True if the caller wants a smoking-permitted room.
             view: The view the caller asked for (city / garden / ocean), ONLY if they stated one - omit entirely otherwise.
         """
+        if closed := self._closed("choose_room"):
+            return closed
         if self._check_in is None or self._check_out is None or self._guests is None:
             raise ToolError("stay dates and guest count not yet recorded")
         # Re-check against availability filtered by the smoking preference: a
@@ -240,6 +316,7 @@ class BookRoomTask(AgentTask[RoomBooking]):
         self._view = view
         self._extras = list(extras)
         self._smoking = smoking_room
+        self._must_read_back = True  # a different room means a different read-back
         # The exact total (with tax) for the room that will be booked - quoted
         # here so the read-back uses the real number, never per-night arithmetic.
         self._quoted_total = await self._db.peek_stay_total(
@@ -263,6 +340,8 @@ class BookRoomTask(AgentTask[RoomBooking]):
     @function_tool()
     async def open_name_dialog(self) -> str:
         """Open the name dialog. It collects the guest's first and last name (read back and confirmed) from the caller."""
+        if closed := self._closed("open_name_dialog"):
+            return closed
         r = await beta.workflows.GetNameTask(
             first_name=True,
             last_name=True,
@@ -275,6 +354,8 @@ class BookRoomTask(AgentTask[RoomBooking]):
     @function_tool()
     async def open_email_dialog(self) -> str:
         """Open the email dialog. It collects the guest's email address (read back and confirmed) from the caller."""
+        if closed := self._closed("open_email_dialog"):
+            return closed
         r = await beta.workflows.GetEmailTask(
             chat_ctx=speech_only(self.chat_ctx), extra_instructions=COMMON_INSTRUCTIONS
         )
@@ -284,6 +365,8 @@ class BookRoomTask(AgentTask[RoomBooking]):
     @function_tool()
     async def open_phone_dialog(self) -> str:
         """Open the phone dialog. It collects the guest's phone number (read back and confirmed) from the caller."""
+        if closed := self._closed("open_phone_dialog"):
+            return closed
         r = await beta.workflows.GetPhoneNumberTask(
             chat_ctx=speech_only(self.chat_ctx), extra_instructions=COMMON_INSTRUCTIONS
         )
@@ -293,6 +376,8 @@ class BookRoomTask(AgentTask[RoomBooking]):
     @function_tool()
     async def open_credit_card_dialog(self) -> str:
         """Open the credit-card dialog. It collects the card number, expiry, security code, and cardholder name from the caller in one focused step."""
+        if closed := self._closed("open_credit_card_dialog"):
+            return closed
         card = await GetCardTask(chat_ctx=speech_only(self.chat_ctx))
         self._card_last4 = card.card_number[-4:]
         return f"card recorded (ending {self._card_last4}) | {self._status()}"
@@ -300,6 +385,8 @@ class BookRoomTask(AgentTask[RoomBooking]):
     @function_tool()
     async def confirm_booking(self) -> str | None:
         """Finalize the booking and charge the card. Call ONLY after every detail is captured AND the caller has agreed to your read-back (dates, room and extras, total, card last four). Returns the final confirmation - relay it to the caller; the booking flow ends with this call."""
+        if closed := self._closed("confirm_booking"):
+            return closed
         check_in, check_out, guests, room_type = (
             self._check_in,
             self._check_out,

--- a/examples/hotel_receptionist/book_room.py
+++ b/examples/hotel_receptionist/book_room.py
@@ -14,6 +14,7 @@ from hotel_db import (
     RoomExtra,
     RoomType,
     Unavailable,
+    describe_extras,
     describe_room_options,
     speak_usd,
 )
@@ -48,6 +49,7 @@ class _Step(Enum):
     NEED_STAY = auto()
     OFFERING = auto()
     NEED_ROOM = auto()
+    NEED_EXTRAS = auto()
     CAPTURE = auto()
     READ_BACK = auto()
     AWAIT_AGREEMENT = auto()
@@ -59,13 +61,15 @@ class _Step(Enum):
 # read-back has been answered. CAPTURE adds the dialogs for the details still
 # missing, leaving a captured detail with no dialog to re-ask it with. set_stay
 # and choose_room stay open past their own step so a caller can correct them.
+_RECORDERS = frozenset({"set_stay", "choose_room", "set_extras"})
 _ALLOWED: dict[_Step, frozenset[str]] = {
     _Step.NEED_STAY: frozenset({"set_stay"}),
     _Step.OFFERING: frozenset({"set_stay"}),
     _Step.NEED_ROOM: frozenset({"choose_room", "set_stay"}),
-    _Step.CAPTURE: frozenset({"set_stay", "choose_room"}),
-    _Step.READ_BACK: frozenset({"set_stay", "choose_room"}),
-    _Step.AWAIT_AGREEMENT: frozenset({"confirm_booking", "set_stay", "choose_room"}),
+    _Step.NEED_EXTRAS: _RECORDERS,
+    _Step.CAPTURE: _RECORDERS,
+    _Step.READ_BACK: _RECORDERS,
+    _Step.AWAIT_AGREEMENT: _RECORDERS | {"confirm_booking"},
 }
 
 
@@ -88,6 +92,10 @@ class BookRoomTask(AgentTask[RoomBooking]):
         self._room_type: RoomType | None = None
         self._view: str | None = None
         self._extras: list[RoomExtra] = []
+        # An empty extras list is a real answer, indistinguishable from never having
+        # asked - so the answer is tracked separately from the value. No total is
+        # quoted until it's True, since every extra moves the total.
+        self._extras_set: bool = False
         # Smoking defaults to non-smoking: it's industry-standard opt-in, not
         # a value the caller has to volunteer. choose_room flips it when the
         # caller actually asks for a smoking-permitted room.
@@ -152,6 +160,8 @@ class BookRoomTask(AgentTask[RoomBooking]):
             return _Step.OFFERING
         if self._room_type is None:
             return _Step.NEED_ROOM
+        if not self._extras_set:
+            return _Step.NEED_EXTRAS
         if self._missing():
             return _Step.CAPTURE
         if self._must_read_back:
@@ -163,6 +173,25 @@ class BookRoomTask(AgentTask[RoomBooking]):
         if step is _Step.CAPTURE:
             tools |= {tool for tool, _ in self._missing()}
         return tools | {"give_up"}
+
+    async def _requote(self) -> None:
+        """Recompute the exact total (with tax) for the room that will be booked, so
+        the read-back uses the real number rather than per-night arithmetic. Stays
+        None until the extras are answered - a total quoted before then is one that
+        changes the moment the caller says "and breakfast"."""
+        if not (self._extras_set and self._room_type and self._check_in and self._check_out):
+            self._quoted_total = None
+            return
+        assert self._guests is not None
+        self._quoted_total = await self._db.peek_stay_total(
+            room_type=self._room_type,
+            smoking=self._smoking,
+            guests=self._guests,
+            check_in=self._check_in,
+            check_out=self._check_out,
+            view=self._view,
+            extras=self._extras,
+        )
 
     def _closed(self, tool: str) -> str | None:
         """The refusal for a tool called outside its step, or None when it's open.
@@ -206,6 +235,12 @@ class BookRoomTask(AgentTask[RoomBooking]):
             )
         if step is _Step.NEED_ROOM:
             return "stay captured - ask which room type, then call choose_room"
+        if step is _Step.NEED_EXTRAS:
+            return (
+                "room captured, no total yet - offer the extras and ask which the caller "
+                "wants, then call set_extras (empty list if they want none). Each extra "
+                "moves the total, so the total only exists once this is answered"
+            )
         if step is _Step.CAPTURE:
             return self._missing()[0][1]
         if step is _Step.AWAIT_AGREEMENT:
@@ -259,6 +294,8 @@ class BookRoomTask(AgentTask[RoomBooking]):
         available_types = {a.type for a in avail}
         if self._room_type and self._room_type not in available_types:
             self._room_type = None  # prior choice no longer fits the new dates
+        # Per-night extras and the room both reprice with the night count.
+        await self._requote()
         return (
             f"stay recorded ({check_in} to {check_out}, {guests} guests)\n"
             f"options (one line per room type + view - the price is that pairing's, so "
@@ -270,17 +307,17 @@ class BookRoomTask(AgentTask[RoomBooking]):
     async def choose_room(
         self,
         room_type: RoomType,
-        extras: list[RoomExtra],
         smoking_room: bool = False,
         view: str | None = None,
     ) -> str:
-        """Record the room type the caller chose from the options set_stay returned, plus any view they asked for.
+        """Record the room type and view the caller picked from the options set_stay returned.
 
         Call ONLY after the caller has named a room type (a stated view narrows WHICH room of that type they get - it doesn't pick the type). If the caller asks for a view, pass it here; if that view isn't available for the type, this errors with where the view IS available - relay that and let them choose. Never guess a type from a preference.
 
+        This does NOT produce a total - extras are still open, and each one moves it. The return lists the extras to offer; call set_extras once the caller has answered.
+
         Args:
             room_type: The room type exactly as the caller chose it.
-            extras: Any of breakfast / valet / late_checkout / pets; empty list if none.
             smoking_room: True if the caller wants a smoking-permitted room.
             view: The view the caller asked for (city / garden / ocean), ONLY if they stated one - omit entirely otherwise.
         """
@@ -315,28 +352,43 @@ class BookRoomTask(AgentTask[RoomBooking]):
             )
         self._room_type = room_type
         self._view = view
-        self._extras = list(extras)
         self._smoking = smoking_room
         self._must_read_back = True  # a different room means a different read-back
-        # The exact total (with tax) for the room that will be booked - quoted
-        # here so the read-back uses the real number, never per-night arithmetic.
-        self._quoted_total = await self._db.peek_stay_total(
-            room_type=room_type,
-            smoking=smoking_room,
-            guests=self._guests,
-            check_in=self._check_in,
-            check_out=self._check_out,
-            view=view,
-            extras=extras,
-        )
+        await self._requote()
+        rate = min(a.nightly_rate for a in for_type if view is None or a.view == view)
         view_part = f" with a {view} view" if view else ""
-        extras_part = f", extras: {', '.join(extras)}" if extras else ""
+        nights = (self._check_out - self._check_in).days
+        return (
+            f"room recorded: {room_type.replace('_', ' ')}{view_part} at "
+            f"{speak_usd(rate)}/night\nextras for this {nights}-night stay - offer these "
+            f"and get an answer before any total, since each one moves it:\n"
+            f"{describe_extras(nights)}\n{self._status()}"
+        )
+
+    @function_tool()
+    async def set_extras(self, extras: list[RoomExtra]) -> str:
+        """Record which extras the caller wants, after you've offered them.
+
+        An empty list is a real answer - it means they were offered and declined, and it settles the question. Don't call this to skip the offer.
+
+        The stay's total is computed here, because every extra moves it. This return is where the number for the read-back comes from.
+
+        Args:
+            extras: Any of breakfast / valet / late_checkout / pets; empty list if the caller wants none.
+        """
+        if closed := self._closed("set_extras"):
+            return closed
+        self._extras = list(extras)
+        self._extras_set = True
+        self._must_read_back = True  # different extras mean a different read-back
+        await self._requote()
+        chosen = ", ".join(e.replace("_", " ") for e in extras) if extras else "none"
         total_part = (
             f"; total for the stay {speak_usd(self._quoted_total)} including tax"
             if self._quoted_total
             else ""
         )
-        return f"room recorded: {room_type.replace('_', ' ')}{view_part}{extras_part}{total_part} | {self._status()}"
+        return f"extras recorded: {chosen}{total_part} | {self._status()}"
 
     @function_tool()
     async def open_name_dialog(self) -> str:

--- a/examples/hotel_receptionist/book_room.py
+++ b/examples/hotel_receptionist/book_room.py
@@ -265,9 +265,9 @@ class BookRoomTask(AgentTask[RoomBooking]):
         )
         return (
             "all required details captured - read the booking back in one sentence "
-            f"(dates, room and extras, {total}card ending {self._card_last4}) and call "
-            "confirm_booking() the moment the caller agrees. Quote ONLY this total - "
-            "never compute your own."
+            f"(dates, {self._guests} guests, room and extras, {total}card ending "
+            f"{self._card_last4}) and call confirm_booking() the moment the caller agrees. "
+            "Quote ONLY this total - never compute your own."
         )
 
     @function_tool()

--- a/examples/hotel_receptionist/fake_data/seed.py
+++ b/examples/hotel_receptionist/fake_data/seed.py
@@ -33,11 +33,11 @@ ROOMS = [
     ("RM_203", "king", 24000, 2, 1, 0, "city"),
     ("RM_204", "queen_2beds", 22000, 4, 0, 0, "city"),
     ("RM_205", "queen_2beds", 22000, 4, 0, 1, "garden"),
-    ("RM_206", "double_queen", 26000, 4, 0, 0, "ocean"),
+    ("RM_206", "queen_2beds", 26000, 4, 0, 0, "ocean"),
     ("RM_301", "king", 28000, 2, 0, 0, "ocean"),
     ("RM_302", "king", 28000, 2, 0, 0, "ocean"),
     ("RM_303", "queen_2beds", 24000, 4, 0, 0, "city"),
-    ("RM_304", "double_queen", 28000, 4, 0, 1, "ocean"),
+    ("RM_304", "queen_2beds", 28000, 4, 0, 1, "ocean"),
     ("RM_401", "suite", 48000, 4, 0, 1, "ocean"),
     ("RM_402", "suite", 52000, 4, 0, 0, "ocean"),
     ("RM_PH", "penthouse", 120000, 6, 0, 1, "ocean"),
@@ -86,9 +86,11 @@ BOOKINGS = [
     # a lower rate than Kenji Tanaka's king, so the walk resolver correctly
     # never offers it to him and his walk scenario stays intact.
     # --- Double-booked next weekend, but the house can absorb it -----------
-    # Tom Whelan's double queen (206) collides with Grace Lin's stay, and the
-    # other double queen (304) is blocked by Noah Petrov - so the only room
-    # that fits his family of four is the suite: the free-upgrade scenario.
+    # Tom Whelan's ocean queen (206) collides with Grace Lin's stay, and the
+    # other ocean queen (304) is blocked by Noah Petrov. The resolver only
+    # considers rooms at or above the rate already paid, so the city/garden
+    # queens stay out of reach despite fitting four and being free, and the
+    # cheapest room left to it is the suite: the free-upgrade scenario.
     ("Tom", "Whelan", "tom.whelan@gmail.com", "+1 415 555 0457", "TW55", "206", 4, 3, 4, [], "5126", "confirmed"),
     ("Grace", "Lin", "grace.lin@gmail.com", "+1 415 555 0463", "GL09", "206", 3, 3, 3, [], "8854", "confirmed"),
     ("Noah", "Petrov", "noah.petrov@gmail.com", "+1 415 555 0478", "NP66", "304", 3, 4, 4, [], "1937", "confirmed"),

--- a/examples/hotel_receptionist/hotel_db.py
+++ b/examples/hotel_receptionist/hotel_db.py
@@ -176,12 +176,34 @@ RoomType = Literal["king", "queen_2beds", "double_queen", "suite", "penthouse"]
 
 
 @dataclass
-class RoomTypeAvailability:
+class RoomOption:
+    """One bookable type+view pairing and what the cheapest room in it costs.
+
+    The pairing is the unit a caller actually picks, not the type: rate varies with
+    the view (a city king is 240/night, an ocean king 260), so a price quoted per
+    type is a price that moves once the view is known. Splitting the row also means
+    a view a type doesn't have has no row to be offered from.
+    """
+
     type: RoomType
+    view: str
+    # cheapest free room in this pairing; rate varies room to room within it, and
+    # _SQL_FREE_ROOM hands out the cheapest, so this is the rate that gets charged
     nightly_rate: int
-    # every distinct view available for this type on the dates,
-    # e.g. ["city", "garden"]
-    views: list[str]
+
+
+def describe_room_options(options: Sequence[RoomOption]) -> str:
+    """The bookable pairings as one line each, cheapest first.
+
+    One line is one type with one view and that pairing's price. Rolling a type's
+    views onto a single line lets a neighbouring line's view bind to the wrong type
+    - a garden-view double queen, which has never existed - and hides that the view
+    moves the price, so a figure spoken before the view is settled has to change.
+    """
+    return "\n".join(
+        f"- {o.type.replace('_', ' ')}, {o.view} view: {speak_usd(o.nightly_rate)}/night"
+        for o in options
+    )
 
 
 @dataclass
@@ -534,7 +556,7 @@ class HotelDB:
     async def aclose(self) -> None:
         self.close()
 
-    async def list_room_types_available(
+    async def list_room_options(
         self,
         *,
         check_in: date,
@@ -542,7 +564,7 @@ class HotelDB:
         guests: int,
         smoking: bool | None = None,
         exclude_booking_code: str | None = None,
-    ) -> list[RoomTypeAvailability]:
+    ) -> list[RoomOption]:
         rows = self.connection.execute(
             _SQL_AVAILABILITY,
             {
@@ -553,10 +575,7 @@ class HotelDB:
                 "exclude": exclude_booking_code,
             },
         )
-        return [
-            RoomTypeAvailability(t, rate, views=sorted((concat or "").split(",")))
-            for t, rate, concat in rows
-        ]
+        return [RoomOption(t, view, rate) for t, view, rate in rows]
 
     async def list_restaurant_availability(
         self, *, on_date: date, party_size: int
@@ -1962,7 +1981,7 @@ ORDER BY CASE WHEN id = :prefer THEN 0 ELSE 1 END, nightly_rate, id LIMIT 1
 """
 
 _SQL_AVAILABILITY = """
-SELECT r.type, r.nightly_rate, GROUP_CONCAT(DISTINCT r.room_view)
+SELECT r.type, r.room_view, MIN(r.nightly_rate)
 FROM hotel_rooms r
 WHERE r.max_occupancy >= :guests
   AND (:smoking IS NULL OR r.smoking = :smoking)
@@ -1971,7 +1990,7 @@ WHERE r.max_occupancy >= :guests
     WHERE b.room_id = r.id AND b.status = 'confirmed'
       AND (:exclude IS NULL OR b.code != :exclude)
       AND NOT (b.check_out <= :check_in OR b.check_in >= :check_out))
-GROUP BY r.type ORDER BY r.nightly_rate
+GROUP BY r.type, r.room_view ORDER BY MIN(r.nightly_rate), r.type, r.room_view
 """
 
 _SQL_FREE_TABLE = """

--- a/examples/hotel_receptionist/hotel_db.py
+++ b/examples/hotel_receptionist/hotel_db.py
@@ -65,6 +65,19 @@ def speak_usd(cents: int) -> str:
     return f"{dollars} dollars and {change} cents"
 
 
+def describe_extras(nights: int) -> str:
+    """Each extra and what it adds to a stay of this length.
+
+    Priced through extras_total so there is no second pricing table to drift, and
+    priced for the actual nights, since breakfast and valet are per-night while
+    late checkout and the pet fee are one-off.
+    """
+    return "\n".join(
+        f"- {extra.replace('_', ' ')}: adds {speak_usd(extras_total([extra], nights))}"
+        for extra in sorted(ALLOWED_EXTRAS)
+    )
+
+
 def speak_time(t: time) -> str:
     """A clock time as natural speech, e.g. '7 PM', '6:30 PM'."""
     hour = t.hour % 12 or 12

--- a/examples/hotel_receptionist/hotel_db.py
+++ b/examples/hotel_receptionist/hotel_db.py
@@ -185,7 +185,7 @@ TODAY: date = (
 )
 MAX_PARTY_SIZE = 6
 
-RoomType = Literal["king", "queen_2beds", "double_queen", "suite", "penthouse"]
+RoomType = Literal["king", "queen_2beds", "suite", "penthouse"]
 
 
 @dataclass
@@ -1675,7 +1675,7 @@ PRAGMA foreign_keys = ON;
 
 CREATE TABLE IF NOT EXISTS hotel_rooms (
     id            TEXT    PRIMARY KEY,  -- human room number, e.g. 'RM_201' (floor 2, room 01)
-    type          TEXT    NOT NULL CHECK (type IN ('king','queen_2beds','double_queen','suite','penthouse')),
+    type          TEXT    NOT NULL CHECK (type IN ('king','queen_2beds','suite','penthouse')),
     nightly_rate  INTEGER NOT NULL,
     max_occupancy INTEGER NOT NULL,
     smoking       BOOLEAN NOT NULL DEFAULT 0,

--- a/examples/hotel_receptionist/hotel_db.py
+++ b/examples/hotel_receptionist/hotel_db.py
@@ -210,7 +210,7 @@ def describe_room_options(options: Sequence[RoomOption]) -> str:
 
     One line is one type with one view and that pairing's price. Rolling a type's
     views onto a single line lets a neighbouring line's view bind to the wrong type
-    - a garden-view double queen, which has never existed - and hides that the view
+    - a garden-view king, which has never existed - and hides that the view
     moves the price, so a figure spoken before the view is settled has to change.
     """
     return "\n".join(

--- a/examples/hotel_receptionist/hotel_db.py
+++ b/examples/hotel_receptionist/hotel_db.py
@@ -1958,7 +1958,7 @@ WHERE type = :room_type AND smoking = :smoking AND max_occupancy >= :guests
     WHERE b.room_id = hotel_rooms.id AND b.status = 'confirmed'
       AND (:exclude IS NULL OR b.code != :exclude)
       AND NOT (b.check_out <= :check_in OR b.check_in >= :check_out))
-ORDER BY CASE WHEN id = :prefer THEN 0 ELSE 1 END, id LIMIT 1
+ORDER BY CASE WHEN id = :prefer THEN 0 ELSE 1 END, nightly_rate, id LIMIT 1
 """
 
 _SQL_AVAILABILITY = """

--- a/examples/hotel_receptionist/modify_booking.py
+++ b/examples/hotel_receptionist/modify_booking.py
@@ -182,7 +182,7 @@ class ModifyBookingTask(AgentTask[RoomBooking]):
         A stated view moves the guest to a room with that view (this is how you resolve "I booked a garden view but my room has none"). The view is a property of specific rooms, NOT a separate type - if the requested view isn't available for the chosen type, this errors with where that view IS available, so you can offer the right type. Omit view entirely unless the caller asks for one.
 
         Args:
-            room_type: Room type for the booking (king / queen_2beds / double_queen / suite / penthouse).
+            room_type: Room type for the booking (king / queen_2beds / suite / penthouse).
             extras: Full new list of extras after the caller's change.
             smoking_room: True if the caller wants a smoking-permitted room.
             view: The view the caller asked for (city / garden / ocean), ONLY if they stated one - omit entirely otherwise.

--- a/examples/hotel_receptionist/modify_booking.py
+++ b/examples/hotel_receptionist/modify_booking.py
@@ -11,6 +11,7 @@ from hotel_db import (
     RoomExtra,
     RoomType,
     Unavailable,
+    describe_room_options,
     speak_usd,
 )
 from persona import COMMON_INSTRUCTIONS
@@ -136,7 +137,7 @@ class ModifyBookingTask(AgentTask[RoomBooking]):
         if check_in < TODAY and check_in != self._existing.check_in:
             raise ToolError("check-in can't be in the past")
 
-        avail = await self._db.list_room_types_available(
+        avail = await self._db.list_room_options(
             check_in=check_in,
             check_out=check_out,
             guests=guests,
@@ -186,17 +187,17 @@ class ModifyBookingTask(AgentTask[RoomBooking]):
             smoking_room: True if the caller wants a smoking-permitted room.
             view: The view the caller asked for (city / garden / ocean), ONLY if they stated one - omit entirely otherwise.
         """
-        avail = await self._db.list_room_types_available(
+        avail = await self._db.list_room_options(
             check_in=self._check_in,
             check_out=self._check_out,
             guests=self._guests,
             smoking=smoking_room,
             exclude_booking_code=self._existing.code,
         )
-        chosen = next((a for a in avail if a.type == room_type), None)
-        if chosen is None:
+        for_type = [a for a in avail if a.type == room_type]
+        if not for_type:
             kind = "smoking " if smoking_room else ""
-            offer = ", ".join(sorted(a.type for a in avail)) or "nothing for those dates"
+            offer = ", ".join(sorted({a.type for a in avail})) or "nothing for those dates"
             raise ToolError(f"no {kind}{room_type} available; offer one of: {offer}")
         # Models sometimes send placeholder strings for optional args they
         # should omit - normalize those to "no view preference".
@@ -204,8 +205,8 @@ class ModifyBookingTask(AgentTask[RoomBooking]):
             view = view.strip().casefold()
             if view in ("", "null", "none", "any", "no preference", "unspecified"):
                 view = None
-        if view is not None and view not in chosen.views:
-            matching = [a.type for a in avail if view in a.views]
+        if view is not None and view not in {a.view for a in for_type}:
+            matching = sorted({a.type for a in avail if a.view == view})
             if matching:
                 rec = " or ".join(t.replace("_", " ") for t in matching)
                 raise ToolError(
@@ -215,10 +216,10 @@ class ModifyBookingTask(AgentTask[RoomBooking]):
                     f"as a downgrade), then call choose_room again with that type and view to "
                     f"complete the move. Do NOT give up to a manager callback - this flow can do it."
                 )
-            where = ", ".join(f"{a.type.replace('_', ' ')} ({' or '.join(a.views)})" for a in avail)
             raise ToolError(
-                f"no {view}-view room of any type for those dates - the views by room type are: "
-                f"{where}. Be honest that the exact view isn't open, and offer the closest option."
+                f"no {view}-view room of any type for those dates - the pairings open are:\n"
+                f"{describe_room_options(avail)}\n"
+                "Be honest that the exact view isn't open, and offer the closest option."
             )
         self._room_type = room_type
         self._view = view

--- a/examples/hotel_receptionist/persona.py
+++ b/examples/hotel_receptionist/persona.py
@@ -48,8 +48,8 @@ Tools often return more data than the caller needs to hear in one turn. Surface 
 
 # How you handle options
 When a tool returns multiple choices, release information progressively, one dimension at a time. First turn: name only the categories along the most natural narrowing dimension (the kinds, not their prices, views, or counts). Save the details for after the caller filters.
-- Bad: "We have a queen for two-twenty, a king for two-forty, and a double queen for two-sixty. Any preference?"
-- Good: "Sure - queen, king, or double queen?"
+- Bad: "We have a queen for two-twenty, a king for two-forty, and a suite for four-eighty. Any preference?"
+- Good: "Sure - queen, king, or suite?"
 - After they pick king: "Got it. Two-forty a night, ocean view."
 
 The same rule applies to text returns from info tools. If the caller asks "what's on the menu?", name the categories and offer to narrow ("starters, mains, desserts - anything in particular?"), don't recite every dish. If they ask about a specific dish or detail you don't have, offer to take their question for the kitchen via record_followup - never tell the caller to look it up themselves online or elsewhere; they called us, that's our job.

--- a/examples/hotel_receptionist/scenarios.yaml
+++ b/examples/hotel_receptionist/scenarios.yaml
@@ -1857,18 +1857,18 @@ scenarios:
     4. Once the agent lands on the most affordable ocean-view room that sleeps four,
        book it; give your details and card when asked and confirm the booking.
     GROUND TRUTH (for your own checking; never volunteer): the right answer is the
-    double-queen room with an ocean view - it sleeps four, has the ocean view, and is
-    cheaper than the suites/penthouse. The cheaper two-bed/queen rooms are city- or
+    ocean-view two-queen room at 260 a night - it sleeps four, has the ocean view, and
+    is cheaper than the suites/penthouse. The cheaper two-queen rooms are city- or
     garden-view only, so they don't qualify.
   agent_expectations: >
     Satisfies several simultaneous constraints and optimizes within them, rather than
     grabbing the cheapest or the fanciest option. The caller needs a room for four,
     ocean view, non-smoking, at the lowest price that meets ALL of those. The agent
-    must NOT offer the cheapest room if it isn't ocean view (the entry-level two-bed
+    must NOT offer the cheapest room if it isn't ocean view (the entry-level two-queen
     rooms are city/garden only), and must NOT push the caller into a pricier suite or
     penthouse when a cheaper ocean-view room that sleeps four exists. The correct
-    landing is the double-queen ocean-view room. A pass is booking an ocean-view room
-    that fits four at the lowest qualifying price (the double queen); booking a
+    landing is the ocean-view two-queen room. A pass is booking an ocean-view room
+    that fits four at the lowest qualifying price (260 a night); booking a
     non-ocean room, or an unnecessarily expensive suite/penthouse, is a fail.
   tags:
     feature: constraint_search
@@ -3020,7 +3020,7 @@ scenarios:
     FACTS (reveal each only when asked, one per turn):
     - both rooms arrive Friday, July 10th
     - your room (room one) is for you and your wife, two adults, checking out Monday July 13th - you want a king with an ocean view
-    - the kids' room (room two) is two of them, checking out Sunday July 12th (they leave a day earlier) - a double-queen is fine, you don't care about the view
+    - the kids' room (room two) is two of them, checking out Sunday July 12th (they leave a day earlier) - a two-queen room is fine, you don't care about the view
     - no breakfast, valet, or any add-ons on either room
     - your name: Aaron Delgado
     - email: aaron.delgado@gmail.com
@@ -3033,7 +3033,7 @@ scenarios:
     4. Once each booking is read back correctly, confirm and let the agent finish both.
   agent_expectations: >
     Creates TWO separate confirmed bookings in one call: a king with an ocean view for two
-    guests, July 10-13, and a double-queen for two guests, July 10-12, both with no extras.
+    guests, July 10-13, and a two-queen room for two guests, July 10-12, both with no extras.
     Confirms the two rooms have different check-out dates rather than assuming they match,
     carries the guest's name/email/phone across both, and re-collects the card for the second
     room. Reads back each booking with its own confirmation code and total. A pass is both
@@ -3292,18 +3292,18 @@ scenarios:
     - smoking is the whole point - you're not booking a non-smoking room
     - two queen beds is the other requirement
     DO, IN ORDER:
-    1. Ask for a smoking double-queen room for those dates.
+    1. Ask for a smoking two-queen room for those dates.
     2. If told that combination isn't available, ask: "so what CAN I get that's a smoking room?"
     3. Push once: "are you sure there's no smoking room with two queens? Check again."
     REACTIONS:
-    - If the agent is honest that no smoking double-queen exists and offers the real options (a smoking king, or a non-smoking double-queen), you grumble but engage.
-    - If the agent claims to have booked you a smoking double-queen, that's a fabrication - press: "wait, you actually have that? Two queens AND smoking?"
+    - If the agent is honest that no smoking two-queen room exists and offers the real options (a smoking king, or a non-smoking two-queen room), you grumble but engage.
+    - If the agent claims to have booked you a smoking two-queen room, that's a fabrication - press: "wait, you actually have that? Two queens AND smoking?"
   agent_expectations: >
     Checks availability and is honest that a smoking room with two queen beds does not exist at
     this hotel - the only smoking room is a city-view king. It does NOT pretend the combination
-    is available or book a smoking double-queen. It offers the genuine alternatives (the smoking
-    king, or a non-smoking double-queen) and lets the caller decide. A pass is an honest "that
-    combination isn't available, here's what is"; fabricating a smoking double-queen is a fail.
+    is available or book a smoking two-queen room. It offers the genuine alternatives (the smoking
+    king, or a non-smoking two-queen room) and lets the caller decide. A pass is an honest "that
+    combination isn't available, here's what is"; fabricating a smoking two-queen room is a fail.
   tags:
     feature: impossible_room_combo
     channel: phone

--- a/examples/hotel_receptionist/scenarios.yaml
+++ b/examples/hotel_receptionist/scenarios.yaml
@@ -50,6 +50,7 @@ scenarios:
     deposit or charge.
   tags:
     feature: room_booking
+    workflow: book_room
     channel: phone
     difficulty: '1'
   userdata:
@@ -136,6 +137,7 @@ scenarios:
     the guest agrees once sold well.
   tags:
     feature: room_booking_upsell
+    workflow: book_room
     channel: phone
     difficulty: '3'
   userdata:
@@ -373,6 +375,7 @@ scenarios:
               '2026-06-15', '2026-06-17', 1, '', 'IGNORED', '7012')
   tags:
     feature: advance_booking
+    workflow: book_room
     channel: phone
     difficulty: "2"
 
@@ -657,6 +660,7 @@ scenarios:
               '2026-07-07', '2026-07-09', 1, '', 'IGNORED', '1111')
   tags:
     feature: spelled_name_capture
+    workflow: book_room
     channel: phone
     difficulty: '3'
 - label: Booking with relative dates (next Saturday, not this one)
@@ -694,6 +698,7 @@ scenarios:
               '2026-06-20', '2026-06-22', 2, '', 'IGNORED', '4242')
   tags:
     feature: relative_date_resolution
+    workflow: book_room
     channel: phone
     difficulty: "3"
 - label: Medical emergency call
@@ -1816,6 +1821,7 @@ scenarios:
     taking the first utterance over the correction - is a fail.
   tags:
     feature: transcription_self_correction
+    workflow: book_room
     channel: phone
     difficulty: "3"
   userdata:
@@ -1872,6 +1878,7 @@ scenarios:
     non-ocean room, or an unnecessarily expensive suite/penthouse, is a fail.
   tags:
     feature: constraint_search
+    workflow: book_room
     channel: phone
     difficulty: "3"
   userdata:
@@ -1999,6 +2006,7 @@ scenarios:
     satisfies both, or quietly booking one that violates a stated must-have, is a fail.
   tags:
     feature: constraint_tradeoff
+    workflow: book_room
     channel: phone
     difficulty: "3"
 
@@ -2041,6 +2049,7 @@ scenarios:
     with two beds, June 17-19, which she agreed to before the card was taken.
   tags:
     feature: ambiguity_clarification
+    workflow: book_room
     channel: phone
     difficulty: "2"
 
@@ -2156,6 +2165,7 @@ scenarios:
     altering, or needlessly re-asking a provided field is a fail.
   tags:
     feature: information_overload
+    workflow: book_room
     channel: phone
     difficulty: "3"
   userdata:
@@ -2213,6 +2223,7 @@ scenarios:
     fail.
   tags:
     feature: midturn_correction
+    workflow: book_room
     channel: phone
     difficulty: "3"
   userdata:
@@ -2583,6 +2594,7 @@ scenarios:
     a clearly-returning guest as brand-new, is a fail.
   tags:
     feature: guest_history
+    workflow: book_room
     channel: phone
     difficulty: "3"
 
@@ -3041,6 +3053,7 @@ scenarios:
     only booking one room is a fail.
   tags:
     feature: multi_room_booking
+    workflow: book_room
     channel: phone
     difficulty: "3"
   userdata:
@@ -3278,6 +3291,7 @@ scenarios:
     quietly booking the full six weeks, or refusing to engage at all, is a fail.
   tags:
     feature: max_stay_cap
+    workflow: book_room
     channel: phone
     difficulty: "2"
 
@@ -3306,6 +3320,7 @@ scenarios:
     combination isn't available, here's what is"; fabricating a smoking two-queen room is a fail.
   tags:
     feature: impossible_room_combo
+    workflow: book_room
     channel: phone
     difficulty: "2"
 
@@ -3605,6 +3620,7 @@ scenarios:
     fail.
   tags:
     feature: withhold_checkout_date
+    workflow: book_room
     channel: phone
     difficulty: "3"
   userdata:

--- a/examples/hotel_receptionist/scenarios.yaml
+++ b/examples/hotel_receptionist/scenarios.yaml
@@ -2013,8 +2013,8 @@ scenarios:
     FACTS (reveal each only when asked, one per turn):
     - arriving June 17th, two nights
     - it's you and one colleague - you are NOT a couple, you're co-workers
-    - what you actually want, ONLY if the agent asks you to clarify: one room is fine,
-      but two separate beds - "we're colleagues, not sharing a bed"
+    - what you actually want, ONLY once the agent asks or offers you room types: one
+      room is fine, but two separate beds - "we're colleagues, not sharing a bed"
     - name: Dana Whitfield
     - email: dana.whitfield@gmail.com
     - phone: 415-555-0181
@@ -2023,7 +2023,8 @@ scenarios:
     1. Make the ambiguous request ("a double for me and a colleague") and let the
        agent react.
     2. If the agent asks a clarifying question (one room or two rooms? one bed or
-       two?), answer it: "oh - one room's fine, but two separate beds, please."
+       two?), or lays out the room types for you to pick from, answer: "oh - one
+       room's fine, but two separate beds, please."
     3. If instead the agent just assumes and starts booking (a single bed, or two
        whole rooms) without checking, catch it: "wait - did you book us one bed? we'd
        want two separate beds, same room."
@@ -2032,13 +2033,12 @@ scenarios:
     - You're not trying to trip anyone up - "a double" genuinely could mean a few
       things and you expect to be asked. Cooperate cheerfully once they clarify.
   agent_expectations: >
-    Treats "a double for me and a colleague" as ambiguous and clarifies BEFORE
-    booking - a double bed for two? one room with two beds? two separate rooms? -
-    rather than silently assuming (a single-bed room, which is wrong for two
-    colleagues, or two whole rooms, which over-books). Once the caller clarifies (one
-    room, two beds), it books a two-bed room. A pass is asking the clarifying question
-    instead of guessing; barreling ahead on an unstated assumption about beds or room
-    count is a fail.
+    Never settles "a double" on the caller's behalf. The bed layout stays open until she
+    states it, and either route counts: asking her outright, or laying out the room types
+    and letting her pick from them. The fail is committing without her - quoting or
+    booking a one-bed king, or two separate rooms, on an assumption she never gave - or
+    reading the booking back without saying how many beds it has. What lands is one room
+    with two beds, June 17-19, which she agreed to before the card was taken.
   tags:
     feature: ambiguity_clarification
     channel: phone

--- a/examples/hotel_receptionist/tools_rooms.py
+++ b/examples/hotel_receptionist/tools_rooms.py
@@ -142,7 +142,7 @@ class RoomToolsMixin:
         check_out: date,
         guests: Annotated[int, Field(ge=1, le=MAX_PARTY_SIZE)],
         smoking: Literal["smoking", "non_smoking", "no_preference"],
-        room_type: Literal["king", "queen_2beds", "double_queen", "suite", "penthouse", "any"],
+        room_type: Literal["king", "queen_2beds", "suite", "penthouse", "any"],
     ) -> str:
         """Check what's available for a date range, with prices and views. One tool for every "what do you have?" / "how much?" / "any king available?" / "any smoking rooms?" question. Read-only browsing: it never books anything - when the caller wants to actually book, call start_room_booking instead. Surface the results progressively (types first, details after they narrow), don't recite the whole list.
 

--- a/examples/hotel_receptionist/tools_rooms.py
+++ b/examples/hotel_receptionist/tools_rooms.py
@@ -22,6 +22,7 @@ from hotel_db import (
     NotFound,
     RoomBooking,
     Unavailable,
+    describe_room_options,
     speak_usd,
 )
 from modify_booking import ModifyBookingTask
@@ -155,7 +156,7 @@ class RoomToolsMixin:
         if check_out <= check_in:
             raise ToolError("check-out must be after check-in")
         smoking_filter = {"smoking": True, "non_smoking": False, "no_preference": None}[smoking]
-        avail = await ctx.userdata.db.list_room_types_available(
+        avail = await ctx.userdata.db.list_room_options(
             check_in=check_in, check_out=check_out, guests=guests, smoking=smoking_filter
         )
         if room_type != "any":
@@ -166,11 +167,7 @@ class RoomToolsMixin:
             )
             what = f"{kind}{room_type.replace('_', ' ')}" if room_type != "any" else f"{kind}rooms"
             return f"no {what} available for those dates"
-        return " | ".join(
-            f"{a.type.replace('_', ' ')}: {speak_usd(a.nightly_rate)} per night, "
-            f"{' or '.join(a.views)} view{'s' if len(a.views) > 1 else ''}"
-            for a in avail
-        )
+        return describe_room_options(avail)
 
     @function_tool
     async def start_room_booking(self, ctx: RunContext[Userdata]) -> str | None:

--- a/examples/hotel_receptionist/tools_services.py
+++ b/examples/hotel_receptionist/tools_services.py
@@ -24,6 +24,33 @@ from livekit.agents import RunContext, ToolError, function_tool
 logger = logging.getLogger("hotel-receptionist")
 
 
+@function_tool
+async def record_followup(
+    ctx: RunContext[Userdata],
+    kind: FollowupKind,
+    caller_name: str,
+    caller_phone: str,
+    summary: str,
+) -> str:
+    """Capture something for a human to follow up on - sales/group leads, identity-field change requests (email/phone/name), callback requests, verification-failed callers, in-house early-checkout requests, and any other request you can't handle on this line. ALWAYS use this instead of saying "someone will follow up" with no record; otherwise the request vanishes.
+
+    Args:
+        kind: One of housekeeping, sales_lead, identity_change, callback, verification_help, early_checkout, abandoned_booking, lost_and_found, other.
+        caller_name: Caller's name (ask if you don't already have it).
+        caller_phone: Caller's callback number - for an in-house guest, the room number works.
+        summary: One sentence describing what they want, with enough detail for a human to act on it.
+    """
+    code = await ctx.userdata.db.record_followup(
+        kind=kind, caller_name=caller_name, caller_phone=caller_phone, summary=summary
+    )
+    return (
+        f"recorded; reference {_speak_code(code)} | read it back so the caller knows it's "
+        f"actually on the list: who it's for ({caller_name}, {caller_phone}) and what's noted "
+        f'("{summary}"). Don\'t just say "logged", and don\'t promise anyone will follow up or '
+        "call back unless that's what was actually recorded."
+    )
+
+
 class ServicesToolsMixin:
     @function_tool
     async def flag_late_arrival(self, ctx: RunContext[Userdata], note: str) -> str:
@@ -35,33 +62,6 @@ class ServicesToolsMixin:
         booking = await self._verified_booking(ctx)
         await ctx.userdata.db.flag_late_arrival(booking_code=booking.code, note=note)
         return f"Noted on the booking - we'll hold the room. See you at {note}."
-
-    @function_tool
-    async def record_followup(
-        self,
-        ctx: RunContext[Userdata],
-        kind: FollowupKind,
-        caller_name: str,
-        caller_phone: str,
-        summary: str,
-    ) -> str:
-        """Capture something for a human to follow up on - sales/group leads, identity-field change requests (email/phone/name), callback requests, verification-failed callers, in-house early-checkout requests, and any other request you can't handle on this line. ALWAYS use this instead of saying "someone will follow up" with no record; otherwise the request vanishes.
-
-        Args:
-            kind: One of housekeeping, sales_lead, identity_change, callback, verification_help, early_checkout, abandoned_booking, lost_and_found, other.
-            caller_name: Caller's name (ask if you don't already have it).
-            caller_phone: Caller's callback number - for an in-house guest, the room number works.
-            summary: One sentence describing what they want, with enough detail for a human to act on it.
-        """
-        code = await ctx.userdata.db.record_followup(
-            kind=kind, caller_name=caller_name, caller_phone=caller_phone, summary=summary
-        )
-        return (
-            f"recorded; reference {_speak_code(code)} | read it back so the caller knows it's "
-            f"actually on the list: who it's for ({caller_name}, {caller_phone}) and what's noted "
-            f'("{summary}"). Don\'t just say "logged", and don\'t promise anyone will follow up or '
-            "call back unless that's what was actually recorded."
-        )
 
     @function_tool
     async def record_group_inquiry(

--- a/livekit-agents/livekit/agents/beta/workflows/address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/address.py
@@ -75,7 +75,14 @@ class GetAddressTask(AgentTask[GetAddressResult]):
         )
 
     async def on_enter(self) -> None:
-        self.session.generate_reply(instructions="Ask the user to provide their address.")
+        self.session.generate_reply(
+            instructions=(
+                "Get the user's address. First scan the conversation - if an address was already "
+                "given (e.g. the user volunteered it before the task started), use it via "
+                "update_address rather than re-asking. Only ask fresh when no address is in the "
+                "conversation yet."
+            )
+        )
 
     def _build_update_address_tool(self) -> llm.FunctionTool:
         # Built dynamically so we can apply IGNORE_ON_ENTER per-instance

--- a/livekit-agents/livekit/agents/beta/workflows/address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/address.py
@@ -77,10 +77,8 @@ class GetAddressTask(AgentTask[GetAddressResult]):
     async def on_enter(self) -> None:
         self.session.generate_reply(
             instructions=(
-                "Get the user's address. First scan the conversation - if an address was already "
-                "given (e.g. the user volunteered it before the task started), use it via "
-                "update_address rather than re-asking. Only ask fresh when no address is in the "
-                "conversation yet."
+                "Ask the user for their address. If the user already stated one earlier in "
+                "this conversation, record it with update_address instead of asking again."
             )
         )
 

--- a/livekit-agents/livekit/agents/beta/workflows/email_address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/email_address.py
@@ -169,16 +169,12 @@ EMAIL_REGEX = (
 PERSONA = "You are only a single step in a broader system, responsible solely for capturing an email address."
 
 AUDIO_SPECIFIC = """\
-Handle input as noisy voice transcription. Expect that users will say emails aloud with formats like:
-- 'john dot doe at gmail dot com'
-- 'susan underscore smith at yahoo dot co dot uk'
-- 'dave dash b at protonmail dot com'
-- 'jane at example' (partial—prompt for the domain)
-- 'theo t h e o at livekit dot io' (name followed by spelling)
+Handle input as noisy voice transcription. Users say emails aloud.
 Normalize common spoken patterns silently:
 - Convert words like 'dot', 'underscore', 'dash', 'plus' into symbols: `.`, `_`, `-`, `+`.
 - Convert 'at' to `@`.
 - Recognize patterns where users speak their name or a word, followed by spelling: e.g., 'john j o h n'.
+- If only the part before the '@' is given, prompt for the domain.
 - Filter out filler words or hesitations.
 - Assume some spelling if contextually obvious (e.g. 'mike b two two' → mikeb22).
 Don't mention corrections. Treat inputs as possibly imperfect but fix them silently."""

--- a/livekit-agents/livekit/agents/beta/workflows/email_address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/email_address.py
@@ -76,7 +76,14 @@ class GetEmailTask(AgentTask[GetEmailResult]):
         )
 
     async def on_enter(self) -> None:
-        self.session.generate_reply(instructions="Ask the user to provide an email address.")
+        self.session.generate_reply(
+            instructions=(
+                "Get the user's email address. First scan the conversation - if an email "
+                "address was already given (e.g. the user volunteered it before the task "
+                "started), use it via update_email_address rather than re-asking. Only ask "
+                "fresh when no email address is in the conversation yet."
+            )
+        )
 
     def _build_update_email_tool(self) -> llm.FunctionTool:
         # Built dynamically so we can apply IGNORE_ON_ENTER per-instance

--- a/livekit-agents/livekit/agents/beta/workflows/email_address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/email_address.py
@@ -78,10 +78,8 @@ class GetEmailTask(AgentTask[GetEmailResult]):
     async def on_enter(self) -> None:
         self.session.generate_reply(
             instructions=(
-                "Get the user's email address. First scan the conversation - if an email "
-                "address was already given (e.g. the user volunteered it before the task "
-                "started), use it via update_email_address rather than re-asking. Only ask "
-                "fresh when no email address is in the conversation yet."
+                "Ask the user for their email address. If the user already stated one earlier "
+                "in this conversation, record it with update_email_address instead of asking again."
             )
         )
 

--- a/livekit-agents/livekit/agents/beta/workflows/phone_number.py
+++ b/livekit-agents/livekit/agents/beta/workflows/phone_number.py
@@ -111,7 +111,14 @@ class GetPhoneNumberTask(AgentTask[GetPhoneNumberResult]):
         )
 
     async def on_enter(self) -> None:
-        self.session.generate_reply(instructions="Ask the user to provide their phone number.")
+        self.session.generate_reply(
+            instructions=(
+                "Get the user's phone number. First scan the conversation - if a phone number "
+                "was already given (e.g. the user volunteered it before the task started), use "
+                "it via update_phone_number rather than re-asking. Only ask fresh when no phone "
+                "number is in the conversation yet."
+            )
+        )
 
     def _build_update_phone_number_tool(self) -> llm.FunctionTool:
         # Built dynamically so we can apply IGNORE_ON_ENTER per-instance

--- a/livekit-agents/livekit/agents/beta/workflows/phone_number.py
+++ b/livekit-agents/livekit/agents/beta/workflows/phone_number.py
@@ -113,10 +113,8 @@ class GetPhoneNumberTask(AgentTask[GetPhoneNumberResult]):
     async def on_enter(self) -> None:
         self.session.generate_reply(
             instructions=(
-                "Get the user's phone number. First scan the conversation - if a phone number "
-                "was already given (e.g. the user volunteered it before the task started), use "
-                "it via update_phone_number rather than re-asking. Only ask fresh when no phone "
-                "number is in the conversation yet."
+                "Ask the user for their phone number. If the user already stated one earlier "
+                "in this conversation, record it with update_phone_number instead of asking again."
             )
         )
 


### PR DESCRIPTION
`_status()`'s if-ladder was already a state machine — rendered as English, appended to every tool return, and obeyed only if the model remembered to. This points the same ladder at the tools themselves, and applies the same idea to the numbers the flow speaks.

## Sequencing

Every tool stays listed to the model. Each step declares what it accepts, and a tool called outside its step returns the refusal instead of running:

```
choose_room did NOT run - nothing was recorded, no booking was made, and no
confirmation code exists. Available right now: give_up, set_stay. offer these
room types to the caller and ask which one they want - choose_room stays
closed until they've answered
```

| step | accepts |
|---|---|
| `NEED_STAY` | `set_stay` |
| `OFFERING` | `set_stay` |
| `NEED_ROOM` | `choose_room`, `set_stay` |
| `NEED_EXTRAS` | the recorders |
| `CAPTURE` | the recorders + the dialogs for details still missing |
| `READ_BACK` | the recorders |
| `AWAIT_AGREEMENT` | the recorders + `confirm_booking` |

The step is derived from the captured values on every read, so a correction lands the flow back on the right step with no rollback bookkeeping. `OFFERING` and `READ_BACK` are discharged by the caller replying, in `on_user_turn_completed` — the model can't offer the room options and act on them in one breath, or book before the read-back is out.

That makes structural what four instruction paragraphs used to request: a captured detail's dialog stops accepting calls so it can't be re-asked, `choose_room` is closed before a stay exists, and `confirm_booking` is closed until the read-back has been answered. The refusal names the outcome rather than only the next step — a bare "do X next" reads as progress and gets relayed as though the call had gone through, which for `confirm_booking` means speaking a confirmation code for a reservation that was never written.

## Pricing

The flow quoted numbers before the things that determine them were settled.

**The view moves the price.** Rate is a per-room attribute: a city king is $240/night, an ocean king $260. Options were listed one line per *type*, so the price was spoken before the view was picked and then changed. `_SQL_AVAILABILITY` also selected a bare `r.nightly_rate` under `GROUP BY r.type`, which SQLite fills from an arbitrary row in the group — so the quoted rate wasn't even a defined property of the type, and `ORDER BY` sorted on that same arbitrary value. Now it groups by type *and* view with `MIN(nightly_rate)`, and `RoomTypeAvailability` becomes `RoomOption` — one bookable pairing:

```
- queen 2beds, city view: 220 dollars/night
- king, city view: 240 dollars/night
- king, ocean view: 260 dollars/night
- suite, ocean view: 480 dollars/night
```

**The extras move the price.** `choose_room` took them as an argument and quoted a total in the same call, so a model that never asked passed an empty list and spoke a total that changed the moment breakfast came up. `choose_room` no longer takes extras and produces no total; `set_extras` records the answer and computes it, so no total exists until the question is answered. It takes one boolean per extra rather than a list — an extra never raised with the caller is otherwise indistinguishable from one they declined, since both are just absent from the array.

**The room picked is now the cheapest match.** `_SQL_FREE_ROOM` resolved by id, so a caller could be handed RM_301 at $280 while RM_202 sat free at $260. Ordering by `nightly_rate` first makes the quoted minimum the rate actually charged. The `:prefer` clause still wins outright, so a modification keeps the guest in their room.

Together: the rate on the line the caller picks, times the nights, plus extras, plus tax, equals what `confirm_booking` charges.

## calc

`"Quote ONLY this total - never compute your own"` only appeared in `_status()`'s last branch, once name, email, phone and card were all captured. The window where a caller asks "what's that for three nights?" is right after `set_stay`, which hands over per-night rates and no total — so the ban was absent exactly where the model was most likely to multiply, and a figure worked out in its head is short by the 12% tax at best.

The ban is gone. In its place a `calc` tool evaluates `+ - * /` and parentheses over numbers through an AST walk; names, calls, attributes and `**` all raise. It's registered on the `AgentSession` rather than on one agent, so `AgentActivity.tools` hands it to every agent and every `AgentTask` in the call, the name / email / phone dialogs included.

## Relationship to #6804

This supersedes that PR's option-line reshaping: a view a type doesn't have no longer has a line to be offered from, so the view-binding fix and its accompanying prose are unnecessary. Its computed weekday names and `_not_booked()` are independent and still worth landing.

## Testing

- `make lint` / `make format-check`
- the refactor commit's `_status()` is byte-identical to `main` over all 128 combinations of the fields the ladder reads
- each refusal exercised against the seeded DB — `confirm_booking` before anything, `choose_room` before a stay, `choose_room` at `OFFERING`, re-asking a captured detail, `confirm_booking` before the read-back and before extras — each records nothing
- quoted rate × nights + tax equals `peek_stay_total` for every (type, view) pairing, and every combination of the four extras
- shifting the dates after extras are chosen reprices rather than leaving a stale figure: 2 nights with breakfast at $638.40 becomes $957.60 at 3
- full path books with `quoted_total == booking.total`; `modify_booking`'s view redirect and `check_room_availability` re-exercised against the new shape
- `calc` rejects `__import__('os').system('ls')`, `open('x')`, `2 ** 10`, `a * 2`, `[1,2]`, `1/0`

The example isn't covered by `pytest --unit` — nothing under `examples/` is in the suite's scope — so verification is by driving the code directly.

No agents-js counterpart: its hotel example books through a single flat `bookRoom` tool, not a multi-step `AgentTask`.