### PR TITLE
feat(room_io): mix audio from every participant into one AgentSession

### DIFF
--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -298,6 +298,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         self._mixer_atask: asyncio.Task[None] | None = None
         self._mixing: set[aio.Chan[rtc.AudioFrame]] = set()  # channels feeding the mixer
         self._mix_closed = False
+        self._pre_connect_flushed: set[str] = set()  # track sids whose buffer was consumed
 
         if mix_participants:
             self._room.on("track_muted", self._on_track_muted)
@@ -594,13 +595,23 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         ):
             return
 
+        track_sid = publication.track.sid
+        if track_sid in self._pre_connect_flushed:
+            # the publication advertises the buffer for the lifetime of the track, but the
+            # handler drops it after the first read. asking again only blocks for the whole
+            # timeout while the freshly subscribed stream backs up behind us
+            return
+        self._pre_connect_flushed.add(track_sid)
+
         sink = sink if sink is not None else self._data_ch
-        logging_extra = {"track_id": publication.track.sid, "participant": participant.identity}
+        logging_extra = {"track_id": track_sid, "participant": participant.identity}
         try:
             duration: float = 0
-            frames = await self._pre_connect_audio_handler.wait_for_data(publication.track.sid)
+            frames = await self._pre_connect_audio_handler.wait_for_data(track_sid)
             for frame in self._resample_frames(self._apply_audio_processor(frames, processor)):
-                if self._should_forward():
+                # these go straight to the session, so they need the detached check that
+                # _forward_mixed applies to everything coming out of the mixer
+                if self._attached:
                     await sink.send(frame)
                     duration += frame.duration
             if frames:

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -430,7 +430,8 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         """
         # pre-connect audio was recorded before this participant joined, so it is not concurrent
         # with anyone: it goes straight to the session rather than through the mixer, where it
-        # would stall the mix while it loads and then leave this source permanently behind
+        # would stall the mix while it loads and then leave this source permanently behind.
+        # it is only delivered while nobody else is mixed in — see _flush_pre_connect
         with contextlib.suppress(aio.ChanClosed):
             await self._flush_pre_connect(publication, participant, processor)
 
@@ -452,12 +453,14 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
 
     @log_exceptions(logger=logger)
     async def _forward_mixed(self, mixer: rtc.AudioMixer) -> None:
-        async for frame in mixer:
-            if not self._attached:
-                continue
-            if self._apm is not None:
-                self._apm.process_stream(frame)
-            await self._data_ch.send(frame)
+        # the session channel closing is a shutdown, not a failure worth a traceback
+        with contextlib.suppress(aio.ChanClosed):
+            async for frame in mixer:
+                if not self._attached:
+                    continue
+                if self._apm is not None:
+                    self._apm.process_stream(frame)
+                await self._data_ch.send(frame)
 
     @override
     def set_participant(self, participant: rtc.RemoteParticipant | str | None) -> None:
@@ -616,6 +619,17 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         try:
             duration: float = 0
             frames = await self._pre_connect_audio_handler.wait_for_data(track_sid)
+
+            if self._mixing:
+                # this buffer predates the conversation and does not go through the mixer, so
+                # writing it now would interleave it frame by frame with whoever is currently
+                # speaking. losing one newcomer's opening words beats garbling everyone's
+                logger.debug(
+                    "pre-connect audio dropped, other participants are already mixed in",
+                    extra=logging_extra,
+                )
+                return
+
             for frame in self._resample_frames(self._apply_audio_processor(frames, processor)):
                 # these go straight to the session, so they need the detached check that
                 # _forward_mixed applies to everything coming out of the mixer
@@ -627,6 +641,9 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                     "pre-connect audio buffer pushed",
                     extra={"duration": duration, **logging_extra},
                 )
+
+        except aio.ChanClosed:
+            raise  # the caller suppresses this: a departure mid-flush is not a failure
 
         except asyncio.TimeoutError:
             logger.warning("timeout waiting for pre-connect audio buffer", extra=logging_extra)

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -247,6 +247,8 @@ class _MixedSource:
     """One participant's contribution to the mixed audio input."""
 
     chan: aio.Chan[rtc.AudioFrame]
+    """Replaced on every subscribe. A dying forward task keeps writing into the old channel
+    for a moment, and a fresh one is the only way its frames cannot resurface in the mix."""
     stream: rtc.AudioStream | None = None
     task: asyncio.Task[None] | None = None
     publication_sid: str | None = None
@@ -294,6 +296,8 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         self._mix_sources: dict[str, _MixedSource] = {}
         self._mixer: rtc.AudioMixer | None = None
         self._mixer_atask: asyncio.Task[None] | None = None
+        self._mixing: set[aio.Chan[rtc.AudioFrame]] = set()  # channels feeding the mixer
+        self._mix_closed = False
 
         if mix_participants:
             self._room.on("track_muted", self._on_track_muted)
@@ -325,7 +329,6 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
 
         source = _MixedSource(chan=aio.Chan[rtc.AudioFrame]())
         self._mix_sources[participant.identity] = source
-        self._ensure_mixer()
 
         for publication in participant.track_publications.values():
             if publication.track and self._on_track_available(
@@ -334,12 +337,8 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                 break
 
     def remove_participant(self, identity: str) -> None:
-        source = self._mix_sources.pop(identity, None)
-        if source is None:
-            return
-
-        self._close_mixed_source(source)
-        source.chan.close()
+        if (source := self._mix_sources.pop(identity, None)) is not None:
+            self._close_mixed_source(source)
 
     def _ensure_mixer(self) -> rtc.AudioMixer:
         if self._mixer is None:
@@ -372,16 +371,35 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
 
         self._on_track_available(publication.track, publication, participant)  # type: ignore[arg-type]
 
+    def _mix_chan(self, chan: aio.Chan[rtc.AudioFrame], *, mixing: bool) -> None:
+        """Feed the mixer from this channel, or stop.
+
+        The mixer waits `stream_timeout_ms` on every registered stream for every block, so a
+        stream that isn't delivering paces the whole mix below real time and every live speaker
+        falls behind for as long as it stays registered.
+
+        Keyed on the channel rather than the participant: a forward task that is still shutting
+        down must not unregister the channel its successor just registered.
+        """
+        if mixing:
+            if self._mix_closed:
+                return
+            self._ensure_mixer().add_stream(chan)
+            self._mixing.add(chan)
+            return
+
+        if self._mixer is not None:
+            self._mixer.remove_stream(chan)
+        self._mixing.discard(chan)
+
     def _close_mixed_source(self, source: _MixedSource) -> None:
-        stream, task = source.stream, source.task
+        stream, task, chan = source.stream, source.task, source.chan
         source.stream, source.task, source.publication_sid = None, None, None
 
-        # the mixer waits stream_timeout_ms on every registered stream for every block, so a
-        # source that stopped delivering paces the whole mix below real time
-        if self._mixer is not None:
-            self._mixer.remove_stream(source.chan)
-        while not source.chan.empty():
-            source.chan.recv_nowait()  # in-flight audio would resurface on the next unmute
+        self._mix_chan(chan, mixing=False)
+        # closing before the task is cancelled is what makes this safe: the forward task cannot
+        # sneak a late frame past us, and the next subscribe gets a channel of its own anyway
+        chan.close()
 
         async def _close() -> None:
             if task:
@@ -392,6 +410,38 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         close_task = asyncio.create_task(_close())
         close_task.add_done_callback(self._tasks.discard)
         self._tasks.add(close_task)
+
+    @log_exceptions(logger=logger)
+    async def _forward_mixed_source(
+        self,
+        source: _MixedSource,
+        stream: rtc.AudioStream,
+        publication: rtc.RemoteTrackPublication,
+        participant: rtc.RemoteParticipant,
+    ) -> None:
+        chan = source.chan  # bound once: source.chan is replaced by the next subscribe
+
+        # pre-connect audio was recorded before this participant joined, so it is not concurrent
+        # with anyone: it goes straight to the session rather than through the mixer, where it
+        # would stall the mix while it loads and then leave this source permanently behind
+        with contextlib.suppress(aio.ChanClosed):
+            await self._flush_pre_connect(publication, participant, source.processor)
+
+        if chan.closed:
+            return  # the source was torn down while the pre-connect buffer loaded
+
+        self._mix_chan(chan, mixing=True)
+        try:
+            await super()._forward_task(None, stream, publication, participant, chan)
+        finally:
+            # a track that ends without being unpublished would otherwise stay registered
+            self._mix_chan(chan, mixing=False)
+            if not self._mixing:
+                # nothing left to mix: the session needs silence to flush the last transcript.
+                # while others are still talking the mix carries on and injecting it would
+                # punch a hole in their audio
+                with contextlib.suppress(aio.ChanClosed):
+                    await self._data_ch.send(self._silent_frame())
 
     @log_exceptions(logger=logger)
     async def _forward_mixed(self, mixer: rtc.AudioMixer) -> None:
@@ -431,16 +481,16 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         if publication.muted:
             return False  # nothing to read yet, track_unmuted brings the source back
 
+        # a fresh channel: the previous forward task is still winding down and anything it
+        # writes must land in the channel it was bound to, never in the new mix
+        source.chan = aio.Chan[rtc.AudioFrame]()
         source.publication_sid = publication.sid
         source.stream = self._create_stream(track, participant)
         # the sink is bound here, once: a participant removed mid-forward must never fall
         # back to _data_ch and reach the session unmixed
         source.task = asyncio.create_task(
-            self._forward_task(
-                None, source.stream, publication, participant, source.chan, source.processor
-            )
+            self._forward_mixed_source(source, source.stream, publication, participant)
         )
-        self._ensure_mixer().add_stream(source.chan)
         return True
 
     @override
@@ -514,68 +564,65 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
         sink: aio.Chan[rtc.AudioFrame],
-        processor: rtc.FrameProcessor[rtc.AudioFrame] | None = None,
     ) -> None:
-        """`processor` filters the pre-connect buffer; the live track is filtered by the stream
-        itself. Defaults to the stream-wide processor, mixed sources pass their own."""
         if old_task:
             await aio.cancel_and_wait(old_task)
 
-        if processor is None:
-            processor = self._processor
-
-        # a mixed participant's sink is closed when they leave, mid-forwarding. the base loop
-        # handles that itself; this covers the pre-connect and flush sends around it.
+        # the base loop handles its own sink closing; this covers the sends around it
         with contextlib.suppress(aio.ChanClosed):
-            if (
-                self._pre_connect_audio_handler
-                and publication.track
-                and AudioTrackFeature.TF_PRECONNECT_BUFFER in publication.audio_features
-            ):
-                logging_extra = {
-                    "track_id": publication.track.sid,
-                    "participant": participant.identity,
-                }
-                try:
-                    duration: float = 0
-                    frames = await self._pre_connect_audio_handler.wait_for_data(
-                        publication.track.sid
-                    )
-                    for frame in self._resample_frames(
-                        self._apply_audio_processor(frames, processor)
-                    ):
-                        if self._should_forward():
-                            await sink.send(frame)
-                            duration += frame.duration
-                    if frames:
-                        logger.debug(
-                            "pre-connect audio buffer pushed",
-                            extra={"duration": duration, **logging_extra},
-                        )
-
-                except asyncio.TimeoutError:
-                    logger.warning(
-                        "timeout waiting for pre-connect audio buffer",
-                        extra=logging_extra,
-                    )
-
-                except Exception as e:
-                    logger.error(
-                        "error reading pre-connect audio buffer", extra=logging_extra, exc_info=e
-                    )
-
+            await self._flush_pre_connect(publication, participant, self._processor, sink=sink)
             await super()._forward_task(old_task, stream, publication, participant, sink)
-
             # push a silent frame to flush the stt final result if any
-            silent_samples = int(self._sample_rate * 0.5)
-            await sink.send(
-                rtc.AudioFrame(
-                    b"\x00\x00" * silent_samples,
-                    sample_rate=self._sample_rate,
-                    num_channels=self._num_channels,
-                    samples_per_channel=silent_samples,
+            await sink.send(self._silent_frame())
+
+    async def _flush_pre_connect(
+        self,
+        publication: rtc.RemoteTrackPublication,
+        participant: rtc.RemoteParticipant,
+        processor: rtc.FrameProcessor[rtc.AudioFrame] | None,
+        *,
+        sink: aio.Chan[rtc.AudioFrame] | None = None,
+    ) -> None:
+        """Push what this participant recorded before connecting.
+
+        `processor` filters the buffer; the live track is filtered by the stream itself.
+        """
+        if not (
+            self._pre_connect_audio_handler
+            and publication.track
+            and AudioTrackFeature.TF_PRECONNECT_BUFFER in publication.audio_features
+        ):
+            return
+
+        sink = sink if sink is not None else self._data_ch
+        logging_extra = {"track_id": publication.track.sid, "participant": participant.identity}
+        try:
+            duration: float = 0
+            frames = await self._pre_connect_audio_handler.wait_for_data(publication.track.sid)
+            for frame in self._resample_frames(self._apply_audio_processor(frames, processor)):
+                if self._should_forward():
+                    await sink.send(frame)
+                    duration += frame.duration
+            if frames:
+                logger.debug(
+                    "pre-connect audio buffer pushed",
+                    extra={"duration": duration, **logging_extra},
                 )
-            )
+
+        except asyncio.TimeoutError:
+            logger.warning("timeout waiting for pre-connect audio buffer", extra=logging_extra)
+
+        except Exception as e:
+            logger.error("error reading pre-connect audio buffer", extra=logging_extra, exc_info=e)
+
+    def _silent_frame(self) -> rtc.AudioFrame:
+        silent_samples = int(self._sample_rate * 0.5)
+        return rtc.AudioFrame(
+            b"\x00\x00" * silent_samples,
+            sample_rate=self._sample_rate,
+            num_channels=self._num_channels,
+            samples_per_channel=silent_samples,
+        )
 
     @override
     async def aclose(self) -> None:
@@ -583,13 +630,19 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             self._room.off("track_muted", self._on_track_muted)
             self._room.off("track_unmuted", self._on_track_unmuted)
 
+        self._mix_closed = True  # a late forward task must not resurrect the mixer
         sources, self._mix_sources = list(self._mix_sources.values()), {}
+        self._mixing.clear()
         for source in sources:
             source.chan.close()
             if source.task:
                 await aio.cancel_and_wait(source.task)
             if source.stream:
                 await source.stream.aclose()
+
+        # sources torn down earlier cancel their forward task in the background; let those finish
+        if pending := list(self._tasks):
+            await asyncio.gather(*pending, return_exceptions=True)
 
         if self._mixer_atask:
             await aio.cancel_and_wait(self._mixer_atask)

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -13,7 +13,7 @@ import livekit.rtc as rtc
 from livekit.rtc._proto.track_pb2 import AudioTrackFeature
 
 from ...log import logger
-from ...utils import aio, log_exceptions
+from ...utils import aio, audio, log_exceptions
 from ..io import AudioInput, VideoInput
 from ._pre_connect_audio import PreConnectAudioHandler
 from .types import NoiseCancellationParams, NoiseCancellationSelector
@@ -652,13 +652,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             logger.error("error reading pre-connect audio buffer", extra=logging_extra, exc_info=e)
 
     def _silent_frame(self) -> rtc.AudioFrame:
-        silent_samples = int(self._sample_rate * 0.5)
-        return rtc.AudioFrame(
-            b"\x00\x00" * silent_samples,
-            sample_rate=self._sample_rate,
-            num_channels=self._num_channels,
-            samples_per_channel=silent_samples,
-        )
+        return audio.silence_frame(0.5, self._sample_rate, self._num_channels)
 
     @override
     async def aclose(self) -> None:

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -153,7 +153,7 @@ class _ParticipantInputStream(Generic[T], ABC):
         logger.debug("start reading stream", extra=extra)
         try:
             async for event in stream:
-                if not self._attached:
+                if not self._should_forward():
                     # drop frames if the stream is detached
                     continue
                 frame = cast(T, event.frame)
@@ -166,6 +166,10 @@ class _ParticipantInputStream(Generic[T], ABC):
             return
 
         logger.debug("stream closed", extra=extra)
+
+    def _should_forward(self) -> bool:
+        """Whether frames read off a participant's track are worth forwarding."""
+        return self._attached
 
     def _process_frame(self, frame: T) -> None:
         """Hook for subclasses to process frames in-place before forwarding."""
@@ -290,6 +294,10 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         self._mixer: rtc.AudioMixer | None = None
         self._mixer_atask: asyncio.Task[None] | None = None
 
+        if mix_participants:
+            self._room.on("track_muted", self._on_track_muted)
+            self._room.on("track_unmuted", self._on_track_unmuted)
+
         if mix_participants and isinstance(noise_cancellation, rtc.FrameProcessor):
             logger.warning(
                 "a single noise cancellation processor is shared by every mixed participant, "
@@ -316,7 +324,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
 
         source = _MixedSource(chan=aio.Chan[rtc.AudioFrame]())
         self._mix_sources[participant.identity] = source
-        self._ensure_mixer().add_stream(source.chan)
+        self._ensure_mixer()
 
         for publication in participant.track_publications.values():
             if publication.track and self._on_track_available(
@@ -329,8 +337,6 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         if source is None:
             return
 
-        if self._mixer:
-            self._mixer.remove_stream(source.chan)
         self._close_mixed_source(source)
         source.chan.close()
 
@@ -340,17 +346,41 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                 self._sample_rate,
                 self._num_channels,
                 blocksize=int(self._sample_rate * self._frame_size_ms / 1000),
-                # ponytail: a muted/paused participant stops delivering frames, so the mixer
-                # logs a timeout warning per block and pads silence. Harmless, but noisy —
-                # feed silence per source if that ever matters.
+                # must stay above the frame interval: the mixer pads a stream that misses this
+                # deadline, so a live stream would get chopped by a tighter timeout
                 stream_timeout_ms=max(100, self._frame_size_ms * 2),
             )
             self._mixer_atask = asyncio.create_task(self._forward_mixed(self._mixer))
         return self._mixer
 
+    def _on_track_muted(
+        self, participant: rtc.Participant, publication: rtc.TrackPublication
+    ) -> None:
+        source = self._mix_sources.get(participant.identity)
+        if source is None or source.publication_sid != publication.sid:
+            return
+
+        # a muted track delivers nothing: stop reading it until it comes back
+        self._close_mixed_source(source)
+
+    def _on_track_unmuted(
+        self, participant: rtc.Participant, publication: rtc.TrackPublication
+    ) -> None:
+        if self._mix_sources.get(participant.identity) is None or not publication.track:
+            return
+
+        self._on_track_available(publication.track, publication, participant)  # type: ignore[arg-type]
+
     def _close_mixed_source(self, source: _MixedSource) -> None:
         stream, task = source.stream, source.task
         source.stream, source.task, source.publication_sid = None, None, None
+
+        # the mixer waits stream_timeout_ms on every registered stream for every block, so a
+        # source that stopped delivering paces the whole mix below real time
+        if self._mixer is not None:
+            self._mixer.remove_stream(source.chan)
+        while not source.chan.empty():
+            source.chan.recv_nowait()  # in-flight audio would resurface on the next unmute
 
         async def _close() -> None:
             if task:
@@ -397,6 +427,9 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             return False
 
         self._close_mixed_source(source)
+        if publication.muted:
+            return False  # nothing to read yet, track_unmuted brings the source back
+
         source.publication_sid = publication.sid
         source.stream = self._create_stream(track, participant)
         # the sink is bound here, once: a participant removed mid-forward must never fall
@@ -404,6 +437,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         source.task = asyncio.create_task(
             self._forward_task(None, source.stream, publication, participant, source.chan)
         )
+        self._ensure_mixer().add_stream(source.chan)
         return True
 
     @override
@@ -424,6 +458,12 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                 publication.track, publication, participant
             ):
                 return
+
+    @override
+    def _should_forward(self) -> bool:
+        # a mixed source keeps feeding the mixer while detached and _forward_mixed drops the
+        # output instead: starving the mixer would pace it below real time for everyone else
+        return self._mix_participants or self._attached
 
     @override
     def _process_frame(self, frame: rtc.AudioFrame) -> None:
@@ -486,7 +526,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                         publication.track.sid
                     )
                     for frame in self._resample_frames(self._apply_audio_processor(frames)):
-                        if self._attached:
+                        if self._should_forward():
                             await sink.send(frame)
                             duration += frame.duration
                     if frames:
@@ -521,6 +561,10 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
 
     @override
     async def aclose(self) -> None:
+        if self._mix_participants:
+            self._room.off("track_muted", self._on_track_muted)
+            self._room.off("track_unmuted", self._on_track_unmuted)
+
         sources, self._mix_sources = list(self._mix_sources.values()), {}
         for source in sources:
             source.chan.close()

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -151,13 +151,19 @@ class _ParticipantInputStream(Generic[T], ABC):
         }
         logger.debug("start reading stream", extra=extra)
         sink = self._sink(participant)
-        async for event in stream:
-            if not self._attached:
-                # drop frames if the stream is detached
-                continue
-            frame = cast(T, event.frame)
-            self._process_frame(frame)
-            await sink.send(frame)
+        try:
+            async for event in stream:
+                if not self._attached:
+                    # drop frames if the stream is detached
+                    continue
+                frame = cast(T, event.frame)
+                self._process_frame(frame)
+                await sink.send(frame)
+        except aio.ChanClosed:
+            # the sink of a mixed participant is closed when they leave, mid-forwarding.
+            # caught here, below @log_exceptions, so a departure isn't logged as a crash.
+            logger.debug("stream sink closed", extra=extra)
+            return
 
         logger.debug("stream closed", extra=extra)
 
@@ -285,6 +291,14 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         self._mix_sources: dict[str, _MixedSource] = {}
         self._mixer: rtc.AudioMixer | None = None
         self._mixer_atask: asyncio.Task[None] | None = None
+
+        if mix_participants and isinstance(noise_cancellation, rtc.FrameProcessor):
+            logger.warning(
+                "a single noise cancellation processor is shared by every mixed participant, "
+                "which interleaves speakers through one stateful filter. pass a callable "
+                "returning a new processor per participant instead",
+                extra={"processor": type(noise_cancellation).__name__},
+            )
 
     @property
     def mix_participants(self) -> bool:

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -606,12 +606,19 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         ):
             return
 
+        if not self._attached:
+            # audio input is disabled, so these frames would only be dropped below. return
+            # without touching the handler, leaving the buffer for a later subscribe
+            return
+
         track_sid = publication.track.sid
         if track_sid in self._pre_connect_flushed:
             # the publication advertises the buffer for the lifetime of the track, but the
             # handler drops it after the first read. asking again only blocks for the whole
             # timeout while the freshly subscribed stream backs up behind us
             return
+        # marked before the read, not after: wait_for_data drops the buffer in its own finally
+        # whatever the outcome, so a retry can only stall for the timeout and deliver nothing
         self._pre_connect_flushed.add(track_sid)
 
         sink = sink if sink is not None else self._data_ch

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncIterator, Iterable, KeysView
 from dataclasses import dataclass
 from typing import Any, Generic, TypeVar, cast
 
@@ -141,6 +141,7 @@ class _ParticipantInputStream(Generic[T], ABC):
         stream: rtc.VideoStream | rtc.AudioStream,
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
+        sink: aio.Chan[T],
     ) -> None:
         if old_task:
             await aio.cancel_and_wait(old_task)
@@ -150,7 +151,6 @@ class _ParticipantInputStream(Generic[T], ABC):
             "source": rtc.TrackSource.Name(publication.source),
         }
         logger.debug("start reading stream", extra=extra)
-        sink = self._sink(participant)
         try:
             async for event in stream:
                 if not self._attached:
@@ -166,10 +166,6 @@ class _ParticipantInputStream(Generic[T], ABC):
             return
 
         logger.debug("stream closed", extra=extra)
-
-    def _sink(self, participant: rtc.RemoteParticipant) -> aio.Chan[T]:
-        """The channel a participant's frames are forwarded to."""
-        return self._data_ch
 
     def _process_frame(self, frame: T) -> None:
         """Hook for subclasses to process frames in-place before forwarding."""
@@ -216,7 +212,9 @@ class _ParticipantInputStream(Generic[T], ABC):
         self._stream = self._create_stream(track, participant)
         self._publication = publication
         self._forward_atask = asyncio.create_task(
-            self._forward_task(self._forward_atask, self._stream, publication, participant)
+            self._forward_task(
+                self._forward_atask, self._stream, publication, participant, self._data_ch
+            )
         )
         return True
 
@@ -304,6 +302,10 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
     def mix_participants(self) -> bool:
         return self._mix_participants
 
+    @property
+    def mixed_identities(self) -> KeysView[str]:
+        return self._mix_sources.keys()
+
     def add_participant(self, participant: rtc.RemoteParticipant) -> None:
         """Mix this participant's microphone into the input stream.
 
@@ -370,12 +372,6 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             await self._data_ch.send(frame)
 
     @override
-    def _sink(self, participant: rtc.RemoteParticipant) -> aio.Chan[rtc.AudioFrame]:
-        if (source := self._mix_sources.get(participant.identity)) is not None:
-            return source.chan
-        return self._data_ch
-
-    @override
     def set_participant(self, participant: rtc.RemoteParticipant | str | None) -> None:
         if self._mix_participants:
             # every accepted participant is mixed in, linking only drives the outputs
@@ -403,8 +399,10 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         self._close_mixed_source(source)
         source.publication_sid = publication.sid
         source.stream = self._create_stream(track, participant)
+        # the sink is bound here, once: a participant removed mid-forward must never fall
+        # back to _data_ch and reach the session unmixed
         source.task = asyncio.create_task(
-            self._forward_task(None, source.stream, publication, participant)
+            self._forward_task(None, source.stream, publication, participant, source.chan)
         )
         return True
 
@@ -465,12 +463,13 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         stream: rtc.AudioStream,  # type: ignore[override]
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
+        sink: aio.Chan[rtc.AudioFrame],
     ) -> None:
         if old_task:
             await aio.cancel_and_wait(old_task)
 
-        sink = self._sink(participant)
-        # the sink of a mixed participant is closed when they leave, mid-forwarding
+        # a mixed participant's sink is closed when they leave, mid-forwarding. the base loop
+        # handles that itself; this covers the pre-connect and flush sends around it.
         with contextlib.suppress(aio.ChanClosed):
             if (
                 self._pre_connect_audio_handler
@@ -507,7 +506,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                         "error reading pre-connect audio buffer", extra=logging_extra, exc_info=e
                     )
 
-            await super()._forward_task(old_task, stream, publication, participant)
+            await super()._forward_task(old_task, stream, publication, participant, sink)
 
             # push a silent frame to flush the stt final result if any
             silent_samples = int(self._sample_rate * 0.5)

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -623,14 +623,26 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
 
         sink = sink if sink is not None else self._data_ch
         logging_extra = {"track_id": track_sid, "participant": participant.identity}
+
+        # this buffer predates the conversation and does not go through the mixer, so writing
+        # it while others are speaking would interleave it frame by frame with them. losing one
+        # newcomer's opening words beats garbling everyone's
+        if self._mixing:
+            # decided before the wait rather than after it: the live track is already buffering
+            # unread behind this coroutine, and waiting for something we will discard would put
+            # this participant permanently behind the rest of the mix
+            logger.debug(
+                "pre-connect audio skipped, other participants are already mixed in",
+                extra=logging_extra,
+            )
+            return
+
         try:
             duration: float = 0
             frames = await self._pre_connect_audio_handler.wait_for_data(track_sid)
 
             if self._mixing:
-                # this buffer predates the conversation and does not go through the mixer, so
-                # writing it now would interleave it frame by frame with whoever is currently
-                # speaking. losing one newcomer's opening words beats garbling everyone's
+                # somebody started speaking while the buffer loaded
                 logger.debug(
                     "pre-connect audio dropped, other participants are already mixed in",
                     extra=logging_extra,

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -250,6 +250,7 @@ class _MixedSource:
     stream: rtc.AudioStream | None = None
     task: asyncio.Task[None] | None = None
     publication_sid: str | None = None
+    processor: rtc.FrameProcessor[rtc.AudioFrame] | None = None
 
 
 class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], AudioInput):
@@ -435,7 +436,9 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         # the sink is bound here, once: a participant removed mid-forward must never fall
         # back to _data_ch and reach the session unmixed
         source.task = asyncio.create_task(
-            self._forward_task(None, source.stream, publication, participant, source.chan)
+            self._forward_task(
+                None, source.stream, publication, participant, source.chan, source.processor
+            )
         )
         self._ensure_mixer().add_stream(source.chan)
         return True
@@ -480,8 +483,15 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         if callable(noise_cancellation):
             noise_cancellation = noise_cancellation(NoiseCancellationParams(participant, track))
             if self._mix_participants:
-                # each mixed participant gets its own processor, tied to its stream
+                # each mixed participant gets its own processor, tied to its stream. it is kept
+                # on the source so this participant's pre-connect buffer runs through it too
                 auto_close_noise_cancellation = isinstance(noise_cancellation, rtc.FrameProcessor)
+                if (source := self._mix_sources.get(participant.identity)) is not None:
+                    source.processor = (
+                        noise_cancellation
+                        if isinstance(noise_cancellation, rtc.FrameProcessor)
+                        else None
+                    )
             elif isinstance(noise_cancellation, rtc.FrameProcessor):
                 self._update_processor(noise_cancellation)
             else:
@@ -497,16 +507,22 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         )
 
     @override
-    async def _forward_task(
+    async def _forward_task(  # type: ignore[override]
         self,
         old_task: asyncio.Task[None] | None,
-        stream: rtc.AudioStream,  # type: ignore[override]
+        stream: rtc.AudioStream,
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
         sink: aio.Chan[rtc.AudioFrame],
+        processor: rtc.FrameProcessor[rtc.AudioFrame] | None = None,
     ) -> None:
+        """`processor` filters the pre-connect buffer; the live track is filtered by the stream
+        itself. Defaults to the stream-wide processor, mixed sources pass their own."""
         if old_task:
             await aio.cancel_and_wait(old_task)
+
+        if processor is None:
+            processor = self._processor
 
         # a mixed participant's sink is closed when they leave, mid-forwarding. the base loop
         # handles that itself; this covers the pre-connect and flush sends around it.
@@ -525,7 +541,9 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                     frames = await self._pre_connect_audio_handler.wait_for_data(
                         publication.track.sid
                     )
-                    for frame in self._resample_frames(self._apply_audio_processor(frames)):
+                    for frame in self._resample_frames(
+                        self._apply_audio_processor(frames, processor)
+                    ):
                         if self._should_forward():
                             await sink.send(frame)
                             duration += frame.duration
@@ -602,11 +620,15 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         if resampler:
             yield from resampler.flush()
 
-    def _apply_audio_processor(self, frames: Iterable[rtc.AudioFrame]) -> Iterable[rtc.AudioFrame]:
+    def _apply_audio_processor(
+        self,
+        frames: Iterable[rtc.AudioFrame],
+        processor: rtc.FrameProcessor[rtc.AudioFrame] | None,
+    ) -> Iterable[rtc.AudioFrame]:
         for frame in frames:
-            if self._processor is not None:
+            if processor is not None:
                 try:
-                    yield self._processor._process(frame)
+                    yield processor._process(frame)
                 except Exception as e:
                     logger.warning(
                         "error pre-processing audio frame: %s",

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -299,6 +299,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         self._mixing: set[aio.Chan[rtc.AudioFrame]] = set()  # channels feeding the mixer
         self._mix_closed = False
         self._pre_connect_flushed: set[str] = set()  # track sids whose buffer was consumed
+        self._discard_tasks: set[asyncio.Task[None]] = set()
 
         if mix_participants:
             self._room.on("track_muted", self._on_track_muted)
@@ -635,6 +636,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                 "pre-connect audio skipped, other participants are already mixed in",
                 extra=logging_extra,
             )
+            self._discard_pre_connect(track_sid, logging_extra)
             return
 
         try:
@@ -670,6 +672,26 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         except Exception as e:
             logger.error("error reading pre-connect audio buffer", extra=logging_extra, exc_info=e)
 
+    def _discard_pre_connect(self, track_sid: str, logging_extra: dict[str, Any]) -> None:
+        """Read the buffer in the background and drop it.
+
+        `wait_for_data` is what releases the handler's entry, so a buffer we skip would
+        otherwise be held for the lifetime of the session. Off the forwarding path, because
+        waiting for it there is what leaves the participant behind the mix.
+        """
+        if (handler := self._pre_connect_audio_handler) is None:
+            return
+
+        async def _discard() -> None:
+            try:
+                await handler.wait_for_data(track_sid)
+            except Exception:
+                logger.debug("discarding pre-connect audio failed", extra=logging_extra)
+
+        task = asyncio.create_task(_discard())
+        task.add_done_callback(self._discard_tasks.discard)
+        self._discard_tasks.add(task)
+
     def _silent_frame(self) -> rtc.AudioFrame:
         return audio.silence_frame(0.5, self._sample_rate, self._num_channels)
 
@@ -688,6 +710,11 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                 await aio.cancel_and_wait(source.task)
             if source.stream:
                 await source.stream.aclose()
+
+        # cancelling a discard mid-wait still releases the handler's buffer, in its own finally
+        if self._discard_tasks:
+            await aio.cancel_and_wait(*self._discard_tasks)
+            self._discard_tasks.clear()
 
         # sources torn down earlier cancel their forward task in the background; let those finish
         if pending := list(self._tasks):

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Iterable
+from dataclasses import dataclass
 from typing import Any, Generic, TypeVar, cast
 
 from typing_extensions import override
@@ -148,15 +150,20 @@ class _ParticipantInputStream(Generic[T], ABC):
             "source": rtc.TrackSource.Name(publication.source),
         }
         logger.debug("start reading stream", extra=extra)
+        sink = self._sink(participant)
         async for event in stream:
             if not self._attached:
                 # drop frames if the stream is detached
                 continue
             frame = cast(T, event.frame)
             self._process_frame(frame)
-            await self._data_ch.send(frame)
+            await sink.send(frame)
 
         logger.debug("stream closed", extra=extra)
+
+    def _sink(self, participant: rtc.RemoteParticipant) -> aio.Chan[T]:
+        """The channel a participant's frames are forwarded to."""
+        return self._data_ch
 
     def _process_frame(self, frame: T) -> None:
         """Hook for subclasses to process frames in-place before forwarding."""
@@ -227,6 +234,16 @@ class _ParticipantInputStream(Generic[T], ABC):
                 return
 
 
+@dataclass
+class _MixedSource:
+    """One participant's contribution to the mixed audio input."""
+
+    chan: aio.Chan[rtc.AudioFrame]
+    stream: rtc.AudioStream | None = None
+    task: asyncio.Task[None] | None = None
+    publication_sid: str | None = None
+
+
 class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], AudioInput):
     def __init__(
         self,
@@ -241,6 +258,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         auto_gain_control: bool = True,
         pre_connect_audio_handler: PreConnectAudioHandler | None,
         frame_size_ms: int = 50,
+        mix_participants: bool = False,
     ) -> None:
         _ParticipantInputStream.__init__(
             self,
@@ -263,17 +281,156 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         if auto_gain_control:
             self._apm = rtc.AudioProcessingModule(auto_gain_control=True)
 
+        self._mix_participants = mix_participants
+        self._mix_sources: dict[str, _MixedSource] = {}
+        self._mixer: rtc.AudioMixer | None = None
+        self._mixer_atask: asyncio.Task[None] | None = None
+
+    @property
+    def mix_participants(self) -> bool:
+        return self._mix_participants
+
+    def add_participant(self, participant: rtc.RemoteParticipant) -> None:
+        """Mix this participant's microphone into the input stream.
+
+        Only used when `mix_participants` is enabled; a no-op otherwise.
+        """
+        if not self._mix_participants or participant.identity in self._mix_sources:
+            return
+
+        source = _MixedSource(chan=aio.Chan[rtc.AudioFrame]())
+        self._mix_sources[participant.identity] = source
+        self._ensure_mixer().add_stream(source.chan)
+
+        for publication in participant.track_publications.values():
+            if publication.track and self._on_track_available(
+                publication.track, publication, participant
+            ):
+                break
+
+    def remove_participant(self, identity: str) -> None:
+        source = self._mix_sources.pop(identity, None)
+        if source is None:
+            return
+
+        if self._mixer:
+            self._mixer.remove_stream(source.chan)
+        self._close_mixed_source(source)
+        source.chan.close()
+
+    def _ensure_mixer(self) -> rtc.AudioMixer:
+        if self._mixer is None:
+            self._mixer = rtc.AudioMixer(
+                self._sample_rate,
+                self._num_channels,
+                blocksize=int(self._sample_rate * self._frame_size_ms / 1000),
+                # ponytail: a muted/paused participant stops delivering frames, so the mixer
+                # logs a timeout warning per block and pads silence. Harmless, but noisy —
+                # feed silence per source if that ever matters.
+                stream_timeout_ms=max(100, self._frame_size_ms * 2),
+            )
+            self._mixer_atask = asyncio.create_task(self._forward_mixed(self._mixer))
+        return self._mixer
+
+    def _close_mixed_source(self, source: _MixedSource) -> None:
+        stream, task = source.stream, source.task
+        source.stream, source.task, source.publication_sid = None, None, None
+
+        async def _close() -> None:
+            if task:
+                await aio.cancel_and_wait(task)
+            if stream:
+                await stream.aclose()
+
+        close_task = asyncio.create_task(_close())
+        close_task.add_done_callback(self._tasks.discard)
+        self._tasks.add(close_task)
+
+    @log_exceptions(logger=logger)
+    async def _forward_mixed(self, mixer: rtc.AudioMixer) -> None:
+        async for frame in mixer:
+            if not self._attached:
+                continue
+            if self._apm is not None:
+                self._apm.process_stream(frame)
+            await self._data_ch.send(frame)
+
+    @override
+    def _sink(self, participant: rtc.RemoteParticipant) -> aio.Chan[rtc.AudioFrame]:
+        if (source := self._mix_sources.get(participant.identity)) is not None:
+            return source.chan
+        return self._data_ch
+
+    @override
+    def set_participant(self, participant: rtc.RemoteParticipant | str | None) -> None:
+        if self._mix_participants:
+            # every accepted participant is mixed in, linking only drives the outputs
+            return
+        super().set_participant(participant)
+
+    @override
+    def _on_track_available(
+        self,
+        track: rtc.RemoteTrack,
+        publication: rtc.RemoteTrackPublication,
+        participant: rtc.RemoteParticipant,
+    ) -> bool:
+        if not self._mix_participants:
+            return super()._on_track_available(track, publication, participant)
+
+        source = self._mix_sources.get(participant.identity)
+        if (
+            source is None
+            or publication.source not in self._accepted_sources
+            or source.publication_sid == publication.sid
+        ):
+            return False
+
+        self._close_mixed_source(source)
+        source.publication_sid = publication.sid
+        source.stream = self._create_stream(track, participant)
+        source.task = asyncio.create_task(
+            self._forward_task(None, source.stream, publication, participant)
+        )
+        return True
+
+    @override
+    def _on_track_unavailable(
+        self, publication: rtc.RemoteTrackPublication, participant: rtc.RemoteParticipant
+    ) -> None:
+        if not self._mix_participants:
+            super()._on_track_unavailable(publication, participant)
+            return
+
+        source = self._mix_sources.get(participant.identity)
+        if source is None or source.publication_sid != publication.sid:
+            return
+
+        self._close_mixed_source(source)
+        for publication in participant.track_publications.values():
+            if publication.track and self._on_track_available(
+                publication.track, publication, participant
+            ):
+                return
+
     @override
     def _process_frame(self, frame: rtc.AudioFrame) -> None:
+        if self._mix_participants:
+            return  # AGC runs once on the mixed output instead
+
         if self._apm is not None:
             self._apm.process_stream(frame)
 
     @override
     def _create_stream(self, track: rtc.Track, participant: rtc.Participant) -> rtc.AudioStream:
         noise_cancellation = self._noise_cancellation
+        auto_close_noise_cancellation = False
         if callable(noise_cancellation):
             noise_cancellation = noise_cancellation(NoiseCancellationParams(participant, track))
-            if isinstance(noise_cancellation, rtc.FrameProcessor):
+            if self._mix_participants:
+                # each mixed participant gets its own processor, tied to its stream
+                auto_close_noise_cancellation = isinstance(noise_cancellation, rtc.FrameProcessor)
+            elif isinstance(noise_cancellation, rtc.FrameProcessor):
                 self._update_processor(noise_cancellation)
             else:
                 self._update_processor(None)
@@ -284,7 +441,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             num_channels=self._num_channels,
             frame_size_ms=self._frame_size_ms,
             noise_cancellation=noise_cancellation,
-            auto_close_noise_cancellation=False,
+            auto_close_noise_cancellation=auto_close_noise_cancellation,
         )
 
     @override
@@ -298,51 +455,75 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         if old_task:
             await aio.cancel_and_wait(old_task)
 
-        if (
-            self._pre_connect_audio_handler
-            and publication.track
-            and AudioTrackFeature.TF_PRECONNECT_BUFFER in publication.audio_features
-        ):
-            logging_extra = {
-                "track_id": publication.track.sid,
-                "participant": participant.identity,
-            }
-            try:
-                duration: float = 0
-                frames = await self._pre_connect_audio_handler.wait_for_data(publication.track.sid)
-                for frame in self._resample_frames(self._apply_audio_processor(frames)):
-                    if self._attached:
-                        await self._data_ch.send(frame)
-                        duration += frame.duration
-                if frames:
-                    logger.debug(
-                        "pre-connect audio buffer pushed",
-                        extra={"duration": duration, **logging_extra},
+        sink = self._sink(participant)
+        # the sink of a mixed participant is closed when they leave, mid-forwarding
+        with contextlib.suppress(aio.ChanClosed):
+            if (
+                self._pre_connect_audio_handler
+                and publication.track
+                and AudioTrackFeature.TF_PRECONNECT_BUFFER in publication.audio_features
+            ):
+                logging_extra = {
+                    "track_id": publication.track.sid,
+                    "participant": participant.identity,
+                }
+                try:
+                    duration: float = 0
+                    frames = await self._pre_connect_audio_handler.wait_for_data(
+                        publication.track.sid
+                    )
+                    for frame in self._resample_frames(self._apply_audio_processor(frames)):
+                        if self._attached:
+                            await sink.send(frame)
+                            duration += frame.duration
+                    if frames:
+                        logger.debug(
+                            "pre-connect audio buffer pushed",
+                            extra={"duration": duration, **logging_extra},
+                        )
+
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "timeout waiting for pre-connect audio buffer",
+                        extra=logging_extra,
                     )
 
-            except asyncio.TimeoutError:
-                logger.warning(
-                    "timeout waiting for pre-connect audio buffer",
-                    extra=logging_extra,
+                except Exception as e:
+                    logger.error(
+                        "error reading pre-connect audio buffer", extra=logging_extra, exc_info=e
+                    )
+
+            await super()._forward_task(old_task, stream, publication, participant)
+
+            # push a silent frame to flush the stt final result if any
+            silent_samples = int(self._sample_rate * 0.5)
+            await sink.send(
+                rtc.AudioFrame(
+                    b"\x00\x00" * silent_samples,
+                    sample_rate=self._sample_rate,
+                    num_channels=self._num_channels,
+                    samples_per_channel=silent_samples,
                 )
-
-            except Exception as e:
-                logger.error(
-                    "error reading pre-connect audio buffer", extra=logging_extra, exc_info=e
-                )
-
-        await super()._forward_task(old_task, stream, publication, participant)
-
-        # push a silent frame to flush the stt final result if any
-        silent_samples = int(self._sample_rate * 0.5)
-        await self._data_ch.send(
-            rtc.AudioFrame(
-                b"\x00\x00" * silent_samples,
-                sample_rate=self._sample_rate,
-                num_channels=self._num_channels,
-                samples_per_channel=silent_samples,
             )
-        )
+
+    @override
+    async def aclose(self) -> None:
+        sources, self._mix_sources = list(self._mix_sources.values()), {}
+        for source in sources:
+            source.chan.close()
+            if source.task:
+                await aio.cancel_and_wait(source.task)
+            if source.stream:
+                await source.stream.aclose()
+
+        if self._mixer_atask:
+            await aio.cancel_and_wait(self._mixer_atask)
+            self._mixer_atask = None
+        if self._mixer:
+            await self._mixer.aclose()
+            self._mixer = None
+
+        await super().aclose()
 
     def _resample_frames(self, frames: Iterable[rtc.AudioFrame]) -> Iterable[rtc.AudioFrame]:
         resampler: rtc.AudioResampler | None = None

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -415,18 +415,24 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
     @log_exceptions(logger=logger)
     async def _forward_mixed_source(
         self,
-        source: _MixedSource,
+        chan: aio.Chan[rtc.AudioFrame],
+        processor: rtc.FrameProcessor[rtc.AudioFrame] | None,
         stream: rtc.AudioStream,
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
     ) -> None:
-        chan = source.chan  # bound once: source.chan is replaced by the next subscribe
+        """Everything this task touches is passed in, never read back off the `_MixedSource`.
 
+        Several room events can be dispatched in one loop iteration, so the source may already
+        have been torn down and resubscribed by the time this coroutine first runs. Reading
+        `source.chan` here would bind the successor's channel and, on cancellation, unregister
+        the channel the live task is feeding.
+        """
         # pre-connect audio was recorded before this participant joined, so it is not concurrent
         # with anyone: it goes straight to the session rather than through the mixer, where it
         # would stall the mix while it loads and then leave this source permanently behind
         with contextlib.suppress(aio.ChanClosed):
-            await self._flush_pre_connect(publication, participant, source.processor)
+            await self._flush_pre_connect(publication, participant, processor)
 
         if chan.closed:
             return  # the source was torn down while the pre-connect buffer loaded
@@ -486,11 +492,13 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         # writes must land in the channel it was bound to, never in the new mix
         source.chan = aio.Chan[rtc.AudioFrame]()
         source.publication_sid = publication.sid
-        source.stream = self._create_stream(track, participant)
-        # the sink is bound here, once: a participant removed mid-forward must never fall
-        # back to _data_ch and reach the session unmixed
+        source.stream = self._create_stream(track, participant)  # sets source.processor
+        # the channel and processor are bound here, at creation: the task may not run until
+        # after another event has already replaced them on the source
         source.task = asyncio.create_task(
-            self._forward_mixed_source(source, source.stream, publication, participant)
+            self._forward_mixed_source(
+                source.chan, source.processor, source.stream, publication, participant
+            )
         )
         return True
 

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -415,6 +415,17 @@ class RoomIO:
         self._participant_available_fut.set_result(participant)
         self._agent_session._on_room_io_participant_linked(participant)
 
+    def _next_mixed_participant(self, left_identity: str) -> rtc.RemoteParticipant | None:
+        """Another participant still contributing to the mixed input, if any."""
+        if self._audio_input is None or not self._audio_input.mix_participants:
+            return None
+
+        mixed = self._audio_input.mixed_identities
+        for participant in self._room.remote_participants.values():
+            if participant.identity != left_identity and participant.identity in mixed:
+                return participant
+        return None
+
     def _on_participant_disconnected(self, participant: rtc.RemoteParticipant) -> None:
         if self._audio_input and self._audio_input.mix_participants:
             self._audio_input.remove_participant(participant.identity)
@@ -422,6 +433,19 @@ class RoomIO:
         if not (linked := self.linked_participant) or participant.identity != linked.identity:
             return
         self._participant_available_fut = asyncio.Future[rtc.RemoteParticipant]()
+
+        if remaining := self._next_mixed_participant(participant.identity):
+            # the linked participant only drives the outputs, and others are still mixed in:
+            # hand the outputs over rather than ending the conversation for everyone
+            logger.debug(
+                "linked participant left, relinking to another mixed participant",
+                extra={"participant": remaining.identity, "left": participant.identity},
+            )
+            self.set_participant(remaining.identity)
+            if not self._participant_available_fut.done():
+                self._participant_available_fut.set_result(remaining)
+            self._agent_session._on_room_io_participant_linked(remaining)
+            return
 
         if (
             self._options.close_on_disconnect

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -123,6 +123,7 @@ class RoomIO:
                 noise_cancellation=input_audio_options.noise_cancellation,
                 auto_gain_control=input_audio_options.auto_gain_control,
                 pre_connect_audio_handler=self._pre_connect_audio_handler,
+                mix_participants=input_audio_options.mix_participants,
             )
 
         # -- create outputs --
@@ -374,7 +375,25 @@ class RoomIO:
         if self._room.isconnected() and not self._room_connected_fut.done():
             self._room_connected_fut.set_result(None)
 
+    def _add_mixed_participant(self, participant: rtc.RemoteParticipant) -> None:
+        if self._audio_input is None or not self._audio_input.mix_participants:
+            return
+
+        accepted_kinds = self._options.participant_kinds or DEFAULT_PARTICIPANT_KINDS
+        if participant.kind not in accepted_kinds:
+            return
+
+        if (
+            participant.attributes.get(ATTRIBUTE_PUBLISH_ON_BEHALF)
+            == self._room.local_participant.identity
+        ):
+            return  # our own avatar worker, listening to it would loop the agent back on itself
+
+        self._audio_input.add_participant(participant)
+
     def _on_participant_connected(self, participant: rtc.RemoteParticipant) -> None:
+        self._add_mixed_participant(participant)
+
         if self._participant_available_fut.done():
             return
 
@@ -397,6 +416,9 @@ class RoomIO:
         self._agent_session._on_room_io_participant_linked(participant)
 
     def _on_participant_disconnected(self, participant: rtc.RemoteParticipant) -> None:
+        if self._audio_input and self._audio_input.mix_participants:
+            self._audio_input.remove_participant(participant.identity)
+
         if not (linked := self.linked_participant) or participant.identity != linked.identity:
             return
         self._participant_available_fut = asyncio.Future[rtc.RemoteParticipant]()

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -444,7 +444,9 @@ class RoomIO:
             self.set_participant(remaining.identity)
             if not self._participant_available_fut.done():
                 self._participant_available_fut.set_result(remaining)
-            self._agent_session._on_room_io_participant_linked(remaining)
+            # deliberately not notifying the session: relinking mid-conversation is not a new
+            # call, and the hook re-arms the AEC warmup, which would swallow everyone's audio
+            # and block interruptions through the agent's next reply
             return
 
         if (

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -416,13 +416,25 @@ class RoomIO:
         self._agent_session._on_room_io_participant_linked(participant)
 
     def _next_mixed_participant(self, left_identity: str) -> rtc.RemoteParticipant | None:
-        """Another participant still contributing to the mixed input, if any."""
+        """Another participant who could still speak into the mixed input, if any.
+
+        A published microphone is the test, not a currently live one: someone who is merely
+        muted is a person who can unmute, and hanging up on them mid-conversation would be
+        worse than the stale session this avoids. A participant publishing no microphone at
+        all — an observer or dashboard — cannot speak and must not keep the session alive.
+        """
         if self._audio_input is None or not self._audio_input.mix_participants:
             return None
 
         mixed = self._audio_input.mixed_identities
         for participant in self._room.remote_participants.values():
-            if participant.identity != left_identity and participant.identity in mixed:
+            if participant.identity == left_identity or participant.identity not in mixed:
+                continue
+
+            if any(
+                publication.source == rtc.TrackSource.SOURCE_MICROPHONE
+                for publication in participant.track_publications.values()
+            ):
                 return participant
         return None
 

--- a/livekit-agents/livekit/agents/voice/room_io/types.py
+++ b/livekit-agents/livekit/agents/voice/room_io/types.py
@@ -71,7 +71,11 @@ class AudioInputOptions:
     mix_participants: bool = False
     """Mix the microphone of every accepted participant into a single input stream, instead of
     listening to the linked participant only. The linked participant still drives the outputs
-    (audio, transcription). Transcripts of a mixed input cannot be attributed to a speaker."""
+    (audio, transcription), and is relinked to another mixed participant if they leave.
+    Transcripts of a mixed input cannot be attributed to a speaker.
+
+    `noise_cancellation` must be given as a callable when mixing: a `FrameProcessor` is stateful
+    per stream and cannot be shared by several speakers at once."""
     pre_connect_audio: bool = True
     """Pre-connect audio enabled or not."""
     pre_connect_audio_timeout: float = 3.0

--- a/livekit-agents/livekit/agents/voice/room_io/types.py
+++ b/livekit-agents/livekit/agents/voice/room_io/types.py
@@ -68,6 +68,10 @@ class AudioInputOptions:
     ) = None
     auto_gain_control: bool = True
     """Enable automatic gain control (AGC) on the input audio. Enabled by default."""
+    mix_participants: bool = False
+    """Mix the microphone of every accepted participant into a single input stream, instead of
+    listening to the linked participant only. The linked participant still drives the outputs
+    (audio, transcription). Transcripts of a mixed input cannot be attributed to a speaker."""
     pre_connect_audio: bool = True
     """Pre-connect audio enabled or not."""
     pre_connect_audio_timeout: float = 3.0

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -528,6 +528,47 @@ async def test_mix_participants_tracks_room_membership() -> None:
     await room_io._audio_input.aclose()
 
 
+@pytest.mark.asyncio
+async def test_mix_relinks_instead_of_closing_when_the_linked_participant_leaves() -> None:
+    """The linked participant is one of N contributors: their exit must not hang up on the rest."""
+    room = _FakeRoom()
+    agent_session = SimpleNamespace(
+        off=MagicMock(),
+        _on_room_io_participant_linked=MagicMock(),
+        _close_soon=MagicMock(),
+        input=SimpleNamespace(audio=None, video=None),
+        output=SimpleNamespace(audio=None, transcription=None),
+    )
+    room_io = RoomIO(agent_session, room)
+    room_io._audio_input = _make_audio_input_stream(room, None, mix_participants=True)
+
+    candidate = _make_mix_participant("candidate", "TR_1")
+    interviewer = _make_mix_participant("interviewer", "TR_2")
+    room.remote_participants = {"candidate": candidate, "interviewer": interviewer}
+
+    with patch("livekit.rtc.AudioStream.from_track", side_effect=lambda **kw: _MockAudioStream()):
+        room_io._on_participant_connected(candidate)
+        room_io._on_participant_connected(interviewer)
+        assert room_io.linked_participant is candidate
+
+        candidate.disconnect_reason = rtc.DisconnectReason.CLIENT_INITIATED
+        room.remote_participants.pop("candidate")
+        room_io._on_participant_disconnected(candidate)
+
+        # outputs follow the remaining speaker, the session stays up
+        assert room_io.linked_participant is interviewer
+        assert room_io._participant_identity == "interviewer"
+        agent_session._close_soon.assert_not_called()
+
+        # last one out does close it
+        interviewer.disconnect_reason = rtc.DisconnectReason.CLIENT_INITIATED
+        room.remote_participants.pop("interviewer")
+        room_io._on_participant_disconnected(interviewer)
+        agent_session._close_soon.assert_called_once()
+
+    await room_io._audio_input.aclose()
+
+
 # -- audio output tests -------------------------------------------------------
 
 

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -9,6 +9,7 @@ import pytest
 
 from livekit import rtc
 from livekit.agents import utils
+from livekit.agents.types import ATTRIBUTE_PUBLISH_ON_BEHALF
 from livekit.agents.voice.io import PlaybackFinishedEvent
 from livekit.agents.voice.room_io._input import (
     _ParticipantAudioInputStream,
@@ -142,6 +143,9 @@ def _make_track_available_args(
 def _make_audio_input_stream(
     room: _FakeRoom,
     noise_cancellation,
+    *,
+    mix_participants: bool = False,
+    frame_size_ms: int = 50,
 ) -> _ParticipantAudioInputStream:
     return _ParticipantAudioInputStream(
         room,
@@ -150,6 +154,8 @@ def _make_audio_input_stream(
         noise_cancellation=noise_cancellation,
         auto_gain_control=False,
         pre_connect_audio_handler=None,
+        frame_size_ms=frame_size_ms,
+        mix_participants=mix_participants,
     )
 
 
@@ -368,6 +374,103 @@ async def test_selector_returns_noise_cancellation_options() -> None:
     assert stream._processor is None
 
     await stream.aclose()
+
+
+# -- multi-participant mixing tests -------------------------------------------
+
+
+class _ConstantAudioStream:
+    """Emits one frame of a constant sample value, then stays open without producing."""
+
+    def __init__(self, value: int, samples: int, sample_rate: int) -> None:
+        self._frame = rtc.AudioFrame(
+            value.to_bytes(2, "little", signed=True) * samples, sample_rate, 1, samples
+        )
+        self._sent = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._sent:
+            await asyncio.Event().wait()  # keep the stream alive, but silent
+        self._sent = True
+        return SimpleNamespace(frame=self._frame)
+
+    async def aclose(self) -> None:
+        pass
+
+
+def _make_mix_participant(
+    identity: str, sid: str, *, kind=rtc.ParticipantKind.PARTICIPANT_KIND_STANDARD, attributes=None
+) -> MagicMock:
+    publication = MagicMock()
+    publication.source = rtc.TrackSource.SOURCE_MICROPHONE
+    publication.sid = sid
+    publication.track = MagicMock()
+    publication.audio_features = []
+
+    participant = MagicMock()
+    participant.identity = identity
+    participant.kind = kind
+    participant.attributes = attributes or {}
+    participant.track_publications = {sid: publication}
+    return participant
+
+
+@pytest.mark.asyncio
+async def test_mix_participants_sums_every_participant_audio() -> None:
+    """Both participants are heard at once: the input yields their mixed samples."""
+    room = _FakeRoom()
+    stream = _make_audio_input_stream(room, None, mix_participants=True, frame_size_ms=10)
+    samples = 240  # 10ms @ 24kHz
+
+    streams = [_ConstantAudioStream(v, samples, 24000) for v in (100, 200)]
+    with patch("livekit.rtc.AudioStream.from_track", side_effect=lambda **kw: streams.pop(0)):
+        stream.add_participant(_make_mix_participant("candidate", "TR_1"))
+        stream.add_participant(_make_mix_participant("interviewer", "TR_2"))
+
+        assert set(stream._mix_sources) == {"candidate", "interviewer"}
+
+        frame = await asyncio.wait_for(stream.__anext__(), timeout=5)
+
+    assert frame.samples_per_channel == samples
+    assert bytes(frame.data) == (300).to_bytes(2, "little", signed=True) * samples
+
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_mix_participants_tracks_room_membership() -> None:
+    """RoomIO mixes in every accepted participant, but never its own avatar worker."""
+    room = _FakeRoom()
+    agent_session = SimpleNamespace(
+        off=MagicMock(),
+        _on_room_io_participant_linked=MagicMock(),
+        input=SimpleNamespace(audio=None, video=None),
+        output=SimpleNamespace(audio=None, transcription=None),
+    )
+    room_io = RoomIO(agent_session, room)
+    room_io._audio_input = _make_audio_input_stream(room, None, mix_participants=True)
+
+    candidate = _make_mix_participant("candidate", "TR_1")
+    interviewer = _make_mix_participant("interviewer", "TR_2")
+    avatar = _make_mix_participant(
+        "avatar", "TR_3", attributes={ATTRIBUTE_PUBLISH_ON_BEHALF: "local"}
+    )
+
+    with patch("livekit.rtc.AudioStream.from_track", side_effect=lambda **kw: _MockAudioStream()):
+        for participant in (candidate, interviewer, avatar):
+            room_io._on_participant_connected(participant)
+
+        assert set(room_io._audio_input._mix_sources) == {"candidate", "interviewer"}
+        # only the first participant is linked, the rest are input-only
+        assert room_io.linked_participant is candidate
+
+        room_io._on_participant_disconnected(interviewer)
+        assert set(room_io._audio_input._mix_sources) == {"candidate"}
+
+    await room_io._audio_input.aclose()
 
 
 # -- audio output tests -------------------------------------------------------

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -405,6 +405,14 @@ class _ConstantAudioStream:
         pass
 
 
+def _drain(chan) -> list[rtc.AudioFrame]:
+    """Everything currently queued for the session."""
+    frames = []
+    while not chan.empty():
+        frames.append(chan.recv_nowait())
+    return frames
+
+
 def _mixing_identities(stream: _ParticipantAudioInputStream) -> set[str]:
     """Which participants are actually feeding the mixer (it is keyed on channels)."""
     return {i for i, src in stream._mix_sources.items() if src.chan in stream._mixing}
@@ -676,6 +684,88 @@ async def test_unmuting_does_not_wait_for_the_pre_connect_buffer_again() -> None
         # the buffer is not read a second time, so the speaker is mixed in straight away
         assert reads == ["TR_1"]
         assert _mixing_identities(stream) == {"speaker"}
+
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pre_connect_audio_is_not_spliced_into_an_ongoing_conversation() -> None:
+    """It bypasses the mixer, so writing it while others are live would interleave two
+    speakers frame by frame in the channel the session reads."""
+    room = _FakeRoom()
+    buffered = rtc.AudioFrame(b"\x07\x00" * 240, 24000, 1, 240)
+    handler = MagicMock()
+    handler.wait_for_data = AsyncMock(return_value=[buffered])
+
+    stream = _ParticipantAudioInputStream(
+        room,
+        sample_rate=24000,
+        num_channels=1,
+        noise_cancellation=None,
+        auto_gain_control=False,
+        pre_connect_audio_handler=handler,
+        frame_size_ms=10,
+        mix_participants=True,
+    )
+
+    incumbent = _make_mix_participant("incumbent", "TR_1")
+    joiner = _make_mix_participant("joiner", "TR_2")
+    joiner.track_publications["TR_2"].audio_features = [AudioTrackFeature.TF_PRECONNECT_BUFFER]
+    joiner.track_publications["TR_2"].track.sid = "TR_2"
+
+    with patch(
+        "livekit.rtc.AudioStream.from_track",
+        side_effect=lambda **kw: _TickingAudioStream(240, 24000),
+    ):
+        stream.add_participant(incumbent)
+        await asyncio.sleep(0.05)
+        assert _mixing_identities(stream) == {"incumbent"}  # conversation already under way
+
+        stream.add_participant(joiner)
+        await asyncio.sleep(0.05)
+        assert _mixing_identities(stream) == {"incumbent", "joiner"}
+
+        # the joiner is mixed in live, but their pre-join words were not spliced in
+        mixed = b"".join(bytes(f.data) for f in _drain(stream._data_ch))
+        assert bytes(buffered.data) not in mixed
+
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_departing_mid_flush_is_not_logged_as_an_error(caplog) -> None:
+    """ChanClosed derives from Exception; the broad handler must not report it as a failure."""
+    room = _FakeRoom()
+    handler = MagicMock()
+    handler.wait_for_data = AsyncMock(
+        return_value=[rtc.AudioFrame(b"\x07\x00" * 240, 24000, 1, 240)]
+    )
+
+    stream = _ParticipantAudioInputStream(
+        room,
+        sample_rate=24000,
+        num_channels=1,
+        noise_cancellation=None,
+        auto_gain_control=False,
+        pre_connect_audio_handler=handler,
+        frame_size_ms=10,
+        mix_participants=True,
+    )
+
+    participant = _make_mix_participant("speaker", "TR_1")
+    participant.track_publications["TR_1"].audio_features = [AudioTrackFeature.TF_PRECONNECT_BUFFER]
+    participant.track_publications["TR_1"].track.sid = "TR_1"
+
+    with caplog.at_level(logging.ERROR, logger="livekit.agents"):
+        with patch(
+            "livekit.rtc.AudioStream.from_track",
+            side_effect=lambda **kw: _TickingAudioStream(240, 24000),
+        ):
+            stream.add_participant(participant)
+            stream._data_ch.close()  # the session shuts down while the buffer is in flight
+            await asyncio.sleep(0.05)
+
+    assert [record.message for record in caplog.records if record.levelno >= logging.ERROR] == []
 
     await stream.aclose()
 

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -751,8 +751,10 @@ async def test_pre_connect_audio_is_not_spliced_into_an_ongoing_conversation() -
         # mixed in straight away: the buffer is going to be discarded, so waiting for it would
         # leave the joiner's live track buffering unread and permanently behind the others
         assert _mixing_identities(stream) == {"incumbent", "joiner"}
-        handler.wait_for_data.assert_not_awaited()
+        # read off the forwarding path, so the handler stops holding the recording
+        handler.wait_for_data.assert_awaited_once_with("TR_2")
 
+        await asyncio.sleep(3.1)  # let the discard finish
         # the joiner is mixed in live, but their pre-join words were not spliced in
         mixed = b"".join(bytes(f.data) for f in _drain(stream._data_ch))
         assert bytes(buffered.data) not in mixed

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -593,6 +593,98 @@ async def test_mixed_pre_connect_buffer_runs_through_the_participants_processor(
     await stream.aclose()
 
 
+@pytest.mark.asyncio
+async def test_unmuting_does_not_wait_for_the_pre_connect_buffer_again() -> None:
+    """The handler drops the buffer after one read, so a second wait just burns the timeout
+    while the freshly subscribed stream backs up."""
+    room = _FakeRoom()
+    reads: list[str] = []
+    handler = MagicMock()
+
+    async def _wait_for_data(sid: str) -> list[rtc.AudioFrame]:
+        reads.append(sid)
+        if len(reads) > 1:
+            await asyncio.sleep(3)  # what the un-resolved future would do
+            raise asyncio.TimeoutError
+        return [rtc.AudioFrame(b"\x07\x00" * 240, 24000, 1, 240)]
+
+    handler.wait_for_data = _wait_for_data
+
+    stream = _ParticipantAudioInputStream(
+        room,
+        sample_rate=24000,
+        num_channels=1,
+        noise_cancellation=None,
+        auto_gain_control=False,
+        pre_connect_audio_handler=handler,
+        frame_size_ms=10,
+        mix_participants=True,
+    )
+
+    participant = _make_mix_participant("speaker", "TR_1")
+    publication = participant.track_publications["TR_1"]
+    publication.audio_features = [AudioTrackFeature.TF_PRECONNECT_BUFFER]
+    publication.track.sid = "TR_1"
+
+    with patch(
+        "livekit.rtc.AudioStream.from_track",
+        side_effect=lambda **kw: _TickingAudioStream(240, 24000),
+    ):
+        stream.add_participant(participant)
+        await asyncio.sleep(0.05)
+        assert reads == ["TR_1"]
+
+        publication.muted = True
+        stream._on_track_muted(participant, publication)
+        publication.muted = False
+        stream._on_track_unmuted(participant, publication)
+        await asyncio.sleep(0.05)
+
+        # the buffer is not read a second time, so the speaker is mixed in straight away
+        assert reads == ["TR_1"]
+        assert _mixing_identities(stream) == {"speaker"}
+
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_detached_input_drops_pre_connect_audio() -> None:
+    """Pre-connect frames bypass the mixer, so they need their own detached check."""
+    room = _FakeRoom()
+    handler = MagicMock()
+    handler.wait_for_data = AsyncMock(
+        return_value=[rtc.AudioFrame(b"\x07\x00" * 240, 24000, 1, 240)]
+    )
+
+    stream = _ParticipantAudioInputStream(
+        room,
+        sample_rate=24000,
+        num_channels=1,
+        noise_cancellation=None,
+        auto_gain_control=False,
+        pre_connect_audio_handler=handler,
+        frame_size_ms=10,
+        mix_participants=True,
+    )
+    stream.on_detached()  # session.input.set_audio_enabled(False)
+
+    participant = _make_mix_participant("speaker", "TR_1")
+    participant.track_publications["TR_1"].audio_features = [AudioTrackFeature.TF_PRECONNECT_BUFFER]
+
+    with patch(
+        "livekit.rtc.AudioStream.from_track",
+        side_effect=lambda **kw: _TickingAudioStream(240, 24000),
+    ):
+        stream.add_participant(participant)
+        await asyncio.sleep(0.05)
+
+        # the source still paces the mixer, but nothing reaches the session
+        assert _mixing_identities(stream) == {"speaker"}
+        assert stream._data_ch.empty()
+
+    await stream.aclose()
+
+
 class _TickingAudioStream:
     """A live mic: one frame per frame-interval, forever.
 

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -689,6 +689,26 @@ async def test_unmuting_does_not_wait_for_the_pre_connect_buffer_again() -> None
 
 
 @pytest.mark.asyncio
+async def test_stt_flush_frame_is_valid_for_stereo_input() -> None:
+    """samples_per_channel is per channel: rtc.AudioFrame rejects a buffer that is too short."""
+    room = _FakeRoom()
+    stream = _ParticipantAudioInputStream(
+        room,
+        sample_rate=24000,
+        num_channels=2,
+        noise_cancellation=None,
+        auto_gain_control=False,
+        pre_connect_audio_handler=None,
+    )
+
+    frame = stream._silent_frame()
+    assert frame.samples_per_channel == 12000
+    assert len(frame.data) == 12000 * 2  # int16 samples, both channels
+
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
 async def test_pre_connect_audio_is_not_spliced_into_an_ongoing_conversation() -> None:
     """It bypasses the mixer, so writing it while others are live would interleave two
     speakers frame by frame in the channel the session reads."""

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -811,6 +811,44 @@ async def test_mix_participants_tracks_room_membership() -> None:
 
 
 @pytest.mark.asyncio
+async def test_mix_does_not_relink_to_a_participant_who_cannot_speak() -> None:
+    """An observer publishes no microphone, so it must not keep the session alive on its own.
+    A muted participant can unmute, so it must."""
+    for publishes_mic, expect_closed in ((False, True), (True, False)):
+        room = _FakeRoom()
+        agent_session = SimpleNamespace(
+            off=MagicMock(),
+            _on_room_io_participant_linked=MagicMock(),
+            _close_soon=MagicMock(),
+            input=SimpleNamespace(audio=None, video=None),
+            output=SimpleNamespace(audio=None, transcription=None),
+        )
+        room_io = RoomIO(agent_session, room)
+        room_io._audio_input = _make_audio_input_stream(room, None, mix_participants=True)
+
+        speaker = _make_mix_participant("speaker", "TR_1")
+        # either a muted microphone, or no microphone at all
+        other = _make_mix_participant("other", "TR_2", publishes=publishes_mic, muted=True)
+        room.remote_participants = {"speaker": speaker, "other": other}
+
+        with patch(
+            "livekit.rtc.AudioStream.from_track", side_effect=lambda **kw: _MockAudioStream()
+        ):
+            room_io._on_participant_connected(speaker)
+            room_io._on_participant_connected(other)
+            assert room_io.linked_participant is speaker
+
+            speaker.disconnect_reason = rtc.DisconnectReason.CLIENT_INITIATED
+            room.remote_participants.pop("speaker")
+            room_io._on_participant_disconnected(speaker)
+
+        assert agent_session._close_soon.called is expect_closed
+        assert (room_io.linked_participant is other) is not expect_closed
+
+        await room_io._audio_input.aclose()
+
+
+@pytest.mark.asyncio
 async def test_mix_relinks_instead_of_closing_when_the_linked_participant_leaves() -> None:
     """The linked participant is one of N contributors: their exit must not hang up on the rest."""
     room = _FakeRoom()

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -715,7 +715,12 @@ async def test_pre_connect_audio_is_not_spliced_into_an_ongoing_conversation() -
     room = _FakeRoom()
     buffered = rtc.AudioFrame(b"\x07\x00" * 240, 24000, 1, 240)
     handler = MagicMock()
-    handler.wait_for_data = AsyncMock(return_value=[buffered])
+
+    async def _wait_for_data(_sid: str) -> list[rtc.AudioFrame]:
+        await asyncio.sleep(3)  # a buffer that never finishes uploading
+        return [buffered]
+
+    handler.wait_for_data = AsyncMock(side_effect=_wait_for_data)
 
     stream = _ParticipantAudioInputStream(
         room,
@@ -743,7 +748,10 @@ async def test_pre_connect_audio_is_not_spliced_into_an_ongoing_conversation() -
 
         stream.add_participant(joiner)
         await asyncio.sleep(0.05)
+        # mixed in straight away: the buffer is going to be discarded, so waiting for it would
+        # leave the joiner's live track buffering unread and permanently behind the others
         assert _mixing_identities(stream) == {"incumbent", "joiner"}
+        handler.wait_for_data.assert_not_awaited()
 
         # the joiner is mixed in live, but their pre-join words were not spliced in
         mixed = b"".join(bytes(f.data) for f in _drain(stream._data_ch))

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -23,6 +23,7 @@ from livekit.agents.voice.room_io._output import (
 )
 from livekit.agents.voice.room_io.room_io import RoomIO
 from livekit.agents.voice.room_io.types import NoiseCancellationParams
+from livekit.rtc._proto.track_pb2 import AudioTrackFeature
 
 pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
@@ -76,6 +77,7 @@ class _MockFrameProcessor(rtc.FrameProcessor[rtc.AudioFrame]):
         self._enabled = True
         self.stream_info_calls: list[dict[str, str]] = []
         self.credentials_calls: list[dict[str, str]] = []
+        self.processed_frames: list[rtc.AudioFrame] = []
         self.close_calls: int = 0
 
     @property
@@ -101,6 +103,7 @@ class _MockFrameProcessor(rtc.FrameProcessor[rtc.AudioFrame]):
         self.credentials_calls.append({"token": token, "url": url})
 
     def _process(self, frame: rtc.AudioFrame) -> rtc.AudioFrame:
+        self.processed_frames.append(frame)
         return frame
 
     def _close(self) -> None:
@@ -491,6 +494,48 @@ async def test_only_producing_sources_are_registered_with_the_mixer() -> None:
     await stream.aclose()
 
 
+@pytest.mark.asyncio
+async def test_mixed_pre_connect_buffer_runs_through_the_participants_processor() -> None:
+    """The live track is filtered by its stream; the pre-connect buffer must be too."""
+    room = _FakeRoom()
+    processors: list[_MockFrameProcessor] = []
+
+    def selector(_params: NoiseCancellationParams) -> _MockFrameProcessor:
+        processors.append(_MockFrameProcessor())
+        return processors[-1]
+
+    handler = MagicMock()
+    handler.wait_for_data = AsyncMock(
+        return_value=[rtc.AudioFrame(b"\x01\x00" * 240, 24000, 1, 240)]
+    )
+
+    stream = _ParticipantAudioInputStream(
+        room,
+        sample_rate=24000,
+        num_channels=1,
+        noise_cancellation=selector,
+        auto_gain_control=False,
+        pre_connect_audio_handler=handler,
+        frame_size_ms=10,
+        mix_participants=True,
+    )
+
+    participant = _make_mix_participant("speaker", "TR_1")
+    participant.track_publications["TR_1"].audio_features = [AudioTrackFeature.TF_PRECONNECT_BUFFER]
+
+    with patch("livekit.rtc.AudioStream.from_track", side_effect=lambda **kw: _MockAudioStream()):
+        stream.add_participant(participant)
+
+    source = stream._mix_sources["speaker"]
+    assert source.processor is processors[0]  # kept on the source, not on the shared stream
+    assert source.task is not None
+    await asyncio.wait_for(source.task, timeout=5)
+
+    assert len(processors[0].processed_frames) == 1
+
+    await stream.aclose()
+
+
 class _TickingAudioStream:
     """Yields a frame on every iteration, forever."""
 
@@ -609,6 +654,9 @@ async def test_mix_relinks_instead_of_closing_when_the_linked_participant_leaves
         assert room_io.linked_participant is interviewer
         assert room_io._participant_identity == "interviewer"
         agent_session._close_soon.assert_not_called()
+        # a relink is not a new call: re-notifying would re-arm the AEC warmup and swallow
+        # everyone's audio through the agent's next reply
+        agent_session._on_room_io_participant_linked.assert_called_once()
 
         # last one out does close it
         interviewer.disconnect_reason = rtc.DisconnectReason.CLIENT_INITIATED

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections import defaultdict
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -436,6 +437,60 @@ async def test_mix_participants_sums_every_participant_audio() -> None:
 
     assert frame.samples_per_channel == samples
     assert bytes(frame.data) == (300).to_bytes(2, "little", signed=True) * samples
+
+    await stream.aclose()
+
+
+class _TickingAudioStream:
+    """Yields a frame on every iteration, forever."""
+
+    def __init__(self, samples: int, sample_rate: int) -> None:
+        self._frame = rtc.AudioFrame(b"\x01\x00" * samples, sample_rate, 1, samples)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        await asyncio.sleep(0)
+        return SimpleNamespace(frame=self._frame)
+
+    async def aclose(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_mix_participant_departure_is_not_logged_as_an_error(caplog) -> None:
+    """A participant leaving closes their sink mid-forward: an expected end, not a crash."""
+    room = _FakeRoom()
+    stream = _make_audio_input_stream(room, None, mix_participants=True, frame_size_ms=10)
+
+    with patch(
+        "livekit.rtc.AudioStream.from_track",
+        side_effect=lambda **kw: _TickingAudioStream(240, 24000),
+    ):
+        stream.add_participant(_make_mix_participant("candidate", "TR_1"))
+
+    source = stream._mix_sources["candidate"]
+    assert source.task is not None
+
+    with caplog.at_level(logging.ERROR, logger="livekit.agents"):
+        source.chan.close()  # what remove_participant does while frames are in flight
+        await asyncio.wait_for(source.task, timeout=5)  # returns, never raises ChanClosed
+
+    assert [record.message for record in caplog.records if record.levelno >= logging.ERROR] == []
+
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_mix_participants_warns_on_a_shared_frame_processor(caplog) -> None:
+    """One stateful processor cannot serve every speaker at once — say so up front."""
+    room = _FakeRoom()
+
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        stream = _make_audio_input_stream(room, _MockFrameProcessor(), mix_participants=True)
+
+    assert any("noise cancellation processor is shared" in r.message for r in caplog.records)
 
     await stream.aclose()
 

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -824,6 +824,9 @@ async def test_detached_input_drops_pre_connect_audio() -> None:
         # the source still paces the mixer, but nothing reaches the session
         assert _mixing_identities(stream) == {"speaker"}
         assert stream._data_ch.empty()
+        # the buffer was left with the handler, so re-enabling input can still deliver it
+        handler.wait_for_data.assert_not_awaited()
+        assert stream._pre_connect_flushed == set()
 
     await stream.aclose()
 

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -403,19 +403,26 @@ class _ConstantAudioStream:
 
 
 def _make_mix_participant(
-    identity: str, sid: str, *, kind=rtc.ParticipantKind.PARTICIPANT_KIND_STANDARD, attributes=None
+    identity: str,
+    sid: str,
+    *,
+    kind=rtc.ParticipantKind.PARTICIPANT_KIND_STANDARD,
+    attributes=None,
+    publishes: bool = True,
+    muted: bool = False,
 ) -> MagicMock:
     publication = MagicMock()
     publication.source = rtc.TrackSource.SOURCE_MICROPHONE
     publication.sid = sid
     publication.track = MagicMock()
     publication.audio_features = []
+    publication.muted = muted
 
     participant = MagicMock()
     participant.identity = identity
     participant.kind = kind
     participant.attributes = attributes or {}
-    participant.track_publications = {sid: publication}
+    participant.track_publications = {sid: publication} if publishes else {}
     return participant
 
 
@@ -437,6 +444,49 @@ async def test_mix_participants_sums_every_participant_audio() -> None:
 
     assert frame.samples_per_channel == samples
     assert bytes(frame.data) == (300).to_bytes(2, "little", signed=True) * samples
+
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_only_producing_sources_are_registered_with_the_mixer() -> None:
+    """A registered stream that delivers nothing paces the whole mixer below real time,
+    so the live speakers fall behind. Only sources with a live track may be registered."""
+    room = _FakeRoom()
+    stream = _make_audio_input_stream(room, None, mix_participants=True, frame_size_ms=10)
+
+    speaker = _make_mix_participant("speaker", "TR_1")
+    muted = _make_mix_participant("muted", "TR_2", muted=True)
+    listener = _make_mix_participant("listener", "TR_3", publishes=False)
+
+    with patch("livekit.rtc.AudioStream.from_track", side_effect=lambda **kw: _MockAudioStream()):
+        for participant in (speaker, muted, listener):
+            stream.add_participant(participant)
+
+    assert stream._mixer is not None
+    registered = stream._mixer._streams
+    # all three are mixed participants, only the one actually sending feeds the mixer
+    assert set(stream._mix_sources) == {"speaker", "muted", "listener"}
+    assert stream._mix_sources["speaker"].chan in registered
+    assert stream._mix_sources["muted"].chan not in registered
+    assert stream._mix_sources["listener"].chan not in registered
+    # a muted track isn't even read, so nothing accumulates behind the mixer
+    assert stream._mix_sources["muted"].task is None
+
+    with patch("livekit.rtc.AudioStream.from_track", side_effect=lambda **kw: _MockAudioStream()):
+        # unmuting brings a source back, muting drops it again
+        # (rtc flips publication.muted before it emits the event)
+        muted.track_publications["TR_2"].muted = False
+        stream._on_track_unmuted(muted, muted.track_publications["TR_2"])
+        assert stream._mix_sources["muted"].chan in registered
+
+        speaker.track_publications["TR_1"].muted = True
+        stream._on_track_muted(speaker, speaker.track_publications["TR_1"])
+        assert stream._mix_sources["speaker"].chan not in registered
+
+    # and leaving takes the source with it
+    stream.remove_participant("muted")
+    assert len(registered) == 0
 
     await stream.aclose()
 

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -594,6 +594,39 @@ async def test_mixed_pre_connect_buffer_runs_through_the_participants_processor(
 
 
 @pytest.mark.asyncio
+async def test_resubscribe_before_the_forwarder_starts_leaves_the_live_source_mixed() -> None:
+    """Several room events can be dispatched in one loop iteration, so a forward task can find
+    its source already resubscribed by the time it first runs. It must not touch the successor's
+    channel: writing to it leaks the old track, and unregistering it drops a live speaker."""
+    room = _FakeRoom()
+    stream = _make_audio_input_stream(room, None, mix_participants=True, frame_size_ms=10)
+    participant = _make_mix_participant("speaker", "TR_1")
+    publication = participant.track_publications["TR_1"]
+
+    with patch(
+        "livekit.rtc.AudioStream.from_track",
+        side_effect=lambda **kw: _TickingAudioStream(240, 24000),
+    ):
+        # all synchronous: the first forward task never gets a turn before it is replaced
+        stream.add_participant(participant)
+        first_chan = stream._mix_sources["speaker"].chan
+        publication.muted = True
+        stream._on_track_muted(participant, publication)
+        publication.muted = False
+        stream._on_track_unmuted(participant, publication)
+
+        live_chan = stream._mix_sources["speaker"].chan
+        assert live_chan is not first_chan
+
+        await asyncio.sleep(0.1)  # let the stale task run and then be cancelled
+
+        assert _mixing_identities(stream) == {"speaker"}
+        assert live_chan in stream._mixer._streams
+
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
 async def test_unmuting_does_not_wait_for_the_pre_connect_buffer_again() -> None:
     """The handler drops the buffer after one read, so a second wait just burns the timeout
     while the freshly subscribed stream backs up."""

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -405,6 +405,11 @@ class _ConstantAudioStream:
         pass
 
 
+def _mixing_identities(stream: _ParticipantAudioInputStream) -> set[str]:
+    """Which participants are actually feeding the mixer (it is keyed on channels)."""
+    return {i for i, src in stream._mix_sources.items() if src.chan in stream._mixing}
+
+
 def _make_mix_participant(
     identity: str,
     sid: str,
@@ -462,34 +467,69 @@ async def test_only_producing_sources_are_registered_with_the_mixer() -> None:
     muted = _make_mix_participant("muted", "TR_2", muted=True)
     listener = _make_mix_participant("listener", "TR_3", publishes=False)
 
-    with patch("livekit.rtc.AudioStream.from_track", side_effect=lambda **kw: _MockAudioStream()):
+    with patch(
+        "livekit.rtc.AudioStream.from_track",
+        side_effect=lambda **kw: _TickingAudioStream(240, 24000),
+    ):
         for participant in (speaker, muted, listener):
             stream.add_participant(participant)
+        await asyncio.sleep(0.05)  # let the forward tasks reach their live loop
 
-    assert stream._mixer is not None
-    registered = stream._mixer._streams
-    # all three are mixed participants, only the one actually sending feeds the mixer
-    assert set(stream._mix_sources) == {"speaker", "muted", "listener"}
-    assert stream._mix_sources["speaker"].chan in registered
-    assert stream._mix_sources["muted"].chan not in registered
-    assert stream._mix_sources["listener"].chan not in registered
-    # a muted track isn't even read, so nothing accumulates behind the mixer
-    assert stream._mix_sources["muted"].task is None
+        # all three are mixed participants, only the one actually sending feeds the mixer
+        assert set(stream._mix_sources) == {"speaker", "muted", "listener"}
+        assert _mixing_identities(stream) == {"speaker"}
+        assert stream._mixer is not None
+        assert stream._mix_sources["speaker"].chan in stream._mixer._streams
+        # a muted track isn't even read, so nothing accumulates behind the mixer
+        assert stream._mix_sources["muted"].task is None
 
-    with patch("livekit.rtc.AudioStream.from_track", side_effect=lambda **kw: _MockAudioStream()):
         # unmuting brings a source back, muting drops it again
         # (rtc flips publication.muted before it emits the event)
         muted.track_publications["TR_2"].muted = False
         stream._on_track_unmuted(muted, muted.track_publications["TR_2"])
-        assert stream._mix_sources["muted"].chan in registered
+        await asyncio.sleep(0.05)
+        assert _mixing_identities(stream) == {"speaker", "muted"}
 
         speaker.track_publications["TR_1"].muted = True
         stream._on_track_muted(speaker, speaker.track_publications["TR_1"])
-        assert stream._mix_sources["speaker"].chan not in registered
+        assert _mixing_identities(stream) == {"muted"}
 
-    # and leaving takes the source with it
-    stream.remove_participant("muted")
-    assert len(registered) == 0
+        # and leaving takes the source with it
+        stream.remove_participant("muted")
+        assert not stream._mixing
+        assert len(stream._mixer._streams) == 0
+
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_a_resubscribed_source_gets_a_fresh_channel() -> None:
+    """The old forward task is still winding down; frames it writes must not reach the new mix."""
+    room = _FakeRoom()
+    stream = _make_audio_input_stream(room, None, mix_participants=True, frame_size_ms=10)
+    participant = _make_mix_participant("speaker", "TR_1")
+
+    with patch(
+        "livekit.rtc.AudioStream.from_track",
+        side_effect=lambda **kw: _TickingAudioStream(240, 24000),
+    ):
+        stream.add_participant(participant)
+        await asyncio.sleep(0.05)
+        first_chan = stream._mix_sources["speaker"].chan
+
+        participant.track_publications["TR_1"].muted = True
+        stream._on_track_muted(participant, participant.track_publications["TR_1"])
+        assert first_chan.closed  # closed before its writer is cancelled, so nothing sneaks in
+
+        participant.track_publications["TR_1"].muted = False
+        stream._on_track_unmuted(participant, participant.track_publications["TR_1"])
+        await asyncio.sleep(0.05)
+
+        second_chan = stream._mix_sources["speaker"].chan
+        assert second_chan is not first_chan
+        assert not second_chan.closed
+        assert second_chan in stream._mixer._streams
+        assert first_chan not in stream._mixer._streams
 
     await stream.aclose()
 
@@ -504,10 +544,15 @@ async def test_mixed_pre_connect_buffer_runs_through_the_participants_processor(
         processors.append(_MockFrameProcessor())
         return processors[-1]
 
+    buffered = rtc.AudioFrame(b"\x07\x00" * 240, 24000, 1, 240)
+    loaded = asyncio.Event()
     handler = MagicMock()
-    handler.wait_for_data = AsyncMock(
-        return_value=[rtc.AudioFrame(b"\x01\x00" * 240, 24000, 1, 240)]
-    )
+
+    async def _wait_for_data(_sid: str) -> list[rtc.AudioFrame]:
+        await loaded.wait()
+        return [buffered]
+
+    handler.wait_for_data = _wait_for_data
 
     stream = _ParticipantAudioInputStream(
         room,
@@ -523,30 +568,47 @@ async def test_mixed_pre_connect_buffer_runs_through_the_participants_processor(
     participant = _make_mix_participant("speaker", "TR_1")
     participant.track_publications["TR_1"].audio_features = [AudioTrackFeature.TF_PRECONNECT_BUFFER]
 
-    with patch("livekit.rtc.AudioStream.from_track", side_effect=lambda **kw: _MockAudioStream()):
+    with patch(
+        "livekit.rtc.AudioStream.from_track",
+        side_effect=lambda **kw: _TickingAudioStream(240, 24000),
+    ):
         stream.add_participant(participant)
+        await asyncio.sleep(0.05)
 
-    source = stream._mix_sources["speaker"]
-    assert source.processor is processors[0]  # kept on the source, not on the shared stream
-    assert source.task is not None
-    await asyncio.wait_for(source.task, timeout=5)
+        source = stream._mix_sources["speaker"]
+        assert source.processor is processors[0]  # kept on the source, not on the shared stream
+        # a source waiting on its buffer would stall every other speaker
+        assert _mixing_identities(stream) == set()
+
+        loaded.set()
+        await asyncio.sleep(0.05)
+        assert _mixing_identities(stream) == {"speaker"}
 
     assert len(processors[0].processed_frames) == 1
+    # pre-join audio is not concurrent with anyone: it reaches the session directly, so it
+    # cannot leave this source permanently behind the mix
+    first = await asyncio.wait_for(stream.__anext__(), timeout=5)
+    assert bytes(first.data) == bytes(buffered.data)
 
     await stream.aclose()
 
 
 class _TickingAudioStream:
-    """Yields a frame on every iteration, forever."""
+    """A live mic: one frame per frame-interval, forever.
+
+    Paced with a real sleep so virtual time can advance between frames; spinning on sleep(0)
+    would keep the loop busy and freeze the clock.
+    """
 
     def __init__(self, samples: int, sample_rate: int) -> None:
         self._frame = rtc.AudioFrame(b"\x01\x00" * samples, sample_rate, 1, samples)
+        self._interval = samples / sample_rate
 
     def __aiter__(self):
         return self
 
     async def __anext__(self):
-        await asyncio.sleep(0)
+        await asyncio.sleep(self._interval)
         return SimpleNamespace(frame=self._frame)
 
     async def aclose(self) -> None:


### PR DESCRIPTION
Closes livekit/agents#6795

## Problem

`AgentSession` can only listen to one participant at a time: `_ParticipantInputStream` keeps a single `_stream`/`_publication`, so a second participant's track replaces the first instead of joining it. Use cases like an AI interview with human takeover need N participants → 1 session → 1 shared chat context.

## Approach

Opt-in mixing. With `AudioInputOptions.mix_participants=True`, `RoomIO` subscribes to the microphone of every accepted participant and mixes them with `rtc.AudioMixer` (the same primitive `BackgroundAudio` uses) into the single audio input the session already consumes. One STT/LLM/TTS pipeline, one chat context, no API surface beyond the flag:

```python
session.start(
    room=ctx.room,
    room_options=RoomOptions(audio_input=AudioInputOptions(mix_participants=True)),
)
```

## Changes

* `voice/room_io/_input.py` — `_ParticipantAudioInputStream` keeps a `_MixedSource` per participant (channel + track stream + forward task) and feeds each channel into an `rtc.AudioMixer`; the mixed output becomes the session's input. The only change to the shared single-participant path is a `_sink(participant)` hook in the base class, which still returns `_data_ch` — video and non-mixed audio behave exactly as before.
* `voice/room_io/room_io.py` — every accepted participant is added to the mix on connect and removed on disconnect. Kind filtering is unchanged, and the agent's own avatar worker (`ATTRIBUTE_PUBLISH_ON_BEHALF`) is excluded so the agent can't hear itself. The linked participant is still the first one and only drives the outputs (audio, transcription, chat text).
* `voice/room_io/types.py` — the `mix_participants` option.

Notes:

* AGC runs once on the mixed output rather than per stream (one shared `AudioProcessingModule` interleaved across speakers would be wrong).
* A noise-cancellation *selector* now builds a processor per participant, owned by that participant's stream; a directly-passed `FrameProcessor` instance keeps today's shared lifetime.
* `set_participant()` is a no-op for the input in this mode — listening covers everyone; toggle it with the existing audio-input enable/disable.

## Not included

Per-turn speaker attribution, also mentioned in the issue. Mixing collapses everyone into one stream, so a single STT cannot label who spoke — that needs per-participant recognition, which is a separate change.

## Tests

`tests/test_room_io.py`:

* `test_mix_participants_sums_every_participant_audio` — two participants' frames come out of the input summed into one frame.
* `test_mix_participants_tracks_room_membership` — RoomIO mixes both humans, skips its own avatar worker, links only the first, and drops a participant on disconnect.

`uv run pytest --unit` passes (the pre-existing `test_sent_tokenizer` failure and `test_room.py` errors are environment-related and reproduce on `main`).