### PR TITLE
fix: mark interrupted tool replies

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/anthropic.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/anthropic.py
@@ -69,9 +69,9 @@ def to_chat_ctx(
                 }
             )
         elif msg.type == "function_call_output":
-            result_content: list[Any] | str = msg.model_output
+            result_content: list[Any] | str = msg.output_for_model
             try:
-                parsed = json.loads(msg.model_output)
+                parsed = json.loads(msg.output_for_model)
                 if isinstance(parsed, list):
                     result_content = parsed
             except (json.JSONDecodeError, TypeError):

--- a/livekit-agents/livekit/agents/llm/_provider_format/anthropic.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/anthropic.py
@@ -69,9 +69,9 @@ def to_chat_ctx(
                 }
             )
         elif msg.type == "function_call_output":
-            result_content: list[Any] | str = msg.output_for_model
+            result_content: list[Any] | str = msg.output_with_states
             try:
-                parsed = json.loads(msg.output_for_model)
+                parsed = json.loads(msg.output_with_states)
                 if isinstance(parsed, list):
                     result_content = parsed
             except (json.JSONDecodeError, TypeError):

--- a/livekit-agents/livekit/agents/llm/_provider_format/anthropic.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/anthropic.py
@@ -69,9 +69,9 @@ def to_chat_ctx(
                 }
             )
         elif msg.type == "function_call_output":
-            result_content: list[Any] | str = msg.output
+            result_content: list[Any] | str = msg.model_output
             try:
-                parsed = json.loads(msg.output)
+                parsed = json.loads(msg.model_output)
                 if isinstance(parsed, list):
                     result_content = parsed
             except (json.JSONDecodeError, TypeError):

--- a/livekit-agents/livekit/agents/llm/_provider_format/anthropic.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/anthropic.py
@@ -69,9 +69,9 @@ def to_chat_ctx(
                 }
             )
         elif msg.type == "function_call_output":
-            result_content: list[Any] | str = msg.output_with_states
+            result_content: list[Any] | str = msg.output_with_metadata
             try:
-                parsed = json.loads(msg.output_with_states)
+                parsed = json.loads(msg.output_with_metadata)
                 if isinstance(parsed, list):
                     result_content = parsed
             except (json.JSONDecodeError, TypeError):

--- a/livekit-agents/livekit/agents/llm/_provider_format/aws.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/aws.py
@@ -76,9 +76,9 @@ def to_chat_ctx(
                     "toolResult": {
                         "toolUseId": msg.call_id,
                         "content": [
-                            {"json": msg.model_output}
-                            if isinstance(msg.model_output, dict)
-                            else {"text": msg.model_output}
+                            {"json": msg.output_for_model}
+                            if isinstance(msg.output_for_model, dict)
+                            else {"text": msg.output_for_model}
                         ],
                         "status": "success",
                     }

--- a/livekit-agents/livekit/agents/llm/_provider_format/aws.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/aws.py
@@ -76,9 +76,9 @@ def to_chat_ctx(
                     "toolResult": {
                         "toolUseId": msg.call_id,
                         "content": [
-                            {"json": msg.output_for_model}
-                            if isinstance(msg.output_for_model, dict)
-                            else {"text": msg.output_for_model}
+                            {"json": msg.output_with_states}
+                            if isinstance(msg.output_with_states, dict)
+                            else {"text": msg.output_with_states}
                         ],
                         "status": "success",
                     }

--- a/livekit-agents/livekit/agents/llm/_provider_format/aws.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/aws.py
@@ -76,9 +76,9 @@ def to_chat_ctx(
                     "toolResult": {
                         "toolUseId": msg.call_id,
                         "content": [
-                            {"json": msg.output_with_states}
-                            if isinstance(msg.output_with_states, dict)
-                            else {"text": msg.output_with_states}
+                            {"json": msg.output_with_metadata}
+                            if isinstance(msg.output_with_metadata, dict)
+                            else {"text": msg.output_with_metadata}
                         ],
                         "status": "success",
                     }

--- a/livekit-agents/livekit/agents/llm/_provider_format/aws.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/aws.py
@@ -76,9 +76,9 @@ def to_chat_ctx(
                     "toolResult": {
                         "toolUseId": msg.call_id,
                         "content": [
-                            {"json": msg.output}
-                            if isinstance(msg.output, dict)
-                            else {"text": msg.output}
+                            {"json": msg.model_output}
+                            if isinstance(msg.model_output, dict)
+                            else {"text": msg.model_output}
                         ],
                         "status": "success",
                     }

--- a/livekit-agents/livekit/agents/llm/_provider_format/google.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/google.py
@@ -74,7 +74,9 @@ def to_chat_ctx(
             parts.append(fc_part)
         elif msg.type == "function_call_output":
             response = (
-                {"output": msg.model_output} if not msg.is_error else {"error": msg.model_output}
+                {"output": msg.output_for_model}
+                if not msg.is_error
+                else {"error": msg.output_for_model}
             )
             parts.append(
                 {

--- a/livekit-agents/livekit/agents/llm/_provider_format/google.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/google.py
@@ -73,7 +73,9 @@ def to_chat_ctx(
                 fc_part["thought_signature"] = sig
             parts.append(fc_part)
         elif msg.type == "function_call_output":
-            response = {"output": msg.output} if not msg.is_error else {"error": msg.output}
+            response = (
+                {"output": msg.model_output} if not msg.is_error else {"error": msg.model_output}
+            )
             parts.append(
                 {
                     "function_response": {

--- a/livekit-agents/livekit/agents/llm/_provider_format/google.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/google.py
@@ -74,9 +74,9 @@ def to_chat_ctx(
             parts.append(fc_part)
         elif msg.type == "function_call_output":
             response = (
-                {"output": msg.output_with_states}
+                {"output": msg.output_with_metadata}
                 if not msg.is_error
-                else {"error": msg.output_with_states}
+                else {"error": msg.output_with_metadata}
             )
             parts.append(
                 {

--- a/livekit-agents/livekit/agents/llm/_provider_format/google.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/google.py
@@ -74,9 +74,9 @@ def to_chat_ctx(
             parts.append(fc_part)
         elif msg.type == "function_call_output":
             response = (
-                {"output": msg.output_for_model}
+                {"output": msg.output_with_states}
                 if not msg.is_error
-                else {"error": msg.output_for_model}
+                else {"error": msg.output_with_states}
             )
             parts.append(
                 {

--- a/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
@@ -61,7 +61,7 @@ def to_conversations_ctx(
                 {
                     "type": "function.result",
                     "tool_call_id": tool_output.call_id,
-                    "result": tool_output.output_with_states,
+                    "result": tool_output.output_with_metadata,
                 }
             )
 

--- a/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
@@ -61,7 +61,7 @@ def to_conversations_ctx(
                 {
                     "type": "function.result",
                     "tool_call_id": tool_output.call_id,
-                    "result": tool_output.output_for_model,
+                    "result": tool_output.output_with_states,
                 }
             )
 

--- a/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
@@ -61,7 +61,7 @@ def to_conversations_ctx(
                 {
                     "type": "function.result",
                     "tool_call_id": tool_output.call_id,
-                    "result": tool_output.model_output,
+                    "result": tool_output.output_for_model,
                 }
             )
 

--- a/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
@@ -61,7 +61,7 @@ def to_conversations_ctx(
                 {
                     "type": "function.result",
                     "tool_call_id": tool_output.call_id,
-                    "result": tool_output.output,
+                    "result": tool_output.model_output,
                 }
             )
 

--- a/livekit-agents/livekit/agents/llm/_provider_format/openai.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/openai.py
@@ -97,7 +97,7 @@ def _to_chat_item(msg: llm.ChatItem) -> dict[str, Any]:
         return {
             "role": "tool",
             "tool_call_id": msg.call_id,
-            "content": msg.output_for_model,
+            "content": msg.output_with_states,
         }
 
     raise ValueError(f"unsupported message type: {msg.type}")
@@ -205,7 +205,7 @@ def _to_responses_chat_item(msg: llm.ChatItem) -> dict[str, Any]:
         return {
             "type": "function_call_output",
             "call_id": msg.call_id,
-            "output": msg.output_for_model,
+            "output": msg.output_with_states,
         }
 
     raise ValueError(f"unsupported message type: {msg.type}")

--- a/livekit-agents/livekit/agents/llm/_provider_format/openai.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/openai.py
@@ -97,7 +97,7 @@ def _to_chat_item(msg: llm.ChatItem) -> dict[str, Any]:
         return {
             "role": "tool",
             "tool_call_id": msg.call_id,
-            "content": msg.output_with_states,
+            "content": msg.output_with_metadata,
         }
 
     raise ValueError(f"unsupported message type: {msg.type}")
@@ -205,7 +205,7 @@ def _to_responses_chat_item(msg: llm.ChatItem) -> dict[str, Any]:
         return {
             "type": "function_call_output",
             "call_id": msg.call_id,
-            "output": msg.output_with_states,
+            "output": msg.output_with_metadata,
         }
 
     raise ValueError(f"unsupported message type: {msg.type}")

--- a/livekit-agents/livekit/agents/llm/_provider_format/openai.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/openai.py
@@ -97,7 +97,7 @@ def _to_chat_item(msg: llm.ChatItem) -> dict[str, Any]:
         return {
             "role": "tool",
             "tool_call_id": msg.call_id,
-            "content": msg.output,
+            "content": msg.model_output,
         }
 
     raise ValueError(f"unsupported message type: {msg.type}")
@@ -205,7 +205,7 @@ def _to_responses_chat_item(msg: llm.ChatItem) -> dict[str, Any]:
         return {
             "type": "function_call_output",
             "call_id": msg.call_id,
-            "output": msg.output,
+            "output": msg.model_output,
         }
 
     raise ValueError(f"unsupported message type: {msg.type}")

--- a/livekit-agents/livekit/agents/llm/_provider_format/openai.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/openai.py
@@ -97,7 +97,7 @@ def _to_chat_item(msg: llm.ChatItem) -> dict[str, Any]:
         return {
             "role": "tool",
             "tool_call_id": msg.call_id,
-            "content": msg.model_output,
+            "content": msg.output_for_model,
         }
 
     raise ValueError(f"unsupported message type: {msg.type}")
@@ -205,7 +205,7 @@ def _to_responses_chat_item(msg: llm.ChatItem) -> dict[str, Any]:
         return {
             "type": "function_call_output",
             "call_id": msg.call_id,
-            "output": msg.model_output,
+            "output": msg.output_for_model,
         }
 
     raise ValueError(f"unsupported message type: {msg.type}")

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -386,8 +386,8 @@ class FunctionCallOutput(BaseModel):
     """
 
     @property
-    def output_for_model(self) -> str:
-        """Return the output with its reply delivery state for model inference."""
+    def output_with_states(self) -> str:
+        """Return the output with its framework-managed state metadata."""
         if not self.reply_interrupted:
             return self.output
         return json.dumps({"output": self.output, "reply_interrupted": True}, ensure_ascii=False)
@@ -1043,9 +1043,9 @@ def _function_call_item_to_message(item: FunctionCall | FunctionCallOutput) -> C
             content=[
                 to_xml(
                     "function_call_output",
-                    item.output_for_model
+                    item.output_with_states
                     if not item.is_error
-                    else to_xml("error", item.output_for_model),
+                    else to_xml("error", item.output_with_states),
                     attrs={
                         "call_id": item.call_id,
                         "name": item.name,

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import json
 import textwrap
 import time
 from collections.abc import Generator, Sequence
@@ -375,12 +376,21 @@ class FunctionCallOutput(BaseModel):
     call_id: str
     output: str
     is_error: bool
+    interrupted: bool = False
+    """Whether the assistant reply for this output was interrupted."""
     created_at: float = Field(default_factory=time.time)
     reply_required: bool = Field(default=True)
     """Whether the model should answer once it receives this output.
 
     Only realtime models read it, since they answer a result on their own.
     """
+
+    @property
+    def model_output(self) -> str:
+        """Return the output with its interrupted delivery state for the model."""
+        if not self.interrupted:
+            return self.output
+        return json.dumps({"output": self.output, "interrupted": True}, ensure_ascii=False)
 
 
 class AgentHandoff(BaseModel):
@@ -921,7 +931,8 @@ class ChatContext:
         Comparison rules:
           - Messages: compares the full `content` list, `role` and `interrupted`.
           - Function calls: compares `name`, `call_id`, and `arguments`.
-          - Function call outputs: compares `name`, `call_id`, `output`, and `is_error`.
+          - Function call outputs: compares `name`, `call_id`, `output`, `is_error`, and
+            `interrupted`.
 
         Does not consider timestamps or other metadata.
         """
@@ -949,6 +960,7 @@ class ChatContext:
                     or a.call_id != b.call_id
                     or a.output != b.output
                     or a.is_error != b.is_error
+                    or a.interrupted != b.interrupted
                 ):
                     return False
 
@@ -1031,7 +1043,7 @@ def _function_call_item_to_message(item: FunctionCall | FunctionCallOutput) -> C
             content=[
                 to_xml(
                     "function_call_output",
-                    item.output if not item.is_error else to_xml("error", item.output),
+                    item.model_output if not item.is_error else to_xml("error", item.model_output),
                     attrs={
                         "call_id": item.call_id,
                         "name": item.name,

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -376,8 +376,8 @@ class FunctionCallOutput(BaseModel):
     call_id: str
     output: str
     is_error: bool
-    interrupted: bool = False
-    """Whether the assistant reply for this output was interrupted."""
+    reply_interrupted: bool = False
+    """Whether delivery of the assistant reply for this output was interrupted."""
     created_at: float = Field(default_factory=time.time)
     reply_required: bool = Field(default=True)
     """Whether the model should answer once it receives this output.
@@ -387,10 +387,10 @@ class FunctionCallOutput(BaseModel):
 
     @property
     def model_output(self) -> str:
-        """Return the output with its interrupted delivery state for the model."""
-        if not self.interrupted:
+        """Return the output with the assistant reply delivery state for the model."""
+        if not self.reply_interrupted:
             return self.output
-        return json.dumps({"output": self.output, "interrupted": True}, ensure_ascii=False)
+        return json.dumps({"output": self.output, "reply_interrupted": True}, ensure_ascii=False)
 
 
 class AgentHandoff(BaseModel):
@@ -932,7 +932,7 @@ class ChatContext:
           - Messages: compares the full `content` list, `role` and `interrupted`.
           - Function calls: compares `name`, `call_id`, and `arguments`.
           - Function call outputs: compares `name`, `call_id`, `output`, `is_error`, and
-            `interrupted`.
+            `reply_interrupted`.
 
         Does not consider timestamps or other metadata.
         """
@@ -960,7 +960,7 @@ class ChatContext:
                     or a.call_id != b.call_id
                     or a.output != b.output
                     or a.is_error != b.is_error
-                    or a.interrupted != b.interrupted
+                    or a.reply_interrupted != b.reply_interrupted
                 ):
                     return False
 

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -386,7 +386,7 @@ class FunctionCallOutput(BaseModel):
     """
 
     @property
-    def output_with_states(self) -> str:
+    def output_with_metadata(self) -> str:
         """Return the output with its framework-managed state metadata."""
         if not self.reply_interrupted:
             return self.output
@@ -1043,9 +1043,9 @@ def _function_call_item_to_message(item: FunctionCall | FunctionCallOutput) -> C
             content=[
                 to_xml(
                     "function_call_output",
-                    item.output_with_states
+                    item.output_with_metadata
                     if not item.is_error
-                    else to_xml("error", item.output_with_states),
+                    else to_xml("error", item.output_with_metadata),
                     attrs={
                         "call_id": item.call_id,
                         "name": item.name,

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -386,8 +386,8 @@ class FunctionCallOutput(BaseModel):
     """
 
     @property
-    def model_output(self) -> str:
-        """Return the output with the assistant reply delivery state for the model."""
+    def output_for_model(self) -> str:
+        """Return the output with its reply delivery state for model inference."""
         if not self.reply_interrupted:
             return self.output
         return json.dumps({"output": self.output, "reply_interrupted": True}, ensure_ascii=False)
@@ -1043,7 +1043,9 @@ def _function_call_item_to_message(item: FunctionCall | FunctionCallOutput) -> C
             content=[
                 to_xml(
                     "function_call_output",
-                    item.model_output if not item.is_error else to_xml("error", item.model_output),
+                    item.output_for_model
+                    if not item.is_error
+                    else to_xml("error", item.output_for_model),
                     attrs={
                         "call_id": item.call_id,
                         "name": item.name,

--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -111,6 +111,12 @@ def compute_chat_ctx_diff(old_ctx: ChatContext, new_ctx: ChatContext) -> DiffOps
                 if new_msg.raw_text_content != old_msg.raw_text_content:
                     to_update.append((prev_id, new_msg.id))
                 # TODO: check other content types
+            elif (
+                new_msg.type == "function_call_output"
+                and old_msg.type == "function_call_output"
+                and new_msg.interrupted != old_msg.interrupted
+            ):
+                to_update.append((prev_id, new_msg.id))
 
         prev_id = new_msg.id
 

--- a/livekit-agents/livekit/agents/llm/utils.py
+++ b/livekit-agents/livekit/agents/llm/utils.py
@@ -114,7 +114,7 @@ def compute_chat_ctx_diff(old_ctx: ChatContext, new_ctx: ChatContext) -> DiffOps
             elif (
                 new_msg.type == "function_call_output"
                 and old_msg.type == "function_call_output"
-                and new_msg.interrupted != old_msg.interrupted
+                and new_msg.reply_interrupted != old_msg.reply_interrupted
             ):
                 to_update.append((prev_id, new_msg.id))
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -4106,15 +4106,24 @@ class AgentActivity(RecognitionHooks):
         if trace_text_parts:
             current_span.set_attribute(trace_types.ATTR_RESPONSE_TEXT, "\n".join(trace_text_parts))
 
-        # sync local chat ctx to the realtime server to remove any items the
-        # model added but the user never heard (interrupted before we pulled
-        # them, or message_outputs entries left in "skipped")
-        if speech_handle.interrupted and any_skipped and self.llm.capabilities.mutable_chat_context:
+        # sync local chat ctx to the realtime server after removing messages the user
+        # never heard or marking a committed tool output's reply as interrupted
+        has_interrupted_tool_output = any(
+            isinstance(item, llm.FunctionCallOutput)
+            and item.interrupted
+            and self._agent._chat_ctx.get_by_id(item.id) is not None
+            for item in speech_handle.chat_items
+        )
+        if (
+            speech_handle.interrupted
+            and (any_skipped or has_interrupted_tool_output)
+            and self.llm.capabilities.mutable_chat_context
+        ):
             try:
                 await self._rt_session.update_chat_ctx(self._agent._chat_ctx)
             except llm.RealtimeError as e:
                 logger.warning(
-                    "failed to sync chat context to remove never-played messages",
+                    "failed to sync interrupted realtime chat context",
                     extra={"error": str(e)},
                 )
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -4110,7 +4110,7 @@ class AgentActivity(RecognitionHooks):
         # never heard or marking a committed tool output's reply as interrupted
         has_interrupted_tool_output = any(
             isinstance(item, llm.FunctionCallOutput)
-            and item.interrupted
+            and item.reply_interrupted
             and self._agent._chat_ctx.get_by_id(item.id) is not None
             for item in speech_handle.chat_items
         )

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -1052,6 +1052,7 @@ def _interrupted_tool_output(out: ToolExecutionOutput) -> llm.FunctionCallOutput
     A handoff answers as a failure, since the interruption left it unapplied.
     """
     fnc_call_out = out.fnc_call_out
+    fnc_call_out.interrupted = True
     if out.agent_task is not None:
         fnc_call_out.output = "the agent handoff was interrupted and did not happen"
         fnc_call_out.is_error = True

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -1052,7 +1052,7 @@ def _interrupted_tool_output(out: ToolExecutionOutput) -> llm.FunctionCallOutput
     A handoff answers as a failure, since the interruption left it unapplied.
     """
     fnc_call_out = out.fnc_call_out
-    fnc_call_out.interrupted = True
+    fnc_call_out.reply_interrupted = True
     if out.agent_task is not None:
         fnc_call_out.output = "the agent handoff was interrupted and did not happen"
         fnc_call_out.is_error = True

--- a/livekit-agents/livekit/agents/voice/speech_handle.py
+++ b/livekit-agents/livekit/agents/voice/speech_handle.py
@@ -238,6 +238,9 @@ class SpeechHandle:
 
         if not self._interrupt_fut.done():
             self._interrupt_fut.set_result(None)
+            for item in self._chat_items:
+                if isinstance(item, llm.FunctionCallOutput):
+                    item.interrupted = True
 
             def _on_timeout() -> None:
                 logger.error(
@@ -262,6 +265,9 @@ class SpeechHandle:
 
     def _item_added(self, items: Sequence[llm.ChatItem]) -> None:
         for item in items:
+            if self.interrupted and isinstance(item, llm.FunctionCallOutput):
+                item.interrupted = True
+
             for cb in list(self._item_added_callbacks):
                 try:
                     cb(item)

--- a/livekit-agents/livekit/agents/voice/speech_handle.py
+++ b/livekit-agents/livekit/agents/voice/speech_handle.py
@@ -240,7 +240,7 @@ class SpeechHandle:
             self._interrupt_fut.set_result(None)
             for item in self._chat_items:
                 if isinstance(item, llm.FunctionCallOutput):
-                    item.interrupted = True
+                    item.reply_interrupted = True
 
             def _on_timeout() -> None:
                 logger.error(
@@ -266,7 +266,7 @@ class SpeechHandle:
     def _item_added(self, items: Sequence[llm.ChatItem]) -> None:
         for item in items:
             if self.interrupted and isinstance(item, llm.FunctionCallOutput):
-                item.interrupted = True
+                item.reply_interrupted = True
 
             for cb in list(self._item_added_callbacks):
                 try:

--- a/livekit-agents/livekit/agents/voice/tool_executor.py
+++ b/livekit-agents/livekit/agents/voice/tool_executor.py
@@ -628,7 +628,7 @@ class _ToolExecutor:
                 reply_status = "interrupted"
                 for item in pending_items:
                     if item.type == "function_call_output":
-                        item.interrupted = True
+                        item.reply_interrupted = True
             elif not speech.chat_items:
                 # the LLM judged the content already covered and produced no output
                 reply_status = "skipped"

--- a/livekit-agents/livekit/agents/voice/tool_executor.py
+++ b/livekit-agents/livekit/agents/voice/tool_executor.py
@@ -626,6 +626,9 @@ class _ToolExecutor:
             reply_status: Literal["completed", "interrupted", "skipped"]
             if speech.interrupted:
                 reply_status = "interrupted"
+                for item in pending_items:
+                    if item.type == "function_call_output":
+                        item.interrupted = True
             elif not speech.chat_items:
                 # the LLM judged the content already covered and produced no output
                 reply_status = "skipped"

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -1779,9 +1779,9 @@ class RealtimeSession(  # noqa: F811
 
                 # Format tool result as proper JSON
                 if item.is_error:
-                    tool_result = json.dumps({"error": item.output_with_states})
+                    tool_result = json.dumps({"error": item.output_with_metadata})
                 else:
-                    tool_result = item.output_with_states
+                    tool_result = item.output_with_metadata
 
                 self._tool_results_ch.send_nowait(
                     {

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -1779,9 +1779,9 @@ class RealtimeSession(  # noqa: F811
 
                 # Format tool result as proper JSON
                 if item.is_error:
-                    tool_result = json.dumps({"error": item.model_output})
+                    tool_result = json.dumps({"error": item.output_for_model})
                 else:
-                    tool_result = item.model_output
+                    tool_result = item.output_for_model
 
                 self._tool_results_ch.send_nowait(
                     {

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -1779,9 +1779,9 @@ class RealtimeSession(  # noqa: F811
 
                 # Format tool result as proper JSON
                 if item.is_error:
-                    tool_result = json.dumps({"error": str(item.output)})
+                    tool_result = json.dumps({"error": item.model_output})
                 else:
-                    tool_result = item.output
+                    tool_result = item.model_output
 
                 self._tool_results_ch.send_nowait(
                     {

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -1779,9 +1779,9 @@ class RealtimeSession(  # noqa: F811
 
                 # Format tool result as proper JSON
                 if item.is_error:
-                    tool_result = json.dumps({"error": item.output_for_model})
+                    tool_result = json.dumps({"error": item.output_with_states})
                 else:
-                    tool_result = item.output_for_model
+                    tool_result = item.output_with_states
 
                 self._tool_results_ch.send_nowait(
                     {

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
@@ -68,9 +68,9 @@ def create_function_response(
     res = types.FunctionResponse(
         name=output.name,
         response=(
-            {"error": output.output_for_model}
+            {"error": output.output_with_states}
             if output.is_error
-            else {"output": output.output_for_model}
+            else {"output": output.output_with_states}
         ),
     )
     if not vertexai:

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
@@ -68,9 +68,9 @@ def create_function_response(
     res = types.FunctionResponse(
         name=output.name,
         response=(
-            {"error": output.output_with_states}
+            {"error": output.output_with_metadata}
             if output.is_error
-            else {"output": output.output_with_states}
+            else {"output": output.output_with_metadata}
         ),
     )
     if not vertexai:

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
@@ -68,7 +68,9 @@ def create_function_response(
     res = types.FunctionResponse(
         name=output.name,
         response=(
-            {"error": output.model_output} if output.is_error else {"output": output.model_output}
+            {"error": output.output_for_model}
+            if output.is_error
+            else {"output": output.output_for_model}
         ),
     )
     if not vertexai:

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
@@ -67,7 +67,9 @@ def create_function_response(
 ) -> types.FunctionResponse:
     res = types.FunctionResponse(
         name=output.name,
-        response={"error": output.output} if output.is_error else {"output": output.output},
+        response=(
+            {"error": output.model_output} if output.is_error else {"output": output.model_output}
+        ),
     )
     if not vertexai:
         # vertexai supports neither scheduling nor id in FunctionResponse; the gemini api

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/utils.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/utils.py
@@ -160,11 +160,11 @@ def livekit_item_to_openai_item(item: llm.ChatItem) -> realtime.ConversationItem
             id=item.id,
             type="function_call_output",
             call_id=_shorten_call_id(item.call_id),
-            output=item.model_output,
+            output=item.output_for_model,
         )
         conversation_item.type = "function_call_output"
         conversation_item.call_id = _shorten_call_id(item.call_id)
-        conversation_item.output = item.model_output
+        conversation_item.output = item.output_for_model
 
     elif item.type == "message":
         if item.role == "system" or item.role == "developer":

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/utils.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/utils.py
@@ -160,11 +160,11 @@ def livekit_item_to_openai_item(item: llm.ChatItem) -> realtime.ConversationItem
             id=item.id,
             type="function_call_output",
             call_id=_shorten_call_id(item.call_id),
-            output=item.output_for_model,
+            output=item.output_with_states,
         )
         conversation_item.type = "function_call_output"
         conversation_item.call_id = _shorten_call_id(item.call_id)
-        conversation_item.output = item.output_for_model
+        conversation_item.output = item.output_with_states
 
     elif item.type == "message":
         if item.role == "system" or item.role == "developer":

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/utils.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/utils.py
@@ -160,11 +160,11 @@ def livekit_item_to_openai_item(item: llm.ChatItem) -> realtime.ConversationItem
             id=item.id,
             type="function_call_output",
             call_id=_shorten_call_id(item.call_id),
-            output=item.output_with_states,
+            output=item.output_with_metadata,
         )
         conversation_item.type = "function_call_output"
         conversation_item.call_id = _shorten_call_id(item.call_id)
-        conversation_item.output = item.output_with_states
+        conversation_item.output = item.output_with_metadata
 
     elif item.type == "message":
         if item.role == "system" or item.role == "developer":

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/utils.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/utils.py
@@ -160,11 +160,11 @@ def livekit_item_to_openai_item(item: llm.ChatItem) -> realtime.ConversationItem
             id=item.id,
             type="function_call_output",
             call_id=_shorten_call_id(item.call_id),
-            output=item.output,
+            output=item.model_output,
         )
         conversation_item.type = "function_call_output"
         conversation_item.call_id = _shorten_call_id(item.call_id)
-        conversation_item.output = item.output
+        conversation_item.output = item.model_output
 
     elif item.type == "message":
         if item.role == "system" or item.role == "developer":

--- a/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
@@ -482,7 +482,7 @@ class RealtimeSession(llm.RealtimeSession):
                     await self._socket.send_tool_call_output(
                         ToolCallOutputPayload(
                             tool_call_id=item.call_id,
-                            output=item.model_output,
+                            output=item.output_for_model,
                         )
                     )
                     sent_tool_call_output = True

--- a/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
@@ -482,7 +482,7 @@ class RealtimeSession(llm.RealtimeSession):
                     await self._socket.send_tool_call_output(
                         ToolCallOutputPayload(
                             tool_call_id=item.call_id,
-                            output=item.output_with_states,
+                            output=item.output_with_metadata,
                         )
                     )
                     sent_tool_call_output = True

--- a/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
@@ -482,7 +482,7 @@ class RealtimeSession(llm.RealtimeSession):
                     await self._socket.send_tool_call_output(
                         ToolCallOutputPayload(
                             tool_call_id=item.call_id,
-                            output=item.output_for_model,
+                            output=item.output_with_states,
                         )
                     )
                     sent_tool_call_output = True

--- a/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
@@ -482,7 +482,7 @@ class RealtimeSession(llm.RealtimeSession):
                     await self._socket.send_tool_call_output(
                         ToolCallOutputPayload(
                             tool_call_id=item.call_id,
-                            output=str(item.output),
+                            output=item.model_output,
                         )
                     )
                     sent_tool_call_output = True

--- a/livekit-plugins/livekit-plugins-ultravox/livekit/plugins/ultravox/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-ultravox/livekit/plugins/ultravox/realtime/realtime_model.py
@@ -407,11 +407,11 @@ class RealtimeSession(
 
                 if getattr(item, "is_error", False):
                     tool_result.error_type = "implementation-error"
-                    tool_result.error_message = getattr(item, "error_message", None) or str(
-                        getattr(item, "output", "")
+                    tool_result.error_message = (
+                        getattr(item, "error_message", None) or item.model_output
                     )
                 else:
-                    tool_result.result = str(getattr(item, "output", ""))
+                    tool_result.result = item.model_output
 
                 self._send_client_event(tool_result)
 

--- a/livekit-plugins/livekit-plugins-ultravox/livekit/plugins/ultravox/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-ultravox/livekit/plugins/ultravox/realtime/realtime_model.py
@@ -408,10 +408,10 @@ class RealtimeSession(
                 if getattr(item, "is_error", False):
                     tool_result.error_type = "implementation-error"
                     tool_result.error_message = (
-                        getattr(item, "error_message", None) or item.output_with_states
+                        getattr(item, "error_message", None) or item.output_with_metadata
                     )
                 else:
-                    tool_result.result = item.output_with_states
+                    tool_result.result = item.output_with_metadata
 
                 self._send_client_event(tool_result)
 

--- a/livekit-plugins/livekit-plugins-ultravox/livekit/plugins/ultravox/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-ultravox/livekit/plugins/ultravox/realtime/realtime_model.py
@@ -408,10 +408,10 @@ class RealtimeSession(
                 if getattr(item, "is_error", False):
                     tool_result.error_type = "implementation-error"
                     tool_result.error_message = (
-                        getattr(item, "error_message", None) or item.model_output
+                        getattr(item, "error_message", None) or item.output_for_model
                     )
                 else:
-                    tool_result.result = item.model_output
+                    tool_result.result = item.output_for_model
 
                 self._send_client_event(tool_result)
 

--- a/livekit-plugins/livekit-plugins-ultravox/livekit/plugins/ultravox/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-ultravox/livekit/plugins/ultravox/realtime/realtime_model.py
@@ -408,10 +408,10 @@ class RealtimeSession(
                 if getattr(item, "is_error", False):
                     tool_result.error_type = "implementation-error"
                     tool_result.error_message = (
-                        getattr(item, "error_message", None) or item.output_for_model
+                        getattr(item, "error_message", None) or item.output_with_states
                     )
                 else:
-                    tool_result.result = item.output_for_model
+                    tool_result.result = item.output_with_states
 
                 self._send_client_event(tool_result)
 

--- a/tests/test_chat_ctx.py
+++ b/tests/test_chat_ctx.py
@@ -137,7 +137,7 @@ def test_chat_ctx_can_be_serialized_and_deserialized_with_defaults():
 def test_normal_tool_output_is_unchanged_for_the_model() -> None:
     output = FunctionCallOutput(name="lookup", call_id="call-1", output="sunny", is_error=False)
 
-    assert output.output_for_model == "sunny"
+    assert output.output_with_states == "sunny"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_chat_ctx.py
+++ b/tests/test_chat_ctx.py
@@ -137,7 +137,7 @@ def test_chat_ctx_can_be_serialized_and_deserialized_with_defaults():
 def test_normal_tool_output_is_unchanged_for_the_model() -> None:
     output = FunctionCallOutput(name="lookup", call_id="call-1", output="sunny", is_error=False)
 
-    assert output.output_with_states == "sunny"
+    assert output.output_with_metadata == "sunny"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_chat_ctx.py
+++ b/tests/test_chat_ctx.py
@@ -165,14 +165,17 @@ def test_interrupted_tool_output_is_marked_for_the_model(
                 call_id="call-1",
                 output="sunny",
                 is_error=False,
-                interrupted=True,
+                reply_interrupted=True,
             ),
         ]
     )
 
     items, _ = chat_ctx.to_provider_format(format=provider_format)
 
-    assert json.loads(extract_output(items)) == {"output": "sunny", "interrupted": True}
+    assert json.loads(extract_output(items)) == {
+        "output": "sunny",
+        "reply_interrupted": True,
+    }
 
 
 @skip_if_no_credentials()

--- a/tests/test_chat_ctx.py
+++ b/tests/test_chat_ctx.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import os
 from typing import Any
 
@@ -131,6 +132,47 @@ def test_chat_ctx_can_be_serialized_and_deserialized_with_defaults():
     ]
     chat_ctx = ChatContext(items)
     assert chat_ctx.is_equivalent(ChatContext.from_dict(chat_ctx.to_dict()))
+
+
+def test_normal_tool_output_is_unchanged_for_the_model() -> None:
+    output = FunctionCallOutput(name="lookup", call_id="call-1", output="sunny", is_error=False)
+
+    assert output.model_output == "sunny"
+
+
+@pytest.mark.parametrize(
+    ("provider_format", "extract_output"),
+    [
+        ("openai", lambda items: items[1]["content"]),
+        ("openai.responses", lambda items: items[1]["output"]),
+        ("anthropic", lambda items: items[2]["content"][0]["content"]),
+        (
+            "google",
+            lambda items: items[1]["parts"][0]["function_response"]["response"]["output"],
+        ),
+        ("aws", lambda items: items[2]["content"][0]["toolResult"]["content"][0]["text"]),
+        ("mistralai", lambda items: items[1]["result"]),
+    ],
+)
+def test_interrupted_tool_output_is_marked_for_the_model(
+    provider_format: str, extract_output: Any
+) -> None:
+    chat_ctx = ChatContext(
+        [
+            FunctionCall(name="lookup", call_id="call-1", arguments="{}"),
+            FunctionCallOutput(
+                name="lookup",
+                call_id="call-1",
+                output="sunny",
+                is_error=False,
+                interrupted=True,
+            ),
+        ]
+    )
+
+    items, _ = chat_ctx.to_provider_format(format=provider_format)
+
+    assert json.loads(extract_output(items)) == {"output": "sunny", "interrupted": True}
 
 
 @skip_if_no_credentials()

--- a/tests/test_chat_ctx.py
+++ b/tests/test_chat_ctx.py
@@ -137,7 +137,7 @@ def test_chat_ctx_can_be_serialized_and_deserialized_with_defaults():
 def test_normal_tool_output_is_unchanged_for_the_model() -> None:
     output = FunctionCallOutput(name="lookup", call_id="call-1", output="sunny", is_error=False)
 
-    assert output.model_output == "sunny"
+    assert output.output_for_model == "sunny"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_openai_realtime_chat_ctx.py
+++ b/tests/test_openai_realtime_chat_ctx.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import types
 from unittest.mock import Mock
 
@@ -142,3 +143,40 @@ def test_short_call_id_is_unchanged() -> None:
         llm.FunctionCall(id="item_1", call_id="call_abc", name="get_weather", arguments="{}")
     )
     assert call.call_id == "call_abc"
+
+
+def test_interrupted_tool_output_is_marked_for_realtime() -> None:
+    from livekit.plugins.openai.realtime.utils import livekit_item_to_openai_item
+
+    output = livekit_item_to_openai_item(
+        llm.FunctionCallOutput(
+            id="item_1",
+            call_id="call_abc",
+            output="sunny",
+            is_error=False,
+            interrupted=True,
+        )
+    )
+
+    assert output.output is not None
+    assert json.loads(output.output) == {"output": "sunny", "interrupted": True}
+
+
+def test_interrupted_tool_output_replaces_realtime_context_item() -> None:
+    from openai.types.realtime import ConversationItemCreateEvent
+
+    session = _create_session()
+    original = llm.FunctionCallOutput(
+        id="item_1", call_id="call_abc", output="sunny", is_error=False
+    )
+    session._remote_chat_ctx.insert(None, original)
+
+    chat_ctx = llm.ChatContext([original.model_copy(update={"interrupted": True})])
+
+    events = session._create_update_chat_ctx_events(chat_ctx)
+
+    assert len(events) == 2
+    assert isinstance(events[1], ConversationItemCreateEvent)
+    recreated = events[1].item
+    assert recreated.output is not None
+    assert json.loads(recreated.output) == {"output": "sunny", "interrupted": True}

--- a/tests/test_openai_realtime_chat_ctx.py
+++ b/tests/test_openai_realtime_chat_ctx.py
@@ -154,12 +154,15 @@ def test_interrupted_tool_output_is_marked_for_realtime() -> None:
             call_id="call_abc",
             output="sunny",
             is_error=False,
-            interrupted=True,
+            reply_interrupted=True,
         )
     )
 
     assert output.output is not None
-    assert json.loads(output.output) == {"output": "sunny", "interrupted": True}
+    assert json.loads(output.output) == {
+        "output": "sunny",
+        "reply_interrupted": True,
+    }
 
 
 def test_interrupted_tool_output_replaces_realtime_context_item() -> None:
@@ -171,7 +174,7 @@ def test_interrupted_tool_output_replaces_realtime_context_item() -> None:
     )
     session._remote_chat_ctx.insert(None, original)
 
-    chat_ctx = llm.ChatContext([original.model_copy(update={"interrupted": True})])
+    chat_ctx = llm.ChatContext([original.model_copy(update={"reply_interrupted": True})])
 
     events = session._create_update_chat_ctx_events(chat_ctx)
 
@@ -179,4 +182,7 @@ def test_interrupted_tool_output_replaces_realtime_context_item() -> None:
     assert isinstance(events[1], ConversationItemCreateEvent)
     recreated = events[1].item
     assert recreated.output is not None
-    assert json.loads(recreated.output) == {"output": "sunny", "interrupted": True}
+    assert json.loads(recreated.output) == {
+        "output": "sunny",
+        "reply_interrupted": True,
+    }

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -264,6 +265,19 @@ def test_function_response_scheduling_only_for_gemini_api(vertexai: bool) -> Non
     else:
         assert res.scheduling == types.FunctionResponseScheduling.SILENT
         assert res.id == "fc_1"
+
+
+def test_interrupted_tool_output_is_marked_in_function_response() -> None:
+    output = _tool_output()
+    output.interrupted = True
+
+    response = create_function_response(output)
+
+    assert response.response is not None
+    assert json.loads(response.response["output"]) == {
+        "output": "42",
+        "interrupted": True,
+    }
 
 
 def test_vertex_scheduling_warns(

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -269,14 +269,14 @@ def test_function_response_scheduling_only_for_gemini_api(vertexai: bool) -> Non
 
 def test_interrupted_tool_output_is_marked_in_function_response() -> None:
     output = _tool_output()
-    output.interrupted = True
+    output.reply_interrupted = True
 
     response = create_function_response(output)
 
     assert response.response is not None
     assert json.loads(response.response["output"]) == {
         "output": "42",
-        "interrupted": True,
+        "reply_interrupted": True,
     }
 
 

--- a/tests/test_tool_results_preserved_on_interruption.py
+++ b/tests/test_tool_results_preserved_on_interruption.py
@@ -107,6 +107,9 @@ async def test_tool_results_preserved_when_tool_reply_turn_interrupted(
 
     assert forced_schedules, "the tool reply turn was never scheduled; the test needs updating"
     _assert_weather_tool_preserved(agent, session)
+    for items in (agent.chat_ctx.items, session.history.items):
+        output = next(item for item in items if item.type == "function_call_output")
+        assert output.interrupted
 
     # the interrupted tool reply turn never spoke, its message must not appear
     assistant_texts = [

--- a/tests/test_tool_results_preserved_on_interruption.py
+++ b/tests/test_tool_results_preserved_on_interruption.py
@@ -109,7 +109,7 @@ async def test_tool_results_preserved_when_tool_reply_turn_interrupted(
     _assert_weather_tool_preserved(agent, session)
     for items in (agent.chat_ctx.items, session.history.items):
         output = next(item for item in items if item.type == "function_call_output")
-        assert output.interrupted
+        assert output.reply_interrupted
 
     # the interrupted tool reply turn never spoke, its message must not appear
     assistant_texts = [
@@ -263,6 +263,7 @@ async def test_realtime_tool_results_preserved_and_synced_when_interrupted() -> 
     synced = [i for i in model.active_session.chat_ctx.items if i.type == "function_call_output"]
     assert len(synced) == 1, "the tool output was never synced to the realtime session"
     assert synced[0].call_id == "1"
+    assert synced[0].reply_interrupted
     assert not synced[0].reply_required
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2258,7 +2258,7 @@ class TestToolCallEvents:
             assert last.status == expected
             deferred_outputs = [output for _, output in run_ctx._updates[1:]]
             assert deferred_outputs
-            assert all(output.interrupted is interrupted for output in deferred_outputs)
+            assert all(output.reply_interrupted is interrupted for output in deferred_outputs)
 
     @pytest.mark.asyncio
     async def test_error_after_update_is_deferred_with_final_id(self):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2256,6 +2256,9 @@ class TestToolCallEvents:
             last = _emitted_items(session)[-1]
             assert isinstance(last, ToolReplyUpdated)
             assert last.status == expected
+            deferred_outputs = [output for _, output in run_ctx._updates[1:]]
+            assert deferred_outputs
+            assert all(output.interrupted is interrupted for output in deferred_outputs)
 
     @pytest.mark.asyncio
     async def test_error_after_update_is_deferred_with_final_id(self):


### PR DESCRIPTION
**Why**

Tool outputs remain in chat history after execution. If the user interrupts their spoken reply, the next LLM turn can treat that explanation as delivered and return no reply.

**Behavior**

Expose incomplete delivery as `{"output":"...","reply_interrupted":true}`. Normal tool outputs stay unchanged, and immediate commits keep tools with side effects from being replayed.

Addresses AGT-3295

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> so today, we commit the tool output after execution, but if the user interrupts the tool reply, llm might treat the tool output as spoken and skips the reply altogether in the new reply. We should try wrapping the tool output with some kind of interrupted:bool flag so it is clear to them that it is delivered or not.
>
> The last thing I want to do is to modify the chat context as it is fairly complex already to maintain the contract between the user and the framework.
>
> okay, let's make the field "reply_interrupted"

</details>
