### PR TITLE
fix(voice): run on_user_turn_completed for text input

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2399,6 +2399,32 @@ class AgentActivity(RecognitionHooks):
         )
         return True
 
+    async def _run_user_turn_hook(
+        self, user_message: llm.ChatMessage
+    ) -> tuple[llm.ChatContext, float] | None:
+        """Run ``on_user_turn_completed`` for a completed user turn.
+
+        Returns the chat context the hook may have edited, along with how long it
+        took, or None when the turn is to be dropped - the hook raised
+        StopResponse, or raised at all.
+        """
+        # create a temporary mutable chat context to pass to on_user_turn_completed
+        # the user can edit it for the current generation, but changes will not be kept inside the
+        # Agent.chat_ctx
+        temp_mutable_chat_ctx = self._agent.chat_ctx.copy()
+        start_time = time.perf_counter()
+        try:
+            await self._agent.on_user_turn_completed(
+                temp_mutable_chat_ctx, new_message=user_message
+            )
+        except StopResponse:
+            return None
+        except Exception:
+            logger.exception("error occurred during on_user_turn_completed")
+            return None
+
+        return temp_mutable_chat_ctx, time.perf_counter() - start_time
+
     @utils.log_exceptions(logger=logger)
     async def _user_turn_completed_task(
         self, old_task: asyncio.Task[None] | None, info: _EndOfTurnInfo
@@ -2476,22 +2502,11 @@ class AgentActivity(RecognitionHooks):
                 self._session._conversation_item_added(user_message)
             return
 
-        # create a temporary mutable chat context to pass to on_user_turn_completed
-        # the user can edit it for the current generation, but changes will not be kept inside the
-        # Agent.chat_ctx
-        temp_mutable_chat_ctx = self._agent.chat_ctx.copy()
-        start_time = time.perf_counter()
-        try:
-            await self._agent.on_user_turn_completed(
-                temp_mutable_chat_ctx, new_message=user_message
-            )
-        except StopResponse:
+        hook_result = await self._run_user_turn_hook(user_message)
+        if hook_result is None:
             return  # ignore this turn
-        except Exception:
-            logger.exception("error occurred during on_user_turn_completed")
-            return
 
-        on_user_turn_completed_delay = time.perf_counter() - start_time
+        temp_mutable_chat_ctx, on_user_turn_completed_delay = hook_result
         metrics_report["on_user_turn_completed_delay"] = on_user_turn_completed_delay
 
         if isinstance(self.llm, llm.RealtimeModel):

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1501,6 +1501,35 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         return handle
 
+    async def _generate_reply_for_user_turn(self, user_input: str) -> None:
+        """Reply to a user turn that arrived off the audio path.
+
+        Runs ``on_user_turn_completed`` before generating, the way a spoken turn
+        does: the hook is the documented seam for editing or dropping a user
+        message before it reaches the LLM, so it can't depend on the modality
+        the turn arrived on.
+        """
+        if self._activity is None:
+            raise RuntimeError("AgentSession isn't running")
+
+        activity = self._next_activity if self._activity.scheduling_paused else self._activity
+        if activity is None:
+            raise RuntimeError("AgentSession is closing, cannot use generate_reply()")
+
+        user_message = llm.ChatMessage(role="user", content=[user_input])
+        hook_result = await activity._run_user_turn_hook(user_message)
+        if hook_result is None:
+            return  # the hook raised StopResponse: drop the turn
+
+        chat_ctx, _ = hook_result
+        handle = activity._generate_reply(
+            user_message=user_message,
+            chat_ctx=chat_ctx,
+            input_details=InputDetails(modality="text"),
+        )
+        if run_state := self._global_run_state:
+            run_state._watch_handle(handle)
+
     def interrupt(self, *, force: bool = False) -> asyncio.Future[None]:
         """Interrupt the current speech generation.
 

--- a/livekit-agents/livekit/agents/voice/room_io/types.py
+++ b/livekit-agents/livekit/agents/voice/room_io/types.py
@@ -46,7 +46,7 @@ NoiseCancellationSelector: TypeAlias = Callable[
 async def _default_text_input_cb(sess: AgentSession, ev: TextInputEvent) -> None:
     async with sess._claim_user_turn():
         await sess.interrupt()
-        sess.generate_reply(user_input=ev.text)
+        await sess._generate_reply_for_user_turn(ev.text)
 
 
 @dataclass

--- a/tests/test_user_turn_hook_modality.py
+++ b/tests/test_user_turn_hook_modality.py
@@ -1,0 +1,127 @@
+"""on_user_turn_completed fires for a user turn regardless of how it arrived.
+
+The hook is the documented seam for editing or dropping a user message before it
+reaches the LLM, so a guard wired there has to hold for typed input the same way
+it does for speech.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+
+from livekit.agents import Agent, AgentSession, StopResponse
+from livekit.agents.llm import ChatContext, ChatMessage
+from livekit.agents.voice.room_io.types import TextInputEvent, _default_text_input_cb
+from livekit.agents.voice.transcription.synchronizer import (
+    TranscriptSynchronizer,
+    _SyncedAudioOutput,
+)
+
+from .fake_session import FakeActions, create_session, run_session
+
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
+
+
+class HookAgent(Agent):
+    def __init__(self, *, stop: bool = False) -> None:
+        super().__init__(instructions="You are a helpful assistant.")
+        self.turns: list[str] = []
+        self._stop = stop
+
+    async def on_user_turn_completed(self, turn_ctx: ChatContext, new_message: ChatMessage) -> None:
+        self.turns.append(new_message.text_content or "")
+        if self._stop:
+            raise StopResponse()
+
+
+async def _run_text_turn(session: AgentSession, agent: Agent, text: str) -> None:
+    """run_session's shape, driven by a typed turn instead of the audio input."""
+    transcription_sync: TranscriptSynchronizer | None = None
+    if isinstance(session.output.audio, _SyncedAudioOutput):
+        transcription_sync = session.output.audio._synchronizer
+
+    await session.start(agent)
+    await _default_text_input_cb(session, TextInputEvent(text=text))
+    await asyncio.sleep(5.0)
+    with contextlib.suppress(RuntimeError):
+        await session.drain()
+    await session.aclose()
+
+    if transcription_sync is not None:
+        await transcription_sync.aclose()
+
+
+async def test_hook_fires_for_spoken_turn() -> None:
+    actions = FakeActions()
+    actions.add_user_speech(start_time=0.0, end_time=1.0, transcript="hello there")
+    actions.add_llm("hi!")
+    actions.add_tts(audio_duration=0.5)
+
+    agent = HookAgent()
+    await asyncio.wait_for(run_session(create_session(actions), agent), timeout=60.0)
+
+    assert agent.turns == ["hello there"]
+
+
+async def test_hook_fires_for_text_turn() -> None:
+    actions = FakeActions()
+    actions.add_llm("hi!", input="hello there")
+    actions.add_tts(audio_duration=0.5)
+
+    agent = HookAgent()
+    await _run_text_turn(create_session(actions, with_stt=False), agent, "hello there")
+
+    assert agent.turns == ["hello there"]
+
+
+async def test_hook_can_edit_the_chat_ctx_for_a_text_turn() -> None:
+    class EditingAgent(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="You are a helpful assistant.")
+
+        async def on_user_turn_completed(
+            self, turn_ctx: ChatContext, new_message: ChatMessage
+        ) -> None:
+            new_message.content = ["edited before the llm saw it"]
+
+    actions = FakeActions()
+    actions.add_llm("hi!", input="edited before the llm saw it")
+    actions.add_tts(audio_duration=0.5)
+
+    session = create_session(actions, with_stt=False)
+    items: list[ChatMessage] = []
+    session.on(
+        "conversation_item_added",
+        lambda ev: items.append(ev.item) if ev.item.type == "message" else None,
+    )
+
+    await _run_text_turn(session, EditingAgent(), "original")
+
+    user_messages = [i for i in items if i.role == "user"]
+    assert [m.text_content for m in user_messages] == ["edited before the llm saw it"]
+
+
+async def test_stop_response_drops_a_text_turn() -> None:
+    actions = FakeActions()
+    actions.add_llm("hi!", input="hello there")
+    actions.add_tts(audio_duration=0.5)
+
+    session = create_session(actions, with_stt=False)
+    replies: list[str] = []
+    session.on(
+        "conversation_item_added",
+        lambda ev: (
+            replies.append(ev.item.text_content or "")
+            if ev.item.type == "message" and ev.item.role == "assistant"
+            else None
+        ),
+    )
+
+    agent = HookAgent(stop=True)
+    await _run_text_turn(session, agent, "hello there")
+
+    assert agent.turns == ["hello there"]
+    assert replies == []


### PR DESCRIPTION
## The bug

`Agent.on_user_turn_completed` only ever ran on the audio end-of-turn path. Text
input went through `generate_reply()`, which never reaches it:

```python
async def _default_text_input_cb(sess, ev):
    async with sess._claim_user_turn():
        await sess.interrupt()
        sess.generate_reply(user_input=ev.text)   # hook never runs
```

So a turn the user *typed* skipped the hook entirely, while the same turn
*spoken* ran it. Two consequences:

- The docs point to `on_user_turn_completed` as the seam for editing or dropping
  a user message before it reaches the LLM. A guard wired there — PII redaction,
  a safety check, `StopResponse` — was silently bypassed whenever the user typed
  instead of spoke.
- Text-only simulation runs never fired it at all, so any agent holding state in
  that hook behaves differently under `lk agent simulate` than in production.
  A tool-gated flow of ours stalled in all 16 simulated calls for exactly this
  reason: a gate cleared in `on_user_turn_completed` never opened, and every
  downstream tool call was refused.

Demonstrated by driving one agent two ways — identical agent, identical message,
only the modality differs:

| turn driven through | `on_user_turn_completed` |
|---|---|
| audio pipeline | fires |
| `_default_text_input_cb` | never fires (LLM still replies) |

## The fix

Route the default text input callback through the same hook before generating,
so `StopResponse` and chat-context edits hold for a typed turn the way they do
for a spoken one.

`generate_reply()` is synchronous and can't await an async hook inline, so the
text path gets a small async seam on `AgentSession` rather than a change to
`generate_reply` itself.

Two commits: a pure refactor extracting the hook invocation out of
`_user_turn_completed_task`, then the functional change reusing it.

## Scope

Only the **default** callback routes through the hook. A custom `text_input_cb`
calling `sess.generate_reply(user_input=...)` still bypasses it, and
`generate_reply` is deliberately left alone — it's a generic "make the agent
reply" API, and `on_user_turn_exceeded`'s own default calls it, so firing the
hook there would be wrong. If custom callbacks should be covered too, the seam
wants to be public API instead of `_`-prefixed; happy to do that here.

## Tests

`tests/test_user_turn_hook_modality.py` pairs each text case against a spoken
control: the hook firing, chat-context edits reaching the LLM, and
`StopResponse` dropping the turn. Against `main` the three text cases fail and
the spoken control passes; with this change all four pass.

Full unit gate: 1949 passed, 5 skipped.

## Cross-SDK parity

`agents-js` has the identical gap at `agents/src/voice/room_io/room_io.ts:49`:

```ts
export const DEFAULT_TEXT_INPUT_CALLBACK: TextInputCallback = (sess, ev) => {
  sess.interrupt();
  sess.generateReply({ userInput: ev.text });
};
```

Not fixed here. It's a larger change there — the callback is synchronous and
doesn't await `interrupt()`, so awaiting the hook means making
`TextInputCallback` async. Happy to open the matching PR.
