### PR TITLE
tests: stop room tests hanging on macOS

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import asyncio
 import dataclasses
 import logging
 import re
+import sys
 from collections.abc import Iterator
 from functools import cache
 from pathlib import Path
@@ -22,6 +23,9 @@ from .virtual_time import (  # noqa: F401  (re-exported so pytest discovers the 
 )
 
 TEST_CONNECT_OPTIONS = dataclasses.replace(DEFAULT_API_CONNECT_OPTIONS, retry_interval=0.0)
+
+# highest fd soft limit the room tests survive on macOS
+_MAX_OPEN_FILES = 8192
 
 # Category names are the pytest markers declared in pyproject.toml — the single
 # source of truth. They're read from the file rather than via config.getini()
@@ -128,10 +132,23 @@ def _uncategorized_modules(config: pytest.Config) -> list[Path]:
     return offenders
 
 
+def _clamp_open_file_limit() -> None:
+    """Cap the fd soft limit on macOS, where a large one deadlocks concurrent `Room.connect`."""
+    if sys.platform != "darwin":
+        return
+
+    import resource  # unix-only
+
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    if soft > _MAX_OPEN_FILES:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (_MAX_OPEN_FILES, hard))
+
+
 def pytest_configure(config: pytest.Config) -> None:
     """Handle `--list-categories` before any collection/import happens."""
     _module_facts.cache_clear()
     _register_virtual_time_marker(config)
+    _clamp_open_file_limit()
 
     if not config.getoption("--list-categories"):
         return

--- a/tests/test_room.py
+++ b/tests/test_room.py
@@ -70,8 +70,8 @@ async def connect_room(
 ):
     room = rtc.Room()
     token = _make_token(identity, room_name, kind=kind, agent=agent)
-    await asyncio.wait_for(room.connect(LK_URL, token), timeout=CONNECT_TIMEOUT)
     try:
+        await asyncio.wait_for(room.connect(LK_URL, token), timeout=CONNECT_TIMEOUT)
         yield room
     finally:
         await room.disconnect()
@@ -89,18 +89,14 @@ async def _publish_audio_track(room: rtc.Room) -> None:
 
 async def _test_wait_disconnect(wait_fn: Callable[[rtc.Room], Awaitable[object]]) -> None:
     """Connect a room, start waiting, disconnect, and assert RuntimeError."""
-    name = _room_name()
-    room = rtc.Room()
-    token = _make_token("observer", name)
-    await asyncio.wait_for(room.connect(LK_URL, token), timeout=CONNECT_TIMEOUT)
+    async with connect_room("observer", _room_name()) as room:
+        task = asyncio.ensure_future(wait_fn(room))
+        # ensure the task is running and has registered its event handlers
+        await asyncio.sleep(0.5)
+        await room.disconnect()
 
-    task = asyncio.ensure_future(wait_fn(room))
-    # ensure the task is running and has registered its event handlers
-    await asyncio.sleep(0.5)
-    await room.disconnect()
-
-    with pytest.raises(RuntimeError, match="disconnected"):
-        await asyncio.wait_for(task, timeout=TIMEOUT)
+        with pytest.raises(RuntimeError, match="disconnected"):
+            await asyncio.wait_for(task, timeout=TIMEOUT)
 
 
 # -- wait_for_participant tests --

--- a/tests/test_room.py
+++ b/tests/test_room.py
@@ -35,6 +35,8 @@ from .utils.livekit_test import (
 pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 TIMEOUT = 5.0
+# nothing else bounds `Room.connect`, and a wedged one would hang the whole session
+CONNECT_TIMEOUT = 15.0
 
 
 def _make_token(
@@ -68,7 +70,7 @@ async def connect_room(
 ):
     room = rtc.Room()
     token = _make_token(identity, room_name, kind=kind, agent=agent)
-    await room.connect(LK_URL, token)
+    await asyncio.wait_for(room.connect(LK_URL, token), timeout=CONNECT_TIMEOUT)
     try:
         yield room
     finally:
@@ -90,7 +92,7 @@ async def _test_wait_disconnect(wait_fn: Callable[[rtc.Room], Awaitable[object]]
     name = _room_name()
     room = rtc.Room()
     token = _make_token("observer", name)
-    await room.connect(LK_URL, token)
+    await asyncio.wait_for(room.connect(LK_URL, token), timeout=CONNECT_TIMEOUT)
 
     task = asyncio.ensure_future(wait_fn(room))
     # ensure the task is running and has registered its event handlers


### PR DESCRIPTION
**Problem**

`tests/test_room.py` is marked `concurrent`, so its nine tests open every room at the same time. When the file descriptor soft limit is large, the native layer on macOS never completes `Room.connect` and `pytest --unit` hangs forever. Nothing bounds `Room.connect`, and per-item timeouts do not arm inside a concurrent group, so the run stops with no test name.

**Fix**

`pytest_configure` now caps the file descriptor soft limit at 8192 on macOS, and only ever lowers it, so a machine already below that value is unaffected. `Room.connect` now runs under `asyncio.wait_for`, so a wedged connection fails in 15 seconds with a test name. Linux is untouched, so CI behavior does not change.

The 8192 value is measured on one macOS machine: 8192 passes on three trials, 12288 and above deadlock, and 1024 and below fail on descriptor exhaustion.