### PR TITLE
feat: Microsoft Teams calls by StandIn (livekit-plugins-standin)

### DIFF
--- a/examples/msteams/.gitignore
+++ b/examples/msteams/.gitignore
@@ -1,0 +1,3 @@
+.venv
+.env
+uv.lock

--- a/examples/msteams/README.md
+++ b/examples/msteams/README.md
@@ -19,7 +19,7 @@ LIVEKIT_API_KEY=...
 LIVEKIT_API_SECRET=...
 ```
 
-Put those in `.env`, run the worker, then expose its port with a tunnel or ingress and register the public URL in the StandIn portal as the agent voice URL: `wss://<your-host>/msteams/calling`.
+Put those in `.env`, run the worker, then expose its port (9442 by default) with a tunnel or ingress, for example `tailscale funnel --bg --set-path /msteams/calling http://127.0.0.1:9442/msteams/calling`, and register the public URL in the StandIn portal as the agent voice URL: `wss://<your-host>/msteams/calling`.
 
 ## What the agent gets
 

--- a/examples/msteams/README.md
+++ b/examples/msteams/README.md
@@ -1,0 +1,32 @@
+# Microsoft Teams plugin by StandIn for LiveKit Agents
+
+A LiveKit agent that answers **Microsoft Teams** calls, through [StandIn](https://standin.komaa.com).
+
+One file, one process, run like any other agent worker:
+
+```bash
+uv sync
+uv run python -m livekit.agents download-files 
+uv run agent.py dev
+```
+
+## Setup
+
+```bash
+STANDIN_SECRET=...            # the connection secret from the StandIn portal
+LIVEKIT_URL=wss://your-project.livekit.cloud
+LIVEKIT_API_KEY=...
+LIVEKIT_API_SECRET=...
+```
+
+Put those in `.env`, run the worker, then expose its port with a tunnel or ingress and register the public URL in the StandIn portal as the agent voice URL: `wss://<your-host>/msteams/calling`.
+
+## What the agent gets
+
+`CallInfo` carries `call_id`, `thread_id`, `caller_name`, `user_id` (the caller's AAD id when Teams provides one), `tenant_id` and `direction`. `call.is_teams_call` is False when the job came from somewhere else, so one worker can serve Teams, SIP and web rooms at the same time.
+
+Two data topics, both handled in `worker.py`:
+
+- `standin.TOPIC_CONTEXT` - participant count, Teams recording state, DTMF digits
+- `standin.TOPIC_GOODBYE` - StandIn's governor is ending the call and wants the agent to say this first, so interrupt the current turn to deliver it
+

--- a/examples/msteams/agent.py
+++ b/examples/msteams/agent.py
@@ -1,0 +1,77 @@
+import os
+
+from dotenv import load_dotenv
+
+from livekit.agents import (
+    Agent,
+    AgentServer,
+    AgentSession,
+    JobContext,
+    cli,
+)
+from livekit.plugins import openai, standin
+
+load_dotenv()
+
+server = AgentServer(
+    api_key=os.environ["LIVEKIT_API_KEY"],
+    api_secret=os.environ["LIVEKIT_API_SECRET"],
+    ws_url=os.environ["LIVEKIT_URL"],
+)
+
+
+class MyAgent(Agent):
+    def __init__(self, call: standin.CallInfo) -> None:
+        # The caller arrives in the job metadata, so the agent is personalized
+        # before the first word. The caller's voice is published into the room
+        # by the plugin's "standin-bridge" participant.
+        who = call.caller_name or "the caller"
+        super().__init__(
+            instructions=(
+                f"You are a helpful colleague on a Microsoft Teams call with {who}. "
+                "You are speaking out loud, so keep replies short and conversational. "
+                "Do not use emojis, asterisks, markdown, or other characters that "
+                "cannot be pronounced."
+            )
+        )
+        self.call = call
+
+    async def on_enter(self) -> None:
+        self.session.generate_reply(
+            instructions=(
+                f"Greet {self.call.caller_name} by name and ask how you can help."
+                if self.call.caller_name
+                else "Greet the caller and ask how you can help."
+            )
+        )
+
+
+@server.rtc_session(agent_name="msteams-agent")
+async def entrypoint(ctx: JobContext) -> None:
+    session = AgentSession(
+        # Half-cascade: the realtime model handles comprehension only (text
+        # modality) and its own server-side turn detection;
+        llm=openai.realtime.RealtimeModel.with_azure(
+            azure_deployment=os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-realtime"),
+            azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+            api_key=os.environ["AZURE_OPENAI_API_KEY"],
+            api_version=os.environ.get("AZURE_OPENAI_API_VERSION", "2024-10-01-preview"),
+        ),
+    )
+
+    # The plugin answered StandIn's dial, created this room, and dispatched this
+    # job. TeamsCall binds what is Teams-specific: the caller identity and the
+    # msteams.context / msteams.goodbye data topics.
+    call = await standin.TeamsCall().start(session, ctx=ctx)
+
+    ctx.log_context_fields = {
+        "room": ctx.room.name,
+        "call_id": call.call_id,
+        "direction": call.direction,
+    }
+
+    await session.start(agent=MyAgent(call), room=ctx.room)
+
+
+if __name__ == "__main__":
+    cli.run_app(server)

--- a/examples/msteams/pyproject.toml
+++ b/examples/msteams/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "livekit-example-msteams"
+version = "0"
+requires-python = ">=3.10"
+dependencies = [
+    "livekit-agents[openai]>=1.6",
+    "livekit-plugins-standin>=0.1",
+    "python-dotenv>=1.0",
+]
+
+[tool.uv]
+# an example is a script collection, not an installable distribution
+package = false
+
+[tool.uv.sources]
+# livekit-plugins-standin is not on PyPI yet, so it resolves from the in-repo
+# copy - and pulling one in-repo package means resolving its livekit-* deps
+# from the repo too, exactly as the workspace root does for members. Drop this
+# table once the package is published and the example resolves on its own,
+# outside the repo, like the other examples.
+livekit-plugins-standin = { path = "../../livekit-plugins/livekit-plugins-standin", editable = true }
+livekit-agents = { path = "../../livekit-agents", editable = true }
+livekit-plugins-openai = { path = "../../livekit-plugins/livekit-plugins-openai", editable = true }

--- a/livekit-plugins/livekit-plugins-standin/README.md
+++ b/livekit-plugins/livekit-plugins-standin/README.md
@@ -1,0 +1,86 @@
+# Microsoft Teams plugin by StandIn for LiveKit Agents
+
+Answer Teams calls and Teams chat messages with a LiveKit agent.
+
+[StandIn](https://standin.komaa.com) is the hosted service that joins the Microsoft Teams call; this plugin answers StandIn's per-call dial inside your agent worker. It is standalone: one worker process creates one LiveKit room per call in your own project, dispatches your agent into it by name, and relays the audio both ways. There is no separate bridge to run and nothing to deploy alongside.
+
+See [docs.komaa.com/livekit/installation](https://docs.komaa.com/livekit/installation) for the full setup.
+
+## Installation
+
+```bash
+pip install livekit-plugins-standin
+```
+
+## Pre-requisites
+
+You'll need a connection secret from StandIn. It can be set as an environment variable: `STANDIN_SECRET`. Your LiveKit project is read from the standard `LIVEKIT_URL` / `LIVEKIT_API_KEY` / `LIVEKIT_API_SECRET`.
+
+## Tiers
+
+Sandbox, Free, Paid and Managed all run the same code. The tier belongs to the connection you paired in the portal, so there is nothing to select here. Managed connections additionally carry the messages lane described below.
+
+## Calls
+
+Your file is shaped like every other agent example, and nothing starts except through `cli.run_app(server)`:
+
+```python
+from livekit.plugins import standin
+
+server = AgentServer()
+
+
+@server.rtc_session(agent_name="msteams-agent")
+async def entrypoint(ctx: JobContext):
+    session = AgentSession(llm=...)
+    call = await standin.TeamsCall().start(session, ctx=ctx)
+    await session.start(agent=MyAgent(call), room=ctx.room)
+
+
+if __name__ == "__main__":
+    cli.run_app(server)
+```
+
+There is no bootstrap call. Importing the plugin registers it with the worker, and setting `STANDIN_SECRET` arms it: the call listener starts with the worker on the agreed layout, port **8080** at **`/msteams/calling`** (`STANDIN_PORT` / `STANDIN_WS_PATH` override), and stops with it. A worker without `STANDIN_SECRET` behaves as if the plugin were not installed. The agent name is read off `@server.rtc_session(agent_name=...)`, so it is declared exactly once.
+
+Expose the port and register the public URL as the identity's **Agent voice URL** in the portal, for example:
+
+```bash
+tailscale funnel --bg --set-path /msteams/calling http://127.0.0.1:8080/msteams/calling
+```
+
+Per call, the plugin verifies StandIn's HMAC handshake, creates room `msteams-{callId}`, dispatches your agent with the call metadata, publishes the caller's audio as a room track, and relays your agent's audio back to Teams. In the entrypoint, `TeamsCall().start()` reads `CallInfo` (`caller_name`, `tenant_id`, `call_id`, `thread_id`, `user_id`, `direction`) and handles the two data topics:
+
+- `msteams.context` - non-interrupting context text: participant changes, DTMF digits, recording state. Pass `on_context=` to read it; by default it is only logged.
+- `msteams.goodbye` - StandIn is ending the call and wants this line spoken first. The default handler interrupts the current turn and says it; pass `on_goodbye=` to replace that.
+
+`CallInfo.from_job(ctx).is_teams_call` is False for a job dispatched by anything else, so one worker can serve Teams, SIP and web rooms at once.
+
+## Messages
+
+Managed connections only, which needs no flag: the channel authenticates with your connection secret, so it opens only for a live managed connection.
+
+```python
+async def on_message(msg: standin.InboundMessage) -> str:
+    return f"You said: {msg.text}"
+
+
+chat = standin.ChatChannel(respond=on_message)
+await chat.start()
+```
+
+The worker dials **out** to StandIn; messages are pushed down that socket and replies go back up it, so this lane needs no port. StandIn authenticates the Teams activity, strips the bot @mention, and performs the Teams send - your agent never holds a Bot Framework credential.
+
+Turns are serialized per conversation, deduped on `activityId`, bounded by a turn timeout, and answered with a typing indicator while your handler thinks.
+
+## Example
+
+A complete single-file worker: [`examples/msteams`](../../examples/msteams/).
+
+## Roadmap
+
+- **Avatar** - the video surface (the agent's face on the Teams tile, caller screen-share and camera) depends on a third-party avatar runtime, so it lands separately. Receiving one of those frames is not an error; it is ignored like any unknown message type.
+
+## License
+
+Apache-2.0

--- a/livekit-plugins/livekit-plugins-standin/README.md
+++ b/livekit-plugins/livekit-plugins-standin/README.md
@@ -41,12 +41,12 @@ if __name__ == "__main__":
     cli.run_app(server)
 ```
 
-There is no bootstrap call. Importing the plugin registers it with the worker, and setting `STANDIN_SECRET` arms it: the call listener starts with the worker on the agreed layout, port **8080** at **`/msteams/calling`** (`STANDIN_PORT` / `STANDIN_WS_PATH` override), and stops with it. A worker without `STANDIN_SECRET` behaves as if the plugin were not installed. The agent name is read off `@server.rtc_session(agent_name=...)`, so it is declared exactly once.
+There is no bootstrap call. Importing the plugin registers it with the worker, and setting `STANDIN_SECRET` arms it: the call listener starts with the worker on the StandIn plugin layout, port **9442** at **`/msteams/calling`** (`STANDIN_PORT` / `STANDIN_HOST` / `STANDIN_WS_PATH` override; the host defaults to `0.0.0.0` for containers, set `127.0.0.1` when only a local tunnel should reach it), and stops with it. A worker without `STANDIN_SECRET` behaves as if the plugin were not installed. The agent name is read off `@server.rtc_session(agent_name=...)`, so it is declared exactly once.
 
 Expose the port and register the public URL as the identity's **Agent voice URL** in the portal, for example:
 
 ```bash
-tailscale funnel --bg --set-path /msteams/calling http://127.0.0.1:8080/msteams/calling
+tailscale funnel --bg --set-path /msteams/calling http://127.0.0.1:9442/msteams/calling
 ```
 
 Per call, the plugin verifies StandIn's HMAC handshake, creates room `msteams-{callId}`, dispatches your agent with the call metadata, publishes the caller's audio as a room track, and relays your agent's audio back to Teams. In the entrypoint, `TeamsCall().start()` reads `CallInfo` (`caller_name`, `tenant_id`, `call_id`, `thread_id`, `user_id`, `direction`) and handles the two data topics:

--- a/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/__init__.py
+++ b/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/__init__.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Komaa DigiTech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""StandIn plugin for LiveKit Agents.
+
+Answer Microsoft Teams calls and chat messages with a LiveKit agent. StandIn
+(https://standin.komaa.com) answers the Teams call and dials this worker; the
+plugin answers that dial, creates one LiveKit room per call, dispatches this
+worker's own agent into it, and relays the audio both ways.
+
+Your file is shaped like every other agent example - nothing starts except
+through cli.run_app(server):
+
+    from livekit.plugins import standin
+
+    server = AgentServer()
+
+    @server.rtc_session(agent_name="msteams-agent")
+    async def entrypoint(ctx: JobContext):
+        session = AgentSession(llm=...)
+        call = await standin.TeamsCall().start(session, ctx=ctx)
+        await session.start(agent=MyAgent(call), room=ctx.room)
+
+    if __name__ == "__main__":
+        cli.run_app(server)
+
+Importing the plugin registers it with the worker; setting STANDIN_SECRET arms
+it. The call listener starts with the worker and stops with it, TeamsCall binds
+the Teams-only surface (caller identity, call context, the governor's goodbye)
+inside the entrypoint, and ChatChannel answers Teams chat on managed
+connections over a socket the worker dials out.
+
+See https://docs.komaa.com/livekit/installation for setup.
+"""
+
+from ._exceptions import StandInError
+from .bridge import CallBridge
+from .call import TOPIC_CONTEXT, TOPIC_GOODBYE, CallInfo, TeamsCall
+from .chat import SCHEMA_VERSION, ChatChannel, InboundMessage, build_reply, parse_inbound
+from .version import __version__
+
+__all__ = [
+    "CallBridge",
+    "CallInfo",
+    "ChatChannel",
+    "InboundMessage",
+    "SCHEMA_VERSION",
+    "StandInError",
+    "TOPIC_CONTEXT",
+    "TOPIC_GOODBYE",
+    "TeamsCall",
+    "__version__",
+    "build_reply",
+    "parse_inbound",
+]
+
+from livekit.agents import Plugin
+
+from .log import logger
+
+
+class StandInPlugin(Plugin):
+    def __init__(self) -> None:
+        super().__init__(__name__, __version__, __package__, logger)
+
+
+Plugin.register_plugin(StandInPlugin())
+
+# Arm the zero-wiring startup: every AgentServer gets the worker_started hook,
+# which starts the call listener only when STANDIN_SECRET is set. See service.py.
+from .service import _install as _service_install  # noqa: E402
+
+_service_install()
+
+# Cleanup docs of unexported modules
+_module = dir()
+NOT_IN_ALL = [m for m in _module if m not in __all__]
+
+__pdoc__ = {}
+
+for n in NOT_IN_ALL:
+    __pdoc__[n] = False

--- a/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/_exceptions.py
+++ b/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/_exceptions.py
@@ -1,0 +1,19 @@
+# Copyright 2026 Komaa DigiTech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+
+class StandInError(Exception):
+    """Raised for StandIn configuration and protocol errors."""

--- a/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/_hmac.py
+++ b/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/_hmac.py
@@ -1,0 +1,66 @@
+# Copyright 2026 Komaa DigiTech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The StandIn handshake HMAC, both directions.
+
+One construction everywhere: ``HMAC-SHA256(secret, "{timestampMs}.{id}")``,
+lowercase hex, carried in ``X-StandIn-Timestamp`` / ``X-StandIn-Signature``.
+
+    inbound   StandIn dials the call listener; ``id`` is the callId in the URL
+              path, and the plugin VERIFIES inside a replay window.
+    outbound  the worker dials the chat channel; ``id`` is the channel name,
+              and the plugin SIGNS.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+
+TIMESTAMP_HEADER = "X-StandIn-Timestamp"
+SIGNATURE_HEADER = "X-StandIn-Signature"
+
+#: Handshakes are dialed and answered immediately; anything older is a replay.
+REPLAY_WINDOW_MS = 60_000
+
+
+def now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def sign_handshake(secret: str, timestamp_ms: int | str, handshake_id: str) -> str:
+    """Signature for a WebSocket upgrade."""
+    payload = f"{timestamp_ms}.{handshake_id}".encode()
+    return hmac.new(secret.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+
+
+def verify_handshake(
+    secret: str,
+    timestamp: str | None,
+    handshake_id: str,
+    signature: str | None,
+    current_ms: int | None = None,
+) -> bool:
+    """Constant-time check of an inbound upgrade. Empty inputs fail CLOSED."""
+    if not secret or not timestamp or not signature:
+        return False
+    try:
+        ts = int(timestamp)
+    except ValueError:
+        return False
+    if abs((now_ms() if current_ms is None else current_ms) - ts) > REPLAY_WINDOW_MS:
+        return False
+    expected = sign_handshake(secret, timestamp, handshake_id)
+    return hmac.compare_digest(expected, signature.strip().lower())

--- a/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/bridge.py
+++ b/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/bridge.py
@@ -1,0 +1,735 @@
+# Copyright 2026 Komaa DigiTech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The embedded call listener: what makes this plugin standalone.
+
+StandIn's media bridge dials ``wss://<your-host>/msteams/calling/{callId}`` per
+call, exactly as it always has. This listener answers that dial inside the
+worker process - no separate bridge to run, nothing to change on StandIn's
+side. Per call it creates one LiveKit room, dispatches the worker's own agent
+into it by name, publishes the caller's audio as a room track, and relays the
+agent's audio back to Teams.
+
+Defaults match the agreed livekit layout: port **8080**, path
+``/msteams/calling``. Expose the port (for example
+``tailscale funnel --bg --set-path /msteams/calling http://127.0.0.1:8080/msteams/calling``)
+and register the public ``wss://`` URL as the identity's agent voice URL.
+
+The room is the hand-off to the entrypoint: the dispatched job sees the caller
+as an ordinary audio track, reads :class:`~.call.CallInfo` from the dispatch
+metadata, and gets call context and the governor's goodbye on the
+``msteams.context`` / ``msteams.goodbye`` data topics - the same contract
+:class:`~.call.TeamsCall` consumes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import re
+import time
+from datetime import timedelta
+from typing import Any
+from urllib.parse import urlparse, urlunparse
+
+from aiohttp import WSMsgType, web
+
+from livekit import api, rtc
+
+from ._exceptions import StandInError
+from ._hmac import (
+    REPLAY_WINDOW_MS,
+    SIGNATURE_HEADER,
+    TIMESTAMP_HEADER,
+    now_ms,
+    verify_handshake,
+)
+from .call import TOPIC_CONTEXT, TOPIC_GOODBYE
+from .log import logger
+from .protocol import (
+    NUM_CHANNELS,
+    SAMPLE_RATE_HZ,
+    SessionStart,
+    audio_frame,
+    decode_pcm,
+    parse_message,
+    parse_session_start,
+    pong,
+    session_end,
+)
+
+#: callId reaches us as a decoded URL segment, so it can contain anything a
+#: %-escape can smuggle. Room names get a conservative charset.
+_UNSAFE = re.compile(r"[^A-Za-z0-9_-]")
+
+#: Log-safe rendering of an attacker-influenceable id: control characters
+#: (CR/LF forge log lines) replaced, length bounded.
+_CTRL = re.compile(r"[^\x20-\x7e]")
+
+
+def _safe(value: str) -> str:
+    return _CTRL.sub("?", value)[:80]
+
+
+_BRIDGE_IDENTITY = "standin-bridge"
+
+
+def _http_url(url: str) -> str:
+    """LiveKitAPI speaks HTTP; accept the ws(s):// form people configure."""
+    parts = urlparse(url)
+    scheme = {"ws": "http", "wss": "https"}.get(parts.scheme, parts.scheme)
+    return urlunparse(parts._replace(scheme=scheme))
+
+
+class _Call:
+    """One live call: the StandIn socket on one side, a LiveKit room on the other."""
+
+    def __init__(self, bridge: CallBridge, call_id: str, ws: web.WebSocketResponse) -> None:
+        self._bridge = bridge
+        self._call_id = call_id
+        self._ws = ws
+        self._room: rtc.Room | None = None
+        self._room_name = ""
+        self._source: rtc.AudioSource | None = None
+        self._agent_identity: str | None = None
+        self._pump_sid: str | None = None
+        self._seq = 0
+        self._sent_ms = 0
+        self._last_audio: float | None = None
+        self._closed = False
+        self._closing_reason = "call-ended"
+        self._close_task: asyncio.Task[None] | None = None
+        self._tasks: set[asyncio.Task[Any]] = set()
+        #: Context published before the agent's audio binds would reach nobody:
+        #: the agent needs seconds to join after dispatch, and a data packet
+        #: reaches only participants connected at that instant. Queue until the
+        #: agent is bound, then flush.
+        self._pending_context: list[tuple[str, str]] = []
+
+    # ---- lifecycle ----
+
+    async def run(self) -> None:
+        """Drive the socket until it ends. Never raises to the caller: a single
+        bad call must not take the worker with it."""
+        try:
+            await self._pump_worker()
+        except asyncio.CancelledError:
+            self._begin_close("bridge-shutdown")
+            raise
+        except Exception:
+            logger.exception("standin: call %s failed", _safe(self._call_id))
+            self._begin_close("transport-failure")
+        finally:
+            await self.aclose()
+
+    async def _pump_worker(self) -> None:
+        started = False
+        async for msg in self._ws:
+            if msg.type is WSMsgType.ERROR:
+                raise StandInError(f"call socket error: {self._ws.exception()}")
+            if msg.type is not WSMsgType.TEXT:
+                continue
+            frame = parse_message(msg.data)
+            if frame is None:
+                continue
+            kind = frame["type"]
+            if kind == "session.start":
+                if started:
+                    continue  # a second start is a sender bug, not a new call
+                started = True
+                await self._on_session_start(parse_session_start(frame))
+            elif kind == "audio.frame":
+                self._last_audio = time.monotonic()
+                await self._on_caller_audio(frame)
+            elif kind == "ping":
+                await self._send(pong(frame.get("ts")))
+            elif kind == "participants":
+                # The same sentences the standalone bridges publish, so agents
+                # written against either read identical context.
+                count = frame.get("count")
+                if isinstance(count, int):
+                    if count <= 1:
+                        sentence = "This is a 1:1 call with a single human caller."
+                    else:
+                        sentence = (
+                            f"There are {count} human participants on this call. "
+                            "Stay quiet unless directly addressed."
+                        )
+                    await self._publish_context(sentence)
+            elif kind == "dtmf":
+                digit = frame.get("digit")
+                if isinstance(digit, str) and digit:
+                    await self._publish_context(
+                        f'The caller pressed the "{digit}" key on their keypad.'
+                    )
+            elif kind == "recording.status":
+                status = frame.get("status")
+                if isinstance(status, str):
+                    await self._publish_context(
+                        "The Microsoft Teams call recording is now ACTIVE."
+                        if status == "active"
+                        else "The Microsoft Teams call recording is not active."
+                    )
+            elif kind == "assistant.say":
+                text = frame.get("text")
+                if isinstance(text, str) and text.strip():
+                    # Flush the worker's queued agent playback FIRST: without the
+                    # cancel, the goodbye publishes behind seconds of already-
+                    # buffered audio and the call is torn down before it plays.
+                    await self._send(
+                        json.dumps(
+                            {"type": "assistant.cancel", "turnId": self._seq},
+                            separators=(",", ":"),
+                        )
+                    )
+                    await self._publish_text(TOPIC_GOODBYE, text)
+            elif kind == "session.end":
+                self._closing_reason = str(frame.get("reason") or "call-ended")
+                return
+            # Anything else (the avatar surface included) is ignored by
+            # contract, so an older plugin and a newer StandIn interoperate.
+
+    async def _on_session_start(self, start: SessionStart) -> None:
+        if start.call_id != self._call_id:
+            # The URL path is what the HMAC signed. A body that disagrees is
+            # either a bug or an attempt to ride one call's signature into
+            # another's room.
+            raise StandInError(
+                f"session.start callId {start.call_id!r} does not match the authenticated path"
+            )
+        await self._join_room(start)
+
+    def _begin_close(self, reason: str) -> asyncio.Task[None]:
+        """Start (or return the in-flight) teardown task. Idempotent, and the
+        FIRST reason wins - a cascade of close causes must not overwrite the
+        one that actually ended the call."""
+        if self._close_task is None:
+            self._closing_reason = reason
+            self._closed = True
+            self._close_task = asyncio.ensure_future(self._teardown())
+        return self._close_task
+
+    async def aclose(self, reason: str | None = None) -> None:
+        """Every caller waits for the SAME teardown, shielded: a caller being
+        cancelled (the pre-start watchdog, a task in _tasks that teardown
+        itself cancels, worker shutdown) must never abort teardown mid-flight -
+        that is how a slot leaks and a callId 409s forever."""
+        task = self._begin_close(reason or self._closing_reason)
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            if task.cancelled():
+                raise
+            # Only the CALLER was cancelled; teardown continues on its own.
+            raise
+        except Exception:
+            pass  # teardown already logged; never raise into callers
+
+    async def _teardown(self) -> None:
+        try:
+            # Teardown runs in its OWN task, never in self._tasks, so cancelling
+            # the whole set is safe here.
+            for task in list(self._tasks):
+                task.cancel()
+            if self._tasks:
+                await asyncio.gather(*self._tasks, return_exceptions=True)
+            self._tasks.clear()
+
+            with contextlib.suppress(Exception):
+                if not self._ws.closed:
+                    await self._send(session_end(self._closing_reason))
+                    await self._ws.close()
+
+            room, self._room = self._room, None
+            if room is not None:
+                with contextlib.suppress(Exception):
+                    await room.disconnect()
+                await self._delete_room()
+        finally:
+            # Unconditional: whatever failed or was cancelled above, the slot is
+            # released and the callId becomes usable again.
+            self._bridge._release(self._call_id)
+            logger.info("standin: call %s ended (%s)", _safe(self._call_id), self._closing_reason)
+
+    # ---- LiveKit side ----
+
+    async def _join_room(self, start: SessionStart) -> None:
+        bridge = self._bridge
+        # Same 100-char budget the standalone bridges use, so both derive the
+        # same room name for the same call.
+        self._room_name = f"{bridge.room_prefix}{_UNSAFE.sub('-', self._call_id)}"[:100]
+
+        token = (
+            api.AccessToken(bridge._api_key, bridge._api_secret)
+            .with_identity(_BRIDGE_IDENTITY)
+            .with_name("Microsoft Teams")
+            .with_ttl(timedelta(hours=6))
+            .with_grants(
+                api.VideoGrants(
+                    room_join=True,
+                    room=self._room_name,
+                    can_publish=True,
+                    can_subscribe=True,
+                    can_publish_data=True,
+                )
+            )
+            .to_jwt()
+        )
+
+        room = rtc.Room()
+        self._room = room
+        self._wire_room_events(room)
+        await room.connect(bridge._livekit_url, token, rtc.RoomOptions(auto_subscribe=True))
+        logger.info('standin: call %s joined room "%s"', self._call_id, self._room_name)
+
+        # Dispatch AFTER connect, because connect is what creates the room.
+        await self._dispatch_agent(start)
+
+        source = rtc.AudioSource(SAMPLE_RATE_HZ, NUM_CHANNELS)
+        track = rtc.LocalAudioTrack.create_audio_track("teams-caller", source)
+        options = rtc.TrackPublishOptions()
+        options.source = rtc.TrackSource.SOURCE_MICROPHONE
+        await room.local_participant.publish_track(track, options)
+        self._source = source
+        self._last_audio = time.monotonic()
+        self._spawn(self._watch_audio_idle())
+
+    async def _watch_audio_idle(self) -> None:
+        """End the call when the caller's audio stops arriving.
+
+        A live Teams call delivers PCM continuously - silence is still frames -
+        so audio going quiet for this long means the call is gone on the far
+        side and nobody told us. That happens: the peer keeps the socket open
+        (and even keeps pinging) while its own teardown is wedged, and without
+        this backstop the room, the agent job, and the realtime session all burn
+        until someone notices."""
+        idle = self._bridge.audio_idle_timeout
+        if idle <= 0:
+            return
+        while not self._closed:
+            await asyncio.sleep(min(idle / 4, 10.0))
+            last = self._last_audio
+            if last is not None and time.monotonic() - last > idle:
+                logger.warning(
+                    "standin: call %s got no caller audio for %.0fs; ending it",
+                    self._call_id,
+                    idle,
+                )
+                self._closing_reason = "caller-idle-timeout"
+                await self.aclose()
+                return
+
+    async def _dispatch_agent(self, start: SessionStart) -> None:
+        bridge = self._bridge
+        if not bridge.agent_name:
+            return  # automatic dispatch projects; nothing to do
+        # The same metadata shape the deployed livekit bridges send, so CallInfo
+        # and existing agents read it unchanged; call_id/thread_id are additive.
+        metadata = {
+            "source": "msteams",
+            "caller_name": start.caller.display_name or "caller",
+            "tenant_id": start.tenant_id or start.caller.tenant_id or "unknown-tenant",
+            "call_direction": start.direction,
+            "call_id": self._call_id,
+            "thread_id": start.thread_id,
+        }
+        if start.caller.aad_id:
+            metadata["user_id"] = start.caller.aad_id
+        lkapi = api.LiveKitAPI(_http_url(bridge._livekit_url), bridge._api_key, bridge._api_secret)
+        try:
+            await lkapi.agent_dispatch.create_dispatch(
+                api.CreateAgentDispatchRequest(
+                    agent_name=bridge.agent_name,
+                    room=self._room_name,
+                    metadata=json.dumps(metadata),
+                )
+            )
+            logger.info('standin: dispatched "%s" into %s', bridge.agent_name, self._room_name)
+        finally:
+            await lkapi.aclose()
+
+    async def _delete_room(self) -> None:
+        """Delete the room so the agent job ends at once instead of idling out."""
+        bridge = self._bridge
+        if not bridge.delete_room_on_end or not self._room_name:
+            return
+        lkapi = api.LiveKitAPI(_http_url(bridge._livekit_url), bridge._api_key, bridge._api_secret)
+        try:
+            await lkapi.room.delete_room(api.DeleteRoomRequest(room=self._room_name))
+        except Exception as err:
+            logger.warning("standin: delete_room failed, room will idle out: %s", err)
+        finally:
+            with contextlib.suppress(Exception):
+                await lkapi.aclose()
+
+    def _wire_room_events(self, room: rtc.Room) -> None:
+        @room.on("track_subscribed")
+        def _on_track(
+            track: rtc.Track,
+            publication: rtc.RemoteTrackPublication,
+            participant: rtc.RemoteParticipant,
+        ) -> None:
+            if track.kind != rtc.TrackKind.KIND_AUDIO:
+                return
+            # Bind the agent by participant KIND, not by whoever publishes audio
+            # first: in a room with a recorder or a monitor, first-audio-wins
+            # binds the wrong identity and then blocks the real agent behind the
+            # single-pump gate.
+            if self._agent_identity is None:
+                if self._bridge.agent_name and not _is_agent(participant):
+                    logger.debug('standin: ignoring audio from "%s"', participant.identity)
+                    return
+                self._agent_identity = participant.identity
+                # The agent can hear us now: deliver the context that arrived
+                # while the room had nobody to deliver it to.
+                self._flush_pending_context()
+            elif participant.identity != self._agent_identity:
+                return
+            self._start_pump(track)
+
+        @room.on("track_unsubscribed")
+        def _on_unsubscribed(
+            track: rtc.Track,
+            publication: rtc.RemoteTrackPublication,
+            participant: rtc.RemoteParticipant,
+        ) -> None:
+            if track.sid and track.sid == self._pump_sid:
+                self._pump_sid = None  # a re-published track may take over
+
+        @room.on("participant_disconnected")
+        def _on_left(participant: rtc.RemoteParticipant) -> None:
+            if self._agent_identity and participant.identity == self._agent_identity:
+                self._end_soon("agent-disconnected")
+
+        @room.on("disconnected")
+        def _on_disconnected(*_: Any) -> None:
+            # Final by the time it fires: the SDK retries transient drops first.
+            self._end_soon("room-disconnected")
+
+    def _start_pump(self, track: rtc.Track) -> None:
+        """Relay the agent's audio back to Teams. One voice at a time."""
+        if self._pump_sid:
+            return
+        sid = track.sid or "unknown"
+        self._pump_sid = sid
+
+        async def pump() -> None:
+            try:
+                # Ask the SDK for 16 kHz mono so our side stays copy-only.
+                stream = rtc.AudioStream.from_track(
+                    track=track, sample_rate=SAMPLE_RATE_HZ, num_channels=NUM_CHANNELS
+                )
+                async for event in stream:
+                    if self._closed:
+                        break
+                    pcm = event.frame.data.tobytes()
+                    self._seq += 1
+                    # The timeline persists across pumps: a re-published track
+                    # (avatar swap, mute cycle) must not jump timestampMs back
+                    # to zero while seq keeps climbing.
+                    await self._send(audio_frame(self._seq, self._sent_ms, pcm))
+                    self._sent_ms += (len(pcm) // 2) * 1000 // SAMPLE_RATE_HZ
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                if not self._closed:
+                    logger.exception("standin: agent audio pump failed")
+            finally:
+                # Release the claim only if it is still OURS: a stale pump
+                # draining its stream after a takeover must not clear the new
+                # pump's claim and let a third pump start alongside it.
+                if self._pump_sid == sid:
+                    self._pump_sid = None
+
+        self._spawn(pump())
+
+    # ---- StandIn side ----
+
+    async def _on_caller_audio(self, frame: dict[str, Any]) -> None:
+        source = self._source
+        if source is None or self._closed:
+            return  # audio before session.start, or after teardown
+        try:
+            pcm = decode_pcm(frame.get("payloadBase64"))
+        except ValueError as err:
+            logger.warning("standin: dropping caller frame: %s", err)
+            return
+        await source.capture_frame(
+            rtc.AudioFrame(
+                data=pcm,
+                sample_rate=SAMPLE_RATE_HZ,
+                num_channels=NUM_CHANNELS,
+                samples_per_channel=len(pcm) // 2,
+            )
+        )
+
+    # ---- plumbing ----
+
+    async def _publish_context(self, text: str) -> None:
+        """Context is queued until the agent's audio is bound: a data packet
+        reaches only participants connected at that instant, and the initial
+        'participants' arrives seconds before the dispatched agent joins."""
+        if self._agent_identity is None:
+            self._pending_context.append((TOPIC_CONTEXT, text))
+            del self._pending_context[:-16]
+            return
+        await self._publish_text(TOPIC_CONTEXT, text)
+
+    def _flush_pending_context(self) -> None:
+        pending, self._pending_context = self._pending_context, []
+        for topic, text in pending:
+            self._spawn(self._publish_text(topic, text))
+
+    async def _publish_text(self, topic: str, text: str) -> None:
+        """The topic contract: both topics carry ``{"text": ...}``."""
+        room = self._room
+        if room is None or self._closed:
+            return
+        with contextlib.suppress(Exception):
+            await room.local_participant.publish_data(
+                json.dumps({"text": text}).encode("utf-8"), reliable=True, topic=topic
+            )
+
+    async def _send(self, text: str) -> None:
+        if self._ws.closed:
+            return
+        with contextlib.suppress(Exception):
+            await self._ws.send_str(text)
+
+    def _end_soon(self, reason: str) -> None:
+        """Close from a synchronous room callback."""
+        self._begin_close(reason)
+
+    def _spawn(self, coro: Any) -> None:
+        task = asyncio.ensure_future(coro)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+
+def _is_agent(participant: rtc.RemoteParticipant) -> bool:
+    kind = getattr(participant, "kind", None)
+    expected = getattr(rtc.ParticipantKind, "PARTICIPANT_KIND_AGENT", None)
+    # Assume agent when the SDK reports no kind, so an older rtc build degrades
+    # to first-audio-wins rather than never binding.
+    return kind is None or expected is None or bool(kind == expected)
+
+
+class CallBridge:
+    """The listener StandIn dials. Started by :func:`~.service.serve`; construct
+    it directly only when embedding without an AgentServer.
+
+    Args:
+        secret: the connection secret from the StandIn portal. Must byte-match,
+            or the handshake is rejected with 401. Defaults to ``STANDIN_SECRET``.
+        agent_name: filled in by ``serve()`` from the worker's own registration;
+            set explicitly only when embedding.
+        livekit_url / livekit_api_key / livekit_api_secret: your LiveKit
+            project, defaulting to the standard env variables.
+        host / port / ws_path: where the listener binds. Defaults to the agreed
+            livekit layout, ``0.0.0.0:8080`` at ``/msteams/calling``.
+        room_prefix: room names are ``{room_prefix}{callId}``.
+        delete_room_on_end: delete the room at teardown so the agent job ends
+            immediately.
+        max_connections: concurrent live calls, checked before any crypto runs.
+        pre_start_timeout: seconds a socket may stay silent after authenticating
+            before it is dropped for never sending ``session.start``.
+        audio_idle_timeout: seconds without caller audio before a live call is
+            declared dead and torn down (0 disables). A live Teams call streams
+            PCM continuously, silence included, so this fires only when the far
+            side is gone but its socket was never closed.
+    """
+
+    def __init__(
+        self,
+        *,
+        secret: str | None = None,
+        agent_name: str = "",
+        livekit_url: str | None = None,
+        livekit_api_key: str | None = None,
+        livekit_api_secret: str | None = None,
+        host: str = "0.0.0.0",
+        port: int = 8080,
+        ws_path: str = "/msteams/calling",
+        room_prefix: str = "msteams-",
+        delete_room_on_end: bool = True,
+        max_connections: int = 64,
+        pre_start_timeout: float = 10.0,
+        audio_idle_timeout: float = 45.0,
+    ) -> None:
+        self._secret = secret or os.environ.get("STANDIN_SECRET", "")
+        if not self._secret:
+            raise StandInError(
+                "a StandIn connection secret is required: pass secret=... or set STANDIN_SECRET"
+            )
+        self.agent_name = agent_name
+        self._livekit_url = livekit_url or os.environ.get("LIVEKIT_URL", "")
+        self._api_key = livekit_api_key or os.environ.get("LIVEKIT_API_KEY", "")
+        self._api_secret = livekit_api_secret or os.environ.get("LIVEKIT_API_SECRET", "")
+        missing = [
+            name
+            for name, value in (
+                ("LIVEKIT_URL", self._livekit_url),
+                ("LIVEKIT_API_KEY", self._api_key),
+                ("LIVEKIT_API_SECRET", self._api_secret),
+            )
+            if not value
+        ]
+        if missing:
+            raise StandInError(f"LiveKit project not configured: missing {', '.join(missing)}")
+
+        self._host = host
+        self._port = port
+        self._ws_path = "/" + (ws_path or "").strip().strip("/")
+        if self._ws_path == "/":
+            raise StandInError("ws_path must be a real path such as /msteams/calling")
+        self.room_prefix = room_prefix
+        self.delete_room_on_end = delete_room_on_end
+        self._max_connections = max_connections
+        self._pre_start_timeout = pre_start_timeout
+        #: Seconds without caller audio before a live call is declared dead
+        #: (0 disables). A live Teams call streams PCM continuously, silence
+        #: included, so this only fires when the far side is gone or wedged.
+        self.audio_idle_timeout = audio_idle_timeout
+
+        self._calls: dict[str, _Call] = {}
+        #: fingerprint -> signing timestamp (ms). Pruned by AGE, never wholesale:
+        #: clearing the set would reopen the replay window for every handshake
+        #: still inside it.
+        self._used_signatures: dict[str, int] = {}
+        self.draining = False
+        self._runner: web.AppRunner | None = None
+
+    @property
+    def ws_path(self) -> str:
+        return self._ws_path
+
+    @property
+    def active_calls(self) -> int:
+        return len(self._calls)
+
+    async def start(self) -> None:
+        """Bind the listener. Transactional: either it is listening when this
+        returns, or nothing of it survives."""
+        app = web.Application()
+        app.router.add_get("/healthz", self._healthz)
+        app.router.add_get(f"{self._ws_path}/{{call_id}}", self._upgrade)
+
+        runner = web.AppRunner(app)
+        await runner.setup()
+        try:
+            await web.TCPSite(runner, self._host, self._port).start()
+        except BaseException:
+            with contextlib.suppress(Exception):
+                await runner.cleanup()
+            raise
+        self._runner = runner
+        logger.info(
+            "standin: answering Teams calls on %s:%s%s", self._host, self._port, self._ws_path
+        )
+
+    async def aclose(self) -> None:
+        """Drain live calls, then stop listening. Awaits the calls' REAL
+        teardown tasks - an aclose that early-returns on an in-flight closer
+        would let the loop stop with teardown still pending, leaking rooms."""
+        calls = list(self._calls.values())
+        if calls:
+            await asyncio.gather(
+                *(c._begin_close("bridge-shutdown") for c in calls), return_exceptions=True
+            )
+        self._calls.clear()
+        runner, self._runner = self._runner, None
+        if runner is not None:
+            with contextlib.suppress(Exception):
+                await runner.cleanup()
+
+    # ---- request handling ----
+
+    async def _healthz(self, _: web.Request) -> web.Response:
+        return web.json_response({"ok": True, "calls": len(self._calls)})
+
+    async def _upgrade(self, request: web.Request) -> web.StreamResponse:
+        call_id = request.match_info.get("call_id", "")
+        if not call_id:
+            return web.Response(status=400, text="missing callId")
+
+        # Draining: live calls continue, new ones are refused so a worker that
+        # is winding down does not accept calls it will never dispatch.
+        if self.draining:
+            return web.Response(status=503, text="draining")
+
+        # Capacity is checked BEFORE any crypto, so a flood cannot make us spend
+        # CPU on signatures for calls we were never going to accept.
+        if len(self._calls) >= self._max_connections:
+            logger.warning("standin: refusing %s, at capacity", _safe(call_id))
+            return web.Response(status=503, text="at capacity")
+
+        timestamp = request.headers.get(TIMESTAMP_HEADER)
+        signature = request.headers.get(SIGNATURE_HEADER)
+        if not verify_handshake(self._secret, timestamp, call_id, signature):
+            return web.Response(status=401, text="unauthorized")
+
+        # Single-use handshake: a correctly signed upgrade replayed inside the
+        # freshness window must not open a second socket. The fingerprint uses
+        # the NORMALIZED signature - verify accepts case/whitespace variants, so
+        # keying on the raw header would let the same capture replay once per
+        # casing. Entries are pruned by age, matching the freshness window.
+        sig_norm = (signature or "").strip().lower()
+        fingerprint = f"{timestamp}.{sig_norm}"
+        now = now_ms()
+        if fingerprint in self._used_signatures:
+            return web.Response(status=401, text="handshake already used")
+        self._used_signatures[fingerprint] = now
+        if len(self._used_signatures) > 4096:
+            cutoff = now - REPLAY_WINDOW_MS
+            self._used_signatures = {
+                fp: ts for fp, ts in self._used_signatures.items() if ts >= cutoff
+            }
+
+        if call_id in self._calls:
+            return web.Response(status=409, text="call already has a live session")
+
+        # 2 MB bounds a single inbound message, matching the sibling providers:
+        # audio is ~856 B base64 per frame, and the protocol caps video.frame
+        # JPEGs to fit this envelope (sent sparsely, dropped when busy).
+        ws = web.WebSocketResponse(heartbeat=None, max_msg_size=2 * 1024 * 1024)
+        await ws.prepare(request)
+
+        call = _Call(self, call_id, ws)
+        self._calls[call_id] = call
+        logger.info("standin: call %s connected", _safe(call_id))
+
+        watchdog = asyncio.ensure_future(self._watch_pre_start(call))
+        try:
+            await call.run()
+        finally:
+            watchdog.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await watchdog
+        return ws
+
+    async def _watch_pre_start(self, call: _Call) -> None:
+        """Drop a socket that authenticates and then never starts a call: it
+        holds a connection slot and a callId that nothing will ever free."""
+        await asyncio.sleep(self._pre_start_timeout)
+        if call._room is None and not call._closed:
+            logger.warning("standin: call %s never sent session.start", _safe(call._call_id))
+            await call.aclose("pre-start-timeout")
+
+    def _release(self, call_id: str) -> None:
+        self._calls.pop(call_id, None)
+
+
+__all__ = ["CallBridge"]

--- a/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/bridge.py
+++ b/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/bridge.py
@@ -86,6 +86,9 @@ def _safe(value: str) -> str:
 
 _BRIDGE_IDENTITY = "standin-bridge"
 
+#: How often the single-use handshake cache is swept for expired entries.
+_PRUNE_INTERVAL_MS = 1_000
+
 
 def _http_url(url: str) -> str:
     """LiveKitAPI speaks HTTP; accept the ws(s):// form people configure."""
@@ -104,6 +107,7 @@ class _Call:
         self._room: rtc.Room | None = None
         self._room_name = ""
         self._source: rtc.AudioSource | None = None
+        self._audio_stream: rtc.AudioStream | None = None
         self._agent_identity: str | None = None
         self._pump_sid: str | None = None
         self._seq = 0
@@ -247,6 +251,20 @@ class _Call:
             if self._tasks:
                 await asyncio.gather(*self._tasks, return_exceptions=True)
             self._tasks.clear()
+
+            # rtc primitives own FFI subscriptions and internal tasks that only
+            # aclose() releases: cancelling the tasks above frees neither, so
+            # every finished call would leave one of each behind for the life of
+            # the worker. Closed here, before the socket and room teardown, so a
+            # hang there cannot skip them.
+            stream, self._audio_stream = self._audio_stream, None
+            if stream is not None:
+                with contextlib.suppress(Exception):
+                    await stream.aclose()
+            source, self._source = self._source, None
+            if source is not None:
+                with contextlib.suppress(Exception):
+                    await source.aclose()
 
             with contextlib.suppress(Exception):
                 if not self._ws.closed:
@@ -427,11 +445,13 @@ class _Call:
         self._pump_sid = sid
 
         async def pump() -> None:
+            stream: rtc.AudioStream | None = None
             try:
                 # Ask the SDK for 16 kHz mono so our side stays copy-only.
                 stream = rtc.AudioStream.from_track(
                     track=track, sample_rate=SAMPLE_RATE_HZ, num_channels=NUM_CHANNELS
                 )
+                self._audio_stream = stream
                 async for event in stream:
                     if self._closed:
                         break
@@ -453,6 +473,13 @@ class _Call:
                 # pump's claim and let a third pump start alongside it.
                 if self._pump_sid == sid:
                     self._pump_sid = None
+                if stream is not None:
+                    if self._audio_stream is stream:
+                        self._audio_stream = None
+                    # The stream owns an FFI subscription and an internal task
+                    # that only aclose() releases; ending the pump does not.
+                    with contextlib.suppress(Exception):
+                        await stream.aclose()
 
         self._spawn(pump())
 
@@ -609,6 +636,7 @@ class CallBridge:
         #: clearing the set would reopen the replay window for every handshake
         #: still inside it.
         self._used_signatures: dict[str, int] = {}
+        self._last_prune = now_ms()
         self.draining = False
         self._runner: web.AppRunner | None = None
 
@@ -691,8 +719,19 @@ class CallBridge:
         now = now_ms()
         if fingerprint in self._used_signatures:
             return web.Response(status=401, text="handshake already used")
-        self._used_signatures[fingerprint] = now
-        if len(self._used_signatures) > 4096:
+        # Key on the SIGNING timestamp, never the arrival time: verification
+        # accepts a timestamp up to REPLAY_WINDOW_MS in the FUTURE, so an entry
+        # aged from arrival can be pruned while its signature is still valid -
+        # reopening the exact replay this guard exists to close. Aged from the
+        # signing time, an entry lives precisely as long as the signature does.
+        self._used_signatures[fingerprint] = int(timestamp) if timestamp else now
+        # Prune on a time throttle, not on a size threshold: rebuilding once the
+        # map passes a watermark makes every later request O(n). Only correctly
+        # signed, not-yet-seen handshakes reach this line (a bad signature 401s
+        # earlier, a replay returns above), so the map tracks StandIn's real
+        # call rate rather than attacker traffic.
+        if now - self._last_prune >= _PRUNE_INTERVAL_MS:
+            self._last_prune = now
             cutoff = now - REPLAY_WINDOW_MS
             self._used_signatures = {
                 fp: ts for fp, ts in self._used_signatures.items() if ts >= cutoff

--- a/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/bridge.py
+++ b/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/bridge.py
@@ -21,9 +21,9 @@ side. Per call it creates one LiveKit room, dispatches the worker's own agent
 into it by name, publishes the caller's audio as a room track, and relays the
 agent's audio back to Teams.
 
-Defaults match the agreed livekit layout: port **8080**, path
+Defaults match the StandIn plugin layout: port **9442**, path
 ``/msteams/calling``. Expose the port (for example
-``tailscale funnel --bg --set-path /msteams/calling http://127.0.0.1:8080/msteams/calling``)
+``tailscale funnel --bg --set-path /msteams/calling http://127.0.0.1:9442/msteams/calling``)
 and register the public ``wss://`` URL as the identity's agent voice URL.
 
 The room is the hand-off to the entrypoint: the dispatched job sees the caller
@@ -311,7 +311,7 @@ class _Call:
         self._room = room
         self._wire_room_events(room)
         await room.connect(bridge._livekit_url, token, rtc.RoomOptions(auto_subscribe=True))
-        logger.info('standin: call %s joined room "%s"', self._call_id, self._room_name)
+        logger.info('standin: call %s joined room "%s"', _safe(self._call_id), self._room_name)
 
         # Dispatch AFTER connect, because connect is what creates the room.
         await self._dispatch_agent(start)
@@ -343,7 +343,7 @@ class _Call:
             if last is not None and time.monotonic() - last > idle:
                 logger.warning(
                     "standin: call %s got no caller audio for %.0fs; ending it",
-                    self._call_id,
+                    _safe(self._call_id),
                     idle,
                 )
                 self._closing_reason = "caller-idle-timeout"
@@ -565,8 +565,11 @@ class CallBridge:
             set explicitly only when embedding.
         livekit_url / livekit_api_key / livekit_api_secret: your LiveKit
             project, defaulting to the standard env variables.
-        host / port / ws_path: where the listener binds. Defaults to the agreed
-            livekit layout, ``0.0.0.0:8080`` at ``/msteams/calling``.
+        host / port / ws_path: where the listener binds. Defaults to the StandIn
+            plugin layout, ``0.0.0.0:9442`` at ``/msteams/calling``. ``0.0.0.0``
+            because the worker usually runs in a container behind an ingress; bind
+            ``127.0.0.1`` when only a local tunnel should reach the listener (the
+            upgrade is HMAC-authenticated either way).
         room_prefix: room names are ``{room_prefix}{callId}``.
         delete_room_on_end: delete the room at teardown so the agent job ends
             immediately.
@@ -588,7 +591,7 @@ class CallBridge:
         livekit_api_key: str | None = None,
         livekit_api_secret: str | None = None,
         host: str = "0.0.0.0",
-        port: int = 8080,
+        port: int = 9442,
         ws_path: str = "/msteams/calling",
         room_prefix: str = "msteams-",
         delete_room_on_end: bool = True,

--- a/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/call.py
+++ b/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/call.py
@@ -1,0 +1,245 @@
+# Copyright 2026 Komaa DigiTech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The Microsoft Teams call, attached to your AgentSession.
+
+StandIn owns the whole Teams side: it answers the call, creates the LiveKit
+room with the credentials you configured in the portal, dispatches your agent
+into it by name, publishes the caller's audio into the room, and relays your
+agent's audio back to Teams. By the time your entrypoint runs, the call is an
+ordinary LiveKit room - the caller's voice is a room track like any other
+participant's, so the session needs no special audio wiring.
+
+What is left for the plugin is the Teams-specific context, and that is all
+:class:`TeamsCall` does:
+
+    @server.rtc_session(agent_name="msteams-agent")
+    async def entrypoint(ctx: JobContext):
+        session = AgentSession(llm=...)
+        call = await standin.TeamsCall().start(session, ctx=ctx)
+        await session.start(agent=MyAgent(call), room=ctx.room)
+
+It reads :class:`CallInfo` from the job metadata StandIn dispatched with, and
+wires the two Teams data topics onto the session:
+
+    msteams.context   non-interrupting context (participants, DTMF, speakers)
+    msteams.goodbye   StandIn is ending the call and wants this line spoken
+                      first; the default handler interrupts the turn and says it
+
+Nothing here speaks the Teams media protocol, listens on a port, or dials a
+socket. That side lives with StandIn, unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from livekit import rtc
+
+from ._exceptions import StandInError
+from .log import logger
+
+if TYPE_CHECKING:
+    from livekit.agents import AgentSession, JobContext
+
+#: The data topics StandIn publishes into the room, both carrying ``{"text": ...}``.
+TOPIC_CONTEXT = "msteams.context"
+TOPIC_GOODBYE = "msteams.goodbye"
+
+
+@dataclass(frozen=True)
+class CallInfo:
+    """The Teams call this job is answering.
+
+    StandIn attaches it as job metadata when it dispatches the agent, so it is
+    available before the first audio frame::
+
+        call = standin.CallInfo.from_job(ctx)
+        if call.is_teams_call:
+            print(call.caller_name, call.direction)
+    """
+
+    caller_name: str = ""
+    tenant_id: str = ""
+    call_id: str = ""
+    thread_id: str = ""
+    #: The caller's AAD object id, when Teams reported one. Empty for guest and
+    #: anonymous callers, so never use it as a bare key for per-caller memory
+    #: without checking it first, or two anonymous callers share one identity.
+    user_id: str = ""
+    direction: str = "inbound"
+    _source: str = ""
+
+    @property
+    def is_teams_call(self) -> bool:
+        """False when this job was dispatched by something other than StandIn,
+        which is the normal case in a worker that also serves web or SIP rooms."""
+        return self._source == "msteams"
+
+    @classmethod
+    def from_job(cls, ctx: JobContext | None) -> CallInfo:
+        """Read the metadata StandIn attached when it dispatched this job.
+
+        Never raises. A job dispatched by anything else has no metadata, or
+        metadata in someone else's shape, and both must read as "not a Teams
+        call" rather than taking the worker down.
+        """
+        raw = getattr(getattr(ctx, "job", None), "metadata", "") or ""
+        try:
+            data: Any = json.loads(raw)
+        except ValueError:
+            return cls()
+        if not isinstance(data, dict) or data.get("source") != "msteams":
+            return cls()
+
+        def field(name: str) -> str:
+            value = data.get(name)
+            return value if isinstance(value, str) else ""
+
+        return cls(
+            caller_name=field("caller_name"),
+            tenant_id=field("tenant_id"),
+            call_id=field("call_id"),
+            thread_id=field("thread_id"),
+            user_id=field("user_id"),
+            direction=field("call_direction") or "inbound",
+            _source="msteams",
+        )
+
+
+class TeamsCall:
+    """Attach the Microsoft Teams call this job was dispatched for.
+
+    Args:
+        on_context: called with the context text whenever StandIn publishes an
+            update (participant changes, DTMF digits, speaker changes). By
+            default the text is only logged; the audio already flows without it.
+        on_goodbye: called with the line StandIn wants spoken before it ends the
+            call. The default interrupts the current turn and says it, which is
+            what you want: the call is torn down shortly after, so a goodbye
+            queued behind a long answer never reaches the caller.
+
+    Example:
+        ```python
+        session = AgentSession(llm=...)
+        call = await standin.TeamsCall().start(session, ctx=ctx)
+        await session.start(agent=MyAgent(call), room=ctx.room)
+        ```
+    """
+
+    def __init__(
+        self,
+        *,
+        on_context: Callable[[str], Any] | None = None,
+        on_goodbye: Callable[[str], Any] | None = None,
+    ) -> None:
+        self._on_context = on_context
+        self._on_goodbye = on_goodbye
+        self._session: AgentSession | None = None
+        self._info: CallInfo | None = None
+
+    @property
+    def info(self) -> CallInfo:
+        """Who is calling, and about what. Available after :meth:`start`."""
+        if self._info is None:
+            raise StandInError("TeamsCall.start() has not run yet")
+        return self._info
+
+    async def start(
+        self,
+        session: AgentSession,
+        *,
+        ctx: JobContext | None = None,
+        room: rtc.Room | None = None,
+    ) -> CallInfo:
+        """Bind the Teams context of this job's call to ``session``.
+
+        The caller's audio needs nothing from this method - StandIn publishes it
+        into the room and ``session.start(room=ctx.room)`` picks it up like any
+        other participant. What is bound here is the Teams-only surface: the
+        caller identity and the two data topics.
+        """
+        info = CallInfo.from_job(ctx)
+        if not info.is_teams_call:
+            raise StandInError(
+                "this job was not dispatched by StandIn, so there is no Teams call to "
+                "attach. Guard with CallInfo.from_job(ctx).is_teams_call when one worker "
+                "serves both Teams and non-Teams rooms."
+            )
+        target = room if room is not None else getattr(ctx, "room", None)
+        if target is None:
+            raise StandInError("TeamsCall.start() needs the job's room (pass ctx= or room=)")
+
+        self._info = info
+        self._session = session
+        target.on("data_received", self._on_data)
+        logger.info("standin: attached to Teams call from %s", info.caller_name or "unknown")
+        return info
+
+    # ---- the data topics ----
+
+    def _on_data(self, packet: rtc.DataPacket) -> None:
+        if packet.topic not in (TOPIC_CONTEXT, TOPIC_GOODBYE):
+            return
+        try:
+            payload = json.loads(packet.data.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            return
+        text = payload.get("text") if isinstance(payload, dict) else None
+        if not isinstance(text, str) or not text:
+            return
+        if packet.topic == TOPIC_CONTEXT:
+            self._handle_context(text)
+        else:
+            self._handle_goodbye(text)
+
+    def _handle_context(self, text: str) -> None:
+        if self._on_context is None:
+            logger.debug("standin: call context: %s", text)
+            return
+        self._invoke(self._on_context, text)
+
+    def _handle_goodbye(self, text: str) -> None:
+        if self._on_goodbye is not None:
+            self._invoke(self._on_goodbye, text)
+            return
+        session = self._session
+        if session is None:
+            return
+        # Interrupt: the call ends shortly after this, so a goodbye queued
+        # behind a long answer is a goodbye the caller never hears.
+        with contextlib.suppress(Exception):
+            session.interrupt()
+            session.say(text)
+
+    @staticmethod
+    def _invoke(handler: Callable[[str], Any], text: str) -> None:
+        try:
+            result = handler(text)
+        except Exception:
+            logger.exception("standin: topic handler failed")
+            return
+        if asyncio.iscoroutine(result):
+            task = asyncio.ensure_future(result)
+            task.add_done_callback(
+                lambda t: t.exception() if not t.cancelled() else None  # surface, never raise
+            )
+
+
+__all__ = ["TOPIC_CONTEXT", "TOPIC_GOODBYE", "CallInfo", "TeamsCall"]

--- a/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/call.py
+++ b/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/call.py
@@ -151,7 +151,7 @@ class TeamsCall:
     ) -> None:
         self._on_context = on_context
         self._on_goodbye = on_goodbye
-        self._session: AgentSession | None = None
+        self._session: AgentSession[Any] | None = None
         self._info: CallInfo | None = None
 
     @property
@@ -163,7 +163,7 @@ class TeamsCall:
 
     async def start(
         self,
-        session: AgentSession,
+        session: AgentSession[Any],
         *,
         ctx: JobContext | None = None,
         room: rtc.Room | None = None,
@@ -223,9 +223,12 @@ class TeamsCall:
         if session is None:
             return
         # Interrupt: the call ends shortly after this, so a goodbye queued
-        # behind a long answer is a goodbye the caller never hears.
+        # behind a long answer is a goodbye the caller never hears. Two blocks on
+        # purpose: interrupt() raises when nothing is speaking yet or the current
+        # speech disallows interruptions, and the goodbye must still be spoken.
         with contextlib.suppress(Exception):
             session.interrupt()
+        with contextlib.suppress(Exception):
             session.say(text)
 
     @staticmethod

--- a/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/chat.py
+++ b/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/chat.py
@@ -1,0 +1,380 @@
+# Copyright 2026 Komaa DigiTech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The messages lane: Microsoft Teams chat, without a bot credential.
+
+Managed connections only. StandIn owns the Teams bot, authenticates the
+activity, resolves it to your connection and strips the bot @mention. Your
+handler returns text and StandIn performs the Teams send, so your agent never
+holds a Bot Framework credential.
+
+Same shape as the call lane: the worker dials OUT and StandIn pushes messages
+down that socket, so there is no listener, no port to expose and no tunnel.
+
+    Teams message
+         |
+         v
+    StandIn gateway        (authenticates, normalizes, signs)
+         |   pushed down the worker's outbound socket
+         v
+    ChatChannel            (this class)
+         |   your async handler returns reply text
+         v
+    back up the same socket; StandIn sends it to Teams
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+from collections import OrderedDict
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import aiohttp
+
+from ._exceptions import StandInError
+from ._hmac import SIGNATURE_HEADER, TIMESTAMP_HEADER, now_ms, sign_handshake
+from .log import logger
+
+#: chat-schema.yaml SCHEMA_VERSION. A MAJOR version: additive evolution does not
+#: bump it, because the schema already requires receivers to ignore unknown
+#: fields. An integer above ours therefore means incompatible semantics.
+SCHEMA_VERSION = 1
+
+DEFAULT_CHAT_URL = "wss://teams.standin.komaa.com/api/chat/channel"
+
+
+@dataclass(frozen=True)
+class InboundMessage:
+    """One user message, already authenticated and resolved to your connection.
+
+    Reserved bot commands are handled by StandIn and never arrive here. In group
+    and channel scope only messages that @mention the bot are relayed, and the
+    mention is already stripped from ``text``.
+    """
+
+    tenant_id: str
+    conversation_id: str
+    activity_id: str
+    scope: str
+    text: str
+    sender_name: str | None = None
+    sender_aad_id: str | None = None
+    sender_is_guest: bool = False
+    sender_is_linked_owner: bool = False
+    attachments: list[dict[str, Any]] = field(default_factory=list)
+    mentions: list[str] = field(default_factory=list)
+    locale: str | None = None
+    #: Submit payload of an Action.Submit on a card this agent sent. ``text`` is
+    #: empty on these messages.
+    card_action: dict[str, Any] | None = None
+
+    @property
+    def is_personal(self) -> bool:
+        return self.scope == "personal"
+
+
+def parse_inbound(body: str) -> InboundMessage:
+    """Parse and validate an inbound message. Raises ValueError naming the
+    problem; the caller maps that to HTTP 400."""
+    try:
+        raw = json.loads(body)
+    except ValueError as exc:
+        raise ValueError("malformed json") from exc
+    if not isinstance(raw, dict):
+        raise ValueError("body must be an object")
+    for key in ("tenantId", "conversationId", "activityId"):
+        if not isinstance(raw.get(key), str) or not raw[key]:
+            raise ValueError(f"{key} is required")
+    version = raw.get("schemaVersion", SCHEMA_VERSION)
+    if isinstance(version, int) and version > SCHEMA_VERSION:
+        raise ValueError(
+            f"unsupported schemaVersion {version} (this plugin speaks {SCHEMA_VERSION})"
+        )
+    raw_sender = raw.get("sender")
+    sender: dict[str, Any] = raw_sender if isinstance(raw_sender, dict) else {}
+    scope = raw.get("scope")
+    return InboundMessage(
+        tenant_id=raw["tenantId"],
+        conversation_id=raw["conversationId"],
+        activity_id=raw["activityId"],
+        # ChatScope is an OPEN enum: an unknown value relays as a group chat
+        # rather than being rejected.
+        scope=scope if isinstance(scope, str) and scope else "personal",
+        text=raw["text"] if isinstance(raw.get("text"), str) else "",
+        sender_name=sender.get("displayName"),
+        sender_aad_id=sender.get("aadObjectId"),
+        sender_is_guest=bool(sender.get("isGuest", False)),
+        sender_is_linked_owner=bool(sender.get("isLinkedOwner", False)),
+        attachments=raw["attachments"] if isinstance(raw.get("attachments"), list) else [],
+        mentions=raw["mentions"] if isinstance(raw.get("mentions"), list) else [],
+        locale=raw.get("locale") if isinstance(raw.get("locale"), str) else None,
+        card_action=raw.get("cardAction") if isinstance(raw.get("cardAction"), dict) else None,
+    )
+
+
+def build_reply(message: InboundMessage, text: str, kind: str = "message") -> dict[str, Any]:
+    """The gateway-bound reply. tenantId and conversationId echo the inbound
+    EXACTLY: the gateway rejects a mismatch, and that check is the cross-tenant
+    leak guard the whole relay rests on."""
+    reply: dict[str, Any] = {
+        "schemaVersion": SCHEMA_VERSION,
+        "tenantId": message.tenant_id,
+        "conversationId": message.conversation_id,
+        "replyToId": message.activity_id,
+        "kind": kind,
+        "idempotencyKey": f"{message.activity_id}:{kind}",
+    }
+    if kind != "typing":
+        reply["text"] = text
+    return reply
+
+
+class _Seen:
+    """At-least-once dedupe on the schema's activityId idempotency key. Bounded
+    LRU: an aged-out redelivery running again is acceptable at-least-once
+    behaviour, a fresh double-run is not."""
+
+    def __init__(self, capacity: int = 2048) -> None:
+        self._capacity = capacity
+        self._seen: OrderedDict[str, None] = OrderedDict()
+
+    def mark_first(self, key: str) -> bool:
+        if key in self._seen:
+            return False
+        self._seen[key] = None
+        if len(self._seen) > self._capacity:
+            self._seen.popitem(last=False)
+        return True
+
+
+class ChatChannel:
+    """Answer Microsoft Teams messages with your agent.
+
+    Dialed out from the worker, like the call lane, so nothing listens and there
+    is nothing to expose. Managed connections only, and that needs no flag: the
+    socket authenticates with your connection secret, so if it opens at all you
+    are managed.
+
+    Args:
+        respond: async callable taking an :class:`InboundMessage` and returning
+            the reply text. An empty string makes the channel say so rather than
+            leaving the user watching a typing indicator forever.
+        secret: your StandIn connection secret, defaulting to ``STANDIN_SECRET``.
+        url: the chat channel URL, defaulting to ``STANDIN_CHAT_URL``.
+
+    Example:
+        ```python
+        async def on_message(msg: standin.InboundMessage) -> str:
+            return f"You said: {msg.text}"
+
+
+        chat = standin.ChatChannel(respond=on_message)
+        await chat.start()
+        ```
+    """
+
+    #: Serialization means a hung turn would wedge its conversation forever, so
+    #: every turn is bounded. Generous: agent turns legitimately run long.
+    TURN_TIMEOUT_S = 300.0
+
+    def __init__(
+        self,
+        *,
+        respond: Callable[[InboundMessage], Awaitable[str]],
+        secret: str | None = None,
+        url: str | None = None,
+    ) -> None:
+        self._secret = secret or os.environ.get("STANDIN_SECRET", "")
+        if not self._secret:
+            raise StandInError(
+                "a StandIn connection secret is required: pass secret=... or set STANDIN_SECRET"
+            )
+        self._respond = respond
+        self._url = url or os.environ.get("STANDIN_CHAT_URL") or DEFAULT_CHAT_URL
+        self._seen = _Seen()
+        self._http: aiohttp.ClientSession | None = None
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._task: asyncio.Task[Any] | None = None
+        self._tasks: set[asyncio.Task[Any]] = set()
+        #: Per-conversation chains. The schema promises per-conversation
+        #: ORDERING; independent tasks would let replies overtake each other.
+        self._chains: dict[str, asyncio.Task[Any]] = {}
+        self._closed = False
+
+    async def start(self) -> None:
+        """Dial StandIn and begin taking messages."""
+        timestamp = now_ms()
+        http = aiohttp.ClientSession()
+        try:
+            self._ws = await http.ws_connect(
+                self._url,
+                headers={
+                    TIMESTAMP_HEADER: str(timestamp),
+                    SIGNATURE_HEADER: sign_handshake(self._secret, timestamp, "chat"),
+                },
+                max_msg_size=2 * 1024 * 1024,
+            )
+        except BaseException:
+            await http.close()
+            raise
+        self._http = http
+        self._task = asyncio.ensure_future(self._run())
+        logger.info("standin: chat channel open")
+
+    async def aclose(self) -> None:
+        self._closed = True
+        for task in [self._task, *self._tasks]:
+            if task is not None:
+                task.cancel()
+        pending = [t for t in (self._task, *self._tasks) if t is not None]
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        self._tasks.clear()
+        self._chains.clear()
+        if self._ws is not None and not self._ws.closed:
+            with contextlib.suppress(Exception):
+                await self._ws.close()
+        if self._http is not None:
+            with contextlib.suppress(Exception):
+                await self._http.close()
+
+    async def _run(self) -> None:
+        assert self._ws is not None
+        try:
+            async for message in self._ws:
+                if message.type is not aiohttp.WSMsgType.TEXT:
+                    continue
+                try:
+                    inbound = parse_inbound(message.data)
+                except ValueError as err:
+                    logger.warning("standin: dropping malformed chat message: %s", err)
+                    continue
+                # Dedupe first: StandIn is at-least-once, and a redelivery must
+                # not start a second turn for the same activity.
+                key = f"{inbound.tenant_id}:{inbound.conversation_id}:{inbound.activity_id}"
+                if self._seen.mark_first(key):
+                    self._enqueue(inbound)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("standin: chat channel failed")
+
+    def _enqueue(self, message: InboundMessage) -> None:
+        chain_key = f"{message.tenant_id}:{message.conversation_id}"
+        previous = self._chains.get(chain_key)
+
+        async def run() -> None:
+            if previous is not None:
+                try:
+                    await previous
+                except asyncio.CancelledError:
+                    # Distinguish the PREVIOUS turn being cancelled from THIS
+                    # task being cancelled while parked on it. Swallowing our own
+                    # cancellation would run a full turn during shutdown.
+                    current = asyncio.current_task()
+                    if (
+                        current is None
+                        or not hasattr(current, "cancelling")
+                        or current.cancelling() > 0
+                    ):
+                        raise
+                except Exception:
+                    pass  # a failed turn must not dam the chain
+            await self._process(message)
+
+        task = asyncio.get_running_loop().create_task(run())
+        self._chains[chain_key] = task
+        self._tasks.add(task)
+
+        def _done(finished: asyncio.Task[Any]) -> None:
+            self._tasks.discard(finished)
+            if self._chains.get(chain_key) is finished:
+                del self._chains[chain_key]
+
+        task.add_done_callback(_done)
+
+    async def _process(self, message: InboundMessage) -> None:
+        # Typing is a courtesy, so it must not sit in FRONT of the turn. Send it
+        # and let the agent think; the indicator still lands first.
+        await self._send(build_reply(message, "", "typing"))
+        try:
+            text = await asyncio.wait_for(self._respond(message), timeout=self.TURN_TIMEOUT_S)
+            if text and text.strip():
+                await self._send(build_reply(message, text))
+            else:
+                # After a typing indicator, silence looks exactly like a hang.
+                logger.warning("standin: chat handler returned an empty answer")
+                await self._send(
+                    build_reply(
+                        message,
+                        "I couldn't come up with an answer to that - try rephrasing, "
+                        "or ask something else.",
+                        "error",
+                    )
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("standin: chat turn failed")
+            await self._send(
+                build_reply(
+                    message, "Something went wrong answering that - please try again.", "error"
+                )
+            )
+
+    async def send(
+        self,
+        *,
+        tenant_id: str,
+        conversation_id: str,
+        text: str,
+        idempotency_key: str | None = None,
+    ) -> bool:
+        """Post into a Teams conversation with no inbound message to answer.
+
+        Useful from inside a call. Best-effort: returns False rather than
+        raising, because a failed post must never break a live call.
+        """
+        payload: dict[str, Any] = {
+            "schemaVersion": SCHEMA_VERSION,
+            "tenantId": tenant_id,
+            "conversationId": conversation_id,
+            "kind": "message",
+            "text": text,
+        }
+        if idempotency_key:
+            payload["idempotencyKey"] = idempotency_key
+        return await self._send(payload)
+
+    async def _send(self, reply: dict[str, Any]) -> bool:
+        ws = self._ws
+        if ws is None or ws.closed:
+            logger.warning("standin: chat channel is not open; dropping a reply")
+            return False
+        try:
+            await ws.send_str(json.dumps(reply, separators=(",", ":")))
+            return True
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("standin: chat reply failed", exc_info=True)
+            return False
+
+
+__all__ = ["ChatChannel", "InboundMessage", "SCHEMA_VERSION", "build_reply", "parse_inbound"]

--- a/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/log.py
+++ b/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/log.py
@@ -1,0 +1,3 @@
+import logging
+
+logger = logging.getLogger("livekit.plugins.standin")

--- a/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/protocol.py
+++ b/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/protocol.py
@@ -1,0 +1,158 @@
+# Copyright 2026 Komaa DigiTech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The StandIn call wire protocol, the subset this plugin speaks.
+
+One WebSocket per live Teams call. JSON text frames, camelCase keys,
+discriminated on ``type``. Evolution is additive by contract: unknown fields are
+ignored and unknown message types degrade to a no-op, so a newer StandIn and an
+older plugin interoperate.
+
+Implemented here (voice + call context):
+
+    in    session.start  audio.frame  ping  participants  dtmf
+          recording.status  assistant.say  session.end
+    out   audio.frame  pong  session.end
+
+Deliberately not implemented: ``video.frame``, ``expression``, ``speech.marks``,
+``display.image`` and ``display.frame``. Those are the avatar surface, which
+depends on a third-party avatar runtime and lands separately. Receiving one is
+not an error - it falls through the same ignore path as any unknown type.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from typing import Any
+
+#: Both directions are PCM 16 kHz, 16-bit, mono, little-endian.
+SAMPLE_RATE_HZ = 16_000
+NUM_CHANNELS = 1
+
+
+@dataclass(frozen=True)
+class Caller:
+    """Teams caller identity. Every field is optional: Graph returns identities
+    without one or more of them for guest and anonymous callers. Blank strings
+    are coerced to None so two anonymous callers never collide on an empty AAD
+    id and share memory."""
+
+    aad_id: str | None = None
+    display_name: str | None = None
+    tenant_id: str | None = None
+
+
+@dataclass(frozen=True)
+class SessionStart:
+    """First message after the socket opens; the call is live from here."""
+
+    call_id: str
+    thread_id: str
+    caller: Caller
+    direction: str = "inbound"
+    recording_status: str | None = None
+    #: MANAGED only. Taken from the signed route grant, never caller input, so
+    #: it may be trusted to address a chat post during the call.
+    tenant_id: str | None = None
+
+
+def _clean(value: Any) -> str | None:
+    """Blank and whitespace-only strings read as absent (see Caller)."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def parse_message(raw: str | bytes) -> dict[str, Any] | None:
+    """Decode one wire frame. Returns None for anything that is not a JSON
+    object with a string ``type`` - malformed input is dropped, never raised,
+    because this runs on the receive path of a live call."""
+    try:
+        obj = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(obj, dict) or not isinstance(obj.get("type"), str):
+        return None
+    return obj
+
+
+def parse_session_start(msg: dict[str, Any]) -> SessionStart:
+    """Read a ``session.start``. Raises ValueError when callId is missing: it is
+    the one field with no safe default, since it names the call."""
+    call_id = _clean(msg.get("callId"))
+    if not call_id:
+        raise ValueError("session.start is missing callId")
+    raw_caller = msg.get("caller")
+    caller_obj = raw_caller if isinstance(raw_caller, dict) else {}
+    direction = _clean(msg.get("direction")) or "inbound"
+    return SessionStart(
+        call_id=call_id,
+        # A 1:1 call has no meeting thread, so an absent threadId is normal.
+        thread_id=_clean(msg.get("threadId")) or "",
+        caller=Caller(
+            aad_id=_clean(caller_obj.get("aadId")),
+            display_name=_clean(caller_obj.get("displayName")),
+            tenant_id=_clean(caller_obj.get("tenantId")),
+        ),
+        direction=direction if direction in ("inbound", "outbound") else "inbound",
+        recording_status=_clean(msg.get("recordingStatus")),
+        tenant_id=_clean(msg.get("tenantId")),
+    )
+
+
+def decode_pcm(payload_base64: Any) -> bytes:
+    """Decode an ``audio.frame`` payload to raw PCM16 bytes.
+
+    Rejects an odd byte count: PCM16 is 2 bytes per sample, so an odd length
+    means a truncated frame. Truncating it silently would shift every following
+    sample by a byte and turn the rest of the utterance into noise."""
+    if not isinstance(payload_base64, str) or not payload_base64:
+        raise ValueError("audio.frame carries no payloadBase64")
+    try:
+        pcm = base64.b64decode(payload_base64, validate=True)
+    except Exception as exc:
+        raise ValueError("audio.frame payloadBase64 is not valid base64") from exc
+    if len(pcm) < 2 or len(pcm) % 2 != 0:
+        raise ValueError(f"malformed PCM16 payload ({len(pcm)} bytes)")
+    return pcm
+
+
+def audio_frame(seq: int, timestamp_ms: int, pcm: bytes) -> str:
+    """Build an outbound ``audio.frame``."""
+    return json.dumps(
+        {
+            "type": "audio.frame",
+            "seq": seq,
+            "timestampMs": timestamp_ms,
+            "payloadBase64": base64.b64encode(pcm).decode("ascii"),
+        },
+        separators=(",", ":"),
+    )
+
+
+def pong(ts: Any) -> str:
+    """Answer a ``ping``. The timestamp is echoed verbatim so the worker can
+    measure the round trip against its own clock."""
+    return json.dumps(
+        {"type": "pong", "ts": ts if isinstance(ts, int) else 0}, separators=(",", ":")
+    )
+
+
+def session_end(reason: str) -> str:
+    """Advisory teardown notice. The close that follows is what ends the call;
+    this carries the only answer to "why" the worker cannot derive itself."""
+    return json.dumps({"type": "session.end", "reason": reason}, separators=(",", ":"))

--- a/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/service.py
+++ b/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/service.py
@@ -1,0 +1,205 @@
+# Copyright 2026 Komaa DigiTech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Zero-wiring startup: the listener starts with your worker.
+
+Your file looks like any other agent example - `AgentServer()`, one decorated
+entrypoint, and nothing starts except through ``cli.run_app(server)``:
+
+    from livekit.plugins import standin
+
+    server = AgentServer()
+
+    @server.rtc_session(agent_name="msteams-agent")
+    async def entrypoint(ctx: JobContext):
+        session = AgentSession(llm=...)
+        call = await standin.TeamsCall().start(session, ctx=ctx)
+        await session.start(agent=MyAgent(call), room=ctx.room)
+
+    if __name__ == "__main__":
+        cli.run_app(server)
+
+There is no bootstrap call. Importing the plugin registers it with the worker
+(the same import-time registration every LiveKit plugin performs), and the call
+listener is ARMED only when ``STANDIN_SECRET`` is set and STARTED only when the
+worker actually runs, on its ``worker_started`` event - which fires once, in the
+main process, with the loop already running. A worker without ``STANDIN_SECRET``
+behaves exactly as if this plugin were not installed.
+
+Why a listener at all: StandIn dials the worker per call, and no job exists
+until that dial has been answered and an agent dispatched - so the listener
+cannot live inside the entrypoint. It lives inside the worker's own lifecycle
+instead, where the developer never sees it.
+
+Configuration is environment-only, matching how every other plugin reads its
+keys: ``STANDIN_SECRET`` (arms the plugin), ``STANDIN_PORT`` (default 8080),
+``STANDIN_WS_PATH`` (default /msteams/calling), plus the standard ``LIVEKIT_*``
+project variables the worker already has.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+from typing import TYPE_CHECKING, Any
+
+from .bridge import CallBridge
+from .log import logger
+
+if TYPE_CHECKING:
+    from livekit.agents import AgentServer
+
+_installed = False
+_startup_tasks: set[asyncio.Task[None]] = set()
+
+
+def _resolve_agent_name(server: AgentServer) -> str:
+    """The name this worker registered with.
+
+    Read off the worker rather than configured twice: the developer states it
+    once, where the framework already requires it, in
+    ``@server.rtc_session(agent_name=...)``. Two copies of a string that MUST
+    match is how you get a room that is created, a job that never arrives, and
+    a caller who hears silence.
+
+    Resolved at worker_started, never earlier: it is the rtc_session decorator
+    that sets it, and it applies the framework's own precedence (including
+    LIVEKIT_AGENT_NAME_OVERRIDE), so the plugin cannot disagree with the worker
+    about who it is.
+    """
+    name = getattr(server, "_agent_name", "") or ""
+    if not name:
+        # Private-attribute read, so fall back rather than break on an SDK that
+        # renames it.
+        name = os.environ.get("LIVEKIT_AGENT_NAME", "")
+    return name
+
+
+def _on_worker_started(server: AgentServer) -> None:
+    """Runs once in the main worker process. Never raises: a misconfigured
+    plugin must log why it is not answering calls, not kill the worker."""
+    secret = os.environ.get("STANDIN_SECRET", "")
+    if not secret:
+        logger.debug("standin: STANDIN_SECRET is not set; not answering Teams calls")
+        return
+
+    try:
+        bridge = CallBridge(
+            secret=secret,
+            port=int(os.environ.get("STANDIN_PORT", "8080")),
+            ws_path=os.environ.get("STANDIN_WS_PATH", "/msteams/calling"),
+        )
+    except Exception:
+        logger.exception("standin: misconfigured; this worker takes no Teams calls")
+        return
+
+    bridge.agent_name = _resolve_agent_name(server)
+    if not bridge.agent_name:
+        # A worker with no registered name relies on AUTOMATIC dispatch: the
+        # room creation itself assigns the job, so the listener still works.
+        # Explicit dispatch is the recommended setup; say so, then proceed.
+        logger.info(
+            "standin: no agent name registered; relying on automatic dispatch "
+            "(set @server.rtc_session(agent_name=...) for explicit dispatch)"
+        )
+
+    async def _start() -> None:
+        try:
+            await bridge.start()
+        except Exception:
+            logger.exception("standin: failed to start; this worker takes no Teams calls")
+
+    # The loop holds only weak references to tasks; keeping ours in a module
+    # set stops the startup task from being garbage-collected mid-flight.
+    start_task = asyncio.ensure_future(_start())
+    _startup_tasks.add(start_task)
+    start_task.add_done_callback(_startup_tasks.discard)
+
+    # Stop ACCEPTING new calls when the worker starts draining: live calls
+    # continue, but a draining worker must not answer dials it will never
+    # dispatch (the default drain window is an hour).
+    original_drain = server.drain
+
+    async def _drain(*args: Any, **kwargs: Any) -> Any:
+        bridge.draining = True
+        return await original_drain(*args, **kwargs)
+
+    server.drain = _drain  # type: ignore[method-assign]
+
+    # Close the listener when the worker shuts down. Wrapping aclose is the
+    # only hook: the worker emits no stopped event. The startup task is
+    # cancelled first so a shutdown racing a slow start cannot bind AFTER
+    # cleanup and leak the port.
+    original_aclose = server.aclose
+
+    async def _aclose(*args: Any, **kwargs: Any) -> Any:
+        start_task.cancel()
+        with contextlib.suppress(BaseException):
+            await start_task
+        with contextlib.suppress(Exception):
+            await bridge.aclose()
+        return await original_aclose(*args, **kwargs)
+
+    server.aclose = _aclose  # type: ignore[method-assign]
+
+
+def _install() -> None:
+    """Auto-subscribe every AgentServer to the startup hook, at plugin import.
+
+    ``server.on("worker_started", ...)`` is the framework's own extension point;
+    the only thing automated here is the subscription, so the developer's file
+    stays exactly the shape of every other example. Idempotent, and inert on
+    servers that never run (a subprocess imports the module but never fires
+    worker_started, so nothing binds there - the reason this must NOT be done
+    in setup_fnc, which runs once per job subprocess)."""
+    global _installed
+    if _installed:
+        return
+    _installed = True
+
+    from livekit.agents import AgentServer
+
+    def _hook(server: AgentServer) -> None:
+        # Idempotent per instance, so init + run hooking (or a double import
+        # path) can never subscribe twice.
+        if getattr(server, "_standin_hooked", False):
+            return
+        server._standin_hooked = True  # type: ignore[attr-defined]
+        try:
+            server.on("worker_started", lambda: _on_worker_started(server))
+        except Exception:
+            logger.exception("standin: could not attach to the worker lifecycle")
+
+    original_init = AgentServer.__init__
+
+    def patched_init(self: AgentServer, *args: Any, **kwargs: Any) -> None:
+        original_init(self, *args, **kwargs)
+        _hook(self)
+
+    AgentServer.__init__ = patched_init  # type: ignore[method-assign]
+
+    # Also hook at run(): a server CONSTRUCTED before this plugin was imported
+    # missed the __init__ patch, and run() is the last moment before
+    # worker_started fires. Between the two, import order cannot matter.
+    original_run = AgentServer.run
+
+    async def patched_run(self: AgentServer, *args: Any, **kwargs: Any) -> Any:
+        _hook(self)
+        return await original_run(self, *args, **kwargs)
+
+    AgentServer.run = patched_run  # type: ignore[method-assign]
+
+
+__all__ = ["_install"]

--- a/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/service.py
+++ b/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/service.py
@@ -43,9 +43,11 @@ cannot live inside the entrypoint. It lives inside the worker's own lifecycle
 instead, where the developer never sees it.
 
 Configuration is environment-only, matching how every other plugin reads its
-keys: ``STANDIN_SECRET`` (arms the plugin), ``STANDIN_PORT`` (default 8080),
-``STANDIN_WS_PATH`` (default /msteams/calling), plus the standard ``LIVEKIT_*``
-project variables the worker already has.
+keys: ``STANDIN_SECRET`` (arms the plugin), ``STANDIN_PORT`` (default 9442, the
+port every StandIn plugin listens on), ``STANDIN_HOST`` (default 0.0.0.0; set
+127.0.0.1 when only a local tunnel should reach the listener), ``STANDIN_WS_PATH``
+(default /msteams/calling), plus the standard ``LIVEKIT_*`` project variables the
+worker already has.
 """
 
 from __future__ import annotations
@@ -98,7 +100,8 @@ def _on_worker_started(server: AgentServer) -> None:
     try:
         bridge = CallBridge(
             secret=secret,
-            port=int(os.environ.get("STANDIN_PORT", "8080")),
+            host=os.environ.get("STANDIN_HOST", "0.0.0.0"),
+            port=int(os.environ.get("STANDIN_PORT", "9442")),
             ws_path=os.environ.get("STANDIN_WS_PATH", "/msteams/calling"),
         )
     except Exception:

--- a/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/version.py
+++ b/livekit-plugins/livekit-plugins-standin/livekit/plugins/standin/version.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Komaa DigiTech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.1.0"

--- a/livekit-plugins/livekit-plugins-standin/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-standin/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "livekit-plugins-standin"
+dynamic = ["version"]
+description = "Agent Framework plugin for StandIn: answer Microsoft Teams calls and messages with a LiveKit Agent"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.10.0"
+authors = [{ name = "Komaa DigiTech", email = "support@komaa.com" }]
+keywords = ["voice", "ai", "realtime", "audio", "video", "livekit", "webrtc", "microsoft teams", "standin"]
+classifiers = [
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: Multimedia :: Sound/Audio",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3 :: Only",
+]
+dependencies = ["livekit-agents>=1.6.10", "aiohttp>=3.9"]
+
+[project.urls]
+Documentation = "https://docs.komaa.com"
+Website = "https://standin.komaa.com"
+Source = "https://github.com/komaa-com/livekit-plugins"
+
+[tool.hatch.version]
+path = "livekit/plugins/standin/version.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["livekit"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/livekit"]
+
+[tool.uv]
+exclude-newer = "7 days"
+exclude-newer-package = { livekit-agents = "0 days" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ livekit-plugins-browser = { workspace = true }
 livekit-plugins-speechmatics = { workspace = true }
 livekit-plugins-spatius = { workspace = true }
 livekit-plugins-spitch = { workspace = true }
+livekit-plugins-standin = { workspace = true }
 livekit-plugins-tavus = { workspace = true }
 livekit-plugins-telnyx = { workspace = true }
 livekit-plugins-trugen = { workspace = true }

--- a/tests/test_standin_plugin.py
+++ b/tests/test_standin_plugin.py
@@ -1,0 +1,302 @@
+"""Unit tests for the StandIn plugin: CallInfo, the TeamsCall attachment, the
+chat schema, and the chat-channel handshake.
+
+Hermetic. Nothing here dials StandIn, LiveKit, or the network.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from livekit.plugins.standin import (
+    SCHEMA_VERSION,
+    TOPIC_CONTEXT,
+    TOPIC_GOODBYE,
+    CallInfo,
+    ChatChannel,
+    InboundMessage,
+    StandInError,
+    TeamsCall,
+    build_reply,
+    parse_inbound,
+)
+from livekit.plugins.standin._hmac import sign_handshake
+
+pytestmark = pytest.mark.unit
+
+SECRET = "test-secret"
+NOW = 1_700_000_000_000
+
+
+def _job(metadata: str) -> object:
+    return SimpleNamespace(job=SimpleNamespace(metadata=metadata), room=None)
+
+
+def _teams_job(**over: object) -> object:
+    # The exact metadata shape StandIn dispatches with: source, caller_name,
+    # tenant_id, call_direction, and user_id only when Teams reported an AAD id.
+    data: dict[str, object] = {
+        "source": "msteams",
+        "caller_name": "Sara",
+        "tenant_id": "t-1",
+        "call_direction": "inbound",
+        "user_id": "aad-1",
+    }
+    data.update(over)
+    return _job(json.dumps(data))
+
+
+# ── CallInfo: what the entrypoint reads ────────────────────────────────────────
+
+
+def test_call_info_reads_the_dispatch_metadata() -> None:
+    call = CallInfo.from_job(_teams_job(call_direction="outbound"))
+    assert call.is_teams_call
+    assert (call.caller_name, call.tenant_id, call.user_id) == ("Sara", "t-1", "aad-1")
+    assert call.direction == "outbound"
+
+
+def test_call_info_defaults_direction_to_inbound() -> None:
+    call = CallInfo.from_job(_teams_job(call_direction=""))
+    assert call.direction == "inbound"
+
+
+def test_call_info_tolerates_a_missing_user_id() -> None:
+    # StandIn includes user_id only when Teams reports an AAD id; guests and
+    # anonymous callers arrive without one.
+    job = _job(json.dumps({"source": "msteams", "caller_name": "caller", "tenant_id": "t"}))
+    call = CallInfo.from_job(job)
+    assert call.is_teams_call
+    assert call.user_id == ""
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        "",  # dispatched with no metadata at all
+        "not json",  # someone else's dispatcher
+        "[]",  # valid json, wrong shape
+        '{"source": "sip", "caller_name": "x"}',  # another source entirely
+    ],
+)
+def test_call_info_never_raises_on_a_foreign_job(metadata: str) -> None:
+    # One worker can serve Teams, SIP and web rooms. A job from elsewhere must
+    # read as "not a Teams call", never take the worker down.
+    call = CallInfo.from_job(_job(metadata))
+    assert not call.is_teams_call
+
+
+def test_call_info_ignores_non_string_fields() -> None:
+    call = CallInfo.from_job(_teams_job(caller_name=42))
+    assert call.caller_name == ""
+
+
+# ── TeamsCall: attaching to the dispatched job ─────────────────────────────────
+
+
+class _FakeRoom:
+    def __init__(self) -> None:
+        self.handlers: dict[str, object] = {}
+
+    def on(self, event: str, handler: object) -> None:
+        self.handlers[event] = handler
+
+    def emit_data(self, topic: str, payload: dict[str, object]) -> None:
+        packet = SimpleNamespace(topic=topic, data=json.dumps(payload).encode())
+        self.handlers["data_received"](packet)  # type: ignore[operator]
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def interrupt(self) -> None:
+        self.calls.append(("interrupt", ""))
+
+    def say(self, text: str) -> None:
+        self.calls.append(("say", text))
+
+
+async def test_teams_call_refuses_a_job_it_was_not_dispatched_for() -> None:
+    with pytest.raises(StandInError, match="not dispatched by StandIn"):
+        await TeamsCall().start(_FakeSession(), ctx=_job(""))  # type: ignore[arg-type]
+
+
+async def test_teams_call_attaches_and_returns_the_caller() -> None:
+    room = _FakeRoom()
+    call = await TeamsCall().start(_FakeSession(), ctx=_teams_job(), room=room)  # type: ignore[arg-type]
+    assert call.caller_name == "Sara"
+    assert "data_received" in room.handlers  # the topics are wired
+
+
+async def test_goodbye_interrupts_the_turn_and_speaks_the_line() -> None:
+    # The default handler. Interrupting matters: the call is torn down shortly
+    # after the goodbye, so one queued behind a long answer is never heard.
+    room, session = _FakeRoom(), _FakeSession()
+    await TeamsCall().start(session, ctx=_teams_job(), room=room)  # type: ignore[arg-type]
+    room.emit_data(TOPIC_GOODBYE, {"text": "Wrapping up now."})
+    assert session.calls == [("interrupt", ""), ("say", "Wrapping up now.")]
+
+
+async def test_goodbye_handler_override_replaces_the_default() -> None:
+    room, session = _FakeRoom(), _FakeSession()
+    heard: list[str] = []
+    await TeamsCall(on_goodbye=heard.append).start(session, ctx=_teams_job(), room=room)  # type: ignore[arg-type]
+    room.emit_data(TOPIC_GOODBYE, {"text": "bye"})
+    assert heard == ["bye"]
+    assert session.calls == []  # the default did not also run
+
+
+async def test_context_reaches_the_handler_as_text() -> None:
+    # StandIn publishes context as {"text": ...} prose, not a structured object.
+    room = _FakeRoom()
+    seen: list[str] = []
+    await TeamsCall(on_context=seen.append).start(_FakeSession(), ctx=_teams_job(), room=room)  # type: ignore[arg-type]
+    room.emit_data(TOPIC_CONTEXT, {"text": "participants: 3"})
+    assert seen == ["participants: 3"]
+
+
+async def test_unrelated_topics_and_malformed_payloads_are_ignored() -> None:
+    room, session = _FakeRoom(), _FakeSession()
+    await TeamsCall().start(session, ctx=_teams_job(), room=room)  # type: ignore[arg-type]
+    room.emit_data("lk.transcription", {"text": "not ours"})
+    room.emit_data(TOPIC_GOODBYE, {"no": "text"})
+    handler = room.handlers["data_received"]
+    handler(SimpleNamespace(topic=TOPIC_GOODBYE, data=b"not json"))  # type: ignore[operator]
+    assert session.calls == []
+
+
+async def test_info_is_available_after_start_and_not_before() -> None:
+    tc = TeamsCall()
+    with pytest.raises(StandInError, match="has not run yet"):
+        _ = tc.info
+    await tc.start(_FakeSession(), ctx=_teams_job(), room=_FakeRoom())  # type: ignore[arg-type]
+    assert tc.info.caller_name == "Sara"
+
+
+# ── the embedded listener's teardown ───────────────────────────────────────────
+
+
+async def test_end_soon_teardown_does_not_deadlock_on_itself() -> None:
+    # _end_soon spawns aclose() into the same task set aclose cancels and
+    # awaits. Without excluding the current task, that is a task awaiting its
+    # own completion: the call hangs half-closed forever and the slot is never
+    # released. This is exactly the room-deleted / agent-left teardown path.
+    import asyncio
+
+    from livekit.plugins.standin.bridge import _Call
+
+    bridge = SimpleNamespace(_release=lambda _cid: None, audio_idle_timeout=0)
+    ws = SimpleNamespace(closed=True)
+    call = _Call(bridge, "c1", ws)  # type: ignore[arg-type]
+
+    call._end_soon("room-disconnected")
+    async with asyncio.timeout(2):
+        while not call._closed or call._tasks:
+            await asyncio.sleep(0.01)
+    assert call._closed
+
+
+# ── chat channel ───────────────────────────────────────────────────────────────
+
+
+def test_chat_channel_dials_out_and_needs_a_secret() -> None:
+    async def respond(_: InboundMessage) -> str:
+        return ""
+
+    with pytest.raises(StandInError, match="secret"):
+        ChatChannel(respond=respond, secret="")
+    channel = ChatChannel(respond=respond, secret=SECRET)
+    # Nothing listens: the channel is dialed out, like the call media.
+    assert not hasattr(channel, "path")
+
+
+def test_handshake_signature_is_over_timestamp_dot_id() -> None:
+    # Pins the wire construction, so the StandIn side can verify against the
+    # same vector: lowercase-hex HMAC-SHA256(secret, "{timestampMs}.{id}").
+    import hashlib
+    import hmac as _hmac
+
+    expected = _hmac.new(SECRET.encode(), f"{NOW}.chat".encode(), hashlib.sha256).hexdigest()
+    assert sign_handshake(SECRET, NOW, "chat") == expected
+
+
+# ── chat wire schema ───────────────────────────────────────────────────────────
+
+
+def _inbound(**over: object) -> str:
+    body = {
+        "schemaVersion": SCHEMA_VERSION,
+        "tenantId": "t-1",
+        "conversationId": "c-1",
+        "activityId": "a-1",
+        "scope": "personal",
+        "text": "hello",
+        "sender": {"displayName": "Sara", "aadObjectId": "aad-1", "isLinkedOwner": True},
+    }
+    body.update(over)
+    return json.dumps(body)
+
+
+def test_parse_inbound_reads_the_message() -> None:
+    msg = parse_inbound(_inbound())
+    assert msg.tenant_id == "t-1"
+    assert msg.text == "hello"
+    assert msg.sender_name == "Sara"
+    assert msg.sender_is_linked_owner is True
+    assert msg.is_personal
+
+
+@pytest.mark.parametrize("missing", ["tenantId", "conversationId", "activityId"])
+def test_parse_inbound_requires_every_routing_key(missing: str) -> None:
+    body = json.loads(_inbound())
+    del body[missing]
+    with pytest.raises(ValueError, match=missing):
+        parse_inbound(json.dumps(body))
+
+
+def test_parse_inbound_refuses_a_future_major_schema() -> None:
+    # Additive evolution does NOT bump schemaVersion, so a higher integer means
+    # semantics we would misread rather than fields we can ignore.
+    with pytest.raises(ValueError, match="schemaVersion"):
+        parse_inbound(_inbound(schemaVersion=SCHEMA_VERSION + 1))
+
+
+def test_parse_inbound_tolerates_an_unknown_scope() -> None:
+    # ChatScope is an OPEN enum: unknown values must relay, not fail.
+    assert parse_inbound(_inbound(scope="sharedChannel")).scope == "sharedChannel"
+
+
+def test_parse_inbound_survives_a_message_that_is_only_attachments() -> None:
+    msg = parse_inbound(_inbound(text="", attachments=[{"kind": "image", "relayable": True}]))
+    assert msg.text == ""
+    assert len(msg.attachments) == 1
+
+
+def test_reply_echoes_tenant_and_conversation_exactly() -> None:
+    # The gateway rejects a mismatch; that check is the cross-tenant leak guard.
+    msg = parse_inbound(_inbound())
+    reply = build_reply(msg, "hi there")
+    assert reply["tenantId"] == msg.tenant_id
+    assert reply["conversationId"] == msg.conversation_id
+    assert reply["replyToId"] == msg.activity_id
+    assert reply["text"] == "hi there"
+    assert reply["idempotencyKey"] == "a-1:message"
+
+
+def test_typing_reply_carries_no_text() -> None:
+    reply = build_reply(parse_inbound(_inbound()), "ignored", "typing")
+    assert "text" not in reply
+    assert reply["kind"] == "typing"
+
+
+def test_reply_idempotency_key_separates_kinds() -> None:
+    # A typing indicator and its answer share an activityId; if they shared an
+    # idempotency key the gateway would drop the answer as a duplicate.
+    msg = parse_inbound(_inbound())
+    assert (
+        build_reply(msg, "x")["idempotencyKey"] != build_reply(msg, "", "typing")["idempotencyKey"]
+    )

--- a/tests/test_standin_plugin.py
+++ b/tests/test_standin_plugin.py
@@ -141,6 +141,21 @@ async def test_goodbye_interrupts_the_turn_and_speaks_the_line() -> None:
     assert session.calls == [("interrupt", ""), ("say", "Wrapping up now.")]
 
 
+async def test_goodbye_is_still_spoken_when_interrupt_raises() -> None:
+    # interrupt() raises RuntimeError when nothing is speaking yet or the current
+    # speech disallows interruptions; the goodbye must still be spoken. (Both
+    # calls used to share one suppress block, so the farewell was skipped.)
+    class _TouchySession(_FakeSession):
+        def interrupt(self) -> None:
+            self.calls.append(("interrupt", ""))
+            raise RuntimeError("no speech to interrupt")
+
+    room, session = _FakeRoom(), _TouchySession()
+    await TeamsCall().start(session, ctx=_teams_job(), room=room)  # type: ignore[arg-type]
+    room.emit_data(TOPIC_GOODBYE, {"text": "Wrapping up now."})
+    assert session.calls == [("interrupt", ""), ("say", "Wrapping up now.")]
+
+
 async def test_goodbye_handler_override_replaces_the_default() -> None:
     room, session = _FakeRoom(), _FakeSession()
     heard: list[str] = []

--- a/tests/test_standin_plugin.py
+++ b/tests/test_standin_plugin.py
@@ -200,6 +200,55 @@ async def test_end_soon_teardown_does_not_deadlock_on_itself() -> None:
     assert call._closed
 
 
+# ── resource release and replay-window retention (upstream review) ─────────────
+
+
+async def test_teardown_closes_the_rtc_primitives() -> None:
+    # rtc.AudioStream and rtc.AudioSource each own an FFI subscription and an
+    # internal task that only aclose() releases. Cancelling the pump task frees
+    # neither, so without this every finished call leaks one of each for the
+    # life of the worker.
+    from livekit.plugins.standin.bridge import _Call
+
+    closed: list[str] = []
+
+    class _Closable:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        async def aclose(self) -> None:
+            closed.append(self.name)
+
+    bridge = SimpleNamespace(_release=lambda _cid: None, audio_idle_timeout=0)
+    call = _Call(bridge, "c1", SimpleNamespace(closed=True))  # type: ignore[arg-type]
+    call._audio_stream = _Closable("stream")  # type: ignore[assignment]
+    call._source = _Closable("source")  # type: ignore[assignment]
+
+    await call.aclose()
+    assert sorted(closed) == ["source", "stream"]
+    assert call._audio_stream is None and call._source is None
+
+
+def test_replay_entries_outlive_a_future_dated_signature() -> None:
+    # verify_handshake accepts a timestamp up to REPLAY_WINDOW_MS in the FUTURE,
+    # so an entry aged from ARRIVAL would be pruned while its signature was
+    # still valid, reopening the replay. Aged from the signing time, retention
+    # matches validity exactly.
+    from livekit.plugins.standin._hmac import REPLAY_WINDOW_MS, verify_handshake
+
+    signed_at = NOW + REPLAY_WINDOW_MS  # the furthest-future timestamp accepted
+    sig = sign_handshake(SECRET, signed_at, "c1")
+    assert verify_handshake(SECRET, str(signed_at), "c1", sig, NOW)
+
+    # Latest moment the signature still verifies, i.e. the entry must survive.
+    last_valid = signed_at + REPLAY_WINDOW_MS
+    assert verify_handshake(SECRET, str(signed_at), "c1", sig, last_valid)
+    assert signed_at >= last_valid - REPLAY_WINDOW_MS, "prune cutoff would drop a live entry"
+
+    # One millisecond later the signature is dead, so dropping it is correct.
+    assert not verify_handshake(SECRET, str(signed_at), "c1", sig, last_valid + 1)
+
+
 # ── chat channel ───────────────────────────────────────────────────────────────
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -87,6 +87,7 @@ members = [
     "livekit-plugins-speechify",
     "livekit-plugins-speechmatics",
     "livekit-plugins-spitch",
+    "livekit-plugins-standin",
     "livekit-plugins-tavus",
     "livekit-plugins-telnyx",
     "livekit-plugins-trugen",
@@ -667,15 +668,15 @@ name = "bithuman"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "av", marker = "python_full_version < '3.14'" },
-    { name = "loguru", marker = "python_full_version < '3.14'" },
-    { name = "networkx", marker = "python_full_version < '3.14'" },
-    { name = "numpy", marker = "python_full_version < '3.14'" },
-    { name = "opencv-python-headless", marker = "python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "pydantic-settings", marker = "python_full_version < '3.14'" },
-    { name = "pyyaml", marker = "python_full_version < '3.14'" },
-    { name = "soundfile", marker = "python_full_version < '3.14'" },
+    { name = "av" },
+    { name = "loguru" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "opencv-python-headless" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyyaml" },
+    { name = "soundfile" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/f4/9faa8a78e8968f4404e5e47a2852d7a97313a667424a8e6f8bff16a28899/bithuman-2.7.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b399a37e187c17a8874e0eeb8e7e7a0907a4155537fac08185dabdb62491a7aa", size = 27205973, upload-time = "2026-07-17T00:14:45.72Z" },
@@ -3464,6 +3465,20 @@ requires-dist = [
 ]
 
 [[package]]
+name = "livekit-plugins-standin"
+source = { editable = "livekit-plugins/livekit-plugins-standin" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "livekit-agents" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.9" },
+    { name = "livekit-agents", editable = "livekit-agents" },
+]
+
+[[package]]
 name = "livekit-plugins-tavus"
 source = { editable = "livekit-plugins/livekit-plugins-tavus" }
 dependencies = [
@@ -3572,8 +3587,8 @@ name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
-    { name = "win32-setctime", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
@@ -4233,7 +4248,7 @@ name = "opencv-python-headless"
 version = "5.0.0.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/99/76b7c80252aa83c1af16393454aafd125a0287101afe8deb0a6821af0e30/opencv_python_headless-5.0.0.93.tar.gz", hash = "sha256:b82f9831daab90b725c7c1ee1b36cb5732c367096ac76d119e64e14eb70d5f3c", size = 81817738, upload-time = "2026-07-02T07:01:06.039Z" }
 wheels = [
@@ -5701,9 +5716,9 @@ name = "soundfile"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "python_full_version < '3.14'" },
-    { name = "numpy", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "cffi" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d2/db/949331952a6fb1c5b12e9de80fd08747966c2039d1a61db4764fbd3981c2/soundfile-0.14.0.tar.gz", hash = "sha256:ba1c1a2d618bca5c406647c83b89f07cc8810fa506a50622a6993ba130c1de11", size = 47842, upload-time = "2026-06-06T08:58:47.869Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -668,15 +668,15 @@ name = "bithuman"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "av" },
-    { name = "loguru" },
-    { name = "networkx" },
-    { name = "numpy" },
-    { name = "opencv-python-headless" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pyyaml" },
-    { name = "soundfile" },
+    { name = "av", marker = "python_full_version < '3.14'" },
+    { name = "loguru", marker = "python_full_version < '3.14'" },
+    { name = "networkx", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "opencv-python-headless", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "pydantic-settings", marker = "python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version < '3.14'" },
+    { name = "soundfile", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/f4/9faa8a78e8968f4404e5e47a2852d7a97313a667424a8e6f8bff16a28899/bithuman-2.7.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b399a37e187c17a8874e0eeb8e7e7a0907a4155537fac08185dabdb62491a7aa", size = 27205973, upload-time = "2026-07-17T00:14:45.72Z" },
@@ -3587,8 +3587,8 @@ name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
@@ -4248,7 +4248,7 @@ name = "opencv-python-headless"
 version = "5.0.0.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/99/76b7c80252aa83c1af16393454aafd125a0287101afe8deb0a6821af0e30/opencv_python_headless-5.0.0.93.tar.gz", hash = "sha256:b82f9831daab90b725c7c1ee1b36cb5732c367096ac76d119e64e14eb70d5f3c", size = 81817738, upload-time = "2026-07-02T07:01:06.039Z" }
 wheels = [
@@ -5716,9 +5716,9 @@ name = "soundfile"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
-    { name = "numpy" },
-    { name = "typing-extensions" },
+    { name = "cffi", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d2/db/949331952a6fb1c5b12e9de80fd08747966c2039d1a61db4764fbd3981c2/soundfile-0.14.0.tar.gz", hash = "sha256:ba1c1a2d618bca5c406647c83b89f07cc8810fa506a50622a6993ba130c1de11", size = 47842, upload-time = "2026-06-06T08:58:47.869Z" }
 wheels = [


### PR DESCRIPTION
Put any LiveKit agent on a real **Microsoft Teams call**.

Your AI teammate in Microsoft Teams calls: a colleague dials your Teams bot (or joins
a test meeting), and the agent you already built with `AgentSession` answers with
voice, tools, turn detection, everything. No Teams media stack, no Graph API, no
Windows media SDK, and nothing about your agent changes.

[StandIn](https://standin.komaa.com) is the hosted service that owns the Teams side:
it joins the call as a compliant Teams bot and relays the audio. This plugin is the
other half, and it is fully standalone: it answers StandIn's per-call dial inside
your worker process, creates one LiveKit room per call in your own project,
dispatches your agent into it by name, and relays the audio both ways.

```text
Microsoft Teams call
       |
       v
StandIn                    (hosted; joins the Teams call)
       |   HMAC WebSocket, PCM 16 kHz
       v
your agent worker          (the plugin answers the dial inside it)
       |   one LiveKit room per call
       v
your entrypoint            (dispatched by agent_name; a normal AgentSession)
```

## See it answer

A real Microsoft Teams call, answered by the example worker exactly as committed
here (Azure OpenAI realtime, greeting the caller by name):

![StandIn answering a Microsoft Teams call](https://raw.githubusercontent.com/komaa-com/livekit-plugins/assets/msteams-demo/teams-call.gif)

Screenshot of the live call, and the original clip with audio:
[teams-call.png](https://raw.githubusercontent.com/komaa-com/livekit-plugins/assets/msteams-demo/teams-call.png) | [teams-call.mp4](https://raw.githubusercontent.com/komaa-com/livekit-plugins/assets/msteams-demo/teams-call.mp4)

## What your agent becomes

This PR ships the plugin (`livekit-plugins/livekit-plugins-standin`) and a
complete single-file example (`examples/msteams`). What that unlocks for a
LiveKit agent, today and next:

**Available now**

- **Virtual customer success manager:** people call it and it answers technical
  and usage questions live, grounded in your product documentation - the
  grounding is your agent's own RAG/tool stack, unchanged.
- **Meeting assistant:** it joins your meetings and takes part like a
  participant, with participant-count and "stay quiet unless directly
  addressed" context fed to the agent. Following the screen share arrives with
  the vision surface on the roadmap.
- **Multilingual:** it answers in your customers' language - across all your
  markets. The audio relay is language-agnostic, so this is purely your model
  stack's strength.

**On the roadmap below**

- **Show, don't just tell:** for "how do I do this?" or "why isn't this
  working?", it walks the caller through the steps or the fix on its video,
  visually and out loud.
- **Watch it work:** ask for something mid-call and it shows its work on its
  video while it works, so people see progress instead of waiting.
- **Chat-to-call:** type "call me" in chat and StandIn calls you for a live
  voice conversation.

## The whole integration

One line inside your entrypoint. The file is shaped like every other agent
example, and nothing starts except through `cli.run_app(server)`:

```python
from livekit.plugins import standin

server = AgentServer()


@server.rtc_session(agent_name="msteams-agent")
async def entrypoint(ctx: JobContext):
    session = AgentSession(llm=...)  # any STT/LLM/TTS or realtime stack
    call = await standin.TeamsCall().start(session, ctx=ctx)
    await session.start(agent=MyAgent(call), room=ctx.room)


if __name__ == "__main__":
    cli.run_app(server)
```

There is no bootstrap call: importing the plugin registers it with the worker,
and setting `STANDIN_SECRET` arms it. The listener starts with the worker and
stops with it.

`call` carries `caller_name`, `tenant_id`, `user_id` (the caller's AAD id when Teams
provides one) and `direction`, so the agent greets the caller by name before the
first word. The governor's goodbye is handled for you: when StandIn is about to end
the call, the default handler interrupts the current turn and speaks the line, so
the caller actually hears it.

`CallInfo.from_job(ctx).is_teams_call` is False for jobs dispatched by anything
else, so one worker can serve Teams, SIP and web rooms at the same time.

## Try it in five minutes (Sandbox: no Microsoft setup at all)

The Sandbox tier gives you a throwaway Teams meeting on StandIn's own bot, so there
is nothing to register with Microsoft.

1. `cd examples/msteams && uv sync`
2. Sign in at [standin.komaa.com](https://standin.komaa.com), create a **Sandbox**
   connection, and copy the **connection secret**.
3. Put the secret and your LiveKit project in `.env`:

   ```bash
   STANDIN_SECRET=...
   LIVEKIT_URL=wss://your-project.livekit.cloud
   LIVEKIT_API_KEY=...
   LIVEKIT_API_SECRET=...
   ```

4. Run the worker and expose its port (any tunnel works; Tailscale shown):

   ```bash
   uv run agent.py dev
   ```

   ```bash
   tailscale funnel --bg --set-path /msteams/calling http://127.0.0.1:9442/msteams/calling
   ```

5. Register `wss://<your-host>/msteams/calling` as the connection's **Agent voice
   URL** in the portal, then join the sandbox meeting from any Teams client.

Your agent picks up. Talk to it.

## Going real (Free tier: your own Teams bot)

The Free tier walks you through registering your own Azure bot, so callers dial
**your** bot in **your** tenant. The worker does not change at all: same
`agent.py`, same `.env`, same funnel. You pair the identity in the portal, point
the Azure bot's calling webhook at the `standin.komaa.com` endpoint the portal
shows you, and register the same Agent voice URL. Then call your bot from Teams.

## What the community gets

- **Any agent stack**: the example uses an Azure OpenAI realtime model, but any
  `AgentSession` combination works unchanged; the caller is an ordinary audio
  track in the room.
- **Standalone**: no separate bridge process, no extra deployment. One worker.
- **Hardened transport**: HMAC-authenticated upgrades with a replay guard,
  capacity checks before crypto, a pre-start watchdog, an audio-idle backstop
  that ends dead calls, and bounded teardown everywhere.
- **Group-call awareness**: participant counts, DTMF digits and Teams recording
  state reach the agent as data topics.
- **Chat-ready API** (coming): `ChatChannel` ships the client side of the
  Teams text lane, so answering chat will be one async handler when the hosted
  channel opens. See the roadmap.

## Verified

- Unit suite (hermetic), mypy `--strict`, ruff clean.
- Live end to end: a real Microsoft Teams call answered by the example worker
  through a Tailscale funnel, with the agent greeting the caller by name and
  holding a multi-turn voice conversation on an Azure OpenAI realtime model.

## Roadmap

- **Chat / text messages** (coming next): answer Microsoft Teams chat with the
  same worker. The plugin already ships `ChatChannel` - one async handler in,
  reply text out, with per-conversation ordering, redelivery dedupe, and a
  typing indicator while the agent thinks. The worker dials OUT to StandIn's
  chat channel, so this lane needs no port either, and on managed connections
  your agent never holds a Bot Framework credential; it goes live when the
  hosted channel endpoint opens.
- **Avatar**: the video surface (the agent's face on the Teams tile, caller
  screen-share and camera) depends on a third-party avatar runtime and lands
  separately. Those frames are ignored gracefully today.

