### PR TITLE
fix(telemetry): report cached input tokens on LLM spans

### DIFF
--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -402,6 +402,9 @@ class LLMStream(ABC):
                     trace_types.ATTR_GEN_AI_REQUEST_MODEL: self._llm.model,
                     trace_types.ATTR_GEN_AI_PROVIDER_NAME: self._llm.provider,
                     trace_types.ATTR_GEN_AI_USAGE_INPUT_TOKENS: metrics.prompt_tokens,
+                    trace_types.ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS: (
+                        metrics.prompt_cached_tokens
+                    ),
                     trace_types.ATTR_GEN_AI_USAGE_OUTPUT_TOKENS: metrics.completion_tokens,
                 },
             )

--- a/livekit-agents/livekit/agents/telemetry/trace_types.py
+++ b/livekit-agents/livekit/agents/telemetry/trace_types.py
@@ -79,6 +79,7 @@ ATTR_GEN_AI_OPERATION_NAME = "gen_ai.operation.name"
 ATTR_GEN_AI_PROVIDER_NAME = "gen_ai.provider.name"
 ATTR_GEN_AI_REQUEST_MODEL = "gen_ai.request.model"
 ATTR_GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
+ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read.input_tokens"
 ATTR_GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
 
 # Unofficial OpenTelemetry GenAI attributes, these are namespaces recognised by LangFuse

--- a/tests/test_llm_telemetry.py
+++ b/tests/test_llm_telemetry.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from livekit.agents import llm
+from livekit.agents.telemetry import set_tracer_provider, tracer
+from livekit.agents.types import (
+    DEFAULT_API_CONNECT_OPTIONS,
+    NOT_GIVEN,
+    APIConnectOptions,
+    NotGivenOr,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.no_concurrent]
+
+
+class _UsageLLM(llm.LLM):
+    @property
+    def model(self) -> str:
+        return "test-model"
+
+    @property
+    def provider(self) -> str:
+        return "test-provider"
+
+    def chat(
+        self,
+        *,
+        chat_ctx: llm.ChatContext,
+        tools: list[llm.Tool] | None = None,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+        parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
+        tool_choice: NotGivenOr[llm.ToolChoice] = NOT_GIVEN,
+        extra_kwargs: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
+    ) -> llm.LLMStream:
+        return _UsageLLMStream(
+            self,
+            chat_ctx=chat_ctx,
+            tools=tools or [],
+            conn_options=conn_options,
+        )
+
+
+class _UsageLLMStream(llm.LLMStream):
+    async def _run(self) -> None:
+        self._event_ch.send_nowait(
+            llm.ChatChunk(
+                id="request-id",
+                delta=llm.ChoiceDelta(role="assistant", content="hello"),
+            )
+        )
+        self._event_ch.send_nowait(
+            llm.ChatChunk(
+                id="request-id",
+                usage=llm.CompletionUsage(
+                    prompt_tokens=100,
+                    prompt_cached_tokens=80,
+                    completion_tokens=5,
+                    total_tokens=105,
+                ),
+            )
+        )
+
+
+@pytest.fixture
+def span_exporter() -> Iterator[InMemorySpanExporter]:
+    original_provider = tracer._tracer_provider
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    set_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        set_tracer_provider(original_provider)
+        provider.shutdown()
+
+
+async def test_llm_span_reports_cached_input_tokens(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    model = _UsageLLM()
+
+    response = await model.chat(chat_ctx=llm.ChatContext()).collect()
+
+    assert response.usage is not None
+    assert response.usage.prompt_cached_tokens == 80
+    spans = [span for span in span_exporter.get_finished_spans() if span.name == "llm_request"]
+    assert len(spans) == 1
+    assert spans[0].attributes["gen_ai.usage.input_tokens"] == 100
+    assert spans[0].attributes["gen_ai.usage.cache_read.input_tokens"] == 80
+    assert "gen_ai.usage.input_cached_tokens" not in spans[0].attributes


### PR DESCRIPTION
## Summary

- export cached prompt token usage with the standard `gen_ai.usage.cache_read.input_tokens` attribute
- keep `gen_ai.usage.input_tokens` inclusive, as required by the OpenTelemetry GenAI semantic conventions, while allowing compatible backends such as Langfuse to normalize cache reads without double-counting
- apply the fix centrally so every provider that populates `CompletionUsage.prompt_cached_tokens` benefits
- preserve the existing Langfuse-specific cache attribute on realtime metrics and evaluation spans so current dashboards remain compatible
- add a provider-independent regression test that verifies the exported span attributes

## Testing

- `pytest tests/test_llm_telemetry.py --unit -q`
- `ruff check livekit-agents/livekit/agents/llm/llm.py livekit-agents/livekit/agents/telemetry/trace_types.py tests/test_llm_telemetry.py`
- `ruff format --check livekit-agents/livekit/agents/llm/llm.py livekit-agents/livekit/agents/telemetry/trace_types.py tests/test_llm_telemetry.py`
- `mypy --config-file pyproject.toml -p livekit.agents.llm.llm`
