### PR TITLE
fix(agents): refuse a second inline AgentTask on the same activity

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -1065,8 +1065,6 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                 await session._update_activity(
                     old_agent, new_activity="resume", wait_on_enter=False
                 )
-            # released only now: the activity is free for another inline task once it has
-            # been resumed, not while the resume is still in flight.
             old_activity._inline_task = None
             self.__inactive_ev.set()
 

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -902,6 +902,27 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                 f"{self.__class__.__name__} cannot be awaited inside a function tool that is already interrupted"
             )
 
+        # Parallel tool calls put every awaited task in the same turn, each pausing the
+        # same activity. Only the last handoff survives, and the others are left waiting
+        # on a result that can no longer be produced - the function calls never return,
+        # so the speech never finishes and the session wedges until close times out.
+        # Refusing the second is what the returned-AgentTask path already does when a
+        # turn yields more than one ("expected to receive only one AgentTask from the
+        # tool executions").
+        #
+        # Raised rather than completed: complete() also hands the result to the enclosing
+        # speech handle, which would make this refusal the whole run's final output. The
+        # claim goes after the interrupted check and before the speech handle is mutated
+        # below, so a refused task leaves both untouched, and the check and the claim stay
+        # in one synchronous block or two tasks both pass the check.
+        if (busy := old_activity._inline_task) is not None:
+            raise ToolError(
+                f"cannot start {self.__class__.__name__}: {busy.__class__.__name__} is "
+                "already running for this turn, and only one can run at a time"
+            )
+
+        old_activity._inline_task = self
+
         def _handle_task_done(_: asyncio.Task[Any]) -> None:
             if self.__fut.done():
                 return
@@ -1001,6 +1022,7 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                 if suspended_handles:
                     run_state._mark_done_if_needed(None)
         except Exception:
+            old_activity._inline_task = None
             self.__inactive_ev.set()
             raise
 
@@ -1049,6 +1071,9 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                 await session._update_activity(
                     old_agent, new_activity="resume", wait_on_enter=False
                 )
+            # released only now: the activity is free for another inline task once it has
+            # been resumed, not while the resume is still in flight.
+            old_activity._inline_task = None
             self.__inactive_ev.set()
 
     def __await__(self) -> Generator[None, None, TaskResult_T]:

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -903,14 +903,6 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                 f"{self.__class__.__name__} cannot be awaited inside a function tool that is already interrupted"
             )
 
-        # An activity holds at most one paused inline task - the awaited path's form of the
-        # one-per-turn rule the returned-AgentTask path enforces ("expected to receive only
-        # one AgentTask from the tool executions").
-        #
-        # Raising rather than completing keeps the refusal off the enclosing speech handle,
-        # whose final output complete() also assigns. Placed after the interrupted check and
-        # before the speech handle is mutated below, a refusal leaves both untouched. Check
-        # and claim stay in one synchronous block, or both tasks pass the check.
         if (busy := old_activity._inline_task) is not None:
             raise ToolError(
                 f"cannot start {self.__class__.__name__}: {busy.__class__.__name__} is "

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -1015,7 +1015,8 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                         suspended_handles.append(blocked)
                 if suspended_handles:
                     run_state._mark_done_if_needed(None)
-        except Exception:
+        # BaseException, so a cancellation landing on the handoff still frees the activity
+        except BaseException:
             old_activity._inline_task = None
             self.__inactive_ev.set()
             raise

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -1007,7 +1007,7 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                         suspended_handles.append(blocked)
                 if suspended_handles:
                     run_state._mark_done_if_needed(None)
-        # BaseException, so a cancellation landing on the handoff still frees the activity
+        # asyncio.CancelledError derives from BaseException, not Exception
         except BaseException:
             old_activity._inline_task = None
             self.__inactive_ev.set()

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -889,6 +889,7 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                 f"{self.__class__.__name__} should only be awaited inside tool_functions or the on_enter/on_exit methods of an Agent"  # noqa: E501
             )
 
+        # imported at call time: agent_activity imports Agent at module scope, so the reverse can't
         from .agent_activity import _AgentActivityContextVar, _SpeechHandleContextVar
 
         speech_handle = _SpeechHandleContextVar.get(None)

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -889,6 +889,19 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                 f"{self.__class__.__name__} should only be awaited inside tool_functions or the on_enter/on_exit methods of an Agent"  # noqa: E501
             )
 
+        from .agent_activity import _AgentActivityContextVar, _SpeechHandleContextVar
+
+        speech_handle = _SpeechHandleContextVar.get(None)
+        old_activity = _AgentActivityContextVar.get()
+        old_agent = old_activity.agent
+        session = old_activity.session
+        self._old_agent = old_agent
+
+        if speech_handle and speech_handle.interrupted:
+            raise RuntimeError(
+                f"{self.__class__.__name__} cannot be awaited inside a function tool that is already interrupted"
+            )
+
         def _handle_task_done(_: asyncio.Task[Any]) -> None:
             if self.__fut.done():
                 return
@@ -905,26 +918,12 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                 )
             )
 
+        # registered only past the checks above: they raise instead of completing the task,
+        # so an early exit must not report the task as finishing prematurely
         current_task.add_done_callback(_handle_task_done)
-
-        from .agent_activity import _AgentActivityContextVar, _SpeechHandleContextVar
-
-        # TODO(theomonnom): add a global lock for inline tasks
-        # This may currently break in the case we use parallel tool calls.
-
-        speech_handle = _SpeechHandleContextVar.get(None)
-        old_activity = _AgentActivityContextVar.get()
-        old_agent = old_activity.agent
-        session = old_activity.session
-        self._old_agent = old_agent
 
         old_allow_interruptions = True
         if speech_handle:
-            if speech_handle.interrupted:
-                raise RuntimeError(
-                    f"{self.__class__.__name__} cannot be awaited inside a function tool that is already interrupted"
-                )
-
             # lock the speech handle to prevent interruptions until the task is complete
             # there should be no await before this line to avoid race conditions
             old_allow_interruptions = speech_handle.allow_interruptions

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -903,19 +903,14 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                 f"{self.__class__.__name__} cannot be awaited inside a function tool that is already interrupted"
             )
 
-        # Parallel tool calls put every awaited task in the same turn, each pausing the
-        # same activity. Only the last handoff survives, and the others are left waiting
-        # on a result that can no longer be produced - the function calls never return,
-        # so the speech never finishes and the session wedges until close times out.
-        # Refusing the second is what the returned-AgentTask path already does when a
-        # turn yields more than one ("expected to receive only one AgentTask from the
-        # tool executions").
+        # An activity holds at most one paused inline task - the awaited path's form of the
+        # one-per-turn rule the returned-AgentTask path enforces ("expected to receive only
+        # one AgentTask from the tool executions").
         #
-        # Raised rather than completed: complete() also hands the result to the enclosing
-        # speech handle, which would make this refusal the whole run's final output. The
-        # claim goes after the interrupted check and before the speech handle is mutated
-        # below, so a refused task leaves both untouched, and the check and the claim stay
-        # in one synchronous block or two tasks both pass the check.
+        # Raising rather than completing keeps the refusal off the enclosing speech handle,
+        # whose final output complete() also assigns. Placed after the interrupted check and
+        # before the speech handle is mutated below, a refusal leaves both untouched. Check
+        # and claim stay in one synchronous block, or both tasks pass the check.
         if (busy := old_activity._inline_task) is not None:
             raise ToolError(
                 f"cannot start {self.__class__.__name__}: {busy.__class__.__name__} is "

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -935,8 +935,6 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                 )
             )
 
-        # registered only past the checks above: they raise instead of completing the task,
-        # so an early exit must not report the task as finishing prematurely
         current_task.add_done_callback(_handle_task_done)
 
         old_allow_interruptions = True

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -39,6 +39,7 @@ from ..utils.misc import is_given
 from ._utils import _set_participant_attributes
 from .agent import (
     Agent,
+    AgentTask,
     ModelSettings,
     _get_activity_task_info,
     _set_activity_task_info,
@@ -225,6 +226,13 @@ class AgentActivity(RecognitionHooks):
         self._authorization_allowed.set()
 
         self._drain_blocked_tasks: set[asyncio.Task[Any]] = set()
+        # At most one inline AgentTask may pause this activity at a time: a second
+        # concurrent handoff overwrites the first one's agent switch, and the loser is
+        # then never active again, so nothing ever completes it - it awaits its result
+        # forever and its function call never returns. Held from before the pause until
+        # after the resume. Nested inline tasks pause different activities, so they
+        # never contend for this.
+        self._inline_task: AgentTask[Any] | None = None
         self._mcp_tools: list[mcp.MCPToolset] = []
 
         # activity-scoped executor: cancels cancellable tools / awaits the rest on drain,

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -226,12 +226,8 @@ class AgentActivity(RecognitionHooks):
         self._authorization_allowed.set()
 
         self._drain_blocked_tasks: set[asyncio.Task[Any]] = set()
-        # At most one inline AgentTask may pause this activity at a time: a second
-        # concurrent handoff overwrites the first one's agent switch, and the loser is
-        # then never active again, so nothing ever completes it - it awaits its result
-        # forever and its function call never returns. Held from before the pause until
-        # after the resume. Nested inline tasks pause different activities, so they
-        # never contend for this.
+        # The inline AgentTask that paused this activity, held from before the pause until
+        # after the resume. At most one at a time.
         self._inline_task: AgentTask[Any] | None = None
         self._mcp_tools: list[mcp.MCPToolset] = []
 

--- a/tests/test_nested_agent_task.py
+++ b/tests/test_nested_agent_task.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 
 import pytest
 
 from livekit.agents import Agent, AgentSession, AgentTask, RunContext, function_tool
-from livekit.agents.llm import FunctionToolCall
+from livekit.agents.llm import FunctionToolCall, ToolError
 
 from .fake_llm import FakeLLM, FakeLLMResponse
 
@@ -150,6 +151,111 @@ async def test_handoff_from_pre_run_speech():
 
         await asyncio.wait_for(sess.run(user_input="bye"), timeout=5.0)
         assert isinstance(sess.current_agent, EnterHandoffAgent)
+
+
+class DialogTask(AgentTask):
+    """A task that needs a user turn to complete, like a detail-capture dialog."""
+
+    def __init__(self) -> None:
+        super().__init__(instructions="dialog task")
+
+    async def on_enter(self) -> None:
+        self.session.generate_reply(instructions="dialog_greeting")
+
+    @function_tool
+    async def finish(self, ctx: RunContext) -> str:
+        """Called to complete the dialog."""
+        self.complete(None)
+        return "done"
+
+
+class ParallelDialogAgent(Agent):
+    """Two tools that each await an AgentTask, for an LLM turn that calls both."""
+
+    def __init__(self) -> None:
+        super().__init__(instructions="root agent")
+        self.outcomes: list[str] = []
+
+    @function_tool
+    async def open_name_dialog(self, ctx: RunContext) -> str:
+        """Collects the name."""
+        return await self._open("name")
+
+    @function_tool
+    async def open_email_dialog(self, ctx: RunContext) -> str:
+        """Collects the email."""
+        return await self._open("email")
+
+    async def _open(self, which: str) -> str:
+        # a refusal is reported back as the tool's output, the way the model would see
+        # it; re-raising would instead surface through the awaiting session.run()
+        try:
+            await DialogTask()
+        except ToolError as e:
+            self.outcomes.append(f"{which}:refused")
+            return f"{which} refused: {e}"
+        self.outcomes.append(f"{which}:ran")
+        return f"{which} captured"
+
+
+@pytest.mark.asyncio
+async def test_parallel_agent_tasks_refuse_the_second() -> None:
+    """Two AgentTasks awaited from one turn's parallel tool calls contend for the same
+    activity. Only one may pause it: the other's handoff would be overwritten, leaving it
+    waiting on a result nothing can produce, so its function call never returns and the
+    speech never finishes. The second is refused with a ToolError instead."""
+    llm = FakeLLM(
+        fake_responses=[
+            # one turn, two tool calls - each tool awaits a DialogTask
+            FakeLLMResponse(
+                input="go",
+                content="",
+                ttft=0,
+                duration=0,
+                tool_calls=[
+                    FunctionToolCall(name="open_name_dialog", arguments="{}", call_id="call_1"),
+                    FunctionToolCall(name="open_email_dialog", arguments="{}", call_id="call_2"),
+                ],
+            ),
+            FakeLLMResponse(input="dialog_greeting", content="what is it?", ttft=0, duration=0),
+            # user answers the dialog that did run -> it completes and hands back
+            FakeLLMResponse(
+                input="done",
+                content="",
+                ttft=0,
+                duration=0,
+                tool_calls=[FunctionToolCall(name="finish", arguments="{}", call_id="call_3")],
+            ),
+        ]
+    )
+    agent = ParallelDialogAgent()
+    sess = AgentSession(llm=llm)
+    try:
+        await sess.start(agent)
+
+        await asyncio.wait_for(sess.run(user_input="go"), timeout=5.0)
+        assert isinstance(sess.current_agent, DialogTask)
+
+        await asyncio.wait_for(sess.run(user_input="done"), timeout=5.0)
+        assert isinstance(sess.current_agent, ParallelDialogAgent)
+    finally:
+        # a refused task that instead hung would leave its function call unfinished, and
+        # the close waiting on it - bounded so that regression reports these assertions
+        # rather than stalling the loop with nothing left to schedule
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(sess.aclose(), timeout=30.0)
+
+    assert sorted(o.split(":")[1] for o in agent.outcomes) == ["ran", "refused"]
+
+    # both calls carry an output: neither func_exec was left awaiting a result forever
+    outputs = {
+        item.call_id: item.output
+        for item in agent.chat_ctx.items
+        if item.type == "function_call_output" and item.call_id in ("call_1", "call_2")
+    }
+    assert set(outputs) == {"call_1", "call_2"}
+    # the refusal reaches the model rather than being silently dropped
+    assert sum(1 for out in outputs.values() if "refused" in out) == 1
 
 
 def _build_fake_llm() -> FakeLLM:


### PR DESCRIPTION
An LLM turn with parallel tool calls can await an `AgentTask` from more than one call; each pauses the same activity, only the last handoff survives, and the losers are never active again so nothing completes them — their function calls never return and the session hangs until close times out. `AgentActivity` now records the inline task that paused it, and a second one awaited while the first is still in flight raises `ToolError`, which is the rule the returned-`AgentTask` path already enforces via `expected to receive only one AgentTask from the tool executions`. The replaced TODO asked for a global lock, but one held across the task's lifetime would deadlock the supported nesting pattern, where an outer task holds it while awaiting an inner one whose own tool needs it to progress.
