### PR TITLE
plugins/phonic: support built-in tools via phonic_tools + configs_for_tools

### DIFF
--- a/livekit-plugins/livekit-plugins-phonic/README.md
+++ b/livekit-plugins/livekit-plugins-phonic/README.md
@@ -1,6 +1,6 @@
 # LiveKit Plugins: Phonic
 
-Realtime voice AI integration for [Phonic](https://phonic.co/) with LiveKit Agents.
+Realtime voice AI integration for [Phonic](https://phonic.ai/) with LiveKit Agents.
 
 ## Installation
 
@@ -93,7 +93,7 @@ Set the `PHONIC_API_KEY` environment variable, or pass `api_key` directly to `Re
 | `additional_languages` | `list[str]` | Further ISO 639-1 codes (must not repeat `default_language`) |
 | `multilingual_mode` | `"auto"` \| `"request"` | Per-utterance language detection vs. change on user request (recommended: `request`) |
 | `audio_speed` | `float` | Audio playback speed |
-| `phonic_tools` | `list[str]` | Names of Phonic-side tools available to the assistant: [Webhook tools](https://docs.phonic.co/docs/using-tools/tools_overview#webhook-tools) and [built-in tools](#built-in-tools) (`choose_not_to_respond`, `keypad_input`, `natural_conversation_ending`) |
+| `phonic_tools` | `list[str]` | Names of Phonic-side tools available to the assistant: [Webhook tools](https://docs.phonic.ai/docs/using-tools/tools_overview#webhook-tools) and [built-in tools](#built-in-tools) (`choose_not_to_respond`, `keypad_input`, `natural_conversation_ending`) |
 | `boosted_keywords` | `list[str]` | Keywords to boost in speech recognition |
 | `min_words_to_interrupt` | `int` | Minimum number of user words required to interrupt the assistant |
 | `generate_no_input_poke_text` | `bool` | Auto-generate poke text when user is silent |

--- a/livekit-plugins/livekit-plugins-phonic/README.md
+++ b/livekit-plugins/livekit-plugins-phonic/README.md
@@ -93,7 +93,7 @@ Set the `PHONIC_API_KEY` environment variable, or pass `api_key` directly to `Re
 | `additional_languages` | `list[str]` | Further ISO 639-1 codes (must not repeat `default_language`) |
 | `multilingual_mode` | `"auto"` \| `"request"` | Per-utterance language detection vs. change on user request (recommended: `request`) |
 | `audio_speed` | `float` | Audio playback speed |
-| `phonic_tools` | `list[str]` | [Phonic Webhook tool](https://docs.phonic.co/docs/using-tools/tools_overview#webhook-tools) names available to the assistant |
+| `phonic_tools` | `list[str]` | Names of Phonic-side tools available to the assistant: [Webhook tools](https://docs.phonic.co/docs/using-tools/tools_overview#webhook-tools) and [built-in tools](#built-in-tools) (`choose_not_to_respond`, `keypad_input`, `natural_conversation_ending`) |
 | `boosted_keywords` | `list[str]` | Keywords to boost in speech recognition |
 | `min_words_to_interrupt` | `int` | Minimum number of user words required to interrupt the assistant |
 | `generate_no_input_poke_text` | `bool` | Auto-generate poke text when user is silent |
@@ -121,11 +121,26 @@ RealtimeModel(
 | `require_speech_before_tool_call` | `bool` | `False` | Require the agent to speak before the tool can be called |
 | `forbid_speech_after_tool_call` | `bool` | `False` | Suppress the auto-generated spoken reply after the tool. Use for tools that always hand off to another agent (a non-handoff tool set here would leave the agent silent) |
 | `forbid_tool_call_after_speech` | `bool` | `False` | Drop the tool call if the agent already spoke this turn |
+| `respond_after_sec` | `float` | — | **`choose_not_to_respond` only.** Seconds to wait after the tool fires; if the user stays silent, the agent speaks a follow-up. Omit to keep the default (stay silent). |
+| `speech_before_tool_call` | `str` | — | **`keypad_input` / `natural_conversation_ending` only.** `required` \| `optional` \| `suppressed`. |
 
 The plugin always sends tool calls with `wait_for_speech_before_tool_call` on and `allow_tool_chaining` off; these are not configurable per tool.
 
 > **Deprecated:** the top-level `forbid_speech_after_tool_call: list[str]` option still works but is deprecated — it now folds each listed tool into `configs_for_tools` as `forbid_speech_after_tool_call=True` (an explicit `configs_for_tools` entry wins) and logs a warning. Prefer `configs_for_tools`.
 
+### Built-in tools
+
+Phonic's built-in tools — `choose_not_to_respond`, `keypad_input`, `natural_conversation_ending` — are enabled by listing their names in `phonic_tools`, alongside any Webhook tools. To configure one, add a `configs_for_tools` entry keyed by the same name (`respond_after_sec` for `choose_not_to_respond`; `speech_before_tool_call` for the other two). A built-in listed without a config uses its Phonic-side defaults.
+
+```python
+RealtimeModel(
+    phonic_tools=["choose_not_to_respond", "keypad_input"],
+    configs_for_tools=[
+        {"name": "choose_not_to_respond", "respond_after_sec": 5},
+    ],
+)
+```
+
 If you already have an agent set up on the Phonic platform, you can use the `phonic_agent` option to specify the agent name. As a note, configuration options you set in the LiveKit Agents SDK will override the agent settings set on the Phonic platform. This means the system prompt you have set on the Phonic platform will be ignored in favor of the `instructions` field set on the LiveKit `Agent`. Likewise, options explicitly set in the `RealtimeModel` constructor will override the Phonic agent's settings.
 
-If you have Webhook tools set up on the Phonic platform, you can use `phonic_tools` to make them available to your agent. Only [Phonic Webhook tools](https://docs.phonic.co/docs/using-tools/tools_overview#webhook-tools) are supported with LiveKit Agents.
+If you have Webhook tools set up on the Phonic platform, you can use `phonic_tools` to make them available to your agent, together with Phonic's [built-in tools](#built-in-tools). Custom function tools you define on the LiveKit `Agent` are also supported and run over the websocket.

--- a/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
@@ -56,6 +56,13 @@ WS_CLOSE_NORMAL = 1000
 TOOL_CALL_OUTPUT_TIMEOUT_MS = 60000
 
 
+# Phonic's built-in tools, referenced by name in ``phonic_tools``. A configs_for_tools entry for one of
+# these carries its built-in config (below) so it is sent to Phonic as an inline object rather than a name.
+_BUILT_IN_TOOL_NAMES = frozenset(
+    {"choose_not_to_respond", "keypad_input", "natural_conversation_ending"}
+)
+
+
 class PhonicToolConfig(TypedDict, total=False):
     """Per-tool behavior overrides for ``configs_for_tools`` (see README). ``name`` is required;
     every other field is optional and falls back to the plugin default when omitted."""
@@ -64,6 +71,11 @@ class PhonicToolConfig(TypedDict, total=False):
     require_speech_before_tool_call: bool
     forbid_speech_after_tool_call: bool
     forbid_tool_call_after_speech: bool
+    # Built-in tools only (set on the matching ``phonic_tools`` entry):
+    respond_after_sec: float  # choose_not_to_respond: seconds to wait before a follow-up (or omit)
+    speech_before_tool_call: (
+        str  # keypad_input / natural_conversation_ending: required|optional|suppressed
+    )
 
 
 @dataclass
@@ -543,10 +555,29 @@ class RealtimeSession(llm.RealtimeSession):
             )
             await self._socket.send_reset(ResetPayload(config=config_options))
 
+    def _serialize_phonic_tool(self, name: str) -> dict | str:
+        """A phonic_tools entry: an inline built-in object when it's a built-in with a config in
+        configs_for_tools (so respond_after_sec / speech_before_tool_call reach Phonic), else the bare
+        name (which uses the tool's default config)."""
+        if name not in _BUILT_IN_TOOL_NAMES:
+            return name
+        cfg = self._configs_for_tools.get(name, {})
+        if name == "choose_not_to_respond":
+            if "respond_after_sec" not in cfg:
+                return name
+            tool_config: dict = {"respond_after_sec": cfg["respond_after_sec"]}
+        else:  # keypad_input, natural_conversation_ending
+            if "speech_before_tool_call" not in cfg:
+                return name
+            tool_config = {"speech_before_tool_call": cfg["speech_before_tool_call"]}
+        return {"type": "built_in", "name": name, "tool_config": tool_config}
+
     def _build_tools_payload(self) -> list[dict | str]:
         tools_payload: list[dict | str] = []
         if is_given(self._opts.phonic_tools) and self._opts.phonic_tools:
-            tools_payload.extend(self._opts.phonic_tools)
+            tools_payload.extend(
+                self._serialize_phonic_tool(name) for name in self._opts.phonic_tools
+            )
         tools_payload.extend(self._tool_definitions)
         return tools_payload
 

--- a/livekit-plugins/livekit-plugins-phonic/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-phonic/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "livekit-agents>=1.6.8",
     "websockets>=11.0",
     "aiohttp>=3.8.0",
-    "phonic>=0.32.9"
+    "phonic>=0.32.22"
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -2864,7 +2864,7 @@ dependencies = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.8.0" },
     { name = "livekit-agents", editable = "livekit-agents" },
-    { name = "phonic", specifier = ">=0.32.9" },
+    { name = "phonic", specifier = ">=0.32.22" },
     { name = "websockets", specifier = ">=11.0" },
 ]
 
@@ -4067,7 +4067,7 @@ wheels = [
 
 [[package]]
 name = "phonic"
-version = "0.32.13"
+version = "0.32.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -4076,9 +4076,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/d8/e370a18f0b9de6c341fd65decb6ddea5c3be2728711f579749a195842acc/phonic-0.32.13.tar.gz", hash = "sha256:2a8bfa5af4258841e24f214e35c3262d447ab0fb397f2722c0f958d8d345fe1d", size = 174860, upload-time = "2026-07-17T02:12:28.469Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/39/267a446db5a65a9c63171fbaa19fb187f222d7b97d69273bc1f825e0297d/phonic-0.32.22.tar.gz", hash = "sha256:70c3fe78e6cfe18b19de07c66e5f28054783aab32df2f821fadc63f8a89209e3", size = 190502, upload-time = "2026-08-14T22:04:32.102Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/97/4038108f606c6dd31e8d718e8c7a644e76b2616aab625da824dc10bf68e5/phonic-0.32.13-py3-none-any.whl", hash = "sha256:fc85bf4aad0ebd0996fb73272fc141adc84d14ae043016f8f5b70e706326812d", size = 376593, upload-time = "2026-07-17T02:12:27.149Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0e/cf17a27cef320c24fc7a163540afd7c76c9537797debbd89255e76923d22/phonic-0.32.22-py3-none-any.whl", hash = "sha256:b366a18173890a17beb1659f7a4d837e055946879710608dc5708184fb1fb9aa", size = 410260, upload-time = "2026-08-14T22:04:30.712Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Enable Phonic's built-in tools (`choose_not_to_respond`, `keypad_input`, `natural_conversation_ending`) in the realtime model by listing their names in `phonic_tools`, and configure them through a matching `configs_for_tools` entry — `respond_after_sec` for `choose_not_to_respond`, `speech_before_tool_call` for the other two.

A built-in listed with a config is serialized as an inline `{ type: "built_in", name, tool_config }` object; without a config it is sent as a bare name and uses the tool's Phonic-side defaults. No new constructor option — this reuses the existing `phonic_tools` / `configs_for_tools` surface.

README updated.