### PR TITLE
feat(room_io): mix audio from every participant into one AgentSession

### DIFF
--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Iterable
+from dataclasses import dataclass
 from typing import Any, Generic, TypeVar, cast
 
 from typing_extensions import override
@@ -148,15 +150,20 @@ class _ParticipantInputStream(Generic[T], ABC):
             "source": rtc.TrackSource.Name(publication.source),
         }
         logger.debug("start reading stream", extra=extra)
+        sink = self._sink(participant)
         async for event in stream:
             if not self._attached:
                 # drop frames if the stream is detached
                 continue
             frame = cast(T, event.frame)
             self._process_frame(frame)
-            await self._data_ch.send(frame)
+            await sink.send(frame)
 
         logger.debug("stream closed", extra=extra)
+
+    def _sink(self, participant: rtc.RemoteParticipant) -> aio.Chan[T]:
+        """The channel a participant's frames are forwarded to."""
+        return self._data_ch
 
     def _process_frame(self, frame: T) -> None:
         """Hook for subclasses to process frames in-place before forwarding."""
@@ -227,6 +234,16 @@ class _ParticipantInputStream(Generic[T], ABC):
                 return
 
 
+@dataclass
+class _MixedSource:
+    """One participant's contribution to the mixed audio input."""
+
+    chan: aio.Chan[rtc.AudioFrame]
+    stream: rtc.AudioStream | None = None
+    task: asyncio.Task[None] | None = None
+    publication_sid: str | None = None
+
+
 class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], AudioInput):
     def __init__(
         self,
@@ -241,6 +258,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         auto_gain_control: bool = True,
         pre_connect_audio_handler: PreConnectAudioHandler | None,
         frame_size_ms: int = 50,
+        mix_participants: bool = False,
     ) -> None:
         _ParticipantInputStream.__init__(
             self,
@@ -263,17 +281,156 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         if auto_gain_control:
             self._apm = rtc.AudioProcessingModule(auto_gain_control=True)
 
+        self._mix_participants = mix_participants
+        self._mix_sources: dict[str, _MixedSource] = {}
+        self._mixer: rtc.AudioMixer | None = None
+        self._mixer_atask: asyncio.Task[None] | None = None
+
+    @property
+    def mix_participants(self) -> bool:
+        return self._mix_participants
+
+    def add_participant(self, participant: rtc.RemoteParticipant) -> None:
+        """Mix this participant's microphone into the input stream.
+
+        Only used when `mix_participants` is enabled; a no-op otherwise.
+        """
+        if not self._mix_participants or participant.identity in self._mix_sources:
+            return
+
+        source = _MixedSource(chan=aio.Chan[rtc.AudioFrame]())
+        self._mix_sources[participant.identity] = source
+        self._ensure_mixer().add_stream(source.chan)
+
+        for publication in participant.track_publications.values():
+            if publication.track and self._on_track_available(
+                publication.track, publication, participant
+            ):
+                break
+
+    def remove_participant(self, identity: str) -> None:
+        source = self._mix_sources.pop(identity, None)
+        if source is None:
+            return
+
+        if self._mixer:
+            self._mixer.remove_stream(source.chan)
+        self._close_mixed_source(source)
+        source.chan.close()
+
+    def _ensure_mixer(self) -> rtc.AudioMixer:
+        if self._mixer is None:
+            self._mixer = rtc.AudioMixer(
+                self._sample_rate,
+                self._num_channels,
+                blocksize=int(self._sample_rate * self._frame_size_ms / 1000),
+                # ponytail: a muted/paused participant stops delivering frames, so the mixer
+                # logs a timeout warning per block and pads silence. Harmless, but noisy —
+                # feed silence per source if that ever matters.
+                stream_timeout_ms=max(100, self._frame_size_ms * 2),
+            )
+            self._mixer_atask = asyncio.create_task(self._forward_mixed(self._mixer))
+        return self._mixer
+
+    def _close_mixed_source(self, source: _MixedSource) -> None:
+        stream, task = source.stream, source.task
+        source.stream, source.task, source.publication_sid = None, None, None
+
+        async def _close() -> None:
+            if task:
+                await aio.cancel_and_wait(task)
+            if stream:
+                await stream.aclose()
+
+        close_task = asyncio.create_task(_close())
+        close_task.add_done_callback(self._tasks.discard)
+        self._tasks.add(close_task)
+
+    @log_exceptions(logger=logger)
+    async def _forward_mixed(self, mixer: rtc.AudioMixer) -> None:
+        async for frame in mixer:
+            if not self._attached:
+                continue
+            if self._apm is not None:
+                self._apm.process_stream(frame)
+            await self._data_ch.send(frame)
+
+    @override
+    def _sink(self, participant: rtc.RemoteParticipant) -> aio.Chan[rtc.AudioFrame]:
+        if (source := self._mix_sources.get(participant.identity)) is not None:
+            return source.chan
+        return self._data_ch
+
+    @override
+    def set_participant(self, participant: rtc.RemoteParticipant | str | None) -> None:
+        if self._mix_participants:
+            # every accepted participant is mixed in, linking only drives the outputs
+            return
+        super().set_participant(participant)
+
+    @override
+    def _on_track_available(
+        self,
+        track: rtc.RemoteTrack,
+        publication: rtc.RemoteTrackPublication,
+        participant: rtc.RemoteParticipant,
+    ) -> bool:
+        if not self._mix_participants:
+            return super()._on_track_available(track, publication, participant)
+
+        source = self._mix_sources.get(participant.identity)
+        if (
+            source is None
+            or publication.source not in self._accepted_sources
+            or source.publication_sid == publication.sid
+        ):
+            return False
+
+        self._close_mixed_source(source)
+        source.publication_sid = publication.sid
+        source.stream = self._create_stream(track, participant)
+        source.task = asyncio.create_task(
+            self._forward_task(None, source.stream, publication, participant)
+        )
+        return True
+
+    @override
+    def _on_track_unavailable(
+        self, publication: rtc.RemoteTrackPublication, participant: rtc.RemoteParticipant
+    ) -> None:
+        if not self._mix_participants:
+            super()._on_track_unavailable(publication, participant)
+            return
+
+        source = self._mix_sources.get(participant.identity)
+        if source is None or source.publication_sid != publication.sid:
+            return
+
+        self._close_mixed_source(source)
+        for publication in participant.track_publications.values():
+            if publication.track and self._on_track_available(
+                publication.track, publication, participant
+            ):
+                return
+
     @override
     def _process_frame(self, frame: rtc.AudioFrame) -> None:
+        if self._mix_participants:
+            return  # AGC runs once on the mixed output instead
+
         if self._apm is not None:
             self._apm.process_stream(frame)
 
     @override
     def _create_stream(self, track: rtc.Track, participant: rtc.Participant) -> rtc.AudioStream:
         noise_cancellation = self._noise_cancellation
+        auto_close_noise_cancellation = False
         if callable(noise_cancellation):
             noise_cancellation = noise_cancellation(NoiseCancellationParams(participant, track))
-            if isinstance(noise_cancellation, rtc.FrameProcessor):
+            if self._mix_participants:
+                # each mixed participant gets its own processor, tied to its stream
+                auto_close_noise_cancellation = isinstance(noise_cancellation, rtc.FrameProcessor)
+            elif isinstance(noise_cancellation, rtc.FrameProcessor):
                 self._update_processor(noise_cancellation)
             else:
                 self._update_processor(None)
@@ -284,7 +441,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             num_channels=self._num_channels,
             frame_size_ms=self._frame_size_ms,
             noise_cancellation=noise_cancellation,
-            auto_close_noise_cancellation=False,
+            auto_close_noise_cancellation=auto_close_noise_cancellation,
         )
 
     @override
@@ -298,51 +455,75 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         if old_task:
             await aio.cancel_and_wait(old_task)
 
-        if (
-            self._pre_connect_audio_handler
-            and publication.track
-            and AudioTrackFeature.TF_PRECONNECT_BUFFER in publication.audio_features
-        ):
-            logging_extra = {
-                "track_id": publication.track.sid,
-                "participant": participant.identity,
-            }
-            try:
-                duration: float = 0
-                frames = await self._pre_connect_audio_handler.wait_for_data(publication.track.sid)
-                for frame in self._resample_frames(self._apply_audio_processor(frames)):
-                    if self._attached:
-                        await self._data_ch.send(frame)
-                        duration += frame.duration
-                if frames:
-                    logger.debug(
-                        "pre-connect audio buffer pushed",
-                        extra={"duration": duration, **logging_extra},
+        sink = self._sink(participant)
+        # the sink of a mixed participant is closed when they leave, mid-forwarding
+        with contextlib.suppress(aio.ChanClosed):
+            if (
+                self._pre_connect_audio_handler
+                and publication.track
+                and AudioTrackFeature.TF_PRECONNECT_BUFFER in publication.audio_features
+            ):
+                logging_extra = {
+                    "track_id": publication.track.sid,
+                    "participant": participant.identity,
+                }
+                try:
+                    duration: float = 0
+                    frames = await self._pre_connect_audio_handler.wait_for_data(
+                        publication.track.sid
+                    )
+                    for frame in self._resample_frames(self._apply_audio_processor(frames)):
+                        if self._attached:
+                            await sink.send(frame)
+                            duration += frame.duration
+                    if frames:
+                        logger.debug(
+                            "pre-connect audio buffer pushed",
+                            extra={"duration": duration, **logging_extra},
+                        )
+
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "timeout waiting for pre-connect audio buffer",
+                        extra=logging_extra,
                     )
 
-            except asyncio.TimeoutError:
-                logger.warning(
-                    "timeout waiting for pre-connect audio buffer",
-                    extra=logging_extra,
+                except Exception as e:
+                    logger.error(
+                        "error reading pre-connect audio buffer", extra=logging_extra, exc_info=e
+                    )
+
+            await super()._forward_task(old_task, stream, publication, participant)
+
+            # push a silent frame to flush the stt final result if any
+            silent_samples = int(self._sample_rate * 0.5)
+            await sink.send(
+                rtc.AudioFrame(
+                    b"\x00\x00" * silent_samples,
+                    sample_rate=self._sample_rate,
+                    num_channels=self._num_channels,
+                    samples_per_channel=silent_samples,
                 )
-
-            except Exception as e:
-                logger.error(
-                    "error reading pre-connect audio buffer", extra=logging_extra, exc_info=e
-                )
-
-        await super()._forward_task(old_task, stream, publication, participant)
-
-        # push a silent frame to flush the stt final result if any
-        silent_samples = int(self._sample_rate * 0.5)
-        await self._data_ch.send(
-            rtc.AudioFrame(
-                b"\x00\x00" * silent_samples,
-                sample_rate=self._sample_rate,
-                num_channels=self._num_channels,
-                samples_per_channel=silent_samples,
             )
-        )
+
+    @override
+    async def aclose(self) -> None:
+        sources, self._mix_sources = list(self._mix_sources.values()), {}
+        for source in sources:
+            source.chan.close()
+            if source.task:
+                await aio.cancel_and_wait(source.task)
+            if source.stream:
+                await source.stream.aclose()
+
+        if self._mixer_atask:
+            await aio.cancel_and_wait(self._mixer_atask)
+            self._mixer_atask = None
+        if self._mixer:
+            await self._mixer.aclose()
+            self._mixer = None
+
+        await super().aclose()
 
     def _resample_frames(self, frames: Iterable[rtc.AudioFrame]) -> Iterable[rtc.AudioFrame]:
         resampler: rtc.AudioResampler | None = None

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -123,6 +123,7 @@ class RoomIO:
                 noise_cancellation=input_audio_options.noise_cancellation,
                 auto_gain_control=input_audio_options.auto_gain_control,
                 pre_connect_audio_handler=self._pre_connect_audio_handler,
+                mix_participants=input_audio_options.mix_participants,
             )
 
         # -- create outputs --
@@ -374,7 +375,25 @@ class RoomIO:
         if self._room.isconnected() and not self._room_connected_fut.done():
             self._room_connected_fut.set_result(None)
 
+    def _add_mixed_participant(self, participant: rtc.RemoteParticipant) -> None:
+        if self._audio_input is None or not self._audio_input.mix_participants:
+            return
+
+        accepted_kinds = self._options.participant_kinds or DEFAULT_PARTICIPANT_KINDS
+        if participant.kind not in accepted_kinds:
+            return
+
+        if (
+            participant.attributes.get(ATTRIBUTE_PUBLISH_ON_BEHALF)
+            == self._room.local_participant.identity
+        ):
+            return  # our own avatar worker, listening to it would loop the agent back on itself
+
+        self._audio_input.add_participant(participant)
+
     def _on_participant_connected(self, participant: rtc.RemoteParticipant) -> None:
+        self._add_mixed_participant(participant)
+
         if self._participant_available_fut.done():
             return
 
@@ -397,6 +416,9 @@ class RoomIO:
         self._agent_session._on_room_io_participant_linked(participant)
 
     def _on_participant_disconnected(self, participant: rtc.RemoteParticipant) -> None:
+        if self._audio_input and self._audio_input.mix_participants:
+            self._audio_input.remove_participant(participant.identity)
+
         if not (linked := self.linked_participant) or participant.identity != linked.identity:
             return
         self._participant_available_fut = asyncio.Future[rtc.RemoteParticipant]()

--- a/livekit-agents/livekit/agents/voice/room_io/types.py
+++ b/livekit-agents/livekit/agents/voice/room_io/types.py
@@ -68,6 +68,10 @@ class AudioInputOptions:
     ) = None
     auto_gain_control: bool = True
     """Enable automatic gain control (AGC) on the input audio. Enabled by default."""
+    mix_participants: bool = False
+    """Mix the microphone of every accepted participant into a single input stream, instead of
+    listening to the linked participant only. The linked participant still drives the outputs
+    (audio, transcription). Transcripts of a mixed input cannot be attributed to a speaker."""
     pre_connect_audio: bool = True
     """Pre-connect audio enabled or not."""
     pre_connect_audio_timeout: float = 3.0

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -9,6 +9,7 @@ import pytest
 
 from livekit import rtc
 from livekit.agents import utils
+from livekit.agents.types import ATTRIBUTE_PUBLISH_ON_BEHALF
 from livekit.agents.voice.io import PlaybackFinishedEvent
 from livekit.agents.voice.room_io._input import (
     _ParticipantAudioInputStream,
@@ -142,6 +143,9 @@ def _make_track_available_args(
 def _make_audio_input_stream(
     room: _FakeRoom,
     noise_cancellation,
+    *,
+    mix_participants: bool = False,
+    frame_size_ms: int = 50,
 ) -> _ParticipantAudioInputStream:
     return _ParticipantAudioInputStream(
         room,
@@ -150,6 +154,8 @@ def _make_audio_input_stream(
         noise_cancellation=noise_cancellation,
         auto_gain_control=False,
         pre_connect_audio_handler=None,
+        frame_size_ms=frame_size_ms,
+        mix_participants=mix_participants,
     )
 
 
@@ -368,6 +374,103 @@ async def test_selector_returns_noise_cancellation_options() -> None:
     assert stream._processor is None
 
     await stream.aclose()
+
+
+# -- multi-participant mixing tests -------------------------------------------
+
+
+class _ConstantAudioStream:
+    """Emits one frame of a constant sample value, then stays open without producing."""
+
+    def __init__(self, value: int, samples: int, sample_rate: int) -> None:
+        self._frame = rtc.AudioFrame(
+            value.to_bytes(2, "little", signed=True) * samples, sample_rate, 1, samples
+        )
+        self._sent = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._sent:
+            await asyncio.Event().wait()  # keep the stream alive, but silent
+        self._sent = True
+        return SimpleNamespace(frame=self._frame)
+
+    async def aclose(self) -> None:
+        pass
+
+
+def _make_mix_participant(
+    identity: str, sid: str, *, kind=rtc.ParticipantKind.PARTICIPANT_KIND_STANDARD, attributes=None
+) -> MagicMock:
+    publication = MagicMock()
+    publication.source = rtc.TrackSource.SOURCE_MICROPHONE
+    publication.sid = sid
+    publication.track = MagicMock()
+    publication.audio_features = []
+
+    participant = MagicMock()
+    participant.identity = identity
+    participant.kind = kind
+    participant.attributes = attributes or {}
+    participant.track_publications = {sid: publication}
+    return participant
+
+
+@pytest.mark.asyncio
+async def test_mix_participants_sums_every_participant_audio() -> None:
+    """Both participants are heard at once: the input yields their mixed samples."""
+    room = _FakeRoom()
+    stream = _make_audio_input_stream(room, None, mix_participants=True, frame_size_ms=10)
+    samples = 240  # 10ms @ 24kHz
+
+    streams = [_ConstantAudioStream(v, samples, 24000) for v in (100, 200)]
+    with patch("livekit.rtc.AudioStream.from_track", side_effect=lambda **kw: streams.pop(0)):
+        stream.add_participant(_make_mix_participant("candidate", "TR_1"))
+        stream.add_participant(_make_mix_participant("interviewer", "TR_2"))
+
+        assert set(stream._mix_sources) == {"candidate", "interviewer"}
+
+        frame = await asyncio.wait_for(stream.__anext__(), timeout=5)
+
+    assert frame.samples_per_channel == samples
+    assert bytes(frame.data) == (300).to_bytes(2, "little", signed=True) * samples
+
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_mix_participants_tracks_room_membership() -> None:
+    """RoomIO mixes in every accepted participant, but never its own avatar worker."""
+    room = _FakeRoom()
+    agent_session = SimpleNamespace(
+        off=MagicMock(),
+        _on_room_io_participant_linked=MagicMock(),
+        input=SimpleNamespace(audio=None, video=None),
+        output=SimpleNamespace(audio=None, transcription=None),
+    )
+    room_io = RoomIO(agent_session, room)
+    room_io._audio_input = _make_audio_input_stream(room, None, mix_participants=True)
+
+    candidate = _make_mix_participant("candidate", "TR_1")
+    interviewer = _make_mix_participant("interviewer", "TR_2")
+    avatar = _make_mix_participant(
+        "avatar", "TR_3", attributes={ATTRIBUTE_PUBLISH_ON_BEHALF: "local"}
+    )
+
+    with patch("livekit.rtc.AudioStream.from_track", side_effect=lambda **kw: _MockAudioStream()):
+        for participant in (candidate, interviewer, avatar):
+            room_io._on_participant_connected(participant)
+
+        assert set(room_io._audio_input._mix_sources) == {"candidate", "interviewer"}
+        # only the first participant is linked, the rest are input-only
+        assert room_io.linked_participant is candidate
+
+        room_io._on_participant_disconnected(interviewer)
+        assert set(room_io._audio_input._mix_sources) == {"candidate"}
+
+    await room_io._audio_input.aclose()
 
 
 # -- audio output tests -------------------------------------------------------


### PR DESCRIPTION
Closes #6795

## Problem

`AgentSession` can only listen to one participant at a time: `_ParticipantInputStream` keeps a single `_stream`/`_publication`, so a second participant's track replaces the first instead of joining it. Use cases like an AI interview with human takeover need N participants → 1 session → 1 shared chat context.

## Approach

Opt-in mixing. With `AudioInputOptions.mix_participants=True`, `RoomIO` subscribes to the microphone of every accepted participant and mixes them with `rtc.AudioMixer` (the same primitive `BackgroundAudio` uses) into the single audio input the session already consumes. One STT/LLM/TTS pipeline, one chat context, no API surface beyond the flag:

```python
session.start(
    room=ctx.room,
    room_options=RoomOptions(audio_input=AudioInputOptions(mix_participants=True)),
)
```

## Changes

- **`voice/room_io/_input.py`** — `_ParticipantAudioInputStream` keeps a `_MixedSource` per participant (channel + track stream + forward task) and feeds each channel into an `rtc.AudioMixer`; the mixed output becomes the session's input. The only change to the shared single-participant path is a `_sink(participant)` hook in the base class, which still returns `_data_ch` — video and non-mixed audio behave exactly as before.
- **`voice/room_io/room_io.py`** — every accepted participant is added to the mix on connect and removed on disconnect. Kind filtering is unchanged, and the agent's own avatar worker (`ATTRIBUTE_PUBLISH_ON_BEHALF`) is excluded so the agent can't hear itself. The linked participant is still the first one and only drives the outputs (audio, transcription, chat text).
- **`voice/room_io/types.py`** — the `mix_participants` option.

Notes:
- AGC runs once on the mixed output rather than per stream (one shared `AudioProcessingModule` interleaved across speakers would be wrong).
- A noise-cancellation *selector* now builds a processor per participant, owned by that participant's stream; a directly-passed `FrameProcessor` instance keeps today's shared lifetime.
- `set_participant()` is a no-op for the input in this mode — listening covers everyone; toggle it with the existing audio-input enable/disable.

## Not included

Per-turn speaker attribution, also mentioned in the issue. Mixing collapses everyone into one stream, so a single STT cannot label who spoke — that needs per-participant recognition, which is a separate change.

## Tests

`tests/test_room_io.py`:
- `test_mix_participants_sums_every_participant_audio` — two participants' frames come out of the input summed into one frame.
- `test_mix_participants_tracks_room_membership` — RoomIO mixes both humans, skips its own avatar worker, links only the first, and drops a participant on disconnect.

`uv run pytest --unit` passes (the pre-existing `test_sent_tokenizer` failure and `test_room.py` errors are environment-related and reproduce on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQ72uVTX79ocrm3KJ3LKYh
